### PR TITLE
Replace wp globals with module equivalents

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,6 @@
 		}
 	},
 	"globals": {
-		"wp": true,
 		"tinymce": true
 	},
 	"plugins": [

--- a/blocks/api/query.js
+++ b/blocks/api/query.js
@@ -12,6 +12,11 @@ import {
 } from 'hpq';
 
 /**
+ * WordPress dependencies
+ */
+import { createElement } from 'element';
+
+/**
  * Given a matcher function creator, returns a new function which applies an
  * internal flag to the created matcher.
  *
@@ -39,7 +44,7 @@ export const children = withKnownMatcherFlag( ( selector ) => {
 		}
 
 		if ( match ) {
-			return nodeListToReact( match.childNodes || [], wp.element.createElement );
+			return nodeListToReact( match.childNodes || [], createElement );
 		}
 
 		return [];

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -5,6 +5,11 @@ import { difference } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 
 /**
+ * WordPress dependencies
+ */
+import { Component, createElement, renderToString } from 'element';
+
+/**
  * Internal dependencies
  */
 import { getBlockSettings } from './registration';
@@ -21,8 +26,8 @@ import { parseBlockAttributes } from './parser';
 export function getSaveContent( save, attributes ) {
 	let rawContent;
 
-	if ( save.prototype instanceof wp.element.Component ) {
-		rawContent = wp.element.createElement( save, { attributes } );
+	if ( save.prototype instanceof Component ) {
+		rawContent = createElement( save, { attributes } );
 	} else {
 		rawContent = save( { attributes } );
 
@@ -33,7 +38,7 @@ export function getSaveContent( save, attributes ) {
 	}
 
 	// Otherwise, infer as element
-	return wp.element.renderToString( rawContent );
+	return renderToString( rawContent );
 }
 
 /**

--- a/blocks/api/test/query.js
+++ b/blocks/api/test/query.js
@@ -5,6 +5,11 @@ import { expect } from 'chai';
 import { parse } from 'hpq';
 
 /**
+ * WordPress dependencies
+ */
+import { renderToString } from 'element';
+
+/**
  * Internal dependencies
  */
 import * as query from '../query';
@@ -29,7 +34,7 @@ describe( 'query', () => {
 			const html = '<blockquote><p>A delicious sundae dessert</p></blockquote>';
 			const match = parse( html, query.children() );
 
-			expect( wp.element.renderToString( match ) ).to.equal( html );
+			expect( renderToString( match ) ).to.equal( html );
 		} );
 	} );
 } );

--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -1,23 +1,25 @@
 /**
  * WordPress dependencies
  */
+import { Component } from 'element';
+import { __ } from 'i18n';
 import IconButton from 'components/icon-button';
 import Toolbar from 'components/toolbar';
 
 const FORMATTING_CONTROLS = [
 	{
 		icon: 'editor-bold',
-		title: wp.i18n.__( 'Bold' ),
+		title: __( 'Bold' ),
 		format: 'bold'
 	},
 	{
 		icon: 'editor-italic',
-		title: wp.i18n.__( 'Italic' ),
+		title: __( 'Italic' ),
 		format: 'italic'
 	},
 	{
 		icon: 'editor-strikethrough',
-		title: wp.i18n.__( 'Strikethrough' ),
+		title: __( 'Strikethrough' ),
 		format: 'strikethrough'
 	}
 ];
@@ -25,7 +27,7 @@ const FORMATTING_CONTROLS = [
 // Default controls shown if no `enabledControls` prop provided
 const DEFAULT_CONTROLS = [ 'bold', 'italic', 'strikethrough', 'link' ];
 
-class FormatToolbar extends wp.element.Component {
+class FormatToolbar extends Component {
 	constructor( props ) {
 		super( ...arguments );
 		this.state = {
@@ -118,7 +120,7 @@ class FormatToolbar extends wp.element.Component {
 		if ( enabledControls.indexOf( 'link' ) !== -1 ) {
 			toolbarControls.push( {
 				icon: 'admin-links',
-				title: wp.i18n.__( 'Link' ),
+				title: __( 'Link' ),
 				onClick: this.addLink,
 				isActive: !! formats.link
 			} );
@@ -139,7 +141,7 @@ class FormatToolbar extends wp.element.Component {
 							required
 							value={ this.state.linkValue }
 							onChange={ this.updateLinkValue }
-							placeholder={ wp.i18n.__( 'Paste URL or type' ) }
+							placeholder={ __( 'Paste URL or type' ) }
 						/>
 						<IconButton icon="editor-break" type="submit" />
 					</form>

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -10,6 +10,8 @@ import 'element-closest';
 /**
  * WordPress dependencies
  */
+import { Component, createElement, renderToString } from 'element';
+import { __ } from 'i18n';
 import Toolbar from 'components/toolbar';
 
 /**
@@ -30,22 +32,22 @@ const alignmentMap = {
 const ALIGNMENT_CONTROLS = [
 	{
 		icon: 'editor-alignleft',
-		title: wp.i18n.__( 'Align left' ),
+		title: __( 'Align left' ),
 		align: 'left'
 	},
 	{
 		icon: 'editor-aligncenter',
-		title: wp.i18n.__( 'Align center' ),
+		title: __( 'Align center' ),
 		align: 'center'
 	},
 	{
 		icon: 'editor-alignright',
-		title: wp.i18n.__( 'Align right' ),
+		title: __( 'Align right' ),
 		align: 'right'
 	}
 ];
 
-function createElement( type, props, ...children ) {
+function createElementWithoutMCEFlags( type, props, ...children ) {
 	if ( props[ 'data-mce-bogus' ] === 'all' ) {
 		return null;
 	}
@@ -54,14 +56,14 @@ function createElement( type, props, ...children ) {
 		return children;
 	}
 
-	return wp.element.createElement(
+	return createElement(
 		type,
 		omitBy( props, ( value, key ) => key.indexOf( 'data-mce-' ) === 0 ),
 		...children
 	);
 }
 
-export default class Editable extends wp.element.Component {
+export default class Editable extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
@@ -229,8 +231,8 @@ export default class Editable extends wp.element.Component {
 		this.setContent( this.props.value );
 
 		this.props.onSplit(
-			nodeListToReact( before, createElement ),
-			nodeListToReact( after, createElement )
+			nodeListToReact( before, createElementWithoutMCEFlags ),
+			nodeListToReact( after, createElementWithoutMCEFlags )
 		);
 	}
 
@@ -266,7 +268,7 @@ export default class Editable extends wp.element.Component {
 			content = '';
 		}
 
-		content = wp.element.renderToString( content );
+		content = renderToString( content );
 		this.editor.setContent( content, { format: 'raw' } );
 	}
 

--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -1,4 +1,9 @@
-export default class TinyMCE extends wp.element.Component {
+/**
+ * WordPress dependencies
+ */
+import { Component, Children, createElement } from 'element';
+
+export default class TinyMCE extends Component {
 	componentDidMount() {
 		this.initialize();
 	}
@@ -62,10 +67,10 @@ export default class TinyMCE extends wp.element.Component {
 		// us to show and focus the content before it's truly ready to edit.
 		let children;
 		if ( defaultValue ) {
-			children = wp.element.Children.toArray( defaultValue );
+			children = Children.toArray( defaultValue );
 		}
 
-		return wp.element.createElement( tagName, {
+		return createElement( tagName, {
 			ref: ( node ) => this.editorNode = node,
 			contentEditable: true,
 			suppressContentEditableWarning: true,

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
 import IconButton from 'components/icon-button';
 
 /**
@@ -27,7 +28,7 @@ function applyOrUnset( align ) {
 }
 
 registerBlock( 'core/button', {
-	title: wp.i18n.__( 'Button' ),
+	title: __( 'Button' ),
 
 	icon: 'marker',
 
@@ -42,19 +43,19 @@ registerBlock( 'core/button', {
 	controls: [
 		{
 			icon: 'align-left',
-			title: wp.i18n.__( 'Align left' ),
+			title: __( 'Align left' ),
 			isActive: ( { align } ) => 'left' === align,
 			onClick: applyOrUnset( 'left' )
 		},
 		{
 			icon: 'align-center',
-			title: wp.i18n.__( 'Align center' ),
+			title: __( 'Align center' ),
 			isActive: ( { align } ) => 'center' === align,
 			onClick: applyOrUnset( 'center' )
 		},
 		{
 			icon: 'align-right',
-			title: wp.i18n.__( 'Align right' ),
+			title: __( 'Align right' ),
 			isActive: ( { align } ) => 'right' === align,
 			onClick: applyOrUnset( 'right' )
 		}
@@ -74,7 +75,7 @@ registerBlock( 'core/button', {
 			<span className="blocks-button" title={ title }>
 				<Editable
 					tagName="span"
-					placeholder={ wp.i18n.__( 'Write some text…' ) }
+					placeholder={ __( 'Write some text…' ) }
 					value={ text }
 					onFocus={ setFocus }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
@@ -90,7 +91,7 @@ registerBlock( 'core/button', {
 							required
 							value={ url }
 							onChange={ ( event ) => setAttributes( { url: event.target.value } ) }
-							placeholder={ wp.i18n.__( 'Paste URL or type' ) }
+							placeholder={ __( 'Paste URL or type' ) }
 						/>
 						<IconButton icon="editor-break" type="submit" />
 					</form>

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
 import Button from 'components/button';
 import Placeholder from 'components/placeholder';
 
@@ -13,7 +14,7 @@ import Editable from '../../editable';
 const { attr, children } = query;
 
 registerBlock( 'core/embed', {
-	title: wp.i18n.__( 'Embed' ),
+	title: __( 'Embed' ),
 
 	icon: 'video-alt3',
 
@@ -30,10 +31,10 @@ registerBlock( 'core/embed', {
 
 		if ( ! url ) {
 			return (
-				<Placeholder icon="cloud" label={ wp.i18n.__( 'Embed URL' ) } className="blocks-embed">
-					<input type="url" className="placeholder__input" placeholder={ wp.i18n.__( 'Enter URL to embed here...' ) } />
+				<Placeholder icon="cloud" label={ __( 'Embed URL' ) } className="blocks-embed">
+					<input type="url" className="placeholder__input" placeholder={ __( 'Enter URL to embed here...' ) } />
 					<Button isLarge>
-						{ wp.i18n.__( 'Embed' ) }
+						{ __( 'Embed' ) }
 					</Button>
 				</Placeholder>
 			);
@@ -47,7 +48,7 @@ registerBlock( 'core/embed', {
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
-						placeholder={ wp.i18n.__( 'Write caption…' ) }
+						placeholder={ __( 'Write caption…' ) }
 						value={ caption }
 						focus={ focus }
 						onFocus={ setFocus }

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
+/**
  * Internal dependencies
  */
 import { registerBlock, query, setUnknownTypeHandler } from '../../api';
@@ -6,7 +11,7 @@ import { registerBlock, query, setUnknownTypeHandler } from '../../api';
 const { html } = query;
 
 registerBlock( 'core/freeform', {
-	title: wp.i18n.__( 'Freeform' ),
+	title: __( 'Freeform' ),
 
 	icon: 'text',
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -1,4 +1,10 @@
 /**
+ * WordPress dependencies
+ */
+import { concatChildren } from 'element';
+import { __, sprintf } from 'i18n';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -8,7 +14,7 @@ import Editable from '../../editable';
 const { children, prop } = query;
 
 registerBlock( 'core/heading', {
-	title: wp.i18n.__( 'Heading' ),
+	title: __( 'Heading' ),
 
 	icon: 'heading',
 
@@ -22,7 +28,7 @@ registerBlock( 'core/heading', {
 	controls: [
 		...'123456'.split( '' ).map( ( level ) => ( {
 			icon: 'heading',
-			title: wp.i18n.sprintf( wp.i18n.__( 'Heading %s' ), level ),
+			title: sprintf( __( 'Heading %s' ), level ),
 			isActive: ( { nodeName } ) => 'H' + level === nodeName,
 			onClick( attributes, setAttributes ) {
 				setAttributes( { nodeName: 'H' + level } );
@@ -75,7 +81,7 @@ registerBlock( 'core/heading', {
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: wp.element.concatChildren( attributes.content, attributesToMerge.content )
+			content: concatChildren( attributes.content, attributesToMerge.content )
 		};
 	},
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
 import Button from 'components/button';
 import Placeholder from 'components/placeholder';
 
@@ -28,7 +29,7 @@ function toggleAlignment( align ) {
 }
 
 registerBlock( 'core/image', {
-	title: wp.i18n.__( 'Image' ),
+	title: __( 'Image' ),
 
 	icon: 'format-image',
 
@@ -43,25 +44,25 @@ registerBlock( 'core/image', {
 	controls: [
 		{
 			icon: 'align-left',
-			title: wp.i18n.__( 'Align left' ),
+			title: __( 'Align left' ),
 			isActive: ( { align } ) => 'left' === align,
 			onClick: toggleAlignment( 'left' )
 		},
 		{
 			icon: 'align-center',
-			title: wp.i18n.__( 'Align center' ),
+			title: __( 'Align center' ),
 			isActive: ( { align } ) => 'center' === align,
 			onClick: toggleAlignment( 'center' )
 		},
 		{
 			icon: 'align-right',
-			title: wp.i18n.__( 'Align right' ),
+			title: __( 'Align right' ),
 			isActive: ( { align } ) => 'right' === align,
 			onClick: toggleAlignment( 'right' )
 		},
 		{
 			icon: 'align-full-width',
-			title: wp.i18n.__( 'Wide width' ),
+			title: __( 'Wide width' ),
 			isActive: ( { align } ) => 'wide' === align,
 			onClick: toggleAlignment( 'wide' )
 		}
@@ -80,12 +81,12 @@ registerBlock( 'core/image', {
 		if ( ! url ) {
 			return (
 				<Placeholder
-					instructions={ wp.i18n.__( 'Drag image here or insert from media library' ) }
+					instructions={ __( 'Drag image here or insert from media library' ) }
 					icon="format-image"
-					label={ wp.i18n.__( 'Image' ) }
+					label={ __( 'Image' ) }
 					className="blocks-image">
 					<Button isLarge>
-						{ wp.i18n.__( 'Insert from Media Library' ) }
+						{ __( 'Insert from Media Library' ) }
 					</Button>
 				</Placeholder>
 			);
@@ -99,7 +100,7 @@ registerBlock( 'core/image', {
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
-						placeholder={ wp.i18n.__( 'Write caption…' ) }
+						placeholder={ __( 'Write caption…' ) }
 						value={ caption }
 						focus={ focus && focus.editable === 'caption' ? focus : undefined }
 						onFocus={ focusCaption }

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -1,4 +1,10 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+import { createElement } from 'element';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -8,7 +14,7 @@ import Editable from '../../editable';
 const { children, prop } = hpq;
 
 registerBlock( 'core/list', {
-	title: wp.i18n.__( 'List' ),
+	title: __( 'List' ),
 	icon: 'editor-ul',
 	category: 'common',
 
@@ -20,7 +26,7 @@ registerBlock( 'core/list', {
 	controls: [
 		{
 			icon: 'editor-ul',
-			title: wp.i18n.__( 'Convert to unordered' ),
+			title: __( 'Convert to unordered' ),
 			isActive: ( { nodeName = 'OL' } ) => nodeName === 'UL',
 			onClick( attributes, setAttributes ) {
 				setAttributes( { nodeName: 'UL' } );
@@ -28,7 +34,7 @@ registerBlock( 'core/list', {
 		},
 		{
 			icon: 'editor-ol',
-			title: wp.i18n.__( 'Convert to ordered' ),
+			title: __( 'Convert to ordered' ),
 			isActive: ( { nodeName = 'OL' } ) => nodeName === 'OL',
 			onClick( attributes, setAttributes ) {
 				setAttributes( { nodeName: 'OL' } );
@@ -55,7 +61,7 @@ registerBlock( 'core/list', {
 	save( { attributes } ) {
 		const { nodeName = 'OL', values = [] } = attributes;
 
-		return wp.element.createElement(
+		return createElement(
 			nodeName.toLowerCase(),
 			null,
 			values

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -8,7 +13,7 @@ import Editable from '../../editable';
 const { children, query } = hpq;
 
 registerBlock( 'core/pullquote', {
-	title: wp.i18n.__( 'Pullquote' ),
+	title: __( 'Pullquote' ),
 	icon: 'format-quote',
 	category: 'common',
 
@@ -23,7 +28,7 @@ registerBlock( 'core/pullquote', {
 		return (
 			<blockquote className="blocks-pullquote">
 				<Editable
-					value={ value || wp.i18n.__( 'Write Quote…' ) }
+					value={ value || __( 'Write Quote…' ) }
 					onChange={
 						( nextValue ) => setAttributes( {
 							value: nextValue
@@ -35,7 +40,7 @@ registerBlock( 'core/pullquote', {
 				{ ( citation || !! focus ) && (
 					<Editable
 						tagName="footer"
-						value={ citation || wp.i18n.__( 'Write caption…' ) }
+						value={ citation || __( 'Write caption…' ) }
 						onChange={
 							( nextCitation ) => setAttributes( {
 								citation: nextCitation

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -1,4 +1,10 @@
 /**
+ * WordPress dependencies
+ */
+import { concatChildren } from 'element';
+import { __, sprintf } from 'i18n';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -8,7 +14,7 @@ import Editable from '../../editable';
 const { children, query } = hpq;
 
 registerBlock( 'core/quote', {
-	title: wp.i18n.__( 'Quote' ),
+	title: __( 'Quote' ),
 	icon: 'format-quote',
 	category: 'common',
 
@@ -19,7 +25,7 @@ registerBlock( 'core/quote', {
 
 	controls: [ 1, 2 ].map( ( variation ) => ( {
 		icon: 'format-quote',
-		title: wp.i18n.sprintf( wp.i18n.__( 'Quote style %d' ), variation ),
+		title: sprintf( __( 'Quote style %d' ), variation ),
 		isActive: ( { style = 1 } ) => Number( style ) === variation,
 		onClick( attributes, setAttributes ) {
 			setAttributes( { style: variation } );
@@ -54,7 +60,7 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/text' ],
 				transform: ( { value, citation } ) => {
 					return createBlock( 'core/text', {
-						content: wp.element.concatChildren( value, citation )
+						content: concatChildren( value, citation )
 					} );
 				}
 			},

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -1,11 +1,16 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 import { registerBlock } from '../../api';
 
 registerBlock( 'core/separator', {
-	title: wp.i18n.__( 'Separator' ),
+	title: __( 'Separator' ),
 
 	icon: 'minus',
 

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -1,4 +1,10 @@
 /**
+ * WordPress dependencies
+ */
+import { concatChildren } from 'element';
+import { __ } from 'i18n';
+
+/**
  * Internal dependencies
  */
 import { registerBlock, createBlock, query } from '../../api';
@@ -7,7 +13,7 @@ import Editable from '../../editable';
 const { children } = query;
 
 registerBlock( 'core/text', {
-	title: wp.i18n.__( 'Text' ),
+	title: __( 'Text' ),
 
 	icon: 'text',
 
@@ -23,7 +29,7 @@ registerBlock( 'core/text', {
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: wp.element.concatChildren( attributes.content, attributesToMerge.content )
+			content: concatChildren( attributes.content, attributesToMerge.content )
 		};
 	},
 

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 import { parse, stringify } from 'querystring';
 
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
 export function savePost( dispatch, postId, edits ) {
 	const toSend = postId ? { id: postId, ...edits } : edits;
 	const isNew = ! postId;
@@ -34,7 +39,7 @@ export function savePost( dispatch, postId, edits ) {
 			type: 'REQUEST_POST_UPDATE_FAILURE',
 			error: get( err, 'responseJSON', {
 				code: 'unknown_error',
-				message: wp.i18n.__( 'An unknown error occurred.' ),
+				message: __( 'An unknown error occurred.' ),
 			} ),
 			edits,
 			isNew,

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -8,6 +8,9 @@ import clickOutside from 'react-click-outside';
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
+import { Component } from 'element';
+import { getBlockSettings, getBlocks, switchToBlockType } from 'blocks';
 import IconButton from 'components/icon-button';
 
 /**
@@ -16,7 +19,7 @@ import IconButton from 'components/icon-button';
 import './style.scss';
 import { getBlock } from '../selectors';
 
-class BlockSwitcher extends wp.element.Component {
+class BlockSwitcher extends Component {
 	constructor() {
 		super( ...arguments );
 		this.toggleMenu = this.toggleMenu.bind( this );
@@ -49,8 +52,8 @@ class BlockSwitcher extends wp.element.Component {
 	}
 
 	render() {
-		const blockSettings = wp.blocks.getBlockSettings( this.props.block.blockType );
-		const blocksToBeTransformedFrom = reduce( wp.blocks.getBlocks(), ( memo, block ) => {
+		const blockSettings = getBlockSettings( this.props.block.blockType );
+		const blocksToBeTransformedFrom = reduce( getBlocks(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );
 			const transformation = transformFrom.find( t => t.blocks.indexOf( this.props.block.blockType ) !== -1 );
 			return transformation ? memo.concat( [ block.slug ] ) : memo;
@@ -59,7 +62,7 @@ class BlockSwitcher extends wp.element.Component {
 			.reduce( ( memo, transformation ) => memo.concat( transformation.blocks ), [] );
 		const allowedBlocks = uniq( blocksToBeTransformedFrom.concat( blocksToBeTransformedTo ) )
 			.reduce( ( memo, blockType ) => {
-				const block = wp.blocks.getBlockSettings( blockType );
+				const block = getBlockSettings( blockType );
 				return !! block ? memo.concat( block ) : memo;
 			}, [] );
 
@@ -75,7 +78,7 @@ class BlockSwitcher extends wp.element.Component {
 					onClick={ this.toggleMenu }
 					aria-haspopup="true"
 					aria-expanded={ this.state.open }
-					label={ wp.i18n.__( 'Change block content type' ) }
+					label={ __( 'Change block type' ) }
 				>
 					<div className="editor-block-switcher__arrow" />
 				</IconButton>
@@ -84,7 +87,7 @@ class BlockSwitcher extends wp.element.Component {
 						className="editor-block-switcher__menu"
 						role="menu"
 						tabIndex="0"
-						aria-label={ wp.i18n.__( 'Content types' ) }
+						aria-label={ __( 'Block types' ) }
 					>
 						{ allowedBlocks.map( ( { slug, title, icon } ) => (
 							<IconButton
@@ -113,7 +116,7 @@ export default connect(
 			dispatch( {
 				type: 'REPLACE_BLOCKS',
 				uids: [ ownProps.uid ],
-				blocks: wp.blocks.switchToBlockType( block, blockType )
+				blocks: switchToBlockType( block, blockType )
 			} );
 		}
 	} )

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import Dashicon from 'components/dashicon';
+import { __, _x } from 'i18n';
 
 /**
  * Internal dependencies
@@ -22,11 +23,11 @@ import { getEditorMode } from '../../selectors';
 const MODES = [
 	{
 		value: 'visual',
-		label: wp.i18n.__( 'Visual' )
+		label: __( 'Visual' )
 	},
 	{
 		value: 'text',
-		label: wp.i18n._x( 'Text', 'Name for the Text editor tab (formerly HTML)' )
+		label: _x( 'Text', 'Name for the Text editor tab (formerly HTML)' )
 	}
 ];
 

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -8,6 +8,7 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import Dashicon from 'components/dashicon';
+import { __ } from 'i18n';
 
 /**
  * Internal dependencies
@@ -23,8 +24,8 @@ function SavedState( { isDirty } ) {
 		? 'warning'
 		: 'saved';
 	const text = isDirty
-		? wp.i18n.__( 'Unsaved changes' )
-		: wp.i18n.__( 'Saved' );
+		? __( 'Unsaved changes' )
+		: __( 'Saved' );
 
 	return (
 		<div className={ classes }>

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import Dashicon from 'components/dashicon';
 import IconButton from 'components/icon-button';
 import Button from 'components/button';
+import { __, _x } from 'i18n';
 
 /**
  * Internal dependencies
@@ -24,24 +25,24 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 			<IconButton
 				className="editor-tools__undo"
 				icon="undo"
-				label={ wp.i18n.__( 'Undo' ) }
+				label={ __( 'Undo' ) }
 				disabled={ ! hasUndo }
 				onClick={ undo } />
 			<IconButton
 				className="editor-tools__redo"
 				icon="redo"
-				label={ wp.i18n.__( 'Redo' ) }
+				label={ __( 'Redo' ) }
 				disabled={ ! hasRedo }
 				onClick={ redo } />
 			<Inserter position="bottom" />
 			<div className="editor-tools__tabs">
 				<Button>
 					<Dashicon icon="visibility" />
-					{ wp.i18n._x( 'Preview', 'imperative verb' ) }
+					{ _x( 'Preview', 'imperative verb' ) }
 				</Button>
 				<Button onClick={ toggleSidebar } isToggled={ isSidebarOpened }>
 					<Dashicon icon="admin-generic" />
-					{ wp.i18n.__( 'Post Settings' ) }
+					{ __( 'Post Settings' ) }
 				</Button>
 			</div>
 			<PublishButton />

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -6,7 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
+import { serialize } from 'blocks';
 import Button from 'components/button';
+import { __ } from 'i18n';
 
 /**
  * Internal dependencies
@@ -40,20 +42,20 @@ function PublishButton( {
 
 	if ( isRequesting ) {
 		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Saving…' )
-			: wp.i18n.__( 'Updating…' );
+			? __( 'Saving…' )
+			: __( 'Updating…' );
 	} else if ( ! dirty && isSuccessful ) {
 		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Saved!' )
-			: wp.i18n.__( 'Updated!' );
+			? __( 'Saved!' )
+			: __( 'Updated!' );
 	} else if ( ! dirty && isError ) {
 		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Save failed' )
-			: wp.i18n.__( 'Update failed' );
+			? __( 'Save failed' )
+			: __( 'Update failed' );
 	} else if ( post && post.id ) {
-		buttonText = wp.i18n.__( 'Update' );
+		buttonText = __( 'Update' );
 	} else {
-		buttonText = wp.i18n.__( 'Save draft' );
+		buttonText = __( 'Save draft' );
 	}
 
 	if ( post && post.id ) {
@@ -88,14 +90,14 @@ export default connect(
 	( dispatch ) => ( {
 		onUpdate( post, edits, blocks ) {
 			savePost( dispatch, post.id, {
-				content: wp.blocks.serialize( blocks ),
+				content: serialize( blocks ),
 				...edits,
 			} );
 		},
 
 		onSaveDraft( post, edits, blocks ) {
 			savePost( dispatch, null /* is a new post */, {
-				content: wp.blocks.serialize( blocks ),
+				content: serialize( blocks ),
 				status: 'draft', // TODO change this after status controls
 				...edits,
 			} );

--- a/editor/index.js
+++ b/editor/index.js
@@ -5,6 +5,12 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { Provider as SlotFillProvider } from 'react-slot-fill';
 
 /**
+ * WordPress dependencies
+ */
+import { render } from 'element';
+import { parse } from 'blocks';
+
+/**
  * Internal dependencies
  */
 import './assets/stylesheets/main.scss';
@@ -22,10 +28,10 @@ export function createEditorInstance( id, post ) {
 	store.dispatch( {
 		type: 'RESET_BLOCKS',
 		post,
-		blocks: wp.blocks.parse( post.content.raw )
+		blocks: parse( post.content.raw )
 	} );
 
-	wp.element.render(
+	render(
 		<ReduxProvider store={ store }>
 			<SlotFillProvider>
 				<Layout />

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -7,13 +7,15 @@ import clickOutside from 'react-click-outside';
  * WordPress dependencies
  */
 import IconButton from 'components/icon-button';
+import { Component } from 'element';
+import { __ } from 'i18n';
 
 /**
  * Internal dependencies
  */
 import InserterMenu from './menu';
 
-class Inserter extends wp.element.Component {
+class Inserter extends Component {
 	constructor() {
 		super( ...arguments );
 		this.toggle = this.toggle.bind( this );
@@ -55,7 +57,7 @@ class Inserter extends wp.element.Component {
 			<div className="editor-inserter">
 				<IconButton
 					icon="insert"
-					label={ wp.i18n.__( 'Insert block' ) }
+					label={ __( 'Insert block' ) }
 					onClick={ this.toggle }
 					className="editor-inserter__toggle"
 					aria-haspopup="true"

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -7,6 +7,9 @@ import { flow, groupBy, sortBy, findIndex, filter } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { getBlocks, getCategories, createBlock } from 'blocks';
+import { Component } from 'element';
+import { __ } from 'i18n';
 import Dashicon from 'components/dashicon';
 
 /**
@@ -14,7 +17,7 @@ import Dashicon from 'components/dashicon';
  */
 import './style.scss';
 
-class InserterMenu extends wp.element.Component {
+class InserterMenu extends Component {
 	constructor() {
 		super( ...arguments );
 		this.nodes = {};
@@ -70,7 +73,7 @@ class InserterMenu extends wp.element.Component {
 
 	sortBlocksByCategory( blockTypes ) {
 		const getCategoryIndex = ( item ) => {
-			return findIndex( wp.blocks.getCategories(), ( category ) => category.slug === item.category );
+			return findIndex( getCategories(), ( category ) => category.slug === item.category );
 		};
 
 		return sortBy( blockTypes, getCategoryIndex );
@@ -135,7 +138,7 @@ class InserterMenu extends wp.element.Component {
 		const sortedByCategory = flow(
 			this.getVisibleBlocks,
 			this.sortBlocksByCategory,
-		)( wp.blocks.getBlocks() );
+		)( getBlocks() );
 
 		// If the block list is empty return early.
 		if ( ! sortedByCategory.length ) {
@@ -150,7 +153,7 @@ class InserterMenu extends wp.element.Component {
 		const sortedByCategory = flow(
 			this.getVisibleBlocks,
 			this.sortBlocksByCategory,
-		)( wp.blocks.getBlocks() );
+		)( getBlocks() );
 
 		// If the block list is empty return early.
 		if ( ! sortedByCategory.length ) {
@@ -223,13 +226,13 @@ class InserterMenu extends wp.element.Component {
 
 	render() {
 		const { position = 'top' } = this.props;
-		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getBlocks() );
+		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( getBlocks() );
 
 		return (
 			<div className={ `editor-inserter__menu is-${ position }` } tabIndex="0">
 				<div className="editor-inserter__arrow" />
 				<div role="menu" className="editor-inserter__content">
-					{ wp.blocks.getCategories()
+					{ getCategories()
 						.map( ( category ) => !! visibleBlocksByCategory[ category.slug ] && (
 							<div key={ category.slug }>
 								<div
@@ -264,12 +267,12 @@ class InserterMenu extends wp.element.Component {
 					}
 				</div>
 				<label htmlFor={ `editor-inserter__search-${ this.instanceId }` } className="screen-reader-text">
-					{ wp.i18n.__( 'Search blocks' ) }
+					{ __( 'Search blocks' ) }
 				</label>
 				<input
 					id={ `editor-inserter__search-${ this.instanceId }` }
 					type="search"
-					placeholder={ wp.i18n.__( 'Search…' ) }
+					placeholder={ __( 'Search…' ) }
 					className="editor-inserter__search"
 					onChange={ this.filter }
 					onClick={ this.setSearchFocus }
@@ -289,7 +292,7 @@ export default connect(
 		onInsertBlock( slug ) {
 			dispatch( {
 				type: 'INSERT_BLOCK',
-				block: wp.blocks.createBlock( slug )
+				block: createBlock( slug )
 			} );
 		}
 	} )

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -5,6 +5,11 @@ import { connect } from 'react-redux';
 import Textarea from 'react-autosize-textarea';
 
 /**
+ * WordPress dependencies
+ */
+import { serialize, parse } from 'blocks';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -35,7 +40,7 @@ function TextEditor( { blocks, onChange } ) {
 				<PostTitle />
 				<Textarea
 					autoComplete="off"
-					defaultValue={ wp.blocks.serialize( blocks ) }
+					defaultValue={ serialize( blocks ) }
 					onBlur={ ( event ) => onChange( event.target.value ) }
 					className="editor-text-editor__textarea"
 				/>
@@ -52,7 +57,7 @@ export default connect(
 		onChange( value ) {
 			dispatch( {
 				type: 'RESET_BLOCKS',
-				blocks: wp.blocks.parse( value )
+				blocks: parse( value )
 			} );
 		}
 	} )

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -9,6 +9,8 @@ import { partial } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { getBlockSettings, switchToBlockType } from 'blocks';
+import { Component } from 'element';
 import Toolbar from 'components/toolbar';
 
 /**
@@ -26,7 +28,7 @@ import {
 	isTypingInBlock
 } from '../../selectors';
 
-class VisualEditorBlock extends wp.element.Component {
+class VisualEditorBlock extends Component {
 	constructor() {
 		super( ...arguments );
 		this.bindBlockNode = this.bindBlockNode.bind( this );
@@ -108,7 +110,7 @@ class VisualEditorBlock extends wp.element.Component {
 			return;
 		}
 
-		const previousBlockSettings = wp.blocks.getBlockSettings( previousBlock.blockType );
+		const previousBlockSettings = getBlockSettings( previousBlock.blockType );
 
 		// Do nothing if the previous block is not mergeable
 		if ( ! previousBlockSettings.merge ) {
@@ -120,7 +122,7 @@ class VisualEditorBlock extends wp.element.Component {
 		// thus, we transform the block to merge first
 		const blocksWithTheSameType = previousBlock.blockType === block.blockType
 			? [ block ]
-			: wp.blocks.switchToBlockType( block, previousBlock.blockType );
+			: switchToBlockType( block, previousBlock.blockType );
 
 		// If the block types can not match, do nothing
 		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {
@@ -169,7 +171,7 @@ class VisualEditorBlock extends wp.element.Component {
 
 	render() {
 		const { block } = this.props;
-		const settings = wp.blocks.getBlockSettings( block.blockType );
+		const settings = getBlockSettings( block.blockType );
 
 		let BlockEdit;
 		if ( settings ) {

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -5,6 +5,11 @@ import { connect } from 'react-redux';
 import Textarea from 'react-autosize-textarea';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -27,7 +32,7 @@ function PostTitle( { title, onUpdate } ) {
 				className="editor-post-title__input"
 				value={ title }
 				onChange={ onChange }
-				placeholder={ wp.i18n.__( 'Enter title here' ) }
+				placeholder={ __( 'Enter title here' ) }
 			/>
 		</h1>
 	);

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -6,6 +6,11 @@ import { values } from 'lodash';
 import deepFreeze from 'deep-freeze';
 
 /**
+ * WordPress dependencies
+ */
+import { registerBlock, unregisterBlock } from 'blocks';
+
+/**
  * Internal dependencies
  */
 import {
@@ -22,11 +27,11 @@ import {
 describe( 'state', () => {
 	describe( 'editor()', () => {
 		before( () => {
-			wp.blocks.registerBlock( 'core/test-block', {} );
+			registerBlock( 'core/test-block', {} );
 		} );
 
 		after( () => {
-			wp.blocks.unregisterBlock( 'core/test-block' );
+			unregisterBlock( 'core/test-block' );
 		} );
 
 		it( 'should return empty blocksByUid, blockOrder, history by default', () => {


### PR DESCRIPTION
Previously: #716, #736, #737, #739 

This pull request expands upon the restructuring outlined in #716, replacing `wp.` global calls with their "WordPress modules" equivalents. It should be the final step in this process.

__Testing instructions:__

Ensure the build completes, tests pass, and editor initializes and appears without regressions. Specifically observe that no errors are logged to the console, blocks appear as registered with localized (likely English) labels intact. 