### PR TITLE
Explicitly target entry modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,10 +22,10 @@ const BASE_PATH = './modules';
  *
  * @type {Object}
  */
-const entry = glob.sync( `${ BASE_PATH }/*/index.js` ).reduce( ( memo, filename ) => {
-	const parent = path.relative( BASE_PATH, path.dirname( filename ) );
-	memo[ parent ] = filename;
-	return memo;
+const entry = [ 'blocks', 'editor', 'element' ].reduce( ( memo, submodule ) => {
+	return Object.assign( memo, {
+		[ submodule ]: [ BASE_PATH, submodule, 'index.js' ].join( '/' )
+	} );
 }, {} );
 
 const config = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,10 @@ const config = {
 			},
 			{
 				test: /\.js$/,
-				exclude: /node_modules/,
+				include: [
+					__dirname + '/modules',
+					__dirname + '/node_modules/hpq'
+				],
 				use: 'babel-loader'
 			},
 			{


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/307#issuecomment-288897341

This pull request...

- Targets entry files explicitly
- Include `hpq` in Babel loader consideration (since it defines `module` of package)

To the latter point, curious if we can avoid explicitly including files to be processed by Babel but instead allow them to be automatically detected. Maybe for a future pull request, as at least the changes here avoid any errors when running `npm run build`.