### PR TITLE
Only show left border on hover.

### DIFF
--- a/style.css
+++ b/style.css
@@ -93,7 +93,7 @@ h6:hover,
 p:hover,
 blockquote:hover,
 img:hover {
-	box-shadow: inset 0px 0px 0px 2px #e0e5e9;
+	box-shadow: inset 9px 0px 0px -7px #e0e5e9;
 }
 
 h1.is-selected,


### PR DESCRIPTION
For #90, this removes the border around the entire block on mouse over, and only shows it on the left.  I might take a go at updating #59 tomorrow and build upon this. 

![hover](https://cloud.githubusercontent.com/assets/22080/23195064/c168486e-f866-11e6-89f7-cfe1bb23dc9c.gif)
