### PR TITLE
Load unminified TinyMCE when SCRIPT_DEBUG constant present

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@ function gutenberg_register_scripts() {
 	wp_register_script( 'react-dom-server', 'https://unpkg.com/react-dom@next/umd/react-dom-server' . $react_suffix . '.js', array( 'react' ) );
 
 	// Editor Scripts.
-	wp_register_script( 'tinymce-nightly', 'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.min.js' );
+	wp_register_script( 'tinymce-nightly', 'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce' . $suffix . '.js' );
 	wp_register_script( 'wp-i18n', plugins_url( 'i18n/build/index.js', __FILE__ ), array(), filemtime( plugin_dir_path( __FILE__ ) . 'i18n/build/index.js' ) );
 	wp_register_script( 'wp-element', plugins_url( 'element/build/index.js', __FILE__ ), array( 'react', 'react-dom', 'react-dom-server' ), filemtime( plugin_dir_path( __FILE__ ) . 'element/build/index.js' ) );
 	wp_register_script( 'wp-blocks', plugins_url( 'blocks/build/index.js', __FILE__ ), array( 'wp-element', 'tinymce-nightly' ), filemtime( plugin_dir_path( __FILE__ ) . 'blocks/build/index.js' ) );


### PR DESCRIPTION
This pull request makes a simple change to load the unminified version of TinyMCE when the `SCRIPT_DEBUG` constant is specified as a truthy value, thus facilitating debugging of TinyMCE internals.

__Testing instructions:__

Verify that the editor loads with and without a `SCRIPT_DEBUG` constant defined as `true`.

https://codex.wordpress.org/Debugging_in_WordPress#SCRIPT_DEBUG