### PR TITLE
Add quote↔text block switching; add block switcher validation

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -29,7 +29,7 @@ export function createBlock( blockType, attributes = {} ) {
  *
  * @param  {Object} block      Block object
  * @param  {string} blockType  BlockType
- * @return {Object?}           Block object
+ * @return {?Object|Error}     Block object, null, or error with failure message
  */
 export function switchToBlockType( block, blockType ) {
 	// Find the right transformation by giving priority to the "to" transformation
@@ -45,9 +45,15 @@ export function switchToBlockType( block, blockType ) {
 		return null;
 	}
 
+	const attributes = transformation.transform( block.attributes );
+	if ( attributes instanceof Error ) {
+		// Blocks can perform validation and cancel transformations if needed.
+		return attributes;
+	}
+
 	return Object.assign( {
 		uid: block.uid,
-		attributes: transformation.transform( block.attributes ),
-		blockType
+		attributes,
+		blockType,
 	} );
 }

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -32,7 +32,7 @@ describe( 'block factory', () => {
 	} );
 
 	describe( 'switchBlockType()', () => {
-		it( 'should switch the blockType of a block using the "transform form"', () => {
+		it( 'should switch the blockType of a block using the "transform from"', () => {
 			registerBlock( 'core/updated-text-block', {
 				transforms: {
 					from: [ {
@@ -115,6 +115,31 @@ describe( 'block factory', () => {
 			const updateBlock = switchToBlockType( block, 'core/updated-text-block' );
 
 			expect( updateBlock ).to.be.null();
+		} );
+
+		it( 'should allow blocks to abort a transformation', () => {
+			registerBlock( 'core/updated-text-block', {} );
+			registerBlock( 'core/text-block', {
+				transforms: {
+					to: [ {
+						blocks: [ 'core/updated-text-block' ],
+						transform: () => new Error( 'no soup for you' ),
+					} ]
+				}
+			} );
+
+			const block = {
+				uid: 1,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'ribs'
+				}
+			};
+
+			const updateBlock = switchToBlockType( block, 'core/updated-text-block' );
+
+			expect( updateBlock ).to.be.an.instanceof( Error );
+			expect( updateBlock.message ).to.eql( 'no soup for you' );
 		} );
 	} );
 } );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -31,6 +31,39 @@ registerBlock( 'core/heading', {
 		} ) )
 	],
 
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/text' ],
+				transform: ( { content, align } ) => {
+					if ( Array.isArray( content ) ) {
+						// TODO this appears to always be true?
+						// TODO reject the switch if more than one paragraph
+						content = content[ 0 ];
+					}
+					return {
+						tag: 'H2',
+						content,
+						align,
+					};
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/text' ],
+				transform: ( { content, align } ) => {
+					return {
+						content: [ content ],
+						align,
+					};
+				},
+			},
+		]
+	},
+
 	edit( { attributes, setAttributes } ) {
 		const { content, tag, align } = attributes;
 
@@ -53,37 +86,4 @@ registerBlock( 'core/heading', {
 				dangerouslySetInnerHTML={ { __html: content } } />
 		);
 	},
-
-	transforms: {
-		from: [
-			{
-				type: 'block',
-				blocks: [ 'core/text' ],
-				transform: ( { content, align } ) => {
-					if ( Array.isArray( content ) ) {
-						// TODO this appears to always be true?
-						// TODO reject the switch if more than one paragraph
-						content = content[ 0 ];
-					}
-					return {
-						tag: 'H2',
-						content,
-						align
-					};
-				}
-			}
-		],
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/text' ],
-				transform: ( { content, align } ) => {
-					return {
-						content: [ content ],
-						align
-					};
-				}
-			}
-		]
-	}
 } );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -38,8 +38,11 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content, align } ) => {
 					if ( Array.isArray( content ) ) {
-						// TODO this appears to always be true?
-						// TODO reject the switch if more than one paragraph
+						if ( content.length > 1 ) {
+							return new Error(
+								'Block has more than one paragraph.'
+							);
+						}
 						content = content[ 0 ];
 					}
 					return {

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -20,6 +20,36 @@ registerBlock( 'core/quote', {
 		citation: html( 'footer' )
 	},
 
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/text' ],
+				transform: ( { content, align } ) => {
+					return {
+						value: content,
+					};
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/text' ],
+				transform: ( { value, citation } ) => {
+					if ( citation ) {
+						return new Error(
+							'Quote citation would be lost on transform.'
+						);
+					}
+					return {
+						content: value,
+					};
+				},
+			},
+		],
+	},
+
 	edit( { attributes, setAttributes } ) {
 		const { value, citation } = attributes;
 

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -25,7 +25,7 @@ registerBlock( 'core/quote', {
 			{
 				type: 'block',
 				blocks: [ 'core/text' ],
-				transform: ( { content, align } ) => {
+				transform: ( { content } ) => {
 					return {
 						value: content,
 					};

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -38,9 +38,7 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/text' ],
 				transform: ( { content, citation } ) => {
 					if ( citation ) {
-						return new Error(
-							'Quote citation would be lost on transform.'
-						);
+						content = ( content || [] ).concat( citation );
 					}
 					return {
 						content,

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -16,7 +16,7 @@ registerBlock( 'core/quote', {
 	category: 'common',
 
 	attributes: {
-		value: query( 'blockquote > p', html() ),
+		content: query( 'blockquote > p', html() ),
 		citation: html( 'footer' )
 	},
 
@@ -27,7 +27,7 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
 					return {
-						value: content,
+						content,
 					};
 				},
 			},
@@ -36,14 +36,14 @@ registerBlock( 'core/quote', {
 			{
 				type: 'block',
 				blocks: [ 'core/text' ],
-				transform: ( { value, citation } ) => {
+				transform: ( { content, citation } ) => {
 					if ( citation ) {
 						return new Error(
 							'Quote citation would be lost on transform.'
 						);
 					}
 					return {
-						content: value,
+						content,
 					};
 				},
 			},
@@ -51,15 +51,15 @@ registerBlock( 'core/quote', {
 	},
 
 	edit( { attributes, setAttributes } ) {
-		const { value, citation } = attributes;
+		const { content, citation } = attributes;
 
 		return (
 			<blockquote className="blocks-quote">
 				<Editable
-					value={ fromValueToParagraphs( value ) }
+					value={ fromValueToParagraphs( content ) }
 					onChange={
 						( paragraphs ) => setAttributes( {
-							value: fromParagraphsToValue( paragraphs )
+							content: fromParagraphsToValue( paragraphs )
 						} )
 					} />
 				<footer>
@@ -76,11 +76,11 @@ registerBlock( 'core/quote', {
 	},
 
 	save( attributes ) {
-		const { value, citation } = attributes;
+		const { content, citation } = attributes;
 
 		return (
 			<blockquote>
-				{ value && value.map( ( paragraph, i ) => (
+				{ content && content.map( ( paragraph, i ) => (
 					<p
 						key={ i }
 						dangerouslySetInnerHTML={ {

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -38,17 +38,23 @@ class BlockSwitcher extends wp.element.Component {
 		const { block } = this.props;
 
 		const blockSettings = wp.blocks.getBlockSettings( block.blockType );
-		const blocksToBeTransformedFrom = reduce( wp.blocks.getBlocks(), ( memo, block ) => {
-			const transformFrom = get( block, 'transforms.from', [] );
-			const transformation = transformFrom.find( t => t.blocks.indexOf( block.blockType ) !== -1 );
-			return transformation ? memo.concat( [ block.slug ] ) : memo;
-		}, [] );
+		const blocksToBeTransformedFrom = reduce(
+			wp.blocks.getBlocks(),
+			( memo, candidateBlock ) => {
+				const transformFrom = get( candidateBlock, 'transforms.from', [] );
+				const transformation = transformFrom.find(
+					t => t.blocks.indexOf( candidateBlock.blockType ) !== -1
+				);
+				return transformation ? memo.concat( [ candidateBlock.slug ] ) : memo;
+			},
+			[]
+		);
 		const blocksToBeTransformedTo = get( blockSettings, 'transforms.to', [] )
 			.reduce( ( memo, transformation ) => memo.concat( transformation.blocks ), [] );
 		const allowedBlocks = uniq( blocksToBeTransformedFrom.concat( blocksToBeTransformedTo ) )
 			.reduce( ( memo, blockType ) => {
-				const block = wp.blocks.getBlockSettings( blockType );
-				return !! block ? memo.concat( block ) : memo;
+				const settings = wp.blocks.getBlockSettings( blockType );
+				return !! settings ? memo.concat( settings ) : memo;
 			}, [] );
 
 		if ( ! allowedBlocks.length ) {

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -43,7 +43,7 @@ class BlockSwitcher extends wp.element.Component {
 			( memo, candidateBlock ) => {
 				const transformFrom = get( candidateBlock, 'transforms.from', [] );
 				const transformation = transformFrom.find(
-					t => t.blocks.indexOf( candidateBlock.blockType ) !== -1
+					t => t.blocks.indexOf( block.blockType ) !== -1
 				);
 				return transformation ? memo.concat( [ candidateBlock.slug ] ) : memo;
 			},

--- a/editor/components/icon-button/index.js
+++ b/editor/components/icon-button/index.js
@@ -10,11 +10,19 @@ import './style.scss';
 import Button from '../button';
 import Dashicon from '../dashicon';
 
-function IconButton( { icon, children, label, className, ...additionalProps } ) {
+function IconButton( {
+	icon, children, label, className, tooltip,
+	...additionalProps
+} ) {
 	const classes = classnames( 'editor-icon-button', className );
 
 	return (
-		<Button { ...additionalProps } aria-label={ label } className={ classes }>
+		<Button
+			{ ...additionalProps }
+			aria-label={ label }
+			className={ classes }
+			title={ tooltip }
+		>
 			<Dashicon icon={ icon } />
 			{ children }
 		</Button>


### PR DESCRIPTION
This PR adds the ability to switch between `quote` and `text` blocks, and also adds a mechanism for blocks to reject transformations.

Currently the following two transformations are rejected because they would cause data loss:

- Switching a multi-paragraph text block to a heading block
- Switching a quote block with a citation to a text block.

In the UI, we show this situation by disabling buttons in the block switcher:

> <img src="https://cloud.githubusercontent.com/assets/227022/25232154/b94cbec0-25da-11e7-8e78-ce64ee126794.png" width="500">

It would be nice if we had a `Tooltip` component to use instead of a `title` attribute, and perhaps a little warning icon, but I think this is good enough for a first PR.

