### PR TITLE
Prevent default enter key behaviour in title

### DIFF
--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -11,15 +11,15 @@ import './style.scss';
 import { getEditedPostTitle } from '../selectors';
 import { editPost } from '../actions';
 
-/**
- * Constants
- */
-const REGEXP_NEWLINES = /[\r\n]+/g;
-
 function PostTitle( { title, onUpdate } ) {
 	const onChange = ( event ) => {
-		const newTitle = event.target.value.replace( REGEXP_NEWLINES, ' ' );
-		onUpdate( newTitle );
+		onUpdate( event.target.value );
+	};
+
+	const onKeyDown = ( event ) => {
+		if ( event.keyCode === 13 ) {
+			event.preventDefault();
+		}
 	};
 
 	return (
@@ -29,6 +29,7 @@ function PostTitle( { title, onUpdate } ) {
 				value={ title }
 				onChange={ onChange }
 				placeholder={ wp.i18n.__( 'Enter title here' ) }
+				onKeyDown={ onKeyDown }
 			/>
 		</h1>
 	);

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -11,9 +11,15 @@ import './style.scss';
 import { getEditedPostTitle } from '../selectors';
 import { editPost } from '../actions';
 
+/**
+ * Constants
+ */
+const REGEXP_NEWLINES = /[\r\n]+/g;
+
 function PostTitle( { title, onUpdate } ) {
 	const onChange = ( event ) => {
-		onUpdate( event.target.value );
+		const newTitle = event.target.value.replace( REGEXP_NEWLINES, ' ' );
+		onUpdate( newTitle );
 	};
 
 	const onKeyDown = ( event ) => {


### PR DESCRIPTION
I noticed an odd behaviour when pressing enter in the title: it inserts a space and the caret is moved to the end. I'm not sure if this is intentional.

This PR would ignore enter key presses. Feel free to close if the current behaviour is intended or if it needs a different fix.