### PR TITLE
Change mode switcher to a select box

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -33,6 +33,11 @@ body.toplevel_page_gutenberg {
 	ol {
 		list-style-type: decimal;
 	}
+
+	select {
+		font-size: 13px;
+		color: $dark-gray-500;
+	}
 }
 
 .gutenberg__editor {

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import './style.scss';
+import Dashicon from '../../components/dashicon';
 
 class ModeSwitcher extends wp.element.Component {
 	constructor() {
@@ -39,6 +40,7 @@ class ModeSwitcher extends wp.element.Component {
 						</option>
 					) }
 				</select>
+				<Dashicon icon="arrow-down" />
 			</div>
 		);
 	}

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -7,55 +7,38 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import './style.scss';
-import Dashicon from '../../components/dashicon';
 
 class ModeSwitcher extends wp.element.Component {
 	constructor() {
 		super( ...arguments );
-		this.toggle = this.toggle.bind( this );
 		this.state = {
-			opened: false
+			value: this.props.mode
 		};
+
+		this.switchMode = this.switchMode.bind( this );
 	}
 
-	toggle() {
-		this.setState( {
-			opened: ! this.state.opened
-		} );
+	switchMode( mode ) {
+		this.setState( { value: mode.target.value } );
+		this.props.onSwitch( mode.target.value );
 	}
 
 	render() {
-		const { opened } = this.state;
 		const modes = [
 			{ value: 'visual', label: wp.i18n.__( 'Visual' ) },
 			{ value: 'text', label: wp.i18n._x( 'Text', 'Name for the Text editor tab (formerly HTML)' ) },
 		];
-		const switchMode = ( mode ) => () => {
-			this.setState( { opened: false } );
-			this.props.onSwitch( mode );
-		};
-		const currentMode = modes.find( ( { value } ) => value === this.props.mode );
+		//const currentMode = modes.find( ( { value } ) => value === this.props.mode );
 
 		return (
 			<div className="editor-mode-switcher">
-				<button
-					className="editor-mode-switcher__toggle"
-					onClick={ this.toggle }
-					aria-label={ wp.i18n.__( 'Switch the editor mode' ) }
-				>
-					{ currentMode.label }
-					<Dashicon icon="arrow-down" />
-				</button>
-				{ opened &&
-					<div className="editor-mode-switcher__content">
-						<div className="editor-mode-switcher__arrow" />
-						{ modes.map( ( mode ) =>
-							<button key={ mode.value } type="button" onClick={ switchMode( mode.value ) }>
-								{ mode.label }
-							</button>
-						) }
-					</div>
-				}
+				<select value={ this.state.value } onChange={ this.switchMode }>
+					{ modes.map( ( mode ) =>
+						<option key={ mode.value } value={ mode.value }>
+							{ mode.label }
+						</option>
+					) }
+				</select>
 			</div>
 		);
 	}

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -9,41 +9,45 @@ import { connect } from 'react-redux';
 import './style.scss';
 import Dashicon from '../../components/dashicon';
 
-class ModeSwitcher extends wp.element.Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			value: this.props.mode
-		};
-
-		this.switchMode = this.switchMode.bind( this );
+/**
+ * Set of available mode options.
+ *
+ * @type {Array}
+ */
+const MODES = [
+	{
+		value: 'visual',
+		label: wp.i18n.__( 'Visual' )
+	},
+	{
+		value: 'text',
+		label: wp.i18n._x( 'Text', 'Name for the Text editor tab (formerly HTML)' )
 	}
+];
 
-	switchMode( mode ) {
-		this.setState( { value: mode.target.value } );
-		this.props.onSwitch( mode.target.value );
-	}
+function ModeSwitcher( { mode, onSwitch } ) {
+	// Disable reason: Toggling between modes should take effect immediately,
+	// arguably even with keyboard navigation. `onBlur` only would require
+	// another action to remove focus from the select (tabbing or clicking
+	// outside the field), which is unexpected when submit button is omitted.
 
-	render() {
-		const modes = [
-			{ value: 'visual', label: wp.i18n.__( 'Visual' ) },
-			{ value: 'text', label: wp.i18n._x( 'Text', 'Name for the Text editor tab (formerly HTML)' ) },
-		];
-		//const currentMode = modes.find( ( { value } ) => value === this.props.mode );
-
-		return (
-			<div className="editor-mode-switcher">
-				<select value={ this.state.value } onChange={ this.switchMode }>
-					{ modes.map( ( mode ) =>
-						<option key={ mode.value } value={ mode.value }>
-							{ mode.label }
-						</option>
-					) }
-				</select>
-				<Dashicon icon="arrow-down" />
-			</div>
-		);
-	}
+	/* eslint-disable jsx-a11y/no-onchange */
+	return (
+		<div className="editor-mode-switcher">
+			<select
+				value={ mode }
+				onChange={ ( event ) => onSwitch( event.target.value ) }
+			>
+				{ MODES.map( ( { value, label } ) =>
+					<option key={ value } value={ value }>
+						{ label }
+					</option>
+				) }
+			</select>
+			<Dashicon icon="arrow-down" />
+		</div>
+	);
+	/* eslint-enable jsx-a11y/no-onchange */
 }
 
 export default connect(

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -37,6 +37,7 @@ function ModeSwitcher( { mode, onSwitch } ) {
 			<select
 				value={ mode }
 				onChange={ ( event ) => onSwitch( event.target.value ) }
+				className="editor-mode-switcher__input"
 			>
 				{ MODES.map( ( { value, label } ) =>
 					<option key={ value } value={ value }>

--- a/editor/header/mode-switcher/style.scss
+++ b/editor/header/mode-switcher/style.scss
@@ -1,64 +1,36 @@
 .editor-mode-switcher {
 	position: relative;
 	margin-right: $item-spacing;
-}
-
-.editor-mode-switcher__toggle {
+	padding-right: $item-spacing;
 	color: $dark-gray-500;
-	padding: $item-spacing;
 	align-items: center;
 	cursor: pointer;
-	border: none;
-	background: none;
 	border-right: 1px solid $light-gray-500;
 	outline: none;
 	display: flex;
 	align-items: center;
-}
 
-.editor-mode-switcher__content {
-	position: absolute;
-	top: 40px;
-	border: 1px solid $light-gray-500;
-	color: $dark-gray-500;
-	min-width: 100px;
-
-	button {
-		padding: 8px;
-		display: block;
-		border: none;
-		background: white;
+	select {
+		background: transparent;
+	    line-height: 1;
+	    border: 0;
+	    border-radius: 0;
+	    -webkit-appearance: none;
 		outline: none;
 		cursor: pointer;
-		width: 100%;
+		box-shadow: none;
+		padding-right: 24px;
 	}
-}
 
-.editor-mode-switcher__arrow {
-	border: 10px dashed $light-gray-500;
-	height: 0;
-	line-height: 0;
-	position: absolute;
-	width: 0;
-	z-index: 1;
-	top: -10px;
-	left: 50%;
-	margin-left: -10px;
-	border-bottom-style: solid;
-	border-top: none;
-	border-left-color: transparent;
-	border-right-color: transparent;
+	svg {
+		position: relative;
+		z-index: -1;
+		margin-left: -24px;
+		margin-top: -1px;
+	}
 
-	&:before {
-		top: 2px;
-		border: 10px solid white;
-		content: " ";
-		position: absolute;
-		left: 50%;
-		margin-left: -10px;
-		border-bottom-style: solid;
-		border-top: none;
-		border-left-color: transparent;
-		border-right-color: transparent;
+	&:hover,
+	select:hover {
+		color: $dark-gray-900;
 	}
 }

--- a/editor/header/mode-switcher/style.scss
+++ b/editor/header/mode-switcher/style.scss
@@ -10,19 +10,19 @@
 	display: flex;
 	align-items: center;
 
-	select {
+	.editor-mode-switcher__input {
 		background: transparent;
-	    line-height: 1;
-	    border: 0;
-	    border-radius: 0;
-	    -webkit-appearance: none;
+		line-height: 1;
+		border: 0;
+		border-radius: 0;
+		-webkit-appearance: none;
 		outline: none;
 		cursor: pointer;
 		box-shadow: none;
 		padding-right: 24px;
 	}
 
-	svg {
+	.dashicon {
 		position: relative;
 		z-index: -1;
 		margin-left: -24px;

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -31,17 +31,13 @@ msgstr ""
 msgid "Align right"
 msgstr ""
 
-#: editor/header/mode-switcher/index.js:30
+#: editor/header/mode-switcher/index.js:28
 msgid "Visual"
 msgstr ""
 
-#: editor/header/mode-switcher/index.js:31
+#: editor/header/mode-switcher/index.js:29
 msgctxt "Name for the Text editor tab (formerly HTML)"
 msgid "Text"
-msgstr ""
-
-#: editor/header/mode-switcher/index.js:44
-msgid "Switch the editor mode"
 msgstr ""
 
 #: editor/header/saved-state/index.js:11

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -31,11 +31,11 @@ msgstr ""
 msgid "Align right"
 msgstr ""
 
-#: editor/header/mode-switcher/index.js:28
+#: editor/header/mode-switcher/index.js:29
 msgid "Visual"
 msgstr ""
 
-#: editor/header/mode-switcher/index.js:29
+#: editor/header/mode-switcher/index.js:30
 msgctxt "Name for the Text editor tab (formerly HTML)"
 msgid "Text"
 msgstr ""

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -31,11 +31,11 @@ msgstr ""
 msgid "Align right"
 msgstr ""
 
-#: editor/header/mode-switcher/index.js:29
+#: editor/header/mode-switcher/index.js:20
 msgid "Visual"
 msgstr ""
 
-#: editor/header/mode-switcher/index.js:30
+#: editor/header/mode-switcher/index.js:24
 msgctxt "Name for the Text editor tab (formerly HTML)"
 msgid "Text"
 msgstr ""


### PR DESCRIPTION
This PR changes the mode switcher from a custom JS thing to be a common selectbox, although heavily styled. The benefit is that you can click/hold the select box and release it on the option you want, making it easier to switch. It would also be more flexible if a plugin wanted to, say, add Markdown as an option.

GIF:

![apr-10-2017 16-17-15](https://cloud.githubusercontent.com/assets/1204802/24866057/6ba81b98-1e09-11e7-8aba-9f0c2b5f7c66.gif)

This will need a review, especially the React bits. 
