### PR TITLE
Do not remove previous block on backspace

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -72,9 +72,8 @@ class VisualEditorBlock extends wp.element.Component {
 
 		const previousBlockSettings = wp.blocks.getBlockSettings( previousBlock.blockType );
 
-		// Remove the previous block if it's not mergeable
+		// Do nothing if the previous block is not mergeable
 		if ( ! previousBlockSettings.merge ) {
-			onRemove( previousBlock.uid );
 			return;
 		}
 


### PR DESCRIPTION
This quick PR is a follow-up to discussion at https://github.com/WordPress/gutenberg/pull/461/files#r112692639.  When testing out the Backspace-to-merge behavior introduced there, I was pretty surprised to learn that pressing Backspace at the beginning of a text block will delete the previous block in a lot of cases (an image/gallery block, for example).

I think it's pretty unlikely that this would be the intended result of such an operation.  In general it should be much more difficult to delete blocks, and it should require an explicit action from the user (I don't think the controls for this exist yet).

Let's go back to the other alternative discussed in that comment thread (do nothing) until we provide a better way to remove blocks.