### PR TITLE
Simplify build script and move it to separate file

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Exit if any command fails
+set -e # exit on error
+
+# Change to the expected directory
+cd "$(dirname "$0")"
+cd ..
+
+# Remove any existing build
+rm -f gutenberg.zip
+
+# Run the build
+npm install
+npm run build
+
+# Generate the plugin zip file
+zip -r gutenberg.zip \
+    index.php \
+    post-content.js \
+    editor/build \
+    i18n/build \
+    element/build \
+    blocks/build \
+    README.md

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -7,12 +7,12 @@ set -e
 cd "$(dirname "$0")"
 cd ..
 
-# Remove any existing build
-rm -f gutenberg.zip
-
 # Run the build
 npm install
 npm run build
+
+# Remove any existing zip file
+rm -f gutenberg.zip
 
 # Generate the plugin zip file
 zip -r gutenberg.zip \

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -18,8 +18,8 @@ rm -f gutenberg.zip
 zip -r gutenberg.zip \
     index.php \
     post-content.js \
-    editor/build \
-    i18n/build \
-    element/build \
     blocks/build \
+    editor/build \
+    element/build \
+    i18n/build \
     README.md

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Exit if any command fails
-set -e # exit on error
+set -e
 
 # Change to the expected directory
 cd "$(dirname "$0")"

--- a/package.json
+++ b/package.json
@@ -10,14 +10,6 @@
     "WordPress",
     "editor"
   ],
-  "files": [
-    "index.php",
-    "post-content.js",
-    "editor/build",
-    "i18n/build",
-    "element/build",
-    "blocks/build"
-  ],
   "scripts": {
     "test-unit": "cross-env NODE_ENV=test webpack && mocha build --require bootstrap-test.js",
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
@@ -26,9 +18,7 @@
     "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "npm run lint && npm run test-unit",
     "ci": "concurrently \"npm run build\" \"npm test\"",
-    "prepackage-plugin": "rm -f gutenberg.zip && npm install && npm run build",
-    "package-plugin": "cat \"$(npm pack)\" | tar xzf - && cd package && zip -r ../gutenberg.zip *",
-    "postpackage-plugin": "rm -r package gutenberg*.tgz"
+    "package-plugin": "./bin/build-plugin-zip.sh"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",


### PR DESCRIPTION
We should split the plugin build script into a separate file.  As currently written, it contains 7 shell commands split across 3 lines in the `package.json` file.  This is hard to read and maintain, and this process will likely need to grow in complexity over time.

I also removed the use of `npm pack` here - it's much simpler to just call `zip` directly, so we can avoid running through whatever code `npm` is using here, unpacking the tar archive it generates, and removing temporary files.  Also, the way we are currently using this function is a bit contrary to its intended purpose (for making release-ready versions of `npm` packages).