### PR TITLE
Style: Set the editor background to white

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -1,7 +1,10 @@
 @import '../../inserter/style';
 
-.gutenberg {
+body.toplevel_page_gutenberg {
 	background: #fff;
+}
+
+.gutenberg {
 	margin: -20px 0 0 -20px;
 	padding: 60px;
 


### PR DESCRIPTION
This tiny PR sets to the wholte gutenberg page's background to white.

*Before*
<img width="971" alt="screen shot 2017-03-27 at 10 19 11" src="https://cloud.githubusercontent.com/assets/272444/24349629/90bb1a3a-12d7-11e7-93cc-3cdc8a12df2e.png">

*After*
<img width="969" alt="screen shot 2017-03-27 at 10 19 42" src="https://cloud.githubusercontent.com/assets/272444/24349644/9c195df6-12d7-11e7-9fea-8cac14bf79bb.png">

Maybe we should update the notifications CSS for this page too.
