### PR TITLE
Restore Inserter menu focus by tracking opening node

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -4,7 +4,7 @@
 import './style.scss';
 import classnames from 'classnames';
 
-function Button( { href, isPrimary, isLarge, isToggled, className, buttonRef, ...additionalProps } ) {
+function Button( { href, isPrimary, isLarge, isToggled, className, ...additionalProps } ) {
 	const classes = classnames( 'components-button', className, {
 		button: ( isPrimary || isLarge ),
 		'button-primary': isPrimary,
@@ -19,7 +19,6 @@ function Button( { href, isPrimary, isLarge, isToggled, className, buttonRef, ..
 		...tagProps,
 		...additionalProps,
 		className: classes,
-		ref: buttonRef,
 	} );
 }
 

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -25,14 +25,23 @@ class Inserter extends wp.element.Component {
 		};
 	}
 
-	toggle() {
+	toggle( event ) {
+		// When opening the menu, track reference to the current active element
+		// so we know where to restore focus after the menu is closed.
+		if ( ! this.state.opened ) {
+			this.toggleNode = event.currentTarget;
+		}
+
 		this.setState( {
 			opened: ! this.state.opened,
 		} );
 	}
 
 	close() {
-		this.toggleNode.focus();
+		// Restore focus to original opening active element before menu closes
+		if ( this.toggleNode ) {
+			this.toggleNode.focus();
+		}
 
 		this.setState( {
 			opened: false,
@@ -67,7 +76,6 @@ class Inserter extends wp.element.Component {
 					onClick={ this.toggle }
 					className="editor-inserter__toggle"
 					aria-haspopup="true"
-					buttonRef={ ( node ) => this.toggleNode = node }
 					aria-expanded={ opened ? 'true' : 'false' } />
 				{ opened && (
 					<InserterMenu

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -27,7 +27,7 @@ class Inserter extends wp.element.Component {
 
 	toggle( event ) {
 		// When opening the menu, track reference to the current active element
-		// so we know where to restore focus after the menu is closed.
+		// so we know where to restore focus after the menu is closed by escape
 		if ( ! this.state.opened ) {
 			this.toggleNode = event.currentTarget;
 		}
@@ -38,11 +38,6 @@ class Inserter extends wp.element.Component {
 	}
 
 	close() {
-		// Restore focus to original opening active element before menu closes
-		if ( this.toggleNode ) {
-			this.toggleNode.focus();
-		}
-
 		this.setState( {
 			opened: false,
 		} );
@@ -51,6 +46,10 @@ class Inserter extends wp.element.Component {
 	insertBlock( slug ) {
 		if ( slug ) {
 			this.props.onInsertBlock( slug );
+		} else if ( this.toggleNode ) {
+			// When menu is closed by pressing escape, restore focus to the
+			// original opening active element before menu closes
+			this.toggleNode.focus();
 		}
 
 		this.close();

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clickOutside from 'react-click-outside';
+import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
@@ -18,25 +19,32 @@ class Inserter extends wp.element.Component {
 		super( ...arguments );
 		this.toggle = this.toggle.bind( this );
 		this.close = this.close.bind( this );
+		this.insertBlock = this.insertBlock.bind( this );
 		this.state = {
 			opened: false,
 		};
 	}
 
 	toggle() {
-		if ( this.state.opened ) {
-			this.toggleNode.focus();
-		}
-
 		this.setState( {
 			opened: ! this.state.opened,
 		} );
 	}
 
 	close() {
+		this.toggleNode.focus();
+
 		this.setState( {
 			opened: false,
 		} );
+	}
+
+	insertBlock( slug ) {
+		if ( slug ) {
+			this.props.onInsertBlock( slug );
+		}
+
+		this.close();
 	}
 
 	handleClickOutside() {
@@ -61,10 +69,25 @@ class Inserter extends wp.element.Component {
 					aria-haspopup="true"
 					buttonRef={ ( node ) => this.toggleNode = node }
 					aria-expanded={ opened ? 'true' : 'false' } />
-				{ opened && <InserterMenu position={ position } onSelect={ this.close } closeMenu={ this.toggle } /> }
+				{ opened && (
+					<InserterMenu
+						position={ position }
+						onSelect={ this.insertBlock }
+					/>
+				) }
 			</div>
 		);
 	}
 }
 
-export default clickOutside( Inserter );
+export default connect(
+	undefined,
+	( dispatch ) => ( {
+		onInsertBlock( slug ) {
+			dispatch( {
+				type: 'INSERT_BLOCK',
+				block: wp.blocks.createBlock( slug ),
+			} );
+		},
+	} )
+)( clickOutside( Inserter ) );

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { flow, groupBy, sortBy, findIndex, filter } from 'lodash';
 import classnames from 'classnames';
 
@@ -56,8 +55,7 @@ class InserterMenu extends wp.element.Component {
 
 	selectBlock( slug ) {
 		return () => {
-			this.props.onInsertBlock( slug );
-			this.props.onSelect();
+			this.props.onSelect( slug );
 			this.setState( {
 				filterValue: '',
 				currentFocus: null,
@@ -177,7 +175,7 @@ class InserterMenu extends wp.element.Component {
 				break;
 			case 27 : /* Escape */
 				keydown.preventDefault();
-				this.props.closeMenu();
+				this.props.onSelect( null );
 
 				break;
 			case 37 : /* ArrowLeft */
@@ -286,14 +284,4 @@ class InserterMenu extends wp.element.Component {
 
 InserterMenu.instances = 0;
 
-export default connect(
-	undefined,
-	( dispatch ) => ( {
-		onInsertBlock( slug ) {
-			dispatch( {
-				type: 'INSERT_BLOCK',
-				block: wp.blocks.createBlock( slug ),
-			} );
-		},
-	} )
-)( InserterMenu );
+export default InserterMenu;


### PR DESCRIPTION
Related: #578

This pull request seeks to revise the Inserter Menu close-on-escape behavior to focus the original opening element by tracking the node when the opening toggle event occurs. A goal with this change is to eliminate ancestor access to a button's rendered node through its `buttonRef` prop (removed by the changes here).

__Implementation notes:__

`event.currentTarget` could be interchangeable with `document.activeElement`, but I chose the former since it feels more reliable to the knowledge that the current target is the rendered button we intend to refocus. The downside is that `toggle` must be used as an event callback (the only current usage).

__Testing instructions:__

Repeat testing instructions from #578.