### PR TITLE
Automatically disable the save button in release builds

### DIFF
--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -62,12 +62,17 @@ function PublishButton( {
 		saveCallback = onSaveDraft;
 	}
 
+	const buttonDisabledHint = process.env.NODE_ENV === 'production'
+		? wp.i18n.__( 'The Save button is disabled during early alpha releases.' )
+		: null;
+
 	return (
 		<Button
 			isPrimary
 			isLarge
 			onClick={ () => saveCallback( post, edits, blocks ) }
-			disabled={ ! buttonEnabled }
+			disabled={ ! buttonEnabled || process.env.NODE_ENV === 'production' }
+			title={ buttonDisabledHint }
 		>
 			{ buttonText }
 		</Button>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,7 +69,7 @@ const config = {
 	},
 	plugins: [
 		new webpack.DefinePlugin( {
-			'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ),
+			'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV || 'development' ),
 		} ),
 		new ExtractTextPlugin( {
 			filename: './[name]/build/style.css',


### PR DESCRIPTION
See #748.  cc @jasmussen - if we want to keep the save button disabled (I would think we do for a few more releases...) then this will automate it.  This method also has a bit better UX becuse the button is visually disabled rather than appearing to work but doing nothing when clicked.

Should we also add a way for power users to save anyway?