### PR TITLE
Avoid serializing undefined attribute values

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -54,6 +54,10 @@ export function getCommentAttributes( realAttributes, expectedAttributes ) {
 	// Serialize the comment attributes
 	return keys.reduce( ( memo, key ) => {
 		const value = realAttributes[ key ];
+		if ( undefined === value ) {
+			return memo;
+		}
+
 		return memo + `${ key }:${ value } `;
 	}, '' );
 }

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -73,6 +73,18 @@ describe( 'block serializer', () => {
 
 			expect( attributes ).to.equal( 'category:food ripeness:ripe ' );
 		} );
+
+		it( 'should not append an undefined attribute value', () => {
+			const attributes = getCommentAttributes( {
+				fruit: 'bananas',
+				category: 'food',
+				ripeness: undefined
+			}, {
+				fruit: 'bananas'
+			} );
+
+			expect( attributes ).to.equal( 'category:food ' );
+		} );
 	} );
 
 	describe( 'serialize()', () => {


### PR DESCRIPTION
This pull request seeks to resolve an issue where `undefined` values are serialized in the comment block attributes.

__Implementation notes:__

I chose to omit the attribute at the serialization step, but we could in addition or alternatively omit these values from state altogether when the block is updated, inserted, etc.

__Testing instructions:__

1. Select a text block
2. Click "Align left"
3. Switch to HTML mode
4. Verify that comment for block aligned in step 2 does not include `align` attribute
   - Previously it'd serialized as `align:undefined`