### PR TITLE
Assign icon button screen reader text as aria-label

### DIFF
--- a/editor/components/button/index.js
+++ b/editor/components/button/index.js
@@ -4,7 +4,7 @@
 import './style.scss';
 import classnames from 'classnames';
 
-function Button( { type = 'button', isPrimary, isLarge, onClick, className, children } ) {
+function Button( { isPrimary, isLarge, className, ...additionalProps } ) {
 	const classes = classnames( 'editor-button', className, {
 		button: ( isPrimary || isLarge ),
 		'button-primary': isPrimary,
@@ -13,11 +13,9 @@ function Button( { type = 'button', isPrimary, isLarge, onClick, className, chil
 
 	return (
 		<button
-			type={ type }
-			onClick={ onClick }
-			className={ classes }>
-			{ children }
-		</button>
+			type="button"
+			{ ...additionalProps }
+			className={ classes } />
 	);
 }
 

--- a/editor/components/icon-button/index.js
+++ b/editor/components/icon-button/index.js
@@ -14,7 +14,7 @@ function IconButton( { icon, label, className, ...additionalProps } ) {
 	const classes = classnames( 'editor-icon-button', className );
 
 	return (
-		<Button { ...additionalProps } title={ label } className={ classes }>
+		<Button { ...additionalProps } aria-label={ label } className={ classes }>
 			<Dashicon icon={ icon } />
 		</Button>
 	);

--- a/editor/components/icon-button/index.js
+++ b/editor/components/icon-button/index.js
@@ -10,15 +10,11 @@ import './style.scss';
 import Button from '../button';
 import Dashicon from '../dashicon';
 
-function IconButton( { icon, label, onClick, className } ) {
+function IconButton( { icon, label, className, ...additionalProps } ) {
 	const classes = classnames( 'editor-icon-button', className );
 
 	return (
-		<Button
-			title={ label }
-			onClick={ onClick }
-			className={ classes }
-		>
+		<Button { ...additionalProps } title={ label } className={ classes }>
 			<Dashicon icon={ icon } />
 		</Button>
 	);

--- a/editor/components/toolbar/index.js
+++ b/editor/components/toolbar/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import './style.scss';
-import Dashicon from 'components/dashicon';
+import IconButton from 'components/icon-button';
 
 function Toolbar( { controls } ) {
 	if ( ! controls || ! controls.length ) {
@@ -17,19 +17,17 @@ function Toolbar( { controls } ) {
 	return (
 		<ul className="editor-toolbar">
 			{ controls.map( ( control, index ) => (
-				<button
+				<IconButton
 					key={ index }
-					className={ classNames( 'editor-toolbar__control', {
-						'is-active': control.isActive && control.isActive()
-					} ) }
-					title={ control.title }
+					icon={ control.icon }
+					label={ control.title }
 					onClick={ ( event ) => {
 						event.stopPropagation();
 						control.onClick();
 					} }
-				>
-					<Dashicon icon={ control.icon } />
-				</button>
+					className={ classNames( 'editor-toolbar__control', {
+						'is-active': control.isActive && control.isActive()
+					} ) } />
 			) ) }
 		</ul>
 	);

--- a/editor/components/toolbar/style.scss
+++ b/editor/components/toolbar/style.scss
@@ -6,6 +6,7 @@
 }
 
 .editor-toolbar__control {
+	display: inline-flex;
 	margin: 2px;
 	margin-left: 0;
 	padding: 6px;


### PR DESCRIPTION
This pull request seeks to change the behavior of the `<IconButton />` `label` prop to define an `aria-label` attribute on the rendered element instead of a `title` attribute:

https://www.w3.org/WAI/GL/wiki/Using_aria-label_to_provide_an_invisible_label

__Implement details / Open questions:__

To support these changes, refactoring was applied to both the `Button` and `IconButton` components to allow pass-through props. We should decide whether this is a pattern we want to support, because it arguably makes props more opaque. Conversely, individually supporting attributes may become needlessly verbose for what are essentially pass-through components anyways. This may even lead to the question of whether these components are necessary, but I do find that they define nice defaults, especially with button `type` and applying a universal base `class` to every editor-specific button.