### PR TITLE
Proposal for Block API

### DIFF
--- a/block-api.js
+++ b/block-api.js
@@ -1,249 +1,245 @@
 /**
  * block-api.js provides an interface for managing content blocks.
  */
-
-/**
- * gutenberg is the top level namespace for housing the block API.
- */
-var gutenberg = function() {
-	var control = function( config ) {
-		if ( typeof config === 'undefined' ) {
-			return {}
-		}
-
-		return {
-			name: config.name,
-			type: config.type,
-			displayArea: config.displayArea
-		}
-	}
-
-	var block = function( config ) {
-		if ( typeof config === 'undefined' ) {
-			return {}
-		}
-
-		return {
-			name: config.name,
-			type: config.type,
-			controls: config.controls
-		}
-	}
-
-	// Standard text block.
-	var textBlock = function( config ) {
-		if ( typeof config === 'undefined' ) {
-			config = {}
-		}
-
-		return Object.assign(
-			{},
-			config,
-			block( {
-				name: 'Text',
-				type: 'wp-text',
-				controls: [
-					gutenberg().control(
-						{
-							name: 'Align Left',
-							type: 'left-align',
-							displayArea: 'block'
-						}
-					),
-					gutenberg().control(
-						{
-							name: 'Align Center',
-							type: 'center-align',
-							displayArea: 'block'
-						}
-					),
-					gutenberg().control(
-						{
-							name: 'Align Right',
-							type: 'right-align',
-							displayArea: 'block'
-						}
-					),
-					gutenberg().control(
-						{
-							name: 'Make Text Bold',
-							type: 'bold',
-							displayArea: 'inline'
-						}
-					),
-					gutenberg().control(
-						{
-							name: 'Italicize Text',
-							type: 'italics',
-							displayArea: 'inline'
-						}
-					),
-					gutenberg().control(
-						{
-							name: 'Add A Link',
-							type: 'link',
-							displayArea: 'inline'
-						}
-					),
-					gutenberg().control(
-						{
-							name: 'Strikethrough Text',
-							type: 'strikethrough',
-							displayArea: 'inline'
-						}
-					),
-					gutenberg().control(
-						{
-							name: 'Underline Text',
-							type: 'underline',
-							displayArea: 'inline'
-						}
-					)
-				]
-			} )
-		)
-	}
-
+( function() {
 	/**
-	 * The blocks registry serves as an interface for de/registering blocks.
-	 *
-	 * For each instance of gutenberg() there will be one instance of the
-	 * blocksRegistry. gutenberg().blocks is equivalent to the invocation of the
-	 * blocksRegistry.
+	 * gutenberg is the top level namespace for housing the block API.
 	 */
-	var blocksRegistry = function() {
-		var registeredBlocks = []
-
-		var register = function( block ) {
-			var blockExists = registeredBlocks.find( function( registeredBlock ) {
-				return registeredBlock.type === block.type
-			} )
-
-			/**
-			 * If the block does not exist add it to the registered blocks.
-			 *
-			 * If it does exist do nothing and return the already registered
-			 * blocks, this can be changed to allow overriding.
-			 */
-			if ( typeof blockExists === 'undefined' ) {
-				registeredBlocks.push( block )
-				return [ block ];
+	var gutenberg = function() {
+		var control = function( config ) {
+			if ( typeof config === 'undefined' ) {
+				return {}
 			}
 
-			return []
+			return {
+				name: config.name,
+				type: config.type,
+				displayArea: config.displayArea,
+				render: config.render,
+				icon: config.icon,
+				handlers: config.handlers
+			}
 		}
 
-		var registerBlock = function( block ) {
-			// Return the list of blocks with the new block if it was added.
-			var blocks = Array.prototype.concat.apply( [], registeredBlocks, register( block ) )
-
-			return Blocks( blocks )
-		}
-
-		var registerBlocks = function( blocks ) {
-			// Return the list of blocks with the new blocks if they were added.
-			var blocks = Array.prototype.concat.apply( [], registeredBlocks, blocks.map( register ) )
-
-			return Blocks( blocks )
-		}
-
-		var unregister = function( block ) {
-			var blockIndex = registeredBlocks.findIndex( function( registeredBlock ) {
-				return registeredBlock.type === block.type
-			} )
-
-			/**
-			 * If the block does not exist remove it from the registered blocks.
-			 *
-			 * If it does exist do nothing and return the already registered
-			 * blocks, this can be changed to allow overriding.
-			 */
-			if ( blockIndex !== -1 ) {
-				delete registeredBlocks[ blockIndex ]
+		var block = function( config ) {
+			if ( typeof config === 'undefined' ) {
+				return {}
 			}
 
-			return registeredBlocks
-		}
-
-		var unregisterBlock = function( block ) {
-			return Blocks( unregister( block ) )
-		}
-
-		var unregisterBlocks = function( blocks ) {
-			var blocks = Array.prototype.concat.apply( [], blocks.map( unregister ) )
-			return Blocks( blocks )
+			return {
+				name: config.name,
+				type: config.type,
+				controls: config.controls
+			}
 		}
 
 		/**
-		 * Add the interface to blocks.
+		 * The blocks registry serves as an interface for de/registering blocks.
 		 *
-		 * It is important to understand that even though it will act like an
-		 * array it is not an Array, so when array methods are used they will
-		 * return an Array type, and must be wrapped in Blocks() if you need to
-		 * chain methods specific to a collection of the registered blocks.
-		 *
-		 * @param {array} blocks List of blocks.
-		 * @returns {Blocks} List of blocks with additional interface.
+		 * For each instance of gutenberg() there will be one instance of the
+		 * blocksRegistry. gutenberg().blocks is equivalent to the invocation of the
+		 * blocksRegistry.
 		 */
-		var Blocks = function( blocks ) {
-			blocks.registerBlock = registerBlock
-			blocks.registerBlocks = registerBlocks
-			blocks.unregisterBlock = unregisterBlock
-			blocks.unregisterBlocks = unregisterBlocks
+		var blocksRegistry = function() {
+			/**
+			 * Collection of registered blocks.
+			 */
+			var registeredBlocks = []
+
+			var register = function( block ) {
+				var blockExists = registeredBlocks.find( function( registeredBlock ) {
+					return registeredBlock.type === block.type
+				} )
+
+				/**
+				 * If the block does not exist add it to the registered blocks.
+				 *
+				 * If it does exist do nothing and return the already registered
+				 * blocks, this can be changed to allow overriding.
+				 */
+				if ( typeof blockExists === 'undefined' ) {
+					registeredBlocks.push( block )
+					return [ block ];
+				}
+
+				return []
+			}
+
+			var registerBlock = function( block ) {
+				// Return the list of blocks with the new block if it was added.
+				var blocks = Array.prototype.concat.apply( [], registeredBlocks, register( block ) )
+
+				return Blocks( blocks )
+			}
+
+			var registerBlocks = function( blocks ) {
+				// Return the list of blocks with the new blocks if they were added.
+				var blocks = Array.prototype.concat.apply( [], registeredBlocks, blocks.map( register ) )
+
+				return Blocks( blocks )
+			}
+
+			var unregister = function( block ) {
+				var blockIndex = registeredBlocks.findIndex( function( registeredBlock ) {
+					return registeredBlock.type === block.type
+				} )
+
+				/**
+				 * If the block does not exist remove it from the registered blocks.
+				 *
+				 * If it does exist do nothing and return the already registered
+				 * blocks, this can be changed to allow overriding.
+				 */
+				if ( blockIndex !== -1 ) {
+					delete registeredBlocks[ blockIndex ]
+				}
+
+				return registeredBlocks
+			}
+
+			var unregisterBlock = function( block ) {
+				return Blocks( unregister( block ) )
+			}
+
+			var unregisterBlocks = function( blocks ) {
+				var blocks = Array.prototype.concat.apply( [], blocks.map( unregister ) )
+				return Blocks( blocks )
+			}
+
+			/**
+			 * Add the interface to blocks.
+			 *
+			 * It is important to understand that even though it will act like an
+			 * array it is not an Array, so when array methods are used they will
+			 * return an Array type, and must be wrapped in Blocks() if you need to
+			 * chain methods specific to a collection of the registered blocks.
+			 *
+			 * @param {array} blocks List of blocks.
+			 * @returns {Blocks} List of blocks with additional interface.
+			 */
+			var Blocks = function( blocks ) {
+				blocks.registerBlock = registerBlock
+				blocks.registerBlocks = registerBlocks
+				blocks.unregisterBlock = unregisterBlock
+				blocks.unregisterBlocks = unregisterBlocks
+
+				return blocks
+			}
+
+			/**
+			 * The blocks property becomes an invocation of Blocks on a copy of the
+			 * list of registered blocks.
+			 */
+			var blocks = Blocks( registeredBlocks.slice( 0 ) )
 
 			return blocks
 		}
 
+		var blocks = blocksRegistry()
+
 		/**
-		 * The blocks property becomes an invocation of Blocks on a copy of the
-		 * list of registered blocks.
+		 * The blocks registry serves as an interface for de/registering blocks.
+		 *
+		 * For each instance of gutenberg() there will be one instance of the
+		 * blocksRegistry. gutenberg().blocks is equivalent to the invocation of the
+		 * blocksRegistry.
 		 */
-		var blocks = Blocks( registeredBlocks.slice( 0 ) )
+		var editor = function( blocks ) {
+			var getControls = function( displayArea ) {
+				return function( type ) {
+					var block = blocks.find( function( block ) {
+						return block.type === type
+					} )
 
-		return blocks
-	}
+					// If the block was not found, or no controls.
+					if ( typeof block === 'undefined' || typeof block.controls === 'undefined' ) {
+						return []
+					}
 
-	var blocks = blocksRegistry()
+					return block.controls.filter( function( control ) {
+						return control.displayArea === displayArea
+					} )
+				}
+			}
 
-	return {
-		block: block,
-		control: control,
-		textBlock: textBlock,
-		blocks: blocks
-	}
-}
+			var getBlockControls = getControls( 'block' )
+			var getInlineControls = getControls( 'inline' )
 
-if ( typeof module !== 'undefined' ) {
-	module.exports = gutenberg
-}
+			/**
+			 * A rendering callback can be registered with the block.
+			 */
+			var renderControl = function( control ) {
+				if ( typeof control !== 'undefined' && typeof control.render === 'function' ) {
+					return control.render( control )
+				}
 
-/**
- * Object assign polyfill per MDN for IE support.
- *
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
- */
-if ( typeof Object.assign !== 'function' ) {
-	Object.assign = function( target, varArgs ) { // .length of function is 2
-		'use strict';
+				return null
+			}
 
-		if ( target == null ) { // TypeError if undefined or null
-			throw new TypeError( 'Cannot convert undefined or null to object' );
+			/**
+			 * Interface for the editor.
+			 */
+			return {
+				getControls: getControls,
+				getBlockControls: getBlockControls,
+				getInlineControls: getInlineControls,
+				renderControl: renderControl
+			}
 		}
 
-		var to = Object( target );
+		/**
+		 * The interface of the Gutenberg block API.
+		 *
+		 * @param {func} block()     Used for creating blocks.
+		 * @param {func} control()   Used for creating controls.
+		 * @param {func} textBlock() Used for creating text blocks.
+		 * @param {obj}  blocks      Interface for the blockRegistry
+		 * @param {func} editor      Interface for the editor.
+		 */
+		return {
+			block: block,
+			control: control,
+			blocks: blocks,
+			editor: editor
+		}
+	}
 
-		for ( var index = 1; index < arguments.length; index++ ) {
-			var nextSource = arguments[ index ];
+	if ( typeof module !== 'undefined' ) {
+		module.exports = gutenberg
+	}
 
-			if ( nextSource != null ) { // Skip over if undefined or null
-				for ( var nextKey in nextSource ) {
-					// Avoid bugs when hasOwnProperty is shadowed
-					if ( Object.prototype.hasOwnProperty.call( nextSource, nextKey ) ) {
-						to[ nextKey ] = nextSource[ nextKey ];
+	if ( typeof window !== 'undefined' ) {
+		window.gutenberg = gutenberg
+	}
+
+	/**
+	 * Object assign polyfill per MDN for IE support.
+	 *
+	 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+	 */
+	if ( typeof Object.assign !== 'function' ) {
+		Object.assign = function( target, varArgs ) { // .length of function is 2
+			'use strict';
+
+			if ( target == null ) { // TypeError if undefined or null
+				throw new TypeError( 'Cannot convert undefined or null to object' );
+			}
+
+			var to = Object( target );
+
+			for ( var index = 1; index < arguments.length; index++ ) {
+				var nextSource = arguments[ index ];
+
+				if ( nextSource != null ) { // Skip over if undefined or null
+					for ( var nextKey in nextSource ) {
+						// Avoid bugs when hasOwnProperty is shadowed
+						if ( Object.prototype.hasOwnProperty.call( nextSource, nextKey ) ) {
+							to[ nextKey ] = nextSource[ nextKey ];
+						}
 					}
 				}
 			}
-		}
-		return to;
-	};
-}
+			return to;
+		};
+	}
+} () )

--- a/block-api.js
+++ b/block-api.js
@@ -1,0 +1,249 @@
+/**
+ * block-api.js provides an interface for managing content blocks.
+ */
+
+/**
+ * gutenberg is the top level namespace for housing the block API.
+ */
+var gutenberg = function() {
+	var control = function( config ) {
+		if ( typeof config === 'undefined' ) {
+			return {}
+		}
+
+		return {
+			name: config.name,
+			type: config.type,
+			displayArea: config.displayArea
+		}
+	}
+
+	var block = function( config ) {
+		if ( typeof config === 'undefined' ) {
+			return {}
+		}
+
+		return {
+			name: config.name,
+			type: config.type,
+			controls: config.controls
+		}
+	}
+
+	// Standard text block.
+	var textBlock = function( config ) {
+		if ( typeof config === 'undefined' ) {
+			config = {}
+		}
+
+		return Object.assign(
+			{},
+			config,
+			block( {
+				name: 'Text',
+				type: 'wp-text',
+				controls: [
+					gutenberg().control(
+						{
+							name: 'Align Left',
+							type: 'left-align',
+							displayArea: 'block'
+						}
+					),
+					gutenberg().control(
+						{
+							name: 'Align Center',
+							type: 'center-align',
+							displayArea: 'block'
+						}
+					),
+					gutenberg().control(
+						{
+							name: 'Align Right',
+							type: 'right-align',
+							displayArea: 'block'
+						}
+					),
+					gutenberg().control(
+						{
+							name: 'Make Text Bold',
+							type: 'bold',
+							displayArea: 'inline'
+						}
+					),
+					gutenberg().control(
+						{
+							name: 'Italicize Text',
+							type: 'italics',
+							displayArea: 'inline'
+						}
+					),
+					gutenberg().control(
+						{
+							name: 'Add A Link',
+							type: 'link',
+							displayArea: 'inline'
+						}
+					),
+					gutenberg().control(
+						{
+							name: 'Strikethrough Text',
+							type: 'strikethrough',
+							displayArea: 'inline'
+						}
+					),
+					gutenberg().control(
+						{
+							name: 'Underline Text',
+							type: 'underline',
+							displayArea: 'inline'
+						}
+					)
+				]
+			} )
+		)
+	}
+
+	/**
+	 * The blocks registry serves as an interface for de/registering blocks.
+	 *
+	 * For each instance of gutenberg() there will be one instance of the
+	 * blocksRegistry. gutenberg().blocks is equivalent to the invocation of the
+	 * blocksRegistry.
+	 */
+	var blocksRegistry = function() {
+		var registeredBlocks = []
+
+		var register = function( block ) {
+			var blockExists = registeredBlocks.find( function( registeredBlock ) {
+				return registeredBlock.type === block.type
+			} )
+
+			/**
+			 * If the block does not exist add it to the registered blocks.
+			 *
+			 * If it does exist do nothing and return the already registered
+			 * blocks, this can be changed to allow overriding.
+			 */
+			if ( typeof blockExists === 'undefined' ) {
+				registeredBlocks.push( block )
+				return [ block ];
+			}
+
+			return []
+		}
+
+		var registerBlock = function( block ) {
+			// Return the list of blocks with the new block if it was added.
+			var blocks = Array.prototype.concat.apply( [], registeredBlocks, register( block ) )
+
+			return Blocks( blocks )
+		}
+
+		var registerBlocks = function( blocks ) {
+			// Return the list of blocks with the new blocks if they were added.
+			var blocks = Array.prototype.concat.apply( [], registeredBlocks, blocks.map( register ) )
+
+			return Blocks( blocks )
+		}
+
+		var unregister = function( block ) {
+			var blockIndex = registeredBlocks.findIndex( function( registeredBlock ) {
+				return registeredBlock.type === block.type
+			} )
+
+			/**
+			 * If the block does not exist remove it from the registered blocks.
+			 *
+			 * If it does exist do nothing and return the already registered
+			 * blocks, this can be changed to allow overriding.
+			 */
+			if ( blockIndex !== -1 ) {
+				delete registeredBlocks[ blockIndex ]
+			}
+
+			return registeredBlocks
+		}
+
+		var unregisterBlock = function( block ) {
+			return Blocks( unregister( block ) )
+		}
+
+		var unregisterBlocks = function( blocks ) {
+			var blocks = Array.prototype.concat.apply( [], blocks.map( unregister ) )
+			return Blocks( blocks )
+		}
+
+		/**
+		 * Add the interface to blocks.
+		 *
+		 * It is important to understand that even though it will act like an
+		 * array it is not an Array, so when array methods are used they will
+		 * return an Array type, and must be wrapped in Blocks() if you need to
+		 * chain methods specific to a collection of the registered blocks.
+		 *
+		 * @param {array} blocks List of blocks.
+		 * @returns {Blocks} List of blocks with additional interface.
+		 */
+		var Blocks = function( blocks ) {
+			blocks.registerBlock = registerBlock
+			blocks.registerBlocks = registerBlocks
+			blocks.unregisterBlock = unregisterBlock
+			blocks.unregisterBlocks = unregisterBlocks
+
+			return blocks
+		}
+
+		/**
+		 * The blocks property becomes an invocation of Blocks on a copy of the
+		 * list of registered blocks.
+		 */
+		var blocks = Blocks( registeredBlocks.slice( 0 ) )
+
+		return blocks
+	}
+
+	var blocks = blocksRegistry()
+
+	return {
+		block: block,
+		control: control,
+		textBlock: textBlock,
+		blocks: blocks
+	}
+}
+
+if ( typeof module !== 'undefined' ) {
+	module.exports = gutenberg
+}
+
+/**
+ * Object assign polyfill per MDN for IE support.
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+ */
+if ( typeof Object.assign !== 'function' ) {
+	Object.assign = function( target, varArgs ) { // .length of function is 2
+		'use strict';
+
+		if ( target == null ) { // TypeError if undefined or null
+			throw new TypeError( 'Cannot convert undefined or null to object' );
+		}
+
+		var to = Object( target );
+
+		for ( var index = 1; index < arguments.length; index++ ) {
+			var nextSource = arguments[ index ];
+
+			if ( nextSource != null ) { // Skip over if undefined or null
+				for ( var nextKey in nextSource ) {
+					// Avoid bugs when hasOwnProperty is shadowed
+					if ( Object.prototype.hasOwnProperty.call( nextSource, nextKey ) ) {
+						to[ nextKey ] = nextSource[ nextKey ];
+					}
+				}
+			}
+		}
+		return to;
+	};
+}

--- a/index.html
+++ b/index.html
@@ -17,29 +17,6 @@
 				<svg width="24" height="24" class="type-icon-image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Image</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M13 9.5c0-.828.672-1.5 1.5-1.5s1.5.672 1.5 1.5-.672 1.5-1.5 1.5-1.5-.672-1.5-1.5zM22 6v12c0 1.105-.895 2-2 2H4c-1.105 0-2-.895-2-2V6c0-1.105.895-2 2-2h16c1.105 0 2 .895 2 2zm-2 0H4v7.444L8 9l5.895 6.55 1.587-1.85c.798-.932 2.24-.932 3.037 0L20 15.426V6z"/></g></svg>
 			</span>
 		</div>
-		<div class="block-controls">
-			<button class="block-text is-active">
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Left</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm10-6H4v2h10v-2zM4 9v2h16V9H4zm10-4H4v2h10V5z"/></g></svg>
-			</button>
-			<button class="block-text">
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Center</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm13-6H7v2h10v-2zM4 9v2h16V9H4zm13-4H7v2h10V5z"/></g></svg>
-			</button>
-			<button class="block-text">
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Right</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 17H4v2h16v-2zm-10-2h10v-2H10v2zM4 9v2h16V9H4zm6-2h10V5H10v2z"/></g></svg>
-			</button>
-			<button class="block-image block-image__no-align">
-				<svg class="gridicon gridicons-align-image-center" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M3 5h18v2H3V5zm0 14h18v-2H3v2zm5-4h8V9H8v6z"></path></g></svg>
-			</button>
-			<button class="block-image block-image__align-left">
-				<svg class="gridicon gridicons-align-image-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M3 5h18v2H3V5zm0 14h18v-2H3v2zm0-4h8V9H3v6zm10 0h8v-2h-8v2zm0-4h8V9h-8v2z"></path></g></svg>
-			</button>
-			<button class="block-image block-image__align-right">
-				<svg class="gridicon gridicons-align-image-right" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M21 7H3V5h18v2zm0 10H3v2h18v-2zm0-8h-8v6h8V9zm-10 4H3v2h8v-2zm0-4H3v2h8V9z"></path></g></svg>
-			</button>
-			<button class="block-image block-image__full-width">
-				<svg class="gridicon gridicons-fullscreen" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><title>Full Bleed</title><path d="M21 3v6h-2V6.41l-3.29 3.3-1.42-1.42L17.59 5H15V3zM3 3v6h2V6.41l3.29 3.3 1.42-1.42L6.41 5H9V3zm18 18v-6h-2v2.59l-3.29-3.29-1.41 1.41L17.59 19H15v2zM9 21v-2H6.41l3.29-3.29-1.41-1.42L5 17.59V15H3v6z"></path></g></svg>
-			</button>
-		</div>
 		<div class="inline-controls">
 			<button><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Bold</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M7 5.01h4.547c2.126 0 3.67.302 4.632.906.96.605 1.44 1.567 1.44 2.887 0 .896-.21 1.63-.63 2.205-.42.574-.98.92-1.678 1.036v.103c.95.212 1.637.608 2.057 1.19.42.58.63 1.35.63 2.315 0 1.367-.494 2.434-1.482 3.2-.99.765-2.332 1.148-4.027 1.148H7V5.01zm3 5.936h2.027c.862 0 1.486-.133 1.872-.4.386-.267.578-.708.578-1.323 0-.574-.21-.986-.63-1.236-.42-.25-1.087-.374-1.996-.374H10v3.333zm0 2.523v3.905h2.253c.876 0 1.52-.167 1.94-.502.416-.335.625-.848.625-1.54 0-1.243-.89-1.864-2.668-1.864H10z"/></g></svg></button>
 			<button><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Italic</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M10.536 5l-.427 2h1.5L9.262 18h-1.5l-.427 2h6.128l.426-2h-1.5l2.347-11h1.5l.427-2"/></g></svg></button>
@@ -85,7 +62,9 @@
 				</div>
 			</div>
 		</div>
-		<script src="blocks.js"></script>
 		<script src="block-api.js"></script>
+		<script src="wp-text.js"></script>
+		<script src="wp-image.js"></script>
+		<script src="blocks.js"></script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -83,5 +83,6 @@
 			</div>
 		</div>
 		<script src="blocks.js"></script>
+		<script src="block-api.js"></script>
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "Prototyping a new WordPress editor experience",
   "main": "index.html",
+  "bin": {
+    "mocha": "./node_modules/.bin/mocha"
+  },
   "scripts": {
     "start": "http-server -p 5000",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -23,6 +26,7 @@
   },
   "homepage": "https://github.com/Automattic/gutenberg#readme",
   "devDependencies": {
-    "http-server": "0.9.0"
+    "http-server": "0.9.0",
+    "mocha": "^3.2.0"
   }
 }

--- a/style.css
+++ b/style.css
@@ -259,7 +259,7 @@ p {
 }
 
 .block-controls button {
-	display: none;
+	/*display: none;*/
 }
 
 .block-controls.is-image .block-image,
@@ -344,7 +344,7 @@ p {
 	margin-right: 4px;
 }
 
-img.align-full-bleed {
+img.align-full-width {
 	margin-left: calc(50% - 50vw);
 	width: 100vw;
 	max-width: none;
@@ -362,4 +362,16 @@ img.align-right {
 	float: right;
 	width: 340px;
 	margin: 0 0 0 16px;
+}
+
+p.align-left {
+	text-align: left;
+}
+
+p.align-center {
+	text-align: center;
+}
+
+p.align-right {
+	text-align: right;
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,6 +3,7 @@
  */
 const gutenberg = require( '../block-api.js' )
 const assert = require( 'assert' )
+const textBlock = require( '../wp-text.js' )
 
 describe( 'gutenberg()', function() {
 	it( 'should return an object with the block api.', function() {
@@ -22,6 +23,9 @@ describe( 'gutenberg()', function() {
 				name: 'Align Left',
 				type: 'left-align',
 				displayArea: 'block',
+				render: undefined,
+				icon: undefined,
+				handlers: undefined
 			}
 			let actual = Gutenberg.control(
 				{
@@ -68,6 +72,9 @@ describe( 'gutenberg()', function() {
 		} )
 	} )
 
+	/**
+	 * textBlock will be deleted soon.
+	 */
 	describe( 'gutenberg.textBlock', function() {
 		it( 'should return a text block with matching properties.', function() {
 			let Gutenberg = gutenberg()
@@ -75,50 +82,12 @@ describe( 'gutenberg()', function() {
 			let expected = {
 				name: 'Text',
 				type: 'wp-text',
-				controls: [
-					{
-						name: 'Align Left',
-						type: 'left-align',
-						displayArea: 'block'
-					},
-					{
-						name: 'Align Center',
-						type: 'center-align',
-						displayArea: 'block'
-					},
-					{
-						name: 'Align Right',
-						type: 'right-align',
-						displayArea: 'block'
-					},
-					{
-						name: 'Make Text Bold',
-						type: 'bold',
-						displayArea: 'inline'
-					},
-					{
-						name: 'Italicize Text',
-						type: 'italics',
-						displayArea: 'inline'
-					},
-					{
-						name: 'Add A Link',
-						type: 'link',
-						displayArea: 'inline'
-					},
-					{
-						name: 'Strikethrough Text',
-						type: 'strikethrough',
-						displayArea: 'inline'
-					},
-					{
-						name: 'Underline Text',
-						type: 'underline',
-						displayArea: 'inline'
-					}
-				]
+				controls: []
 			}
-			let actual = Gutenberg.textBlock()
+
+			// Override controls so function calls do not have to match.
+			textBlock.controls = [];
+			let actual = textBlock
 
 			assert.deepEqual( actual, expected )
 		} )
@@ -129,9 +98,9 @@ describe( 'gutenberg()', function() {
 			let Gutenberg = gutenberg()
 			let blocks = Gutenberg.blocks
 
-			let expected = [ Gutenberg.textBlock() ]
+			let expected = [ textBlock ]
 			// Blocks() is a monad that sprinkles on some extra methods. Just compare the arrays.
-			let actual = blocks.registerBlock( Gutenberg.textBlock() ).slice( 0 )
+			let actual = blocks.registerBlock( textBlock ).slice( 0 )
 
 			assert.deepEqual( actual, expected )
 		} )
@@ -140,9 +109,9 @@ describe( 'gutenberg()', function() {
 			let Gutenberg = gutenberg()
 			let blocks = Gutenberg.blocks
 
-			let expected = [ Gutenberg.textBlock() ]
+			let expected = [ textBlock ]
 			// Blocks() is a monad that sprinkles on some extra methods. Just compare the arrays.
-			let actual = blocks.registerBlock( Gutenberg.textBlock() ).registerBlock( Gutenberg.textBlock() ).slice( 0 )
+			let actual = blocks.registerBlock( textBlock ).registerBlock( textBlock ).slice( 0 )
 
 			assert.deepEqual( actual, expected )
 		} )
@@ -151,9 +120,9 @@ describe( 'gutenberg()', function() {
 			let Gutenberg = gutenberg()
 			let blocks = Gutenberg.blocks
 
-			let expected = [ Gutenberg.textBlock(), Gutenberg.block( { type: 'yolo' } ) ]
+			let expected = [ textBlock, Gutenberg.block( { type: 'yolo' } ) ]
 			// Blocks() is a monad that sprinkles on some extra methods. Just compare the arrays.
-			let actual = blocks.registerBlock( Gutenberg.textBlock() ).registerBlock( Gutenberg.block( { type: 'yolo' } ) ).slice( 0 )
+			let actual = blocks.registerBlock( textBlock ).registerBlock( Gutenberg.block( { type: 'yolo' } ) ).slice( 0 )
 
 			assert.deepEqual( actual, expected )
 		} )
@@ -164,7 +133,10 @@ describe( 'gutenberg()', function() {
 			let Gutenberg = gutenberg()
 			let blocks = Gutenberg.blocks
 
-			let expected = [ Gutenberg.textBlock(), Gutenberg.block( { type: 'yolo' } ) ]
+			let imageBlock = Object.assign( {}, textBlock );
+			imageBlock.type = 'wp-image'
+
+			let expected = [ textBlock, imageBlock ]
 			let actual = blocks.registerBlocks( expected ).slice( 0 )
 
 			assert.deepEqual( actual, expected )
@@ -177,7 +149,7 @@ describe( 'gutenberg()', function() {
 			let blocks = Gutenberg.blocks
 
 			let someBlock = Gutenberg.block( { type: 'yolo' } )
-			let someBlocks = [ Gutenberg.textBlock(), Gutenberg.block( { type: 'image' } ) ]
+			let someBlocks = [ textBlock, Gutenberg.block( { type: 'image' } ) ]
 
 			// Look for the whole list.
 			let expected = [].concat( someBlocks, [ someBlock ] )
@@ -193,7 +165,7 @@ describe( 'gutenberg()', function() {
 			let blocks = Gutenberg.blocks
 
 			let someBlock = Gutenberg.block( { type: 'yolo' } )
-			let someBlocks = [ Gutenberg.textBlock() ]
+			let someBlocks = [ textBlock ]
 
 			// Look for the whole list.
 			let expected = [].concat( someBlocks, [ someBlock ] )
@@ -208,8 +180,7 @@ describe( 'gutenberg()', function() {
 			let Gutenberg = gutenberg()
 			let blocks = Gutenberg.blocks
 
-			let someBlock = Gutenberg.textBlock()
-
+			let someBlock = textBlock
 			blocks.registerBlock( someBlock )
 
 			// Look for the empty list.
@@ -223,7 +194,7 @@ describe( 'gutenberg()', function() {
 			let Gutenberg = gutenberg()
 			let blocks = Gutenberg.blocks
 
-			let someBlock = Gutenberg.textBlock()
+			let someBlock = textBlock
 			let blockDoesNotExist = Gutenberg.block( { type: 'I do not exist' } )
 
 			blocks.registerBlock( someBlock )
@@ -241,12 +212,164 @@ describe( 'gutenberg()', function() {
 			let Gutenberg = gutenberg()
 			let blocks = Gutenberg.blocks
 
-			let someBlocks = [ Gutenberg.textBlock(), Gutenberg.block( { type: 'yolo' } ), Gutenberg.block( { type: 'image' } ) ]
+			let someBlocks = [ textBlock, Gutenberg.block( { type: 'yolo' } ), Gutenberg.block( { type: 'image' } ) ]
 			let someBlocksToTakeAway = [ Gutenberg.block( { type: 'yolo' } ), Gutenberg.block( { type: 'image' } ) ]
 
 			// Look for partial list.
 			let expected = []
 			let actual = blocks.unregisterBlocks( someBlocksToTakeAway ).splice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.blocks.unregisterBlocks', function() {
+		it( 'should allow the registry of multiple blocks in a chain.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let someBlocks = [ textBlock, Gutenberg.block( { type: 'yolo' } ), Gutenberg.block( { type: 'image' } ) ]
+			let someBlocksToTakeAway = [ Gutenberg.block( { type: 'yolo' } ), Gutenberg.block( { type: 'image' } ) ]
+
+			// Look for partial list.
+			let expected = []
+			let actual = blocks.unregisterBlocks( someBlocksToTakeAway ).splice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.editor.getControls', function() {
+		it( 'should grab controls.', function() {
+			let Gutenberg = gutenberg()
+
+			// Register blocks.
+
+			let someBlocks = [ textBlock ]
+			let editor = Gutenberg.editor( someBlocks )
+
+			// Look for partial list.
+			let expected = textBlock.controls.filter( control => control.displayArea === 'block' )
+			let actual = editor.getControls( 'block' )( 'wp-text' )
+
+			assert.deepEqual( actual, expected )
+		} )
+		it( 'should return empty when no blocks are present.', function() {
+			let Gutenberg = gutenberg()
+
+			// Register blocks.
+			let someBlocks = []
+			let editor = Gutenberg.editor( someBlocks )
+
+			// Look for partial list.
+			let expected = []
+			let actual = editor.getControls( 'block' )( 'wp-text' )
+
+			assert.deepEqual( actual, expected )
+		} )
+		it( 'should return empty when no controls are present.', function() {
+			let Gutenberg = gutenberg()
+
+			// Register blocks.
+			let aBlockWithoutControls = Gutenberg.block( { type: 'no-controls' } )
+			let someBlocks = [ aBlockWithoutControls ]
+			let editor = Gutenberg.editor( someBlocks )
+
+			// Look for partial list.
+			let expected = []
+			let actual = editor.getControls( 'block' )( 'no-controls' )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.editor.getBlockControls', function() {
+		it( 'should grab controls.', function() {
+			let Gutenberg = gutenberg()
+
+			// Register blocks.
+			let someBlocks = [ textBlock ]
+			let editor = Gutenberg.editor( someBlocks )
+
+			// Look for partial list.
+			let expected = textBlock.controls.filter( control => control.displayArea === 'block' )
+			let actual = editor.getBlockControls( 'wp-text' )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.editor.getInlineControls', function() {
+		it( 'should grab controls.', function() {
+			let Gutenberg = gutenberg()
+
+			// Register blocks.
+			let someBlocks = [ textBlock ]
+			let editor = Gutenberg.editor( someBlocks )
+
+			// Look for partial list.
+			let expected = textBlock.controls.filter( control => control.displayArea === 'inline' )
+			let actual = editor.getInlineControls( 'wp-text' )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.editor.renderControl', function() {
+		it( 'should apply the callback for control.render().', function() {
+			let Gutenberg = gutenberg()
+
+			// Register blocks.
+
+			let render = function( control ) {
+				return control
+			}
+			let someBlocks = [ textBlock ]
+			let editor = Gutenberg.editor( someBlocks )
+
+			// Override the textBlock controls.
+			textBlock.controls.push( { type: 'yolo' } )
+			let index = textBlock.controls.findIndex( control => 'yolo' === control.type )
+			let yoloControl = textBlock.controls[ index ]
+			yoloControl.render = render
+
+			// Look for partial list.
+			let expected = { type: 'yolo', render }
+			let actual = editor.renderControl( yoloControl )
+
+			assert.deepEqual( actual, expected )
+		} )
+
+		it( 'should return null when control is not defined.', function() {
+			let Gutenberg = gutenberg()
+
+			// Register blocks.
+			let aBlockWithoutControls = Gutenberg.block( { type: 'no-controls' } )
+			let someBlocks = [ aBlockWithoutControls ]
+			let editor = Gutenberg.editor( someBlocks )
+
+			// Look for partial list.
+			let expected = null
+			let actual = editor.renderControl( aBlockWithoutControls )
+
+			assert.deepEqual( actual, expected )
+		} )
+
+		it( 'should return null when control.render() is not a function.', function() {
+			let Gutenberg = gutenberg()
+
+			// Register blocks.
+			let controlWithoutRender = Gutenberg.control( { type: 'yolo' } )
+			let aBlock = Gutenberg.block( {
+				type: 'no-controls',
+				controls: [ controlWithoutRender ]
+			} )
+			let someBlocks = [ aBlock ]
+			let editor = Gutenberg.editor( someBlocks )
+
+			// Look for partial list.
+			let expected = null
+			let actual = editor.renderControl( aBlock )
 
 			assert.deepEqual( actual, expected )
 		} )

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,0 +1,254 @@
+/**
+ * Test the blocks API.
+ */
+const gutenberg = require( '../block-api.js' )
+const assert = require( 'assert' )
+
+describe( 'gutenberg()', function() {
+	it( 'should return an object with the block api.', function() {
+		let Gutenberg = gutenberg()
+
+		let expected = 'function'
+		let actual = typeof Gutenberg.block
+
+		assert.equal( actual, expected )
+	} );
+
+	describe( 'gutenberg.control', function() {
+		it( 'should return a control with matching properties.', function() {
+			let Gutenberg = gutenberg()
+
+			let expected = {
+				name: 'Align Left',
+				type: 'left-align',
+				displayArea: 'block',
+			}
+			let actual = Gutenberg.control(
+				{
+					name: 'Align Left',
+					type: 'left-align',
+					displayArea: 'block',
+				}
+			)
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.block', function() {
+		it( 'should return a block with matching properties.', function() {
+			let Gutenberg = gutenberg()
+
+			let expected = {
+				name: 'Text',
+				type: 'wp-text',
+				controls: [
+					{
+						name: 'Align Left',
+						type: 'left-align',
+						handler: {}
+					}
+				]
+			}
+			let actual = Gutenberg.block(
+				{
+					name: 'Text',
+					type: 'wp-text',
+					controls: [
+						{
+							name: 'Align Left',
+							type: 'left-align',
+							handler: {}
+						}
+					]
+				}
+			)
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.textBlock', function() {
+		it( 'should return a text block with matching properties.', function() {
+			let Gutenberg = gutenberg()
+
+			let expected = {
+				name: 'Text',
+				type: 'wp-text',
+				controls: [
+					{
+						name: 'Align Left',
+						type: 'left-align',
+						displayArea: 'block'
+					},
+					{
+						name: 'Align Center',
+						type: 'center-align',
+						displayArea: 'block'
+					},
+					{
+						name: 'Align Right',
+						type: 'right-align',
+						displayArea: 'block'
+					},
+					{
+						name: 'Make Text Bold',
+						type: 'bold',
+						displayArea: 'inline'
+					},
+					{
+						name: 'Italicize Text',
+						type: 'italics',
+						displayArea: 'inline'
+					},
+					{
+						name: 'Add A Link',
+						type: 'link',
+						displayArea: 'inline'
+					},
+					{
+						name: 'Strikethrough Text',
+						type: 'strikethrough',
+						displayArea: 'inline'
+					},
+					{
+						name: 'Underline Text',
+						type: 'underline',
+						displayArea: 'inline'
+					}
+				]
+			}
+			let actual = Gutenberg.textBlock()
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.blocks.registerBlock', function() {
+		it( 'should return a list of registered blocks.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let expected = [ Gutenberg.textBlock() ]
+			// Blocks() is a monad that sprinkles on some extra methods. Just compare the arrays.
+			let actual = blocks.registerBlock( Gutenberg.textBlock() ).slice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+
+		it( 'should not allow blocks of the same type to exist.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let expected = [ Gutenberg.textBlock() ]
+			// Blocks() is a monad that sprinkles on some extra methods. Just compare the arrays.
+			let actual = blocks.registerBlock( Gutenberg.textBlock() ).registerBlock( Gutenberg.textBlock() ).slice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+
+		it( 'should have two blocks.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let expected = [ Gutenberg.textBlock(), Gutenberg.block( { type: 'yolo' } ) ]
+			// Blocks() is a monad that sprinkles on some extra methods. Just compare the arrays.
+			let actual = blocks.registerBlock( Gutenberg.textBlock() ).registerBlock( Gutenberg.block( { type: 'yolo' } ) ).slice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.blocks.registerBlocks', function() {
+		it( 'should allow the registry of multiple blocks.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let expected = [ Gutenberg.textBlock(), Gutenberg.block( { type: 'yolo' } ) ]
+			let actual = blocks.registerBlocks( expected ).slice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.blocks.registerBlocks.registerBlock', function() {
+		it( 'should allow the registry of multiple blocks in a chain.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let someBlock = Gutenberg.block( { type: 'yolo' } )
+			let someBlocks = [ Gutenberg.textBlock(), Gutenberg.block( { type: 'image' } ) ]
+
+			// Look for the whole list.
+			let expected = [].concat( someBlocks, [ someBlock ] )
+			let actual = blocks.registerBlocks( someBlocks ).registerBlock( someBlock ).slice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.blocks.registerBlock.registerBlocks', function() {
+		it( 'should allow the registry of multiple blocks in a chain.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let someBlock = Gutenberg.block( { type: 'yolo' } )
+			let someBlocks = [ Gutenberg.textBlock() ]
+
+			// Look for the whole list.
+			let expected = [].concat( someBlocks, [ someBlock ] )
+			let actual = blocks.registerBlocks( someBlocks ).registerBlock( someBlock ).slice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.blocks.unregisterBlock', function() {
+		it( 'should allow the registry of multiple blocks in a chain.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let someBlock = Gutenberg.textBlock()
+
+			blocks.registerBlock( someBlock )
+
+			// Look for the empty list.
+			let expected = []
+			let actual = blocks.unregisterBlock( someBlock ).splice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+
+		it( 'should do nothing if the blocks do not exist.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let someBlock = Gutenberg.textBlock()
+			let blockDoesNotExist = Gutenberg.block( { type: 'I do not exist' } )
+
+			blocks.registerBlock( someBlock )
+
+			// Look for the empty list.
+			let expected = [ someBlock ]
+			let actual = blocks.unregisterBlock( blockDoesNotExist ).splice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+
+	describe( 'gutenberg.blocks.unregisterBlocks', function() {
+		it( 'should allow the registry of multiple blocks in a chain.', function() {
+			let Gutenberg = gutenberg()
+			let blocks = Gutenberg.blocks
+
+			let someBlocks = [ Gutenberg.textBlock(), Gutenberg.block( { type: 'yolo' } ), Gutenberg.block( { type: 'image' } ) ]
+			let someBlocksToTakeAway = [ Gutenberg.block( { type: 'yolo' } ), Gutenberg.block( { type: 'image' } ) ]
+
+			// Look for partial list.
+			let expected = []
+			let actual = blocks.unregisterBlocks( someBlocksToTakeAway ).splice( 0 )
+
+			assert.deepEqual( actual, expected )
+		} )
+	} )
+} );

--- a/wp-image.js
+++ b/wp-image.js
@@ -1,0 +1,152 @@
+/**
+ * wp-image.js is the standard block for image handling.
+ */
+
+( function() {
+	var create
+
+	// In Browser.
+	if ( typeof window !== 'undefined' ) {
+		create = window.gutenberg()
+	}
+
+	// In Node.js
+	if ( typeof module !== 'undefined' && typeof module.exports !== 'undefined' ) {
+		create = require( './block-api.js' )()
+	}
+
+	/**
+	 * Control renderer.
+	 */
+	var renderBlockImageControl = function( control ) {
+		if ( typeof document !== 'undefined' ) {
+			var button = document.createElement( 'button' );
+			button.className = 'block-text is-active';
+
+			var icon = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
+			icon.setAttribute( 'xmlns', 'http://www.w3.org/2000/svg' );
+			icon.setAttribute( 'viewBox', '0 0 24 24' );
+
+			var title = document.createElement( 'title' );
+			var titleText = document.createTextNode( control.name );
+			title.appendChild( titleText );
+
+			var rect = document.createElementNS( 'http://www.w3.org/2000/svg', 'rect' )
+			rect.setAttribute( 'x', '0' );
+			rect.setAttribute( 'fill', 'none' );
+			rect.setAttribute( 'width', '24' );
+			rect.setAttribute( 'heigh', '24' );
+
+			var group = document.createElementNS( 'http://www.w3.org/2000/svg', 'g' );
+
+			var path = document.createElementNS( 'http://www.w3.org/2000/svg', 'path' );
+			path.setAttribute( 'd', control.icon.path );
+
+			group.appendChild( path );
+
+			icon.appendChild( title );
+			icon.appendChild( rect );
+			icon.appendChild( group );
+
+			button.appendChild( icon );
+
+			return button;
+		}
+	}
+
+	/**
+	 * Control actions.
+	 */
+	var setImageState = function( classes, event ) {
+		event.stopPropagation();
+		selectedBlock.className = 'is-selected ' + classes;
+	}
+
+	var setImageFullWidth = setImageState.bind( null, 'align-full-width' );
+	var setImageAlignNone = setImageState.bind( null, '' );
+	var setImageAlignLeft = setImageState.bind( null, 'align-left' );
+	var setImageAlignRight = setImageState.bind( null, 'align-right' );
+
+	var imageBlock = create.block( {
+		name: 'Image',
+		type: 'wp-image',
+		controls: [
+			create.control(
+				{
+					name: 'No Alignment',
+					type: 'no-align',
+					displayArea: 'block',
+					render: renderBlockImageControl,
+					icon: {
+						path: 'M3 5h18v2H3V5zm0 14h18v-2H3v2zm5-4h8V9H8v6z'
+					},
+					handlers: [
+						{
+							'type': 'click',
+							'action': setImageAlignNone
+						}
+					]
+				}
+			),
+			create.control(
+				{
+					name: 'Align Left',
+					type: 'left-align',
+					displayArea: 'block',
+					render: renderBlockImageControl,
+					icon: {
+						path: 'M3 5h18v2H3V5zm0 14h18v-2H3v2zm0-4h8V9H3v6zm10 0h8v-2h-8v2zm0-4h8V9h-8v2z'
+					},
+					handlers: [
+						{
+							'type': 'click',
+							'action': setImageAlignLeft
+						}
+					]
+				}
+			),
+			create.control(
+				{
+					name: 'Align Right',
+					type: 'right-align',
+					displayArea: 'block',
+					render: renderBlockImageControl,
+					icon: {
+						path: 'M21 7H3V5h18v2zm0 10H3v2h18v-2zm0-8h-8v6h8V9zm-10 4H3v2h8v-2zm0-4H3v2h8V9z'
+					},
+					handlers: [
+						{
+							'type': 'click',
+							'action': setImageAlignRight
+						}
+					]
+				}
+			),
+			create.control(
+				{
+					name: 'Make Full Width',
+					type: 'full-wdith',
+					displayArea: 'block',
+					render: renderBlockImageControl,
+					icon: {
+						path: 'M21 3v6h-2V6.41l-3.29 3.3-1.42-1.42L17.59 5H15V3zM3 3v6h2V6.41l3.29 3.3 1.42-1.42L6.41 5H9V3zm18 18v-6h-2v2.59l-3.29-3.29-1.41 1.41L17.59 19H15v2zM9 21v-2H6.41l3.29-3.29-1.41-1.42L5 17.59V15H3v6z'
+					},
+					handlers: [
+						{
+							'type': 'click',
+							'action': setImageFullWidth
+						}
+					]
+				}
+			)
+		]
+	} )
+
+	if ( typeof window !== 'undefined' ) {
+		window.imageBlock = imageBlock
+	}
+
+	if ( typeof module !== 'undefined' ) {
+		module.exports = imageBlock
+	}
+} () )

--- a/wp-text.js
+++ b/wp-text.js
@@ -1,0 +1,136 @@
+/**
+ * wp-text.js is the standard block for text handling.
+ */
+( function() {
+	var create
+
+	// In Browser.
+	if ( typeof window !== 'undefined' ) {
+		create = window.gutenberg()
+	}
+
+	// In Node.js
+	if ( typeof module !== 'undefined' && typeof module.exports !== 'undefined' ) {
+		create = require( './block-api.js' )()
+	}
+
+	/**
+	 * Control render functions.
+	 */
+	var renderBlockTextControl = function( control ) {
+		if ( typeof document !== 'undefined' ) {
+			var button = document.createElement( 'button' );
+			button.className = 'block-text is-active';
+
+			var icon = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
+			icon.setAttribute( 'xmlns', 'http://www.w3.org/2000/svg' );
+			icon.setAttribute( 'viewBox', '0 0 24 24' );
+
+			var title = document.createElement( 'title' );
+			var titleText = document.createTextNode( control.name );
+			title.appendChild( titleText );
+
+			var rect = document.createElementNS( 'http://www.w3.org/2000/svg', 'rect' )
+			rect.setAttribute( 'x', '0' );
+			rect.setAttribute( 'fill', 'none' );
+			rect.setAttribute( 'width', '24' );
+			rect.setAttribute( 'heigh', '24' );
+
+			var group = document.createElementNS( 'http://www.w3.org/2000/svg', 'g' );
+
+			var path = document.createElementNS( 'http://www.w3.org/2000/svg', 'path' );
+			path.setAttribute( 'd', control.icon.path );
+
+			group.appendChild( path );
+
+			icon.appendChild( title );
+			icon.appendChild( rect );
+			icon.appendChild( group );
+
+			button.appendChild( icon );
+
+			return button;
+		}
+	}
+
+	/**
+	 * Control actions.
+	 */
+	var setTextState = function( classes, event ) {
+		event.stopPropagation();
+		selectedBlock.className = 'is-selected ' + classes;
+	}
+
+	var setTextAlignLeft = setTextState.bind( null, 'align-left' );
+	var setTextAlignCenter = setTextState.bind( null, 'align-center' );
+	var setTextAlignRight = setTextState.bind( null, 'align-right' );
+
+	 /**
+	 * Block.
+	 */
+	var textBlock = create.block( {
+		name: 'Text',
+		type: 'wp-text',
+		controls: [
+			create.control(
+				{
+					name: 'Align Left',
+					type: 'left-align',
+					displayArea: 'block',
+					render: renderBlockTextControl,
+					icon: {
+						path: 'M4 19h16v-2H4v2zm10-6H4v2h10v-2zM4 9v2h16V9H4zm10-4H4v2h10V5z'
+					},
+					handlers: [
+						{
+							'type': 'click',
+							'action': setTextAlignLeft
+						}
+					]
+				}
+			),
+			create.control(
+				{
+					name: 'Align Center',
+					type: 'center-align',
+					displayArea: 'block',
+					render: renderBlockTextControl,
+					icon: {
+						path: 'M4 19h16v-2H4v2zm13-6H7v2h10v-2zM4 9v2h16V9H4zm13-4H7v2h10V5z'
+					},
+					handlers: [
+						{
+							'type': 'click',
+							'action': setTextAlignCenter
+						}
+					]
+				}
+			),
+			create.control(
+				{
+					name: 'Align Right',
+					type: 'right-align',
+					displayArea: 'block',
+					render: renderBlockTextControl,
+					icon: {
+						path: 'M20 17H4v2h16v-2zm-10-2h10v-2H10v2zM4 9v2h16V9H4zm6-2h10V5H10v2z'
+					},
+					handlers: [
+						{
+							'type': 'click',
+							'action': setTextAlignRight
+						}
+					]
+				}
+			)
+		]
+	} )
+
+	if ( typeof window !== 'undefined' ) {
+		window.textBlock = textBlock
+	}
+
+	if ( typeof module !== 'undefined' ) {
+		module.exports = textBlock
+	}
+} () );


### PR DESCRIPTION
Fixes #27. Here is my intial proposal for a blocks API for Gutenberg.  If es6 were available for use this could be cleaned up big time.  I still need to add some polyfills for compatability, but overall, I think this came out decently well.  I would love some feedback!

How to use:

`gutenberg()` is currently used as a namespace for three different things:

- Factories for blocks and controls.
- Interface for registering blocks to a specific instance of `gutenberg()`.
- Interface for the editor to interact with registered blocks.

Using factories:

```js
// Create gutenberg() instance.
const create = gutenberg()

const renderListControl( control ) {
  // Do stuff here to create DOM element. This can be further abstracted to become vDOM.
}

const setListState = function( classes, event ) {
    event.stopPropagation();
    selectedBlock.className = 'is-selected ' + classes;
}

const setListDisplayOpenDiscs = setListState.bind( null, 'open-discs' );

const listBlock = create.Block( {
  name: 'List',
  type: 'wp-list',
  controls: [
    create.control( {
      name: 'Display Open Discs',
      type: 'open-discs',
      displayArea: 'block',
      render: renderListControl,
      icon: {
        path: 'svg path data'
      },
      handlers: [
          {
              'type': 'click',
              'action': setListDisplayOpenDiscs
          }
      ]
    } )
  ]
} )
```

In the above we are creating an instance of `gutenberg()` as `create`.  We use the `block()` and `control` factories to create a list block with one control.  All you need to do now is associate a dom element with the block and the Oila, a block element is already created.

Using the interface for registering blocks:

```js
const blocks = gutenberg().blocks

let registeredBlocks = blocks.registerBlock( imageBlock ).registerBlocks( [ listBlock, quoteBlock, textBlock ] )
```

You can chain a set of registered blocks using `registerBlock()`, `registerBlocks()`, `unregisterBlock()`, and `unregisterBlocks()`

The return of the methods will act like an array but it is not an array.  It is also import to understand that the blocks are encapsulated and the reference you store is meant to be generated in one go and not changed later on during run time.

Using the editor interface:

```js
const blocks = gutenberg().blocks

let registeredBlocks = blocks.registerBlock( imageBlock ).registerBlocks( [ listBlock, quoteBlock, textBlock ] )

// Create instance of the editor interface as Gutenberg
const Gutenberg = gutenberg().editor( registeredBlocks )

// Get the block area controls for the wp-text block.
const textBlockControls = Gutenberg.getBlockControls( 'wp-text' )

// Create a DOM or vDOM, or whatever you want really, representation of the control.
const mySuperAwesomeVDOMnode = control => // Cool VDOM node stuff.
const control = create.control( {
  name: 'My Control',
  type: 'my-control',
  //
  render: mySuperAwesomeVDOMnode
} )
const controlElement = Gutenberg.renderControl( control )
```

There is a lot more that the API can currently handle and I have replaced block level controls with the API in its current standing.

Let me know what you think.
