### PR TITLE
WIP: Adds new RegExp-based "parser"

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -363,16 +363,18 @@ function simpleTrampoline( f ) {
 }
 
 export function parseWithRegExp( content ) {
-	const [ doc, /* remaining */ ] = simpleTrampoline( regExpParser( content ) );
+	const [ doc, remaining ] = simpleTrampoline( regExpParser( content ) );
 
-	return doc.reduce( ( memo, blockNode ) => {
-		const { blockType, rawContent, attrs } = blockNode;
-		const block = createBlockWithFallback( blockType, rawContent, attrs );
-		if ( block ) {
-			memo.push( block );
-		}
-		return memo;
-	}, [] );
+	return doc
+		.concat( { attrs: {}, rawContent: remaining } )
+		.reduce( ( memo, blockNode ) => {
+			const { blockType, rawContent, attrs } = blockNode;
+			const block = createBlockWithFallback( blockType, rawContent, attrs );
+			if ( block ) {
+				memo.push( block );
+			}
+			return memo;
+		}, [] );
 }
 
 export default parseWithRegExp;


### PR DESCRIPTION
Since we're only delineating the blocks in the "parser" there's no great
need to pull in a heavyweight parser. This uses RegExps and a
recursive-descent approach to split the blocks.

Still yet to do is parse the attributes but that shouldn't take much effort.

Granted, I think we should pull more parsing of the inside of the blocks
into this file, but if we're leaving all the dirty parsing up to the blocks then
this is sufficient.