### PR TITLE
Fix/form toggle accessibility

### DIFF
--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -8,53 +8,35 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Component } from 'element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-class FormToggle extends Component {
-	constructor() {
-		super( ...arguments );
-		this.id = this.constructor.instances++;
-	}
+function FormToggle( { className, checked, id, onChange = noop, showHint = true } ) {
+	const wrapperClasses = classNames(
+		'components-form-toggle',
+		className,
+		{ 'is-checked': checked }
+	);
 
-	render() {
-		const {
-			className,
-			checked,
-			onChange = noop,
-			showHint = true,
-			id = 'toggle-' + this.id,
-		} = this.props;
-
-		const wrapperClasses = classNames(
-			'components-form-toggle',
-			className,
-			{ 'is-checked': checked }
-		);
-
-		return (
-			<span className={ wrapperClasses }>
-				<input
-					className="components-form-toggle__input"
-					id={ id }
-					type="checkbox"
-					value={ checked }
-					onChange={ onChange }
-				/>
-				{ showHint &&
-					<span className="components-form-toggle__hint" aria-hidden>
-						{ checked ? __( 'On' ) : __( 'Off' ) }
-					</span>
-				}
-			</span>
-		);
-	}
+	return (
+		<span className={ wrapperClasses }>
+			<input
+				className="components-form-toggle__input"
+				id={ id }
+				type="checkbox"
+				value={ checked }
+				onChange={ onChange }
+			/>
+			{ showHint &&
+				<span className="components-form-toggle__hint" aria-hidden>
+					{ checked ? __( 'On' ) : __( 'Off' ) }
+				</span>
+			}
+		</span>
+	);
 }
-
-FormToggle.instances = 1;
 
 export default FormToggle;

--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -7,6 +7,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
 import { Component } from 'element';
 
 /**
@@ -21,8 +22,14 @@ class FormToggle extends Component {
 	}
 
 	render() {
-		const { className, checked, children, onChange = noop } = this.props;
-		const id = 'toggle-' + this.id;
+		const {
+			className,
+			checked,
+			onChange = noop,
+			showHint = true,
+			id = 'toggle-' + this.id,
+		} = this.props;
+
 		const wrapperClasses = classNames(
 			'components-form-toggle',
 			className,
@@ -30,7 +37,7 @@ class FormToggle extends Component {
 		);
 
 		return (
-			<div className={ wrapperClasses }>
+			<span className={ wrapperClasses }>
 				<input
 					className="components-form-toggle__input"
 					id={ id }
@@ -38,10 +45,12 @@ class FormToggle extends Component {
 					value={ checked }
 					onChange={ onChange }
 				/>
-				<label className="components-form-toggle__label" htmlFor={ id }>
-					{ children }
-				</label>
-			</div>
+				{ showHint &&
+					<span className="components-form-toggle__hint">
+						{ checked ? __( 'On' ) : __( 'Off' ) }
+					</span>
+				}
+			</span>
 		);
 	}
 }

--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -46,7 +46,7 @@ class FormToggle extends Component {
 					onChange={ onChange }
 				/>
 				{ showHint &&
-					<span className="components-form-toggle__hint">
+					<span className="components-form-toggle__hint" aria-hidden>
 						{ checked ? __( 'On' ) : __( 'Off' ) }
 					</span>
 				}

--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -60,9 +60,9 @@ $toggle-border-width: 2px;
 	width: 100%;
 	height: 100%;
 	opacity: 0;
-	pointer-events: none;
 	margin: 0;
 	padding: 0;
+	z-index: z-index( '.components-form-toggle__input' );
 }
 
 .components-form-toggle__hint {

--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -1,19 +1,10 @@
-.components-form-toggle {
-	position: relative;
-}
-
-.components-form-toggle__input[type=checkbox] {
-	position: absolute;
-	opacity: 0;
-	pointer-events: none;
-	margin: 0;
-	padding: 0;
-}
-
 $toggle-width: 32px;
 $toggle-height: 18px;
 $toggle-border-width: 2px;
-.components-form-toggle__label {
+
+.components-form-toggle {
+	position: relative;
+
 	&:before {
 		content: '';
 		display: inline-block;
@@ -34,11 +25,6 @@ $toggle-border-width: 2px;
 
 	&:hover:before {
 		background-color: $light-gray-500;
-
-		.components-form-toggle.is-checked & {
-			background-color: $blue-medium;
-			border: $toggle-border-width solid $blue-medium;
-		}
 	}
 
 	&:after {
@@ -52,11 +38,35 @@ $toggle-border-width: 2px;
 		border-radius: 50%;
 		background: $dark-gray-500;
 		transition: 0.1s transform ease;
+	}
 
-
-		.components-form-toggle.is-checked & {
+	&.is-checked {
+		&:after {
 			background-color: $white;
 			transform: translateX( $toggle-width - ( $toggle-border-width * 4 ) - ( $toggle-height - ( $toggle-border-width * 4 ) ) );
 		}
+
+		&:before {
+			background-color: $blue-medium;
+			border: $toggle-border-width solid $blue-medium;
+		}
 	}
+}
+
+.components-form-toggle__input[type=checkbox] {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	opacity: 0;
+	pointer-events: none;
+	margin: 0;
+	padding: 0;
+}
+
+.components-form-toggle__hint {
+	display: inline-block;
+	margin-left: 10px;
+	font-weight: 500;
 }

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -6,10 +6,10 @@ $z-layers: (
 	'.editor-visual-editor__block:before': -1,
 	'.editor-visual-editor__block {core/image aligned left or right}': 10,
 	'.editor-visual-editor__block-controls': 1,
+	'.components-form-toggle__input': 1,
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
-	'.components-form-toggle__input': 40,
 );
 
 @function z-index( $key ) {

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -9,6 +9,7 @@ $z-layers: (
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
+	'.components-form-toggle__input': 40,
 );
 
 @function z-index( $key ) {

--- a/editor/sidebar/discussion-panel/index.js
+++ b/editor/sidebar/discussion-panel/index.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
+import { Component } from 'element';
 import PanelBody from 'components/panel/body';
 import FormToggle from 'components/form-toggle';
 
@@ -17,32 +18,46 @@ import './style.scss';
 import { getEditedPostAttribute } from '../../selectors';
 import { editPost } from '../../actions';
 
-function DiscussionPanel( { pingStatus = 'open', commentStatus = 'open', ...props } ) {
-	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
-	const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
+class DiscussionPanel extends Component {
+	constructor() {
+		super( ...arguments );
+		this.id = this.constructor.instances++;
+	}
 
-	// Disable Reason: The input is inside the label, we shouldn't need the htmlFor
-	/* eslint-disable jsx-a11y/label-has-for */
-	return (
-		<PanelBody title={ __( 'Discussion' ) } initialOpen={ false }>
-			<label className="editor-discussion-panel__row">
-				<span>{ __( 'Allow Comments' ) }</span>
-				<FormToggle
-					checked={ commentStatus === 'open' }
-					onChange={ onToggleComments }
-				/>
-			</label>
-			<label className="editor-discussion-panel__row">
-				<span>{ __( 'Allow Pingbacks & Trackbacks' ) }</span>
-				<FormToggle
-					checked={ pingStatus === 'open' }
-					onChange={ onTogglePingback }
-				/>
-			</label>
-		</PanelBody>
-	);
-	/* eslint-enable jsx-a11y/label-has-for */
+	render() {
+		const { pingStatus = 'open', commentStatus = 'open', ...props } = this.props;
+		const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
+		const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
+
+		const commentsToggleId = 'allow-comments-toggle-' + this.id;
+		const pingbacksToggleId = 'allow-pingbacks-toggle-' + this.id;
+
+		return (
+			<PanelBody title={ __( 'Discussion' ) } initialOpen={ false }>
+				<div className="editor-discussion-panel__row">
+					<label htmlFor={ commentsToggleId }>{ __( 'Allow Comments' ) }</label>
+					<FormToggle
+						checked={ commentStatus === 'open' }
+						onChange={ onToggleComments }
+						showHint={ false }
+						id={ commentsToggleId }
+					/>
+				</div>
+				<div className="editor-discussion-panel__row">
+					<label htmlFor={ pingbacksToggleId }>{ __( 'Allow Pingbacks & Trackbacks' ) }</label>
+					<FormToggle
+						checked={ pingStatus === 'open' }
+						onChange={ onTogglePingback }
+						showHint={ false }
+						id={ pingbacksToggleId }
+					/>
+				</div>
+			</PanelBody>
+		);
+	}
 }
+
+DiscussionPanel.instances = 1;
 
 export default connect(
 	( state ) => {

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
+import { Component } from 'element';
 import PanelBody from 'components/panel/body';
 import FormToggle from 'components/form-toggle';
 
@@ -20,44 +21,54 @@ import PostSchedule from '../post-schedule';
 import { getEditedPostStatus, getSuggestedPostFormat } from '../../selectors';
 import { editPost } from '../../actions';
 
-function PostStatus( { status, onUpdateStatus, suggestedFormat } ) {
-	const onToggle = () => {
-		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
-		onUpdateStatus( updatedStatus );
-	};
+class PostStatus extends Component {
+	constructor() {
+		super( ...arguments );
+		this.id = this.constructor.instances++;
+	}
 
-	// Use the suggested post format based on the blocks content of the post
-	// or the default post format setting for the site.
-	const format = suggestedFormat || __( 'Standard' );
+	render() {
+		const { status, onUpdateStatus, suggestedFormat } = this.props;
+		const onToggle = () => {
+			const updatedStatus = status === 'pending' ? 'draft' : 'pending';
+			onUpdateStatus( updatedStatus );
+		};
 
-	// Disable Reason: The input is inside the label, we shouldn't need the htmlFor
-	/* eslint-disable jsx-a11y/label-has-for */
-	return (
-		<PanelBody title={ __( 'Status & Visibility' ) }>
-			<label className="editor-post-status__row">
-				<span>{ __( 'Pending review' ) }</span>
-				<FormToggle
-					checked={ status === 'pending' }
-					onChange={ onToggle }
-				/>
-			</label>
-			<div className="editor-post-status__row">
-				<PostVisibility />
-			</div>
-			<div className="editor-post-status__row">
-				<PostSchedule />
-			</div>
-			<div className="editor-post-status__row">
-				<span>{ __( 'Post Format' ) }</span>
-				<span>{ format }</span>
-			</div>
-			<div className="editor-post-status__row">
-				<PostTrash />
-			</div>
-		</PanelBody>
-	);
-	/* eslint-enable jsx-a11y/label-has-for */
+		// Use the suggested post format based on the blocks content of the post
+		// or the default post format setting for the site.
+		const format = suggestedFormat || __( 'Standard' );
+		const pendingId = 'pending-toggle-' + this.id;
+
+		return (
+			<PanelBody title={ __( 'Status & Visibility' ) }>
+				<div className="editor-post-status__row">
+					<label htmlFor={ pendingId }>{ __( 'Pending review' ) }</label>
+					<FormToggle
+						id={ pendingId }
+						checked={ status === 'pending' }
+						onChange={ onToggle }
+						showHint={ false }
+					/>
+				</div>
+				<div className="editor-post-status__row">
+					<PostVisibility />
+				</div>
+				<div className="editor-post-status__row">
+					<PostSchedule />
+				</div>
+				<div className="editor-post-status__row">
+					<span>{ __( 'Post Format' ) }</span>
+					<span>{ format }</span>
+				</div>
+				<div className="editor-post-status__row">
+					<PostTrash />
+				</div>
+			</PanelBody>
+		);
+	}
 }
+
+PostStatus.instances = 1;
 
 export default connect(
 	( state ) => ( {


### PR DESCRIPTION
This PR closes #906 by:

 - Adding an optional "On/Off" Toggle to the `FormToggle` component
 - Transforming the `FormToggle` component to an inline component
 - Dropping the embedded `label` from the `FormToggle` component
 - Explicitly use `id/for` for the input/label of the "Pending review" toggle.
