### PR TITLE
Fix issue with margin on blocks with no toolbars

### DIFF
--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -52,6 +52,7 @@ $text-editor-max-width: 760px;
 /* Editor */
 $text-editor-max-width: 760px;
 $visual-editor-max-width: 700px;
+$block-controls-height: 46px;
 
 /* Blocks */
 $block-padding: 14px;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -76,8 +76,9 @@
 	display: flex;
 	position: sticky;
 	z-index: 1;
-	margin-top: -46px - $item-spacing;		// 46 is toolbar height
+	margin-top: -$block-controls-height - $item-spacing;
 	margin-bottom: $item-spacing + 20px;	// 20px is the offset from the bottom of the selected block where it stops sticking
+	height: $block-controls-height;
 
 	top: $header-height + $admin-bar-height-big + $item-spacing;
 


### PR DESCRIPTION
This fixes an issue with the current embed block placeholder, which has an empty toolbar. With the recent merge of the position sticky toolbars, we're using some negative margins, which when the toolbar isn't present, caused some bleed issues.