### PR TITLE
Docs and API: clarify naming around block registration

### DIFF
--- a/blocks/README.md
+++ b/blocks/README.md
@@ -146,7 +146,7 @@ Registers a new block-level control. Controls appear in a block's toolbar when i
 
 Inline controls for [`Editable`](#editable) elements are identical for every block and cannot be modified.
 
-### `wp.blocks.getBlockSettings( slug: string )`
+### `wp.blocks.getBlockType( slug: string )`
 
 Returns settings associated with a registered block.
 

--- a/blocks/README.md
+++ b/blocks/README.md
@@ -58,7 +58,7 @@ function RandomImage( props ) {
 	} );
 }
 
-wp.blocks.registerBlock( 'myplugin/random-image', {
+wp.blocks.registerBlockType( 'myplugin/random-image', {
 	title: 'Random Image',
 
 	icon: 'format-image',
@@ -121,7 +121,7 @@ In the random image block above, we've given the `alt` attribute of the image a 
 
 ## API
 
-### `wp.blocks.registerBlock( slug: string, settings: Object )`
+### `wp.blocks.registerBlockType( slug: string, settings: Object )`
 
 Registers a new block provided a unique slug and an object defining its behavior. Once registered, the block is made available as an option to any editor interface where blocks are implemented.
 

--- a/blocks/README.md
+++ b/blocks/README.md
@@ -121,7 +121,7 @@ In the random image block above, we've given the `alt` attribute of the image a 
 
 ## API
 
-### `wp.blocks.registerBlockType( slug: string, settings: Object )`
+### `wp.blocks.registerBlockType( name: string, typeDefinition: Object )`
 
 Registers a new block provided a unique slug and an object defining its behavior. Once registered, the block is made available as an option to any editor interface where blocks are implemented.
 
@@ -148,7 +148,7 @@ Inline controls for [`Editable`](#editable) elements are identical for every blo
 
 ### `wp.blocks.getBlockType( slug: string )`
 
-Returns settings associated with a registered block.
+Returns type definitions associated with a registered block.
 
 ### `wp.blocks.getControlSettings( slug: string )`
 

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -48,10 +48,10 @@ export function createBlock( blockName, attributes = {} ) {
 export function switchToBlockType( block, blockName ) {
 	// Find the right transformation by giving priority to the "to"
 	// transformation.
-	const destinationSettings = getBlockType( blockName );
-	const sourceSettings = getBlockType( block.blockName );
-	const transformationsFrom = get( destinationSettings, 'transforms.from', [] );
-	const transformationsTo = get( sourceSettings, 'transforms.to', [] );
+	const destinationType = getBlockType( blockName );
+	const sourceType = getBlockType( block.blockName );
+	const transformationsFrom = get( destinationType, 'transforms.from', [] );
+	const transformationsTo = get( sourceType, 'transforms.to', [] );
 	const transformation =
 		find( transformationsTo, t => t.blocks.indexOf( blockName ) !== -1 ) ||
 		find( transformationsFrom, t => t.blocks.indexOf( block.blockName ) !== -1 );

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -10,20 +10,24 @@ import { get, castArray, findIndex, isObjectLike, find } from 'lodash';
 import { getBlockSettings } from './registration';
 
 /**
- * Returns a block object given its type and attributes
+ * Returns a block object given its type and attributes.
  *
  * @param  {String} blockType   BlockType
  * @param  {Object} attributes  Block attributes
  * @return {Object}             Block object
  */
 export function createBlock( blockType, attributes = {} ) {
+	// Get the type definition associated with a registered block.
 	const blockSettings = getBlockSettings( blockType );
 
+	// Do we need this? What purpose does it have?
 	let defaultAttributes;
 	if ( blockSettings ) {
 		defaultAttributes = blockSettings.defaultAttributes;
 	}
 
+	// Blocks are stored with a unique ID, the assigned type name,
+	// and the block attributes.
 	return {
 		uid: uuid(),
 		blockType,
@@ -35,7 +39,7 @@ export function createBlock( blockType, attributes = {} ) {
 }
 
 /**
- * Switch a block into one or more blocks of the new block type
+ * Switch a block into one or more blocks of the new block type.
  *
  * @param  {Object} block      Block object
  * @param  {string} blockType  BlockType
@@ -52,7 +56,7 @@ export function switchToBlockType( block, blockType ) {
 		find( transformationsTo, t => t.blocks.indexOf( blockType ) !== -1 ) ||
 		find( transformationsFrom, t => t.blocks.indexOf( block.blockType ) !== -1 );
 
-	// If no valid transformation, stop.  (How did we get here?)
+	// Stop if there is no valid transformation. (How did we get here?)
 	if ( ! transformation ) {
 		return null;
 	}

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -7,30 +7,30 @@ import { get, castArray, findIndex, isObjectLike, find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getBlockSettings } from './registration';
+import { getBlockType } from './registration';
 
 /**
  * Returns a block object given its type and attributes.
  *
- * @param  {String} blockType   BlockType
+ * @param  {String} blockName   Block name
  * @param  {Object} attributes  Block attributes
  * @return {Object}             Block object
  */
-export function createBlock( blockType, attributes = {} ) {
+export function createBlock( blockName, attributes = {} ) {
 	// Get the type definition associated with a registered block.
-	const blockSettings = getBlockSettings( blockType );
+	const blockType = getBlockType( blockName );
 
 	// Do we need this? What purpose does it have?
 	let defaultAttributes;
-	if ( blockSettings ) {
-		defaultAttributes = blockSettings.defaultAttributes;
+	if ( blockType ) {
+		defaultAttributes = blockType.defaultAttributes;
 	}
 
 	// Blocks are stored with a unique ID, the assigned type name,
 	// and the block attributes.
 	return {
 		uid: uuid(),
-		blockType,
+		blockName,
 		attributes: {
 			...defaultAttributes,
 			...attributes,
@@ -48,13 +48,13 @@ export function createBlock( blockType, attributes = {} ) {
 export function switchToBlockType( block, blockType ) {
 	// Find the right transformation by giving priority to the "to"
 	// transformation.
-	const destinationSettings = getBlockSettings( blockType );
-	const sourceSettings = getBlockSettings( block.blockType );
+	const destinationSettings = getBlockType( blockType );
+	const sourceSettings = getBlockType( block.blockName );
 	const transformationsFrom = get( destinationSettings, 'transforms.from', [] );
 	const transformationsTo = get( sourceSettings, 'transforms.to', [] );
 	const transformation =
 		find( transformationsTo, t => t.blocks.indexOf( blockType ) !== -1 ) ||
-		find( transformationsFrom, t => t.blocks.indexOf( block.blockType ) !== -1 );
+		find( transformationsFrom, t => t.blocks.indexOf( block.blockName ) !== -1 );
 
 	// Stop if there is no valid transformation. (How did we get here?)
 	if ( ! transformation ) {
@@ -75,7 +75,7 @@ export function switchToBlockType( block, blockType ) {
 
 	// Ensure that every block object returned by the transformation has a
 	// valid block type.
-	if ( transformationResults.some( ( result ) => ! getBlockSettings( result.blockType ) ) ) {
+	if ( transformationResults.some( ( result ) => ! getBlockType( result.blockType ) ) ) {
 		return null;
 	}
 

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -42,18 +42,18 @@ export function createBlock( blockName, attributes = {} ) {
  * Switch a block into one or more blocks of the new block type.
  *
  * @param  {Object} block      Block object
- * @param  {string} blockType  BlockType
+ * @param  {string} blockName  Block name
  * @return {Array}             Block object
  */
-export function switchToBlockType( block, blockType ) {
+export function switchToBlockType( block, blockName ) {
 	// Find the right transformation by giving priority to the "to"
 	// transformation.
-	const destinationSettings = getBlockType( blockType );
+	const destinationSettings = getBlockType( blockName );
 	const sourceSettings = getBlockType( block.blockName );
 	const transformationsFrom = get( destinationSettings, 'transforms.from', [] );
 	const transformationsTo = get( sourceSettings, 'transforms.to', [] );
 	const transformation =
-		find( transformationsTo, t => t.blocks.indexOf( blockType ) !== -1 ) ||
+		find( transformationsTo, t => t.blocks.indexOf( blockName ) !== -1 ) ||
 		find( transformationsFrom, t => t.blocks.indexOf( block.blockName ) !== -1 );
 
 	// Stop if there is no valid transformation. (How did we get here?)
@@ -75,11 +75,11 @@ export function switchToBlockType( block, blockType ) {
 
 	// Ensure that every block object returned by the transformation has a
 	// valid block type.
-	if ( transformationResults.some( ( result ) => ! getBlockType( result.blockType ) ) ) {
+	if ( transformationResults.some( ( result ) => ! getBlockType( result.blockName ) ) ) {
 		return null;
 	}
 
-	const firstSwitchedBlock = findIndex( transformationResults, ( result ) => result.blockType === blockType );
+	const firstSwitchedBlock = findIndex( transformationResults, ( result ) => result.blockName === blockName );
 
 	// Ensure that at least one block object returned by the transformation has
 	// the expected "destination" block type.
@@ -92,7 +92,7 @@ export function switchToBlockType( block, blockType ) {
 			// The first transformed block whose type matches the "destination"
 			// type gets to keep the existing block's UID.
 			uid: index === firstSwitchedBlock ? block.uid : result.uid,
-			blockType: result.blockType,
+			blockName: result.blockName,
 			attributes: result.attributes,
 		};
 	} );

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -12,13 +12,13 @@ import { getBlockType } from './registration';
 /**
  * Returns a block object given its type and attributes.
  *
- * @param  {String} blockName   Block name
+ * @param  {String} name        Block name
  * @param  {Object} attributes  Block attributes
  * @return {Object}             Block object
  */
-export function createBlock( blockName, attributes = {} ) {
+export function createBlock( name, attributes = {} ) {
 	// Get the type definition associated with a registered block.
-	const blockType = getBlockType( blockName );
+	const blockType = getBlockType( name );
 
 	// Do we need this? What purpose does it have?
 	let defaultAttributes;
@@ -30,7 +30,7 @@ export function createBlock( blockName, attributes = {} ) {
 	// and the block attributes.
 	return {
 		uid: uuid(),
-		blockName,
+		name,
 		attributes: {
 			...defaultAttributes,
 			...attributes,
@@ -42,19 +42,19 @@ export function createBlock( blockName, attributes = {} ) {
  * Switch a block into one or more blocks of the new block type.
  *
  * @param  {Object} block      Block object
- * @param  {string} blockName  Block name
+ * @param  {string} name       Block name
  * @return {Array}             Block object
  */
-export function switchToBlockType( block, blockName ) {
+export function switchToBlockType( block, name ) {
 	// Find the right transformation by giving priority to the "to"
 	// transformation.
-	const destinationType = getBlockType( blockName );
-	const sourceType = getBlockType( block.blockName );
+	const destinationType = getBlockType( name );
+	const sourceType = getBlockType( block.name );
 	const transformationsFrom = get( destinationType, 'transforms.from', [] );
 	const transformationsTo = get( sourceType, 'transforms.to', [] );
 	const transformation =
-		find( transformationsTo, t => t.blocks.indexOf( blockName ) !== -1 ) ||
-		find( transformationsFrom, t => t.blocks.indexOf( block.blockName ) !== -1 );
+		find( transformationsTo, t => t.blocks.indexOf( name ) !== -1 ) ||
+		find( transformationsFrom, t => t.blocks.indexOf( block.name ) !== -1 );
 
 	// Stop if there is no valid transformation. (How did we get here?)
 	if ( ! transformation ) {
@@ -75,11 +75,11 @@ export function switchToBlockType( block, blockName ) {
 
 	// Ensure that every block object returned by the transformation has a
 	// valid block type.
-	if ( transformationResults.some( ( result ) => ! getBlockType( result.blockName ) ) ) {
+	if ( transformationResults.some( ( result ) => ! getBlockType( result.name ) ) ) {
 		return null;
 	}
 
-	const firstSwitchedBlock = findIndex( transformationResults, ( result ) => result.blockName === blockName );
+	const firstSwitchedBlock = findIndex( transformationResults, ( result ) => result.name === name );
 
 	// Ensure that at least one block object returned by the transformation has
 	// the expected "destination" block type.
@@ -92,7 +92,7 @@ export function switchToBlockType( block, blockName ) {
 			// The first transformed block whose type matches the "destination"
 			// type gets to keep the existing block's UID.
 			uid: index === firstSwitchedBlock ? block.uid : result.uid,
-			blockName: result.blockName,
+			name: result.name,
 			attributes: result.attributes,
 		};
 	} );

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -14,5 +14,5 @@ export {
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
 	getBlockSettings,
-	getBlocks,
+	getRegisteredBlocks,
 } from './registration';

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -9,8 +9,8 @@ export { default as parse } from './parser';
 export { default as serialize } from './serializer';
 export { getCategories } from './categories';
 export {
-	registerBlock,
-	unregisterBlock,
+	registerBlockType,
+	unregisterBlockType,
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
 	getBlockType,

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -14,5 +14,5 @@ export {
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
 	getBlockSettings,
-	getRegisteredBlocks,
+	getBlockTypes,
 } from './registration';

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -13,6 +13,6 @@ export {
 	unregisterBlock,
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
-	getBlockSettings,
+	getBlockType,
 	getBlockTypes,
 } from './registration';

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -39,7 +39,7 @@ export function parseBlockAttributes( rawContent, blockType ) {
 }
 
 /**
- * Returns the block attributes of a registered block node given its settings.
+ * Returns the block attributes of a registered block node given its type.
  *
  * @param  {?Object} blockType     Block type
  * @param  {string}  rawContent    Raw block content
@@ -73,7 +73,7 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
 	// Use type from block content, otherwise find unknown handler.
 	name = name || getUnknownTypeHandler();
 
-	// Try finding settings for known block name, else fall back again.
+	// Try finding type for known block name, else fall back again.
 	let blockType = getBlockType( name );
 	const fallbackBlock = getUnknownTypeHandler();
 	if ( ! blockType ) {
@@ -81,7 +81,7 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
 		blockType = getBlockType( name );
 	}
 
-	// Include in set only if settings were determined.
+	// Include in set only if type were determined.
 	// TODO do we ever expect there to not be an unknown type handler?
 	if ( blockType && ( rawContent.trim() || name !== fallbackBlock ) ) {
 		// TODO allow blocks to opt-in to receiving a tree instead of a string.

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -47,7 +47,8 @@ export function parseBlockAttributes( rawContent, blockSettings ) {
  * @return {Object}                All block attributes
  */
 export function getBlockAttributes( blockSettings, rawContent, attributes ) {
-	// Merge any attributes from comment delimiters with block implementation
+	// Merge any attributes present in comment delimiters with those
+	// that are specified in the block implementation.
 	attributes = attributes || {};
 	if ( blockSettings ) {
 		attributes = {
@@ -69,10 +70,10 @@ export function getBlockAttributes( blockSettings, rawContent, attributes ) {
  * @return {?Object}            An initialized block object (if possible)
  */
 export function createBlockWithFallback( blockType, rawContent, attributes ) {
-	// Use type from block content, otherwise find unknown handler
+	// Use type from block content, otherwise find unknown handler.
 	blockType = blockType || getUnknownTypeHandler();
 
-	// Try finding settings for known block type, else again fall back
+	// Try finding settings for known block type, else fall back again.
 	let blockSettings = getBlockSettings( blockType );
 	const fallbackBlockType = getUnknownTypeHandler();
 	if ( ! blockSettings ) {
@@ -80,7 +81,7 @@ export function createBlockWithFallback( blockType, rawContent, attributes ) {
 		blockSettings = getBlockSettings( blockType );
 	}
 
-	// Include in set only if settings were determined
+	// Include in set only if settings were determined.
 	// TODO do we ever expect there to not be an unknown type handler?
 	if ( blockSettings && ( rawContent.trim() || blockType !== fallbackBlockType ) ) {
 		// TODO allow blocks to opt-in to receiving a tree instead of a string.
@@ -123,16 +124,19 @@ export function parseWithTinyMCE( content ) {
 		}
 	);
 
-	// Create a custom HTML schema
+	// Create a custom HTML schema.
 	const schema = new tinymce.html.Schema();
-	// Add <wp-block> "tags" to our schema
+
+	// Add <wp-block> "tags" to our schema.
 	schema.addCustomElements( 'wp-block' );
-	// Add valid <wp-block> "attributes" also
+
+	// Add valid <wp-block> "attributes" also.
 	schema.addValidElements( 'wp-block[slug|attributes]' );
-	// Initialize the parser with our custom schema
+
+	// Initialize the parser with our custom schema.
 	const parser = new tinymce.html.DomParser( { validate: true }, schema );
 
-	// Parse the content into an object tree
+	// Parse the content into an object tree.
 	const tree = parser.parse( content );
 
 	// Create a serializer that we will use to pass strings to blocks.
@@ -140,10 +144,10 @@ export function parseWithTinyMCE( content ) {
 	// shapes that each block can accept.
 	const serializer = new tinymce.html.Serializer( { validate: true }, schema );
 
-	// Walk the tree and initialize blocks
+	// Walk the tree and initialize blocks.
 	const blocks = [];
 
-	// Store markup we found in between blocks
+	// Store markup we found in between blocks.
 	let contentBetweenBlocks = null;
 	function flushContentBetweenBlocks() {
 		if ( contentBetweenBlocks && contentBetweenBlocks.firstChild ) {
@@ -164,19 +168,19 @@ export function parseWithTinyMCE( content ) {
 	while ( currentNode ) {
 		if ( currentNode.name === 'wp-block' ) {
 			// Set node type to document fragment so that the TinyMCE
-			// serializer doesn't output its markup
+			// serializer doesn't output its markup.
 			currentNode.type = 11;
 
 			// Serialize the content
 			const rawContent = serializer.serialize( currentNode );
 
-			// Retrieve the attributes from the <wp-block> tag
+			// Retrieve the attributes from the <wp-block> tag.
 			const nodeAttributes = currentNode.attributes.reduce( ( memo, attr ) => {
 				memo[ attr.name ] = attr.value;
 				return memo;
 			}, {} );
 
-			// Retrieve the block attributes from the original delimiters
+			// Retrieve the block attributes from the original delimiters.
 			const attributesMatcher = /([a-z0-9_-]+)(="([^"]*)")?/g;
 			const blockAttributes = {};
 			let match;
@@ -187,7 +191,7 @@ export function parseWithTinyMCE( content ) {
 				}
 			} while ( !! match );
 
-			// Try to create the block
+			// Try to create the block.
 			const block = createBlockWithFallback(
 				nodeAttributes.slug,
 				rawContent,

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -87,7 +87,7 @@ export function getUnknownTypeHandler() {
 }
 
 /**
- * Returns settings associated with a registered block.
+ * Returns a registered block and its settings.
  *
  * @param  {string}  slug Block slug
  * @return {?Object}      Block settings
@@ -101,6 +101,6 @@ export function getBlockSettings( slug ) {
  *
  * @return {Array} Block settings
  */
-export function getBlocks() {
+export function getRegisteredBlocks() {
 	return Object.values( blocks );
 }

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -87,12 +87,12 @@ export function getUnknownTypeHandler() {
 }
 
 /**
- * Returns a registered block and its settings.
+ * Returns a registered block type.
  *
  * @param  {string}  slug Block slug
- * @return {?Object}      Block settings
+ * @return {?Object}      Block type
  */
-export function getBlockSettings( slug ) {
+export function getBlockType( slug ) {
 	return blocks[ slug ];
 }
 

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -24,7 +24,7 @@ let unknownTypeHandler;
  * @return {?WPBlock}          The block, if it has been successfully
  *                             registered; otherwise `undefined`.
  */
-export function registerBlock( slug, settings ) {
+export function registerBlockType( slug, settings ) {
 	if ( typeof slug !== 'string' ) {
 		console.error(
 			'Block slugs must be strings.'
@@ -55,7 +55,7 @@ export function registerBlock( slug, settings ) {
  * @return {?WPBlock}      The previous block value, if it has been
  *                         successfully unregistered; otherwise `undefined`.
  */
-export function unregisterBlock( slug ) {
+export function unregisterBlockType( slug ) {
 	if ( ! blocks[ slug ] ) {
 		console.error(
 			'Block "' + slug + '" is not registered.'

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -101,6 +101,6 @@ export function getBlockSettings( slug ) {
  *
  * @return {Array} Block settings
  */
-export function getRegisteredBlocks() {
+export function getBlockTypes() {
 	return Object.values( blocks );
 }

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -52,7 +52,7 @@ export function getCommentAttributes( realAttributes, expectedAttributes ) {
 		Object.keys( expectedAttributes )
 	);
 
-	// Serialize the comment attributes
+	// Serialize the comment attributes as `key="value"`.
 	return keys.reduce( ( memo, key ) => {
 		const value = realAttributes[ key ];
 		if ( undefined === value ) {
@@ -64,7 +64,7 @@ export function getCommentAttributes( realAttributes, expectedAttributes ) {
 }
 
 /**
- * Takes a block list and returns the serialized post content
+ * Takes a block list and returns the serialized post content.
  *
  * @param  {Array}  blocks Block list
  * @return {String}        The post content

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -71,7 +71,7 @@ export function getCommentAttributes( realAttributes, expectedAttributes ) {
  */
 export default function serialize( blocks ) {
 	return blocks.reduce( ( memo, block ) => {
-		const blockName = block.blockName;
+		const blockName = block.name;
 		const blockType = getBlockType( blockName );
 		const saveContent = getSaveContent( blockType.save, block.attributes );
 		const beautifyOptions = {

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -7,7 +7,7 @@ import { html as beautifyHtml } from 'js-beautify';
 /**
  * Internal dependencies
  */
-import { getBlockSettings } from './registration';
+import { getBlockType } from './registration';
 import { parseBlockAttributes } from './parser';
 
 /**
@@ -71,9 +71,9 @@ export function getCommentAttributes( realAttributes, expectedAttributes ) {
  */
 export default function serialize( blocks ) {
 	return blocks.reduce( ( memo, block ) => {
-		const blockType = block.blockType;
-		const settings = getBlockSettings( blockType );
-		const saveContent = getSaveContent( settings.save, block.attributes );
+		const blockName = block.blockName;
+		const blockType = getBlockType( blockName );
+		const saveContent = getSaveContent( blockType.save, block.attributes );
 		const beautifyOptions = {
 			indent_inner_html: true,
 			wrap_line_length: 0,
@@ -81,16 +81,16 @@ export default function serialize( blocks ) {
 
 		return memo + (
 			'<!-- wp:' +
-			blockType +
+			blockName +
 			' ' +
 			getCommentAttributes(
 				block.attributes,
-				parseBlockAttributes( saveContent, settings )
+				parseBlockAttributes( saveContent, blockType )
 			) +
 			'-->' +
 			( saveContent ? '\n' + beautifyHtml( saveContent, beautifyOptions ) + '\n' : '' ) +
 			'<!-- /wp:' +
-			blockType +
+			blockName +
 			' -->'
 		) + '\n\n';
 	}, '' );

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -7,12 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { createBlock, switchToBlockType } from '../factory';
-import { getBlocks, unregisterBlock, setUnknownTypeHandler, registerBlock } from '../registration';
+import { getRegisteredBlocks, unregisterBlock, setUnknownTypeHandler, registerBlock } from '../registration';
 
 describe( 'block factory', () => {
 	afterEach( () => {
 		setUnknownTypeHandler( undefined );
-		getBlocks().forEach( ( block ) => {
+		getRegisteredBlocks().forEach( ( block ) => {
 			unregisterBlock( block.slug );
 		} );
 	} );

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -28,7 +28,7 @@ describe( 'block factory', () => {
 				align: 'left',
 			} );
 
-			expect( block.blockName ).to.eql( 'core/test-block' );
+			expect( block.name ).to.eql( 'core/test-block' );
 			expect( block.attributes ).to.eql( {
 				includesDefault: true,
 				align: 'left',
@@ -55,7 +55,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -65,7 +65,7 @@ describe( 'block factory', () => {
 
 			expect( updatedBlock ).to.eql( [ {
 				uid: 1,
-				blockName: 'core/updated-text-block',
+				name: 'core/updated-text-block',
 				attributes: {
 					value: 'chicken ribs',
 				},
@@ -89,7 +89,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -99,7 +99,7 @@ describe( 'block factory', () => {
 
 			expect( updatedBlock ).to.eql( [ {
 				uid: 1,
-				blockName: 'core/updated-text-block',
+				name: 'core/updated-text-block',
 				attributes: {
 					value: 'chicken ribs',
 				},
@@ -112,7 +112,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -136,7 +136,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -160,7 +160,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -190,7 +190,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -225,7 +225,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -253,7 +253,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -286,7 +286,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -319,7 +319,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -337,13 +337,13 @@ describe( 'block factory', () => {
 
 			expect( updatedBlock ).to.eql( [ {
 				uid: 2,
-				blockName: 'core/text-block',
+				name: 'core/text-block',
 				attributes: {
 					value: 'chicken ribs',
 				},
 			}, {
 				uid: 1,
-				blockName: 'core/updated-text-block',
+				name: 'core/updated-text-block',
 				attributes: {
 					value: 'smoked ribs',
 				},

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -7,19 +7,19 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { createBlock, switchToBlockType } from '../factory';
-import { getBlockTypes, unregisterBlock, setUnknownTypeHandler, registerBlock } from '../registration';
+import { getBlockTypes, unregisterBlockType, setUnknownTypeHandler, registerBlockType } from '../registration';
 
 describe( 'block factory', () => {
 	afterEach( () => {
 		setUnknownTypeHandler( undefined );
 		getBlockTypes().forEach( ( block ) => {
-			unregisterBlock( block.slug );
+			unregisterBlockType( block.slug );
 		} );
 	} );
 
 	describe( 'createBlock()', () => {
 		it( 'should create a block given its blockType and attributes', () => {
-			registerBlock( 'core/test-block', {
+			registerBlockType( 'core/test-block', {
 				defaultAttributes: {
 					includesDefault: true,
 				},
@@ -39,7 +39,7 @@ describe( 'block factory', () => {
 
 	describe( 'switchToBlockType()', () => {
 		it( 'should switch the blockType of a block using the "transform form"', () => {
-			registerBlock( 'core/updated-text-block', {
+			registerBlockType( 'core/updated-text-block', {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -51,7 +51,7 @@ describe( 'block factory', () => {
 					} ],
 				},
 			} );
-			registerBlock( 'core/text-block', {} );
+			registerBlockType( 'core/text-block', {} );
 
 			const block = {
 				uid: 1,
@@ -73,8 +73,8 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should switch the blockType of a block using the "transform to"', () => {
-			registerBlock( 'core/updated-text-block', {} );
-			registerBlock( 'core/text-block', {
+			registerBlockType( 'core/updated-text-block', {} );
+			registerBlockType( 'core/text-block', {
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
@@ -107,8 +107,8 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should return null if no transformation is found', () => {
-			registerBlock( 'core/updated-text-block', {} );
-			registerBlock( 'core/text-block', {} );
+			registerBlockType( 'core/updated-text-block', {} );
+			registerBlockType( 'core/text-block', {} );
 
 			const block = {
 				uid: 1,
@@ -124,7 +124,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should reject transformations that return null', () => {
-			registerBlock( 'core/updated-text-block', {
+			registerBlockType( 'core/updated-text-block', {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -132,7 +132,7 @@ describe( 'block factory', () => {
 					} ],
 				},
 			} );
-			registerBlock( 'core/text-block', {} );
+			registerBlockType( 'core/text-block', {} );
 
 			const block = {
 				uid: 1,
@@ -148,7 +148,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should reject transformations that return an empty array', () => {
-			registerBlock( 'core/updated-text-block', {
+			registerBlockType( 'core/updated-text-block', {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -156,7 +156,7 @@ describe( 'block factory', () => {
 					} ],
 				},
 			} );
-			registerBlock( 'core/text-block', {} );
+			registerBlockType( 'core/text-block', {} );
 
 			const block = {
 				uid: 1,
@@ -172,7 +172,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should reject single transformations that do not include block types', () => {
-			registerBlock( 'core/updated-text-block', {
+			registerBlockType( 'core/updated-text-block', {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -186,7 +186,7 @@ describe( 'block factory', () => {
 					} ],
 				},
 			} );
-			registerBlock( 'core/text-block', {} );
+			registerBlockType( 'core/text-block', {} );
 
 			const block = {
 				uid: 1,
@@ -202,7 +202,7 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should reject array transformations that do not include block types', () => {
-			registerBlock( 'core/updated-text-block', {
+			registerBlockType( 'core/updated-text-block', {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -221,7 +221,7 @@ describe( 'block factory', () => {
 					} ],
 				},
 			} );
-			registerBlock( 'core/text-block', {} );
+			registerBlockType( 'core/text-block', {} );
 
 			const block = {
 				uid: 1,
@@ -237,8 +237,8 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should reject single transformations with unexpected block types', () => {
-			registerBlock( 'core/updated-text-block', {} );
-			registerBlock( 'core/text-block', {
+			registerBlockType( 'core/updated-text-block', {} );
+			registerBlockType( 'core/text-block', {
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
@@ -265,8 +265,8 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should reject array transformations with unexpected block types', () => {
-			registerBlock( 'core/updated-text-block', {} );
-			registerBlock( 'core/text-block', {
+			registerBlockType( 'core/updated-text-block', {} );
+			registerBlockType( 'core/text-block', {
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
@@ -298,8 +298,8 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should accept valid array transformations', () => {
-			registerBlock( 'core/updated-text-block', {} );
-			registerBlock( 'core/text-block', {
+			registerBlockType( 'core/updated-text-block', {} );
+			registerBlockType( 'core/text-block', {
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -28,7 +28,7 @@ describe( 'block factory', () => {
 				align: 'left',
 			} );
 
-			expect( block.blockType ).to.eql( 'core/test-block' );
+			expect( block.blockName ).to.eql( 'core/test-block' );
 			expect( block.attributes ).to.eql( {
 				includesDefault: true,
 				align: 'left',
@@ -55,7 +55,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -65,7 +65,7 @@ describe( 'block factory', () => {
 
 			expect( updatedBlock ).to.eql( [ {
 				uid: 1,
-				blockType: 'core/updated-text-block',
+				blockName: 'core/updated-text-block',
 				attributes: {
 					value: 'chicken ribs',
 				},
@@ -89,7 +89,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -99,7 +99,7 @@ describe( 'block factory', () => {
 
 			expect( updatedBlock ).to.eql( [ {
 				uid: 1,
-				blockType: 'core/updated-text-block',
+				blockName: 'core/updated-text-block',
 				attributes: {
 					value: 'chicken ribs',
 				},
@@ -112,7 +112,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -136,7 +136,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -160,7 +160,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -190,7 +190,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -225,7 +225,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -253,7 +253,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -286,7 +286,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -319,7 +319,7 @@ describe( 'block factory', () => {
 
 			const block = {
 				uid: 1,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'ribs',
 				},
@@ -337,13 +337,13 @@ describe( 'block factory', () => {
 
 			expect( updatedBlock ).to.eql( [ {
 				uid: 2,
-				blockType: 'core/text-block',
+				blockName: 'core/text-block',
 				attributes: {
 					value: 'chicken ribs',
 				},
 			}, {
 				uid: 1,
-				blockType: 'core/updated-text-block',
+				blockName: 'core/updated-text-block',
 				attributes: {
 					value: 'smoked ribs',
 				},

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -7,12 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { createBlock, switchToBlockType } from '../factory';
-import { getRegisteredBlocks, unregisterBlock, setUnknownTypeHandler, registerBlock } from '../registration';
+import { getBlockTypes, unregisterBlock, setUnknownTypeHandler, registerBlock } from '../registration';
 
 describe( 'block factory', () => {
 	afterEach( () => {
 		setUnknownTypeHandler( undefined );
-		getRegisteredBlocks().forEach( ( block ) => {
+		getBlockTypes().forEach( ( block ) => {
 			unregisterBlock( block.slug );
 		} );
 	} );

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -17,14 +17,14 @@ import {
 import {
 	registerBlock,
 	unregisterBlock,
-	getBlocks,
+	getRegisteredBlocks,
 	setUnknownTypeHandler,
 } from '../registration';
 
 describe( 'block parser', () => {
 	afterEach( () => {
 		setUnknownTypeHandler( undefined );
-		getBlocks().forEach( ( block ) => {
+		getRegisteredBlocks().forEach( ( block ) => {
 			unregisterBlock( block.slug );
 		} );
 	} );

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -100,7 +100,7 @@ describe( 'block parser', () => {
 				'content',
 				{ attr: 'value' }
 			);
-			expect( block.blockName ).to.eql( 'core/test-block' );
+			expect( block.name ).to.eql( 'core/test-block' );
 			expect( block.attributes ).to.eql( { attr: 'value' } );
 		} );
 
@@ -108,7 +108,7 @@ describe( 'block parser', () => {
 			registerBlockType( 'core/test-block', {} );
 
 			const block = createBlockWithFallback( 'core/test-block', 'content' );
-			expect( block.blockName ).to.eql( 'core/test-block' );
+			expect( block.name ).to.eql( 'core/test-block' );
 			expect( block.attributes ).to.eql( {} );
 		} );
 
@@ -121,7 +121,7 @@ describe( 'block parser', () => {
 				'content',
 				{ attr: 'value' }
 			);
-			expect( block.blockName ).to.eql( 'core/unknown-block' );
+			expect( block.name ).to.eql( 'core/unknown-block' );
 			expect( block.attributes ).to.eql( { attr: 'value' } );
 		} );
 
@@ -130,7 +130,7 @@ describe( 'block parser', () => {
 			setUnknownTypeHandler( 'core/unknown-block' );
 
 			const block = createBlockWithFallback( null, 'content' );
-			expect( block.blockName ).to.eql( 'core/unknown-block' );
+			expect( block.name ).to.eql( 'core/unknown-block' );
 			expect( block.attributes ).to.eql( {} );
 		} );
 
@@ -162,7 +162,7 @@ describe( 'block parser', () => {
 					);
 
 					expect( parsed ).to.have.lengthOf( 1 );
-					expect( parsed[ 0 ].blockName ).to.equal( 'core/test-block' );
+					expect( parsed[ 0 ].name ).to.equal( 'core/test-block' );
 					expect( parsed[ 0 ].attributes ).to.eql( {
 						content: 'Brisket',
 						smoked: 'yes',
@@ -195,7 +195,7 @@ describe( 'block parser', () => {
 					);
 
 					expect( parsed ).to.have.lengthOf( 1 );
-					expect( parsed[ 0 ].blockName ).to.equal( 'core/test-block' );
+					expect( parsed[ 0 ].name ).to.equal( 'core/test-block' );
 					expect( parsed[ 0 ].attributes ).to.eql( {
 						content: 'Ribs & Chicken',
 					} );
@@ -215,7 +215,7 @@ describe( 'block parser', () => {
 					);
 
 					expect( parsed ).to.have.lengthOf( 3 );
-					expect( parsed.map( ( { blockName } ) => blockName ) ).to.eql( [
+					expect( parsed.map( ( { name } ) => name ) ).to.eql( [
 						'core/test-block',
 						'core/unknown-block',
 						'core/unknown-block',
@@ -244,7 +244,7 @@ describe( 'block parser', () => {
 					);
 
 					expect( parsed ).to.have.lengthOf( 5 );
-					expect( parsed.map( ( { blockName } ) => blockName ) ).to.eql( [
+					expect( parsed.map( ( { name } ) => name ) ).to.eql( [
 						'core/unknown-block',
 						'core/test-block',
 						'core/unknown-block',

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -31,7 +31,7 @@ describe( 'block parser', () => {
 
 	describe( 'parseBlockAttributes()', () => {
 		it( 'should use the function implementation', () => {
-			const blockSettings = {
+			const blockType = {
 				attributes: function( rawContent ) {
 					return {
 						content: rawContent + ' & Chicken',
@@ -39,13 +39,13 @@ describe( 'block parser', () => {
 				},
 			};
 
-			expect( parseBlockAttributes( 'Ribs', blockSettings ) ).to.eql( {
+			expect( parseBlockAttributes( 'Ribs', blockType ) ).to.eql( {
 				content: 'Ribs & Chicken',
 			} );
 		} );
 
 		it( 'should use the query object implementation', () => {
-			const blockSettings = {
+			const blockType = {
 				attributes: {
 					emphasis: text( 'strong' ),
 					ignoredDomMatcher: ( node ) => node.innerHTML,
@@ -54,22 +54,22 @@ describe( 'block parser', () => {
 
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( parseBlockAttributes( rawContent, blockSettings ) ).to.eql( {
+			expect( parseBlockAttributes( rawContent, blockType ) ).to.eql( {
 				emphasis: '& Chicken',
 			} );
 		} );
 
 		it( 'should return an empty object if no attributes defined', () => {
-			const blockSettings = {};
+			const blockType = {};
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( parseBlockAttributes( rawContent, blockSettings ) ).to.eql( {} );
+			expect( parseBlockAttributes( rawContent, blockType ) ).to.eql( {} );
 		} );
 	} );
 
 	describe( 'getBlockAttributes()', () => {
 		it( 'should merge attributes with the parsed and default attributes', () => {
-			const blockSettings = {
+			const blockType = {
 				attributes: function( rawContent ) {
 					return {
 						content: rawContent + ' & Chicken',
@@ -83,7 +83,7 @@ describe( 'block parser', () => {
 			const rawContent = 'Ribs';
 			const attrs = { align: 'left' };
 
-			expect( getBlockAttributes( blockSettings, rawContent, attrs ) ).to.eql( {
+			expect( getBlockAttributes( blockType, rawContent, attrs ) ).to.eql( {
 				align: 'left',
 				topic: 'none',
 				content: 'Ribs & Chicken',

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -15,8 +15,8 @@ import {
 	parseWithTinyMCE,
 } from '../parser';
 import {
-	registerBlock,
-	unregisterBlock,
+	registerBlockType,
+	unregisterBlockType,
 	getBlockTypes,
 	setUnknownTypeHandler,
 } from '../registration';
@@ -25,7 +25,7 @@ describe( 'block parser', () => {
 	afterEach( () => {
 		setUnknownTypeHandler( undefined );
 		getBlockTypes().forEach( ( block ) => {
-			unregisterBlock( block.slug );
+			unregisterBlockType( block.slug );
 		} );
 	} );
 
@@ -93,7 +93,7 @@ describe( 'block parser', () => {
 
 	describe( 'createBlockWithFallback', () => {
 		it( 'should create the requested block if it exists', () => {
-			registerBlock( 'core/test-block', {} );
+			registerBlockType( 'core/test-block', {} );
 
 			const block = createBlockWithFallback(
 				'core/test-block',
@@ -105,7 +105,7 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should create the requested block with no attributes if it exists', () => {
-			registerBlock( 'core/test-block', {} );
+			registerBlockType( 'core/test-block', {} );
 
 			const block = createBlockWithFallback( 'core/test-block', 'content' );
 			expect( block.blockName ).to.eql( 'core/test-block' );
@@ -113,7 +113,7 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should fall back to the unknown type handler for unknown blocks if present', () => {
-			registerBlock( 'core/unknown-block', {} );
+			registerBlockType( 'core/unknown-block', {} );
 			setUnknownTypeHandler( 'core/unknown-block' );
 
 			const block = createBlockWithFallback(
@@ -126,7 +126,7 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should fall back to the unknown type handler if block type not specified', () => {
-			registerBlock( 'core/unknown-block', {} );
+			registerBlockType( 'core/unknown-block', {} );
 			setUnknownTypeHandler( 'core/unknown-block' );
 
 			const block = createBlockWithFallback( null, 'content' );
@@ -146,7 +146,7 @@ describe( 'block parser', () => {
 			const parse = parsers[ parser ];
 			describe( parser, () => {
 				it( 'should parse the post content, including block attributes', () => {
-					registerBlock( 'core/test-block', {
+					registerBlockType( 'core/test-block', {
 						// Currently this is the only way to test block content parsing?
 						attributes: function( rawContent ) {
 							return {
@@ -180,7 +180,7 @@ describe( 'block parser', () => {
 				} );
 
 				it( 'should parse the post content, ignoring unknown blocks', () => {
-					registerBlock( 'core/test-block', {
+					registerBlockType( 'core/test-block', {
 						attributes: function( rawContent ) {
 							return {
 								content: rawContent + ' & Chicken',
@@ -203,8 +203,8 @@ describe( 'block parser', () => {
 				} );
 
 				it( 'should parse the post content, using unknown block handler', () => {
-					registerBlock( 'core/test-block', {} );
-					registerBlock( 'core/unknown-block', {} );
+					registerBlockType( 'core/test-block', {} );
+					registerBlockType( 'core/unknown-block', {} );
 
 					setUnknownTypeHandler( 'core/unknown-block' );
 
@@ -223,8 +223,8 @@ describe( 'block parser', () => {
 				} );
 
 				it( 'should parse the post content, including raw HTML at each end', () => {
-					registerBlock( 'core/test-block', {} );
-					registerBlock( 'core/unknown-block', {
+					registerBlockType( 'core/test-block', {} );
+					registerBlockType( 'core/unknown-block', {
 						// Currently this is the only way to test block content parsing?
 						attributes: function( rawContent ) {
 							return {

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -100,7 +100,7 @@ describe( 'block parser', () => {
 				'content',
 				{ attr: 'value' }
 			);
-			expect( block.blockType ).to.eql( 'core/test-block' );
+			expect( block.blockName ).to.eql( 'core/test-block' );
 			expect( block.attributes ).to.eql( { attr: 'value' } );
 		} );
 
@@ -108,7 +108,7 @@ describe( 'block parser', () => {
 			registerBlock( 'core/test-block', {} );
 
 			const block = createBlockWithFallback( 'core/test-block', 'content' );
-			expect( block.blockType ).to.eql( 'core/test-block' );
+			expect( block.blockName ).to.eql( 'core/test-block' );
 			expect( block.attributes ).to.eql( {} );
 		} );
 
@@ -121,7 +121,7 @@ describe( 'block parser', () => {
 				'content',
 				{ attr: 'value' }
 			);
-			expect( block.blockType ).to.eql( 'core/unknown-block' );
+			expect( block.blockName ).to.eql( 'core/unknown-block' );
 			expect( block.attributes ).to.eql( { attr: 'value' } );
 		} );
 
@@ -130,7 +130,7 @@ describe( 'block parser', () => {
 			setUnknownTypeHandler( 'core/unknown-block' );
 
 			const block = createBlockWithFallback( null, 'content' );
-			expect( block.blockType ).to.eql( 'core/unknown-block' );
+			expect( block.blockName ).to.eql( 'core/unknown-block' );
 			expect( block.attributes ).to.eql( {} );
 		} );
 
@@ -162,7 +162,7 @@ describe( 'block parser', () => {
 					);
 
 					expect( parsed ).to.have.lengthOf( 1 );
-					expect( parsed[ 0 ].blockType ).to.equal( 'core/test-block' );
+					expect( parsed[ 0 ].blockName ).to.equal( 'core/test-block' );
 					expect( parsed[ 0 ].attributes ).to.eql( {
 						content: 'Brisket',
 						smoked: 'yes',
@@ -195,7 +195,7 @@ describe( 'block parser', () => {
 					);
 
 					expect( parsed ).to.have.lengthOf( 1 );
-					expect( parsed[ 0 ].blockType ).to.equal( 'core/test-block' );
+					expect( parsed[ 0 ].blockName ).to.equal( 'core/test-block' );
 					expect( parsed[ 0 ].attributes ).to.eql( {
 						content: 'Ribs & Chicken',
 					} );
@@ -215,7 +215,7 @@ describe( 'block parser', () => {
 					);
 
 					expect( parsed ).to.have.lengthOf( 3 );
-					expect( parsed.map( ( { blockType } ) => blockType ) ).to.eql( [
+					expect( parsed.map( ( { blockName } ) => blockName ) ).to.eql( [
 						'core/test-block',
 						'core/unknown-block',
 						'core/unknown-block',
@@ -244,7 +244,7 @@ describe( 'block parser', () => {
 					);
 
 					expect( parsed ).to.have.lengthOf( 5 );
-					expect( parsed.map( ( { blockType } ) => blockType ) ).to.eql( [
+					expect( parsed.map( ( { blockName } ) => blockName ) ).to.eql( [
 						'core/unknown-block',
 						'core/test-block',
 						'core/unknown-block',

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -17,14 +17,14 @@ import {
 import {
 	registerBlock,
 	unregisterBlock,
-	getRegisteredBlocks,
+	getBlockTypes,
 	setUnknownTypeHandler,
 } from '../registration';
 
 describe( 'block parser', () => {
 	afterEach( () => {
 		setUnknownTypeHandler( undefined );
-		getRegisteredBlocks().forEach( ( block ) => {
+		getBlockTypes().forEach( ( block ) => {
 			unregisterBlock( block.slug );
 		} );
 	} );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -15,7 +15,7 @@ import {
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
 	getBlockSettings,
-	getBlocks,
+	getRegisteredBlocks,
 } from '../registration';
 
 describe( 'blocks', () => {
@@ -25,7 +25,7 @@ describe( 'blocks', () => {
 	} );
 
 	afterEach( () => {
-		getBlocks().forEach( block => {
+		getRegisteredBlocks().forEach( block => {
 			unregisterBlock( block.slug );
 		} );
 		setUnknownTypeHandler( undefined );
@@ -84,13 +84,13 @@ describe( 'blocks', () => {
 
 		it( 'should unregister existing blocks', () => {
 			registerBlock( 'core/test-block' );
-			expect( getBlocks() ).to.eql( [
+			expect( getRegisteredBlocks() ).to.eql( [
 				{ slug: 'core/test-block' },
 			] );
 			const oldBlock = unregisterBlock( 'core/test-block' );
 			expect( console.error ).to.not.have.been.called();
 			expect( oldBlock ).to.eql( { slug: 'core/test-block' } );
-			expect( getBlocks() ).to.eql( [] );
+			expect( getRegisteredBlocks() ).to.eql( [] );
 		} );
 	} );
 
@@ -126,16 +126,16 @@ describe( 'blocks', () => {
 		} );
 	} );
 
-	describe( 'getBlocks()', () => {
+	describe( 'getRegisteredBlocks()', () => {
 		it( 'should return an empty array at first', () => {
-			expect( getBlocks() ).to.eql( [] );
+			expect( getRegisteredBlocks() ).to.eql( [] );
 		} );
 
 		it( 'should return all registered blocks', () => {
 			registerBlock( 'core/test-block' );
 			const blockSettings = { settingName: 'settingValue' };
 			registerBlock( 'core/test-block-with-settings', blockSettings );
-			expect( getBlocks() ).to.eql( [
+			expect( getRegisteredBlocks() ).to.eql( [
 				{ slug: 'core/test-block' },
 				{ slug: 'core/test-block-with-settings', settingName: 'settingValue' },
 			] );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -14,7 +14,7 @@ import {
 	unregisterBlock,
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
-	getBlockSettings,
+	getBlockType,
 	getBlockTypes,
 } from '../registration';
 
@@ -64,11 +64,11 @@ describe( 'blocks', () => {
 			expect( block ).to.be.undefined();
 		} );
 
-		it( 'should store a copy of block settings', () => {
-			const blockSettings = { settingName: 'settingValue' };
-			registerBlock( 'core/test-block-with-settings', blockSettings );
-			blockSettings.mutated = true;
-			expect( getBlockSettings( 'core/test-block-with-settings' ) ).to.eql( {
+		it( 'should store a copy of block type', () => {
+			const blockType = { settingName: 'settingValue' };
+			registerBlock( 'core/test-block-with-settings', blockType );
+			blockType.mutated = true;
+			expect( getBlockType( 'core/test-block-with-settings' ) ).to.eql( {
 				slug: 'core/test-block-with-settings',
 				settingName: 'settingValue',
 			} );
@@ -108,18 +108,18 @@ describe( 'blocks', () => {
 		} );
 	} );
 
-	describe( 'getBlockSettings()', () => {
+	describe( 'getBlockType()', () => {
 		it( 'should return { slug } for blocks with no settings', () => {
 			registerBlock( 'core/test-block' );
-			expect( getBlockSettings( 'core/test-block' ) ).to.eql( {
+			expect( getBlockType( 'core/test-block' ) ).to.eql( {
 				slug: 'core/test-block',
 			} );
 		} );
 
-		it( 'should return all block settings', () => {
-			const blockSettings = { settingName: 'settingValue' };
-			registerBlock( 'core/test-block-with-settings', blockSettings );
-			expect( getBlockSettings( 'core/test-block-with-settings' ) ).to.eql( {
+		it( 'should return all block type elements', () => {
+			const blockType = { settingName: 'settingValue' };
+			registerBlock( 'core/test-block-with-settings', blockType );
+			expect( getBlockType( 'core/test-block-with-settings' ) ).to.eql( {
 				slug: 'core/test-block-with-settings',
 				settingName: 'settingValue',
 			} );
@@ -133,8 +133,8 @@ describe( 'blocks', () => {
 
 		it( 'should return all registered blocks', () => {
 			registerBlock( 'core/test-block' );
-			const blockSettings = { settingName: 'settingValue' };
-			registerBlock( 'core/test-block-with-settings', blockSettings );
+			const blockType = { settingName: 'settingValue' };
+			registerBlock( 'core/test-block-with-settings', blockType );
 			expect( getBlockTypes() ).to.eql( [
 				{ slug: 'core/test-block' },
 				{ slug: 'core/test-block-with-settings', settingName: 'settingValue' },

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -15,7 +15,7 @@ import {
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
 	getBlockSettings,
-	getRegisteredBlocks,
+	getBlockTypes,
 } from '../registration';
 
 describe( 'blocks', () => {
@@ -25,7 +25,7 @@ describe( 'blocks', () => {
 	} );
 
 	afterEach( () => {
-		getRegisteredBlocks().forEach( block => {
+		getBlockTypes().forEach( block => {
 			unregisterBlock( block.slug );
 		} );
 		setUnknownTypeHandler( undefined );
@@ -84,13 +84,13 @@ describe( 'blocks', () => {
 
 		it( 'should unregister existing blocks', () => {
 			registerBlock( 'core/test-block' );
-			expect( getRegisteredBlocks() ).to.eql( [
+			expect( getBlockTypes() ).to.eql( [
 				{ slug: 'core/test-block' },
 			] );
 			const oldBlock = unregisterBlock( 'core/test-block' );
 			expect( console.error ).to.not.have.been.called();
 			expect( oldBlock ).to.eql( { slug: 'core/test-block' } );
-			expect( getRegisteredBlocks() ).to.eql( [] );
+			expect( getBlockTypes() ).to.eql( [] );
 		} );
 	} );
 
@@ -126,16 +126,16 @@ describe( 'blocks', () => {
 		} );
 	} );
 
-	describe( 'getRegisteredBlocks()', () => {
+	describe( 'getBlockTypes()', () => {
 		it( 'should return an empty array at first', () => {
-			expect( getRegisteredBlocks() ).to.eql( [] );
+			expect( getBlockTypes() ).to.eql( [] );
 		} );
 
 		it( 'should return all registered blocks', () => {
 			registerBlock( 'core/test-block' );
 			const blockSettings = { settingName: 'settingValue' };
 			registerBlock( 'core/test-block-with-settings', blockSettings );
-			expect( getRegisteredBlocks() ).to.eql( [
+			expect( getBlockTypes() ).to.eql( [
 				{ slug: 'core/test-block' },
 				{ slug: 'core/test-block-with-settings', settingName: 'settingValue' },
 			] );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -10,8 +10,8 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import {
-	registerBlock,
-	unregisterBlock,
+	registerBlockType,
+	unregisterBlockType,
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
 	getBlockType,
@@ -26,47 +26,47 @@ describe( 'blocks', () => {
 
 	afterEach( () => {
 		getBlockTypes().forEach( block => {
-			unregisterBlock( block.slug );
+			unregisterBlockType( block.slug );
 		} );
 		setUnknownTypeHandler( undefined );
 		console.error.restore();
 	} );
 
-	describe( 'registerBlock()', () => {
+	describe( 'registerBlockType()', () => {
 		it( 'should reject numbers', () => {
-			const block = registerBlock( 999 );
+			const block = registerBlockType( 999 );
 			expect( console.error ).to.have.been.calledWith( 'Block slugs must be strings.' );
 			expect( block ).to.be.undefined();
 		} );
 
 		it( 'should reject blocks without a namespace', () => {
-			const block = registerBlock( 'doing-it-wrong' );
+			const block = registerBlockType( 'doing-it-wrong' );
 			expect( console.error ).to.have.been.calledWith( 'Block slugs must contain a namespace prefix. Example: my-plugin/my-custom-block' );
 			expect( block ).to.be.undefined();
 		} );
 
 		it( 'should reject blocks with invalid characters', () => {
-			const block = registerBlock( 'still/_doing_it_wrong' );
+			const block = registerBlockType( 'still/_doing_it_wrong' );
 			expect( console.error ).to.have.been.calledWith( 'Block slugs must contain a namespace prefix. Example: my-plugin/my-custom-block' );
 			expect( block ).to.be.undefined();
 		} );
 
 		it( 'should accept valid block names', () => {
-			const block = registerBlock( 'my-plugin/fancy-block-4' );
+			const block = registerBlockType( 'my-plugin/fancy-block-4' );
 			expect( console.error ).to.not.have.been.called();
 			expect( block ).to.eql( { slug: 'my-plugin/fancy-block-4' } );
 		} );
 
 		it( 'should prohibit registering the same block twice', () => {
-			registerBlock( 'core/test-block' );
-			const block = registerBlock( 'core/test-block' );
+			registerBlockType( 'core/test-block' );
+			const block = registerBlockType( 'core/test-block' );
 			expect( console.error ).to.have.been.calledWith( 'Block "core/test-block" is already registered.' );
 			expect( block ).to.be.undefined();
 		} );
 
 		it( 'should store a copy of block type', () => {
 			const blockType = { settingName: 'settingValue' };
-			registerBlock( 'core/test-block-with-settings', blockType );
+			registerBlockType( 'core/test-block-with-settings', blockType );
 			blockType.mutated = true;
 			expect( getBlockType( 'core/test-block-with-settings' ) ).to.eql( {
 				slug: 'core/test-block-with-settings',
@@ -75,19 +75,19 @@ describe( 'blocks', () => {
 		} );
 	} );
 
-	describe( 'unregisterBlock()', () => {
+	describe( 'unregisterBlockType()', () => {
 		it( 'should fail if a block is not registered', () => {
-			const oldBlock = unregisterBlock( 'core/test-block' );
+			const oldBlock = unregisterBlockType( 'core/test-block' );
 			expect( console.error ).to.have.been.calledWith( 'Block "core/test-block" is not registered.' );
 			expect( oldBlock ).to.be.undefined();
 		} );
 
 		it( 'should unregister existing blocks', () => {
-			registerBlock( 'core/test-block' );
+			registerBlockType( 'core/test-block' );
 			expect( getBlockTypes() ).to.eql( [
 				{ slug: 'core/test-block' },
 			] );
-			const oldBlock = unregisterBlock( 'core/test-block' );
+			const oldBlock = unregisterBlockType( 'core/test-block' );
 			expect( console.error ).to.not.have.been.called();
 			expect( oldBlock ).to.eql( { slug: 'core/test-block' } );
 			expect( getBlockTypes() ).to.eql( [] );
@@ -110,7 +110,7 @@ describe( 'blocks', () => {
 
 	describe( 'getBlockType()', () => {
 		it( 'should return { slug } for blocks with no settings', () => {
-			registerBlock( 'core/test-block' );
+			registerBlockType( 'core/test-block' );
 			expect( getBlockType( 'core/test-block' ) ).to.eql( {
 				slug: 'core/test-block',
 			} );
@@ -118,7 +118,7 @@ describe( 'blocks', () => {
 
 		it( 'should return all block type elements', () => {
 			const blockType = { settingName: 'settingValue' };
-			registerBlock( 'core/test-block-with-settings', blockType );
+			registerBlockType( 'core/test-block-with-settings', blockType );
 			expect( getBlockType( 'core/test-block-with-settings' ) ).to.eql( {
 				slug: 'core/test-block-with-settings',
 				settingName: 'settingValue',
@@ -132,9 +132,9 @@ describe( 'blocks', () => {
 		} );
 
 		it( 'should return all registered blocks', () => {
-			registerBlock( 'core/test-block' );
+			registerBlockType( 'core/test-block' );
 			const blockType = { settingName: 'settingValue' };
-			registerBlock( 'core/test-block-with-settings', blockType );
+			registerBlockType( 'core/test-block-with-settings', blockType );
 			expect( getBlockTypes() ).to.eql( [
 				{ slug: 'core/test-block' },
 				{ slug: 'core/test-block-with-settings', settingName: 'settingValue' },

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -7,11 +7,11 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import serialize, { getCommentAttributes, getSaveContent } from '../serializer';
-import { getBlocks, registerBlock, unregisterBlock } from '../registration';
+import { getRegisteredBlocks, registerBlock, unregisterBlock } from '../registration';
 
 describe( 'block serializer', () => {
 	afterEach( () => {
-		getBlocks().forEach( block => {
+		getRegisteredBlocks().forEach( block => {
 			unregisterBlock( block.slug );
 		} );
 	} );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -89,7 +89,7 @@ describe( 'block serializer', () => {
 
 	describe( 'serialize()', () => {
 		it( 'should serialize the post content properly', () => {
-			const blockSettings = {
+			const blockType = {
 				attributes: ( rawContent ) => {
 					return {
 						content: rawContent,
@@ -99,7 +99,7 @@ describe( 'block serializer', () => {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;
 				},
 			};
-			registerBlockType( 'core/test-block', blockSettings );
+			registerBlockType( 'core/test-block', blockType );
 			const blockList = [
 				{
 					blockName: 'core/test-block',

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -7,11 +7,11 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import serialize, { getCommentAttributes, getSaveContent } from '../serializer';
-import { getRegisteredBlocks, registerBlock, unregisterBlock } from '../registration';
+import { getBlockTypes, registerBlock, unregisterBlock } from '../registration';
 
 describe( 'block serializer', () => {
 	afterEach( () => {
-		getRegisteredBlocks().forEach( block => {
+		getBlockTypes().forEach( block => {
 			unregisterBlock( block.slug );
 		} );
 	} );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -7,12 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import serialize, { getCommentAttributes, getSaveContent } from '../serializer';
-import { getBlockTypes, registerBlock, unregisterBlock } from '../registration';
+import { getBlockTypes, registerBlockType, unregisterBlockType } from '../registration';
 
 describe( 'block serializer', () => {
 	afterEach( () => {
 		getBlockTypes().forEach( block => {
-			unregisterBlock( block.slug );
+			unregisterBlockType( block.slug );
 		} );
 	} );
 
@@ -99,7 +99,7 @@ describe( 'block serializer', () => {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;
 				},
 			};
-			registerBlock( 'core/test-block', blockSettings );
+			registerBlockType( 'core/test-block', blockSettings );
 			const blockList = [
 				{
 					blockName: 'core/test-block',

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -12,7 +12,7 @@ import { getBlockTypes, registerBlockType, unregisterBlockType } from '../regist
 describe( 'block serializer', () => {
 	afterEach( () => {
 		getBlockTypes().forEach( block => {
-			unregisterBlockType( block.slug );
+			unregisterBlockType( block.name );
 		} );
 	} );
 
@@ -102,7 +102,7 @@ describe( 'block serializer', () => {
 			registerBlockType( 'core/test-block', blockType );
 			const blockList = [
 				{
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {
 						content: 'Ribs & Chicken',
 						align: 'left',

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -102,7 +102,7 @@ describe( 'block serializer', () => {
 			registerBlock( 'core/test-block', blockSettings );
 			const blockList = [
 				{
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {
 						content: 'Ribs & Chicken',
 						align: 'left',

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -306,9 +306,9 @@ export default class Editable extends wp.element.Component {
 		this.savedContent = this.props.value;
 		this.setContent( this.savedContent );
 		this.editor.selection.moveToBookmark( bookmark );
+
 		// Saving the editor on updates avoid unecessary onChanges calls
 		// These calls can make the focus jump
-
 		this.editor.save();
 	}
 
@@ -348,7 +348,7 @@ export default class Editable extends wp.element.Component {
 			this.updateFocus();
 		}
 
-		// The savedContent var allows us to avoid updating the content right after an onChange call
+		// The `savedContent` var allows us to avoid updating the content right after an `onChange` call
 		if (
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
@@ -425,8 +425,8 @@ export default class Editable extends wp.element.Component {
 		} = this.props;
 
 		// Generating a key that includes `tagName` ensures that if the tag
-		// changes, we unmount (+ destroy) the previous TinyMCE element, then
-		// mount (+ initialize) a new child element in its place.
+		// changes, we unmount and destroy the previous TinyMCE element, then
+		// mount and initialize a new child element in its place.
 		const key = [ 'editor', tagName ].join();
 		const classes = classnames( className, 'blocks-editable' );
 
@@ -449,18 +449,17 @@ export default class Editable extends wp.element.Component {
 									...control,
 									onClick: () => this.toggleAlignment( control.align ),
 									isActive: this.isAlignmentActive( control.align ),
-								} ) ) } />
+								} ) ) }
+							/>
 						}
 						{ ! inlineToolbar && formatToolbar }
 					</Fill>
 				}
-
 				{ focus && inlineToolbar &&
 					<div className="block-editable__inline-toolbar">
 						{ formatToolbar }
 					</div>
 				}
-
 				<TinyMCE
 					tagName={ tagName }
 					getSettings={ this.getSettings }
@@ -469,7 +468,8 @@ export default class Editable extends wp.element.Component {
 					defaultValue={ value }
 					isEmpty={ this.state.empty }
 					placeholder={ placeholder }
-					key={ key } />
+					key={ key }
+				/>
 			</div>
 		);
 	}

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -7,7 +7,7 @@ import './library';
 // when composed together, form the content or layout of a page.
 // The API for blocks is exposed via `wp.blocks`.
 //
-// Supported blocks are registered by calling `registerBlock`. Once registered,
+// Supported blocks are registered by calling `registerBlockType`. Once registered,
 // the block is made available as an option to the editor interface.
 //
 // Blocks are inferred from the HTML source of a post through a parsing mechanism

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -7,7 +7,7 @@ import { IconButton } from 'components';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query } from '../../api';
+import { registerBlockType, query } from '../../api';
 import Editable from '../../editable';
 
 const { attr, children } = query;
@@ -26,7 +26,7 @@ function applyOrUnset( align ) {
 	};
 }
 
-registerBlock( 'core/button', {
+registerBlockType( 'core/button', {
 	title: wp.i18n.__( 'Button' ),
 
 	icon: 'button',

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -7,11 +7,11 @@ import TextareaAutosize from 'react-autosize-textarea';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query } from '../../api';
+import { registerBlockType, query } from '../../api';
 
 const { prop } = query;
 
-registerBlock( 'core/code', {
+registerBlockType( 'core/code', {
 	title: wp.i18n.__( 'Code' ),
 
 	icon: 'editor-code',

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -7,7 +7,7 @@ import { Button, Placeholder } from 'components';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query } from '../../api';
+import { registerBlockType, query } from '../../api';
 import Editable from '../../editable';
 
 const { attr, children } = query;
@@ -26,7 +26,7 @@ function toggleAlignment( align ) {
 	};
 }
 
-registerBlock( 'core/embed', {
+registerBlockType( 'core/embed', {
 	title: wp.i18n.__( 'Embed' ),
 
 	icon: 'video-alt3',

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-import { registerBlock, query, setUnknownTypeHandler } from '../../api';
+import { registerBlockType, query, setUnknownTypeHandler } from '../../api';
 
 const { html } = query;
 
-registerBlock( 'core/freeform', {
+registerBlockType( 'core/freeform', {
 	title: wp.i18n.__( 'Freeform' ),
 
 	icon: 'text',

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -7,13 +7,13 @@ import { isString } from 'lodash';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, createBlock, query } from '../../api';
+import { registerBlockType, createBlock, query } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 
 const { children, prop } = query;
 
-registerBlock( 'core/heading', {
+registerBlockType( 'core/heading', {
 	title: wp.i18n.__( 'Heading' ),
 
 	icon: 'heading',

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -7,7 +7,7 @@ import { Placeholder } from 'components';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query } from '../../api';
+import { registerBlockType, query } from '../../api';
 import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
 
@@ -27,7 +27,7 @@ function toggleAlignment( align ) {
 	};
 }
 
-registerBlock( 'core/image', {
+registerBlockType( 'core/image', {
 	title: wp.i18n.__( 'Image' ),
 
 	icon: 'format-image',

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -8,7 +8,7 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query as hpq, createBlock } from '../../api';
+import { registerBlockType, query as hpq, createBlock } from '../../api';
 import Editable from '../../editable';
 
 const { children, prop } = hpq;
@@ -47,7 +47,7 @@ function findInternalListType( { parents } ) {
 	return list ? list.nodeName : null;
 }
 
-registerBlock( 'core/list', {
+registerBlockType( 'core/list', {
 	title: wp.i18n.__( 'List' ),
 	icon: 'editor-ul',
 	category: 'common',

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, createBlock, query } from '../../api';
+import { registerBlockType, createBlock, query } from '../../api';
 import Editable from '../../editable';
 
 const { children } = query;
 
-registerBlock( 'core/preformatted', {
+registerBlockType( 'core/preformatted', {
 	title: wp.i18n.__( 'Preformatted' ),
 
 	icon: 'text',

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query as hpq } from '../../api';
+import { registerBlockType, query as hpq } from '../../api';
 import Editable from '../../editable';
 
 const { children, query } = hpq;
 
-registerBlock( 'core/pullquote', {
+registerBlockType( 'core/pullquote', {
 
 	title: wp.i18n.__( 'Pullquote' ),
 

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -7,12 +7,12 @@ import { switchChildrenNodeName } from 'element';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, createBlock, query as hpq } from '../../api';
+import { registerBlockType, createBlock, query as hpq } from '../../api';
 import Editable from '../../editable';
 
 const { children, query } = hpq;
 
-registerBlock( 'core/quote', {
+registerBlockType( 'core/quote', {
 	title: wp.i18n.__( 'Quote' ),
 	icon: 'format-quote',
 	category: 'common',

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -2,9 +2,9 @@
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock } from '../../api';
+import { registerBlockType } from '../../api';
 
-registerBlock( 'core/separator', {
+registerBlockType( 'core/separator', {
 	title: wp.i18n.__( 'Separator' ),
 
 	icon: 'minus',

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query as hpq } from '../../api';
+import { registerBlockType, query as hpq } from '../../api';
 import Editable from '../../editable';
 
 const { children, query } = hpq;
@@ -21,7 +21,7 @@ function toggleAlignment( align ) {
 	};
 }
 
-registerBlock( 'core/table', {
+registerBlockType( 'core/table', {
 	title: wp.i18n.__( 'Table' ),
 	icon: 'editor-table',
 	category: 'formatting',

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -1,12 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerBlock, createBlock, query } from '../../api';
+import { registerBlockType, createBlock, query } from '../../api';
 import Editable from '../../editable';
 
 const { children } = query;
 
-registerBlock( 'core/text', {
+registerBlockType( 'core/text', {
 	title: wp.i18n.__( 'Text' ),
 
 	icon: 'text',

--- a/blocks/test/fixtures/core-button-center.json
+++ b/blocks/test/fixtures/core-button-center.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/button",
+        "name": "core/button",
         "attributes": {
             "align": "center",
             "url": "https://github.com/WordPress/gutenberg",

--- a/blocks/test/fixtures/core-button-center.json
+++ b/blocks/test/fixtures/core-button-center.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/button",
+        "blockName": "core/button",
         "attributes": {
             "align": "center",
             "url": "https://github.com/WordPress/gutenberg",

--- a/blocks/test/fixtures/core-code.json
+++ b/blocks/test/fixtures/core-code.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/code",
+        "blockName": "core/code",
         "attributes": {
             "content": "export default function MyButton() {\n\treturn <Button>Click Me!</Button>;\n}"
         }

--- a/blocks/test/fixtures/core-code.json
+++ b/blocks/test/fixtures/core-code.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/code",
+        "name": "core/code",
         "attributes": {
             "content": "export default function MyButton() {\n\treturn <Button>Click Me!</Button>;\n}"
         }

--- a/blocks/test/fixtures/core-embed-youtube-caption.json
+++ b/blocks/test/fixtures/core-embed-youtube-caption.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/embed",
+        "blockName": "core/embed",
         "attributes": {
             "url": "//www.youtube.com/embed/Nl6U7UotA-M",
             "caption": [

--- a/blocks/test/fixtures/core-embed-youtube-caption.json
+++ b/blocks/test/fixtures/core-embed-youtube-caption.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/embed",
+        "name": "core/embed",
         "attributes": {
             "url": "//www.youtube.com/embed/Nl6U7UotA-M",
             "caption": [

--- a/blocks/test/fixtures/core-freeform.json
+++ b/blocks/test/fixtures/core-freeform.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/freeform",
+        "name": "core/freeform",
         "attributes": {
             "html": "Testing freeform block with some<div class=\"wp-some-class\">HTML <span style=\"color: red;\">content</span></div>"
         }

--- a/blocks/test/fixtures/core-freeform.json
+++ b/blocks/test/fixtures/core-freeform.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/freeform",
+        "blockName": "core/freeform",
         "attributes": {
             "html": "Testing freeform block with some<div class=\"wp-some-class\">HTML <span style=\"color: red;\">content</span></div>"
         }

--- a/blocks/test/fixtures/core-heading-h2-em.json
+++ b/blocks/test/fixtures/core-heading-h2-em.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/heading",
+        "name": "core/heading",
         "attributes": {
             "content": [
                 "The ",

--- a/blocks/test/fixtures/core-heading-h2-em.json
+++ b/blocks/test/fixtures/core-heading-h2-em.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/heading",
+        "blockName": "core/heading",
         "attributes": {
             "content": [
                 "The ",

--- a/blocks/test/fixtures/core-heading-h2.json
+++ b/blocks/test/fixtures/core-heading-h2.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/heading",
+        "name": "core/heading",
         "attributes": {
             "content": [
                 "A picture is worth a thousand words, or so the saying goes"

--- a/blocks/test/fixtures/core-heading-h2.json
+++ b/blocks/test/fixtures/core-heading-h2.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/heading",
+        "blockName": "core/heading",
         "attributes": {
             "content": [
                 "A picture is worth a thousand words, or so the saying goes"

--- a/blocks/test/fixtures/core-image-center-caption.json
+++ b/blocks/test/fixtures/core-image-center-caption.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/image",
+        "blockName": "core/image",
         "attributes": {
             "align": "center",
             "url": "https://cldup.com/YLYhpou2oq.jpg",

--- a/blocks/test/fixtures/core-image-center-caption.json
+++ b/blocks/test/fixtures/core-image-center-caption.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/image",
+        "name": "core/image",
         "attributes": {
             "align": "center",
             "url": "https://cldup.com/YLYhpou2oq.jpg",

--- a/blocks/test/fixtures/core-image.json
+++ b/blocks/test/fixtures/core-image.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/image",
+        "name": "core/image",
         "attributes": {
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "caption": []

--- a/blocks/test/fixtures/core-image.json
+++ b/blocks/test/fixtures/core-image.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/image",
+        "blockName": "core/image",
         "attributes": {
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "caption": []

--- a/blocks/test/fixtures/core-list-ul.json
+++ b/blocks/test/fixtures/core-list-ul.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/list",
+        "name": "core/list",
         "attributes": {
             "nodeName": "UL",
             "values": [

--- a/blocks/test/fixtures/core-list-ul.json
+++ b/blocks/test/fixtures/core-list-ul.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/list",
+        "blockName": "core/list",
         "attributes": {
             "nodeName": "UL",
             "values": [

--- a/blocks/test/fixtures/core-preformatted.json
+++ b/blocks/test/fixtures/core-preformatted.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/preformatted",
+        "blockName": "core/preformatted",
         "attributes": {
             "content": [
                 "Some ",

--- a/blocks/test/fixtures/core-preformatted.json
+++ b/blocks/test/fixtures/core-preformatted.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/preformatted",
+        "name": "core/preformatted",
         "attributes": {
             "content": [
                 "Some ",

--- a/blocks/test/fixtures/core-pullquote.json
+++ b/blocks/test/fixtures/core-pullquote.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/pullquote",
+        "name": "core/pullquote",
         "attributes": {
             "value": [
                 [

--- a/blocks/test/fixtures/core-pullquote.json
+++ b/blocks/test/fixtures/core-pullquote.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/pullquote",
+        "blockName": "core/pullquote",
         "attributes": {
             "value": [
                 [

--- a/blocks/test/fixtures/core-quote-style-1.json
+++ b/blocks/test/fixtures/core-quote-style-1.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/quote",
+        "name": "core/quote",
         "attributes": {
             "style": "1",
             "value": [

--- a/blocks/test/fixtures/core-quote-style-1.json
+++ b/blocks/test/fixtures/core-quote-style-1.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/quote",
+        "blockName": "core/quote",
         "attributes": {
             "style": "1",
             "value": [

--- a/blocks/test/fixtures/core-quote-style-2.json
+++ b/blocks/test/fixtures/core-quote-style-2.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/quote",
+        "name": "core/quote",
         "attributes": {
             "style": "2",
             "value": [

--- a/blocks/test/fixtures/core-quote-style-2.json
+++ b/blocks/test/fixtures/core-quote-style-2.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/quote",
+        "blockName": "core/quote",
         "attributes": {
             "style": "2",
             "value": [

--- a/blocks/test/fixtures/core-separator.json
+++ b/blocks/test/fixtures/core-separator.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/separator",
+        "name": "core/separator",
         "attributes": {}
     }
 ]

--- a/blocks/test/fixtures/core-separator.json
+++ b/blocks/test/fixtures/core-separator.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/separator",
+        "blockName": "core/separator",
         "attributes": {}
     }
 ]

--- a/blocks/test/fixtures/core-table.json
+++ b/blocks/test/fixtures/core-table.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/table",
+        "blockName": "core/table",
         "attributes": {
             "body": [
                 [

--- a/blocks/test/fixtures/core-table.json
+++ b/blocks/test/fixtures/core-table.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/table",
+        "name": "core/table",
         "attributes": {
             "body": [
                 [

--- a/blocks/test/fixtures/core-text-align-right.json
+++ b/blocks/test/fixtures/core-text-align-right.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/text",
+        "name": "core/text",
         "attributes": {
             "content": [
                 {

--- a/blocks/test/fixtures/core-text-align-right.json
+++ b/blocks/test/fixtures/core-text-align-right.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/text",
+        "blockName": "core/text",
         "attributes": {
             "content": [
                 {

--- a/blocks/test/fixtures/core-text-multi-paragraph.json
+++ b/blocks/test/fixtures/core-text-multi-paragraph.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockName": "core/text",
+        "name": "core/text",
         "attributes": {
             "content": [
                 {

--- a/blocks/test/fixtures/core-text-multi-paragraph.json
+++ b/blocks/test/fixtures/core-text-multi-paragraph.json
@@ -1,7 +1,7 @@
 [
     {
         "uid": "_uid_0",
-        "blockType": "core/text",
+        "blockName": "core/text",
         "attributes": {
             "content": [
                 {

--- a/blocks/test/full-content.js
+++ b/blocks/test/full-content.js
@@ -15,7 +15,7 @@ import {
 	parseWithTinyMCE,
 } from '../api/parser';
 import serialize from '../api/serializer';
-import { getBlocks } from '../api/registration';
+import { getBlockTypes } from '../api/registration';
 
 const fixturesDir = path.join( __dirname, 'fixtures' );
 
@@ -134,7 +134,7 @@ describe( 'full post content fixture', () => {
 	it( 'should be present for each block', () => {
 		const errors = [];
 
-		getBlocks().map( block => block.slug ).forEach( slug => {
+		getBlockTypes().map( block => block.slug ).forEach( slug => {
 			const slugToFilename = slug.replace( /\//g, '-' );
 			const foundFixtures = fileBasenames
 				.filter( basename => (

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -50,10 +50,10 @@ class BlockSwitcher extends wp.element.Component {
 	}
 
 	render() {
-		const blockType = wp.blocks.getBlockType( this.props.block.blockName );
+		const blockType = wp.blocks.getBlockType( this.props.block.name );
 		const blocksToBeTransformedFrom = reduce( wp.blocks.getBlockTypes(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );
-			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.blockName ) !== -1 );
+			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.name ) !== -1 );
 			return transformation ? memo.concat( [ block.slug ] ) : memo;
 		}, [] );
 		const blocksToBeTransformedTo = get( blockType, 'transforms.to', [] )

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -40,27 +40,27 @@ class BlockSwitcher extends wp.element.Component {
 		} );
 	}
 
-	switchBlockType( blockType ) {
+	switchBlockType( name ) {
 		return () => {
 			this.setState( {
 				open: false,
 			} );
-			this.props.onTransform( this.props.block, blockType );
+			this.props.onTransform( this.props.block, name );
 		};
 	}
 
 	render() {
-		const blockSettings = wp.blocks.getBlockSettings( this.props.block.blockType );
+		const blockType = wp.blocks.getBlockType( this.props.block.blockType );
 		const blocksToBeTransformedFrom = reduce( wp.blocks.getBlockTypes(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );
 			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.blockType ) !== -1 );
 			return transformation ? memo.concat( [ block.slug ] ) : memo;
 		}, [] );
-		const blocksToBeTransformedTo = get( blockSettings, 'transforms.to', [] )
+		const blocksToBeTransformedTo = get( blockType, 'transforms.to', [] )
 			.reduce( ( memo, transformation ) => memo.concat( transformation.blocks ), [] );
 		const allowedBlocks = uniq( blocksToBeTransformedFrom.concat( blocksToBeTransformedTo ) )
-			.reduce( ( memo, blockType ) => {
-				const block = wp.blocks.getBlockSettings( blockType );
+			.reduce( ( memo, name ) => {
+				const block = wp.blocks.getBlockType( name );
 				return !! block ? memo.concat( block ) : memo;
 			}, [] );
 
@@ -72,7 +72,7 @@ class BlockSwitcher extends wp.element.Component {
 			<div className="editor-block-switcher">
 				<IconButton
 					className="editor-block-switcher__toggle"
-					icon={ blockSettings.icon }
+					icon={ blockType.icon }
 					onClick={ this.toggleMenu }
 					aria-haspopup="true"
 					aria-expanded={ this.state.open }
@@ -110,10 +110,10 @@ export default connect(
 		block: getBlock( state, ownProps.uid ),
 	} ),
 	( dispatch, ownProps ) => ( {
-		onTransform( block, blockType ) {
+		onTransform( block, name ) {
 			dispatch( replaceBlocks(
 				[ ownProps.uid ],
-				wp.blocks.switchToBlockType( block, blockType )
+				wp.blocks.switchToBlockType( block, name )
 			) );
 		},
 	} )

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -51,7 +51,7 @@ class BlockSwitcher extends wp.element.Component {
 
 	render() {
 		const blockSettings = wp.blocks.getBlockSettings( this.props.block.blockType );
-		const blocksToBeTransformedFrom = reduce( wp.blocks.getRegisteredBlocks(), ( memo, block ) => {
+		const blocksToBeTransformedFrom = reduce( wp.blocks.getBlockTypes(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );
 			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.blockType ) !== -1 );
 			return transformation ? memo.concat( [ block.slug ] ) : memo;

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -51,7 +51,7 @@ class BlockSwitcher extends wp.element.Component {
 
 	render() {
 		const blockSettings = wp.blocks.getBlockSettings( this.props.block.blockType );
-		const blocksToBeTransformedFrom = reduce( wp.blocks.getBlocks(), ( memo, block ) => {
+		const blocksToBeTransformedFrom = reduce( wp.blocks.getRegisteredBlocks(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );
 			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.blockType ) !== -1 );
 			return transformation ? memo.concat( [ block.slug ] ) : memo;

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -50,10 +50,10 @@ class BlockSwitcher extends wp.element.Component {
 	}
 
 	render() {
-		const blockType = wp.blocks.getBlockType( this.props.block.blockType );
+		const blockType = wp.blocks.getBlockType( this.props.block.blockName );
 		const blocksToBeTransformedFrom = reduce( wp.blocks.getBlockTypes(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );
-			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.blockType ) !== -1 );
+			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.blockName ) !== -1 );
 			return transformation ? memo.concat( [ block.slug ] ) : memo;
 		}, [] );
 		const blocksToBeTransformedTo = get( blockType, 'transforms.to', [] )

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { getBlockSettings, switchToBlockType } from 'blocks';
+import { getBlockType, switchToBlockType } from 'blocks';
 import { __ } from 'i18n';
 
 /**
@@ -71,10 +71,10 @@ export default {
 	MERGE_BLOCKS( action, store ) {
 		const { dispatch } = store;
 		const [ blockA, blockB ] = action.blocks;
-		const blockASettings = getBlockSettings( blockA.blockType );
+		const blockType = getBlockType( blockA.blockType );
 
 		// Only focus the previous block if it's not mergeable
-		if ( ! blockASettings.merge ) {
+		if ( ! blockType.merge ) {
 			dispatch( focusBlock( blockA.uid ) );
 			return;
 		}
@@ -91,7 +91,7 @@ export default {
 		}
 
 		// Calling the merge to update the attributes and remove the block to be merged
-		const updatedAttributes = blockASettings.merge(
+		const updatedAttributes = blockType.merge(
 			blockA.attributes,
 			blocksWithTheSameType[ 0 ].attributes
 		);

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -71,7 +71,7 @@ export default {
 	MERGE_BLOCKS( action, store ) {
 		const { dispatch } = store;
 		const [ blockA, blockB ] = action.blocks;
-		const blockType = getBlockType( blockA.blockName );
+		const blockType = getBlockType( blockA.name );
 
 		// Only focus the previous block if it's not mergeable
 		if ( ! blockType.merge ) {
@@ -81,9 +81,9 @@ export default {
 
 		// We can only merge blocks with similar types
 		// thus, we transform the block to merge first
-		const blocksWithTheSameType = blockA.blockName === blockB.blockName
+		const blocksWithTheSameType = blockA.name === blockB.name
 			? [ blockB ]
-			: switchToBlockType( blockB, blockA.blockName );
+			: switchToBlockType( blockB, blockA.name );
 
 		// If the block types can not match, do nothing
 		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -71,7 +71,7 @@ export default {
 	MERGE_BLOCKS( action, store ) {
 		const { dispatch } = store;
 		const [ blockA, blockB ] = action.blocks;
-		const blockType = getBlockType( blockA.blockType );
+		const blockType = getBlockType( blockA.blockName );
 
 		// Only focus the previous block if it's not mergeable
 		if ( ! blockType.merge ) {
@@ -81,9 +81,9 @@ export default {
 
 		// We can only merge blocks with similar types
 		// thus, we transform the block to merge first
-		const blocksWithTheSameType = blockA.blockType === blockB.blockType
+		const blocksWithTheSameType = blockA.blockName === blockB.blockName
 			? [ blockB ]
-			: switchToBlockType( blockB, blockA.blockType );
+			: switchToBlockType( blockB, blockA.blockName );
 
 		// If the block types can not match, do nothing
 		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -150,7 +150,7 @@ class InserterMenu extends wp.element.Component {
 		const sortedByCategory = flow(
 			this.getVisibleBlocks,
 			this.sortBlocksByCategory,
-		)( wp.blocks.getRegisteredBlocks() );
+		)( wp.blocks.getBlockTypes() );
 
 		// If the block list is empty return early.
 		if ( ! sortedByCategory.length ) {
@@ -165,7 +165,7 @@ class InserterMenu extends wp.element.Component {
 		const sortedByCategory = flow(
 			this.getVisibleBlocks,
 			this.sortBlocksByCategory,
-		)( wp.blocks.getRegisteredBlocks() );
+		)( wp.blocks.getBlockTypes() );
 
 		// If the block list is empty return early.
 		if ( ! sortedByCategory.length ) {
@@ -238,7 +238,7 @@ class InserterMenu extends wp.element.Component {
 
 	render() {
 		const { position = 'top' } = this.props;
-		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getRegisteredBlocks() );
+		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getBlockTypes() );
 		const positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
 		const className = classnames( 'editor-inserter__menu', positionClasses );
 

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -150,7 +150,7 @@ class InserterMenu extends wp.element.Component {
 		const sortedByCategory = flow(
 			this.getVisibleBlocks,
 			this.sortBlocksByCategory,
-		)( wp.blocks.getBlocks() );
+		)( wp.blocks.getRegisteredBlocks() );
 
 		// If the block list is empty return early.
 		if ( ! sortedByCategory.length ) {
@@ -165,7 +165,7 @@ class InserterMenu extends wp.element.Component {
 		const sortedByCategory = flow(
 			this.getVisibleBlocks,
 			this.sortBlocksByCategory,
-		)( wp.blocks.getBlocks() );
+		)( wp.blocks.getRegisteredBlocks() );
 
 		// If the block list is empty return early.
 		if ( ! sortedByCategory.length ) {
@@ -238,7 +238,7 @@ class InserterMenu extends wp.element.Component {
 
 	render() {
 		const { position = 'top' } = this.props;
-		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getBlocks() );
+		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getRegisteredBlocks() );
 		const positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
 		const className = classnames( 'editor-inserter__menu', positionClasses );
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -182,11 +182,11 @@ class VisualEditorBlock extends wp.element.Component {
 
 	render() {
 		const { block, selectedBlocks } = this.props;
-		const settings = wp.blocks.getBlockSettings( block.blockType );
+		const blockType = wp.blocks.getBlockType( block.blockType );
 
 		let BlockEdit;
-		if ( settings ) {
-			BlockEdit = settings.edit || settings.save;
+		if ( blockType ) {
+			BlockEdit = blockType.edit || blockType.save;
 		}
 
 		if ( ! BlockEdit ) {
@@ -205,8 +205,8 @@ class VisualEditorBlock extends wp.element.Component {
 
 		// Determine whether the block has props to apply to the wrapper
 		let wrapperProps;
-		if ( settings.getEditWrapperProps ) {
-			wrapperProps = settings.getEditWrapperProps( block.attributes );
+		if ( blockType.getEditWrapperProps ) {
+			wrapperProps = blockType.getEditWrapperProps( block.attributes );
 		}
 
 		// Disable reason: Each block can be selected by clicking on it
@@ -244,9 +244,9 @@ class VisualEditorBlock extends wp.element.Component {
 					>
 						<div className="editor-visual-editor__block-controls">
 							<BlockSwitcher uid={ block.uid } />
-							{ !! settings.controls && (
+							{ !! blockType.controls && (
 								<Toolbar
-									controls={ settings.controls.map( ( control ) => ( {
+									controls={ blockType.controls.map( ( control ) => ( {
 										...control,
 										onClick: () => control.onClick( block.attributes, this.setAttributes ),
 										isActive: control.isActive ? control.isActive( block.attributes ) : false,

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -182,7 +182,7 @@ class VisualEditorBlock extends wp.element.Component {
 
 	render() {
 		const { block, selectedBlocks } = this.props;
-		const blockType = wp.blocks.getBlockType( block.blockType );
+		const blockType = wp.blocks.getBlockType( block.blockName );
 
 		let BlockEdit;
 		if ( blockType ) {
@@ -228,7 +228,7 @@ class VisualEditorBlock extends wp.element.Component {
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
 				className={ className }
-				data-type={ block.blockType }
+				data-type={ block.blockName }
 				tabIndex="0"
 				{ ...wrapperProps }
 			>

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -182,7 +182,7 @@ class VisualEditorBlock extends wp.element.Component {
 
 	render() {
 		const { block, selectedBlocks } = this.props;
-		const blockType = wp.blocks.getBlockType( block.blockName );
+		const blockType = wp.blocks.getBlockType( block.name );
 
 		let BlockEdit;
 		if ( blockType ) {
@@ -228,7 +228,7 @@ class VisualEditorBlock extends wp.element.Component {
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
 				className={ className }
-				data-type={ block.blockName }
+				data-type={ block.name }
 				tabIndex="0"
 				{ ...wrapperProps }
 			>

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -35,7 +35,7 @@ const BlockInspector = ( { selectedBlock, ...props } ) => {
 		<Panel>
 			<PanelHeader label={ header } />
 			<PanelBody>
-				<div>{ selectedBlock.blockName } settings...</div>
+				<div>{ selectedBlock.name } settings...</div>
 				<ul>
 					{ Object.keys( selectedBlock.attributes ).map( ( attribute, index ) => (
 						<li key={ index }>{ attribute }: { selectedBlock.attributes[ attribute ] }</li>

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -35,7 +35,7 @@ const BlockInspector = ( { selectedBlock, ...props } ) => {
 		<Panel>
 			<PanelHeader label={ header } />
 			<PanelBody>
-				<div>{ selectedBlock.blockType } settings...</div>
+				<div>{ selectedBlock.blockName } settings...</div>
 				<ul>
 					{ Object.keys( selectedBlock.attributes ).map( ( attribute, index ) => (
 						<li key={ index }>{ attribute }: { selectedBlock.attributes[ attribute ] }</li>

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 /**
  * WordPress dependencies
  */
-import { getBlocks, unregisterBlock, registerBlock, createBlock } from 'blocks';
+import { getBlockTypes, unregisterBlock, registerBlock, createBlock } from 'blocks';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ describe( 'effects', () => {
 		const handler = effects.MERGE_BLOCKS;
 
 		afterEach( () => {
-			getBlocks().forEach( ( block ) => {
+			getBlockTypes().forEach( ( block ) => {
 				unregisterBlock( block.slug );
 			} );
 		} );
@@ -29,11 +29,11 @@ describe( 'effects', () => {
 			registerBlock( 'core/test-block', {} );
 			const blockA = {
 				uid: 'chicken',
-				blockType: 'core/test-block',
+				blockName: 'core/test-block',
 			};
 			const blockB = {
 				uid: 'ribs',
-				blockType: 'core/test-block',
+				blockName: 'core/test-block',
 			};
 			const dispatch = sinon.spy();
 			handler( mergeBlocks( blockA, blockB ), { dispatch } );
@@ -52,12 +52,12 @@ describe( 'effects', () => {
 			} );
 			const blockA = {
 				uid: 'chicken',
-				blockType: 'core/test-block',
+				blockName: 'core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				blockType: 'core/test-block',
+				blockName: 'core/test-block',
 				attributes: { content: 'ribs' },
 			};
 			const dispatch = sinon.spy();
@@ -67,7 +67,7 @@ describe( 'effects', () => {
 			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
 			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
 				uid: 'chicken',
-				blockType: 'core/test-block',
+				blockName: 'core/test-block',
 				attributes: { content: 'chicken ribs' },
 			} ] ) );
 		} );
@@ -83,12 +83,12 @@ describe( 'effects', () => {
 			registerBlock( 'core/test-block-2', {} );
 			const blockA = {
 				uid: 'chicken',
-				blockType: 'core/test-block',
+				blockName: 'core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				blockType: 'core/test-block2',
+				blockName: 'core/test-block2',
 				attributes: { content: 'ribs' },
 			};
 			const dispatch = sinon.spy();
@@ -120,12 +120,12 @@ describe( 'effects', () => {
 			} );
 			const blockA = {
 				uid: 'chicken',
-				blockType: 'core/test-block',
+				blockName: 'core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				blockType: 'core/test-block-2',
+				blockName: 'core/test-block-2',
 				attributes: { content2: 'ribs' },
 			};
 			const dispatch = sinon.spy();
@@ -135,7 +135,7 @@ describe( 'effects', () => {
 			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
 			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
 				uid: 'chicken',
-				blockType: 'core/test-block',
+				blockName: 'core/test-block',
 				attributes: { content: 'chicken ribs' },
 			} ] ) );
 		} );

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 /**
  * WordPress dependencies
  */
-import { getBlockTypes, unregisterBlock, registerBlock, createBlock } from 'blocks';
+import { getBlockTypes, unregisterBlockType, registerBlockType, createBlock } from 'blocks';
 
 /**
  * Internal dependencies
@@ -21,12 +21,12 @@ describe( 'effects', () => {
 
 		afterEach( () => {
 			getBlockTypes().forEach( ( block ) => {
-				unregisterBlock( block.slug );
+				unregisterBlockType( block.slug );
 			} );
 		} );
 
 		it( 'should only focus the blockA if the blockA has no merge function', () => {
-			registerBlock( 'core/test-block', {} );
+			registerBlockType( 'core/test-block', {} );
 			const blockA = {
 				uid: 'chicken',
 				blockName: 'core/test-block',
@@ -43,7 +43,7 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should merge the blocks if blocks of the same type', () => {
-			registerBlock( 'core/test-block', {
+			registerBlockType( 'core/test-block', {
 				merge( attributes, attributesToMerge ) {
 					return {
 						content: attributes.content + ' ' + attributesToMerge.content,
@@ -73,14 +73,14 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should not merge the blocks have different types without transformation', () => {
-			registerBlock( 'core/test-block', {
+			registerBlockType( 'core/test-block', {
 				merge( attributes, attributesToMerge ) {
 					return {
 						content: attributes.content + ' ' + attributesToMerge.content,
 					};
 				},
 			} );
-			registerBlock( 'core/test-block-2', {} );
+			registerBlockType( 'core/test-block-2', {} );
 			const blockA = {
 				uid: 'chicken',
 				blockName: 'core/test-block',
@@ -98,14 +98,14 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should transform and merge the blocks', () => {
-			registerBlock( 'core/test-block', {
+			registerBlockType( 'core/test-block', {
 				merge( attributes, attributesToMerge ) {
 					return {
 						content: attributes.content + ' ' + attributesToMerge.content,
 					};
 				},
 			} );
-			registerBlock( 'core/test-block-2', {
+			registerBlockType( 'core/test-block-2', {
 				transforms: {
 					to: [ {
 						type: 'blocks',

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -29,11 +29,11 @@ describe( 'effects', () => {
 			registerBlockType( 'core/test-block', {} );
 			const blockA = {
 				uid: 'chicken',
-				blockName: 'core/test-block',
+				name: 'core/test-block',
 			};
 			const blockB = {
 				uid: 'ribs',
-				blockName: 'core/test-block',
+				name: 'core/test-block',
 			};
 			const dispatch = sinon.spy();
 			handler( mergeBlocks( blockA, blockB ), { dispatch } );
@@ -52,12 +52,12 @@ describe( 'effects', () => {
 			} );
 			const blockA = {
 				uid: 'chicken',
-				blockName: 'core/test-block',
+				name: 'core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				blockName: 'core/test-block',
+				name: 'core/test-block',
 				attributes: { content: 'ribs' },
 			};
 			const dispatch = sinon.spy();
@@ -67,7 +67,7 @@ describe( 'effects', () => {
 			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
 			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
 				uid: 'chicken',
-				blockName: 'core/test-block',
+				name: 'core/test-block',
 				attributes: { content: 'chicken ribs' },
 			} ] ) );
 		} );
@@ -83,12 +83,12 @@ describe( 'effects', () => {
 			registerBlockType( 'core/test-block-2', {} );
 			const blockA = {
 				uid: 'chicken',
-				blockName: 'core/test-block',
+				name: 'core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				blockName: 'core/test-block2',
+				name: 'core/test-block2',
 				attributes: { content: 'ribs' },
 			};
 			const dispatch = sinon.spy();
@@ -120,12 +120,12 @@ describe( 'effects', () => {
 			} );
 			const blockA = {
 				uid: 'chicken',
-				blockName: 'core/test-block',
+				name: 'core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				blockName: 'core/test-block-2',
+				name: 'core/test-block-2',
 				attributes: { content2: 'ribs' },
 			};
 			const dispatch = sinon.spy();
@@ -135,7 +135,7 @@ describe( 'effects', () => {
 			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
 			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
 				uid: 'chicken',
-				blockName: 'core/test-block',
+				name: 'core/test-block',
 				attributes: { content: 'chicken ribs' },
 			} ] ) );
 		} );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -360,12 +360,12 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						123: { uid: 123, blockType: 'core/text' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 				},
 			};
 
-			expect( getBlock( state, 123 ) ).to.eql( { uid: 123, blockType: 'core/text' } );
+			expect( getBlock( state, 123 ) ).to.eql( { uid: 123, blockName: 'core/text' } );
 		} );
 	} );
 
@@ -374,16 +374,16 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' },
+						23: { uid: 23, blockName: 'core/heading' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},
 			};
 
 			expect( getBlocks( state ) ).to.eql( [
-				{ uid: 123, blockType: 'core/text' },
-				{ uid: 23, blockType: 'core/heading' },
+				{ uid: 123, blockName: 'core/text' },
+				{ uid: 23, blockName: 'core/heading' },
 			] );
 		} );
 	} );
@@ -393,8 +393,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' },
+						23: { uid: 23, blockName: 'core/heading' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 				},
 				selectedBlock: { uid: null },
@@ -408,8 +408,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' },
+						23: { uid: 23, blockName: 'core/heading' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 				},
 				selectedBlock: { uid: 23 },
@@ -423,8 +423,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' },
+						23: { uid: 23, blockName: 'core/heading' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 				},
 				selectedBlock: { uid: 23 },
@@ -532,15 +532,15 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' },
+						23: { uid: 23, blockName: 'core/heading' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},
 			};
 
 			expect( getPreviousBlock( state, 23 ) ).to.eql(
-				{ uid: 123, blockType: 'core/text' },
+				{ uid: 123, blockName: 'core/text' },
 			);
 		} );
 
@@ -548,8 +548,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' },
+						23: { uid: 23, blockName: 'core/heading' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},
@@ -564,15 +564,15 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' },
+						23: { uid: 23, blockName: 'core/heading' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},
 			};
 
 			expect( getNextBlock( state, 123 ) ).to.eql(
-				{ uid: 23, blockType: 'core/heading' },
+				{ uid: 23, blockName: 'core/heading' },
 			);
 		} );
 
@@ -580,8 +580,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockType: 'core/heading' },
-						123: { uid: 123, blockType: 'core/text' },
+						23: { uid: 23, blockName: 'core/heading' },
+						123: { uid: 123, blockName: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -360,12 +360,12 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						123: { uid: 123, blockName: 'core/text' },
+						123: { uid: 123, name: 'core/text' },
 					},
 				},
 			};
 
-			expect( getBlock( state, 123 ) ).to.eql( { uid: 123, blockName: 'core/text' } );
+			expect( getBlock( state, 123 ) ).to.eql( { uid: 123, name: 'core/text' } );
 		} );
 	} );
 
@@ -374,16 +374,16 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockName: 'core/heading' },
-						123: { uid: 123, blockName: 'core/text' },
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},
 			};
 
 			expect( getBlocks( state ) ).to.eql( [
-				{ uid: 123, blockName: 'core/text' },
-				{ uid: 23, blockName: 'core/heading' },
+				{ uid: 123, name: 'core/text' },
+				{ uid: 23, name: 'core/heading' },
 			] );
 		} );
 	} );
@@ -393,8 +393,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockName: 'core/heading' },
-						123: { uid: 123, blockName: 'core/text' },
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
 					},
 				},
 				selectedBlock: { uid: null },
@@ -408,8 +408,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockName: 'core/heading' },
-						123: { uid: 123, blockName: 'core/text' },
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
 					},
 				},
 				selectedBlock: { uid: 23 },
@@ -423,8 +423,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockName: 'core/heading' },
-						123: { uid: 123, blockName: 'core/text' },
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
 					},
 				},
 				selectedBlock: { uid: 23 },
@@ -532,15 +532,15 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockName: 'core/heading' },
-						123: { uid: 123, blockName: 'core/text' },
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},
 			};
 
 			expect( getPreviousBlock( state, 23 ) ).to.eql(
-				{ uid: 123, blockName: 'core/text' },
+				{ uid: 123, name: 'core/text' },
 			);
 		} );
 
@@ -548,8 +548,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockName: 'core/heading' },
-						123: { uid: 123, blockName: 'core/text' },
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},
@@ -564,15 +564,15 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockName: 'core/heading' },
-						123: { uid: 123, blockName: 'core/text' },
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},
 			};
 
 			expect( getNextBlock( state, 123 ) ).to.eql(
-				{ uid: 23, blockName: 'core/heading' },
+				{ uid: 23, name: 'core/heading' },
 			);
 		} );
 
@@ -580,8 +580,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					blocksByUid: {
-						23: { uid: 23, blockName: 'core/heading' },
-						123: { uid: 123, blockName: 'core/text' },
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
 					},
 					blockOrder: [ 123, 23 ],
 				},

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -24,11 +24,11 @@ import {
 describe( 'state', () => {
 	describe( 'editor()', () => {
 		before( () => {
-			wp.blocks.registerBlock( 'core/test-block', {} );
+			wp.blocks.registerBlockType( 'core/test-block', {} );
 		} );
 
 		after( () => {
-			wp.blocks.unregisterBlock( 'core/test-block' );
+			wp.blocks.unregisterBlockType( 'core/test-block' );
 		} );
 
 		it( 'should return empty blocksByUid, blockOrder, history by default', () => {

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -77,7 +77,7 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -85,7 +85,7 @@ describe( 'state', () => {
 				type: 'INSERT_BLOCK',
 				block: {
 					uid: 'ribs',
-					blockType: 'core/freeform',
+					blockName: 'core/freeform',
 				},
 			} );
 
@@ -99,7 +99,7 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -108,12 +108,12 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform',
+					blockName: 'core/freeform',
 				} ],
 			} );
 
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 1 );
-			expect( values( state.blocksByUid )[ 0 ].blockType ).to.equal( 'core/freeform' );
+			expect( values( state.blocksByUid )[ 0 ].blockName ).to.equal( 'core/freeform' );
 			expect( values( state.blocksByUid )[ 0 ].uid ).to.equal( 'wings' );
 			expect( state.blockOrder ).to.eql( [ 'wings' ] );
 		} );
@@ -123,11 +123,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -144,15 +144,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -169,11 +169,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -190,11 +190,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -211,15 +211,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -236,11 +236,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -257,11 +257,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -274,7 +274,7 @@ describe( 'state', () => {
 			expect( state.blocksByUid ).to.eql( {
 				ribs: {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				},
 			} );
@@ -285,15 +285,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -306,7 +306,7 @@ describe( 'state', () => {
 			expect( state.blocksByUid ).to.eql( {
 				ribs: {
 					uid: 'ribs',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				},
 			} );
@@ -317,11 +317,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'kumquat',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'loquat',
-					blockType: 'core/test-block',
+					blockName: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -331,7 +331,7 @@ describe( 'state', () => {
 				after: 'kumquat',
 				block: {
 					uid: 'persimmon',
-					blockType: 'core/freeform',
+					blockName: 'core/freeform',
 				},
 			} );
 
@@ -539,7 +539,7 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform',
+					blockName: 'core/freeform',
 				} ],
 			} );
 
@@ -552,7 +552,7 @@ describe( 'state', () => {
 				uids: [ 'ribs' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform',
+					blockName: 'core/freeform',
 				} ],
 			} );
 
@@ -657,7 +657,7 @@ describe( 'state', () => {
 				type: 'INSERT_BLOCK',
 				block: {
 					uid: 'ribs',
-					blockType: 'core/freeform',
+					blockName: 'core/freeform',
 				},
 			} );
 
@@ -739,7 +739,7 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform',
+					blockName: 'core/freeform',
 				} ],
 			} );
 
@@ -753,7 +753,7 @@ describe( 'state', () => {
 				uids: [ 'ribs' ],
 				blocks: [ {
 					uid: 'wings',
-					blockType: 'core/freeform',
+					blockName: 'core/freeform',
 				} ],
 			} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -77,7 +77,7 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -85,7 +85,7 @@ describe( 'state', () => {
 				type: 'INSERT_BLOCK',
 				block: {
 					uid: 'ribs',
-					blockName: 'core/freeform',
+					name: 'core/freeform',
 				},
 			} );
 
@@ -99,7 +99,7 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -108,12 +108,12 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockName: 'core/freeform',
+					name: 'core/freeform',
 				} ],
 			} );
 
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 1 );
-			expect( values( state.blocksByUid )[ 0 ].blockName ).to.equal( 'core/freeform' );
+			expect( values( state.blocksByUid )[ 0 ].name ).to.equal( 'core/freeform' );
 			expect( values( state.blocksByUid )[ 0 ].uid ).to.equal( 'wings' );
 			expect( state.blockOrder ).to.eql( [ 'wings' ] );
 		} );
@@ -123,11 +123,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -144,15 +144,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -169,11 +169,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -190,11 +190,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -211,15 +211,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -236,11 +236,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -257,11 +257,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -274,7 +274,7 @@ describe( 'state', () => {
 			expect( state.blocksByUid ).to.eql( {
 				ribs: {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				},
 			} );
@@ -285,15 +285,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -306,7 +306,7 @@ describe( 'state', () => {
 			expect( state.blocksByUid ).to.eql( {
 				ribs: {
 					uid: 'ribs',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				},
 			} );
@@ -317,11 +317,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'kumquat',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				}, {
 					uid: 'loquat',
-					blockName: 'core/test-block',
+					name: 'core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -331,7 +331,7 @@ describe( 'state', () => {
 				after: 'kumquat',
 				block: {
 					uid: 'persimmon',
-					blockName: 'core/freeform',
+					name: 'core/freeform',
 				},
 			} );
 
@@ -539,7 +539,7 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockName: 'core/freeform',
+					name: 'core/freeform',
 				} ],
 			} );
 
@@ -552,7 +552,7 @@ describe( 'state', () => {
 				uids: [ 'ribs' ],
 				blocks: [ {
 					uid: 'wings',
-					blockName: 'core/freeform',
+					name: 'core/freeform',
 				} ],
 			} );
 
@@ -657,7 +657,7 @@ describe( 'state', () => {
 				type: 'INSERT_BLOCK',
 				block: {
 					uid: 'ribs',
-					blockName: 'core/freeform',
+					name: 'core/freeform',
 				},
 			} );
 
@@ -739,7 +739,7 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 				blocks: [ {
 					uid: 'wings',
-					blockName: 'core/freeform',
+					name: 'core/freeform',
 				} ],
 			} );
 
@@ -753,7 +753,7 @@ describe( 'state', () => {
 				uids: [ 'ribs' ],
 				blocks: [ {
 					uid: 'wings',
-					blockName: 'core/freeform',
+					name: 'core/freeform',
 				} ],
 			} );
 

--- a/index.php
+++ b/index.php
@@ -38,7 +38,7 @@ $wp_registered_blocks = array();
 
  * @return array            The block, if it has been successfully registered.
  */
-function register_block( $slug, $settings ) {
+function register_block_type( $slug, $settings ) {
 	global $wp_registered_blocks;
 
 	if ( ! is_string( $slug ) ) {
@@ -74,7 +74,7 @@ function register_block( $slug, $settings ) {
  * @return array        The previous block value, if it has been
  *                        successfully unregistered; otherwise `null`.
  */
-function unregister_block( $slug ) {
+function unregister_block_type( $slug ) {
 	global $wp_registered_blocks;
 	if ( ! isset( $wp_registered_blocks[ $slug ] ) ) {
 		/* translators: 1: block slug */

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -31,7 +31,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 				'render_dummy_block',
 			),
 		);
-		register_block( 'core/dummy', $settings );
+		register_block_type( 'core/dummy', $settings );
 		$post_content =
 			'before' .
 			'<!-- wp:core/dummy value="b1" --><!-- /wp:core/dummy -->' .
@@ -56,7 +56,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 				'render_dummy_block',
 			),
 		);
-		register_block( 'core/dummy', $settings );
+		register_block_type( 'core/dummy', $settings );
 		$post_content =
 			'before' .
 			'<!-- wp:core/dummy value="b1" -->this should be ignored<!-- /wp:core/dummy -->' .

--- a/phpunit/class-registration-test.php
+++ b/phpunit/class-registration-test.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Test register_block
+ * Test register_block_type
  */
 class Registration_Test extends WP_UnitTestCase {
 	function tearDown() {
@@ -16,42 +16,42 @@ class Registration_Test extends WP_UnitTestCase {
 	/**
 	 * Should reject numbers
 	 *
-	 * @expectedIncorrectUsage register_block
+	 * @expectedIncorrectUsage register_block_type
 	 */
 	function test_invalid_non_string_slugs() {
-		$result = register_block( 1, array() );
+		$result = register_block_type( 1, array() );
 		$this->assertFalse( $result );
 	}
 
 	/**
 	 * Should reject blocks without a namespace
 	 *
-	 * @expectedIncorrectUsage register_block
+	 * @expectedIncorrectUsage register_block_type
 	 */
 	function test_invalid_slugs_without_namespace() {
-		$result = register_block( 'text', array() );
+		$result = register_block_type( 'text', array() );
 		$this->assertFalse( $result );
 	}
 
 	/**
 	 * Should reject blocks with invalid characters
 	 *
-	 * @expectedIncorrectUsage register_block
+	 * @expectedIncorrectUsage register_block_type
 	 */
 	function test_invlalid_characters() {
-		$result = register_block( 'still/_doing_it_wrong', array() );
+		$result = register_block_type( 'still/_doing_it_wrong', array() );
 		$this->assertFalse( $result );
 	}
 
 	/**
 	 * Should accept valid block names
 	 */
-	function test_register_block() {
+	function test_register_block_type() {
 		global $wp_registered_blocks;
 		$settings = array(
 			'icon' => 'text',
 		);
-		$updated_settings = register_block( 'core/text', $settings );
+		$updated_settings = register_block_type( 'core/text', $settings );
 		$this->assertEquals( $updated_settings, array(
 			'icon' => 'text',
 			'slug' => 'core/text',
@@ -62,38 +62,38 @@ class Registration_Test extends WP_UnitTestCase {
 	/**
 	 * Should fail to re-register the same block
 	 *
-	 * @expectedIncorrectUsage register_block
+	 * @expectedIncorrectUsage register_block_type
 	 */
-	function test_register_block_twice() {
+	function test_register_block_type_twice() {
 		$settings = array(
 			'icon' => 'text',
 		);
-		$result = register_block( 'core/text', $settings );
+		$result = register_block_type( 'core/text', $settings );
 		$this->assertNotFalse( $result );
-		$result = register_block( 'core/text', $settings );
+		$result = register_block_type( 'core/text', $settings );
 		$this->assertFalse( $result );
 	}
 
 	/**
 	 * Unregistering should fail if a block is not registered
 	 *
-	 * @expectedIncorrectUsage unregister_block
+	 * @expectedIncorrectUsage unregister_block_type
 	 */
 	function test_unregister_not_registered_block() {
-		$result = unregister_block( 'core/unregistered' );
+		$result = unregister_block_type( 'core/unregistered' );
 		$this->assertFalse( $result );
 	}
 
 	/**
 	 * Should unregister existing blocks
 	 */
-	function test_unregister_block() {
+	function test_unregister_block_type() {
 		global $wp_registered_blocks;
 		$settings = array(
 			'icon' => 'text',
 		);
-		register_block( 'core/text', $settings );
-		$unregistered_block = unregister_block( 'core/text' );
+		register_block_type( 'core/text', $settings );
+		$unregistered_block = unregister_block_type( 'core/text' );
 		$this->assertEquals( $unregistered_block, array(
 			'icon' => 'text',
 			'slug' => 'core/text',


### PR DESCRIPTION
There is some confusion around block instances as consumed in the editor and the registration API. We have two functions for `getBlocks` that return different things.

At the same time, we are keeping the block definition behind a getter like `getBlockSettings` where it is not immediately clear what the return value would be. (i.e. we return the `save` and `edit` render methods there.)

These are mainly relevant internally, but still important to be as clear as possible.

----

I propose we do one of the following:
- `/registration.js`: `getRegisteredBlock( name )` replaces `getBlockSettings( slug )`.
- `/registration.js`: rename `getBlocks` to `getRegisteredBlocks`. 

Or...

- `/registration.js`: `getBlockType( name )` replaces `getBlockSettings( slug )`.
- `/registration.js`: rename `getBlocks` to `getBlockTypes`. 

When retrieving settings and using them:
```js
const blockType = getRegisteredBlock( name ) || getBlockType( name );
const EditBlock = blockType.edit;
```