### PR TITLE
Replace babel-preset-latest with babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,17 @@
 {
 	"presets": [
-		[ "latest", {
-			"es2015": {
-				"modules": false
+		[ "env", {
+			"modules": false,
+			"targets": {
+				"browsers": [
+					"last 2 Chrome versions",
+					"last 2 Firefox versions",
+					"last 2 Safari versions",
+					"last 2 iOS versions",
+					"last 1 Android version",
+					"last 1 ChromeAndroid version",
+					"ie 11"
+				]
 			}
 		} ]
 	],
@@ -20,7 +29,7 @@
 			]
 		},
 		"test": {
-			"presets": [ "latest" ]
+			"presets": [ "env" ]
 		},
 		"gettext": {
 			"plugins": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-latest": "^6.24.0",
+    "babel-preset-env": "^1.4.0",
     "chai": "^3.5.0",
     "concurrently": "^3.4.0",
     "cross-env": "^3.2.4",


### PR DESCRIPTION
`babel-preset-latest` [has been deprecated](https://babeljs.io/docs/plugins/preset-latest/) in favor of [`babel-preset-env`](https://babeljs.io/docs/plugins/preset-env/). With consideration of [recent browser support changes](https://make.wordpress.org/core/), combined with [previously established browser support](https://make.wordpress.org/design/handbook/browser-support/), browser targets have been configured as follows:

```json
[
	"last 2 Chrome versions",
	"last 2 Firefox versions",
	"last 2 Safari versions",
	"last 2 iOS versions",
	"last 1 Android version",
	"last 1 ChromeAndroid version",
	"ie 11"
]
```

The advantage of defining browser support explicitly is that Babel can optimize to remove unnecessary transformations when supported by all supported versions.

__Testing instructions:__

Verify that build completes without errors.