### PR TITLE
Add "Latest Posts" Block

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -16,6 +16,7 @@ const categories = [
 	{ slug: 'formatting', title: __( 'Formatting' ) },
 	{ slug: 'embed', title: __( 'Embed' ) },
 	{ slug: 'layout', title: __( 'Layout Blocks' ) },
+	{ slug: 'rest-api', title: __( 'REST API Blocks' ) },
 ];
 
 /**

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -11,4 +11,4 @@ import './pullquote';
 import './table';
 import './preformatted';
 import './code';
-import './rest-api-latest-posts';
+import './latest-posts';

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -11,3 +11,4 @@ import './pullquote';
 import './table';
 import './preformatted';
 import './code';
+import './rest-api-latest-posts';

--- a/blocks/library/latest-posts/data.js
+++ b/blocks/library/latest-posts/data.js
@@ -1,0 +1,18 @@
+/**
+ * Returns a Promise with the latest posts or an error on failure.
+ *
+ * @param   {Number} postsToShow
+ * @returns {Object}
+ */
+export function getLatestPosts( postsToShow = 5 ) {
+	const postsCollection = new wp.api.collections.Posts();
+
+	const posts = postsCollection.fetch( {
+		data: {
+			per_page: postsToShow
+		}
+	} );
+
+	return posts;
+}
+

--- a/blocks/library/latest-posts/data.js
+++ b/blocks/library/latest-posts/data.js
@@ -1,15 +1,16 @@
 /**
  * Returns a Promise with the latest posts or an error on failure.
  *
- * @param   {Number} postsToShow
- * @returns {wp.api.collections.Posts}
+ * @param   {Number} postsToShow       Number of posts to display.
+ *
+ * @returns {wp.api.collections.Posts} Returns a Promise with the latest posts.
  */
 export function getLatestPosts( postsToShow = 5 ) {
 	const postsCollection = new wp.api.collections.Posts();
 
 	const posts = postsCollection.fetch( {
 		data: {
-			per_page: postsToShow
+			per_page: postsToShow,
 		}
 	} );
 

--- a/blocks/library/latest-posts/data.js
+++ b/blocks/library/latest-posts/data.js
@@ -2,7 +2,7 @@
  * Returns a Promise with the latest posts or an error on failure.
  *
  * @param   {Number} postsToShow
- * @returns {Object}
+ * @returns {wp.api.collections.Posts}
  */
 export function getLatestPosts( postsToShow = 5 ) {
 	const postsCollection = new wp.api.collections.Posts();

--- a/blocks/library/latest-posts/data.js
+++ b/blocks/library/latest-posts/data.js
@@ -11,7 +11,7 @@ export function getLatestPosts( postsToShow = 5 ) {
 	const posts = postsCollection.fetch( {
 		data: {
 			per_page: postsToShow,
-		}
+		},
 	} );
 
 	return posts;

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -30,7 +30,7 @@ function renderList( latestPosts ) {
 	);
 }
 
-registerBlock( 'core/rest-api-latest-posts', {
+registerBlock( 'core/latest-posts', {
 	title: wp.i18n.__( 'Latest Posts' ),
 
 	icon: 'list-view',
@@ -53,7 +53,7 @@ registerBlock( 'core/rest-api-latest-posts', {
 		}
 
 		return (
-			<div className="blocks-rest-api-latest-posts">
+			<div className="blocks-latest-posts">
 				{ renderList( latestPosts ) }
 			</div>
 		);

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -10,7 +10,7 @@ import { registerBlock } from '../../api';
 import { getLatestPosts } from './data.js';
 
 
-registerBlock( 'core/latest-posts', {
+registerBlock( 'core/latestposts', {
 	title: wp.i18n.__( 'Latest Posts' ),
 
 	icon: 'list-view',

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -17,6 +17,10 @@ registerBlock( 'core/latestposts', {
 
 	category: 'rest-api',
 
+	defaultAttributes: {
+		poststoshow: 5
+	},
+
 	edit: class extends wp.element.Component {
 		constructor() {
 			super( ...arguments );
@@ -25,15 +29,7 @@ registerBlock( 'core/latestposts', {
 				latestPosts: []
 			};
 
-			let { poststoshow } = this.props.attributes;
-
-			if ( ! poststoshow ) {
-				poststoshow = 5;
-
-				this.props.setAttributes( {
-					poststoshow
-				} );
-			}
+			const { poststoshow } = this.props.attributes;
 
 			getLatestPosts( poststoshow )
 				.then( latestPosts => this.setState( { latestPosts } ) );

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -25,7 +25,18 @@ registerBlock( 'core/latest-posts', {
 				latestPosts: []
 			};
 
-			getLatestPosts().then( latestPosts => this.setState( { latestPosts } ) );
+			let { poststoshow } = this.props.attributes;
+
+			if ( ! poststoshow ) {
+				poststoshow = 5;
+
+				this.props.setAttributes( {
+					poststoshow
+				} );
+			}
+
+			getLatestPosts( poststoshow )
+				.then( latestPosts => this.setState( { latestPosts } ) );
 		}
 
 		renderPostsLoading() {

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -7,18 +7,7 @@ import Placeholder from 'components/placeholder';
  * Internal dependencies
  */
 import { registerBlock } from '../../api';
-
-function getLatestPosts( postsToShow = 5 ) {
-	const postsCollection = new wp.api.collections.Posts();
-
-	const posts = postsCollection.fetch( {
-		data: {
-			per_page: postsToShow
-		}
-	} );
-
-	return posts;
-}
+import { getLatestPosts } from './data.js';
 
 function renderList( latestPosts ) {
 	return (

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -9,7 +9,6 @@ import Placeholder from 'components/placeholder';
 import { registerBlock } from '../../api';
 import { getLatestPosts } from './data.js';
 
-
 registerBlock( 'core/latestposts', {
 	title: wp.i18n.__( 'Latest Posts' ),
 
@@ -18,7 +17,7 @@ registerBlock( 'core/latestposts', {
 	category: 'rest-api',
 
 	defaultAttributes: {
-		poststoshow: 5
+		poststoshow: 5,
 	},
 
 	edit: class extends wp.element.Component {
@@ -26,7 +25,7 @@ registerBlock( 'core/latestposts', {
 			super( ...arguments );
 
 			this.state = {
-				latestPosts: []
+				latestPosts: [],
 			};
 
 			const { poststoshow } = this.props.attributes;
@@ -48,8 +47,8 @@ registerBlock( 'core/latestposts', {
 		renderPostsList( latestPosts ) {
 			return (
 				<ul>
-					{ latestPosts.map( (post) =>
-						<li><a href={ post.link }>{ post.title.rendered }</a></li>
+					{ latestPosts.map( ( post, i ) =>
+						<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>
 					) }
 				</ul>
 			);
@@ -69,7 +68,6 @@ registerBlock( 'core/latestposts', {
 			);
 
 		}
-
 	},
 
 	save() {

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -9,15 +9,6 @@ import Placeholder from 'components/placeholder';
 import { registerBlock } from '../../api';
 import { getLatestPosts } from './data.js';
 
-function renderList( latestPosts ) {
-	return (
-		<ul>
-			{ latestPosts.map( (post) =>
-				<li><a href={ post.link }>{ post.title.rendered }</a></li>
-			) }
-		</ul>
-	);
-}
 
 registerBlock( 'core/latest-posts', {
 	title: wp.i18n.__( 'Latest Posts' ),
@@ -26,12 +17,18 @@ registerBlock( 'core/latest-posts', {
 
 	category: 'rest-api',
 
-	edit( { attributes, setAttributes } ) {
-		const { latestPosts } = attributes;
+	edit: class extends wp.element.Component {
+		constructor() {
+			super( ...arguments );
 
-		if ( ! latestPosts ) {
-			getLatestPosts().then( latestPosts => setAttributes( { latestPosts } ) );
+			this.state = {
+				latestPosts: []
+			};
 
+			getLatestPosts().then( latestPosts => this.setState( { latestPosts } ) );
+		}
+
+		renderPostsLoading() {
 			return (
 				<Placeholder
 					icon="update"
@@ -41,20 +38,34 @@ registerBlock( 'core/latest-posts', {
 			);
 		}
 
-		return (
-			<div className="blocks-latest-posts">
-				{ renderList( latestPosts ) }
-			</div>
-		);
+		renderPostsList( latestPosts ) {
+			return (
+				<ul>
+					{ latestPosts.map( (post) =>
+						<li><a href={ post.link }>{ post.title.rendered }</a></li>
+					) }
+				</ul>
+			);
+		}
+
+		render() {
+			const { latestPosts } = this.state;
+
+			if ( ! latestPosts.length ) {
+				return this.renderPostsLoading();
+			}
+
+			return (
+				<div className="blocks-latest-posts">
+					{ this.renderPostsList( latestPosts ) }
+				</div>
+			);
+
+		}
+
 	},
 
-	save( { attributes } ) {
-		const { latestPosts } = attributes;
-
-		return (
-			<div>
-				{ renderList( latestPosts ) }
-			</div>
-		);
+	save() {
+		return null;
 	},
 } );

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -6,10 +6,10 @@ import Placeholder from 'components/placeholder';
 /**
  * Internal dependencies
  */
-import { registerBlock } from '../../api';
+import { registerBlockType } from '../../api';
 import { getLatestPosts } from './data.js';
 
-registerBlock( 'core/latestposts', {
+registerBlockType( 'core/latestposts', {
 	title: wp.i18n.__( 'Latest Posts' ),
 
 	icon: 'list-view',
@@ -66,7 +66,6 @@ registerBlock( 'core/latestposts', {
 					{ this.renderPostsList( latestPosts ) }
 				</div>
 			);
-
 		}
 	},
 

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Placeholder } from 'components';
+import { __ } from 'i18n';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import { registerBlockType } from '../../api';
 import { getLatestPosts } from './data.js';
 
 registerBlockType( 'core/latestposts', {
-	title: wp.i18n.__( 'Latest Posts' ),
+	title: __( 'Latest Posts' ),
 
 	icon: 'list-view',
 
@@ -42,7 +43,7 @@ registerBlockType( 'core/latestposts', {
 				return (
 					<Placeholder
 						icon="update"
-						label={ wp.i18n.__( 'Loading latest posts, please wait' ) }
+						label={ __( 'Loading latest posts, please wait' ) }
 					>
 					</Placeholder>
 				);

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -24,13 +24,14 @@ registerBlockType( 'core/latestposts', {
 		constructor() {
 			super( ...arguments );
 
-			this.state = {
-				latestPosts: [],
-			};
-
 			const { poststoshow } = this.props.attributes;
 
-			getLatestPosts( poststoshow )
+			this.state = {
+				latestPosts: [],
+				latestPostsRequest: getLatestPosts( poststoshow ),
+			};
+
+			this.state.latestPostsRequest
 				.then( latestPosts => this.setState( { latestPosts } ) );
 		}
 
@@ -56,6 +57,14 @@ registerBlockType( 'core/latestposts', {
 					</ul>
 				</div>
 			);
+		}
+	},
+
+	componentWillUnmount() {
+		const { latestPostsRequest } = this.state;
+
+		if ( latestPostsRequest.state() === 'pending' ) {
+			latestPostsRequest.abort();
 		}
 	},
 

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -29,10 +29,11 @@ registerBlockType( 'core/latestposts', {
 
 			this.state = {
 				latestPosts: [],
-				latestPostsRequest: getLatestPosts( poststoshow ),
 			};
 
-			this.state.latestPostsRequest
+			this.latestPostsRequest = getLatestPosts( poststoshow );
+
+			this.latestPostsRequest
 				.then( latestPosts => this.setState( { latestPosts } ) );
 		}
 
@@ -62,10 +63,8 @@ registerBlockType( 'core/latestposts', {
 	},
 
 	componentWillUnmount() {
-		const { latestPostsRequest } = this.state;
-
-		if ( latestPostsRequest.state() === 'pending' ) {
-			latestPostsRequest.abort();
+		if ( this.latestPostsRequest.state() === 'pending' ) {
+			this.latestPostsRequest.abort();
 		}
 	},
 

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import Placeholder from 'components/placeholder';
+import { Placeholder } from 'components';
 
 /**
  * Internal dependencies
@@ -34,36 +34,26 @@ registerBlockType( 'core/latestposts', {
 				.then( latestPosts => this.setState( { latestPosts } ) );
 		}
 
-		renderPostsLoading() {
-			return (
-				<Placeholder
-					icon="update"
-					label={ wp.i18n.__( 'Loading latest posts, please wait' ) }
-				>
-				</Placeholder>
-			);
-		}
-
-		renderPostsList( latestPosts ) {
-			return (
-				<ul>
-					{ latestPosts.map( ( post, i ) =>
-						<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>
-					) }
-				</ul>
-			);
-		}
-
 		render() {
 			const { latestPosts } = this.state;
 
 			if ( ! latestPosts.length ) {
-				return this.renderPostsLoading();
+				return (
+					<Placeholder
+						icon="update"
+						label={ wp.i18n.__( 'Loading latest posts, please wait' ) }
+					>
+					</Placeholder>
+				);
 			}
 
 			return (
 				<div className="blocks-latest-posts">
-					{ this.renderPostsList( latestPosts ) }
+					<ul>
+						{ latestPosts.map( ( post, i ) =>
+							<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>
+						) }
+					</ul>
 				</div>
 			);
 		}

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -1,0 +1,37 @@
+<?php
+
+function gutenberg_block_core_latest_posts( $attributes ) {
+	$postsToShow = 5;
+
+	if ( array_key_exists( 'poststoshow', $attributes ) ) {
+		$postsToShow = $attributes['poststoshow'];
+	}
+
+	$recent_posts = wp_get_recent_posts( array(
+		'numberposts' => $postsToShow,
+		'post_status' => 'publish'
+	) );
+
+	$posts_content = '';
+
+	foreach( $recent_posts as $post ) {
+		$post_permalink = get_permalink( $post['ID'] );
+
+		$posts_content .= "<li><a href='{$post_permalink}'>{$post['post_title']}</a></li>\n";
+	}
+
+	$block_content = <<<CONTENT
+<div class="blocks-latest-posts">
+	<ul>
+		{$posts_content}
+	</ul>
+</div>
+
+CONTENT;
+
+	return $block_content;
+}
+
+register_block( 'core/latestposts', array(
+	'render' => 'gutenberg_block_core_latest_posts'
+) );

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -1,5 +1,17 @@
 <?php
+/**
+ * Server-side rendering of the `core/latest-posts` block.
+ *
+ * @package gutenberg
+ */
 
+/**
+ * Renders the `core/latest-posts` block on server.
+ *
+ * @param $attributes
+ *
+ * @return string
+ */
 function gutenberg_block_core_latest_posts( $attributes ) {
 	$posts_to_show = 5;
 
@@ -9,12 +21,12 @@ function gutenberg_block_core_latest_posts( $attributes ) {
 
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => $posts_to_show,
-		'post_status' => 'publish'
+		'post_status' => 'publish',
 	) );
 
 	$posts_content = '';
 
-	foreach( $recent_posts as $post ) {
+	foreach ( $recent_posts as $post ) {
 		$post_id = $post['ID'];
 		$post_permalink = get_permalink( $post_id );
 		$post_title = get_the_title( $post_id );
@@ -35,5 +47,5 @@ CONTENT;
 }
 
 register_block( 'core/latestposts', array(
-	'render' => 'gutenberg_block_core_latest_posts'
+	'render' => 'gutenberg_block_core_latest_posts',
 ) );

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -1,23 +1,25 @@
 <?php
 
 function gutenberg_block_core_latest_posts( $attributes ) {
-	$postsToShow = 5;
+	$posts_to_show = 5;
 
 	if ( array_key_exists( 'poststoshow', $attributes ) ) {
-		$postsToShow = $attributes['poststoshow'];
+		$posts_to_show = $attributes['poststoshow'];
 	}
 
 	$recent_posts = wp_get_recent_posts( array(
-		'numberposts' => $postsToShow,
+		'numberposts' => $posts_to_show,
 		'post_status' => 'publish'
 	) );
 
 	$posts_content = '';
 
 	foreach( $recent_posts as $post ) {
-		$post_permalink = get_permalink( $post['ID'] );
+		$post_id = $post['ID'];
+		$post_permalink = get_permalink( $post_id );
+		$post_title = get_the_title( $post_id );
 
-		$posts_content .= "<li><a href='{$post_permalink}'>{$post['post_title']}</a></li>\n";
+		$posts_content .= "<li><a href='{$post_permalink}'>{$post_title}</a></li>\n";
 	}
 
 	$block_content = <<<CONTENT

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -8,9 +8,9 @@
 /**
  * Renders the `core/latest-posts` block on server.
  *
- * @param $attributes
+ * @param array $attributes The block attributes.
  *
- * @return string
+ * @return string Returns the post content with latest posts added.
  */
 function gutenberg_block_core_latest_posts( $attributes ) {
 	$posts_to_show = 5;
@@ -46,6 +46,6 @@ CONTENT;
 	return $block_content;
 }
 
-register_block( 'core/latestposts', array(
+register_block_type( 'core/latestposts', array(
 	'render' => 'gutenberg_block_core_latest_posts',
 ) );

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -16,7 +16,16 @@ function gutenberg_block_core_latest_posts( $attributes ) {
 	$posts_to_show = 5;
 
 	if ( array_key_exists( 'poststoshow', $attributes ) ) {
-		$posts_to_show = $attributes['poststoshow'];
+		$posts_to_show_attr = $attributes['poststoshow'];
+
+		// Basic attribute validation.
+		if (
+			is_numeric( $posts_to_show_attr ) &&
+			$posts_to_show_attr > 0 &&
+			$posts_to_show_attr < 100
+		) {
+			$posts_to_show = $attributes['poststoshow'];
+		}
 	}
 
 	$recent_posts = wp_get_recent_posts( array(

--- a/blocks/library/rest-api-latest-posts/index.js
+++ b/blocks/library/rest-api-latest-posts/index.js
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+import Placeholder from 'components/placeholder';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlock, query } from '../../api';
+import Editable from '../../editable';
+
+const { attr, children } = query;
+
+function getLatestPosts( postsToShow = 5 ) {
+	const postsCollection = new wp.api.collections.Posts();
+
+	const posts = postsCollection.fetch( {
+		data: {
+			per_page: postsToShow
+		}
+	} );
+
+	return posts;
+}
+
+function renderList( posts ) {
+	console.log( posts );
+	return (
+		<ul>
+			<li>post</li>
+		</ul>
+	);
+}
+
+let latestPosts = null;
+
+registerBlock( 'core/rest-api-latest-posts', {
+	title: wp.i18n.__( 'Latest Posts' ),
+
+	icon: 'list-view',
+
+	category: 'rest-api',
+
+
+	edit( { attributes, setAttributes, focus, setFocus } ) {
+		getLatestPosts().then( posts => latestPosts = posts );
+
+		if ( ! latestPosts ) {
+			return (
+				<Placeholder
+					icon="update"
+					label={ wp.i18n.__( 'Loading latest posts, please wait' ) }
+				>
+				</Placeholder>
+			);
+		}
+
+		return (
+			<div className="blocks-rest-api-latest-posts">
+				{ renderList( latestPosts ) }
+			</div>
+		);
+	},
+
+	save( { attributes } ) {
+		return (
+			<div>
+				hello
+			</div>
+		);
+	},
+} );

--- a/blocks/library/rest-api-latest-posts/index.js
+++ b/blocks/library/rest-api-latest-posts/index.js
@@ -6,10 +6,7 @@ import Placeholder from 'components/placeholder';
 /**
  * Internal dependencies
  */
-import { registerBlock, query } from '../../api';
-import Editable from '../../editable';
-
-const { attr, children } = query;
+import { registerBlock } from '../../api';
 
 function getLatestPosts( postsToShow = 5 ) {
 	const postsCollection = new wp.api.collections.Posts();
@@ -23,16 +20,15 @@ function getLatestPosts( postsToShow = 5 ) {
 	return posts;
 }
 
-function renderList( posts ) {
-	console.log( posts );
+function renderList( latestPosts ) {
 	return (
 		<ul>
-			<li>post</li>
+			{ latestPosts.map( (post) =>
+				<li><a href={ post.link }>{ post.title.rendered }</a></li>
+			) }
 		</ul>
 	);
 }
-
-let latestPosts = null;
 
 registerBlock( 'core/rest-api-latest-posts', {
 	title: wp.i18n.__( 'Latest Posts' ),
@@ -41,11 +37,12 @@ registerBlock( 'core/rest-api-latest-posts', {
 
 	category: 'rest-api',
 
-
-	edit( { attributes, setAttributes, focus, setFocus } ) {
-		getLatestPosts().then( posts => latestPosts = posts );
+	edit( { attributes, setAttributes } ) {
+		const { latestPosts } = attributes;
 
 		if ( ! latestPosts ) {
+			getLatestPosts().then( latestPosts => setAttributes( { latestPosts } ) );
+
 			return (
 				<Placeholder
 					icon="update"
@@ -63,9 +60,11 @@ registerBlock( 'core/rest-api-latest-posts', {
 	},
 
 	save( { attributes } ) {
+		const { latestPosts } = attributes;
+
 		return (
 			<div>
-				hello
+				{ renderList( latestPosts ) }
 			</div>
 		);
 	},

--- a/blocks/test/fixtures/core-latestposts.html
+++ b/blocks/test/fixtures/core-latestposts.html
@@ -1,0 +1,2 @@
+<!-- wp:core/latestposts poststoshow="5" --><!-- /wp:core/latestposts -->
+

--- a/blocks/test/fixtures/core-latestposts.json
+++ b/blocks/test/fixtures/core-latestposts.json
@@ -1,0 +1,9 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/latestposts",
+        "attributes": {
+            "poststoshow": 5
+        }
+    }
+]

--- a/blocks/test/fixtures/core-latestposts.serialized.html
+++ b/blocks/test/fixtures/core-latestposts.serialized.html
@@ -1,0 +1,2 @@
+<!-- wp:core/latestposts poststoshow="5" --><!-- /wp:core/latestposts -->
+

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -9,6 +9,8 @@
  * @package gutenberg
  */
 
+define( 'GUTENBERG__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+
 require_once dirname( __FILE__ ) . '/lib/blocks.php';
 require_once dirname( __FILE__ ) . '/lib/client-assets.php';
 require_once dirname( __FILE__ ) . '/lib/i18n.php';

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+define( 'GUTENBERG__BLOCKS_LIBRARY_DIR', GUTENBERG__PLUGIN_DIR . 'blocks/library' );
+
 $wp_registered_blocks = array();
 
 /**
@@ -128,3 +130,12 @@ function do_blocks( $content ) {
 	return $new_content;
 }
 add_filter( 'the_content', 'do_blocks', 10 ); // BEFORE do_shortcode().
+
+/**
+ * Loads the server-side rendering of blocks. If your block supports
+ * server-side rendering, add it here.
+ */
+function gutenberg_load_blocks_server_side_rendering() {
+	require_once GUTENBERG__BLOCKS_LIBRARY_DIR . '/latest-posts/index.php';
+}
+add_action( 'init', 'gutenberg_load_blocks_server_side_rendering' );


### PR DESCRIPTION
@mtias suggested to me to create a simple block to get latest posts with the WP REST API. It should also serve as an example for other developers so they can start experimenting with the API and create some cool blocks.

I've been studying Gutenberg (pretty good editor!) and come up with something really simple. It's still a work in progress since I want to fix a few things and maybe make it a bit better.

I'd like to also open a discussion about some of the things here:
- naming: I prefixed it with `rest-api-` since we could have another 'latest posts' block without using rest api
- new category called `rest-api`: are we planning to have more such components using rest api? If yes, I think it would be nice to give them their own category
- getting the posts/using the rest api: I'm using the [Backbone rest api js client](https://developer.wordpress.org/rest-api/using-the-rest-api/backbone-javascript-client/) as it seems to be the officially supported one. It offers a few niceties and it's quite easy to use but: isn't Backbone a bit dated? (I've never used it). Are we okay with this or should we create some custom rest api wrapper/client?

Asking for help: after saving a post with this latest posts block and then reloading the saved post, instead of having the block parsed and displayed as other blocks, it shows with the Gutenberg tags and HTML code. Can you spot what I'm doing wrong, please? It works fine when seeing the post on the front-end though.

Am I using the `attributes` of `registerBlock` properly? I use them to store the latest posts retrieved from DB but don't define them in `registerBlock`.

Thanks!

## Nice to have/TODO
- [ ] have some UI so users can filter the posts by number of them to show, author, categories, etc