### PR TITLE
Image Block: Fix adding an image caption to the image block

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -138,6 +138,7 @@ export default class Editable extends wp.element.Component {
 
 	componentWillUnmount() {
 		if ( this.editor ) {
+			this.onChange();
 			this.editor.destroy();
 		}
 	}


### PR DESCRIPTION
This tiny PR fixes adding a caption to an image block with an empty caption. The edited caption was not saved because we're destroying the editor before the `onFocusOut` (that triggers `onChange`) is being called, thus, the value was not saved.

You can experience the same bug with the quote citation.