### PR TITLE
Guarantee POT string ordering by file, line reference

### DIFF
--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -33,6 +33,7 @@
  */
 
 const { po } = require( 'gettext-parser' );
+const { fromPairs, sortBy, toPairs } = require( 'lodash' );
 const { relative } = require( 'path' );
 const { writeFileSync } = require( 'fs' );
 
@@ -166,6 +167,16 @@ module.exports = function() {
 					if ( ! this.hasPendingWrite ) {
 						return;
 					}
+
+					// By spec, enumeration order of object keys cannot be
+					// guaranteed, but in practice most runtimes respect order
+					// in which keys are inserted. We rely on this to specify
+					// ordering alphabetically by file, line. A better solution
+					// is to support or reimplement translations as array.
+					data.translations.messages = fromPairs( sortBy(
+						toPairs( data.translations.messages ),
+						( [ , translation ] ) => translation.comments.reference
+					) );
 
 					// Ideally we could wait until Babel has finished parsing
 					// all files or at least asynchronously write, but Babel

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,11 +3,6 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: editor/header/mode-switcher/index.js:31
-msgctxt "Name for the Text editor tab (formerly HTML)"
-msgid "Text"
-msgstr ""
-
 #: editor/blocks/freeform/index.js:4
 msgid "Freeform"
 msgstr ""
@@ -18,6 +13,11 @@ msgstr ""
 
 #: editor/header/mode-switcher/index.js:30
 msgid "Visual"
+msgstr ""
+
+#: editor/header/mode-switcher/index.js:31
+msgctxt "Name for the Text editor tab (formerly HTML)"
+msgid "Text"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:44


### PR DESCRIPTION
Fixes #377 

This pull request seeks to resolve occasional unintended reordering of strings by enforcing alphabetical ordering by file, line reference. Per inline comments, this ordering relies on runtime implementations of object enumeration which, for the most part, respect key insertion order.

```
// By spec, enumeration order of object keys cannot be
// guaranteed, but in practice most runtimes respect order
// in which keys are inserted. We rely on this to specify
// ordering alphabetically by file, line. A better solution
// is to support or reimplement translations as array.
```

See: http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ordinary-object-internal-methods-and-internal-slots-enumerate

>The mechanics and **order of enumerating the properties is not specified** but must conform to the rules specified below.

This is more fragile than I'd like, but otherwise would require additional functionality in `gettext-parser` or a reimplementation thereof to support inserting translations by array.

__Testing Instructions:__

Run `npm run build` a few times and ensure there are no changes to `languages/gutenberg.pot` via `git status` afterward.

A better test would be changing logic to sort by `msgid` to confirm sorting by string:

```diff
diff --git a/i18n/babel-plugin.js b/i18n/babel-plugin.js
index 9126e85..7b9389d 100644
--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -175,7 +175,7 @@ module.exports = function() {
                                        // is to support or reimplement translations as array.
                                        data.translations.messages = fromPairs( sortBy(
                                                toPairs( data.translations.messages ),
-                                               ( [ , translation ] ) => translation.comments.reference
+                                               ( [ msgid ] ) => msgid
                                        ) );
 
                                        // Ideally we could wait until Babel has finished parsing
```

Applying these changes and running `npm run build`, you should see more drastic changes with strings ordered by the text of `msgid`.