### PR TITLE
Only dispatch START_TYPING if not already typing

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -177,7 +177,7 @@ class VisualEditorBlock extends wp.element.Component {
 						<Slot name="Formatting.Toolbar" />
 					</div>
 				}
-				<div onKeyDown={ onStartTyping }>
+				<div onKeyDown={ isTyping ? null : onStartTyping }>
 					<BlockEdit
 						focus={ focus }
 						attributes={ block.attributes }


### PR DESCRIPTION
Currently typing within a text block is very noisy in dispatching Redux actions, since it is bound as the `onKeyDown` event handler for the block wrapper. We only need to dispatch the typing start action if the block state `selectedBlock.typing` value is not currently `true` for the current block.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/25668333/656565a4-2ff4-11e7-9ead-6fe90474eb89.png)|![After](https://cloud.githubusercontent.com/assets/1779930/25668298/5495a0a4-2ff4-11e7-9e27-c5d168a13c8e.png)

__Testing instructions:__

It's easiest to test [Redux DevTools Chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en). Verify that when typing in a text block, there's only a single `START_TYPING` action dispatched. Ensure that no regressions occur to the behavior affected by typing started (controls disappear).
