### PR TITLE
Validate block settings for edit() and save()

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -43,6 +43,13 @@ export function registerBlock( slug, settings ) {
 		);
 		return;
 	}
+	if ( true !== validateBlockSettings( settings ) ) {
+		console.error(
+			'Block not registered.'
+		);
+		// Return the block even though it was not registered.
+		return Object.assign( { slug }, settings );
+	}
 	const block = Object.assign( { slug }, settings );
 	blocks[ slug ] = block;
 	return block;
@@ -103,4 +110,35 @@ export function getBlockSettings( slug ) {
  */
 export function getBlocks() {
 	return Object.values( blocks );
+}
+
+/**
+ * Validates the block settings.
+ *
+ * @param  {Object}  settings Block settings.
+ * @return {Boolean} Whether the block settings are valid.
+ */
+export function validateBlockSettings( settings ) {
+	if ( ! settings ) {
+		console.error(
+			'Block settings must specify a save() and edit() method for each block.'
+		);
+		return false;
+	}
+
+	if ( ! settings.save || 'function' !== typeof settings.save ) {
+		console.error(
+			'Block settings must specify a save() method for each block.'
+		);
+		return false;
+	}
+
+	if ( ! settings.edit || 'function' !== typeof settings.edit ) {
+		console.error(
+			'Block settings must specify a edit() method for each block.'
+		);
+		return false;
+	}
+
+	return true;
 }

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import { createBlock, switchToBlockType } from '../factory';
 import { getBlocks, unregisterBlock, setUnknownTypeHandler, registerBlock } from '../registration';
+import { edit, save } from './function-refs';
 
 describe( 'block factory', () => {
 	afterEach( () => {
@@ -43,9 +44,14 @@ describe( 'block factory', () => {
 							};
 						}
 					} ]
-				}
+				},
+				edit: edit,
+				save: save
 			} );
-			registerBlock( 'core/text-block', {} );
+			registerBlock( 'core/text-block', {
+				edit: edit,
+				save: save
+			} );
 
 			const block = {
 				uid: 1,
@@ -67,7 +73,10 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should switch the blockType of a block using the "transform to"', () => {
-			registerBlock( 'core/updated-text-block', {} );
+			registerBlock( 'core/updated-text-block', {
+				edit: edit,
+				save: save
+			} );
 			registerBlock( 'core/text-block', {
 				transforms: {
 					to: [ {
@@ -78,7 +87,9 @@ describe( 'block factory', () => {
 							};
 						}
 					} ]
-				}
+				},
+				edit: edit,
+				save: save
 			} );
 
 			const block = {
@@ -101,8 +112,14 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should return null if no transformation is found', () => {
-			registerBlock( 'core/updated-text-block', {} );
-			registerBlock( 'core/text-block', {} );
+			registerBlock( 'core/updated-text-block', {
+				edit: edit,
+				save: save
+			} );
+			registerBlock( 'core/text-block', {
+				edit: edit,
+				save: save
+			} );
 
 			const block = {
 				uid: 1,

--- a/blocks/api/test/function-refs.js
+++ b/blocks/api/test/function-refs.js
@@ -1,0 +1,13 @@
+/**
+ * Function references used so that Chai doesn't complain about functions
+ * not being equal.
+ *
+ * These are methods that should be assigned to a valid block.
+ */
+export const edit = function edit() {
+	'tacos';
+};
+
+export const save = function save() {
+	'delicious';
+};

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -19,6 +19,10 @@ import {
 	getBlocks,
 	setUnknownTypeHandler,
 } from '../registration';
+import {
+	edit,
+	save
+} from './function-refs.js';
 
 describe( 'block parser', () => {
 	afterEach( () => {
@@ -87,7 +91,10 @@ describe( 'block parser', () => {
 
 	describe( 'createBlockWithFallback', () => {
 		it( 'should create the requested block if it exists', () => {
-			registerBlock( 'core/test-block', {} );
+			registerBlock( 'core/test-block', {
+				edit: edit,
+				save: save
+			} );
 
 			const block = createBlockWithFallback(
 				'core/test-block',
@@ -99,7 +106,10 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should create the requested block with no attributes if it exists', () => {
-			registerBlock( 'core/test-block', {} );
+			registerBlock( 'core/test-block', {
+				edit: edit,
+				save: save
+			} );
 
 			const block = createBlockWithFallback( 'core/test-block', 'content' );
 			expect( block.blockType ).to.eql( 'core/test-block' );
@@ -107,7 +117,10 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should fall back to the unknown type handler for unknown blocks if present', () => {
-			registerBlock( 'core/unknown-block', {} );
+			registerBlock( 'core/unknown-block', {
+				edit: edit,
+				save: save
+			} );
 			setUnknownTypeHandler( 'core/unknown-block' );
 
 			const block = createBlockWithFallback(
@@ -120,7 +133,10 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should fall back to the unknown type handler if block type not specified', () => {
-			registerBlock( 'core/unknown-block', {} );
+			registerBlock( 'core/unknown-block', {
+				edit: edit,
+				save: save
+			} );
 			setUnknownTypeHandler( 'core/unknown-block' );
 
 			const block = createBlockWithFallback( null, 'content' );
@@ -142,7 +158,9 @@ describe( 'block parser', () => {
 					return {
 						content: rawContent,
 					};
-				}
+				},
+				edit: edit,
+				save: save
 			} );
 
 			const parsed = parse(
@@ -166,7 +184,9 @@ describe( 'block parser', () => {
 					return {
 						content: rawContent + ' & Chicken'
 					};
-				}
+				},
+				edit: edit,
+				save: save
 			} );
 
 			const parsed = parse(
@@ -184,8 +204,14 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should parse the post content, using unknown block handler', () => {
-			registerBlock( 'core/test-block', {} );
-			registerBlock( 'core/unknown-block', {} );
+			registerBlock( 'core/test-block', {
+				edit: edit,
+				save: save
+			} );
+			registerBlock( 'core/unknown-block', {
+				edit: edit,
+				save: save
+			} );
 
 			setUnknownTypeHandler( 'core/unknown-block' );
 
@@ -204,14 +230,19 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should parse the post content, including raw HTML at each end', () => {
-			registerBlock( 'core/test-block', {} );
+			registerBlock( 'core/test-block', {
+				edit: edit,
+				save: save
+			} );
 			registerBlock( 'core/unknown-block', {
 				// Currently this is the only way to test block content parsing?
 				attributes: function( rawContent ) {
 					return {
 						content: rawContent,
 					};
-				}
+				},
+				edit: edit,
+				save: save
 			} );
 
 			setUnknownTypeHandler( 'core/unknown-block' );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -8,6 +8,9 @@ import { expect } from 'chai';
  */
 import serialize, { getCommentAttributes, getSaveContent } from '../serializer';
 import { getBlocks, registerBlock, unregisterBlock } from '../registration';
+import {
+	edit
+} from './function-refs';
 
 describe( 'block serializer', () => {
 	afterEach( () => {
@@ -97,7 +100,8 @@ describe( 'block serializer', () => {
 				},
 				save( { attributes } ) {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;
-				}
+				},
+				edit
 			};
 			registerBlock( 'core/test-block', blockSettings );
 			const blockList = [

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -16,11 +16,18 @@ import {
 	isSidebarOpened,
 	createReduxStore
 } from '../state';
+import {
+	edit,
+	save
+} from '../../blocks/api/test/function-refs';
 
 describe( 'state', () => {
 	describe( 'blocks()', () => {
 		before( () => {
-			wp.blocks.registerBlock( 'core/test-block', {} );
+			wp.blocks.registerBlock( 'core/test-block', {
+				edit: edit,
+				save: save
+			} );
 		} );
 
 		after( () => {


### PR DESCRIPTION
Fixes #362. Validates that a block has a `save()` and `edit()`.  This is
probably a temporary solution.  The API should probably be cleaned up a
bit so everything is not quite as coupled and tests can be done
differently.