### PR TITLE
Assign control isActive as boolean

### DIFF
--- a/editor/components/toolbar/index.js
+++ b/editor/components/toolbar/index.js
@@ -27,7 +27,7 @@ function Toolbar( { controls } ) {
 						control.onClick();
 					} }
 					className={ classNames( 'editor-toolbar__control', {
-						'is-active': control.isActive && control.isActive()
+						'is-active': control.isActive
 					} ) } />
 			) ) }
 		</ul>

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -158,7 +158,7 @@ class VisualEditorBlock extends wp.element.Component {
 								controls={ settings.controls.map( ( control ) => ( {
 									...control,
 									onClick: () => control.onClick( block.attributes, this.setAttributes ),
-									isActive: () => control.isActive( block.attributes )
+									isActive: control.isActive( block.attributes )
 								} ) ) } />
 						) }
 						{ this.state.hasEditable && (
@@ -166,7 +166,7 @@ class VisualEditorBlock extends wp.element.Component {
 								controls={ formattingControls.map( ( control ) => ( {
 									...control,
 									onClick: () => this.toggleFormat( control.format ),
-									isActive: () => !! this.state.formats[ control.format ]
+									isActive: !! this.state.formats[ control.format ]
 								} ) ) } />
 						) }
 					</div>


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/460#discussion_r112552048

This pull request seeks to change the behavior of the `<Toolbar />` component's `control.isActive` from a function to plain boolean. Since it's currently never the case that we need to asynchronously determine the active value, there's no real need for it to be treated as a callback.

__Testing instructions:__

Verify that button active (selected) states behave as expected, between both the block controls (e.g. text alignment) and formatting controls (e.g. bold, italic, see #460).