### PR TITLE
Editable: Enter splits the current paragraph into two blocks

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -78,8 +78,7 @@ export default class Editable extends wp.element.Component {
 			// Avoid splitting on single enter
 			if (
 				! lastNodeBeforeCursor ||
-				lastNodeBeforeCursor.childNodes.length !== 1 ||
-				lastNodeBeforeCursor.firstChild.tagName !== 'BR'
+				!! lastNodeBeforeCursor.textContent
 			) {
 				return;
 			}

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -68,8 +68,10 @@ export default class Editable extends wp.element.Component {
 
 		// Wait for the event to propagate
 		setTimeout( () => {
+			if ( ! this.editor ) {
+				return;
+			}
 			// Getting the content before and after the cursor
-			this.editor.selection.getStart();
 			const childNodes = Array.from( this.editor.getBody().childNodes );
 			const splitIndex = childNodes.indexOf( this.editor.selection.getStart() );
 			const getHtml = ( nodes ) => nodes.reduce( ( memo, node ) => memo + node.outerHTML, '' );
@@ -78,6 +80,7 @@ export default class Editable extends wp.element.Component {
 			// Avoid splitting on single enter
 			if (
 				! lastNodeBeforeCursor ||
+				beforeNodes.length < 2 ||
 				!! lastNodeBeforeCursor.textContent
 			) {
 				return;
@@ -86,7 +89,7 @@ export default class Editable extends wp.element.Component {
 			const after = getHtml( childNodes.slice( splitIndex ) );
 
 			// Splitting into two blocks
-			this.editor.setContent( this.props.value );
+			this.editor.setContent( this.props.value || '' );
 			const hasAfter = !! childNodes.slice( splitIndex )
 				.reduce( ( memo, node ) => memo + node.textContent, '' );
 			this.props.onSplit( before, hasAfter ? after : '' );

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -14,6 +14,7 @@ export default class Editable extends wp.element.Component {
 		this.onInit = this.onInit.bind( this );
 		this.onSetup = this.onSetup.bind( this );
 		this.onChange = this.onChange.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
 		this.bindNode = this.bindNode.bind( this );
 	}
 
@@ -42,6 +43,7 @@ export default class Editable extends wp.element.Component {
 		this.editor = editor;
 		editor.on( 'init', this.onInit );
 		editor.on( 'focusout', this.onChange );
+		editor.on( 'keydown', this.onKeyDown );
 	}
 
 	onInit() {
@@ -56,6 +58,28 @@ export default class Editable extends wp.element.Component {
 		const value = this.editor.getContent();
 		this.editor.save();
 		this.props.onChange( value );
+	}
+
+	onKeyDown( event ) {
+		if ( ! this.props.tagName && event.keyCode === 13 ) {
+			// Wait for the event to propagate
+			setTimeout( () => {
+				// Getting the content before and after the cursor
+				this.editor.selection.getStart();
+				const childNodes = Array.from( this.editor.getBody().childNodes );
+				const splitIndex = childNodes.indexOf( this.editor.selection.getStart() );
+				const getHtml = ( nodes ) => nodes.reduce( ( memo, node ) => memo + node.outerHTML, '' );
+				const beforeNodes = childNodes.slice( 0, splitIndex );
+				const before = getHtml( beforeNodes );
+				const after = getHtml( childNodes.slice( splitIndex ) );
+
+				// Splitting into two blocks
+				this.editor.setContent( this.props.value );
+				const hasAfter = !! childNodes.slice( splitIndex )
+					.reduce( ( memo, node ) => memo + node.textContent, '' );
+				this.props.onSplit( before, hasAfter ? after : '' );
+			} );
+		}
 	}
 
 	bindNode( ref ) {
@@ -100,3 +124,7 @@ export default class Editable extends wp.element.Component {
 		);
 	}
 }
+
+Editable.defaultProps = {
+	onSplit: () => {}
+};

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -62,7 +62,7 @@ export default class Editable extends wp.element.Component {
 	}
 
 	onKeyDown( event ) {
-		if ( this.props.tagName || event.keyCode !== 13 ) {
+		if ( this.props.tagName || event.keyCode !== 13 || ! this.props.onSplit ) {
 			return;
 		}
 
@@ -136,7 +136,3 @@ export default class Editable extends wp.element.Component {
 		);
 	}
 }
-
-Editable.defaultProps = {
-	onSplit: () => {}
-};

--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -1,3 +1,13 @@
-.blocks-editable:focus {
-	outline: none;
+.blocks-editable {
+	> p:first-child {
+		margin-top: 0;
+	}
+
+	> p:last-child {
+		margin-bottom: 0;
+	}
+
+	&:focus {
+		outline: none;
+	}
 }

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import uuid from 'uuid/v4';
+
+/**
  * Internal dependencies
  */
 import { registerBlock, query } from 'api';
@@ -45,15 +50,24 @@ registerBlock( 'core/text', {
 		}
 	],
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, insertBlockAfter } ) {
 		const { content, align } = attributes;
 
 		return (
 			<Editable
-				tagName="p"
 				value={ content }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				style={ align ? { textAlign: align } : null }
+				onSplit={ ( before, after ) => {
+					setAttributes( { content: before } );
+					insertBlockAfter( {
+						uid: uuid(),
+						blockType: 'core/text',
+						attributes: {
+							content: after
+						}
+					} );
+				} }
 			/>
 		);
 	},

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -19,8 +19,8 @@ registerBlock( 'core/text', {
 	category: 'common',
 
 	attributes: {
-		content: html( 'p' ),
-		align: prop( 'p', 'style.textAlign' )
+		content: html( 'div' ),
+		align: prop( 'div', 'style.textAlign' )
 	},
 
 	controls: [
@@ -76,9 +76,10 @@ registerBlock( 'core/text', {
 		const { align, content } = attributes;
 
 		return (
-			<p
+			<div
 				style={ align ? { textAlign: align } : null }
-				dangerouslySetInnerHTML={ { __html: content } } />
+				dangerouslySetInnerHTML={ { __html: content } }
+			/>
 		);
 	}
 } );

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import uuid from 'uuid/v4';
-
-/**
  * Internal dependencies
  */
 import { registerBlock, query } from 'api';

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -60,13 +60,9 @@ registerBlock( 'core/text', {
 				style={ align ? { textAlign: align } : null }
 				onSplit={ ( before, after ) => {
 					setAttributes( { content: before } );
-					insertBlockAfter( {
-						uid: uuid(),
-						blockType: 'core/text',
-						attributes: {
-							content: after
-						}
-					} );
+					insertBlockAfter( wp.blocks.createBlock( 'core/text', {
+						content: after
+					} ) );
 				} }
 			/>
 		);

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -70,6 +70,7 @@ registerBlock( 'core/text', {
 	save( { attributes } ) {
 		const { align, content } = attributes;
 
+		// Todo: Remove the temporary <div> wrapper once the serializer supports returning an array
 		return (
 			<div>
 				{ content && content.map( ( paragraph, i ) => (

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -30,7 +30,7 @@ function VisualEditorBlock( props ) {
 		'is-hovered': isHovered
 	} );
 
-	const { onChange, onSelect, onDeselect, onMouseEnter, onMouseLeave } = props;
+	const { onChange, onSelect, onDeselect, onMouseEnter, onMouseLeave, onInsertAfter } = props;
 
 	function setAttributes( attributes ) {
 		onChange( {
@@ -75,7 +75,9 @@ function VisualEditorBlock( props ) {
 			<BlockEdit
 				isSelected={ isSelected }
 				attributes={ block.attributes }
-				setAttributes={ setAttributes } />
+				setAttributes={ setAttributes }
+				insertBlockAfter={ onInsertAfter }
+			/>
 		</div>
 	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
@@ -121,6 +123,13 @@ export default connect(
 				type: 'TOGGLE_BLOCK_HOVERED',
 				hovered: false,
 				uid: ownProps.uid
+			} );
+		},
+		onInsertAfter( block ) {
+			dispatch( {
+				type: 'INSERT_BLOCK',
+				after: ownProps.uid,
+				block
 			} );
 		}
 	} )

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -8,11 +8,6 @@
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
 	}
-
-	p {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
 }
 
 .editor-visual-editor__block {

--- a/editor/state.js
+++ b/editor/state.js
@@ -48,6 +48,14 @@ export const blocks = combineUndoableReducers( {
 			case 'REPLACE_BLOCKS':
 				return action.blockNodes.map( ( { uid } ) => uid );
 
+			case 'INSERT_BLOCK':
+				const position = action.after ? state.indexOf( action.after ) + 1 : state.length;
+				return [
+					...state.slice( 0, position ),
+					action.block.uid,
+					...state.slice( position )
+				];
+
 			case 'MOVE_BLOCK_UP':
 				if ( action.uid === state[ 0 ] ) {
 					return state;
@@ -72,12 +80,6 @@ export const blocks = combineUndoableReducers( {
 					swappedUid,
 					action.uid,
 					...state.slice( index + 2 )
-				];
-
-			case 'INSERT_BLOCK':
-				return [
-					...state,
-					action.block.uid
 				];
 		}
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -244,7 +244,7 @@ describe( 'state', () => {
 					blockType: 'core/test-block',
 					attributes: {}
 				}, {
-					uid: 'kumquat2',
+					uid: 'loquat',
 					blockType: 'core/test-block',
 					attributes: {}
 				} ]
@@ -254,13 +254,13 @@ describe( 'state', () => {
 				type: 'INSERT_BLOCK',
 				after: 'kumquat',
 				block: {
-					uid: 'kumquat3',
+					uid: 'persimmon',
 					blockType: 'core/freeform'
 				}
 			} );
 
 			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 3 );
-			expect( state.order ).to.eql( [ 'kumquat', 'kumquat3', 'kumquat2' ] );
+			expect( state.order ).to.eql( [ 'kumquat', 'persimmon', 'loquat' ] );
 		} );
 	} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -235,6 +235,33 @@ describe( 'state', () => {
 
 			expect( state ).to.equal( 'chicken' );
 		} );
+
+		it( 'should insert after the specified block uid', () => {
+			const original = blocks( undefined, {
+				type: 'REPLACE_BLOCKS',
+				blockNodes: [ {
+					uid: 'kumquat',
+					blockType: 'core/test-block',
+					attributes: {}
+				}, {
+					uid: 'kumquat2',
+					blockType: 'core/test-block',
+					attributes: {}
+				} ]
+			} );
+
+			const state = blocks( original, {
+				type: 'INSERT_BLOCK',
+				after: 'kumquat',
+				block: {
+					uid: 'kumquat3',
+					blockType: 'core/freeform'
+				}
+			} );
+
+			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 3 );
+			expect( state.order ).to.eql( [ 'kumquat', 'kumquat3', 'kumquat2' ] );
+		} );
 	} );
 
 	describe( 'mode()', () => {

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -28,17 +28,17 @@ msgid "List"
 msgstr ""
 
 #: blocks/library/list/index.js:25
-#: blocks/library/text/index.js:24
+#: blocks/library/text/index.js:26
 msgid "Align left"
 msgstr ""
 
 #: blocks/library/list/index.js:33
-#: blocks/library/text/index.js:32
+#: blocks/library/text/index.js:34
 msgid "Align center"
 msgstr ""
 
 #: blocks/library/list/index.js:41
-#: blocks/library/text/index.js:40
+#: blocks/library/text/index.js:42
 msgid "Align right"
 msgstr ""
 
@@ -50,7 +50,7 @@ msgstr ""
 msgid "Quote"
 msgstr ""
 
-#: blocks/library/text/index.js:10
+#: blocks/library/text/index.js:13
 msgid "Text"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -28,17 +28,17 @@ msgid "List"
 msgstr ""
 
 #: blocks/library/list/index.js:25
-#: blocks/library/text/index.js:29
+#: blocks/library/text/index.js:24
 msgid "Align left"
 msgstr ""
 
 #: blocks/library/list/index.js:33
-#: blocks/library/text/index.js:37
+#: blocks/library/text/index.js:32
 msgid "Align center"
 msgstr ""
 
 #: blocks/library/list/index.js:41
-#: blocks/library/text/index.js:45
+#: blocks/library/text/index.js:40
 msgid "Align right"
 msgstr ""
 
@@ -50,7 +50,7 @@ msgstr ""
 msgid "Quote"
 msgstr ""
 
-#: blocks/library/text/index.js:15
+#: blocks/library/text/index.js:10
 msgid "Text"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -28,17 +28,17 @@ msgid "List"
 msgstr ""
 
 #: blocks/library/list/index.js:25
-#: blocks/library/text/index.js:24
+#: blocks/library/text/index.js:29
 msgid "Align left"
 msgstr ""
 
 #: blocks/library/list/index.js:33
-#: blocks/library/text/index.js:32
+#: blocks/library/text/index.js:37
 msgid "Align center"
 msgstr ""
 
 #: blocks/library/list/index.js:41
-#: blocks/library/text/index.js:40
+#: blocks/library/text/index.js:45
 msgid "Align right"
 msgstr ""
 
@@ -50,7 +50,7 @@ msgstr ""
 msgid "Quote"
 msgstr ""
 
-#: blocks/library/text/index.js:10
+#: blocks/library/text/index.js:15
 msgid "Text"
 msgstr ""
 

--- a/post-content.js
+++ b/post-content.js
@@ -9,7 +9,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/heading -->',
 
 			'<!-- wp:core/text -->',
-			'<p>I imagine prior to the launch of the iPod, or the iPhone, there were teams saying the same thing: the copy + paste guys are <em>so close</em> to being ready and we know Walt Mossberg is going to ding us for this so let\'s just not ship to the manufacturers in China for just a few more weeks… The Apple teams were probably embarrassed. But <strong>if you\'re not embarrassed when you ship your first version you waited too long</strong>.</p>',
+			'<div><p>I imagine prior to the launch of the iPod, or the iPhone, there were teams saying the same thing: the copy + paste guys are <em>so close</em> to being ready and we know Walt Mossberg is going to ding us for this so let\'s just not ship to the manufacturers in China for just a few more weeks… The Apple teams were probably embarrassed. But <strong>if you\'re not embarrassed when you ship your first version you waited too long</strong>.</p></div>',
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/image -->',
@@ -17,7 +17,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
-			'<p>A beautiful thing about Apple is how quickly they obsolete their own products. I imagine this also makes the discipline of getting things out there easier. Like I mentioned before, the longer it’s been since the last release the more pressure there is, but if you know that if your bit of code doesn’t make this version but there’s the +0.1 coming out in 6 weeks, then it’s not that bad. It’s like flights from San Francisco to LA, if you miss one you know there’s another one an hour later so it’s not a big deal. Amazon has done a fantastic job of this with the Kindle as well, with a new model every year.</p>',
+			'<div><p>A beautiful thing about Apple is how quickly they obsolete their own products. I imagine this also makes the discipline of getting things out there easier. Like I mentioned before, the longer it’s been since the last release the more pressure there is, but if you know that if your bit of code doesn’t make this version but there’s the +0.1 coming out in 6 weeks, then it’s not that bad. It’s like flights from San Francisco to LA, if you miss one you know there’s another one an hour later so it’s not a big deal. Amazon has done a fantastic job of this with the Kindle as well, with a new model every year.</p></div>',
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/quote -->',
@@ -29,7 +29,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
-			'<p>By shipping early and often you have the unique competitive advantage of hearing from real people what they think of your work, which in best case helps you anticipate market direction, and in worst case gives you a few people rooting for you that you can email when your team pivots to a new idea. Nothing can recreate the crucible of real usage.</p>',
+			'<div><p>By shipping early and often you have the unique competitive advantage of hearing from real people what they think of your work, which in best case helps you anticipate market direction, and in worst case gives you a few people rooting for you that you can email when your team pivots to a new idea. Nothing can recreate the crucible of real usage.</p></div>',
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/list -->',


### PR DESCRIPTION
This PR builds on #407 
Tries to address #375 #374 

The idea for this PR is to catch `Enter` key down event and split the text blocks into two text blocks.

**How it works?**

 - If we specify a `tagName` on the `Editable` component, I'm assuming we want TinyMCE to handle the `Enter` key press (see list block for example)
 - For the `text/block` I'm dropping the tagName to allow custom `Enter` behavior. 
 - When we hit enter, we let TinyMCE update the dom ( see `setTimeout` ), and then we tries to figure out how to split the content ( computing `before` and `after` ) . These values are passed to a new callback prop `onSplit`
 - In this PR, I'm providing a new eventHandler to the `edit` property of blocks. I'm calling it `insertBlockAfter`. The block author can call this function to append a new block after the current block. 
 - I was thinking of splitting the block only on two enters, but this assumes the text block can store multiple paragraphs which is not the case for now. Storing multiple paragraphs on the text block will lead us to reconsider how to serialize/parse the `text-align` attribute. Will we duplicate it on the different paragraphs?  Should we add a `div` wrapper.
 - This is the first PR introducing Keyboard interaction, and we should consider how to update the focus and the caret position across blocks. Should we follow the same idea used in the multi-instance prototype where we store the focused block and the focus position in the state?