### PR TITLE
Visual Editor: Adding the global controls concept

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -37,12 +37,17 @@ export function parseBlockAttributes( rawContent, blockSettings ) {
  * @return {Object}                All block attributes
  */
 export function getBlockAttributes( blockSettings, rawContent, attributes ) {
+	// Handle global controls
+	const contentToParse = attributes.position
+		? query.parse( rawContent, query.html( 'div' ) )
+		: rawContent;
+
 	// Merge any attributes from comment delimiters with block implementation
 	attributes = attributes || {};
 	if ( blockSettings ) {
 		attributes = {
 			...attributes,
-			...parseBlockAttributes( rawContent, blockSettings ),
+			...parseBlockAttributes( contentToParse, blockSettings ),
 		};
 	}
 

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -38,7 +38,7 @@ export function parseBlockAttributes( rawContent, blockSettings ) {
  */
 export function getBlockAttributes( blockSettings, rawContent, attributes ) {
 	// Handle global controls
-	const contentToParse = attributes.position
+	const contentToParse = attributes && attributes.position
 		? query.parse( rawContent, query.html( 'div' ) )
 		: rawContent;
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -69,6 +69,9 @@ export default function serialize( blocks ) {
 		const blockType = block.blockType;
 		const settings = getBlockSettings( blockType );
 		const saveContent = getSaveContent( settings.save, block.attributes );
+		const wrappedSavedContent = block.attributes.position
+			? `<div classname="align${ block.attributes.position }">${ saveContent }</div>`
+			: saveContent;
 
 		return memo + (
 			'<!-- wp:' +
@@ -79,7 +82,7 @@ export default function serialize( blocks ) {
 				parseBlockAttributes( saveContent, settings )
 			) +
 			'-->' +
-			saveContent +
+			wrappedSavedContent +
 			'<!-- /wp:' +
 			blockType +
 			' -->'

--- a/blocks/controls/index.js
+++ b/blocks/controls/index.js
@@ -1,0 +1,35 @@
+function applyOrUnset( position ) {
+	return ( attributes, setAttributes ) => {
+		const nextPosition = attributes.position === position ? undefined : position;
+		setAttributes( { position: nextPosition } );
+	};
+}
+
+const controls = [
+	{
+		icon: 'align-left',
+		title: wp.i18n.__( 'Position left' ),
+		isActive: ( { position } ) => 'left' === position,
+		onClick: applyOrUnset( 'left' )
+	},
+	{
+		icon: 'align-center',
+		title: wp.i18n.__( 'Position center' ),
+		isActive: ( { position } ) => 'center' === position,
+		onClick: applyOrUnset( 'center' )
+	},
+	{
+		icon: 'align-right',
+		title: wp.i18n.__( 'Position right' ),
+		isActive: ( { position } ) => 'right' === position,
+		onClick: applyOrUnset( 'right' )
+	},
+	{
+		icon: 'align-none',
+		title: wp.i18n.__( 'No positionning' ),
+		isActive: ( { position } ) => ! position || 'none' === position,
+		onClick: applyOrUnset( 'none' )
+	}
+];
+
+export default controls;

--- a/blocks/controls/index.js
+++ b/blocks/controls/index.js
@@ -5,35 +5,31 @@ function applyOrUnset( position ) {
 	};
 }
 
-const controls = [
-	{
-		slug: 'core/position-left',
+const controls = {
+	'core/position-left': {
 		icon: 'align-left',
 		title: wp.i18n.__( 'Position left' ),
 		isActive: ( { position } ) => 'left' === position,
 		onClick: applyOrUnset( 'left' )
 	},
-	{
-		slug: 'core/position-center',
+	'core/position-center': {
 		icon: 'align-center',
 		title: wp.i18n.__( 'Position center' ),
 		isActive: ( { position } ) => 'center' === position,
 		onClick: applyOrUnset( 'center' )
 	},
-	{
-		slug: 'core/position-right',
+	'core/position-right':	{
 		icon: 'align-right',
 		title: wp.i18n.__( 'Position right' ),
 		isActive: ( { position } ) => 'right' === position,
 		onClick: applyOrUnset( 'right' )
 	},
-	{
-		slug: 'core/position-none',
+	'core/position-none': {
 		icon: 'align-none',
 		title: wp.i18n.__( 'No positionning' ),
 		isActive: ( { position } ) => ! position || 'none' === position,
 		onClick: applyOrUnset( 'none' )
 	}
-];
+};
 
 export default controls;

--- a/blocks/controls/index.js
+++ b/blocks/controls/index.js
@@ -7,24 +7,28 @@ function applyOrUnset( position ) {
 
 const controls = [
 	{
+		slug: 'core/position-left',
 		icon: 'align-left',
 		title: wp.i18n.__( 'Position left' ),
 		isActive: ( { position } ) => 'left' === position,
 		onClick: applyOrUnset( 'left' )
 	},
 	{
+		slug: 'core/position-center',
 		icon: 'align-center',
 		title: wp.i18n.__( 'Position center' ),
 		isActive: ( { position } ) => 'center' === position,
 		onClick: applyOrUnset( 'center' )
 	},
 	{
+		slug: 'core/position-right',
 		icon: 'align-right',
 		title: wp.i18n.__( 'Position right' ),
 		isActive: ( { position } ) => 'right' === position,
 		onClick: applyOrUnset( 'right' )
 	},
 	{
+		slug: 'core/position-none',
 		icon: 'align-none',
 		title: wp.i18n.__( 'No positionning' ),
 		isActive: ( { position } ) => ! position || 'none' === position,

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -5,3 +5,4 @@ import './library';
 
 export * from './api';
 export * from './components';
+export { default as controls } from './controls';

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -19,6 +19,13 @@ registerBlock( 'core/image', {
 		caption: html( 'figcaption' )
 	},
 
+	controls: [
+		'core/position-left',
+		'core/position-center',
+		'core/position-right',
+		'core/position-none'
+	],
+
 	edit( { attributes, isSelected, setAttributes } ) {
 		const { url, alt, caption } = attributes;
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -53,10 +53,7 @@ function VisualEditorBlock( props ) {
 
 	const controls = settings.controls && compact(
 		settings.controls.map( ( control ) => {
-			if ( isString( control ) ) {
-				return wp.blocks.controls.find( ctrl => ctrl.slug === control );
-			}
-			return control;
+			return isString( control ) ? wp.blocks.controls[ control ] : control;
 		} )
 	);
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -29,7 +29,7 @@ function VisualEditorBlock( props ) {
 	const className = classnames( 'editor-visual-editor__block', {
 		'is-selected': isSelected,
 		'is-hovered': isHovered
-	} );
+	}, block.attributes.position && `align${ block.attributes.position }` );
 
 	const { onChange, onSelect, onDeselect, onMouseEnter, onMouseLeave, onInsertAfter } = props;
 
@@ -50,6 +50,8 @@ function VisualEditorBlock( props ) {
 		}
 	}
 
+	const controls = wp.blocks.controls.concat( settings.controls || [] );
+
 	// Disable reason: Each block can receive focus but must be able to contain
 	// block children. Tab keyboard navigation enabled by tabIndex assignment.
 
@@ -67,9 +69,9 @@ function VisualEditorBlock( props ) {
 			{ ( isSelected || isHovered ) && <BlockMover uid={ block.uid } /> }
 			<div className="editor-visual-editor__block-controls">
 				{ isSelected && <BlockSwitcher uid={ block.uid } /> }
-				{ isSelected && settings.controls ? (
+				{ isSelected && controls ? (
 					<Toolbar
-						controls={ settings.controls.map( ( control ) => ( {
+						controls={ controls.map( ( control ) => ( {
 							...control,
 							onClick: () => control.onClick( block.attributes, setAttributes ),
 							isActive: () => control.isActive( block.attributes )

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { isString, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,7 +51,14 @@ function VisualEditorBlock( props ) {
 		}
 	}
 
-	const controls = wp.blocks.controls.concat( settings.controls || [] );
+	const controls = settings.controls && compact(
+		settings.controls.map( ( control ) => {
+			if ( isString( control ) ) {
+				return wp.blocks.controls.find( ctrl => ctrl.slug === control );
+			}
+			return control;
+		} )
+	);
 
 	// Disable reason: Each block can receive focus but must be able to contain
 	// block children. Tab keyboard navigation enabled by tabIndex assignment.

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -57,3 +57,19 @@
 .editor-visual-editor .editor-inserter {
 	margin: $item-spacing;
 }
+
+.editor-visual-editor .alignright,
+.editor-visual-editor .alignleft,
+.editor-visual-editor .aligncenter {
+	z-index: 1;
+}
+
+// Temporary styling before having the possibility
+// to edit the block width
+.editor-visual-editor .alignright,
+.editor-visual-editor .alignleft {
+	max-width: 50%;
+	img {
+		max-width: 100%;
+	}
+}

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,19 +3,19 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/controls/index.js:11
+#: blocks/controls/index.js:12
 msgid "Position left"
 msgstr ""
 
-#: blocks/controls/index.js:17
+#: blocks/controls/index.js:19
 msgid "Position center"
 msgstr ""
 
-#: blocks/controls/index.js:23
+#: blocks/controls/index.js:26
 msgid "Position right"
 msgstr ""
 
-#: blocks/controls/index.js:29
+#: blocks/controls/index.js:33
 msgid "No positionning"
 msgstr ""
 
@@ -35,7 +35,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: blocks/library/image/index.js:31
+#: blocks/library/image/index.js:38
 msgid "Write caption…"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,6 +3,22 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
+#: blocks/controls/index.js:11
+msgid "Position left"
+msgstr ""
+
+#: blocks/controls/index.js:17
+msgid "Position center"
+msgstr ""
+
+#: blocks/controls/index.js:23
+msgid "Position right"
+msgstr ""
+
+#: blocks/controls/index.js:29
+msgid "No positionning"
+msgstr ""
+
 #: blocks/library/freeform/index.js:9
 msgid "Freeform"
 msgstr ""

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,19 +3,19 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/controls/index.js:12
+#: blocks/controls/index.js:11
 msgid "Position left"
 msgstr ""
 
-#: blocks/controls/index.js:19
+#: blocks/controls/index.js:17
 msgid "Position center"
 msgstr ""
 
-#: blocks/controls/index.js:26
+#: blocks/controls/index.js:23
 msgid "Position right"
 msgstr ""
 
-#: blocks/controls/index.js:33
+#: blocks/controls/index.js:29
 msgid "No positionning"
 msgstr ""
 


### PR DESCRIPTION
In this PR. I'm exploring the idea of global controls as an alternative to #416 (image alignments)

Global controls are controls that can be automatically applied to any block type. I'm using the block positioning controls (float left, right, center) as an example. 

For now these controls are automatically enabled for all blocks but I'm thinking of introducing an opt-in (or opt-out) attribute in the Block API.

**Testing instructions**

 - Try using the positioning controls in different blocks. (image, text, quote)