### PR TITLE
TinyMCE per block: Trying the temporary content editable approach for cross-block selection

### DIFF
--- a/tinymce-per-block/package.json
+++ b/tinymce-per-block/package.json
@@ -52,6 +52,7 @@
     "classnames": "^2.2.5",
     "is-equal-shallow": "^0.1.3",
     "lodash": "^4.17.4",
+    "rangy": "^1.3.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-textarea-autosize": "^4.0.5"

--- a/tinymce-per-block/src/blocks/embed-block/form.js
+++ b/tinymce-per-block/src/blocks/embed-block/form.js
@@ -91,6 +91,7 @@ export default class EmbedBlockForm extends Component {
 										placeholder="Write caption"
 										focusConfig={ focusConfig }
 										onFocusChange={ api.focus }
+										selectionName="caption"
 									/>
 								</div>
 							}

--- a/tinymce-per-block/src/blocks/heading-block/form.js
+++ b/tinymce-per-block/src/blocks/heading-block/form.js
@@ -91,6 +91,7 @@ export default class HeadingBlockForm extends Component {
 						focusConfig={ focusConfig }
 						onFocusChange={ api.focus }
 						onType={ api.unselect }
+						selectionName="content"
 						single
 						inline
 					/>

--- a/tinymce-per-block/src/blocks/html-block/form.js
+++ b/tinymce-per-block/src/blocks/html-block/form.js
@@ -72,6 +72,7 @@ export default class HtmlBlockForm extends Component {
 						focusConfig={ focusConfig }
 						onFocusChange={ api.focus }
 						onType={ api.unselect }
+						selectionName="caption"
 					/>
 				</div>
 			</div>

--- a/tinymce-per-block/src/blocks/image-block/form.js
+++ b/tinymce-per-block/src/blocks/image-block/form.js
@@ -61,6 +61,7 @@ export default class ImageBlockForm extends Component {
 								placeholder="Write caption"
 								focusConfig={ focusConfig }
 								onFocusChange={ api.focus }
+								selectionName="caption"
 							/>
 						</div>
 					}

--- a/tinymce-per-block/src/blocks/quote-block/form.js
+++ b/tinymce-per-block/src/blocks/quote-block/form.js
@@ -106,6 +106,7 @@ export default class QuoteBlockForm extends Component {
 							focusConfig={ focusInput === 'content' ? focusConfig : null }
 							onFocusChange={ ( config ) => api.focus( Object.assign( { input: 'content' }, config ) ) }
 							onType={ api.unselect }
+							selectionName="caption"
 							inline
 						/>
 					</div>
@@ -124,6 +125,7 @@ export default class QuoteBlockForm extends Component {
 								focusConfig={ focusInput === 'cite' ? focusConfig : null }
 								onFocusChange={ ( config ) => api.focus( Object.assign( { input: 'cite' }, config ) ) }
 								onType={ api.unselect }
+								selectionName="cite"
 								inline
 								single
 							/>

--- a/tinymce-per-block/src/blocks/text-block/form.js
+++ b/tinymce-per-block/src/blocks/text-block/form.js
@@ -86,6 +86,7 @@ export default class TextBlockForm extends Component {
 						focusConfig={ focusConfig }
 						onFocusChange={ api.focus }
 						onType={ api.unselect }
+						selectionName="content"
 						inline
 					/>
 				</div>

--- a/tinymce-per-block/src/external/wp-blocks/editable/index.js
+++ b/tinymce-per-block/src/external/wp-blocks/editable/index.js
@@ -217,8 +217,10 @@ export default class EditableComponent extends Component {
 	};
 
 	onFocus = () => {
-		const bookmark = this.editor.selection.getBookmark( 2, true );
-		this.props.onFocusChange( { bookmark } );
+		if ( ! this.props.focusConfig ) {
+			const bookmark = this.editor.selection.getBookmark( 2, true );
+			this.props.onFocusChange( { bookmark } );
+		}
 	};
 
 	onSetup = ( editor ) => {
@@ -256,7 +258,7 @@ export default class EditableComponent extends Component {
 	render() {
 		return (
 			<div ref={ this.setRef }>
-				<div contentEditable />
+				<div contentEditable data-selection={ this.props.selectionName } />
 			</div>
 		);
 	}

--- a/tinymce-per-block/src/external/wp-blocks/input/index.js
+++ b/tinymce-per-block/src/external/wp-blocks/input/index.js
@@ -84,7 +84,8 @@ export default class EnhancedInput extends Component {
 	render() {
 		// Keeping splitValue to exclude it from props
 		const ignoredProps = [
-			'value', 'splitValue', 'removePrevious', 'moveCursorDown', 'moveCursorUp', 'focusConfig', 'onFocusChange'
+			'value', 'splitValue', 'removePrevious', 'moveCursorDown', 'moveCursorUp',
+			'focusConfig', 'onFocusChange', 'selectionName'
 		];
 		const { value } = this.props;
 		const props = omit( this.props, ignoredProps );
@@ -100,7 +101,8 @@ export default class EnhancedInput extends Component {
 				<div
 					className="textarea-mirror"
 					ref={ this.bindMirror }
-					style={ style } />
+					style={ style }
+				/>
 				<Textarea
 					ref={ this.bindInput }
 					{ ...props }
@@ -109,6 +111,7 @@ export default class EnhancedInput extends Component {
 					onKeyDown={ this.onKeyDown }
 					onChange={ this.onChange }
 					onFocus={ this.onFocus }
+					data-selection={ this.props.selectionName }
 				/>
 			</div>
 		);

--- a/tinymce-per-block/src/renderers/block/_style.scss
+++ b/tinymce-per-block/src/renderers/block/_style.scss
@@ -2,6 +2,10 @@
 	list-style: none;
 	padding: 0;
 	margin: 0;
+
+	&:focus {
+		outline: 0;
+	}
 }
 
 .block-list__block {


### PR DESCRIPTION
For now, it supports:

 - Cross selection using the mouse
 - Deleting the selected content

I noticed this introduced a bug when selecting inside a TinyMCE (the cursor jumps)