### PR TITLE
Reference TinyMCE as external module, not assumed global

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,8 +18,7 @@
 		}
 	},
 	"globals": {
-		"wp": true,
-		"tinymce": true
+		"wp": true
 	},
 	"plugins": [
 		"react",

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import tinymce from 'tinymce';
 import { parse as hpqParse } from 'hpq';
 import { escape, unescape, pickBy } from 'lodash';
 

--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce';
+
 export default class TinyMCE extends wp.element.Component {
 	componentDidMount() {
 		this.initialize();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,8 @@ const config = {
 	externals: {
 		react: 'React',
 		'react-dom': 'ReactDOM',
-		'react-dom/server': 'ReactDOMServer'
+		'react-dom/server': 'ReactDOMServer',
+		tinymce: 'tinymce'
 	},
 	resolve: {
 		modules: [


### PR DESCRIPTION
This pull request seeks to treat TinyMCE as though it were a module. The Webpack configuration has been updated to still reference the global, but we should not be accessing the global directly in code. This is for consistency in how we treat dependencies, and to leave open the possibility of modifying the source from which TinyMCE is resolved (e.g. npm).

__Testing instructions:__

Verify that no regressions occur in the display and behavior of the editor, notably parsing of blocks and Editable field usage (text blocks, heading blocks, etc.)