### PR TITLE
Chrome: Adding a functional pending review toggle

### DIFF
--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -27,7 +27,7 @@
 		}
 
 		.components-form-toggle.is-checked & {
-			background-color: $blue-wordpress;
+			background-color: $blue-medium;
 
 			&:hover {
 				background-color: $dark-gray-100;
@@ -45,7 +45,7 @@
 		height: 8px;
 		border-radius: 50%;
 		background: $white;
-		transition: 0.3s transform ease-out;
+		transition: 0.2s transform ease-out;
 
 
 		.components-form-toggle.is-checked & {

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -20,6 +20,13 @@ export function replaceBlocks( uids, blocks ) {
 	};
 }
 
+export function editPost( edits ) {
+	return {
+		type: 'EDIT_POST',
+		edits,
+	};
+}
+
 export function savePost( dispatch, postId, edits ) {
 	const toSend = postId ? { id: postId, ...edits } : edits;
 	const isNew = ! postId;

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -9,6 +9,7 @@ import Textarea from 'react-autosize-textarea';
  */
 import './style.scss';
 import { getEditedPostTitle } from '../selectors';
+import { editPost } from '../actions';
 
 /**
  * Constants
@@ -40,10 +41,7 @@ export default connect(
 	( dispatch ) => {
 		return {
 			onUpdate( title ) {
-				dispatch( {
-					type: 'EDIT_POST',
-					edits: { title },
-				} );
+				dispatch( editPost( { title } ) );
 			},
 		};
 	}

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -36,6 +36,12 @@ export function getPostEdits( state ) {
 	return state.editor.edits;
 }
 
+export function getEditedPostStatus( state ) {
+	return state.editor.edits.status === undefined
+		? state.currentPost.status
+		: state.editor.edits.status;
+}
+
 export function getEditedPostTitle( state ) {
 	return state.editor.edits.title === undefined
 		? state.currentPost.title.raw

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
  * WordPress dependencies
  */
 import { __ } from 'i18n';
@@ -9,15 +14,38 @@ import FormToggle from 'components/form-toggle';
  * Internal Dependencies
  */
 import './style.scss';
-function PostStatus() {
+import { getEditedPostStatus } from '../../selectors';
+import { editPost } from '../../actions';
+
+function PostStatus( { status, onUpdateStatus } ) {
+	const onToggle = () => {
+		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
+		onUpdateStatus( updatedStatus );
+	};
+
 	return (
 		<PanelBody title={ __( 'Status & Visibility' ) }>
 			<div className="editor-post-status__row">
 				<span>{ __( 'Pending review' ) }</span>
-				<FormToggle />
+				<FormToggle
+					checked={ status === 'pending' }
+					onChange={ onToggle }
+				/>
 			</div>
 		</PanelBody>
 	);
 }
 
-export default PostStatus;
+export default connect(
+	( state ) => ( {
+		status: getEditedPostStatus( state ),
+	} ),
+	( dispatch ) => {
+		return {
+			onUpdateStatus( status ) {
+				dispatch( editPost( { status } ) );
+			},
+		};
+	}
+)( PostStatus );
+

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -23,17 +23,20 @@ function PostStatus( { status, onUpdateStatus } ) {
 		onUpdateStatus( updatedStatus );
 	};
 
+	// Disable Reason: The input is inside the label, we shouldn't need the htmlFor
+	/* eslint-disable jsx-a11y/label-has-for */
 	return (
 		<PanelBody title={ __( 'Status & Visibility' ) }>
-			<div className="editor-post-status__row">
+			<label className="editor-post-status__row">
 				<span>{ __( 'Pending review' ) }</span>
 				<FormToggle
 					checked={ status === 'pending' }
 					onChange={ onToggle }
 				/>
-			</div>
+			</label>
 		</PanelBody>
 	);
+	/* eslint-enable jsx-a11y/label-has-for */
 }
 
 export default connect(

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -14,6 +14,7 @@ import {
 	isEditedPostDirty,
 	getCurrentPost,
 	getPostEdits,
+	getEditedPostStatus,
 	getEditedPostTitle,
 	getEditedPostPreviewLink,
 	getBlock,
@@ -160,6 +161,34 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPostEdits( state ) ).to.eql( { title: 'terga' } );
+		} );
+	} );
+
+	describe( 'getEditedPostStatus', () => {
+		it( 'should return the post saved status if the status is not edited', () => {
+			const state = {
+				currentPost: {
+					status: 'draft',
+				},
+				editor: {
+					edits: { title: 'chicken' },
+				},
+			};
+
+			expect( getEditedPostStatus( state ) ).to.equal( 'draft' );
+		} );
+
+		it( 'should return the edited status', () => {
+			const state = {
+				currentPost: {
+					status: 'draft',
+				},
+				editor: {
+					edits: { status: 'pending' },
+				},
+			};
+
+			expect( getEditedPostStatus( state ) ).to.equal( 'pending' );
 		} );
 	} );
 


### PR DESCRIPTION
In this PR, I'm starting to add the different UI elements of the editor chrome starting with the "pending review" toggle.

You can now set the post status to pending and back to draft using this toggle.