### PR TITLE
Editable: Extract the format toolbar out of the editable

### DIFF
--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -97,7 +97,12 @@ class FormatToolbar extends Component {
 
 		const focusPosition = this.getRelativePosition( element );
 		const bookmark = this.props.editor.selection.getBookmark( 2, true );
-		this.setState( { bookmark, formats, focusPosition } );
+		this.setState( {
+			bookmark,
+			formats,
+			focusPosition,
+			linkValue: '',
+		} );
 	}
 
 	isFormatActive( format ) {
@@ -163,6 +168,7 @@ class FormatToolbar extends Component {
 		event.preventDefault();
 		this.setState( {
 			isEditingLink: true,
+			linkValue: this.state.formats.link.value,
 		} );
 	}
 
@@ -230,7 +236,7 @@ class FormatToolbar extends Component {
 				{ !! formats.link && ! this.state.isEditingLink &&
 					<div className="editable-format-toolbar__link-modal" style={ linkStyle }>
 						<a className="editable-format-toolbar__link-value" href="" onClick={ this.editLink }>
-							{ this.state.linkValue && decodeURI( this.state.linkValue ) }
+							{ !! formats.link && decodeURI( formats.link.value ) }
 						</a>
 						<IconButton icon="edit" onClick={ this.editLink } />
 						<IconButton icon="editor-unlink" onClick={ this.dropLink } />

--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -236,7 +236,7 @@ class FormatToolbar extends Component {
 				{ !! formats.link && ! this.state.isEditingLink &&
 					<div className="editable-format-toolbar__link-modal" style={ linkStyle }>
 						<a className="editable-format-toolbar__link-value" href="" onClick={ this.editLink }>
-							{ !! formats.link && decodeURI( formats.link.value ) }
+							{ !! formats.link.value && decodeURI( formats.link.value ) }
 						</a>
 						<IconButton icon="edit" onClick={ this.editLink } />
 						<IconButton icon="editor-unlink" onClick={ this.dropLink } />

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -131,12 +131,13 @@ export default class Editable extends wp.element.Component {
 
 		const content = this.getContent();
 		const collapsed = this.editor.selection.isCollapsed();
+		const previousCollpsedValue = this.props.focus.collapsed !== undefined ? this.props.focus.collapsed : true;
 
 		this.setState( {
 			empty: ! content || ! content.length,
 		} );
 
-		if ( this.props.focus.collapsed !== collapsed ) {
+		if ( collapsed !== previousCollpsedValue ) {
 			this.props.onFocus( {
 				...this.props.focus,
 				collapsed,
@@ -308,7 +309,7 @@ export default class Editable extends wp.element.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.focus !== prevProps.focus ) {
+		if ( ! isEqual( this.props.focus, prevProps.focus ) ) {
 			this.updateFocus();
 		}
 

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -131,13 +131,13 @@ export default class Editable extends wp.element.Component {
 
 		const content = this.getContent();
 		const collapsed = this.editor.selection.isCollapsed();
-		const previousCollpsedValue = this.props.focus.collapsed !== undefined ? this.props.focus.collapsed : true;
+		const previousCollpsedValue = this.props.focus && this.props.focus.collapsed !== undefined ? this.props.focus.collapsed : true;
 
 		this.setState( {
 			empty: ! content || ! content.length,
 		} );
 
-		if ( collapsed !== previousCollpsedValue ) {
+		if ( ! this.props.focus || collapsed !== previousCollpsedValue ) {
 			this.props.onFocus( {
 				...this.props.focus,
 				collapsed,
@@ -309,7 +309,7 @@ export default class Editable extends wp.element.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( ! isEqual( this.props.focus, prevProps.focus ) ) {
+		if ( this.props.focus !== prevProps.focus ) {
 			this.updateFocus();
 		}
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -2,6 +2,13 @@
  * External dependencies
  */
 import { isString } from 'lodash';
+import { Fill } from 'react-slot-fill';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+import Toolbar from 'components/toolbar';
 
 /**
  * Internal dependencies
@@ -9,7 +16,7 @@ import { isString } from 'lodash';
 import './style.scss';
 import { registerBlock, createBlock, query } from '../../api';
 import Editable from '../../editable';
-import BlockControls from '../../block-controls';
+import FormatToolbar from '../../editable/format-toolbar';
 
 const { children, prop } = query;
 
@@ -76,35 +83,51 @@ registerBlock( 'core/heading', {
 		};
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks } ) {
-		const { content, nodeName = 'H2' } = attributes;
+	edit: class extends Component {
+		constructor() {
+			super( ...arguments );
+			this.onSetup = this.onSetup.bind( this );
+		}
 
-		return [
-			focus && (
-				<BlockControls
-					key="controls"
-					controls={
-						'123456'.split( '' ).map( ( level ) => ( {
-							icon: 'heading',
-							title: wp.i18n.sprintf( wp.i18n.__( 'Heading %s' ), level ),
-							isActive: 'H' + level === nodeName,
-							onClick: () => setAttributes( { nodeName: 'H' + level } ),
-							subscript: level,
-						} ) )
-					}
-				/>
-			),
-			<Editable
-				key="editable"
-				tagName={ nodeName.toLowerCase() }
-				value={ content }
-				focus={ focus }
-				onFocus={ setFocus }
-				onChange={ ( value ) => setAttributes( { content: value } ) }
-				onMerge={ mergeBlocks }
-				inline
-			/>,
-		];
+		onSetup( editor ) {
+			this.editor = editor;
+		}
+
+		render() {
+			const { attributes, setAttributes, focus, setFocus, mergeBlocks } = this.props;
+			const { content, nodeName = 'H2' } = attributes;
+
+			return [
+				focus && (
+					<Fill name="Formatting.Toolbar">
+						<Toolbar
+							controls={
+								'123456'.split( '' ).map( ( level ) => ( {
+									icon: 'heading',
+									title: wp.i18n.sprintf( wp.i18n.__( 'Heading %s' ), level ),
+									isActive: 'H' + level === nodeName,
+									onClick: () => setAttributes( { nodeName: 'H' + level } ),
+									subscript: level,
+								} ) )
+							}
+						/>
+						{ this.editor && <FormatToolbar editor={ this.editor } /> }
+					</Fill>
+				),
+				<Editable
+					key="editable"
+					tagName={ nodeName.toLowerCase() }
+					value={ content }
+					focus={ focus }
+					onFocus={ setFocus }
+					onChange={ ( value ) => setAttributes( { content: value } ) }
+					onMerge={ mergeBlocks }
+					onSetup={ this.onSetup }
+					showFormattingToolbar={ false }
+					inline
+				/>,
+			];
+		}
 	},
 
 	save( { attributes } ) {


### PR DESCRIPTION
This idea builds on top of #830 to allow block authors to explicitly include the formatting toolbar inside the `edit` function the same way they include the other controls.

Allowing the block author to explicitly include the toolbars let the block author controls the order of these toolbars. Another advantage of this PR is that the code required to apply these formats is not split between two components and the `Editable` component is way simpler.

I'm seeing some focus jumps (especially when using the `link` control), I'll try to address them asap.

Once we refactor all the blocks to use this technique, we'll be able to drop the temporary "showFormattingToolbar" prop.

A next step to this PR would be to do the same for the alignment toolbar.