### PR TITLE
Editable: Adding the inlineToolbar prop

### DIFF
--- a/blocks/components/editable/format-toolbar.js
+++ b/blocks/components/editable/format-toolbar.js
@@ -150,7 +150,7 @@ class FormatToolbar extends wp.element.Component {
 				{ !! formats.link && ! this.state.isEditingLink &&
 					<div className="editable-format-toolbar__link-modal" style={ linkStyle }>
 						<a className="editable-format-toolbar__link-value" href="" onClick={ this.editLink }>
-							{ decodeURI( this.state.linkValue ) }
+							{ this.state.linkValue && decodeURI( this.state.linkValue ) }
 						</a>
 						<IconButton icon="edit" onClick={ this.editLink } />
 						<IconButton icon="editor-unlink" onClick={ this.dropLink } />

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -118,12 +118,21 @@ export default class Editable extends wp.element.Component {
 		const container = this.props.inlineToolbar
 			? this.editor.getBody().closest( '.blocks-editable' )
 			: this.editor.getBody().closest( '.editor-visual-editor__block' );
-		const editorPosition = container.getBoundingClientRect();
+		const containerPosition = container.getBoundingClientRect();
+		const blockPadding = 14;
+		const blockMoverMargin = 18;
 
-		// The margins are different depending on the container
+		// These offsets are necessary because the toolbar where the link modal lives
+		// is absolute positioned and it's not shown when we compute the position here
+		// so we compute the position about its parent relative position and adds the offset
+		const toolbarOffset = this.props.inlineToolbar
+			? { top: 50, left: 0 }
+			: { top: 40, left: -( ( blockPadding * 2 ) + blockMoverMargin ) };
+		const linkModalWidth = 250;
+
 		return {
-			top: position.top - editorPosition.top + position.height + ( this.props.inlineToolbar ? 50 : 40 ),
-			left: position.left - editorPosition.left - ( this.props.inlineToolbar ? 100 : 157 )
+			top: position.top - containerPosition.top + ( position.height ) + toolbarOffset.top,
+			left: position.left - containerPosition.left - ( linkModalWidth / 2 ) + ( position.width / 2 ) + toolbarOffset.left
 		};
 	}
 

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -338,7 +338,6 @@ export default class Editable extends wp.element.Component {
 			inline,
 			formattingControls
 		} = this.props;
-		const classes = classnames( 'blocks-editable', className );
 
 		// Generating a key that includes `tagName` ensures that if the tag
 		// changes, we unmount (+ destroy) the previous TinyMCE element, then

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -344,6 +344,7 @@ export default class Editable extends wp.element.Component {
 		// changes, we unmount (+ destroy) the previous TinyMCE element, then
 		// mount (+ initialize) a new child element in its place.
 		const key = [ 'editor', tagName ].join();
+		const classes = classnames( className, 'blocks-editable' );
 
 		const formatToolbar = (
 			<FormatToolbar
@@ -355,7 +356,7 @@ export default class Editable extends wp.element.Component {
 		);
 
 		return (
-			<div className="blocks-editable">
+			<div className={ classes }>
 				{ focus &&
 					<Fill name="Formatting.Toolbar">
 						{ showAlignments &&

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -112,11 +112,18 @@ export default class Editable extends wp.element.Component {
 	}
 
 	getRelativePosition( node ) {
-		const editorPosition = this.editor.getBody().closest( '.editor-visual-editor__block' ).getBoundingClientRect();
 		const position = node.getBoundingClientRect();
+
+		// Find the parent "relative" positioned container
+		const container = this.props.inlineToolbar
+			? this.editor.getBody().closest( '.blocks-editable' )
+			: this.editor.getBody().closest( '.editor-visual-editor__block' );
+		const editorPosition = container.getBoundingClientRect();
+
+		// The margins are different depending on the container
 		return {
-			top: position.top - editorPosition.top + 40 + ( position.height ),
-			left: position.left - editorPosition.left - 157
+			top: position.top - editorPosition.top + position.height + ( this.props.inlineToolbar ? 50 : 40 ),
+			left: position.left - editorPosition.left - ( this.props.inlineToolbar ? 100 : 157 )
 		};
 	}
 
@@ -327,6 +334,7 @@ export default class Editable extends wp.element.Component {
 			focus,
 			className,
 			showAlignments = false,
+			inlineToolbar = false,
 			inline,
 			formattingControls
 		} = this.props;
@@ -337,41 +345,48 @@ export default class Editable extends wp.element.Component {
 		// mount (+ initialize) a new child element in its place.
 		const key = [ 'editor', tagName ].join();
 
-		let element = (
-			<TinyMCE
-				tagName={ tagName }
-				onSetup={ this.onSetup }
-				style={ style }
-				className={ classes }
-				defaultValue={ value }
-				settings={ {
-					forced_root_block: inline ? false : 'p'
-				} }
-				key={ key } />
+		const formatToolbar = (
+			<FormatToolbar
+				focusPosition={ this.state.focusPosition }
+				formats={ this.state.formats }
+				onChange={ this.changeFormats }
+				enabledControls={ formattingControls }
+			/>
 		);
 
-		if ( focus ) {
-			element = [
-				<Fill name="Formatting.Toolbar" key="fill">
-					{ showAlignments &&
-						<Toolbar
-							controls={ ALIGNMENT_CONTROLS.map( ( control ) => ( {
-								...control,
-								onClick: () => this.toggleAlignment( control.align ),
-								isActive: this.isAlignmentActive( control.align )
-							} ) ) } />
-					}
-					<FormatToolbar
-						focusPosition={ this.state.focusPosition }
-						formats={ this.state.formats }
-						onChange={ this.changeFormats }
-						enabledControls={ formattingControls }
-					/>
-				</Fill>,
-				element
-			];
-		}
+		return (
+			<div className="blocks-editable">
+				{ focus &&
+					<Fill name="Formatting.Toolbar">
+						{ showAlignments &&
+							<Toolbar
+								controls={ ALIGNMENT_CONTROLS.map( ( control ) => ( {
+									...control,
+									onClick: () => this.toggleAlignment( control.align ),
+									isActive: this.isAlignmentActive( control.align )
+								} ) ) } />
+						}
+						{ ! inlineToolbar && formatToolbar }
+					</Fill>
+				}
 
-		return element;
+				{ focus && inlineToolbar &&
+					<div className="block-editable__inline-toolbar">
+						{ formatToolbar }
+					</div>
+				}
+
+				<TinyMCE
+					tagName={ tagName }
+					onSetup={ this.onSetup }
+					style={ style }
+					className={ classes }
+					defaultValue={ value }
+					settings={ {
+						forced_root_block: inline ? false : 'p'
+					} }
+					key={ key } />
+			</div>
+		);
 	}
 }

--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -380,7 +380,6 @@ export default class Editable extends wp.element.Component {
 					tagName={ tagName }
 					onSetup={ this.onSetup }
 					style={ style }
-					className={ classes }
 					defaultValue={ value }
 					settings={ {
 						forced_root_block: inline ? false : 'p'

--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -1,6 +1,8 @@
 .blocks-editable {
 	position: relative;
+}
 
+.blocks-editable__tinymce {
 	> p:first-child {
 		margin-top: 0;
 	}
@@ -22,7 +24,17 @@
 	}
 }
 
-figcaption.blocks-editable {
+.block-editable__inline-toolbar {
+	display: flex;
+	justify-content: center;
+	position: absolute;
+	top: -50px;
+	left: 0;
+	right: 0;
+	z-index: 1;
+}
+
+figcaption.blocks-editable__tinymce {
 	margin-top: 0.5em;
 	color: $dark-gray-100;
 	text-align: center;

--- a/blocks/components/editable/style.scss
+++ b/blocks/components/editable/style.scss
@@ -48,7 +48,6 @@ figcaption.blocks-editable__tinymce {
 
 .editable-format-toolbar__link-modal {
 	position: absolute;
-	top: 42px;
 	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
 	background: #fff;

--- a/blocks/components/editable/tinymce.js
+++ b/blocks/components/editable/tinymce.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import classnames from 'classnames';
-
 export default class TinyMCE extends wp.element.Component {
 	componentDidMount() {
 		this.initialize();
@@ -52,7 +47,7 @@ export default class TinyMCE extends wp.element.Component {
 	}
 
 	render() {
-		const { tagName = 'div', style, className, defaultValue } = this.props;
+		const { tagName = 'div', style, defaultValue } = this.props;
 
 		// If a default value is provided, render it into the DOM even before
 		// TinyMCE finishes initializing. This avoids a short delay by allowing
@@ -61,13 +56,12 @@ export default class TinyMCE extends wp.element.Component {
 		if ( defaultValue ) {
 			children = wp.element.Children.toArray( defaultValue );
 		}
-		const classes = classnames( className, 'blocks-editable__tinymce' );
 
 		return wp.element.createElement( tagName, {
 			ref: ( node ) => this.editorNode = node,
 			contentEditable: true,
 			suppressContentEditableWarning: true,
-			className: classes,
+			className: 'blocks-editable__tinymce',
 			style
 		}, children );
 	}

--- a/blocks/components/editable/tinymce.js
+++ b/blocks/components/editable/tinymce.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
 export default class TinyMCE extends wp.element.Component {
 	componentDidMount() {
 		this.initialize();
@@ -56,13 +61,14 @@ export default class TinyMCE extends wp.element.Component {
 		if ( defaultValue ) {
 			children = wp.element.Children.toArray( defaultValue );
 		}
+		const classes = classnames( className, 'blocks-editable__tinymce' );
 
 		return wp.element.createElement( tagName, {
 			ref: ( node ) => this.editorNode = node,
 			contentEditable: true,
 			suppressContentEditableWarning: true,
-			style,
-			className
+			className: classes,
+			style
 		}, children );
 	}
 }

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -103,6 +103,7 @@ registerBlock( 'core/image', {
 						onFocus={ setFocus }
 						onChange={ ( value ) => setAttributes( { caption: value } ) }
 						inline
+						inlineToolbar
 					/>
 				) : null }
 			</figure>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -91,6 +91,8 @@ registerBlock( 'core/image', {
 			);
 		}
 
+		const focusCaption = ( focusValue = {} ) => setFocus( { editable: 'caption', ...focusValue } );
+
 		return (
 			<figure className="blocks-image">
 				<img src={ url } alt={ alt } />
@@ -99,8 +101,8 @@ registerBlock( 'core/image', {
 						tagName="figcaption"
 						placeholder={ wp.i18n.__( 'Write caption…' ) }
 						value={ caption }
-						focus={ focus }
-						onFocus={ setFocus }
+						focus={ focus && focus.editable === 'caption' ? focus : undefined }
+						onFocus={ focusCaption }
 						onChange={ ( value ) => setAttributes( { caption: value } ) }
 						inline
 						inlineToolbar

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -91,7 +91,7 @@ registerBlock( 'core/image', {
 			);
 		}
 
-		const focusCaption = ( focusValue = {} ) => setFocus( { editable: 'caption', ...focusValue } );
+		const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );
 
 		return (
 			<figure className="blocks-image">

--- a/blocks/library/list/style.scss
+++ b/blocks/library/list/style.scss
@@ -1,3 +1,3 @@
-.blocks-list {
+.blocks-list .blocks-editable__tinymce {
 	list-style-position: inside;
 }


### PR DESCRIPTION
Some Editable need to show the formatting toolbar inlined with the Editable. This PR adds the `inlineToolbar` prop to solve this.

closes #541 

**Testing instructions**

 - Focus a text block, notice that the formatting toolbar is docked to the top of the block
 - Focus the caption of an image block and notice that the toolbar is shown Right on the top of the Editable.