### PR TITLE
Blocks: Reselect the current block if we click again on it

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -108,8 +108,9 @@ export default class Editable extends wp.element.Component {
 			return;
 		}
 
+		this.savedContent = this.getContent();
 		this.editor.save();
-		this.props.onChange( this.getContent() );
+		this.props.onChange( this.savedContent );
 	}
 
 	isStartOfEditor() {
@@ -216,7 +217,8 @@ export default class Editable extends wp.element.Component {
 
 	updateContent() {
 		const bookmark = this.editor.selection.getBookmark( 2, true );
-		this.setContent( this.props.value );
+		this.savedContent = this.props.value;
+		this.setContent( this.savedContent );
 		this.editor.selection.moveToBookmark( bookmark );
 		// Saving the editor on updates avoid unecessary onChanges calls
 		// These calls can make the focus jump
@@ -266,10 +268,13 @@ export default class Editable extends wp.element.Component {
 			this.focus();
 		}
 
+		// The savedContent var allows us to avoid updating the content right after an onChange call
 		if (
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
-			! isEqual( this.props.value, prevProps.value )
+			this.props.value !== this.savedContent &&
+			! isEqual( this.props.value, prevProps.value ) &&
+			! isEqual( this.props.value, this.savedContent )
 		) {
 			this.updateContent();
 		}

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -42,6 +42,7 @@ registerBlock( 'core/quote', {
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { value, citation, style = 1 } = attributes;
+		const focusedEditable = focus ? focus.editable || 'value' : null;
 
 		return (
 			<blockquote className={ `blocks-quote blocks-quote-style-${ style }` }>
@@ -52,7 +53,7 @@ registerBlock( 'core/quote', {
 							value: nextValue
 						} )
 					}
-					focus={ focus && focus.editable === 'value' ? focus : null }
+					focus={ focusedEditable === 'value' ? focus : null }
 					onFocus={ () => setFocus( { editable: 'value' } ) }
 				/>
 				{ ( citation || !! focus ) && (
@@ -64,7 +65,7 @@ registerBlock( 'core/quote', {
 									citation: nextCitation
 								} )
 							}
-							focus={ focus && focus.editable === 'citation' ? focus : null }
+							focus={ focusedEditable === 'citation' ? focus : null }
 							onFocus={ () => setFocus( { editable: 'citation' } ) }
 						/>
 					</footer>

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -144,6 +144,7 @@ class VisualEditorBlock extends wp.element.Component {
 			<div
 				ref={ this.bindBlockNode }
 				onClick={ onSelect }
+				onFocus={ onSelect }
 				onBlur={ this.maybeDeselect }
 				onKeyDown={ onStartTyping }
 				onMouseEnter={ onHover }
@@ -151,6 +152,7 @@ class VisualEditorBlock extends wp.element.Component {
 				onMouseLeave={ onMouseLeave }
 				className={ className }
 				data-type={ block.blockType }
+				tabIndex="0"
 				{ ...wrapperProps }
 			>
 				{ ( ( isSelected && ! isTyping ) || isHovered ) && <BlockMover uid={ block.uid } /> }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -137,15 +137,13 @@ class VisualEditorBlock extends wp.element.Component {
 			wrapperProps = settings.getEditWrapperProps( block.attributes );
 		}
 
-		// Disable reason: Each block can receive focus but must be able to contain
-		// block children. Tab keyboard navigation enabled by tabIndex assignment.
+		// Disable reason: Each block can be selected by clicking on it
 
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role */
 		return (
 			<div
 				ref={ this.bindBlockNode }
-				tabIndex="0"
-				onFocus={ onSelect }
+				onClick={ onSelect }
 				onBlur={ this.maybeDeselect }
 				onKeyDown={ onStartTyping }
 				onMouseEnter={ onHover }

--- a/editor/state.js
+++ b/editor/state.js
@@ -112,9 +112,13 @@ export function selectedBlock( state = {}, action ) {
 			if ( ! action.selected ) {
 				return state.uid === action.uid ? {} : state;
 			}
-			return action.uid === state.uid
+			return action.uid === state.uid && ! state.typing
 				? state
-				: { uid: action.uid, typing: false, focus: {} };
+				: {
+					uid: action.uid,
+					typing: false,
+					focus: action.uid === state.uid ? state.focus : {}
+				};
 
 		case 'MOVE_BLOCK_UP':
 		case 'MOVE_BLOCK_DOWN':

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -258,8 +258,8 @@ describe( 'state', () => {
 			expect( state ).to.eql( { uid: 'kumquat', typing: false, focus: {} } );
 		} );
 
-		it( 'should not update the state if already selected', () => {
-			const original = deepFreeze( { uid: 'kumquat', typing: true, focus: {} } );
+		it( 'should not update the state if already selected and not typing', () => {
+			const original = deepFreeze( { uid: 'kumquat', typing: false, focus: {} } );
 			const state = selectedBlock( original, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
@@ -267,6 +267,21 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).to.equal( original );
+		} );
+
+		it( 'should update the state if already selected and typing', () => {
+			const original = deepFreeze( { uid: 'kumquat', typing: true, focus: { editable: 'content' } } );
+			const state = selectedBlock( original, {
+				type: 'TOGGLE_BLOCK_SELECTED',
+				uid: 'kumquat',
+				selected: true
+			} );
+
+			expect( state ).to.eql( {
+				uid: 'kumquat',
+				typing: false,
+				focus: { editable: 'content' }
+			} );
 		} );
 
 		it( 'should unselect the block if currently selected', () => {


### PR DESCRIPTION
closes #498 

This PR allows reselecting a block (showing the controls) when clicking on the block again.

**Testing instructions**

 - Select a block
 - Type some text on it
 - Click on the block again
 - The controls should show up