### PR TITLE
Include block default attributes in created block

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -17,10 +17,20 @@ import { getBlockSettings } from './registration';
  * @return {Object}             Block object
  */
 export function createBlock( blockType, attributes = {} ) {
+	const blockSettings = getBlockSettings( blockType );
+
+	let defaultAttributes;
+	if ( blockSettings ) {
+		defaultAttributes = blockSettings.defaultAttributes;
+	}
+
 	return {
 		uid: uuid(),
 		blockType,
-		attributes
+		attributes: {
+			...defaultAttributes,
+			...attributes
+		}
 	};
 }
 

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -19,12 +19,18 @@ describe( 'block factory', () => {
 
 	describe( 'createBlock()', () => {
 		it( 'should create a block given its blockType and attributes', () => {
+			registerBlock( 'core/test-block', {
+				defaultAttributes: {
+					includesDefault: true
+				}
+			} );
 			const block = createBlock( 'core/test-block', {
 				align: 'left'
 			} );
 
 			expect( block.blockType ).to.eql( 'core/test-block' );
 			expect( block.attributes ).to.eql( {
+				includesDefault: true,
 				align: 'left'
 			} );
 			expect( block.uid ).to.be.a( 'string' );


### PR DESCRIPTION
Originally considered for #684, this pull request improves the behavior of `createBlock` by considering a block's `defaultAttributes` in the return value attributes. Per discussion at #684 and https://github.com/WordPress/gutenberg/pull/674#issuecomment-299535581, we may want to standardize on any `children` attribute being provided a default empty array value, but we should be able to create these blocks without explicitly providing that value (when the block defines it already as a default).

__Testing instructions:__

There is no expected visual changes, though you should verify no regressions in inserting a new block.

Ensure unit tests pass:

```
npm test
```