### PR TITLE
Disable `fopen` warnings

### DIFF
--- a/index.php
+++ b/index.php
@@ -284,7 +284,9 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 	if ( $needs_fetch ) {
 		// Determine whether we can write to this file.  If not, don't waste
 		// time doing a network request.
+		// @codingStandardsIgnoreStart
 		$f = @fopen( $full_path, 'a' );
+		// @codingStandardsIgnoreEnd
 		if ( ! $f ) {
 			// Failed to open the file for writing, probably due to server
 			// permissions.  Enqueue the script directly from the URL instead.

--- a/index.php
+++ b/index.php
@@ -284,11 +284,10 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 	if ( $needs_fetch ) {
 		// Determine whether we can write to this file.  If not, don't waste
 		// time doing a network request.
-		$f = fopen( $full_path, 'a' );
+		$f = @fopen( $full_path, 'a' );
 		if ( ! $f ) {
 			// Failed to open the file for writing, probably due to server
 			// permissions.  Enqueue the script directly from the URL instead.
-			// Note: the `fopen` call above will have generated a warning.
 			wp_register_script( $handle, $src, $deps );
 			return;
 		}


### PR DESCRIPTION
It's pretty common for servers (e.g. VVV) to be configured to show these inline, so they are probably more annoying than useful.

Note these warnings aren't indicative of breakage, it just means that the server-side code won't be able to cache nightly scripts so they will need to be downloaded more often.