### PR TITLE
Add missing trailing commas

### DIFF
--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -49,10 +49,10 @@ registerBlock( 'core/list', {
 				transform: ( { content } ) => {
 					return createBlock( 'core/list', {
 						nodeName: 'ul',
-						values: switchChildrenNodeName( content, 'li' )
+						values: switchChildrenNodeName( content, 'li' ),
 					} );
-				}
-			}
+				},
+			},
 		],
 		to: [
 			{
@@ -60,11 +60,11 @@ registerBlock( 'core/list', {
 				blocks: [ 'core/text' ],
 				transform: ( { values } ) => {
 					return createBlock( 'core/text', {
-						content: switchChildrenNodeName( values, 'p' )
+						content: switchChildrenNodeName( values, 'p' ),
 					} );
-				}
-			}
-		]
+				},
+			},
+		],
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -48,9 +48,9 @@ registerBlock( 'core/quote', {
 				blocks: [ 'core/list' ],
 				transform: ( { values } ) => {
 					return createBlock( 'core/quote', {
-						value: switchChildrenNodeName( values, 'p' )
+						value: switchChildrenNodeName( values, 'p' ),
 					} );
-				}
+				},
 			},
 			{
 				type: 'block',
@@ -82,9 +82,9 @@ registerBlock( 'core/quote', {
 						: valueElements;
 					return createBlock( 'core/list', {
 						nodeName: 'ul',
-						values
+						values,
 					} );
-				}
+				},
 			},
 			{
 				type: 'block',

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -73,7 +73,7 @@ describe( 'element', () => {
 		it( 'should switch elements', () => {
 			const children = switchChildrenNodeName( [
 				createElement( 'strong', { align: 'left' }, 'Courgette' ),
-				createElement( 'strong', {}, 'Concombre' )
+				createElement( 'strong', {}, 'Concombre' ),
 			], 'em' );
 			expect( children.length ).to.equal( 2 );
 			expect( children[ 0 ].type ).to.equal( 'em' );


### PR DESCRIPTION
#766 and possibly a couple more PRs introduced lines without trailing commas after the lint rule requiring them was merged (#741).  This is causing Travis builds to fail on `master` and any new PRs.  Let's fix that quickly.