### PR TITLE
Fix arrows moving up and down

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -140,14 +140,14 @@ function attachControlActions() {
 		var classes = node.className.baseVal;
 
 		if ( 'up' === classes ) {
-			node.addEventListener( 'click', function() {
+			node.addEventListener( 'click', function( event ) {
 				event.stopPropagation();
 				swapNodes( selectedBlock, getPreviousSibling( selectedBlock ) );
 				attachBlockHandlers();
 				reselect();
 			}, false );
 		} else if ( 'down' === classes ) {
-			node.addEventListener( 'click', function() {
+			node.addEventListener( 'click', function( event ) {
 				event.stopPropagation();
 				swapNodes( selectedBlock, getNextSibling( selectedBlock ) );
 				attachBlockHandlers();


### PR DESCRIPTION
Clicking an up or down arrow would result in `ReferenceError: event is not defined`.