### PR TITLE
Blocks: Animate the controls on appear only

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -210,7 +210,7 @@ class VisualEditorBlock extends wp.element.Component {
 					<CSSTransitionGroup
 						transitionName={ { appear: 'appear-animation', appearActive: 'is-appearing' } }
 						transitionAppear={ true }
-						transitionAppearTimeout={ 10000 }
+						transitionAppearTimeout={ 100 }
 						transitionEnter={ false }
 						transitionLeave={ false }
 						component={ FirstChild }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -5,10 +5,12 @@ import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { Slot } from 'react-slot-fill';
 import { partial } from 'lodash';
+import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
  * WordPress dependencies
  */
+import { Children } from 'element';
 import Toolbar from 'components/toolbar';
 
 /**
@@ -32,6 +34,11 @@ import {
 	isBlockSelected,
 	isTypingInBlock,
 } from '../../selectors';
+
+function FirstChild( { children } ) {
+	const childrenArray = Children.toArray( children );
+	return childrenArray[ 0 ] || null;
+}
 
 class VisualEditorBlock extends wp.element.Component {
 	constructor() {
@@ -200,18 +207,27 @@ class VisualEditorBlock extends wp.element.Component {
 			>
 				{ ( showUI || isHovered ) && <BlockMover uid={ block.uid } /> }
 				{ showUI &&
-					<div className="editor-visual-editor__block-controls">
-						<BlockSwitcher uid={ block.uid } />
-						{ !! settings.controls && (
-							<Toolbar
-								controls={ settings.controls.map( ( control ) => ( {
-									...control,
-									onClick: () => control.onClick( block.attributes, this.setAttributes ),
-									isActive: control.isActive ? control.isActive( block.attributes ) : false,
-								} ) ) } />
-						) }
-						<Slot name="Formatting.Toolbar" />
-					</div>
+					<CSSTransitionGroup
+						transitionName="controls"
+						transitionAppear={ true }
+						transitionAppearTimeout={ 100 }
+						transitionEnter={ false }
+						transitionLeave={ false }
+						component={ FirstChild }
+					>
+						<div className="editor-visual-editor__block-controls">
+							<BlockSwitcher uid={ block.uid } />
+							{ !! settings.controls && (
+								<Toolbar
+									controls={ settings.controls.map( ( control ) => ( {
+										...control,
+										onClick: () => control.onClick( block.attributes, this.setAttributes ),
+										isActive: control.isActive ? control.isActive( block.attributes ) : false,
+									} ) ) } />
+							) }
+							<Slot name="Formatting.Toolbar" />
+						</div>
+					</CSSTransitionGroup>
 				}
 				<div onKeyPress={ this.maybeStartTyping }>
 					<BlockEdit

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -208,7 +208,7 @@ class VisualEditorBlock extends wp.element.Component {
 				{ ( showUI || isHovered ) && <BlockMover uid={ block.uid } /> }
 				{ showUI &&
 					<CSSTransitionGroup
-						transitionName={ { appear: 'appear-animation', appearActive: 'is-appearing' } }
+						transitionName={ { appear: 'is-appearing', appearActive: 'is-appearing-active' } }
 						transitionAppear={ true }
 						transitionAppearTimeout={ 100 }
 						transitionEnter={ false }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -208,9 +208,9 @@ class VisualEditorBlock extends wp.element.Component {
 				{ ( showUI || isHovered ) && <BlockMover uid={ block.uid } /> }
 				{ showUI &&
 					<CSSTransitionGroup
-						transitionName="controls"
+						transitionName={ { appear: 'appear-animation', appearActive: 'is-appearing' } }
 						transitionAppear={ true }
-						transitionAppearTimeout={ 100 }
+						transitionAppearTimeout={ 10000 }
 						transitionEnter={ false }
 						transitionLeave={ false }
 						component={ FirstChild }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -87,7 +87,7 @@
 		top: $header-height + $admin-bar-height + $item-spacing;
 	}
 
-	&.controls-appear.controls-appear-active {
+	&.is-appearing {
 		@include animate_fade;
 	}
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -72,7 +72,6 @@
 }
 
 .editor-visual-editor__block-controls {
-	@include animate_fade;
 	display: flex;
 	position: sticky;
 	z-index: z-index( '.editor-visual-editor__block-controls' );
@@ -86,6 +85,10 @@
 
 	@include break-medium() {
 		top: $header-height + $admin-bar-height + $item-spacing;
+	}
+
+	&.controls-appear.controls-appear-active {
+		@include animate_fade;
 	}
 }
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -87,7 +87,7 @@
 		top: $header-height + $admin-bar-height + $item-spacing;
 	}
 
-	&.is-appearing {
+	&.is-appearing-active {
 		@include animate_fade;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.4",
     "react-slot-fill": "^1.0.0-alpha.11",
+    "react-transition-group": "^1.1.3",
     "redux": "^3.6.0",
     "uuid": "^3.0.1"
   }


### PR DESCRIPTION
Since we can't avoid the rerendering when we move the block down, this uses `react-transition-group` to animate the controls only when they appear the first time.
