### PR TITLE
Dismiss inline toolbar by blur

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -79,6 +79,7 @@ export default class Editable extends Component {
 		editor.on( 'nodechange', this.onNodeChange );
 		editor.on( 'keydown', this.onKeyDown );
 		editor.on( 'keyup', this.onKeyUp );
+		editor.on( 'blur', this.props.onBlur );
 		editor.on( 'selectionChange', this.onSelectionChange );
 		editor.on( 'PastePostProcess', this.onPastePostProcess );
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -63,7 +63,7 @@ registerBlockType( 'core/image', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, className } ) {
+	edit( { attributes, setAttributes, focus, setFocus, clearFocus, className } ) {
 		const { url, alt, caption, align, id, href } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
@@ -160,9 +160,6 @@ registerBlockType( 'core/image', {
 			'is-transient': 0 === url.indexOf( 'blob:' ),
 		} );
 
-		// Disable reason: Each block can be selected by clicking on it
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return [
 			controls,
 			focus && (
@@ -175,7 +172,7 @@ registerBlockType( 'core/image', {
 				</InspectorControls>
 			),
 			<figure key="image" className={ classes }>
-				<img src={ url } alt={ alt } onClick={ setFocus } />
+				<img src={ url } alt={ alt } tabIndex="-1" />
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
@@ -183,13 +180,13 @@ registerBlockType( 'core/image', {
 						value={ caption }
 						focus={ focus && focus.editable === 'caption' ? focus : undefined }
 						onFocus={ focusCaption }
+						onBlur={ () => clearFocus() }
 						onChange={ ( value ) => setAttributes( { caption: value } ) }
 						inlineToolbar
 					/>
 				) : null }
 			</figure>,
 		];
-		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -5,6 +5,7 @@
 	img {
 		display: block;
 		width: 100%;
+		outline: none;
 	}
 
 	&.is-transient img {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -337,7 +337,7 @@ class VisualEditorBlock extends Component {
 			'is-showing-mobile-controls': showMobileControls,
 		} );
 
-		const { onMouseLeave, onFocus, onInsertBlocksAfter, onReplace } = this.props;
+		const { onMouseLeave, onFocus, onDeselect, onInsertBlocksAfter, onReplace } = this.props;
 
 		// Determine whether the block has props to apply to the wrapper.
 		let wrapperProps;
@@ -412,6 +412,7 @@ class VisualEditorBlock extends Component {
 							insertBlocksAfter={ onInsertBlocksAfter }
 							onReplace={ onReplace }
 							setFocus={ partial( onFocus, block.uid ) }
+							clearFocus={ onDeselect }
 							mergeBlocks={ this.mergeBlocks }
 							className={ className }
 							id={ block.uid }


### PR DESCRIPTION
Related: #762 

This pull request seeks to explore dismissal of Editable toolbar controls by capturing focus loss instead of relying on events bound to all other elements of a block (or forced dismissal by block becoming otherwise unselected). Notably, some blocks may contain many focusable elements and Editables, and ideally it should not be the responsibility of the block implementer to capture focus or clicks on all elements of the block to ensure that an Editable's toolbars are dismissed. However, this means that they _would_ be responsible for capturing the blur of an editable to unset focus. To me, this seems reasonable to expect.

__Implementation notes:__

As noted in #762, this one is tough because the specific behavior of clicking on an `img` while focused on a `contenteditable` within a wrapper with `tabindex` (focusable) is rather unexpected: focus changes to the wrapper but the caret still pulses.

![Focus](https://cloud.githubusercontent.com/assets/1779930/26003868/e7857e2a-3701-11e7-8c1d-f24f6ba296c0.gif)

http://jsbin.com/kudozoqone/1/edit?html,js,output

The solution here was to add a negative tabIndex to the image to allow it to receive focus but not be accessible by keyboard navigation. This feels a little strange, but (a) with #600 I expect is a temporary solution and (b) the need for blur extends beyond just this image case, so I think it's worth considering this approach anyways.

__Testing instructions:__

Repeat testing steps from #727 

Another case to test which doesn't work in master is that shift-tabbing from caption dismisses inline toolbar.