### PR TITLE
Image Block: Add "full width" control option

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -59,12 +59,18 @@ registerBlock( 'core/image', {
 			title: wp.i18n.__( 'No alignment' ),
 			isActive: ( { align } ) => ! align || 'none' === align,
 			onClick: applyOrUnset( 'none' )
+		},
+		{
+			icon: 'align-full-width',
+			title: wp.i18n.__( 'Wide width' ),
+			isActive: ( { align } ) => 'wide' === align,
+			onClick: applyOrUnset( 'wide' )
 		}
 	],
 
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
-		if ( 'left' === align || 'right' === align ) {
+		if ( 'left' === align || 'right' === align || 'wide' === align ) {
 			return { 'data-align': align };
 		}
 	},

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -15,6 +15,24 @@
 		float: right;
 		margin-left: 15px;
 	}
+
+	&[data-align="wide"] {
+		left: 0;
+		padding-left: 0;
+		padding-right: 0;
+		width: 100%;
+		max-width: none;
+
+		&:before {
+			left: 0;
+			border-left-width: 0;
+			border-right-width: 0;
+		}
+
+		.editor-block-mover {
+			display: none;
+		}
+	}
 }
 
 .blocks-image {
@@ -22,5 +40,6 @@
 
 	img {
 		display: block;
+		width: 100%;
 	}
 }

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -17,11 +17,57 @@
 	}
 
 	&[data-align="wide"] {
-		left: 0;
+		// Here be dragons...
+		//
+		// Variable offsets:
+		//  - Left sidebar
+		//   - Hidden at small viewports
+		//   - Foldable
+		//   - Expanded at medium and above
+		//  - Post settings
+		//   - Collapsed
+		//   - Expanded
+
+		left: 50%;
+		right: 50%;
+		margin-left: -50vw;
+		margin-right: -50vw;
+		width: 100vw;
 		padding-left: 0;
 		padding-right: 0;
-		width: 100%;
 		max-width: none;
+
+		.editor-layout.is-sidebar-opened & {
+			margin-left: calc( -50vw + #{ $sidebar-width / 2 } );
+			margin-right: calc( -50vw + #{ $sidebar-width / 2 } );
+			width: calc( 100vw - #{ $sidebar-width } );
+		}
+
+		@include break-medium() {
+			margin-left: calc( -50vw + 80px );
+			margin-right: calc( -50vw + 80px );
+			width: calc( 100vw - 160px );
+
+			.auto-fold &,
+			.folded & {
+				margin-left: calc( -50vw + 18px );
+				margin-right: calc( -50vw + 18px );
+				width: calc( 100vw - 36px );
+			}
+
+			.editor-layout.is-sidebar-opened & {
+				margin-left: calc( -50vw + 80px + #{ $sidebar-width / 2 } );
+				margin-right: calc( -50vw + 80px + #{ $sidebar-width / 2 } );
+				width: calc( 100vw - 160px - #{ $sidebar-width } );
+
+				.auto-fold &,
+				.folded & {
+					margin-left: calc( -50vw + 18px + #{ $sidebar-width / 2 } );
+					margin-right: calc( -50vw + 18px + #{ $sidebar-width / 2 } );
+					width: calc( 100vw - 36px - #{ $sidebar-width } );
+				}
+			}
+		}
 
 		&:before {
 			left: 0;

--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -1,3 +1,7 @@
-.editor-layout.is-sidebar-opened .editor-layout__content {
-	margin-right: $sidebar-width;
+.editor-layout__content {
+	overflow: hidden;
+
+	.editor-layout.is-sidebar-opened & {
+		margin-right: $sidebar-width;
+	}
 }

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -16,7 +16,9 @@ function VisualEditor( { blocks } ) {
 			{ blocks.map( ( uid ) => (
 				<VisualEditorBlock key={ uid } uid={ uid } />
 			) ) }
-			<Inserter />
+			<div className="editor-visual-editor__container">
+				<Inserter />
+			</div>
 		</div>
 	);
 }

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -16,9 +16,7 @@ function VisualEditor( { blocks } ) {
 			{ blocks.map( ( uid ) => (
 				<VisualEditorBlock key={ uid } uid={ uid } />
 			) ) }
-			<div className="editor-visual-editor__container">
-				<Inserter />
-			</div>
+			<Inserter />
 		</div>
 	);
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -19,7 +19,6 @@
 	position: relative;
 	left: -35px;
 	padding: 15px 15px 15px 50px;
-	border: 2px solid transparent;
 	transition: 0.2s border-color;
 
 	&:before {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -1,6 +1,5 @@
 .editor-visual-editor {
-	margin: 60px auto 0;
-	width: 700px;
+	margin-top: 60px;
 
 	&,
 	& p {
@@ -10,12 +9,18 @@
 	}
 }
 
+.editor-visual-editor__block,
+.editor-visual-editor__container {
+	max-width: 700px;
+	margin: 0 auto;
+}
+
 .editor-visual-editor__block {
 	position: relative;
+	left: -35px;
+	padding: 15px 15px 15px 50px;
 	border: 2px solid transparent;
 	transition: 0.2s border-color;
-	margin-left: -35px;
-	padding: 15px 15px 15px 50px;
 
 	&:before {
 		z-index: -1;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -1,5 +1,6 @@
 .editor-visual-editor {
-	margin-top: 60px;
+	margin: 60px auto 0;
+	max-width: 700px;
 
 	&,
 	& p {
@@ -7,12 +8,6 @@
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
 	}
-}
-
-.editor-visual-editor__block,
-.editor-visual-editor__container {
-	max-width: 700px;
-	margin: 0 auto;
 }
 
 .editor-visual-editor__block {

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -46,7 +46,7 @@ msgid "Embed"
 msgstr ""
 
 #: blocks/library/embed/index.js:33
-#: blocks/library/image/index.js:81
+#: blocks/library/image/index.js:87
 msgid "Write caption…"
 msgstr ""
 
@@ -68,6 +68,10 @@ msgstr ""
 
 #: blocks/library/image/index.js:59
 msgid "No alignment"
+msgstr ""
+
+#: blocks/library/image/index.js:65
+msgid "Wide width"
 msgstr ""
 
 #: blocks/library/list/index.js:11


### PR DESCRIPTION
Related: #310
Related: #416

This pull request seeks to add a new "Full width" option to the image block controls, intended for cases where the image is to break out of any constraining container.

![full](https://cloud.githubusercontent.com/assets/1779930/25454439/6cba5d1e-2a9a-11e7-9c43-7468f8a11950.gif)

__Open questions:__

- Label name? There's some heated debate in the original issue.

__Testing instructions:__

Verify that the full width option can be toggled like other image alignment controls (#416), and that it visually breaks out of the editor container. 

__Future considerations:__

- Currently I'm using an `align-center` icon, as there's not a Dashicon yet which fits well for the intended action. @jasmussen [has committed to incorporating one](https://wordpress.slack.com/archives/C02QB2JS7/p1493236482591946?thread_ts=1493114261.780578&cid=C02QB2JS7).
- As a new option, existing themes are unlikely to support this. We'll need to consider some hooks by which a theme can define its support and conditionally show the control.