### PR TITLE
Improve TinyMCE link boundary visuals

### DIFF
--- a/docs/tinymce/style.css
+++ b/docs/tinymce/style.css
@@ -25,11 +25,12 @@ body {
 
 body #editor a {
 	color: #009fd4;
-	padding: 0 2px;
 }
 
 a[data-mce-selected] {
+	padding: 0 2px;
+	margin: 0 -2px;
 	background: #dcf2f8;
-	border-radius: 1px;
+	border-radius: 2px;
 	box-shadow: 0 0 0 1px #dcf2f8;
 }

--- a/docs/tinymce/style.css
+++ b/docs/tinymce/style.css
@@ -37,12 +37,13 @@ em[data-mce-selected] {
 }
 
 code {
-	color: #00924b;
+	color: #222;
+	background: #f8f9f9;
 	font-family: Menlo, Monaco, Andale Mono, Courier New, monospace;
 	font-size: 14px;
 	padding: 2px 4px;
 	border-radius: 2px;
 }
 code[data-mce-selected] {
-	background: #e8f0ec;
+	background: #eef0f0;
 }

--- a/docs/tinymce/style.css
+++ b/docs/tinymce/style.css
@@ -28,11 +28,21 @@ body #editor a {
 }
 
 a[data-mce-selected],
-em[data-mce-selected],
-code[data-mce-selected] {
+em[data-mce-selected] {
 	padding: 0 2px;
 	margin: 0 -2px;
 	background: #dcf2f8;
 	border-radius: 2px;
 	box-shadow: 0 0 0 1px #dcf2f8;
+}
+
+code {
+	color: #00924b;
+	font-family: Menlo, Monaco, Andale Mono, Courier New, monospace;
+	font-size: 14px;
+	padding: 2px 4px;
+	border-radius: 2px;
+}
+code[data-mce-selected] {
+	background: #e8f0ec;
 }

--- a/docs/tinymce/style.css
+++ b/docs/tinymce/style.css
@@ -27,7 +27,9 @@ body #editor a {
 	color: #009fd4;
 }
 
-a[data-mce-selected] {
+a[data-mce-selected],
+em[data-mce-selected],
+code[data-mce-selected] {
 	padding: 0 2px;
 	margin: 0 -2px;
 	background: #dcf2f8;

--- a/docs/tinymce/style.css
+++ b/docs/tinymce/style.css
@@ -45,5 +45,5 @@ code {
 	border-radius: 2px;
 }
 code[data-mce-selected] {
-	background: #eef0f0;
+	background: #e9ebec;
 }


### PR DESCRIPTION
This PR adds a little CSS polish to link boundaries:

- The padding for the link now doesn't make it wider through negative margin tricks
- Code and em have been added, even though em doesn't have the feature yet

I can't tell you folks how much I love this feature. Check out this video:

https://cloudup.com/cKfxO3jDBbP

It's SOLID! 👏👏👏👏👏

Props @spocke and @Afraithe 