### PR TITLE
Enable per-root module imports

### DIFF
--- a/editor/components/toolbar/index.js
+++ b/editor/components/toolbar/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import './style.scss';
-import Dashicon from '../dashicon';
+import Dashicon from 'components/dashicon';
 
 function Toolbar( { controls } ) {
 	if ( ! controls || ! controls.length ) {

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import './style.scss';
-import Dashicon from '../../components/dashicon';
+import Dashicon from 'components/dashicon';
 
 class ModeSwitcher extends wp.element.Component {
 	constructor() {

--- a/editor/inserter/button.js
+++ b/editor/inserter/button.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import Inserter from './';
-import Dashicon from '../components/dashicon';
+import Dashicon from 'components/dashicon';
 
 class InserterButton extends wp.element.Component {
 	constructor() {

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import './style.scss';
-import Dashicon from '../components/dashicon';
+import Dashicon from 'components/dashicon';
 
 function Inserter() {
 	const blocks = wp.blocks.getBlocks();

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -6,9 +6,9 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Header from '../header';
-import TextEditor from '../modes/text-editor';
-import VisualEditor from '../modes/visual-editor';
+import Header from 'header';
+import TextEditor from 'modes/text-editor';
+import VisualEditor from 'modes/visual-editor';
 
 function Layout( { mode } ) {
 	return (

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import Toolbar from '../../components/toolbar';
+import Toolbar from 'components/toolbar';
 
 function VisualEditorBlock( props ) {
 	const { block } = props;

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import './style.scss';
-import InserterButton from '../../inserter/button';
+import InserterButton from 'inserter/button';
 import VisualEditorBlock from './block';
 
 function VisualEditor( { blocks } ) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "raw-loader": "^0.5.1",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "resolve-entry-modules-webpack-plugin": "^1.0.0",
     "sass-loader": "^6.0.3",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,46 +2,10 @@
  * External dependencies
  */
 
-const path = require( 'path' );
 const glob = require( 'glob' );
 const webpack = require( 'webpack' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
-
-/**
- * Webpack plugin that adds the containing directory of each entry point as an
- * effective `resolve.modules` root for all module resolution within that path.
- */
-class EntryResolvePlugin {
-	apply( compiler ) {
-		// Map entries into array of absolute paths
-		const entryRoots = Object.keys( compiler.options.entry ).map( ( entry ) => {
-			return path.dirname( path.resolve( compiler.options.entry[ entry ] ) );
-		} );
-
-		compiler.plugin( 'after-resolvers', () => {
-			compiler.resolvers.normal.apply( {
-				apply( resolver ) {
-					resolver.plugin( 'module', ( request, callback ) => {
-						// Find entry root which contains the requesting path
-						const resolvePath = entryRoots.find( ( entryRoot ) => {
-							return request.path.startsWith( entryRoot );
-						} );
-
-						if ( ! resolvePath ) {
-							return callback();
-						}
-
-						// Add entry root as resolve base path
-						resolver.doResolve( 'resolve', Object.assign( {}, request, {
-							path: resolvePath,
-							request: './' + request.request
-						} ), '', callback );
-					} );
-				}
-			} );
-		} );
-	}
-}
+const ResolveEntryModulesPlugin = require( 'resolve-entry-modules-webpack-plugin' );
 
 const config = {
 	entry: {
@@ -92,7 +56,7 @@ const config = {
 		]
 	},
 	plugins: [
-		new EntryResolvePlugin(),
+		new ResolveEntryModulesPlugin(),
 		new ExtractTextPlugin( {
 			filename: './[name]/build/style.css'
 		} ),


### PR DESCRIPTION
Closes: #380

This pull request seeks to enable importing by assuming a root path of each entry in the Webpack configuration. This turned out to be hilariously difficult to achieve, eventually resulting in the implementation of a custom Webpack plugin, currently inlined in the Webpack configuration.

__Example:__

_Before_

```js
import Dashicon from '../../components/dashicon';
```

_After:_

```js
import Dashicon from 'components/dashicon';
```

__Open questions:__

- We could simplify this by merely defining `resolve.modules = [ 'editor', 'i18n', 'element', 'blocks', 'node_modules' ]`, with the downside being that it becomes possible to `import Editable from 'components/editable';` (a `blocks` component) from the `editor` path.
- Should we move the Webpack plugin elsewhere? A separate repository? A standalone file?

__Testing instructions:__

Verify that `npm run build` results in no module resolution errors.