### PR TITLE
Sidebar: Add a sidebar to hold the post settings and inspector

### DIFF
--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -40,6 +40,7 @@ $editor-font-size: 16px;
 $editor-line-height: 1.8em;
 $item-spacing: 10px;
 $header-height: 56px;
+$sidebar-width: 320px;
 $admin-bar-height: 32px;
 $admin-bar-height-big: 46px;
 $admin-sidebar-width: 160px;

--- a/editor/components/button/index.js
+++ b/editor/components/button/index.js
@@ -4,12 +4,12 @@
 import './style.scss';
 import classnames from 'classnames';
 
-function Button( { isPrimary, isLarge, isActive, className, ...additionalProps } ) {
+function Button( { isPrimary, isLarge, isToggled, className, ...additionalProps } ) {
 	const classes = classnames( 'editor-button', className, {
 		button: ( isPrimary || isLarge ),
 		'button-primary': isPrimary,
 		'button-large': isLarge,
-		'is-toggled': isActive
+		'is-toggled': isToggled
 	} );
 
 	return (

--- a/editor/components/button/index.js
+++ b/editor/components/button/index.js
@@ -9,7 +9,7 @@ function Button( { isPrimary, isLarge, isActive, className, ...additionalProps }
 		button: ( isPrimary || isLarge ),
 		'button-primary': isPrimary,
 		'button-large': isLarge,
-		'is-active': isActive
+		'is-toggled': isActive
 	} );
 
 	return (

--- a/editor/components/button/index.js
+++ b/editor/components/button/index.js
@@ -4,11 +4,12 @@
 import './style.scss';
 import classnames from 'classnames';
 
-function Button( { isPrimary, isLarge, className, ...additionalProps } ) {
+function Button( { isPrimary, isLarge, isActive, className, ...additionalProps } ) {
 	const classes = classnames( 'editor-button', className, {
 		button: ( isPrimary || isLarge ),
 		'button-primary': isPrimary,
-		'button-large': isLarge
+		'button-large': isLarge,
+		'is-active': isActive
 	} );
 
 	return (

--- a/editor/components/button/style.scss
+++ b/editor/components/button/style.scss
@@ -7,7 +7,7 @@
 		opacity: 0.6;
 	}
 
-	&.is-active {
+	&.is-toggled {
 		background: $dark-gray-500;
 		color: $white;
 	}

--- a/editor/components/button/style.scss
+++ b/editor/components/button/style.scss
@@ -1,8 +1,14 @@
 .editor-button {
 	background: none;
 	border: none;
+	outline: none;
 
 	&:disabled {
 		opacity: 0.6;
+	}
+
+	&.is-active {
+		background: $dark-gray-500;
+		color: $white;
 	}
 }

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -12,7 +12,7 @@ import IconButton from '../../components/icon-button';
 import Inserter from '../../components/inserter';
 import Button from '../../components/button';
 
-function Tools( { undo, redo, hasUndo, hasRedo, sidebarOpened, toggleSidebar } ) {
+function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar } ) {
 	return (
 		<div className="editor-tools">
 			<IconButton
@@ -31,7 +31,7 @@ function Tools( { undo, redo, hasUndo, hasRedo, sidebarOpened, toggleSidebar } )
 					<Dashicon icon="visibility" />
 					{ wp.i18n._x( 'Preview', 'imperative verb' ) }
 				</Button>
-				<Button onClick={ toggleSidebar } isActive={ sidebarOpened }>
+				<Button onClick={ toggleSidebar } isActive={ isSidebarOpened }>
 					<Dashicon icon="admin-generic" />
 					{ wp.i18n.__( 'Post Settings' ) }
 				</Button>
@@ -47,7 +47,7 @@ export default connect(
 	( state ) => ( {
 		hasUndo: state.blocks.history.past.length > 0,
 		hasRedo: state.blocks.history.future.length > 0,
-		sidebarOpened: state.sidebar.opened,
+		isSidebarOpened: state.isSidebarOpened,
 	} ),
 	( dispatch ) => ( {
 		undo: () => dispatch( { type: 'UNDO' } ),

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -31,7 +31,7 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 					<Dashicon icon="visibility" />
 					{ wp.i18n._x( 'Preview', 'imperative verb' ) }
 				</Button>
-				<Button onClick={ toggleSidebar } isActive={ isSidebarOpened }>
+				<Button onClick={ toggleSidebar } isToggled={ isSidebarOpened }>
 					<Dashicon icon="admin-generic" />
 					{ wp.i18n.__( 'Post Settings' ) }
 				</Button>

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -12,7 +12,7 @@ import IconButton from '../../components/icon-button';
 import Inserter from '../../components/inserter';
 import Button from '../../components/button';
 
-function Tools( { undo, redo, hasUndo, hasRedo } ) {
+function Tools( { undo, redo, hasUndo, hasRedo, sidebarOpened, toggleSidebar } ) {
 	return (
 		<div className="editor-tools">
 			<IconButton
@@ -31,7 +31,7 @@ function Tools( { undo, redo, hasUndo, hasRedo } ) {
 					<Dashicon icon="visibility" />
 					{ wp.i18n._x( 'Preview', 'imperative verb' ) }
 				</Button>
-				<Button>
+				<Button onClick={ toggleSidebar } isActive={ sidebarOpened }>
 					<Dashicon icon="admin-generic" />
 					{ wp.i18n.__( 'Post Settings' ) }
 				</Button>
@@ -46,10 +46,12 @@ function Tools( { undo, redo, hasUndo, hasRedo } ) {
 export default connect(
 	( state ) => ( {
 		hasUndo: state.blocks.history.past.length > 0,
-		hasRedo: state.blocks.history.future.length > 0
+		hasRedo: state.blocks.history.future.length > 0,
+		sidebarOpened: state.sidebar.opened,
 	} ),
 	( dispatch ) => ( {
 		undo: () => dispatch( { type: 'UNDO' } ),
-		redo: () => dispatch( { type: 'REDO' } )
+		redo: () => dispatch( { type: 'REDO' } ),
+		toggleSidebar: () => dispatch( { type: 'TOGGLE_SIDEBAR' } )
 	} )
 )( Tools );

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -20,6 +20,9 @@
 		color: $dark-gray-500;
 		margin-right: $item-spacing;
 		cursor: pointer;
+		height: 30px;
+		padding: 0 10px;
+		border-radius: 3px;
 
 		&:hover {
 			color: $blue-medium;

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -13,9 +13,9 @@ import Sidebar from 'sidebar';
 import TextEditor from 'modes/text-editor';
 import VisualEditor from 'modes/visual-editor';
 
-function Layout( { mode, sidebarOpened } ) {
+function Layout( { mode, isSidebarOpened } ) {
 	const className = classnames( 'editor-layout', {
-		'sidebar-opened': sidebarOpened
+		'is-sidebar-opened': isSidebarOpened
 	} );
 
 	return (
@@ -25,12 +25,12 @@ function Layout( { mode, sidebarOpened } ) {
 				{ mode === 'text' && <TextEditor /> }
 				{ mode === 'visual' && <VisualEditor /> }
 			</div>
-			{ sidebarOpened && <Sidebar /> }
+			{ isSidebarOpened && <Sidebar /> }
 		</div>
 	);
 }
 
 export default connect( ( state ) => ( {
 	mode: state.mode,
-	sidebarOpened: state.sidebar.opened
+	isSidebarOpened: state.isSidebarOpened
 } ) )( Layout );

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -2,24 +2,35 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import './style.scss';
 import Header from 'header';
+import Sidebar from 'sidebar';
 import TextEditor from 'modes/text-editor';
 import VisualEditor from 'modes/visual-editor';
 
-function Layout( { mode } ) {
+function Layout( { mode, sidebarOpened } ) {
+	const className = classnames( 'editor-layout', {
+		'sidebar-opened': sidebarOpened
+	} );
+
 	return (
-		<div>
+		<div className={ className }>
 			<Header />
-			{ mode === 'text' && <TextEditor /> }
-			{ mode === 'visual' && <VisualEditor /> }
+			<div className="editor-layout__content">
+				{ mode === 'text' && <TextEditor /> }
+				{ mode === 'visual' && <VisualEditor /> }
+			</div>
+			{ sidebarOpened && <Sidebar /> }
 		</div>
 	);
 }
 
 export default connect( ( state ) => ( {
-	mode: state.mode
+	mode: state.mode,
+	sidebarOpened: state.sidebar.opened
 } ) )( Layout );

--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -1,0 +1,7 @@
+.editor-layout.sidebar-opened .editor-layout__content {
+	margin-right: $sidebar-width;
+
+	.editor-text-editor__formatting {
+		margin-right: $sidebar-width;
+	}
+}

--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -1,7 +1,3 @@
-.editor-layout.sidebar-opened .editor-layout__content {
+.editor-layout.is-sidebar-opened .editor-layout__content {
 	margin-right: $sidebar-width;
-
-	.editor-text-editor__formatting {
-		margin-right: $sidebar-width;
-	}
 }

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -36,6 +36,10 @@
 
 	@include break-small() {
 		position: fixed;
+
+		.editor-layout.is-sidebar-opened & {
+			margin-right: $sidebar-width;
+		}
 	}
 }
 

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal Dependencies
+ */
+import './style.scss';
+
+const Sidebar = () => {
+	return (
+		<div className="editor-sidebar">
+		</div>
+	);
+};
+
+export default Sidebar;

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -1,0 +1,9 @@
+.editor-sidebar {
+	position: fixed;
+	right: 0;
+	top: 32px + $header-height;
+	bottom: 0;
+	width: $sidebar-width;
+	border-left: 1px solid $light-gray-500;
+	background: $light-gray-300;
+}

--- a/editor/state.js
+++ b/editor/state.js
@@ -148,10 +148,10 @@ export function mode( state = 'visual', action ) {
 	return state;
 }
 
-export function sidebar( state = { opened: false }, action ) {
+export function isSidebarOpened( state = false, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_SIDEBAR':
-			return { opened: ! state.opened };
+			return ! state;
 	}
 
 	return state;
@@ -168,7 +168,7 @@ export function createReduxStore() {
 		selectedBlock,
 		hoveredBlock,
 		mode,
-		sidebar
+		isSidebarOpened
 	} );
 
 	return createStore(

--- a/editor/state.js
+++ b/editor/state.js
@@ -148,6 +148,15 @@ export function mode( state = 'visual', action ) {
 	return state;
 }
 
+export function sidebar( state = { opened: false }, action ) {
+	switch ( action.type ) {
+		case 'TOGGLE_SIDEBAR':
+			return { opened: ! state.opened };
+	}
+
+	return state;
+}
+
 /**
  * Creates a new instance of a Redux store.
  *
@@ -158,7 +167,8 @@ export function createReduxStore() {
 		blocks,
 		selectedBlock,
 		hoveredBlock,
-		mode
+		mode,
+		sidebar
 	} );
 
 	return createStore(

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -12,6 +12,7 @@ import {
 	hoveredBlock,
 	selectedBlock,
 	mode,
+	sidebar,
 	createReduxStore
 } from '../state';
 
@@ -281,6 +282,22 @@ describe( 'state', () => {
 		} );
 	} );
 
+	describe( 'sidebar()', () => {
+		it( 'should be closed by default', () => {
+			const state = sidebar( undefined, {} );
+
+			expect( state.opened ).to.be.false();
+		} );
+
+		it( 'should toggle the sidebar open flag', () => {
+			const state = sidebar( { opened: false }, {
+				type: 'TOGGLE_SIDEBAR'
+			} );
+
+			expect( state.opened ).to.be.true();
+		} );
+	} );
+
 	describe( 'createReduxStore()', () => {
 		it( 'should return a redux store', () => {
 			const store = createReduxStore();
@@ -297,7 +314,8 @@ describe( 'state', () => {
 				'blocks',
 				'selectedBlock',
 				'hoveredBlock',
-				'mode'
+				'mode',
+				'sidebar'
 			] );
 		} );
 	} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -12,7 +12,7 @@ import {
 	hoveredBlock,
 	selectedBlock,
 	mode,
-	sidebar,
+	isSidebarOpened,
 	createReduxStore
 } from '../state';
 
@@ -282,19 +282,19 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'sidebar()', () => {
+	describe( 'isSidebarOpened()', () => {
 		it( 'should be closed by default', () => {
-			const state = sidebar( undefined, {} );
+			const state = isSidebarOpened( undefined, {} );
 
-			expect( state.opened ).to.be.false();
+			expect( state ).to.be.false();
 		} );
 
 		it( 'should toggle the sidebar open flag', () => {
-			const state = sidebar( { opened: false }, {
+			const state = isSidebarOpened( false, {
 				type: 'TOGGLE_SIDEBAR'
 			} );
 
-			expect( state.opened ).to.be.true();
+			expect( state ).to.be.true();
 		} );
 	} );
 
@@ -315,7 +315,7 @@ describe( 'state', () => {
 				'selectedBlock',
 				'hoveredBlock',
 				'mode',
-				'sidebar'
+				'isSidebarOpened'
 			] );
 		} );
 	} );


### PR DESCRIPTION
This PRs triggers the work on the editor's sidebar. I kept it minimal, just opening and closing an empty sidebar when clicking on "Post Settings".

This probably needs more design ❤️ cc @jasmussen 