### PR TITLE
Add unimplemented block structuring and complementary modules

### DIFF
--- a/plugin/editor/blocks/index.js
+++ b/plugin/editor/blocks/index.js
@@ -1,0 +1,1 @@
+import './text-block';

--- a/plugin/editor/blocks/text-block/index.js
+++ b/plugin/editor/blocks/text-block/index.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/elements';
+import { registerBlock, Editable } from '@wordpress/blocks';
+
+registerBlock( 'wp', 'Text', {
+	edit( state, onChange ) {
+		return createElement( Editable, {
+			value: state.value,
+			onChange: ( value ) => onChange( { value } )
+		} );
+	},
+	save( state ) {
+		return createElement( 'p', null, state.value );
+	}
+} );

--- a/plugin/editor/editor.js
+++ b/plugin/editor/editor.js
@@ -1,0 +1,3 @@
+export default class Editor {
+
+}

--- a/plugin/editor/index.js
+++ b/plugin/editor/index.js
@@ -1,3 +1,26 @@
+/**
+ * Internal dependencies
+ */
 import 'assets/stylesheets/main.scss';
+import 'blocks';
 
-console.log( 'Welcome to gutenberg' ); // eslint-disable-line no-console
+/**
+ * Returns an instance of Editor.
+ *
+ * @param  {String}    id Unique identifier for editor instance
+ * @return {wp.Editor}    Editor instance
+ */
+export function getInstance( id ) {
+
+}
+
+/**
+ * Initializes and returns an instance of Editor
+ *
+ * @param  {String}    id       Unique identifier for editor instance
+ * @param  {Object}    settings [description]
+ * @return {wp.Editor}          Editor instance
+ */
+export function createInstance( id, settings ) {
+
+}

--- a/plugin/external/@wordpress/blocks/components/editable/index.js
+++ b/plugin/external/@wordpress/blocks/components/editable/index.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/elements';
+
+export default function Editable() {
+
+}

--- a/plugin/external/@wordpress/blocks/index.js
+++ b/plugin/external/@wordpress/blocks/index.js
@@ -1,0 +1,32 @@
+export { default as Editable } from './components/editable';
+
+/**
+ * Registers a block.
+ *
+ * @param  {string} namespace Block grouping unique to package or plugin
+ * @param  {string} block     Block name
+ * @param  {Object} settings  Block settings
+ */
+export function registerBlock( namespace, block, settings ) {
+
+}
+
+/**
+ * Returns settings associated with a block.
+ *
+ * @param  {string}  namespace Block grouping unique to package or plugin
+ * @param  {string}  block     Block name
+ * @return {?Object}           Block settings
+ */
+export function getBlockSettings( namespace, block ) {
+
+}
+
+/**
+ * Returns all registered blocks.
+ *
+ * @return {Object} Block settings keyed by block name
+ */
+export function getBlocks() {
+
+}

--- a/plugin/external/@wordpress/elements/index.js
+++ b/plugin/external/@wordpress/elements/index.js
@@ -3,9 +3,9 @@
  * another function which itself returns an element.
  *
  * @param  {?(string|Function)} type     Tag name or element creator
- * @param  {Object}             props    Props of components, either attribute
+ * @param  {Object}             props    Element properties, either attribute
  *                                       set to apply to DOM node or values to
- *                                       pass through to element creators
+ *                                       pass through to element creator
  * @param  {...wp.Element}      children Descendant elements
  * @return {wp.Element}                  Element
  */
@@ -16,8 +16,8 @@ export function createElement( type, props, ...children ) {
 /**
  * Renders a given element into the target DOM node.
  *
- * @param  {wp.Element} element Element to render
- * @param  {Element}    target  DOM node into which element should be rendered
+ * @param {wp.Element} element Element to render
+ * @param {Element}    target  DOM node into which element should be rendered
  */
 export function render( element, target ) {
 

--- a/plugin/external/@wordpress/elements/index.js
+++ b/plugin/external/@wordpress/elements/index.js
@@ -1,0 +1,24 @@
+/**
+ * Returns a new element of given type. Type can be either a string tag name or
+ * another function which itself returns an element.
+ *
+ * @param  {?(string|Function)} type     Tag name or element creator
+ * @param  {Object}             props    Props of components, either attribute
+ *                                       set to apply to DOM node or values to
+ *                                       pass through to element creators
+ * @param  {...wp.Element}      children Descendant elements
+ * @return {wp.Element}                  Element
+ */
+export function createElement( type, props, ...children ) {
+
+}
+
+/**
+ * Renders a given element into the target DOM node.
+ *
+ * @param  {wp.Element} element Element to render
+ * @param  {Element}    target  DOM node into which element should be rendered
+ */
+export function render( element, target ) {
+
+}

--- a/plugin/index.php
+++ b/plugin/index.php
@@ -38,3 +38,15 @@ function the_gutenberg_project() {
 	</div>
 	<?php
 }
+
+/**
+ * Registers a block.
+ *
+ * @param  string $namespace Block grouping unique to package or plugin
+ * @param  string $block     Block name
+ * @param  array  $args      Optional. Array of settings for the block. Default empty array.
+ * @return bool              True on success, false on error
+ */
+function register_block( $namespace, $block, $args = array() ) {
+
+}

--- a/plugin/webpack.config.js
+++ b/plugin/webpack.config.js
@@ -15,6 +15,7 @@ const config = module.exports = {
 	resolve: {
 		modules: [
 			'editor',
+			'external',
 			'node_modules'
 		]
 	},


### PR DESCRIPTION
This pull request seeks to add some very rough folder structuring around blocks and complementary external modules. Much of this is based on conversations evolved from #104 and prototyped in [`tinymce-per-block/src`](https://github.com/WordPress/gutenberg/tree/master/tinymce-per-block/src).

It includes non-implemented block APIs both in JavaScript and PHP with function signatures intentionally designed to mimic some similar already in WordPress (e.g. [`register_rest_route`](https://developer.wordpress.org/reference/functions/register_rest_route/)). Namespacing hadn't been considered before, but could be useful to prevent block name conflicts between plugin, such as if two plugins were to each attempt to register their own `map` or `contactform` block types. 

Base settings for a block follow those explored at https://github.com/WordPress/gutenberg/issues/104#issuecomment-286814466 , with assumption that blocks own state will serve as single source of truth, persisted in post meta and adhering to a structure defined by the block's schema defined in `register_block`.

The idea with external modules is not only to help separate and isolate related logic, but also a means to enforce using standard APIs even in "first-party" blocks. The idea is that modules exist as an alternative to and in addition to window globals.