### PR TITLE
Polish image captions

### DIFF
--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -13,3 +13,13 @@
 		outline: none;
 	}
 }
+
+figcaption.blocks-editable {
+	margin-top: 0.5em;
+	color: $dark-gray-100;
+	text-align: center;
+
+	p {
+		font-size: $default-font-size;
+	}
+}

--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -1,7 +1,6 @@
 .blocks-quote {
 	margin: 0;
 	box-shadow: inset 0px 0px 0px 0px $light-gray-500;
-	transition: all .2s ease;
 
 	footer {
 		color: $dark-gray-100;

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -33,11 +33,11 @@ $blue-medium-100: #E5F5FA;
 /* Other */
 $default-font: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 $default-font-size: 13px;
-$default-line-height: 1.4em;
+$default-line-height: 1.4;
 $editor-font: "Noto Serif", serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;
 $editor-font-size: 16px;
-$editor-line-height: 1.8em;
+$editor-line-height: 1.8;
 $item-spacing: 10px;
 $header-height: 56px;
 $sidebar-width: 320px;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -58,7 +58,7 @@ class VisualEditorBlock extends wp.element.Component {
 		// Annoyingly React does not support focusOut and we're forced to check
 		// related target to ensure it's not a child when blur fires.
 		if ( ! event.currentTarget.contains( event.relatedTarget ) ) {
-			this.props.onDeselect();
+			// this.props.onDeselect();
 		}
 	}
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -58,7 +58,7 @@ class VisualEditorBlock extends wp.element.Component {
 		// Annoyingly React does not support focusOut and we're forced to check
 		// related target to ensure it's not a child when blur fires.
 		if ( ! event.currentTarget.contains( event.relatedTarget ) ) {
-			// this.props.onDeselect();
+			this.props.onDeselect();
 		}
 	}
 


### PR DESCRIPTION
This PR polishes captions for images by porting the style, with a little tweak, from the prototypes. This fixes #534.

There were also two minor fixes, removing units from lineheights, and removing the transition between quote styles. 