### PR TITLE
Display tooltip on button hover and focus

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -3,23 +3,122 @@
  */
 import './style.scss';
 import classnames from 'classnames';
+import { compact, over } from 'lodash';
 
-function Button( { href, isPrimary, isLarge, isToggled, className, ...additionalProps } ) {
-	const classes = classnames( 'components-button', className, {
-		button: ( isPrimary || isLarge ),
-		'button-primary': isPrimary,
-		'button-large': isLarge,
-		'is-toggled': isToggled,
-	} );
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
 
-	const tag = href !== undefined ? 'a' : 'button';
-	const tagProps = tag === 'a' ? { href } : { type: 'button' };
+class Button extends Component {
+	constructor() {
+		super( ...arguments );
 
-	return wp.element.createElement( tag, {
-		...tagProps,
-		...additionalProps,
-		className: classes,
-	} );
+		this.setFocused = this.setFocused.bind( this );
+		this.checkTooltipBounds = this.checkTooltipBounds.bind( this );
+		this.resetBoundedTooltip = this.resetBoundedTooltip.bind( this );
+
+		this.state = {
+			hasFocus: false,
+			bounded: [],
+		};
+	}
+
+	setFocused() {
+		this.setState( { hasFocus: true } );
+	}
+
+	checkTooltipBounds( event ) {
+		// Prevent calculating bounded restrictions if the button has no title
+		// or if bounds have already been calculated in current hover/focus
+		if ( ! this.props.title || this.state.bounded.length ) {
+			return;
+		}
+
+		const { currentTarget } = event;
+
+		// TODO: Find a better way to determine bounds of the content area,
+		// This is implemented with padding on the content element, meaning
+		// it's not as simple as referencing the root or body nodes. A better
+		// solution would not be tied to specific element IDs but instead
+		// offet values calculated from the editor's root layout element.
+		const contentTop = document.getElementById( 'wpbody-content' ).getBoundingClientRect().top;
+
+		// Because tooltip is rendered as a pseudo-element, positional offsets
+		// are calculated relative the button
+		const targetRect = currentTarget.getBoundingClientRect();
+		const targetCenter = targetRect.left + ( targetRect.width / 2 );
+		const tooltipStyles = window.getComputedStyle( currentTarget, ':after' );
+		const tooltipWidth = parseInt( tooltipStyles.width, 10 );
+		const tooltipTop = targetRect.top + parseInt( tooltipStyles.top, 10 );
+		const tooltipLeft = targetCenter - ( tooltipWidth / 2 );
+		const tooltipRight = targetCenter + ( tooltipWidth / 2 );
+
+		this.setState( {
+			// If the default position of the tooltip exceeds any bounds of the
+			// page content, assign into state so it can be flipped by styling
+			bounded: compact( [
+				tooltipTop < contentTop ? 'top' : null,
+				tooltipLeft < 0 ? 'left' : null,
+				tooltipRight > document.documentElement.clientWidth ? 'right' : null,
+			] ),
+		} );
+	}
+
+	resetBoundedTooltip( event ) {
+		// If button currently has focus, only reset flipped state when focus
+		// leaves, not on mouse out.
+		if ( this.state.hasFocus && 'blur' !== event.type ) {
+			return;
+		}
+
+		this.setState( {
+			bounded: [],
+			hasFocus: false,
+		} );
+	}
+
+	render() {
+		const { href, isPrimary, isLarge, isToggled, disabled, title, className, ...additionalProps } = this.props;
+		const { bounded } = this.state;
+		const classes = classnames( 'components-button', className, {
+			button: ( isPrimary || isLarge ),
+			'button-primary': isPrimary,
+			'button-large': isLarge,
+			'is-toggled': isToggled,
+			'is-disabled': disabled,
+		}, bounded.map( ( bound ) => 'is-tooltip-bounded-' + bound ) );
+
+		let tag;
+		if ( href ) {
+			tag = 'a';
+		} else if ( disabled ) {
+			// Treat disabled button as styled static element, to avoid needing
+			// to handle focus events since we can't assign disabled attribute
+			tag = 'span';
+		} else {
+			tag = 'button';
+		}
+
+		const tagProps = tag === 'a' ? { href } : { type: 'button' };
+
+		return wp.element.createElement( tag, {
+			...tagProps,
+			...additionalProps,
+			'aria-label': title,
+			// We can't assign a disabled attribute, both because it's invalid
+			// for anchor elements, and also because it interferes with mouse
+			// events on tooltip bounds check
+			'aria-disabled': disabled,
+			role: 'button',
+			className: classes,
+			onClick: disabled ? null : this.props.onClick,
+			onFocus: over( this.setFocused, this.checkTooltipBounds, this.props.onFocus ),
+			onBlur: over( this.resetBoundedTooltip, this.props.onBlur ),
+			onMouseEnter: over( this.checkTooltipBounds, this.props.onMouseEnter ),
+			onMouseLeave: over( this.resetBoundedTooltip, this.props.onMouseLeave ),
+		} );
+	}
 }
 
 export default Button;

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -1,4 +1,6 @@
 .components-button {
+	display: inline-block;
+	position: relative;
 	background: none;
 	border: none;
 	outline: none;
@@ -14,7 +16,90 @@
 		background: $dark-gray-400;
 	}
 
-	&:disabled {
+	&.is-disabled {
 		opacity: 0.6;
+		cursor: default;
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba( 30, 140, 190, .8 );
+	}
+
+	&[aria-label]:focus,
+	&[aria-label]:hover {
+		&:before,
+		&:after {
+			box-sizing: border-box;
+			z-index: z-index( '.components-button[aria-label]:after' );
+			position: absolute;
+			bottom: 100%;
+			left: 50%;
+			transform: translateX( -50% );
+			pointer-events: none;
+			text-shadow: none;
+			font-family: $default-font;
+			font-size: $default-font-size;
+		}
+
+		&:before {
+			content: '';
+			width: 0;
+			height: 0;
+			margin-bottom: -6px;
+			border: 6px solid transparent;
+			border-bottom-width: 0;
+			border-top-color: $dark-gray-400;
+		}
+
+		&:after {
+			content: attr( aria-label );
+			padding: 4px 12px;
+			background: $dark-gray-400;
+			white-space: nowrap;
+			font-size: $default-font-size;
+			color: white;
+		}
+	}
+
+	&.is-tooltip-bounded-top {
+		&[aria-label]:focus,
+		&[aria-label]:hover {
+			&:before,
+			&:after {
+				top: 100%;
+				bottom: auto;
+			}
+
+			&:before {
+				margin-top: -6px;
+				margin-bottom: 0;
+				border-top-width: 0;
+				border-bottom-width: 6px;
+				border-top-color: transparent;
+				border-bottom-color: $dark-gray-400;
+			}
+		}
+	}
+
+	&.is-tooltip-bounded-right {
+		&[aria-label]:focus,
+		&[aria-label]:hover {
+			&:after {
+				left: auto;
+				right: 50%;
+				margin-right: -12px;
+				transform: none;
+			}
+		}
+	}
+
+	&.is-tooltip-bounded-left {
+		&[aria-label]:focus,
+		&[aria-label]:hover {
+			&:after {
+				margin-left: -12px;
+				transform: none;
+			}
+		}
 	}
 }

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -4,6 +4,16 @@
 	outline: none;
 	text-decoration: none;
 
+	&.is-toggled {
+		background: $dark-gray-500;
+		color: $white;
+	}
+
+	&.is-toggled:hover {
+		color: $white;
+		background: $dark-gray-400;
+	}
+
 	&:disabled {
 		opacity: 0.6;
 	}

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -10,11 +10,11 @@ import './style.scss';
 import Button from '../button';
 import Dashicon from '../dashicon';
 
-function IconButton( { icon, children, label, className, ...additionalProps } ) {
+function IconButton( { icon, children, className, ...additionalProps } ) {
 	const classes = classnames( 'components-icon-button', className );
 
 	return (
-		<Button { ...additionalProps } aria-label={ label } className={ classes }>
+		<Button { ...additionalProps } className={ classes }>
 			<Dashicon icon={ icon } />
 			{ children }
 		</Button>

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -7,21 +7,9 @@
 	color: $dark-gray-500;
 	position: relative;
 
-	&:not( :disabled ) {
-		cursor: pointer;
-
+	&:not( .is-disabled ) {
 		&:hover {
 			color: $blue-medium;
 		}
-	}
-
-	&:focus:before {
-		content: '';
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, .8);
 	}
 }

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -20,7 +20,7 @@ function Toolbar( { controls } ) {
 				<IconButton
 					key={ index }
 					icon={ control.icon }
-					label={ control.title }
+					title={ control.title }
 					data-subscript={ control.subscript }
 					onClick={ ( event ) => {
 						event.stopPropagation();

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -21,13 +21,6 @@
 		margin-left: 3px;
 	}
 
-	&:focus:before {
-		top: -4px;
-		right: -4px;
-		bottom: -4px;
-		left: -4px;
-	}
-
 	&.is-active,
 	&:hover,
 	&:not(:disabled):hover {

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -7,6 +7,7 @@ $z-layers: (
 	'.editor-visual-editor__block {core/image aligned left or right}': 10,
 	'.editor-visual-editor__block-controls': 1,
 	'.editor-header': 20,
+	'.components-button[aria-label]:before': 30,
 );
 
 @function z-index( $key ) {

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -77,7 +77,7 @@ class BlockSwitcher extends wp.element.Component {
 					onClick={ this.toggleMenu }
 					aria-haspopup="true"
 					aria-expanded={ this.state.open }
-					label={ wp.i18n.__( 'Change block type' ) }
+					title={ wp.i18n.__( 'Change block type' ) }
 				>
 					<Dashicon icon="arrow-down" />
 				</IconButton>

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -12,13 +12,6 @@
 	width: auto;
 	margin: 3px;
 	padding: 6px;
-
-	&:focus:before {
-		top: -3px;
-		right: -3px;
-		bottom: -3px;
-		left: -3px;
-	}
 }
 
 .editor-block-switcher__menu {

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -25,13 +25,13 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 			<IconButton
 				className="editor-tools__undo"
 				icon="undo"
-				label={ wp.i18n.__( 'Undo' ) }
+				title={ wp.i18n.__( 'Undo' ) }
 				disabled={ ! hasUndo }
 				onClick={ undo } />
 			<IconButton
 				className="editor-tools__redo"
 				icon="redo"
-				label={ wp.i18n.__( 'Redo' ) }
+				title={ wp.i18n.__( 'Redo' ) }
 				disabled={ ! hasRedo }
 				onClick={ redo } />
 			<Inserter position="bottom" />

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -59,16 +59,4 @@
 			margin-right: 4px;
 		}
 	}
-
-	.components-button {
-		&.is-toggled {
-			background: $dark-gray-500;
-			color: $white;
-		}
-
-		&.is-toggled:hover {
-			color: $white;
-			background: $dark-gray-400;
-		}
-	}
 }

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -71,7 +71,7 @@ class Inserter extends wp.element.Component {
 			<div className="editor-inserter">
 				<IconButton
 					icon="insert"
-					label={ wp.i18n.__( 'Insert block' ) }
+					title={ wp.i18n.__( 'Insert block' ) }
 					onClick={ this.toggle }
 					className="editor-inserter__toggle"
 					aria-haspopup="true"


### PR DESCRIPTION
Closes #531

This pull request seeks to implement a tooltip to be shown on hover and focus for `<Button />` components passed a `title` prop.

<img src="https://cloud.githubusercontent.com/assets/1779930/26229326/f5edb6aa-3c0e-11e7-9ea4-d18d3a9609af.png" width="238" alt="Tooltip">
<img src="https://cloud.githubusercontent.com/assets/1779930/26229585/de2d92ea-3c10-11e7-8c05-3b5b904e26cf.png" width="366" alt="Disabled save">

__Implementation notes:__

This turned out to be quite complex implement, mainly due to the nature of recreating disabled button behaviors manually. This was necessary because mouse events are not fired on disabled elements. The mouseover events are used to handle the case where tooltips exceeds page content bounds, which itself turned out to be complex to implement. Tooltips should flip vertical if exceeding the top of page content, or stretch left or right if exceeding right or left bounds of page content.

I expect that tooltip behavior could be generalized outside the `Button` case, but decided against preoptimizing for this need in this iteration.

Because of the effort needed to handle focus and mouse events, it's tempting to not bother with leveraging `:hover` and `:focus` selectors with `:before` and `:after` pseudo-elements, but rather render a custom element. One advantage this could have is that it would avoid the need to "reset" tooltip styles which are otherwise inherited from the button (like font, text shadow, color, etc).

__Testing instructions:__

Verify that normal tab and focus behaviors exist for disabled buttons: they are skipped by tab presses, do not receive focus, and do not trigger click callbacks.

Verify that both disabled and enabled buttons with titles show tooltips on both hover and on focus events. Notably those in the header and block toolbars.

Verify that tooltips exceeding top, right, or left bounds of page content are reoriented to fit correctly. Notably the disabled "Save" button in the production build (`npm run build`).