### PR TITLE
Preserve isNew after save completes successfully

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -55,6 +55,7 @@ export function savePost( postId, edits ) {
 		type: 'REQUEST_POST_UPDATE',
 		edits,
 		postId,
+		isNew: ! postId,
 	};
 }
 

--- a/editor/state.js
+++ b/editor/state.js
@@ -397,7 +397,7 @@ export function saving( state = {}, action ) {
 				requesting: false,
 				successful: true,
 				error: null,
-				isNew: false,
+				isNew: action.isNew,
 			};
 
 		case 'REQUEST_POST_UPDATE_FAILURE':

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -6,7 +6,11 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { focusBlock, replaceBlocks } from '../actions';
+import {
+	focusBlock,
+	replaceBlocks,
+	savePost,
+} from '../actions';
 
 describe( 'actions', () => {
 	describe( 'focusBlock', () => {
@@ -33,6 +37,26 @@ describe( 'actions', () => {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks,
+			} );
+		} );
+	} );
+
+	describe( 'savePost', () => {
+		it( 'should return the REQUEST_POST_UPDATE action for a new post', () => {
+			expect( savePost( null, { title: 'changed' } ) ).to.eql( {
+				type: 'REQUEST_POST_UPDATE',
+				edits: { title: 'changed' },
+				postId: null,
+				isNew: true,
+			} );
+		} );
+
+		it( 'should return the REQUEST_POST_UPDATE action for an existing post', () => {
+			expect( savePost( 1, { title: 'changed' } ) ).to.eql( {
+				type: 'REQUEST_POST_UPDATE',
+				edits: { title: 'changed' },
+				postId: 1,
+				isNew: false,
 			} );
 		} );
 	} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -845,7 +845,7 @@ describe( 'state', () => {
 				requesting: false,
 				successful: true,
 				error: null,
-				isNew: false,
+				isNew: true,
 			} );
 		} );
 


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/907#issuecomment-304391118

This pull request resolves an issue where the `state.saving.isNew` value is inaccurate after a post is saved successfully. 

__Testing instructions:__

Repeat instructions from https://github.com/WordPress/gutenberg/pull/907#issuecomment-304391118

Ensure unit tests pass:

```
npm test
```