### PR TITLE
Introduce and bind components to global app state

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
 		} ]
 	],
 	"plugins": [
+		"lodash",
 		"transform-runtime",
 		"transform-object-rest-spread",
 		[ "transform-react-jsx", {

--- a/blocks/parser.js
+++ b/blocks/parser.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as query from 'hpq';
+import uuid from 'uuid/v4';
 
 /**
  * Internal dependencies
@@ -54,6 +55,7 @@ export default function parse( content ) {
 		if ( settings ) {
 			memo.push( {
 				blockType,
+				uid: uuid(),
 				rawContent: blockNode.rawContent,
 				attributes: getBlockAttributes( blockNode, settings )
 			} );

--- a/blocks/test/parser.js
+++ b/blocks/test/parser.js
@@ -96,13 +96,13 @@ describe( 'block parser', () => {
 				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->'
 			);
 
-			expect( parsed ).to.eql( [ {
-				blockType: 'core/test-block',
-				attributes: {
-					content: 'Ribs & Chicken'
-				},
-				rawContent: 'Ribs'
-			} ] );
+			expect( parsed ).to.have.lengthOf( 1 );
+			expect( parsed[ 0 ].blockType ).to.equal( 'core/test-block' );
+			expect( parsed[ 0 ].attributes ).to.eql( {
+				content: 'Ribs & Chicken'
+			} );
+			expect( parsed[ 0 ].rawContent ).to.equal( 'Ribs' );
+			expect( parsed[ 0 ].uid ).to.be.a( 'string' );
 		} );
 
 		it( 'should parse the post content, using unknown block handler', () => {

--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -3,12 +3,10 @@
  */
 import ModeSwitcher from './mode-switcher';
 
-function Header( { mode, onSwitchMode } ) {
+function Header() {
 	return (
 		<header className="editor-header">
-			<ModeSwitcher
-				mode={ mode }
-				onSwitch={ onSwitchMode } />
+			<ModeSwitcher />
 		</header>
 	);
 }

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
 class ModeSwitcher extends wp.element.Component {
 	constructor() {
 		super( ...arguments );
@@ -50,4 +55,16 @@ class ModeSwitcher extends wp.element.Component {
 	}
 }
 
-export default ModeSwitcher;
+export default connect(
+	( state ) => ( {
+		mode: state.mode
+	} ),
+	( dispatch ) => ( {
+		onSwitch( mode ) {
+			dispatch( {
+				type: 'SWITCH_MODE',
+				mode: mode
+			} );
+		}
+	} )
+)( ModeSwitcher );

--- a/editor/index.js
+++ b/editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Provider } from 'react-redux';
+
+/**
  * Internal dependencies
  */
 import './assets/stylesheets/main.scss';
@@ -20,7 +25,9 @@ export function createEditorInstance( id, post ) {
 	} );
 
 	wp.element.render(
-		<Layout initialContent={ post.content.raw } />,
+		<Provider store={ store }>
+			<Layout />
+		</Provider>,
 		document.getElementById( id )
 	);
 }

--- a/editor/index.js
+++ b/editor/index.js
@@ -4,6 +4,7 @@
 import './assets/stylesheets/main.scss';
 import './blocks';
 import Layout from './layout';
+import { createReduxStore } from './state';
 
 /**
  * Initializes and returns an instance of Editor.
@@ -12,6 +13,12 @@ import Layout from './layout';
  * @param {Object} post API entity for post to edit
  */
 export function createEditorInstance( id, post ) {
+	const store = createReduxStore();
+	store.dispatch( {
+		type: 'SET_HTML',
+		html: post.content.raw
+	} );
+
 	wp.element.render(
 		<Layout initialContent={ post.content.raw } />,
 		document.getElementById( id )

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -1,48 +1,25 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
  * Internal dependencies
  */
 import Header from '../header';
 import TextEditor from '../modes/text-editor';
 import VisualEditor from '../modes/visual-editor';
 
-class Layout extends wp.element.Component {
-	constructor( props ) {
-		super( ...arguments );
-		this.switchMode = this.switchMode.bind( this );
-		this.state = {
-			mode: 'visual',
-			html: props.initialContent,
-			blocks: wp.blocks.parse( this.props.initialContent )
-		};
-	}
-
-	switchMode( newMode ) {
-		// TODO: we need a serializer from blocks here
-		const html = this.state.html;
-		const blocks = this.mode === 'visual' ? this.state.blocks : wp.blocks.parse( this.state.html );
-		this.setState( {
-			mode: newMode,
-			html,
-			blocks
-		} );
-	}
-
-	createChangeHandler( type ) {
-		return ( value ) => this.setState( { [ type ]: value } );
-	}
-
-	render() {
-		const { mode, html, blocks } = this.state;
-		return (
-			<div>
-				<Header
-					mode={ mode }
-					onSwitchMode={ this.switchMode } />
-				{ mode === 'text' && <TextEditor html={ html } onChange={ this.createChangeHandler( 'html' ) } /> }
-				{ mode === 'visual' && <VisualEditor blocks={ blocks } onChange={ this.createChangeHandler( 'blocks' ) } /> }
-			</div>
-		);
-	}
+function Layout( { mode } ) {
+	return (
+		<div>
+			<Header />
+			{ mode === 'text' && <TextEditor /> }
+			{ mode === 'visual' && <VisualEditor /> }
+		</div>
+	);
 }
 
-export default Layout;
+export default connect( ( state ) => ( {
+	mode: state.mode
+} ) )( Layout );

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import Textarea from 'react-textarea-autosize';
 
 function TextEditor( { html, onChange } ) {
@@ -18,4 +19,16 @@ function TextEditor( { html, onChange } ) {
 	);
 }
 
-export default TextEditor;
+export default connect(
+	( state ) => ( {
+		html: state.html
+	} ),
+	( dispatch ) => ( {
+		onChange( value ) {
+			dispatch( {
+				type: 'SET_HTML',
+				html: value
+			} );
+		}
+	} )
+)( TextEditor );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+function VisualEditorBlock( { block, onChange } ) {
+	const settings = wp.blocks.getBlockSettings( block.blockType );
+
+	let BlockEdit;
+	if ( settings ) {
+		BlockEdit = settings.edit || settings.save;
+	}
+
+	if ( ! BlockEdit ) {
+		return null;
+	}
+
+	function onAttributesChange( attributes ) {
+		onChange( {
+			attributes: {
+				...block.attributes,
+				...attributes
+			}
+		} );
+	}
+
+	return (
+		<BlockEdit
+			key={ block.uid }
+			attributes={ block.attributes }
+			onChange={ onAttributesChange } />
+	);
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		block: state.blocks.byUid[ ownProps.uid ]
+	} ),
+	( dispatch, ownProps ) => ( {
+		onChange( updates ) {
+			dispatch( {
+				type: 'UPDATE_BLOCK',
+				uid: ownProps.uid,
+				updates
+			} );
+		}
+	} )
+)( VisualEditorBlock );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -26,7 +26,6 @@ function VisualEditorBlock( { block, onChange } ) {
 
 	return (
 		<BlockEdit
-			key={ block.uid }
 			attributes={ block.attributes }
 			onChange={ onAttributesChange } />
 	);

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -1,46 +1,25 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
  * Internal dependencies
  */
 import InserterButton from '../../inserter/button';
+import VisualEditorBlock from './block';
 
-function VisualEditor( { blocks, onChange } ) {
-	const onChangeBlock = ( index ) => ( changes ) => {
-		const newBlock = {
-			...blocks[ index ],
-			changes
-		};
-
-		onChange( [
-			...blocks.slice( 0, index ),
-			newBlock,
-			...blocks.slice( index + 1 )
-		] );
-	};
-
+function VisualEditor( { blocks } ) {
 	return (
 		<div className="editor-visual-editor">
-			{ blocks.map( ( block, index ) => {
-				const settings = wp.blocks.getBlockSettings( block.blockType );
-
-				let BlockEdit;
-				if ( settings ) {
-					BlockEdit = settings.edit || settings.save;
-				}
-
-				if ( ! BlockEdit ) {
-					return;
-				}
-
-				return (
-					<BlockEdit
-						key={ index }
-						attributes={ block.attributes }
-						onChange={ onChangeBlock( index ) } />
-				);
-			} ) }
+			{ blocks.map( ( uid ) => (
+				<VisualEditorBlock key={ uid } uid={ uid } />
+			) ) }
 			<InserterButton />
 		</div>
 	);
 }
 
-export default VisualEditor;
+export default connect( ( state ) => ( {
+	blocks: state.blocks.order
+} ) )( VisualEditor );

--- a/editor/state.js
+++ b/editor/state.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { combineReducers, createStore } from 'redux';
+import { keyBy } from 'lodash';
+
+/**
+ * Reducer returning editor HTML state, representing the markup source of the
+ * current post.
+ *
+ * @param  {?string} state  Current state
+ * @param  {Object}  action Dispatched action
+ * @return {?string}        Updated state
+ */
+export function html( state = null, action ) {
+	switch ( action.type ) {
+		case 'SET_HTML':
+			return action.html;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning editor blocks state, an object with keys byUid and order,
+ * where blocks are parsed from current HTML markup.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {Object}        Updated state
+ */
+export function blocks( state, action ) {
+	if ( undefined === state ) {
+		state = {
+			byUid: {},
+			order: []
+		};
+	}
+
+	switch ( action.type ) {
+		case 'SET_HTML':
+			const blockNodes = wp.blocks.parse( action.html );
+			return {
+				byUid: keyBy( blockNodes, 'uid' ),
+				order: blockNodes.map( ( { uid } ) => uid )
+			};
+
+		case 'UPDATE_BLOCK':
+			return {
+				...state,
+				byUid: {
+					...state.byUid,
+					[ action.uid ]: {
+						...state.byUid[ action.uid ],
+						...action.updates
+					}
+				}
+			};
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning current editor mode, either "visual" or "text".
+ *
+ * @param  {string} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {string}        Updated state
+ */
+export function mode( state = 'visual', action ) {
+	switch ( action.type ) {
+		case 'SWITCH_MODE':
+			return action.mode;
+	}
+
+	return state;
+}
+
+/**
+ * Creates a new instance of a Redux store.
+ *
+ * @return {Redux.Store} Redux store
+ */
+export function createReduxStore() {
+	const reducer = combineReducers( {
+		html,
+		blocks,
+		mode
+	} );
+
+	return createStore(
+		reducer,
+		window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+	);
+}
+
+export default createReduxStore;

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -1,0 +1,133 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+import { values } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	html,
+	blocks,
+	mode,
+	createReduxStore
+} from '../state';
+
+describe( 'state', () => {
+	describe( 'html()', () => {
+		it( 'should return null by default', () => {
+			const state = html( undefined, {} );
+
+			expect( state ).to.be.null();
+		} );
+
+		it( 'should return set html', () => {
+			const markup = '<!-- wp:core/test-block -->Bananas<!-- /wp:core/test-block -->';
+			const state = html( null, {
+				type: 'SET_HTML',
+				html: markup
+			} );
+
+			expect( state ).to.be.equal( markup );
+		} );
+	} );
+
+	describe( 'blocks()', () => {
+		before( () => {
+			wp.blocks.registerBlock( 'core/test-block', {} );
+		} );
+
+		after( () => {
+			wp.blocks.unregisterBlock( 'core/test-block' );
+		} );
+
+		it( 'should return empty byUid, order by default', () => {
+			const state = blocks( undefined, {} );
+
+			expect( state ).to.eql( {
+				byUid: {},
+				order: []
+			} );
+		} );
+
+		it( 'should key set html blocks', () => {
+			const original = deepFreeze( {
+				byUid: {},
+				order: []
+			} );
+			const state = blocks( original, {
+				type: 'SET_HTML',
+				html: '<!-- wp:core/test-block -->Bananas<!-- /wp:core/test-block -->'
+			} );
+
+			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 1 );
+			expect( values( state.byUid )[ 0 ].blockType ).to.equal( 'core/test-block' );
+			expect( state.order ).to.have.lengthOf( 1 );
+			expect( state.order[ 0 ] ).to.be.a( 'string' );
+		} );
+
+		it( 'should return with block updates', () => {
+			const original = deepFreeze( {
+				byUid: {
+					kumquat: {
+						uid: 'kumquat',
+						blockType: 'core/test-block',
+						attributes: {}
+					}
+				},
+				order: [ 'kumquat' ]
+			} );
+			const state = blocks( original, {
+				type: 'UPDATE_BLOCK',
+				uid: 'kumquat',
+				updates: {
+					attributes: {
+						updated: true
+					}
+				}
+			} );
+
+			expect( state.byUid.kumquat.attributes.updated ).to.be.true();
+			expect( state.order[ 0 ] ).to.equal( 'kumquat' );
+		} );
+	} );
+
+	describe( 'mode()', () => {
+		it( 'should return "visual" by default', () => {
+			const state = mode( undefined, {} );
+
+			expect( state ).to.equal( 'visual' );
+		} );
+
+		it( 'should return switched mode', () => {
+			const state = mode( null, {
+				type: 'SWITCH_MODE',
+				mode: 'text'
+			} );
+
+			expect( state ).to.equal( 'text' );
+		} );
+	} );
+
+	describe( 'createReduxStore()', () => {
+		it( 'should return a redux store', () => {
+			const store = createReduxStore();
+
+			expect( store.dispatch ).to.be.a( 'function' );
+			expect( store.getState ).to.be.a( 'function' );
+		} );
+
+		it( 'should have expected reducer keys', () => {
+			const store = createReduxStore();
+			const state = store.getState();
+
+			expect( Object.keys( state ) ).to.have.members( [
+				'html',
+				'blocks',
+				'mode'
+			] );
+		} );
+	} );
+} );

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "hpq": "^1.1.1",
-    "react-textarea-autosize": "^4.0.5"
+    "react-textarea-autosize": "^4.0.5",
+    "uuid": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-plugin-lodash": "^3.2.11",
     "hpq": "^1.1.1",
     "lodash": "^4.17.4",
+    "react-redux": "^5.0.3",
     "react-textarea-autosize": "^4.0.5",
     "redux": "^3.6.0",
     "uuid": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-preset-latest": "^6.24.0",
     "chai": "^3.5.0",
     "cross-env": "^3.2.4",
+    "deep-freeze": "0.0.1",
     "dirty-chai": "^1.2.2",
     "eslint": "^3.17.1",
     "eslint-config-wordpress": "^1.1.0",
@@ -53,8 +54,11 @@
     "webpack-node-externals": "^1.5.4"
   },
   "dependencies": {
+    "babel-plugin-lodash": "^3.2.11",
     "hpq": "^1.1.1",
+    "lodash": "^4.17.4",
     "react-textarea-autosize": "^4.0.5",
+    "redux": "^3.6.0",
     "uuid": "^3.0.1"
   }
 }


### PR DESCRIPTION
This pull request seeks to introduce a global state powered by Redux. See previous discussion at https://github.com/WordPress/gutenberg/pull/360#discussion_r109190570 . Specifically this will assist in allowing disparate components of the application retrieve and manipulate state of the broader application. Encouraging self-sufficient components will also facilitate future refactoring if components need to be moved or reused.

It also effectively supersedes #361, implementing block UID in the proposed state shape.

__Testing Instructions:__

Existing behavior should remain unaffected.

__Follow-up Tasks:__

- Parsing on `SET_HTML` may need to be optimized, especially in current implementation where this is called on every `change` event of the rendered text-mode `textarea`.
- We will need to decide how to apply updates via `UPDATE_BLOCK`, whether to allow the block implementation access to updating top-level properties like `blockType` or expecting them only to update attributes (and regardless, allowing easy patch updates of attributes).