### PR TITLE
Fix the block switcher position

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -337,6 +337,7 @@ function showControls( node ) {
 	var position = node.getBoundingClientRect();
 	switcher.style.opacity = 1;
 	switcher.style.top = ( position.top + 18 + window.scrollY ) + 'px';
+	switcher.style.left = position.left - 10 + 'px';
 
 	// show/hide block-specific block controls
 	dockedControls.className = 'docked-controls';


### PR DESCRIPTION
The regression was introduced in https://github.com/WordPress/gutenberg/commit/befc304b28d77e99b0c1196632adfafd8fe41b3c when we dropped the max-width of the body.

With the current layout, we need to update the `left` position of the switcher while selecting a block.