### PR TITLE
Polish text editor mode

### DIFF
--- a/editor/components/toolbar/style.scss
+++ b/editor/components/toolbar/style.scss
@@ -7,7 +7,7 @@
 
 .editor-toolbar__control {
 	display: inline-flex;
-	margin: 2px;
+	margin: 3px;
 	margin-left: 0;
 	padding: 6px;
 	background: none;
@@ -17,7 +17,7 @@
 	cursor: pointer;
 
 	&:first-child {
-		margin-left: 2px;
+		margin-left: 3px;
 	}
 
 	&.is-active,

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -13,21 +13,19 @@ function TextEditor( { blocks, onChange } ) {
 	return (
 		<div>
 			<header className="editor-text-editor__formatting">
-				<div>
-					<button className="editor-text-editor__bold">b</button>
-					<button className="editor-text-editor__italic">i</button>
-					<button className="editor-text-editor__link">link</button>
-					<button>b-quote</button>
-					<button className="editor-text-editor__del">del</button>
-					<button>ins</button>
-					<button>img</button>
-					<button>ul</button>
-					<button>ol</button>
-					<button>li</button>
-					<button>code</button>
-					<button>more</button>
-					<button>close tags</button>
-				</div>
+				<button className="editor-text-editor__bold">b</button>
+				<button className="editor-text-editor__italic">i</button>
+				<button className="editor-text-editor__link">link</button>
+				<button>b-quote</button>
+				<button className="editor-text-editor__del">del</button>
+				<button>ins</button>
+				<button>img</button>
+				<button>ul</button>
+				<button>ol</button>
+				<button>li</button>
+				<button>code</button>
+				<button>more</button>
+				<button>close tags</button>
 			</header>
 			<Textarea
 				autoComplete="off"

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -11,12 +11,32 @@ import './style.scss';
 
 function TextEditor( { blocks, onChange } ) {
 	return (
-		<Textarea
-			defaultValue={ wp.blocks.serialize( blocks ) }
-			onBlur={ ( event ) => onChange( event.target.value ) }
-			className="editor-text-editor"
-			useCacheForDOMMeasurements
-		/>
+		<div>
+			<header className="editor-text-editor__formatting">
+				<div>
+					<button className="editor-text-editor__bold">b</button>
+					<button className="editor-text-editor__italic">i</button>
+					<button className="editor-text-editor__link">link</button>
+					<button>b-quote</button>
+					<button className="editor-text-editor__del">del</button>
+					<button>ins</button>
+					<button>img</button>
+					<button>ul</button>
+					<button>ol</button>
+					<button>li</button>
+					<button>code</button>
+					<button>more</button>
+					<button>close tags</button>
+				</div>
+			</header>
+			<Textarea
+				autoComplete="off"
+				defaultValue={ wp.blocks.serialize( blocks ) }
+				onBlur={ ( event ) => onChange( event.target.value ) }
+				className="editor-text-editor"
+				useCacheForDOMMeasurements
+			/>
+		</div>
 	);
 }
 

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -65,7 +65,7 @@
 }
 
 /* Use padding to center text in the textarea, this allows you to click anywhere to focus it */
-.editor-text-editor__formatting div,
+.editor-text-editor__formatting,
 .editor-text-editor {
 	padding-left: $item-spacing * 2;
 	padding-right: $item-spacing * 2;
@@ -74,7 +74,7 @@
 }
 
 @media only screen and ( min-width: 960px ) {
-	.editor-text-editor__formatting div,
+	.editor-text-editor__formatting,
 	.editor-text-editor {
 		padding-left: 10%;
 		padding-right: 10%;
@@ -82,7 +82,7 @@
 }
 
 @media only screen and ( min-width: 1280px ) {
-	.editor-text-editor__formatting div,
+	.editor-text-editor__formatting,
 	.editor-text-editor {
 		padding-left: 15%;
 		padding-right: 15%;
@@ -90,7 +90,7 @@
 }
 
 @media only screen and ( min-width: 1440px ) {
-	.editor-text-editor__formatting div,
+	.editor-text-editor__formatting,
 	.editor-text-editor {
 		padding-left: 200px;
 		padding-right: 200px;

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -27,21 +27,21 @@
 	button:focus {
 		outline: none;
 	}
+}
 
-	.editor-text-editor__bold {
-		font-weight: bold;
-	}
+.editor-text-editor__bold {
+	font-weight: bold;
+}
 
-	.editor-text-editor__italic {
-		font-style: italic;
-	}
-	.editor-text-editor__link {
-		text-decoration: underline;
-		color: $blue-medium;
-	}
-	.editor-text-editor__del {
-		text-decoration:line-through;
-	}
+.editor-text-editor__italic {
+	font-style: italic;
+}
+.editor-text-editor__link {
+	text-decoration: underline;
+	color: $blue-medium;
+}
+.editor-text-editor__del {
+	text-decoration:line-through;
 }
 
 .editor-text-editor {

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -1,19 +1,14 @@
 .editor-text-editor__formatting {
 	background: $white;
 	border-bottom: 1px solid $light-gray-500;
-	height: 36px;
-
-	div {
-		max-width: 700px;
-		margin: 0 auto;
-	}
+	min-height: 36px;
 
 	button {
 		height: 30px;
 		border: none;
 		background: none;
 		padding: 0 8px;
-		margin: 3px 4px 0 4px;
+		margin: 3px 4px;
 		text-align: center;
 		cursor: pointer;
 		font-family: $editor-html-font;
@@ -51,18 +46,53 @@
 
 .editor-text-editor {
 	display: block;
-	margin: 60px auto 0;
-	width: 700px;
+	padding-top: 60px;
+	padding-bottom: 0;
+	margin: 0;
+	width: 100%;
 	border: none;
 	outline: none;
 	box-shadow: none;
 	resize: none;
-	padding: 0;
 	overflow: hidden;
 	font-family: $editor-html-font;
 	line-height: 150%;
+	transition: padding .2s linear;
 
 	&:focus {
 		box-shadow: none;
+	}
+}
+
+/* Use padding to center text in the textarea, this allows you to click anywhere to focus it */
+.editor-text-editor__formatting div,
+.editor-text-editor {
+	padding-left: $item-spacing * 2;
+	padding-right: $item-spacing * 2;
+	max-width: 1440px;
+	margin: 0 auto;
+}
+
+@media only screen and ( min-width: 960px ) {
+	.editor-text-editor__formatting div,
+	.editor-text-editor {
+		padding-left: 10%;
+		padding-right: 10%;
+	}
+}
+
+@media only screen and ( min-width: 1280px ) {
+	.editor-text-editor__formatting div,
+	.editor-text-editor {
+		padding-left: 15%;
+		padding-right: 15%;
+	}
+}
+
+@media only screen and ( min-width: 1440px ) {
+	.editor-text-editor__formatting div,
+	.editor-text-editor {
+		padding-left: 200px;
+		padding-right: 200px;
 	}
 }

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -1,3 +1,54 @@
+.editor-text-editor__formatting {
+	background: $white;
+	border-bottom: 1px solid $light-gray-500;
+	height: 36px;
+
+	div {
+		max-width: 700px;
+		margin: 0 auto;
+	}
+
+	button {
+		height: 30px;
+		border: none;
+		background: none;
+		padding: 0 8px;
+		margin: 3px 4px 0 4px;
+		text-align: center;
+		cursor: pointer;
+		font-family: $editor-html-font;
+		color: $dark-gray-500;
+		border: 1px solid transparent;
+	}
+
+	button:first-child {
+		margin-left: 0;
+	}
+
+	button:hover {
+		border: 1px solid $dark-gray-500;
+	}
+
+	button:focus {
+		outline: none;
+	}
+
+	.editor-text-editor__bold {
+		font-weight: bold;
+	}
+
+	.editor-text-editor__italic {
+		font-style: italic;
+	}
+	.editor-text-editor__link {
+		text-decoration: underline;
+		color: $blue-medium;
+	}
+	.editor-text-editor__del {
+		text-decoration:line-through;
+	}
+}
+
 .editor-text-editor {
 	display: block;
 	margin: 60px auto 0;
@@ -9,4 +60,9 @@
 	padding: 0;
 	overflow: hidden;
 	font-family: $editor-html-font;
+	line-height: 150%;
+
+	&:focus {
+		box-shadow: none;
+	}
 }


### PR DESCRIPTION
This PR adds some polish to the text editor mode:

It adds a dummy formatting toolbar. Not yet sticky. 

It makes the editor textarea 100% full width and uses paddings to center it. I feel this is somewhat controversial, so please share your concerns here. My reason for doing this is that it allows you to click _anywhere_ on the page to set focus on the text editor. Since we are using a very boundless and full-bleed look for this, I feel that is important for accessibility.

I was also fiddling a bit with CSS classes and tags to use in the dummy markup, please share your thoughts here as well, thanks. 

Finally, Andrew brought up media queries in another PR — since the padding trick (if you should all find it kosher) relies on a few of these, might as well bring that up here. Should we bring in a mixin to handle this? Should we use a whitelist of breakpoints, or just assign them as valuable and use the existing WordPress ones as the baseline?

Thanks for your time!