### PR TITLE
Allow saving and publishing posts

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -4,14 +4,17 @@
 import { get } from 'lodash';
 import { parse, stringify } from 'querystring';
 
-export function savePost( dispatch, post ) {
-	const isNew = ! post.id;
+export function savePost( dispatch, postId, edits ) {
+	const toSend = postId ? { id: postId, ...edits } : edits;
+	const isNew = ! postId;
+
 	dispatch( {
 		type: 'REQUEST_POST_UPDATE',
-		post,
+		edits,
 		isNew,
 	} );
-	new wp.api.models.Post( post ).save().done( ( newPost ) => {
+
+	new wp.api.models.Post( toSend ).save().done( ( newPost ) => {
 		dispatch( {
 			type: 'REQUEST_POST_UPDATE_SUCCESS',
 			post: newPost,
@@ -33,7 +36,7 @@ export function savePost( dispatch, post ) {
 				code: 'unknown_error',
 				message: wp.i18n.__( 'An unknown error occurred.' ),
 			} ),
-			post,
+			edits,
 			isNew,
 		} );
 	} );

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export function savePost( dispatch, post ) {
+	const isNew = ! post.id;
+	dispatch( {
+		type: 'POST_UPDATE_REQUEST',
+		post,
+		isNew,
+	} );
+	new wp.api.models.Post( post ).save().done( ( newPost ) => {
+		dispatch( {
+			type: 'POST_UPDATE_REQUEST_SUCCESS',
+			post: newPost,
+			isNew,
+		} );
+		if ( isNew && window.history.replaceState ) {
+			window.history.replaceState(
+				{},
+				'Post ' + newPost.id,
+				window.location.href.replace( /&post_id=[^&]*$/, '' )
+					+ '&post_id=' + newPost.id
+			);
+		}
+	} ).fail( ( err ) => {
+		dispatch( {
+			type: 'POST_UPDATE_REQUEST_FAILURE',
+			error: get( err, 'responseJSON', {
+				code: 'unknown_error',
+				message: wp.i18n.__( 'An unknown error occurred.' ),
+			} ),
+			post,
+			isNew,
+		} );
+	} );
+}

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -6,13 +6,13 @@ import { get } from 'lodash';
 export function savePost( dispatch, post ) {
 	const isNew = ! post.id;
 	dispatch( {
-		type: 'POST_UPDATE_REQUEST',
+		type: 'REQUEST_POST_UPDATE',
 		post,
 		isNew,
 	} );
 	new wp.api.models.Post( post ).save().done( ( newPost ) => {
 		dispatch( {
-			type: 'POST_UPDATE_REQUEST_SUCCESS',
+			type: 'REQUEST_POST_UPDATE_SUCCESS',
 			post: newPost,
 			isNew,
 		} );
@@ -26,7 +26,7 @@ export function savePost( dispatch, post ) {
 		}
 	} ).fail( ( err ) => {
 		dispatch( {
-			type: 'POST_UPDATE_REQUEST_FAILURE',
+			type: 'REQUEST_POST_UPDATE_FAILURE',
 			error: get( err, 'responseJSON', {
 				code: 'unknown_error',
 				message: wp.i18n.__( 'An unknown error occurred.' ),

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { get } from 'lodash';
+import { parse, stringify } from 'querystring';
 
 export function savePost( dispatch, post ) {
 	const isNew = ! post.id;
@@ -17,12 +18,13 @@ export function savePost( dispatch, post ) {
 			isNew,
 		} );
 		if ( isNew && window.history.replaceState ) {
-			window.history.replaceState(
-				{},
-				'Post ' + newPost.id,
-				window.location.href.replace( /&post_id=[^&]*$/, '' )
-					+ '&post_id=' + newPost.id
-			);
+			const urlPieces = window.location.href.split( '?' );
+			const qs = parse( urlPieces[ 1 ] || '' );
+			const newUrl = urlPieces[ 0 ] + '?' + stringify( {
+				...qs,
+				post_id: newPost.id,
+			} );
+			window.history.replaceState( {}, 'Post ' + newPost.id, newUrl );
 		}
 	} ).fail( ( err ) => {
 		dispatch( {

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -21,9 +21,9 @@ export function savePost( dispatch, postId, edits ) {
 			isNew,
 		} );
 		if ( isNew && window.history.replaceState ) {
-			const urlPieces = window.location.href.split( '?' );
-			const qs = parse( urlPieces[ 1 ] || '' );
-			const newUrl = urlPieces[ 0 ] + '?' + stringify( {
+			const [ baseUrl, query ] = window.location.href.split( '?' );
+			const qs = parse( query || '' );
+			const newUrl = baseUrl + '?' + stringify( {
 				...qs,
 				post_id: newPost.id,
 			} );

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -31,8 +31,8 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 
 export default connect(
 	( state, ownProps ) => ( {
-		isFirst: first( state.blocks.order ) === ownProps.uid,
-		isLast: last( state.blocks.order ) === ownProps.uid
+		isFirst: first( state.editor.blockOrder ) === ownProps.uid,
+		isLast: last( state.editor.blockOrder ) === ownProps.uid
 	} ),
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -92,7 +92,7 @@ class BlockSwitcher extends wp.element.Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		block: state.blocks.byUid[ ownProps.uid ]
+		block: state.editor.blocksByUid[ ownProps.uid ]
 	} ),
 	( dispatch, ownProps ) => ( {
 		onTransform( block, blockType ) {

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -31,6 +31,6 @@ function SavedState( { isDirty } ) {
 
 export default connect(
 	( state ) => ( {
-		isDirty: state.blocks.dirty,
+		isDirty: state.editor.dirty,
 	} )
 )( SavedState );

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -11,6 +11,7 @@ import Dashicon from '../../components/dashicon';
 import IconButton from '../../components/icon-button';
 import Inserter from '../../components/inserter';
 import Button from '../../components/button';
+import PublishButton from './publish-button';
 
 function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar } ) {
 	return (
@@ -38,9 +39,7 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 					{ wp.i18n.__( 'Post Settings' ) }
 				</Button>
 			</div>
-			<Button isPrimary isLarge>
-				{ wp.i18n.__( 'Publish' ) }
-			</Button>
+			<PublishButton />
 		</div>
 	);
 }

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -47,8 +47,8 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 
 export default connect(
 	( state ) => ( {
-		hasUndo: state.blocks.history.past.length > 0,
-		hasRedo: state.blocks.history.future.length > 0,
+		hasUndo: state.editor.history.past.length > 0,
+		hasRedo: state.editor.history.future.length > 0,
 		isSidebarOpened: state.isSidebarOpened,
 	} ),
 	( dispatch ) => ( {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -41,12 +41,10 @@ function PublishButton( {
 		} else {
 			buttonText = wp.i18n.__( 'Update failed' );
 		}
+	} else if ( post && post.id ) {
+		buttonText = wp.i18n.__( 'Update' );
 	} else {
-		if ( post && post.id ) {
-			buttonText = wp.i18n.__( 'Update' );
-		} else {
-			buttonText = wp.i18n.__( 'Publish' );
-		}
+		buttonText = wp.i18n.__( 'Publish' );
 	}
 
 	if ( post && post.id ) {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../../components/button';
+
+function PublishButton( { blocks, post, onUpdate, onPublish } ) {
+	let buttonText, saveCallback;
+	if ( post && post.id ) {
+		buttonText = wp.i18n.__( 'Update' );
+		saveCallback = onUpdate;
+	} else {
+		buttonText = wp.i18n.__( 'Publish' );
+		saveCallback = onPublish;
+	}
+
+	return (
+		<Button
+			isPrimary
+			isLarge
+			onClick={ () => saveCallback( post, blocks ) }
+		>
+			{ buttonText }
+		</Button>
+	);
+}
+
+export default connect(
+	( state ) => ( {
+		blocks: state.editor.blockOrder.map( ( uid ) => (
+			state.editor.blocksByUid[ uid ]
+		) ),
+		post: state.editor.post,
+	} ),
+	( dispatch ) => ( {
+		onUpdate( post, blocks ) {
+			post.content.raw = wp.blocks.serialize( blocks );
+			dispatch( {
+				type: 'UPDATE_POST',
+				post,
+			} );
+		},
+		onPublish( post, blocks ) {
+			post.content.raw = wp.blocks.serialize( blocks );
+			post.status = 'publish'; // TODO draft first?
+			dispatch( {
+				type: 'PUBLISH_NEW_POST',
+				post,
+			} );
+		},
+	} )
+)( PublishButton );

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -80,6 +80,14 @@ function savePost( dispatch, post ) {
 			post: newPost,
 			isNew,
 		} );
+		if ( isNew && window.history.replaceState ) {
+			window.history.replaceState(
+				{},
+				'Post ' + newPost.id,
+				window.location.href.replace( /&post_id=[^&]*$/, '' )
+					+ '&post_id=' + newPost.id
+			);
+		}
 	} ).fail( ( err ) => {
 		dispatch( {
 			type: 'POST_UPDATE_REQUEST_FAILURE',

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -24,23 +24,17 @@ function PublishButton( {
 
 	if ( isRequesting ) {
 		buttonEnabled = false;
-		if ( requestIsNewPost ) {
-			buttonText = wp.i18n.__( 'Publishing...' );
-		} else {
-			buttonText = wp.i18n.__( 'Updating...' );
-		}
+		buttonText = requestIsNewPost
+			? wp.i18n.__( 'Publishing...' )
+			: wp.i18n.__( 'Updating...' );
 	} else if ( isSuccessful ) {
-		if ( requestIsNewPost ) {
-			buttonText = wp.i18n.__( 'Published!' );
-		} else {
-			buttonText = wp.i18n.__( 'Updated!' );
-		}
+		buttonText = requestIsNewPost
+			? wp.i18n.__( 'Published!' )
+			: wp.i18n.__( 'Updated!' );
 	} else if ( isError ) {
-		if ( requestIsNewPost ) {
-			buttonText = wp.i18n.__( 'Publish failed' );
-		} else {
-			buttonText = wp.i18n.__( 'Update failed' );
-		}
+		buttonText = requestIsNewPost
+			? wp.i18n.__( 'Publish failed' )
+			: wp.i18n.__( 'Update failed' );
 	} else if ( post && post.id ) {
 		buttonText = wp.i18n.__( 'Update' );
 	} else {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -25,8 +25,8 @@ function PublishButton( {
 
 	if ( isRequesting ) {
 		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Saving...' )
-			: wp.i18n.__( 'Updating...' );
+			? wp.i18n.__( 'Saving…' )
+			: wp.i18n.__( 'Updating…' );
 	} else if ( isSuccessful ) {
 		buttonText = requestIsNewPost
 			? wp.i18n.__( 'Saved!' )

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -65,10 +65,10 @@ export default connect(
 			state.editor.blocksByUid[ uid ]
 		) ),
 		post: state.editor.post,
-		isRequesting: state.api.requesting,
-		isSuccessful: state.api.successful,
-		isError: !! state.api.error,
-		requestIsNewPost: state.api.isNew,
+		isRequesting: state.saving.requesting,
+		isSuccessful: state.saving.successful,
+		isError: !! state.saving.error,
+		requestIsNewPost: state.saving.isNew,
 	} ),
 	( dispatch ) => ( {
 		onUpdate( post, blocks ) {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -20,11 +20,10 @@ function PublishButton( {
 	onUpdate,
 	onSaveDraft,
 } ) {
-	let buttonEnabled = true;
+	const buttonEnabled = ! isRequesting;
 	let buttonText, saveCallback;
 
 	if ( isRequesting ) {
-		buttonEnabled = false;
 		buttonText = requestIsNewPost
 			? wp.i18n.__( 'Saving...' )
 			: wp.i18n.__( 'Updating...' );

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import { savePost } from 'actions';
 
 function PublishButton( {
 	blocks,
@@ -57,40 +57,6 @@ function PublishButton( {
 			{ buttonText }
 		</Button>
 	);
-}
-
-function savePost( dispatch, post ) {
-	const isNew = ! post.id;
-	dispatch( {
-		type: 'POST_UPDATE_REQUEST',
-		post,
-		isNew,
-	} );
-	new wp.api.models.Post( post ).save().done( ( newPost ) => {
-		dispatch( {
-			type: 'POST_UPDATE_REQUEST_SUCCESS',
-			post: newPost,
-			isNew,
-		} );
-		if ( isNew && window.history.replaceState ) {
-			window.history.replaceState(
-				{},
-				'Post ' + newPost.id,
-				window.location.href.replace( /&post_id=[^&]*$/, '' )
-					+ '&post_id=' + newPost.id
-			);
-		}
-	} ).fail( ( err ) => {
-		dispatch( {
-			type: 'POST_UPDATE_REQUEST_FAILURE',
-			error: get( err, 'responseJSON', {
-				code: 'unknown_error',
-				message: wp.i18n.__( 'An unknown error occurred.' ),
-			} ),
-			post,
-			isNew,
-		} );
-	} );
 }
 
 export default connect(

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -10,8 +10,9 @@ import Button from 'components/button';
 import { savePost } from 'actions';
 
 function PublishButton( {
-	blocks,
 	post,
+	edits,
+	blocks,
 	isSuccessful,
 	isRequesting,
 	isError,
@@ -51,7 +52,7 @@ function PublishButton( {
 		<Button
 			isPrimary
 			isLarge
-			onClick={ () => saveCallback( post, blocks ) }
+			onClick={ () => saveCallback( post, edits, blocks ) }
 			disabled={ ! buttonEnabled }
 		>
 			{ buttonText }
@@ -61,25 +62,30 @@ function PublishButton( {
 
 export default connect(
 	( state ) => ( {
+		post: state.currentPost,
+		edits: state.editor.edits,
 		blocks: state.editor.blockOrder.map( ( uid ) => (
 			state.editor.blocksByUid[ uid ]
 		) ),
-		post: state.editor.post,
 		isRequesting: state.saving.requesting,
 		isSuccessful: state.saving.successful,
 		isError: !! state.saving.error,
 		requestIsNewPost: state.saving.isNew,
 	} ),
 	( dispatch ) => ( {
-		onUpdate( post, blocks ) {
-			post.content.raw = wp.blocks.serialize( blocks );
-			savePost( dispatch, post );
+		onUpdate( post, edits, blocks ) {
+			savePost( dispatch, post.id, {
+				content: wp.blocks.serialize( blocks ),
+				...edits,
+			} );
 		},
 
-		onSaveDraft( post, blocks ) {
-			post.content.raw = wp.blocks.serialize( blocks );
-			post.status = 'draft'; // TODO change this after status controls
-			savePost( dispatch, post );
+		onSaveDraft( post, edits, blocks ) {
+			savePost( dispatch, null /* is a new post */, {
+				content: wp.blocks.serialize( blocks ),
+				status: 'draft', // TODO change this after status controls
+				...edits,
+			} );
 		},
 	} )
 )( PublishButton );

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -17,7 +17,7 @@ function PublishButton( {
 	isError,
 	requestIsNewPost,
 	onUpdate,
-	onPublish
+	onSaveDraft,
 } ) {
 	let buttonEnabled = true;
 	let buttonText, saveCallback;
@@ -25,26 +25,26 @@ function PublishButton( {
 	if ( isRequesting ) {
 		buttonEnabled = false;
 		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Publishing...' )
+			? wp.i18n.__( 'Saving...' )
 			: wp.i18n.__( 'Updating...' );
 	} else if ( isSuccessful ) {
 		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Published!' )
+			? wp.i18n.__( 'Saved!' )
 			: wp.i18n.__( 'Updated!' );
 	} else if ( isError ) {
 		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Publish failed' )
+			? wp.i18n.__( 'Save failed' )
 			: wp.i18n.__( 'Update failed' );
 	} else if ( post && post.id ) {
 		buttonText = wp.i18n.__( 'Update' );
 	} else {
-		buttonText = wp.i18n.__( 'Publish' );
+		buttonText = wp.i18n.__( 'Save draft' );
 	}
 
 	if ( post && post.id ) {
 		saveCallback = onUpdate;
 	} else {
-		saveCallback = onPublish;
+		saveCallback = onSaveDraft;
 	}
 
 	return (
@@ -110,9 +110,9 @@ export default connect(
 			savePost( dispatch, post );
 		},
 
-		onPublish( post, blocks ) {
+		onSaveDraft( post, blocks ) {
 			post.content.raw = wp.blocks.serialize( blocks );
-			post.status = 'publish'; // TODO draft first?
+			post.status = 'draft'; // TODO change this after status controls
 			savePost( dispatch, post );
 		},
 	} )

--- a/editor/index.js
+++ b/editor/index.js
@@ -21,6 +21,7 @@ export function createEditorInstance( id, post ) {
 	const store = createReduxStore();
 	store.dispatch( {
 		type: 'RESET_BLOCKS',
+		post,
 		blocks: wp.blocks.parse( post.content.raw )
 	} );
 

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -41,8 +41,8 @@ function TextEditor( { blocks, onChange } ) {
 
 export default connect(
 	( state ) => ( {
-		blocks: state.blocks.order.map( ( uid ) => (
-			state.blocks.byUid[ uid ]
+		blocks: state.editor.blockOrder.map( ( uid ) => (
+			state.editor.blocksByUid[ uid ]
 		) )
 	} ),
 	( dispatch ) => ( {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -208,10 +208,10 @@ class VisualEditorBlock extends wp.element.Component {
 
 export default connect(
 	( state, ownProps ) => {
-		const order = state.blocks.order.indexOf( ownProps.uid );
+		const order = state.editor.blockOrder.indexOf( ownProps.uid );
 		return {
-			previousBlock: state.blocks.byUid[ state.blocks.order[ order - 1 ] ] || null,
-			block: state.blocks.byUid[ ownProps.uid ],
+			previousBlock: state.editor.blocksByUid[ state.editor.blockOrder[ order - 1 ] ] || null,
+			block: state.editor.blocksByUid[ ownProps.uid ],
 			isSelected: state.selectedBlock.uid === ownProps.uid,
 			isHovered: state.hoveredBlock === ownProps.uid,
 			focus: state.selectedBlock.uid === ownProps.uid ? state.selectedBlock.focus : null,

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -22,5 +22,5 @@ function VisualEditor( { blocks } ) {
 }
 
 export default connect( ( state ) => ( {
-	blocks: state.blocks.order
+	blocks: state.editor.blockOrder
 } ) )( VisualEditor );

--- a/editor/state.js
+++ b/editor/state.js
@@ -28,6 +28,9 @@ export const editor = combineUndoableReducers( {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
 				return action.post || state;
+
+			case 'POST_UPDATE_REQUEST_SUCCESS':
+				return action.post;
 		}
 
 		return state;
@@ -280,6 +283,44 @@ export function isSidebarOpened( state = false, action ) {
 }
 
 /**
+ * Reducer returning current network request state (whether a request to the WP
+ * REST API is in progress, successful, or failed).
+ *
+ * @param  {string} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {string}        Updated state
+ */
+export function api( state = {}, action ) {
+	switch ( action.type ) {
+		case 'POST_UPDATE_REQUEST':
+			return {
+				requesting: true,
+				successful: false,
+				error: null,
+				isNew: action.isNew,
+			};
+
+		case 'POST_UPDATE_REQUEST_SUCCESS':
+			return {
+				requesting: false,
+				successful: true,
+				error: null,
+				isNew: action.isNew,
+			};
+
+		case 'POST_UPDATE_REQUEST_FAILURE':
+			return {
+				requesting: false,
+				successful: true,
+				error: action.error,
+				isNew: action.isNew,
+			};
+	}
+
+	return state;
+}
+
+/**
  * Creates a new instance of a Redux store.
  *
  * @return {Redux.Store} Redux store
@@ -290,7 +331,8 @@ export function createReduxStore() {
 		selectedBlock,
 		hoveredBlock,
 		mode,
-		isSidebarOpened
+		isSidebarOpened,
+		api,
 	} );
 
 	return createStore(

--- a/editor/state.js
+++ b/editor/state.js
@@ -29,7 +29,7 @@ export const editor = combineUndoableReducers( {
 			case 'RESET_BLOCKS':
 				return action.post || state;
 
-			case 'POST_UPDATE_REQUEST_SUCCESS':
+			case 'REQUEST_POST_UPDATE_SUCCESS':
 				return action.post;
 		}
 
@@ -292,7 +292,7 @@ export function isSidebarOpened( state = false, action ) {
  */
 export function saving( state = {}, action ) {
 	switch ( action.type ) {
-		case 'POST_UPDATE_REQUEST':
+		case 'REQUEST_POST_UPDATE':
 			return {
 				requesting: true,
 				successful: false,
@@ -300,7 +300,7 @@ export function saving( state = {}, action ) {
 				isNew: action.isNew,
 			};
 
-		case 'POST_UPDATE_REQUEST_SUCCESS':
+		case 'REQUEST_POST_UPDATE_SUCCESS':
 			return {
 				requesting: false,
 				successful: true,
@@ -308,7 +308,7 @@ export function saving( state = {}, action ) {
 				isNew: action.isNew,
 			};
 
-		case 'POST_UPDATE_REQUEST_FAILURE':
+		case 'REQUEST_POST_UPDATE_FAILURE':
 			return {
 				requesting: false,
 				successful: true,

--- a/editor/state.js
+++ b/editor/state.js
@@ -14,8 +14,8 @@ import { combineUndoableReducers } from 'utils/undoable-reducer';
  * from current HTML markup.
  *
  * Handles the following state keys:
- *  - post: an object describing the current post, in the format used by the WP
- *  REST API
+ *  - edits: an object describing changes to be made to the current post, in
+ *           the format accepted by the WP REST API
  *  - blocksByUid: post content blocks keyed by UID
  *  - blockOrder: list of block UIDs in order
  *
@@ -24,13 +24,13 @@ import { combineUndoableReducers } from 'utils/undoable-reducer';
  * @return {Object}        Updated state
  */
 export const editor = combineUndoableReducers( {
-	post( state = {}, action ) {
+	edits( state = {}, action ) {
 		switch ( action.type ) {
-			case 'RESET_BLOCKS':
-				return action.post || state;
-
-			case 'REQUEST_POST_UPDATE_SUCCESS':
-				return action.post;
+			case 'EDIT_POST':
+				return {
+					...state,
+					...action.post,
+				};
 		}
 
 		return state;
@@ -154,6 +154,26 @@ export const editor = combineUndoableReducers( {
 		return state;
 	}
 }, { resetTypes: [ 'RESET_BLOCKS' ] } );
+
+/**
+ * Reducer returning the last-known state of the current post, in the format
+ * returned by the WP REST API.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {Object}        Updated state
+ */
+export function currentPost( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RESET_BLOCKS':
+			return action.post || state;
+
+		case 'REQUEST_POST_UPDATE_SUCCESS':
+			return action.post;
+	}
+
+	return state;
+}
 
 /**
  * Reducer returning selected block state.
@@ -328,6 +348,7 @@ export function saving( state = {}, action ) {
 export function createReduxStore() {
 	const reducer = combineReducers( {
 		editor,
+		currentPost,
 		selectedBlock,
 		hoveredBlock,
 		mode,

--- a/editor/state.js
+++ b/editor/state.js
@@ -10,14 +10,29 @@ import { keyBy, last, omit, without } from 'lodash';
 import { combineUndoableReducers } from 'utils/undoable-reducer';
 
 /**
- * Reducer returning editor blocks state, an combined reducer of keys byUid,
- * order, where blocks are parsed from current HTML markup.
+ * Undoable reducer returning the editor post state, including blocks parsed
+ * from current HTML markup.
+ *
+ * Handles the following state keys:
+ *  - post: an object describing the current post, in the format used by the WP
+ *  REST API
+ *  - blocksByUid: post content blocks keyed by UID
+ *  - blockOrder: list of block UIDs in order
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export const blocks = combineUndoableReducers( {
+export const editor = combineUndoableReducers( {
+	post( state = {}, action ) {
+		switch ( action.type ) {
+			case 'RESET_BLOCKS':
+				return action.post || state;
+		}
+
+		return state;
+	},
+
 	dirty( state = false, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
@@ -34,7 +49,8 @@ export const blocks = combineUndoableReducers( {
 
 		return state;
 	},
-	byUid( state = {}, action ) {
+
+	blocksByUid( state = {}, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
 				return keyBy( action.blocks, 'uid' );
@@ -71,7 +87,8 @@ export const blocks = combineUndoableReducers( {
 
 		return state;
 	},
-	order( state = [], action ) {
+
+	blockOrder( state = [], action ) {
 		let index;
 		let swappedUid;
 		switch ( action.type ) {
@@ -269,7 +286,7 @@ export function isSidebarOpened( state = false, action ) {
  */
 export function createReduxStore() {
 	const reducer = combineReducers( {
-		blocks,
+		editor,
 		selectedBlock,
 		hoveredBlock,
 		mode,

--- a/editor/state.js
+++ b/editor/state.js
@@ -331,7 +331,7 @@ export function saving( state = {}, action ) {
 		case 'REQUEST_POST_UPDATE_FAILURE':
 			return {
 				requesting: false,
-				successful: true,
+				successful: false,
 				error: action.error,
 				isNew: action.isNew,
 			};

--- a/editor/state.js
+++ b/editor/state.js
@@ -290,7 +290,7 @@ export function isSidebarOpened( state = false, action ) {
  * @param  {Object} action Dispatched action
  * @return {string}        Updated state
  */
-export function api( state = {}, action ) {
+export function saving( state = {}, action ) {
 	switch ( action.type ) {
 		case 'POST_UPDATE_REQUEST':
 			return {
@@ -332,7 +332,7 @@ export function createReduxStore() {
 		hoveredBlock,
 		mode,
 		isSidebarOpened,
-		api,
+		saving,
 	} );
 
 	return createStore(

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -517,6 +517,7 @@ describe( 'state', () => {
 
 			expect( Object.keys( state ) ).to.have.members( [
 				'editor',
+				'currentPost',
 				'selectedBlock',
 				'hoveredBlock',
 				'mode',

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -521,7 +521,7 @@ describe( 'state', () => {
 				'hoveredBlock',
 				'mode',
 				'isSidebarOpened',
-				'api',
+				'saving',
 			] );
 		} );
 	} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -252,6 +252,56 @@ describe( 'state', () => {
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 3 );
 			expect( state.blockOrder ).to.eql( [ 'kumquat', 'persimmon', 'loquat' ] );
 		} );
+
+		describe( 'edits()', () => {
+			it( 'should save newly edited properties', () => {
+				const original = editor( undefined, {
+					type: 'EDIT_POST',
+					post: {
+						status: 'draft',
+						title: 'post title',
+					}
+				} );
+
+				const state = editor( original, {
+					type: 'EDIT_POST',
+					post: {
+						tags: [ 1 ],
+					},
+				} );
+
+				expect( state.edits ).to.eql( {
+					status: 'draft',
+					title: 'post title',
+					tags: [ 1 ],
+				} );
+			} );
+
+			it( 'should save modified properties', () => {
+				const original = editor( undefined, {
+					type: 'EDIT_POST',
+					post: {
+						status: 'draft',
+						title: 'post title',
+						tags: [ 1 ],
+					}
+				} );
+
+				const state = editor( original, {
+					type: 'EDIT_POST',
+					post: {
+						title: 'modified title',
+						tags: [ 2 ],
+					},
+				} );
+
+				expect( state.edits ).to.eql( {
+					status: 'draft',
+					title: 'modified title',
+					tags: [ 2 ],
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'hoveredBlock()', () => {

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -15,6 +15,7 @@ import {
 	selectedBlock,
 	mode,
 	isSidebarOpened,
+	saving,
 	createReduxStore
 } from '../state';
 
@@ -594,6 +595,54 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).to.be.true();
+		} );
+	} );
+
+	describe( 'saving()', () => {
+		it( 'should update when a request is started', () => {
+			const state = saving( null, {
+				type: 'REQUEST_POST_UPDATE',
+				isNew: true,
+			} );
+			expect( state ).to.eql( {
+				requesting: true,
+				successful: false,
+				error: null,
+				isNew: true,
+			} );
+		} );
+
+		it( 'should update when a request succeeds', () => {
+			const state = saving( null, {
+				type: 'REQUEST_POST_UPDATE_SUCCESS',
+				isNew: true,
+			} );
+			expect( state ).to.eql( {
+				requesting: false,
+				successful: true,
+				error: null,
+				isNew: true,
+			} );
+		} );
+
+		it( 'should update when a request fails', () => {
+			const state = saving( null, {
+				type: 'REQUEST_POST_UPDATE_FAILURE',
+				isNew: true,
+				error: {
+					code: 'pretend_error',
+					message: 'update failed',
+				}
+			} );
+			expect( state ).to.eql( {
+				requesting: false,
+				successful: false,
+				error: {
+					code: 'pretend_error',
+					message: 'update failed',
+				},
+				isNew: true,
+			} );
 		} );
 	} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -10,6 +10,7 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	editor,
+	currentPost,
 	hoveredBlock,
 	selectedBlock,
 	mode,
@@ -300,6 +301,49 @@ describe( 'state', () => {
 					title: 'modified title',
 					tags: [ 2 ],
 				} );
+			} );
+		} );
+	} );
+
+	describe( 'currentPost()', () => {
+		it( 'should remember a post object sent with RESET_BLOCKS', () => {
+			const original = deepFreeze( { title: 'unmodified' } );
+
+			const state = currentPost( original, {
+				type: 'RESET_BLOCKS',
+				post: {
+					title: 'new post',
+				},
+			} );
+
+			expect( state ).to.eql( {
+				title: 'new post',
+			} );
+		} );
+
+		it( 'should ignore RESET_BLOCKS without a post object', () => {
+			const original = deepFreeze( { title: 'unmodified' } );
+
+			const state = currentPost( original, {
+				type: 'RESET_BLOCKS',
+				post: null,
+			} );
+
+			expect( state ).to.equal( original );
+		} );
+
+		it( 'should remember a post object sent with REQUEST_POST_UPDATE_SUCCESS', () => {
+			const original = deepFreeze( { title: 'unmodified' } );
+
+			const state = currentPost( original, {
+				type: 'REQUEST_POST_UPDATE_SUCCESS',
+				post: {
+					title: 'updated post object from server',
+				},
+			} );
+
+			expect( state ).to.eql( {
+				title: 'updated post object from server',
 			} );
 		} );
 	} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -9,7 +9,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	blocks,
+	editor,
 	hoveredBlock,
 	selectedBlock,
 	mode,
@@ -18,7 +18,7 @@ import {
 } from '../state';
 
 describe( 'state', () => {
-	describe( 'blocks()', () => {
+	describe( 'editor()', () => {
 		before( () => {
 			wp.blocks.registerBlock( 'core/test-block', {} );
 		} );
@@ -27,35 +27,35 @@ describe( 'state', () => {
 			wp.blocks.unregisterBlock( 'core/test-block' );
 		} );
 
-		it( 'should return empty byUid, order, history by default', () => {
-			const state = blocks( undefined, {} );
+		it( 'should return empty blocksByUid, blockOrder, history by default', () => {
+			const state = editor( undefined, {} );
 
-			expect( state.byUid ).to.eql( {} );
-			expect( state.order ).to.eql( [] );
+			expect( state.blocksByUid ).to.eql( {} );
+			expect( state.blockOrder ).to.eql( [] );
 			expect( state ).to.have.keys( 'history' );
 		} );
 
 		it( 'should key by replaced blocks uid', () => {
-			const original = blocks( undefined, {} );
-			const state = blocks( original, {
+			const original = editor( undefined, {} );
+			const state = editor( original, {
 				type: 'RESET_BLOCKS',
 				blocks: [ { uid: 'bananas' } ]
 			} );
 
-			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 1 );
-			expect( values( state.byUid )[ 0 ].uid ).to.equal( 'bananas' );
-			expect( state.order ).to.eql( [ 'bananas' ] );
+			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 1 );
+			expect( values( state.blocksByUid )[ 0 ].uid ).to.equal( 'bananas' );
+			expect( state.blockOrder ).to.eql( [ 'bananas' ] );
 		} );
 
 		it( 'should return with block updates', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'kumquat',
 					attributes: {}
 				} ]
 			} );
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'UPDATE_BLOCK',
 				uid: 'kumquat',
 				updates: {
@@ -65,11 +65,11 @@ describe( 'state', () => {
 				}
 			} );
 
-			expect( state.byUid.kumquat.attributes.updated ).to.be.true();
+			expect( state.blocksByUid.kumquat.attributes.updated ).to.be.true();
 		} );
 
 		it( 'should insert block', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
@@ -77,7 +77,7 @@ describe( 'state', () => {
 					attributes: {}
 				} ]
 			} );
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'INSERT_BLOCK',
 				block: {
 					uid: 'ribs',
@@ -85,13 +85,13 @@ describe( 'state', () => {
 				}
 			} );
 
-			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 2 );
-			expect( values( state.byUid )[ 1 ].uid ).to.equal( 'ribs' );
-			expect( state.order ).to.eql( [ 'chicken', 'ribs' ] );
+			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 2 );
+			expect( values( state.blocksByUid )[ 1 ].uid ).to.equal( 'ribs' );
+			expect( state.blockOrder ).to.eql( [ 'chicken', 'ribs' ] );
 		} );
 
 		it( 'should replace the block', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
@@ -99,7 +99,7 @@ describe( 'state', () => {
 					attributes: {}
 				} ]
 			} );
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks: [ {
@@ -108,14 +108,14 @@ describe( 'state', () => {
 				} ]
 			} );
 
-			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 1 );
-			expect( values( state.byUid )[ 0 ].blockType ).to.equal( 'core/freeform' );
-			expect( values( state.byUid )[ 0 ].uid ).to.equal( 'wings' );
-			expect( state.order ).to.eql( [ 'wings' ] );
+			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 1 );
+			expect( values( state.blocksByUid )[ 0 ].blockType ).to.equal( 'core/freeform' );
+			expect( values( state.blocksByUid )[ 0 ].uid ).to.equal( 'wings' );
+			expect( state.blockOrder ).to.eql( [ 'wings' ] );
 		} );
 
 		it( 'should move the block up', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
@@ -127,16 +127,16 @@ describe( 'state', () => {
 					attributes: {}
 				} ]
 			} );
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'MOVE_BLOCK_UP',
 				uid: 'ribs'
 			} );
 
-			expect( state.order ).to.eql( [ 'ribs', 'chicken' ] );
+			expect( state.blockOrder ).to.eql( [ 'ribs', 'chicken' ] );
 		} );
 
 		it( 'should not move the first block up', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
@@ -148,16 +148,16 @@ describe( 'state', () => {
 					attributes: {}
 				} ]
 			} );
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'MOVE_BLOCK_UP',
 				uid: 'chicken'
 			} );
 
-			expect( state.order ).to.equal( original.order );
+			expect( state.blockOrder ).to.equal( original.blockOrder );
 		} );
 
 		it( 'should move the block down', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
@@ -169,16 +169,16 @@ describe( 'state', () => {
 					attributes: {}
 				} ]
 			} );
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'MOVE_BLOCK_DOWN',
 				uid: 'chicken'
 			} );
 
-			expect( state.order ).to.eql( [ 'ribs', 'chicken' ] );
+			expect( state.blockOrder ).to.eql( [ 'ribs', 'chicken' ] );
 		} );
 
 		it( 'should not move the last block down', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
@@ -190,16 +190,16 @@ describe( 'state', () => {
 					attributes: {}
 				} ]
 			} );
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'MOVE_BLOCK_DOWN',
 				uid: 'ribs'
 			} );
 
-			expect( state.order ).to.equal( original.order );
+			expect( state.blockOrder ).to.equal( original.blockOrder );
 		} );
 
 		it( 'should remove the block', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
@@ -211,13 +211,13 @@ describe( 'state', () => {
 					attributes: {}
 				} ]
 			} );
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'REMOVE_BLOCK',
 				uid: 'chicken'
 			} );
 
-			expect( state.order ).to.eql( [ 'ribs' ] );
-			expect( state.byUid ).to.eql( {
+			expect( state.blockOrder ).to.eql( [ 'ribs' ] );
+			expect( state.blocksByUid ).to.eql( {
 				ribs: {
 					uid: 'ribs',
 					blockType: 'core/test-block',
@@ -227,7 +227,7 @@ describe( 'state', () => {
 		} );
 
 		it( 'should insert after the specified block uid', () => {
-			const original = blocks( undefined, {
+			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'kumquat',
@@ -240,7 +240,7 @@ describe( 'state', () => {
 				} ]
 			} );
 
-			const state = blocks( original, {
+			const state = editor( original, {
 				type: 'INSERT_BLOCK',
 				after: 'kumquat',
 				block: {
@@ -249,8 +249,8 @@ describe( 'state', () => {
 				}
 			} );
 
-			expect( Object.keys( state.byUid ) ).to.have.lengthOf( 3 );
-			expect( state.order ).to.eql( [ 'kumquat', 'persimmon', 'loquat' ] );
+			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 3 );
+			expect( state.blockOrder ).to.eql( [ 'kumquat', 'persimmon', 'loquat' ] );
 		} );
 	} );
 
@@ -516,7 +516,7 @@ describe( 'state', () => {
 			const state = store.getState();
 
 			expect( Object.keys( state ) ).to.have.members( [
-				'blocks',
+				'editor',
 				'selectedBlock',
 				'hoveredBlock',
 				'mode',

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -520,7 +520,8 @@ describe( 'state', () => {
 				'selectedBlock',
 				'hoveredBlock',
 				'mode',
-				'isSidebarOpened'
+				'isSidebarOpened',
+				'api',
 			] );
 		} );
 	} );

--- a/index.php
+++ b/index.php
@@ -158,7 +158,7 @@ function gutenberg_scripts_and_styles( $hook ) {
 	wp_enqueue_script(
 		'wp-editor',
 		plugins_url( 'editor/build/index.js', __FILE__ ),
-		array( 'wp-i18n', 'wp-blocks', 'wp-element' ),
+		array( 'wp-api', 'wp-i18n', 'wp-blocks', 'wp-element' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'editor/build/index.js' ),
 		true   // $in_footer
 	);

--- a/index.php
+++ b/index.php
@@ -180,7 +180,10 @@ function gutenberg_scripts_and_styles( $hook ) {
 	// Initialize the post data...
 	if ( $post_to_edit ) {
 		// ...with a real post
-		wp_localize_script( 'wp-editor', '_wpGutenbergPost', $post_to_edit );
+		wp_add_inline_script(
+			'wp-editor',
+			'window._wpGutenbergPost = ' . wp_json_encode( $post_to_edit ) . ';'
+		);
 	} else {
 		// ...with some test content
 		// TODO: replace this with error handling


### PR DESCRIPTION
This PR adds the capability to publish new posts and update existing posts via the WP REST API.  Closes #526.

This PR is the first time we actually need to store all of the data for a post object in the Redux state.  It looks like our `combineUndoableReducers` utility expects to have all undoable actions reside within a single key in the state tree, and the post properties should be part of the undo history.  Accordingly, I've renamed `state.blocks` to `state.editor`:

- `state.blocks.byUid` &rarr; `state.editor.blocksByUid`
- `state.blocks.order` &rarr; `state.editor.blockOrder`
- newly introduced `state.editor.post`

Even though we're not using Backbone in this project, I'm using the [`wp-api.js` Backbone client](https://developer.wordpress.org/rest-api/using-the-rest-api/backbone-javascript-client/) to save posts because the library is already included in WP core and is the simplest way to make an API call.  The alternative would be to use jQuery or another AJAX library, which would involve some error-prone bits of setup that are already handled for us (like building the API URLs and making sure they work with all the different permalink structures).

Currently the state of the publish/update operation is reflected in the main action button text.  I expect we'll want to change this later, but there are 8 possible messages currently:

- **Publish** (editing a new post; no action has been taken)
- **Publishing...** (in the process of publishing a new post; the button is disabled)
- **Published!** (just published a new post)
- **Publish failed** (an error occurred)
- **Update** (editing an existing post; no action has been taken)
- **Updating...** (in the process of updating an existing post; the button is disabled)
- **Updated!** (just updated an existing post)
- **Update failed** (an error occurred)

Until the plugin is more stable, I wonder if we should update the default action to be creating a new draft instead of immediately publishing a post?