### PR TITLE
Fix regression with manually opened nav menu

### DIFF
--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -14,12 +14,21 @@
 	@include break-small() {
 		position: fixed;
 	}
+
+	@include break-medium() {
+		top: $admin-bar-height;
+	}
 }
 
-.auto-fold .editor-header {
+.sticky-menu .editor-header {	/* Sticky is when on smaller breakpoints, nav menu is manually opened */
+	@include break-medium() {
+		left: $admin-sidebar-width;
+	}
+}
+
+.auto-fold .editor-header {		/* Auto fold is when on smaller breakpoints, nav menu auto colllapses */
 	@include break-medium() {
 		left: $admin-sidebar-width-collapsed;
-		top: $admin-bar-height;
 	}
 
 	@include break-large() {


### PR DESCRIPTION
This PR fixes a responsive regression where around the 800px break, if you had manually opened the auto-collapsed nav menu sidebar, positioning would be off.

<img width="870" alt="screen shot 2017-05-08 at 13 44 07" src="https://cloud.githubusercontent.com/assets/1204802/25803030/643dfc22-33f5-11e7-98fe-e0364a50559b.png">