### PR TITLE
Inserter: Trying v1 for the block inserter

### DIFF
--- a/index.php
+++ b/index.php
@@ -79,7 +79,7 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_scripts_and_styles' );
 function the_gutenberg_project() {
 	?>
 	<div class="gutenberg">
-		<section id="editor" class="gutenberg__editor" contenteditable="true"></section>
+		<section id="editor" class="gutenberg__editor"></section>
 	</div>
 	<?php
 }

--- a/modules/editor/assets/stylesheets/main.scss
+++ b/modules/editor/assets/stylesheets/main.scss
@@ -1,12 +1,19 @@
+@import '../../inserter/style';
+
 .gutenberg {
 	background: #fff;
 	margin: -20px 0 0 -20px;
 	padding: 60px;
+
+	* {
+		box-sizing: border-box;
+	}
 }
 
 .gutenberg__editor {
 	max-width: 700px;
 	margin: 0 auto;
+	position: relative;
 	img {
 		max-width: 100%;
 	}

--- a/modules/editor/blocks/text-block/index.js
+++ b/modules/editor/blocks/text-block/index.js
@@ -1,6 +1,9 @@
 const { query, html } = wp.blocks.query;
 
 wp.blocks.registerBlock( 'wp/text', {
+	title: 'Text',
+	icon: 'text',
+
 	attributes: {
 		value: query( 'p', html() )
 	},

--- a/modules/editor/editor.js
+++ b/modules/editor/editor.js
@@ -1,15 +1,48 @@
+import InserterButton from './inserter/button';
+
+const h = wp.element.createElement;
+
+const EditorComponent = ( { state: { inserter, blocks }, toggleInserter } ) => {
+	return h( 'div', {},
+		h( 'div', { contentEditable: true },
+			wp.blocks.createBlockElement( blocks[ 1 ] )
+		),
+		h( InserterButton, { onClick: toggleInserter, opened: inserter.opened } )
+	);
+};
+
 export default class Editor {
 	constructor( id, settings ) {
-		const blocks = wp.blocks.parse( settings.content );
-		console.log( blocks ); // eslint-disable-line no-console
+		this.toggleInserter = this.toggleInserter.bind( this );
 
-		if ( ! blocks.length ) {
-			return;
-		}
+		this.id = id;
+		this.settings = settings;
+		this.state = {
+			inserter: { opened: false },
+			blocks: wp.blocks.parse( settings.content )
+		};
+		console.log( this.state.blocks ); // eslint-disable-line no-console
+		this.render();
+	}
 
+	setState( newState ) {
+		this.state = Object.assign( {}, this.state, newState );
+		this.render();
+	}
+
+	toggleInserter() {
+		this.setState( {
+			inserter: { opened: ! this.state.inserter.opened }
+		} );
+	}
+
+	render() {
 		wp.element.render(
-			wp.blocks.createBlockElement( blocks[ 1 ] ),
-			document.getElementById( id )
+			h( EditorComponent, {
+				state: this.state,
+				toggleInserter: this.toggleInserter
+			} ),
+			document.getElementById( this.id )
 		);
 	}
 }

--- a/modules/editor/editor/editor.js
+++ b/modules/editor/editor/editor.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import InserterButton from '../inserter/button';
+
+const el = wp.element.createElement;
+
+const Editor = ( { state: { blocks, inserter }, toggleInserter } ) => {
+	return el( 'div', null,
+		el( 'div', { contentEditable: true },
+			wp.blocks.createBlockElement( blocks[ 1 ] )
+		),
+		el( InserterButton, { onClick: toggleInserter, opened: inserter.opened } )
+	);
+};
+
+export default Editor;

--- a/modules/editor/editor/index.js
+++ b/modules/editor/editor/index.js
@@ -1,20 +1,13 @@
-import InserterButton from './inserter/button';
+/**
+ * Internal dependencies
+ */
+import EditorComponent from './editor';
 
-const h = wp.element.createElement;
-
-const EditorComponent = ( { state: { inserter, blocks }, toggleInserter } ) => {
-	return h( 'div', {},
-		h( 'div', { contentEditable: true },
-			wp.blocks.createBlockElement( blocks[ 1 ] )
-		),
-		h( InserterButton, { onClick: toggleInserter, opened: inserter.opened } )
-	);
-};
+const el = wp.element.createElement;
 
 export default class Editor {
 	constructor( id, settings ) {
 		this.toggleInserter = this.toggleInserter.bind( this );
-
 		this.id = id;
 		this.settings = settings;
 		this.state = {
@@ -38,7 +31,7 @@ export default class Editor {
 
 	render() {
 		wp.element.render(
-			h( EditorComponent, {
+			el( EditorComponent, {
 				state: this.state,
 				toggleInserter: this.toggleInserter
 			} ),

--- a/modules/editor/inserter/button.js
+++ b/modules/editor/inserter/button.js
@@ -1,13 +1,16 @@
+/**
+ * Internal dependencies
+ */
 import Inserter from './';
 
-const h = wp.element.createElement;
+const el = wp.element.createElement;
 
 const InserterButton = ( { opened, onClick } ) => {
-	return h( 'div', { className: 'inserter__button' },
-		h( 'a', { onClick },
-			h( 'span', { className: 'dashicons dashicons-plus' } )
+	return el( 'div', { className: 'inserter__button' },
+		el( 'a', { className: 'inserter__button-toggle', onClick },
+			el( 'span', { className: 'dashicons dashicons-plus' } )
 		),
-		opened && h( Inserter )
+		opened && el( Inserter )
 	);
 };
 

--- a/modules/editor/inserter/button.js
+++ b/modules/editor/inserter/button.js
@@ -1,0 +1,14 @@
+import Inserter from './';
+
+const h = wp.element.createElement;
+
+const InserterButton = ( { opened, onClick } ) => {
+	return h( 'div', { className: 'inserter__button' },
+		h( 'a', { onClick },
+			h( 'span', { className: 'dashicons dashicons-plus' } )
+		),
+		opened && h( Inserter )
+	);
+};
+
+export default InserterButton;

--- a/modules/editor/inserter/index.js
+++ b/modules/editor/inserter/index.js
@@ -1,21 +1,21 @@
-const h = wp.element.createElement;
+const el = wp.element.createElement;
 
 const Inserter = () => {
 	const blocks = wp.blocks.getBlocks();
 
-	return h( 'div', { className: 'inserter' },
-		h( 'div', { className: 'inserter__arrow' } ),
-		h( 'div', { className: 'inserter__content' },
-			h( 'div', { className: 'inserter__category-blocks' },
+	return el( 'div', { className: 'inserter' },
+		el( 'div', { className: 'inserter__arrow' } ),
+		el( 'div', { className: 'inserter__content' },
+			el( 'div', { className: 'inserter__category-blocks' },
 				blocks.map( ( { slug, title, icon } ) => (
-					h( 'div', { key: slug, className: 'inserter__block' },
-						h( 'span', { className: 'dashicons dashicons-' + icon } ),
+					el( 'div', { key: slug, className: 'inserter__block' },
+						el( 'span', { className: 'dashicons dashicons-' + icon } ),
 						title
 					)
 				) )
 			)
 		),
-		h( 'input', { className: 'inserter__search', type: 'search', placeholder: 'Search...' } )
+		el( 'input', { className: 'inserter__search', type: 'search', placeholder: 'Search...' } )
 	);
 };
 

--- a/modules/editor/inserter/index.js
+++ b/modules/editor/inserter/index.js
@@ -1,0 +1,22 @@
+const h = wp.element.createElement;
+
+const Inserter = () => {
+	const blocks = wp.blocks.getBlocks();
+
+	return h( 'div', { className: 'inserter' },
+		h( 'div', { className: 'inserter__arrow' } ),
+		h( 'div', { className: 'inserter__content' },
+			h( 'div', { className: 'inserter__category-blocks' },
+				blocks.map( ( { slug, title, icon } ) => (
+					h( 'div', { key: slug, className: 'inserter__block' },
+						h( 'span', { className: 'dashicons dashicons-' + icon } ),
+						title
+					)
+				) )
+			)
+		),
+		h( 'input', { className: 'inserter__search', type: 'search', placeholder: 'Search...' } )
+	);
+};
+
+export default Inserter;

--- a/modules/editor/inserter/style.scss
+++ b/modules/editor/inserter/style.scss
@@ -5,26 +5,26 @@
 	border: none;
 	padding: 0;
 	margin-top: 20px;
+}
 
-	a {
-		display: inline-block;
-		color: #87919d;
-		cursor: pointer;
-		border-radius: 12px;
-		border: 2px solid #87919d;
-		width: 24px;
-		height: 24px;
-		padding: 0;
-		margin: 0;
+.inserter__button-toggle {
+	display: inline-block;
+	color: #87919d;
+	cursor: pointer;
+	border-radius: 12px;
+	border: 2px solid #87919d;
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	margin: 0;
 
-		.dashicons {
-			padding: 1px 0;
-		}
+	.dashicons {
+		padding: 1px 0;
+	}
 
-		&:hover {
-			color: #12181e;
-			border-color: #12181e;
-		}
+	&:hover {
+		color: #12181e;
+		border-color: #12181e;
 	}
 }
 
@@ -36,101 +36,101 @@
 	left: -130px;
 	bottom: 40px;
 	background: #fff;
+}
 
-	.inserter__arrow {
-		border: 10px dashed #e0e5e9;
-		height: 0;
-		line-height: 0;
+.inserter__arrow {
+	border: 10px dashed #e0e5e9;
+	height: 0;
+	line-height: 0;
+	position: absolute;
+	width: 0;
+	z-index: 1;
+	bottom: -10px;
+	left: 50%;
+	margin-left: -10px;
+	border-top-style: solid;
+	border-bottom: none;
+	border-left-color: transparent;
+	border-right-color: transparent;
+
+	&:before {
+		bottom: 2px;
+		border: 10px solid white;
+		content: " ";
 		position: absolute;
-		width: 0;
-		z-index: 1;
-		bottom: -10px;
 		left: 50%;
 		margin-left: -10px;
 		border-top-style: solid;
 		border-bottom: none;
 		border-left-color: transparent;
 		border-right-color: transparent;
+	}
+}
 
-		&:before {
-			bottom: 2px;
-			border: 10px solid white;
-			content: " ";
-			position: absolute;
-			left: 50%;
-			margin-left: -10px;
-			border-top-style: solid;
-			border-bottom: none;
-			border-left-color: transparent;
-			border-right-color: transparent;
-		}
+.inserter__content {
+	max-height: 180px;
+	overflow: auto;
+
+	&:focus {
+		outline: none;
+	}
+}
+
+.inserter__search {
+	display: block;
+	width: 100%;
+	border: none;
+	margin: 0;
+	border-top: 1px solid #e0e5e9;
+	padding: 8px 16px;
+	font-size: 13px;
+
+	&:focus {
+		outline: none;
+	}
+}
+
+.inserter__category-blocks {
+	display: flex;
+	flex-flow: row wrap;
+}
+
+.inserter__block {
+	display: flex;
+	width: 50%;
+	color: #86909B;
+	padding: 8px;
+	font-size: 11px;
+	align-items: center;
+	cursor: pointer;
+	border: 1px solid transparent;
+
+	&:hover {
+		background: #f8f9f9;
+		border: 1px solid #6d7882;
+		position: relative;
 	}
 
-	.inserter__content {
-		max-height: 180px;
-		overflow: auto;
-
-		&:focus {
-			outline: none;
-		}
-
-		.inserter__category-blocks {
-			display: flex;
-			flex-flow: row wrap;
-
-			.inserter__block {
-				display: flex;
-				width: 50%;
-				color: #86909B;
-				padding: 8px;
-				font-size: 11px;
-				align-items: center;
-				cursor: pointer;
-				border: 1px solid transparent;
-
-				&:hover {
-					background: #f8f9f9;
-					border: 1px solid #6d7882;
-					position: relative;
-				}
-
-				&.is-active {
-					background: #eef0f0;
-					border: 1px solid #6d7882;
-					position: relative;
-					color: #3e444c;
-				}
-
-				.dashicons {
-					color: #191e23;
-					margin-right: 8px;
-				}
-			}
-		}
+	&.is-active {
+		background: #eef0f0;
+		border: 1px solid #6d7882;
+		position: relative;
+		color: #3e444c;
 	}
 
-	.inserter__search {
-		display: block;
-		width: 100%;
-		border: none;
-		margin: 0;
-		border-top: 1px solid #e0e5e9;
-		padding: 8px 16px;
-		font-size: 13px;
-
-		&:focus {
-			outline: none;
-		}
+	.dashicons {
+		color: #191e23;
+		margin-right: 8px;
 	}
+}
 
-	.inserter__separator {
-		background: rgb(247,248,249);
-		display: block;
-		padding: 2px 12px;
-		letter-spacing: 1px;
-		text-transform: uppercase;
-		font-size: 11px;
-		font-weight: 500;
-		color: #9ea7af;
-	}
+.inserter__separator {
+	background: rgb(247,248,249);
+	display: block;
+	padding: 2px 12px;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	font-size: 11px;
+	font-weight: 500;
+	color: #9ea7af;
 }

--- a/modules/editor/inserter/style.scss
+++ b/modules/editor/inserter/style.scss
@@ -1,0 +1,136 @@
+.inserter__button {
+	display: inline-block;
+	position: relative;
+	background: none;
+	border: none;
+	padding: 0;
+	margin-top: 20px;
+
+	a {
+		display: inline-block;
+		color: #87919d;
+		cursor: pointer;
+		border-radius: 12px;
+		border: 2px solid #87919d;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		margin: 0;
+
+		.dashicons {
+			padding: 1px 0;
+		}
+
+		&:hover {
+			color: #12181e;
+			border-color: #12181e;
+		}
+	}
+}
+
+.inserter {
+	width: 280px;
+	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
+	border: 1px solid #e0e5e9;
+	position: absolute;
+	left: -130px;
+	bottom: 40px;
+	background: #fff;
+
+	.inserter__arrow {
+		border: 10px dashed #e0e5e9;
+		height: 0;
+		line-height: 0;
+		position: absolute;
+		width: 0;
+		z-index: 1;
+		bottom: -10px;
+		left: 50%;
+		margin-left: -10px;
+		border-top-style: solid;
+		border-bottom: none;
+		border-left-color: transparent;
+		border-right-color: transparent;
+
+		&:before {
+			bottom: 2px;
+			border: 10px solid white;
+			content: " ";
+			position: absolute;
+			left: 50%;
+			margin-left: -10px;
+			border-top-style: solid;
+			border-bottom: none;
+			border-left-color: transparent;
+			border-right-color: transparent;
+		}
+	}
+
+	.inserter__content {
+		max-height: 180px;
+		overflow: auto;
+
+		&:focus {
+			outline: none;
+		}
+
+		.inserter__category-blocks {
+			display: flex;
+			flex-flow: row wrap;
+
+			.inserter__block {
+				display: flex;
+				width: 50%;
+				color: #86909B;
+				padding: 8px;
+				font-size: 11px;
+				align-items: center;
+				cursor: pointer;
+				border: 1px solid transparent;
+
+				&:hover {
+					background: #f8f9f9;
+					border: 1px solid #6d7882;
+					position: relative;
+				}
+
+				&.is-active {
+					background: #eef0f0;
+					border: 1px solid #6d7882;
+					position: relative;
+					color: #3e444c;
+				}
+
+				.dashicons {
+					color: #191e23;
+					margin-right: 8px;
+				}
+			}
+		}
+	}
+
+	.inserter__search {
+		display: block;
+		width: 100%;
+		border: none;
+		margin: 0;
+		border-top: 1px solid #e0e5e9;
+		padding: 8px 16px;
+		font-size: 13px;
+
+		&:focus {
+			outline: none;
+		}
+	}
+
+	.inserter__separator {
+		background: rgb(247,248,249);
+		display: block;
+		padding: 2px 12px;
+		letter-spacing: 1px;
+		text-transform: uppercase;
+		font-size: 11px;
+		font-weight: 500;
+		color: #9ea7af;
+	}
+}


### PR DESCRIPTION
In this PR, I'm trying to add the block inserter to the plugin. This is the first UI element we make, thus, it raises a lot of questions we need to answer before merging this.

**Block API:** 
In this PR, I'm adding a title and an icon as strings to the block API, we probably need a `category` as well (I left it for another PR)

**React Component**
We're relying on `createElement` which is an abstraction of React to compose our UI. But we'll probably need more than that. Think refs, state ..... Should we export `Component` as well in `wp.element`?

In the first iteration of this PR, I avoided explicitly `Component` and simulated `setState` on the `Editor` class.

**React Dependencies: react-tooltip, react-clickoutside, ...** 
Another thing to consider while building the UI is the need of some ready to use React Components (external dependencies like `react-tooltip` or anything else). I think, even if using these external components would work like a charm, "logically", we can not use them in our UI because we're hiding React, this means we don't know if they're compatible with our abstraction.

**JSX**
I avoided explicitly JSX here, IMO this is not a big "loss" but this point should be raised I think.

**Icons**
I'm using the regular WordPress Dashicons (using classnames) in this PR, but I know these are not perfect and we may prefer using SVG. Maybe this could be changed later.

**Class properties**
I've used `.bind` (this makes me think I should have moved the call to the constructor) while using https://babeljs.io/docs/plugins/transform-class-properties/ is nicer. Thoughts on adding this babel plugin?