### PR TITLE
Force POSIX implementation for strings relative path output

### DIFF
--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -34,7 +34,7 @@
 
 const { po } = require( 'gettext-parser' );
 const { pick, reduce, uniq, forEach, sortBy, isEqual, merge, isEmpty } = require( 'lodash' );
-const { relative } = require( 'path' ).posix;
+const { relative, sep } = require( 'path' );
 const { writeFileSync } = require( 'fs' );
 
 /**
@@ -199,10 +199,12 @@ module.exports = function() {
 					translation.msgstr = '';
 				}
 
-				// Assign file reference comment
+				// Assign file reference comment, ensuring consistent pathname
+				// reference between Win32 and POSIX
 				const { filename } = this.file.opts;
+				const pathname = relative( '.', filename ).split( sep ).join( '/' );
 				translation.comments = {
-					reference: relative( process.cwd(), filename ) + ':' + path.node.loc.start.line
+					reference: pathname + ':' + path.node.loc.start.line
 				};
 
 				// If exists, also assign translator comment

--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -34,7 +34,7 @@
 
 const { po } = require( 'gettext-parser' );
 const { pick, reduce, uniq, forEach, sortBy, isEqual, merge, isEmpty } = require( 'lodash' );
-const { relative } = require( 'path' );
+const { relative } = require( 'path' ).posix;
 const { writeFileSync } = require( 'fs' );
 
 /**


### PR DESCRIPTION
Fixes #597 

This pull request seeks to ensure consistent output of the `languages/gutenberg.pot` file between Windows and Unix by forcing the relative path string references to use the POSIX implementation of [Node's `path` module](https://nodejs.org/api/path.html#path_path_posix).

__Testing instructions:__

1. Run `npm run gettext-strings`
2. View `languages/gutenberg.pot`
3. Note that file references use `/` slash, not `\`

@BE-Webdesign, would you mind taking this for a spin on Windows?

Note: As of #614, the `.pot` file is now ignored from the Git repository, so you shouldn't expect to see any changes reported by `git status`.