### PR TITLE
Blocks: Scroll the page to the inserted block

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -161,6 +161,12 @@ class VisualEditorBlock extends wp.element.Component {
 		}
 	}
 
+	componentDidMount() {
+		if ( this.props.focus ) {
+			this.node.focus();
+		}
+	}
+
 	render() {
 		const { block } = this.props;
 		const settings = wp.blocks.getBlockSettings( block.blockType );


### PR DESCRIPTION
closes #621 

Try inserting an image, a text, a button, a separator.
The editor should scroll to the inserted block properly.