### PR TITLE
Chrome: Adding the post title input

### DIFF
--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -47,6 +47,7 @@ $admin-sidebar-width: 160px;
 $admin-sidebar-width-big: 190px;
 $admin-sidebar-width-collapsed: 36px;
 $shadow-popover: 0px 3px 20px rgba( $dark-gray-900, .1 ), 0px 1px 3px rgba( $dark-gray-900, .1 );
+$text-editor-max-width: 760px;
 
 /* Blocks */
 $block-padding: 14px;

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -8,10 +8,11 @@ import Textarea from 'react-autosize-textarea';
  * Internal dependencies
  */
 import './style.scss';
+import PostTitle from 'post-title';
 
 function TextEditor( { blocks, onChange } ) {
 	return (
-		<div>
+		<div className="editor-text-editor">
 			<header className="editor-text-editor__formatting">
 				<div className="editor-text-editor__formatting-group">
 					<button className="editor-text-editor__bold">b</button>
@@ -29,11 +30,12 @@ function TextEditor( { blocks, onChange } ) {
 					<button>close tags</button>
 				</div>
 			</header>
+			<PostTitle />
 			<Textarea
 				autoComplete="off"
 				defaultValue={ wp.blocks.serialize( blocks ) }
 				onBlur={ ( event ) => onChange( event.target.value ) }
-				className="editor-text-editor"
+				className="editor-text-editor__textarea"
 			/>
 		</div>
 	);

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -30,13 +30,15 @@ function TextEditor( { blocks, onChange } ) {
 					<button>close tags</button>
 				</div>
 			</header>
-			<PostTitle />
-			<Textarea
-				autoComplete="off"
-				defaultValue={ wp.blocks.serialize( blocks ) }
-				onBlur={ ( event ) => onChange( event.target.value ) }
-				className="editor-text-editor__textarea"
-			/>
+			<div className="editor-text-editor__body">
+				<PostTitle />
+				<Textarea
+					autoComplete="off"
+					defaultValue={ wp.blocks.serialize( blocks ) }
+					onBlur={ ( event ) => onChange( event.target.value ) }
+					className="editor-text-editor__textarea"
+				/>
+			</div>
 		</div>
 	);
 }

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -1,3 +1,23 @@
+.editor-text-editor {
+	padding-top: 60px;
+
+	@include break-small() {
+		padding-top: 60px + $admin-bar-height-big;
+	}
+
+	@include break-medium() {
+		padding-top: 60px + $admin-bar-height;
+	}
+
+	padding-left: 20px;
+	padding-right: 20px;
+
+	@include break-large() {
+		padding-left: calc( 50% - #{ $text-editor-max-width / 2 } );
+		padding-right: calc( 50% - #{ $text-editor-max-width / 2 } );
+	}
+}
+
 .editor-text-editor__formatting {
 	background: $white;
 	border-bottom: 1px solid $light-gray-500;
@@ -71,10 +91,9 @@
 	left: $admin-sidebar-width-collapsed;
 }
 
-
-.editor-text-editor {
+.editor-text-editor__textarea {
 	display: block;
-	padding-top: 60px;
+	padding-top: 20px;
 	padding-bottom: 0;
 	margin: 0;
 	width: 100%;
@@ -87,29 +106,8 @@
 	line-height: 150%;
 	transition: padding .2s linear;
 
-	@include break-small() {
-		padding-top: 60px + $admin-bar-height-big;
-	}
-
-	@include break-medium() {
-		padding-top: 60px + $admin-bar-height;
-	}
-
 	&:focus {
 		box-shadow: none;
-	}
-}
-
-/* Use padding to center text in the textarea, this allows you to click anywhere to focus it */
-$text-editor-max-width: 760px;
-
-.editor-text-editor {
-	padding-left: 20px;
-	padding-right: 20px;
-
-	@include break-large() {
-		padding-left: calc( 50% - #{ $text-editor-max-width / 2 } );
-		padding-right: calc( 50% - #{ $text-editor-max-width / 2 } );
 	}
 }
 

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -1,23 +1,3 @@
-.editor-text-editor {
-	padding-top: 60px;
-
-	@include break-small() {
-		padding-top: 60px + $admin-bar-height-big;
-	}
-
-	@include break-medium() {
-		padding-top: 60px + $admin-bar-height;
-	}
-
-	padding-left: 20px;
-	padding-right: 20px;
-
-	@include break-large() {
-		padding-left: calc( 50% - #{ $text-editor-max-width / 2 } );
-		padding-right: calc( 50% - #{ $text-editor-max-width / 2 } );
-	}
-}
-
 .editor-text-editor__formatting {
 	background: $white;
 	border-bottom: 1px solid $light-gray-500;
@@ -91,6 +71,18 @@
 	left: $admin-sidebar-width-collapsed;
 }
 
+.editor-text-editor__body {
+	padding-top: 40px;
+
+	@include break-small() {
+		padding-top: 40px + $admin-bar-height-big;
+	}
+
+	@include break-medium() {
+		padding-top: 40px + $admin-bar-height;
+	}
+}
+
 .editor-text-editor__textarea {
 	display: block;
 	padding-top: 20px;
@@ -108,6 +100,14 @@
 
 	&:focus {
 		box-shadow: none;
+	}
+
+	padding-left: 20px;
+	padding-right: 20px;
+
+	@include break-large() {
+		padding-left: calc( 50% - #{ $text-editor-max-width / 2 } );
+		padding-right: calc( 50% - #{ $text-editor-max-width / 2 } );
 	}
 }
 

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -9,10 +9,12 @@ import { connect } from 'react-redux';
 import './style.scss';
 import Inserter from 'components/inserter';
 import VisualEditorBlock from './block';
+import PostTitle from 'post-title';
 
 function VisualEditor( { blocks } ) {
 	return (
 		<div className="editor-visual-editor">
+			<PostTitle />
 			{ blocks.map( ( uid ) => (
 				<VisualEditorBlock key={ uid } uid={ uid } />
 			) ) }

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function PostTitle( { title, onUpdate } ) {
+	const onChange = ( event ) => onUpdate( event.target.value );
+
+	return (
+		<h1 className="editor-post-title">
+			<input
+				className="editor-post-title__input"
+				type="text"
+				value={ title }
+				onChange={ onChange }
+			/>
+		</h1>
+	);
+}
+
+export default connect(
+	( state ) => ( {
+		title: state.editor.edits.title === undefined
+			? state.currentPost.title.raw
+			: state.editor.edits.title,
+	} ),
+	( dispatch ) => {
+		return {
+			onUpdate( title ) {
+				dispatch( {
+					type: 'EDIT_POST',
+					post: { title }
+				} );
+			}
+		};
+	}
+)( PostTitle );

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -18,6 +18,7 @@ function PostTitle( { title, onUpdate } ) {
 				type="text"
 				value={ title }
 				onChange={ onChange }
+				placeholder={ wp.i18n.__( 'Enter title here' ) }
 			/>
 		</h1>
 	);

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -35,7 +35,7 @@ export default connect(
 			onUpdate( title ) {
 				dispatch( {
 					type: 'EDIT_POST',
-					post: { title }
+					edits: { title }
 				} );
 			}
 		};

--- a/editor/post-title/style.scss
+++ b/editor/post-title/style.scss
@@ -1,0 +1,28 @@
+.editor-post-title {
+	font-size: $editor-font-size;
+
+	.editor-text-editor & {
+		margin: 0 auto;
+		max-width: $text-editor-max-width;
+	}
+}
+
+input.editor-post-title__input {
+	font-size: 2em;
+	font-family: $editor-font;
+	line-height: $editor-line-height;
+	outline: none;
+	border: none;
+	box-shadow: none;
+	width: 100%;
+	padding: 10px;
+
+	&:focus {
+		outline: none;
+		box-shadow: none;
+	}
+
+	.editor-text-editor & {
+		padding: 0;
+	}
+}

--- a/editor/post-title/style.scss
+++ b/editor/post-title/style.scss
@@ -2,8 +2,14 @@
 	font-size: $editor-font-size;
 
 	.editor-text-editor & {
-		margin: 0 auto;
-		max-width: $text-editor-max-width;
+		padding-left: 20px;
+		padding-right: 20px;
+
+		@include break-large() {
+			max-width: $text-editor-max-width;
+			margin: 0 auto;
+			padding: 0;
+		}
 	}
 }
 

--- a/editor/state.js
+++ b/editor/state.js
@@ -29,7 +29,7 @@ export const editor = combineUndoableReducers( {
 			case 'EDIT_POST':
 				return {
 					...state,
-					...action.post,
+					...action.edits,
 				};
 		}
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -259,7 +259,7 @@ describe( 'state', () => {
 			it( 'should save newly edited properties', () => {
 				const original = editor( undefined, {
 					type: 'EDIT_POST',
-					post: {
+					edits: {
 						status: 'draft',
 						title: 'post title',
 					}
@@ -267,7 +267,7 @@ describe( 'state', () => {
 
 				const state = editor( original, {
 					type: 'EDIT_POST',
-					post: {
+					edits: {
 						tags: [ 1 ],
 					},
 				} );
@@ -282,7 +282,7 @@ describe( 'state', () => {
 			it( 'should save modified properties', () => {
 				const original = editor( undefined, {
 					type: 'EDIT_POST',
-					post: {
+					edits: {
 						status: 'draft',
 						title: 'post title',
 						tags: [ 1 ],
@@ -291,7 +291,7 @@ describe( 'state', () => {
 
 				const state = editor( original, {
 					type: 'EDIT_POST',
-					post: {
+					edits: {
 						title: 'modified title',
 						tags: [ 2 ],
 					},

--- a/post-content.js
+++ b/post-content.js
@@ -2,12 +2,11 @@
  * Temporary test post content
  */
 window._wpGutenbergPost = {
+	title: {
+		raw: 'Welcome to the Gutenberg Editor'
+	},
 	content: {
 		raw: [
-			'<!-- wp:core/heading -->',
-			'<h1>Welcome to the Gutenberg Editor</h1>',
-			'<!-- /wp:core/heading -->',
-
 			'<!-- wp:core/text -->',
 			'<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you\'ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>',
 			'<p>What you are reading now is a <strong>text block</strong>, the most basic block of all. A text block can have multiple paragraphs, if that\'s how you prefer to write your posts. But you can also split it by hitting enter twice. Once blocks are split they get their own controls to be moved freely around the post...</p>',


### PR DESCRIPTION
Now that we're able to save posts, we need a Post Title input. 
This PR adds this and shows the input in the Visual and the Text Editor.
This PR doesn't include the permalink editor yet.
It probably needs some design polish.