### PR TITLE
Chrome: Rearrange the preview button in the header

### DIFF
--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -6,6 +6,16 @@
 	background: none;
 	color: $dark-gray-500;
 	position: relative;
+	width: 36px;	// show only icon on small breakpoints
+	overflow: hidden;
+
+	.dashicon {
+		flex: 0 0 auto;
+	}
+
+	@include break-medium() {
+		width: auto;
+	}
 
 	&:not( :disabled ) {
 		cursor: pointer;

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -6,9 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import Dashicon from 'components/dashicon';
+import { __ } from 'i18n';
 import IconButton from 'components/icon-button';
-import Button from 'components/button';
 
 /**
  * Internal dependencies
@@ -34,13 +33,14 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 				label={ wp.i18n.__( 'Redo' ) }
 				disabled={ ! hasRedo }
 				onClick={ redo } />
-			<Inserter position="bottom" />
+			<Inserter position="bottom">
+				{ __( 'Insert' ) }
+			</Inserter>
+			<PreviewButton />
 			<div className="editor-tools__tabs">
-				<PreviewButton />
-				<Button onClick={ toggleSidebar } isToggled={ isSidebarOpened }>
-					<Dashicon icon="admin-generic" />
+				<IconButton icon="admin-generic" onClick={ toggleSidebar } isToggled={ isSidebarOpened }>
 					{ wp.i18n.__( 'Post Settings' ) }
-				</Button>
+				</IconButton>
 			</div>
 			<PublishButton />
 		</div>

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -6,8 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import Dashicon from 'components/dashicon';
-import Button from 'components/button';
+import IconButton from 'components/icon-button';
 
 /**
  * Internal dependencies
@@ -16,10 +15,14 @@ import { getEditedPostPreviewLink } from '../../selectors';
 
 function PreviewButton( { link } ) {
 	return (
-		<Button href={ link } target="_blank">
-			<Dashicon icon="visibility" />
+		<IconButton
+			href={ !! link ? link : undefined }
+			target="_blank"
+			icon="visibility"
+			disabled={ ! link }
+		>
 			{ wp.i18n._x( 'Preview', 'imperative verb' ) }
-		</Button>
+		</IconButton>
 	);
 }
 

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -13,6 +13,14 @@
 	}
 }
 
+.editor-tools .components-icon-button .dashicon {
+	margin-right: 10px;
+
+	@include break-medium() {
+		margin-right: 4px;
+	}
+}
+
 .editor-tools__tabs {
 	margin: 0 $item-spacing;
 	padding: 0;
@@ -52,12 +60,7 @@
 	}
 
 	.components-button .dashicon {
-		margin-right: 10px;
 		flex-shrink: 0;
-
-		@include break-medium() {
-			margin-right: 4px;
-		}
 	}
 
 	.components-button {

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -75,7 +75,7 @@ class Inserter extends wp.element.Component {
 					onClick={ this.toggle }
 					className="editor-inserter__toggle"
 					aria-haspopup="true"
-					aria-expanded={ opened ? 'true' : 'false' }
+					aria-expanded={ opened }
 				>
 					{ children }
 				</IconButton>

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -65,7 +65,7 @@ class Inserter extends wp.element.Component {
 
 	render() {
 		const { opened } = this.state;
-		const { position } = this.props;
+		const { position, children } = this.props;
 
 		return (
 			<div className="editor-inserter">
@@ -75,7 +75,10 @@ class Inserter extends wp.element.Component {
 					onClick={ this.toggle }
 					className="editor-inserter__toggle"
 					aria-haspopup="true"
-					aria-expanded={ opened ? 'true' : 'false' } />
+					aria-expanded={ opened ? 'true' : 'false' }
+				>
+					{ children }
+				</IconButton>
 				{ opened && (
 					<InserterMenu
 						position={ position }

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -12,7 +12,6 @@
 
 .editor-inserter__toggle {
 	display: inline-flex;
-	justify-content: center;
 	align-items: center;
 	color: $dark-gray-500;
 	background: none;


### PR DESCRIPTION
closes #818 

This PR tries to match the design in https://github.com/WordPress/gutenberg/issues/818#issuecomment-302145088

I also disabled the "preview" button when the post is not saved yet.