### PR TITLE
Hide update nag

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -2,9 +2,7 @@ body.toplevel_page_gutenberg {
 	background: $white;
 
 	#update-nag, .update-nag {
-		position: absolute;
-		right: 0;
-		top: 50px;
+		display: none;
 	}
 
 	#wpcontent {


### PR DESCRIPTION
This PR hides the update nag. In part it's to open the discussion, in part it's because the update nag is already visible on every other screen in the admin, and it also has a spot in the adminbar even in the editor.

![screen shot 2017-05-02 at 10 55 08](https://cloud.githubusercontent.com/assets/1204802/25611097/1aab02c2-2f26-11e7-9ba3-89be8175fd99.png)

We will probably encounter further notice work in the future. There's a separate ticket for it (#486). But for now, let's see if we can't make an exception to the update nag on this screen.