### PR TITLE
Visual Editor: Adding the arrangement toolbar (up/down arrows)

### DIFF
--- a/editor/components/arrangement-toolbar/index.js
+++ b/editor/components/arrangement-toolbar/index.js
@@ -9,23 +9,21 @@ import { first, last } from 'lodash';
  * Internal dependencies
  */
 import './style.scss';
-import Dashicon from 'components/dashicon';
+import IconButton from 'components/icon-button';
 
 function BlockArrangement( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 	return (
 		<div className="editor-arrangement-toolbar">
-			<button
+			<IconButton
 				className={ classnames( 'editor-arrangement-toolbar__control', { 'is-disabled': isFirst } ) }
 				onClick={ onMoveUp }
-			>
-				<Dashicon icon="arrow-up-alt2" />
-			</button>
-			<button
+				icon="arrow-up-alt2"
+			/>
+			<IconButton
 				className={ classnames( 'editor-arrangement-toolbar__control', { 'is-disabled': isLast } ) }
 				onClick={ onMoveDown }
-			>
-				<Dashicon icon="arrow-down-alt2" />
-			</button>
+				icon="arrow-down-alt2"
+			/>
 		</div>
 	);
 }
@@ -33,7 +31,7 @@ function BlockArrangement( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 export default connect(
 	( state, ownProps ) => ( {
 		isFirst: first( state.blocks.order ) === ownProps.uid,
-		isLirst: last( state.blocks.order ) === ownProps.uid
+		isLast: last( state.blocks.order ) === ownProps.uid
 	} ),
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {

--- a/editor/components/arrangement-toolbar/index.js
+++ b/editor/components/arrangement-toolbar/index.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+import { first, last } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import Dashicon from 'components/dashicon';
+
+function BlockArrangement( { onMoveUp, onMoveDown, isFirst, isLast } ) {
+	return (
+		<div className="editor-arrangement-toolbar">
+			<button
+				className={ classnames( 'editor-arrangement-toolbar__control', { 'is-disabled': isFirst } ) }
+				onClick={ onMoveUp }
+			>
+				<Dashicon icon="arrow-up-alt2" />
+			</button>
+			<button
+				className={ classnames( 'editor-arrangement-toolbar__control', { 'is-disabled': isLast } ) }
+				onClick={ onMoveDown }
+			>
+				<Dashicon icon="arrow-down-alt2" />
+			</button>
+		</div>
+	);
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		isFirst: first( state.blocks.order ) === ownProps.uid,
+		isLirst: last( state.blocks.order ) === ownProps.uid
+	} ),
+	( dispatch, ownProps ) => ( {
+		onMoveDown() {
+			dispatch( {
+				type: 'MOVE_BLOCK_DOWN',
+				uid: ownProps.uid
+			} );
+		},
+		onMoveUp() {
+			dispatch( {
+				type: 'MOVE_BLOCK_UP',
+				uid: ownProps.uid
+			} );
+		}
+	} )
+)( BlockArrangement );

--- a/editor/components/arrangement-toolbar/style.scss
+++ b/editor/components/arrangement-toolbar/style.scss
@@ -12,6 +12,10 @@
 		color: $light-gray-600;
 		cursor: pointer;
 
+		&:hover {
+			color: $dark-gray-900;
+		}
+
 		&.is-disabled {
 			color: $light-gray-100;
 		}

--- a/editor/components/arrangement-toolbar/style.scss
+++ b/editor/components/arrangement-toolbar/style.scss
@@ -1,0 +1,23 @@
+.editor-arrangement-toolbar {
+	position: absolute;
+	top: 10px;
+	left: 0;
+
+	.editor-arrangement-toolbar__control {
+		display: block;
+		padding: 0;
+		border: none;
+		outline: none;
+		background: none;
+		color: $light-gray-600;
+		cursor: pointer;
+
+		&.is-disabled {
+			color: $light-gray-100;
+		}
+
+		.dashicon {
+			display: block;
+		}
+	}
+}

--- a/editor/components/arrangement-toolbar/style.scss
+++ b/editor/components/arrangement-toolbar/style.scss
@@ -2,26 +2,28 @@
 	position: absolute;
 	top: 10px;
 	left: 0;
+}
 
-	.editor-arrangement-toolbar__control {
+.editor-arrangement-toolbar__control {
+	display: block;
+	padding: 0;
+	border: none;
+	outline: none;
+	background: none;
+	color: $light-gray-600;
+	cursor: pointer;
+	width: 20px;
+	height: 20px;
+
+	&:hover {
+		color: $dark-gray-900;
+	}
+
+	&.is-disabled {
+		color: $light-gray-100;
+	}
+
+	.dashicon {
 		display: block;
-		padding: 0;
-		border: none;
-		outline: none;
-		background: none;
-		color: $light-gray-600;
-		cursor: pointer;
-
-		&:hover {
-			color: $dark-gray-900;
-		}
-
-		&.is-disabled {
-			color: $light-gray-100;
-		}
-
-		.dashicon {
-			display: block;
-		}
 	}
 }

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -11,16 +11,16 @@ import { first, last } from 'lodash';
 import './style.scss';
 import IconButton from 'components/icon-button';
 
-function BlockArrangement( { onMoveUp, onMoveDown, isFirst, isLast } ) {
+function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 	return (
-		<div className="editor-arrangement-toolbar">
+		<div className="editor-block-mover">
 			<IconButton
-				className={ classnames( 'editor-arrangement-toolbar__control', { 'is-disabled': isFirst } ) }
+				className={ classnames( 'editor-block-mover__control', { 'is-disabled': isFirst } ) }
 				onClick={ onMoveUp }
 				icon="arrow-up-alt2"
 			/>
 			<IconButton
-				className={ classnames( 'editor-arrangement-toolbar__control', { 'is-disabled': isLast } ) }
+				className={ classnames( 'editor-block-mover__control', { 'is-disabled': isLast } ) }
 				onClick={ onMoveDown }
 				icon="arrow-down-alt2"
 			/>
@@ -47,4 +47,4 @@ export default connect(
 			} );
 		}
 	} )
-)( BlockArrangement );
+)( BlockMover );

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -1,10 +1,10 @@
-.editor-arrangement-toolbar {
+.editor-block-mover {
 	position: absolute;
 	top: 10px;
 	left: 0;
 }
 
-.editor-arrangement-toolbar__control {
+.editor-block-mover__control {
 	display: block;
 	padding: 0;
 	border: none;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Toolbar from 'components/toolbar';
-import ArrangementToolbar from 'components/arrangement-toolbar';
+import BlockMover from 'components/block-mover';
 
 function VisualEditorBlock( props ) {
 	const { block } = props;
@@ -63,7 +63,7 @@ function VisualEditorBlock( props ) {
 			onMouseLeave={ onMouseLeave }
 			className={ className }
 		>
-			{ ( isSelected || isHovered ) && <ArrangementToolbar uid={ block.uid } /> }
+			{ ( isSelected || isHovered ) && <BlockMover uid={ block.uid } /> }
 			{ isSelected && settings.controls ? (
 				<Toolbar
 					controls={ settings.controls.map( ( control ) => ( {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -63,7 +63,7 @@ function VisualEditorBlock( props ) {
 			onMouseLeave={ onMouseLeave }
 			className={ className }
 		>
-			{ ( isSelected || isHovered || true ) && <ArrangementToolbar uid={ block.uid } /> }
+			{ ( isSelected || isHovered ) && <ArrangementToolbar uid={ block.uid } /> }
 			{ isSelected && settings.controls ? (
 				<Toolbar
 					controls={ settings.controls.map( ( control ) => ( {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -63,7 +63,7 @@ function VisualEditorBlock( props ) {
 			onMouseLeave={ onMouseLeave }
 			className={ className }
 		>
-			{ ( isSelected || isHovered ) && <ArrangementToolbar uid={ block.uid } /> }
+			{ ( isSelected || isHovered || true ) && <ArrangementToolbar uid={ block.uid } /> }
 			{ isSelected && settings.controls ? (
 				<Toolbar
 					controls={ settings.controls.map( ( control ) => ( {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -72,12 +72,10 @@ function VisualEditorBlock( props ) {
 						isActive: () => control.isActive( block.attributes )
 					} ) ) } />
 			) : null }
-			<div className="editor-visual-editor__block-edit">
-				<BlockEdit
-					isSelected={ isSelected }
-					attributes={ block.attributes }
-					setAttributes={ setAttributes } />
-			</div>
+			<BlockEdit
+				isSelected={ isSelected }
+				attributes={ block.attributes }
+				setAttributes={ setAttributes } />
 		</div>
 	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Toolbar from 'components/toolbar';
+import ArrangementToolbar from 'components/arrangement-toolbar';
 
 function VisualEditorBlock( props ) {
 	const { block } = props;
@@ -62,6 +63,7 @@ function VisualEditorBlock( props ) {
 			onMouseLeave={ onMouseLeave }
 			className={ className }
 		>
+			{ ( isSelected || isHovered ) && <ArrangementToolbar uid={ block.uid } /> }
 			{ isSelected && settings.controls ? (
 				<Toolbar
 					controls={ settings.controls.map( ( control ) => ( {
@@ -70,10 +72,12 @@ function VisualEditorBlock( props ) {
 						isActive: () => control.isActive( block.attributes )
 					} ) ) } />
 			) : null }
-			<BlockEdit
-				isSelected={ isSelected }
-				attributes={ block.attributes }
-				setAttributes={ setAttributes } />
+			<div className="editor-visual-editor__block-edit">
+				<BlockEdit
+					isSelected={ isSelected }
+					attributes={ block.attributes }
+					setAttributes={ setAttributes } />
+			</div>
 		</div>
 	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -20,10 +20,7 @@
 	border: 2px solid transparent;
 	transition: 0.2s border-color;
 	margin-left: -35px;
-
-	.editor-visual-editor__block-edit {
-		padding: 15px 15px 15px 50px;
-	}
+	padding: 15px 15px 15px 50px;
 
 	&:before {
 		z-index: -1;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -17,16 +17,32 @@
 
 .editor-visual-editor__block {
 	position: relative;
-	padding: 15px;
 	border: 2px solid transparent;
 	transition: 0.2s border-color;
+	margin-left: -35px;
 
-	&.is-hovered {
-		border-left: 2px solid $light-gray-500;
+	.editor-visual-editor__block-edit {
+		padding: 15px 15px 15px 50px;
 	}
 
-	&.is-selected {
-		border: 2px solid $light-gray-500;
+	&:before {
+		z-index: -1;
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 33px;
+		right: 0;
+		border: 2px solid transparent;
+		transition: 0.2s border-color;
+	}
+
+	&.is-hovered:before {
+		border-left-color: $light-gray-500;
+	}
+
+	&.is-selected:before {
+		border-color: $light-gray-500;
 	}
 }
 
@@ -34,7 +50,7 @@
 	position: absolute;
 	bottom: 100%;
 	margin-bottom: -4px;
-	left: 8px;
+	left: 43px;
 }
 
 .editor-visual-editor .editor-inserter {

--- a/editor/state.js
+++ b/editor/state.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers, createStore } from 'redux';
-import { keyBy } from 'lodash';
+import { keyBy, last } from 'lodash';
 
 /**
  * Reducer returning editor blocks state, an combined reducer of keys byUid,
@@ -31,9 +31,37 @@ export const blocks = combineReducers( {
 		return state;
 	},
 	order( state = [], action ) {
+		let index;
+		let swappedUid;
 		switch ( action.type ) {
 			case 'REPLACE_BLOCKS':
 				return action.blockNodes.map( ( { uid } ) => uid );
+
+			case 'MOVE_BLOCK_UP':
+				if ( action.uid === state[ 0 ] ) {
+					return state;
+				}
+				index = state.indexOf( action.uid );
+				swappedUid = state[ index - 1 ];
+				return [
+					...state.slice( 0, index - 1 ),
+					action.uid,
+					swappedUid,
+					...state.slice( index + 1 )
+				];
+
+			case 'MOVE_BLOCK_DOWN':
+				if ( action.uid === last( state ) ) {
+					return state;
+				}
+				index = state.indexOf( action.uid );
+				swappedUid = state[ index + 1 ];
+				return [
+					...state.slice( 0, index ),
+					swappedUid,
+					action.uid,
+					...state.slice( index + 2 )
+				];
 		}
 
 		return state;

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -124,6 +124,110 @@ describe( 'state', () => {
 			expect( state.hovered.kumquat ).to.be.false();
 			expect( state.selected.kumquat ).to.be.true();
 		} );
+
+		it( 'should move the block up', () => {
+			const original = deepFreeze( {
+				byUid: {
+					chicken: {
+						uid: 'chicken',
+						blockType: 'core/test-block',
+						attributes: {}
+					},
+					ribs: {
+						uid: 'ribs',
+						blockType: 'core/test-block',
+						attributes: {}
+					}
+				},
+				order: [ 'chicken', 'ribs' ],
+				selected: {},
+				hovered: {}
+			} );
+			const state = blocks( original, {
+				type: 'MOVE_BLOCK_UP',
+				uid: 'ribs'
+			} );
+
+			expect( state.order ).to.eql( [ 'ribs', 'chicken' ] );
+		} );
+
+		it( 'should not move the first block up', () => {
+			const original = deepFreeze( {
+				byUid: {
+					chicken: {
+						uid: 'chicken',
+						blockType: 'core/test-block',
+						attributes: {}
+					},
+					ribs: {
+						uid: 'ribs',
+						blockType: 'core/test-block',
+						attributes: {}
+					}
+				},
+				order: [ 'chicken', 'ribs' ],
+				selected: {},
+				hovered: {}
+			} );
+			const state = blocks( original, {
+				type: 'MOVE_BLOCK_UP',
+				uid: 'chicken'
+			} );
+
+			expect( state.order ).to.equal( original.order );
+		} );
+
+		it( 'should move the block down', () => {
+			const original = deepFreeze( {
+				byUid: {
+					chicken: {
+						uid: 'chicken',
+						blockType: 'core/test-block',
+						attributes: {}
+					},
+					ribs: {
+						uid: 'ribs',
+						blockType: 'core/test-block',
+						attributes: {}
+					}
+				},
+				order: [ 'chicken', 'ribs' ],
+				selected: {},
+				hovered: {}
+			} );
+			const state = blocks( original, {
+				type: 'MOVE_BLOCK_DOWN',
+				uid: 'chicken'
+			} );
+
+			expect( state.order ).to.eql( [ 'ribs', 'chicken' ] );
+		} );
+
+		it( 'should not move the last block down', () => {
+			const original = deepFreeze( {
+				byUid: {
+					chicken: {
+						uid: 'chicken',
+						blockType: 'core/test-block',
+						attributes: {}
+					},
+					ribs: {
+						uid: 'ribs',
+						blockType: 'core/test-block',
+						attributes: {}
+					}
+				},
+				order: [ 'chicken', 'ribs' ],
+				selected: {},
+				hovered: {}
+			} );
+			const state = blocks( original, {
+				type: 'MOVE_BLOCK_DOWN',
+				uid: 'ribs'
+			} );
+
+			expect( state.order ).to.equal( original.order );
+		} );
 	} );
 
 	describe( 'mode()', () => {


### PR DESCRIPTION
This PR adds the up/down arrows to move blocks. The arrangement toolbar is shown if the block is selected or hovered.

Missing in this PR: Selecting the block being moved, I'm waiting to the simplification of the reducers in #407 to add this.