### PR TITLE
Allow editing actual posts and pages

### DIFF
--- a/editor/editor/index.js
+++ b/editor/editor/index.js
@@ -4,15 +4,15 @@
 import EditorLayout from './layout';
 
 export default class Editor {
-	constructor( id, settings ) {
+	constructor( id, post ) {
 		this.id = id;
-		this.settings = settings;
+		this.post = post;
 		this.render();
 	}
 
 	render() {
 		wp.element.render(
-			<EditorLayout initialContent={ this.settings.content } />,
+			<EditorLayout initialContent={ this.post.content.raw } />,
 			document.getElementById( this.id )
 		);
 	}

--- a/index.php
+++ b/index.php
@@ -118,15 +118,9 @@ function gutenberg_scripts_and_styles( $hook ) {
 	wp_enqueue_script(
 		'wp-editor',
 		plugins_url( 'editor/build/index.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-element', 'gutenberg-content' ),
+		array( 'wp-blocks', 'wp-element' ),
 		false, // $ver
 		true   // $in_footer
-	);
-
-	// Temporary test content
-	wp_register_script(
-		'gutenberg-content',
-		plugins_url( 'post-content.js', __FILE__ )
 	);
 
 	// Load an actual post if an ID is specified
@@ -146,22 +140,20 @@ function gutenberg_scripts_and_styles( $hook ) {
 	// Initialize the post data...
 	if ( $post_to_edit ) {
 		// ...with a real post
-		wp_add_inline_script(
-			'wp-editor',
-			'wp.editor.post = ' . json_encode( $post_to_edit )
-		);
+		wp_localize_script( 'wp-editor', '_wpGutenbergPost', $post_to_edit );
 	} else {
 		// ...with some test content
+		// TODO: replace this with error handling
 		wp_add_inline_script(
 			'wp-editor',
-			'wp.editor.post = { content: { raw: window.content } };'
+			file_get_contents( plugin_dir_path( __FILE__ ) . 'post-content.js' )
 		);
 	}
 
 	// Initialize the editor
 	wp_add_inline_script(
 		'wp-editor',
-		'wp.editor.createEditorInstance( \'editor\', wp.editor.post );'
+		'wp.editor.createEditorInstance( \'editor\', _wpGutenbergPost );'
 	);
 
 	/**

--- a/index.php
+++ b/index.php
@@ -47,6 +47,56 @@ function gutenberg_register_scripts() {
 add_action( 'init', 'gutenberg_register_scripts' );
 
 /**
+ * Adds the filters to register additional links for the Gutenberg editor in
+ * the post/page screens.
+ *
+ * @since 0.1.0
+ */
+function gutenberg_add_edit_links_filters() {
+	// For hierarchical post types
+	add_filter( 'page_row_actions', 'gutenberg_add_edit_links', 10, 2 );
+	// For non-hierarchical post types
+	add_filter( 'post_row_actions', 'gutenberg_add_edit_links', 10, 2 );
+}
+add_action( 'admin_init', 'gutenberg_add_edit_links_filters' );
+
+/**
+ * Registers additional links in the post/page screens to edit any post/page in
+ * the Gutenberg editor.
+ *
+ * @since 0.1.0
+ */
+function gutenberg_add_edit_links( $actions, $post ) {
+	$can_edit_post = current_user_can( 'edit_post', $post->ID );
+	$title = _draft_or_post_title( $post->ID );
+
+	if ( $can_edit_post && 'trash' !== $post->post_status ) {
+		// Build the Gutenberg edit action.  See also:
+		// WP_Posts_List_Table::handle_row_actions()
+		$gutenberg_url = menu_page_url( 'gutenberg', false );
+		$gutenberg_action = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			add_query_arg( 'post_id', $post->ID, $gutenberg_url ),
+			esc_attr( sprintf(
+				/* translators: %s: post title */
+				__( 'Edit &#8220;%s&#8221; in the Gutenberg editor', 'gutenberg' ),
+				$title
+			) ),
+			__( 'Gutenberg', 'gutenberg' )
+		);
+		// Insert the Gutenberg action immediately after the Edit action.
+		$edit_offset = array_search( 'edit', array_keys( $actions ), true );
+		$actions = array_merge(
+			array_slice( $actions, 0, $edit_offset + 1 ),
+			array( 'gutenberg hide-if-no-js' => $gutenberg_action ),
+			array_slice( $actions, $edit_offset + 1 )
+		);
+	}
+
+	return $actions;
+}
+
+/**
  * Scripts & Styles.
  *
  * Enqueues the needed scripts and styles when visiting the top-level page of

--- a/post-content.js
+++ b/post-content.js
@@ -1,7 +1,7 @@
 /**
  * Temporary test post content
  */
-var _wpGutenbergPost = {
+window._wpGutenbergPost = {
 	content: {
 		raw: [
 			'<!-- wp:core/heading -->',

--- a/post-content.js
+++ b/post-content.js
@@ -1,33 +1,40 @@
-window.content = [
-	'<!-- wp:core/heading -->',
-	'<h1>1.0 Is The Loneliest Number</h1>',
-	'<!-- /wp:core/heading -->',
+/**
+ * Temporary test post content
+ */
+var _wpGutenbergPost = {
+	content: {
+		raw: [
+			'<!-- wp:core/heading -->',
+			'<h1>1.0 Is The Loneliest Number</h1>',
+			'<!-- /wp:core/heading -->',
 
-	'<!-- wp:core/text -->',
-	'<p>I imagine prior to the launch of the iPod, or the iPhone, there were teams saying the same thing: the copy + paste guys are <em>so close</em> to being ready and we know Walt Mossberg is going to ding us for this so let\'s just not ship to the manufacturers in China for just a few more weeks… The Apple teams were probably embarrassed. But <strong>if you\'re not embarrassed when you ship your first version you waited too long</strong>.</p>',
-	'<!-- /wp:core/text -->',
+			'<!-- wp:core/text -->',
+			'<p>I imagine prior to the launch of the iPod, or the iPhone, there were teams saying the same thing: the copy + paste guys are <em>so close</em> to being ready and we know Walt Mossberg is going to ding us for this so let\'s just not ship to the manufacturers in China for just a few more weeks… The Apple teams were probably embarrassed. But <strong>if you\'re not embarrassed when you ship your first version you waited too long</strong>.</p>',
+			'<!-- /wp:core/text -->',
 
-	'<!-- wp:core/image -->',
-	'<figure><img src="https://cldup.com/Bc9YxmqFnJ.jpg" /></figure>',
-	'<!-- /wp:core/image -->',
+			'<!-- wp:core/image -->',
+			'<figure><img src="https://cldup.com/Bc9YxmqFnJ.jpg" /></figure>',
+			'<!-- /wp:core/image -->',
 
-	'<!-- wp:core/text -->',
-	'<p>A beautiful thing about Apple is how quickly they obsolete their own products. I imagine this also makes the discipline of getting things out there easier. Like I mentioned before, the longer it’s been since the last release the more pressure there is, but if you know that if your bit of code doesn’t make this version but there’s the +0.1 coming out in 6 weeks, then it’s not that bad. It’s like flights from San Francisco to LA, if you miss one you know there’s another one an hour later so it’s not a big deal. Amazon has done a fantastic job of this with the Kindle as well, with a new model every year.</p>',
-	'<!-- /wp:core/text -->',
+			'<!-- wp:core/text -->',
+			'<p>A beautiful thing about Apple is how quickly they obsolete their own products. I imagine this also makes the discipline of getting things out there easier. Like I mentioned before, the longer it’s been since the last release the more pressure there is, but if you know that if your bit of code doesn’t make this version but there’s the +0.1 coming out in 6 weeks, then it’s not that bad. It’s like flights from San Francisco to LA, if you miss one you know there’s another one an hour later so it’s not a big deal. Amazon has done a fantastic job of this with the Kindle as well, with a new model every year.</p>',
+			'<!-- /wp:core/text -->',
 
-	'<!-- wp:core/quote -->',
-	'<blockquote><p>Real artists ship.</p><footer><p><a href="http://www.folklore.org/StoryView.py?story=Real_Artists_Ship.txt">Steve Jobs, 1983</a></p></footer></blockquote>',
-	'<!-- /wp:core/quote -->',
+			'<!-- wp:core/quote -->',
+			'<blockquote><p>Real artists ship.</p><footer><p><a href="http://www.folklore.org/StoryView.py?story=Real_Artists_Ship.txt">Steve Jobs, 1983</a></p></footer></blockquote>',
+			'<!-- /wp:core/quote -->',
 
-	'<!-- wp:core/image -->',
-	'<figure><img src="https://cldup.com/vuGcj2VB8M.jpg" /><figcaption>Beautiful landscape</figcaption></figure>',
-	'<!-- /wp:core/image -->',
+			'<!-- wp:core/image -->',
+			'<figure><img src="https://cldup.com/vuGcj2VB8M.jpg" /><figcaption>Beautiful landscape</figcaption></figure>',
+			'<!-- /wp:core/image -->',
 
-	'<!-- wp:core/text -->',
-	'<p>By shipping early and often you have the unique competitive advantage of hearing from real people what they think of your work, which in best case helps you anticipate market direction, and in worst case gives you a few people rooting for you that you can email when your team pivots to a new idea. Nothing can recreate the crucible of real usage.</p>',
-	'<!-- /wp:core/text -->',
+			'<!-- wp:core/text -->',
+			'<p>By shipping early and often you have the unique competitive advantage of hearing from real people what they think of your work, which in best case helps you anticipate market direction, and in worst case gives you a few people rooting for you that you can email when your team pivots to a new idea. Nothing can recreate the crucible of real usage.</p>',
+			'<!-- /wp:core/text -->',
 
-	'<!-- wp:core/embed url:https://www.youtube.com/watch?v=Nl6U7UotA-M -->',
-	'<iframe width="560" height="315" src="//www.youtube.com/embed/Nl6U7UotA-M" frameborder="0" allowfullscreen></iframe>',
-	'<!-- /wp:core/embed -->'
-].join( '' );
+			'<!-- wp:core/embed url:https://www.youtube.com/watch?v=Nl6U7UotA-M -->',
+			'<iframe width="560" height="315" src="//www.youtube.com/embed/Nl6U7UotA-M" frameborder="0" allowfullscreen></iframe>',
+			'<!-- /wp:core/embed -->',
+		].join( '' ),
+	},
+};


### PR DESCRIPTION
This PR builds the initial flow for editing actual posts and pages in the Gutenberg editor.  Until the editor is further along, the link to Gutenberg is an additional link on the posts/pages screens rather than a replacement for the default editor:

<img src="https://cloud.githubusercontent.com/assets/227022/24510045/6ee5c72a-153e-11e7-8d1f-3bcf76ce22f9.png" width="380">

Much like the built-in "Quick Edit" link, this link is hidden if JavaScript is disabled.

The PR works as follows:

- Restructure the editor initialization code to accept a post object in the format returned by the WP REST API, with the expectation that we will use this API to build out the editor.
- If a `?post_id=X` value is set, perform an internal (server-side) WP REST API request to load the post with id `X`.  If that succeeds, pass this data to the editor; otherwise use the current "dummy" post content.
- Add links to the Edit screens for all post types to edit posts/pages in the Gutenberg editor, using the new `post_id` parameter.

This works well in my testing; however, in order to see post content in the editor, you will currently need to make sure that your post content has some block comment delimiters.  For example:

```html
<!-- wp:core/text -->
Welcome to WordPress. This is your first post. Edit or delete it, then start writing!
<!-- /wp:core/text -->
```

Result:

![2017-03-30t07 50 19-0700](https://cloud.githubusercontent.com/assets/227022/24510227/ff6e5b68-153e-11e7-9d6b-908880f21a56.png)
