### PR TITLE
Polish the block switcher styles

### DIFF
--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -1,4 +1,7 @@
 .blocks-editable {
+	position: relative;
+	z-index: -1;
+
 	> p:first-child {
 		margin-top: 0;
 	}

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -64,7 +64,6 @@ class BlockSwitcher extends wp.element.Component {
 				</IconButton>
 				{ this.state.open &&
 					<div className="editor-block-switcher__menu">
-						<div className="editor-block-switcher__menu-arrow" />
 						{ allowedBlocks.map( ( { slug, title, icon } ) => (
 							<IconButton
 								key={ slug }

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -11,6 +11,7 @@
 .editor-block-switcher__toggle {
 	width: auto;
 	margin: 3px;
+	padding: 6px;
 }
 
 .editor-block-switcher__arrow {
@@ -25,6 +26,10 @@
 	border-bottom: none;
 	border-left-color: transparent;
 	border-right-color: transparent;
+
+	.editor-block-switcher__toggle:hover & {
+		border-top-color: $blue-medium;
+	}
 }
 
 .editor-block-switcher__menu {

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -34,7 +34,8 @@
 
 .editor-block-switcher__menu {
 	position: absolute;
-	top: 50px;
+	top: 43px;
+	margin-left: -1px;
 	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
 	background: #fff;
@@ -42,35 +43,6 @@
 
 	input {
 		font-size: 13px;
-	}
-}
-
-.editor-block-switcher__menu-arrow {
-	border: 10px dashed $light-gray-500;
-	height: 0;
-	line-height: 0;
-	position: absolute;
-	width: 0;
-	z-index: 1;
-	top: -10px;
-	left: 50%;
-	margin-left: -10px;
-	border-bottom-style: solid;
-	border-top: none;
-	border-left-color: transparent;
-	border-right-color: transparent;
-
-	&:before {
-		top: 2px;
-		border: 10px solid $white;
-		content: " ";
-		position: absolute;
-		left: 50%;
-		margin-left: -10px;
-		border-bottom-style: solid;
-		border-top: none;
-		border-left-color: transparent;
-		border-right-color: transparent;
 	}
 }
 
@@ -84,7 +56,9 @@
 	color: $dark-gray-500;
 	cursor: pointer;
 
-	&:hover {
+	&:hover,
+	&:not(:disabled):hover {
+		color: $dark-gray-500;
 		border-color: $dark-gray-500;
 	}
 


### PR DESCRIPTION
This PR adds a little polish to the block switcher. 

- It normalizes padding, which fixes an alignment issue
- It adjusts hover colors
- It removes the arrow from the dropdown —  I'm still chewing on this one but let's try out out for size

One thing that needs an extra pair of eyes is that I added a negative z index on `.blocks-editable`. It seems a recent change to that component added a `position: relative;` inline style. Which is fine, but it also caused the switcher to .. underlap, is that a word? ... the contents of the block, regardless of how high a z index the switcher had. By giving the editable a negative z index this fixes that. But I can't quite predict the consequences. 