### PR TITLE
Fix dashicons CSS bleed

### DIFF
--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -29,7 +29,7 @@ function applyOrUnset( align ) {
 registerBlock( 'core/button', {
 	title: wp.i18n.__( 'Button' ),
 
-	icon: 'marker',
+	icon: 'button',
 
 	category: 'layout',
 

--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -991,7 +991,7 @@ export default class Dashicon extends wp.element.Component {
 			return null;
 		}
 
-		const iconClass = [ 'dashicon', icon, className ].filter( Boolean ).join( ' ' );
+		const iconClass = [ 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
 
 		return (
 			<svg className={ iconClass } xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">


### PR DESCRIPTION
This PR fixes #719, but adding a `dashicons-` prefix to the CSS classes applied to the SVGs.

It also changes the Button block to use the new button icon.

Upstream PR: https://github.com/WordPress/dashicons/pull/183

Screenshot:

<img width="396" alt="screen shot 2017-05-11 at 12 46 25" src="https://cloud.githubusercontent.com/assets/1204802/25945690/2a64a2bc-3648-11e7-9965-2a68e13bc35f.png">
