### PR TITLE
Test: Move the merge block handler to the actions file and unit test it

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -79,7 +79,7 @@ registerBlock( 'core/heading', {
 		};
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeWithPrevious } ) {
+	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks } ) {
 		const { content, nodeName = 'H2' } = attributes;
 
 		return (
@@ -89,7 +89,7 @@ registerBlock( 'core/heading', {
 				focus={ focus }
 				onFocus={ setFocus }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
-				onMerge={ mergeWithPrevious }
+				onMerge={ mergeBlocks }
 				inline
 			/>
 		);

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -82,7 +82,7 @@ registerBlock( 'core/quote', {
 		],
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeWithPrevious } ) {
+	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks } ) {
 		const { value, citation, style = 1 } = attributes;
 		const focusedEditable = focus ? focus.editable || 'value' : null;
 
@@ -97,7 +97,7 @@ registerBlock( 'core/quote', {
 					}
 					focus={ focusedEditable === 'value' ? focus : null }
 					onFocus={ () => setFocus( { editable: 'value' } ) }
-					onMerge={ mergeWithPrevious }
+					onMerge={ mergeBlocks }
 					showAlignments
 				/>
 				{ ( ( citation && citation.length > 0 ) || !! focus ) && (

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -27,7 +27,7 @@ registerBlock( 'core/text', {
 		};
 	},
 
-	edit( { attributes, setAttributes, insertBlockAfter, focus, setFocus, mergeWithPrevious } ) {
+	edit( { attributes, setAttributes, insertBlockAfter, focus, setFocus, mergeBlocks } ) {
 		const { content } = attributes;
 
 		return (
@@ -46,7 +46,7 @@ registerBlock( 'core/text', {
 						content: after,
 					} ) );
 				} }
-				onMerge={ mergeWithPrevious }
+				onMerge={ mergeBlocks }
 				showAlignments
 			/>
 		);

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -15,6 +15,7 @@ import Dashicon from 'components/dashicon';
  * Internal dependencies
  */
 import './style.scss';
+import { replaceBlocks } from '../actions';
 import { getBlock } from '../selectors';
 
 class BlockSwitcher extends wp.element.Component {
@@ -111,11 +112,10 @@ export default connect(
 	} ),
 	( dispatch, ownProps ) => ( {
 		onTransform( block, blockType ) {
-			dispatch( {
-				type: 'REPLACE_BLOCKS',
-				uids: [ ownProps.uid ],
-				blocks: wp.blocks.switchToBlockType( block, blockType ),
-			} );
+			dispatch( replaceBlocks(
+				[ ownProps.uid ],
+				wp.blocks.switchToBlockType( block, blockType )
+			) );
 		},
 	} )
 )( clickOutside( BlockSwitcher ) );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -19,6 +19,7 @@ import BlockSwitcher from '../../block-switcher';
 import { focusBlock, mergeBlocks } from '../../actions';
 import {
 	getPreviousBlock,
+	getNextBlock,
 	getBlock,
 	getBlockFocus,
 	getBlockOrder,
@@ -36,7 +37,7 @@ class VisualEditorBlock extends wp.element.Component {
 		this.maybeHover = this.maybeHover.bind( this );
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
 		this.removeOnBackspace = this.removeOnBackspace.bind( this );
-		this.mergeWithPrevious = this.mergeWithPrevious.bind( this );
+		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.previousOffset = null;
 	}
 
@@ -101,15 +102,22 @@ class VisualEditorBlock extends wp.element.Component {
 		}
 	}
 
-	mergeWithPrevious() {
-		const { block, previousBlock, onMerge } = this.props;
+	mergeBlocks( forward = false ) {
+		const { block, previousBlock, nextBlock, onMerge } = this.props;
 
 		// Do nothing when it's the first block
-		if ( ! previousBlock ) {
+		if (
+			( ! forward && ! previousBlock ) ||
+			( forward && ! nextBlock )
+		) {
 			return;
 		}
 
-		onMerge( previousBlock, block );
+		if ( forward ) {
+			onMerge( block, nextBlock );
+		} else {
+			onMerge( previousBlock, block );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -200,7 +208,7 @@ class VisualEditorBlock extends wp.element.Component {
 						setAttributes={ this.setAttributes }
 						insertBlockAfter={ onInsertAfter }
 						setFocus={ partial( onFocus, block.uid ) }
-						mergeWithPrevious={ this.mergeWithPrevious }
+						mergeBlocks={ this.mergeBlocks }
 					/>
 				</div>
 			</div>
@@ -213,6 +221,7 @@ export default connect(
 	( state, ownProps ) => {
 		return {
 			previousBlock: getPreviousBlock( state, ownProps.uid ),
+			nextBlock: getNextBlock( state, ownProps.uid ),
 			block: getBlock( state, ownProps.uid ),
 			isSelected: isBlockSelected( state, ownProps.uid ),
 			isHovered: isBlockHovered( state, ownProps.uid ),

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -16,6 +16,7 @@ import Toolbar from 'components/toolbar';
  */
 import BlockMover from '../../block-mover';
 import BlockSwitcher from '../../block-switcher';
+import { focusBlock, mergeBlocks } from '../../actions';
 import {
 	getPreviousBlock,
 	getBlock,
@@ -101,49 +102,14 @@ class VisualEditorBlock extends wp.element.Component {
 	}
 
 	mergeWithPrevious() {
-		const { block, previousBlock, onFocus, replaceBlocks } = this.props;
+		const { block, previousBlock, onMerge } = this.props;
 
 		// Do nothing when it's the first block
 		if ( ! previousBlock ) {
 			return;
 		}
 
-		const previousBlockSettings = wp.blocks.getBlockSettings( previousBlock.blockType );
-
-		// Do nothing if the previous block is not mergeable
-		if ( ! previousBlockSettings.merge ) {
-			onFocus( previousBlock.uid );
-			return;
-		}
-
-		// We can only merge blocks with similar types
-		// thus, we transform the block to merge first
-		const blocksWithTheSameType = previousBlock.blockType === block.blockType
-			? [ block ]
-			: wp.blocks.switchToBlockType( block, previousBlock.blockType );
-
-		// If the block types can not match, do nothing
-		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {
-			return;
-		}
-
-		// Calling the merge to update the attributes and remove the block to be merged
-		const updatedAttributes = previousBlockSettings.merge( previousBlock.attributes, blocksWithTheSameType[ 0 ].attributes );
-
-		onFocus( previousBlock.uid, { offset: -1 } );
-		replaceBlocks(
-			[ previousBlock.uid, block.uid ],
-			[
-				{
-					...previousBlock,
-					attributes: {
-						...previousBlock.attributes,
-						...updatedAttributes,
-					},
-				},
-				...blocksWithTheSameType.slice( 1 ),
-			]
-		);
+		onMerge( previousBlock, block );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -306,12 +272,8 @@ export default connect(
 			} );
 		},
 
-		onFocus( uid, config ) {
-			dispatch( {
-				type: 'UPDATE_FOCUS',
-				uid,
-				config,
-			} );
+		onFocus( ...args ) {
+			dispatch( focusBlock( ...args ) );
 		},
 
 		onRemove( uid ) {
@@ -321,12 +283,8 @@ export default connect(
 			} );
 		},
 
-		replaceBlocks( uids, blocks ) {
-			dispatch( {
-				type: 'REPLACE_BLOCKS',
-				uids,
-				blocks,
-			} );
+		onMerge( ...args ) {
+			mergeBlocks( dispatch, ...args );
 		},
 	} )
 )( VisualEditorBlock );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -68,6 +68,11 @@ export function getPreviousBlock( state, uid ) {
 	return state.editor.blocksByUid[ state.editor.blockOrder[ order - 1 ] ] || null;
 }
 
+export function getNextBlock( state, uid ) {
+	const order = getBlockOrder( state, uid );
+	return state.editor.blocksByUid[ state.editor.blockOrder[ order + 1 ] ] || null;
+}
+
 export function isBlockSelected( state, uid ) {
 	return state.selectedBlock.uid === uid;
 }

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -1,0 +1,168 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlocks, unregisterBlock, registerBlock, createBlock } from 'blocks';
+
+/**
+ * Internal dependencies
+ */
+import { focusBlock, replaceBlocks, mergeBlocks } from '../actions';
+
+describe( 'actions', () => {
+	describe( 'focusBlock', () => {
+		it( 'should return the UPDATE_FOCUS action', () => {
+			const focusConfig = {
+				editable: 'cite',
+			};
+
+			expect( focusBlock( 'chicken', focusConfig ) ).to.eql( {
+				type: 'UPDATE_FOCUS',
+				uid: 'chicken',
+				config: focusConfig,
+			} );
+		} );
+	} );
+
+	describe( 'replaceBlocks', () => {
+		it( 'should return the REPLACE_BLOCKS action', () => {
+			const blocks = [ {
+				uid: 'ribs',
+			} ];
+
+			expect( replaceBlocks( [ 'chicken' ], blocks ) ).to.eql( {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'chicken' ],
+				blocks,
+			} );
+		} );
+	} );
+
+	describe( 'mergeBlocks', () => {
+		afterEach( () => {
+			getBlocks().forEach( ( block ) => {
+				unregisterBlock( block.slug );
+			} );
+		} );
+
+		it( 'should only focus the blockA if the blockA has no merge function', () => {
+			registerBlock( 'core/test-block', {} );
+			const blockA = {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+			};
+			const blockB = {
+				uid: 'ribs',
+				blockType: 'core/test-block',
+			};
+			const dispatch = sinon.spy();
+			mergeBlocks( dispatch, blockA, blockB );
+
+			expect( dispatch ).to.have.been.calledOnce();
+			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken' ) );
+		} );
+
+		it( 'should merge the blocks if blocks of the same type', () => {
+			registerBlock( 'core/test-block', {
+				merge( attributes, attributesToMerge ) {
+					return {
+						content: attributes.content + ' ' + attributesToMerge.content,
+					};
+				},
+			} );
+			const blockA = {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken' },
+			};
+			const blockB = {
+				uid: 'ribs',
+				blockType: 'core/test-block',
+				attributes: { content: 'ribs' },
+			};
+			const dispatch = sinon.spy();
+			mergeBlocks( dispatch, blockA, blockB );
+
+			expect( dispatch ).to.have.been.calledTwice();
+			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
+			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken ribs' },
+			} ] ) );
+		} );
+
+		it( 'should not merge the blocks have different types without transformation', () => {
+			registerBlock( 'core/test-block', {
+				merge( attributes, attributesToMerge ) {
+					return {
+						content: attributes.content + ' ' + attributesToMerge.content,
+					};
+				},
+			} );
+			registerBlock( 'core/test-block-2', {} );
+			const blockA = {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken' },
+			};
+			const blockB = {
+				uid: 'ribs',
+				blockType: 'core/test-block2',
+				attributes: { content: 'ribs' },
+			};
+			const dispatch = sinon.spy();
+			mergeBlocks( dispatch, blockA, blockB );
+
+			expect( dispatch ).to.have.not.been.called();
+		} );
+
+		it( 'should transform and merge the blocks', () => {
+			registerBlock( 'core/test-block', {
+				merge( attributes, attributesToMerge ) {
+					return {
+						content: attributes.content + ' ' + attributesToMerge.content,
+					};
+				},
+			} );
+			registerBlock( 'core/test-block-2', {
+				transforms: {
+					to: [ {
+						type: 'blocks',
+						blocks: [ 'core/test-block' ],
+						transform: ( { content2 } ) => {
+							return createBlock( 'core/test-block', {
+								content: content2,
+							} );
+						},
+					} ],
+				},
+			} );
+			const blockA = {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken' },
+			};
+			const blockB = {
+				uid: 'ribs',
+				blockType: 'core/test-block-2',
+				attributes: { content2: 'ribs' },
+			};
+			const dispatch = sinon.spy();
+			mergeBlocks( dispatch, blockA, blockB );
+
+			expect( dispatch ).to.have.been.calledTwice();
+			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
+			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken ribs' },
+			} ] ) );
+		} );
+	} );
+} );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -22,6 +22,7 @@ import {
 	isFirstBlock,
 	isLastBlock,
 	getPreviousBlock,
+	getNextBlock,
 	isBlockSelected,
 	isBlockHovered,
 	getBlockFocus,
@@ -319,6 +320,38 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPreviousBlock( state, 123 ) ).to.be.null();
+		} );
+	} );
+
+	describe( 'getNextBlock', () => {
+		it( 'should return the following block', () => {
+			const state = {
+				editor: {
+					blocksByUid: {
+						23: { uid: 23, blockType: 'core/heading' },
+						123: { uid: 123, blockType: 'core/text' },
+					},
+					blockOrder: [ 123, 23 ],
+				},
+			};
+
+			expect( getNextBlock( state, 123 ) ).to.eql(
+				{ uid: 23, blockType: 'core/heading' },
+			);
+		} );
+
+		it( 'should return null for the last block', () => {
+			const state = {
+				editor: {
+					blocksByUid: {
+						23: { uid: 23, blockType: 'core/heading' },
+						123: { uid: 123, blockType: 'core/text' },
+					},
+					blockOrder: [ 123, 23 ],
+				},
+			};
+
+			expect( getNextBlock( state, 23 ) ).to.be.null();
 		} );
 	} );
 


### PR DESCRIPTION
I'm planning to work on the "forward merge", before this, I've moved the `mergeBlocks` action creator into `actions.js` and unit test it.

*Side note:* We start having action creators that take "dispatch" as a parameter and others that return actions, we should probably decide to include `thunks` or an alternative soon.

**Edit:** The last commit adds forward deletion and should close #506 