### PR TITLE
Avoid block unselection by focus leave

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -37,11 +37,11 @@ class VisualEditorBlock extends wp.element.Component {
 		super( ...arguments );
 		this.bindBlockNode = this.bindBlockNode.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
-		this.maybeDeselect = this.maybeDeselect.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
 		this.removeOnBackspace = this.removeOnBackspace.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
+		this.selectAndStopPropagation = this.selectAndStopPropagation.bind( this );
 		this.previousOffset = null;
 	}
 
@@ -73,14 +73,6 @@ class VisualEditorBlock extends wp.element.Component {
 		const { isTyping, isHovered, onHover } = this.props;
 		if ( isTyping && ! isHovered ) {
 			onHover();
-		}
-	}
-
-	maybeDeselect( event ) {
-		// Annoyingly React does not support focusOut and we're forced to check
-		// related target to ensure it's not a child when blur fires.
-		if ( ! event.currentTarget.contains( event.relatedTarget ) ) {
-			this.props.onDeselect();
 		}
 	}
 
@@ -122,6 +114,14 @@ class VisualEditorBlock extends wp.element.Component {
 		} else {
 			onMerge( previousBlock, block );
 		}
+	}
+
+	selectAndStopPropagation( event ) {
+		this.props.onSelect();
+
+		// Visual editor infers click as intent to clear the selected block, so
+		// prevent bubbling when occurring on block where selection is intended
+		event.stopPropagation();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -178,9 +178,8 @@ class VisualEditorBlock extends wp.element.Component {
 		return (
 			<div
 				ref={ this.bindBlockNode }
-				onClick={ onSelect }
+				onClick={ this.selectAndStopPropagation }
 				onFocus={ onSelect }
-				onBlur={ this.maybeDeselect }
 				onKeyDown={ this.removeOnBackspace }
 				onMouseEnter={ onHover }
 				onMouseMove={ this.maybeHover }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -39,7 +39,7 @@ class VisualEditorBlock extends wp.element.Component {
 		this.setAttributes = this.setAttributes.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
-		this.removeOnBackspace = this.removeOnBackspace.bind( this );
+		this.removeOrDeselect = this.removeOrDeselect.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.selectAndStopPropagation = this.selectAndStopPropagation.bind( this );
 		this.previousOffset = null;
@@ -88,13 +88,20 @@ class VisualEditorBlock extends wp.element.Component {
 		}
 	}
 
-	removeOnBackspace( event ) {
+	removeOrDeselect( event ) {
 		const { keyCode, target } = event;
+
+		// Remove block on backspace
 		if ( 8 /* Backspace */ === keyCode && target === this.node ) {
 			this.props.onRemove( this.props.uid );
 			if ( this.props.previousBlock ) {
 				this.props.onFocus( this.props.previousBlock.uid, { offset: -1 } );
 			}
+		}
+
+		// Deselect on escape
+		if ( 27 /* Escape */ === event.keyCode ) {
+			this.props.onDeselect();
 		}
 	}
 
@@ -180,7 +187,7 @@ class VisualEditorBlock extends wp.element.Component {
 				ref={ this.bindBlockNode }
 				onClick={ this.selectAndStopPropagation }
 				onFocus={ onSelect }
-				onKeyDown={ this.removeOnBackspace }
+				onKeyDown={ this.removeOrDeselect }
 				onMouseEnter={ onHover }
 				onMouseMove={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -2,6 +2,12 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { cond } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
 
 /**
  * Internal dependencies
@@ -12,9 +18,28 @@ import VisualEditorBlock from './block';
 import PostTitle from '../../post-title';
 import { getBlockUids } from '../../selectors';
 
-function VisualEditor( { blocks } ) {
+/**
+ * Returns true if the key pressed is the escape key, or false otherwise.
+ *
+ * @param  {KeyboardEvent} event Key event to test
+ * @return {Boolean}             Whether event is escape key press
+ */
+function isEscapeKey( event ) {
+	return 27 /* Escape */ === event.keyCode;
+}
+
+function VisualEditor( { blocks, clearSelectedBlock } ) {
+	// Disable reason: Focus transfers between blocks are handled by focusable
+	// block elements. Capture unhandled event bubbling as unselect intent.
+
+	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
-		<div className="editor-visual-editor">
+		<div
+			role="region"
+			aria-label={ __( 'Visual Editor' ) }
+			onKeyPress={ cond( [ [ isEscapeKey, clearSelectedBlock ] ] ) }
+			onClick={ clearSelectedBlock }
+			className="editor-visual-editor">
 			<PostTitle />
 			{ blocks.map( ( uid ) => (
 				<VisualEditorBlock key={ uid } uid={ uid } />
@@ -22,8 +47,14 @@ function VisualEditor( { blocks } ) {
 			<Inserter position="top right" />
 		</div>
 	);
+	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }
 
-export default connect( ( state ) => ( {
-	blocks: getBlockUids( state ),
-} ) )( VisualEditor );
+export default connect(
+	( state ) => ( {
+		blocks: getBlockUids( state ),
+	} ),
+	( dispatch ) => ( {
+		clearSelectedBlock: () => dispatch( { type: 'CLEAR_SELECTED_BLOCK' } ),
+	} )
+)( VisualEditor );

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { cond } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,26 +17,15 @@ import VisualEditorBlock from './block';
 import PostTitle from '../../post-title';
 import { getBlockUids } from '../../selectors';
 
-/**
- * Returns true if the key pressed is the escape key, or false otherwise.
- *
- * @param  {KeyboardEvent} event Key event to test
- * @return {Boolean}             Whether event is escape key press
- */
-function isEscapeKey( event ) {
-	return 27 /* Escape */ === event.keyCode;
-}
-
 function VisualEditor( { blocks, clearSelectedBlock } ) {
-	// Disable reason: Focus transfers between blocks are handled by focusable
-	// block elements. Capture unhandled event bubbling as unselect intent.
+	// Disable reason: Focus transfer between blocks and key events are handled
+	// by focused block element. Consider unhandled click bubbling as unselect.
 
-	/* eslint-disable jsx-a11y/no-static-element-interactions */
+	/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	return (
 		<div
 			role="region"
 			aria-label={ __( 'Visual Editor' ) }
-			onKeyPress={ cond( [ [ isEscapeKey, clearSelectedBlock ] ] ) }
 			onClick={ clearSelectedBlock }
 			className="editor-visual-editor">
 			<PostTitle />
@@ -47,7 +35,7 @@ function VisualEditor( { blocks, clearSelectedBlock } ) {
 			<Inserter position="top right" />
 		</div>
 	);
-	/* eslint-enable jsx-a11y/no-static-element-interactions */
+	/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 }
 
 export default connect(

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -79,6 +79,8 @@
 	margin-top: -$block-controls-height - $item-spacing;
 	margin-bottom: $item-spacing + 20px;	// 20px is the offset from the bottom of the selected block where it stops sticking
 	height: $block-controls-height;
+	width: 0;
+	white-space: nowrap;
 
 	top: $header-height + $admin-bar-height-big + $item-spacing;
 

--- a/editor/state.js
+++ b/editor/state.js
@@ -197,6 +197,9 @@ export function selectedBlock( state = {}, action ) {
 					focus: action.uid === state.uid ? state.focus : {},
 				};
 
+		case 'CLEAR_SELECTED_BLOCK':
+			return {};
+
 		case 'MOVE_BLOCK_UP':
 		case 'MOVE_BLOCK_DOWN':
 			return action.uid === state.uid

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -408,6 +408,15 @@ describe( 'state', () => {
 			expect( state ).to.eql( { uid: 'kumquat', typing: false, focus: {} } );
 		} );
 
+		it( 'returns an empty object when clearing selected block', () => {
+			const original = deepFreeze( { uid: 'kumquat', typing: false, focus: {} } );
+			const state = selectedBlock( original, {
+				type: 'CLEAR_SELECTED_BLOCK',
+			} );
+
+			expect( state ).to.eql( {} );
+		} );
+
 		it( 'should not update the state if already selected and not typing', () => {
 			const original = deepFreeze( { uid: 'kumquat', typing: false, focus: {} } );
 			const state = selectedBlock( original, {


### PR DESCRIPTION
Closes #827
Closes #763

This pull request seeks to change the behavior of block selection, tracking selection by focus entering the block, but unselection only by an escape key press or click on the editor canvas (whitespace). It also resolves an issue described in #763 where the area next to the block controls was not considered outside the toolbar (8c9ba15).

__Testing instructions:__

Ensure that only one block can be selected at a time, either by tabbing into or clicking on the block.
Ensure that a block only becomes unselected when (a) another block becomes selected, (b) the escape key is pressed while focusing a block, or (c) the editor whitespace is clicked.