### PR TITLE
Fix Safari quirks and issues

### DIFF
--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -9,6 +9,7 @@ import clickOutside from 'react-click-outside';
  * WordPress dependencies
  */
 import IconButton from 'components/icon-button';
+import Dashicon from 'components/dashicon';
 
 /**
  * Internal dependencies
@@ -77,7 +78,7 @@ class BlockSwitcher extends wp.element.Component {
 					aria-expanded={ this.state.open }
 					label={ wp.i18n.__( 'Change block content type' ) }
 				>
-					<div className="editor-block-switcher__arrow" />
+					<Dashicon icon="arrow-down" />
 				</IconButton>
 				{ this.state.open &&
 					<div

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -35,7 +35,7 @@
 .editor-block-switcher__menu {
 	position: absolute;
 	top: 43px;
-	margin-left: -1px;
+	left: 0;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -14,24 +14,6 @@
 	padding: 6px;
 }
 
-.editor-block-switcher__arrow {
-	display: inline-flex;
-	border: 6px dashed $dark-gray-500;
-	margin-left: 5px;
-	height: 0;
-	line-height: 0;
-	width: 0;
-	z-index: 1;
-	border-top-style: solid;
-	border-bottom: none;
-	border-left-color: transparent;
-	border-right-color: transparent;
-
-	.editor-block-switcher__toggle:hover & {
-		border-top-color: $blue-medium;
-	}
-}
-
 .editor-block-switcher__menu {
 	position: absolute;
 	top: 43px;


### PR DESCRIPTION
This PR addresses two tickets with Safari 10.1 specific issues. One related to the switcher menu positioning, one related to the dropdown arrow. 

Screenshot:

<img width="208" alt="screen shot 2017-05-11 at 13 41 41" src="https://cloud.githubusercontent.com/assets/1204802/25947461/d6a4256e-364f-11e7-9474-c97a6b23a47a.png">
