### PR TITLE
Plugin: Add a script to build the plugin zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gutenberg.pot
 .vscode
 *.log
 yarn.lock
+gutenberg.zip

--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
     "WordPress",
     "editor"
   ],
+  "files": [
+    "index.php",
+    "post-content.js",
+    "editor/build",
+    "i18n/build",
+    "element/build",
+    "blocks/build"
+  ],
   "scripts": {
     "test-unit": "cross-env NODE_ENV=test webpack && mocha build --require bootstrap-test.js",
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
@@ -17,7 +25,8 @@
     "lint": "eslint .",
     "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "npm run lint && npm run test-unit",
-    "ci": "concurrently \"npm run build\" \"npm test\""
+    "ci": "concurrently \"npm run build\" \"npm test\"",
+    "build-plugin": "rimraf gutenberg.zip && npm install && npm run build && cat \"$(npm pack)\" | tar xzf - && cd package && zip -r ../gutenberg.zip * && cd - && rimraf package gutenberg*.tgz"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",
@@ -49,6 +58,7 @@
     "pegjs-loader": "^0.5.1",
     "postcss-loader": "^1.3.3",
     "raw-loader": "^0.5.1",
+    "rimraf": "^2.6.1",
     "sass-loader": "^6.0.3",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "npm run lint && npm run test-unit",
     "ci": "concurrently \"npm run build\" \"npm test\"",
-    "build-plugin": "rm -f gutenberg.zip && npm install && npm run build && cat \"$(npm pack)\" | tar xzf - && cd package && zip -r ../gutenberg.zip * && cd - && rm -r package gutenberg*.tgz"
+    "prepackage-plugin": "rm -f gutenberg.zip && npm install && npm run build",
+    "package-plugin": "cat \"$(npm pack)\" | tar xzf - && cd package && zip -r ../gutenberg.zip *",
+    "postpackage-plugin": "rm -r package gutenberg*.tgz"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "npm run lint && npm run test-unit",
     "ci": "concurrently \"npm run build\" \"npm test\"",
-    "build-plugin": "rimraf gutenberg.zip && npm install && npm run build && cat \"$(npm pack)\" | tar xzf - && cd package && zip -r ../gutenberg.zip * && cd - && rimraf package gutenberg*.tgz"
+    "build-plugin": "rm -f gutenberg.zip && npm install && npm run build && cat \"$(npm pack)\" | tar xzf - && cd package && zip -r ../gutenberg.zip * && cd - && rm -r package gutenberg*.tgz"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",
@@ -58,7 +58,6 @@
     "pegjs-loader": "^0.5.1",
     "postcss-loader": "^1.3.3",
     "raw-loader": "^0.5.1",
-    "rimraf": "^2.6.1",
     "sass-loader": "^6.0.3",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",


### PR DESCRIPTION
closes #658 

This PR adds a small script to build a zip for the plugin.
One thing to note is that I'm whitelisting which directories go into the plugin folder (because we have so many "junk" files), so We'll have to update this list if we add new folders/files.

To try this, run `npm run build-plugin`, it should give you a `gutenberg.zip` on the root folder.