### PR TITLE
Add meta viewport tag.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<title>Editor Blocks</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel='stylesheet' id='h5-font-css' href='https://fonts.googleapis.com/css?family=Merriweather:700,300,700italic,300italic' />
 		<link href="style.css" rel="stylesheet" type="text/css" media="all">
 	</head>


### PR DESCRIPTION
For scaling of the viewport, add in standard meta tag.  I noticed the mobile view was not fitting the viewport.  Not sure how important this is, but though it would be nice to add anyways.