### PR TITLE
Use raw format when setting Editable content

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -228,7 +228,7 @@ export default class Editable extends wp.element.Component {
 		}
 
 		content = wp.element.renderToString( content );
-		this.editor.setContent( content );
+		this.editor.setContent( content, { format: 'raw' } );
 	}
 
 	getContent() {

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -42,7 +42,7 @@ registerBlock( 'core/heading', {
 							blockType: 'core/heading',
 							attributes: {
 								nodeName: 'H2',
-								content: content[ 0 ]
+								content: content[ 0 ].props.children
 							}
 						};
 						const blocks = [ heading ];


### PR DESCRIPTION
Related: #635 

This is a continuation of #635, applying a commit that had been removed there to use raw formatting when setting content to the TinyMCE instance. It was removed due to the behavior of the Text -> Heading transform creating content with an invalid structure that had relied on TinyMCE's content sanitization.

For example, what would have previously been transformed as `<h2>foo<p>bar</p></h2>` should now be correctly transformed as `<h2>foobar</h2>`.

__Implementation notes:__

I don't like that I chose to call to `.props.children` in assigning the heading content. In fact, I think if at all possible, we should avoid having block implementers work with or manipulate these element trees at all. I think this can be improved by structuring the Text block's content attribute as an array. I recall we'd explored this at one point but found it "easy" to treat the text content as a single element blob. I suspect this will be an tempting escape for many blocks, so we should consider how best to encourage meaningful data structures for blocks, because doing so will help facilitate manipulating those structures (such as in transforming or merging blocks).

I'll plan to explore these ideas further in a subsequent pull request.

__Testing instructions:__

Verify that there are no regressions in merging a paragraph block into a heading block, including if the text block includes multiple paragraphs (should only merge the first of the paragraphs into the heading and preserve the rest).

1. Add a Heading block
2. Insert some text into the new Heading block
3. Add a Text block
4. Insert multiple paragraphs of text into the new Text block
5. Put cursor focus at beginning of text block
6. Press backspace
7. Note that the first of the Text block's paragraphs is appended to the Heading content