### PR TITLE
Quote Block: Support Block Switcher

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -32,7 +32,8 @@ export function createBlock( blockType, attributes = {} ) {
  * @return {Array}             Block object
  */
 export function switchToBlockType( block, blockType ) {
-	// Find the right transformation by giving priority to the "to" transformation
+	// Find the right transformation by giving priority to the "to"
+	// transformation.
 	const destinationSettings = getBlockSettings( blockType );
 	const sourceSettings = getBlockSettings( block.blockType );
 	const transformationsFrom = get( destinationSettings, 'transforms.from', [] );
@@ -41,6 +42,7 @@ export function switchToBlockType( block, blockType ) {
 		transformationsTo.find( t => t.blocks.indexOf( blockType ) !== -1 ) ||
 		transformationsFrom.find( t => t.blocks.indexOf( block.blockType ) !== -1 );
 
+	// If no valid transformation, stop.  (How did we get here?)
 	if ( ! transformation ) {
 		return null;
 	}
@@ -73,6 +75,8 @@ export function switchToBlockType( block, blockType ) {
 
 	return transformationResults.map( ( result, index ) => {
 		return {
+			// The first transformed block whose type matches the "destination"
+			// type gets to keep the existing block's UID.
 			uid: index === firstSwitchedBlock ? block.uid : uuid(),
 			blockType: result.blockType,
 			attributes: result.attributes

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import uuid from 'uuid/v4';
-import { get, castArray, findIndex } from 'lodash';
+import { get, castArray, findIndex, isObjectLike } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,7 +45,17 @@ export function switchToBlockType( block, blockType ) {
 		return null;
 	}
 
-	const transformationResults = castArray( transformation.transform( block.attributes ) );
+	let transformationResults = transformation.transform( block.attributes );
+
+	// Ensure that the transformation function returned an object or an array
+	// of objects.
+	if ( ! isObjectLike( transformationResults ) ) {
+		return null;
+	}
+
+	// If the transformation function returned a single object, we want to work
+	// with an array instead.
+	transformationResults = castArray( transformationResults );
 
 	// Ensure that every block object returned by the transformation has a
 	// valid block type.

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -46,27 +46,26 @@ export function switchToBlockType( block, blockType ) {
 	}
 
 	const transformationResults = castArray( transformation.transform( block.attributes ) );
+
+	// Ensure that every block object returned by the transformation has a
+	// valid block type.
+	if ( transformationResults.some( ( result ) => ! getBlockSettings( result.blockType ) ) ) {
+		return null;
+	}
+
 	const firstSwitchedBlock = findIndex( transformationResults, ( result ) => result.blockType === blockType );
 
-	const transformedBlocks = transformationResults.map( ( result, index ) => {
+	// Ensure that at least one block object returned by the transformation has
+	// the expected "destination" block type.
+	if ( firstSwitchedBlock < 0 ) {
+		return null;
+	}
+
+	return transformationResults.map( ( result, index ) => {
 		return {
 			uid: index === firstSwitchedBlock ? block.uid : uuid(),
 			blockType: result.blockType,
 			attributes: result.attributes
 		};
 	} );
-
-	// Ensure that every block object returned by the transformation has a
-	// block type
-	if ( transformedBlocks.some( ( block ) => ! getBlockSettings( block.blockType ) ) ) {
-		return null;
-	}
-
-	// Ensure that at least one block object returned by the transformation has
-	// the expected "destination" block type
-	if ( ! transformedBlocks.some( ( block ) => block.blockType === blockType ) ) {
-		return null;
-	}
-
-	return transformedBlocks;
 }

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import uuid from 'uuid/v4';
-import { get, castArray } from 'lodash';
+import { get, castArray, findIndex } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,13 +45,14 @@ export function switchToBlockType( block, blockType ) {
 		return null;
 	}
 
-	const transformtionResult = castArray( transformation.transform( block.attributes ) );
+	const transformationResults = castArray( transformation.transform( block.attributes ) );
+	const firstSwitchedBlock = findIndex( transformationResults, ( result ) => result.blockType === blockType );
 
-	return transformtionResult.map( ( attributes, index ) => {
+	return transformationResults.map( ( result, index ) => {
 		return {
-			uid: index === 0 ? block.uid : uuid(),
-			blockType: index === 0 ? blockType : block.blockType,
-			attributes
+			uid: index === firstSwitchedBlock ? block.uid : uuid(),
+			blockType: result.blockType,
+			attributes: result.attributes
 		};
 	} );
 }

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -47,11 +47,11 @@ export function switchToBlockType( block, blockType ) {
 
 	const transformtionResult = castArray( transformation.transform( block.attributes ) );
 
-	return transformtionResult.map( ( attributes, index ) =>
-		Object.assign( {
+	return transformtionResult.map( ( attributes, index ) => {
+		return {
 			uid: index === 0 ? block.uid : uuid(),
-			attributes,
-			blockType
-		} )
-	);
+			blockType: index === 0 ? blockType : block.blockType,
+			attributes
+		};
+	} );
 }

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -48,11 +48,17 @@ export function switchToBlockType( block, blockType ) {
 	const transformationResults = castArray( transformation.transform( block.attributes ) );
 	const firstSwitchedBlock = findIndex( transformationResults, ( result ) => result.blockType === blockType );
 
-	return transformationResults.map( ( result, index ) => {
+	const transformedBlocks = transformationResults.map( ( result, index ) => {
 		return {
 			uid: index === firstSwitchedBlock ? block.uid : uuid(),
 			blockType: result.blockType,
 			attributes: result.attributes
 		};
 	} );
+
+	if ( transformedBlocks.some( ( block ) => ! getBlockSettings( block.blockType ) ) ) {
+		return null;
+	}
+
+	return transformedBlocks;
 }

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -56,7 +56,15 @@ export function switchToBlockType( block, blockType ) {
 		};
 	} );
 
+	// Ensure that every block object returned by the transformation has a
+	// block type
 	if ( transformedBlocks.some( ( block ) => ! getBlockSettings( block.blockType ) ) ) {
+		return null;
+	}
+
+	// Ensure that at least one block object returned by the transformation has
+	// the expected "destination" block type
+	if ( ! transformedBlocks.some( ( block ) => block.blockType === blockType ) ) {
 		return null;
 	}
 

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import uuid from 'uuid/v4';
-import { get } from 'lodash';
+import { get, castArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,11 +25,11 @@ export function createBlock( blockType, attributes = {} ) {
 }
 
 /**
- * Switch Block Type and returns the updated block
+ * Switch a block into one or more blocks of the new block type
  *
  * @param  {Object} block      Block object
  * @param  {string} blockType  BlockType
- * @return {Object?}           Block object
+ * @return {Array}             Block object
  */
 export function switchToBlockType( block, blockType ) {
 	// Find the right transformation by giving priority to the "to" transformation
@@ -45,9 +45,13 @@ export function switchToBlockType( block, blockType ) {
 		return null;
 	}
 
-	return Object.assign( {
-		uid: block.uid,
-		attributes: transformation.transform( block.attributes ),
-		blockType
-	} );
+	const transformtionResult = castArray( transformation.transform( block.attributes ) );
+
+	return transformtionResult.map( ( attributes, index ) =>
+		Object.assign( {
+			uid: index === 0 ? block.uid : uuid(),
+			attributes,
+			blockType
+		} )
+	);
 }

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -39,7 +39,10 @@ describe( 'block factory', () => {
 						blocks: [ 'core/text-block' ],
 						transform: ( { value } ) => {
 							return {
-								value: 'chicken ' + value
+								blockType: 'core/updated-text-block',
+								attributes: {
+									value: 'chicken ' + value
+								}
 							};
 						}
 					} ]
@@ -74,7 +77,10 @@ describe( 'block factory', () => {
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return {
-								value: 'chicken ' + value
+								blockType: 'core/updated-text-block',
+								attributes: {
+									value: 'chicken ' + value
+								}
 							};
 						}
 					} ]

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -31,7 +31,7 @@ describe( 'block factory', () => {
 		} );
 	} );
 
-	describe( 'switchBlockType()', () => {
+	describe( 'switchToBlockType()', () => {
 		it( 'should switch the blockType of a block using the "transform form"', () => {
 			registerBlock( 'core/updated-text-block', {
 				transforms: {
@@ -57,13 +57,13 @@ describe( 'block factory', () => {
 
 			const updateBlock = switchToBlockType( block, 'core/updated-text-block' );
 
-			expect( updateBlock ).to.eql( {
+			expect( updateBlock ).to.eql( [ {
 				uid: 1,
 				blockType: 'core/updated-text-block',
 				attributes: {
 					value: 'chicken ribs'
 				}
-			} );
+			} ] );
 		} );
 
 		it( 'should switch the blockType of a block using the "transform to"', () => {
@@ -91,13 +91,13 @@ describe( 'block factory', () => {
 
 			const updateBlock = switchToBlockType( block, 'core/updated-text-block' );
 
-			expect( updateBlock ).to.eql( {
+			expect( updateBlock ).to.eql( [ {
 				uid: 1,
 				blockType: 'core/updated-text-block',
 				attributes: {
 					value: 'chicken ribs'
 				}
-			} );
+			} ] );
 		} );
 
 		it( 'should return null if no transformation is found', () => {

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -123,6 +123,59 @@ describe( 'block factory', () => {
 			expect( updatedBlock ).to.be.null();
 		} );
 
+		it( 'should reject transformations that return null', () => {
+			registerBlock( 'core/updated-text-block', {
+				transforms: {
+					from: [ {
+						blocks: [ 'core/text-block' ],
+						transform: ( { value } ) => {
+							return null;
+						}
+					} ]
+				}
+			} );
+			registerBlock( 'core/text-block', {} );
+
+			const block = {
+				uid: 1,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'ribs'
+				}
+			};
+
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
+
+			expect( updatedBlock ).to.be.null();
+		} );
+
+
+		it( 'should reject transformations that return an empty array', () => {
+			registerBlock( 'core/updated-text-block', {
+				transforms: {
+					from: [ {
+						blocks: [ 'core/text-block' ],
+						transform: ( { value } ) => {
+							return [];
+						}
+					} ]
+				}
+			} );
+			registerBlock( 'core/text-block', {} );
+
+			const block = {
+				uid: 1,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'ribs'
+				}
+			};
+
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
+
+			expect( updatedBlock ).to.be.null();
+		} );
+
 		it( 'should reject single transformations that do not include block types', () => {
 			registerBlock( 'core/updated-text-block', {
 				transforms: {

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -58,9 +58,9 @@ describe( 'block factory', () => {
 				}
 			};
 
-			const updateBlock = switchToBlockType( block, 'core/updated-text-block' );
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
 
-			expect( updateBlock ).to.eql( [ {
+			expect( updatedBlock ).to.eql( [ {
 				uid: 1,
 				blockType: 'core/updated-text-block',
 				attributes: {
@@ -95,9 +95,9 @@ describe( 'block factory', () => {
 				}
 			};
 
-			const updateBlock = switchToBlockType( block, 'core/updated-text-block' );
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
 
-			expect( updateBlock ).to.eql( [ {
+			expect( updatedBlock ).to.eql( [ {
 				uid: 1,
 				blockType: 'core/updated-text-block',
 				attributes: {
@@ -118,9 +118,76 @@ describe( 'block factory', () => {
 				}
 			};
 
-			const updateBlock = switchToBlockType( block, 'core/updated-text-block' );
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
 
-			expect( updateBlock ).to.be.null();
+			expect( updatedBlock ).to.be.null();
+		} );
+
+		it( 'should reject single transformations that do not include block types', () => {
+			registerBlock( 'core/updated-text-block', {
+				transforms: {
+					from: [ {
+						blocks: [ 'core/text-block' ],
+						transform: ( { value } ) => {
+							return {
+								attributes: {
+									value: 'chicken ' + value
+								}
+							};
+						}
+					} ]
+				}
+			} );
+			registerBlock( 'core/text-block', {} );
+
+			const block = {
+				uid: 1,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'ribs'
+				}
+			};
+
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
+
+			expect( updatedBlock ).to.be.null();
+		} );
+
+		it( 'should reject array transformations that do not include block types', () => {
+			registerBlock( 'core/updated-text-block', {
+				transforms: {
+					from: [ {
+						blocks: [ 'core/text-block' ],
+						transform: ( { value } ) => {
+							return [
+								{
+									blockType: 'core/updated-text-block',
+									attributes: {
+										value: 'chicken ' + value
+									}
+								}, {
+									attributes: {
+										value: 'chicken ' + value
+									}
+								}
+							];
+						}
+					} ]
+				}
+			} );
+			registerBlock( 'core/text-block', {} );
+
+			const block = {
+				uid: 1,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'ribs'
+				}
+			};
+
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
+
+			expect( updatedBlock ).to.be.null();
 		} );
 	} );
 } );

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -128,9 +128,7 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
-						transform: ( { value } ) => {
-							return null;
-						}
+						transform: () => null
 					} ]
 				}
 			} );
@@ -149,15 +147,12 @@ describe( 'block factory', () => {
 			expect( updatedBlock ).to.be.null();
 		} );
 
-
 		it( 'should reject transformations that return an empty array', () => {
 			registerBlock( 'core/updated-text-block', {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
-						transform: ( { value } ) => {
-							return [];
-						}
+						transform: () => []
 					} ]
 				}
 			} );

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -258,5 +258,63 @@ describe( 'block factory', () => {
 
 			expect( updatedBlock ).to.eql( null );
 		} );
+
+		it( 'should accept valid array transformations', () => {
+			registerBlock( 'core/updated-text-block', {} );
+			registerBlock( 'core/text-block', {
+				transforms: {
+					to: [ {
+						blocks: [ 'core/updated-text-block' ],
+						transform: ( { value } ) => {
+							return [
+								{
+									blockType: 'core/text-block',
+									attributes: {
+										value: 'chicken ' + value
+									}
+								}, {
+									blockType: 'core/updated-text-block',
+									attributes: {
+										value: 'smoked ' + value
+									}
+								}
+							];
+						}
+					} ]
+				}
+			} );
+
+			const block = {
+				uid: 1,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'ribs'
+				}
+			};
+
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
+
+			// Make sure the block UIDs are set as expected: the first
+			// transformed block whose type matches the "destination" type gets
+			// to keep the existing block's UID.
+			expect( updatedBlock ).to.have.lengthOf( 2 );
+			expect( updatedBlock[ 0 ].uid ).to.exist().and.not.eql( 1 );
+			expect( updatedBlock[ 1 ].uid ).to.eql( 1 );
+			updatedBlock[ 0 ].uid = 2;
+
+			expect( updatedBlock ).to.eql( [ {
+				uid: 2,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'chicken ribs'
+				}
+			}, {
+				uid: 1,
+				blockType: 'core/updated-text-block',
+				attributes: {
+					value: 'smoked ribs'
+				}
+			} ] );
+		} );
 	} );
 } );

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -167,7 +167,7 @@ describe( 'block factory', () => {
 									}
 								}, {
 									attributes: {
-										value: 'chicken ' + value
+										value: 'smoked ' + value
 									}
 								}
 							];
@@ -188,6 +188,75 @@ describe( 'block factory', () => {
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
 
 			expect( updatedBlock ).to.be.null();
+		} );
+
+		it( 'should reject single transformations with unexpected block types', () => {
+			registerBlock( 'core/updated-text-block', {} );
+			registerBlock( 'core/text-block', {
+				transforms: {
+					to: [ {
+						blocks: [ 'core/updated-text-block' ],
+						transform: ( { value } ) => {
+							return {
+								blockType: 'core/text-block',
+								attributes: {
+									value: 'chicken ' + value
+								}
+							};
+						}
+					} ]
+				}
+			} );
+
+			const block = {
+				uid: 1,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'ribs'
+				}
+			};
+
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
+
+			expect( updatedBlock ).to.eql( null );
+		} );
+
+		it( 'should reject array transformations with unexpected block types', () => {
+			registerBlock( 'core/updated-text-block', {} );
+			registerBlock( 'core/text-block', {
+				transforms: {
+					to: [ {
+						blocks: [ 'core/updated-text-block' ],
+						transform: ( { value } ) => {
+							return [
+								{
+									blockType: 'core/text-block',
+									attributes: {
+										value: 'chicken ' + value
+									}
+								}, {
+									blockType: 'core/text-block',
+									attributes: {
+										value: 'smoked ' + value
+									}
+								}
+							];
+						}
+					} ]
+				}
+			} );
+
+			const block = {
+				uid: 1,
+				blockType: 'core/text-block',
+				attributes: {
+					value: 'ribs'
+				}
+			};
+
+			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
+
+			expect( updatedBlock ).to.eql( null );
 		} );
 	} );
 } );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -35,14 +35,23 @@ registerBlock( 'core/heading', {
 			{
 				type: 'block',
 				blocks: [ 'core/text' ],
-				transform: ( { content } ) => {
+				transform: ( { content, ...attrs } ) => {
 					if ( Array.isArray( content ) ) {
-						return content.map( ( elt ) => {
-							return {
-								nodeName: 'H2',
-								content: elt
+						const heading = {
+							nodeName: 'H2',
+							content: content[ 0 ]
+						};
+						const blocks = [ heading ];
+
+						if ( content.slice( 1 ).length ) {
+							const text = {
+								...attrs,
+								content: content.slice( 1 )
 							};
-						} );
+							blocks.push( text );
+						}
+
+						return blocks;
 					}
 					return {
 						nodeName: 'H2',

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -46,12 +46,13 @@ registerBlock( 'core/heading', {
 						};
 						const blocks = [ heading ];
 
-						if ( content.slice( 1 ).length ) {
+						const remainingContent = content.slice( 1 );
+						if ( remainingContent.length ) {
 							const text = {
 								blockType: 'core/text',
 								attributes: {
 									...attrs,
-									content: content.slice( 1 )
+									content: remainingContent
 								}
 							};
 							blocks.push( text );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isString } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { registerBlock, query } from 'api';
@@ -37,9 +42,9 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
 					if ( Array.isArray( content ) ) {
-						// TODO this appears to always be true?
-						// TODO reject the switch if more than one paragraph
-						content = content[ 0 ];
+						content = wp.element.concatChildren( content.map( ( elt ) =>
+							! elt || isString( elt ) || elt.type !== 'p' ? elt : elt.props.children
+						) );
 					}
 					return {
 						nodeName: 'H2',
@@ -54,7 +59,7 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
 					return {
-						content: [ content ]
+						content
 					};
 				}
 			}

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isString } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { registerBlock, query } from 'api';
@@ -42,9 +37,12 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
 					if ( Array.isArray( content ) ) {
-						content = wp.element.concatChildren( content.map( ( elt ) =>
-							! elt || isString( elt ) || elt.type !== 'p' ? elt : elt.props.children
-						) );
+						return content.map( ( elt ) => {
+							return {
+								nodeName: 'H2',
+								content: elt
+							};
+						} );
 					}
 					return {
 						nodeName: 'H2',

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -38,15 +38,21 @@ registerBlock( 'core/heading', {
 				transform: ( { content, ...attrs } ) => {
 					if ( Array.isArray( content ) ) {
 						const heading = {
-							nodeName: 'H2',
-							content: content[ 0 ]
+							blockType: 'core/heading',
+							attributes: {
+								nodeName: 'H2',
+								content: content[ 0 ]
+							}
 						};
 						const blocks = [ heading ];
 
 						if ( content.slice( 1 ).length ) {
 							const text = {
-								...attrs,
-								content: content.slice( 1 )
+								blockType: 'core/text',
+								attributes: {
+									...attrs,
+									content: content.slice( 1 )
+								}
 							};
 							blocks.push( text );
 						}
@@ -54,8 +60,11 @@ registerBlock( 'core/heading', {
 						return blocks;
 					}
 					return {
-						nodeName: 'H2',
-						content
+						blockType: 'core/heading',
+						attributes: {
+							nodeName: 'H2',
+							content
+						}
 					};
 				}
 			}
@@ -66,7 +75,10 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
 					return {
-						content
+						blockType: 'core/text',
+						attributes: {
+							content
+						}
 					};
 				}
 			}

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -40,6 +40,52 @@ registerBlock( 'core/quote', {
 		subscript: variation
 	} ) ),
 
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/text' ],
+				transform: ( { content } ) => {
+					return {
+						value: content
+					};
+				}
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/heading' ],
+				transform: ( { content = '' } ) => {
+					return {
+						value: [ content ]
+					};
+				}
+			}
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/text' ],
+				transform: ( { value, citation } ) => {
+					let content = value ? value : [];
+					content = citation && citation.trim() ? content.concat( citation ) : content;
+					return {
+						content
+					};
+				}
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/heading' ],
+				transform: ( { value } ) => {
+					return {
+						nodeName: 'H2',
+						content: value && value[ 0 ]
+					};
+				}
+			}
+		]
+	},
+
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { value, citation, style = 1 } = attributes;
 		const focusedEditable = focus ? focus.editable || 'value' : null;

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -74,22 +74,30 @@ registerBlock( 'core/quote', {
 			{
 				type: 'block',
 				blocks: [ 'core/heading' ],
-				transform: ( { value, citation } ) => {
-					return wp.element.Children.map( value, ( elt ) => {
-						return {
+				transform: ( { value, citation, ...attrs } ) => {
+					if ( Array.isArray( value ) || citation ) {
+						const heading = {
 							nodeName: 'H2',
-							content: elt
+							content: Array.isArray( value ) ? value[ 0 ] : value
 						};
-					} ).concat( [ {
+						const quote = {
+							...attrs,
+							citation,
+							value: Array.isArray( value ) ? value.slice( 1 ) : ''
+						};
+
+						return [ heading, quote ];
+					}
+					return {
 						nodeName: 'H2',
-						content: citation
-					} ] );
+						content: value
+					};
 				}
 			}
 		]
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, mergeWithPrevious } ) {
 		const { value, citation, style = 1 } = attributes;
 		const focusedEditable = focus ? focus.editable || 'value' : null;
 
@@ -104,6 +112,7 @@ registerBlock( 'core/quote', {
 					}
 					focus={ focusedEditable === 'value' ? focus : null }
 					onFocus={ () => setFocus( { editable: 'value' } ) }
+					onMerge={ mergeWithPrevious }
 					showAlignments
 				/>
 				{ ( citation || !! focus ) && (

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isString } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -54,9 +59,9 @@ registerBlock( 'core/quote', {
 			{
 				type: 'block',
 				blocks: [ 'core/heading' ],
-				transform: ( { content = '' } ) => {
+				transform: ( { content } ) => {
 					return {
-						value: [ content ]
+						value: content
 					};
 				}
 			}
@@ -66,20 +71,23 @@ registerBlock( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { value, citation } ) => {
-					let content = value ? value : [];
-					content = citation && citation.trim() ? content.concat( citation ) : content;
 					return {
-						content
+						content: wp.element.concatChildren( value, citation )
 					};
 				}
 			},
 			{
 				type: 'block',
 				blocks: [ 'core/heading' ],
-				transform: ( { value } ) => {
+				transform: ( { value, citation } ) => {
+					if ( Array.isArray( value ) ) {
+						value = wp.element.concatChildren( value.map( ( elt ) =>
+							! elt || isString( elt ) || elt.type !== 'p' ? elt : elt.props.children
+						) );
+					}
 					return {
 						nodeName: 'H2',
-						content: value && value[ 0 ]
+						content: wp.element.concatChildren( value, citation )
 					};
 				}
 			}

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -47,7 +47,10 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
 					return {
-						value: content
+						blockType: 'core/quote',
+						attributes: {
+							value: content
+						}
 					};
 				}
 			},
@@ -56,7 +59,10 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/heading' ],
 				transform: ( { content } ) => {
 					return {
-						value: content
+						blockType: 'core/quote',
+						attributes: {
+							value: content
+						}
 					};
 				}
 			}
@@ -67,7 +73,10 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/text' ],
 				transform: ( { value, citation } ) => {
 					return {
-						content: wp.element.concatChildren( value, citation )
+						blockType: 'core/text',
+						attributes: {
+							content: wp.element.concatChildren( value, citation )
+						}
 					};
 				}
 			},
@@ -77,20 +86,29 @@ registerBlock( 'core/quote', {
 				transform: ( { value, citation, ...attrs } ) => {
 					if ( Array.isArray( value ) || citation ) {
 						const heading = {
-							nodeName: 'H2',
-							content: Array.isArray( value ) ? value[ 0 ] : value
+							blockType: 'core/heading',
+							attributes: {
+								nodeName: 'H2',
+								content: Array.isArray( value ) ? value[ 0 ] : value
+							}
 						};
 						const quote = {
-							...attrs,
-							citation,
-							value: Array.isArray( value ) ? value.slice( 1 ) : ''
+							blockType: 'core/quote',
+							attributes: {
+								...attrs,
+								citation,
+								value: Array.isArray( value ) ? value.slice( 1 ) : ''
+							}
 						};
 
 						return [ heading, quote ];
 					}
 					return {
-						nodeName: 'H2',
-						content: value
+						blockType: 'core/heading',
+						attributes: {
+							nodeName: 'H2',
+							content: value
+						}
 					};
 				}
 			}

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isString } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import './style.scss';
@@ -80,15 +75,15 @@ registerBlock( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/heading' ],
 				transform: ( { value, citation } ) => {
-					if ( Array.isArray( value ) ) {
-						value = wp.element.concatChildren( value.map( ( elt ) =>
-							! elt || isString( elt ) || elt.type !== 'p' ? elt : elt.props.children
-						) );
-					}
-					return {
+					return wp.element.Children.map( value, ( elt ) => {
+						return {
+							nodeName: 'H2',
+							content: elt
+						};
+					} ).concat( [ {
 						nodeName: 'H2',
-						content: wp.element.concatChildren( value, citation )
-					};
+						content: citation
+					} ] );
 				}
 			}
 		]

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -88,9 +88,9 @@ export default connect(
 	( dispatch, ownProps ) => ( {
 		onTransform( block, blockType ) {
 			dispatch( {
-				type: 'SWITCH_BLOCK_TYPE',
-				uid: ownProps.uid,
-				block: wp.blocks.switchToBlockType( block, blockType )
+				type: 'REPLACE_BLOCKS',
+				uids: [ ownProps.uid ],
+				blocks: wp.blocks.switchToBlockType( block, blockType )
 			} );
 		}
 	} )

--- a/editor/index.js
+++ b/editor/index.js
@@ -20,8 +20,8 @@ import { createReduxStore } from './state';
 export function createEditorInstance( id, post ) {
 	const store = createReduxStore();
 	store.dispatch( {
-		type: 'REPLACE_BLOCKS',
-		blockNodes: wp.blocks.parse( post.content.raw )
+		type: 'RESET_BLOCKS',
+		blocks: wp.blocks.parse( post.content.raw )
 	} );
 
 	wp.element.render(

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -48,8 +48,8 @@ export default connect(
 	( dispatch ) => ( {
 		onChange( value ) {
 			dispatch( {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: wp.blocks.parse( value )
+				type: 'RESET_BLOCKS',
+				blocks: wp.blocks.parse( value )
 			} );
 		}
 	} )

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -91,6 +91,7 @@ class VisualEditorBlock extends wp.element.Component {
 
 		// Calling the merge to update the attributes and remove the block to be merged
 		const updatedAttributes = previousBlockSettings.merge( previousBlock.attributes, blocksWithTheSameType[ 0 ].attributes );
+
 		onFocus( previousBlock.uid, { offset: -1 } );
 		replaceBlocks(
 			[ previousBlock.uid, block.uid ],

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -81,7 +81,7 @@ class VisualEditorBlock extends wp.element.Component {
 		// We can only merge blocks with similar types
 		// thus, we transform the block to merge first
 		const blocksWithTheSameType = previousBlock.blockType === block.blockType
-			? block
+			? [ block ]
 			: wp.blocks.switchToBlockType( block, previousBlock.blockType );
 
 		// If the block types can not match, do nothing

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -38,8 +38,8 @@ describe( 'state', () => {
 		it( 'should key by replaced blocks uid', () => {
 			const original = blocks( undefined, {} );
 			const state = blocks( original, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ { uid: 'bananas' } ]
+				type: 'RESET_BLOCKS',
+				blocks: [ { uid: 'bananas' } ]
 			} );
 
 			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 1 );
@@ -49,8 +49,8 @@ describe( 'state', () => {
 
 		it( 'should return with block updates', () => {
 			const original = blocks( undefined, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
 					uid: 'kumquat',
 					attributes: {}
 				} ]
@@ -70,8 +70,8 @@ describe( 'state', () => {
 
 		it( 'should insert block', () => {
 			const original = blocks( undefined, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
 					attributes: {}
@@ -90,32 +90,34 @@ describe( 'state', () => {
 			expect( state.order ).to.eql( [ 'chicken', 'ribs' ] );
 		} );
 
-		it( 'should switch the block', () => {
+		it( 'should replace the block', () => {
 			const original = blocks( undefined, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
 					attributes: {}
 				} ]
 			} );
 			const state = blocks( original, {
-				type: 'SWITCH_BLOCK_TYPE',
-				uid: 'chicken',
-				block: {
-					uid: 'chicken',
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'chicken' ],
+				blocks: [ {
+					uid: 'wings',
 					blockType: 'core/freeform'
-				}
+				} ]
 			} );
 
 			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 1 );
 			expect( values( state.byUid )[ 0 ].blockType ).to.equal( 'core/freeform' );
+			expect( values( state.byUid )[ 0 ].uid ).to.equal( 'wings' );
+			expect( state.order ).to.eql( [ 'wings' ] );
 		} );
 
 		it( 'should move the block up', () => {
 			const original = blocks( undefined, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
 					attributes: {}
@@ -135,8 +137,8 @@ describe( 'state', () => {
 
 		it( 'should not move the first block up', () => {
 			const original = blocks( undefined, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
 					attributes: {}
@@ -156,8 +158,8 @@ describe( 'state', () => {
 
 		it( 'should move the block down', () => {
 			const original = blocks( undefined, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
 					attributes: {}
@@ -177,8 +179,8 @@ describe( 'state', () => {
 
 		it( 'should not move the last block down', () => {
 			const original = blocks( undefined, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
 					attributes: {}
@@ -198,8 +200,8 @@ describe( 'state', () => {
 
 		it( 'should remove the block', () => {
 			const original = blocks( undefined, {
-				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
 					attributes: {}
@@ -223,6 +225,33 @@ describe( 'state', () => {
 				}
 			} );
 		} );
+
+		it( 'should insert after the specified block uid', () => {
+			const original = blocks( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
+					uid: 'kumquat',
+					blockType: 'core/test-block',
+					attributes: {}
+				}, {
+					uid: 'loquat',
+					blockType: 'core/test-block',
+					attributes: {}
+				} ]
+			} );
+
+			const state = blocks( original, {
+				type: 'INSERT_BLOCK',
+				after: 'kumquat',
+				block: {
+					uid: 'persimmon',
+					blockType: 'core/freeform'
+				}
+			} );
+
+			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 3 );
+			expect( state.order ).to.eql( [ 'kumquat', 'persimmon', 'loquat' ] );
+		} );
 	} );
 
 	describe( 'hoveredBlock()', () => {
@@ -244,6 +273,32 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).to.be.null();
+		} );
+
+		it( 'should replace the hovered block', () => {
+			const state = hoveredBlock( 'chicken', {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'chicken' ],
+				blocks: [ {
+					uid: 'wings',
+					blockType: 'core/freeform'
+				} ]
+			} );
+
+			expect( state ).to.equal( 'wings' );
+		} );
+
+		it( 'should keep the hovered block', () => {
+			const state = hoveredBlock( 'chicken', {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'ribs' ],
+				blocks: [ {
+					uid: 'wings',
+					blockType: 'core/freeform'
+				} ]
+			} );
+
+			expect( state ).to.equal( 'chicken' );
 		} );
 	} );
 
@@ -386,31 +441,32 @@ describe( 'state', () => {
 			expect( state ).to.eql( { uid: 'ribs', typing: true, focus: { editable: 'citation' } } );
 		} );
 
-		it( 'should insert after the specified block uid', () => {
-			const original = blocks( undefined, {
+		it( 'should replace the selected block', () => {
+			const original = deepFreeze( { uid: 'chicken', typing: false, focus: { editable: 'citation' } } );
+			const state = selectedBlock( original, {
 				type: 'REPLACE_BLOCKS',
-				blockNodes: [ {
-					uid: 'kumquat',
-					blockType: 'core/test-block',
-					attributes: {}
-				}, {
-					uid: 'loquat',
-					blockType: 'core/test-block',
-					attributes: {}
+				uids: [ 'chicken' ],
+				blocks: [ {
+					uid: 'wings',
+					blockType: 'core/freeform'
 				} ]
 			} );
 
-			const state = blocks( original, {
-				type: 'INSERT_BLOCK',
-				after: 'kumquat',
-				block: {
-					uid: 'persimmon',
+			expect( state ).to.eql( { uid: 'wings', typing: false, focus: {} } );
+		} );
+
+		it( 'should keep the selected block', () => {
+			const original = deepFreeze( { uid: 'chicken', typing: false, focus: { editable: 'citation' } } );
+			const state = selectedBlock( original, {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'ribs' ],
+				blocks: [ {
+					uid: 'wings',
 					blockType: 'core/freeform'
-				}
+				} ]
 			} );
 
-			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 3 );
-			expect( state.order ).to.eql( [ 'kumquat', 'persimmon', 'loquat' ] );
+			expect( state ).to.equal( original );
 		} );
 	} );
 

--- a/element/index.js
+++ b/element/index.js
@@ -79,7 +79,7 @@ export function renderToString( element ) {
 export function concatChildren( ...childrens ) {
 	return childrens.reduce( ( memo, children, i ) => {
 		Children.forEach( children, ( child, j ) => {
-			if ( 'string' !== typeof child ) {
+			if ( child && 'string' !== typeof child ) {
 				child = cloneElement( child, {
 					key: [ i, j ].join()
 				} );

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -54,11 +54,11 @@ msgstr ""
 msgid "Freeform"
 msgstr ""
 
-#: blocks/library/heading/index.js:10
+#: blocks/library/heading/index.js:15
 msgid "Heading"
 msgstr ""
 
-#: blocks/library/heading/index.js:24
+#: blocks/library/heading/index.js:29
 msgid "Heading %s"
 msgstr ""
 
@@ -78,11 +78,11 @@ msgstr ""
 msgid "Justify"
 msgstr ""
 
-#: blocks/library/quote/index.js:11
+#: blocks/library/quote/index.js:16
 msgid "Quote"
 msgstr ""
 
-#: blocks/library/quote/index.js:35
+#: blocks/library/quote/index.js:40
 msgid "Quote style %d"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -54,11 +54,11 @@ msgstr ""
 msgid "Freeform"
 msgstr ""
 
-#: blocks/library/heading/index.js:15
+#: blocks/library/heading/index.js:10
 msgid "Heading"
 msgstr ""
 
-#: blocks/library/heading/index.js:29
+#: blocks/library/heading/index.js:24
 msgid "Heading %s"
 msgstr ""
 
@@ -78,11 +78,11 @@ msgstr ""
 msgid "Justify"
 msgstr ""
 
-#: blocks/library/quote/index.js:16
+#: blocks/library/quote/index.js:11
 msgid "Quote"
 msgstr ""
 
-#: blocks/library/quote/index.js:40
+#: blocks/library/quote/index.js:35
 msgid "Quote style %d"
 msgstr ""
 


### PR DESCRIPTION
refs #419 

This PR adds the support for the block switcher to the quote block.

**Question:**

While switching from a quote to heading, this PR is taking the first Paragraph of the quote only, we'll lose the other paragraphs and the citation. We should take a decision whether or not this is acceptable. The alternatives are: 
 * concat all the paragraphs and the citation with a space.
 * disable this transformation.
We should take a decision here to make this behaviour consistent for all the "Multi-paragraph" to "Single paragraph" switches. @jasmussen. This is also addressed in #465 for the text block.  
