### PR TITLE
Blocks: Unselect the block when clicking outside the current block

### DIFF
--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -124,6 +124,7 @@ class FormatToolbar extends wp.element.Component {
 			} );
 		}
 
+		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<div className="editable-format-toolbar">
 				<Toolbar controls={ toolbarControls } />
@@ -134,6 +135,7 @@ class FormatToolbar extends wp.element.Component {
 						style={ linkStyle }
 						onSubmit={ this.submitLink }>
 						<input
+							autoFocus
 							className="editable-format-toolbar__link-input"
 							type="url"
 							required
@@ -156,6 +158,7 @@ class FormatToolbar extends wp.element.Component {
 				}
 			</div>
 		);
+		/* eslint-enable jsx-a11y/no-autofocus */
 	}
 }
 

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -15,17 +15,22 @@ import './style.scss';
 import { isFirstBlock, isLastBlock } from '../selectors';
 
 function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
+	// We emulate a disabled state because forcefully applying the `disabled`
+	// attribute on the button while it has focus causes the screen to change
+	// to an unfocused state (body as active element) without firing blur on,
+	// the rendering parent, leaving it unable to react to focus out.
+
 	return (
 		<div className="editor-block-mover">
 			<IconButton
 				className="editor-block-mover__control"
-				onClick={ onMoveUp }
+				onClick={ isFirst ? null : onMoveUp }
 				icon="arrow-up-alt2"
 				aria-disabled={ isFirst }
 			/>
 			<IconButton
 				className="editor-block-mover__control"
-				onClick={ onMoveDown }
+				onClick={ isLast ? null : onMoveDown }
 				icon="arrow-down-alt2"
 				aria-disabled={ isLast }
 			/>

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -21,13 +21,13 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 				className="editor-block-mover__control"
 				onClick={ onMoveUp }
 				icon="arrow-up-alt2"
-				disabled={ isFirst }
+				aria-disabled={ isFirst }
 			/>
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ onMoveDown }
 				icon="arrow-down-alt2"
-				disabled={ isLast }
+				aria-disabled={ isLast }
 			/>
 		</div>
 	);

--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -19,9 +19,10 @@
 		color: $dark-gray-900;
 	}
 
-	&[disabled] {
+	&[aria-disabled="true"] {
 		cursor: default;
 		color: $light-gray-300;
+		pointer-events: none;
 	}
 
 	.dashicon {


### PR DESCRIPTION
closes #723 

This PR changes the way we trigger the "deselect" action, leveraging the `react-click-outside` library instead of the `onBlur` event handler.

This should fix the issues seen in #723 
The fix here also fix the auto focus on link input closes #679  