### PR TITLE
Add standard `npm start` to run local webserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "gutenberg",
+  "version": "1.0.0",
+  "description": "Prototyping a new WordPress editor experience",
+  "main": "index.html",
+  "scripts": {
+    "start": "http-server -p 5000",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/gutenberg.git"
+  },
+  "keywords": [
+    "WordPress",
+    "editor",
+    "prototype"
+  ],
+  "author": "Automattic, Inc.",
+  "license": "GPL-2.0+",
+  "bugs": {
+    "url": "https://github.com/Automattic/gutenberg/issues"
+  },
+  "homepage": "https://github.com/Automattic/gutenberg#readme",
+  "devDependencies": {
+    "http-server": "0.9.0"
+  }
+}


### PR DESCRIPTION
Nothing fancy, just a basic `npm start` to spin up a local http server