### PR TITLE
Fix text colour of ‘Post Settings’ button when the sidebar is toggled.

### DIFF
--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -41,7 +41,7 @@
 		width: 40px;
 		overflow: hidden;
 
-		&:hover {
+		&:hover:not(.is-toggled) {
 			color: $blue-medium;
 		}
 


### PR DESCRIPTION
Small style tweak. Below is a before/after comparison.

<img width="385" alt="screen shot 2017-05-02 at 18 57 56" src="https://cloud.githubusercontent.com/assets/704594/25632076/3e32f058-2f6a-11e7-86f1-cb042b8bfdd6.png">
