### PR TITLE
Enhance the embed block to support all WP_oEmbed embeds

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,8 @@
 		}
 	},
 	"globals": {
-		"wp": true
+		"wp": true,
+		"wpApiSettings": true
 	},
 	"plugins": [
 		"react",

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -4,6 +4,7 @@
 import Button from 'components/button';
 import Placeholder from 'components/placeholder';
 import HtmlEmbed from 'components/html-embed';
+import { Spinner } from 'components';
 
 /**
  * Internal dependencies
@@ -132,20 +133,15 @@ registerBlock( 'core/embed', {
 								className="components-placeholder__input"
 								placeholder={ wp.i18n.__( 'Enter URL to embed here...' ) }
 								onChange={ ( event ) => setAttributes( { url: event.target.value } ) } />
-							{ ! fetching ?
-								(
-									<Button
-										isLarge
-										type="submit">
-										{ wp.i18n.__( 'Embed' ) }
-									</Button>
-								) : (
-									<span className="spinner is-active" />
-								)
+							{ ! fetching
+								? <Button
+									isLarge
+									type="submit">
+									{ wp.i18n.__( 'Embed' ) }
+								</Button>
+								: <Spinner />
 							}
-							{ ( error ) ? (
-								<p className="components-placeholder__error">{ wp.i18n.__( 'Sorry, we could not embed that content.' ) }</p>
-							) : null }
+							{ error && <p className="components-placeholder__error">{ wp.i18n.__( 'Sorry, we could not embed that content.' ) }</p> }
 						</form>
 					</Placeholder>
 				);

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -96,7 +96,7 @@ registerBlock( 'core/embed', {
 				event.preventDefault();
 			}
 			const { url } = this.props.attributes;
-			const api_url = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce; // eslint-disable-line no-undef
+			const api_url = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce;
 
 			this.setState( { error: false, fetching: true } );
 			fetch( api_url, {

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -92,7 +92,7 @@ registerBlock( 'core/embed', {
 		doServerSideRender( event ) {
 			event.preventDefault();
 			const { url } = this.props.attributes;
-			const api_url = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce
+			const api_url = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce; // eslint-disable-line no-undef
 
 			this.setState( { error: false, fetching: true } );
 			fetch( api_url, {
@@ -119,7 +119,7 @@ registerBlock( 'core/embed', {
 
 			if ( ! html ) {
 				return (
-					<Placeholder icon="cloud" label={ wp.i18n.__( 'Embed URL' ) } className={ placeholderClassName }>
+					<Placeholder icon="cloud" label={ wp.i18n.__( 'Embed URL' ) } className="blocks-embed">
 						<form onSubmit={ this.doServerSideRender }>
 							<input
 								type="url"
@@ -149,14 +149,14 @@ registerBlock( 'core/embed', {
 			const cannotPreview = this.noPreview.includes( domain );
 			let placeholderClassName = 'blocks-embed';
 
-			if ( 'video' == type ) {
+			if ( 'video' === type ) {
 				placeholderClassName = 'blocks-embed-video';
 			}
 
 			return (
 				<figure>
 					{ ( cannotPreview ) ? (
-						<Placeholder icon="cloud" label={ wp.i18n.__( 'Embed URL' ) } className="blocks-embed">
+						<Placeholder icon="cloud" label={ wp.i18n.__( 'Embed URL' ) } className={ placeholderClassName }>
 							<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>
 							<p className="components-placeholder__error">{ wp.i18n.__( 'Previews for this are unavailable in the editor, sorry!' ) }</p>
 						</Placeholder>

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -91,6 +91,11 @@ registerBlock( 'core/embed', {
 			}
 		}
 
+		componentWillUnmount() {
+			// can't about the fetch promise, so let it know we will unmount
+			this.unmounting = true;
+		}
+
 		doServerSideRender( event ) {
 			if ( event ) {
 				event.preventDefault();
@@ -103,6 +108,9 @@ registerBlock( 'core/embed', {
 				credentials: 'include',
 			} ).then(
 				( response ) => {
+					if ( this.unmounting ) {
+						return;
+					}
 					response.json().then( ( obj ) => {
 						const { html, type } = obj;
 						if ( html ) {

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -87,10 +87,16 @@ registerBlock( 'core/embed', {
 			this.noPreview = [
 				'facebook.com',
 			];
+			if ( this.props.attributes.url ) {
+				// if the url is already there, we're loading a saved block, so we need to render
+				this.doServerSideRender();
+			}
 		}
 
 		doServerSideRender( event ) {
-			event.preventDefault();
+			if ( event ) {
+				event.preventDefault();
+			}
 			const { url } = this.props.attributes;
 			const api_url = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce; // eslint-disable-line no-undef
 

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -92,7 +92,7 @@ registerBlock( 'core/embed', {
 		}
 
 		componentWillUnmount() {
-			// can't about the fetch promise, so let it know we will unmount
+			// can't abort the fetch promise, so let it know we will unmount
 			this.unmounting = true;
 		}
 

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -129,7 +129,7 @@ registerBlock( 'core/embed', {
 						<form onSubmit={ this.doServerSideRender }>
 							<input
 								type="url"
-								className="placeholder__input"
+								className="components-placeholder__input"
 								placeholder={ wp.i18n.__( 'Enter URL to embed here...' ) }
 								onChange={ ( event ) => setAttributes( { url: event.target.value } ) } />
 							{ ! fetching ?

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import Button from 'components/button';
-import Placeholder from 'components/placeholder';
-import HtmlEmbed from 'components/html-embed';
-import { Spinner } from 'components';
+import { Button, Placeholder, HtmlEmbed, Spinner } from 'components';
 
 /**
  * Internal dependencies

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -153,16 +153,16 @@ registerBlock( 'core/embed', {
 
 			const domain = url.split( '/' )[ 2 ].replace( /^www\./, '' );
 			const cannotPreview = this.noPreview.includes( domain );
-			let placeholderClassName = 'blocks-embed';
+			let typeClassName = 'blocks-embed';
 
 			if ( 'video' === type ) {
-				placeholderClassName = 'blocks-embed-video';
+				typeClassName = 'blocks-embed-video';
 			}
 
 			return (
-				<figure>
+				<figure className={ typeClassName }>
 					{ ( cannotPreview ) ? (
-						<Placeholder icon="cloud" label={ wp.i18n.__( 'Embed URL' ) } className={ placeholderClassName }>
+						<Placeholder icon="cloud" label={ wp.i18n.__( 'Embed URL' ) }>
 							<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>
 							<p className="components-placeholder__error">{ wp.i18n.__( 'Previews for this are unavailable in the editor, sorry!' ) }</p>
 						</Placeholder>

--- a/blocks/library/embed/style.scss
+++ b/blocks/library/embed/style.scss
@@ -1,15 +1,16 @@
-.blocks-embed {
+.blocks-embed,
+.blocks-embed-video {
 	margin: 0;
 }
 
-.blocks-embed .iframe-overlay {
+.blocks-embed-video > div:first-child {
 	position: relative;
 	width: 100%;
 	height: 0;
 	padding-bottom: 56.25%; /* 16:9 */
 }
 
-.blocks-embed iframe {
+.blocks-embed-video > div > iframe {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -55,6 +56,5 @@ div[data-type="core/embed"] {
 			margin-left: auto;
 			margin-right: auto;
 		}
-
 	}
 }

--- a/blocks/test/fixtures/core-embed-youtube-caption.html
+++ b/blocks/test/fixtures/core-embed-youtube-caption.html
@@ -1,3 +1,3 @@
 <!-- wp:core/embed url="https://www.youtube.com/watch?v=Nl6U7UotA-M" -->
-<figure><iframe src="//www.youtube.com/embed/Nl6U7UotA-M" frameborder="0" allowfullscreen></iframe><figcaption>State of the Word 2016</figcaption></figure>
+<figure>https://www.youtube.com/embed/Nl6U7UotA-M"<figcaption>State of the Word 2016</figcaption></figure>
 <!-- /wp:core/embed -->

--- a/blocks/test/fixtures/core-embed-youtube-caption.json
+++ b/blocks/test/fixtures/core-embed-youtube-caption.json
@@ -3,7 +3,7 @@
         "uid": "_uid_0",
         "blockType": "core/embed",
         "attributes": {
-            "url": "//www.youtube.com/embed/Nl6U7UotA-M",
+            "url": "https://www.youtube.com/watch?v=Nl6U7UotA-M",
             "caption": [
                 "State of the Word 2016"
             ]

--- a/blocks/test/fixtures/core-embed-youtube-caption.serialized.html
+++ b/blocks/test/fixtures/core-embed-youtube-caption.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:core/embed -->
-<figure><iframe src="//www.youtube.com/embed/Nl6U7UotA-M"></iframe>
+<!-- wp:core/embed url="https://www.youtube.com/watch?v=Nl6U7UotA-M" -->
+<figure>https://www.youtube.com/watch?v=Nl6U7UotA-M
     <figcaption>State of the Word 2016</figcaption>
 </figure>
 <!-- /wp:core/embed -->

--- a/components/html-embed/index.js
+++ b/components/html-embed/index.js
@@ -13,20 +13,17 @@ export default class HtmlEmbed extends wp.element.Component {
 		body.innerHTML = html;
 
 		const scripts = body.getElementsByTagName( 'script' );
-		const newscripts = [];
-
-		for ( let i = 0; i < scripts.length; i++ ) {
-			const newscript = document.createElement( 'script' );
-			if ( scripts[ i ].src ) {
-				newscript.src = scripts[ i ].src;
+		const newScripts = Array.from( scripts ).map( ( script ) => {
+			const newScript = document.createElement( 'script' );
+			if ( script.src ) {
+				newScript.src = script.src;
 			} else {
-				newscript.innerHTML = scripts[ i ].innerHTML;
+				newScript.innerHTML = script.innerHTML;
 			}
-			newscripts.push( newscript );
-		}
-		for ( let i = 0; i < newscripts.length; i++ ) {
-			body.appendChild( newscripts[ i ] );
-		}
+			return newScript;
+		});
+
+		newScripts.forEach( ( script ) => body.appendChild( script ) );
 	}
 
 	render() {

--- a/components/html-embed/index.js
+++ b/components/html-embed/index.js
@@ -1,3 +1,9 @@
+/***
+ * When embedding HTML from the WP oEmbed proxy, we need to insert it
+ * into a div and make sure any scripts get run. This component takes
+ * HTML and puts it into a div element, and creates and adds new script
+ * elements so all scripts get run as expected.
+ */
 export default class HtmlEmbed extends wp.element.Component {
 
 	static get defaultProps() {

--- a/components/html-embed/index.js
+++ b/components/html-embed/index.js
@@ -1,9 +1,8 @@
-/***
- * When embedding HTML from the WP oEmbed proxy, we need to insert it
- * into a div and make sure any scripts get run. This component takes
- * HTML and puts it into a div element, and creates and adds new script
- * elements so all scripts get run as expected.
- */
+// When embedding HTML from the WP oEmbed proxy, we need to insert it
+// into a div and make sure any scripts get run. This component takes
+// HTML and puts it into a div element, and creates and adds new script
+// elements so all scripts get run as expected.
+
 export default class HtmlEmbed extends wp.element.Component {
 
 	componentDidMount() {

--- a/components/html-embed/index.js
+++ b/components/html-embed/index.js
@@ -1,0 +1,37 @@
+export default class HtmlEmbed extends wp.element.Component {
+
+	static get defaultProps() {
+		return {
+			html: '',
+		};
+	}
+
+	componentDidMount() {
+		const body = this.node;
+		const { html } = this.props;
+
+		body.innerHTML = html;
+
+		const scripts = body.getElementsByTagName( 'script' );
+		const newscripts = [];
+
+		for ( let i = 0; i < scripts.length; i++ ) {
+			const newscript = document.createElement( 'script' );
+			if ( scripts[ i ].src ) {
+				newscript.src = scripts[ i ].src;
+			} else {
+				newscript.innerHTML = scripts[ i ].innerHTML;
+			}
+			newscripts.push( newscript );
+		}
+		for ( let i = 0; i < newscripts.length; i++ ) {
+			body.appendChild( newscripts[ i ] );
+		}
+	}
+
+	render() {
+		return (
+			<div ref={ ( node ) => this.node = node } />
+		);
+	}
+}

--- a/components/html-embed/index.js
+++ b/components/html-embed/index.js
@@ -6,15 +6,9 @@
  */
 export default class HtmlEmbed extends wp.element.Component {
 
-	static get defaultProps() {
-		return {
-			html: '',
-		};
-	}
-
 	componentDidMount() {
 		const body = this.node;
-		const { html } = this.props;
+		const { html = '' } = this.props;
 
 		body.innerHTML = html;
 

--- a/components/html-embed/index.js
+++ b/components/html-embed/index.js
@@ -21,7 +21,7 @@ export default class HtmlEmbed extends wp.element.Component {
 				newScript.innerHTML = script.innerHTML;
 			}
 			return newScript;
-		});
+		} );
 
 		newScripts.forEach( ( script ) => body.appendChild( script ) );
 	}

--- a/components/index.js
+++ b/components/index.js
@@ -1,6 +1,7 @@
 export { default as Button } from './button';
 export { default as Dashicon } from './dashicon';
 export { default as FormToggle } from './form-toggle';
+export { default as HtmlEmbed } from './html-embed';
 export { default as IconButton } from './icon-button';
 export { default as Panel } from './panel';
 export { default as PanelHeader } from './panel/header';

--- a/components/placeholder/style.scss
+++ b/components/placeholder/style.scss
@@ -22,7 +22,8 @@
 	}
 }
 
-.components-placeholder__fieldset {
+.components-placeholder__fieldset,
+.components-placeholder__fieldset form {
 	display: flex;
 	flex-direction: row;
 	justify-content: center;

--- a/post-content.js
+++ b/post-content.js
@@ -41,7 +41,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/embed url="https://www.youtube.com/watch?v=Nl6U7UotA-M" -->',
-			'<figure><iframe src="//www.youtube.com/embed/Nl6U7UotA-M" frameborder="0" allowfullscreen></iframe><figcaption>State of the Word 2016</figcaption></figure>',
+			'<figure>https://www.youtube.com/watch?v=Nl6U7UotA-M<figcaption>State of the Word 2016</figcaption></figure>',
 			'<!-- /wp:core/embed -->',
 
 			'<!-- wp:core/heading -->',


### PR DESCRIPTION
~~Implements server side rendering for the Embed block so that it supports all urls processed by WP_oEmbed~~

~~Adds a REST API endpoint so we can post a serialized block and get back the rendered HTML.~~

~~Adds a server side block, 'core/oembed', that exists to render URLs with WP_oEmbed.~~

~~Extracts individual block serialization in the serializer, so that we can serialize individual blocks for server side rendering.~~

Adds awareness of domains we cannot preview content for in the editor, due to javascript issues.

Adds a ~~Sandbox~~ HtmlEmbed component that will put rendered HTML into ~~an iframe~~ a div, and make sure all script blocks get run. ~~It uses the ResizableIframe from Calypso to make sure all rendered content is shown.~~

URLs for testing:

https://twitter.com/mrbiffo/status/864555311918714880 : short tweet, iframe should resize.

http://doctorwho.tumblr.com/post/160705586507/onaperduamedee-to-really-feel-it-you-need-the : tall tumblr post, iframe should resize to show it all.

https://www.facebook.com/DoctorWho/videos/1854859861194699/ : facebook video, should show the url as a hyperlink with a message saying we're sorry that we cannot preview that content in the editor.

http://example.com/ : not supported by oEmbed, should display an error saying that we cannot embed that content.