### PR TITLE
Try: Alternative attributes initialization

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -7,11 +7,10 @@ import Placeholder from 'components/placeholder';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlock, query } from '../../api';
+import { registerBlock } from '../../api';
+import { findNodeAttribute, getEditableContent } from '../../api/source';
 import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
-
-const { attr, children } = query;
 
 /**
  * Returns an attribute setter with behavior that if the target value is
@@ -34,10 +33,20 @@ registerBlock( 'core/image', {
 
 	category: 'common',
 
-	attributes: {
-		url: attr( 'img', 'src' ),
-		alt: attr( 'img', 'alt' ),
-		caption: children( 'figcaption' ),
+	getInitialAttributes( node, encodedAttributes ) {
+		return {
+			align: 'none',
+			...encodedAttributes,
+			url: findNodeAttribute( node, 'img', 'src' ),
+			alt: findNodeAttribute( node, 'img', 'alt' ),
+			content: getEditableContent( node, [ 'figure', 'figcaption' ] ),
+		};
+	},
+
+	encodeAttributes( attributes ) {
+		const { align } = attributes;
+
+		return { align };
 	},
 
 	controls: [
@@ -124,7 +133,7 @@ registerBlock( 'core/image', {
 	},
 
 	save( { attributes } ) {
-		const { url, alt, caption, align = 'none' } = attributes;
+		const { url, alt, caption, align } = attributes;
 		const img = <img src={ url } alt={ alt } className={ `align${ align }` } />;
 
 		if ( ! caption || ! caption.length ) {


### PR DESCRIPTION
Closes #865
Related: #391

This pull request seeks to explore an alternative approach to initializing and serializing attributes. See #865 for more detail on motivation.

Specifically, the goals with these changes are:

- Clarify attributes initialization as a getter action
- Consolidate to single signature for attributes initialization
- Provide mechanism for default values
- Refactor encoded attributes as explicit opt-in
  - Many blocks will not need it, thereby being able to disregard second argument to `getInitialAttributes`
- Rename `wp.blocks.query` to `wp.blocks.source` in an effort to clarify their passiveness and use as extraction strategies
  - Also incidentally resolves [shadowing issue](https://github.com/WordPress/gutenberg/blob/f1d1296bafc40b53f7bd0dcd2c60e02fe95ab332/blocks/library/quote/index.js#L10-L13) with `wp.blocks.query.query`
- Limit capabilities of source matching to discourage assumption of DOM ([example](https://github.com/WordPress/gutenberg/blob/f1d1296bafc40b53f7bd0dcd2c60e02fe95ab332/blocks/library/heading/index.js#L24))
- Create distinction between "finding" and "getting" attributes and content, where the former is a blind query and the latter a tree path traversal
- Rename source matching functions to more verbose equivalents, for consistency with other methods and clarity of usage

Downsides being:

- Would we want to discourage block implementers having access to the parsed content node (first argument to `getInitialAttributes`)? Ideally they'd not be traversing it themselves, and we might like to have the option to change its structure without impacting backwards compatibility. My first approach passed `content` as the raw HTML string, but at this point we'd already have done a single HTML parse pass, and would presumably like to limit the number of parsing passes.
  - We have the option of treating source functions as curried, to be satisfied at the time that attributes initialization occurs, e.g. `getNodeAttribute( 'img', 'src' )( node );`, where block implementation only returns `getNodeAttribute( 'img', 'src' )`
- How would we implement [this sort of matcher](https://github.com/WordPress/gutenberg/blob/f1d1296bafc40b53f7bd0dcd2c60e02fe95ab332/blocks/library/heading/index.js#L24) without a presumed DOM? Do we need more matchers, maybe like: `nodeName: getNodeName( node, [ '*' ] )`
- I'm not sure whether `get` / `find` distinction is one we want

__Testing instructions:__

This is not a complete implementation and will surely fail tests and usage in the editor. At this point it's more an exploration / proposal / example. Review code changes instead. Also note that the implementation of the image block's encoded `align` attribute is subject to change in future efforts to eliminate duplicated source of truth, but is not a focus of this pull request.