### PR TITLE
Update Automattic package references to WordPress

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,19 +9,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Automattic/gutenberg.git"
+    "url": "git+https://github.com/WordPress/gutenberg.git"
   },
   "keywords": [
     "WordPress",
     "editor",
     "prototype"
   ],
-  "author": "Automattic, Inc.",
+  "author": "The WordPress Contributors",
   "license": "GPL-2.0+",
   "bugs": {
-    "url": "https://github.com/Automattic/gutenberg/issues"
+    "url": "https://github.com/WordPress/gutenberg/issues"
   },
-  "homepage": "https://github.com/Automattic/gutenberg#readme",
+  "homepage": "https://github.com/WordPress/gutenberg#readme",
   "devDependencies": {
     "http-server": "0.9.0"
   }


### PR DESCRIPTION
This pull request seeks to update `package.json` details since migration to WordPress owner- and contributor-ship. The `author` name was derived from the equivalent field in the WordPress core source `package.json`:

https://develop.svn.wordpress.org/trunk/package.json