### PR TITLE
Improve the inserter a11y

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -5,7 +5,7 @@
  * @var {Array} categories
  */
 const categories = [
-	{ slug: 'common', title: 'Common' }
+	{ slug: 'common', title: 'Common blocks' }
 ];
 
 /**

--- a/editor/components/icon-button/style.scss
+++ b/editor/components/icon-button/style.scss
@@ -1,8 +1,7 @@
 .editor-icon-button {
 	display: flex;
 	align-items: center;
-	min-width: 36px;
-	height: 36px;
+	padding: 8px;
 	border: none;
 	background: none;
 	color: $dark-gray-500;

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -49,7 +49,9 @@ class Inserter extends wp.element.Component {
 					icon="insert"
 					label={ wp.i18n.__( 'Insert block' ) }
 					onClick={ this.toggle }
-					className="editor-inserter__toggle" />
+					className="editor-inserter__toggle"
+					aria-haspopup="true"
+					aria-expanded={ opened ? 'true' : 'false' } />
 				{ opened && <InserterMenu position={ position } onSelect={ this.close } /> }
 			</div>
 		);

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -55,10 +55,21 @@ class InserterMenu extends wp.element.Component {
 					{ categories
 						.map( ( category ) => !! blocksByCategory[ category.slug ] && (
 							<div key={ category.slug }>
-								<div className="editor-inserter__separator">{ category.title }</div>
-								<div className="editor-inserter__category-blocks">
+								<div
+									className="editor-inserter__separator"
+									id={ `editor-inserter__separator-${ category.slug }` }
+									aria-hidden="true"
+								>
+									{ category.title }
+								</div>
+								<div
+									className="editor-inserter__category-blocks"
+									role="menu"
+									aria-labelledby={ `editor-inserter__separator-${ category.slug }` }
+								>
 									{ blocksByCategory[ category.slug ].map( ( { slug, title, icon } ) => (
 										<button
+											role="menuitem"
 											key={ slug }
 											className="editor-inserter__block"
 											onClick={ this.selectBlock( slug ) }
@@ -72,7 +83,11 @@ class InserterMenu extends wp.element.Component {
 						) )
 					}
 				</div>
+				<label htmlFor={ `editor-inserter__search-${ position }` } className="screen-reader-text">
+					{ wp.i18n.__( 'Search blocks' ) }
+				</label>
 				<input
+					id={ `editor-inserter__search-${ position }` }
 					type="search"
 					placeholder={ wp.i18n.__( 'Search…' ) }
 					className="editor-inserter__search"

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -65,6 +65,7 @@ class InserterMenu extends wp.element.Component {
 								<div
 									className="editor-inserter__category-blocks"
 									role="menu"
+									tabIndex="0"
 									aria-labelledby={ `editor-inserter__separator-${ category.slug }` }
 								>
 									{ blocksByCategory[ category.slug ].map( ( { slug, title, icon } ) => (

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -16,6 +16,7 @@ class InserterMenu extends wp.element.Component {
 			filterValue: ''
 		};
 		this.filter = this.filter.bind( this );
+		this.instanceId = this.constructor.instances++;
 	}
 
 	filter( event ) {
@@ -57,7 +58,7 @@ class InserterMenu extends wp.element.Component {
 							<div key={ category.slug }>
 								<div
 									className="editor-inserter__separator"
-									id={ `editor-inserter__separator-${ category.slug }` }
+									id={ `editor-inserter__separator-${ category.slug }-${ this.instanceId }` }
 									aria-hidden="true"
 								>
 									{ category.title }
@@ -66,7 +67,7 @@ class InserterMenu extends wp.element.Component {
 									className="editor-inserter__category-blocks"
 									role="menu"
 									tabIndex="0"
-									aria-labelledby={ `editor-inserter__separator-${ category.slug }` }
+									aria-labelledby={ `editor-inserter__separator-${ category.slug }-${ this.instanceId }` }
 								>
 									{ blocksByCategory[ category.slug ].map( ( { slug, title, icon } ) => (
 										<button
@@ -84,11 +85,11 @@ class InserterMenu extends wp.element.Component {
 						) )
 					}
 				</div>
-				<label htmlFor={ `editor-inserter__search-${ position }` } className="screen-reader-text">
+				<label htmlFor={ `editor-inserter__search-${ this.instanceId }` } className="screen-reader-text">
 					{ wp.i18n.__( 'Search blocks' ) }
 				</label>
 				<input
-					id={ `editor-inserter__search-${ position }` }
+					id={ `editor-inserter__search-${ this.instanceId }` }
 					type="search"
 					placeholder={ wp.i18n.__( 'Search…' ) }
 					className="editor-inserter__search"
@@ -98,6 +99,8 @@ class InserterMenu extends wp.element.Component {
 		);
 	}
 }
+
+InserterMenu.instances = 0;
 
 export default connect(
 	undefined,

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -27,6 +27,10 @@
 	&:hover {
 		color: $blue-medium;
 	}
+
+	.dashicon.insert {
+		margin: 0 auto; // Fixes horizontal alignment in Safari 10.
+	}
 }
 
 .editor-inserter__menu {
@@ -102,7 +106,7 @@
 }
 
 .editor-inserter__content {
-	max-height: 180px;
+	max-height: 186px;
 	overflow: auto;
 
 	&:focus {
@@ -136,15 +140,18 @@ input[type=search].editor-inserter__search {
 	width: 50%;
 	font-size: 12px;
 	color: $dark-gray-500;
+	margin: 0;
 	padding: 8px;
 	align-items: center;
 	cursor: pointer;
 	border: 1px solid transparent;
 	background: none;
+	line-height: 20px;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		border: 1px solid $dark-gray-500;
-		position: relative;
+		outline: none;
 	}
 
 	&:active,
@@ -161,6 +168,7 @@ input[type=search].editor-inserter__search {
 
 .editor-inserter__separator {
 	display: block;
+	margin: 0;
 	padding: 4px 8px;
 	font-size: 11px;
 	font-weight: 600;

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -18,18 +18,11 @@
 	background: none;
 	cursor: pointer;
 	border: none;
-	width: 36px;
-	height: 36px;
 	outline: none;
-	padding: 0;
 	transition: color .2s ease;
 
 	&:hover {
 		color: $blue-medium;
-	}
-
-	.dashicon.insert {
-		margin: 0 auto; // Fixes horizontal alignment in Safari 10.
 	}
 }
 

--- a/editor/components/toolbar/style.scss
+++ b/editor/components/toolbar/style.scss
@@ -7,9 +7,9 @@
 
 .editor-toolbar__control.editor-button {
 	display: inline-flex;
+	align-items: flex-end;
 	margin: 3px;
 	margin-left: 0;
-	padding: 6px;
 	background: none;
 	border: 1px solid transparent;
 	outline: none;
@@ -39,9 +39,9 @@
 		font-family: $default-font;
 		font-size: 10px;
 		font-weight: bold;
-		position: absolute;
-		bottom: 8px;
-		right: 5px;
+		position: relative;
+		top: -1px;
+		margin-left: -3px;
 	}
 }
 


### PR DESCRIPTION
Improves the inserter accessibility.

- renames 'Common' to 'Common blocks', to give better context (by the way, I guess this should be made translatable?)
- adds `aria-haspopup="true"` and `aria-expanded` to the inserter toggle button
- adds `role="menu"` and `aria-labelledby` to the inserter menu, and necessary IDs
- adds `tabIndex="0"` to the menu to make it focusable, this way it gets announced as "menu" with the name provided by `aria-labelledby`; this will work with multiple menus too, each one will be announced with the `category.title`
- adds `role="menuitem"` to the inserter menu items
- adds a properly associated `label` to the search field, adding necessary ID
- fixes toggle button position in Safari 10
- adjusts menu max-height (I guess this would need further adjustments)
- improves menu items text alignment in Safari 10
- adds focus style on the menu items, same as hover

*Important note*:
when #515 will be done, the menu items will need `tabIndex="-1"`, as focus should be managed programmatically for the Tab and Arrows keys

Fixes #525 