### PR TITLE
Heading Block: Fix Text To Heading block

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isString } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -38,8 +43,11 @@ registerBlock( 'core/heading', {
 				blocks: [ 'core/text' ],
 				transform: ( { content, ...attrs } ) => {
 					if ( Array.isArray( content ) ) {
+						const headingContent = isString( content[ 0 ] )
+							? content[ 0 ]
+							: content[ 0 ].props.children;
 						const heading = createBlock( 'core/heading', {
-							content: content[ 0 ].props.children,
+							content: headingContent,
 						} );
 						const blocks = [ heading ];
 


### PR DESCRIPTION
This PR fixes transforming a single paragraph text into a heading block. The solution is not perfect because the current representation of Editable's content is not consistent, and it could be improved with the global reflexion taking place here #771 