### PR TITLE
Block Switcher: Fix heading to text transformation

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -79,7 +79,7 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content, align } ) => {
 					return {
-						content,
+						content: [ content ],
 						align
 					};
 				}


### PR DESCRIPTION
The text content attribute changed from string to array. This was causing the editor to blow up