### PR TITLE
Single TinyMCE: Drop window element global

### DIFF
--- a/shared/tinymce/toolbar.js
+++ b/shared/tinymce/toolbar.js
@@ -75,7 +75,8 @@
 					function onClick( callback ) {
 						return function() {
 							editor.undoManager.transact( function() {
-								callback( editor, window.element );
+								var element = editor.selection.getSelectedBlocks()[ 0 ];
+								callback( editor, element );
 							} );
 						}
 					}

--- a/tinymce-single/tinymce/block.js
+++ b/tinymce-single/tinymce/block.js
@@ -4,8 +4,8 @@
 
 		// Set focussed block. Global variable for now. Top-level node for now.
 
-		editor.on( 'nodechange', function( event ) {
-			element = window.element = event.parents[ event.parents.length - 1 ];
+		editor.on( 'nodechange', function() {
+			element = editor.selection.getSelectedBlocks()[ 0 ];
 		} );
 
 		// Global controls


### PR DESCRIPTION
This pull request seeks to remove the last remaining reference to the `window.element` global by instead leveraging the `editor.selection.getSelectedBlocks` method wherever it's needed.