### PR TITLE
Blocks API: Adding a block uid to identify the block

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
 		} ]
 	],
 	"plugins": [
+		"lodash",
 		"transform-runtime",
 		"transform-object-rest-spread",
 		[ "transform-react-jsx", {

--- a/blocks/parser.js
+++ b/blocks/parser.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as query from 'hpq';
+import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,6 +43,7 @@ export default function parse( content ) {
 
 		if ( settings ) {
 			memo.push( {
+				uid: uniqueId(),
 				blockType: blockNode.blockType,
 				attributes: getBlockAttributes( blockNode, settings )
 			} );

--- a/blocks/test/parser.js
+++ b/blocks/test/parser.js
@@ -75,6 +75,7 @@ describe( 'block parser', () => {
 				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->';
 
 			expect( parse( postContent ) ).to.eql( [ {
+				uid: '1',
 				blockType: 'core/test-block',
 				attributes: {
 					content: 'Ribs & Chicken'

--- a/editor/editor/mode/visual.js
+++ b/editor/editor/mode/visual.js
@@ -1,13 +1,22 @@
 /**
+ * External dependencies
+ */
+import { findIndex } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import InserterButton from '../../inserter/button';
 
 function Blocks( { blocks, onChange } ) {
-	const onChangeBlock = ( index ) => ( changes ) => {
+	const onChangeBlock = ( uid ) => ( changes ) => {
+		const index = findIndex( blocks, { uid } );
 		const newBlock = {
 			...blocks[ index ],
-			changes
+			attributes: {
+				...blocks[ index ].attributes,
+				...changes
+			}
 		};
 
 		onChange( [
@@ -20,9 +29,9 @@ function Blocks( { blocks, onChange } ) {
 	return (
 		<div className="editor-mode-visual">
 			<div>
-				{ blocks.map( ( block, index ) =>
-					<div key={ index }>
-						{ wp.blocks.getBlockSettings( block.blockType ).edit( block.attributes, onChangeBlock( index ) ) }
+				{ blocks.map( ( block ) =>
+					<div key={ block.uid }>
+						{ wp.blocks.getBlockSettings( block.blockType ).edit( block.attributes, onChangeBlock( block.uid ) ) }
 					</div>
 				) }
 			</div>

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -1,12 +1,11 @@
+/**
+ * External dependencies
+ */
+import { groupBy } from 'lodash';
+
 function Inserter() {
 	const blocks = wp.blocks.getBlocks();
-	const blocksByCategory = blocks.reduce( ( groups, block ) => {
-		if ( ! groups[ block.category ] ) {
-			groups[ block.category ] = [];
-		}
-		groups[ block.category ].push( block );
-		return groups;
-	}, {} );
+	const blocksByCategory = groupBy( blocks, 'category' );
 	const categories = wp.blocks.getCategories();
 
 	return (

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.2.0",
     "babel-loader": "^6.4.1",
+    "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",
@@ -54,6 +55,7 @@
   },
   "dependencies": {
     "hpq": "^1.1.1",
+    "lodash": "^4.17.4",
     "react-textarea-autosize": "^4.0.5"
   }
 }


### PR DESCRIPTION
In this PR, I'm adding a `uid` to identify blocks. It's used right now as a `key` for the rendered block. But it's important to have for block states `selected` / `hover` / `focused`. It allows identify the same block even if we move it up/down.

Also. See this PR as the PR we discuss adding `lodash` since I'm using `uniqueId` to generate the id. 