### PR TITLE
Apply placeholder on editable wrapper

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -373,6 +373,7 @@ export default class Editable extends wp.element.Component {
 			formattingControls,
 			placeholder
 		} = this.props;
+		const { empty } = this.state;
 
 		// Generating a key that includes `tagName` ensures that if the tag
 		// changes, we unmount (+ destroy) the previous TinyMCE element, then
@@ -390,7 +391,9 @@ export default class Editable extends wp.element.Component {
 		);
 
 		return (
-			<div className={ classes }>
+			<div
+				className={ classes }
+				data-placeholder={ empty ? placeholder : null }>
 				{ focus &&
 					<Fill name="Formatting.Toolbar">
 						{ showAlignments &&
@@ -419,8 +422,6 @@ export default class Editable extends wp.element.Component {
 					settings={ {
 						forced_root_block: inline ? false : 'p'
 					} }
-					isEmpty={ this.state.empty }
-					placeholder={ placeholder }
 					key={ key } />
 			</div>
 		);

--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -1,5 +1,17 @@
 .blocks-editable {
 	position: relative;
+
+	&[data-placeholder]:before {
+		content: attr( data-placeholder );
+		position: absolute;
+		top: 50%;
+		right: 0;
+		left: 0;
+		transform: translateY( -50% );
+		text-align: center;
+		opacity: 0.5;
+		pointer-events: none;
+	}
 }
 
 .blocks-editable__tinymce {
@@ -39,17 +51,6 @@
 	code[data-mce-selected] {
 		background: $light-gray-400;
 	}
-
-	&[data-is-empty="true"] {
-		position: relative;
-	}
-
-	&[data-is-empty="true"]:before {
-		content: attr( data-placeholder );
-		opacity: 0.5;
-		pointer-events: none;
-		position: absolute;
-	}
 }
 
 .block-editable__inline-toolbar {
@@ -67,11 +68,6 @@ figcaption.blocks-editable__tinymce {
 	color: $dark-gray-100;
 	text-align: center;
 	font-size: $default-font-size;
-
-	&:before {
-		left: 50%;
-		transform: translateX( -50% );
-	}
 }
 
 

--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -11,14 +11,6 @@ export default class TinyMCE extends wp.element.Component {
 		return false;
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		const isEmpty = String( nextProps.isEmpty );
-
-		if ( this.editorNode.getAttribute( 'data-is-empty' ) !== isEmpty ) {
-			this.editorNode.setAttribute( 'data-is-empty', isEmpty );
-		}
-	}
-
 	componentWillUnmount() {
 		if ( ! this.editor ) {
 			return;
@@ -55,7 +47,7 @@ export default class TinyMCE extends wp.element.Component {
 	}
 
 	render() {
-		const { tagName = 'div', style, defaultValue, placeholder } = this.props;
+		const { tagName = 'div', style, defaultValue } = this.props;
 
 		// If a default value is provided, render it into the DOM even before
 		// TinyMCE finishes initializing. This avoids a short delay by allowing
@@ -70,8 +62,7 @@ export default class TinyMCE extends wp.element.Component {
 			contentEditable: true,
 			suppressContentEditableWarning: true,
 			className: 'blocks-editable__tinymce',
-			style,
-			'data-placeholder': placeholder
+			style
 		}, children );
 	}
 }


### PR DESCRIPTION
Previously: #756, #475, specifically https://github.com/WordPress/gutenberg/pull/475#discussion_r115020606

This pull request seeks to simplify the placeholder implementation slightly by moving it up one level to the base `Editable` component's wrapper. This avoids needing to manage lifecycle to apply attributes to the TinyMCE node directly.

__Open questions:__

Should the placeholder be centered by default? This makes sense for the image caption, but I'd first experimented with applying it to the heading block, where it felt off (I'd have expected left-aligned). I guess this depends on where we expect placeholders to be used.

When I tried applying placeholder to heading, I found it doesn't always work correctly when removing text from an existing header then focusing out (shown empty instead of with placeholder).

__Testing instructions:__

There should be no regressions from #756. Notably, you should be able to focus an image block and see a placeholder shown 'til text is entered.