### PR TITLE
Unset keys when concatenating child elements

### DIFF
--- a/element/index.js
+++ b/element/index.js
@@ -77,11 +77,11 @@ export function renderToString( element ) {
  * @return {Array}                The concatenated value
  */
 export function concatChildren( ...childrens ) {
-	return childrens.reduce( ( memo, children, i ) => {
-		Children.forEach( children, ( child, j ) => {
+	return childrens.reduce( ( memo, children ) => {
+		Children.forEach( children, ( child ) => {
 			if ( child && 'string' !== typeof child ) {
 				child = cloneElement( child, {
-					key: [ i, j ].join()
+					key: undefined
 				} );
 			}
 

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -45,14 +45,14 @@ describe( 'element', () => {
 			expect( concatChildren( [ 'a' ], 'b' ) ).to.eql( [ 'a', 'b' ] );
 		} );
 
-		it( 'should concat the object arrays and rewrite keys', () => {
+		it( 'should concat the object arrays and unset keys', () => {
 			const concat = concatChildren(
 				[ createElement( 'strong', {}, 'Courgette' ) ],
 				createElement( 'strong', {}, 'Concombre' )
 			);
 			expect( concat.length ).to.equal( 2 );
-			expect( concat[ 0 ].key ).to.equal( '0,0' );
-			expect( concat[ 1 ].key ).to.equal( '1,0' );
+			expect( concat[ 0 ].key ).to.be.null();
+			expect( concat[ 1 ].key ).to.be.null();
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to modify the behavior of `wp.element.concatChildren` to unset keys instead of defining new keys by indices within the children and sets of children. Originally these keys were assigned to avoid conflict when a child shared the same key across the sets of children. The problem with this approach is that by only using the array indices, React may try to reconcile two elements from different sets of children that are not truly the same, but merely share the same index (e.g. key `0,0`). Instead, we could either ensure a unique key every time we concatenate (via Lodash's `uniqueId`) or as proposed here, simply unset the key. I had worried this might have produced a React warning recommending that keys be assigned, but in my testing, this does not appear to be the case.

__Testing instructions:__

Ensure tests pass:

```
npm test
```

Verify that there is no regression in the behavior of merging text or heading blocks, and that in doing so, no warnings or errors are logged to your browser developer tools console.