### PR TITLE
Visual Editor: Keep track of the focused block

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -17,6 +17,7 @@ export default class Editable extends wp.element.Component {
 		this.onChange = this.onChange.bind( this );
 		this.onNewBlock = this.onNewBlock.bind( this );
 		this.bindNode = this.bindNode.bind( this );
+		this.onFocus = this.onFocus.bind( this );
 	}
 
 	componentDidMount() {
@@ -44,12 +45,23 @@ export default class Editable extends wp.element.Component {
 		this.editor = editor;
 		editor.on( 'init', this.onInit );
 		editor.on( 'focusout', this.onChange );
-		editor.on( 'NewBlock', this.onNewBlock );
+		editor.on( 'NewBlock', this.onNewBlock )
+		editor.on( 'focusin', this.onFocus );
 	}
 
 	onInit() {
 		const { value = '' } = this.props;
 		this.editor.setContent( value );
+		this.focus();
+	}
+
+	onFocus() {
+		if ( ! this.props.onFocus ) {
+			return;
+		}
+
+		// TODO: We need a way to save the focus position ( bookmark maybe )
+		this.props.onFocus();
 	}
 
 	onChange() {
@@ -107,6 +119,12 @@ export default class Editable extends wp.element.Component {
 		this.editor.selection.moveToBookmark( bookmark );
 	}
 
+	focus() {
+		if ( this.props.focus ) {
+			this.editor.focus();
+		}
+	}
+
 	componentWillUpdate( nextProps ) {
 		if ( this.editor && this.props.tagName !== nextProps.tagName ) {
 			this.editor.destroy();
@@ -122,7 +140,16 @@ export default class Editable extends wp.element.Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.tagName !== prevProps.tagName ) {
 			this.initialize();
-		} else if ( this.props.value !== prevProps.value ) {
+		}
+
+		if ( this.props.focus !== prevProps.focus && this.props.focus ) {
+			this.focus();
+		}
+
+		if (
+			this.props.tagName === prevProps.tagName &&
+			this.props.value !== prevProps.value
+		) {
 			this.updateContent();
 		}
 	}

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -142,7 +142,7 @@ export default class Editable extends wp.element.Component {
 			this.initialize();
 		}
 
-		if ( this.props.focus !== prevProps.focus && this.props.focus ) {
+		if ( !! this.props.focus && ! prevProps.focus ) {
 			this.focus();
 		}
 

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -45,7 +45,7 @@ export default class Editable extends wp.element.Component {
 		this.editor = editor;
 		editor.on( 'init', this.onInit );
 		editor.on( 'focusout', this.onChange );
-		editor.on( 'NewBlock', this.onNewBlock )
+		editor.on( 'NewBlock', this.onNewBlock );
 		editor.on( 'focusin', this.onFocus );
 	}
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -31,13 +31,15 @@ registerBlock( 'core/heading', {
 		} ) )
 	],
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, focus, updateFocus } ) {
 		const { content, tag, align } = attributes;
 
 		return (
 			<Editable
 				tagName={ tag }
 				value={ content }
+				focus={ focus }
+				onFocus={ updateFocus }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				style={ align ? { textAlign: align } : null }
 			/>

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -31,7 +31,7 @@ registerBlock( 'core/heading', {
 		} ) )
 	],
 
-	edit( { attributes, setAttributes, focus, updateFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { content, tag, align } = attributes;
 
 		return (
@@ -39,7 +39,7 @@ registerBlock( 'core/heading', {
 				tagName={ tag }
 				value={ content }
 				focus={ focus }
-				onFocus={ updateFocus }
+				onFocus={ setFocus }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				style={ align ? { textAlign: align } : null }
 			/>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -21,24 +21,25 @@ registerBlock( 'core/image', {
 
 	edit( { attributes, setAttributes, focus, updateFocus } ) {
 		const { url, alt, caption } = attributes;
-		const focusCaption = () => updateFocus( { editable: 'caption' } );
 
-		/* eslint-disable */
+		// Disable reason: Clicking the image should set the focus to its caption
+
+		/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/onclick-has-role, jsx-a11y/no-static-element-interactions */
 		return (
 			<figure>
-				<img src={ url } alt={ alt } onClick={ focusCaption } />
+				<img src={ url } alt={ alt } onClick={ updateFocus } />
 				{ caption || !! focus ? (
 					<Editable
 						tagName="figcaption"
 						placeholder={ wp.i18n.__( 'Write caption…' ) }
 						value={ caption }
-						focus={ focus && focus.editable === 'caption' ? focus : null }
-						onFocus={ focusCaption }
+						focus={ focus }
+						onFocus={ updateFocus }
 						onChange={ ( value ) => setAttributes( { caption: value } ) } />
 				) : null }
 			</figure>
 		);
-		/* eslint-enable */
+		/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/onclick-has-role, jsx-a11y/no-static-element-interactions */
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -19,7 +19,7 @@ registerBlock( 'core/image', {
 		caption: html( 'figcaption' )
 	},
 
-	edit( { attributes, setAttributes, focus, updateFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { url, alt, caption } = attributes;
 
 		return (
@@ -31,7 +31,7 @@ registerBlock( 'core/image', {
 						placeholder={ wp.i18n.__( 'Write caption…' ) }
 						value={ caption }
 						focus={ focus }
-						onFocus={ updateFocus }
+						onFocus={ setFocus }
 						onChange={ ( value ) => setAttributes( { caption: value } ) } />
 				) : null }
 			</figure>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -19,21 +19,26 @@ registerBlock( 'core/image', {
 		caption: html( 'figcaption' )
 	},
 
-	edit( { attributes, isSelected, setAttributes } ) {
+	edit( { attributes, setAttributes, focus, updateFocus } ) {
 		const { url, alt, caption } = attributes;
+		const focusCaption = () => updateFocus( { editable: 'caption' } );
 
+		/* eslint-disable */
 		return (
 			<figure>
-				<img src={ url } alt={ alt } />
-				{ caption || isSelected ? (
+				<img src={ url } alt={ alt } onClick={ focusCaption } />
+				{ caption || !! focus ? (
 					<Editable
 						tagName="figcaption"
 						placeholder={ wp.i18n.__( 'Write caption…' ) }
 						value={ caption }
+						focus={ focus && focus.editable === 'caption' ? focus : null }
+						onFocus={ focusCaption }
 						onChange={ ( value ) => setAttributes( { caption: value } ) } />
 				) : null }
 			</figure>
 		);
+		/* eslint-enable */
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -22,12 +22,9 @@ registerBlock( 'core/image', {
 	edit( { attributes, setAttributes, focus, updateFocus } ) {
 		const { url, alt, caption } = attributes;
 
-		// Disable reason: Clicking the image should set the focus to its caption
-
-		/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/onclick-has-role, jsx-a11y/no-static-element-interactions */
 		return (
 			<figure>
-				<img src={ url } alt={ alt } onClick={ updateFocus } />
+				<img src={ url } alt={ alt } />
 				{ caption || !! focus ? (
 					<Editable
 						tagName="figcaption"
@@ -39,7 +36,6 @@ registerBlock( 'core/image', {
 				) : null }
 			</figure>
 		);
-		/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/onclick-has-role, jsx-a11y/no-static-element-interactions */
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -54,7 +54,7 @@ registerBlock( 'core/list', {
 		}
 	],
 
-	edit( { attributes } ) {
+	edit( { attributes, focus, updateFocus } ) {
 		const { listType = 'ol', items = [], align } = attributes;
 		const content = items.map( item => {
 			return `<li>${ item.value }</li>`;
@@ -65,6 +65,8 @@ registerBlock( 'core/list', {
 				tagName={ listType }
 				style={ align ? { textAlign: align } : null }
 				value={ content }
+				focus={ focus }
+				onFocus={ updateFocus }
 				className="blocks-list" />
 		);
 	},

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -54,7 +54,7 @@ registerBlock( 'core/list', {
 		}
 	],
 
-	edit( { attributes, focus, updateFocus } ) {
+	edit( { attributes, focus, setFocus } ) {
 		const { listType = 'ol', items = [], align } = attributes;
 		const content = items.map( item => {
 			return `<li>${ item.value }</li>`;
@@ -66,7 +66,7 @@ registerBlock( 'core/list', {
 				style={ align ? { textAlign: align } : null }
 				value={ content }
 				focus={ focus }
-				onFocus={ updateFocus }
+				onFocus={ setFocus }
 				className="blocks-list" />
 		);
 	},

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -20,7 +20,7 @@ registerBlock( 'core/quote', {
 		citation: html( 'footer' )
 	},
 
-	edit( { attributes, setAttributes, focus, updateFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { value, citation } = attributes;
 
 		return (
@@ -33,7 +33,7 @@ registerBlock( 'core/quote', {
 						} )
 					}
 					focus={ focus && focus.editable === 'value' ? focus : null }
-					onFocus={ () => updateFocus( { editable: 'value' } ) }
+					onFocus={ () => setFocus( { editable: 'value' } ) }
 				/>
 				{ ( citation || !! focus ) &&
 					<footer>
@@ -45,7 +45,7 @@ registerBlock( 'core/quote', {
 								} )
 							}
 							focus={ focus && focus.editable === 'citation' ? focus : null }
-							onFocus={ () => updateFocus( { editable: 'citation' } ) }
+							onFocus={ () => setFocus( { editable: 'citation' } ) }
 						/>
 					</footer>
 				}

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -20,7 +20,7 @@ registerBlock( 'core/quote', {
 		citation: html( 'footer' )
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, focus, updateFocus } ) {
 		const { value, citation } = attributes;
 
 		return (
@@ -31,16 +31,24 @@ registerBlock( 'core/quote', {
 						( paragraphs ) => setAttributes( {
 							value: fromParagraphsToValue( paragraphs )
 						} )
-					} />
-				<footer>
-					<Editable
-						value={ citation }
-						onChange={
-							( newValue ) => setAttributes( {
-								citation: newValue
-							} )
-						} />
-				</footer>
+					}
+					focus={ focus && focus.editable === 'value' ? focus : null }
+					onFocus={ () => updateFocus( { editable: 'value' } ) }
+				/>
+				{ ( citation || !! focus ) &&
+					<footer>
+						<Editable
+							value={ citation }
+							onChange={
+								( newValue ) => setAttributes( {
+									citation: newValue
+								} )
+							}
+							focus={ focus && focus.editable === 'citation' ? focus : null }
+							onFocus={ () => updateFocus( { editable: 'citation' } ) }
+						/>
+					</footer>
+				}
 			</blockquote>
 		);
 	},

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -47,7 +47,7 @@ registerBlock( 'core/text', {
 		}
 	],
 
-	edit( { attributes, setAttributes, insertBlockAfter, focus, updateFocus } ) {
+	edit( { attributes, setAttributes, insertBlockAfter, focus, setFocus } ) {
 		const { content, align } = attributes;
 
 		return (
@@ -57,7 +57,7 @@ registerBlock( 'core/text', {
 					content: fromParagraphsToValue( paragraphs )
 				} ) }
 				focus={ focus }
-				onFocus={ updateFocus }
+				onFocus={ setFocus }
 				style={ align ? { textAlign: align } : null }
 				onSplit={ ( before, after ) => {
 					setAttributes( { content: fromParagraphsToValue( before ) } );

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -47,7 +47,7 @@ registerBlock( 'core/text', {
 		}
 	],
 
-	edit( { attributes, setAttributes, insertBlockAfter } ) {
+	edit( { attributes, setAttributes, insertBlockAfter, focus, updateFocus } ) {
 		const { content, align } = attributes;
 
 		return (
@@ -56,6 +56,8 @@ registerBlock( 'core/text', {
 				onChange={ ( paragraphs ) => setAttributes( {
 					content: fromParagraphsToValue( paragraphs )
 				} ) }
+				focus={ focus }
+				onFocus={ updateFocus }
 				style={ align ? { textAlign: align } : null }
 				onSplit={ ( before, after ) => {
 					setAttributes( { content: fromParagraphsToValue( before ) } );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -17,6 +17,7 @@ class VisualEditorBlock extends wp.element.Component {
 		this.bindBlockNode = this.bindBlockNode.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
 		this.maybeDeselect = this.maybeDeselect.bind( this );
+		this.maybeHover = this.maybeHover.bind( this );
 		this.previousOffset = null;
 	}
 
@@ -42,6 +43,13 @@ class VisualEditorBlock extends wp.element.Component {
 				...attributes
 			}
 		} );
+	}
+
+	maybeHover() {
+		const { isTyping, isHovered, onHover } = this.props;
+		if ( isTyping && ! isHovered ) {
+			onHover();
+		}
 	}
 
 	maybeDeselect( event ) {
@@ -81,7 +89,7 @@ class VisualEditorBlock extends wp.element.Component {
 			'is-hovered': isHovered
 		} );
 
-		const { onSelect, onStartTyping, onMouseMove, onMouseLeave, onFocus, onInsertAfter } = this.props;
+		const { onSelect, onStartTyping, onHover, onMouseLeave, onFocus, onInsertAfter } = this.props;
 
 		// Disable reason: Each block can receive focus but must be able to contain
 		// block children. Tab keyboard navigation enabled by tabIndex assignment.
@@ -94,7 +102,8 @@ class VisualEditorBlock extends wp.element.Component {
 				onFocus={ onSelect }
 				onBlur={ this.maybeDeselect }
 				onKeyDown={ onStartTyping }
-				onMouseMove={ onMouseMove }
+				onMouseEnter={ onHover }
+				onMouseMove={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
 				className={ className }
 			>
@@ -160,7 +169,7 @@ export default connect(
 				uid: ownProps.uid
 			} );
 		},
-		onMouseMove() {
+		onHover() {
 			dispatch( {
 				type: 'TOGGLE_BLOCK_HOVERED',
 				hovered: true,

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -75,13 +75,13 @@ class VisualEditorBlock extends wp.element.Component {
 			return null;
 		}
 
-		const { isHovered, isSelected } = this.props;
+		const { isHovered, isSelected, focus } = this.props;
 		const className = classnames( 'editor-visual-editor__block', {
 			'is-selected': isSelected,
 			'is-hovered': isHovered
 		} );
 
-		const { onSelect, onDeselect, onMouseEnter, onMouseLeave, onInsertAfter } = this.props;
+		const { onSelect, onDeselect, onMouseEnter, onMouseLeave, onInsertAfter, onFocus } = this.props;
 
 		// Disable reason: Each block can receive focus but must be able to contain
 		// block children. Tab keyboard navigation enabled by tabIndex assignment.
@@ -112,9 +112,11 @@ class VisualEditorBlock extends wp.element.Component {
 				</div>
 				<BlockEdit
 					isSelected={ isSelected }
+					focus={ focus }
 					attributes={ block.attributes }
 					setAttributes={ this.setAttributes }
 					insertBlockAfter={ onInsertAfter }
+					updateFocus={ onFocus }
 				/>
 			</div>
 		);
@@ -127,7 +129,8 @@ export default connect(
 		order: state.blocks.order.indexOf( ownProps.uid ),
 		block: state.blocks.byUid[ ownProps.uid ],
 		isSelected: state.selectedBlock === ownProps.uid,
-		isHovered: state.hoveredBlock === ownProps.uid
+		isHovered: state.hoveredBlock === ownProps.uid,
+		focus: state.focus.uid === ownProps.uid ? state.focus.config : null
 	} ),
 	( dispatch, ownProps ) => ( {
 		onChange( updates ) {
@@ -165,11 +168,20 @@ export default connect(
 				uid: ownProps.uid
 			} );
 		},
+
 		onInsertAfter( block ) {
 			dispatch( {
 				type: 'INSERT_BLOCK',
 				after: ownProps.uid,
 				block
+			} );
+		},
+
+		onFocus( config = {} ) {
+			dispatch( {
+				type: 'UPDATE_FOCUS',
+				uid: ownProps.uid,
+				config
 			} );
 		}
 	} )

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -183,7 +183,7 @@ export default connect(
 			} );
 		},
 
-		onFocus( config = {} ) {
+		onFocus( config ) {
 			dispatch( {
 				type: 'UPDATE_FOCUS',
 				uid: ownProps.uid,

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -124,7 +124,7 @@ class VisualEditorBlock extends wp.element.Component {
 					attributes={ block.attributes }
 					setAttributes={ this.setAttributes }
 					insertBlockAfter={ onInsertAfter }
-					updateFocus={ onFocus }
+					setFocus={ onFocus }
 				/>
 			</div>
 		);

--- a/editor/state.js
+++ b/editor/state.js
@@ -127,7 +127,7 @@ export function selectedBlock( state = {}, action ) {
 			return {
 				uid: action.uid,
 				typing: state.uid === action.uid ? state.typing : false,
-				focus: action.config
+				focus: action.config || {}
 			};
 
 		case 'START_TYPING':

--- a/editor/state.js
+++ b/editor/state.js
@@ -139,6 +139,25 @@ export function hoveredBlock( state = null, action ) {
 }
 
 /**
+ * Reducer returning the focused block state.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {Object}        Updated state
+ */
+export function focus( state = {}, action ) {
+	switch ( action.type ) {
+		case 'UPDATE_FOCUS':
+			return {
+				uid: action.uid,
+				config: action.config
+			};
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning current editor mode, either "visual" or "text".
  *
  * @param  {string} state  Current state
@@ -171,6 +190,7 @@ export function isSidebarOpened( state = false, action ) {
 export function createReduxStore() {
 	const reducer = combineReducers( {
 		blocks,
+		focus,
 		selectedBlock,
 		hoveredBlock,
 		mode,

--- a/editor/state.js
+++ b/editor/state.js
@@ -100,17 +100,49 @@ export const blocks = combineUndoableReducers( {
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function selectedBlock( state = null, action ) {
+export function selectedBlock( state = {}, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_BLOCK_SELECTED':
-			return action.selected ? action.uid : null;
+			if ( ! action.selected ) {
+				return state.uid === action.uid ? {} : state;
+			}
+			return action.uid === state.uid
+				? state
+				: { uid: action.uid, typing: false, focus: {} };
 
 		case 'MOVE_BLOCK_UP':
 		case 'MOVE_BLOCK_DOWN':
-			return action.uid;
+			return action.uid === state.uid
+				? state
+				: { uid: action.uid, typing: false, focus: {} };
 
 		case 'INSERT_BLOCK':
-			return action.block.uid;
+			return {
+				uid: action.block.uid,
+				typing: false,
+				focus: {}
+			};
+
+		case 'UPDATE_FOCUS':
+			return {
+				uid: action.uid,
+				typing: state.uid === action.uid ? state.typing : false,
+				focus: action.config
+			};
+
+		case 'START_TYPING':
+			if ( action.uid !== state.uid ) {
+				return {
+					uid: action.uid,
+					typing: true,
+					focus: {}
+				};
+			}
+
+			return {
+				...state,
+				typing: true
+			};
 	}
 
 	return state;
@@ -133,25 +165,8 @@ export function hoveredBlock( state = null, action ) {
 				return null;
 			}
 			break;
-	}
-
-	return state;
-}
-
-/**
- * Reducer returning the focused block state.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Dispatched action
- * @return {Object}        Updated state
- */
-export function focus( state = {}, action ) {
-	switch ( action.type ) {
-		case 'UPDATE_FOCUS':
-			return {
-				uid: action.uid,
-				config: action.config
-			};
+		case 'START_TYPING':
+			return null;
 	}
 
 	return state;
@@ -190,7 +205,6 @@ export function isSidebarOpened( state = false, action ) {
 export function createReduxStore() {
 	const reducer = combineReducers( {
 		blocks,
-		focus,
 		selectedBlock,
 		hoveredBlock,
 		mode,

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -9,6 +9,7 @@ import { values } from 'lodash';
  */
 import {
 	blocks,
+	focus,
 	hoveredBlock,
 	selectedBlock,
 	mode,
@@ -320,6 +321,30 @@ describe( 'state', () => {
 		} );
 	} );
 
+	describe( 'focus()', () => {
+		it( 'should return an empty object by default', () => {
+			const state = focus( undefined, {} );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should update the focused block', () => {
+			const state = focus( null, {
+				type: 'UPDATE_FOCUS',
+				uid: 'chicken',
+				config: {
+					editable: 'ribs'
+				}
+			} );
+
+			expect( state ).to.eql( {
+				uid: 'chicken',
+				config: {
+					editable: 'ribs'
+				}
+			} );
+		} );
+	} );
+
 	describe( 'createReduxStore()', () => {
 		it( 'should return a redux store', () => {
 			const store = createReduxStore();
@@ -337,7 +362,8 @@ describe( 'state', () => {
 				'selectedBlock',
 				'hoveredBlock',
 				'mode',
-				'isSidebarOpened'
+				'isSidebarOpened',
+				'focus'
 			] );
 		} );
 	} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -3,13 +3,13 @@
  */
 import { expect } from 'chai';
 import { values } from 'lodash';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
 import {
 	blocks,
-	focus,
 	hoveredBlock,
 	selectedBlock,
 	mode,
@@ -227,7 +227,40 @@ describe( 'state', () => {
 				selected: true
 			} );
 
-			expect( state ).to.equal( 'kumquat' );
+			expect( state ).to.eql( { uid: 'kumquat', typing: false, focus: {} } );
+		} );
+
+		it( 'should not update the state if already selected', () => {
+			const original = deepFreeze( { uid: 'kumquat', typing: true, focus: {} } );
+			const state = selectedBlock( original, {
+				type: 'TOGGLE_BLOCK_SELECTED',
+				uid: 'kumquat',
+				selected: true
+			} );
+
+			expect( state ).to.equal( original );
+		} );
+
+		it( 'should unselect the block if currently selected', () => {
+			const original = deepFreeze( { uid: 'kumquat', typing: true, focus: {} } );
+			const state = selectedBlock( original, {
+				type: 'TOGGLE_BLOCK_SELECTED',
+				uid: 'kumquat',
+				selected: false
+			} );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should not unselect the block if another block is selected', () => {
+			const original = deepFreeze( { uid: 'loquat', typing: true, focus: {} } );
+			const state = selectedBlock( original, {
+				type: 'TOGGLE_BLOCK_SELECTED',
+				uid: 'kumquat',
+				selected: false
+			} );
+
+			expect( state ).to.equal( original );
 		} );
 
 		it( 'should return with inserted block', () => {
@@ -239,7 +272,7 @@ describe( 'state', () => {
 				}
 			} );
 
-			expect( state ).to.equal( 'ribs' );
+			expect( state ).to.eql( { uid: 'ribs', typing: false, focus: {} } );
 		} );
 
 		it( 'should return with block moved up', () => {
@@ -248,7 +281,7 @@ describe( 'state', () => {
 				uid: 'ribs'
 			} );
 
-			expect( state ).to.equal( 'ribs' );
+			expect( state ).to.eql( { uid: 'ribs', typing: false, focus: {} } );
 		} );
 
 		it( 'should return with block moved down', () => {
@@ -257,7 +290,57 @@ describe( 'state', () => {
 				uid: 'chicken'
 			} );
 
-			expect( state ).to.equal( 'chicken' );
+			expect( state ).to.eql( { uid: 'chicken', typing: false, focus: {} } );
+		} );
+
+		it( 'should not update the state if the block moved is already selected', () => {
+			const original = deepFreeze( { uid: 'ribs', typing: true, focus: {} } );
+			const state = selectedBlock( original, {
+				type: 'MOVE_BLOCK_UP',
+				uid: 'ribs'
+			} );
+
+			expect( state ).to.equal( original );
+		} );
+
+		it( 'should update the focus and selects the block', () => {
+			const state = selectedBlock( undefined, {
+				type: 'UPDATE_FOCUS',
+				uid: 'chicken',
+				config: { editable: 'citation' }
+			} );
+
+			expect( state ).to.eql( { uid: 'chicken', typing: false, focus: { editable: 'citation' } } );
+		} );
+
+		it( 'should update the focus and merge the existing state', () => {
+			const original = deepFreeze( { uid: 'ribs', typing: true, focus: {} } );
+			const state = selectedBlock( original, {
+				type: 'UPDATE_FOCUS',
+				uid: 'ribs',
+				config: { editable: 'citation' }
+			} );
+
+			expect( state ).to.eql( { uid: 'ribs', typing: true, focus: { editable: 'citation' } } );
+		} );
+
+		it( 'should set the typing flag and selects the block', () => {
+			const state = selectedBlock( undefined, {
+				type: 'START_TYPING',
+				uid: 'chicken'
+			} );
+
+			expect( state ).to.eql( { uid: 'chicken', typing: true, focus: {} } );
+		} );
+
+		it( 'should set the typing flag and merge the existing state', () => {
+			const original = deepFreeze( { uid: 'ribs', typing: false, focus: { editable: 'citation' } } );
+			const state = selectedBlock( original, {
+				type: 'START_TYPING',
+				uid: 'ribs'
+			} );
+
+			expect( state ).to.eql( { uid: 'ribs', typing: true, focus: { editable: 'citation' } } );
 		} );
 
 		it( 'should insert after the specified block uid', () => {
@@ -321,30 +404,6 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'focus()', () => {
-		it( 'should return an empty object by default', () => {
-			const state = focus( undefined, {} );
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should update the focused block', () => {
-			const state = focus( null, {
-				type: 'UPDATE_FOCUS',
-				uid: 'chicken',
-				config: {
-					editable: 'ribs'
-				}
-			} );
-
-			expect( state ).to.eql( {
-				uid: 'chicken',
-				config: {
-					editable: 'ribs'
-				}
-			} );
-		} );
-	} );
-
 	describe( 'createReduxStore()', () => {
 		it( 'should return a redux store', () => {
 			const store = createReduxStore();
@@ -362,8 +421,7 @@ describe( 'state', () => {
 				'selectedBlock',
 				'hoveredBlock',
 				'mode',
-				'isSidebarOpened',
-				'focus'
+				'isSidebarOpened'
 			] );
 		} );
 	} );

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -19,7 +19,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: blocks/library/image/index.js:33
+#: blocks/library/image/index.js:34
 msgid "Write caption…"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -19,7 +19,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: blocks/library/image/index.js:34
+#: blocks/library/image/index.js:31
 msgid "Write caption…"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -19,7 +19,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: blocks/library/image/index.js:31
+#: blocks/library/image/index.js:33
 msgid "Write caption…"
 msgstr ""
 


### PR DESCRIPTION
references #420 

In this PR, I'm adding the `focus` state to keep track of the focused block and any extra config that let us focus the right element. For now, I'm storing the focused block and the focused editable inside the block. To make undo/redo work correctly, we'll need to add the position inside the focused editable.

closes #437 
