### PR TITLE
Add proper label to IconButton number element.

### DIFF
--- a/editor/components/icon-button/index.js
+++ b/editor/components/icon-button/index.js
@@ -14,9 +14,8 @@ function IconButton( { icon, children, label, className, ...additionalProps } ) 
 	const classes = classnames( 'editor-icon-button', className );
 
 	return (
-		<Button { ...additionalProps } aria-label={ label } className={ classes }>
+		<Button { ...additionalProps } aria-label={ label } className={ classes } data-level={ children ? children : null }>
 			<Dashicon icon={ icon } />
-			{ children ? <span className="editor-icon-button__level">{ children }</span> : null }
 		</Button>
 	);
 }

--- a/editor/components/icon-button/index.js
+++ b/editor/components/icon-button/index.js
@@ -16,7 +16,7 @@ function IconButton( { icon, children, label, className, ...additionalProps } ) 
 	return (
 		<Button { ...additionalProps } aria-label={ label } className={ classes }>
 			<Dashicon icon={ icon } />
-			{ children ? <span>{ children }</span> : null }
+			{ children ? <span className="editor-icon-button__level">{ children }</span> : null }
 		</Button>
 	);
 }

--- a/editor/components/icon-button/style.scss
+++ b/editor/components/icon-button/style.scss
@@ -14,13 +14,14 @@
 			color: $blue-medium;
 		}
 	}
-}
 
-.editor-icon-button__level {
-	font-family: $default-font;
-	font-size: 10px;
-	font-weight: bold;
-	position: absolute;
-	bottom: 8px;
-	right: 4px;
+	&:after {
+		content: attr( data-level );
+		font-family: $default-font;
+		font-size: 10px;
+		font-weight: bold;
+		position: absolute;
+		bottom: 8px;
+		right: 4px;
+	}
 }

--- a/editor/components/icon-button/style.scss
+++ b/editor/components/icon-button/style.scss
@@ -14,8 +14,13 @@
 			color: $blue-medium;
 		}
 	}
+}
 
-	span {
-		font-size: 12px;
-	}
+.editor-icon-button__level {
+	font-family: $default-font;
+	font-size: 10px;
+	font-weight: bold;
+	position: absolute;
+	bottom: 8px;
+	right: 4px;
 }

--- a/editor/components/toolbar/style.scss
+++ b/editor/components/toolbar/style.scss
@@ -30,17 +30,6 @@
 		background-color: $dark-gray-500;
 		color: $white;
 	}
-
-	/* Optional number, e.g. for headings */
-	span {
-		font-family: $default-font;
-		font-size: 10px;
-		font-weight: bold;
-		position: absolute;
-		bottom: 8px;
-		right: 4px;
-	}
-
 }
 
 .editor-toolbar__control .dashicon {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -45,7 +45,7 @@ function VisualEditorBlock( props ) {
 		// Annoyingly React does not support focusOut and we're forced to check
 		// related target to ensure it's not a child when blur fires.
 		if ( ! event.currentTarget.contains( event.relatedTarget ) ) {
-			onDeselect();
+			//onDeselect();
 		}
 	}
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -45,7 +45,7 @@ function VisualEditorBlock( props ) {
 		// Annoyingly React does not support focusOut and we're forced to check
 		// related target to ensure it's not a child when blur fires.
 		if ( ! event.currentTarget.contains( event.relatedTarget ) ) {
-			//onDeselect();
+			onDeselect();
 		}
 	}
 


### PR DESCRIPTION
The IconButton can optionally have a number indicating the level. For example heading might have this, quote has two styles, galleries might have multiple styles also. This PR adds a classname to indicate this, and moves the style to the iconbutton itself.

This intends to address feedback in https://github.com/WordPress/gutenberg/pull/423#discussion_r111736548 and https://github.com/WordPress/gutenberg/pull/436#discussion_r111736572.