### PR TITLE
Text Block: Fix updating the content of an empty text block

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -42,6 +42,7 @@ export function getBlockAttributes( blockSettings, rawContent, attributes ) {
 	if ( blockSettings ) {
 		attributes = {
 			...attributes,
+			...blockSettings.defaultAttributes,
 			...parseBlockAttributes( rawContent, blockSettings ),
 		};
 	}

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -66,12 +66,15 @@ describe( 'block parser', () => {
 	} );
 
 	describe( 'getBlockAttributes()', () => {
-		it( 'should merge attributes with the parsed attributes', () => {
+		it( 'should merge attributes with the parsed and default attributes', () => {
 			const blockSettings = {
 				attributes: function( rawContent ) {
 					return {
 						content: rawContent + ' & Chicken'
 					};
+				},
+				defaultAttributes: {
+					topic: 'none'
 				}
 			};
 
@@ -80,6 +83,7 @@ describe( 'block parser', () => {
 
 			expect( getBlockAttributes( blockSettings, rawContent, attrs ) ).to.eql( {
 				align: 'left',
+				topic: 'none',
 				content: 'Ribs & Chicken'
 			} );
 		} );

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -261,7 +261,8 @@ export default class Editable extends wp.element.Component {
 
 		if (
 			this.props.tagName === prevProps.tagName &&
-			this.props.value !== prevProps.value
+			this.props.value !== prevProps.value &&
+			! isEqual( this.props.value, prevProps.value )
 		) {
 			this.updateContent();
 		}

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -17,6 +17,10 @@ registerBlock( 'core/text', {
 		content: children(),
 	},
 
+	defaultAttributes: {
+		content: <p />
+	},
+
 	controls: [
 		{
 			icon: 'editor-alignleft',
@@ -51,7 +55,7 @@ registerBlock( 'core/text', {
 	},
 
 	edit( { attributes, setAttributes, insertBlockAfter, focus, setFocus, mergeWithPrevious } ) {
-		const { content = <p />, align } = attributes;
+		const { content, align } = attributes;
 
 		return (
 			<Editable

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -42,19 +42,19 @@ msgstr ""
 
 #: blocks/library/image/index.js:41
 #: blocks/library/list/index.js:25
-#: blocks/library/text/index.js:23
+#: blocks/library/text/index.js:27
 msgid "Align left"
 msgstr ""
 
 #: blocks/library/image/index.js:47
 #: blocks/library/list/index.js:33
-#: blocks/library/text/index.js:31
+#: blocks/library/text/index.js:35
 msgid "Align center"
 msgstr ""
 
 #: blocks/library/image/index.js:53
 #: blocks/library/list/index.js:41
-#: blocks/library/text/index.js:39
+#: blocks/library/text/index.js:43
 msgid "Align right"
 msgstr ""
 


### PR DESCRIPTION
Treating `Editable`'s value as a React Element introduced a regression when updating the content of an empty text block. The content of the text block was constantly being reset to "empty" because the `updateContent` was called too many times.

This fix may cause a performance loss (not noticeable right now for me).