### PR TITLE
Standardize on children value as array (step 1)

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -37,37 +37,26 @@ registerBlock( 'core/heading', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { content, ...attrs } ) => {
-					if ( Array.isArray( content ) ) {
-						const heading = {
-							blockType: 'core/heading',
-							attributes: {
-								nodeName: 'H2',
-								content: content[ 0 ].props.children
-							}
-						};
-						const blocks = [ heading ];
-
-						const remainingContent = content.slice( 1 );
-						if ( remainingContent.length ) {
-							const text = {
-								blockType: 'core/text',
-								attributes: {
-									...attrs,
-									content: remainingContent
-								}
-							};
-							blocks.push( text );
-						}
-
-						return blocks;
+					if ( ! content ) {
+						return wp.blocks.createBlock( 'core/heading' );
 					}
-					return {
-						blockType: 'core/heading',
-						attributes: {
-							nodeName: 'H2',
-							content
-						}
-					};
+
+					const [ paragraph, ...remainingContent ] = content;
+					const heading = wp.blocks.createBlock( 'core/heading', {
+						content: paragraph.props.children
+					} );
+
+					if ( ! remainingContent.length ) {
+						return heading;
+					}
+
+					return [
+						heading,
+						wp.blocks.createBlock( 'core/text', {
+							...attrs,
+							content: remainingContent
+						} )
+					];
 				}
 			}
 		],
@@ -76,12 +65,9 @@ registerBlock( 'core/heading', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
-					return {
-						blockType: 'core/text',
-						attributes: {
-							content
-						}
-					};
+					return wp.blocks.createBlock( 'core/text', {
+						content
+					} );
 				}
 			}
 		]
@@ -89,7 +75,10 @@ registerBlock( 'core/heading', {
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: wp.element.concatChildren( attributes.content, attributesToMerge.content )
+			content: [
+				...attributes.content,
+				...attributesToMerge.content
+			]
 		};
 	},
 

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -62,7 +62,10 @@ registerBlock( 'core/quote', {
 					return {
 						blockType: 'core/text',
 						attributes: {
-							content: wp.element.concatChildren( value, citation )
+							content: [
+								...( value || [] ),
+								...( citation || [] )
+							]
 						}
 					};
 				}

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -23,7 +23,10 @@ registerBlock( 'core/text', {
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: wp.element.concatChildren( attributes.content, attributesToMerge.content )
+			content: [
+				...attributes.content,
+				...attributesToMerge.content
+			]
 		};
 	},
 

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -18,7 +18,7 @@ registerBlock( 'core/text', {
 	},
 
 	defaultAttributes: {
-		content: <p />
+		content: []
 	},
 
 	merge( attributes, attributesToMerge ) {

--- a/element/index.js
+++ b/element/index.js
@@ -69,25 +69,3 @@ export function renderToString( element ) {
 
 	return renderToStaticMarkup( element );
 }
-
-/**
- * Concatenate two or more React children objects
- *
- * @param  {...?Object} childrens Set of children to concatenate
- * @return {Array}                The concatenated value
- */
-export function concatChildren( ...childrens ) {
-	return childrens.reduce( ( memo, children, i ) => {
-		Children.forEach( children, ( child, j ) => {
-			if ( child && 'string' !== typeof child ) {
-				child = cloneElement( child, {
-					key: [ i, j ].join()
-				} );
-			}
-
-			memo.push( child );
-		} );
-
-		return memo;
-	}, [] );
-}

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { createElement, renderToString, concatChildren } from '../';
+import { createElement, renderToString } from '../';
 
 describe( 'element', () => {
 	describe( 'renderToString', () => {
@@ -33,26 +33,6 @@ describe( 'element', () => {
 			expect( renderToString(
 				createElement( 'strong', null, 'Courgette' )
 			) ).to.equal( '<strong>Courgette</strong>' );
-		} );
-	} );
-
-	describe( 'concatChildren', () => {
-		it( 'should return an empty array for undefined children', () => {
-			expect( concatChildren() ).to.eql( [] );
-		} );
-
-		it( 'should concat the string arrays', () => {
-			expect( concatChildren( [ 'a' ], 'b' ) ).to.eql( [ 'a', 'b' ] );
-		} );
-
-		it( 'should concat the object arrays and rewrite keys', () => {
-			const concat = concatChildren(
-				[ createElement( 'strong', {}, 'Courgette' ) ],
-				createElement( 'strong', {}, 'Concombre' )
-			);
-			expect( concat.length ).to.equal( 2 );
-			expect( concat[ 0 ].key ).to.equal( '0,0' );
-			expect( concat[ 1 ].key ).to.equal( '1,0' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Supersedes #640
~~Blocked by https://github.com/iseulde/dom-react/pull/1~~
~~Blocked by #686~~
Partial resolution of #688

This pull request is a step toward treating any attribute which is derived using the `children` matcher as guaranteed to be an array. Subsequent pull requests will expand upon this to provide default values for existing blocks and eliminate truthy tests on these values in favor of length tests only (see: #684).

__Implementation notes:__

I'd hoped to use this opportunity to remove the `props.children` property access I'd lamented about in #667, but unfortunately we can't easily structure the text block as an array of paragraphs, since we need to preserve the text alignment style assigned to the paragraph itself. So for now this remains, but I left some of the general refactoring of the heading "transform from text" I'd explored in the process.

__Testing instructions:__

Verify that there are no regressions in merging a text block into a heading block.
Verify that there are no regressions in merging two of the same text or heading blocks.
Verify that there are no regressions in switching types between heading, text, and quote.

_*_ Caveat: Note that these testing instructions may be broken until blockers are resolved. 