### PR TITLE
Parsing: Declare all block attributes

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import * as query from './query';
-
-export { query };
+export { default as query } from './query';
 export { createBlock, switchToBlockType } from './factory';
 export { default as parse } from './parser';
 export { default as serialize } from './serializer';

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -20,6 +20,9 @@ import { createBlock } from './factory';
  * @return {Object}                All block attributes
  */
 export function getBlockAttributes( blockSettings, rawContent, attributes ) {
+	// The blockSettings.attributes contains the definition of each attribute
+	// depending on its "source", we retrieve its value from the comment attribute
+	// or by parsing the block content
 	const computedAttributes = reduce( blockSettings.attributes, ( memo, attribute, key ) => {
 		if ( attribute.source === 'metadata' ) {
 			memo[ key ] = attributes[ attribute.name || key ];

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { parse as hpqParse } from 'hpq';
-import { escape, unescape, pickBy } from 'lodash';
+import { escape, unescape, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,32 +10,6 @@ import { escape, unescape, pickBy } from 'lodash';
 import { parse as grammarParse } from './post.pegjs';
 import { getBlockSettings, getUnknownTypeHandler } from './registration';
 import { createBlock } from './factory';
-
-/**
- * Returns the block attributes parsed from raw content.
- *
- * @param  {String} rawContent    Raw block content
- * @param  {Object} blockSettings Block settings
- * @return {Object}               Block attributes
- */
-export function parseBlockAttributes( rawContent, blockSettings ) {
-	const { attributes } = blockSettings;
-	if ( 'function' === typeof attributes ) {
-		return attributes( rawContent );
-	} else if ( attributes ) {
-		// Matchers are implemented as functions that receive a DOM node from
-		// which to select data. Use of the DOM is incidental and we shouldn't
-		// guarantee a contract that this be provided, else block implementers
-		// may feel compelled to use the node. Instead, matchers are intended
-		// as a generic interface to query data from any tree shape. Here we
-		// pick only matchers which include an internal flag.
-		const knownMatchers = pickBy( attributes, '_wpBlocksKnownMatcher' );
-
-		return hpqParse( rawContent, knownMatchers );
-	}
-
-	return {};
-}
 
 /**
  * Returns the block attributes of a registered block node given its settings.
@@ -46,17 +20,20 @@ export function parseBlockAttributes( rawContent, blockSettings ) {
  * @return {Object}                All block attributes
  */
 export function getBlockAttributes( blockSettings, rawContent, attributes ) {
-	// Merge any attributes from comment delimiters with block implementation
-	attributes = attributes || {};
-	if ( blockSettings ) {
-		attributes = {
-			...attributes,
-			...blockSettings.defaultAttributes,
-			...parseBlockAttributes( rawContent, blockSettings ),
-		};
-	}
+	const computedAttributes = reduce( blockSettings.attributes, ( memo, attribute, key ) => {
+		if ( attribute.source === 'metadata' ) {
+			memo[ key ] = attributes[ attribute.name || key ];
+		} else if ( attribute.source === 'content' ) {
+			memo[ key ] = hpqParse( rawContent, attribute.parse );
+		}
 
-	return attributes;
+		return memo;
+	}, {} );
+
+	return {
+		...blockSettings.defaultAttributes,
+		...computedAttributes,
+	};
 }
 
 /**

--- a/blocks/api/query.js
+++ b/blocks/api/query.js
@@ -31,6 +31,11 @@ const addDescriptor = ( description ) => ( memo ) => {
 	return Object.assign( memo, description );
 };
 
+// Source descriptors
+// Each one of these functions defines how to retrieve the attribute value
+//
+//  - the descriptor sets "source: content" and a parse function for attributes parsed from block content
+//  - the descriptor sets "source: metadata" and an attribute name for attributes stored in the block comment
 const attr = ( ...args ) => addDescriptor( { source: 'content', parse: originalAttr( ...args ) } );
 const prop = ( ...args ) => addDescriptor( { source: 'content', parse: originalProp( ...args ) } );
 const html = ( ...args ) => addDescriptor( { source: 'content', parse: originalHtml( ...args ) } );
@@ -44,13 +49,20 @@ const query = ( selector, descriptor ) => {
 	} );
 };
 
-const accumulateOn = ( description ) => {
+/**
+ * Takes an argument description and returns a chainable API to describe the current attribute
+ *
+ * @param  {?Object} description The argument description
+ *
+ * @return {Object}              descriptors chainable API
+ */
+const getChainableAPI = ( description ) => {
 	return reduce( { attr, prop, html, text, query, children, metadata }, ( memo, fct, key ) => {
 		const wrappedFct = ( ...args ) => {
 			const accumulator = fct( ...args );
 			const newDescription = accumulator( description || {} );
 			return {
-				...accumulateOn( newDescription ),
+				...getChainableAPI( newDescription ),
 				__description: newDescription
 			};
 		};
@@ -60,4 +72,4 @@ const accumulateOn = ( description ) => {
 	}, {} );
 };
 
-export default accumulateOn();
+export default getChainableAPI();

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { reduce } from 'lodash';
+
 /* eslint-disable no-console */
 
 /**
@@ -43,7 +48,13 @@ export function registerBlock( slug, settings ) {
 		);
 		return;
 	}
-	const block = Object.assign( { slug }, settings );
+
+	const attributes = reduce( settings ? settings.attributes : {}, ( memo, value, key ) => {
+		memo[ key ] = value.__description;
+		return memo;
+	}, {} );
+
+	const block = Object.assign( {}, settings, { slug, attributes } );
 	blocks[ slug ] = block;
 	return block;
 }

--- a/blocks/api/test/query.js
+++ b/blocks/api/test/query.js
@@ -7,18 +7,12 @@ import { parse } from 'hpq';
 /**
  * Internal dependencies
  */
-import * as query from '../query';
+import { originalChildren } from '../query';
 
 describe( 'query', () => {
-	it( 'should generate matchers which apply internal flag', () => {
-		for ( const matcherFn in query ) {
-			expect( query[ matcherFn ]()._wpBlocksKnownMatcher ).to.be.true();
-		}
-	} );
-
 	describe( 'children()', () => {
 		it( 'should return a matcher function', () => {
-			const matcher = query.children();
+			const matcher = originalChildren;
 
 			expect( matcher ).to.be.a( 'function' );
 		} );
@@ -27,7 +21,7 @@ describe( 'query', () => {
 			// Assumption here is that we can cleanly convert back and forth
 			// between a string and WPElement representation
 			const html = '<blockquote><p>A delicious sundae dessert</p></blockquote>';
-			const match = parse( html, query.children() );
+			const match = parse( html, originalChildren() );
 
 			expect( wp.element.renderToString( match ) ).to.equal( html );
 		} );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -18,6 +18,8 @@ import {
 	getBlocks
 } from '../registration';
 
+import query from '../query';
+
 describe( 'blocks', () => {
 	// Reset block state before each test.
 	beforeEach( () => {
@@ -54,7 +56,7 @@ describe( 'blocks', () => {
 		it( 'should accept valid block names', () => {
 			const block = registerBlock( 'my-plugin/fancy-block-4' );
 			expect( console.error ).to.not.have.been.called();
-			expect( block ).to.eql( { slug: 'my-plugin/fancy-block-4' } );
+			expect( block ).to.eql( { slug: 'my-plugin/fancy-block-4', attributes: {} } );
 		} );
 
 		it( 'should prohibit registering the same block twice', () => {
@@ -71,6 +73,22 @@ describe( 'blocks', () => {
 			expect( getBlockSettings( 'core/test-block-with-settings' ) ).to.eql( {
 				slug: 'core/test-block-with-settings',
 				settingName: 'settingValue',
+				attributes: {}
+			} );
+		} );
+
+		it( 'should compute block attributes', () => {
+			const blockSettings = { settingName: 'settingValue', attributes: {
+				align: query.metadata( 'align' )
+			} };
+			registerBlock( 'core/test-block-with-settings', blockSettings );
+			blockSettings.mutated = true;
+			expect( getBlockSettings( 'core/test-block-with-settings' ) ).to.eql( {
+				slug: 'core/test-block-with-settings',
+				settingName: 'settingValue',
+				attributes: {
+					align: { source: 'metadata', name: 'align' }
+				}
 			} );
 		} );
 	} );
@@ -85,11 +103,11 @@ describe( 'blocks', () => {
 		it( 'should unregister existing blocks', () => {
 			registerBlock( 'core/test-block' );
 			expect( getBlocks() ).to.eql( [
-				{ slug: 'core/test-block' },
+				{ slug: 'core/test-block', attributes: {} },
 			] );
 			const oldBlock = unregisterBlock( 'core/test-block' );
 			expect( console.error ).to.not.have.been.called();
-			expect( oldBlock ).to.eql( { slug: 'core/test-block' } );
+			expect( oldBlock ).to.eql( { slug: 'core/test-block', attributes: {} } );
 			expect( getBlocks() ).to.eql( [] );
 		} );
 	} );
@@ -113,6 +131,7 @@ describe( 'blocks', () => {
 			registerBlock( 'core/test-block' );
 			expect( getBlockSettings( 'core/test-block' ) ).to.eql( {
 				slug: 'core/test-block',
+				attributes: {}
 			} );
 		} );
 
@@ -122,6 +141,7 @@ describe( 'blocks', () => {
 			expect( getBlockSettings( 'core/test-block-with-settings' ) ).to.eql( {
 				slug: 'core/test-block-with-settings',
 				settingName: 'settingValue',
+				attributes: {}
 			} );
 		} );
 	} );
@@ -136,8 +156,8 @@ describe( 'blocks', () => {
 			const blockSettings = { settingName: 'settingValue' };
 			registerBlock( 'core/test-block-with-settings', blockSettings );
 			expect( getBlocks() ).to.eql( [
-				{ slug: 'core/test-block' },
-				{ slug: 'core/test-block-with-settings', settingName: 'settingValue' },
+				{ slug: 'core/test-block', attributes: {} },
+				{ slug: 'core/test-block-with-settings', settingName: 'settingValue', attributes: {} },
 			] );
 		} );
 	} );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import serialize, { getCommentAttributes, getSaveContent } from '../serializer';
 import { getBlocks, registerBlock, unregisterBlock } from '../registration';
+import query from '../query';
 
 describe( 'block serializer', () => {
 	afterEach( () => {
@@ -64,36 +65,40 @@ describe( 'block serializer', () => {
 
 		it( 'should return joined string of key:value pairs by difference subset', () => {
 			const attributes = getCommentAttributes( {
+				attributes: {
+					category: { source: 'metadata', name: 'cat' },
+					ripeness: { source: 'metadata', name: 'ripeness' },
+				}
+			}, {
 				fruit: 'bananas',
 				category: 'food',
 				ripeness: 'ripe'
-			}, {
-				fruit: 'bananas'
 			} );
 
-			expect( attributes ).to.equal( 'category="food" ripeness="ripe" ' );
+			expect( attributes ).to.equal( 'cat="food" ripeness="ripe" ' );
 		} );
 
 		it( 'should not append an undefined attribute value', () => {
 			const attributes = getCommentAttributes( {
+				attributes: {
+					category: { source: 'metadata', name: 'cat' },
+					ripeness: { source: 'metadata', name: 'ripeness' },
+				}
+			}, {
 				fruit: 'bananas',
 				category: 'food',
 				ripeness: undefined
-			}, {
-				fruit: 'bananas'
 			} );
 
-			expect( attributes ).to.equal( 'category="food" ' );
+			expect( attributes ).to.equal( 'cat="food" ' );
 		} );
 	} );
 
 	describe( 'serialize()', () => {
 		it( 'should serialize the post content properly', () => {
 			const blockSettings = {
-				attributes: ( rawContent ) => {
-					return {
-						content: rawContent
-					};
+				attributes: {
+					align: query.metadata( 'align' )
 				},
 				save( { attributes } ) {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -6,7 +6,7 @@ import { registerBlock, query } from 'api';
 import Editable from 'components/editable';
 import IconButton from '../../../editor/components/icon-button';
 
-const { attr, children } = query;
+const { attr, children, metadata } = query;
 
 /**
  * Returns an attribute setter with behavior that if the target value is
@@ -32,7 +32,8 @@ registerBlock( 'core/button', {
 	attributes: {
 		url: attr( 'a', 'href' ),
 		title: attr( 'a', 'title' ),
-		text: children( 'a' )
+		text: children( 'a' ),
+		align: metadata()
 	},
 
 	controls: [

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -8,7 +8,7 @@ import Editable from 'components/editable';
 import Dashicon from '../../../editor/components/dashicon';
 import Button from '../../../editor/components/button';
 
-const { attr, children } = query;
+const { attr, children, metadata } = query;
 
 /**
  * Returns an attribute setter with behavior that if the target value is
@@ -34,7 +34,8 @@ registerBlock( 'core/image', {
 	attributes: {
 		url: attr( 'img', 'src' ),
 		alt: attr( 'img', 'alt' ),
-		caption: children( 'figcaption' )
+		caption: children( 'figcaption' ),
+		align: metadata()
 	},
 
 	controls: [

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -5,7 +5,7 @@ import './style.scss';
 import { registerBlock, query as hpq } from 'api';
 import Editable from 'components/editable';
 
-const { children, query } = hpq;
+const { children, query, metadata } = hpq;
 
 registerBlock( 'core/quote', {
 	title: wp.i18n.__( 'Quote' ),
@@ -14,7 +14,8 @@ registerBlock( 'core/quote', {
 
 	attributes: {
 		value: query( 'blockquote > p', children() ),
-		citation: children( 'footer' )
+		citation: children( 'footer' ),
+		style: metadata()
 	},
 
 	controls: [ 1, 2 ].map( ( variation ) => ( {


### PR DESCRIPTION
closes #609 

- This PR tries to resolve #609 by allowing a chainable API to define blocks.
- With this PR, all block attributes should be defined in the `attributes` property
- The `attributes` property` can not be defined as a function anymore
- Adds the `metadata` descriptor to declare an attribute as a comment attribute.

This PR doesn't solve the typing yet, but the chainable API allows easily to add type descriptors (`isString`, `isNumber`) etc...

The chainable API allows things like that https://github.com/WordPress/gutenberg/issues/609#issuecomment-298846083