### PR TITLE
Focus: Fix focus jumps when splitting a text block

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -106,7 +106,9 @@ export default class Editable extends wp.element.Component {
 		this.editor.setContent( this.props.value || '' );
 		const hasAfter = !! childNodes.slice( splitIndex )
 			.reduce( ( memo, node ) => memo + node.textContent, '' );
-		this.props.onSplit( before, hasAfter ? after : '' );
+
+		// The setTimeout fixes the focus jump to the original block
+		setTimeout( () => this.props.onSplit( before, hasAfter ? after : '' ) );
 	}
 
 	bindNode( ref ) {
@@ -117,6 +119,9 @@ export default class Editable extends wp.element.Component {
 		const bookmark = this.editor.selection.getBookmark( 2, true );
 		this.editor.setContent( this.props.value );
 		this.editor.selection.moveToBookmark( bookmark );
+		// Saving the editor on updates avoid unecessary onChanges calls
+		// These calls can make the focus jump
+		this.editor.save();
 	}
 
 	focus() {


### PR DESCRIPTION
We have to be very careful while dealing the with the different TinyMCE events. Triggering unnecessary events can make the focus jump to other blocks.

**Testing instructions**

 - Split a text block (double enter)
 - Make sure the focus is correctly set to the beginning of the newly created block.