### PR TITLE
Manage Editable value as React element

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as query from 'hpq';
+import * as query from './query';
 
 export { query };
 export { createBlock, switchToBlockType } from './factory';

--- a/blocks/api/query.js
+++ b/blocks/api/query.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { flow } from 'lodash';
+import { html } from 'hpq';
+import { Parser } from 'html-to-react';
+
+export * from 'hpq';
+
+const parser = new Parser();
+export function children( selector ) {
+	return flow( html( selector ), parser.parse );
+}

--- a/blocks/api/test/query.js
+++ b/blocks/api/test/query.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { parse, children } from '../query';
+
+describe( 'query', () => {
+	describe( 'children()', () => {
+		it( 'should return a matcher function', () => {
+			const matcher = children();
+
+			expect( matcher ).to.be.a( 'function' );
+		} );
+
+		it( 'should return HTML equivalent WPElement of matched element', () => {
+			// Assumption here is that we can cleanly convert back and forth
+			// between a string and WPElement representation
+			const html = '<blockquote><p>A delicious sundae dessert</p></blockquote>';
+			const match = parse( html, children() );
+
+			expect( wp.element.renderToString( match ) ).to.equal( html );
+		} );
+	} );
+} );

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -142,7 +142,7 @@ export default class Editable extends wp.element.Component {
 	}
 
 	getContent() {
-		const content = this.editor.getContent();
+		const content = this.editor.getContent( { format: 'raw' } );
 
 		return htmlToReactParser.parse( content );
 	}

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -4,7 +4,7 @@
 import { registerBlock, query } from 'api';
 import Editable from 'components/editable';
 
-const { attr, html } = query;
+const { attr, children } = query;
 
 registerBlock( 'core/embed', {
 	title: wp.i18n.__( 'Embed' ),
@@ -16,7 +16,7 @@ registerBlock( 'core/embed', {
 	attributes: {
 		url: attr( 'iframe', 'src' ),
 		title: attr( 'iframe', 'title' ),
-		caption: html( 'figcaption' )
+		caption: children( 'figcaption' )
 	},
 
 	edit( { attributes, isSelected, setAttributes } ) {
@@ -47,7 +47,7 @@ registerBlock( 'core/embed', {
 		return (
 			<figure>
 				{ iframe }
-				<figcaption dangerouslySetInnerHTML={ { __html: caption } } />
+				<figcaption>{ caption }</figcaption>
 			</figure>
 		);
 	}

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -4,7 +4,7 @@
 import { registerBlock, query } from 'api';
 import Editable from 'components/editable';
 
-const { html, prop } = query;
+const { children, prop } = query;
 
 registerBlock( 'core/heading', {
 	title: wp.i18n.__( 'Heading' ),
@@ -14,7 +14,7 @@ registerBlock( 'core/heading', {
 	category: 'common',
 
 	attributes: {
-		content: html( 'h1,h2,h3,h4,h5,h6' ),
+		content: children( 'h1,h2,h3,h4,h5,h6' ),
 		nodeName: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
 		align: prop( 'h1,h2,h3,h4,h5,h6', 'style.textAlign' )
 	},
@@ -51,9 +51,9 @@ registerBlock( 'core/heading', {
 		const Tag = nodeName.toLowerCase();
 
 		return (
-			<Tag
-				style={ align ? { textAlign: align } : null }
-				dangerouslySetInnerHTML={ { __html: content } } />
+			<Tag style={ align ? { textAlign: align } : null }>
+				{ content }
+			</Tag>
 		);
 	},
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -4,7 +4,7 @@
 import { registerBlock, query } from 'api';
 import Editable from 'components/editable';
 
-const { attr, html } = query;
+const { attr, children } = query;
 
 registerBlock( 'core/image', {
 	title: wp.i18n.__( 'Image' ),
@@ -16,7 +16,7 @@ registerBlock( 'core/image', {
 	attributes: {
 		url: attr( 'img', 'src' ),
 		alt: attr( 'img', 'alt' ),
-		caption: html( 'figcaption' )
+		caption: children( 'figcaption' )
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
@@ -49,7 +49,7 @@ registerBlock( 'core/image', {
 		return (
 			<figure>
 				{ img }
-				<figcaption dangerouslySetInnerHTML={ { __html: caption } } />
+				<figcaption>{ caption }</figcaption>
 			</figure>
 		);
 	}

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -75,7 +75,7 @@ registerBlock( 'core/list', {
 		const { nodeName = 'OL', items = [] } = attributes;
 
 		return wp.element.createElement(
-			listType.toLowerCase(),
+			nodeName.toLowerCase(),
 			null,
 			items.map( ( item, index ) => (
 				<li key={ index }>{ item.value }</li>

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -5,7 +5,7 @@ import './style.scss';
 import { registerBlock, query as hpq } from 'api';
 import Editable from 'components/editable';
 
-const { html, prop, query } = hpq;
+const { children, prop, query } = hpq;
 
 registerBlock( 'core/list', {
 	title: wp.i18n.__( 'List' ),
@@ -15,7 +15,7 @@ registerBlock( 'core/list', {
 	attributes: {
 		nodeName: prop( 'ol,ul', 'nodeName' ),
 		items: query( 'li', {
-			value: html()
+			value: children()
 		} )
 	},
 
@@ -56,9 +56,9 @@ registerBlock( 'core/list', {
 
 	edit( { attributes, focus, setFocus } ) {
 		const { nodeName = 'OL', items = [], align } = attributes;
-		const content = items.map( item => {
-			return `<li>${ item.value }</li>`;
-		} ).join( '' );
+		const content = items.map( ( item, i ) => {
+			return <li key={ i }>{ item.value }</li>;
+		} );
 
 		return (
 			<Editable
@@ -73,9 +73,13 @@ registerBlock( 'core/list', {
 
 	save( { attributes } ) {
 		const { nodeName = 'OL', items = [] } = attributes;
-		const children = items.map( ( item, index ) => (
-			<li key={ index } dangerouslySetInnerHTML={ { __html: item.value } } />
-		) );
-		return wp.element.createElement( nodeName.toLowerCase(), null, children );
+
+		return wp.element.createElement(
+			listType.toLowerCase(),
+			null,
+			items.map( ( item, index ) => (
+				<li key={ index }>{ item.value }</li>
+			) )
+		);
 	}
 } );

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -5,10 +5,7 @@ import './style.scss';
 import { registerBlock, query as hpq } from 'api';
 import Editable from 'components/editable';
 
-const { parse, html, query, attr } = hpq;
-
-const fromValueToParagraphs = ( value ) => value ? value.map( ( paragraph ) => `<p>${ paragraph }</p>` ).join( '' ) : '';
-const fromParagraphsToValue = ( paragraphs ) => parse( paragraphs, query( 'p', html() ) );
+const { children, query, attr } = hpq;
 
 registerBlock( 'core/quote', {
 	title: wp.i18n.__( 'Quote' ),
@@ -16,13 +13,13 @@ registerBlock( 'core/quote', {
 	category: 'common',
 
 	attributes: {
-		value: query( 'blockquote > p', html() ),
-		citation: html( 'footer' ),
+		value: query( 'blockquote > p', children() ),
+		citation: children( 'footer' ),
 		style: node => {
 			const value = attr( 'blockquote', 'class' )( node );
 			const match = value.match( /\bblocks-quote-style-(\d+)\b/ );
 			return match ? +match[ 1 ] : null;
-		},
+		}
 	},
 
 	controls: [ 1, 2 ].map( ( variation ) => ( {
@@ -42,29 +39,29 @@ registerBlock( 'core/quote', {
 		return (
 			<blockquote className={ `blocks-quote blocks-quote-style-${ style }` }>
 				<Editable
-					value={ fromValueToParagraphs( value ) }
+					value={ value }
 					onChange={
-						( paragraphs ) => setAttributes( {
-							value: fromParagraphsToValue( paragraphs )
+						( nextValue ) => setAttributes( {
+							value: nextValue
 						} )
 					}
 					focus={ focus && focus.editable === 'value' ? focus : null }
 					onFocus={ () => setFocus( { editable: 'value' } ) }
 				/>
-				{ ( citation || !! focus ) &&
+				{ ( citation || !! focus ) && (
 					<footer>
 						<Editable
 							value={ citation }
 							onChange={
-								( newValue ) => setAttributes( {
-									citation: newValue
+								( nextCitation ) => setAttributes( {
+									citation: nextCitation
 								} )
 							}
 							focus={ focus && focus.editable === 'citation' ? focus : null }
 							onFocus={ () => setFocus( { editable: 'citation' } ) }
 						/>
 					</footer>
-				}
+				) }
 			</blockquote>
 		);
 	},
@@ -76,15 +73,9 @@ registerBlock( 'core/quote', {
 		return (
 			<blockquote className={ `blocks-quote-style-${ style }` }>
 				{ value && value.map( ( paragraph, i ) => (
-					<p
-						key={ i }
-						dangerouslySetInnerHTML={ {
-							__html: paragraph
-						} } />
+					<p key={ i }>{ paragraph }</p>
 				) ) }
-				<footer dangerouslySetInnerHTML={ {
-					__html: citation
-				} } />
+				<footer>{ citation }</footer>
 			</blockquote>
 		);
 	}

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -90,14 +90,10 @@ registerBlock( 'core/text', {
 			return content;
 		}
 
-		return content.map( ( paragraph ) => {
-			if ( 'string' === typeof paragraph ) {
-				return null;
-			}
-
-			return wp.element.cloneElement( paragraph, {
+		return content.map( ( paragraph ) => (
+			wp.element.cloneElement( paragraph, {
 				style: { textAlign: align }
-			} );
-		} );
+			} )
+		) );
 	}
 } );

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -71,16 +71,9 @@ registerBlock( 'core/text', {
 	save( { attributes } ) {
 		// An empty block will have an undefined content field. Return early
 		// as an empty string.
-		let { content } = attributes;
+		const { content } = attributes;
 		if ( ! content ) {
 			return '';
-		}
-
-		// Content can be in the following shapes, so we normalize to an array:
-		// - Single paragraph: Object
-		// - Multiple paragraph: Array of objects
-		if ( ! Array.isArray( content ) ) {
-			content = [ content ];
 		}
 
 		// We only need to transform content if we need to apply the alignment
@@ -90,7 +83,7 @@ registerBlock( 'core/text', {
 			return content;
 		}
 
-		return content.map( ( paragraph ) => (
+		return wp.element.Children.map( content, ( paragraph ) => (
 			wp.element.cloneElement( paragraph, {
 				style: { textAlign: align }
 			} )

--- a/element/index.js
+++ b/element/index.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { createElement, Component } from 'react';
+import { createElement, Component, cloneElement } from 'react';
 import { render } from 'react-dom';
-import ReactDOMServer from 'react-dom/server';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -13,16 +13,16 @@ import ReactDOMServer from 'react-dom/server';
  * @param  {Object}             props    Element properties, either attribute
  *                                       set to apply to DOM node or values to
  *                                       pass through to element creator
- * @param  {...wp.Element}      children Descendant elements
- * @return {wp.Element}                  Element
+ * @param  {...WPElement}       children Descendant elements
+ * @return {WPElement}                   Element
  */
 export { createElement };
 
 /**
  * Renders a given element into the target DOM node.
  *
- * @param {wp.Element} element Element to render
- * @param {Element}    target  DOM node into which element should be rendered
+ * @param {WPElement} element Element to render
+ * @param {Element}   target  DOM node into which element should be rendered
  */
 export { render };
 
@@ -32,9 +32,34 @@ export { render };
 export { Component };
 
 /**
+ * Creates a copy of an element with extended props.
+ *
+ * @param  {WPElement} element Element
+ * @param  {?Object}   props   Props to apply to cloned element
+ * @return {WPElement}         Cloned element
+ */
+export { cloneElement };
+
+/**
  * Renders a given element into a string
  *
- * @param {wp.Element} element Element to render
+ * @param  {WPElement} element Element to render
  * @return {String}            HTML
  */
-export const renderToString = ReactDOMServer.renderToStaticMarkup;
+export function renderToString( element ) {
+	if ( ! element ) {
+		return '';
+	}
+
+	if ( 'string' === typeof element ) {
+		return element;
+	}
+
+	if ( Array.isArray( element ) ) {
+		return renderToStaticMarkup(
+			createElement( 'div', null, ...element )
+		).slice( 5, -6 );
+	}
+
+	return renderToStaticMarkup( element );
+}

--- a/element/index.js
+++ b/element/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement, Component, cloneElement } from 'react';
+import { createElement, Component, cloneElement, Children } from 'react';
 import { render } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -39,6 +39,8 @@ export { Component };
  * @return {WPElement}         Cloned element
  */
 export { cloneElement };
+
+export { Children };
 
 /**
  * Renders a given element into a string

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { createElement, renderToString } from '../';
+
+describe( 'element', () => {
+	describe( 'renderToString', () => {
+		it( 'should return an empty string for a falsey value', () => {
+			expect( renderToString() ).to.equal( '' );
+			expect( renderToString( false ) ).to.equal( '' );
+			expect( renderToString( null ) ).to.equal( '' );
+			expect( renderToString( 0 ) ).to.equal( '' );
+		} );
+
+		it( 'should return a string verbatim', () => {
+			expect( renderToString( 'Zucchini' ) ).to.equal( 'Zucchini' );
+		} );
+
+		it( 'should return a string from an array', () => {
+			expect( renderToString( [
+				'Zucchini ',
+				createElement( 'em', null, 'is a' ),
+				' summer squash'
+			] ) ).to.equal( 'Zucchini <em>is a</em> summer squash' );
+		} );
+
+		it( 'should return a string from an element', () => {
+			expect( renderToString(
+				createElement( 'strong', null, 'Courgette' )
+			) ).to.equal( '<strong>Courgette</strong>' );
+		} );
+	} );
+} );

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -33,17 +33,17 @@ msgid "List"
 msgstr ""
 
 #: blocks/library/list/index.js:25
-#: blocks/library/text/index.js:26
+#: blocks/library/text/index.js:23
 msgid "Align left"
 msgstr ""
 
 #: blocks/library/list/index.js:33
-#: blocks/library/text/index.js:34
+#: blocks/library/text/index.js:31
 msgid "Align center"
 msgstr ""
 
 #: blocks/library/list/index.js:41
-#: blocks/library/text/index.js:42
+#: blocks/library/text/index.js:39
 msgid "Align right"
 msgstr ""
 
@@ -51,15 +51,15 @@ msgstr ""
 msgid "Justify"
 msgstr ""
 
-#: blocks/library/quote/index.js:14
+#: blocks/library/quote/index.js:11
 msgid "Quote"
 msgstr ""
 
-#: blocks/library/quote/index.js:30
+#: blocks/library/quote/index.js:27
 msgid "Quote style %d"
 msgstr ""
 
-#: blocks/library/text/index.js:13
+#: blocks/library/text/index.js:10
 msgid "Text"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "hpq": "^1.2.0",
+    "html-to-react": "^1.2.7",
     "jed": "^1.1.1",
     "lodash": "^4.17.4",
     "react": "^15.5.4",

--- a/post-content.js
+++ b/post-content.js
@@ -9,7 +9,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/heading -->',
 
 			'<!-- wp:core/text -->',
-			'<div><p>I imagine prior to the launch of the iPod, or the iPhone, there were teams saying the same thing: the copy + paste guys are <em>so close</em> to being ready and we know Walt Mossberg is going to ding us for this so let\'s just not ship to the manufacturers in China for just a few more weeks… The Apple teams were probably embarrassed. But <strong>if you\'re not embarrassed when you ship your first version you waited too long</strong>.</p></div>',
+			'<p>I imagine prior to the launch of the iPod, or the iPhone, there were teams saying the same thing: the copy + paste guys are <em>so close</em> to being ready and we know Walt Mossberg is going to ding us for this so let\'s just not ship to the manufacturers in China for just a few more weeks… The Apple teams were probably embarrassed. But <strong>if you\'re not embarrassed when you ship your first version you waited too long</strong>.</p>',
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/image -->',
@@ -17,7 +17,8 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
-			'<div><p>A beautiful thing about Apple is how quickly they obsolete their own products. I imagine this also makes the discipline of getting things out there easier. Like I mentioned before, the longer it’s been since the last release the more pressure there is, but if you know that if your bit of code doesn’t make this version but there’s the +0.1 coming out in 6 weeks, then it’s not that bad. It’s like flights from San Francisco to LA, if you miss one you know there’s another one an hour later so it’s not a big deal. Amazon has done a fantastic job of this with the Kindle as well, with a new model every year.</p></div>',
+			'<p>A beautiful thing about Apple is <em>how quickly</em> they obsolete their own products. I imagine this also makes the discipline of getting things out there easier. Like I mentioned before, the longer it’s been since the last release the more pressure there is, but if you know that if your bit of code doesn’t make this version but there’s the +0.1 coming out in 6 weeks, then it’s not that bad.</p>',
+			'<p>It’s like flights from San Francisco to LA, if you miss one you know there’s another one an hour later so it’s not a big deal. Amazon has done a fantastic job of this with the Kindle as well, with a new model every year.</p>',
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/quote -->',
@@ -29,7 +30,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
-			'<div><p>By shipping early and often you have the unique competitive advantage of hearing from real people what they think of your work, which in best case helps you anticipate market direction, and in worst case gives you a few people rooting for you that you can email when your team pivots to a new idea. Nothing can recreate the crucible of real usage.</p></div>',
+			'<p>By shipping early and often you have the unique competitive advantage of hearing from real people what they think of your work, which in best case helps you anticipate market direction, and in worst case gives you a few people rooting for you that you can email when your team pivots to a new idea. Nothing can recreate the crucible of real usage.</p>',
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/list -->',


### PR DESCRIPTION
Closes #421 

This pull request seeks to address issues with treating the Editable value as a string. Specifically, the need to manage a string value counteracts the promise of avoiding manual manipulation of HTML and adds complexity to serialization.

Related discussion at https://github.com/WordPress/gutenberg/pull/413#issuecomment-294725153

__Implementation details:__

- Introduces a new `children` hpq matcher to extract content as a React element, using [html-to-react](https://www.npmjs.com/package/html-to-react)
- Enhances `renderToString` to handle more incoming value types (falsey, string, array)

It's admittedly concerning to apply _even more parsing_ in the form of HTML → React transformation, especially in juggling the incoming and outgoing value on the Editable (TinyMCE) component. I think we'll need to address this sooner than later, but the changes introduced here are aimed at shaping expectations of managing attributes of a block which contain elements.

__Testing instructions:__

Verify that there are no regressions of existing behavior:

- Confirming serialization of changes are respected (switching to HTML mode)
- Text blocks can contain multiple paragraphs
- Text block splitting

Ensure included tests pass:

```
npm test
```