### PR TITLE
Ability to save and restore the editor. Swap list type ability

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -54,7 +54,7 @@ export default class Editable extends wp.element.Component {
 		}
 		const value = this.editor.getContent();
 		this.editor.save();
-		this.props.onChange( value );
+		this.props.onChange( value, this.node );
 	}
 
 	bindNode( ref ) {

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -54,6 +54,8 @@ export default class Editable extends wp.element.Component {
 		}
 		const value = this.editor.getContent();
 		this.editor.save();
+		// We need the node itself to parse the content and being
+		// able to correctly swap tags.
 		this.props.onChange( value, this.node );
 	}
 
@@ -74,6 +76,13 @@ export default class Editable extends wp.element.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		// TinyMCE wouldn't be aware of the fact that
+		// its root node has been replaced.
+		if ( prevProps.tagName !== this.props.tagName ) {
+			this.editor.destroy();
+			this.initialize();
+		}
+
 		if ( this.props.value !== prevProps.value ) {
 			this.updateContent();
 		}

--- a/editor/blocks/list/index.js
+++ b/editor/blocks/list/index.js
@@ -2,10 +2,9 @@
  * Internal dependencies
  */
 import './style.scss';
-import * as hpqQuery from 'hpq';
 
 const Editable = wp.blocks.Editable;
-const { html, prop, query, text } = wp.blocks.query;
+const { html, prop, query, parse } = wp.blocks.query;
 
 const parseAttrs = {
 	listType: prop( 'ol,ul', 'nodeName' ),
@@ -58,7 +57,17 @@ wp.blocks.registerBlock( 'core/list', {
 			onClick( attributes, setAttributes ) {
 				setAttributes( { align: 'justify' } );
 			}
+		},
+
+		{
+			icon: 'editor-ul',
+			title: wp.i18n.__( 'Convert to unordered' ),
+			isActive: ( { } ) => false, // To be implemented
+			onClick( attributes, setAttributes ) {
+				setAttributes( { listType: 'ul' } );
+			}
 		}
+
 	],
 
 	edit( { attributes, setAttributes } ) {
@@ -66,14 +75,15 @@ wp.blocks.registerBlock( 'core/list', {
 		const content = items.map( item => {
 			return `<li>${ item.value }</li>`;
 		} ).join( '' );
-
 		return (
 			<Editable
 				tagName={ listType }
 				style={ align ? { textAlign: align } : null }
 				onChange={ ( v, node ) => {
-					const attrs = hpqQuery.parse('<' + node.nodeName + '>' +  v + '</'  + node.nodeName + '>', parseAttrs );
-					console.log('attrs', attrs);
+					// The node is getting passed through from Tiny.
+					// Is there a way to parse this with hpq that doesn't
+					// involve a string?
+					const attrs = parse( '<' + node.nodeName + '>' + v + '</' + node.nodeName + '>', parseAttrs );
 					setAttributes( attrs );
 				} }
 				value={ content }
@@ -82,11 +92,8 @@ wp.blocks.registerBlock( 'core/list', {
 	},
 
 	save( { attributes } ) {
-		const { listType = 'ol', items = [], content } = attributes;
+		const { listType = 'ol', items = [] } = attributes;
 		const ListType = listType.toLowerCase();
-		console.log( items );
-		console.log( content );
-		debugger;
 		const inner = items.map( item => {
 			return `<li>${ item.value }</li>`;
 		} ).join( '' );

--- a/editor/blocks/list/index.js
+++ b/editor/blocks/list/index.js
@@ -66,6 +66,15 @@ wp.blocks.registerBlock( 'core/list', {
 			onClick( attributes, setAttributes ) {
 				setAttributes( { listType: 'ul' } );
 			}
+		},
+
+		{
+			icon: 'editor-ol',
+			title: wp.i18n.__( 'Convert to ordered' ),
+			isActive: ( { } ) => false, // To be implemented
+			onClick( attributes, setAttributes ) {
+				setAttributes( { listType: 'ol' } );
+			}
 		}
 
 	],

--- a/editor/blocks/list/index.js
+++ b/editor/blocks/list/index.js
@@ -58,7 +58,6 @@ wp.blocks.registerBlock( 'core/list', {
 				setAttributes( { align: 'justify' } );
 			}
 		},
-
 		{
 			icon: 'editor-ul',
 			title: wp.i18n.__( 'Convert to unordered' ),

--- a/editor/blocks/list/index.js
+++ b/editor/blocks/list/index.js
@@ -13,6 +13,10 @@ wp.blocks.registerBlock( 'core/list', {
 
 	attributes: {
 		listType: prop( 'ol,ul', 'nodeName' ),
+		content: () => {
+			debugger;
+			return html( 'li' );
+		},
 		items: wp.blocks.query.query(
 			'li',
 			{
@@ -53,14 +57,20 @@ wp.blocks.registerBlock( 'core/list', {
 			onClick( attributes, setAttributes ) {
 				setAttributes( { align: 'justify' } );
 			}
+		},
+		{
+			icon: 'editor-ol',
+			title: wp.i18n.__( 'Ordered list' ),
+			isActive: ( { } ) => false,
+			onClick( attributes, setAttributes ) {
+				debugger;
+				setAttributes( { listType: 'ol' } );
+			}
 		}
 	],
 
 	edit( { attributes } ) {
-		const { listType = 'ol', items = [], align } = attributes;
-		const content = items.map( item => {
-			return `<li>${ item.value }</li>`;
-		} ).join( '' );
+		const { listType = 'ol', align, content } = attributes;
 
 		return (
 			<Editable
@@ -72,10 +82,11 @@ wp.blocks.registerBlock( 'core/list', {
 	},
 
 	save( { attributes } ) {
-		const { listType = 'ol', items = [] } = attributes;
-		const children = items.map( ( item, index ) => (
-			<li key={ index } dangerouslySetInnerHTML={ { __html: item.value } } />
-		) );
-		return wp.element.createElement( listType.toLowerCase(), null, children );
+		const { listType = 'ol', align, content } = attributes;
+		const ListElement = listType.toLocaleLowerCase();
+		return (
+			<ListElement style={ align ? { textAlign: align } : null } dangerouslySetInnerHTML={ { __html: content } }>
+			</ListElement>
+		);
 	}
 } );

--- a/editor/blocks/list/index.js
+++ b/editor/blocks/list/index.js
@@ -67,7 +67,6 @@ wp.blocks.registerBlock( 'core/list', {
 				setAttributes( { listType: 'ul' } );
 			}
 		},
-
 		{
 			icon: 'editor-ol',
 			title: wp.i18n.__( 'Convert to ordered' ),

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -19,20 +19,24 @@ msgstr ""
 msgid "List"
 msgstr ""
 
-#: editor/blocks/list/index.js:27
+#: editor/blocks/list/index.js:31
 msgid "Align left"
 msgstr ""
 
-#: editor/blocks/list/index.js:35
+#: editor/blocks/list/index.js:39
 msgid "Align center"
 msgstr ""
 
-#: editor/blocks/list/index.js:43
+#: editor/blocks/list/index.js:47
 msgid "Align right"
 msgstr ""
 
-#: editor/blocks/list/index.js:51
+#: editor/blocks/list/index.js:55
 msgid "Justify"
+msgstr ""
+
+#: editor/blocks/list/index.js:63
+msgid "Ordered list"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:20

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -15,27 +15,35 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: editor/blocks/list/index.js:10
+#: editor/blocks/list/index.js:22
 msgid "List"
 msgstr ""
 
-#: editor/blocks/list/index.js:27
+#: editor/blocks/list/index.js:31
 #: editor/blocks/text/index.js:19
 msgid "Align left"
 msgstr ""
 
-#: editor/blocks/list/index.js:35
+#: editor/blocks/list/index.js:39
 #: editor/blocks/text/index.js:27
 msgid "Align center"
 msgstr ""
 
-#: editor/blocks/list/index.js:43
+#: editor/blocks/list/index.js:47
 #: editor/blocks/text/index.js:35
 msgid "Align right"
 msgstr ""
 
-#: editor/blocks/list/index.js:51
+#: editor/blocks/list/index.js:55
 msgid "Justify"
+msgstr ""
+
+#: editor/blocks/list/index.js:63
+msgid "Convert to unordered"
+msgstr ""
+
+#: editor/blocks/list/index.js:71
+msgid "Convert to ordered"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:20

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: editor/blocks/list/index.js:10
+#: editor/blocks/list/index.js:22
 msgid "List"
 msgstr ""
 
@@ -35,8 +35,12 @@ msgstr ""
 msgid "Justify"
 msgstr ""
 
-#: editor/blocks/list/index.js:63
-msgid "Ordered list"
+#: editor/blocks/list/index.js:64
+msgid "Convert to unordered"
+msgstr ""
+
+#: editor/blocks/list/index.js:72
+msgid "Convert to ordered"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:20

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -35,21 +35,28 @@ msgstr ""
 msgid "Justify"
 msgstr ""
 
-#: editor/blocks/list/index.js:64
+#: editor/blocks/list/index.js:63
+msgid "Ordered list"
+msgstr ""
+
+#: editor/blocks/list/index.js:63
 msgid "Convert to unordered"
 msgstr ""
 
-#: editor/blocks/list/index.js:72
+#: editor/blocks/list/index.js:64
+msgid "swap to ul"
+msgstr ""
+
+#: editor/blocks/list/index.js:71
 msgid "Convert to ordered"
+msgstr ""
+
+#: editor/blocks/text/index.js:5
+msgid "Text"
 msgstr ""
 
 #: editor/header/mode-switcher/index.js:20
 msgid "Visual"
-msgstr ""
-
-#: editor/header/mode-switcher/index.js:24
-msgctxt "Name for the Text editor tab (formerly HTML)"
-msgid "Text"
 msgstr ""
 
 #: editor/header/saved-state/index.js:11


### PR DESCRIPTION
In this PR I am adding two main parts:

- Adding the ability to swap the list type (does this through two buttons inline in the toolbar, waiting for an hook that I can use for the block dropdown).
- Implements the `onChange` for the list block to preserve the content of the list, which as [pointed out](https://github.com/WordPress/gutenberg/pull/387#discussion_r110728439) by @aduth 