### PR TITLE
Try: Block controls rendering by block's `edit`

### DIFF
--- a/blocks/block-controls/index.js
+++ b/blocks/block-controls/index.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { Fill } from 'react-slot-fill';
+
+/**
+ * WordPress dependencies
+ */
+import Toolbar from 'components/toolbar';
+
+export default function BlockControls( { controls } ) {
+	controls = controls.map( ( control ) => ( {
+		...control,
+		isActive: !! control.isActive && control.isActive(),
+	} ) );
+
+	return (
+		<Fill name="Formatting.Toolbar">
+			<Toolbar controls={ controls } />
+		</Fill>
+	);
+}

--- a/blocks/block-controls/index.js
+++ b/blocks/block-controls/index.js
@@ -9,11 +9,6 @@ import { Fill } from 'react-slot-fill';
 import Toolbar from 'components/toolbar';
 
 export default function BlockControls( { controls } ) {
-	controls = controls.map( ( control ) => ( {
-		...control,
-		isActive: !! control.isActive && control.isActive(),
-	} ) );
-
 	return (
 		<Fill name="Formatting.Toolbar">
 			<Toolbar controls={ controls } />

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -87,7 +87,7 @@ registerBlock( 'core/heading', {
 						'123456'.split( '' ).map( ( level ) => ( {
 							icon: 'heading',
 							title: wp.i18n.sprintf( wp.i18n.__( 'Heading %s' ), level ),
-							isActive: () => 'H' + level === nodeName,
+							isActive: 'H' + level === nodeName,
 							onClick: () => setAttributes( { nodeName: 'H' + level } ),
 							subscript: level,
 						} ) )

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -9,6 +9,7 @@ import { isString } from 'lodash';
 import './style.scss';
 import { registerBlock, createBlock, query } from '../../api';
 import Editable from '../../editable';
+import BlockControls from '../../block-controls';
 
 const { children, prop } = query;
 
@@ -23,18 +24,6 @@ registerBlock( 'core/heading', {
 		content: children( 'h1,h2,h3,h4,h5,h6' ),
 		nodeName: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
 	},
-
-	controls: [
-		...'123456'.split( '' ).map( ( level ) => ( {
-			icon: 'heading',
-			title: wp.i18n.sprintf( wp.i18n.__( 'Heading %s' ), level ),
-			isActive: ( { nodeName } ) => 'H' + level === nodeName,
-			onClick( attributes, setAttributes ) {
-				setAttributes( { nodeName: 'H' + level } );
-			},
-			subscript: level,
-		} ) ),
-	],
 
 	transforms: {
 		from: [
@@ -90,8 +79,23 @@ registerBlock( 'core/heading', {
 	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks } ) {
 		const { content, nodeName = 'H2' } = attributes;
 
-		return (
+		return [
+			focus && (
+				<BlockControls
+					key="controls"
+					controls={
+						'123456'.split( '' ).map( ( level ) => ( {
+							icon: 'heading',
+							title: wp.i18n.sprintf( wp.i18n.__( 'Heading %s' ), level ),
+							isActive: () => 'H' + level === nodeName,
+							onClick: () => setAttributes( { nodeName: 'H' + level } ),
+							subscript: level,
+						} ) )
+					}
+				/>
+			),
 			<Editable
+				key="editable"
 				tagName={ nodeName.toLowerCase() }
 				value={ content }
 				focus={ focus }
@@ -99,8 +103,8 @@ registerBlock( 'core/heading', {
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
 				inline
-			/>
-		);
+			/>,
+		];
 	},
 
 	save( { attributes } ) {


### PR DESCRIPTION
This pull request explores an option to render a block's controls in its `edit` implementation.

Benefits:

- The current `controls` callbacks have no access to the `edit` component instance, so in the case of proper component classes, they cannot make use of component state
- Controls are not inherent to the concept of a block. More precisely they are a concern of the block's rendering in the visual editor, reflected here in the return value of `edit`
- We do not need to create a separate argument signature for `isActive` and `onClick` callbacks, since it's easy enough to bind use `attributes` and `setAttributes` from the bound component instance or rendering scope.

Downsides:

- Requires block implementer to concern themselves with `focus` to ensure controls are only rendered if the block is currently selected
- It is not well-settled the extent to which we want to lean on the Slot-Fill pattern, which this uses

For related discussion, see also https://github.com/WordPress/gutenberg/pull/717#issuecomment-302175541.

__Open questions:__

- Would we care to have `<BlockControls />` as an additional layer when the block implementer could as easily render the `<Fill />` directly?
- Since the implementation is supported already via the `Formatting.Controls` slot, do we care to make this the preferred approach if we could support both just the same? Could be nice to consolidate, but only if it's not viewed as more complex.
- We could abuse [React's context feature](https://facebook.github.io/react/docs/context.html) to transparently pass the block's `uid` from `VisualEditorBlock` to `BlockControls` directly, bypassing the need for the block implementer to concern themselves with whether the block is currently selected, at the cost of reducing transparency

__Testing instructions:__

Ensure that heading block controls are shown and behave the same as in master. Only the heading block has been ported in this demonstration.