### PR TITLE
Text Block: When splitting a text block, avoid empty paragraphs at the begining of the created block

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -180,7 +180,7 @@ export default class Editable extends wp.element.Component {
 
 			memo.push( node );
 			return memo;
-		} ), [] );
+		}, [] ) );
 
 		// Splitting into two blocks
 		this.setContent( this.props.value );

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -171,12 +171,19 @@ export default class Editable extends wp.element.Component {
 		}
 		const before = getHtml( beforeNodes.slice( 0, beforeNodes.length - 1 ) );
 
+		// Removing empty nodes from the beginning of the "after"
+		// avoids empty paragraphs at the beginning of newly created blocks.
+		const after = getHtml( childNodes.slice( splitIndex ).reduce( ( memo, node ) => {
+			if ( ! memo.length && ! node.textContent ) {
+				return memo;
+			}
+
+			memo.push( node );
+			return memo;
+		} ), [] );
+
 		// Splitting into two blocks
 		this.setContent( this.props.value );
-		const hasAfter = !! childNodes.slice( splitIndex )
-			.reduce( ( memo, node ) => memo + node.textContent, '' );
-
-		const after = hasAfter ? getHtml( childNodes.slice( splitIndex ) ) : '';
 
 		// The setTimeout fixes the focus jump to the original block
 		setTimeout( () => {


### PR DESCRIPTION
closes #543 

**Testing instructions**

When putting the cursor in an empty line of a text block and splitting this text block, the empty line should be dropped from the created block.