### PR TITLE
Make header responsive

### DIFF
--- a/editor/header/mode-switcher/style.scss
+++ b/editor/header/mode-switcher/style.scss
@@ -1,4 +1,4 @@
-.editor-mode-switcher {
+#wpbody .editor-mode-switcher {	/* #wpbody for extra specificity */
 	position: relative;
 	margin-right: $item-spacing;
 	padding-right: $item-spacing;
@@ -19,7 +19,13 @@
 		outline: none;
 		cursor: pointer;
 		box-shadow: none;
-		padding-right: 24px;
+		padding-right: 0;
+		font-size: 13px;
+		height: auto;
+
+		@include break-small {
+			padding-right: 24px;
+		}
 	}
 
 	.dashicon {

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -16,11 +16,13 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 	return (
 		<div className="editor-tools">
 			<IconButton
+				className="editor-tools__undo"
 				icon="undo"
 				label={ wp.i18n.__( 'Undo' ) }
 				disabled={ ! hasUndo }
 				onClick={ undo } />
 			<IconButton
+				className="editor-tools__redo"
 				icon="redo"
 				label={ wp.i18n.__( 'Redo' ) }
 				disabled={ ! hasRedo }

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -4,13 +4,26 @@
 	align-items: center;
 }
 
+.editor-tools__undo,
+.editor-tools__redo {
+	display: none;
+
+	@include break-mobile {
+		display: flex;
+	}
+}
+
 .editor-tools__tabs {
 	margin: 0 $item-spacing;
-	padding: 0 0 0 $item-spacing;
+	padding: 0;
 	border-left: 1px solid $light-gray-500;
 	border-right: 1px solid $light-gray-500;
 	display: flex;
 	align-items: center;
+
+	@include break-medium {
+		padding: 0 0 0 $item-spacing;
+	}
 
 	.editor-button {
 		display: flex;
@@ -20,7 +33,7 @@
 		border: none;
 		background: none;
 		color: $dark-gray-500;
-		margin-right: $item-spacing;
+		margin-right: 0;
 		cursor: pointer;
 		height: 30px;
 		padding: 0 10px;
@@ -34,6 +47,7 @@
 
 		@include break-medium() {
 			width: auto;
+			margin-right: $item-spacing;
 		}
 	}
 

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -14,6 +14,8 @@
 
 	.editor-button {
 		display: flex;
+		flex-wrap: nowrap;
+		white-space: nowrap;
 		align-items: center;
 		border: none;
 		background: none;
@@ -23,13 +25,24 @@
 		height: 30px;
 		padding: 0 10px;
 		border-radius: 3px;
+		width: 40px;
+		overflow: hidden;
 
 		&:hover {
 			color: $blue-medium;
 		}
+
+		@include break-medium() {
+			width: auto;
+		}
 	}
 
 	.editor-button .dashicon {
-		margin-right: 4px;
+		margin-right: 10px;
+		flex-shrink: 0;
+
+		@include break-medium() {
+			margin-right: 4px;
+		}
 	}
 }

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -98,19 +98,19 @@ msgstr ""
 msgid "Saved"
 msgstr ""
 
-#: editor/header/tools/index.js:20
+#: editor/header/tools/index.js:21
 msgid "Undo"
 msgstr ""
 
-#: editor/header/tools/index.js:25
+#: editor/header/tools/index.js:27
 msgid "Redo"
 msgstr ""
 
-#: editor/header/tools/index.js:36
+#: editor/header/tools/index.js:38
 msgid "Post Settings"
 msgstr ""
 
-#: editor/header/tools/index.js:40
+#: editor/header/tools/index.js:42
 msgid "Publish"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgctxt "Name for the Text editor tab (formerly HTML)"
 msgid "Text"
 msgstr ""
 
-#: editor/header/tools/index.js:32
+#: editor/header/tools/index.js:34
 msgctxt "imperative verb"
 msgid "Preview"
 msgstr ""


### PR DESCRIPTION
This PR makes the header, "Editor Bar" responsive. 

It does this by removing labels from the toggle buttons, tightening space overall, and hiding undo/redo on the smallest breakpoints. 