### PR TITLE
Suppress freeform block contenteditable warning

### DIFF
--- a/editor/blocks/freeform/index.js
+++ b/editor/blocks/freeform/index.js
@@ -12,7 +12,14 @@ wp.blocks.registerBlock( 'core/freeform', {
 	},
 
 	edit( { attributes } ) {
-		return <div contentEditable>{ attributes.html }</div>;
+		return (
+			<div
+				contentEditable
+				suppressContentEditableWarning
+			>
+				{ attributes.html }
+			</div>
+		);
 	},
 
 	save( { attributes } ) {


### PR DESCRIPTION
Related: #335

This pull request seeks to silence a warning logged to the console by the freeform fallback block. While not great as a permanent solution, this at least temporarily helps clear the console in case true errors are to occur. A more permanent solution will be to implement the freeform block in such a way that it handles and appropriately displays arbitrary markup (perhaps tied to #365).

__Testing instructions:__

Verify that warnings relating to `contenteditable` are no longer logged to the developer tools console.