### PR TITLE
Change 'wp/' namespace to 'core/'

### DIFF
--- a/editor/blocks/text-block/index.js
+++ b/editor/blocks/text-block/index.js
@@ -1,7 +1,7 @@
 const { query, html } = wp.blocks.query;
 const Editable = wp.blocks.Editable;
 
-wp.blocks.registerBlock( 'wp/text', {
+wp.blocks.registerBlock( 'core/text', {
 	title: 'Text',
 	icon: 'text',
 

--- a/post-content.js
+++ b/post-content.js
@@ -1,33 +1,33 @@
 window.content = [
-	'<!-- wp:wp/heading -->',
+	'<!-- wp:core/heading -->',
 	'<h1>1.0 Is The Loneliest Number</h1>',
-	'<!-- /wp:wp/heading -->',
+	'<!-- /wp:core/heading -->',
 
-	'<!-- wp:wp/text -->',
+	'<!-- wp:core/text -->',
 	'<p>I imagine prior to the launch of the iPod, or the iPhone, there were teams saying the same thing: the copy + paste guys are <em>so close</em> to being ready and we know Walt Mossberg is going to ding us for this so let\'s just not ship to the manufacturers in China for just a few more weeks… The Apple teams were probably embarrassed. But <strong>if you\'re not embarrassed when you ship your first version you waited too long</strong>.</p>',
-	'<!-- /wp:wp/text -->',
+	'<!-- /wp:core/text -->',
 
-	'<!-- wp:wp/image -->',
+	'<!-- wp:core/image -->',
 	'<figure><img src="https://cldup.com/Bc9YxmqFnJ.jpg" /></figure>',
-	'<!-- /wp:wp/image -->',
+	'<!-- /wp:core/image -->',
 
-	'<!-- wp:wp/text -->',
+	'<!-- wp:core/text -->',
 	'<p>A beautiful thing about Apple is how quickly they obsolete their own products. I imagine this also makes the discipline of getting things out there easier. Like I mentioned before, the longer it’s been since the last release the more pressure there is, but if you know that if your bit of code doesn’t make this version but there’s the +0.1 coming out in 6 weeks, then it’s not that bad. It’s like flights from San Francisco to LA, if you miss one you know there’s another one an hour later so it’s not a big deal. Amazon has done a fantastic job of this with the Kindle as well, with a new model every year.</p>',
-	'<!-- /wp:wp/text -->',
+	'<!-- /wp:core/text -->',
 
-	'<!-- wp:wp/quote -->',
+	'<!-- wp:core/quote -->',
 	'<blockquote><p>Real artists ship.</p><footer><p><a href="http://www.folklore.org/StoryView.py?story=Real_Artists_Ship.txt">Steve Jobs, 1983</a></p></footer></blockquote>',
-	'<!-- /wp:wp/quote -->',
+	'<!-- /wp:core/quote -->',
 
-	'<!-- wp:wp/image -->',
+	'<!-- wp:core/image -->',
 	'<figure><img src="https://cldup.com/vuGcj2VB8M.jpg" /><figcaption>Beautiful landscape</figcaption></figure>',
-	'<!-- /wp:wp/image -->',
+	'<!-- /wp:core/image -->',
 
-	'<!-- wp:wp/text -->',
+	'<!-- wp:core/text -->',
 	'<p>By shipping early and often you have the unique competitive advantage of hearing from real people what they think of your work, which in best case helps you anticipate market direction, and in worst case gives you a few people rooting for you that you can email when your team pivots to a new idea. Nothing can recreate the crucible of real usage.</p>',
-	'<!-- /wp:wp/text -->',
+	'<!-- /wp:core/text -->',
 
-	'<!-- wp:wp/embed url:https://www.youtube.com/watch?v=Nl6U7UotA-M -->',
+	'<!-- wp:core/embed url:https://www.youtube.com/watch?v=Nl6U7UotA-M -->',
 	'<iframe width="560" height="315" src="//www.youtube.com/embed/Nl6U7UotA-M" frameborder="0" allowfullscreen></iframe>',
-	'<!-- /wp:wp/embed -->'
+	'<!-- /wp:core/embed -->'
 ].join( '' );


### PR DESCRIPTION
This PR changes the namespace for built-in blocks from `wp/` to `core/`.  I think the delimiter tags look nicer this way:

```diff
- <!-- wp:wp/text -->
+ <!-- wp:core/text ->
```