### PR TITLE
Editable: Set default alignment to "left"

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -268,7 +268,7 @@ export default class Editable extends wp.element.Component {
 		const activeFormats = this.editor.formatter.matchAll( [	'bold', 'italic', 'strikethrough' ] );
 		activeFormats.forEach( ( activeFormat ) => formats[ activeFormat ] = true );
 		const alignments = this.editor.formatter.matchAll( [ 'alignleft', 'aligncenter', 'alignright' ] );
-		const alignment = alignments.length > 0 ? alignmentMap[ alignments[ 0 ] ] : null;
+		const alignment = alignments.length > 0 ? alignmentMap[ alignments[ 0 ] ] : 'left';
 
 		const focusPosition = this.getRelativePosition( element );
 		const bookmark = this.editor.selection.getBookmark( 2, true );


### PR DESCRIPTION
closes #815 

If no alignment information is found in the DOM, default to "left"