### PR TITLE
Plugin: Fix test runner. Use babel-register instead of mocha-webpack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,5 +8,10 @@
 	],
 	"plugins": [
 		"transform-runtime"
-	]
+	],
+	"env": {
+		"test": {
+			"presets": [ "latest" ]
+		}
+	}
 }

--- a/bootstrap-test.js
+++ b/bootstrap-test.js
@@ -4,10 +4,4 @@
 import chai from 'chai';
 import dirtyChai from 'dirty-chai';
 
-/** Internal dependencies */
-import * as blocks from './modules/blocks';
-import * as element from './modules/element';
-
 chai.use( dirtyChai );
-
-global.wp = { blocks, element };

--- a/bootstrap-test.js
+++ b/bootstrap-test.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import chai from 'chai';
+import dirtyChai from 'dirty-chai';
+
+/** Internal dependencies */
+import * as blocks from './modules/blocks';
+import * as element from './modules/element';
+
+chai.use( dirtyChai );
+
+global.wp = { blocks, element };

--- a/modules/blocks/index.js
+++ b/modules/blocks/index.js
@@ -16,7 +16,7 @@ export function validateBlockSlug( slug ) {
 	if ( ! /^[a-z0-9-]+\/[a-z0-9-]+$/.test( slug ) ) {
 		throw new Error(
 			'Block slugs must contain a namespace prefix.  Example:  my-plugin/my-custom-block'
-		)
+		);
 	}
 }
 

--- a/modules/blocks/test/index.js
+++ b/modules/blocks/test/index.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import * as blocks from 'blocks';
+import * as blocks from '../';
 
 describe( 'blocks API', () => {
 	// TODO: We probably want a way to undo this, and split this logic out into

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "editor"
   ],
   "scripts": {
-    "test-unit": "cross-env NODE_ENV=test mocha-webpack test/ --webpack-config webpack.config.js --recursive --include test/boot.js",
+    "test-unit": "cross-env NODE_ENV=test mocha modules/**/test/*.js --compilers js:babel-register --recursive --require ./bootstrap-test.js",
     "build": "cross-env NODE_ENV=production webpack",
     "lint": "eslint editor",
     "test": "npm run lint && npm run test-unit"
@@ -22,6 +22,7 @@
     "babel-loader": "^6.4.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-latest": "^6.24.0",
+    "babel-register": "^6.24.0",
     "chai": "^3.5.0",
     "cross-env": "^3.2.4",
     "css-loader": "^0.27.3",
@@ -29,13 +30,11 @@
     "eslint": "^3.17.1",
     "eslint-config-wordpress": "^1.1.0",
     "mocha": "^3.2.0",
-    "mocha-webpack": "^0.7.0",
     "node-sass": "^4.5.0",
     "postcss-loader": "^1.3.3",
     "sass-loader": "^6.0.3",
     "style-loader": "^0.14.1",
-    "webpack": "^2.2.1",
-    "webpack-node-externals": "^1.5.4"
+    "webpack": "^2.2.1"
   },
   "dependencies": {
     "react": "^15.4.2",

--- a/test/boot.js
+++ b/test/boot.js
@@ -1,7 +1,0 @@
-/**
- * External dependencies
- */
-import chai from 'chai';
-import dirtyChai from 'dirty-chai';
-
-chai.use( dirtyChai );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,9 +82,4 @@ if ( 'production' === process.env.NODE_ENV ) {
 	config.devtool = 'source-map';
 }
 
-if ( 'test' === process.env.NODE_ENV ) {
-	config.target = 'node';
-	config.externals = [ nodeExternals() ];
-}
-
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
-const nodeExternals = require( 'webpack-node-externals' );
 
 /**
  * Base path from which modules are to be discovered.


### PR DESCRIPTION
As noted by @aduth mocha-webpack overrides the default webpack entry, so we'll have issues to make it work with our globals config.

 - In this PR, I'm replacing mocha-webpack with babel-register
 - Moving the tests close to the source code
 - Defining the globals for test in `bootstrap-test.js`

I avoided publishing directly to #289 PR in case you have objections here.