### PR TITLE
Implement image block placeholder

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -4,6 +4,9 @@
 import './style.scss';
 import { registerBlock, query } from 'api';
 import Editable from 'components/editable';
+// TODO: Revisit when we have a common components solution
+import Dashicon from '../../../editor/components/dashicon';
+import Button from '../../../editor/components/button';
 
 const { attr, children } = query;
 
@@ -77,6 +80,23 @@ registerBlock( 'core/image', {
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { url, alt, caption } = attributes;
+
+		if ( ! url ) {
+			return (
+				<div className="blocks-image is-placeholder">
+					<div className="blocks-image__placeholder-label">
+						<Dashicon icon="format-image" />
+						{ wp.i18n.__( 'Image' ) }
+					</div>
+					<div className="blocks-image__placeholder-instructions">
+						{ wp.i18n.__( 'Drag image here or insert from media library' ) }
+					</div>
+					<Button isLarge>
+						{ wp.i18n.__( 'Insert from Media Library' ) }
+					</Button>
+				</div>
+			);
+		}
 
 		return (
 			<figure className="blocks-image">

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -89,3 +89,25 @@
 		width: 100%;
 	}
 }
+
+.blocks-image.is-placeholder {
+	margin: -15px;
+	padding: 6em 0;
+	border: 2px solid $light-gray-500;
+	text-align: center;
+}
+
+.blocks-image__placeholder-label {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: bold;
+
+	.dashicon {
+		margin-right: 1ch;
+	}
+}
+
+.blocks-image__placeholder-instructions {
+	margin: 1.8em 0;
+}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -22,7 +22,7 @@
 		position: absolute;
 		top: 0;
 		bottom: 0;
-		left: 33px;
+		left: 35px;
 		right: 0;
 		border: 2px solid transparent;
 		transition: 0.2s border-color;

--- a/languages/gutenberg.pot
+++ b/languages/gutenberg.pot
@@ -24,19 +24,19 @@ msgid "Strikethrough"
 msgstr ""
 
 #: blocks/components/editable/index.js:29
-#: blocks/library/image/index.js:41
+#: blocks/library/image/index.js:44
 #: blocks/library/list/index.js:25
 msgid "Align left"
 msgstr ""
 
 #: blocks/components/editable/index.js:34
-#: blocks/library/image/index.js:47
+#: blocks/library/image/index.js:50
 #: blocks/library/list/index.js:33
 msgid "Align center"
 msgstr ""
 
 #: blocks/components/editable/index.js:39
-#: blocks/library/image/index.js:53
+#: blocks/library/image/index.js:56
 #: blocks/library/list/index.js:41
 msgid "Align right"
 msgstr ""
@@ -46,7 +46,7 @@ msgid "Embed"
 msgstr ""
 
 #: blocks/library/embed/index.js:33
-#: blocks/library/image/index.js:87
+#: blocks/library/image/index.js:107
 msgid "Write caption…"
 msgstr ""
 
@@ -62,16 +62,24 @@ msgstr ""
 msgid "Heading %s"
 msgstr ""
 
-#: blocks/library/image/index.js:25
-msgid "Image"
-msgstr ""
-
-#: blocks/library/image/index.js:59
+#: blocks/library/image/index.js:62
 msgid "No alignment"
 msgstr ""
 
-#: blocks/library/image/index.js:65
+#: blocks/library/image/index.js:68
 msgid "Wide width"
+msgstr ""
+
+#: blocks/library/image/index.js:89
+msgid "Image"
+msgstr ""
+
+#: blocks/library/image/index.js:92
+msgid "Drag image here or insert from media library"
+msgstr ""
+
+#: blocks/library/image/index.js:95
+msgid "Insert from Media Library"
 msgstr ""
 
 #: blocks/library/list/index.js:11


### PR DESCRIPTION
Closes #454 

This pull request seeks to implement the placeholder image block. It is currently not functional; there are no behaviors to drop or insert an image from the media library.

![Placeholder Image](https://cloud.githubusercontent.com/assets/1779930/25546345/a7dfabdc-2c30-11e7-9d6b-5c81dacaea40.png)

__Open questions:__

- I'm thinking it probably doesn't make much sense for the alignment controls to be shown while the placeholder is shown. This exposes a need to be able to dynamically generate a block's `controls` depending on its current attributes. We could do this by allowing the block implementer to optionally specify `controls` as a function. Or, depending on how far we want to take the Slot & Fill idea (#507), assume that a block must render its own controls via `<Fill>`, meaning they'd have full control over the rendering from the `edit` function.

__Testing instructions:__

Verify that after inserting a new image block, a new block is added with a placeholder appearance.