### PR TITLE
Image Block: Hide inline toolbar when we focus out of the caption editable

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -93,9 +93,12 @@ registerBlock( 'core/image', {
 
 		const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );
 
+		// Disable reason: Each block can be selected by clicking on it
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<figure className="blocks-image">
-				<img src={ url } alt={ alt } />
+				<img src={ url } alt={ alt } onClick={ setFocus } />
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
@@ -110,6 +113,7 @@ registerBlock( 'core/image', {
 				) : null }
 			</figure>
 		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 	},
 
 	save( { attributes } ) {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -239,7 +239,7 @@ class VisualEditorBlock extends wp.element.Component {
 				</div>
 			</div>
 		);
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 	}
 }
 


### PR DESCRIPTION
closes #727 

For some reason I don't understand yet, when we trigger "blur" on the Editable, the caret is still shown there. Regardless, this is a bit better that what we have on master.