### PR TITLE
Incorporate refx as Redux side effect pattern

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { parse, stringify } from 'querystring';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockSettings, switchToBlockType } from 'blocks';
+import { __ } from 'i18n';
+
+/**
+ * Internal dependencies
+ */
+import { focusBlock, replaceBlocks } from './actions';
+
+export default {
+	REQUEST_POST_UPDATE( action, store ) {
+		const { dispatch } = store;
+		const { postId, edits } = action;
+		const isNew = ! postId;
+		const toSend = postId ? { id: postId, ...edits } : edits;
+
+		new wp.api.models.Post( toSend ).save().done( ( newPost ) => {
+			dispatch( {
+				type: 'REQUEST_POST_UPDATE_SUCCESS',
+				post: newPost,
+			} );
+		} ).fail( ( err ) => {
+			dispatch( {
+				type: 'REQUEST_POST_UPDATE_FAILURE',
+				error: get( err, 'responseJSON', {
+					code: 'unknown_error',
+					message: __( 'An unknown error occurred.' ),
+				} ),
+				edits,
+				isNew,
+			} );
+		} );
+	},
+	REQUEST_POST_UPDATE_SUCCESS( action ) {
+		const { post } = action;
+		const [ baseUrl, query ] = window.location.href.split( '?' );
+		const qs = parse( query || '' );
+		if ( qs.post_id === post.id ) {
+			return;
+		}
+
+		const newUrl = baseUrl + '?' + stringify( {
+			...qs,
+			post_id: post.id,
+		} );
+		window.history.replaceState( {}, 'Post ' + post.id, newUrl );
+	},
+	TRASH_POST( action, store ) {
+		const { dispatch } = store;
+		const { postId } = action;
+		new wp.api.models.Post( { id: postId } ).destroy().done( () => {
+			dispatch( {
+				...action,
+				type: 'TRASH_POST_SUCCESS',
+			} );
+		} );
+	},
+	TRASH_POST_SUCCESS( action ) {
+		const { postId, postType } = action;
+		window.location.href = 'edit.php?' + stringify( {
+			trashed: 1,
+			post_type: postType,
+			ids: postId,
+		} );
+	},
+	MERGE_BLOCKS( action, store ) {
+		const { dispatch } = store;
+		const [ blockA, blockB ] = action.blocks;
+		const blockASettings = getBlockSettings( blockA.blockType );
+
+		// Only focus the previous block if it's not mergeable
+		if ( ! blockASettings.merge ) {
+			dispatch( focusBlock( blockA.uid ) );
+			return;
+		}
+
+		// We can only merge blocks with similar types
+		// thus, we transform the block to merge first
+		const blocksWithTheSameType = blockA.blockType === blockB.blockType
+			? [ blockB ]
+			: switchToBlockType( blockB, blockA.blockType );
+
+		// If the block types can not match, do nothing
+		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {
+			return;
+		}
+
+		// Calling the merge to update the attributes and remove the block to be merged
+		const updatedAttributes = blockASettings.merge(
+			blockA.attributes,
+			blocksWithTheSameType[ 0 ].attributes
+		);
+
+		dispatch( focusBlock( blockA.uid, { offset: -1 } ) );
+		dispatch( replaceBlocks(
+			[ blockA.uid, blockB.uid ],
+			[
+				{
+					...blockA,
+					attributes: {
+						...blockA.attributes,
+						...updatedAttributes,
+					},
+				},
+				...blocksWithTheSameType.slice( 1 ),
+			]
+		) );
+	},
+};

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -85,10 +85,10 @@ export default connect(
 	} ),
 	( dispatch ) => ( {
 		onSave( post, edits, blocks ) {
-			savePost( dispatch, post.id, {
+			dispatch( savePost( post.id, {
 				content: wp.blocks.serialize( blocks ),
 				...edits,
-			} );
+			} ) );
 		},
 	} )
 )( PublishButton );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -297,7 +297,7 @@ export default connect(
 		},
 
 		onMerge( ...args ) {
-			mergeBlocks( dispatch, ...args );
+			dispatch( mergeBlocks( ...args ) );
 		},
 	} )
 )( VisualEditorBlock );

--- a/editor/sidebar/post-trash/index.js
+++ b/editor/sidebar/post-trash/index.js
@@ -40,11 +40,5 @@ export default connect(
 			postType: post.type,
 		};
 	},
-	( dispatch ) => {
-		return {
-			trashPost( postId, postType ) {
-				return trashPost( dispatch, postId, postType );
-			},
-		};
-	}
+	{ trashPost }
 )( PostTrash );

--- a/editor/state.js
+++ b/editor/state.js
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-import { combineReducers, createStore } from 'redux';
-import { keyBy, last, omit, without } from 'lodash';
+import { combineReducers, applyMiddleware, createStore } from 'redux';
+import refx from 'refx';
+import { keyBy, last, omit, without, flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { combineUndoableReducers } from './utils/undoable-reducer';
+import effects from './effects';
 
 /**
  * Undoable reducer returning the editor post state, including blocks parsed
@@ -354,7 +356,7 @@ export function saving( state = {}, action ) {
 				requesting: false,
 				successful: true,
 				error: null,
-				isNew: action.isNew,
+				isNew: false,
 			};
 
 		case 'REQUEST_POST_UPDATE_FAILURE':
@@ -386,10 +388,12 @@ export function createReduxStore() {
 		saving,
 	} );
 
-	return createStore(
-		reducer,
-		window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-	);
+	const enhancers = [ applyMiddleware( refx( effects ) ) ];
+	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
+		enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
+	}
+
+	return createStore( reducer, flowRight( enhancers ) );
 }
 
 export default createReduxStore;

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -2,17 +2,11 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
-
-/**
- * WordPress dependencies
- */
-import { getBlocks, unregisterBlock, registerBlock, createBlock } from 'blocks';
 
 /**
  * Internal dependencies
  */
-import { focusBlock, replaceBlocks, mergeBlocks } from '../actions';
+import { focusBlock, replaceBlocks } from '../actions';
 
 describe( 'actions', () => {
 	describe( 'focusBlock', () => {
@@ -40,129 +34,6 @@ describe( 'actions', () => {
 				uids: [ 'chicken' ],
 				blocks,
 			} );
-		} );
-	} );
-
-	describe( 'mergeBlocks', () => {
-		afterEach( () => {
-			getBlocks().forEach( ( block ) => {
-				unregisterBlock( block.slug );
-			} );
-		} );
-
-		it( 'should only focus the blockA if the blockA has no merge function', () => {
-			registerBlock( 'core/test-block', {} );
-			const blockA = {
-				uid: 'chicken',
-				blockType: 'core/test-block',
-			};
-			const blockB = {
-				uid: 'ribs',
-				blockType: 'core/test-block',
-			};
-			const dispatch = sinon.spy();
-			mergeBlocks( dispatch, blockA, blockB );
-
-			expect( dispatch ).to.have.been.calledOnce();
-			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken' ) );
-		} );
-
-		it( 'should merge the blocks if blocks of the same type', () => {
-			registerBlock( 'core/test-block', {
-				merge( attributes, attributesToMerge ) {
-					return {
-						content: attributes.content + ' ' + attributesToMerge.content,
-					};
-				},
-			} );
-			const blockA = {
-				uid: 'chicken',
-				blockType: 'core/test-block',
-				attributes: { content: 'chicken' },
-			};
-			const blockB = {
-				uid: 'ribs',
-				blockType: 'core/test-block',
-				attributes: { content: 'ribs' },
-			};
-			const dispatch = sinon.spy();
-			mergeBlocks( dispatch, blockA, blockB );
-
-			expect( dispatch ).to.have.been.calledTwice();
-			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
-			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
-				uid: 'chicken',
-				blockType: 'core/test-block',
-				attributes: { content: 'chicken ribs' },
-			} ] ) );
-		} );
-
-		it( 'should not merge the blocks have different types without transformation', () => {
-			registerBlock( 'core/test-block', {
-				merge( attributes, attributesToMerge ) {
-					return {
-						content: attributes.content + ' ' + attributesToMerge.content,
-					};
-				},
-			} );
-			registerBlock( 'core/test-block-2', {} );
-			const blockA = {
-				uid: 'chicken',
-				blockType: 'core/test-block',
-				attributes: { content: 'chicken' },
-			};
-			const blockB = {
-				uid: 'ribs',
-				blockType: 'core/test-block2',
-				attributes: { content: 'ribs' },
-			};
-			const dispatch = sinon.spy();
-			mergeBlocks( dispatch, blockA, blockB );
-
-			expect( dispatch ).to.have.not.been.called();
-		} );
-
-		it( 'should transform and merge the blocks', () => {
-			registerBlock( 'core/test-block', {
-				merge( attributes, attributesToMerge ) {
-					return {
-						content: attributes.content + ' ' + attributesToMerge.content,
-					};
-				},
-			} );
-			registerBlock( 'core/test-block-2', {
-				transforms: {
-					to: [ {
-						type: 'blocks',
-						blocks: [ 'core/test-block' ],
-						transform: ( { content2 } ) => {
-							return createBlock( 'core/test-block', {
-								content: content2,
-							} );
-						},
-					} ],
-				},
-			} );
-			const blockA = {
-				uid: 'chicken',
-				blockType: 'core/test-block',
-				attributes: { content: 'chicken' },
-			};
-			const blockB = {
-				uid: 'ribs',
-				blockType: 'core/test-block-2',
-				attributes: { content2: 'ribs' },
-			};
-			const dispatch = sinon.spy();
-			mergeBlocks( dispatch, blockA, blockB );
-
-			expect( dispatch ).to.have.been.calledTwice();
-			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
-			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
-				uid: 'chicken',
-				blockType: 'core/test-block',
-				attributes: { content: 'chicken ribs' },
-			} ] ) );
 		} );
 	} );
 } );

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -1,0 +1,143 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlocks, unregisterBlock, registerBlock, createBlock } from 'blocks';
+
+/**
+ * Internal dependencies
+ */
+import { mergeBlocks, focusBlock, replaceBlocks } from '../actions';
+import effects from '../effects';
+
+describe( 'effects', () => {
+	describe( '.MERGE_BLOCKS', () => {
+		const handler = effects.MERGE_BLOCKS;
+
+		afterEach( () => {
+			getBlocks().forEach( ( block ) => {
+				unregisterBlock( block.slug );
+			} );
+		} );
+
+		it( 'should only focus the blockA if the blockA has no merge function', () => {
+			registerBlock( 'core/test-block', {} );
+			const blockA = {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+			};
+			const blockB = {
+				uid: 'ribs',
+				blockType: 'core/test-block',
+			};
+			const dispatch = sinon.spy();
+			handler( mergeBlocks( blockA, blockB ), { dispatch } );
+
+			expect( dispatch ).to.have.been.calledOnce();
+			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken' ) );
+		} );
+
+		it( 'should merge the blocks if blocks of the same type', () => {
+			registerBlock( 'core/test-block', {
+				merge( attributes, attributesToMerge ) {
+					return {
+						content: attributes.content + ' ' + attributesToMerge.content,
+					};
+				},
+			} );
+			const blockA = {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken' },
+			};
+			const blockB = {
+				uid: 'ribs',
+				blockType: 'core/test-block',
+				attributes: { content: 'ribs' },
+			};
+			const dispatch = sinon.spy();
+			handler( mergeBlocks( blockA, blockB ), { dispatch } );
+
+			expect( dispatch ).to.have.been.calledTwice();
+			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
+			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken ribs' },
+			} ] ) );
+		} );
+
+		it( 'should not merge the blocks have different types without transformation', () => {
+			registerBlock( 'core/test-block', {
+				merge( attributes, attributesToMerge ) {
+					return {
+						content: attributes.content + ' ' + attributesToMerge.content,
+					};
+				},
+			} );
+			registerBlock( 'core/test-block-2', {} );
+			const blockA = {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken' },
+			};
+			const blockB = {
+				uid: 'ribs',
+				blockType: 'core/test-block2',
+				attributes: { content: 'ribs' },
+			};
+			const dispatch = sinon.spy();
+			handler( mergeBlocks( blockA, blockB ), { dispatch } );
+
+			expect( dispatch ).to.not.have.been.called();
+		} );
+
+		it( 'should transform and merge the blocks', () => {
+			registerBlock( 'core/test-block', {
+				merge( attributes, attributesToMerge ) {
+					return {
+						content: attributes.content + ' ' + attributesToMerge.content,
+					};
+				},
+			} );
+			registerBlock( 'core/test-block-2', {
+				transforms: {
+					to: [ {
+						type: 'blocks',
+						blocks: [ 'core/test-block' ],
+						transform: ( { content2 } ) => {
+							return createBlock( 'core/test-block', {
+								content: content2,
+							} );
+						},
+					} ],
+				},
+			} );
+			const blockA = {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken' },
+			};
+			const blockB = {
+				uid: 'ribs',
+				blockType: 'core/test-block-2',
+				attributes: { content2: 'ribs' },
+			};
+			const dispatch = sinon.spy();
+			handler( mergeBlocks( blockA, blockB ), { dispatch } );
+
+			expect( dispatch ).to.have.been.calledTwice();
+			expect( dispatch ).to.have.been.calledWith( focusBlock( 'chicken', { offset: -1 } ) );
+			expect( dispatch ).to.have.been.calledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
+				uid: 'chicken',
+				blockType: 'core/test-block',
+				attributes: { content: 'chicken ribs' },
+			} ] ) );
+		} );
+	} );
+} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -734,7 +734,7 @@ describe( 'state', () => {
 				requesting: false,
 				successful: true,
 				error: null,
-				isNew: true,
+				isNew: false,
 			} );
 		} );
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-redux": "^5.0.4",
     "react-slot-fill": "^1.0.0-alpha.11",
     "redux": "^3.6.0",
+    "refx": "^2.0.0",
     "uuid": "^3.0.1"
   }
 }


### PR DESCRIPTION
Closes #691

This pull request seeks to implement a pattern for managing side effects, in many cases but not exclusively network requests incidentally incurred by dispatched action intents. Doing so eliminates our pattern for passing `dispatch` as an argument to pseudo-action creators, standardizing on a single synchronous return value for action creators defined in `actions.js`, moving side-effects into a separate `effects.js` file. This implementation is achieved using [`refx`](https://github.com/aduth/refx), a middleware for "watching" actions.

See also #691 for related discussion.

__Implementation notes:__

Behaviors of merging, trashing, and saving posts should be unaffected by these changes, with one exception: When a post save completes, it appeared to me we should be updating the post's state `isNew` value to `false`. @nylen let me know if this was intended to remain `true`.

__Testing instructions:__

Verify that there are no regressions in saving, trashing, or merging blocks:

- Save post, noting that post is saved and URL updates with post ID
- Trash post, noting that post is trashed and you are redirected to posts list
- Merge two blocks, for example the first two text blocks

Ensure that tests pass:

```
npm test
```