### PR TITLE
Update hover styles

### DIFF
--- a/editor/components/button/style.scss
+++ b/editor/components/button/style.scss
@@ -11,4 +11,10 @@
 		background: $dark-gray-500;
 		color: $white;
 	}
+
+	&.is-toggled:hover {
+		color: $white;
+		background: $dark-gray-400;
+	}
+
 }

--- a/editor/components/toolbar/style.scss
+++ b/editor/components/toolbar/style.scss
@@ -22,11 +22,14 @@
 	}
 
 	&.is-active,
-	&:hover {
+	&:hover,
+	&:not(:disabled):hover {
 		border-color: $dark-gray-500;
+		color: $dark-gray-500;
 	}
 
-	&.is-active {
+	&.is-active,
+	&.is-active:hover {
 		background-color: $dark-gray-500;
 		color: $white;
 	}


### PR DESCRIPTION
This is a tiny PR that updates the hover styles of our various buttons. 

In order to avoid some !importants, I had to up the specificity a bit to use the same button component but with differing hover styles for the body and the toolbar. For formatting controls we want a border, and no color change. For the Editor Bar, we want a blue hover color. 