### PR TITLE
Improve the block switcher a11y

### DIFF
--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -73,17 +73,26 @@ class BlockSwitcher extends wp.element.Component {
 					className="editor-block-switcher__toggle"
 					icon={ blockSettings.icon }
 					onClick={ this.toggleMenu }
+					aria-haspopup="true"
+					aria-expanded={ this.state.open }
+					label={ wp.i18n.__( 'Change block content type' ) }
 				>
 					<div className="editor-block-switcher__arrow" />
 				</IconButton>
 				{ this.state.open &&
-					<div className="editor-block-switcher__menu">
+					<div
+						className="editor-block-switcher__menu"
+						role="menu"
+						tabIndex="0"
+						aria-label={ wp.i18n.__( 'Content types' ) }
+					>
 						{ allowedBlocks.map( ( { slug, title, icon } ) => (
 							<IconButton
 								key={ slug }
 								onClick={ this.switchBlockType( slug ) }
 								className="editor-block-switcher__menu-item"
 								icon={ icon }
+								role="menuitem"
 							>
 								{ title }
 							</IconButton>

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -56,6 +56,7 @@
 	cursor: pointer;
 
 	&:hover,
+	&:focus,
 	&:not(:disabled):hover {
 		color: $dark-gray-500;
 		border-color: $dark-gray-500;


### PR DESCRIPTION
As done for the Inserter (see #527 ) this PR adds ARIA roles, states, and properties to the Block switcher.
Adds focus style to the menu items, same as hover.
Also, adds an `aria-label` to the block switcher toggle button and to the menu. Any suggestions for a better wording very welcome, for now the labels are:
- `Change block content type` on the toggle
- `Content types` on the menu

The block switcher menu will need also arrow keys navigation, see #696 

Collapsed:

<img width="799" alt="screen shot 2017-05-06 at 16 54 05" src="https://cloud.githubusercontent.com/assets/1682452/25773468/0b2fc80e-327e-11e7-9fd8-c9abe7b0ab2e.png">

Expanded:

<img width="815" alt="expanded" src="https://cloud.githubusercontent.com/assets/1682452/25773475/184bf1ca-327e-11e7-9da2-30794af6cc5d.png">

Menu label:

<img width="785" alt="screen shot 2017-05-06 at 16 55 57" src="https://cloud.githubusercontent.com/assets/1682452/25773474/14f6c1a8-327e-11e7-83ea-80595b4f274a.png">


Fixes #695 