### PR TITLE
Use `disabled` attribute to disable block mover buttons

### DIFF
--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -17,13 +17,13 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 				className="editor-block-mover__control"
 				onClick={ onMoveUp }
 				icon="arrow-up-alt2"
-				disabled={ !! isFirst }
+				disabled={ isFirst }
 			/>
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ onMoveDown }
 				icon="arrow-down-alt2"
-				disabled={ !! isLast }
+				disabled={ isLast }
 			/>
 		</div>
 	);

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import classnames from 'classnames';
 import { first, last } from 'lodash';
 
 /**
@@ -15,14 +14,16 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 	return (
 		<div className="editor-block-mover">
 			<IconButton
-				className={ classnames( 'editor-block-mover__control', { 'is-disabled': isFirst } ) }
+				className="editor-block-mover__control"
 				onClick={ onMoveUp }
 				icon="arrow-up-alt2"
+				disabled={ !! isFirst }
 			/>
 			<IconButton
-				className={ classnames( 'editor-block-mover__control', { 'is-disabled': isLast } ) }
+				className="editor-block-mover__control"
 				onClick={ onMoveDown }
 				icon="arrow-down-alt2"
+				disabled={ !! isLast }
 			/>
 		</div>
 	);

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -19,8 +19,9 @@
 		color: $dark-gray-900;
 	}
 
-	&.is-disabled {
-		color: $light-gray-100;
+	&[disabled] {
+		cursor: default;
+		color: $light-gray-300;
 	}
 
 	.dashicon {


### PR DESCRIPTION
Fixes #575.

Also darkens the color of a disabled block-mover button somewhat... before this change it is almost invisible.  There are likely further changes needed here - see #587.