### PR TITLE
Integrate `dirty` state, API requests, and publish button

### DIFF
--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -12,6 +12,7 @@ import { savePost } from 'actions';
 function PublishButton( {
 	post,
 	edits,
+	dirty,
 	blocks,
 	isSuccessful,
 	isRequesting,
@@ -27,11 +28,11 @@ function PublishButton( {
 		buttonText = requestIsNewPost
 			? wp.i18n.__( 'Saving…' )
 			: wp.i18n.__( 'Updating…' );
-	} else if ( isSuccessful ) {
+	} else if ( ! dirty && isSuccessful ) {
 		buttonText = requestIsNewPost
 			? wp.i18n.__( 'Saved!' )
 			: wp.i18n.__( 'Updated!' );
-	} else if ( isError ) {
+	} else if ( ! dirty && isError ) {
 		buttonText = requestIsNewPost
 			? wp.i18n.__( 'Save failed' )
 			: wp.i18n.__( 'Update failed' );
@@ -63,6 +64,7 @@ export default connect(
 	( state ) => ( {
 		post: state.currentPost,
 		edits: state.editor.edits,
+		dirty: state.editor.dirty,
 		blocks: state.editor.blockOrder.map( ( uid ) => (
 			state.editor.blocksByUid[ uid ]
 		) ),

--- a/editor/state.js
+++ b/editor/state.js
@@ -39,6 +39,7 @@ export const editor = combineUndoableReducers( {
 	dirty( state = false, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
+			case 'REQUEST_POST_UPDATE_SUCCESS':
 				return false;
 
 			case 'UPDATE_BLOCK':


### PR DESCRIPTION
This simple PR integrates post saving/updating introduced in #594 and dirty state introduced in #610.

### Make `SavedState` aware of API requests

**To test:** Edit a post until it shows "Unsaved changes" in the top left.  Save it via the Update/Save draft button and observe that the text changes from "Unsaved changes" to "Saved".

### Make `PublishButton` aware of `dirty` state

**To test:** Save a post using the Update/Save draft button.  The button will show "Updated!" or "Saved!". 
 Edit a post until it shows "Unsaved changes" in the top left.  Verify that the button text changes back to "Update" or "Save".

### Next steps

In short: **error handling**.  Currently errors are indicated by the `PublishButton` showing "Update failed" or "Save failed".  In this PR, the error state is **cleared** when the post is modified again.  However, really we probably want a red error icon/message next to the publish button instead, and this would stick around after the post is edited.  This should be a separate task that builds on @jasmussen's mockups from https://github.com/WordPress/gutenberg/pull/594#issuecomment-298871748.