### PR TITLE
Define editor output as library

### DIFF
--- a/index.php
+++ b/index.php
@@ -49,7 +49,9 @@ add_action( 'init', 'gutenberg_register_scripts' );
  */
 function gutenberg_scripts_and_styles( $hook ) {
 	if ( 'toplevel_page_gutenberg' === $hook ) {
-		wp_enqueue_script( 'wp-editor', plugins_url( 'modules/editor/build/index.js', __FILE__ ), array( 'wp-blocks', 'wp-element' ) );
+		wp_register_script( 'gutenberg-content', plugins_url( 'docs/shared/post-content.js', __FILE__ ) );
+		wp_enqueue_script( 'wp-editor', plugins_url( 'modules/editor/build/index.js', __FILE__ ), array( 'wp-blocks', 'wp-element', 'gutenberg-content' ), false, true );
+		wp_add_inline_script( 'wp-editor', 'wp.editor.createEditorInstance( \'editor\', { content: window.content } );' );
 	}
 }
 
@@ -66,12 +68,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_scripts_and_styles' );
 function the_gutenberg_project() {
 	?>
 	<div class="gutenberg">
-		<section class="gutenberg__editor" contenteditable="true">
-			<h2>1.0 Is The Loneliest Number</h2>
-			<p>Many entrepreneurs idolize Steve Jobs. He’s such a <a href=""><span class="space-sep">&nbsp;</span>perfectionist<span class="space-sep-end">&nbsp;</span></a>, they say. Nothing leaves the doors of 1 Infinite Loop in Cupertino without a polish and finish that makes geeks everywhere drool. No compromise!</p>
-			<img alt="" src="https://cldup.com/HN3-c7ER9p.jpg" />
-			<p>I like Apple for the opposite reason: they’re not afraid of getting a rudimentary 1.0 out into the world.</p>
-		</section>
+		<section id="editor" class="gutenberg__editor" contenteditable="true"></section>
 	</div>
 	<?php
 }

--- a/modules/editor/editor.js
+++ b/modules/editor/editor.js
@@ -1,3 +1,5 @@
 export default class Editor {
-
+	constructor( id, settings ) {
+		document.getElementById( id ).innerHTML = settings.content;
+	}
 }

--- a/modules/editor/index.js
+++ b/modules/editor/index.js
@@ -3,6 +3,14 @@
  */
 import 'assets/stylesheets/main.scss';
 import 'blocks';
+import Editor from './editor';
+
+/**
+ * Editor instances keyed by ID.
+ *
+ * @type {Object}
+ */
+const editors = {};
 
 /**
  * Returns an instance of Editor.
@@ -10,17 +18,18 @@ import 'blocks';
  * @param  {String}    id Unique identifier for editor instance
  * @return {wp.Editor}    Editor instance
  */
-export function getInstance( id ) {
-
+export function getEditorInstance( id ) {
+	return editors[ id ];
 }
 
 /**
- * Initializes and returns an instance of Editor
+ * Initializes and returns an instance of Editor.
  *
  * @param  {String}    id       Unique identifier for editor instance
  * @param  {Object}    settings [description]
  * @return {wp.Editor}          Editor instance
  */
-export function createInstance( id, settings ) {
-
+export function createEditorInstance( id, settings ) {
+	editors[ id ] = new Editor( id, settings );
+	return getEditorInstance( id );
 }


### PR DESCRIPTION
This pull request seeks to wire up exports from base entry point of the editor bundle. The idea being that for best compatibility with existing editor APIs, we'll need to support multiple instances that are to be initialized on a window global.

In testing the behavior, the plugin is now wired to use the shared content defined at [`shared/post-content.js`](https://github.com/WordPress/gutenberg/blob/master/docs/shared/post-content.js).

__Testing Instructions:__

1. Clone repository to WordPress site plugin directory.
2. `cd gutenberg && npm install && npm run build`
3. Activate plugin from wp-admin Plugins screen
4. Navigate to Gutenberg admin menu item
5. Confirm shared post content is shown