### PR TITLE
Test caption length when considering to show editable

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -67,7 +67,7 @@ registerBlock( 'core/embed', {
 		const { url, title, caption } = attributes;
 		const iframe = <iframe src={ url } title={ title } />;
 
-		if ( ! caption ) {
+		if ( ! caption.length ) {
 			return iframe;
 		}
 

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -48,7 +48,7 @@ registerBlock( 'core/embed', {
 				<div className="iframe-overlay">
 					<iframe src={ url } title={ title } />
 				</div>
-				{ caption.length > 0 || !! focus ? (
+				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
 						placeholder={ wp.i18n.__( 'Write caption…' ) }
@@ -67,7 +67,7 @@ registerBlock( 'core/embed', {
 		const { url, title, caption } = attributes;
 		const iframe = <iframe src={ url } title={ title } />;
 
-		if ( ! caption.length ) {
+		if ( ! caption || ! caption.length ) {
 			return iframe;
 		}
 

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -48,7 +48,7 @@ registerBlock( 'core/embed', {
 				<div className="iframe-overlay">
 					<iframe src={ url } title={ title } />
 				</div>
-				{ caption || !! focus ? (
+				{ caption.length > 0 || !! focus ? (
 					<Editable
 						tagName="figcaption"
 						placeholder={ wp.i18n.__( 'Write caption…' ) }

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -113,7 +113,7 @@ registerBlock( 'core/image', {
 		const { url, alt, caption, align = 'none' } = attributes;
 		const img = <img src={ url } alt={ alt } className={ `align${ align }` } />;
 
-		if ( ! caption ) {
+		if ( ! caption.length ) {
 			return img;
 		}
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -94,7 +94,7 @@ registerBlock( 'core/image', {
 		return (
 			<figure className="blocks-image">
 				<img src={ url } alt={ alt } />
-				{ caption.length > 0 || !! focus ? (
+				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
 						placeholder={ wp.i18n.__( 'Write caption…' ) }
@@ -113,7 +113,7 @@ registerBlock( 'core/image', {
 		const { url, alt, caption, align = 'none' } = attributes;
 		const img = <img src={ url } alt={ alt } className={ `align${ align }` } />;
 
-		if ( ! caption.length ) {
+		if ( ! caption || ! caption.length ) {
 			return img;
 		}
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -94,7 +94,7 @@ registerBlock( 'core/image', {
 		return (
 			<figure className="blocks-image">
 				<img src={ url } alt={ alt } />
-				{ caption || !! focus ? (
+				{ caption.length > 0 || !! focus ? (
 					<Editable
 						tagName="figcaption"
 						placeholder={ wp.i18n.__( 'Write caption…' ) }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -120,7 +120,7 @@ registerBlock( 'core/quote', {
 					onMerge={ mergeWithPrevious }
 					showAlignments
 				/>
-				{ ( citation || !! focus ) && (
+				{ ( citation.length > 0 || !! focus ) && (
 					<Editable
 						tagName="footer"
 						value={ citation }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -143,10 +143,12 @@ registerBlock( 'core/quote', {
 
 		return (
 			<blockquote className={ `blocks-quote-style-${ style }` }>
-				{ value && wp.element.Children.map( value, ( paragraph, i ) => (
+				{ value.map( ( paragraph, i ) => (
 					<p key={ i }>{ paragraph }</p>
 				) ) }
-				<footer>{ citation }</footer>
+				{ citation.length > 0 && (
+					<footer>{ citation }</footer>
+				) }
 			</blockquote>
 		);
 	}

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -120,7 +120,7 @@ registerBlock( 'core/quote', {
 					onMerge={ mergeWithPrevious }
 					showAlignments
 				/>
-				{ ( citation.length > 0 || !! focus ) && (
+				{ ( ( citation && citation.length > 0 ) || !! focus ) && (
 					<Editable
 						tagName="footer"
 						value={ citation }
@@ -143,10 +143,10 @@ registerBlock( 'core/quote', {
 
 		return (
 			<blockquote className={ `blocks-quote-style-${ style }` }>
-				{ value.map( ( paragraph, i ) => (
+				{ value && value.map( ( paragraph, i ) => (
 					<p key={ i }>{ paragraph }</p>
 				) ) }
-				{ citation.length > 0 && (
+				{ citation && citation.length > 0 && (
 					<footer>{ citation }</footer>
 				) }
 			</blockquote>

--- a/post-content.js
+++ b/post-content.js
@@ -30,7 +30,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/image align="center" -->',
-			'<figure><img src="https://cldup.com/E4PzNdrFSQ.jpg" class="aligncenter"/><figcaption><p>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</p></figcaption></figure>',
+			'<figure><img src="https://cldup.com/E4PzNdrFSQ.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
@@ -38,7 +38,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/embed url="https://www.youtube.com/watch?v=Nl6U7UotA-M" -->',
-			'<figure><iframe width="560" height="315" src="//www.youtube.com/embed/Nl6U7UotA-M" frameborder="0" allowfullscreen></iframe><figcaption><p>State of the Word 2016</p></figcaption></figure>',
+			'<figure><iframe width="560" height="315" src="//www.youtube.com/embed/Nl6U7UotA-M" frameborder="0" allowfullscreen></iframe><figcaption>State of the Word 2016</figcaption></figure>',
 			'<!-- /wp:core/embed -->',
 
 			'<!-- wp:core/heading -->',


### PR DESCRIPTION
Fixes #673 
Related: #668

This pull request seeks to resolve an issue where caption and citation fields are shown when the block has no focus and no caption content. In doing so, it also removes invalid paragraphs from the demo `post-content.js` text.

__Implementation notes:__

The `children` matcher always returns an array. An array is truthy even when it has no values. Instead, test length of the array to see if any content is to be shown.

__Testing instructions:__

Verify that only images, quotes, and embeds with caption text show the caption Editable, except when focused (in which case, Editable should always be shown).