### PR TITLE
Plugin: Drop `Array.prototype.find` calls and replace with lodash

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import uuid from 'uuid/v4';
-import { get, castArray, findIndex, isObjectLike } from 'lodash';
+import { get, castArray, findIndex, isObjectLike, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -49,8 +49,8 @@ export function switchToBlockType( block, blockType ) {
 	const transformationsFrom = get( destinationSettings, 'transforms.from', [] );
 	const transformationsTo = get( sourceSettings, 'transforms.to', [] );
 	const transformation =
-		transformationsTo.find( t => t.blocks.indexOf( blockType ) !== -1 ) ||
-		transformationsFrom.find( t => t.blocks.indexOf( block.blockType ) !== -1 );
+		find( transformationsTo, t => t.blocks.indexOf( blockType ) !== -1 ) ||
+		find( transformationsFrom, t => t.blocks.indexOf( block.blockType ) !== -1 );
 
 	// If no valid transformation, stop.  (How did we get here?)
 	if ( ! transformation ) {

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { last, isEqual, capitalize, omitBy, forEach, merge, identity } from 'lodash';
+import { last, isEqual, capitalize, omitBy, forEach, merge, identity, find } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 import { Fill } from 'react-slot-fill';
 import 'element-closest';
@@ -289,7 +289,7 @@ export default class Editable extends wp.element.Component {
 
 	onNodeChange( { element, parents } ) {
 		const formats = {};
-		const link = parents.find( ( node ) => node.nodeName.toLowerCase() === 'a' );
+		const link = find( parents, ( node ) => node.nodeName.toLowerCase() === 'a' );
 		if ( link ) {
 			formats.link = { value: link.getAttribute( 'href' ), link };
 		}

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { uniq, get, reduce } from 'lodash';
+import { uniq, get, reduce, find } from 'lodash';
 import clickOutside from 'react-click-outside';
 
 /**
@@ -54,7 +54,7 @@ class BlockSwitcher extends wp.element.Component {
 		const blockSettings = wp.blocks.getBlockSettings( this.props.block.blockType );
 		const blocksToBeTransformedFrom = reduce( wp.blocks.getBlocks(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );
-			const transformation = transformFrom.find( t => t.blocks.indexOf( this.props.block.blockType ) !== -1 );
+			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.blockType ) !== -1 );
 			return transformation ? memo.concat( [ block.slug ] ) : memo;
 		}, [] );
 		const blocksToBeTransformedTo = get( blockSettings, 'transforms.to', [] )


### PR DESCRIPTION
closes #922 

I'm still seeing some visual bugs in IE11 but these should be tracked separately.