### PR TITLE
Adding back the `package.json` for the docs folder

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gutenberg",
+  "version": "1.0.0",
+  "description": "Prototyping a new WordPress editor experience",
+  "main": "index.html",
+  "scripts": {
+    "start": "http-server -p 5000"
+  },
+  "devDependencies": {
+    "http-server": "0.9.0"
+  }
+}


### PR DESCRIPTION
This should make `npm start` script work properly from the `docs` folder