### PR TITLE
Editor: add suggestedPostFormat selector.

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -152,10 +152,13 @@ export function getSuggestedPostFormat( state ) {
 	const blocks = state.editor.blockOrder;
 
 	let type;
+	// If there is only one block in the content of the post grab its
+	// `blockType` name so we can derive a suitable post format from it.
 	if ( blocks.length === 1 ) {
 		type = state.editor.blocksByUid[ blocks[ 0 ] ].blockType;
 	}
 
+	// We only convert to default post formats in core.
 	switch ( type ) {
 		case 'core/image':
 			return 'Image';

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -147,3 +147,21 @@ export function didPostSaveRequestFail( state ) {
 export function isSavingNewPost( state ) {
 	return state.saving.isNew;
 }
+
+export function getSuggestedPostFormat( state ) {
+	const blocks = state.editor.blockOrder;
+
+	let type;
+	if ( blocks.length === 1 ) {
+		type = state.editor.blocksByUid[ blocks[ 0 ] ].blockType;
+	}
+
+	switch ( type ) {
+		case 'core/image':
+			return 'Image';
+		case 'core/quote':
+			return 'Quote';
+		default:
+			return false;
+	}
+}

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -15,14 +15,16 @@ import FormToggle from 'components/form-toggle';
  */
 import './style.scss';
 import PostVisibility from '../post-visibility';
-import { getEditedPostStatus } from '../../selectors';
+import { getEditedPostStatus, getSuggestedPostFormat } from '../../selectors';
 import { editPost } from '../../actions';
 
-function PostStatus( { status, onUpdateStatus } ) {
+function PostStatus( { status, onUpdateStatus, suggestedFormat } ) {
 	const onToggle = () => {
 		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
 		onUpdateStatus( updatedStatus );
 	};
+
+	const format = suggestedFormat || __( 'Standard' );
 
 	// Disable Reason: The input is inside the label, we shouldn't need the htmlFor
 	/* eslint-disable jsx-a11y/label-has-for */
@@ -35,9 +37,12 @@ function PostStatus( { status, onUpdateStatus } ) {
 					onChange={ onToggle }
 				/>
 			</label>
-
 			<div className="editor-post-status__row">
 				<PostVisibility />
+			</div>
+			<div className="editor-post-status__row">
+				<span>{ __( 'Post Format' ) }</span>
+				<span>{ format }</span>
 			</div>
 		</PanelBody>
 	);
@@ -47,6 +52,7 @@ function PostStatus( { status, onUpdateStatus } ) {
 export default connect(
 	( state ) => ( {
 		status: getEditedPostStatus( state ),
+		suggestedFormat: getSuggestedPostFormat( state ),
 	} ),
 	( dispatch ) => {
 		return {

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -24,6 +24,8 @@ function PostStatus( { status, onUpdateStatus, suggestedFormat } ) {
 		onUpdateStatus( updatedStatus );
 	};
 
+	// Use the suggested post format based on the blocks content of the post
+	// or the default post format setting for the site.
 	const format = suggestedFormat || __( 'Standard' );
 
 	// Disable Reason: The input is inside the label, we shouldn't need the htmlFor


### PR DESCRIPTION
Returns a suggested post format based on what blocks exist in the post. This is an initial approximation to a flow that is able to set post format for the user based on the kind of content they have added.

![image](https://cloud.githubusercontent.com/assets/548849/26311329/399c9496-3f04-11e7-8ef7-990254c6297c.png)
