### PR TITLE
Polish the editor toolbars and their sizes

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	a {
-		color: $blue-medium;
+		color: $blue-medium-500;
 	}
 
 	&:focus a[data-mce-selected] {

--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -56,7 +56,8 @@
 	display: flex;
 	justify-content: center;
 	position: absolute;
-	top: -50px;
+	top: -$block-controls-height - 4px;
+	line-height: 0;
 	left: 0;
 	right: 0;
 	z-index: 1;

--- a/blocks/library/preformatted/style.scss
+++ b/blocks/library/preformatted/style.scss
@@ -1,5 +1,8 @@
 div[data-type="core/preformatted"] {
 	pre {
 		white-space: pre-wrap;
+		font-family: $editor-html-font;
+		font-size: $text-editor-font-size;
+		color: $dark-gray-800;
 	}
 }

--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -25,6 +25,11 @@ $toggle-border-width: 2px;
 
 	&:hover:before {
 		background-color: $light-gray-500;
+
+		.components-form-toggle.is-checked & {
+			background-color: $blue-medium-500;
+			border: $toggle-border-width solid $blue-medium-500;
+		}
 	}
 
 	&:after {

--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -52,8 +52,8 @@ $toggle-border-width: 2px;
 		}
 
 		&:before {
-			background-color: $blue-medium;
-			border: $toggle-border-width solid $blue-medium;
+			background-color: $blue-medium-500;
+			border: $toggle-border-width solid $blue-medium-500;
 		}
 	}
 }

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -6,7 +6,7 @@
 	background: none;
 	color: $dark-gray-500;
 	position: relative;
-	width: 36px;	// show only icon on small breakpoints
+	width: $icon-button-size;	// show only icon on small breakpoints
 	overflow: hidden;
 
 	.dashicon {

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -21,7 +21,7 @@
 		cursor: pointer;
 
 		&:hover {
-			color: $blue-medium;
+			color: $blue-medium-500;
 		}
 	}
 

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -64,6 +64,11 @@
 	}
 }
 
+// compensate for making the button hit area include the visual spacing
+.components-toolbar__control.components-button + .components-toolbar__control.components-button {
+	margin-left: -3px;
+}
+
 .components-toolbar__control .dashicon {
 	display: block;
 }

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -8,17 +8,19 @@
 .components-toolbar__control.components-button {
 	display: inline-flex;
 	align-items: flex-end;
-	margin: 3px;
-	margin-left: 0;
+	margin: 0;
+	padding: 3px;
 	background: none;
-	border: 1px solid transparent;
 	outline: none;
 	color: $dark-gray-500;
 	cursor: pointer;
 	position: relative;
+	width: $icon-button-size;
 
-	&:first-child {
-		margin-left: 3px;
+	svg {
+		border: 1px solid transparent;
+		padding: 4px;
+		box-sizing: content-box;
 	}
 
 	&:focus:before {
@@ -28,16 +30,26 @@
 		left: -4px;
 	}
 
-	&.is-active,
-	&:hover,
-	&:not(:disabled):hover {
+	&.is-active svg,
+	&:hover svg,
+	&:not(:disabled):hover svg {
 		border: 1px solid $dark-gray-500;
 		color: $dark-gray-500;
 	}
 
+	&:hover,
+	&:not(:disabled):hover {
+		color: $dark-gray-500;
+	}
+
+	&.is-active svg,
+	&.is-active:hover svg {
+		background-color: $dark-gray-500;
+		color: $white;
+	}
+
 	&.is-active,
 	&.is-active:hover {
-		background-color: $dark-gray-500;
 		color: $white;
 	}
 
@@ -47,8 +59,8 @@
 		font-size: 10px;
 		font-weight: bold;
 		position: relative;
-		top: -1px;
-		margin-left: -3px;
+		top: -5px;
+		left: -9px;
 	}
 }
 

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -59,7 +59,7 @@
 		font-size: 10px;
 		font-weight: bold;
 		position: relative;
-		top: -5px;
+		top: -6px;
 		left: -9px;
 	}
 }

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -24,7 +24,7 @@ $white: #fff;
 $blue-wordpress-700: #00669b;
 $blue-wordpress: #0073aa;
 
-$blue-medium: #00a0d2;
+$blue-medium-500: #00a0d2;
 $blue-medium-400: #33B3DB;
 $blue-medium-300: #66C6E4;
 $blue-medium-200: #BFE7F3;

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -54,7 +54,8 @@ $text-editor-max-width: 760px;
 /* Editor */
 $text-editor-max-width: 760px;
 $visual-editor-max-width: 700px;
-$block-controls-height: 46px;
+$block-controls-height: 38px;
+$icon-button-size: 36px;
 
 /* Blocks */
 $block-padding: 14px;

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -10,8 +10,8 @@
 
 .editor-block-switcher__toggle {
 	width: auto;
-	margin: 3px;
-	padding: 6px;
+	margin: 0;
+	padding: 8px;
 
 	&:focus:before {
 		top: -3px;
@@ -23,7 +23,7 @@
 
 .editor-block-switcher__menu {
 	position: absolute;
-	top: 43px;
+	top: $block-controls-height - 1px;
 	left: 0;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -50,7 +50,7 @@
 		overflow: hidden;
 
 		&:hover {
-			color: $blue-medium;
+			color: $blue-medium-500;
 		}
 
 		@include break-medium() {

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -22,7 +22,7 @@
 
 	&:hover,
 	&:focus {
-		color: $blue-medium;
+		color: $blue-medium-500;
 	}
 }
 
@@ -153,7 +153,7 @@ input[type=search].editor-inserter__search {
 
 	&:hover,
 	&:focus {
-		color: $blue-medium;
+		color: $blue-medium-500;
 		outline: none;
 		position: relative;
 	}

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -49,7 +49,7 @@
 
 .editor-text-editor__formatting .editor-text-editor__link {
 	text-decoration: underline;
-	color: $blue-medium;
+	color: $blue-medium-500;
 }
 
 .editor-text-editor__formatting .editor-text-editor__del {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -125,7 +125,7 @@
 		right: #{ $block-padding + $block-mover-margin };
 		left: 0;
 		height: 3px;
-		background: $blue-medium;
+		background: $blue-medium-500;
 		content: '';
 	}
 }

--- a/editor/sidebar/featured-image/style.scss
+++ b/editor/sidebar/featured-image/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	&:hover {
-		color: $blue-medium;
+		color: $blue-medium-500;
 	}
 }
 

--- a/editor/sidebar/post-schedule/style.scss
+++ b/editor/sidebar/post-schedule/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	&:hover {
-		color: $blue-medium;
+		color: $blue-medium-500;
 	}
 }
 

--- a/editor/sidebar/post-trash/style.scss
+++ b/editor/sidebar/post-trash/style.scss
@@ -11,6 +11,6 @@
 	}
 
 	&:hover {
-		color: $blue-medium;
+		color: $blue-medium-500;
 	}
 }

--- a/editor/sidebar/post-visibility/style.scss
+++ b/editor/sidebar/post-visibility/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	&:hover {
-		color: $blue-medium;
+		color: $blue-medium-500;
 	}
 }
 


### PR DESCRIPTION
This is a bundle PR, and improves a few things.

1. It normalizes toolbars back to the design they have in the mockups. Through only my own fault, they had regressed to grow in size (46px), and we'd forgotten they were supposed to be smaller (38px)
2. It maximizes the hit area of the buttons, by including the margin between buttons. 
3. Fixes an issue where the inline toolbar could be subject to lineheight bleed.
4. Renames `$blue-medium` to `$blue-medium-500`, to match the hierarchy of the other medium blues

Screenshots:

![screen shot 2017-05-24 at 15 02 02](https://cloud.githubusercontent.com/assets/1204802/26404374/f69b7ad8-4091-11e7-91b4-0c834208018e.png)

![screen shot 2017-05-24 at 14 54 04](https://cloud.githubusercontent.com/assets/1204802/26404377/f89c8ec6-4091-11e7-9e80-4a771867d0af.png)

![screen shot 2017-05-24 at 14 54 08](https://cloud.githubusercontent.com/assets/1204802/26404379/fa6dfd84-4091-11e7-9cc7-f41e792ba4d1.png)
