### PR TITLE
Keep the block position on the screen when moving blocks

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -308,9 +308,11 @@ function attachControlActions() {
 		if ( getter ) {
 			node.addEventListener( 'click', function( event ) {
 				event.stopPropagation();
+				var previousOffset = selectedBlock.offsetTop;
 				swapNodes( selectedBlock, getter( selectedBlock ) );
 				attachBlockHandlers();
 				reselect();
+				window.scrollTo( window.scrollX, window.scrollY + selectedBlock.offsetTop - previousOffset );
 			}, false );
 		}
 	} );


### PR DESCRIPTION
closes #97 

This PR ensures the block position on the screen stays the same when we reorder the blocks.

![kapture 2017-02-20 at 14 01 16](https://cloud.githubusercontent.com/assets/272444/23126032/21580496-f775-11e6-9ff6-b2f4bb0f1edb.gif)
