### PR TITLE
Bump dom-react dependency version (fixes IE11 breakage)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "dom-react": "^2.0.0",
+    "dom-react": "^2.2.0",
     "element-closest": "^2.0.2",
     "hpq": "^1.2.0",
     "jed": "^1.1.1",


### PR DESCRIPTION
Fixes #664

This pull request seeks to upgrade our `dom-react` dependency from `2.0.0` to `2.2.0`, which notably resolves issues with the Gutenberg editor loading in IE11 due to lack of runtime transforms (see iseulde/dom-react@a5a588f).

![IE11](https://cloud.githubusercontent.com/assets/1779930/26512717/d82e55b6-4235-11e7-8ec3-1ab6735c06e0.png)

__Testing instructions:__

Verify that the editor loads in IE11 and your preferred browser.