### PR TITLE
Apply block order by Flexbox order property

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { Slot } from 'react-slot-fill';
-import { partial } from 'lodash';
+import { partial, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -186,7 +186,14 @@ class VisualEditorBlock extends wp.element.Component {
 			'is-hovered': isHovered,
 		} );
 
-		const { onSelect, onHover, onMouseLeave, onFocus, onInsertAfter } = this.props;
+		const {
+			onSelect,
+			onHover,
+			onMouseLeave,
+			onFocus,
+			onInsertAfter,
+			order,
+		} = this.props;
 
 		// Determine whether the block has props to apply to the wrapper
 		let wrapperProps;
@@ -209,8 +216,9 @@ class VisualEditorBlock extends wp.element.Component {
 				onMouseLeave={ onMouseLeave }
 				className={ className }
 				data-type={ block.blockType }
-				tabIndex="0"
+				tabIndex={ order }
 				{ ...wrapperProps }
+				style={ { ...get( wrapperProps, 'style' ), order } }
 			>
 				{ ( ( isSelected && ! isTyping ) || isHovered ) && <BlockMover uid={ block.uid } /> }
 				{ isSelected && ! isTyping &&

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,20 +11,21 @@ import './style.scss';
 import Inserter from '../../inserter';
 import VisualEditorBlock from './block';
 import PostTitle from '../../post-title';
-import { getBlockUids } from '../../selectors';
 
 function VisualEditor( { blocks } ) {
 	return (
 		<div className="editor-visual-editor">
 			<PostTitle />
-			{ blocks.map( ( uid ) => (
-				<VisualEditorBlock key={ uid } uid={ uid } />
-			) ) }
+			<div className="editor-visual-editor__blocks">
+				{ map( blocks, ( block, uid ) => (
+					<VisualEditorBlock key={ uid } uid={ uid } />
+				) ) }
+			</div>
 			<Inserter />
 		</div>
 	);
 }
 
 export default connect( ( state ) => ( {
-	blocks: getBlockUids( state ),
+	blocks: state.editor.blocksByUid,
 } ) )( VisualEditor );

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -25,6 +25,11 @@
 	margin-right: auto;
 }
 
+.editor-visual-editor__blocks {
+	display: flex;
+	flex-direction: column;
+}
+
 .editor-visual-editor__block {
 	position: relative;
 	left: -#{ $block-padding + $block-mover-margin };	/* Make room for the mover */


### PR DESCRIPTION
Fixes #544 

This pull request seeks to implement an unfortunate but surprisingly reasonable hack to resolve `iframe` flickering of embed blocks using [Flexbox's `order` property](https://developer.mozilla.org/en-US/docs/Web/CSS/order) instead of natural DOM ordering. The default behavior of moving an iframe in a DOM results in the iframe being reloaded. The effect here is to never rearrange the DOM position but instead affect ordering through the `order` styling. From a user's perspective, there should be no difference.

See also:

- facebook/react#858
- http://stackoverflow.com/a/8318401

Minimal proof-of-concept:

- Before: https://codepen.io/aduth/pen/QvpxwL
- After: https://codepen.io/aduth/pen/eWvKeW

__Testing instructions:__

Repeat steps to reproduce from #544, verifying that neither moving the embed up nor down results in a flickering reload of the iframe.