### PR TITLE
Editable: Fix focusing the editable component

### DIFF
--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -1,6 +1,5 @@
 .blocks-editable {
 	position: relative;
-	z-index: -1;
 
 	> p:first-child {
 		margin-top: 0;

--- a/editor/components/block-switcher/style.scss
+++ b/editor/components/block-switcher/style.scss
@@ -39,7 +39,6 @@
 	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
 	background: #fff;
-	z-index: 1;
 
 	input {
 		font-size: 13px;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -45,6 +45,7 @@
 	margin-bottom: -4px;
 	left: 43px;
 	display: flex;
+	z-index: 1;
 }
 
 .editor-visual-editor__block-controls .editor-toolbar {


### PR DESCRIPTION
This fixed the regression introduced by #492 while we were not able to focus the Editable.
In the same time it ensures the block switcher is shown above the `Editable` component.