### PR TITLE
Dismiss block borders by key press

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -205,7 +205,7 @@ class VisualEditorBlock extends wp.element.Component {
 						<Slot name="Formatting.Toolbar" />
 					</div>
 				}
-				<div onKeyDown={ this.maybeStartTyping }>
+				<div onKeyPress={ this.maybeStartTyping }>
 					<BlockEdit
 						focus={ focus }
 						attributes={ block.attributes }


### PR DESCRIPTION
Closes #669 

This pull request seeks to change the behavior of block border dismissal by typing to only dismiss borders when a key is _pressed_, excluding modifier keys (shift, etc.).

__Implementation notes:__

Technically this doesn't detect that input occurred, but rather that the key being pressed is not merely the first of a sequence of keys in a modifier combination.

__Testing instructions:__

Verify that block borders are dismissed when entering a character.
Verify that block borders are not dismissed when pressing shift.