### PR TITLE
Editable: Adding an inline link control to the format toolbar

### DIFF
--- a/blocks/components/editable/format-toolbar.js
+++ b/blocks/components/editable/format-toolbar.js
@@ -69,6 +69,9 @@ class FormatToolbar extends wp.element.Component {
 		if ( ! this.props.formats.link ) {
 			// TODO find a way to add an empty link to TinyMCE
 			this.props.onChange( { link: { value: 'http://wordpress.org' } } );
+
+			// Debounce the call to avoid the reset in willReceiveProps
+			setTimeout( () => this.setState( { isEditingLink: true } ) );
 		}
 	}
 
@@ -104,8 +107,8 @@ class FormatToolbar extends wp.element.Component {
 			: null;
 
 		return (
-			<div>
-				<ul className="editable-format-toolbar editor-toolbar">
+			<div className="editable-format-toolbar">
+				<ul className="editor-toolbar">
 					{ FORMATTING_CONTROLS.map( ( control, index ) => (
 						<IconButton
 							key={ index }
@@ -131,7 +134,11 @@ class FormatToolbar extends wp.element.Component {
 						className="editable-format-toolbr__link-modal"
 						style={ linkStyle }
 						onSubmit={ this.submitLink }>
-						<input type="url" value={ this.state.linkValue } onChange={ this.updateLinkValue } />
+						<input
+							type="url"
+							value={ this.state.linkValue }
+							onChange={ this.updateLinkValue }
+						/>
 						<IconButton icon="editor-break" type="submit" />
 					</form>
 				}

--- a/blocks/components/editable/format-toolbar.js
+++ b/blocks/components/editable/format-toolbar.js
@@ -67,8 +67,7 @@ class FormatToolbar extends wp.element.Component {
 
 	addLink() {
 		if ( ! this.props.formats.link ) {
-			// TODO find a way to add an empty link to TinyMCE
-			this.props.onChange( { link: { value: 'http://wordpress.org' } } );
+			this.props.onChange( { link: { value: '' } } );
 
 			// Debounce the call to avoid the reset in willReceiveProps
 			setTimeout( () => this.setState( { isEditingLink: true } ) );
@@ -131,25 +130,28 @@ class FormatToolbar extends wp.element.Component {
 
 				{ !! formats.link && this.state.isEditingLink &&
 					<form
-						className="editable-format-toolbr__link-modal"
+						className="editable-format-toolbar__link-modal"
 						style={ linkStyle }
 						onSubmit={ this.submitLink }>
 						<input
+							className="editable-format-toolbar__link-input"
 							type="url"
+							required
 							value={ this.state.linkValue }
 							onChange={ this.updateLinkValue }
+							placeholder={ wp.i18n.__( 'Paste URL or type' ) }
 						/>
 						<IconButton icon="editor-break" type="submit" />
 					</form>
 				}
 
 				{ !! formats.link && ! this.state.isEditingLink &&
-					<div className="editable-format-toolbr__link-modal" style={ linkStyle }>
-						<a href="" onClick={ this.editLink }>
+					<div className="editable-format-toolbar__link-modal" style={ linkStyle }>
+						<a className="editable-format-toolbar__link-value" href="" onClick={ this.editLink }>
 							{ decodeURI( this.state.linkValue ) }
 						</a>
 						<IconButton icon="edit" onClick={ this.editLink } />
-						<IconButton icon="trash" onClick={ this.dropLink } />
+						<IconButton icon="editor-unlink" onClick={ this.dropLink } />
 					</div>
 				}
 			</div>

--- a/blocks/components/editable/format-toolbar.js
+++ b/blocks/components/editable/format-toolbar.js
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+ // TODO: We mustn't import by relative path traversing from blocks to editor
+ // as we're doing here; instead, we should consider a common components path.
+import IconButton from '../../../editor/components/icon-button';
+
+const formattingControls = [
+	{
+		icon: 'editor-bold',
+		title: wp.i18n.__( 'Bold' ),
+		format: 'bold'
+	},
+	{
+		icon: 'editor-italic',
+		title: wp.i18n.__( 'Italic' ),
+		format: 'italic'
+	},
+	{
+		icon: 'editor-strikethrough',
+		title: wp.i18n.__( 'Strikethrough' ),
+		format: 'strikethrough'
+	}
+];
+
+class FormatToolbar extends wp.element.Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			linkValue: ''
+		};
+		this.addLink = this.addLink.bind( this );
+		this.dropLink = this.dropLink.bind( this );
+		this.submitLink = this.submitLink.bind( this );
+		this.updateLinkValue = this.updateLinkValue.bind( this );
+	}
+
+	componentWillMount() {
+		this.setState( { linkValue: this.props.formats.link } );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.setState( { linkValue: nextProps.formats.link } );
+	}
+
+	toggleFormat( format ) {
+		return ( event ) => {
+			event.stopPropagation();
+			this.props.onChange( {
+				[ format ]: ! this.props.formats[ format ]
+			} );
+		};
+	}
+
+	addLink() {
+		if ( ! this.props.formats.link ) {
+			// TODO find a way to add an empty link to TinyMCE
+			this.props.onChange( { link: 'http://wordpress.org' } );
+		}
+	}
+
+	dropLink() {
+		this.props.onChange( { link: undefined } );
+	}
+
+	submitLink( event ) {
+		event.preventDefault();
+		this.props.onChange( { link: this.state.linkValue } );
+	}
+
+	updateLinkValue( event ) {
+		this.setState( {
+			linkValue: event.target.value
+		} );
+	}
+
+	render() {
+		const { formats, focusPosition } = this.props;
+		const linkStyle = focusPosition
+			? { position: 'absolute', ...focusPosition }
+			: {};
+
+		return (
+			<div>
+				<ul className="editable-format-toolbar editor-toolbar">
+					{ formattingControls.map( ( control, index ) => (
+						<IconButton
+							key={ index }
+							icon={ control.icon }
+							label={ control.title }
+							onClick={ this.toggleFormat( control.format ) }
+							className={ classNames( 'editor-toolbar__control', {
+								'is-active': !! formats[ control.format ]
+							} ) } />
+					) ) }
+					<IconButton
+						icon="admin-links"
+						label={ wp.i18n.__( 'Link' ) }
+						onClick={ this.addLink }
+						className={ classNames( 'editor-toolbar__control', {
+							'is-active': !! formats.link
+						} ) }
+					/>
+				</ul>
+
+				{ !! formats.link &&
+					<form
+						className="editable-format-toolbr__link-modal"
+						style={ linkStyle }
+						onSubmit={ this.submitLink }>
+						<input type="url" value={ this.state.linkValue } onChange={ this.updateLinkValue } />
+						<IconButton icon="editor-break" onClick={ this.submitLink } />
+						<IconButton icon="trash" onClick={ this.dropLink } />
+					</form>
+				}
+			</div>
+		);
+	}
+}
+
+export default FormatToolbar;

--- a/blocks/components/editable/format-toolbar.js
+++ b/blocks/components/editable/format-toolbar.js
@@ -6,13 +6,11 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import './style.scss';
-
  // TODO: We mustn't import by relative path traversing from blocks to editor
  // as we're doing here; instead, we should consider a common components path.
 import IconButton from '../../../editor/components/icon-button';
 
-const formattingControls = [
+const FORMATTING_CONTROLS = [
 	{
 		icon: 'editor-bold',
 		title: wp.i18n.__( 'Bold' ),
@@ -85,12 +83,12 @@ class FormatToolbar extends wp.element.Component {
 		const { formats, focusPosition } = this.props;
 		const linkStyle = focusPosition
 			? { position: 'absolute', ...focusPosition }
-			: {};
+			: null;
 
 		return (
 			<div>
 				<ul className="editable-format-toolbar editor-toolbar">
-					{ formattingControls.map( ( control, index ) => (
+					{ FORMATTING_CONTROLS.map( ( control, index ) => (
 						<IconButton
 							key={ index }
 							icon={ control.icon }
@@ -116,7 +114,7 @@ class FormatToolbar extends wp.element.Component {
 						style={ linkStyle }
 						onSubmit={ this.submitLink }>
 						<input type="url" value={ this.state.linkValue } onChange={ this.updateLinkValue } />
-						<IconButton icon="editor-break" onClick={ this.submitLink } />
+						<IconButton icon="editor-break" type="submit" />
 						<IconButton icon="trash" onClick={ this.dropLink } />
 					</form>
 				}

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -5,12 +5,13 @@ import classnames from 'classnames';
 import { last, isEqual, capitalize, omitBy } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 import { Fill } from 'react-slot-fill';
+import 'element-closest';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-
+import FormatToolbar from './format-toolbar';
  // TODO: We mustn't import by relative path traversing from blocks to editor
  // as we're doing here; instead, we should consider a common components path.
 import Toolbar from '../../../editor/components/toolbar';
@@ -21,24 +22,6 @@ const formatMap = {
 	em: 'italic',
 	del: 'strikethrough'
 };
-
-const FORMATTING_CONTROLS = [
-	{
-		icon: 'editor-bold',
-		title: wp.i18n.__( 'Bold' ),
-		format: 'bold'
-	},
-	{
-		icon: 'editor-italic',
-		title: wp.i18n.__( 'Italic' ),
-		format: 'italic'
-	},
-	{
-		icon: 'editor-strikethrough',
-		title: wp.i18n.__( 'Strikethrough' ),
-		format: 'strikethrough'
-	}
-];
 
 const ALIGNMENT_CONTROLS = [
 	{
@@ -86,6 +69,7 @@ export default class Editable extends wp.element.Component {
 		this.onFocus = this.onFocus.bind( this );
 		this.onNodeChange = this.onNodeChange.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
+		this.changeFormats = this.changeFormats.bind( this );
 		this.state = {
 			formats: {},
 			alignment: null
@@ -145,6 +129,15 @@ export default class Editable extends wp.element.Component {
 		this.savedContent = this.getContent();
 		this.editor.save();
 		this.props.onChange( this.savedContent );
+	}
+
+	getRelativePosition( node ) {
+		const editorPosition = this.editorNode.closest( '.editor-visual-editor__block' ).getBoundingClientRect();
+		const position = node.getBoundingClientRect();
+		return {
+			top: position.top - editorPosition.top + 40 + ( position.height ),
+			left: position.left - editorPosition.left - 157
+		};
 	}
 
 	isStartOfEditor() {
@@ -225,15 +218,16 @@ export default class Editable extends wp.element.Component {
 		} );
 	}
 
-	onNodeChange( { parents } ) {
+	onNodeChange( { element, parents } ) {
 		let alignment = null;
 		const formats = {};
-
 		parents.forEach( ( node ) => {
 			const tag = node.nodeName.toLowerCase();
 
 			if ( formatMap.hasOwnProperty( tag ) ) {
 				formats[ formatMap[ tag ] ] = true;
+			} else if ( tag === 'a' ) {
+				formats.link = node.getAttribute( 'href' );
 			}
 
 			if ( tag === 'p' ) {
@@ -241,12 +235,8 @@ export default class Editable extends wp.element.Component {
 			}
 		} );
 
-		if (
-			this.state.alignment !== alignment ||
-			! isEqual( this.state.formats, formats )
-		) {
-			this.setState( { alignment, formats } );
-		}
+		const focusPosition = this.getRelativePosition( element );
+		this.setState( { alignment, formats, focusPosition } );
 	}
 
 	bindEditorNode( ref ) {
@@ -326,14 +316,26 @@ export default class Editable extends wp.element.Component {
 		return !! this.state.formats[ format ];
 	}
 
-	toggleFormat( format ) {
+	changeFormats( formats ) {
 		this.editor.focus();
 
-		if ( this.isFormatActive( format ) ) {
-			this.editor.formatter.remove( format );
-		} else {
-			this.editor.formatter.apply( format );
-		}
+		Object.keys( formats ).forEach( format => {
+			const formatValue = formats[ format ];
+			if ( format === 'link' ) {
+				if ( formatValue !== undefined ) {
+					this.editor.execCommand( 'mceInsertLink', true, formatValue );
+				} else {
+					this.editor.execCommand( 'Unlink' );
+				}
+			} else {
+				const isActive = this.isFormatActive( format );
+				if ( isActive && ! formatValue ) {
+					this.editor.formatter.remove( format );
+				} else if ( ! isActive && formatValue ) {
+					this.editor.formatter.apply( format );
+				}
+			}
+		} );
 	}
 
 	isAlignmentActive( align ) {
@@ -373,13 +375,7 @@ export default class Editable extends wp.element.Component {
 								isActive: this.isAlignmentActive( control.align )
 							} ) ) } />
 					}
-
-					<Toolbar
-						controls={ FORMATTING_CONTROLS.map( ( control ) => ( {
-							...control,
-							onClick: () => this.toggleFormat( control.format ),
-							isActive: this.isFormatActive( control.format )
-						} ) ) } />
+					<FormatToolbar focusPosition={ this.state.focusPosition } formats={ this.state.formats } onChange={ this.changeFormats } />
 				</Fill>,
 				element
 			];

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { last, isEqual, capitalize, omitBy } from 'lodash';
+import { last, isEqual, capitalize, omitBy, forEach } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 import { Fill } from 'react-slot-fill';
 import 'element-closest';
@@ -319,8 +319,7 @@ export default class Editable extends wp.element.Component {
 	changeFormats( formats ) {
 		this.editor.focus();
 
-		Object.keys( formats ).forEach( format => {
-			const formatValue = formats[ format ];
+		forEach( formats, ( formatValue, format ) => {
 			if ( format === 'link' ) {
 				if ( formatValue !== undefined ) {
 					this.editor.execCommand( 'mceInsertLink', true, formatValue );

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -72,7 +72,8 @@ export default class Editable extends wp.element.Component {
 		this.changeFormats = this.changeFormats.bind( this );
 		this.state = {
 			formats: {},
-			alignment: null
+			alignment: null,
+			bookmark: null
 		};
 	}
 
@@ -227,7 +228,7 @@ export default class Editable extends wp.element.Component {
 			if ( formatMap.hasOwnProperty( tag ) ) {
 				formats[ formatMap[ tag ] ] = true;
 			} else if ( tag === 'a' ) {
-				formats.link = node.getAttribute( 'href' );
+				formats.link = { value: node.getAttribute( 'href' ), node };
 			}
 
 			if ( tag === 'p' ) {
@@ -236,7 +237,8 @@ export default class Editable extends wp.element.Component {
 		} );
 
 		const focusPosition = this.getRelativePosition( element );
-		this.setState( { alignment, formats, focusPosition } );
+		const bookmark = this.editor.selection.getBookmark( 2, true );
+		this.setState( { alignment, bookmark, formats, focusPosition } );
 	}
 
 	bindEditorNode( ref ) {
@@ -317,12 +319,14 @@ export default class Editable extends wp.element.Component {
 	}
 
 	changeFormats( formats ) {
-		this.editor.focus();
+		if ( this.state.bookmark ) {
+			this.editor.selection.moveToBookmark( this.state.bookmark );
+		}
 
 		forEach( formats, ( formatValue, format ) => {
 			if ( format === 'link' ) {
 				if ( formatValue !== undefined ) {
-					this.editor.execCommand( 'mceInsertLink', true, formatValue );
+					this.editor.execCommand( 'mceInsertLink', true, formatValue.value );
 				} else {
 					this.editor.execCommand( 'Unlink' );
 				}

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { last, isEqual, capitalize, omitBy, forEach } from 'lodash';
+import { last, isEqual, capitalize, omitBy, forEach, merge } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 import { Fill } from 'react-slot-fill';
 import 'element-closest';
@@ -89,6 +89,7 @@ export default class Editable extends wp.element.Component {
 			toolbar: false,
 			browser_spellcheck: true,
 			entity_encoding: 'raw',
+			convert_urls: false,
 			setup: this.onSetup,
 			formats: {
 				strikethrough: { inline: 'del' }
@@ -327,7 +328,11 @@ export default class Editable extends wp.element.Component {
 		forEach( formats, ( formatValue, format ) => {
 			if ( format === 'link' ) {
 				if ( formatValue !== undefined ) {
-					this.editor.execCommand( 'mceInsertLink', true, formatValue.value );
+					const anchor = this.editor.dom.getParent( this.editor.selection.getNode(), 'a' );
+					if ( ! anchor ) {
+						this.editor.formatter.remove( 'link' );
+					}
+					this.editor.formatter.apply( 'link', { href: formatValue.value }, anchor );
 				} else {
 					this.editor.execCommand( 'Unlink' );
 				}
@@ -339,6 +344,10 @@ export default class Editable extends wp.element.Component {
 					this.editor.formatter.apply( format );
 				}
 			}
+		} );
+
+		this.setState( {
+			formats: merge( this.state.formats, formats )
 		} );
 	}
 

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -252,6 +252,7 @@ export default class Editable extends wp.element.Component {
 		this.editor.selection.moveToBookmark( bookmark );
 		// Saving the editor on updates avoid unecessary onChanges calls
 		// These calls can make the focus jump
+
 		this.editor.save();
 	}
 

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -347,7 +347,7 @@ export default class Editable extends wp.element.Component {
 		} );
 
 		this.setState( {
-			formats: merge( this.state.formats, formats )
+			formats: merge( {}, this.state.formats, formats )
 		} );
 	}
 

--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -29,19 +29,38 @@ figcaption.blocks-editable {
 	display: inline-flex;
 }
 
-.editable-format-toolbr__link-modal {
+.editable-format-toolbar__link-modal {
 	position: absolute;
 	top: 42px;
 	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
 	background: #fff;
-	padding: 10px;
 	width: 250px;
 	display: inline-flex;
+	align-items: center;
+	font-family: $default-font;
+	font-size: $default-font-size;
+	line-height: $default-line-height;
+}
 
-	input {
-		font-size: 13px;
-		flex-grow: 1;
-		width: 100%;
+
+input.editable-format-toolbar__link-input {
+	padding: 10px;
+	font-size: 13px;
+	width: 100%;
+	border: none;
+	outline: none;
+	box-shadow: none;
+	flex-grow: 1;
+
+	&:focus {
+		border: none;
+		box-shadow: none;
+		outline: none;
 	}
+}
+
+.editable-format-toolbar__link-value {
+	padding: 10px;
+	flex-grow: 1;
 }

--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -23,3 +23,20 @@ figcaption.blocks-editable {
 		font-size: $default-font-size;
 	}
 }
+
+.editable-format-toolbr__link-modal {
+	position: absolute;
+	top: 42px;
+	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
+	border: 1px solid #e0e5e9;
+	background: #fff;
+	padding: 10px;
+	width: 250px;
+	display: inline-flex;
+
+	input {
+		font-size: 13px;
+		flex-grow: 1;
+		width: 100%;
+	}
+}

--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -24,6 +24,11 @@ figcaption.blocks-editable {
 	}
 }
 
+
+.editable-format-toolbar {
+	display: inline-flex;
+}
+
 .editable-format-toolbr__link-modal {
 	position: absolute;
 	top: 42px;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -147,7 +147,6 @@ class VisualEditorBlock extends wp.element.Component {
 				onClick={ onSelect }
 				onFocus={ onSelect }
 				onBlur={ this.maybeDeselect }
-				onKeyDown={ onStartTyping }
 				onMouseEnter={ onHover }
 				onMouseMove={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
@@ -171,14 +170,16 @@ class VisualEditorBlock extends wp.element.Component {
 						<Slot name="Formatting.Toolbar" />
 					</div>
 				}
-				<BlockEdit
-					focus={ focus }
-					attributes={ block.attributes }
-					setAttributes={ this.setAttributes }
-					insertBlockAfter={ onInsertAfter }
-					setFocus={ partial( onFocus, block.uid ) }
-					mergeWithPrevious={ this.mergeWithPrevious }
-				/>
+				<div onKeyDown={ onStartTyping }>
+					<BlockEdit
+						focus={ focus }
+						attributes={ block.attributes }
+						setAttributes={ this.setAttributes }
+						insertBlockAfter={ onInsertAfter }
+						setFocus={ partial( onFocus, block.uid ) }
+						mergeWithPrevious={ this.mergeWithPrevious }
+					/>
+				</div>
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -140,7 +140,7 @@ class VisualEditorBlock extends wp.element.Component {
 
 		// Disable reason: Each block can be selected by clicking on it
 
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role */
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<div
 				ref={ this.bindBlockNode }

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,23 +3,23 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/components/editable/format-toolbar.js:123
-msgid "Link"
-msgstr ""
-
-#: blocks/components/editable/format-toolbar.js:142
-msgid "Paste URL or type"
-msgstr ""
-
-#: blocks/components/editable/format-toolbar.js:16
+#: blocks/components/editable/format-toolbar.js:12
 msgid "Bold"
 msgstr ""
 
-#: blocks/components/editable/format-toolbar.js:21
+#: blocks/components/editable/format-toolbar.js:121
+msgid "Link"
+msgstr ""
+
+#: blocks/components/editable/format-toolbar.js:139
+msgid "Paste URL or type"
+msgstr ""
+
+#: blocks/components/editable/format-toolbar.js:17
 msgid "Italic"
 msgstr ""
 
-#: blocks/components/editable/format-toolbar.js:26
+#: blocks/components/editable/format-toolbar.js:22
 msgid "Strikethrough"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,31 +3,35 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/components/editable/index.js:28
+#: blocks/components/editable/format-toolbar.js:105
+msgid "Link"
+msgstr ""
+
+#: blocks/components/editable/format-toolbar.js:18
 msgid "Bold"
 msgstr ""
 
-#: blocks/components/editable/index.js:33
+#: blocks/components/editable/format-toolbar.js:23
 msgid "Italic"
 msgstr ""
 
-#: blocks/components/editable/index.js:38
+#: blocks/components/editable/format-toolbar.js:28
 msgid "Strikethrough"
 msgstr ""
 
-#: blocks/components/editable/index.js:47
+#: blocks/components/editable/index.js:29
 #: blocks/library/image/index.js:41
 #: blocks/library/list/index.js:25
 msgid "Align left"
 msgstr ""
 
-#: blocks/components/editable/index.js:52
+#: blocks/components/editable/index.js:34
 #: blocks/library/image/index.js:47
 #: blocks/library/list/index.js:33
 msgid "Align center"
 msgstr ""
 
-#: blocks/components/editable/index.js:57
+#: blocks/components/editable/index.js:39
 #: blocks/library/image/index.js:53
 #: blocks/library/list/index.js:41
 msgid "Align right"

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,7 +3,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/components/editable/format-toolbar.js:121
+#: blocks/components/editable/format-toolbar.js:124
 msgid "Link"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,19 +3,19 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/components/editable/format-toolbar.js:105
+#: blocks/components/editable/format-toolbar.js:103
 msgid "Link"
 msgstr ""
 
-#: blocks/components/editable/format-toolbar.js:18
+#: blocks/components/editable/format-toolbar.js:16
 msgid "Bold"
 msgstr ""
 
-#: blocks/components/editable/format-toolbar.js:23
+#: blocks/components/editable/format-toolbar.js:21
 msgid "Italic"
 msgstr ""
 
-#: blocks/components/editable/format-toolbar.js:28
+#: blocks/components/editable/format-toolbar.js:26
 msgid "Strikethrough"
 msgstr ""
 

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,8 +3,12 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/components/editable/format-toolbar.js:124
+#: blocks/components/editable/format-toolbar.js:123
 msgid "Link"
+msgstr ""
+
+#: blocks/components/editable/format-toolbar.js:142
+msgid "Paste URL or type"
 msgstr ""
 
 #: blocks/components/editable/format-toolbar.js:16

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -3,7 +3,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "X-Generator: babel-plugin-wp-i18n\n"
 
-#: blocks/components/editable/format-toolbar.js:103
+#: blocks/components/editable/format-toolbar.js:121
 msgid "Link"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "dom-react": "^2.0.0",
+    "element-closest": "^2.0.2",
     "hpq": "^1.2.0",
     "jed": "^1.1.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This PR adds the link control to the formatting toolbar.

**Testing instructions**

- Try adding links and navigating inside an Editable.