### PR TITLE
Remove image block align none control

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -58,12 +58,6 @@ registerBlock( 'core/image', {
 			onClick: applyOrUnset( 'right' )
 		},
 		{
-			icon: 'align-none',
-			title: wp.i18n.__( 'No alignment' ),
-			isActive: ( { align } ) => ! align || 'none' === align,
-			onClick: applyOrUnset( 'none' )
-		},
-		{
 			icon: 'align-full-width',
 			title: wp.i18n.__( 'Wide width' ),
 			isActive: ( { align } ) => 'wide' === align,

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -17,7 +17,7 @@ const { attr, children } = query;
  * @param  {string}   align Alignment value
  * @return {Function}       Attribute setter
  */
-function applyOrUnset( align ) {
+function toggleAlignment( align ) {
 	return ( attributes, setAttributes ) => {
 		const nextAlign = attributes.align === align ? undefined : align;
 		setAttributes( { align: nextAlign } );
@@ -43,25 +43,25 @@ registerBlock( 'core/image', {
 			icon: 'align-left',
 			title: wp.i18n.__( 'Align left' ),
 			isActive: ( { align } ) => 'left' === align,
-			onClick: applyOrUnset( 'left' )
+			onClick: toggleAlignment( 'left' )
 		},
 		{
 			icon: 'align-center',
 			title: wp.i18n.__( 'Align center' ),
 			isActive: ( { align } ) => 'center' === align,
-			onClick: applyOrUnset( 'center' )
+			onClick: toggleAlignment( 'center' )
 		},
 		{
 			icon: 'align-right',
 			title: wp.i18n.__( 'Align right' ),
 			isActive: ( { align } ) => 'right' === align,
-			onClick: applyOrUnset( 'right' )
+			onClick: toggleAlignment( 'right' )
 		},
 		{
 			icon: 'align-full-width',
 			title: wp.i18n.__( 'Wide width' ),
 			isActive: ( { align } ) => 'wide' === align,
-			onClick: applyOrUnset( 'wide' )
+			onClick: toggleAlignment( 'wide' )
 		}
 	],
 


### PR DESCRIPTION
Closes #545

This pull request seeks to remove the "Align None" image control. The image controls already behave as toggles, so unsetting alignment back to "none" is a matter of clicking the selected option once more.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/25541885/60cb1266-2c1e-11e7-9087-bfcc030e28ac.png)|![After](https://cloud.githubusercontent.com/assets/1779930/25541843/3f1fa730-2c1e-11e7-8bab-0cf24b132233.png)

__Testing instructions:__

Verify that there is no "Align None" option shown in the controls toolbar when selecting an image block, and that you can still restore the "none" alignment by toggling any active alignment.