### PR TITLE
Editable: Fix long links using a gradient to hide the overflow

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -84,7 +84,7 @@ figcaption.blocks-editable__tinymce {
 	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
 	background: #fff;
-	width: 250px;
+	width: 300px;
 	display: inline-flex;
 	align-items: center;
 	font-family: $default-font;
@@ -112,4 +112,10 @@ input.editable-format-toolbar__link-input {
 .editable-format-toolbar__link-value {
 	padding: 10px;
 	flex-grow: 1;
+	overflow: hidden;
+	position: relative;
+
+	&:after {
+		@include long-content-fade( $size: 40% );
+	}
 }

--- a/editor/assets/stylesheets/_mixins.scss
+++ b/editor/assets/stylesheets/_mixins.scss
@@ -33,3 +33,64 @@
 		@content;
 	}
 }
+
+// ==========================================================================
+// Long content fade mixin
+//
+// Creates a fading overlay to signify that the content is longer
+// than the space allows.
+// ==========================================================================
+@mixin long-content-fade( $direction: right, $size: 20%, $color: #fff, $edge: 0px, $z-index: false) {
+	content: '';
+	display: block;
+	position: absolute;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	pointer-events: none;
+
+	@if $z-index {
+		z-index: $z-index;
+	}
+
+	@if $direction == 'bottom' {
+		background: linear-gradient( to top, rgba( $color, 0 ), $color 90% );
+		left: $edge;
+		right: $edge;
+		top: $edge;
+		bottom: calc(100% - $size);
+		width: auto;
+	}
+
+	@if $direction == 'top' {
+		background: linear-gradient( to bottom, rgba( $color, 0 ), $color 90% );
+		top: calc(100% - $size);
+		left: $edge;
+		right: $edge;
+		bottom: $edge;
+		width: auto;
+	}
+
+	@if $direction == 'left' {
+		background: linear-gradient( to left, rgba( $color, 0 ), $color 90% );
+		top: $edge;
+		left: $edge;
+		bottom: $edge;
+		right: auto;
+		width: $size;
+		height: auto;
+	}
+
+	@if $direction == 'right' {
+		background: linear-gradient( to right, rgba( $color, 0 ), $color 90% );
+		top: $edge;
+		bottom: $edge;
+		right: $edge;
+		left: auto;
+		width: $size;
+		height: auto;
+	}
+}


### PR DESCRIPTION
closes #678 

I've used the same technique we use in Calypso for long content. The `long-content-fade` mixin. Does this look good for you @jasmussen ?