### PR TITLE
Add test fixture for `core/code` block

### DIFF
--- a/blocks/test/fixtures/core-code.html
+++ b/blocks/test/fixtures/core-code.html
@@ -1,0 +1,5 @@
+<!-- wp:core/code -->
+<pre><code>export default function MyButton() {
+	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
+}</code></pre>
+<!-- /wp:core/code -->

--- a/blocks/test/fixtures/core-code.json
+++ b/blocks/test/fixtures/core-code.json
@@ -1,0 +1,9 @@
+[
+    {
+        "uid": "_uid_0",
+        "blockType": "core/code",
+        "attributes": {
+            "content": "export default function MyButton() {\n\treturn <Button>Click Me!</Button>;\n}"
+        }
+    }
+]

--- a/blocks/test/fixtures/core-code.serialized.html
+++ b/blocks/test/fixtures/core-code.serialized.html
@@ -1,0 +1,6 @@
+<!-- wp:core/code -->
+<pre><code>export default function MyButton() {
+	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
+}</code></pre>
+<!-- /wp:core/code -->
+


### PR DESCRIPTION
Fixes the Travis build (see https://travis-ci.org/WordPress/gutenberg/jobs/236135405).