### PR TITLE
Add base ESLint and EditorConfig configurations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[package.json]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+	"root": true,
+	"extends": "wpcalypso",
+	"env": {
+		"browser": true
+	},
+	"rules": {
+		"no-var": "off",
+		"camelcase": "off"
+	}
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,53 @@
 {
 	"root": true,
-	"extends": "wpcalypso",
+	"extends": "wordpress",
 	"env": {
 		"browser": true
 	},
 	"rules": {
-		"no-var": "off",
-		"camelcase": "off"
+		"array-bracket-spacing": [ "error", "always" ],
+		"brace-style": [ "error", "1tbs" ],
+		"comma-spacing": "error",
+		"comma-style": "error",
+		"computed-property-spacing": [ "error", "always" ],
+		"dot-notation": "error",
+		"eol-last": "error",
+		"func-call-spacing": "error",
+		"indent": [ "error", "tab", { "SwitchCase": 1 } ],
+		"key-spacing": "error",
+		"keyword-spacing": "error",
+		"no-console": "error",
+		"no-debugger": "error",
+		"no-dupe-args": "error",
+		"no-dupe-keys": "error",
+		"no-duplicate-case": "error",
+		"no-else-return": "error",
+		"no-extra-semi": "error",
+		"no-lonely-if": "error",
+		"no-mixed-spaces-and-tabs": "error",
+		"no-multiple-empty-lines": [ "error", { "max": 1 } ],
+		"no-multi-spaces": "error",
+		"no-negated-in-lhs": "error",
+		"no-nested-ternary": "error",
+		"no-redeclare": "error",
+		"no-shadow": "error",
+		"no-unreachable": "error",
+		"no-use-before-define": [ "error", "nofunc" ],
+		"no-var": "error",
+		"object-curly-spacing": [ "error", "always" ],
+		"padded-blocks": [ "error", "never" ],
+		"quote-props": [ "error", "as-needed", { "keywords": true } ],
+		"semi": "error",
+		"semi-spacing": "error",
+		"space-before-blocks": [ "error", "always" ],
+		"space-before-function-paren": [ "error", "never" ],
+		"space-in-parens": [ "error", "always" ],
+		"space-infix-ops": [ "error", { "int32Hint": false } ],
+		"space-unary-ops": [ "error", {
+			"overrides": {
+				"!": true
+			}
+		} ],
+		"valid-jsdoc": [ "error", { "requireReturn": false } ]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "homepage": "https://github.com/WordPress/gutenberg#readme",
   "devDependencies": {
     "eslint": "^3.16.1",
-    "eslint-config-wpcalypso": "^0.6.0",
-    "eslint-plugin-wpcalypso": "^3.0.2",
+    "eslint-config-wordpress": "^1.1.0",
     "http-server": "0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "homepage": "https://github.com/WordPress/gutenberg#readme",
   "devDependencies": {
+    "eslint": "^3.16.1",
+    "eslint-config-wpcalypso": "^0.6.0",
+    "eslint-plugin-wpcalypso": "^3.0.2",
     "http-server": "0.9.0"
   }
 }


### PR DESCRIPTION
This pull request seeks to add base ESLint and EditorConfig configurations. This should help myself and other developers discover erroneous or stylistically incorrect code. It uses the [`eslint-config-wordpress`](https://github.com/ntwb/eslint-config-wordpress) base configuration, extended with additional rules. Since `tinymce-per-block` defines its own ESLint configuration as `root`, there should be no conflict with this configuration (cc @youknowriad).