### PR TITLE
Don't assume spread operator available on client

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -40,10 +40,10 @@ function attachBlockHandlers() {
 }
 
 function getBlocks() {
-	var text = document.getElementsByTagName( 'p' );
-	var heading = document.getElementsByTagName( 'h2' );
-	var images = document.getElementsByTagName( 'img' );
-	return [ ...text, ...heading, ...images ];
+	return Array.prototype.concat.apply( [], [ 'p', 'h2', 'img' ]
+		.map( function( tagName ) {
+			return Array.from( document.getElementsByTagName( tagName ) );
+		} ) );
 }
 
 function selectBlock( event ) {

--- a/blocks.js
+++ b/blocks.js
@@ -40,10 +40,8 @@ function attachBlockHandlers() {
 }
 
 function getBlocks() {
-	return Array.prototype.concat.apply( [], [ 'p', 'h2', 'img' ]
-		.map( function( tagName ) {
-			return Array.from( document.getElementsByTagName( tagName ) );
-		} ) );
+	return Array.prototype.concat.apply( [],
+			[ 'p', 'h2', 'img' ].map( query ) );
 }
 
 function selectBlock( event ) {
@@ -208,4 +206,8 @@ function hideMenu() {
 function l( data ) {
 	console.log( data );
 	return data;
+}
+
+function query( selector ) {
+	return Array.from( document.querySelectorAll( selector ) );
 }


### PR DESCRIPTION
Fixes UI for Safari by preferring `Array#concat`.

Also, refactor to avoid repetition.