### PR TITLE
Plugin: Avoid throwing errors on invalid block registration

### DIFF
--- a/bootstrap-test.js
+++ b/bootstrap-test.js
@@ -3,5 +3,7 @@
  */
 import chai from 'chai';
 import dirtyChai from 'dirty-chai';
+import sinonChai from 'sinon-chai';
 
 chai.use( dirtyChai );
+chai.use( sinonChai );

--- a/modules/blocks/registration.js
+++ b/modules/blocks/registration.js
@@ -10,24 +10,29 @@ const blocks = {};
  *
  * @param {string} slug     Block slug
  * @param {Object} settings Block settings
+ * @return {Boolean}        Whether the block has been successfuly registered
  */
 export function registerBlock( slug, settings ) {
 	if ( typeof slug !== 'string' ) {
-		throw new Error(
+		console.error( // eslint-disable-line no-console
 			'Block slugs must be strings.'
 		);
+		return false;
 	}
 	if ( ! /^[a-z0-9-]+\/[a-z0-9-]+$/.test( slug ) ) {
-		throw new Error(
-			'Block slugs must contain a namespace prefix.  Example:  my-plugin/my-custom-block'
+		console.error( // eslint-disable-line no-console
+			'Block slugs must contain a namespace prefix. Example: my-plugin/my-custom-block'
 		);
+		return false;
 	}
 	if ( blocks[ slug ] ) {
-		throw new Error(
+		console.error( // eslint-disable-line no-console
 			'Block "' + slug + '" is already registered.'
 		);
+		return false;
 	}
 	blocks[ slug ] = Object.assign( { slug }, settings );
+	return true;
 }
 
 /**

--- a/modules/blocks/registration.js
+++ b/modules/blocks/registration.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 /**
  * Block settings keyed by block slug.
  *
@@ -10,29 +12,30 @@ const blocks = {};
  *
  * @param {string} slug     Block slug
  * @param {Object} settings Block settings
- * @return {Boolean}        Whether the block has been successfuly registered
+ * @return {?WPBlock}        Whether the block has been successfuly registered
  */
 export function registerBlock( slug, settings ) {
 	if ( typeof slug !== 'string' ) {
-		console.error( // eslint-disable-line no-console
+		console.error(
 			'Block slugs must be strings.'
 		);
-		return false;
+		return;
 	}
 	if ( ! /^[a-z0-9-]+\/[a-z0-9-]+$/.test( slug ) ) {
-		console.error( // eslint-disable-line no-console
+		console.error(
 			'Block slugs must contain a namespace prefix. Example: my-plugin/my-custom-block'
 		);
-		return false;
+		return;
 	}
 	if ( blocks[ slug ] ) {
-		console.error( // eslint-disable-line no-console
+		console.error(
 			'Block "' + slug + '" is already registered.'
 		);
-		return false;
+		return;
 	}
-	blocks[ slug ] = Object.assign( { slug }, settings );
-	return true;
+	const block = Object.assign( { slug }, settings );
+	blocks[ slug ] = block;
+	return block;
 }
 
 /**

--- a/modules/blocks/registration.js
+++ b/modules/blocks/registration.js
@@ -12,7 +12,8 @@ const blocks = {};
  *
  * @param  {string}   slug     Block slug
  * @param  {Object}   settings Block settings
- * @return {?WPBlock}          Whether the block has been successfuly registered
+ * @return {?WPBlock}          The block, if it has been successfully
+ *                             registered; otherwise `undefined`.
  */
 export function registerBlock( slug, settings ) {
 	if ( typeof slug !== 'string' ) {

--- a/modules/blocks/registration.js
+++ b/modules/blocks/registration.js
@@ -42,15 +42,20 @@ export function registerBlock( slug, settings ) {
 /**
  * Unregisters a block.
  *
- * @param {string} slug Block slug
+ * @param  {string}   slug Block slug
+ * @return {?WPBlock}      The previous block value, if it has been
+ *                         successfully unregistered; otherwise `undefined`.
  */
 export function unregisterBlock( slug ) {
 	if ( ! blocks[ slug ] ) {
-		throw new Error(
+		console.error(
 			'Block "' + slug + '" is not registered.'
 		);
+		return;
 	}
+	const oldBlock = blocks[ slug ];
 	delete blocks[ slug ];
+	return oldBlock;
 }
 
 /**

--- a/modules/blocks/registration.js
+++ b/modules/blocks/registration.js
@@ -10,9 +10,9 @@ const blocks = {};
 /**
  * Registers a block.
  *
- * @param {string} slug     Block slug
- * @param {Object} settings Block settings
- * @return {?WPBlock}        Whether the block has been successfuly registered
+ * @param  {string}   slug     Block slug
+ * @param  {Object}   settings Block settings
+ * @return {?WPBlock}          Whether the block has been successfuly registered
  */
 export function registerBlock( slug, settings ) {
 	if ( typeof slug !== 'string' ) {

--- a/modules/blocks/test/registration.js
+++ b/modules/blocks/test/registration.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 /**
  * External dependencies
  */
@@ -9,7 +11,6 @@ import sinon from 'sinon';
  */
 import * as blocks from '../registration';
 
-/* eslint-disable no-console */
 describe( 'blocks API', () => {
 	// Reset block state before each test.
 	beforeEach( () => {
@@ -25,34 +26,34 @@ describe( 'blocks API', () => {
 
 	describe( 'registerBlock', () => {
 		it( 'should reject numbers', () => {
-			const isRegistered = blocks.registerBlock( 999 );
+			const block = blocks.registerBlock( 999 );
 			expect( console.error ).to.have.been.calledWith( 'Block slugs must be strings.' );
-			expect( isRegistered ).to.eql( false );
+			expect( block ).to.be.undefined();
 		} );
 
 		it( 'should reject blocks without a namespace', () => {
-			const isRegistered = blocks.registerBlock( 'doing-it-wrong' );
+			const block = blocks.registerBlock( 'doing-it-wrong' );
 			expect( console.error ).to.have.been.calledWith( 'Block slugs must contain a namespace prefix. Example: my-plugin/my-custom-block' );
-			expect( isRegistered ).to.eql( false );
+			expect( block ).to.be.undefined();
 		} );
 
 		it( 'should reject blocks with invalid characters', () => {
-			const isRegistered = blocks.registerBlock( 'still/_doing_it_wrong' );
+			const block = blocks.registerBlock( 'still/_doing_it_wrong' );
 			expect( console.error ).to.have.been.calledWith( 'Block slugs must contain a namespace prefix. Example: my-plugin/my-custom-block' );
-			expect( isRegistered ).to.eql( false );
+			expect( block ).to.be.undefined();
 		} );
 
 		it( 'should accept valid block names', () => {
-			const isRegistered = blocks.registerBlock( 'my-plugin/fancy-block-4' );
+			const block = blocks.registerBlock( 'my-plugin/fancy-block-4' );
 			expect( console.error ).to.not.have.been.called();
-			expect( isRegistered ).to.eql( true );
+			expect( block ).to.eql( { slug: 'my-plugin/fancy-block-4' } );
 		} );
 
 		it( 'should prohibit registering the same block twice', () => {
 			blocks.registerBlock( 'core/test-block' );
-			const isRegistered = blocks.registerBlock( 'core/test-block' );
+			const block = blocks.registerBlock( 'core/test-block' );
 			expect( console.error ).to.have.been.calledWith( 'Block "core/test-block" is already registered.' );
-			expect( isRegistered ).to.eql( false );
+			expect( block ).to.be.undefined();
 		} );
 
 		it( 'should store a copy of block settings', () => {

--- a/modules/blocks/test/registration.js
+++ b/modules/blocks/test/registration.js
@@ -69,9 +69,9 @@ describe( 'blocks API', () => {
 
 	describe( 'unregisterBlock', () => {
 		it( 'should fail if a block is not registered', () => {
-			expect(
-				() => blocks.unregisterBlock( 'core/test-block' )
-			).to.throw( 'Block "core/test-block" is not registered.' );
+			const oldBlock = blocks.unregisterBlock( 'core/test-block' );
+			expect( console.error ).to.have.been.calledWith( 'Block "core/test-block" is not registered.' );
+			expect( oldBlock ).to.be.undefined();
 		} );
 
 		it( 'should unregister existing blocks', () => {
@@ -79,7 +79,9 @@ describe( 'blocks API', () => {
 			expect( blocks.getBlocks() ).to.eql( [
 				{ slug: 'core/test-block' },
 			] );
-			blocks.unregisterBlock( 'core/test-block' );
+			const oldBlock = blocks.unregisterBlock( 'core/test-block' );
+			expect( console.error ).to.not.have.been.called();
+			expect( oldBlock ).to.eql( { slug: 'core/test-block' } );
 			expect( blocks.getBlocks() ).to.eql( [] );
 		} );
 	} );

--- a/modules/blocks/test/registration.js
+++ b/modules/blocks/test/registration.js
@@ -17,7 +17,7 @@ describe( 'blocks API', () => {
 		blocks.getBlocks().forEach( block => {
 			blocks.unregisterBlock( block.slug );
 		} );
-		sinon.spy( console, 'error' );
+		sinon.stub( console, 'error' );
 	} );
 
 	afterEach( () => {

--- a/modules/blocks/test/registration.js
+++ b/modules/blocks/test/registration.js
@@ -2,50 +2,57 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
 import * as blocks from '../registration';
 
+/* eslint-disable no-console */
 describe( 'blocks API', () => {
 	// Reset block state before each test.
 	beforeEach( () => {
 		blocks.getBlocks().forEach( block => {
 			blocks.unregisterBlock( block.slug );
 		} );
+		sinon.spy( console, 'error' );
+	} );
+
+	afterEach( () => {
+		console.error.restore();
 	} );
 
 	describe( 'registerBlock', () => {
 		it( 'should reject numbers', () => {
-			expect(
-				() => blocks.registerBlock( 999 )
-			).to.throw( 'Block slugs must be strings.' );
+			const isRegistered = blocks.registerBlock( 999 );
+			expect( console.error ).to.have.been.calledWith( 'Block slugs must be strings.' );
+			expect( isRegistered ).to.eql( false );
 		} );
 
 		it( 'should reject blocks without a namespace', () => {
-			expect(
-				() => blocks.registerBlock( 'doing-it-wrong' )
-			).to.throw( /^Block slugs must contain a namespace prefix/ );
+			const isRegistered = blocks.registerBlock( 'doing-it-wrong' );
+			expect( console.error ).to.have.been.calledWith( 'Block slugs must contain a namespace prefix. Example: my-plugin/my-custom-block' );
+			expect( isRegistered ).to.eql( false );
 		} );
 
 		it( 'should reject blocks with invalid characters', () => {
-			expect(
-				() => blocks.registerBlock( 'still/_doing_it_wrong' )
-			).to.throw( /^Block slugs must contain a namespace prefix/ );
+			const isRegistered = blocks.registerBlock( 'still/_doing_it_wrong' );
+			expect( console.error ).to.have.been.calledWith( 'Block slugs must contain a namespace prefix. Example: my-plugin/my-custom-block' );
+			expect( isRegistered ).to.eql( false );
 		} );
 
 		it( 'should accept valid block names', () => {
-			expect(
-				() => blocks.registerBlock( 'my-plugin/fancy-block-4' )
-			).not.to.throw();
+			const isRegistered = blocks.registerBlock( 'my-plugin/fancy-block-4' );
+			expect( console.error ).to.not.have.been.called();
+			expect( isRegistered ).to.eql( true );
 		} );
 
 		it( 'should prohibit registering the same block twice', () => {
 			blocks.registerBlock( 'core/test-block' );
-			expect(
-				() => blocks.registerBlock( 'core/test-block' )
-			).to.throw( 'Block "core/test-block" is already registered.' );
+			const isRegistered = blocks.registerBlock( 'core/test-block' );
+			expect( console.error ).to.have.been.calledWith( 'Block "core/test-block" is already registered.' );
+			expect( isRegistered ).to.eql( false );
 		} );
 
 		it( 'should store a copy of block settings', () => {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "postcss-loader": "^1.3.3",
     "raw-loader": "^0.5.1",
     "sass-loader": "^6.0.3",
+    "sinon": "^2.1.0",
+    "sinon-chai": "^2.9.0",
     "style-loader": "^0.14.1",
     "webpack": "^2.2.1"
   }


### PR DESCRIPTION
In this PR, I'm updating `registerBlock` to avoid throwing errors and `console.error` instead. This prevents the editor from failing if a plugin tries to register a wrong block.