### PR TITLE
Fix parsing empty post content with TinyMCE

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -161,7 +161,7 @@ export function parseWithTinyMCE( content ) {
 	flushContentBetweenBlocks();
 
 	let currentNode = tree.firstChild;
-	do {
+	while ( currentNode ) {
 		if ( currentNode.name === 'wp-block' ) {
 			// Set node type to document fragment so that the TinyMCE
 			// serializer doesn't output its markup
@@ -208,7 +208,7 @@ export function parseWithTinyMCE( content ) {
 			currentNode = currentNode.next;
 			contentBetweenBlocks.append( toAppend );
 		}
-	} while ( currentNode );
+	}
 
 	flushContentBetweenBlocks();
 

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -173,6 +173,12 @@ describe( 'block parser', () => {
 					expect( parsed[ 0 ].uid ).to.be.a( 'string' );
 				} );
 
+				it( 'should parse empty post content', () => {
+					const parsed = parse( '' );
+
+					expect( parsed ).to.eql( [] );
+				} );
+
 				it( 'should parse the post content, ignoring unknown blocks', () => {
 					registerBlock( 'core/test-block', {
 						attributes: function( rawContent ) {


### PR DESCRIPTION
When attempting to parse a post with empty content using the TinyMCE-based parser (the current default), the editor fails to initialize because the following error is thrown:

> Uncaught TypeError: Cannot read property 'name' of undefined
>    at Object.parseWithTinyMCE (parser.js:165)

This happens because the parse tree of `parse( '' )` has no children, so we need to move the `if ( currentNode )` check from the end of the loop to the beginning.