### PR TITLE
Text align block controls

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -316,6 +316,7 @@ function showSwitcherMenu( event ) {
 function setImageState( classes, event ) {
 	event.stopPropagation();
 	selectedBlock.classList.add( 'is-selected' );
+	selectedBlock.classList.add( classes );
 }
 
 function l( data ) {

--- a/blocks.js
+++ b/blocks.js
@@ -90,7 +90,7 @@ function getBlocks() {
 function selectBlock( event ) {
 	clearBlocks();
 	event.stopPropagation();
-	event.target.className += ' is-selected';
+	event.target.classList.add( 'is-selected' );
 
 	selectedBlock = event.target;
 	showControls( selectedBlock );
@@ -98,7 +98,7 @@ function selectBlock( event ) {
 
 function clearBlocks() {
 	getBlocks().forEach( function( block ) {
-		block.className = block.className.replace( 'is-selected', '' );
+		block.classList.remove( 'is-selected' );
 	} );
 	selectedBlock = null;
 
@@ -125,7 +125,7 @@ function showControls( node ) {
 	var kindClasses = kinds.map( function( kind ) {
 		return 'is-' + kind;
 	} ).join( ' ' );
-	blockControls.className = 'block-controls ' + kindClasses;
+	blockControls.classList.add( 'block-controls' );
 	blockControls.style.display = 'block';
 
 	// reposition block-specific block controls
@@ -312,7 +312,7 @@ function showSwitcherMenu( event ) {
 
 function setImageState( classes, event ) {
 	event.stopPropagation();
-	selectedBlock.className = 'is-selected ' + classes;
+	selectedBlock.classList.add( 'is-selected' );
 }
 
 function l( data ) {

--- a/blocks.js
+++ b/blocks.js
@@ -313,10 +313,10 @@ function showSwitcherMenu( event ) {
 	switcherMenu.style.display = 'block';
 }
 
-function setImageState( classes, event ) {
+function setImageState( className, event ) {
 	event.stopPropagation();
 	selectedBlock.classList.add( 'is-selected' );
-	selectedBlock.classList.add( classes );
+	selectedBlock.classList.add( className );
 }
 
 function l( data ) {

--- a/blocks.js
+++ b/blocks.js
@@ -122,9 +122,12 @@ function showControls( node ) {
 
 	// show/hide block-specific block controls
 	var kinds = getTypeKinds( blockType );
-	var kindClasses = kinds.map( function( kind ) {
+	kinds.map( function( kind ) {
 		return 'is-' + kind;
-	} ).join( ' ' );
+	} )
+	.forEach( function( className ) {
+	  blockControls.classList.add( className );
+	} );
 	blockControls.classList.add( 'block-controls' );
 	blockControls.style.display = 'block';
 

--- a/blocks.js
+++ b/blocks.js
@@ -121,10 +121,10 @@ function showControls( node ) {
 	switcher.style.top = ( position.top + 18 + window.scrollY ) + 'px';
 
 	// show/hide block-specific block controls
+	blockControls.className = 'block-controls';
 	getTypeKinds( blockType ).forEach( function( kind ) {
-	  blockControls.classList.add( 'is-' + kind );
+		blockControls.classList.add( 'is-' + kind );
 	} );
-	blockControls.classList.add( 'block-controls' );
 	blockControls.style.display = 'block';
 
 	// reposition block-specific block controls
@@ -311,8 +311,10 @@ function showSwitcherMenu( event ) {
 
 function setImageState( className, event ) {
 	event.stopPropagation();
-	selectedBlock.classList.add( 'is-selected' );
-	selectedBlock.classList.add( className );
+	selectedBlock.className = 'is-selected';
+	if ( className ) {
+		selectedBlock.classList.add( className );
+	}
 }
 
 function l( data ) {

--- a/blocks.js
+++ b/blocks.js
@@ -7,10 +7,14 @@ var getNextSibling = siblingGetter( 'next' );
 var getPreviousSibling = siblingGetter( 'previous' );
 var getTagType = getConfig.bind( null, 'tagTypes' );
 var getTypeKinds = getConfig.bind( null, 'typeKinds' );
-var setImageFullBleed = setImageState.bind( null, 'align-full-bleed' );
-var setImageAlignNone = setImageState.bind( null, '' );
-var setImageAlignLeft = setImageState.bind( null, 'align-left' );
-var setImageAlignRight = setImageState.bind( null, 'align-right' );
+var setImageFullBleed = setElementState.bind( null, 'align-full-bleed' );
+var setImageAlignNone = setElementState.bind( null, '' );
+var setImageAlignLeft = setElementState.bind( null, 'align-left' );
+var setImageAlignRight = setElementState.bind( null, 'align-right' );
+
+var setTextAlignLeft = setElementState.bind( null, 'align-left' );
+var setTextAlignCenter = setElementState.bind( null, 'align-center' );
+var setTextAlignRight = setElementState.bind( null, 'align-right' );
 
 /**
  * Globals
@@ -45,6 +49,9 @@ var blockControls = queryFirst( '.block-controls' );
 var inlineControls = queryFirst( '.inline-controls' );
 var insertBlockButton = queryFirst( '.insert-block__button' );
 var insertBlockMenu = queryFirst( '.insert-block__menu' );
+var textAlignLeft = queryFirst( '.block-text__align-left' );
+var textAlignCenter = queryFirst( '.block-text__align-center' );
+var textAlignRight = queryFirst( '.block-text__align-right' );
 var imageFullBleed = queryFirst( '.block-image__full-width' );
 var imageAlignNone = queryFirst( '.block-image__no-align' );
 var imageAlignLeft = queryFirst( '.block-image__align-left' );
@@ -187,6 +194,16 @@ function attachControlActions() {
 		}
 	} );
 
+	// Text block event handlers.
+	textAlignLeft.addEventListener( 'click', setTextAlignLeft, false );
+	textAlignCenter.addEventListener( 'click', setTextAlignCenter, false );
+	textAlignRight.addEventListener( 'click', setTextAlignRight, false );
+
+	switcherButtons.forEach( function( button ) {
+		button.addEventListener( 'click', showSwitcherMenu, false );
+	} );
+
+	// Image block event handlers.
 	imageFullBleed.addEventListener( 'click', setImageFullBleed, false );
 	imageAlignNone.addEventListener( 'click', setImageAlignNone, false );
 	imageAlignLeft.addEventListener( 'click', setImageAlignLeft, false );
@@ -309,7 +326,7 @@ function showSwitcherMenu( event ) {
 	switcherMenu.style.display = 'block';
 }
 
-function setImageState( className, event ) {
+function setElementState( className, event ) {
 	event.stopPropagation();
 	selectedBlock.className = 'is-selected';
 	if ( className ) {

--- a/blocks.js
+++ b/blocks.js
@@ -121,12 +121,8 @@ function showControls( node ) {
 	switcher.style.top = ( position.top + 18 + window.scrollY ) + 'px';
 
 	// show/hide block-specific block controls
-	var kinds = getTypeKinds( blockType );
-	kinds.map( function( kind ) {
-		return 'is-' + kind;
-	} )
-	.forEach( function( className ) {
-	  blockControls.classList.add( className );
+	getTypeKinds( blockType ).forEach( function( kind ) {
+	  blockControls.classList.add( 'is-' + kind );
 	} );
 	blockControls.classList.add( 'block-controls' );
 	blockControls.style.display = 'block';

--- a/blocks.js
+++ b/blocks.js
@@ -7,14 +7,10 @@ var getNextSibling = siblingGetter( 'next' );
 var getPreviousSibling = siblingGetter( 'previous' );
 var getTagType = getConfig.bind( null, 'tagTypes' );
 var getTypeKinds = getConfig.bind( null, 'typeKinds' );
-var setImageFullBleed = setElementState.bind( null, 'align-full-bleed' );
-var setImageAlignNone = setElementState.bind( null, '' );
-var setImageAlignLeft = setElementState.bind( null, 'align-left' );
-var setImageAlignRight = setElementState.bind( null, 'align-right' );
-
-var setTextAlignLeft = setElementState.bind( null, 'align-left' );
-var setTextAlignCenter = setElementState.bind( null, 'align-center' );
-var setTextAlignRight = setElementState.bind( null, 'align-right' );
+var setImageFullBleed = setImageState.bind( null, 'align-full-bleed' );
+var setImageAlignNone = setImageState.bind( null, '' );
+var setImageAlignLeft = setImageState.bind( null, 'align-left' );
+var setImageAlignRight = setImageState.bind( null, 'align-right' );
 
 /**
  * Globals
@@ -48,10 +44,12 @@ var switcherMenu = queryFirst( '.switch-block__menu' );
 var blockControls = queryFirst( '.block-controls' );
 var inlineControls = queryFirst( '.inline-controls' );
 var insertBlockButton = queryFirst( '.insert-block__button' );
+
 var textAlignLeft = queryFirst( '.block-text__align-left' );
 var textAlignCenter = queryFirst( '.block-text__align-center' );
 var textAlignRight = queryFirst( '.block-text__align-right' );
 var insertBlockMenu = queryFirst( '.insert-block__menu' );
+
 var imageFullBleed = queryFirst( '.block-image__full-width' );
 var imageAlignNone = queryFirst( '.block-image__no-align' );
 var imageAlignLeft = queryFirst( '.block-image__align-left' );
@@ -195,9 +193,6 @@ function attachControlActions() {
 		}
 	} );
 
-	textAlignLeft.addEventListener( 'click', setTextAlignLeft, false );
-	textAlignCenter.addEventListener( 'click', setTextAlignCenter, false );
-	textAlignRight.addEventListener( 'click', setTextAlignRight, false );
 	imageFullBleed.addEventListener( 'click', setImageFullBleed, false );
 	imageAlignNone.addEventListener( 'click', setImageAlignNone, false );
 	imageAlignLeft.addEventListener( 'click', setImageAlignLeft, false );
@@ -320,10 +315,9 @@ function showSwitcherMenu( event ) {
 	switcherMenu.style.display = 'block';
 }
 
-function setElementState( classes, event ) {
+function setImageState( classes, event ) {
 	event.stopPropagation();
 	selectedBlock.className = 'is-selected ' + classes;
-
 }
 
 function l( data ) {

--- a/blocks.js
+++ b/blocks.js
@@ -44,12 +44,7 @@ var switcherMenu = queryFirst( '.switch-block__menu' );
 var blockControls = queryFirst( '.block-controls' );
 var inlineControls = queryFirst( '.inline-controls' );
 var insertBlockButton = queryFirst( '.insert-block__button' );
-
-var textAlignLeft = queryFirst( '.block-text__align-left' );
-var textAlignCenter = queryFirst( '.block-text__align-center' );
-var textAlignRight = queryFirst( '.block-text__align-right' );
 var insertBlockMenu = queryFirst( '.insert-block__menu' );
-
 var imageFullBleed = queryFirst( '.block-image__full-width' );
 var imageAlignNone = queryFirst( '.block-image__no-align' );
 var imageAlignLeft = queryFirst( '.block-image__align-left' );

--- a/blocks.js
+++ b/blocks.js
@@ -7,10 +7,14 @@ var getNextSibling = siblingGetter( 'next' );
 var getPreviousSibling = siblingGetter( 'previous' );
 var getTagType = getConfig.bind( null, 'tagTypes' );
 var getTypeKinds = getConfig.bind( null, 'typeKinds' );
-var setImageFullBleed = setImageState.bind( null, 'align-full-bleed' );
-var setImageAlignNone = setImageState.bind( null, '' );
-var setImageAlignLeft = setImageState.bind( null, 'align-left' );
-var setImageAlignRight = setImageState.bind( null, 'align-right' );
+var setImageFullBleed = setElementState.bind( null, 'align-full-bleed' );
+var setImageAlignNone = setElementState.bind( null, '' );
+var setImageAlignLeft = setElementState.bind( null, 'align-left' );
+var setImageAlignRight = setElementState.bind( null, 'align-right' );
+
+var setTextAlignLeft = setElementState.bind( null, 'align-left' );
+var setTextAlignCenter = setElementState.bind( null, 'align-center' );
+var setTextAlignRight = setElementState.bind( null, 'align-right' );
 
 /**
  * Globals
@@ -45,6 +49,9 @@ var blockControls = queryFirst( '.block-controls' );
 var inlineControls = queryFirst( '.inline-controls' );
 var insertBlockButton = queryFirst( '.insert-block__button' );
 var insertBlockMenu = queryFirst( '.insert-block__menu' );
+var textAlignLeft = queryFirst( '.block-text__align-left' );
+var textAlignCenter = queryFirst( '.block-text__align-center' );
+var textAlignRight = queryFirst( '.block-text__align-right' );
 var imageFullBleed = queryFirst( '.block-image__full-width' );
 var imageAlignNone = queryFirst( '.block-image__no-align' );
 var imageAlignLeft = queryFirst( '.block-image__align-left' );
@@ -188,6 +195,12 @@ function attachControlActions() {
 		}
 	} );
 
+	// Text block event handlers.
+	textAlignLeft.addEventListener( 'click', setTextAlignLeft, false );
+	textAlignCenter.addEventListener( 'click', setTextAlignCenter, false );
+	textAlignRight.addEventListener( 'click', setTextAlignRight, false );
+
+	// Image block event handlers.
 	imageFullBleed.addEventListener( 'click', setImageFullBleed, false );
 	imageAlignNone.addEventListener( 'click', setImageAlignNone, false );
 	imageAlignLeft.addEventListener( 'click', setImageAlignLeft, false );
@@ -310,7 +323,7 @@ function showSwitcherMenu( event ) {
 	switcherMenu.style.display = 'block';
 }
 
-function setImageState( classes, event ) {
+function setElementState( classes, event ) {
 	event.stopPropagation();
 	selectedBlock.className = 'is-selected ' + classes;
 }

--- a/blocks.js
+++ b/blocks.js
@@ -7,10 +7,14 @@ var getNextSibling = siblingGetter( 'next' );
 var getPreviousSibling = siblingGetter( 'previous' );
 var getTagType = getConfig.bind( null, 'tagTypes' );
 var getTypeKinds = getConfig.bind( null, 'typeKinds' );
-var setImageFullBleed = setImageState.bind( null, 'align-full-bleed' );
-var setImageAlignNone = setImageState.bind( null, '' );
-var setImageAlignLeft = setImageState.bind( null, 'align-left' );
-var setImageAlignRight = setImageState.bind( null, 'align-right' );
+var setImageFullBleed = setElementState.bind( null, 'align-full-bleed' );
+var setImageAlignNone = setElementState.bind( null, '' );
+var setImageAlignLeft = setElementState.bind( null, 'align-left' );
+var setImageAlignRight = setElementState.bind( null, 'align-right' );
+
+var setTextAlignLeft = setElementState.bind( null, 'align-left' );
+var setTextAlignCenter = setElementState.bind( null, 'align-center' );
+var setTextAlignRight = setElementState.bind( null, 'align-right' );
 
 /**
  * Globals
@@ -40,6 +44,9 @@ var switcherButtons = query( '.block-switcher .type svg' );
 var blockControls = queryFirst( '.block-controls' );
 var inlineControls = queryFirst( '.inline-controls' );
 var insertBlockButton = queryFirst( '.insert-block__button' );
+var textAlignLeft = queryFirst( '.block-text__align-left' );
+var textAlignCenter = queryFirst( '.block-text__align-center' );
+var textAlignRight = queryFirst( '.block-text__align-right' );
 var imageFullBleed = queryFirst( '.block-image__full-width' );
 var imageAlignNone = queryFirst( '.block-image__no-align' );
 var imageAlignLeft = queryFirst( '.block-image__align-left' );
@@ -174,6 +181,9 @@ function attachControlActions() {
 		}
 	} );
 
+	textAlignLeft.addEventListener( 'click', setTextAlignLeft, false );
+	textAlignCenter.addEventListener( 'click', setTextAlignCenter, false );
+	textAlignRight.addEventListener( 'click', setTextAlignRight, false );
 	imageFullBleed.addEventListener( 'click', setImageFullBleed, false );
 	imageAlignNone.addEventListener( 'click', setImageAlignNone, false );
 	imageAlignLeft.addEventListener( 'click', setImageAlignLeft, false );
@@ -238,9 +248,10 @@ function hideMenu() {
 	menu.style.display = 'none';
 }
 
-function setImageState( classes, event ) {
+function setElementState( classes, event ) {
 	event.stopPropagation();
 	selectedBlock.className = 'is-selected ' + classes;
+
 }
 
 function l( data ) {

--- a/index.html
+++ b/index.html
@@ -19,13 +19,13 @@
 			</span>
 		</div>
 		<div class="block-controls">
-			<button class="block-text is-active">
+			<button class="block-text block-text__align-left is-active">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Left</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm10-6H4v2h10v-2zM4 9v2h16V9H4zm10-4H4v2h10V5z"/></g></svg>
 			</button>
-			<button class="block-text">
+			<button class="block-text block-text__align-center">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Center</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm13-6H7v2h10v-2zM4 9v2h16V9H4zm13-4H7v2h10V5z"/></g></svg>
 			</button>
-			<button class="block-text">
+			<button class="block-text block-text__align-right">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Right</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 17H4v2h16v-2zm-10-2h10v-2H10v2zM4 9v2h16V9H4zm6-2h10V5H10v2z"/></g></svg>
 			</button>
 			<button class="block-image block-image__no-align">

--- a/index.html
+++ b/index.html
@@ -18,13 +18,13 @@
 			</span>
 		</div>
 		<div class="block-controls">
-			<button class="block-text is-active">
+			<button class="block-text block-text__align-left is-active">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Left</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm10-6H4v2h10v-2zM4 9v2h16V9H4zm10-4H4v2h10V5z"/></g></svg>
 			</button>
-			<button class="block-text">
+			<button class="block-text block-text__align-center">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Center</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm13-6H7v2h10v-2zM4 9v2h16V9H4zm13-4H7v2h10V5z"/></g></svg>
 			</button>
-			<button class="block-text">
+			<button class="block-text block-text__align-right">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Right</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 17H4v2h16v-2zm-10-2h10v-2H10v2zM4 9v2h16V9H4zm6-2h10V5H10v2z"/></g></svg>
 			</button>
 			<button class="block-image block-image__no-align">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<title>Editor Blocks</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel='stylesheet' id='h5-font-css' href='https://fonts.googleapis.com/css?family=Merriweather:700,300,700italic,300italic' />
 		<link href="style.css" rel="stylesheet" type="text/css" media="all">
 	</head>
@@ -14,17 +15,30 @@
 				<svg width="24" height="24" class="type-icon-paragraph" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path id="path-1_2_" class="st0" d="M13 5h2v16h2V5h2V3h-6.7.2-3C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2v-7h-.5.5V5z"/><path class="st1" d="M9.5 3C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3H9.5z"/></svg>
 				<svg width="24" height="24" class="type-icon-heading" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Heading</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M18 20h-3v-6H9v6H6V5.01h3V11h6V5.01h3V20z"/></g></svg>
 				<svg width="24" height="24" class="type-icon-image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Image</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M13 9.5c0-.828.672-1.5 1.5-1.5s1.5.672 1.5 1.5-.672 1.5-1.5 1.5-1.5-.672-1.5-1.5zM22 6v12c0 1.105-.895 2-2 2H4c-1.105 0-2-.895-2-2V6c0-1.105.895-2 2-2h16c1.105 0 2 .895 2 2zm-2 0H4v7.444L8 9l5.895 6.55 1.587-1.85c.798-.932 2.24-.932 3.037 0L20 15.426V6z"/></g></svg>
+				<svg width="24" height="24" class="type-icon-quote" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Quote</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M11.192 15.757c0-.88-.23-1.618-.69-2.217-.326-.412-.768-.683-1.327-.812-.55-.128-1.07-.137-1.54-.028-.16-.95.1-1.956.76-3.022.66-1.065 1.515-1.867 2.558-2.403L9.373 5c-.8.396-1.56.898-2.26 1.505-.71.607-1.34 1.305-1.9 2.094s-.98 1.68-1.25 2.69-.346 2.04-.217 3.1c.168 1.4.62 2.52 1.356 3.35.735.84 1.652 1.26 2.748 1.26.965 0 1.766-.29 2.4-.878.628-.576.94-1.365.94-2.368l.002.003zm9.124 0c0-.88-.23-1.618-.69-2.217-.326-.42-.77-.692-1.327-.817-.56-.124-1.074-.13-1.54-.022-.16-.94.09-1.95.75-3.02.66-1.06 1.514-1.86 2.557-2.4L18.49 5c-.8.396-1.555.898-2.26 1.505-.708.607-1.34 1.305-1.894 2.094-.556.79-.97 1.68-1.24 2.69-.273 1-.345 2.04-.217 3.1.165 1.4.615 2.52 1.35 3.35.732.833 1.646 1.25 2.742 1.25.967 0 1.768-.29 2.402-.876.627-.576.942-1.365.942-2.368v.01z"/></g></svg>
 			</span>
 		</div>
 		<div class="block-controls">
-			<button class="is-active">
+			<button class="block-text block-text__align-left is-active">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Left</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm10-6H4v2h10v-2zM4 9v2h16V9H4zm10-4H4v2h10V5z"/></g></svg>
 			</button>
-			<button>
+			<button class="block-text block-text__align-center">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Center</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm13-6H7v2h10v-2zM4 9v2h16V9H4zm13-4H7v2h10V5z"/></g></svg>
 			</button>
-			<button>
+			<button class="block-text block-text__align-right">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Right</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 17H4v2h16v-2zm-10-2h10v-2H10v2zM4 9v2h16V9H4zm6-2h10V5H10v2z"/></g></svg>
+			</button>
+			<button class="block-image block-image__no-align">
+				<svg class="gridicon gridicons-align-image-center" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M3 5h18v2H3V5zm0 14h18v-2H3v2zm5-4h8V9H8v6z"></path></g></svg>
+			</button>
+			<button class="block-image block-image__align-left">
+				<svg class="gridicon gridicons-align-image-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M3 5h18v2H3V5zm0 14h18v-2H3v2zm0-4h8V9H3v6zm10 0h8v-2h-8v2zm0-4h8V9h-8v2z"></path></g></svg>
+			</button>
+			<button class="block-image block-image__align-right">
+				<svg class="gridicon gridicons-align-image-right" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M21 7H3V5h18v2zm0 10H3v2h18v-2zm0-8h-8v6h8V9zm-10 4H3v2h8v-2zm0-4H3v2h8V9z"></path></g></svg>
+			</button>
+			<button class="block-image block-image__full-width">
+				<svg class="gridicon gridicons-fullscreen" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><title>Full Bleed</title><path d="M21 3v6h-2V6.41l-3.29 3.3-1.42-1.42L17.59 5H15V3zM3 3v6h2V6.41l3.29 3.3 1.42-1.42L6.41 5H9V3zm18 18v-6h-2v2.59l-3.29-3.29-1.41 1.41L17.59 19H15v2zM9 21v-2H6.41l3.29-3.29-1.41-1.42L5 17.59V15H3v6z"></path></g></svg>
 			</button>
 		</div>
 		<div class="inline-controls">
@@ -33,19 +47,30 @@
 			<button><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Link</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M17 13H7v-2h10v2zm1-6h-1c-1.63 0-3.065.792-3.977 2H18c1.103 0 2 .897 2 2v2c0 1.103-.897 2-2 2h-4.977c.913 1.208 2.347 2 3.977 2h1c2.21 0 4-1.79 4-4v-2c0-2.21-1.79-4-4-4zM2 11v2c0 2.21 1.79 4 4 4h1c1.63 0 3.065-.792 3.977-2H6c-1.103 0-2-.897-2-2v-2c0-1.103.897-2 2-2h4.977C10.065 7.792 8.63 7 7 7H6c-2.21 0-4 1.79-4 4z"/></g></svg></button>
 			<button><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Strikethrough</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M14.348 12H21v2h-4.613c.24.515.368 1.094.368 1.748 0 1.317-.474 2.355-1.423 3.114-.947.76-2.266 1.138-3.956 1.138-1.557 0-2.934-.293-4.132-.878v-2.874c.985.44 1.818.75 2.5.928.682.18 1.306.27 1.872.27.68 0 1.2-.13 1.562-.39.363-.26.545-.644.545-1.158 0-.285-.08-.54-.24-.763-.16-.222-.394-.437-.704-.643-.18-.12-.483-.287-.88-.49H3v-2H14.347zm-3.528-2c-.073-.077-.143-.155-.193-.235-.126-.202-.19-.44-.19-.713 0-.44.157-.795.47-1.068.313-.273.762-.41 1.348-.41.492 0 .993.064 1.502.19.51.127 1.153.35 1.93.67l1-2.405c-.753-.327-1.473-.58-2.16-.76-.69-.18-1.414-.27-2.173-.27-1.544 0-2.753.37-3.628 1.108-.874.738-1.312 1.753-1.312 3.044 0 .302.036.58.088.848h3.318z"/></g></svg></button>
 			<button><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Text Color</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M3 19h18v3H3v-3zM15.82 17h3.424L14 3h-4L4.756 17H8.18l1.067-3.5h5.506L15.82 17zm-1.952-6h-3.73l1.868-5.725L13.868 11z"/></g></svg></button>
-			<span class="control-group">
-				<button><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Quote</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M11.192 15.757c0-.88-.23-1.618-.69-2.217-.326-.412-.768-.683-1.327-.812-.55-.128-1.07-.137-1.54-.028-.16-.95.1-1.956.76-3.022.66-1.065 1.515-1.867 2.558-2.403L9.373 5c-.8.396-1.56.898-2.26 1.505-.71.607-1.34 1.305-1.9 2.094s-.98 1.68-1.25 2.69-.346 2.04-.217 3.1c.168 1.4.62 2.52 1.356 3.35.735.84 1.652 1.26 2.748 1.26.965 0 1.766-.29 2.4-.878.628-.576.94-1.365.94-2.368l.002.003zm9.124 0c0-.88-.23-1.618-.69-2.217-.326-.42-.77-.692-1.327-.817-.56-.124-1.074-.13-1.54-.022-.16-.94.09-1.95.75-3.02.66-1.06 1.514-1.86 2.557-2.4L18.49 5c-.8.396-1.555.898-2.26 1.505-.708.607-1.34 1.305-1.894 2.094-.556.79-.97 1.68-1.24 2.69-.273 1-.345 2.04-.217 3.1.165 1.4.615 2.52 1.35 3.35.732.833 1.646 1.25 2.742 1.25.967 0 1.768-.29 2.402-.876.627-.576.942-1.365.942-2.368v.01z"/></g></svg>
-				<button class="heading-dropdown">
-					<svg class="heading" width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Heading</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M18 20h-3v-6H9v6H6V5.01h3V11h6V5.01h3V20z"/></g></svg>
-					<sub>1</sub>
-					<svg class="dropdown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Dropdown</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M7 10l5 5 5-5"/></g></svg>
-				</button>
-				</span>
-			</span>
+			<button class="do-not-work">These don't work yet.</button>
+		</div>
+		<div class="switch-block__menu popover is-bottom">
+			<div class="popover__arrow"></div>
+			<div class="switch-block__block-list switch-block__block-list-text">
+				<div class="switch-block__block">
+					<svg width="24" height="24" class="type-icon-paragraph" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path id="path-1_2_" class="st0" d="M13 5h2v16h2V5h2V3h-6.7.2-3C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2v-7h-.5.5V5z"/><path class="st1" d="M9.5 3C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3H9.5z"/></svg><label>Paragraph</label>
+				</div>
+				<div class="switch-block__block">
+					<svg width="24" height="24" class="type-icon-heading" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Heading</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M18 20h-3v-6H9v6H6V5.01h3V11h6V5.01h3V20z"/></g></svg><label>Heading</label>
+				</div>
+				<div class="switch-block__block">
+					<svg class="type-icon-quote gridicon gridicons-quote" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M11.192 15.757c0-.88-.23-1.618-.69-2.217-.326-.412-.768-.683-1.327-.812-.55-.128-1.07-.137-1.54-.028-.16-.95.1-1.956.76-3.022.66-1.065 1.515-1.867 2.558-2.403L9.373 5c-.8.396-1.56.898-2.26 1.505-.71.607-1.34 1.305-1.9 2.094s-.98 1.68-1.25 2.69-.346 2.04-.217 3.1c.168 1.4.62 2.52 1.356 3.35.735.84 1.652 1.26 2.748 1.26.965 0 1.766-.29 2.4-.878.628-.576.94-1.365.94-2.368l.002.003zm9.124 0c0-.88-.23-1.618-.69-2.217-.326-.42-.77-.692-1.327-.817-.56-.124-1.074-.13-1.54-.022-.16-.94.09-1.95.75-3.02.66-1.06 1.514-1.86 2.557-2.4L18.49 5c-.8.396-1.555.898-2.26 1.505-.708.607-1.34 1.305-1.894 2.094-.556.79-.97 1.68-1.24 2.69-.273 1-.345 2.04-.217 3.1.165 1.4.615 2.52 1.35 3.35.732.833 1.646 1.25 2.742 1.25.967 0 1.768-.29 2.402-.876.627-.576.942-1.365.942-2.368v.01z"></path></g></svg><label>Quote</label>
+				</div>
+			</div>
+			<div class="switch-block__block-list switch-block__block-list-image">
+				<div class="switch-block__block">
+					<p>Nothing here.</p>
+				</div>
+			</div>
 		</div>
 		<section class="editor" contenteditable="true">
 			<h2>1.0 Is The Loneliest Number</h2>
-			<p>Many entrepreneurs idolize Steve Jobs. He’s such a perfectionist, they say. Nothing leaves the doors of 1 Infinite Loop in Cupertino without a polish and finish that makes geeks everywhere drool. No compromise!</p>
+			<p>Many entrepreneurs idolize Steve Jobs. He’s such a <a href=""><span class="space-sep">&nbsp;</span>perfectionist<span class="space-sep-end">&nbsp;</span></a>, they say. Nothing leaves the doors of 1 Infinite Loop in Cupertino without a polish and finish that makes geeks everywhere drool. No compromise!</p>
 			<img alt="" src="https://cldup.com/HN3-c7ER9p.jpg" />
 			<p>I like Apple for the opposite reason: they’re not afraid of getting a rudimentary 1.0 out into the world.</p>
 		</section>
@@ -53,7 +78,8 @@
 			<button class="insert-block__button">
 				<svg class="gridicon gridicons-add-outline" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm5 9h-4V7h-2v4H7v2h4v4h2v-4h4v-2z"></path></g></svg>
 			</button>
-			<div class="insert-block__menu">
+			<div class="insert-block__menu popover is-top">
+				<div class="popover__arrow"></div>
 				<input class="insert-block__search" type="search" placeholder="Search..." />
 				<span class="insert-block__separator">Recent</span>
 				<div class="insert-block__block-list">
@@ -78,6 +104,7 @@
 					<div class="insert-block__block">
 						<svg class="gridicon gridicons-list-ordered" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M8 19h13v-2H8v2zm0-6h13v-2H8v2zm0-8v2h13V5H8zm-4.425.252c.107-.096.197-.188.27-.275-.013.228-.02.48-.02.756V8h1.176V3.717H3.96L2.487 4.915l.6.738.487-.4zm.334 7.764c.474-.426.784-.715.93-.867.145-.153.26-.298.35-.436.087-.138.152-.278.194-.42.042-.143.063-.298.063-.466 0-.225-.06-.427-.18-.608s-.29-.32-.507-.417c-.218-.1-.465-.148-.742-.148-.22 0-.42.022-.596.067s-.34.11-.49.195c-.15.085-.337.226-.558.423l.636.744c.174-.15.33-.264.467-.34.138-.078.274-.117.41-.117.13 0 .232.032.304.097.073.064.11.152.11.264 0 .09-.02.176-.055.258-.036.082-.1.18-.192.294-.092.114-.287.328-.586.64L2.42 13.238V14h3.11v-.955H3.91v-.03zm.53 4.746v-.018c.306-.086.54-.225.702-.414.162-.19.243-.42.243-.685 0-.31-.126-.55-.378-.727-.252-.176-.6-.264-1.043-.264-.307 0-.58.033-.816.1s-.47.178-.696.334l.48.773c.293-.183.576-.274.85-.274.147 0 .263.027.35.082s.13.14.13.252c0 .3-.294.45-.882.45h-.27v.87h.264c.217 0 .393.017.527.05.136.03.233.08.294.143.06.064.09.154.09.27 0 .153-.057.265-.173.337-.115.07-.3.106-.554.106-.164 0-.343-.022-.538-.07-.194-.044-.385-.115-.573-.21v.96c.228.088.44.148.637.182.196.033.41.05.64.05.56 0 .998-.114 1.314-.343.315-.228.473-.542.473-.94.002-.585-.356-.923-1.07-1.013z"></path></g></svg> Ordered List
 					</div>
+					<dic class="insert-block__block">These don't work yet.</div>
 				</div>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -19,13 +19,13 @@
 			</span>
 		</div>
 		<div class="block-controls">
-			<button class="block-text block-text__align-left is-active">
+			<button class="block-text is-active">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Left</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm10-6H4v2h10v-2zM4 9v2h16V9H4zm10-4H4v2h10V5z"/></g></svg>
 			</button>
-			<button class="block-text block-text__align-center">
+			<button class="block-text">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Center</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M4 19h16v-2H4v2zm13-6H7v2h10v-2zM4 9v2h16V9H4zm13-4H7v2h10V5z"/></g></svg>
 			</button>
-			<button class="block-text block-text__align-right">
+			<button class="block-text">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Align Right</title><rect x="0" fill="none" width="24" height="24"/><g><path d="M20 17H4v2h16v-2zm-10-2h10v-2H10v2zM4 9v2h16V9H4zm6-2h10V5H10v2z"/></g></svg>
 			</button>
 			<button class="block-image block-image__no-align">

--- a/style.css
+++ b/style.css
@@ -443,6 +443,43 @@ img.is-selected {
 }
 
 /*
+ * Text actions
+ */
+
+p.align-left,
+h1.align-left,
+h2.align-left,
+h3.align-left,
+h4.align-left,
+h5.align-left,
+h6.align-left,
+blockquote.align-left {
+	text-align: left;
+}
+
+p.align-center,
+h1.align-center,
+h2.align-center,
+h3.align-center,
+h4.align-center,
+h5.align-center,
+h6.align-center,
+blockquote.align-center {
+	text-align: center;
+}
+
+p.align-right,
+h1.align-right,
+h2.align-right,
+h3.align-right,
+h4.align-right,
+h5.align-right,
+h6.align-right,
+blockquote.align-right {
+	text-align: right;
+}
+
+/*
  * Image actions
  */
 

--- a/style.css
+++ b/style.css
@@ -466,6 +466,43 @@ img.align-right {
 	margin: 0 0 0 16px;
 }
 
+/*
+ * Text actions
+ */
+
+p.align-left,
+h1.align-left,
+h2.align-left,
+h3.align-left,
+h4.align-left,
+h5.align-left,
+h6.align-left,
+blockquote.align-left {
+	text-align: left;
+}
+
+p.align-center,
+h1.align-center,
+h2.align-center,
+h3.align-center,
+h4.align-center,
+h5.align-center,
+h6.align-center,
+blockquote.align-center {
+	text-align: center;
+}
+
+p.align-right,
+h1.align-right,
+h2.align-right,
+h3.align-right,
+h4.align-right,
+h5.align-right,
+h6.align-right,
+blockquote.align-right {
+	text-align: right;
+}
+
 p a {
 	text-decoration: none;
 	color: #006799;

--- a/style.css
+++ b/style.css
@@ -30,6 +30,7 @@ svg {
 }
 
 p,
+blockquote,
 h1,
 h2,
 h3,
@@ -49,6 +50,13 @@ h2 {
 
 p {
 	font-size: 16px;
+	min-height: 3.4em;
+}
+
+blockquote {
+	font-size: 20px;
+	border-left: 4px solid black;
+	font-style: italic;
 }
 
 section:focus {
@@ -67,6 +75,7 @@ h4,
 h5,
 h6,
 p,
+blockquote,
 img {
 	position: relative;
 	box-shadow: inset 0px 0px 0px 0px #e0e5e9;
@@ -82,6 +91,7 @@ h4:hover,
 h5:hover,
 h6:hover,
 p:hover,
+blockquote:hover,
 img:hover {
 	box-shadow: inset 0px 0px 0px 2px #e0e5e9;
 }
@@ -93,14 +103,10 @@ h4.is-selected,
 h5.is-selected,
 h6.is-selected,
 p.is-selected,
+blockquote.is-selected,
 img.is-selected {
 	box-shadow: inset 0px 0px 0px 2px #6d7882;
 }
-
-p {
-	min-height: 3.4em;
-}
-
 
 /**
  * Block Switcher
@@ -184,6 +190,11 @@ p {
 	float: left;
 }
 
+.inline-controls button.do-not-work {
+	margin: 0 8px;
+	width: auto;
+}
+
 .inline-controls button:hover {
 	background: #f0f2f4;
 }
@@ -231,7 +242,7 @@ p {
  * Block Controls
  */
 
- .block-controls {
+.block-controls {
  	background: #191e23;
  	display: inline-block;
  	max-height: 36px;
@@ -242,7 +253,7 @@ p {
     transform: translateZ( 0 );
  }
 
- .block-controls button {
+.block-controls button {
  	background: #191e23;
     color: #fff;
  	border: none;
@@ -258,16 +269,31 @@ p {
     background: #6d7882;
 }
 
+.block-controls button {
+	display: none;
+}
+
+.block-controls.is-image .block-image,
+.block-controls.is-text .block-text {
+	display: block;
+}
 
 /**
- * Inserter
+ * Block inserter and switcher
  */
 
 .insert-block {
 	padding: 14px 0 0 14px;
+	position: relative;
+	display: inline-block;
 }
 
-.insert-block__button {
+.switch-block__menu {
+	z-index: 10;
+}
+
+.insert-block__button,
+.switch-block__button {
 	background: none;
 	border: none;
 	margin: 0;
@@ -275,23 +301,101 @@ p {
 	cursor: pointer;
 }
 
-.insert-block svg {
+.insert-block svg,
+.switch-block__block svg,
+.switch-block__block label {
 	cursor: pointer;
 	fill: #87919d;
 }
 
-.insert-block__button:hover svg {
+.insert-block__button:hover svg,
+.switch-block__button:hover svg {
 	fill: #12181e;
 }
 
-.insert-block__menu {
+.insert-block__button:focus,
+.switch-block__button:focus {
+	box-shadow: none;
+	outline: none;
+}
+
+.insert-block__menu,
+.switch-block__menu {
 	display: none;
 	width: 280px;
 	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
+	position: absolute;
+	left: -114px;
+	bottom: 50px;
+	background: #fff;
+}
+.switch-block__menu {
+	width: 140px;
 }
 
-.insert-block__search {
+.switch-block__menu {
+	bottom: auto;
+}
+.popover {}
+
+.popover__arrow {
+	border: 10px dashed #e0e5e9;
+	height: 0;
+	line-height: 0;
+	position: absolute;
+	width: 0;
+	z-index: 1;
+}
+
+.popover.is-top .popover__arrow {
+	bottom: -10px;
+	left: 50%;
+	margin-left: -10px;
+	border-top-style: solid;
+	border-bottom: none;
+	border-left-color: transparent;
+	border-right-color: transparent;
+}
+
+.popover.is-bottom .popover__arrow {
+	top: -10px;
+    left: 50%;
+    margin-left: -10px;
+    border-bottom-style: solid;
+    border-top: none;
+    border-left-color: transparent;
+    border-right-color: transparent;
+}
+
+.popover.is-bottom .popover__arrow::before {
+	top: 2px;
+	border: 10px solid white;
+	content: " ";
+	position: absolute;
+	left: 50%;
+	margin-left: -10px;
+	border-bottom-style: solid;
+	border-top: none;
+	border-left-color: transparent;
+	border-right-color: transparent;
+}
+
+.popover.is-top .popover__arrow::before {
+	bottom: 2px;
+	border: 10px solid white;
+	content: " ";
+	position: absolute;
+	left: 50%;
+	margin-left: -10px;
+	border-top-style: solid;
+	border-bottom: none;
+	border-left-color: transparent;
+	border-right-color: transparent;
+}
+
+.insert-block__search,
+.switch-block__search {
 	display: block;
 	width: 100%;
 	border: none;
@@ -300,7 +404,8 @@ p {
 	font-size: 13px;
 }
 
-.insert-block__separator {
+.insert-block__separator,
+.switch-block__separator {
 	background: rgb(247,248,249);
 	display: block;
 	padding: 4px 16px;
@@ -309,18 +414,111 @@ p {
 	font-weight: 500;
 	color: #9ea7af;
 }
+
 .insert-block__block-list {
 	display: flex;
 	flex-flow: row wrap;
 }
-.insert-block__block {
+
+.insert-block__block,
+.switch-block__block {
 	display: flex;
-	width: 50%;
-	color: #606a73;
+	color: #86909B;
 	padding: 8px;
-	font-size: 12px;
+	font-size: 11px;
 	align-items: center;
 }
-.insert-block__block svg {
-	margin-right: 4px;
+.insert-block__block:hover,
+.switch-block__block:hover {
+	background: #f0f2f4;
+}
+
+.insert-block__block {
+	width: 50%;
+}
+.insert-block__block svg,
+.switch-block__block svg {
+	margin-right: 8px;
+	fill: #191e23;
+}
+
+/*
+ * Text actions
+ */
+
+p.align-left,
+h1.align-left,
+h2.align-left,
+h3.align-left,
+h4.align-left,
+h5.align-left,
+h6.align-left,
+blockquote.align-left {
+	text-align: left;
+}
+
+p.align-center,
+h1.align-center,
+h2.align-center,
+h3.align-center,
+h4.align-center,
+h5.align-center,
+h6.align-center,
+blockquote.align-center {
+	text-align: center;
+}
+
+p.align-right,
+h1.align-right,
+h2.align-right,
+h3.align-right,
+h4.align-right,
+h5.align-right,
+h6.align-right,
+blockquote.align-right {
+	text-align: right;
+}
+
+/*
+ * Image actions
+ */
+
+img.align-full-bleed {
+	margin-left: calc(50% - 50vw);
+	width: 100vw;
+	max-width: none;
+	padding-left: 0;
+	padding-right: 0;
+}
+
+img.align-left {
+	float: left;
+	width: 340px;
+	margin: 0 16px 0 0;
+}
+
+img.align-right {
+	float: right;
+	width: 340px;
+	margin: 0 0 0 16px;
+}
+
+p a {
+	text-decoration: none;
+	color: #006799;
+	background: rgba(0, 142, 194, 0.2);
+	padding: 0 6px;
+	border-radius: 2px;
+}
+
+.space-sep {
+	text-indent: -5px;
+	display: inline-block;
+}
+
+.space-sep-end {
+	text-indent: -5px;
+	display: inline-block;
+	position: relative;
+	left: 5px;
 }

--- a/style.css
+++ b/style.css
@@ -466,39 +466,6 @@ img.align-right {
 	margin: 0 0 0 16px;
 }
 
-p.align-left,
-h1.align-left,
-h2.align-left,
-h3.align-left,
-h4.align-left,
-h5.align-left,
-h6.align-left,
-blockquote.align-left {
-	text-align: left;
-}
-
-p.align-center,
-h1.align-center,
-h2.align-center,
-h3.align-center,
-h4.align-center,
-h5.align-center,
-h6.align-center,
-blockquote.align-center {
-	text-align: center;
-}
-
-p.align-right,
-h1.align-right,
-h2.align-right,
-h3.align-right,
-h4.align-right,
-h5.align-right,
-h6.align-right,
-blockquote.align-right {
-	text-align: right;
-}
-
 p a {
 	text-decoration: none;
 	color: #006799;

--- a/style.css
+++ b/style.css
@@ -363,3 +363,36 @@ img.align-right {
 	width: 340px;
 	margin: 0 0 0 16px;
 }
+
+p.align-left,
+h1.align-left,
+h2.align-left,
+h3.align-left,
+h4.align-left,
+h5.align-left,
+h6.align-left,
+blockquote.align-left {
+	text-align: left;
+}
+
+p.align-center,
+h1.align-center,
+h2.align-center,
+h3.align-center,
+h4.align-center,
+h5.align-center,
+h6.align-center,
+blockquote.align-center {
+	text-align: center;
+}
+
+p.align-right,
+h1.align-right,
+h2.align-right,
+h3.align-right,
+h4.align-right,
+h5.align-right,
+h6.align-right,
+blockquote.align-right {
+	text-align: right;
+}


### PR DESCRIPTION
Fixes #54.  Adds event handlers following the way image block controls work.  This will work for any `text` type and the css classes, for now, cover `p`, `h1-6`, and blockquote.