### PR TITLE
Chrome: Fix the post schedule z-index

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -8,6 +8,7 @@ $z-layers: (
 	'.editor-visual-editor__block-controls': 1,
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
+	'.editor-post-schedule__dialog': 30,
 );
 
 @function z-index( $key ) {

--- a/editor/sidebar/post-schedule/style.scss
+++ b/editor/sidebar/post-schedule/style.scss
@@ -31,6 +31,7 @@
 	background: $white;
 	padding: 10px;
 	min-width: 265px;
+	z-index: z-index( '.editor-post-schedule__dialog' );
 }
 
 .editor-post-schedule__dialog-arrow {


### PR DESCRIPTION
Before
<img width="280" alt="screen shot 2017-05-26 at 16 17 31" src="https://cloud.githubusercontent.com/assets/272444/26500726/f51a744a-422e-11e7-8cc1-1516be240f4f.png">

After
<img width="281" alt="screen shot 2017-05-26 at 16 17 15" src="https://cloud.githubusercontent.com/assets/272444/26500745/099e9dec-422f-11e7-9d79-12cbdb8fdb05.png">
