### PR TITLE
Post Title: Auto-growing textarea instead of input

### DIFF
--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -2,20 +2,28 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import Textarea from 'react-autosize-textarea';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
+/**
+ * Constants
+ */
+const REGEXP_NEWLINES = /[\r\n]+/g;
+
 function PostTitle( { title, onUpdate } ) {
-	const onChange = ( event ) => onUpdate( event.target.value );
+	const onChange = ( event ) => {
+		const newTitle = event.target.value.replace( REGEXP_NEWLINES, ' ' );
+		onUpdate( newTitle );
+	};
 
 	return (
 		<h1 className="editor-post-title">
-			<input
+			<Textarea
 				className="editor-post-title__input"
-				type="text"
 				value={ title }
 				onChange={ onChange }
 				placeholder={ wp.i18n.__( 'Enter title here' ) }

--- a/editor/post-title/style.scss
+++ b/editor/post-title/style.scss
@@ -13,7 +13,7 @@
 	}
 }
 
-input.editor-post-title__input {
+textarea.editor-post-title__input {
 	font-size: 2em;
 	font-family: $editor-font;
 	line-height: $editor-line-height;


### PR DESCRIPTION
Closes #722 

This PRs switches from an input to an auto-growing textarea to allow the post title to be shown on multiple lines.