### PR TITLE
Add basic 'dirty state' handling

### DIFF
--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -18,7 +18,7 @@ function SavedState( { isDirty } ) {
 		? 'warning'
 		: 'saved';
 	const text = isDirty
-		? wp.i18n.__( 'Modified' )
+		? wp.i18n.__( 'Unsaved changes' )
 		: wp.i18n.__( 'Saved' );
 
 	return (

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -1,16 +1,36 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 import Dashicon from '../../components/dashicon';
 
-function SavedState() {
+function SavedState( { isDirty } ) {
+	const classes = classNames( 'editor-saved-state', {
+		'is-dirty': isDirty,
+	} );
+	const icon = isDirty
+		? 'warning'
+		: 'saved';
+	const text = isDirty
+		? wp.i18n.__( 'Modified' )
+		: wp.i18n.__( 'Saved' );
+
 	return (
-		<div className="editor-saved-state">
-			<Dashicon icon="saved" />
-			{ wp.i18n.__( 'Saved' ) }
+		<div className={ classes }>
+			<Dashicon icon={ icon } />
+			{ text }
 		</div>
 	);
 }
 
-export default SavedState;
+export default connect(
+	( state ) => ( {
+		isDirty: state.blocks.dirty,
+	} )
+)( SavedState );

--- a/editor/state.js
+++ b/editor/state.js
@@ -18,6 +18,23 @@ import { combineUndoableReducers } from 'utils/undoable-reducer';
  * @return {Object}        Updated state
  */
 export const blocks = combineUndoableReducers( {
+	dirty( state = false, action ) {
+		switch ( action.type ) {
+			case 'RESET_BLOCKS':
+				return false;
+
+			case 'UPDATE_BLOCK':
+			case 'INSERT_BLOCK':
+			case 'MOVE_BLOCK_DOWN':
+			case 'MOVE_BLOCK_UP':
+			case 'REPLACE_BLOCKS':
+			case 'REMOVE_BLOCK':
+			case 'SWITCH_BLOCK_TYPE':
+				return true;
+		}
+
+		return state;
+	},
 	byUid( state = {}, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':

--- a/editor/state.js
+++ b/editor/state.js
@@ -29,7 +29,6 @@ export const blocks = combineUndoableReducers( {
 			case 'MOVE_BLOCK_UP':
 			case 'REPLACE_BLOCKS':
 			case 'REMOVE_BLOCK':
-			case 'SWITCH_BLOCK_TYPE':
 				return true;
 		}
 


### PR DESCRIPTION
This PR adds a first pass at a `state.blocks.dirty` state key and uses it to display "Saved" or "Modified" in the toolbar:

## No changes to content

> <img src="https://cloud.githubusercontent.com/assets/227022/25642338/ca5c8bf4-2f5e-11e7-84d3-ebf286c385b5.png" width="400">

Note, this is always the current state in `master`.

## Content is dirty

> <img src="https://cloud.githubusercontent.com/assets/227022/25642354/e3ff17d4-2f5e-11e7-969a-631559a0a881.png" width="450">

## Notes

Spun off from https://github.com/WordPress/gutenberg/pull/594#pullrequestreview-35716231 - after that PR is merged, I expect this will be called `state.editor.dirty` instead, and we can update this state key to be aware of post save actions and use it to alter the Publish/Update button message as well.

This uses the list of actions from https://github.com/WordPress/gutenberg/pull/594#issuecomment-298662384 to update the `dirty` state key.  One thing that's missing: we should probably update the dirty state as soon as some content is edited within a block, rather than after the focus is switched to another block.