### PR TITLE
Assign more interesting icon for menu item

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,7 +21,8 @@ function gutenberg_menu() {
 		'Gutenberg',
 		'manage_options',
 		'gutenberg',
-		'the_gutenberg_project'
+		'the_gutenberg_project',
+		'dashicons-edit'
 	);
 }
 add_action( 'admin_menu', 'gutenberg_menu' );


### PR DESCRIPTION
Gears aren't very interesting. This pull request seeks to make the menu item _pop_.

Before|After
---|---
![:(](https://cloud.githubusercontent.com/assets/1779930/25251799/843572b4-25e8-11e7-9952-c94ba8b15c56.png)|![:)](https://cloud.githubusercontent.com/assets/1779930/25251775/74d7f79c-25e8-11e7-9f3f-2dad2e6433ee.png)

Alternative suggestions welcome. See also:

https://developer.wordpress.org/resource/dashicons/#edit