### PR TITLE
Blocks: Select the previous block when clicking backspace

### DIFF
--- a/blocks/components/editable/index.js
+++ b/blocks/components/editable/index.js
@@ -89,7 +89,7 @@ export default class Editable extends wp.element.Component {
 	}
 
 	onInit() {
-		this.focus();
+		this.updateFocus();
 	}
 
 	onFocus() {
@@ -235,7 +235,7 @@ export default class Editable extends wp.element.Component {
 		return nodeListToReact( this.editor.getBody().childNodes || [], createElement );
 	}
 
-	focus() {
+	updateFocus() {
 		const { focus } = this.props;
 		if ( focus ) {
 			this.editor.focus();
@@ -244,6 +244,8 @@ export default class Editable extends wp.element.Component {
 				this.editor.selection.select( this.editor.getBody(), true );
 				this.editor.selection.collapse( false );
 			}
+		} else {
+			this.editor.getBody().blur();
 		}
 	}
 
@@ -252,8 +254,8 @@ export default class Editable extends wp.element.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( !! this.props.focus && ! prevProps.focus ) {
-			this.focus();
+		if ( this.props.focus !== prevProps.focus ) {
+			this.updateFocus();
 		}
 
 		// The savedContent var allows us to avoid updating the content right after an onChange call

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -81,6 +81,9 @@ class VisualEditorBlock extends wp.element.Component {
 		const { keyCode, target } = event;
 		if ( 8 /* Backspace */ === keyCode && target === this.node ) {
 			this.props.onRemove( this.props.uid );
+			if ( this.props.previousBlock ) {
+				this.props.onFocus( this.props.previousBlock.uid, { offset: -1 } );
+			}
 		}
 	}
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { Slot } from 'react-slot-fill';
 import { partial } from 'lodash';
-import 'element-closest';
 
 /**
  * Internal dependencies
@@ -140,15 +139,8 @@ class VisualEditorBlock extends wp.element.Component {
 			this.previousOffset = null;
 		}
 
-		// Focusing the block node if no inner element is focused
-		if (
-			!! this.props.focus &&
-			! prevProps.focus &&
-			(
-				! document.activeElement ||
-				document.activeElement.closest( '.editor-visual-editor__block' ) !== this.node
-			)
-		) {
+		// Focus node when focus state is programmatically transferred
+		if ( this.props.focus && ! prevProps.focus ) {
 			this.node.focus();
 		}
 	}

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { Slot } from 'react-slot-fill';
 import { partial } from 'lodash';
+import 'element-closest';
 
 /**
  * Internal dependencies
@@ -96,6 +97,7 @@ class VisualEditorBlock extends wp.element.Component {
 
 		// Do nothing if the previous block is not mergeable
 		if ( ! previousBlockSettings.merge ) {
+			onFocus( previousBlock.uid );
 			return;
 		}
 
@@ -129,13 +131,25 @@ class VisualEditorBlock extends wp.element.Component {
 		);
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate( prevProps ) {
 		if ( this.previousOffset ) {
 			window.scrollTo(
 				window.scrollX,
 				window.scrollY + this.node.getBoundingClientRect().top - this.previousOffset
 			);
 			this.previousOffset = null;
+		}
+
+		// Focusing the block node if no inner element is focused
+		if (
+			!! this.props.focus &&
+			! prevProps.focus &&
+			(
+				! document.activeElement ||
+				document.activeElement.closest( '.editor-visual-editor__block' ) !== this.node
+			)
+		) {
+			this.node.focus();
 		}
 	}
 


### PR DESCRIPTION
This solves the second part of #666 

When we hit backspace and we can't merge the block with the previous one, we select the previous one to be able to hit backspace a second time and delete it.

You can currently test it with the `separator` block followed by a text block (the image and the embed block have small focus issues right now, but there are open PRs to fix those)