### PR TITLE
Chrome: Adding a v1 of the preview button

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -19,7 +19,7 @@ function Button( { href, isPrimary, isLarge, isToggled, className, buttonRef, ..
 		...tagProps,
 		...additionalProps,
 		className: classes,
-		ref: buttonRef
+		ref: buttonRef,
 	} );
 }
 

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -4,7 +4,7 @@
 import './style.scss';
 import classnames from 'classnames';
 
-function Button( { isPrimary, isLarge, isToggled, className, buttonRef, ...additionalProps } ) {
+function Button( { href, isPrimary, isLarge, isToggled, className, buttonRef, ...additionalProps } ) {
 	const classes = classnames( 'components-button', className, {
 		button: ( isPrimary || isLarge ),
 		'button-primary': isPrimary,
@@ -12,13 +12,15 @@ function Button( { isPrimary, isLarge, isToggled, className, buttonRef, ...addit
 		'is-toggled': isToggled,
 	} );
 
-	return (
-		<button
-			type="button"
-			{ ...additionalProps }
-			ref={ buttonRef }
-			className={ classes } />
-	);
+	const tag = href !== undefined ? 'a' : 'button';
+	const tagProps = tag === 'a' ? { href } : { type: 'button' };
+
+	return wp.element.createElement( tag, {
+		...tagProps,
+		...additionalProps,
+		className: classes,
+		ref: buttonRef
+	} );
 }
 
 export default Button;

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -2,8 +2,13 @@
 	background: none;
 	border: none;
 	outline: none;
+	text-decoration: none;
 
 	&:disabled {
 		opacity: 0.6;
+	}
+
+	&:focus {
+		box-shadow: none;
 	}
 }

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -16,6 +16,7 @@ import Button from 'components/button';
 import './style.scss';
 import Inserter from '../../inserter';
 import PublishButton from './publish-button';
+import PreviewButton from './preview-button';
 import { isEditorSidebarOpened, hasEditorUndo, hasEditorRedo } from '../../selectors';
 
 function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar } ) {
@@ -35,10 +36,7 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 				onClick={ redo } />
 			<Inserter position="bottom" />
 			<div className="editor-tools__tabs">
-				<Button>
-					<Dashicon icon="visibility" />
-					{ wp.i18n._x( 'Preview', 'imperative verb' ) }
-				</Button>
+				<PreviewButton />
 				<Button onClick={ toggleSidebar } isToggled={ isSidebarOpened }>
 					<Dashicon icon="admin-generic" />
 					{ wp.i18n.__( 'Post Settings' ) }

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import Dashicon from 'components/dashicon';
+import Button from 'components/button';
+
+/**
+ * Internal dependencies
+ */
+import { getEditedPostPreviewLink } from '../../selectors';
+
+function PreviewButton( { link } ) {
+	return (
+		<Button href={ link } target="_blank">
+			<Dashicon icon="visibility" />
+			{ wp.i18n._x( 'Preview', 'imperative verb' ) }
+		</Button>
+	);
+}
+
+export default connect(
+	( state ) => ( {
+		link: getEditedPostPreviewLink( state ),
+	} )
+)( PreviewButton );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { first, last } from 'lodash';
+import qs from 'qs';
 
 export function getEditorMode( state ) {
 	return state.mode;
@@ -35,6 +36,20 @@ export function getEditedPostTitle( state ) {
 	return state.editor.edits.title === undefined
 		? state.currentPost.title.raw
 		: state.editor.edits.title;
+}
+
+export function getEditedPostPreviewLink( state ) {
+	const link = state.currentPost.link;
+	if ( ! link ) {
+		return null;
+	}
+
+	const queryStringPosition = link.indexOf( '?' );
+	const baseUrl = queryStringPosition !== -1 ? link.substring( 0, queryStringPosition ) : link;
+	const args = queryStringPosition !== -1 ? qs.parse( link.substring( queryStringPosition + 1 ) ) : {};
+	args.preview = 'true';
+
+	return `${ baseUrl }?${ qs.stringify( args ) }`;
 }
 
 export function getBlock( state, uid ) {

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { first, last } from 'lodash';
-import qs from 'qs';
+
+/**
+ * Internal dependencies
+ */
+import { addQueryArgs } from './utils/url';
 
 export function getEditorMode( state ) {
 	return state.mode;
@@ -44,12 +48,7 @@ export function getEditedPostPreviewLink( state ) {
 		return null;
 	}
 
-	const queryStringPosition = link.indexOf( '?' );
-	const baseUrl = queryStringPosition !== -1 ? link.substring( 0, queryStringPosition ) : link;
-	const args = queryStringPosition !== -1 ? qs.parse( link.substring( queryStringPosition + 1 ) ) : {};
-	args.preview = 'true';
-
-	return `${ baseUrl }?${ qs.stringify( args ) }`;
+	return addQueryArgs( link, { preview: 'true' } );
 }
 
 export function getBlock( state, uid ) {

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -199,24 +199,14 @@ describe( 'selectors', () => {
 			expect( getEditedPostPreviewLink( state ) ).to.be.null();
 		} );
 
-		it( 'should return the correct url adding a query string', () => {
+		it( 'should return the correct url adding a preview parameter to the query string', () => {
 			const state = {
 				currentPost: {
-					link: 'https://andalouses.com/beach'
-				}
+					link: 'https://andalouses.com/beach',
+				},
 			};
 
 			expect( getEditedPostPreviewLink( state ) ).to.equal( 'https://andalouses.com/beach?preview=true' );
-		} );
-
-		it( 'should return the correct url concatening the query string', () => {
-			const state = {
-				currentPost: {
-					link: 'https://andalouses.com/?p=1'
-				}
-			};
-
-			expect( getEditedPostPreviewLink( state ) ).to.equal( 'https://andalouses.com/?p=1&preview=true' );
 		} );
 	} );
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -15,6 +15,7 @@ import {
 	getCurrentPost,
 	getPostEdits,
 	getEditedPostTitle,
+	getEditedPostPreviewLink,
 	getBlock,
 	getBlocks,
 	getBlockUids,
@@ -186,6 +187,36 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditedPostTitle( state ) ).to.equal( 'youcha' );
+		} );
+	} );
+
+	describe( 'getEditedPostPreviewLink', () => {
+		it( 'should return null if the post has not link yet', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( getEditedPostPreviewLink( state ) ).to.be.null();
+		} );
+
+		it( 'should return the correct url adding a query string', () => {
+			const state = {
+				currentPost: {
+					link: 'https://andalouses.com/beach'
+				}
+			};
+
+			expect( getEditedPostPreviewLink( state ) ).to.equal( 'https://andalouses.com/beach?preview=true' );
+		} );
+
+		it( 'should return the correct url concatening the query string', () => {
+			const state = {
+				currentPost: {
+					link: 'https://andalouses.com/?p=1'
+				}
+			};
+
+			expect( getEditedPostPreviewLink( state ) ).to.equal( 'https://andalouses.com/?p=1&preview=true' );
 		} );
 	} );
 

--- a/editor/utils/test/url.js
+++ b/editor/utils/test/url.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { addQueryArgs } from '../url';
+
+describe( 'addQueryArgs', () => {
+	it( 'should append args to an URL without query string', () => {
+		const url = 'https://andalouses.com/beach';
+		const args = { sun: 'true', sand: 'false' };
+
+		expect( addQueryArgs( url, args ) ).to.eql( 'https://andalouses.com/beach?sun=true&sand=false' );
+	} );
+
+	it( 'should append args to an URL with query string', () => {
+		const url = 'https://andalouses.com/beach?night=false';
+		const args = { sun: 'true', sand: 'false' };
+
+		expect( addQueryArgs( url, args ) ).to.eql( 'https://andalouses.com/beach?night=false&sun=true&sand=false' );
+	} );
+} );

--- a/editor/utils/url.js
+++ b/editor/utils/url.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { parse, format } from 'url';
+
+/**
+ * Appends arguments to the query string of the url
+ *
+ * @param  {String} url   URL
+ * @param  {Object} args  Query Args
+ *
+ * @return {String}       Updated URL
+ */
+export function addQueryArgs( url, args ) {
+	const parsedUrl = parse( url, true );
+	const query = { ...parsedUrl.query, ...args };
+	delete parsedUrl.search;
+
+	return format( { ...parsedUrl, query } );
+}

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "jed": "^1.1.1",
     "js-beautify": "^1.6.12",
     "lodash": "^4.17.4",
-    "qs": "^6.4.0",
     "react": "^15.5.4",
     "react-autosize-textarea": "^0.4.2",
     "react-click-outside": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "jed": "^1.1.1",
     "js-beautify": "^1.6.12",
     "lodash": "^4.17.4",
+    "qs": "^6.4.0",
     "react": "^15.5.4",
     "react-autosize-textarea": "^0.4.2",
     "react-click-outside": "^2.3.0",


### PR DESCRIPTION
refs #659 

This PR adds a v1 for the preview button, nothing fancy for now, we just display a link to the preview page for "saved" posts only.

I'm not aware of how the "preview" button should work, do we need to save the post each time we hit the button? or do we need to save a "revision"? Is there an API for this @nylen?