### PR TITLE
Fix missing variable `event` in switcher handlers

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -154,18 +154,15 @@ function attachControlActions() {
 		}
 
 		var classes = node.className.baseVal;
+		var getter = {
+			up: getPreviousSibling,
+			down: getNextSibling
+		}[ classes ];
 
-		if ( 'up' === classes ) {
+		if ( getter ) {
 			node.addEventListener( 'click', function( event ) {
 				event.stopPropagation();
-				swapNodes( selectedBlock, getPreviousSibling( selectedBlock ) );
-				attachBlockHandlers();
-				reselect();
-			}, false );
-		} else if ( 'down' === classes ) {
-			node.addEventListener( 'click', function( event ) {
-				event.stopPropagation();
-				swapNodes( selectedBlock, getNextSibling( selectedBlock ) );
+				swapNodes( selectedBlock, getter( selectedBlock ) );
 				attachBlockHandlers();
 				reselect();
 			}, false );


### PR DESCRIPTION
~Fixes error in #37~ Fixed in #36, but I'll still merge this one for the refactor.