### PR TITLE
Use createBlock helper in place of manual block creation

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -87,7 +87,7 @@ export function switchToBlockType( block, blockType ) {
 		return {
 			// The first transformed block whose type matches the "destination"
 			// type gets to keep the existing block's UID.
-			uid: index === firstSwitchedBlock ? block.uid : uuid(),
+			uid: index === firstSwitchedBlock ? block.uid : result.uid,
 			blockType: result.blockType,
 			attributes: result.attributes
 		};

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -44,12 +44,9 @@ describe( 'block factory', () => {
 					from: [ {
 						blocks: [ 'core/text-block' ],
 						transform: ( { value } ) => {
-							return {
-								blockType: 'core/updated-text-block',
-								attributes: {
-									value: 'chicken ' + value
-								}
-							};
+							return createBlock( 'core/updated-text-block', {
+								value: 'chicken ' + value
+							} );
 						}
 					} ]
 				}
@@ -82,12 +79,9 @@ describe( 'block factory', () => {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
-							return {
-								blockType: 'core/updated-text-block',
-								attributes: {
-									value: 'chicken ' + value
-								}
-							};
+							return createBlock( 'core/updated-text-block', {
+								value: 'chicken ' + value
+							} );
 						}
 					} ]
 				}
@@ -214,12 +208,10 @@ describe( 'block factory', () => {
 						blocks: [ 'core/text-block' ],
 						transform: ( { value } ) => {
 							return [
+								createBlock( 'core/updated-text-block', {
+									value: 'chicken ' + value
+								} ),
 								{
-									blockType: 'core/updated-text-block',
-									attributes: {
-										value: 'chicken ' + value
-									}
-								}, {
 									attributes: {
 										value: 'smoked ' + value
 									}
@@ -251,12 +243,9 @@ describe( 'block factory', () => {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
-							return {
-								blockType: 'core/text-block',
-								attributes: {
-									value: 'chicken ' + value
-								}
-							};
+							return createBlock( 'core/text-block', {
+								value: 'chicken ' + value
+							} );
 						}
 					} ]
 				}
@@ -283,17 +272,12 @@ describe( 'block factory', () => {
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return [
-								{
-									blockType: 'core/text-block',
-									attributes: {
-										value: 'chicken ' + value
-									}
-								}, {
-									blockType: 'core/text-block',
-									attributes: {
-										value: 'smoked ' + value
-									}
-								}
+								createBlock( 'core/text-block', {
+									value: 'chicken ' + value
+								} ),
+								createBlock( 'core/text-block', {
+									value: 'smoked ' + value
+								} )
 							];
 						}
 					} ]
@@ -321,17 +305,12 @@ describe( 'block factory', () => {
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return [
-								{
-									blockType: 'core/text-block',
-									attributes: {
-										value: 'chicken ' + value
-									}
-								}, {
-									blockType: 'core/updated-text-block',
-									attributes: {
-										value: 'smoked ' + value
-									}
-								}
+								createBlock( 'core/text-block', {
+									value: 'chicken ' + value
+								} ),
+								createBlock( 'core/updated-text-block', {
+									value: 'smoked ' + value
+								} )
 							];
 						}
 					} ]

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query } from '../../api';
+import { registerBlock, createBlock, query } from '../../api';
 import Editable from '../../editable';
 
 const { children, prop } = query;
@@ -38,14 +38,14 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content, ...attrs } ) => {
 					if ( Array.isArray( content ) ) {
-						const heading = wp.blocks.createBlock( 'core/heading', {
+						const heading = createBlock( 'core/heading', {
 							content: content[ 0 ].props.children
 						} );
 						const blocks = [ heading ];
 
 						const remainingContent = content.slice( 1 );
 						if ( remainingContent.length ) {
-							const text = wp.blocks.createBlock( 'core/text', {
+							const text = createBlock( 'core/text', {
 								...attrs,
 								content: remainingContent
 							} );
@@ -54,7 +54,7 @@ registerBlock( 'core/heading', {
 
 						return blocks;
 					}
-					return wp.blocks.createBlock( 'core/heading', {
+					return createBlock( 'core/heading', {
 						content
 					} );
 				}
@@ -65,7 +65,7 @@ registerBlock( 'core/heading', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
-					return wp.blocks.createBlock( 'core/text', {
+					return createBlock( 'core/text', {
 						content
 					} );
 				}

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -38,36 +38,25 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content, ...attrs } ) => {
 					if ( Array.isArray( content ) ) {
-						const heading = {
-							blockType: 'core/heading',
-							attributes: {
-								nodeName: 'H2',
-								content: content[ 0 ].props.children
-							}
-						};
+						const heading = wp.blocks.createBlock( 'core/heading', {
+							content: content[ 0 ].props.children
+						} );
 						const blocks = [ heading ];
 
 						const remainingContent = content.slice( 1 );
 						if ( remainingContent.length ) {
-							const text = {
-								blockType: 'core/text',
-								attributes: {
-									...attrs,
-									content: remainingContent
-								}
-							};
+							const text = wp.blocks.createBlock( 'core/text', {
+								...attrs,
+								content: remainingContent
+							} );
 							blocks.push( text );
 						}
 
 						return blocks;
 					}
-					return {
-						blockType: 'core/heading',
-						attributes: {
-							nodeName: 'H2',
-							content
-						}
-					};
+					return wp.blocks.createBlock( 'core/heading', {
+						content
+					} );
 				}
 			}
 		],
@@ -76,12 +65,9 @@ registerBlock( 'core/heading', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
-					return {
-						blockType: 'core/text',
-						attributes: {
-							content
-						}
-					};
+					return wp.blocks.createBlock( 'core/text', {
+						content
+					} );
 				}
 			}
 		]

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query as hpq } from '../../api';
+import { registerBlock, createBlock, query as hpq } from '../../api';
 import Editable from '../../editable';
 
 const { children, query } = hpq;
@@ -33,7 +33,7 @@ registerBlock( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
-					return wp.blocks.createBlock( 'core/quote', {
+					return createBlock( 'core/quote', {
 						value: content
 					} );
 				}
@@ -42,7 +42,7 @@ registerBlock( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/heading' ],
 				transform: ( { content } ) => {
-					return wp.blocks.createBlock( 'core/quote', {
+					return createBlock( 'core/quote', {
 						value: content
 					} );
 				}
@@ -53,7 +53,7 @@ registerBlock( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { value, citation } ) => {
-					return wp.blocks.createBlock( 'core/text', {
+					return createBlock( 'core/text', {
 						content: wp.element.concatChildren( value, citation )
 					} );
 				}
@@ -63,10 +63,10 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/heading' ],
 				transform: ( { value, citation, ...attrs } ) => {
 					if ( Array.isArray( value ) || citation ) {
-						const heading = wp.blocks.createBlock( 'core/heading', {
+						const heading = createBlock( 'core/heading', {
 							content: Array.isArray( value ) ? value[ 0 ] : value
 						} );
-						const quote = wp.blocks.createBlock( 'core/quote', {
+						const quote = createBlock( 'core/quote', {
 							...attrs,
 							citation,
 							value: Array.isArray( value ) ? value.slice( 1 ) : ''
@@ -74,7 +74,7 @@ registerBlock( 'core/quote', {
 
 						return [ heading, quote ];
 					}
-					return wp.blocks.createBlock( 'core/heading', {
+					return createBlock( 'core/heading', {
 						content: value
 					} );
 				}

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -33,24 +33,18 @@ registerBlock( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
-					return {
-						blockType: 'core/quote',
-						attributes: {
-							value: content
-						}
-					};
+					return wp.blocks.createBlock( 'core/quote', {
+						value: content
+					} );
 				}
 			},
 			{
 				type: 'block',
 				blocks: [ 'core/heading' ],
 				transform: ( { content } ) => {
-					return {
-						blockType: 'core/quote',
-						attributes: {
-							value: content
-						}
-					};
+					return wp.blocks.createBlock( 'core/quote', {
+						value: content
+					} );
 				}
 			}
 		],
@@ -59,12 +53,9 @@ registerBlock( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { value, citation } ) => {
-					return {
-						blockType: 'core/text',
-						attributes: {
-							content: wp.element.concatChildren( value, citation )
-						}
-					};
+					return wp.blocks.createBlock( 'core/text', {
+						content: wp.element.concatChildren( value, citation )
+					} );
 				}
 			},
 			{
@@ -72,31 +63,20 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/heading' ],
 				transform: ( { value, citation, ...attrs } ) => {
 					if ( Array.isArray( value ) || citation ) {
-						const heading = {
-							blockType: 'core/heading',
-							attributes: {
-								nodeName: 'H2',
-								content: Array.isArray( value ) ? value[ 0 ] : value
-							}
-						};
-						const quote = {
-							blockType: 'core/quote',
-							attributes: {
-								...attrs,
-								citation,
-								value: Array.isArray( value ) ? value.slice( 1 ) : ''
-							}
-						};
+						const heading = wp.blocks.createBlock( 'core/heading', {
+							content: Array.isArray( value ) ? value[ 0 ] : value
+						} );
+						const quote = wp.blocks.createBlock( 'core/quote', {
+							...attrs,
+							citation,
+							value: Array.isArray( value ) ? value.slice( 1 ) : ''
+						} );
 
 						return [ heading, quote ];
 					}
-					return {
-						blockType: 'core/heading',
-						attributes: {
-							nodeName: 'H2',
-							content: value
-						}
-					};
+					return wp.blocks.createBlock( 'core/heading', {
+						content: value
+					} );
 				}
 			}
 		]


### PR DESCRIPTION
Closes #688 

This pull request seeks to use the `wp.blocks.createBlock` helper consistently for creating blocks, particularly in block transforms.

__Testing instructions:__

Verify that there are no regressions in changing between heading, text, and quote block types.