### PR TITLE
Refine ESLint configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[package.json]
+[{package.json,.travis.yml}]
 indent_style = space
 indent_size = 2
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
 	"root": true,
 	"extends": "wordpress",
 	"env": {
-		"browser": true
+		"browser": true,
+		"node": true
 	},
 	"parserOptions": {
 		"sourceType": "module"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
 		"no-unreachable": "error",
 		"no-use-before-define": [ "error", "nofunc" ],
 		"object-curly-spacing": [ "error", "always" ],
+		"one-var": "off",
 		"padded-blocks": [ "error", "never" ],
 		"quote-props": [ "error", "as-needed", { "keywords": true } ],
 		"semi": "error",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "node"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "lint": "eslint editor",
+    "test": "npm run lint"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",


### PR DESCRIPTION
Specifies Node environment to avoid errors on keywords such as `require`, `process`. Notably in `webpack.config.js`. While these will likely not be common in client code, they're supported by Webpack nonetheless.

Disables `one-var` ESLint rule. I'd argue this is a complementary of [`vars-on-top`](http://eslint.org/docs/rules/vars-on-top) which is not relevant in an ES2015+ environment.

Adds configuration for Travis CI. This is not yet enabled and we'll need to resolve a few of the outstanding errors (from stubbed functions). Travis was chosen for best consistency with core integration ([source](https://core.trac.wordpress.org/browser/trunk/.travis.yml)).