### PR TITLE
Define coding guidelines for CSS class naming

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -1,0 +1,33 @@
+Coding Guidelines
+=================
+
+This living document serves to prescribe coding guidelines specific to the Gutenberg editor project. Base coding guidelines follow the [WordPress Coding Standards](https://codex.wordpress.org/WordPress_Coding_Standards). The following sections outline additional patterns and conventions used in the Gutenberg project.
+
+## CSS
+
+### Naming
+
+To avoid class name collisions between elements of the editor and to the enclosing WordPress dashboard, class names **must** adhere to the following guidelines:
+
+Any default export of a folder's `index.js` **must** be prefixed with `editor-` followed by the directory name in which it resides:
+
+>.editor-_[ directory name ]_
+
+(Example: `.editor-inserter` from `inserter/index.js`)
+
+For any descendant of the top-level (`index.js`) element, prefix using the top-level element's class name separated by two underscores:
+
+>.editor-_[ directory name ]_\_\__[ descendant description ]_
+
+(Example: `.editor-inserter__button-toggle` from `inserter/button.js`)
+
+For optional variations of an element or its descendants, you may use a modifier class, but you **must not** apply styles to the modifier class directly; only as an additional selector to the element to which the modifier applies:
+
+>.editor-_[ directory name ]_.is-_[ modifier description ]_
+>.editor-_[ directory name ]_\_\__[ descendant description ]_.is-_[ modifier description ]_
+
+(Example: `.editor-inserter__button-toggle.is-active` )
+
+In all of the above cases, except in separating the top-level element from its descendants, you **must** use dash delimiters when expressing multiple terms of a name.
+
+You may observe that these conventions adhere closely to the [BEM (Blocks, Elements, Modifiers)](http://getbem.com/introduction/) CSS methodology, with minor adjustments to the application of modifiers.


### PR DESCRIPTION
Related: #366

This pull request seeks to include a new `docs/coding-guidelines.md` document describing coding conventions specific to the project. At this time this only includes CSS class naming of editor elements. It prescribes a [BEM](http://getbem.com/introduction/)-like structure seeking to remove uncertainty about class naming and reducing chances of a name collision within the editor and between the editor and the enclosing dashboard.

[View Document](https://github.com/WordPress/gutenberg/blob/a5c84d3c943381053fe71164abc837327fe2ddc5/docs/coding-guidelines.md)

__Anticipated / Open Questions:__

_Is this necessary?_

A primary objective of a naming standard is to remove doubt and uncertainty from the developer's mind while simultaneously avoiding unintended bugs. The proposed standard is intentionally minimal to avoid familiarization with any new tools; rather, it's simply a naming convention.

_What about [insert cool new stylesheet alternative]?_

There are a number of interesting new approaches to solve the same problem addressed here, usually tailored at avoiding class names altogether in lieu of inline styling or automated class name assignment. By this fact they tend to be harder to extend outside the application itself (like in a WordPress context). Further, the ecosystem has not coalesced to any individual solution so I am wary against leaning too heavily on any one of these approaches for fear of future churn. To the previous question, these tools also introduce overhead of coming to understand their specific APIs, syntax, etc.