### PR TITLE
Revert "Single TinyMCE: Drop window element global"

### DIFF
--- a/shared/tinymce/toolbar.js
+++ b/shared/tinymce/toolbar.js
@@ -75,8 +75,7 @@
 					function onClick( callback ) {
 						return function() {
 							editor.undoManager.transact( function() {
-								var element = editor.selection.getSelectedBlocks()[ 0 ];
-								callback( editor, element );
+								callback( editor, window.element );
 							} );
 						}
 					}

--- a/tinymce-single/tinymce/block.js
+++ b/tinymce-single/tinymce/block.js
@@ -4,8 +4,8 @@
 
 		// Set focussed block. Global variable for now. Top-level node for now.
 
-		editor.on( 'nodechange', function() {
-			element = editor.selection.getSelectedBlocks()[ 0 ];
+		editor.on( 'nodechange', function( event ) {
+			element = window.element = event.parents[ event.parents.length - 1 ];
 		} );
 
 		// Global controls


### PR DESCRIPTION
Reverts WordPress/gutenberg#168

A little more complex than anticipated, because `window.element` was assigning from ancestor chain of `NodeChange`, not necessarily the currently selected element. Might be a matter of using a combination of `getSelectedBlocks` and traversing `parentNode` chain, but we'll need to consider how this works with multi-select.

cc @iseulde 