### PR TITLE
Bump react-redux dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "hpq": "^1.2.0",
     "jed": "^1.1.1",
     "lodash": "^4.17.4",
-    "react-redux": "^5.0.3",
+    "react-redux": "^5.0.4",
     "react-textarea-autosize": "^4.0.5",
     "redux": "^3.6.0",
     "uuid": "^3.0.1"


### PR DESCRIPTION
This pull request seeks to bump the version of our `react-redux` dependency, resolving a warning which is logged to the console since the release of React 15.5.0 (deprecating built-in `React.PropTypes`).

Changelog: https://github.com/reactjs/react-redux/releases/tag/v5.0.4

__Testing instructions:__

Verify after running `npm run build` and navigating to the Gutenberg screen with a fresh cache in your browser that there are no warnings logged to the developer tools console.