### PR TITLE
Define node environment constant in Webpack configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,6 +67,9 @@ const config = {
 		]
 	},
 	plugins: [
+		new webpack.DefinePlugin( {
+			'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV )
+		} ),
 		new ExtractTextPlugin( {
 			filename: './[name]/build/style.css'
 		} ),


### PR DESCRIPTION
This pull request seeks to resolve a warning which is logged to the console when visiting the Gutenberg editor using the production build:

>You are currently using minified code outside of NODE_ENV === 'production'. This means that you are running a slower development build of Redux. You can use loose-envify (https://github.com/zertosh/loose-envify) for browserify or DefinePlugin for webpack (http://stackoverflow.com/questions/30030031) to ensure you have the correct code for your production build.

__Testing instructions:__

1. Run `npm run build`
2. Visit the Gutenberg screen
3. Verify no warnings or errors are logged to the browser developer tools console

__Caveats:__

You may find different warnings are logged if you have a `SCRIPT_DEBUG` active. This is expected, and we should discourage mismatched environments (production built editor script, debug script constant).