### PR TITLE
Fix a few issues with saving post titles, dirty handling, etc.

### DIFF
--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -18,11 +18,14 @@ import { isEditedPostNew, isEditedPostDirty } from '../../selectors';
 function SavedState( { isNew, isDirty } ) {
 	const classes = classNames( 'editor-saved-state', {
 		'is-new': isNew,
-		'is-existing-dirty': isDirty && ! isNew,
+		'is-dirty': isDirty,
 	} );
 
 	let icon, text;
-	if ( isNew ) {
+	if ( isNew && isDirty ) {
+		icon = 'warning';
+		text = wp.i18n.__( 'New post with changes' );
+	} else if ( isNew ) {
 		icon = 'edit';
 		text = wp.i18n.__( 'New post' );
 	} else if ( isDirty ) {

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -13,18 +13,25 @@ import Dashicon from 'components/dashicon';
  * Internal dependencies
  */
 import './style.scss';
-import { isEditedPostDirty } from '../../selectors';
+import { isEditedPostNew, isEditedPostDirty } from '../../selectors';
 
-function SavedState( { isDirty } ) {
+function SavedState( { isNew, isDirty } ) {
 	const classes = classNames( 'editor-saved-state', {
-		'is-dirty': isDirty,
+		'is-new': isNew,
+		'is-existing-dirty': isDirty && ! isNew,
 	} );
-	const icon = isDirty
-		? 'warning'
-		: 'saved';
-	const text = isDirty
-		? wp.i18n.__( 'Unsaved changes' )
-		: wp.i18n.__( 'Saved' );
+
+	let icon, text;
+	if ( isNew ) {
+		icon = 'edit';
+		text = wp.i18n.__( 'New post' );
+	} else if ( isDirty ) {
+		icon = 'warning';
+		text = wp.i18n.__( 'Unsaved changes' );
+	} else {
+		icon = 'saved';
+		text = wp.i18n.__( 'Saved' );
+	}
 
 	return (
 		<div className={ classes }>
@@ -36,6 +43,7 @@ function SavedState( { isDirty } ) {
 
 export default connect(
 	( state ) => ( {
+		isNew: isEditedPostNew( state ),
 		isDirty: isEditedPostDirty( state ),
 	} )
 )( SavedState );

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -32,12 +32,11 @@ function PublishButton( {
 	isRequesting,
 	isError,
 	requestIsNewPost,
-	onUpdate,
-	onSaveDraft,
+	onSave,
 } ) {
 	const buttonEnabled = ! isRequesting;
-	let buttonText, saveCallback;
 
+	let buttonText;
 	if ( isRequesting ) {
 		buttonText = requestIsNewPost
 			? wp.i18n.__( 'Saving…' )
@@ -56,12 +55,6 @@ function PublishButton( {
 		buttonText = wp.i18n.__( 'Save draft' );
 	}
 
-	if ( post && post.id ) {
-		saveCallback = onUpdate;
-	} else {
-		saveCallback = onSaveDraft;
-	}
-
 	const buttonDisabledHint = process.env.NODE_ENV === 'production'
 		? wp.i18n.__( 'The Save button is disabled during early alpha releases.' )
 		: null;
@@ -70,7 +63,7 @@ function PublishButton( {
 		<Button
 			isPrimary
 			isLarge
-			onClick={ () => saveCallback( post, edits, blocks ) }
+			onClick={ () => onSave( post, edits, blocks ) }
 			disabled={ ! buttonEnabled || process.env.NODE_ENV === 'production' }
 			title={ buttonDisabledHint }
 		>
@@ -91,17 +84,9 @@ export default connect(
 		requestIsNewPost: isSavingNewPost( state ),
 	} ),
 	( dispatch ) => ( {
-		onUpdate( post, edits, blocks ) {
+		onSave( post, edits, blocks ) {
 			savePost( dispatch, post.id, {
 				content: wp.blocks.serialize( blocks ),
-				...edits,
-			} );
-		},
-
-		onSaveDraft( post, edits, blocks ) {
-			savePost( dispatch, null /* is a new post */, {
-				content: wp.blocks.serialize( blocks ),
-				status: 'draft', // TODO change this after status controls
 				...edits,
 			} );
 		},

--- a/editor/index.js
+++ b/editor/index.js
@@ -3,6 +3,7 @@
  */
 import { Provider as ReduxProvider } from 'react-redux';
 import { Provider as SlotFillProvider } from 'react-slot-fill';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,14 +26,15 @@ export function createEditorInstance( id, post ) {
 		blocks: wp.blocks.parse( post.content.raw ),
 	} );
 
-	// Each property that is set in `post-content.js` (other than `content`)
-	// needs to be registered as an edit now.  Otherwise it will not be saved
-	// with the post.
+	// Each property that is set in `post-content.js` (other than `content`
+	// because it is serialized when a save is requested) needs to be
+	// registered as an edit now.  Otherwise the initial values of these
+	// properties will not be properly saved with the post.
 	store.dispatch( {
 		type: 'EDIT_POST',
 		edits: {
 			title: post.title.raw,
-			// ...omit( post, 'title', 'content' ),
+			...omit( post, 'title', 'content' ),
 		},
 	} );
 

--- a/editor/index.js
+++ b/editor/index.js
@@ -26,17 +26,19 @@ export function createEditorInstance( id, post ) {
 		blocks: wp.blocks.parse( post.content.raw ),
 	} );
 
-	// Each property that is set in `post-content.js` (other than `content`
-	// because it is serialized when a save is requested) needs to be
-	// registered as an edit now.  Otherwise the initial values of these
-	// properties will not be properly saved with the post.
-	store.dispatch( {
-		type: 'SETUP_POST',
-		edits: {
-			title: post.title.raw,
-			...omit( post, 'title', 'content' ),
-		},
-	} );
+	if ( ! post.id ) {
+		// Each property that is set in `post-content.js` (other than `content`
+		// because it is serialized when a save is requested) needs to be
+		// registered as an edit now.  Otherwise the initial values of these
+		// properties will not be properly saved with the post.
+		store.dispatch( {
+			type: 'SETUP_NEW_POST',
+			edits: {
+				title: post.title.raw,
+				...omit( post, 'title', 'content' ),
+			},
+		} );
+	}
 
 	wp.element.render(
 		<ReduxProvider store={ store }>

--- a/editor/index.js
+++ b/editor/index.js
@@ -25,6 +25,17 @@ export function createEditorInstance( id, post ) {
 		blocks: wp.blocks.parse( post.content.raw ),
 	} );
 
+	// Each property that is set in `post-content.js` (other than `content`)
+	// needs to be registered as an edit now.  Otherwise it will not be saved
+	// with the post.
+	store.dispatch( {
+		type: 'EDIT_POST',
+		edits: {
+			title: post.title.raw,
+			// ...omit( post, 'title', 'content' ),
+		},
+	} );
+
 	wp.element.render(
 		<ReduxProvider store={ store }>
 			<SlotFillProvider>

--- a/editor/index.js
+++ b/editor/index.js
@@ -36,6 +36,7 @@ export function createEditorInstance( id, post ) {
 			title: post.title.raw,
 			...omit( post, 'title', 'content' ),
 		},
+		shouldMarkDirty: false,
 	} );
 
 	wp.element.render(

--- a/editor/index.js
+++ b/editor/index.js
@@ -31,12 +31,11 @@ export function createEditorInstance( id, post ) {
 	// registered as an edit now.  Otherwise the initial values of these
 	// properties will not be properly saved with the post.
 	store.dispatch( {
-		type: 'EDIT_POST',
+		type: 'SETUP_POST',
 		edits: {
 			title: post.title.raw,
 			...omit( post, 'title', 'content' ),
 		},
-		shouldMarkDirty: false,
 	} );
 
 	wp.element.render(

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -24,6 +24,10 @@ export function hasEditorRedo( state ) {
 	return state.editor.history.future.length > 0;
 }
 
+export function isEditedPostNew( state ) {
+	return ! state.currentPost.id;
+}
+
 export function isEditedPostDirty( state ) {
 	return state.editor.dirty;
 }

--- a/editor/state.js
+++ b/editor/state.js
@@ -27,6 +27,7 @@ export const editor = combineUndoableReducers( {
 	edits( state = {}, action ) {
 		switch ( action.type ) {
 			case 'EDIT_POST':
+			case 'SETUP_POST':
 				return {
 					...state,
 					...action.edits,
@@ -49,9 +50,6 @@ export const editor = combineUndoableReducers( {
 			case 'REPLACE_BLOCKS':
 			case 'REMOVE_BLOCK':
 			case 'EDIT_POST':
-				if ( action.shouldMarkDirty === false ) {
-					return false;
-				}
 				return true;
 		}
 

--- a/editor/state.js
+++ b/editor/state.js
@@ -49,6 +49,9 @@ export const editor = combineUndoableReducers( {
 			case 'REPLACE_BLOCKS':
 			case 'REMOVE_BLOCK':
 			case 'EDIT_POST':
+				if ( action.shouldMarkDirty === false ) {
+					return false;
+				}
 				return true;
 		}
 

--- a/editor/state.js
+++ b/editor/state.js
@@ -27,7 +27,7 @@ export const editor = combineUndoableReducers( {
 	edits( state = {}, action ) {
 		switch ( action.type ) {
 			case 'EDIT_POST':
-			case 'SETUP_POST':
+			case 'SETUP_NEW_POST':
 				return {
 					...state,
 					...action.edits,

--- a/editor/state.js
+++ b/editor/state.js
@@ -48,6 +48,7 @@ export const editor = combineUndoableReducers( {
 			case 'MOVE_BLOCK_UP':
 			case 'REPLACE_BLOCKS':
 			case 'REMOVE_BLOCK':
+			case 'EDIT_POST':
 				return true;
 		}
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	isEditorSidebarOpened,
 	hasEditorUndo,
 	hasEditorRedo,
+	isEditedPostNew,
 	isEditedPostDirty,
 	getCurrentPost,
 	getPostEdits,
@@ -120,6 +121,26 @@ describe( 'selectors', () => {
 			};
 
 			expect( hasEditorRedo( state ) ).to.be.false();
+		} );
+	} );
+
+	describe( 'isEditedPostNew', () => {
+		it( 'should return true when the post is new', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( isEditedPostNew( state ) ).to.be.true();
+		} );
+
+		it( 'should return false when the post has an ID', () => {
+			const state = {
+				currentPost: {
+					id: 1,
+				},
+			};
+
+			expect( isEditedPostNew( state ) ).to.be.false();
 		} );
 	} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -307,7 +307,7 @@ describe( 'state', () => {
 
 			it( 'should save initial post state', () => {
 				const state = editor( undefined, {
-					type: 'SETUP_POST',
+					type: 'SETUP_NEW_POST',
 					edits: {
 						status: 'draft',
 						title: 'post title',
@@ -341,7 +341,7 @@ describe( 'state', () => {
 
 			it( 'should be false when the post is initialized', () => {
 				const state = editor( undefined, {
-					type: 'SETUP_POST',
+					type: 'SETUP_NEW_POST',
 					edits: {},
 				} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -305,6 +305,35 @@ describe( 'state', () => {
 				} );
 			} );
 		} );
+
+		describe( 'dirty()', () => {
+			it( 'should be true when the post is edited', () => {
+				const state = editor( undefined, {
+					type: 'EDIT_POST',
+					edits: {},
+				} );
+
+				expect( state.dirty ).to.be.true();
+			} );
+
+			it( 'should be false when an unrelated action occurs', () => {
+				const state = editor( undefined, {
+					type: 'BRISKET_READY',
+				} );
+
+				expect( state.dirty ).to.be.false();
+			} );
+
+			it( 'should be false with shouldMarkDirty: false', () => {
+				const state = editor( undefined, {
+					type: 'EDIT_POST',
+					edits: {},
+					shouldMarkDirty: false,
+				} );
+
+				expect( state.dirty ).to.be.false();
+			} );
+		} );
 	} );
 
 	describe( 'currentPost()', () => {

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -304,6 +304,21 @@ describe( 'state', () => {
 					tags: [ 2 ],
 				} );
 			} );
+
+			it( 'should save initial post state', () => {
+				const state = editor( undefined, {
+					type: 'SETUP_POST',
+					edits: {
+						status: 'draft',
+						title: 'post title',
+					},
+				} );
+
+				expect( state.edits ).to.eql( {
+					status: 'draft',
+					title: 'post title',
+				} );
+			} );
 		} );
 
 		describe( 'dirty()', () => {
@@ -324,11 +339,10 @@ describe( 'state', () => {
 				expect( state.dirty ).to.be.false();
 			} );
 
-			it( 'should be false with shouldMarkDirty: false', () => {
+			it( 'should be false when the post is initialized', () => {
 				const state = editor( undefined, {
-					type: 'EDIT_POST',
+					type: 'SETUP_POST',
 					edits: {},
-					shouldMarkDirty: false,
 				} );
 
 				expect( state.dirty ).to.be.false();

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -331,8 +331,44 @@ describe( 'state', () => {
 				expect( state.dirty ).to.be.true();
 			} );
 
-			it( 'should be false when an unrelated action occurs', () => {
-				const state = editor( undefined, {
+			it( 'should change to false when the post is reset', () => {
+				const original = editor( undefined, {
+					type: 'EDIT_POST',
+					edits: {},
+				} );
+
+				const state = editor( original, {
+					type: 'RESET_BLOCKS',
+					post: {},
+					blocks: [],
+				} );
+
+				expect( state.dirty ).to.be.false();
+			} );
+
+			it( 'should not change from true when an unrelated action occurs', () => {
+				const original = editor( undefined, {
+					type: 'EDIT_POST',
+					edits: {},
+				} );
+
+				const state = editor( original, {
+					type: 'BRISKET_READY',
+				} );
+
+				expect( state.dirty ).to.be.true();
+			} );
+
+			it( 'should not change from false when an unrelated action occurs', () => {
+				const original = editor( undefined, {
+					type: 'RESET_BLOCKS',
+					post: {},
+					blocks: [],
+				} );
+
+				expect( original.dirty ).to.be.false();
+
+				const state = editor( original, {
 					type: 'BRISKET_READY',
 				} );
 

--- a/post-content.js
+++ b/post-content.js
@@ -5,6 +5,7 @@ window._wpGutenbergPost = {
 	title: {
 		raw: 'Welcome to the Gutenberg Editor',
 	},
+	status: 'draft',
 	content: {
 		raw: [
 			'<!-- wp:core/text -->',

--- a/post-content.js
+++ b/post-content.js
@@ -5,6 +5,9 @@ window._wpGutenbergPost = {
 	title: {
 		raw: 'Welcome to the Gutenberg Editor',
 	},
+	// TODO `status` and any other initial attributes other than content and
+	// title need to move somewhere else when this file goes away.  See:
+	// https://github.com/WordPress/gutenberg/pull/848#issuecomment-302836177
 	status: 'draft',
 	content: {
 		raw: [


### PR DESCRIPTION
I originally started this PR to fix the following bug:

> When loading the example post content in the editor and clicking "Save", the post is saved with an empty title.

In the process it became a bit sprawly because I found some other related issues to fix.

The original bug is fixed by sending an `EDIT_POST` action when the editor is initialized with the new post content.  This currently contains `title` and `status`.  Adding `status` here also allowed me to eliminate the distinction the `PublishButton` currently makes between `onSaveDraft` and `onUpdate`, unifying these into a single `onSave` callback.

I also discovered that editing post visiblility or other properties was not registered as a change by the "dirty" logic.  Adding `EDIT_POST` to the list of "dirtying" actions (except for the initial `EDIT_POST` action) fixes this.

Finally, it seems useful to have another flag that determines the information `SavedState` displays: whether the current post is new or existing.  If the current post has not yet been saved, we should indicate this here.  This component now has 4 states (the first 2 are new):

- New post, no changes: "edit" icon with text "New post"
- New post, changes: "warning" icon with text "New post with changes"
- Existing post, no changes: "saved" icon with text "Saved"
- Existing post, changes: "warning" icon with text "Unsaved changes"

### To test

Test various combinations of loading new and existing posts, modifying them or not, then saving them.   For example:

- Load the Gutenberg editor as a new post.  Verify that the `SavedState` indicator displays an "editing" icon and the text "New post".
- Save the post.  Verify that the title is saved correctly with the post content (**fixed in this PR**).  Verify that the `SavedState` indicator displays "Saved".
- Refresh the page.  Verify that the post has the correct title and the `SavedState` indicator still displays "Saved".

Load a new post.  Make a change to the visibility under "Post settings" and verify that the `SavedState` indicator changes to "New post with changes" (**fixed in this PR**).

Load an existing post.  Verify that the `SavedState` indicator switches between "Saved" and "Unsaved changes" when edits are made, Undo/Redo is clicked, and the post is saved (as appropriate).  **Fixed in this PR** for updates like post visibility.

### Questions

It seems like we need a way to initialize the `edits` state with properties that should be sent to save a new post.  The need to initialize the title this way will go away when we remove `post-content.js`; however, there will probably be other properties we should set this way (`status` for example).  Currently this PR accomplishes the task using an `EDIT_POST` action with `shouldMarkDirty: false` - but this feels like a bit of a hack to me.  Can you think of a better way?

This PR introduces a new selector: `isEditedPostNew`.  It feels to me like maybe we should be using this in the [publish button](https://github.com/WordPress/gutenberg/blob/652d9079b696622ce461f4ebe3626e2b433c4303/editor/header/tools/publish-button.js#L88) and the [`savePost` action](https://github.com/WordPress/gutenberg/blob/652d9079b696622ce461f4ebe3626e2b433c4303/editor/actions.js#L39) as well, but it's not entirely clear to me how, because we do still need the actual post ID here to send it to the API.  How can this be improved?