### PR TITLE
Add click outside toggling to block switcher menu.

### DIFF
--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { uniq, get, reduce } from 'lodash';
+import clickOutside from 'react-click-outside';
 
 /**
  * Internal dependencies
@@ -17,6 +18,14 @@ class BlockSwitcher extends wp.element.Component {
 		this.state = {
 			open: false
 		};
+	}
+
+	handleClickOutside() {
+		if ( ! this.state.open ) {
+			return;
+		}
+
+		this.toggleMenu();
 	}
 
 	toggleMenu() {
@@ -94,4 +103,4 @@ export default connect(
 			} );
 		}
 	} )
-)( BlockSwitcher );
+)( clickOutside( BlockSwitcher ) );

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lodash": "^4.17.4",
     "react": "^15.5.4",
     "react-autosize-textarea": "^0.4.2",
+    "react-click-outside": "^2.3.0",
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.4",
     "react-slot-fill": "^1.0.0-alpha.11",


### PR DESCRIPTION
Along with #582 this will cover #376.  This adds the click outside
higher order component to the block switcher menu. So that clicks into
block content will close the menu while it is open.

**Testing instructions:**

Go to a heading or text block.  Open the block switcher menu in the top
left.  Click on that blocks text content outside of the menu.  Verify
that the menu closes.  Repeat this by clicking anywhere and verifying
that the switcher closes.  Verify that the switcher still works by
clicking on it.