### PR TITLE
Quote Block: Fix parsing a blockquote without a classname

### DIFF
--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -15,20 +15,25 @@ registerBlock( 'core/quote', {
 	attributes: {
 		value: query( 'blockquote > p', children() ),
 		citation: children( 'footer' ),
-		style: node => {
+		style: ( node ) => {
 			const value = attr( 'blockquote', 'class' )( node );
 			if ( ! value ) {
-				return 1;
+				return;
 			}
+
 			const match = value.match( /\bblocks-quote-style-(\d+)\b/ );
-			return match ? +match[ 1 ] : null;
+			if ( ! match ) {
+				return;
+			}
+
+			return Number( match[ 1 ] );
 		}
 	},
 
 	controls: [ 1, 2 ].map( ( variation ) => ( {
 		icon: 'format-quote',
 		title: wp.i18n.sprintf( wp.i18n.__( 'Quote style %d' ), variation ),
-		isActive: ( { style = 1 } ) => +style === +variation,
+		isActive: ( { style = 1 } ) => style === variation,
 		onClick( attributes, setAttributes ) {
 			setAttributes( { style: variation } );
 		},
@@ -36,8 +41,7 @@ registerBlock( 'core/quote', {
 	} ) ),
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
-		const { value, citation } = attributes;
-		const style = +attributes.style || 1;
+		const { value, citation, style = 1 } = attributes;
 
 		return (
 			<blockquote className={ `blocks-quote blocks-quote-style-${ style }` }>
@@ -70,8 +74,7 @@ registerBlock( 'core/quote', {
 	},
 
 	save( attributes ) {
-		const { value, citation } = attributes;
-		const style = +attributes.style || 1;
+		const { value, citation, style = 1 } = attributes;
 
 		return (
 			<blockquote className={ `blocks-quote-style-${ style }` }>

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -17,6 +17,9 @@ registerBlock( 'core/quote', {
 		citation: children( 'footer' ),
 		style: node => {
 			const value = attr( 'blockquote', 'class' )( node );
+			if ( ! value ) {
+				return 1;
+			}
 			const match = value.match( /\bblocks-quote-style-(\d+)\b/ );
 			return match ? +match[ 1 ] : null;
 		}

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -55,7 +55,7 @@ msgstr ""
 msgid "Quote"
 msgstr ""
 
-#: blocks/library/quote/index.js:30
+#: blocks/library/quote/index.js:35
 msgid "Quote style %d"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -55,7 +55,7 @@ msgstr ""
 msgid "Quote"
 msgstr ""
 
-#: blocks/library/quote/index.js:27
+#: blocks/library/quote/index.js:30
 msgid "Quote style %d"
 msgstr ""
 

--- a/post-content.js
+++ b/post-content.js
@@ -22,7 +22,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/quote -->',
-			'<blockquote class="blocks-quote-style-2"><p>Real artists ship.</p><footer><p><a href="http://www.folklore.org/StoryView.py?story=Real_Artists_Ship.txt">Steve Jobs, 1983</a></p></footer></blockquote>',
+			'<blockquote><p>Real artists ship.</p><footer><p><a href="http://www.folklore.org/StoryView.py?story=Real_Artists_Ship.txt">Steve Jobs, 1983</a></p></footer></blockquote>',
 			'<!-- /wp:core/quote -->',
 
 			'<!-- wp:core/image -->',


### PR DESCRIPTION
This PR fixes parsing a blockquote without a classname, and returns `1` as the default styling for quotes without classnames.