### PR TITLE
Implement image block

### DIFF
--- a/editor/blocks/image/index.js
+++ b/editor/blocks/image/index.js
@@ -33,13 +33,16 @@ wp.blocks.registerBlock( 'core/image', {
 
 	save( { attributes } ) {
 		const { url, alt, caption } = attributes;
+		const img = <img src={ url } alt={ alt } />;
+
+		if ( ! caption ) {
+			return img;
+		}
 
 		return (
 			<figure>
-				<img src={ url } alt={ alt } />
-				{ caption ? (
-					<figcaption dangerouslySetInnerHTML={ { __html: caption } } />
-				) : null }
+				{ img }
+				<figcaption dangerouslySetInnerHTML={ { __html: caption } } />
 			</figure>
 		);
 	}

--- a/editor/blocks/image/index.js
+++ b/editor/blocks/image/index.js
@@ -1,0 +1,46 @@
+const { attr, html } = wp.blocks.query;
+const Editable = wp.blocks.Editable;
+
+wp.blocks.registerBlock( 'core/image', {
+	title: wp.i18n.__( 'Image' ),
+
+	icon: 'format-image',
+
+	category: 'common',
+
+	attributes: {
+		src: attr( 'img', 'src' ),
+		alt: attr( 'img', 'alt' ),
+		caption: html( 'figcaption' )
+	},
+
+	edit( { attributes, isSelected, setAttributes } ) {
+		const { src, alt, caption } = attributes;
+
+		return (
+			<figure>
+				<img src={ src } alt={ alt } />
+				{ caption || isSelected ? (
+					<Editable
+						tagName="figcaption"
+						placeholder={ wp.i18n.__( 'Write caption…' ) }
+						value={ caption }
+						onChange={ ( value ) => setAttributes( { caption: value } ) } />
+				) : null }
+			</figure>
+		);
+	},
+
+	save( { attributes } ) {
+		const { src, alt, caption } = attributes;
+
+		return (
+			<figure>
+				<img src={ src } alt={ alt } />
+				{ caption ? (
+					<figcaption dangerouslySetInnerHTML={ { __html: caption } } />
+				) : null }
+			</figure>
+		);
+	}
+} );

--- a/editor/blocks/image/index.js
+++ b/editor/blocks/image/index.js
@@ -9,17 +9,17 @@ wp.blocks.registerBlock( 'core/image', {
 	category: 'common',
 
 	attributes: {
-		src: attr( 'img', 'src' ),
+		url: attr( 'img', 'src' ),
 		alt: attr( 'img', 'alt' ),
 		caption: html( 'figcaption' )
 	},
 
 	edit( { attributes, isSelected, setAttributes } ) {
-		const { src, alt, caption } = attributes;
+		const { url, alt, caption } = attributes;
 
 		return (
 			<figure>
-				<img src={ src } alt={ alt } />
+				<img src={ url } alt={ alt } />
 				{ caption || isSelected ? (
 					<Editable
 						tagName="figcaption"
@@ -32,11 +32,11 @@ wp.blocks.registerBlock( 'core/image', {
 	},
 
 	save( { attributes } ) {
-		const { src, alt, caption } = attributes;
+		const { url, alt, caption } = attributes;
 
 		return (
 			<figure>
-				<img src={ src } alt={ alt } />
+				<img src={ url } alt={ alt } />
 				{ caption ? (
 					<figcaption dangerouslySetInnerHTML={ { __html: caption } } />
 				) : null }

--- a/editor/blocks/index.js
+++ b/editor/blocks/index.js
@@ -1,4 +1,5 @@
 import './freeform';
+import './image';
 import './text';
 import './list';
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -71,6 +71,7 @@ function VisualEditorBlock( props ) {
 					} ) ) } />
 			) : null }
 			<BlockEdit
+				isSelected={ isSelected }
 				attributes={ block.attributes }
 				setAttributes={ setAttributes } />
 		</div>

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -7,6 +7,14 @@ msgstr ""
 msgid "Freeform"
 msgstr ""
 
+#: editor/blocks/image/index.js:26
+msgid "Write caption…"
+msgstr ""
+
+#: editor/blocks/image/index.js:5
+msgid "Image"
+msgstr ""
+
 #: editor/blocks/list/index.js:5
 msgid "List"
 msgstr ""


### PR DESCRIPTION
Related: #310

This pull request seeks to implement the `core/image` block. It should serve as a reference for a slightly more complex block type with multiple attributes, optional attributes, and selected state render handling.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/24770134/e5d927f8-1ad6-11e7-9dd9-b6640a72c1ca.png)|![After](https://cloud.githubusercontent.com/assets/1779930/24770121/db24fd14-1ad6-11e7-8219-ee118ce4f5ab.png)

__Testing Instructions:__

Verify that images in the sample Gutenberg post content are shown correctly, including caption. Selecting the image without caption should expand the selection. Per [mockups](https://github.com/WordPress/gutenberg/issues/310) we'd expect this to show placeholder text, but the `<Editable />` component does not yet support placeholders (#378).