### PR TITLE
Test: Extracting the block settings object to test the blocks

### DIFF
--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -5,11 +5,9 @@ import { registerBlock, query, setUnknownTypeHandler } from 'api';
 
 const { html } = query;
 
-registerBlock( 'core/freeform', {
+const blockSettings = {
 	title: wp.i18n.__( 'Freeform' ),
-
 	icon: 'text',
-
 	category: 'common',
 
 	attributes: {
@@ -30,6 +28,7 @@ registerBlock( 'core/freeform', {
 	save( { attributes } ) {
 		return attributes.html;
 	}
-} );
+};
 
+registerBlock( 'core/freeform', blockSettings );
 setUnknownTypeHandler( 'core/freeform' );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -6,11 +6,9 @@ import Editable from 'components/editable';
 
 const { html, prop } = query;
 
-registerBlock( 'core/heading', {
+export const blockSettings = {
 	title: wp.i18n.__( 'Heading' ),
-
 	icon: 'heading',
-
 	category: 'common',
 
 	attributes: {
@@ -53,4 +51,6 @@ registerBlock( 'core/heading', {
 				dangerouslySetInnerHTML={ { __html: content } } />
 		);
 	}
-} );
+};
+
+registerBlock( 'core/heading', blockSettings );

--- a/blocks/library/heading/test/index.js
+++ b/blocks/library/heading/test/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { query, getBlocks, unregisterBlock, setUnknownTypeHandler } from 'api';
+import { blockSettings } from '../';
+
+describe( 'heading block', () => {
+	afterEach( () => {
+		setUnknownTypeHandler( undefined );
+		getBlocks().forEach( ( block ) => {
+			unregisterBlock( block.slug );
+		} );
+	} );
+
+	it( 'should parse the block properly', () => {
+		const rawContent = '<h4 style="text-align: right;">Chicken</h4>';
+		const attrs = query.parse( rawContent, blockSettings.attributes );
+
+		expect( attrs ).to.eql( {
+			content: 'Chicken',
+			tag: 'H4',
+			align: 'right'
+		} );
+	} );
+} );

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -6,11 +6,9 @@ import Editable from 'components/editable';
 
 const { attr, html } = query;
 
-registerBlock( 'core/image', {
+const blockSettings = {
 	title: wp.i18n.__( 'Image' ),
-
 	icon: 'format-image',
-
 	category: 'common',
 
 	attributes: {
@@ -51,4 +49,6 @@ registerBlock( 'core/image', {
 			</figure>
 		);
 	}
-} );
+};
+
+registerBlock( 'core/image', blockSettings );

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -7,7 +7,7 @@ import Editable from 'components/editable';
 
 const { html, prop } = query;
 
-registerBlock( 'core/list', {
+const blockSettings = {
 	title: wp.i18n.__( 'List' ),
 	icon: 'editor-ul',
 	category: 'common',
@@ -76,4 +76,6 @@ registerBlock( 'core/list', {
 		) );
 		return wp.element.createElement( listType.toLowerCase(), null, children );
 	}
-} );
+};
+
+registerBlock( 'core/list', blockSettings );

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -10,7 +10,7 @@ const { parse, html, query } = hpq;
 const fromValueToParagraphs = ( value ) => value ? value.map( ( paragraph ) => `<p>${ paragraph }</p>` ).join( '' ) : '';
 const fromParagraphsToValue = ( paragraphs ) => parse( paragraphs, query( 'p', html() ) );
 
-registerBlock( 'core/quote', {
+const blockSettings = {
 	title: wp.i18n.__( 'Quote' ),
 	icon: 'format-quote',
 	category: 'common',
@@ -63,4 +63,6 @@ registerBlock( 'core/quote', {
 			</blockquote>
 		);
 	}
-} );
+};
+
+registerBlock( 'core/quote', blockSettings );

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -9,11 +9,9 @@ const { html, parse, query } = hpq;
 const fromValueToParagraphs = ( value ) => value ? value.map( ( paragraph ) => `<p>${ paragraph }</p>` ).join( '' ) : '';
 const fromParagraphsToValue = ( paragraphs ) => parse( paragraphs, query( 'p', html() ) );
 
-registerBlock( 'core/text', {
+const blockSettings = {
 	title: wp.i18n.__( 'Text' ),
-
 	icon: 'text',
-
 	category: 'common',
 
 	attributes: {
@@ -84,4 +82,6 @@ registerBlock( 'core/text', {
 			</div>
 		);
 	}
-} );
+};
+
+registerBlock( 'core/text', blockSettings );

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -11,7 +11,7 @@ msgstr ""
 msgid "Heading"
 msgstr ""
 
-#: blocks/library/heading/index.js:25
+#: blocks/library/heading/index.js:23
 msgid "Heading %s"
 msgstr ""
 
@@ -19,7 +19,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: blocks/library/image/index.js:31
+#: blocks/library/image/index.js:29
 msgid "Write caption…"
 msgstr ""
 
@@ -28,17 +28,17 @@ msgid "List"
 msgstr ""
 
 #: blocks/library/list/index.js:25
-#: blocks/library/text/index.js:26
+#: blocks/library/text/index.js:24
 msgid "Align left"
 msgstr ""
 
 #: blocks/library/list/index.js:33
-#: blocks/library/text/index.js:34
+#: blocks/library/text/index.js:32
 msgid "Align center"
 msgstr ""
 
 #: blocks/library/list/index.js:41
-#: blocks/library/text/index.js:42
+#: blocks/library/text/index.js:40
 msgid "Align right"
 msgstr ""
 


### PR DESCRIPTION
In this PR, I'm proposing a way to test the block settings (and precisely parsing each block's attribute for now).

I'm just exporting the block settings and using those in the tests (see the heading block).

Maybe this won't be necessary once we implement the schema parsing? or it can serve as a validation to this approach?