### PR TITLE
Components: Fix the icon button level prop

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -22,12 +22,12 @@ registerBlock( 'core/heading', {
 	controls: [
 		...'123456'.split( '' ).map( ( level ) => ( {
 			icon: 'heading',
-			text: level,
 			title: wp.i18n.sprintf( wp.i18n.__( 'Heading %s' ), level ),
 			isActive: ( { tag } ) => 'H' + level === tag,
 			onClick( attributes, setAttributes ) {
 				setAttributes( { tag: 'H' + level } );
-			}
+			},
+			level
 		} ) )
 	],
 

--- a/editor/components/icon-button/index.js
+++ b/editor/components/icon-button/index.js
@@ -10,11 +10,11 @@ import './style.scss';
 import Button from '../button';
 import Dashicon from '../dashicon';
 
-function IconButton( { icon, level, children, label, className, ...additionalProps } ) {
+function IconButton( { icon, children, label, className, ...additionalProps } ) {
 	const classes = classnames( 'editor-icon-button', className );
 
 	return (
-		<Button { ...additionalProps } aria-label={ label } className={ classes } data-level={ level ? level : null }>
+		<Button { ...additionalProps } aria-label={ label } className={ classes }>
 			<Dashicon icon={ icon } />
 			{ children }
 		</Button>

--- a/editor/components/icon-button/index.js
+++ b/editor/components/icon-button/index.js
@@ -10,12 +10,13 @@ import './style.scss';
 import Button from '../button';
 import Dashicon from '../dashicon';
 
-function IconButton( { icon, children, label, className, ...additionalProps } ) {
+function IconButton( { icon, level, children, label, className, ...additionalProps } ) {
 	const classes = classnames( 'editor-icon-button', className );
 
 	return (
-		<Button { ...additionalProps } aria-label={ label } className={ classes } data-level={ children ? children : null }>
+		<Button { ...additionalProps } aria-label={ label } className={ classes } data-level={ level ? level : null }>
 			<Dashicon icon={ icon } />
+			{ children }
 		</Button>
 	);
 }

--- a/editor/components/icon-button/style.scss
+++ b/editor/components/icon-button/style.scss
@@ -14,14 +14,4 @@
 			color: $blue-medium;
 		}
 	}
-
-	&:after {
-		content: attr( data-level );
-		font-family: $default-font;
-		font-size: 10px;
-		font-weight: bold;
-		position: absolute;
-		bottom: 8px;
-		right: 4px;
-	}
 }

--- a/editor/components/icon-button/style.scss
+++ b/editor/components/icon-button/style.scss
@@ -22,6 +22,6 @@
 		font-weight: bold;
 		position: absolute;
 		bottom: 8px;
-		right: 4px;
+		right: 5px;
 	}
 }

--- a/editor/components/toolbar/index.js
+++ b/editor/components/toolbar/index.js
@@ -21,15 +21,14 @@ function Toolbar( { controls } ) {
 					key={ index }
 					icon={ control.icon }
 					label={ control.title }
+					level={ control.level }
 					onClick={ ( event ) => {
 						event.stopPropagation();
 						control.onClick();
 					} }
 					className={ classNames( 'editor-toolbar__control', {
 						'is-active': control.isActive && control.isActive()
-					} ) }>
-					{ control.text }
-				</IconButton>
+					} ) } />
 			) ) }
 		</ul>
 	);

--- a/editor/components/toolbar/index.js
+++ b/editor/components/toolbar/index.js
@@ -21,7 +21,7 @@ function Toolbar( { controls } ) {
 					key={ index }
 					icon={ control.icon }
 					label={ control.title }
-					level={ control.level }
+					data-level={ control.level }
 					onClick={ ( event ) => {
 						event.stopPropagation();
 						control.onClick();

--- a/editor/components/toolbar/style.scss
+++ b/editor/components/toolbar/style.scss
@@ -30,6 +30,16 @@
 		background-color: $dark-gray-500;
 		color: $white;
 	}
+
+	&:after {
+		content: attr( data-level );
+		font-family: $default-font;
+		font-size: 10px;
+		font-weight: bold;
+		position: absolute;
+		bottom: 8px;
+		right: 4px;
+	}
 }
 
 .editor-toolbar__control .dashicon {

--- a/editor/components/toolbar/style.scss
+++ b/editor/components/toolbar/style.scss
@@ -31,7 +31,7 @@
 		color: $white;
 	}
 
-	&:after {
+	&[data-level]:after {
 		content: attr( data-level );
 		font-family: $default-font;
 		font-size: 10px;

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -11,7 +11,7 @@ msgstr ""
 msgid "Heading"
 msgstr ""
 
-#: blocks/library/heading/index.js:26
+#: blocks/library/heading/index.js:25
 msgid "Heading %s"
 msgstr ""
 


### PR DESCRIPTION
This PR introduces a `level` prop for the `IconButton` instead of using the `children` prop for this purpose. Children can contain components etc... I think it's not suited for this.

Also, in #429 I'm using the children prop to display text next to the icon which is more appropriate IMO.

