### PR TITLE
Render generic fallback block for unknown block type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,8 @@
 		"one-var": "off",
 		"padded-blocks": [ "error", "never" ],
 		"quote-props": [ "error", "as-needed", { "keywords": true } ],
+		"react/prop-types": "off",
+		"react/display-name": "off",
 		"semi": "error",
 		"semi-spacing": "error",
 		"space-before-blocks": [ "error", "always" ],
@@ -74,7 +76,6 @@
 				"!": true
 			}
 		} ],
-		"valid-jsdoc": [ "error", { "requireReturn": false } ],
-		"react/prop-types": "off"
+		"valid-jsdoc": [ "error", { "requireReturn": false } ]
 	}
 }

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -7,4 +7,11 @@ export { query };
 export { default as Editable } from './components/editable';
 export { default as parse } from './parser';
 export { getCategories } from './categories';
-export { registerBlock, unregisterBlock, getBlockSettings, getBlocks } from './registration';
+export {
+	registerBlock,
+	unregisterBlock,
+	setUnknownTypeHandler,
+	getUnknownTypeHandler,
+	getBlockSettings,
+	getBlocks
+} from './registration';

--- a/blocks/parser.js
+++ b/blocks/parser.js
@@ -12,19 +12,21 @@ import { getBlockSettings } from './registration';
 /**
  * Returns the block attributes of a registered block node given its settings.
  *
- * @param  {Object}   blockNode     Parsed block node
- * @param  {Object}   blockSettings Block settings
- * @return {Object}                 Block state, or undefined if type unknown
+ * @param  {Object} blockNode     Parsed block node
+ * @param  {Object} blockSettings Block settings
+ * @return {Object}               Block attributes
  */
 export function getBlockAttributes( blockNode, blockSettings ) {
 	const { rawContent } = blockNode;
 
 	// Merge attributes from parse with block implementation
 	let { attrs } = blockNode;
-	if ( 'function' === typeof blockSettings.attributes ) {
-		attrs = { ...attrs, ...blockSettings.attributes( rawContent ) };
-	} else if ( blockSettings.attributes ) {
-		attrs = { ...attrs, ...query.parse( rawContent, blockSettings.attributes ) };
+	if ( blockSettings ) {
+		if ( 'function' === typeof blockSettings.attributes ) {
+			attrs = { ...attrs, ...blockSettings.attributes( rawContent ) };
+		} else if ( blockSettings.attributes ) {
+			attrs = { ...attrs, ...query.parse( rawContent, blockSettings.attributes ) };
+		}
 	}
 
 	return attrs;
@@ -37,16 +39,14 @@ export function getBlockAttributes( blockNode, blockSettings ) {
  * @return {Array}          Block list
  */
 export default function parse( content ) {
-	return grammarParse( content ).reduce( ( memo, blockNode ) => {
+	return grammarParse( content ).map( ( blockNode ) => {
 		const settings = getBlockSettings( blockNode.blockType );
+		const { blockType, rawContent } = blockNode;
 
-		if ( settings ) {
-			memo.push( {
-				blockType: blockNode.blockType,
-				attributes: getBlockAttributes( blockNode, settings )
-			} );
-		}
-
-		return memo;
-	}, [] );
+		return {
+			blockType,
+			rawContent,
+			attributes: getBlockAttributes( blockNode, settings )
+		};
+	} );
 }

--- a/blocks/post.pegjs
+++ b/blocks/post.pegjs
@@ -20,7 +20,6 @@ WP_Block_Html
   = ts:(!WP_Block_Balanced c:Any { return c })+
   {
     return {
-      blockType: 'html',
       attrs: {},
       rawContent: ts.join( '' )
     }

--- a/blocks/registration.js
+++ b/blocks/registration.js
@@ -77,9 +77,10 @@ export function setUnknownTypeHandler( slug ) {
 }
 
 /**
- * Retrieves slug of block handling unknown block types.
+ * Retrieves slug of block handling unknown block types, or undefined if no
+ * handler has been defined.
  *
- * @return {string} Blog slug
+ * @return {?string} Blog slug
  */
 export function getUnknownTypeHandler() {
 	return unknownTypeHandler;

--- a/blocks/registration.js
+++ b/blocks/registration.js
@@ -3,9 +3,16 @@
 /**
  * Block settings keyed by block slug.
  *
- * @var {Object} blocks
+ * @type {Object}
  */
 const blocks = {};
+
+/**
+ * Slug of block handling unknown types.
+ *
+ * @type {?string}
+ */
+let unknownTypeHandler;
 
 /**
  * Registers a new block provided a unique slug and an object defining its
@@ -58,6 +65,24 @@ export function unregisterBlock( slug ) {
 	const oldBlock = blocks[ slug ];
 	delete blocks[ slug ];
 	return oldBlock;
+}
+
+/**
+ * Assigns slug of block handling unknown block types.
+ *
+ * @param {string} slug Block slug
+ */
+export function setUnknownTypeHandler( slug ) {
+	unknownTypeHandler = slug;
+}
+
+/**
+ * Retrieves slug of block handling unknown block types.
+ *
+ * @return {string} Blog slug
+ */
+export function getUnknownTypeHandler() {
+	return unknownTypeHandler;
 }
 
 /**

--- a/blocks/test/parser.js
+++ b/blocks/test/parser.js
@@ -50,12 +50,31 @@ describe( 'block parser', () => {
 
 			const blockNode = {
 				blockType: 'core/test-block',
-				attrs: {},
+				attrs: {
+					align: 'left'
+				},
 				rawContent: '<span>Ribs <strong>& Chicken</strong></span>'
 			};
 
 			expect( getBlockAttributes( blockNode, blockSettings ) ).to.eql( {
+				align: 'left',
 				emphasis: '& Chicken'
+			} );
+		} );
+
+		it( 'should return parsed attributes for block without attributes defined', () => {
+			const blockSettings = {};
+
+			const blockNode = {
+				blockType: 'core/test-block',
+				attrs: {
+					align: 'left'
+				},
+				rawContent: '<span>Ribs <strong>& Chicken</strong></span>'
+			};
+
+			expect( getBlockAttributes( blockNode, blockSettings ) ).to.eql( {
+				align: 'left'
 			} );
 		} );
 	} );

--- a/blocks/test/parser.js
+++ b/blocks/test/parser.js
@@ -90,11 +90,13 @@ describe( 'block parser', () => {
 				}
 			} );
 
-			const postContent = '<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
+			const parsed = parse(
+				'<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
 				'<p>Broccoli</p>' +
-				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->';
+				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->'
+			);
 
-			expect( parse( postContent ) ).to.eql( [ {
+			expect( parsed ).to.eql( [ {
 				blockType: 'core/test-block',
 				attributes: {
 					content: 'Ribs & Chicken'
@@ -109,11 +111,18 @@ describe( 'block parser', () => {
 
 			setUnknownTypeHandler( 'core/unknown-block' );
 
-			const postContent = '<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
+			const parsed = parse(
+				'<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
 				'<p>Broccoli</p>' +
-				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->';
+				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->'
+			);
 
-			expect( parse( postContent ) ).to.have.lengthOf( 3 );
+			expect( parsed ).to.have.lengthOf( 3 );
+			expect( parsed.map( ( { blockType } ) => blockType ) ).to.eql( [
+				'core/test-block',
+				'core/unknown-block',
+				'core/unknown-block'
+			] );
 		} );
 	} );
 } );

--- a/blocks/test/parser.js
+++ b/blocks/test/parser.js
@@ -80,7 +80,7 @@ describe( 'block parser', () => {
 	} );
 
 	describe( 'parse()', () => {
-		it( 'should parse the post content properly and ignore unknown blocks', () => {
+		it( 'should parse the post content properly', () => {
 			const blockSettings = {
 				attributes: function( rawContent ) {
 					return {
@@ -93,12 +93,20 @@ describe( 'block parser', () => {
 			const postContent = '<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
 				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->';
 
-			expect( parse( postContent ) ).to.eql( [ {
-				blockType: 'core/test-block',
-				attributes: {
-					content: 'Ribs & Chicken'
+			expect( parse( postContent ) ).to.eql( [
+				{
+					blockType: 'core/test-block',
+					attributes: {
+						content: 'Ribs & Chicken'
+					},
+					rawContent: 'Ribs'
+				},
+				{
+					blockType: 'core/unknown-block',
+					attributes: {},
+					rawContent: 'Ribs'
 				}
-			} ] );
+			] );
 		} );
 	} );
 } );

--- a/blocks/test/registration.js
+++ b/blocks/test/registration.js
@@ -9,18 +9,26 @@ import sinon from 'sinon';
 /**
  * Internal dependencies
  */
-import { getBlocks, unregisterBlock, registerBlock, getBlockSettings } from '../registration';
+import {
+	registerBlock,
+	unregisterBlock,
+	setUnknownTypeHandler,
+	getUnknownTypeHandler,
+	getBlockSettings,
+	getBlocks
+} from '../registration';
 
 describe( 'blocks', () => {
 	// Reset block state before each test.
 	beforeEach( () => {
-		getBlocks().forEach( block => {
-			unregisterBlock( block.slug );
-		} );
 		sinon.stub( console, 'error' );
 	} );
 
 	afterEach( () => {
+		getBlocks().forEach( block => {
+			unregisterBlock( block.slug );
+		} );
+		setUnknownTypeHandler( undefined );
 		console.error.restore();
 	} );
 
@@ -83,6 +91,20 @@ describe( 'blocks', () => {
 			expect( console.error ).to.not.have.been.called();
 			expect( oldBlock ).to.eql( { slug: 'core/test-block' } );
 			expect( getBlocks() ).to.eql( [] );
+		} );
+	} );
+
+	describe( 'setUnknownTypeHandler()', () => {
+		it( 'assigns unknown type handler', () => {
+			setUnknownTypeHandler( 'core/test-block' );
+
+			expect( getUnknownTypeHandler() ).to.equal( 'core/test-block' );
+		} );
+	} );
+
+	describe( 'getUnknownTypeHandler()', () => {
+		it( 'defaults to undefined', () => {
+			expect( getUnknownTypeHandler() ).to.be.undefined();
 		} );
 	} );
 

--- a/editor/blocks/freeform/index.js
+++ b/editor/blocks/freeform/index.js
@@ -1,0 +1,23 @@
+const { html } = wp.blocks.query;
+
+wp.blocks.registerBlock( 'core/freeform', {
+	title: 'Freeform',
+
+	icon: 'text',
+
+	category: 'common',
+
+	attributes: {
+		html: html()
+	},
+
+	edit( { attributes } ) {
+		return <div contentEditable>{ attributes.html }</div>;
+	},
+
+	save( { attributes } ) {
+		return attributes.html;
+	}
+} );
+
+wp.blocks.setUnknownTypeHandler( 'core/freeform' );

--- a/editor/blocks/index.js
+++ b/editor/blocks/index.js
@@ -1,1 +1,2 @@
+import './freeform';
 import './text';

--- a/editor/blocks/text/index.js
+++ b/editor/blocks/text/index.js
@@ -10,7 +10,7 @@ wp.blocks.registerBlock( 'core/text', {
 		value: html()
 	},
 
-	edit( attributes, onChange ) {
+	edit( { attributes, onChange } ) {
 		return (
 			<Editable
 				value={ attributes.value }
@@ -19,7 +19,7 @@ wp.blocks.registerBlock( 'core/text', {
 		);
 	},
 
-	save( attributes ) {
+	save( { attributes } ) {
 		return <p>{ attributes.value }</p>;
 	}
 } );

--- a/editor/editor/mode/visual.js
+++ b/editor/editor/mode/visual.js
@@ -20,11 +20,16 @@ function Blocks( { blocks, onChange } ) {
 	return (
 		<div className="editor-mode-visual">
 			<div>
-				{ blocks.map( ( block, index ) =>
-					<div key={ index }>
-						{ wp.blocks.getBlockSettings( block.blockType ).edit( block.attributes, onChangeBlock( index ) ) }
-					</div>
-				) }
+				{ blocks.map( ( block, index ) => {
+					const settings = wp.blocks.getBlockSettings( block.blockType );
+
+					return (
+						<settings.edit
+							key={ index }
+							attributes={ block.attributes }
+							onChange={ onChangeBlock( index ) } />
+					);
+				} ) }
 			</div>
 			<InserterButton />
 		</div>

--- a/editor/editor/mode/visual.js
+++ b/editor/editor/mode/visual.js
@@ -19,27 +19,25 @@ function Blocks( { blocks, onChange } ) {
 
 	return (
 		<div className="editor-mode-visual">
-			<div>
-				{ blocks.map( ( block, index ) => {
-					const settings = wp.blocks.getBlockSettings( block.blockType );
+			{ blocks.map( ( block, index ) => {
+				const settings = wp.blocks.getBlockSettings( block.blockType );
 
-					let Edit;
-					if ( settings ) {
-						Edit = settings.edit || settings.save;
-					}
+				let BlockEdit;
+				if ( settings ) {
+					BlockEdit = settings.edit || settings.save;
+				}
 
-					if ( ! Edit ) {
-						Edit = () => <div dangerouslySetInnerHTML={ { __html: block.rawContent } } />;
-					}
+				if ( ! BlockEdit ) {
+					return;
+				}
 
-					return (
-						<Edit
-							key={ index }
-							attributes={ block.attributes }
-							onChange={ onChangeBlock( index ) } />
-					);
-				} ) }
-			</div>
+				return (
+					<BlockEdit
+						key={ index }
+						attributes={ block.attributes }
+						onChange={ onChangeBlock( index ) } />
+				);
+			} ) }
 			<InserterButton />
 		</div>
 	);

--- a/editor/editor/mode/visual.js
+++ b/editor/editor/mode/visual.js
@@ -23,8 +23,17 @@ function Blocks( { blocks, onChange } ) {
 				{ blocks.map( ( block, index ) => {
 					const settings = wp.blocks.getBlockSettings( block.blockType );
 
+					let Edit;
+					if ( settings ) {
+						Edit = settings.edit || settings.save;
+					}
+
+					if ( ! Edit ) {
+						Edit = () => <div dangerouslySetInnerHTML={ { __html: block.rawContent } } />;
+					}
+
 					return (
-						<settings.edit
+						<Edit
 							key={ index }
 							attributes={ block.attributes }
 							onChange={ onChangeBlock( index ) } />


### PR DESCRIPTION
This pull request seeks to start handling of blocks which cannot be associated with a known registered block type. The current implementation is very basic and unfinished; merely setting HTML of a `div` (dangerously) and displaying an overlay with messaging atop the rendered content.

![Unknown Block](https://cloud.githubusercontent.com/assets/1779930/24380342/c9c7bcf2-1318-11e7-9889-0fbbc7d00ed6.png)

Caveats:

- Again, this is temporary / WIP. I highly doubt we'd want "Unknown Block" messaging shown atop the block, but at least this gives a better sense that those blocks were detected by the parser.

Open questions:

- How do we expect these sorts of blocks to behave from a UX perspective? (cc @jasmussen)
- Is a "generic" block a good approach as the fallback?
- Does it make sense to expose `isVisible` as an option to blocks? In this case it was something of an internal flag to prevent the generic block being made available as an option in the inserter, but I could potentially see this being useful for other cases (discontinuing blocks) and aligns reasonably well to `isVisible` control behavior.

Implementation notes:

- Moved parser logic back into base `blocks/index.js` . Primarily to enable attribute parsing to wait until block has been determined. The fallback logic occurs in the `Editor` class, not in the parsing, since the block parser should not be aware of this generic block type. (cc @youknowriad for thoughts)
- Now treating `settings.edit` as a component, which has a few nice advantages around avoiding wrapper elements and enabling the plugin author to define `edit` and `save` as `Component` classes (e.g. if needing to trigger network request upon mount)