### PR TITLE
Implement basic undo history

### DIFF
--- a/editor/components/button/style.scss
+++ b/editor/components/button/style.scss
@@ -1,4 +1,8 @@
 .editor-button {
 	background: none;
 	border: none;
+
+	&:disabled {
+		opacity: 0.6;
+	}
 }

--- a/editor/components/icon-button/style.scss
+++ b/editor/components/icon-button/style.scss
@@ -6,9 +6,12 @@
 	border: none;
 	background: none;
 	color: $dark-gray-500;
-	cursor: pointer;
 
-	&:hover {
-		color: $blue-medium;
+	&:not( :disabled ) {
+		cursor: pointer;
+
+		&:hover {
+			color: $blue-medium;
+		}
 	}
 }

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -7,11 +12,19 @@ import IconButton from '../../components/icon-button';
 import Inserter from '../../components/inserter';
 import Button from '../../components/button';
 
-function Tools() {
+function Tools( { undo, redo, hasUndo, hasRedo } ) {
 	return (
 		<div className="editor-tools">
-			<IconButton icon="undo" label={ wp.i18n.__( 'Undo' ) } />
-			<IconButton icon="redo" label={ wp.i18n.__( 'Redo' ) } />
+			<IconButton
+				icon="undo"
+				label={ wp.i18n.__( 'Undo' ) }
+				disabled={ ! hasUndo }
+				onClick={ undo } />
+			<IconButton
+				icon="redo"
+				label={ wp.i18n.__( 'Redo' ) }
+				disabled={ ! hasRedo }
+				onClick={ redo } />
 			<Inserter position="bottom" />
 			<div className="editor-tools__tabs">
 				<Button>
@@ -30,4 +43,13 @@ function Tools() {
 	);
 }
 
-export default Tools;
+export default connect(
+	( state ) => ( {
+		hasUndo: state.blocks.history.past.length > 0,
+		hasRedo: state.blocks.history.future.length > 0
+	} ),
+	( dispatch ) => ( {
+		undo: () => dispatch( { type: 'UNDO' } ),
+		redo: () => dispatch( { type: 'REDO' } )
+	} )
+)( Tools );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -84,8 +84,8 @@ function VisualEditorBlock( props ) {
 export default connect(
 	( state, ownProps ) => ( {
 		block: state.blocks.byUid[ ownProps.uid ],
-		isSelected: state.blocks.selected === ownProps.uid,
-		isHovered: state.blocks.hovered === ownProps.uid
+		isSelected: state.selectedBlock === ownProps.uid,
+		isHovered: state.hoveredBlock === ownProps.uid
 	} ),
 	( dispatch, ownProps ) => ( {
 		onChange( updates ) {

--- a/editor/state.js
+++ b/editor/state.js
@@ -10,20 +10,14 @@ import { includes, keyBy, last } from 'lodash';
  *
  * @param  {Function} reducer            Original reducer
  * @param  {?Object}  options            Optional options
- * @param  {?Number}  options.limit      Maximum length of past history
  * @param  {?Array}   options.resetTypes Action types upon which to clear past
  * @return {Function}                    Enhanced reducer
  */
-export function undoable( reducer, options ) {
+export function undoable( reducer, options = {} ) {
 	const initialState = {
 		past: [],
 		present: reducer( undefined, {} ),
 		future: []
-	};
-
-	options = {
-		limit: 10,
-		...options
 	};
 
 	return ( state = initialState, action ) => {
@@ -60,7 +54,7 @@ export function undoable( reducer, options ) {
 		}
 
 		return {
-			past: [ ...past, present ].slice( -1 * options.limit ),
+			past: [ ...past, present ],
 			present: nextPresent,
 			future: []
 		};

--- a/editor/state.js
+++ b/editor/state.js
@@ -2,107 +2,12 @@
  * External dependencies
  */
 import { combineReducers, createStore } from 'redux';
-import { includes, keyBy, last } from 'lodash';
+import { keyBy, last } from 'lodash';
 
 /**
- * Reducer enhancer which transforms the result of the original reducer into an
- * object tracking its own history (past, present, future).
- *
- * @param  {Function} reducer            Original reducer
- * @param  {?Object}  options            Optional options
- * @param  {?Array}   options.resetTypes Action types upon which to clear past
- * @return {Function}                    Enhanced reducer
+ * Internal dependencies
  */
-export function undoable( reducer, options = {} ) {
-	const initialState = {
-		past: [],
-		present: reducer( undefined, {} ),
-		future: []
-	};
-
-	return ( state = initialState, action ) => {
-		const { past, present, future } = state;
-
-		switch ( action.type ) {
-			case 'UNDO':
-				return {
-					past: past.slice( 0, past.length - 1 ),
-					present: past[ past.length - 1 ],
-					future: [ present, ...future ]
-				};
-
-			case 'REDO':
-				return {
-					past: [ ...past, present ],
-					present: future[ 0 ],
-					future: future.slice( 1 )
-				};
-		}
-
-		const nextPresent = reducer( present, action );
-
-		if ( includes( options.resetTypes, action.type ) ) {
-			return {
-				past: [],
-				present: nextPresent,
-				future: []
-			};
-		}
-
-		if ( present === nextPresent ) {
-			return state;
-		}
-
-		return {
-			past: [ ...past, present ],
-			present: nextPresent,
-			future: []
-		};
-	};
-}
-
-/**
- * A wrapper for combineReducers which applies an undo history to the combined
- * reducer. As a convenience, properties of the reducers object are accessible
- * via object getters, with history assigned to a nested history property.
- *
- * @see undoable
- *
- * @param  {Object}   reducers Object of reducers
- * @param  {?Object}  options  Optional options
- * @return {Function}          Combined reducer
- */
-export function combineUndoableReducers( reducers, options ) {
-	const reducer = undoable( combineReducers( reducers ), options );
-
-	function withGetters( history ) {
-		const state = { history };
-		const keys = Object.getOwnPropertyNames( history.present );
-		const getters = keys.reduce( ( memo, key ) => {
-			memo[ key ] = {
-				get: function() {
-					return this.history.present[ key ];
-				}
-			};
-
-			return memo;
-		}, {} );
-		Object.defineProperties( state, getters );
-
-		return state;
-	}
-
-	const initialState = withGetters( reducer( undefined, {} ) );
-
-	return ( state = initialState, action ) => {
-		const nextState = reducer( state.history, action );
-		if ( nextState === state.history.present ) {
-			return state;
-		}
-
-		return withGetters( nextState );
-	};
-}
+import { combineUndoableReducers } from 'utils/undoable-reducer';
 
 /**
  * Reducer returning editor blocks state, an combined reducer of keys byUid,

--- a/editor/state.js
+++ b/editor/state.js
@@ -6,7 +6,7 @@ import { keyBy, last } from 'lodash';
 
 /**
  * Reducer returning editor blocks state, an combined reducer of keys byUid,
- * order, selected, hovered, where blocks are parsed from current HTML markup.
+ * order, where blocks are parsed from current HTML markup.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Dispatched action
@@ -77,51 +77,53 @@ export const blocks = combineReducers( {
 		}
 
 		return state;
-	},
-	selected( state = null, action ) {
-		switch ( action.type ) {
-			case 'TOGGLE_BLOCK_SELECTED':
-				if ( action.selected ) {
-					return action.uid;
-				}
-
-				if ( ! action.selected && action.uid === state ) {
-					return null;
-				}
-
-				return state;
-			case 'MOVE_BLOCK_UP':
-			case 'MOVE_BLOCK_DOWN':
-				return action.uid;
-			case 'INSERT_BLOCK':
-				return action.block.uid;
-		}
-
-		return state;
-	},
-	hovered( state = null, action ) {
-		switch ( action.type ) {
-			case 'TOGGLE_BLOCK_HOVERED':
-				if ( action.hovered ) {
-					return action.uid;
-				}
-
-				if ( ! action.hovered && action.uid === state ) {
-					return null;
-				}
-
-				return state;
-
-			case 'TOGGLE_BLOCK_SELECTED':
-				if ( state === action.uid ) {
-					return null;
-				}
-				break;
-		}
-
-		return state;
 	}
 } );
+
+/**
+ * Reducer returning selected block state.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {Object}        Updated state
+ */
+export function selectedBlock( state = null, action ) {
+	switch ( action.type ) {
+		case 'TOGGLE_BLOCK_SELECTED':
+			return action.selected ? action.uid : null;
+
+		case 'MOVE_BLOCK_UP':
+		case 'MOVE_BLOCK_DOWN':
+			return action.uid;
+
+		case 'INSERT_BLOCK':
+			return action.block.uid;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning hovered block state.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {Object}        Updated state
+ */
+export function hoveredBlock( state = null, action ) {
+	switch ( action.type ) {
+		case 'TOGGLE_BLOCK_HOVERED':
+			return action.hovered ? action.uid : null;
+
+		case 'TOGGLE_BLOCK_SELECTED':
+			if ( action.selected ) {
+				return null;
+			}
+			break;
+	}
+
+	return state;
+}
 
 /**
  * Reducer returning current editor mode, either "visual" or "text".
@@ -147,6 +149,8 @@ export function mode( state = 'visual', action ) {
 export function createReduxStore() {
 	const reducer = combineReducers( {
 		blocks,
+		selectedBlock,
+		hoveredBlock,
 		mode
 	} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -8,8 +8,6 @@ import { values } from 'lodash';
  * Internal dependencies
  */
 import {
-	undoable,
-	combineUndoableReducers,
 	blocks,
 	hoveredBlock,
 	selectedBlock,
@@ -18,105 +16,6 @@ import {
 } from '../state';
 
 describe( 'state', () => {
-	describe( 'undoable()', () => {
-		const counter = ( state = 0, { type } ) => (
-			type === 'INCREMENT' ? state + 1 : state
-		);
-
-		it( 'should return a new reducer', () => {
-			const reducer = undoable( counter );
-
-			expect( reducer ).to.be.a( 'function' );
-			expect( reducer( undefined, {} ) ).to.eql( {
-				past: [],
-				present: 0,
-				future: []
-			} );
-		} );
-
-		it( 'should track history', () => {
-			const reducer = undoable( counter );
-
-			let state;
-			state = reducer( undefined, {} );
-			state = reducer( state, { type: 'INCREMENT' } );
-
-			expect( state ).to.eql( {
-				past: [ 0 ],
-				present: 1,
-				future: []
-			} );
-		} );
-
-		it( 'should perform undo', () => {
-			const reducer = undoable( counter );
-
-			let state;
-			state = reducer( undefined, {} );
-			state = reducer( state, { type: 'INCREMENT' } );
-			state = reducer( state, { type: 'UNDO' } );
-
-			expect( state ).to.eql( {
-				past: [],
-				present: 0,
-				future: [ 1 ]
-			} );
-		} );
-
-		it( 'should perform redo', () => {
-			const reducer = undoable( counter );
-
-			let state;
-			state = reducer( undefined, {} );
-			state = reducer( state, { type: 'INCREMENT' } );
-			state = reducer( state, { type: 'UNDO' } );
-			state = reducer( state, { type: 'REDO' } );
-
-			expect( state ).to.eql( {
-				past: [ 0 ],
-				present: 1,
-				future: []
-			} );
-		} );
-
-		it( 'should reset history by options.resetTypes', () => {
-			const reducer = undoable( counter, { resetTypes: [ 'RESET_HISTORY' ] } );
-
-			let state;
-			state = reducer( undefined, {} );
-			state = reducer( state, { type: 'INCREMENT' } );
-			state = reducer( state, { type: 'RESET_HISTORY' } );
-			state = reducer( state, { type: 'INCREMENT' } );
-			state = reducer( state, { type: 'INCREMENT' } );
-
-			expect( state ).to.eql( {
-				past: [ 1, 2 ],
-				present: 3,
-				future: []
-			} );
-		} );
-	} );
-
-	describe( 'combineUndoableReducers()', () => {
-		it( 'should return a combined reducer with getters', () => {
-			const reducer = combineUndoableReducers( {
-				count: ( state = 0 ) => state
-			} );
-			const state = reducer( undefined, {} );
-
-			expect( reducer ).to.be.a( 'function' );
-			expect( state ).to.have.keys( 'history' );
-			expect( state.count ).to.equal( 0 );
-			expect( state.history ).to.eql( {
-				past: [],
-				present: {
-					count: 0
-				},
-				future: []
-			} );
-		} );
-	} );
-
 	describe( 'blocks()', () => {
 		before( () => {
 			wp.blocks.registerBlock( 'core/test-block', {} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -10,6 +10,8 @@ import { values } from 'lodash';
  */
 import {
 	blocks,
+	hoveredBlock,
+	selectedBlock,
 	mode,
 	createReduxStore
 } from '../state';
@@ -24,23 +26,19 @@ describe( 'state', () => {
 			wp.blocks.unregisterBlock( 'core/test-block' );
 		} );
 
-		it( 'should return empty byUid, order, selected, hovered by default', () => {
+		it( 'should return empty byUid, order by default', () => {
 			const state = blocks( undefined, {} );
 
 			expect( state ).to.eql( {
 				byUid: {},
-				order: [],
-				selected: null,
-				hovered: null
+				order: []
 			} );
 		} );
 
 		it( 'should key by replaced blocks uid', () => {
 			const original = deepFreeze( {
 				byUid: {},
-				order: [],
-				selected: null,
-				hovered: null
+				order: []
 			} );
 			const state = blocks( original, {
 				type: 'REPLACE_BLOCKS',
@@ -61,9 +59,7 @@ describe( 'state', () => {
 						attributes: {}
 					}
 				},
-				order: [ 'kumquat' ],
-				selected: null,
-				hovered: null
+				order: [ 'kumquat' ]
 			} );
 			const state = blocks( original, {
 				type: 'UPDATE_BLOCK',
@@ -78,52 +74,7 @@ describe( 'state', () => {
 			expect( state.byUid.kumquat.attributes.updated ).to.be.true();
 		} );
 
-		it( 'should return with block uid as hovered', () => {
-			const original = deepFreeze( {
-				byUid: {
-					kumquat: {
-						uid: 'kumquat',
-						blockType: 'core/test-block',
-						attributes: {}
-					}
-				},
-				order: [ 'kumquat' ],
-				selected: null,
-				hovered: null
-			} );
-			const state = blocks( original, {
-				type: 'TOGGLE_BLOCK_HOVERED',
-				uid: 'kumquat',
-				hovered: true
-			} );
-
-			expect( state.hovered ).to.equal( 'kumquat' );
-		} );
-
-		it( 'should return with block uid as selected, clearing hover', () => {
-			const original = deepFreeze( {
-				byUid: {
-					kumquat: {
-						uid: 'kumquat',
-						blockType: 'core/test-block',
-						attributes: {}
-					}
-				},
-				order: [ 'kumquat' ],
-				selected: null,
-				hovered: 'kumquat'
-			} );
-			const state = blocks( original, {
-				type: 'TOGGLE_BLOCK_SELECTED',
-				uid: 'kumquat',
-				selected: true
-			} );
-
-			expect( state.hovered ).to.be.null();
-			expect( state.selected ).to.equal( 'kumquat' );
-		} );
-
-		it( 'should insert and select block', () => {
+		it( 'should insert block', () => {
 			const original = deepFreeze( {
 				byUid: {
 					kumquat: {
@@ -132,9 +83,7 @@ describe( 'state', () => {
 						attributes: {}
 					}
 				},
-				order: [ 'chicken' ],
-				selected: null,
-				hovered: null
+				order: [ 'chicken' ]
 			} );
 			const state = blocks( original, {
 				type: 'INSERT_BLOCK',
@@ -147,11 +96,9 @@ describe( 'state', () => {
 			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 2 );
 			expect( values( state.byUid )[ 1 ].uid ).to.equal( 'ribs' );
 			expect( state.order ).to.eql( [ 'chicken', 'ribs' ] );
-			expect( state.hovered ).to.be.null();
-			expect( state.selected ).to.equal( 'ribs' );
 		} );
 
-		it( 'should move the block up and select it', () => {
+		it( 'should move the block up', () => {
 			const original = deepFreeze( {
 				byUid: {
 					chicken: {
@@ -165,9 +112,7 @@ describe( 'state', () => {
 						attributes: {}
 					}
 				},
-				order: [ 'chicken', 'ribs' ],
-				selected: {},
-				hovered: {}
+				order: [ 'chicken', 'ribs' ]
 			} );
 			const state = blocks( original, {
 				type: 'MOVE_BLOCK_UP',
@@ -175,7 +120,6 @@ describe( 'state', () => {
 			} );
 
 			expect( state.order ).to.eql( [ 'ribs', 'chicken' ] );
-			expect( state.selected ).to.eql( 'ribs' );
 		} );
 
 		it( 'should not move the first block up', () => {
@@ -192,9 +136,7 @@ describe( 'state', () => {
 						attributes: {}
 					}
 				},
-				order: [ 'chicken', 'ribs' ],
-				selected: {},
-				hovered: {}
+				order: [ 'chicken', 'ribs' ]
 			} );
 			const state = blocks( original, {
 				type: 'MOVE_BLOCK_UP',
@@ -204,7 +146,7 @@ describe( 'state', () => {
 			expect( state.order ).to.equal( original.order );
 		} );
 
-		it( 'should move the block down and select it', () => {
+		it( 'should move the block down', () => {
 			const original = deepFreeze( {
 				byUid: {
 					chicken: {
@@ -218,9 +160,7 @@ describe( 'state', () => {
 						attributes: {}
 					}
 				},
-				order: [ 'chicken', 'ribs' ],
-				selected: {},
-				hovered: {}
+				order: [ 'chicken', 'ribs' ]
 			} );
 			const state = blocks( original, {
 				type: 'MOVE_BLOCK_DOWN',
@@ -228,7 +168,6 @@ describe( 'state', () => {
 			} );
 
 			expect( state.order ).to.eql( [ 'ribs', 'chicken' ] );
-			expect( state.selected ).to.eql( 'chicken' );
 		} );
 
 		it( 'should not move the last block down', () => {
@@ -245,9 +184,7 @@ describe( 'state', () => {
 						attributes: {}
 					}
 				},
-				order: [ 'chicken', 'ribs' ],
-				selected: {},
-				hovered: {}
+				order: [ 'chicken', 'ribs' ]
 			} );
 			const state = blocks( original, {
 				type: 'MOVE_BLOCK_DOWN',
@@ -255,6 +192,70 @@ describe( 'state', () => {
 			} );
 
 			expect( state.order ).to.equal( original.order );
+		} );
+	} );
+
+	describe( 'hoveredBlock()', () => {
+		it( 'should return with block uid as hovered', () => {
+			const state = hoveredBlock( null, {
+				type: 'TOGGLE_BLOCK_HOVERED',
+				uid: 'kumquat',
+				hovered: true
+			} );
+
+			expect( state ).to.equal( 'kumquat' );
+		} );
+
+		it( 'should return null when a block is selected', () => {
+			const state = hoveredBlock( 'kumquat', {
+				type: 'TOGGLE_BLOCK_SELECTED',
+				uid: 'kumquat',
+				selected: true
+			} );
+
+			expect( state ).to.be.null();
+		} );
+	} );
+
+	describe( 'selectedBlock()', () => {
+		it( 'should return with block uid as selected', () => {
+			const state = selectedBlock( undefined, {
+				type: 'TOGGLE_BLOCK_SELECTED',
+				uid: 'kumquat',
+				selected: true
+			} );
+
+			expect( state ).to.equal( 'kumquat' );
+		} );
+
+		it( 'should return with inserted block', () => {
+			const state = selectedBlock( undefined, {
+				type: 'INSERT_BLOCK',
+				block: {
+					uid: 'ribs',
+					blockType: 'core/freeform'
+				}
+			} );
+
+			expect( state ).to.equal( 'ribs' );
+		} );
+
+		it( 'should return with block moved up', () => {
+			const state = selectedBlock( undefined, {
+				type: 'MOVE_BLOCK_UP',
+				uid: 'ribs'
+			} );
+
+			expect( state ).to.equal( 'ribs' );
+		} );
+
+		it( 'should return with block moved down', () => {
+			const state = selectedBlock( undefined, {
+				type: 'MOVE_BLOCK_DOWN',
+				uid: 'chicken'
+			} );
+
+			expect( state ).to.equal( 'chicken' );
 		} );
 	} );
 
@@ -289,6 +290,8 @@ describe( 'state', () => {
 
 			expect( Object.keys( state ) ).to.have.members( [
 				'blocks',
+				'selectedBlock',
+				'hoveredBlock',
 				'mode'
 			] );
 		} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -79,23 +79,6 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should allow limiting history by options.limit', () => {
-			const reducer = undoable( counter, { limit: 2 } );
-
-			let state;
-			state = reducer( undefined, {} );
-			state = reducer( state, { type: 'INCREMENT' } );
-			state = reducer( state, { type: 'INCREMENT' } );
-			state = reducer( state, { type: 'INCREMENT' } );
-			state = reducer( state, { type: 'INCREMENT' } );
-
-			expect( state ).to.eql( {
-				past: [ 2, 3 ],
-				present: 4,
-				future: []
-			} );
-		} );
-
 		it( 'should reset history by options.resetTypes', () => {
 			const reducer = undoable( counter, { resetTypes: [ 'RESET_HISTORY' ] } );
 

--- a/editor/utils/test/undoable-reducer.js
+++ b/editor/utils/test/undoable-reducer.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { undoable, combineUndoableReducers } from '../undoable-reducer';
+
+describe( 'undoableReducer', () => {
+	describe( 'undoable()', () => {
+		const counter = ( state = 0, { type } ) => (
+			type === 'INCREMENT' ? state + 1 : state
+		);
+
+		it( 'should return a new reducer', () => {
+			const reducer = undoable( counter );
+
+			expect( reducer ).to.be.a( 'function' );
+			expect( reducer( undefined, {} ) ).to.eql( {
+				past: [],
+				present: 0,
+				future: []
+			} );
+		} );
+
+		it( 'should track history', () => {
+			const reducer = undoable( counter );
+
+			let state;
+			state = reducer( undefined, {} );
+			state = reducer( state, { type: 'INCREMENT' } );
+
+			expect( state ).to.eql( {
+				past: [ 0 ],
+				present: 1,
+				future: []
+			} );
+		} );
+
+		it( 'should perform undo', () => {
+			const reducer = undoable( counter );
+
+			let state;
+			state = reducer( undefined, {} );
+			state = reducer( state, { type: 'INCREMENT' } );
+			state = reducer( state, { type: 'UNDO' } );
+
+			expect( state ).to.eql( {
+				past: [],
+				present: 0,
+				future: [ 1 ]
+			} );
+		} );
+
+		it( 'should perform redo', () => {
+			const reducer = undoable( counter );
+
+			let state;
+			state = reducer( undefined, {} );
+			state = reducer( state, { type: 'INCREMENT' } );
+			state = reducer( state, { type: 'UNDO' } );
+			state = reducer( state, { type: 'REDO' } );
+
+			expect( state ).to.eql( {
+				past: [ 0 ],
+				present: 1,
+				future: []
+			} );
+		} );
+
+		it( 'should reset history by options.resetTypes', () => {
+			const reducer = undoable( counter, { resetTypes: [ 'RESET_HISTORY' ] } );
+
+			let state;
+			state = reducer( undefined, {} );
+			state = reducer( state, { type: 'INCREMENT' } );
+			state = reducer( state, { type: 'RESET_HISTORY' } );
+			state = reducer( state, { type: 'INCREMENT' } );
+			state = reducer( state, { type: 'INCREMENT' } );
+
+			expect( state ).to.eql( {
+				past: [ 1, 2 ],
+				present: 3,
+				future: []
+			} );
+		} );
+	} );
+
+	describe( 'combineUndoableReducers()', () => {
+		it( 'should return a combined reducer with getters', () => {
+			const reducer = combineUndoableReducers( {
+				count: ( state = 0 ) => state
+			} );
+			const state = reducer( undefined, {} );
+
+			expect( reducer ).to.be.a( 'function' );
+			expect( state ).to.have.keys( 'history' );
+			expect( state.count ).to.equal( 0 );
+			expect( state.history ).to.eql( {
+				past: [],
+				present: {
+					count: 0
+				},
+				future: []
+			} );
+		} );
+	} );
+} );

--- a/editor/utils/undoable-reducer.js
+++ b/editor/utils/undoable-reducer.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+import { includes } from 'lodash';
+
+/**
+ * Reducer enhancer which transforms the result of the original reducer into an
+ * object tracking its own history (past, present, future).
+ *
+ * @param  {Function} reducer            Original reducer
+ * @param  {?Object}  options            Optional options
+ * @param  {?Array}   options.resetTypes Action types upon which to clear past
+ * @return {Function}                    Enhanced reducer
+ */
+export function undoable( reducer, options = {} ) {
+	const initialState = {
+		past: [],
+		present: reducer( undefined, {} ),
+		future: []
+	};
+
+	return ( state = initialState, action ) => {
+		const { past, present, future } = state;
+
+		switch ( action.type ) {
+			case 'UNDO':
+				return {
+					past: past.slice( 0, past.length - 1 ),
+					present: past[ past.length - 1 ],
+					future: [ present, ...future ]
+				};
+
+			case 'REDO':
+				return {
+					past: [ ...past, present ],
+					present: future[ 0 ],
+					future: future.slice( 1 )
+				};
+		}
+
+		const nextPresent = reducer( present, action );
+
+		if ( includes( options.resetTypes, action.type ) ) {
+			return {
+				past: [],
+				present: nextPresent,
+				future: []
+			};
+		}
+
+		if ( present === nextPresent ) {
+			return state;
+		}
+
+		return {
+			past: [ ...past, present ],
+			present: nextPresent,
+			future: []
+		};
+	};
+}
+
+/**
+ * A wrapper for combineReducers which applies an undo history to the combined
+ * reducer. As a convenience, properties of the reducers object are accessible
+ * via object getters, with history assigned to a nested history property.
+ *
+ * @see undoable
+ *
+ * @param  {Object}   reducers Object of reducers
+ * @param  {?Object}  options  Optional options
+ * @return {Function}          Combined reducer
+ */
+export function combineUndoableReducers( reducers, options ) {
+	const reducer = undoable( combineReducers( reducers ), options );
+
+	function withGetters( history ) {
+		const state = { history };
+		const keys = Object.getOwnPropertyNames( history.present );
+		const getters = keys.reduce( ( memo, key ) => {
+			memo[ key ] = {
+				get: function() {
+					return this.history.present[ key ];
+				}
+			};
+
+			return memo;
+		}, {} );
+		Object.defineProperties( state, getters );
+
+		return state;
+	}
+
+	const initialState = withGetters( reducer( undefined, {} ) );
+
+	return ( state = initialState, action ) => {
+		const nextState = reducer( state.history, action );
+		if ( nextState === state.history.present ) {
+			return state;
+		}
+
+		return withGetters( nextState );
+	};
+}

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -58,19 +58,19 @@ msgstr ""
 msgid "Saved"
 msgstr ""
 
-#: editor/header/tools/index.js:13
+#: editor/header/tools/index.js:20
 msgid "Undo"
 msgstr ""
 
-#: editor/header/tools/index.js:14
+#: editor/header/tools/index.js:25
 msgid "Redo"
 msgstr ""
 
-#: editor/header/tools/index.js:23
+#: editor/header/tools/index.js:36
 msgid "Post Settings"
 msgstr ""
 
-#: editor/header/tools/index.js:27
+#: editor/header/tools/index.js:40
 msgid "Publish"
 msgstr ""
 
@@ -79,7 +79,7 @@ msgctxt "Name for the Text editor tab (formerly HTML)"
 msgid "Text"
 msgstr ""
 
-#: editor/header/tools/index.js:19
+#: editor/header/tools/index.js:32
 msgctxt "imperative verb"
 msgid "Preview"
 msgstr ""


### PR DESCRIPTION
This pull request seeks to introduce an undo history for blocks state.

![undo](https://cloud.githubusercontent.com/assets/1779930/24976827/f52bb3a8-1f98-11e7-9881-fa284f129431.gif)

__Implementation notes:__

The undo implementation is roughly based on the one explored in [official Redux documentation](http://redux.js.org/docs/recipes/ImplementingUndoHistory.html).

[`redux-undo`](https://github.com/omnidan/redux-undo) is a popular alternative module which exists to implement this behavior, but also includes a number of features we don't need.

To the previous point, the changes include a proposed `combineUndoableReducers` which defines getters for transparent property access on the original reducer object (allow access by `state.blocks.byUid` directly rather than `state.blocks.present.byUid`). I feel ever-so-slightly uncomfortable including enhanced objects like this in state.

We may want to move these utilities to a separate file or, more likely, a separate module, but they're included here for initial discussion before being referenced more formally.

__Testing instructions:__

Verify that unit tests pass:

```
npm run test-unit
```

Confirm that upon changing a text block†, the undo buttons become activated in the editor header and behave as expected upon toggling.

† The text block's change behavior is currently only triggered when blurring the `contenteditable`, meaning you'll need to click elsewhere on the screen first before the buttons become active.