### PR TITLE
i18n: Support multiple reference files for same translation

### DIFF
--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -37,11 +37,23 @@ const { pick, uniq, fromPairs, sortBy, toPairs, isEqual } = require( 'lodash' );
 const { relative } = require( 'path' );
 const { writeFileSync } = require( 'fs' );
 
+/**
+ * Default output headers if none specified in plugin options.
+ *
+ * @type {Object}
+ */
 const DEFAULT_HEADERS = {
 	'content-type': 'text/plain; charset=UTF-8',
 	'x-generator': 'babel-plugin-wp-i18n'
 };
 
+/**
+ * Default functions to parse if none specified in plugin options. Each key is
+ * a CallExpression name (or member name) and the value an array corresponding
+ * to translation key argument position.
+ *
+ * @type {Object}
+ */
 const DEFAULT_FUNCTIONS = {
 	__: [ 'msgid' ],
 	_n: [ 'msgid', 'msgid_plural' ],
@@ -49,10 +61,26 @@ const DEFAULT_FUNCTIONS = {
 	_nx: [ 'msgid', 'msgctxt', 'msgid_plural' ]
 };
 
+/**
+ * Default file output if none specified.
+ *
+ * @type {string}
+ */
 const DEFAULT_OUTPUT = 'gettext.pot';
 
+/**
+ * Set of keys which are valid to be assigned into a translation object.
+ *
+ * @type {string[]}
+ */
 const VALID_TRANSLATION_KEYS = [ 'msgid', 'msgid_plural', 'msgctxt' ];
 
+/**
+ * Returns translator comment for a given AST node if one exists.
+ *
+ * @param  {Object}  node AST node
+ * @return {?string}      Translator comment
+ */
 function getTranslatorComment( node ) {
 	if ( ! node.leadingComments ) {
 		return;
@@ -72,10 +100,25 @@ function getTranslatorComment( node ) {
 	}
 }
 
+/**
+ * Returns true if the specified key of a function is valid for assignment in
+ * the translation object.
+ *
+ * @param  {string}  key Key to test
+ * @return {Boolean}     Whether key is valid for assignment
+ */
 function isValidTranslationKey( key ) {
 	return -1 !== VALID_TRANSLATION_KEYS.indexOf( key );
 }
 
+/**
+ * Given two translation objects, returns true if valid translation keys match,
+ * or false otherwise.
+ *
+ * @param  {Object}  a First translation object
+ * @param  {Object}  b Second translation object
+ * @return {Boolean}   Whether valid translation keys match
+ */
 function isSameTranslation( a, b ) {
 	return isEqual(
 		pick( a, VALID_TRANSLATION_KEYS ),
@@ -208,3 +251,6 @@ module.exports = function() {
 		}
 	};
 };
+
+module.exports.isValidTranslationKey = isValidTranslationKey;
+module.exports.isSameTranslation = isSameTranslation;

--- a/i18n/test/babel-plugin.js
+++ b/i18n/test/babel-plugin.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import babelPlugin from '../babel-plugin';
+
+describe( 'babel-plugin', () => {
+	const { isValidTranslationKey, isSameTranslation } = babelPlugin;
+
+	describe( '.isValidTranslationKey()', () => {
+		it( 'should return false if not one of valid keys', () => {
+			expect( isValidTranslationKey( 'foo' ) ).to.be.false();
+		} );
+
+		it( 'should return true if one of valid keys', () => {
+			expect( isValidTranslationKey( 'msgid' ) ).to.be.true();
+		} );
+	} );
+
+	describe( '.isSameTranslation()', () => {
+		it( 'should return false if any translation keys differ', () => {
+			const a = { msgid: 'foo' };
+			const b = { msgid: 'bar' };
+
+			expect( isSameTranslation( a, b ) ).to.be.false();
+		} );
+
+		it( 'should return true if all translation keys the same', () => {
+			const a = { msgid: 'foo', comments: { reference: 'a' } };
+			const b = { msgid: 'foo', comments: { reference: 'b' } };
+
+			expect( isSameTranslation( a, b ) ).to.be.true();
+		} );
+	} );
+} );

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -20,14 +20,17 @@ msgid "List"
 msgstr ""
 
 #: editor/blocks/list/index.js:27
+#: editor/blocks/text/index.js:19
 msgid "Align left"
 msgstr ""
 
 #: editor/blocks/list/index.js:35
+#: editor/blocks/text/index.js:27
 msgid "Align center"
 msgstr ""
 
 #: editor/blocks/list/index.js:43
+#: editor/blocks/text/index.js:35
 msgid "Align right"
 msgstr ""
 


### PR DESCRIPTION
Closes #388 

This pull request seeks to add support for including references of multiple files using the same translation. Both references and the position of multi-referenced strings are alphabetized in the generated template file.

__Testing instructions:__

You may try to add a new instance of translating an existing string and verify that it's reference is included in alphabetical order in the generated `languages/gutenberg.pot` after running `npm run build`. Or simply confirm that there are no changes or errors when running this script.