### PR TITLE
Make header sticky

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -42,6 +42,7 @@ body.toplevel_page_gutenberg {
 
 .gutenberg__editor {
 	position: relative;
+	padding-top: $header-height;
 	img {
 		max-width: 100%;
 	}

--- a/editor/assets/stylesheets/variables.scss
+++ b/editor/assets/stylesheets/variables.scss
@@ -36,3 +36,4 @@ $editor-html-font: Menlo, Consolas, monaco, monospace;
 $editor-font-size: 16px;
 $editor-line-height: 1.8em;
 $item-spacing: 10px;
+$header-height: 56px;

--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -1,8 +1,68 @@
 .editor-header {
-	height: 56px;
+	height: $header-height;
 	padding: $item-spacing;
 	border-bottom: 1px solid $light-gray-500;
+	background: $white;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	position: fixed;
+	z-index: 1;
+	top: 32px;
+	left: 160px;
+	right: 0;
+
+	/* Responsive and folded */
+	body.folded & {
+		left: 36px;
+	}
+
+	/* RTL */
+	body.rtl & {
+		left: 0;
+		right: 160px;
+	}
+
+	body.rtl.folded & {
+		left: 0;
+		right: 36px;
+	}
+}
+
+@media only screen and ( max-width: 960px ) {
+	body.auto-fold .editor-header {
+		left: 36px;
+	}
+
+	body.rtl.auto-fold .editor-header {
+		left: 0;
+		right: 36px;
+	}
+}
+
+@media only screen and ( max-width: 782px ) {
+
+	body.auto-fold .editor-header {
+		left: 0;
+	}
+
+	body.rtl.auto-fold .editor-header {
+		left: 0;
+		right: 0;
+	}
+
+	body.auto-fold .wp-responsive-open .editor-header {
+		left: 190px;
+		right: -190px;
+	}
+
+	body.rtl.auto-fold .wp-responsive-open .editor-header {
+		left: -190px;
+		right: 190px;
+	}
+
+	.editor-header {
+		top: 46px;
+	}
+
 }


### PR DESCRIPTION
This PR gives the editor bar a fixed position so it scrolls with you down the page. It contains a bunch of responsive and RTL CSS to account for all configurations:

- RTL and LTR
- Sidebar manually closed
- Sidebar auto-hiding
- Various responsive sidebar header heights and sidebar widths.