### PR TITLE
Blocks: Handle pressing backspace at the beginning of blocks

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -120,13 +120,13 @@ export default class Editable extends wp.element.Component {
 		const start = range.startContainer;
 		const body = this.editor.getBody();
 		let element = start;
-		do {
+		while ( element !== body ) {
 			const child = element;
 			element = element.parentNode;
 			if ( element.firstChild !== child ) {
 				return false;
 			}
-		} while ( element !== body );
+		}
 		return true;
 	}
 

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -133,9 +133,13 @@ export default class Editable extends wp.element.Component {
 	onKeyDown( event ) {
 		if ( this.props.onMerge && event.keyCode === KEYCODE_BACKSPACE && this.isStartOfEditor() ) {
 			this.onChange();
+			this.props.onMerge( this.editor.getContent() );
 
-			// Debouncing this call avoids TinyMCE error while handling `keydown` event
-			setTimeout( () => this.props.onMerge( this.editor.getContent() ) );
+			// If merge causes editor to be removed, stop other callbacks from
+			// trying to handle the event
+			if ( this.editor.removed ) {
+				event.stopImmediatePropagation();
+			}
 		}
 	}
 

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -132,9 +132,10 @@ export default class Editable extends wp.element.Component {
 
 	onKeyDown( event ) {
 		if ( this.props.onMerge && event.keyCode === KEYCODE_BACKSPACE && this.isStartOfEditor() ) {
-			event.preventDefault();
 			this.onChange();
-			this.props.onMerge( this.editor.getContent() );
+
+			// Debouncing this call avoids TinyMCE error while handling `keydown` event
+			setTimeout( () => this.props.onMerge( this.editor.getContent() ) );
 		}
 	}
 

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -123,7 +123,7 @@ export default class Editable extends wp.element.Component {
 		do {
 			const child = element;
 			element = element.parentNode;
-			if ( element.childNodes[ 0 ] !== child ) {
+			if ( element.firstChild !== child ) {
 				return false;
 			}
 		} while ( element !== body );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -66,7 +66,7 @@ registerBlock( 'core/heading', {
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: wp.element.concatValues( attributes.content, attributesToMerge.content )
+			content: wp.element.concatChildren( attributes.content, attributesToMerge.content )
 		};
 	},
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -31,32 +31,6 @@ registerBlock( 'core/heading', {
 		} ) )
 	],
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
-		const { content, nodeName = 'H2', align } = attributes;
-
-		return (
-			<Editable
-				tagName={ nodeName.toLowerCase() }
-				value={ content }
-				focus={ focus }
-				onFocus={ setFocus }
-				onChange={ ( value ) => setAttributes( { content: value } ) }
-				style={ align ? { textAlign: align } : null }
-			/>
-		);
-	},
-
-	save( { attributes } ) {
-		const { align, nodeName = 'H2', content } = attributes;
-		const Tag = nodeName.toLowerCase();
-
-		return (
-			<Tag style={ align ? { textAlign: align } : null }>
-				{ content }
-			</Tag>
-		);
-	},
-
 	transforms: {
 		from: [
 			{
@@ -88,5 +62,38 @@ registerBlock( 'core/heading', {
 				}
 			}
 		]
-	}
+	},
+
+	merge( attributes, attributesToMerge ) {
+		return {
+			content: wp.element.concatValues( attributes.content, attributesToMerge.content )
+		};
+	},
+
+	edit( { attributes, setAttributes, focus, setFocus, mergeWithPrevious } ) {
+		const { content, nodeName = 'H2', align } = attributes;
+
+		return (
+			<Editable
+				tagName={ nodeName.toLowerCase() }
+				value={ content }
+				focus={ focus }
+				onFocus={ setFocus }
+				onChange={ ( value ) => setAttributes( { content: value } ) }
+				style={ align ? { textAlign: align } : null }
+				onMerge={ mergeWithPrevious }
+			/>
+		);
+	},
+
+	save( { attributes } ) {
+		const { align, nodeName = 'H2', content } = attributes;
+		const Tag = nodeName.toLowerCase();
+
+		return (
+			<Tag style={ align ? { textAlign: align } : null }>
+				{ content }
+			</Tag>
+		);
+	},
 } );

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -46,7 +46,7 @@ registerBlock( 'core/text', {
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: wp.element.concatValues( attributes.content, attributesToMerge.content )
+			content: wp.element.concatChildren( attributes.content, attributesToMerge.content )
 		};
 	},
 

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -44,7 +44,13 @@ registerBlock( 'core/text', {
 		}
 	],
 
-	edit( { attributes, setAttributes, insertBlockAfter, focus, setFocus } ) {
+	merge( attributes, attributesToMerge ) {
+		return {
+			content: wp.element.concatValues( attributes.content, attributesToMerge.content )
+		};
+	},
+
+	edit( { attributes, setAttributes, insertBlockAfter, focus, setFocus, mergeWithPrevious } ) {
 		const { content = <p />, align } = attributes;
 
 		return (
@@ -64,6 +70,7 @@ registerBlock( 'core/text', {
 						content: after
 					} ) );
 				} }
+				onMerge={ mergeWithPrevious }
 			/>
 		);
 	},

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -188,7 +188,7 @@ export default connect(
 	( state, ownProps ) => {
 		const order = state.blocks.order.indexOf( ownProps.uid );
 		return {
-			previousBlock: order === 0 ? null : state.blocks.byUid[ state.blocks.order[ order - 1 ] ],
+			previousBlock: state.blocks.byUid[ state.blocks.order[ order - 1 ] ] || null,
 			block: state.blocks.byUid[ ownProps.uid ],
 			isSelected: state.selectedBlock.uid === ownProps.uid,
 			isHovered: state.hoveredBlock === ownProps.uid,

--- a/editor/state.js
+++ b/editor/state.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers, createStore } from 'redux';
-import { keyBy, last } from 'lodash';
+import { keyBy, last, omit, without } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,6 +43,9 @@ export const blocks = combineUndoableReducers( {
 					...state,
 					[ action.uid ]: action.block
 				};
+
+			case 'REMOVE_BLOCK':
+				return omit( state, action.uid );
 		}
 
 		return state;
@@ -87,6 +90,9 @@ export const blocks = combineUndoableReducers( {
 					action.uid,
 					...state.slice( index + 2 )
 				];
+
+			case 'REMOVE_BLOCK':
+				return without( state, action.uid );
 		}
 
 		return state;

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -195,6 +195,34 @@ describe( 'state', () => {
 
 			expect( state.order ).to.equal( original.order );
 		} );
+
+		it( 'should remove the block', () => {
+			const original = blocks( undefined, {
+				type: 'REPLACE_BLOCKS',
+				blockNodes: [ {
+					uid: 'chicken',
+					blockType: 'core/test-block',
+					attributes: {}
+				}, {
+					uid: 'ribs',
+					blockType: 'core/test-block',
+					attributes: {}
+				} ]
+			} );
+			const state = blocks( original, {
+				type: 'REMOVE_BLOCK',
+				uid: 'chicken'
+			} );
+
+			expect( state.order ).to.eql( [ 'ribs' ] );
+			expect( state.byUid ).to.eql( {
+				ribs: {
+					uid: 'ribs',
+					blockType: 'core/test-block',
+					attributes: {}
+				}
+			} );
+		} );
 	} );
 
 	describe( 'hoveredBlock()', () => {

--- a/element/index.js
+++ b/element/index.js
@@ -4,6 +4,7 @@
 import { createElement, Component, cloneElement, Children } from 'react';
 import { render } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { isString } from 'lodash';
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -64,4 +65,21 @@ export function renderToString( element ) {
 	}
 
 	return renderToStaticMarkup( element );
+}
+
+export function concatValues( value1, value2 ) {
+	const toArray = value => Array.isArray( value ) ? Children.toArray( value ) : [ value ];
+
+	return toArray( value1 )
+		.concat( toArray( value2 ) )
+		.map( ( elt, index ) => {
+			if ( isString( elt ) ) {
+				return elt;
+			}
+
+			return {
+				...elt,
+				key: index
+			};
+		} );
 }

--- a/element/index.js
+++ b/element/index.js
@@ -67,19 +67,34 @@ export function renderToString( element ) {
 	return renderToStaticMarkup( element );
 }
 
-export function concatValues( value1, value2 ) {
-	const toArray = value => Array.isArray( value ) ? Children.toArray( value ) : [ value ];
+/**
+ * Concat two React children objects
+ *
+ * @param  {?Object} children1 First children value
+ * @param  {?Object} children2 Second children value
+ *
+ * @return {Array}             The concatenation
+ */
+export function concatChildren( children1, children2 ) {
+	const toArray = ( children ) => {
+		if ( ! children ) {
+			return [];
+		}
 
-	return toArray( value1 )
-		.concat( toArray( value2 ) )
-		.map( ( elt, index ) => {
-			if ( isString( elt ) ) {
-				return elt;
-			}
+		return Array.isArray( children ) ? Children.toArray( children ) : [ children ];
+	};
 
-			return {
-				...elt,
-				key: index
-			};
-		} );
+	return [
+		...toArray( children1 ),
+		...toArray( children2 )
+	].map( ( elt, index ) => {
+		if ( isString( elt ) ) {
+			return elt;
+		}
+
+		return {
+			...elt,
+			key: index
+		};
+	} );
 }

--- a/element/index.js
+++ b/element/index.js
@@ -4,7 +4,6 @@
 import { createElement, Component, cloneElement, Children } from 'react';
 import { render } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { isString } from 'lodash';
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -68,33 +67,23 @@ export function renderToString( element ) {
 }
 
 /**
- * Concat two React children objects
+ * Concatenate two or more React children objects
  *
- * @param  {?Object} children1 First children value
- * @param  {?Object} children2 Second children value
- *
- * @return {Array}             The concatenation
+ * @param  {...?Object} childrens Set of children to concatenate
+ * @return {Array}                The concatenated value
  */
-export function concatChildren( children1, children2 ) {
-	const toArray = ( children ) => {
-		if ( ! children ) {
-			return [];
-		}
+export function concatChildren( ...childrens ) {
+	return childrens.reduce( ( memo, children, i ) => {
+		Children.forEach( children, ( child, j ) => {
+			if ( 'string' !== typeof child ) {
+				child = cloneElement( child, {
+					key: [ i, j ].join()
+				} );
+			}
 
-		return Array.isArray( children ) ? Children.toArray( children ) : [ children ];
-	};
+			memo.push( child );
+		} );
 
-	return [
-		...toArray( children1 ),
-		...toArray( children2 )
-	].map( ( elt, index ) => {
-		if ( isString( elt ) ) {
-			return elt;
-		}
-
-		return {
-			...elt,
-			key: index
-		};
-	} );
+		return memo;
+	}, [] );
 }

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { createElement, renderToString } from '../';
+import { createElement, renderToString, concatChildren } from '../';
 
 describe( 'element', () => {
 	describe( 'renderToString', () => {
@@ -33,6 +33,26 @@ describe( 'element', () => {
 			expect( renderToString(
 				createElement( 'strong', null, 'Courgette' )
 			) ).to.equal( '<strong>Courgette</strong>' );
+		} );
+	} );
+
+	describe( 'concatChildren', () => {
+		it( 'should return an empty array for undefined children', () => {
+			expect( concatChildren() ).to.eql( [] );
+		} );
+
+		it( 'should concat the string arrays', () => {
+			expect( concatChildren( [ 'a' ], 'b' ) ).to.eql( [ 'a', 'b' ] );
+		} );
+
+		it( 'should concat the object arrays and rewrite keys', () => {
+			const concat = concatChildren(
+				[ createElement( 'strong', null, 'Courgette' ) ],
+				createElement( 'strong', null, 'Concombre' )
+			);
+			expect( concat.length ).to.equal( 2 );
+			expect( concat[ 0 ].key = 0 );
+			expect( concat[ 1 ].key = 1 );
 		} );
 	} );
 } );

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -47,12 +47,12 @@ describe( 'element', () => {
 
 		it( 'should concat the object arrays and rewrite keys', () => {
 			const concat = concatChildren(
-				[ createElement( 'strong', null, 'Courgette' ) ],
-				createElement( 'strong', null, 'Concombre' )
+				[ createElement( 'strong', {}, 'Courgette' ) ],
+				createElement( 'strong', {}, 'Concombre' )
 			);
 			expect( concat.length ).to.equal( 2 );
-			expect( concat[ 0 ].key = 0 );
-			expect( concat[ 1 ].key = 1 );
+			expect( concat[ 0 ].key ).to.equal( '0,0' );
+			expect( concat[ 1 ].key ).to.equal( '1,0' );
 		} );
 	} );
 } );

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,15 +3,15 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/components/editable/index.js:28
+#: blocks/components/editable/index.js:29
 msgid "Bold"
 msgstr ""
 
-#: blocks/components/editable/index.js:33
+#: blocks/components/editable/index.js:34
 msgid "Italic"
 msgstr ""
 
-#: blocks/components/editable/index.js:38
+#: blocks/components/editable/index.js:39
 msgid "Strikethrough"
 msgstr ""
 


### PR DESCRIPTION
In this PR, I'm handling the backspace behaviour. I've tried to keep the API needed for this as minimal as possible:
 - A single callback `mergeWithPrevious` to be called when we hit backspace at the beginning of a block.
- A `merge` function responsible of merging attributes of a block with the same type.

The different use cases are:

- If the `merge` function is not defined in a block, this means the blocks is an "object" block that can not be merged (think image, embed, gallery), thus, the block is removed when we hit backspace in a following block.

- If the `merge` function is defined, we can merge this block with the following one but before doing that we need to match the block types of these two blocks. We transform the following block to the same block type and then we call the merge function to merge them. If the following block can not be switched to the current block, this means these two blocks are not mergeable.