### PR TITLE
Fix splitting in the middle of a text block

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -68,7 +68,14 @@ export default class Editable extends wp.element.Component {
 
 		// Getting the content before and after the cursor
 		const childNodes = Array.from( this.editor.getBody().childNodes );
-		const splitIndex = childNodes.indexOf( this.editor.selection.getStart() );
+		let selectedChild = this.editor.selection.getStart();
+		while ( childNodes.indexOf( selectedChild ) === -1 && selectedChild.parentNode ) {
+			selectedChild = selectedChild.parentNode;
+		}
+		const splitIndex = childNodes.indexOf( selectedChild );
+		if ( splitIndex === -1 ) {
+			return;
+		}
 		const getHtml = ( nodes ) => nodes.reduce( ( memo, node ) => memo + node.outerHTML, '' );
 		const beforeNodes = childNodes.slice( 0, splitIndex );
 		const lastNodeBeforeCursor = last( beforeNodes );


### PR DESCRIPTION
As a follow-up to #409, this fixes an issue with splitting a text block in the middle of its content:

- Create a text block with two paragraphs of content
- Move the cursor to the end of the first paragraph
- Press Enter.  The text block will be split into two.

Instead, I'd expect that two Enter presses would be required to split the text block in the middle of its content, like when we edit at the end of a block.

The reason for this issue was that TinyMCE inserts a `<br data-mce-bogus=1>` element inside of our new second paragraph, and this causes the `splitIndex` to be `-1` because we should really be looking for the parent `p` element of the `br`.  The solution I found is to walk the DOM tree until we find the currently selected top-level element of the block (in this case the `p` element).