### PR TITLE
Polish heading size numbers

### DIFF
--- a/editor/components/toolbar/style.scss
+++ b/editor/components/toolbar/style.scss
@@ -15,6 +15,7 @@
 	outline: none;
 	color: $dark-gray-500;
 	cursor: pointer;
+	position: relative;
 
 	&:first-child {
 		margin-left: 3px;
@@ -29,6 +30,17 @@
 		background-color: $dark-gray-500;
 		color: $white;
 	}
+
+	/* Optional number, e.g. for headings */
+	span {
+		font-family: $default-font;
+		font-size: 10px;
+		font-weight: bold;
+		position: absolute;
+		bottom: 8px;
+		right: 4px;
+	}
+
 }
 
 .editor-toolbar__control .dashicon {


### PR DESCRIPTION
This PR polishes the tiny number label next to heading buttons.

Screenshot:

![screen shot 2017-04-17 at 11 50 18](https://cloud.githubusercontent.com/assets/1204802/25085785/37f8dcc8-2364-11e7-957b-c82879bfc746.png)
