### PR TITLE
Remove focused block on backspace

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -21,6 +21,7 @@ class VisualEditorBlock extends wp.element.Component {
 		this.maybeDeselect = this.maybeDeselect.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
+		this.removeOnBackspace = this.removeOnBackspace.bind( this );
 		this.mergeWithPrevious = this.mergeWithPrevious.bind( this );
 		this.previousOffset = null;
 	}
@@ -73,6 +74,13 @@ class VisualEditorBlock extends wp.element.Component {
 		const { isTyping, isSelected, onStartTyping } = this.props;
 		if ( ! isTyping && isSelected ) {
 			onStartTyping();
+		}
+	}
+
+	removeOnBackspace( event ) {
+		const { keyCode, target } = event;
+		if ( 8 /* Backspace */ === keyCode && target === this.node ) {
+			this.props.onRemove( this.props.uid );
 		}
 	}
 
@@ -167,6 +175,7 @@ class VisualEditorBlock extends wp.element.Component {
 				onClick={ onSelect }
 				onFocus={ onSelect }
 				onBlur={ this.maybeDeselect }
+				onKeyDown={ this.removeOnBackspace }
 				onMouseEnter={ onHover }
 				onMouseMove={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }


### PR DESCRIPTION
Related: #130

This pull request seeks to add basic backspace behavior for removing a block. We'll need to expand upon this, especially for blocks using the `Editable` component, as the block rendering cannot know when a block is empty (it should be up to a block to manage this consideration). As such, the changes here work best with blocks which do not auto-focus an Editable, e.g. the `<hr>` separator block. Blocks with editable text can be deleted by carefully clicking twice on the outer border of the block.

__Testing instructions:__

Verify that backspace deletes a block:

1. Select the separator block
2. Hit backspace
3. Note that the block is removed

Verify that backspace within a text region does not delete the block:

2. Select within a text block
3. Hit backspace
3. Note that the block is not removed