### PR TITLE
UI: Adding the selected and hover state for the visual editor

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
-function VisualEditorBlock( { block, onChange } ) {
+function VisualEditorBlock( { block, onChange, onFocus, onBlur, isSelected } ) {
 	const settings = wp.blocks.getBlockSettings( block.blockType );
 
 	let BlockEdit;
@@ -24,16 +25,28 @@ function VisualEditorBlock( { block, onChange } ) {
 		} );
 	}
 
+	const className = classnames( 'editor-visual-editor__block', {
+		'is-selected': isSelected
+	} );
+
 	return (
-		<BlockEdit
-			attributes={ block.attributes }
-			onChange={ onAttributesChange } />
+		<div
+			tabIndex="0"
+			onFocus={ onFocus }
+			onBlur={ onBlur }
+			className={ className }
+		>
+			<BlockEdit
+				attributes={ block.attributes }
+				onChange={ onAttributesChange } />
+		</div>
 	);
 }
 
 export default connect(
 	( state, ownProps ) => ( {
-		block: state.blocks.byUid[ ownProps.uid ]
+		block: state.blocks.byUid[ ownProps.uid ],
+		isSelected: ownProps.uid === state.selectedBlockUid
 	} ),
 	( dispatch, ownProps ) => ( {
 		onChange( updates ) {
@@ -41,6 +54,17 @@ export default connect(
 				type: 'UPDATE_BLOCK',
 				uid: ownProps.uid,
 				updates
+			} );
+		},
+		onFocus() {
+			dispatch( {
+				type: 'SELECT_BLOCK',
+				uid: ownProps.uid
+			} );
+		},
+		onBlur() {
+			dispatch( {
+				type: 'CLEAR_SELECTED_BLOCK'
 			} );
 		}
 	} )

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -4,7 +4,8 @@
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 
-function VisualEditorBlock( { block, onChange, onFocus, onBlur, isSelected } ) {
+function VisualEditorBlock( props ) {
+	const { block } = props;
 	const settings = wp.blocks.getBlockSettings( block.blockType );
 
 	let BlockEdit;
@@ -17,7 +18,7 @@ function VisualEditorBlock( { block, onChange, onFocus, onBlur, isSelected } ) {
 	}
 
 	function onAttributesChange( attributes ) {
-		onChange( {
+		props.onChange( {
 			attributes: {
 				...block.attributes,
 				...attributes
@@ -25,15 +26,26 @@ function VisualEditorBlock( { block, onChange, onFocus, onBlur, isSelected } ) {
 		} );
 	}
 
+	const { isSelected, isHovered } = props;
 	const className = classnames( 'editor-visual-editor__block', {
-		'is-selected': isSelected
+		'is-selected': isSelected,
+		'is-hovered': isHovered
 	} );
 
+	const { onSelect, onDeselect, onMouseEnter, onMouseLeave } = props;
+
+	// Disable reason: Each block can receive focus but must be able to contain
+	// block children. Tab keyboard navigation enabled by tabIndex assignment.
+
+	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
 		<div
 			tabIndex="0"
-			onFocus={ onFocus }
-			onBlur={ onBlur }
+			onFocus={ onSelect }
+			onBlur={ onDeselect }
+			onKeyDown={ onDeselect }
+			onMouseEnter={ onMouseEnter }
+			onMouseLeave={ onMouseLeave }
 			className={ className }
 		>
 			<BlockEdit
@@ -41,12 +53,14 @@ function VisualEditorBlock( { block, onChange, onFocus, onBlur, isSelected } ) {
 				onChange={ onAttributesChange } />
 		</div>
 	);
+	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }
 
 export default connect(
 	( state, ownProps ) => ( {
 		block: state.blocks.byUid[ ownProps.uid ],
-		isSelected: ownProps.uid === state.selectedBlockUid
+		isSelected: !! state.blocks.selected[ ownProps.uid ],
+		isHovered: !! state.blocks.hovered[ ownProps.uid ]
 	} ),
 	( dispatch, ownProps ) => ( {
 		onChange( updates ) {
@@ -56,15 +70,32 @@ export default connect(
 				updates
 			} );
 		},
-		onFocus() {
+		onSelect() {
 			dispatch( {
-				type: 'SELECT_BLOCK',
+				type: 'TOGGLE_BLOCK_SELECTED',
+				selected: true,
 				uid: ownProps.uid
 			} );
 		},
-		onBlur() {
+		onDeselect() {
 			dispatch( {
-				type: 'CLEAR_SELECTED_BLOCK'
+				type: 'TOGGLE_BLOCK_SELECTED',
+				selected: false,
+				uid: ownProps.uid
+			} );
+		},
+		onMouseEnter() {
+			dispatch( {
+				type: 'TOGGLE_BLOCK_HOVERED',
+				hovered: true,
+				uid: ownProps.uid
+			} );
+		},
+		onMouseLeave() {
+			dispatch( {
+				type: 'TOGGLE_BLOCK_HOVERED',
+				hovered: false,
+				uid: ownProps.uid
 			} );
 		}
 	} )

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -20,7 +20,7 @@
 	border: 2px solid transparent;
 	transition: 0.2s border-color;
 
-	&:hover {
+	&.is-hovered {
 		border-left: 2px solid $light-gray-500;
 	}
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -8,4 +8,23 @@
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
 	}
+
+	p {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}
+
+.editor-visual-editor__block {
+	padding: 15px;
+	border: 2px solid transparent;
+	transition: 0.2s border-color;
+
+	&:hover {
+		border-left: 2px solid $light-gray-500;
+	}
+
+	&.is-selected {
+		border: 2px solid $light-gray-500;
+	}
 }

--- a/editor/state.js
+++ b/editor/state.js
@@ -78,6 +78,25 @@ export function mode( state = 'visual', action ) {
 }
 
 /**
+ * Reducer returning currently selected block UID.
+ *
+ * @param  {?string} state  Current state
+ * @param  {Object}  action Dispatched action
+ * @return {?string}        Updated state
+ */
+export function selectedBlockUid( state = null, action ) {
+	switch ( action.type ) {
+		case 'SELECT_BLOCK':
+			return action.uid;
+
+		case 'CLEAR_SELECTED_BLOCK':
+			return null;
+	}
+
+	return state;
+}
+
+/**
  * Creates a new instance of a Redux store.
  *
  * @return {Redux.Store} Redux store
@@ -86,7 +105,8 @@ export function createReduxStore() {
 	const reducer = combineReducers( {
 		html,
 		blocks,
-		mode
+		mode,
+		selectedBlockUid
 	} );
 
 	return createStore(

--- a/editor/state.js
+++ b/editor/state.js
@@ -22,44 +22,84 @@ export function html( state = null, action ) {
 }
 
 /**
- * Reducer returning editor blocks state, an object with keys byUid and order,
- * where blocks are parsed from current HTML markup.
+ * Reducer returning editor blocks state, an combined reducer of keys byUid,
+ * order, selected, hovered, where blocks are parsed from current HTML markup.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function blocks( state, action ) {
-	if ( undefined === state ) {
-		state = {
-			byUid: {},
-			order: []
-		};
-	}
+export const blocks = ( () => {
+	const reducer = combineReducers( {
+		byUid( state = {}, action ) {
+			switch ( action.type ) {
+				case 'SET_HTML':
+					return keyBy( action.blockNodes, 'uid' );
 
-	switch ( action.type ) {
-		case 'SET_HTML':
-			const blockNodes = wp.blocks.parse( action.html );
-			return {
-				byUid: keyBy( blockNodes, 'uid' ),
-				order: blockNodes.map( ( { uid } ) => uid )
-			};
+				case 'UPDATE_BLOCK':
+					return {
+						...state,
+						[ action.uid ]: {
+							...state[ action.uid ],
+							...action.updates
+						}
+					};
+			}
 
-		case 'UPDATE_BLOCK':
-			return {
-				...state,
-				byUid: {
-					...state.byUid,
-					[ action.uid ]: {
-						...state.byUid[ action.uid ],
-						...action.updates
+			return state;
+		},
+		order( state = [], action ) {
+			switch ( action.type ) {
+				case 'SET_HTML':
+					return action.blockNodes.map( ( { uid } ) => uid );
+			}
+
+			return state;
+		},
+		selected( state = {}, action ) {
+			switch ( action.type ) {
+				case 'TOGGLE_BLOCK_SELECTED':
+					return {
+						...state,
+						[ action.uid ]: action.selected
+					};
+			}
+
+			return state;
+		},
+		hovered( state = {}, action ) {
+			switch ( action.type ) {
+				case 'TOGGLE_BLOCK_HOVERED':
+					return {
+						...state,
+						[ action.uid ]: action.hovered
+					};
+
+				case 'TOGGLE_BLOCK_SELECTED':
+					if ( state[ action.uid ] ) {
+						return {
+							...state,
+							[ action.uid ]: false
+						};
 					}
-				}
-			};
-	}
+					break;
+			}
 
-	return state;
-}
+			return state;
+		}
+	} );
+
+	return ( state, action ) => {
+		if ( 'SET_HTML' === action.type ) {
+			action = {
+				...action,
+				blockNodes: wp.blocks.parse( action.html )
+			};
+		}
+
+		return reducer( state, action );
+	};
+} )();
 
 /**
  * Reducer returning current editor mode, either "visual" or "text".
@@ -78,25 +118,6 @@ export function mode( state = 'visual', action ) {
 }
 
 /**
- * Reducer returning currently selected block UID.
- *
- * @param  {?string} state  Current state
- * @param  {Object}  action Dispatched action
- * @return {?string}        Updated state
- */
-export function selectedBlockUid( state = null, action ) {
-	switch ( action.type ) {
-		case 'SELECT_BLOCK':
-			return action.uid;
-
-		case 'CLEAR_SELECTED_BLOCK':
-			return null;
-	}
-
-	return state;
-}
-
-/**
  * Creates a new instance of a Redux store.
  *
  * @return {Redux.Store} Redux store
@@ -105,8 +126,7 @@ export function createReduxStore() {
 	const reducer = combineReducers( {
 		html,
 		blocks,
-		mode,
-		selectedBlockUid
+		mode
 	} );
 
 	return createStore(

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -12,6 +12,7 @@ import {
 	html,
 	blocks,
 	mode,
+	selectedBlockUid,
 	createReduxStore
 } from '../state';
 
@@ -111,6 +112,31 @@ describe( 'state', () => {
 		} );
 	} );
 
+	describe( 'selectedBlockUid()', () => {
+		it( 'should return null by default', () => {
+			const state = selectedBlockUid( undefined, {} );
+
+			expect( state ).to.be.null();
+		} );
+
+		it( 'should return selected block uid', () => {
+			const state = selectedBlockUid( null, {
+				type: 'SELECT_BLOCK',
+				uid: 'bananas'
+			} );
+
+			expect( state ).to.equal( 'bananas' );
+		} );
+
+		it( 'should return null on unselecting', () => {
+			const state = selectedBlockUid( 'bananas', {
+				type: 'CLEAR_SELECTED_BLOCK'
+			} );
+
+			expect( state ).to.be.null();
+		} );
+	} );
+
 	describe( 'createReduxStore()', () => {
 		it( 'should return a redux store', () => {
 			const store = createReduxStore();
@@ -126,7 +152,8 @@ describe( 'state', () => {
 			expect( Object.keys( state ) ).to.have.members( [
 				'html',
 				'blocks',
-				'mode'
+				'mode',
+				'selectedBlockUid'
 			] );
 		} );
 	} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -12,7 +12,6 @@ import {
 	html,
 	blocks,
 	mode,
-	selectedBlockUid,
 	createReduxStore
 } from '../state';
 
@@ -44,19 +43,23 @@ describe( 'state', () => {
 			wp.blocks.unregisterBlock( 'core/test-block' );
 		} );
 
-		it( 'should return empty byUid, order by default', () => {
+		it( 'should return empty byUid, order, selected, hovered by default', () => {
 			const state = blocks( undefined, {} );
 
 			expect( state ).to.eql( {
 				byUid: {},
-				order: []
+				order: [],
+				selected: {},
+				hovered: {}
 			} );
 		} );
 
 		it( 'should key set html blocks', () => {
 			const original = deepFreeze( {
 				byUid: {},
-				order: []
+				order: [],
+				selected: {},
+				hovered: {}
 			} );
 			const state = blocks( original, {
 				type: 'SET_HTML',
@@ -65,8 +68,6 @@ describe( 'state', () => {
 
 			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 1 );
 			expect( values( state.byUid )[ 0 ].blockType ).to.equal( 'core/test-block' );
-			expect( state.order ).to.have.lengthOf( 1 );
-			expect( state.order[ 0 ] ).to.be.a( 'string' );
 		} );
 
 		it( 'should return with block updates', () => {
@@ -78,7 +79,9 @@ describe( 'state', () => {
 						attributes: {}
 					}
 				},
-				order: [ 'kumquat' ]
+				order: [ 'kumquat' ],
+				selected: {},
+				hovered: {}
 			} );
 			const state = blocks( original, {
 				type: 'UPDATE_BLOCK',
@@ -91,7 +94,53 @@ describe( 'state', () => {
 			} );
 
 			expect( state.byUid.kumquat.attributes.updated ).to.be.true();
-			expect( state.order[ 0 ] ).to.equal( 'kumquat' );
+		} );
+
+		it( 'should return with block uid as hovered', () => {
+			const original = deepFreeze( {
+				byUid: {
+					kumquat: {
+						uid: 'kumquat',
+						blockType: 'core/test-block',
+						attributes: {}
+					}
+				},
+				order: [ 'kumquat' ],
+				selected: {},
+				hovered: {}
+			} );
+			const state = blocks( original, {
+				type: 'TOGGLE_BLOCK_HOVERED',
+				uid: 'kumquat',
+				hovered: true
+			} );
+
+			expect( state.hovered.kumquat ).to.be.true();
+		} );
+
+		it( 'should return with block uid as selected, clearing hover', () => {
+			const original = deepFreeze( {
+				byUid: {
+					kumquat: {
+						uid: 'kumquat',
+						blockType: 'core/test-block',
+						attributes: {}
+					}
+				},
+				order: [ 'kumquat' ],
+				selected: {},
+				hovered: {
+					kumquat: true
+				}
+			} );
+			const state = blocks( original, {
+				type: 'TOGGLE_BLOCK_SELECTED',
+				uid: 'kumquat',
+				selected: true
+			} );
+
+			expect( state.hovered.kumquat ).to.be.false();
+			expect( state.selected.kumquat ).to.be.true();
 		} );
 	} );
 
@@ -112,31 +161,6 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'selectedBlockUid()', () => {
-		it( 'should return null by default', () => {
-			const state = selectedBlockUid( undefined, {} );
-
-			expect( state ).to.be.null();
-		} );
-
-		it( 'should return selected block uid', () => {
-			const state = selectedBlockUid( null, {
-				type: 'SELECT_BLOCK',
-				uid: 'bananas'
-			} );
-
-			expect( state ).to.equal( 'bananas' );
-		} );
-
-		it( 'should return null on unselecting', () => {
-			const state = selectedBlockUid( 'bananas', {
-				type: 'CLEAR_SELECTED_BLOCK'
-			} );
-
-			expect( state ).to.be.null();
-		} );
-	} );
-
 	describe( 'createReduxStore()', () => {
 		it( 'should return a redux store', () => {
 			const store = createReduxStore();
@@ -152,8 +176,7 @@ describe( 'state', () => {
 			expect( Object.keys( state ) ).to.have.members( [
 				'html',
 				'blocks',
-				'mode',
-				'selectedBlockUid'
+				'mode'
 			] );
 		} );
 	} );

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.2.0",
     "babel-loader": "^6.4.1",
+    "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",
@@ -54,7 +55,7 @@
     "webpack-node-externals": "^1.5.4"
   },
   "dependencies": {
-    "babel-plugin-lodash": "^3.2.11",
+    "classnames": "^2.2.5",
     "hpq": "^1.1.1",
     "lodash": "^4.17.4",
     "react-redux": "^5.0.3",


### PR DESCRIPTION
In this PR, I'm adding the "selected" and "hover" state for blocks.
For now, hovering a block shows the left border while selecting it shows the full border.
Typing the keyboard inside a block unselect it.