### PR TITLE
Add client-side localization with string extraction

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,6 +12,9 @@
 		"transform-object-rest-spread",
 		[ "transform-react-jsx", {
 			"pragma": "wp.element.createElement"
+		} ],
+		[ "./i18n/babel-plugin", {
+			"output": "languages/gutenberg.pot"
 		} ]
 	],
 	"env": {

--- a/editor/blocks/freeform/index.js
+++ b/editor/blocks/freeform/index.js
@@ -1,7 +1,7 @@
 const { html } = wp.blocks.query;
 
 wp.blocks.registerBlock( 'core/freeform', {
-	title: 'Freeform',
+	title: wp.i18n.__( 'Freeform' ),
 
 	icon: 'text',
 

--- a/editor/blocks/text/index.js
+++ b/editor/blocks/text/index.js
@@ -2,8 +2,10 @@ const { html } = wp.blocks.query;
 const Editable = wp.blocks.Editable;
 
 wp.blocks.registerBlock( 'core/text', {
-	title: 'Text',
+	title: wp.i18n.__( 'Text' ),
+
 	icon: 'text',
+
 	category: 'common',
 
 	attributes: {

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -21,8 +21,8 @@ class ModeSwitcher extends wp.element.Component {
 	render() {
 		const { opened } = this.state;
 		const modes = [
-			{ value: 'visual', label: 'Visual' },
-			{ value: 'text', label: 'Text' },
+			{ value: 'visual', label: wp.i18n.__( 'Visual' ) },
+			{ value: 'text', label: wp.i18n._x( 'Text', 'Name for the Text editor tab (formerly HTML)' ) },
 		];
 		const switchMode = ( mode ) => () => {
 			this.setState( { opened: false } );
@@ -35,7 +35,7 @@ class ModeSwitcher extends wp.element.Component {
 				<button
 					className="editor-mode-switcher__toggle"
 					onClick={ this.toggle }
-					aria-label="Switch the editor mode"
+					aria-label={ wp.i18n.__( 'Switch the editor mode' ) }
 				>
 					{ currentMode.label }
 					<span className="dashicons dashicons-arrow-down" />

--- a/editor/inserter/button.js
+++ b/editor/inserter/button.js
@@ -27,7 +27,7 @@ class InserterButton extends wp.element.Component {
 					className="editor-inserter__button-toggle"
 					onClick={ this.toggle }
 					type="button"
-					aria-label="Add a block"
+					aria-label={ wp.i18n.__( 'Add a block' ) }
 				>
 					<span className="dashicons dashicons-plus" />
 				</button>

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -29,7 +29,10 @@ function Inserter() {
 					) )
 				}
 			</div>
-			<input className="editor-inserter__search" type="search" placeholder="Search..." />
+			<input
+				type="search"
+				placeholder={ wp.i18n.__( 'Search…' ) }
+				className="editor-inserter__search" />
 		</div>
 	);
 }

--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -159,13 +159,22 @@ module.exports = function() {
 				}
 
 				data.translations.messages[ translation.msgid ] = translation;
+				this.hasPendingWrite = true;
+			},
+			Program: {
+				exit( path, state ) {
+					if ( ! this.hasPendingWrite ) {
+						return;
+					}
 
-				// Ideally we could wait until Babel has finished parsing all files
-				// or at least asynchronously write, but Babel doesn't expose these
-				// entry points and async write may hit file lock (need queue).
-
-				const compiled = po.compile( data );
-				writeFileSync( state.opts.output || DEFAULT_OUTPUT, compiled );
+					// Ideally we could wait until Babel has finished parsing
+					// all files or at least asynchronously write, but Babel
+					// doesn't expose these entry points and async write may
+					// hit file lock (need queue).
+					const compiled = po.compile( data );
+					writeFileSync( state.opts.output || DEFAULT_OUTPUT, compiled );
+					this.hasPendingWrite = false;
+				}
 			}
 		}
 	};

--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -1,4 +1,34 @@
 /**
+ * Credits:
+ *
+ * babel-gettext-extractor
+ * https://github.com/getsentry/babel-gettext-extractor
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 jruchaud
+ * Copyright (c) 2015 Sentry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
  * External dependencies
  */
 

--- a/i18n/index.js
+++ b/i18n/index.js
@@ -5,10 +5,21 @@ import Jed from 'jed';
 
 let i18n;
 
+/**
+ * Creates a new Jed instance with specified locale data configuration.
+ *
+ * @param {Object} data Locale data configuration
+ */
 export function setLocaleData( data ) {
 	i18n = new Jed( data );
 }
 
+/**
+ * Returns the current Jed instance, initializing with a default configuration
+ * if not already assigned.
+ *
+ * @return {Jed} Jed instance
+ */
 export function getI18n() {
 	if ( ! i18n ) {
 		setLocaleData( { '': {} } );
@@ -17,20 +28,61 @@ export function getI18n() {
 	return i18n;
 }
 
-export function __( string ) {
-	return getI18n().gettext( string );
+/**
+ * Retrieve the translation of text.
+ *
+ * @param  {string} text Text to translate
+ * @return {string}      Translated text
+ */
+export function __( text ) {
+	return getI18n().gettext( text );
 }
 
-export function _x( string, context ) {
-	return getI18n().pgettext( context, string );
+/**
+ * Retrieve translated string with gettext context.
+ *
+ * @param  {string} text    Text to translate
+ * @param  {string} context Context information for the translators
+ * @return {string}         Translated context string without pipe
+ */
+export function _x( text, context ) {
+	return getI18n().pgettext( context, text );
 }
 
+/**
+ * Translates and retrieves the singular or plural form based on the supplied
+ * number.
+ *
+ * @param  {string} single The text to be used if the number is singular
+ * @param  {string} plural The text to be used if the number is plural
+ * @param  {Number} number The number to compare against to use either the
+ *                         singular or plural form
+ * @return {string}        The translated singular or plural form
+ */
 export function _n( single, plural, number ) {
 	return getI18n().ngettext( single, plural, number );
 }
 
+/**
+ * Translates and retrieves the singular or plural form based on the supplied
+ * number, with gettext context.
+ *
+ * @param  {string} single  The text to be used if the number is singular
+ * @param  {string} plural  The text to be used if the number is plural
+ * @param  {Number} number  The number to compare against to use either the
+ *                          singular or plural form
+ * @param  {string} context Context information for the translators
+ * @return {string}         The translated singular or plural form
+ */
 export function _nx( single, plural, number, context ) {
 	return getI18n().npgettext( context, single, plural, number );
 }
 
+/**
+ * Returns a formatted string.
+ *
+ * @see http://www.diveintojavascript.com/projects/javascript-sprintf
+ *
+ * @type {string}
+ */
 export const sprintf = Jed.sprintf;

--- a/i18n/index.js
+++ b/i18n/index.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import Jed from 'jed';
+
+let i18n;
+
+export function setLocaleData( data ) {
+	i18n = new Jed( data );
+}
+
+export function getI18n() {
+	if ( ! i18n ) {
+		setLocaleData( { '': {} } );
+	}
+
+	return i18n;
+}
+
+export function __( string ) {
+	return getI18n().gettext( string );
+}
+
+export function _x( string, context ) {
+	return getI18n().pgettext( context, string );
+}
+
+export function _n( single, plural, number ) {
+	return getI18n().ngettext( single, plural, number );
+}
+
+export function _nx( single, plural, number, context ) {
+	return getI18n().npgettext( context, single, plural, number );
+}
+
+export const sprintf = Jed.sprintf;

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=utf-8\n"
+"X-Generator: babel-plugin-wp-i18n\n"
+
+#: editor/blocks/freeform/index.js:4
+msgid "Freeform"
+msgstr ""
+
+#: editor/header/mode-switcher/index.js:25
+msgctxt "Name for the Text editor tab (formerly HTML)"
+msgid "Text"
+msgstr ""
+
+#: editor/header/mode-switcher/index.js:24
+msgid "Visual"
+msgstr ""
+
+#: editor/header/mode-switcher/index.js:38
+msgid "Switch the editor mode"
+msgstr ""
+
+#: editor/inserter/button.js:30
+msgid "Add a block"
+msgstr ""
+
+#: editor/inserter/index.js:34
+msgid "Search…"
+msgstr ""

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,8 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: editor/blocks/freeform/index.js:4
-msgid "Freeform"
+#: editor/inserter/button.js:30
+msgid "Add a block"
+msgstr ""
+
+#: editor/header/mode-switcher/index.js:24
+msgid "Visual"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:25
@@ -12,18 +16,20 @@ msgctxt "Name for the Text editor tab (formerly HTML)"
 msgid "Text"
 msgstr ""
 
-#: editor/header/mode-switcher/index.js:24
-msgid "Visual"
+#: editor/layout/index.js:37
+msgid "foo"
+msgid_plural "foos"
+msgstr[0] ""
+msgstr[1] ""
+
+#: editor/inserter/index.js:34
+msgid "Search…"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:38
 msgid "Switch the editor mode"
 msgstr ""
 
-#: editor/inserter/button.js:30
-msgid "Add a block"
-msgstr ""
-
-#: editor/inserter/index.js:34
-msgid "Search…"
+#: editor/blocks/freeform/index.js:4
+msgid "Freeform"
 msgstr ""

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,12 +3,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: editor/inserter/button.js:30
-msgid "Add a block"
-msgstr ""
-
-#: editor/header/mode-switcher/index.js:24
-msgid "Visual"
+#: editor/blocks/freeform/index.js:4
+msgid "Freeform"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:25
@@ -16,20 +12,18 @@ msgctxt "Name for the Text editor tab (formerly HTML)"
 msgid "Text"
 msgstr ""
 
-#: editor/layout/index.js:37
-msgid "foo"
-msgid_plural "foos"
-msgstr[0] ""
-msgstr[1] ""
-
-#: editor/inserter/index.js:34
-msgid "Search…"
+#: editor/header/mode-switcher/index.js:24
+msgid "Visual"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:38
 msgid "Switch the editor mode"
 msgstr ""
 
-#: editor/blocks/freeform/index.js:4
-msgid "Freeform"
+#: editor/inserter/button.js:30
+msgid "Add a block"
+msgstr ""
+
+#: editor/inserter/index.js:34
+msgid "Search…"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "babel-plugin-lodash": "^3.2.11",
     "hpq": "^1.1.1",
+    "jed": "^1.1.1",
     "lodash": "^4.17.4",
     "react-redux": "^5.0.3",
     "react-textarea-autosize": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-react": "^6.10.3",
     "expose-loader": "^0.7.3",
     "extract-text-webpack-plugin": "^2.1.0",
+    "gettext-parser": "^1.2.2",
     "glob": "^7.1.1",
     "jsdom": "^9.12.0",
     "mocha": "^3.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
 const config = {
 	entry: {
+		i18n: './i18n/index.js',
 		blocks: './blocks/index.js',
 		editor: './editor/index.js',
 		element: './element/index.js'
@@ -85,6 +86,7 @@ switch ( process.env.NODE_ENV ) {
 			'./element/index.js',
 			'./blocks/index.js',
 			'./editor/index.js',
+			'./i18n/index.js',
 			...glob.sync( `./{${ Object.keys( config.entry ).join() }}/**/test/*.js` )
 		];
 		config.externals = [ require( 'webpack-node-externals' )() ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,17 +76,17 @@ switch ( process.env.NODE_ENV ) {
 	case 'test':
 		config.target = 'node';
 		config.module.rules = [
-			...[ 'element', 'blocks', 'editor' ].map( ( entry ) => ( {
+			...[ 'i18n', 'element', 'blocks', 'editor' ].map( ( entry ) => ( {
 				test: require.resolve( './' + entry + '/index.js' ),
 				use: 'expose-loader?wp.' + entry
 			} ) ),
 			...config.module.rules
 		];
 		config.entry = [
+			'./i18n/index.js',
 			'./element/index.js',
 			'./blocks/index.js',
 			'./editor/index.js',
-			'./i18n/index.js',
 			...glob.sync( `./{${ Object.keys( config.entry ).join() }}/**/test/*.js` )
 		];
 		config.externals = [ require( 'webpack-node-externals' )() ];


### PR DESCRIPTION
This pull request seeks to introduce a pattern for simple localization in editor scripts.

![Localized Mode Switcher](https://cloud.githubusercontent.com/assets/1779930/24675554/9959c66a-194d-11e7-97cb-c3d5a1213821.png)

_(Note localized mode switcher text)_

__Implementation Details:__

The API aligns quite well with existing expectations from PHP WordPress localization, with support for the following functions:

- `wp.i18n.__` ([equivalent `__()`](https://developer.wordpress.org/reference/functions/__/))
- `wp.i18n._x` ([equivalent `_x()`](https://developer.wordpress.org/reference/functions/_x/))
- `wp.i18n._n` ([equivalent `_n()`](https://developer.wordpress.org/reference/functions/_n/))
- `wp.i18n._nx` ([equivalent `_nx()`](https://developer.wordpress.org/reference/functions/_nx/))
- `wp.i18n.sprintf` ([equivalent `sprintf()`](http://php.net/manual/en/function.sprintf.php))

String extraction is implemented into the build process automatically via a custom Babel plugin, supporting translator comments and file / line reference. It's expected we'll commit an updated `.pot` file with every change or addition of strings.

Server-side, translation data is transformed into a format to be consumed by [Jed](https://github.com/messageformat/Jed) and populated before the editor is initialized.

__Testing Instructions:__

Verify that existing behavior is unaffected (English locale strings shown).

Download example `gutenberg-zh_TW.mo` to your `wp-content/languages/plugins` directory (create if needed) or `wp-content/plugins/gutenberg/languages` and verify that localized strings are shown in mode switcher after switching to zh_TW (繁體中文) locale:

https://cloudup.com/files/i43j7T6_ixa/download