### PR TITLE
Blocks API: add "Layout" category

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -1,11 +1,15 @@
 
 /**
- * Block categories
+ * Block categories.
+ *
+ * Group blocks together based on common traits
+ * The block "inserter" relies on these to present the list blocks
  *
  * @var {Array} categories
  */
 const categories = [
-	{ slug: 'common', title: 'Common blocks' }
+	{ slug: 'common', title: 'Common Blocks' },
+	{ slug: 'layout', title: 'Layout Blocks' }
 ];
 
 /**

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -27,7 +27,7 @@ registerBlock( 'core/button', {
 
 	icon: 'marker',
 
-	category: 'common',
+	category: 'layout',
 
 	attributes: {
 		url: attr( 'a', 'href' ),

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -9,7 +9,7 @@ registerBlock( 'core/separator', {
 
 	icon: 'minus',
 
-	category: 'common',
+	category: 'layout',
 
 	edit() {
 		return <hr className="blocks-separator" />;


### PR DESCRIPTION
And moves `separator` and `button` out of "common".

![image](https://cloud.githubusercontent.com/assets/548849/25700344/aa50b3f2-30c7-11e7-8cdf-c4ea1db700a7.png)
