### PR TITLE
Add ESLint `comma-dangle` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
 	"rules": {
 		"array-bracket-spacing": [ "error", "always" ],
 		"brace-style": [ "error", "1tbs" ],
+		"comma-dangle": [ "error", "always-multiline" ],
 		"comma-spacing": "error",
 		"comma-style": "error",
 		"computed-property-spacing": [ "error", "always" ],

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -13,7 +13,7 @@ import { __ } from 'i18n';
  */
 const categories = [
 	{ slug: 'common', title: __( 'Common Blocks' ) },
-	{ slug: 'layout', title: __( 'Layout Blocks' ) }
+	{ slug: 'layout', title: __( 'Layout Blocks' ) },
 ];
 
 /**

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -29,8 +29,8 @@ export function createBlock( blockType, attributes = {} ) {
 		blockType,
 		attributes: {
 			...defaultAttributes,
-			...attributes
-		}
+			...attributes,
+		},
 	};
 }
 
@@ -89,7 +89,7 @@ export function switchToBlockType( block, blockType ) {
 			// type gets to keep the existing block's UID.
 			uid: index === firstSwitchedBlock ? block.uid : result.uid,
 			blockType: result.blockType,
-			attributes: result.attributes
+			attributes: result.attributes,
 		};
 	} );
 }

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -14,5 +14,5 @@ export {
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
 	getBlockSettings,
-	getBlocks
+	getBlocks,
 } from './registration';

--- a/blocks/api/query.js
+++ b/blocks/api/query.js
@@ -8,7 +8,7 @@ import {
 	prop as originalProp,
 	html as originalHtml,
 	text as originalText,
-	query as originalQuery
+	query as originalQuery,
 } from 'hpq';
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -76,7 +76,7 @@ export default function serialize( blocks ) {
 		const saveContent = getSaveContent( settings.save, block.attributes );
 		const beautifyOptions = {
 			indent_inner_html: true,
-			wrap_line_length: 0
+			wrap_line_length: 0,
 		};
 
 		return memo + (

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -21,17 +21,17 @@ describe( 'block factory', () => {
 		it( 'should create a block given its blockType and attributes', () => {
 			registerBlock( 'core/test-block', {
 				defaultAttributes: {
-					includesDefault: true
-				}
+					includesDefault: true,
+				},
 			} );
 			const block = createBlock( 'core/test-block', {
-				align: 'left'
+				align: 'left',
 			} );
 
 			expect( block.blockType ).to.eql( 'core/test-block' );
 			expect( block.attributes ).to.eql( {
 				includesDefault: true,
-				align: 'left'
+				align: 'left',
 			} );
 			expect( block.uid ).to.be.a( 'string' );
 		} );
@@ -45,11 +45,11 @@ describe( 'block factory', () => {
 						blocks: [ 'core/text-block' ],
 						transform: ( { value } ) => {
 							return createBlock( 'core/updated-text-block', {
-								value: 'chicken ' + value
+								value: 'chicken ' + value,
 							} );
-						}
-					} ]
-				}
+						},
+					} ],
+				},
 			} );
 			registerBlock( 'core/text-block', {} );
 
@@ -57,8 +57,8 @@ describe( 'block factory', () => {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -67,8 +67,8 @@ describe( 'block factory', () => {
 				uid: 1,
 				blockType: 'core/updated-text-block',
 				attributes: {
-					value: 'chicken ribs'
-				}
+					value: 'chicken ribs',
+				},
 			} ] );
 		} );
 
@@ -80,19 +80,19 @@ describe( 'block factory', () => {
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return createBlock( 'core/updated-text-block', {
-								value: 'chicken ' + value
+								value: 'chicken ' + value,
 							} );
-						}
-					} ]
-				}
+						},
+					} ],
+				},
 			} );
 
 			const block = {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -101,8 +101,8 @@ describe( 'block factory', () => {
 				uid: 1,
 				blockType: 'core/updated-text-block',
 				attributes: {
-					value: 'chicken ribs'
-				}
+					value: 'chicken ribs',
+				},
 			} ] );
 		} );
 
@@ -114,8 +114,8 @@ describe( 'block factory', () => {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -128,9 +128,9 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
-						transform: () => null
-					} ]
-				}
+						transform: () => null,
+					} ],
+				},
 			} );
 			registerBlock( 'core/text-block', {} );
 
@@ -138,8 +138,8 @@ describe( 'block factory', () => {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -152,9 +152,9 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
-						transform: () => []
-					} ]
-				}
+						transform: () => [],
+					} ],
+				},
 			} );
 			registerBlock( 'core/text-block', {} );
 
@@ -162,8 +162,8 @@ describe( 'block factory', () => {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -179,12 +179,12 @@ describe( 'block factory', () => {
 						transform: ( { value } ) => {
 							return {
 								attributes: {
-									value: 'chicken ' + value
-								}
+									value: 'chicken ' + value,
+								},
 							};
-						}
-					} ]
-				}
+						},
+					} ],
+				},
 			} );
 			registerBlock( 'core/text-block', {} );
 
@@ -192,8 +192,8 @@ describe( 'block factory', () => {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -209,17 +209,17 @@ describe( 'block factory', () => {
 						transform: ( { value } ) => {
 							return [
 								createBlock( 'core/updated-text-block', {
-									value: 'chicken ' + value
+									value: 'chicken ' + value,
 								} ),
 								{
 									attributes: {
-										value: 'smoked ' + value
-									}
-								}
+										value: 'smoked ' + value,
+									},
+								},
 							];
-						}
-					} ]
-				}
+						},
+					} ],
+				},
 			} );
 			registerBlock( 'core/text-block', {} );
 
@@ -227,8 +227,8 @@ describe( 'block factory', () => {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -244,19 +244,19 @@ describe( 'block factory', () => {
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return createBlock( 'core/text-block', {
-								value: 'chicken ' + value
+								value: 'chicken ' + value,
 							} );
-						}
-					} ]
-				}
+						},
+					} ],
+				},
 			} );
 
 			const block = {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -273,23 +273,23 @@ describe( 'block factory', () => {
 						transform: ( { value } ) => {
 							return [
 								createBlock( 'core/text-block', {
-									value: 'chicken ' + value
+									value: 'chicken ' + value,
 								} ),
 								createBlock( 'core/text-block', {
-									value: 'smoked ' + value
-								} )
+									value: 'smoked ' + value,
+								} ),
 							];
-						}
-					} ]
-				}
+						},
+					} ],
+				},
 			} );
 
 			const block = {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -306,23 +306,23 @@ describe( 'block factory', () => {
 						transform: ( { value } ) => {
 							return [
 								createBlock( 'core/text-block', {
-									value: 'chicken ' + value
+									value: 'chicken ' + value,
 								} ),
 								createBlock( 'core/updated-text-block', {
-									value: 'smoked ' + value
-								} )
+									value: 'smoked ' + value,
+								} ),
 							];
-						}
-					} ]
-				}
+						},
+					} ],
+				},
 			} );
 
 			const block = {
 				uid: 1,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'ribs'
-				}
+					value: 'ribs',
+				},
 			};
 
 			const updatedBlock = switchToBlockType( block, 'core/updated-text-block' );
@@ -339,14 +339,14 @@ describe( 'block factory', () => {
 				uid: 2,
 				blockType: 'core/text-block',
 				attributes: {
-					value: 'chicken ribs'
-				}
+					value: 'chicken ribs',
+				},
 			}, {
 				uid: 1,
 				blockType: 'core/updated-text-block',
 				attributes: {
-					value: 'smoked ribs'
-				}
+					value: 'smoked ribs',
+				},
 			} ] );
 		} );
 	} );

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -12,7 +12,7 @@ import {
 	parseBlockAttributes,
 	createBlockWithFallback,
 	parseWithGrammar,
-	parseWithTinyMCE
+	parseWithTinyMCE,
 } from '../parser';
 import {
 	registerBlock,
@@ -34,13 +34,13 @@ describe( 'block parser', () => {
 			const blockSettings = {
 				attributes: function( rawContent ) {
 					return {
-						content: rawContent + ' & Chicken'
+						content: rawContent + ' & Chicken',
 					};
-				}
+				},
 			};
 
 			expect( parseBlockAttributes( 'Ribs', blockSettings ) ).to.eql( {
-				content: 'Ribs & Chicken'
+				content: 'Ribs & Chicken',
 			} );
 		} );
 
@@ -48,14 +48,14 @@ describe( 'block parser', () => {
 			const blockSettings = {
 				attributes: {
 					emphasis: text( 'strong' ),
-					ignoredDomMatcher: ( node ) => node.innerHTML
-				}
+					ignoredDomMatcher: ( node ) => node.innerHTML,
+				},
 			};
 
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
 			expect( parseBlockAttributes( rawContent, blockSettings ) ).to.eql( {
-				emphasis: '& Chicken'
+				emphasis: '& Chicken',
 			} );
 		} );
 
@@ -72,12 +72,12 @@ describe( 'block parser', () => {
 			const blockSettings = {
 				attributes: function( rawContent ) {
 					return {
-						content: rawContent + ' & Chicken'
+						content: rawContent + ' & Chicken',
 					};
 				},
 				defaultAttributes: {
-					topic: 'none'
-				}
+					topic: 'none',
+				},
 			};
 
 			const rawContent = 'Ribs';
@@ -86,7 +86,7 @@ describe( 'block parser', () => {
 			expect( getBlockAttributes( blockSettings, rawContent, attrs ) ).to.eql( {
 				align: 'left',
 				topic: 'none',
-				content: 'Ribs & Chicken'
+				content: 'Ribs & Chicken',
 			} );
 		} );
 	} );
@@ -152,7 +152,7 @@ describe( 'block parser', () => {
 							return {
 								content: rawContent,
 							};
-						}
+						},
 					} );
 
 					const parsed = parse(
@@ -168,7 +168,7 @@ describe( 'block parser', () => {
 						smoked: 'yes',
 						url: 'http://google.com',
 						chicken: 'ribs & \'wings\'',
-						checked: true
+						checked: true,
 					} );
 					expect( parsed[ 0 ].uid ).to.be.a( 'string' );
 				} );
@@ -177,9 +177,9 @@ describe( 'block parser', () => {
 					registerBlock( 'core/test-block', {
 						attributes: function( rawContent ) {
 							return {
-								content: rawContent + ' & Chicken'
+								content: rawContent + ' & Chicken',
 							};
-						}
+						},
 					} );
 
 					const parsed = parse(
@@ -191,7 +191,7 @@ describe( 'block parser', () => {
 					expect( parsed ).to.have.lengthOf( 1 );
 					expect( parsed[ 0 ].blockType ).to.equal( 'core/test-block' );
 					expect( parsed[ 0 ].attributes ).to.eql( {
-						content: 'Ribs & Chicken'
+						content: 'Ribs & Chicken',
 					} );
 					expect( parsed[ 0 ].uid ).to.be.a( 'string' );
 				} );
@@ -224,7 +224,7 @@ describe( 'block parser', () => {
 							return {
 								content: rawContent,
 							};
-						}
+						},
 					} );
 
 					setUnknownTypeHandler( 'core/unknown-block' );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -15,7 +15,7 @@ import {
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
 	getBlockSettings,
-	getBlocks
+	getBlocks,
 } from '../registration';
 
 describe( 'blocks', () => {

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -66,9 +66,9 @@ describe( 'block serializer', () => {
 			const attributes = getCommentAttributes( {
 				fruit: 'bananas',
 				category: 'food',
-				ripeness: 'ripe'
+				ripeness: 'ripe',
 			}, {
-				fruit: 'bananas'
+				fruit: 'bananas',
 			} );
 
 			expect( attributes ).to.equal( 'category="food" ripeness="ripe" ' );
@@ -78,9 +78,9 @@ describe( 'block serializer', () => {
 			const attributes = getCommentAttributes( {
 				fruit: 'bananas',
 				category: 'food',
-				ripeness: undefined
+				ripeness: undefined,
 			}, {
-				fruit: 'bananas'
+				fruit: 'bananas',
 			} );
 
 			expect( attributes ).to.equal( 'category="food" ' );
@@ -92,12 +92,12 @@ describe( 'block serializer', () => {
 			const blockSettings = {
 				attributes: ( rawContent ) => {
 					return {
-						content: rawContent
+						content: rawContent,
 					};
 				},
 				save( { attributes } ) {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;
-				}
+				},
 			};
 			registerBlock( 'core/test-block', blockSettings );
 			const blockList = [
@@ -105,9 +105,9 @@ describe( 'block serializer', () => {
 					blockType: 'core/test-block',
 					attributes: {
 						content: 'Ribs & Chicken',
-						align: 'left'
-					}
-				}
+						align: 'left',
+					},
+				},
 			];
 			const expectedPostContent = '<!-- wp:core/test-block align="left" -->\n<p>Ribs & Chicken</p>\n<!-- /wp:core/test-block -->\n\n';
 

--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -8,18 +8,18 @@ const FORMATTING_CONTROLS = [
 	{
 		icon: 'editor-bold',
 		title: wp.i18n.__( 'Bold' ),
-		format: 'bold'
+		format: 'bold',
 	},
 	{
 		icon: 'editor-italic',
 		title: wp.i18n.__( 'Italic' ),
-		format: 'italic'
+		format: 'italic',
 	},
 	{
 		icon: 'editor-strikethrough',
 		title: wp.i18n.__( 'Strikethrough' ),
-		format: 'strikethrough'
-	}
+		format: 'strikethrough',
+	},
 ];
 
 // Default controls shown if no `enabledControls` prop provided
@@ -30,7 +30,7 @@ class FormatToolbar extends wp.element.Component {
 		super( ...arguments );
 		this.state = {
 			linkValue: props.formats.link ? props.formats.link.value : '',
-			isEditingLink: false
+			isEditingLink: false,
 		};
 		this.addLink = this.addLink.bind( this );
 		this.editLink = this.editLink.bind( this );
@@ -47,7 +47,7 @@ class FormatToolbar extends wp.element.Component {
 
 	componentWillReceiveProps( nextProps ) {
 		const newState = {
-			linkValue: nextProps.formats.link ? nextProps.formats.link.value : ''
+			linkValue: nextProps.formats.link ? nextProps.formats.link.value : '',
 		};
 		if (
 			! this.props.formats.link ||
@@ -62,7 +62,7 @@ class FormatToolbar extends wp.element.Component {
 	toggleFormat( format ) {
 		return () => {
 			this.props.onChange( {
-				[ format ]: ! this.props.formats[ format ]
+				[ format ]: ! this.props.formats[ format ],
 			} );
 		};
 	}
@@ -83,7 +83,7 @@ class FormatToolbar extends wp.element.Component {
 	editLink( event ) {
 		event.preventDefault();
 		this.setState( {
-			isEditingLink: true
+			isEditingLink: true,
 		} );
 	}
 
@@ -91,13 +91,13 @@ class FormatToolbar extends wp.element.Component {
 		event.preventDefault();
 		this.props.onChange( { link: { value: this.state.linkValue } } );
 		this.setState( {
-			isEditingLink: false
+			isEditingLink: false,
 		} );
 	}
 
 	updateLinkValue( event ) {
 		this.setState( {
-			linkValue: event.target.value
+			linkValue: event.target.value,
 		} );
 	}
 
@@ -112,7 +112,7 @@ class FormatToolbar extends wp.element.Component {
 			.map( ( control ) => ( {
 				...control,
 				onClick: this.toggleFormat( control.format ),
-				isActive: !! formats[ control.format ]
+				isActive: !! formats[ control.format ],
 			} ) );
 
 		if ( enabledControls.indexOf( 'link' ) !== -1 ) {
@@ -120,7 +120,7 @@ class FormatToolbar extends wp.element.Component {
 				icon: 'admin-links',
 				title: wp.i18n.__( 'Link' ),
 				onClick: this.addLink,
-				isActive: !! formats.link
+				isActive: !! formats.link,
 			} );
 		}
 

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -24,25 +24,25 @@ const KEYCODE_BACKSPACE = 8;
 const alignmentMap = {
 	alignleft: 'left',
 	alignright: 'right',
-	aligncenter: 'center'
+	aligncenter: 'center',
 };
 
 const ALIGNMENT_CONTROLS = [
 	{
 		icon: 'editor-alignleft',
 		title: wp.i18n.__( 'Align left' ),
-		align: 'left'
+		align: 'left',
 	},
 	{
 		icon: 'editor-aligncenter',
 		title: wp.i18n.__( 'Align center' ),
-		align: 'center'
+		align: 'center',
 	},
 	{
 		icon: 'editor-alignright',
 		title: wp.i18n.__( 'Align right' ),
-		align: 'right'
-	}
+		align: 'right',
+	},
 ];
 
 function createElement( type, props, ...children ) {
@@ -79,7 +79,7 @@ export default class Editable extends wp.element.Component {
 			formats: {},
 			alignment: null,
 			bookmark: null,
-			empty: ! props.value || ! props.value.length
+			empty: ! props.value || ! props.value.length,
 		};
 	}
 
@@ -120,7 +120,7 @@ export default class Editable extends wp.element.Component {
 		const content = this.getContent();
 
 		this.setState( {
-			empty: ! content || ! content.length
+			empty: ! content || ! content.length,
 		} );
 	}
 
@@ -155,7 +155,7 @@ export default class Editable extends wp.element.Component {
 
 		return {
 			top: position.top - containerPosition.top + ( position.height ) + toolbarOffset.top,
-			left: position.left - containerPosition.left - ( linkModalWidth / 2 ) + ( position.width / 2 ) + toolbarOffset.left
+			left: position.left - containerPosition.left - ( linkModalWidth / 2 ) + ( position.width / 2 ) + toolbarOffset.left,
 		};
 	}
 
@@ -340,7 +340,7 @@ export default class Editable extends wp.element.Component {
 		} );
 
 		this.setState( {
-			formats: merge( {}, this.state.formats, formats )
+			formats: merge( {}, this.state.formats, formats ),
 		} );
 
 		this.editor.setDirty( true );
@@ -371,7 +371,7 @@ export default class Editable extends wp.element.Component {
 			inlineToolbar = false,
 			inline,
 			formattingControls,
-			placeholder
+			placeholder,
 		} = this.props;
 
 		// Generating a key that includes `tagName` ensures that if the tag
@@ -398,7 +398,7 @@ export default class Editable extends wp.element.Component {
 								controls={ ALIGNMENT_CONTROLS.map( ( control ) => ( {
 									...control,
 									onClick: () => this.toggleAlignment( control.align ),
-									isActive: this.isAlignmentActive( control.align )
+									isActive: this.isAlignmentActive( control.align ),
 								} ) ) } />
 						}
 						{ ! inlineToolbar && formatToolbar }
@@ -417,7 +417,7 @@ export default class Editable extends wp.element.Component {
 					style={ style }
 					defaultValue={ value }
 					settings={ {
-						forced_root_block: inline ? false : 'p'
+						forced_root_block: inline ? false : 'p',
 					} }
 					isEmpty={ this.state.empty }
 					placeholder={ placeholder }

--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -49,9 +49,9 @@ export default class TinyMCE extends wp.element.Component {
 				this.props.onSetup( editor );
 			},
 			formats: {
-				strikethrough: { inline: 'del' }
+				strikethrough: { inline: 'del' },
 			},
-			...settings
+			...settings,
 		} );
 
 		if ( focus ) {
@@ -76,7 +76,7 @@ export default class TinyMCE extends wp.element.Component {
 			suppressContentEditableWarning: true,
 			className: 'blocks-editable__tinymce',
 			style,
-			'data-placeholder': placeholder
+			'data-placeholder': placeholder,
 		}, children );
 	}
 }

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -36,7 +36,7 @@ registerBlock( 'core/button', {
 	attributes: {
 		url: attr( 'a', 'href' ),
 		title: attr( 'a', 'title' ),
-		text: children( 'a' )
+		text: children( 'a' ),
 	},
 
 	controls: [
@@ -44,20 +44,20 @@ registerBlock( 'core/button', {
 			icon: 'align-left',
 			title: wp.i18n.__( 'Align left' ),
 			isActive: ( { align } ) => 'left' === align,
-			onClick: applyOrUnset( 'left' )
+			onClick: applyOrUnset( 'left' ),
 		},
 		{
 			icon: 'align-center',
 			title: wp.i18n.__( 'Align center' ),
 			isActive: ( { align } ) => 'center' === align,
-			onClick: applyOrUnset( 'center' )
+			onClick: applyOrUnset( 'center' ),
 		},
 		{
 			icon: 'align-right',
 			title: wp.i18n.__( 'Align right' ),
 			isActive: ( { align } ) => 'right' === align,
-			onClick: applyOrUnset( 'right' )
-		}
+			onClick: applyOrUnset( 'right' ),
+		},
 	],
 
 	getEditWrapperProps( attributes ) {
@@ -109,5 +109,5 @@ registerBlock( 'core/button', {
 				</a>
 			</div>
 		);
-	}
+	},
 } );

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -23,7 +23,7 @@ registerBlock( 'core/embed', {
 	attributes: {
 		url: attr( 'iframe', 'src' ),
 		title: attr( 'iframe', 'title' ),
-		caption: children( 'figcaption' )
+		caption: children( 'figcaption' ),
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
@@ -75,5 +75,5 @@ registerBlock( 'core/embed', {
 				<figcaption>{ caption }</figcaption>
 			</figure>
 		);
-	}
+	},
 } );

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -13,7 +13,7 @@ registerBlock( 'core/freeform', {
 	category: 'common',
 
 	attributes: {
-		html: html()
+		html: html(),
 	},
 
 	edit( { attributes } ) {
@@ -29,7 +29,7 @@ registerBlock( 'core/freeform', {
 
 	save( { attributes } ) {
 		return attributes.html;
-	}
+	},
 } );
 
 setUnknownTypeHandler( 'core/freeform' );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -16,7 +16,7 @@ registerBlock( 'core/heading', {
 
 	attributes: {
 		content: children( 'h1,h2,h3,h4,h5,h6' ),
-		nodeName: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' )
+		nodeName: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
 	},
 
 	controls: [
@@ -27,8 +27,8 @@ registerBlock( 'core/heading', {
 			onClick( attributes, setAttributes ) {
 				setAttributes( { nodeName: 'H' + level } );
 			},
-			subscript: level
-		} ) )
+			subscript: level,
+		} ) ),
 	],
 
 	transforms: {
@@ -39,7 +39,7 @@ registerBlock( 'core/heading', {
 				transform: ( { content, ...attrs } ) => {
 					if ( Array.isArray( content ) ) {
 						const heading = createBlock( 'core/heading', {
-							content: content[ 0 ].props.children
+							content: content[ 0 ].props.children,
 						} );
 						const blocks = [ heading ];
 
@@ -47,7 +47,7 @@ registerBlock( 'core/heading', {
 						if ( remainingContent.length ) {
 							const text = createBlock( 'core/text', {
 								...attrs,
-								content: remainingContent
+								content: remainingContent,
 							} );
 							blocks.push( text );
 						}
@@ -55,10 +55,10 @@ registerBlock( 'core/heading', {
 						return blocks;
 					}
 					return createBlock( 'core/heading', {
-						content
+						content,
 					} );
-				}
-			}
+				},
+			},
 		],
 		to: [
 			{
@@ -66,16 +66,16 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
 					return createBlock( 'core/text', {
-						content
+						content,
 					} );
-				}
-			}
-		]
+				},
+			},
+		],
 	},
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: wp.element.concatChildren( attributes.content, attributesToMerge.content )
+			content: wp.element.concatChildren( attributes.content, attributesToMerge.content ),
 		};
 	},
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -37,7 +37,7 @@ registerBlock( 'core/image', {
 	attributes: {
 		url: attr( 'img', 'src' ),
 		alt: attr( 'img', 'alt' ),
-		caption: children( 'figcaption' )
+		caption: children( 'figcaption' ),
 	},
 
 	controls: [
@@ -45,26 +45,26 @@ registerBlock( 'core/image', {
 			icon: 'align-left',
 			title: wp.i18n.__( 'Align left' ),
 			isActive: ( { align } ) => 'left' === align,
-			onClick: toggleAlignment( 'left' )
+			onClick: toggleAlignment( 'left' ),
 		},
 		{
 			icon: 'align-center',
 			title: wp.i18n.__( 'Align center' ),
 			isActive: ( { align } ) => 'center' === align,
-			onClick: toggleAlignment( 'center' )
+			onClick: toggleAlignment( 'center' ),
 		},
 		{
 			icon: 'align-right',
 			title: wp.i18n.__( 'Align right' ),
 			isActive: ( { align } ) => 'right' === align,
-			onClick: toggleAlignment( 'right' )
+			onClick: toggleAlignment( 'right' ),
 		},
 		{
 			icon: 'align-full-width',
 			title: wp.i18n.__( 'Wide width' ),
 			isActive: ( { align } ) => 'wide' === align,
-			onClick: toggleAlignment( 'wide' )
-		}
+			onClick: toggleAlignment( 'wide' ),
+		},
 	],
 
 	getEditWrapperProps( attributes ) {
@@ -130,5 +130,5 @@ registerBlock( 'core/image', {
 				<figcaption>{ caption }</figcaption>
 			</figure>
 		);
-	}
+	},
 } );

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -14,7 +14,7 @@ registerBlock( 'core/list', {
 
 	attributes: {
 		nodeName: prop( 'ol,ul', 'nodeName' ),
-		values: children( 'ol,ul' )
+		values: children( 'ol,ul' ),
 	},
 
 	controls: [
@@ -24,7 +24,7 @@ registerBlock( 'core/list', {
 			isActive: ( { nodeName = 'OL' } ) => nodeName === 'UL',
 			onClick( attributes, setAttributes ) {
 				setAttributes( { nodeName: 'UL' } );
-			}
+			},
 		},
 		{
 			icon: 'editor-ol',
@@ -32,8 +32,8 @@ registerBlock( 'core/list', {
 			isActive: ( { nodeName = 'OL' } ) => nodeName === 'OL',
 			onClick( attributes, setAttributes ) {
 				setAttributes( { nodeName: 'OL' } );
-			}
-		}
+			},
+		},
 	],
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
@@ -60,5 +60,5 @@ registerBlock( 'core/list', {
 			null,
 			values
 		);
-	}
+	},
 } );

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -26,7 +26,7 @@ registerBlock( 'core/pullquote', {
 					value={ value || wp.i18n.__( 'Write Quote…' ) }
 					onChange={
 						( nextValue ) => setAttributes( {
-							value: nextValue
+							value: nextValue,
 						} )
 					}
 					focus={ focus && focus.editable === 'value' ? focus : null }
@@ -38,7 +38,7 @@ registerBlock( 'core/pullquote', {
 						value={ citation || wp.i18n.__( 'Write caption…' ) }
 						onChange={
 							( nextCitation ) => setAttributes( {
-								citation: nextCitation
+								citation: nextCitation,
 							} )
 						}
 						focus={ focus && focus.editable === 'citation' ? focus : null }
@@ -64,5 +64,5 @@ registerBlock( 'core/pullquote', {
 				) }
 			</blockquote>
 		);
-	}
+	},
 } );

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -14,7 +14,7 @@ registerBlock( 'core/quote', {
 
 	attributes: {
 		value: query( 'blockquote > p', children() ),
-		citation: children( 'footer' )
+		citation: children( 'footer' ),
 	},
 
 	controls: [ 1, 2 ].map( ( variation ) => ( {
@@ -24,7 +24,7 @@ registerBlock( 'core/quote', {
 		onClick( attributes, setAttributes ) {
 			setAttributes( { style: variation } );
 		},
-		subscript: variation
+		subscript: variation,
 	} ) ),
 
 	transforms: {
@@ -34,19 +34,19 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/text' ],
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
-						value: content
+						value: content,
 					} );
-				}
+				},
 			},
 			{
 				type: 'block',
 				blocks: [ 'core/heading' ],
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
-						value: content
+						value: content,
 					} );
-				}
-			}
+				},
+			},
 		],
 		to: [
 			{
@@ -54,9 +54,9 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/text' ],
 				transform: ( { value, citation } ) => {
 					return createBlock( 'core/text', {
-						content: wp.element.concatChildren( value, citation )
+						content: wp.element.concatChildren( value, citation ),
 					} );
-				}
+				},
 			},
 			{
 				type: 'block',
@@ -64,22 +64,22 @@ registerBlock( 'core/quote', {
 				transform: ( { value, citation, ...attrs } ) => {
 					if ( Array.isArray( value ) || citation ) {
 						const heading = createBlock( 'core/heading', {
-							content: Array.isArray( value ) ? value[ 0 ] : value
+							content: Array.isArray( value ) ? value[ 0 ] : value,
 						} );
 						const quote = createBlock( 'core/quote', {
 							...attrs,
 							citation,
-							value: Array.isArray( value ) ? value.slice( 1 ) : ''
+							value: Array.isArray( value ) ? value.slice( 1 ) : '',
 						} );
 
 						return [ heading, quote ];
 					}
 					return createBlock( 'core/heading', {
-						content: value
+						content: value,
 					} );
-				}
-			}
-		]
+				},
+			},
+		],
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus, mergeWithPrevious } ) {
@@ -92,7 +92,7 @@ registerBlock( 'core/quote', {
 					value={ value }
 					onChange={
 						( nextValue ) => setAttributes( {
-							value: nextValue
+							value: nextValue,
 						} )
 					}
 					focus={ focusedEditable === 'value' ? focus : null }
@@ -106,7 +106,7 @@ registerBlock( 'core/quote', {
 						value={ citation }
 						onChange={
 							( nextCitation ) => setAttributes( {
-								citation: nextCitation
+								citation: nextCitation,
 							} )
 						}
 						focus={ focusedEditable === 'citation' ? focus : null }
@@ -131,5 +131,5 @@ registerBlock( 'core/quote', {
 				) }
 			</blockquote>
 		);
-	}
+	},
 } );

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -17,5 +17,5 @@ registerBlock( 'core/separator', {
 
 	save() {
 		return <hr />;
-	}
+	},
 } );

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -18,12 +18,12 @@ registerBlock( 'core/text', {
 	},
 
 	defaultAttributes: {
-		content: <p />
+		content: <p />,
 	},
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: wp.element.concatChildren( attributes.content, attributesToMerge.content )
+			content: wp.element.concatChildren( attributes.content, attributesToMerge.content ),
 		};
 	},
 
@@ -35,7 +35,7 @@ registerBlock( 'core/text', {
 				value={ content }
 				onChange={ ( nextContent ) => {
 					setAttributes( {
-						content: nextContent
+						content: nextContent,
 					} );
 				} }
 				focus={ focus }
@@ -43,7 +43,7 @@ registerBlock( 'core/text', {
 				onSplit={ ( before, after ) => {
 					setAttributes( { content: before } );
 					insertBlockAfter( createBlock( 'core/text', {
-						content: after
+						content: after,
 					} ) );
 				} }
 				onMerge={ mergeWithPrevious }
@@ -55,5 +55,5 @@ registerBlock( 'core/text', {
 	save( { attributes } ) {
 		const { content } = attributes;
 		return content;
-	}
+	},
 } );

--- a/bootstrap-test.js
+++ b/bootstrap-test.js
@@ -8,8 +8,8 @@ global.document = require( 'jsdom' ).jsdom( '', {
 	features: {
 		FetchExternalResources: false,
 		ProcessExternalResources: false,
-		SkipExternalResources: true
-	}
+		SkipExternalResources: true,
+	},
 } );
 global.window = document.defaultView;
 global.requestAnimationFrame = setTimeout;

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -9,7 +9,7 @@ function Button( { isPrimary, isLarge, isToggled, className, buttonRef, ...addit
 		button: ( isPrimary || isLarge ),
 		'button-primary': isPrimary,
 		'button-large': isLarge,
-		'is-toggled': isToggled
+		'is-toggled': isToggled,
 	} );
 
 	return (

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -27,7 +27,7 @@ function Toolbar( { controls } ) {
 						control.onClick();
 					} }
 					className={ classNames( 'components-toolbar__control', {
-						'is-active': control.isActive
+						'is-active': control.isActive,
 					} ) }
 					aria-pressed={ control.isActive }
 				/>

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -36,20 +36,20 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 export default connect(
 	( state, ownProps ) => ( {
 		isFirst: isFirstBlock( state, ownProps.uid ),
-		isLast: isLastBlock( state, ownProps.uid )
+		isLast: isLastBlock( state, ownProps.uid ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {
 			dispatch( {
 				type: 'MOVE_BLOCK_DOWN',
-				uid: ownProps.uid
+				uid: ownProps.uid,
 			} );
 		},
 		onMoveUp() {
 			dispatch( {
 				type: 'MOVE_BLOCK_UP',
-				uid: ownProps.uid
+				uid: ownProps.uid,
 			} );
-		}
+		},
 	} )
 )( BlockMover );

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -22,7 +22,7 @@ class BlockSwitcher extends wp.element.Component {
 		super( ...arguments );
 		this.toggleMenu = this.toggleMenu.bind( this );
 		this.state = {
-			open: false
+			open: false,
 		};
 	}
 
@@ -36,14 +36,14 @@ class BlockSwitcher extends wp.element.Component {
 
 	toggleMenu() {
 		this.setState( {
-			open: ! this.state.open
+			open: ! this.state.open,
 		} );
 	}
 
 	switchBlockType( blockType ) {
 		return () => {
 			this.setState( {
-				open: false
+				open: false,
 			} );
 			this.props.onTransform( this.props.block, blockType );
 		};
@@ -107,15 +107,15 @@ class BlockSwitcher extends wp.element.Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		block: getBlock( state, ownProps.uid )
+		block: getBlock( state, ownProps.uid ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onTransform( block, blockType ) {
 			dispatch( {
 				type: 'REPLACE_BLOCKS',
 				uids: [ ownProps.uid ],
-				blocks: wp.blocks.switchToBlockType( block, blockType )
+				blocks: wp.blocks.switchToBlockType( block, blockType ),
 			} );
-		}
+		},
 	} )
 )( clickOutside( BlockSwitcher ) );

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -22,12 +22,12 @@ import { getEditorMode } from '../../selectors';
 const MODES = [
 	{
 		value: 'visual',
-		label: wp.i18n.__( 'Visual' )
+		label: wp.i18n.__( 'Visual' ),
 	},
 	{
 		value: 'text',
-		label: wp.i18n._x( 'Text', 'Name for the Text editor tab (formerly HTML)' )
-	}
+		label: wp.i18n._x( 'Text', 'Name for the Text editor tab (formerly HTML)' ),
+	},
 ];
 
 function ModeSwitcher( { mode, onSwitch } ) {
@@ -58,14 +58,14 @@ function ModeSwitcher( { mode, onSwitch } ) {
 
 export default connect(
 	( state ) => ( {
-		mode: getEditorMode( state )
+		mode: getEditorMode( state ),
 	} ),
 	( dispatch ) => ( {
 		onSwitch( mode ) {
 			dispatch( {
 				type: 'SWITCH_MODE',
-				mode: mode
+				mode: mode,
 			} );
-		}
+		},
 	} )
 )( ModeSwitcher );

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -58,6 +58,6 @@ export default connect(
 	( dispatch ) => ( {
 		undo: () => dispatch( { type: 'UNDO' } ),
 		redo: () => dispatch( { type: 'REDO' } ),
-		toggleSidebar: () => dispatch( { type: 'TOGGLE_SIDEBAR' } )
+		toggleSidebar: () => dispatch( { type: 'TOGGLE_SIDEBAR' } ),
 	} )
 )( Tools );

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -20,7 +20,7 @@ import {
 	isSavingPost,
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
-	isSavingNewPost
+	isSavingNewPost,
 } from '../../selectors';
 
 function PublishButton( {

--- a/editor/index.js
+++ b/editor/index.js
@@ -22,7 +22,7 @@ export function createEditorInstance( id, post ) {
 	store.dispatch( {
 		type: 'RESET_BLOCKS',
 		post,
-		blocks: wp.blocks.parse( post.content.raw )
+		blocks: wp.blocks.parse( post.content.raw ),
 	} );
 
 	wp.element.render(

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -19,7 +19,7 @@ class Inserter extends wp.element.Component {
 		this.toggle = this.toggle.bind( this );
 		this.close = this.close.bind( this );
 		this.state = {
-			opened: false
+			opened: false,
 		};
 	}
 
@@ -29,13 +29,13 @@ class Inserter extends wp.element.Component {
 		}
 
 		this.setState( {
-			opened: ! this.state.opened
+			opened: ! this.state.opened,
 		} );
 	}
 
 	close() {
 		this.setState( {
-			opened: false
+			opened: false,
 		} );
 	}
 

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -20,7 +20,7 @@ class InserterMenu extends wp.element.Component {
 		this.nodes = {};
 		this.state = {
 			filterValue: '',
-			currentFocus: null
+			currentFocus: null,
 		};
 		this.filter = this.filter.bind( this );
 		this.instanceId = this.constructor.instances++;
@@ -49,7 +49,7 @@ class InserterMenu extends wp.element.Component {
 
 	filter( event ) {
 		this.setState( {
-			filterValue: event.target.value
+			filterValue: event.target.value,
 		} );
 	}
 
@@ -59,7 +59,7 @@ class InserterMenu extends wp.element.Component {
 			this.props.onSelect();
 			this.setState( {
 				filterValue: '',
-				currentFocus: null
+				currentFocus: null,
 			} );
 		};
 	}
@@ -210,7 +210,7 @@ class InserterMenu extends wp.element.Component {
 
 	changeMenuSelection( refName ) {
 		this.setState( {
-			currentFocus: refName
+			currentFocus: refName,
 		} );
 
 		// Focus the DOM node.
@@ -289,8 +289,8 @@ export default connect(
 		onInsertBlock( slug ) {
 			dispatch( {
 				type: 'INSERT_BLOCK',
-				block: wp.blocks.createBlock( slug )
+				block: wp.blocks.createBlock( slug ),
 			} );
-		}
+		},
 	} )
 )( InserterMenu );

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -15,7 +15,7 @@ import { getEditorMode, isEditorSidebarOpened } from '../selectors';
 
 function Layout( { mode, isSidebarOpened } ) {
 	const className = classnames( 'editor-layout', {
-		'is-sidebar-opened': isSidebarOpened
+		'is-sidebar-opened': isSidebarOpened,
 	} );
 
 	return (
@@ -32,5 +32,5 @@ function Layout( { mode, isSidebarOpened } ) {
 
 export default connect( ( state ) => ( {
 	mode: getEditorMode( state ),
-	isSidebarOpened: isEditorSidebarOpened( state )
+	isSidebarOpened: isEditorSidebarOpened( state ),
 } ) )( Layout );

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -46,14 +46,14 @@ function TextEditor( { blocks, onChange } ) {
 
 export default connect(
 	( state ) => ( {
-		blocks: getBlocks( state )
+		blocks: getBlocks( state ),
 	} ),
 	( dispatch ) => ( {
 		onChange( value ) {
 			dispatch( {
 				type: 'RESET_BLOCKS',
-				blocks: wp.blocks.parse( value )
+				blocks: wp.blocks.parse( value ),
 			} );
-		}
+		},
 	} )
 )( TextEditor );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -23,7 +23,7 @@ import {
 	getBlockOrder,
 	isBlockHovered,
 	isBlockSelected,
-	isTypingInBlock
+	isTypingInBlock,
 } from '../../selectors';
 
 class VisualEditorBlock extends wp.element.Component {
@@ -58,8 +58,8 @@ class VisualEditorBlock extends wp.element.Component {
 		onChange( block.uid, {
 			attributes: {
 				...block.attributes,
-				...attributes
-			}
+				...attributes,
+			},
 		} );
 	}
 
@@ -138,10 +138,10 @@ class VisualEditorBlock extends wp.element.Component {
 					...previousBlock,
 					attributes: {
 						...previousBlock.attributes,
-						...updatedAttributes
-					}
+						...updatedAttributes,
+					},
 				},
-				...blocksWithTheSameType.slice( 1 )
+				...blocksWithTheSameType.slice( 1 ),
 			]
 		);
 	}
@@ -183,7 +183,7 @@ class VisualEditorBlock extends wp.element.Component {
 		const { isHovered, isSelected, isTyping, focus } = this.props;
 		const className = classnames( 'editor-visual-editor__block', {
 			'is-selected': isSelected && ! isTyping,
-			'is-hovered': isHovered
+			'is-hovered': isHovered,
 		} );
 
 		const { onSelect, onHover, onMouseLeave, onFocus, onInsertAfter } = this.props;
@@ -221,7 +221,7 @@ class VisualEditorBlock extends wp.element.Component {
 								controls={ settings.controls.map( ( control ) => ( {
 									...control,
 									onClick: () => control.onClick( block.attributes, this.setAttributes ),
-									isActive: control.isActive( block.attributes )
+									isActive: control.isActive( block.attributes ),
 								} ) ) } />
 						) }
 						<Slot name="Formatting.Toolbar" />
@@ -252,7 +252,7 @@ export default connect(
 			isHovered: isBlockHovered( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
 			isTyping: isTypingInBlock( state, ownProps.uid ),
-			order: getBlockOrder( state, ownProps.uid )
+			order: getBlockOrder( state, ownProps.uid ),
 		};
 	},
 	( dispatch, ownProps ) => ( {
@@ -260,41 +260,41 @@ export default connect(
 			dispatch( {
 				type: 'UPDATE_BLOCK',
 				uid,
-				updates
+				updates,
 			} );
 		},
 		onSelect() {
 			dispatch( {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				selected: true,
-				uid: ownProps.uid
+				uid: ownProps.uid,
 			} );
 		},
 		onDeselect() {
 			dispatch( {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				selected: false,
-				uid: ownProps.uid
+				uid: ownProps.uid,
 			} );
 		},
 		onStartTyping() {
 			dispatch( {
 				type: 'START_TYPING',
-				uid: ownProps.uid
+				uid: ownProps.uid,
 			} );
 		},
 		onHover() {
 			dispatch( {
 				type: 'TOGGLE_BLOCK_HOVERED',
 				hovered: true,
-				uid: ownProps.uid
+				uid: ownProps.uid,
 			} );
 		},
 		onMouseLeave() {
 			dispatch( {
 				type: 'TOGGLE_BLOCK_HOVERED',
 				hovered: false,
-				uid: ownProps.uid
+				uid: ownProps.uid,
 			} );
 		},
 
@@ -302,7 +302,7 @@ export default connect(
 			dispatch( {
 				type: 'INSERT_BLOCK',
 				after: ownProps.uid,
-				block
+				block,
 			} );
 		},
 
@@ -310,14 +310,14 @@ export default connect(
 			dispatch( {
 				type: 'UPDATE_FOCUS',
 				uid,
-				config
+				config,
 			} );
 		},
 
 		onRemove( uid ) {
 			dispatch( {
 				type: 'REMOVE_BLOCK',
-				uid
+				uid,
 			} );
 		},
 
@@ -325,8 +325,8 @@ export default connect(
 			dispatch( {
 				type: 'REPLACE_BLOCKS',
 				uids,
-				blocks
+				blocks,
 			} );
-		}
+		},
 	} )
 )( VisualEditorBlock );

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -25,5 +25,5 @@ function VisualEditor( { blocks } ) {
 }
 
 export default connect( ( state ) => ( {
-	blocks: getBlockUids( state )
+	blocks: getBlockUids( state ),
 } ) )( VisualEditor );

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -42,9 +42,9 @@ export default connect(
 			onUpdate( title ) {
 				dispatch( {
 					type: 'EDIT_POST',
-					edits: { title }
+					edits: { title },
 				} );
-			}
+			},
 		};
 	}
 )( PostTitle );

--- a/editor/state.js
+++ b/editor/state.js
@@ -64,14 +64,14 @@ export const editor = combineUndoableReducers( {
 					...state,
 					[ action.uid ]: {
 						...state[ action.uid ],
-						...action.updates
-					}
+						...action.updates,
+					},
 				};
 
 			case 'INSERT_BLOCK':
 				return {
 					...state,
-					[ action.block.uid ]: action.block
+					[ action.block.uid ]: action.block,
 				};
 
 			case 'REPLACE_BLOCKS':
@@ -81,7 +81,7 @@ export const editor = combineUndoableReducers( {
 				return action.blocks.reduce( ( memo, block ) => {
 					return {
 						...memo,
-						[ block.uid ]: block
+						[ block.uid ]: block,
 					};
 				}, omit( state, action.uids ) );
 
@@ -104,7 +104,7 @@ export const editor = combineUndoableReducers( {
 				return [
 					...state.slice( 0, position ),
 					action.block.uid,
-					...state.slice( position )
+					...state.slice( position ),
 				];
 
 			case 'MOVE_BLOCK_UP':
@@ -117,7 +117,7 @@ export const editor = combineUndoableReducers( {
 					...state.slice( 0, index - 1 ),
 					action.uid,
 					swappedUid,
-					...state.slice( index + 1 )
+					...state.slice( index + 1 ),
 				];
 
 			case 'MOVE_BLOCK_DOWN':
@@ -130,7 +130,7 @@ export const editor = combineUndoableReducers( {
 					...state.slice( 0, index ),
 					swappedUid,
 					action.uid,
-					...state.slice( index + 2 )
+					...state.slice( index + 2 ),
 				];
 
 			case 'REPLACE_BLOCKS':
@@ -153,7 +153,7 @@ export const editor = combineUndoableReducers( {
 		}
 
 		return state;
-	}
+	},
 }, { resetTypes: [ 'RESET_BLOCKS' ] } );
 
 /**
@@ -194,7 +194,7 @@ export function selectedBlock( state = {}, action ) {
 				: {
 					uid: action.uid,
 					typing: false,
-					focus: action.uid === state.uid ? state.focus : {}
+					focus: action.uid === state.uid ? state.focus : {},
 				};
 
 		case 'MOVE_BLOCK_UP':
@@ -207,14 +207,14 @@ export function selectedBlock( state = {}, action ) {
 			return {
 				uid: action.block.uid,
 				typing: false,
-				focus: {}
+				focus: {},
 			};
 
 		case 'UPDATE_FOCUS':
 			return {
 				uid: action.uid,
 				typing: state.uid === action.uid ? state.typing : false,
-				focus: action.config || {}
+				focus: action.config || {},
 			};
 
 		case 'START_TYPING':
@@ -222,13 +222,13 @@ export function selectedBlock( state = {}, action ) {
 				return {
 					uid: action.uid,
 					typing: true,
-					focus: {}
+					focus: {},
 				};
 			}
 
 			return {
 				...state,
-				typing: true
+				typing: true,
 			};
 
 		case 'REPLACE_BLOCKS':
@@ -239,7 +239,7 @@ export function selectedBlock( state = {}, action ) {
 			return {
 				uid: action.blocks[ 0 ].uid,
 				typing: false,
-				focus: {}
+				focus: {},
 			};
 	}
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -29,14 +29,14 @@ import {
 	isSavingPost,
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
-	isSavingNewPost
+	isSavingNewPost,
 } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( 'getEditorMode', () => {
 		it( 'should return the selected editor mode', () => {
 			const state = {
-				mode: 'visual'
+				mode: 'visual',
 			};
 
 			expect( getEditorMode( state ) ).to.eql( 'visual' );
@@ -46,7 +46,7 @@ describe( 'selectors', () => {
 	describe( 'isEditorSidebarOpened', () => {
 		it( 'should return true when the sidebar is opened', () => {
 			const state = {
-				isSidebarOpened: true
+				isSidebarOpened: true,
 			};
 
 			expect( isEditorSidebarOpened( state ) ).to.be.true();
@@ -54,7 +54,7 @@ describe( 'selectors', () => {
 
 		it( 'should return false when the sidebar is opened', () => {
 			const state = {
-				isSidebarOpened: false
+				isSidebarOpened: false,
 			};
 
 			expect( isEditorSidebarOpened( state ) ).to.be.false();
@@ -67,10 +67,10 @@ describe( 'selectors', () => {
 				editor: {
 					history: {
 						past: [
-							{}
-						]
-					}
-				}
+							{},
+						],
+					},
+				},
 			};
 
 			expect( hasEditorUndo( state ) ).to.be.true();
@@ -80,9 +80,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					history: {
-						past: []
-					}
-				}
+						past: [],
+					},
+				},
 			};
 
 			expect( hasEditorUndo( state ) ).to.be.false();
@@ -95,10 +95,10 @@ describe( 'selectors', () => {
 				editor: {
 					history: {
 						future: [
-							{}
-						]
-					}
-				}
+							{},
+						],
+					},
+				},
 			};
 
 			expect( hasEditorRedo( state ) ).to.be.true();
@@ -108,9 +108,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					history: {
-						future: []
-					}
-				}
+						future: [],
+					},
+				},
 			};
 
 			expect( hasEditorRedo( state ) ).to.be.false();
@@ -121,8 +121,8 @@ describe( 'selectors', () => {
 		it( 'should return true when the post is dirty', () => {
 			const state = {
 				editor: {
-					dirty: true
-				}
+					dirty: true,
+				},
 			};
 
 			expect( isEditedPostDirty( state ) ).to.be.true();
@@ -131,8 +131,8 @@ describe( 'selectors', () => {
 		it( 'should return false when the post is not dirty', () => {
 			const state = {
 				editor: {
-					dirty: false
-				}
+					dirty: false,
+				},
 			};
 
 			expect( isEditedPostDirty( state ) ).to.be.false();
@@ -142,7 +142,7 @@ describe( 'selectors', () => {
 	describe( 'getCurrentPost', () => {
 		it( 'should return the current post', () => {
 			const state = {
-				currentPost: { ID: 1 }
+				currentPost: { ID: 1 },
 			};
 
 			expect( getCurrentPost( state ) ).to.eql( { ID: 1 } );
@@ -153,8 +153,8 @@ describe( 'selectors', () => {
 		it( 'should return the post edits', () => {
 			const state = {
 				editor: {
-					edits: { title: 'terga' }
-				}
+					edits: { title: 'terga' },
+				},
 			};
 
 			expect( getPostEdits( state ) ).to.eql( { title: 'terga' } );
@@ -165,11 +165,11 @@ describe( 'selectors', () => {
 		it( 'should return the post saved title if the title is not edited', () => {
 			const state = {
 				currentPost: {
-					title: { raw: 'sassel' }
+					title: { raw: 'sassel' },
 				},
 				editor: {
-					edits: { status: 'private' }
-				}
+					edits: { status: 'private' },
+				},
 			};
 
 			expect( getEditedPostTitle( state ) ).to.equal( 'sassel' );
@@ -178,11 +178,11 @@ describe( 'selectors', () => {
 		it( 'should return the edited title', () => {
 			const state = {
 				currentPost: {
-					title: { raw: 'sassel' }
+					title: { raw: 'sassel' },
 				},
 				editor: {
-					edits: { title: 'youcha' }
-				}
+					edits: { title: 'youcha' },
+				},
 			};
 
 			expect( getEditedPostTitle( state ) ).to.equal( 'youcha' );
@@ -194,9 +194,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						123: { uid: 123, blockType: 'core/text' }
-					}
-				}
+						123: { uid: 123, blockType: 'core/text' },
+					},
+				},
 			};
 
 			expect( getBlock( state, 123 ) ).to.eql( { uid: 123, blockType: 'core/text' } );
@@ -209,15 +209,15 @@ describe( 'selectors', () => {
 				editor: {
 					blocksByUid: {
 						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' }
+						123: { uid: 123, blockType: 'core/text' },
 					},
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( getBlocks( state ) ).to.eql( [
 				{ uid: 123, blockType: 'core/text' },
-				{ uid: 23, blockType: 'core/heading' }
+				{ uid: 23, blockType: 'core/heading' },
 			] );
 		} );
 	} );
@@ -226,8 +226,8 @@ describe( 'selectors', () => {
 		it( 'should return the ordered block UIDs', () => {
 			const state = {
 				editor: {
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( getBlockUids( state ) ).to.eql( [ 123, 23 ] );
@@ -238,8 +238,8 @@ describe( 'selectors', () => {
 		it( 'should return the block order', () => {
 			const state = {
 				editor: {
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( getBlockOrder( state, 23 ) ).to.equal( 1 );
@@ -250,8 +250,8 @@ describe( 'selectors', () => {
 		it( 'should return true when the block is first', () => {
 			const state = {
 				editor: {
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( isFirstBlock( state, 123 ) ).to.be.true();
@@ -260,8 +260,8 @@ describe( 'selectors', () => {
 		it( 'should return false when the block is not first', () => {
 			const state = {
 				editor: {
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( isFirstBlock( state, 23 ) ).to.be.false();
@@ -272,8 +272,8 @@ describe( 'selectors', () => {
 		it( 'should return true when the block is last', () => {
 			const state = {
 				editor: {
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( isLastBlock( state, 23 ) ).to.be.true();
@@ -282,8 +282,8 @@ describe( 'selectors', () => {
 		it( 'should return false when the block is not last', () => {
 			const state = {
 				editor: {
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( isLastBlock( state, 123 ) ).to.be.false();
@@ -296,10 +296,10 @@ describe( 'selectors', () => {
 				editor: {
 					blocksByUid: {
 						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' }
+						123: { uid: 123, blockType: 'core/text' },
 					},
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( getPreviousBlock( state, 23 ) ).to.eql(
@@ -312,10 +312,10 @@ describe( 'selectors', () => {
 				editor: {
 					blocksByUid: {
 						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' }
+						123: { uid: 123, blockType: 'core/text' },
 					},
-					blockOrder: [ 123, 23 ]
-				}
+					blockOrder: [ 123, 23 ],
+				},
 			};
 
 			expect( getPreviousBlock( state, 123 ) ).to.be.null();
@@ -325,7 +325,7 @@ describe( 'selectors', () => {
 	describe( 'isBlockSelected', () => {
 		it( 'should return true if the block is selected', () => {
 			const state = {
-				selectedBlock: { uid: 123 }
+				selectedBlock: { uid: 123 },
 			};
 
 			expect( isBlockSelected( state, 123 ) ).to.be.true();
@@ -333,7 +333,7 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is not selected', () => {
 			const state = {
-				selectedBlock: { uid: 123 }
+				selectedBlock: { uid: 123 },
 			};
 
 			expect( isBlockSelected( state, 23 ) ).to.be.false();
@@ -343,7 +343,7 @@ describe( 'selectors', () => {
 	describe( 'isBlockHovered', () => {
 		it( 'should return true if the block is hovered', () => {
 			const state = {
-				hoveredBlock: 123
+				hoveredBlock: 123,
 			};
 
 			expect( isBlockHovered( state, 123 ) ).to.be.true();
@@ -351,7 +351,7 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is not hovered', () => {
 			const state = {
-				hoveredBlock: 123
+				hoveredBlock: 123,
 			};
 
 			expect( isBlockHovered( state, 23 ) ).to.be.false();
@@ -363,8 +363,8 @@ describe( 'selectors', () => {
 			const state = {
 				selectedBlock: {
 					uid: 123,
-					focus: { editable: 'cite' }
-				}
+					focus: { editable: 'cite' },
+				},
 			};
 
 			expect( getBlockFocus( state, 123 ) ).to.be.eql( { editable: 'cite' } );
@@ -374,8 +374,8 @@ describe( 'selectors', () => {
 			const state = {
 				selectedBlock: {
 					uid: 123,
-					focus: { editable: 'cite' }
-				}
+					focus: { editable: 'cite' },
+				},
 			};
 
 			expect( getBlockFocus( state, 23 ) ).to.be.eql( null );
@@ -387,8 +387,8 @@ describe( 'selectors', () => {
 			const state = {
 				selectedBlock: {
 					uid: 123,
-					typing: true
-				}
+					typing: true,
+				},
 			};
 
 			expect( isTypingInBlock( state, 123 ) ).to.be.true();
@@ -398,8 +398,8 @@ describe( 'selectors', () => {
 			const state = {
 				selectedBlock: {
 					uid: 123,
-					typing: true
-				}
+					typing: true,
+				},
 			};
 
 			expect( isTypingInBlock( state, 23 ) ).to.be.false();
@@ -410,8 +410,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the post is currently being saved', () => {
 			const state = {
 				saving: {
-					requesting: true
-				}
+					requesting: true,
+				},
 			};
 
 			expect( isSavingPost( state ) ).to.be.true();
@@ -420,8 +420,8 @@ describe( 'selectors', () => {
 		it( 'should return false if the post is currently being saved', () => {
 			const state = {
 				saving: {
-					requesting: false
-				}
+					requesting: false,
+				},
 			};
 
 			expect( isSavingPost( state ) ).to.be.false();
@@ -432,8 +432,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the post save request is successful', () => {
 			const state = {
 				saving: {
-					successful: true
-				}
+					successful: true,
+				},
 			};
 
 			expect( didPostSaveRequestSucceed( state ) ).to.be.true();
@@ -442,8 +442,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the post save request has failed', () => {
 			const state = {
 				saving: {
-					successful: false
-				}
+					successful: false,
+				},
 			};
 
 			expect( didPostSaveRequestSucceed( state ) ).to.be.false();
@@ -454,8 +454,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the post save request has failed', () => {
 			const state = {
 				saving: {
-					error: 'error'
-				}
+					error: 'error',
+				},
 			};
 
 			expect( didPostSaveRequestFail( state ) ).to.be.true();
@@ -464,8 +464,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the post save request is successful', () => {
 			const state = {
 				saving: {
-					error: false
-				}
+					error: false,
+				},
 			};
 
 			expect( didPostSaveRequestFail( state ) ).to.be.false();
@@ -476,8 +476,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the post being saved is new', () => {
 			const state = {
 				saving: {
-					isNew: true
-				}
+					isNew: true,
+				},
 			};
 
 			expect( isSavingNewPost( state ) ).to.be.true();
@@ -486,8 +486,8 @@ describe( 'selectors', () => {
 		it( 'should return false if the post being saved is not new', () => {
 			const state = {
 				saving: {
-					isNew: false
-				}
+					isNew: false,
+				},
 			};
 
 			expect( isSavingNewPost( state ) ).to.be.false();

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -16,7 +16,7 @@ import {
 	mode,
 	isSidebarOpened,
 	saving,
-	createReduxStore
+	createReduxStore,
 } from '../state';
 
 describe( 'state', () => {
@@ -41,7 +41,7 @@ describe( 'state', () => {
 			const original = editor( undefined, {} );
 			const state = editor( original, {
 				type: 'RESET_BLOCKS',
-				blocks: [ { uid: 'bananas' } ]
+				blocks: [ { uid: 'bananas' } ],
 			} );
 
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 1 );
@@ -54,17 +54,17 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'kumquat',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 			const state = editor( original, {
 				type: 'UPDATE_BLOCK',
 				uid: 'kumquat',
 				updates: {
 					attributes: {
-						updated: true
-					}
-				}
+						updated: true,
+					},
+				},
 			} );
 
 			expect( state.blocksByUid.kumquat.attributes.updated ).to.be.true();
@@ -76,15 +76,15 @@ describe( 'state', () => {
 				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 			const state = editor( original, {
 				type: 'INSERT_BLOCK',
 				block: {
 					uid: 'ribs',
-					blockType: 'core/freeform'
-				}
+					blockType: 'core/freeform',
+				},
 			} );
 
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 2 );
@@ -98,16 +98,16 @@ describe( 'state', () => {
 				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 			const state = editor( original, {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform'
-				} ]
+					blockType: 'core/freeform',
+				} ],
 			} );
 
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 1 );
@@ -122,16 +122,16 @@ describe( 'state', () => {
 				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
-					attributes: {}
+					attributes: {},
 				}, {
 					uid: 'ribs',
 					blockType: 'core/test-block',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 			const state = editor( original, {
 				type: 'MOVE_BLOCK_UP',
-				uid: 'ribs'
+				uid: 'ribs',
 			} );
 
 			expect( state.blockOrder ).to.eql( [ 'ribs', 'chicken' ] );
@@ -143,16 +143,16 @@ describe( 'state', () => {
 				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
-					attributes: {}
+					attributes: {},
 				}, {
 					uid: 'ribs',
 					blockType: 'core/test-block',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 			const state = editor( original, {
 				type: 'MOVE_BLOCK_UP',
-				uid: 'chicken'
+				uid: 'chicken',
 			} );
 
 			expect( state.blockOrder ).to.equal( original.blockOrder );
@@ -164,16 +164,16 @@ describe( 'state', () => {
 				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
-					attributes: {}
+					attributes: {},
 				}, {
 					uid: 'ribs',
 					blockType: 'core/test-block',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 			const state = editor( original, {
 				type: 'MOVE_BLOCK_DOWN',
-				uid: 'chicken'
+				uid: 'chicken',
 			} );
 
 			expect( state.blockOrder ).to.eql( [ 'ribs', 'chicken' ] );
@@ -185,16 +185,16 @@ describe( 'state', () => {
 				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
-					attributes: {}
+					attributes: {},
 				}, {
 					uid: 'ribs',
 					blockType: 'core/test-block',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 			const state = editor( original, {
 				type: 'MOVE_BLOCK_DOWN',
-				uid: 'ribs'
+				uid: 'ribs',
 			} );
 
 			expect( state.blockOrder ).to.equal( original.blockOrder );
@@ -206,16 +206,16 @@ describe( 'state', () => {
 				blocks: [ {
 					uid: 'chicken',
 					blockType: 'core/test-block',
-					attributes: {}
+					attributes: {},
 				}, {
 					uid: 'ribs',
 					blockType: 'core/test-block',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 			const state = editor( original, {
 				type: 'REMOVE_BLOCK',
-				uid: 'chicken'
+				uid: 'chicken',
 			} );
 
 			expect( state.blockOrder ).to.eql( [ 'ribs' ] );
@@ -223,8 +223,8 @@ describe( 'state', () => {
 				ribs: {
 					uid: 'ribs',
 					blockType: 'core/test-block',
-					attributes: {}
-				}
+					attributes: {},
+				},
 			} );
 		} );
 
@@ -234,12 +234,12 @@ describe( 'state', () => {
 				blocks: [ {
 					uid: 'kumquat',
 					blockType: 'core/test-block',
-					attributes: {}
+					attributes: {},
 				}, {
 					uid: 'loquat',
 					blockType: 'core/test-block',
-					attributes: {}
-				} ]
+					attributes: {},
+				} ],
 			} );
 
 			const state = editor( original, {
@@ -247,8 +247,8 @@ describe( 'state', () => {
 				after: 'kumquat',
 				block: {
 					uid: 'persimmon',
-					blockType: 'core/freeform'
-				}
+					blockType: 'core/freeform',
+				},
 			} );
 
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 3 );
@@ -262,7 +262,7 @@ describe( 'state', () => {
 					edits: {
 						status: 'draft',
 						title: 'post title',
-					}
+					},
 				} );
 
 				const state = editor( original, {
@@ -286,7 +286,7 @@ describe( 'state', () => {
 						status: 'draft',
 						title: 'post title',
 						tags: [ 1 ],
-					}
+					},
 				} );
 
 				const state = editor( original, {
@@ -354,7 +354,7 @@ describe( 'state', () => {
 			const state = hoveredBlock( null, {
 				type: 'TOGGLE_BLOCK_HOVERED',
 				uid: 'kumquat',
-				hovered: true
+				hovered: true,
 			} );
 
 			expect( state ).to.equal( 'kumquat' );
@@ -364,7 +364,7 @@ describe( 'state', () => {
 			const state = hoveredBlock( 'kumquat', {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
-				selected: true
+				selected: true,
 			} );
 
 			expect( state ).to.be.null();
@@ -376,8 +376,8 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform'
-				} ]
+					blockType: 'core/freeform',
+				} ],
 			} );
 
 			expect( state ).to.equal( 'wings' );
@@ -389,8 +389,8 @@ describe( 'state', () => {
 				uids: [ 'ribs' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform'
-				} ]
+					blockType: 'core/freeform',
+				} ],
 			} );
 
 			expect( state ).to.equal( 'chicken' );
@@ -402,7 +402,7 @@ describe( 'state', () => {
 			const state = selectedBlock( undefined, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
-				selected: true
+				selected: true,
 			} );
 
 			expect( state ).to.eql( { uid: 'kumquat', typing: false, focus: {} } );
@@ -413,7 +413,7 @@ describe( 'state', () => {
 			const state = selectedBlock( original, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
-				selected: true
+				selected: true,
 			} );
 
 			expect( state ).to.equal( original );
@@ -424,13 +424,13 @@ describe( 'state', () => {
 			const state = selectedBlock( original, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
-				selected: true
+				selected: true,
 			} );
 
 			expect( state ).to.eql( {
 				uid: 'kumquat',
 				typing: false,
-				focus: { editable: 'content' }
+				focus: { editable: 'content' },
 			} );
 		} );
 
@@ -439,7 +439,7 @@ describe( 'state', () => {
 			const state = selectedBlock( original, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
-				selected: false
+				selected: false,
 			} );
 
 			expect( state ).to.eql( {} );
@@ -450,7 +450,7 @@ describe( 'state', () => {
 			const state = selectedBlock( original, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
-				selected: false
+				selected: false,
 			} );
 
 			expect( state ).to.equal( original );
@@ -461,8 +461,8 @@ describe( 'state', () => {
 				type: 'INSERT_BLOCK',
 				block: {
 					uid: 'ribs',
-					blockType: 'core/freeform'
-				}
+					blockType: 'core/freeform',
+				},
 			} );
 
 			expect( state ).to.eql( { uid: 'ribs', typing: false, focus: {} } );
@@ -471,7 +471,7 @@ describe( 'state', () => {
 		it( 'should return with block moved up', () => {
 			const state = selectedBlock( undefined, {
 				type: 'MOVE_BLOCK_UP',
-				uid: 'ribs'
+				uid: 'ribs',
 			} );
 
 			expect( state ).to.eql( { uid: 'ribs', typing: false, focus: {} } );
@@ -480,7 +480,7 @@ describe( 'state', () => {
 		it( 'should return with block moved down', () => {
 			const state = selectedBlock( undefined, {
 				type: 'MOVE_BLOCK_DOWN',
-				uid: 'chicken'
+				uid: 'chicken',
 			} );
 
 			expect( state ).to.eql( { uid: 'chicken', typing: false, focus: {} } );
@@ -490,7 +490,7 @@ describe( 'state', () => {
 			const original = deepFreeze( { uid: 'ribs', typing: true, focus: {} } );
 			const state = selectedBlock( original, {
 				type: 'MOVE_BLOCK_UP',
-				uid: 'ribs'
+				uid: 'ribs',
 			} );
 
 			expect( state ).to.equal( original );
@@ -500,7 +500,7 @@ describe( 'state', () => {
 			const state = selectedBlock( undefined, {
 				type: 'UPDATE_FOCUS',
 				uid: 'chicken',
-				config: { editable: 'citation' }
+				config: { editable: 'citation' },
 			} );
 
 			expect( state ).to.eql( { uid: 'chicken', typing: false, focus: { editable: 'citation' } } );
@@ -511,7 +511,7 @@ describe( 'state', () => {
 			const state = selectedBlock( original, {
 				type: 'UPDATE_FOCUS',
 				uid: 'ribs',
-				config: { editable: 'citation' }
+				config: { editable: 'citation' },
 			} );
 
 			expect( state ).to.eql( { uid: 'ribs', typing: true, focus: { editable: 'citation' } } );
@@ -520,7 +520,7 @@ describe( 'state', () => {
 		it( 'should set the typing flag and selects the block', () => {
 			const state = selectedBlock( undefined, {
 				type: 'START_TYPING',
-				uid: 'chicken'
+				uid: 'chicken',
 			} );
 
 			expect( state ).to.eql( { uid: 'chicken', typing: true, focus: {} } );
@@ -530,7 +530,7 @@ describe( 'state', () => {
 			const original = deepFreeze( { uid: 'ribs', typing: false, focus: { editable: 'citation' } } );
 			const state = selectedBlock( original, {
 				type: 'START_TYPING',
-				uid: 'ribs'
+				uid: 'ribs',
 			} );
 
 			expect( state ).to.eql( { uid: 'ribs', typing: true, focus: { editable: 'citation' } } );
@@ -543,8 +543,8 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform'
-				} ]
+					blockType: 'core/freeform',
+				} ],
 			} );
 
 			expect( state ).to.eql( { uid: 'wings', typing: false, focus: {} } );
@@ -557,8 +557,8 @@ describe( 'state', () => {
 				uids: [ 'ribs' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform'
-				} ]
+					blockType: 'core/freeform',
+				} ],
 			} );
 
 			expect( state ).to.equal( original );
@@ -575,7 +575,7 @@ describe( 'state', () => {
 		it( 'should return switched mode', () => {
 			const state = mode( null, {
 				type: 'SWITCH_MODE',
-				mode: 'text'
+				mode: 'text',
 			} );
 
 			expect( state ).to.equal( 'text' );
@@ -591,7 +591,7 @@ describe( 'state', () => {
 
 		it( 'should toggle the sidebar open flag', () => {
 			const state = isSidebarOpened( false, {
-				type: 'TOGGLE_SIDEBAR'
+				type: 'TOGGLE_SIDEBAR',
 			} );
 
 			expect( state ).to.be.true();
@@ -632,7 +632,7 @@ describe( 'state', () => {
 				error: {
 					code: 'pretend_error',
 					message: 'update failed',
-				}
+				},
 			} );
 			expect( state ).to.eql( {
 				requesting: false,

--- a/editor/utils/test/undoable-reducer.js
+++ b/editor/utils/test/undoable-reducer.js
@@ -21,7 +21,7 @@ describe( 'undoableReducer', () => {
 			expect( reducer( undefined, {} ) ).to.eql( {
 				past: [],
 				present: 0,
-				future: []
+				future: [],
 			} );
 		} );
 
@@ -35,7 +35,7 @@ describe( 'undoableReducer', () => {
 			expect( state ).to.eql( {
 				past: [ 0 ],
 				present: 1,
-				future: []
+				future: [],
 			} );
 		} );
 
@@ -50,7 +50,7 @@ describe( 'undoableReducer', () => {
 			expect( state ).to.eql( {
 				past: [],
 				present: 0,
-				future: [ 1 ]
+				future: [ 1 ],
 			} );
 		} );
 
@@ -66,7 +66,7 @@ describe( 'undoableReducer', () => {
 			expect( state ).to.eql( {
 				past: [ 0 ],
 				present: 1,
-				future: []
+				future: [],
 			} );
 		} );
 
@@ -83,7 +83,7 @@ describe( 'undoableReducer', () => {
 			expect( state ).to.eql( {
 				past: [ 1, 2 ],
 				present: 3,
-				future: []
+				future: [],
 			} );
 		} );
 	} );
@@ -91,7 +91,7 @@ describe( 'undoableReducer', () => {
 	describe( 'combineUndoableReducers()', () => {
 		it( 'should return a combined reducer with getters', () => {
 			const reducer = combineUndoableReducers( {
-				count: ( state = 0 ) => state
+				count: ( state = 0 ) => state,
 			} );
 			const state = reducer( undefined, {} );
 
@@ -101,9 +101,9 @@ describe( 'undoableReducer', () => {
 			expect( state.history ).to.eql( {
 				past: [],
 				present: {
-					count: 0
+					count: 0,
 				},
-				future: []
+				future: [],
 			} );
 		} );
 	} );

--- a/editor/utils/undoable-reducer.js
+++ b/editor/utils/undoable-reducer.js
@@ -17,7 +17,7 @@ export function undoable( reducer, options = {} ) {
 	const initialState = {
 		past: [],
 		present: reducer( undefined, {} ),
-		future: []
+		future: [],
 	};
 
 	return ( state = initialState, action ) => {
@@ -28,14 +28,14 @@ export function undoable( reducer, options = {} ) {
 				return {
 					past: past.slice( 0, past.length - 1 ),
 					present: past[ past.length - 1 ],
-					future: [ present, ...future ]
+					future: [ present, ...future ],
 				};
 
 			case 'REDO':
 				return {
 					past: [ ...past, present ],
 					present: future[ 0 ],
-					future: future.slice( 1 )
+					future: future.slice( 1 ),
 				};
 		}
 
@@ -45,7 +45,7 @@ export function undoable( reducer, options = {} ) {
 			return {
 				past: [],
 				present: nextPresent,
-				future: []
+				future: [],
 			};
 		}
 
@@ -56,7 +56,7 @@ export function undoable( reducer, options = {} ) {
 		return {
 			past: [ ...past, present ],
 			present: nextPresent,
-			future: []
+			future: [],
 		};
 	};
 }
@@ -82,7 +82,7 @@ export function combineUndoableReducers( reducers, options ) {
 			memo[ key ] = {
 				get: function() {
 					return this.history.present[ key ];
-				}
+				},
 			};
 
 			return memo;

--- a/element/index.js
+++ b/element/index.js
@@ -81,7 +81,7 @@ export function concatChildren( ...childrens ) {
 		Children.forEach( children, ( child, j ) => {
 			if ( child && 'string' !== typeof child ) {
 				child = cloneElement( child, {
-					key: [ i, j ].join()
+					key: [ i, j ].join(),
 				} );
 			}
 

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -25,7 +25,7 @@ describe( 'element', () => {
 			expect( renderToString( [
 				'Zucchini ',
 				createElement( 'em', null, 'is a' ),
-				' summer squash'
+				' summer squash',
 			] ) ).to.equal( 'Zucchini <em>is a</em> summer squash' );
 		} );
 

--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -44,7 +44,7 @@ const { writeFileSync } = require( 'fs' );
  */
 const DEFAULT_HEADERS = {
 	'content-type': 'text/plain; charset=UTF-8',
-	'x-generator': 'babel-plugin-wp-i18n'
+	'x-generator': 'babel-plugin-wp-i18n',
 };
 
 /**
@@ -58,7 +58,7 @@ const DEFAULT_FUNCTIONS = {
 	__: [ 'msgid' ],
 	_n: [ 'msgid', 'msgid_plural' ],
 	_x: [ 'msgid', 'msgctxt' ],
-	_nx: [ 'msgid', 'msgctxt', 'msgid_plural' ]
+	_nx: [ 'msgid', 'msgctxt', 'msgid_plural' ],
 };
 
 /**
@@ -175,10 +175,10 @@ module.exports = function() {
 							'': {
 								'': {
 									msgid: '',
-									msgstr: []
-								}
-							}
-						}
+									msgstr: [],
+								},
+							},
+						},
 					};
 
 					for ( const key in baseData.headers ) {
@@ -204,7 +204,7 @@ module.exports = function() {
 				const { filename } = this.file.opts;
 				const pathname = relative( '.', filename ).split( sep ).join( '/' );
 				translation.comments = {
-					reference: pathname + ':' + path.node.loc.start.line
+					reference: pathname + ':' + path.node.loc.start.line,
 				};
 
 				// If exists, also assign translator comment
@@ -254,7 +254,7 @@ module.exports = function() {
 								if ( isSameTranslation( translation, memo[ msgctxt ][ msgid ] ) ) {
 									translation.comments.reference = uniq( [
 										memo[ msgctxt ][ msgid ].comments.reference,
-										translation.comments.reference
+										translation.comments.reference,
 									].join( '\n' ).split( '\n' ) ).join( '\n' );
 								}
 
@@ -275,9 +275,9 @@ module.exports = function() {
 					const compiled = po.compile( data );
 					writeFileSync( state.opts.output || DEFAULT_OUTPUT, compiled );
 					this.hasPendingWrite = false;
-				}
-			}
-		}
+				},
+			},
+		},
 	};
 };
 

--- a/post-content.js
+++ b/post-content.js
@@ -3,7 +3,7 @@
  */
 window._wpGutenbergPost = {
 	title: {
-		raw: 'Welcome to the Gutenberg Editor'
+		raw: 'Welcome to the Gutenberg Editor',
 	},
 	content: {
 		raw: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,41 +11,41 @@ const config = {
 		i18n: './i18n/index.js',
 		blocks: './blocks/index.js',
 		editor: './editor/index.js',
-		element: './element/index.js'
+		element: './element/index.js',
 	},
 	output: {
 		filename: '[name]/build/index.js',
 		path: __dirname,
 		library: [ 'wp', '[name]' ],
-		libraryTarget: 'this'
+		libraryTarget: 'this',
 	},
 	externals: {
 		react: 'React',
 		'react-dom': 'ReactDOM',
 		'react-dom/server': 'ReactDOMServer',
-		tinymce: 'tinymce'
+		tinymce: 'tinymce',
 	},
 	resolve: {
 		modules: [
 			__dirname,
-			'node_modules'
+			'node_modules',
 		],
 		alias: {
 			// There are currently resolution errors on RSF's "mitt" dependency
 			// when imported as native ES module
-			'react-slot-fill': 'react-slot-fill/lib/rsf.js'
-		}
+			'react-slot-fill': 'react-slot-fill/lib/rsf.js',
+		},
 	},
 	module: {
 		rules: [
 			{
 				test: /\.pegjs/,
-				use: 'pegjs-loader'
+				use: 'pegjs-loader',
 			},
 			{
 				test: /\.js$/,
 				exclude: /node_modules/,
-				use: 'babel-loader'
+				use: 'babel-loader',
 			},
 			{
 				test: /\.s?css$/,
@@ -59,34 +59,34 @@ const config = {
 								includePaths: [ 'editor/assets/stylesheets' ],
 								data: '@import "variables"; @import "mixins"; @import "animations";@import "z-index";',
 								outputStyle: 'production' === process.env.NODE_ENV ?
-									'compressed' : 'nested'
-							}
-						}
-					]
-				} )
-			}
-		]
+									'compressed' : 'nested',
+							},
+						},
+					],
+				} ),
+			},
+		],
 	},
 	plugins: [
 		new webpack.DefinePlugin( {
-			'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV )
+			'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ),
 		} ),
 		new ExtractTextPlugin( {
-			filename: './[name]/build/style.css'
+			filename: './[name]/build/style.css',
 		} ),
 		new webpack.LoaderOptionsPlugin( {
 			minimize: process.env.NODE_ENV === 'production',
 			debug: process.env.NODE_ENV !== 'production',
 			options: {
 				postcss: [
-					require( 'autoprefixer' )
-				]
-			}
-		} )
+					require( 'autoprefixer' ),
+				],
+			},
+		} ),
 	],
 	stats: {
-		children: false
-	}
+		children: false,
+	},
 };
 
 switch ( process.env.NODE_ENV ) {
@@ -99,21 +99,21 @@ switch ( process.env.NODE_ENV ) {
 		config.module.rules = [
 			...[ 'i18n', 'element', 'blocks', 'editor' ].map( ( entry ) => ( {
 				test: require.resolve( './' + entry + '/index.js' ),
-				use: 'expose-loader?wp.' + entry
+				use: 'expose-loader?wp.' + entry,
 			} ) ),
-			...config.module.rules
+			...config.module.rules,
 		];
 		config.entry = [
 			'./i18n/index.js',
 			'./element/index.js',
 			'./blocks/index.js',
 			'./editor/index.js',
-			...glob.sync( `./{${ Object.keys( config.entry ).join() }}/**/test/*.js` )
+			...glob.sync( `./{${ Object.keys( config.entry ).join() }}/**/test/*.js` ),
 		];
 		config.externals = [ require( 'webpack-node-externals' )() ];
 		config.output = {
 			filename: 'build/test.js',
-			path: __dirname
+			path: __dirname,
 		};
 		config.plugins.push( new webpack.ProvidePlugin( {
 			tinymce: 'tinymce/tinymce',


### PR DESCRIPTION
Enforce trailing comma syntax for JavaScript arrays and objects:

```js
return [
  'nice',
  'simple',
  'keys',
];
```

```js
return {
  not: {
    so: {
      simple: {
        keys: {},
      },
    },
  },
};
```

Closes #612 - more discussion over there.