### PR TITLE
Fix switching between block types (paragraph, quote and heading)

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -468,12 +468,9 @@ function attachTypeSwitcherActions() {
 	} );
 
 	Object.keys( typeToTag ).forEach( function( type ) {
-		var selector = '.switch-block__block .type-icon-' + type;
-		var button = queryFirst( selector );
-		var label = queryFirst( selector + ' + label' );
-
+		var iconSelector = '.switch-block__block .type-icon-' + type;
+		var button = queryFirst( iconSelector ).parentNode;
 		button.addEventListener( 'click', switchBlockType, false );
-		label.addEventListener( 'click', switchBlockType, false );
 
 		function switchBlockType( event ) {
 			if ( ! selectedBlock ) {


### PR DESCRIPTION
I found that when clicking on the space between the icon and the label on the switch block type menu, the switch was not triggered. In this PR, I just move the clickHandler to the parent dom.