### PR TITLE
Quote Block: Fix serializing the quote block

### DIFF
--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -74,12 +74,12 @@ registerBlock( 'core/quote', {
 		);
 	},
 
-	save( attributes ) {
+	save( { attributes } ) {
 		const { value, citation, style = 1 } = attributes;
 
 		return (
 			<blockquote className={ `blocks-quote-style-${ style }` }>
-				{ value && value.map( ( paragraph, i ) => (
+				{ value && wp.element.Children.map( value, ( paragraph, i ) => (
 					<p key={ i }>{ paragraph }</p>
 				) ) }
 				<footer>{ citation }</footer>


### PR DESCRIPTION
closes #564 

Follow the steps in #564 and ensures that the block is not empty anymore.