### PR TITLE
Remove the PHP `register_block` function

### DIFF
--- a/index.php
+++ b/index.php
@@ -85,15 +85,3 @@ function the_gutenberg_project() {
 	</div>
 	<?php
 }
-
-/**
- * Registers a block.
- *
- * @param  string $name Block name including namespace.
- * @param  array  $args Optional. Array of settings for the block. Default
- *                      empty array.
- * @return bool         True on success, false on error.
- */
-function register_block( $name, $args = array() ) {
-	// Not implemented yet.
-}


### PR DESCRIPTION
As far as I can tell, we are going to do this in JavaScript only, at least for now.  Let's not duplicate functionality unless we have to.