### PR TITLE
Text Editor: Fix switching to the text editor mode

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -11,6 +11,23 @@ import { getBlockSettings, getUnknownTypeHandler } from './registration';
 import { createBlock } from './factory';
 
 /**
+ * Returns the block attributes parsed from raw content.
+ *
+ * @param  {String} rawContent    Raw block content
+ * @param  {Object} blockSettings Block settings
+ * @return {Object}               Block attributes
+ */
+export function parseBlockAttributes( rawContent, blockSettings ) {
+	if ( 'function' === typeof blockSettings.attributes ) {
+		return blockSettings.attributes( rawContent );
+	} else if ( blockSettings.attributes ) {
+		return query.parse( rawContent, blockSettings.attributes );
+	}
+
+	return {};
+}
+
+/**
  * Returns the block attributes of a registered block node given its settings.
  *
  * @param  {Object} blockNode     Parsed block node
@@ -19,15 +36,10 @@ import { createBlock } from './factory';
  */
 export function getBlockAttributes( blockNode, blockSettings ) {
 	const { rawContent } = blockNode;
-
 	// Merge attributes from parse with block implementation
 	let { attrs } = blockNode;
 	if ( blockSettings ) {
-		if ( 'function' === typeof blockSettings.attributes ) {
-			attrs = { ...attrs, ...blockSettings.attributes( rawContent ) };
-		} else if ( blockSettings.attributes ) {
-			attrs = { ...attrs, ...query.parse( rawContent, blockSettings.attributes ) };
-		}
+		attrs = { ...attrs, ...parseBlockAttributes( rawContent, blockSettings ) };
 	}
 
 	return attrs;

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -7,7 +7,7 @@ import { difference } from 'lodash';
  * Internal dependencies
  */
 import { getBlockSettings } from './registration';
-import { getBlockAttributes } from './parser';
+import { parseBlockAttributes } from './parser';
 
 /**
  * Given a block's save render implementation and attributes, returns the
@@ -68,6 +68,7 @@ export default function serialize( blocks ) {
 	return blocks.reduce( ( memo, block ) => {
 		const blockType = block.blockType;
 		const settings = getBlockSettings( blockType );
+		const saveContent = getSaveContent( settings.save, block.attributes );
 
 		return memo + (
 			'<!-- wp:' +
@@ -75,10 +76,10 @@ export default function serialize( blocks ) {
 			' ' +
 			getCommentAttributes(
 				block.attributes,
-				getBlockAttributes( block, settings )
+				parseBlockAttributes( saveContent, settings )
 			) +
 			'-->' +
-			getSaveContent( settings.save, block.attributes ) +
+			saveContent +
 			'<!-- /wp:' +
 			blockType +
 			' -->'

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -7,7 +7,7 @@ import { text } from 'hpq';
 /**
  * Internal dependencies
  */
-import { default as parse, getBlockAttributes } from '../parser';
+import { default as parse, getBlockAttributes, parseBlockAttributes } from '../parser';
 import { getBlocks, unregisterBlock, setUnknownTypeHandler, registerBlock } from '../registration';
 
 describe( 'block parser', () => {
@@ -18,8 +18,45 @@ describe( 'block parser', () => {
 		} );
 	} );
 
+	describe( 'parseBlockAttributes()', () => {
+		it( 'should use the function implementation', () => {
+			const blockSettings = {
+				attributes: function( rawContent ) {
+					return {
+						content: rawContent + ' & Chicken'
+					};
+				}
+			};
+
+			expect( parseBlockAttributes( 'Ribs', blockSettings ) ).to.eql( {
+				content: 'Ribs & Chicken'
+			} );
+		} );
+
+		it( 'should use the query object implementation', () => {
+			const blockSettings = {
+				attributes: {
+					emphasis: text( 'strong' )
+				}
+			};
+
+			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
+
+			expect( parseBlockAttributes( rawContent, blockSettings ) ).to.eql( {
+				emphasis: '& Chicken'
+			} );
+		} );
+
+		it( 'should return an empty object if no attributes defined', () => {
+			const blockSettings = {};
+			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
+
+			expect( parseBlockAttributes( rawContent, blockSettings ) ).to.eql( {} );
+		} );
+	} );
+
 	describe( 'getBlockAttributes()', () => {
-		it( 'should merge attributes from function implementation', () => {
+		it( 'should merge attributes with the parsed attributes', () => {
 			const blockSettings = {
 				attributes: function( rawContent ) {
 					return {
@@ -39,43 +76,6 @@ describe( 'block parser', () => {
 			expect( getBlockAttributes( blockNode, blockSettings ) ).to.eql( {
 				align: 'left',
 				content: 'Ribs & Chicken'
-			} );
-		} );
-
-		it( 'should merge attributes from query object implementation', () => {
-			const blockSettings = {
-				attributes: {
-					emphasis: text( 'strong' )
-				}
-			};
-
-			const blockNode = {
-				blockType: 'core/test-block',
-				attrs: {
-					align: 'left'
-				},
-				rawContent: '<span>Ribs <strong>& Chicken</strong></span>'
-			};
-
-			expect( getBlockAttributes( blockNode, blockSettings ) ).to.eql( {
-				align: 'left',
-				emphasis: '& Chicken'
-			} );
-		} );
-
-		it( 'should return parsed attributes for block without attributes defined', () => {
-			const blockSettings = {};
-
-			const blockNode = {
-				blockType: 'core/test-block',
-				attrs: {
-					align: 'left'
-				},
-				rawContent: '<span>Ribs <strong>& Chicken</strong></span>'
-			};
-
-			expect( getBlockAttributes( blockNode, blockSettings ) ).to.eql( {
-				align: 'left'
 			} );
 		} );
 	} );


### PR DESCRIPTION
closes #434

This PR fixes the following error we're having when switching to the text editor

<img width="779" alt="screen shot 2017-04-17 at 10 20 18" src="https://cloud.githubusercontent.com/assets/272444/25085568/d60b7bf0-235a-11e7-8f20-1a18330aa153.png">

The problem was that we were using the `rawContent` from the block state object to serialize its attributes. And this property is no longer stored in the block state and even if it's stored , i'll be outdated.