### PR TITLE
Update README, add CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+If you'd like to try or contribute to the plugin, you can clone this repo into your `wp-content/plugins` directory, then activate the plugin. You'll get a separate WordPress menu item called Gutenberg.
+
+Be sure to have <a href="https://nodejs.org/en/">Node installed first</a>. Then, in a terminal, type `npm install` to get the dependencies all set up. Once that finishes, you can type `npm run build` to make the plugin functional, or `npm run dev` to keep the plugin building in the background as you work on it.
+
+## Workflow
+
+A good workflow is to work directly in this repo, branch off `master`, and submit your changes as a pull request.
+
+Ideally name your branches with prefixes and descriptions, like this: `[type]/[change]`. A good prefix would be:
+
+- `add/` = add a new feature
+- `try/` = experimental feature, "tentatively add"
+- `update/` = update an existing feature
+
+For example, `add/gallery-block` means you're working on adding a new gallery block. 
+
+You can pick among all the <a href="https://github.com/WordPress/gutenberg/issues">tickets</a>, or some of the ones labelled <a href="https://github.com/WordPress/gutenberg/labels/Good%20First%20Task">Good First Task</a>.
+
+## How Designers Can Contribute
+
+If you'd like to contribute to the design or front-end, feel free to contribute to tickets labelled <a href="https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3ADesign">Design</a>. We could use your thoughtful replies, mockups, animatics, sketches, doodles. Proposed changes are best done as minimal and specific iterations on the work that precedes it so we can compare. If you use <a href="https://www.sketchapp.com/">Sketch</a>, you can grab <a href="https://cloudup.com/cMPXM8Va2cy">the source file for the mockups</a> (updated April 6th).

--- a/README.md
+++ b/README.md
@@ -20,15 +20,9 @@ In the end you should be able to start up a new post, _type type type_ then _cli
 - <a href="https://wordpress.github.io/gutenberg/">Prototypes</a>.
 - <a href="https://github.com/Automattic/wp-post-grammar">WP Post grammar parser</a>.
 
-## How Developers Can Contribute
+## How You Can Contribute
 
-If you'd like to try or contribute to the plugin, you can clone this repo into your `wp-content/plugins` directory, then activate the plugin. You'll get a separate WordPress menu item called Gutenberg.
-
-Be sure to have <a href="https://nodejs.org/en/">Node installed first</a>. Then, in a terminal, type `npm install` to get the dependencies all set up. Once that finishes, you can type `npm run build` to make the plugin functional, or `npm run dev` to keep the plugin building in the background as you work on it. You can pick among all the <a href="https://github.com/WordPress/gutenberg/issues">tickets</a>, or some of the ones labelled <a href="https://github.com/WordPress/gutenberg/labels/Good%20First%20Task">Good First Task</a>.
-
-## How Designers Can Contribute
-
-If you'd like to contribute to the design or front-end, feel free to contribute to tickets labelled <a href="https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3ADesign">Design</a>. We could use your thoughtful replies, mockups, animatics, sketches, doodles. Proposed changes are best done as minimal and specific iterations on the work that precedes it so we can compare. If you use <a href="https://www.sketchapp.com/">Sketch</a>, you can grab <a href="https://cloudup.com/cMPXM8Va2cy">the source file for the mockups</a> (updated April 6th).
+Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Why
 


### PR DESCRIPTION
Per discussion in WordPress slack office hours this past Wednesday, this PR seeks to clarify the developer contribution workflow by adding a new separate contribution document. In this I expanded on how to name branches, and branch off master.

Context: https://wordpress.slack.com/archives/C02QB2JS7/p1492017131774539