### PR TITLE
Inserter: Add a visual placeholder at the position where the block is going to be inserted

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -28,6 +28,14 @@ export function replaceBlocks( uids, blocks ) {
 	};
 }
 
+export function insertBlock( block, after ) {
+	return {
+		type: 'INSERT_BLOCK',
+		block,
+		after,
+	};
+}
+
 export function editPost( edits ) {
 	return {
 		type: 'EDIT_POST',

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -36,11 +36,16 @@ export function insertBlock( block, after ) {
 	};
 }
 
-export function setBlockToInsert( slug, after ) {
+export function setInsertionPoint( uid ) {
 	return {
-		type: 'SET_BLOCK_TO_INSERT',
-		slug,
-		after,
+		type: 'SET_INSERTION_POINT',
+		uid,
+	};
+}
+
+export function clearInsertionPoint() {
+	return {
+		type: 'CLEAR_INSERTION_POINT',
 	};
 }
 

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -36,6 +36,14 @@ export function insertBlock( block, after ) {
 	};
 }
 
+export function setBlockToInsert( slug, after ) {
+	return {
+		type: 'SET_BLOCK_TO_INSERT',
+		slug,
+		after,
+	};
+}
+
 export function editPost( edits ) {
 	return {
 		type: 'EDIT_POST',

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -13,6 +13,8 @@ import IconButton from 'components/icon-button';
  * Internal dependencies
  */
 import InserterMenu from './menu';
+import { getSelectedBlock } from '../selectors';
+import { insertBlock } from '../actions';
 
 class Inserter extends wp.element.Component {
 	constructor() {
@@ -45,7 +47,11 @@ class Inserter extends wp.element.Component {
 
 	insertBlock( slug ) {
 		if ( slug ) {
-			this.props.onInsertBlock( slug );
+			const { selectedBlock, onInsertBlock } = this.props;
+			onInsertBlock(
+				slug,
+				selectedBlock ? selectedBlock.uid : null
+			);
 		} else if ( this.toggleNode ) {
 			// When menu is closed by pressing escape, restore focus to the
 			// original opening active element before menu closes
@@ -88,13 +94,17 @@ class Inserter extends wp.element.Component {
 }
 
 export default connect(
-	undefined,
+	( state ) => {
+		return {
+			selectedBlock: getSelectedBlock( state ),
+		};
+	},
 	( dispatch ) => ( {
-		onInsertBlock( slug ) {
-			dispatch( {
-				type: 'INSERT_BLOCK',
-				block: wp.blocks.createBlock( slug ),
-			} );
+		onInsertBlock( slug, after ) {
+			dispatch( insertBlock(
+				wp.blocks.createBlock( slug ),
+				after
+			) );
 		},
 	} )
 )( clickOutside( Inserter ) );

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -14,7 +14,7 @@ import IconButton from 'components/icon-button';
  */
 import InserterMenu from './menu';
 import { getSelectedBlock } from '../selectors';
-import { insertBlock } from '../actions';
+import { insertBlock, setBlockToInsert } from '../actions';
 
 class Inserter extends wp.element.Component {
 	constructor() {
@@ -101,6 +101,7 @@ export default connect(
 	},
 	( dispatch ) => ( {
 		onInsertBlock( slug, after ) {
+			dispatch( setBlockToInsert() );
 			dispatch( insertBlock(
 				wp.blocks.createBlock( slug ),
 				after

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -14,7 +14,7 @@ import IconButton from 'components/icon-button';
  */
 import InserterMenu from './menu';
 import { getSelectedBlock } from '../selectors';
-import { insertBlock, setBlockToInsert } from '../actions';
+import { insertBlock, clearInsertionPoint } from '../actions';
 
 class Inserter extends wp.element.Component {
 	constructor() {
@@ -101,7 +101,7 @@ export default connect(
 	},
 	( dispatch ) => ( {
 		onInsertBlock( slug, after ) {
-			dispatch( setBlockToInsert() );
+			dispatch( clearInsertionPoint() );
 			dispatch( insertBlock(
 				wp.blocks.createBlock( slug ),
 				after

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -3,6 +3,7 @@
  */
 import { flow, groupBy, sortBy, findIndex, filter } from 'lodash';
 import classnames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
@@ -13,6 +14,7 @@ import Dashicon from 'components/dashicon';
  * Internal dependencies
  */
 import './style.scss';
+import { getSelectedBlock } from '../selectors';
 
 class InserterMenu extends wp.element.Component {
 	constructor() {
@@ -60,6 +62,15 @@ class InserterMenu extends wp.element.Component {
 				filterValue: '',
 				currentFocus: null,
 			} );
+		};
+	}
+
+	hoverBlock( slug = null ) {
+		return () => {
+			this.props.onUpdatedBlockToInsert(
+				slug,
+				this.props.selectedBlock ? this.props.selectedBlock.uid : null
+			);
 		};
 	}
 
@@ -254,6 +265,8 @@ class InserterMenu extends wp.element.Component {
 											onClick={ this.selectBlock( slug ) }
 											ref={ this.bindReferenceNode( slug ) }
 											tabIndex="-1"
+											onMouseEnter={ this.hoverBlock( slug ) }
+											onMouseLeave={ this.hoverBlock() }
 										>
 											<Dashicon icon={ icon } />
 											{ title }
@@ -284,4 +297,19 @@ class InserterMenu extends wp.element.Component {
 
 InserterMenu.instances = 0;
 
-export default InserterMenu;
+export default connect(
+	( state ) => {
+		return {
+			selectedBlock: getSelectedBlock( state ),
+		};
+	},
+	( dispatch ) => ( {
+		onUpdatedBlockToInsert( slug, uid ) {
+			dispatch( {
+				type: 'SET_BLOCK_TO_INSERT',
+				after: uid,
+				slug,
+			} );
+		},
+	} )
+)( InserterMenu );

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -15,6 +15,7 @@ import Dashicon from 'components/dashicon';
  */
 import './style.scss';
 import { getSelectedBlock } from '../selectors';
+import { setBlockToInsert } from '../actions';
 
 class InserterMenu extends wp.element.Component {
 	constructor() {
@@ -67,7 +68,7 @@ class InserterMenu extends wp.element.Component {
 
 	hoverBlock( slug = null ) {
 		return () => {
-			this.props.onUpdatedBlockToInsert(
+			this.props.setBlockToInsert(
 				slug,
 				this.props.selectedBlock ? this.props.selectedBlock.uid : null
 			);
@@ -303,13 +304,5 @@ export default connect(
 			selectedBlock: getSelectedBlock( state ),
 		};
 	},
-	( dispatch ) => ( {
-		onUpdatedBlockToInsert( slug, uid ) {
-			dispatch( {
-				type: 'SET_BLOCK_TO_INSERT',
-				after: uid,
-				slug,
-			} );
-		},
-	} )
+	{ setBlockToInsert }
 )( InserterMenu );

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -15,7 +15,7 @@ import Dashicon from 'components/dashicon';
  */
 import './style.scss';
 import { getSelectedBlock } from '../selectors';
-import { setBlockToInsert } from '../actions';
+import { setInsertionPoint, clearInsertionPoint } from '../actions';
 
 class InserterMenu extends wp.element.Component {
 	constructor() {
@@ -66,13 +66,16 @@ class InserterMenu extends wp.element.Component {
 		};
 	}
 
-	hoverBlock( slug = null ) {
+	hoverBlock() {
 		return () => {
-			this.props.setBlockToInsert(
-				slug,
+			this.props.setInsertionPoint(
 				this.props.selectedBlock ? this.props.selectedBlock.uid : null
 			);
 		};
+	}
+
+	unhoverBlock() {
+		return () => this.props.clearInsertionPoint();
 	}
 
 	getVisibleBlocks( blockTypes ) {
@@ -266,8 +269,8 @@ class InserterMenu extends wp.element.Component {
 											onClick={ this.selectBlock( slug ) }
 											ref={ this.bindReferenceNode( slug ) }
 											tabIndex="-1"
-											onMouseEnter={ this.hoverBlock( slug ) }
-											onMouseLeave={ this.hoverBlock() }
+											onMouseEnter={ this.hoverBlock() }
+											onMouseLeave={ this.unhoverBlock() }
 										>
 											<Dashicon icon={ icon } />
 											{ title }
@@ -304,5 +307,5 @@ export default connect(
 			selectedBlock: getSelectedBlock( state ),
 		};
 	},
-	{ setBlockToInsert }
+	{ setInsertionPoint, clearInsertionPoint }
 )( InserterMenu );

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -148,13 +148,13 @@ input[type=search].editor-inserter__search {
 	padding: 8px;
 	align-items: center;
 	cursor: pointer;
-	border: 1px solid transparent;
+	border: none;
 	background: none;
 	line-height: 20px;
 
 	&:hover,
 	&:focus {
-		border: 1px solid $dark-gray-500;
+		color: $blue-medium;
 		outline: none;
 		position: relative;
 	}

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -31,7 +31,6 @@ import {
 	isBlockHovered,
 	isBlockSelected,
 	isTypingInBlock,
-	isBlockBeforeInsertPoint,
 } from '../../selectors';
 
 class VisualEditorBlock extends wp.element.Component {
@@ -167,12 +166,11 @@ class VisualEditorBlock extends wp.element.Component {
 			return null;
 		}
 
-		const { isHovered, isSelected, isTyping, focus, isInsertionPoint } = this.props;
+		const { isHovered, isSelected, isTyping, focus } = this.props;
 		const showUI = isSelected && ( ! isTyping || ! focus.collapsed );
 		const className = classnames( 'editor-visual-editor__block', {
 			'is-selected': showUI,
 			'is-hovered': isHovered,
-			'is-insertion-point': isInsertionPoint,
 		} );
 
 		const { onSelect, onHover, onMouseLeave, onFocus, onInsertAfter } = this.props;
@@ -239,7 +237,6 @@ export default connect(
 			block: getBlock( state, ownProps.uid ),
 			isSelected: isBlockSelected( state, ownProps.uid ),
 			isHovered: isBlockHovered( state, ownProps.uid ),
-			isInsertionPoint: isBlockBeforeInsertPoint( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
 			isTyping: isTypingInBlock( state, ownProps.uid ),
 			order: getBlockOrder( state, ownProps.uid ),

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -20,6 +20,7 @@ import {
 	deselectBlock,
 	focusBlock,
 	mergeBlocks,
+	insertBlock,
 } from '../../actions';
 import {
 	getPreviousBlock,
@@ -30,6 +31,7 @@ import {
 	isBlockHovered,
 	isBlockSelected,
 	isTypingInBlock,
+	isBlockBeforeInsertPoint,
 } from '../../selectors';
 
 class VisualEditorBlock extends wp.element.Component {
@@ -165,11 +167,12 @@ class VisualEditorBlock extends wp.element.Component {
 			return null;
 		}
 
-		const { isHovered, isSelected, isTyping, focus } = this.props;
+		const { isHovered, isSelected, isTyping, focus, isInsertionPoint } = this.props;
 		const showUI = isSelected && ( ! isTyping || ! focus.collapsed );
 		const className = classnames( 'editor-visual-editor__block', {
 			'is-selected': showUI,
 			'is-hovered': isHovered,
+			'is-insertion-point': isInsertionPoint,
 		} );
 
 		const { onSelect, onHover, onMouseLeave, onFocus, onInsertAfter } = this.props;
@@ -236,6 +239,7 @@ export default connect(
 			block: getBlock( state, ownProps.uid ),
 			isSelected: isBlockSelected( state, ownProps.uid ),
 			isHovered: isBlockHovered( state, ownProps.uid ),
+			isInsertionPoint: isBlockBeforeInsertPoint( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
 			isTyping: isTypingInBlock( state, ownProps.uid ),
 			order: getBlockOrder( state, ownProps.uid ),
@@ -281,11 +285,7 @@ export default connect(
 		},
 
 		onInsertAfter( block ) {
-			dispatch( {
-				type: 'INSERT_BLOCK',
-				after: ownProps.uid,
-				block,
-			} );
+			dispatch( insertBlock( block, ownProps.uid ) );
 		},
 
 		onFocus( ...args ) {

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -15,9 +15,19 @@ import './style.scss';
 import Inserter from '../../inserter';
 import VisualEditorBlock from './block';
 import PostTitle from '../../post-title';
-import { getBlockUids } from '../../selectors';
+import { getBlockUids, getBlockInsertionPoint } from '../../selectors';
 
-function VisualEditor( { blocks, clearSelectedBlock } ) {
+const INSERTION_POINT_PLACEHOLDER = '[[insertion-point]]';
+
+function VisualEditor( { blocks, insertionPoint, clearSelectedBlock } ) {
+	const insertionPointIndex = blocks.indexOf( insertionPoint );
+	const blocksWithInsertionPoint = insertionPoint
+		? [
+			...blocks.slice( 0, insertionPointIndex + 1 ),
+			INSERTION_POINT_PLACEHOLDER,
+			...blocks.slice( insertionPointIndex + 1 ),
+		]
+		: blocks;
 	// Disable reason: Focus transfer between blocks and key events are handled
 	// by focused block element. Consider unhandled click bubbling as unselect.
 
@@ -29,9 +39,12 @@ function VisualEditor( { blocks, clearSelectedBlock } ) {
 			onClick={ clearSelectedBlock }
 			className="editor-visual-editor">
 			<PostTitle />
-			{ blocks.map( ( uid ) => (
-				<VisualEditorBlock key={ uid } uid={ uid } />
-			) ) }
+			{ blocksWithInsertionPoint.map( ( uid ) => {
+				if ( uid === INSERTION_POINT_PLACEHOLDER ) {
+					return <div key={ INSERTION_POINT_PLACEHOLDER } className="editor-visual-editor__insertion-point" />;
+				}
+				return <VisualEditorBlock key={ uid } uid={ uid } />;
+			} ) }
 			<Inserter position="top right" />
 		</div>
 	);
@@ -41,8 +54,8 @@ function VisualEditor( { blocks, clearSelectedBlock } ) {
 export default connect(
 	( state ) => ( {
 		blocks: getBlockUids( state ),
+		insertionPoint: getBlockInsertionPoint( state ),
 	} ),
 	( dispatch ) => ( {
 		clearSelectedBlock: () => dispatch( { type: 'CLEAR_SELECTED_BLOCK' } ),
-	} )
-)( VisualEditor );
+	} ) )( VisualEditor );

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -69,17 +69,6 @@
 	&.is-selected .iframe-overlay:before {
 		display: none;
 	}
-
-	&.is-insertion-point:after {
-		position: absolute;
-		top: 100%;
-		left: $block-mover-margin + $block-padding;
-		right: 0;
-		display: block;
-		content: '';
-		height: 3px;
-		background: $blue-medium;
-	}
 }
 
 .editor-visual-editor__block-controls {
@@ -122,4 +111,18 @@
 
 .editor-visual-editor .editor-inserter {
 	margin: $item-spacing $item-spacing $item-spacing calc( 50% - #{ $visual-editor-max-width / 2 } );	// account for full-width trick
+}
+
+.editor-visual-editor > .editor-visual-editor__insertion-point {
+	position: relative;
+
+	&:before {
+		position: absolute;
+		top: 2px;
+		right: #{ $block-padding + $block-mover-margin };
+		left: 0;
+		height: 3px;
+		background: $blue-medium;
+		content: '';
+	}
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -73,7 +73,7 @@
 	&.is-insertion-point:after {
 		position: absolute;
 		top: 100%;
-		left: 0;
+		left: $block-mover-margin + $block-padding;
 		right: 0;
 		display: block;
 		content: '';

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -118,7 +118,7 @@
 
 	&:before {
 		position: absolute;
-		top: 2px;
+		top: 6px;
 		right: #{ $block-padding + $block-mover-margin };
 		left: 0;
 		height: 3px;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -69,6 +69,17 @@
 	&.is-selected .iframe-overlay:before {
 		display: none;
 	}
+
+	&.is-insertion-point:after {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		display: block;
+		content: '';
+		height: 3px;
+		background: $blue-medium;
+	}
 }
 
 .editor-visual-editor__block-controls {

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -132,6 +132,17 @@ export function isTypingInBlock( state, uid ) {
 	return state.selectedBlock.uid === uid ? state.selectedBlock.typing : false;
 }
 
+export function isBlockBeforeInsertPoint( state, uid ) {
+	if ( ! state.blockToInsert.slug ) {
+		return false;
+	}
+	const blockToInsertAfter = state.blockToInsert.after;
+
+	return !! blockToInsertAfter
+		? blockToInsertAfter === uid
+		: last( state.editor.blockOrder ) === uid;
+}
+
 export function isSavingPost( state ) {
 	return state.saving.requesting;
 }

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -132,15 +132,13 @@ export function isTypingInBlock( state, uid ) {
 	return state.selectedBlock.uid === uid ? state.selectedBlock.typing : false;
 }
 
-export function isBlockBeforeInsertPoint( state, uid ) {
-	if ( ! state.blockToInsert.slug ) {
-		return false;
+export function getBlockInsertionPoint( state ) {
+	if ( ! state.insertionPoint.show ) {
+		return null;
 	}
-	const blockToInsertAfter = state.blockToInsert.after;
+	const blockToInsertAfter = state.insertionPoint.uid;
 
-	return !! blockToInsertAfter
-		? blockToInsertAfter === uid
-		: last( state.editor.blockOrder ) === uid;
+	return blockToInsertAfter || last( state.editor.blockOrder );
 }
 
 export function isSavingPost( state ) {

--- a/editor/state.js
+++ b/editor/state.js
@@ -282,6 +282,22 @@ export function hoveredBlock( state = null, action ) {
 }
 
 /**
+ * Reducer returning the block slug to be inserter.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {Object}        Updated state
+ */
+export function blockToInsert( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SET_BLOCK_TO_INSERT':
+			return { slug: action.slug, after: action.after };
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning current editor mode, either "visual" or "text".
  *
  * @param  {string} state  Current state
@@ -355,6 +371,7 @@ export function createReduxStore() {
 		currentPost,
 		selectedBlock,
 		hoveredBlock,
+		blockToInsert,
 		mode,
 		isSidebarOpened,
 		saving,

--- a/editor/state.js
+++ b/editor/state.js
@@ -282,16 +282,23 @@ export function hoveredBlock( state = null, action ) {
 }
 
 /**
- * Reducer returning the block slug to be inserter.
+ * Reducer returning the block insertion point
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function blockToInsert( state = {}, action ) {
+export function insertionPoint( state = { show: false }, action ) {
 	switch ( action.type ) {
-		case 'SET_BLOCK_TO_INSERT':
-			return { slug: action.slug, after: action.after };
+		case 'SET_INSERTION_POINT':
+			return {
+				show: true,
+				uid: action.uid,
+			};
+		case 'CLEAR_INSERTION_POINT':
+			return {
+				show: false,
+			};
 	}
 
 	return state;
@@ -371,7 +378,7 @@ export function createReduxStore() {
 		currentPost,
 		selectedBlock,
 		hoveredBlock,
-		blockToInsert,
+		insertionPoint,
 		mode,
 		isSidebarOpened,
 		saving,

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -31,7 +31,7 @@ import {
 	isBlockHovered,
 	getBlockFocus,
 	isTypingInBlock,
-	isBlockBeforeInsertPoint,
+	getBlockInsertionPoint,
 	isSavingPost,
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
@@ -581,55 +581,40 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isBlockBeforeInsertPoint', () => {
-		it( 'should return true if the block is right before the insertion point', () => {
+	describe( 'getBlockInsertionPoint', () => {
+		it( 'should return the uid of the insertion point', () => {
 			const state = {
-				blockToInsert: {
-					slug: 'core/test',
-					after: 123,
+				insertionPoint: {
+					show: true,
+					uid: 123,
 				},
 			};
 
-			expect( isBlockBeforeInsertPoint( state, 123 ) ).to.be.true();
+			expect( getBlockInsertionPoint( state ) ).to.equal( 123 );
 		} );
 
-		it( 'should return false if the block is not right before the insertion point', () => {
+		it( 'should return return the last block uid if the insertion point is null', () => {
 			const state = {
-				blockToInsert: {
-					slug: 'core/test',
-					after: 23,
-				},
-			};
-
-			expect( isBlockBeforeInsertPoint( state, 123 ) ).to.be.false();
-		} );
-
-		it( 'should return true for the last block if we insert at the end of the editor', () => {
-			const state = {
-				blockToInsert: {
-					slug: 'core/test',
-					after: null,
+				insertionPoint: {
+					show: true,
+					uid: null,
 				},
 				editor: {
 					blockOrder: [ 34, 23 ],
 				},
 			};
 
-			expect( isBlockBeforeInsertPoint( state, 23 ) ).to.be.true();
+			expect( getBlockInsertionPoint( state ) ).to.equal( 23 );
 		} );
 
-		it( 'should return false if we\'re not inserting a block', () => {
+		it( 'should return null if the insertion point is not shown', () => {
 			const state = {
-				blockToInsert: {
-					slug: null,
-					after: null,
-				},
-				editor: {
-					blockOrder: [ 34, 23 ],
+				insertionPoint: {
+					show: false,
 				},
 			};
 
-			expect( isBlockBeforeInsertPoint( state, 23 ) ).to.be.false();
+			expect( getBlockInsertionPoint( state, 23 ) ).to.be.null();
 		} );
 	} );
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -31,6 +31,7 @@ import {
 	isBlockHovered,
 	getBlockFocus,
 	isTypingInBlock,
+	isBlockBeforeInsertPoint,
 	isSavingPost,
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
@@ -577,6 +578,58 @@ describe( 'selectors', () => {
 			};
 
 			expect( isTypingInBlock( state, 23 ) ).to.be.false();
+		} );
+	} );
+
+	describe( 'isBlockBeforeInsertPoint', () => {
+		it( 'should return true if the block is right before the insertion point', () => {
+			const state = {
+				blockToInsert: {
+					slug: 'core/test',
+					after: 123,
+				},
+			};
+
+			expect( isBlockBeforeInsertPoint( state, 123 ) ).to.be.true();
+		} );
+
+		it( 'should return false if the block is not right before the insertion point', () => {
+			const state = {
+				blockToInsert: {
+					slug: 'core/test',
+					after: 23,
+				},
+			};
+
+			expect( isBlockBeforeInsertPoint( state, 123 ) ).to.be.false();
+		} );
+
+		it( 'should return true for the last block if we insert at the end of the editor', () => {
+			const state = {
+				blockToInsert: {
+					slug: 'core/test',
+					after: null,
+				},
+				editor: {
+					blockOrder: [ 34, 23 ],
+				},
+			};
+
+			expect( isBlockBeforeInsertPoint( state, 23 ) ).to.be.true();
+		} );
+
+		it( 'should return false if we\'re not inserting a block', () => {
+			const state = {
+				blockToInsert: {
+					slug: null,
+					after: null,
+				},
+				editor: {
+					blockOrder: [ 34, 23 ],
+				},
+			};
+
+			expect( isBlockBeforeInsertPoint( state, 23 ) ).to.be.false();
 		} );
 	} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -16,7 +16,7 @@ import {
 	mode,
 	isSidebarOpened,
 	saving,
-	blockToInsert,
+	insertionPoint,
 	createReduxStore,
 } from '../state';
 
@@ -398,17 +398,26 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'blockToInsert', () => {
-		it( 'should return with block uid as hovered', () => {
-			const state = blockToInsert( {}, {
-				type: 'SET_BLOCK_TO_INSERT',
-				after: 'kumquat',
-				slug: 'core/text',
+	describe( 'insertionPoint', () => {
+		it( 'should set the insertion point', () => {
+			const state = insertionPoint( {}, {
+				type: 'SET_INSERTION_POINT',
+				uid: 'kumquat',
 			} );
 
 			expect( state ).to.eql( {
-				after: 'kumquat',
-				slug: 'core/text',
+				show: true,
+				uid: 'kumquat',
+			} );
+		} );
+
+		it( 'should clear the insertion point', () => {
+			const state = insertionPoint( {}, {
+				type: 'CLEAR_INSERTION_POINT',
+			} );
+
+			expect( state ).to.eql( {
+				show: false,
 			} );
 		} );
 	} );
@@ -691,7 +700,7 @@ describe( 'state', () => {
 				'mode',
 				'isSidebarOpened',
 				'saving',
-				'blockToInsert',
+				'insertionPoint',
 			] );
 		} );
 	} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -16,6 +16,7 @@ import {
 	mode,
 	isSidebarOpened,
 	saving,
+	blockToInsert,
 	createReduxStore,
 } from '../state';
 
@@ -397,6 +398,21 @@ describe( 'state', () => {
 		} );
 	} );
 
+	describe( 'blockToInsert', () => {
+		it( 'should return with block uid as hovered', () => {
+			const state = blockToInsert( {}, {
+				type: 'SET_BLOCK_TO_INSERT',
+				after: 'kumquat',
+				slug: 'core/text',
+			} );
+
+			expect( state ).to.eql( {
+				after: 'kumquat',
+				slug: 'core/text',
+			} );
+		} );
+	} );
+
 	describe( 'selectedBlock()', () => {
 		it( 'should return with block uid as selected', () => {
 			const state = selectedBlock( undefined, {
@@ -675,6 +691,7 @@ describe( 'state', () => {
 				'mode',
 				'isSidebarOpened',
 				'saving',
+				'blockToInsert',
 			] );
 		} );
 	} );


### PR DESCRIPTION
closes #833 

~This is not completely functional, because each time we click the inserter, the block is unselected which is not the desired behaviour and should be fixed by #827~

Anyway, this is adding the placeholder at the end of the editor right now.