### PR TITLE
Fix text editor style regression

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -48,7 +48,10 @@ body.toplevel_page_gutenberg {
 	@include break-small() {
 		padding-top: $header-height;
 	}
+}
 
+.editor-sidebar,
+.editor-visual-editor__block {
 	input, textarea {
 		border-radius: 4px;
 		border-color: $light-gray-500;


### PR DESCRIPTION
This is a PR to fix a regression I introduced in https://github.com/WordPress/gutenberg/pull/603#pullrequestreview-36284813.

This moves the styles to input fields to be scoped to blocks, and the sidebar, both of which will benefit from this style.