### PR TITLE
De-duplicate Webpack build, especially `components/`

### DIFF
--- a/blocks/block-controls/index.js
+++ b/blocks/block-controls/index.js
@@ -6,7 +6,7 @@ import { Fill } from 'react-slot-fill';
 /**
  * WordPress dependencies
  */
-import Toolbar from 'components/toolbar';
+import { Toolbar } from 'components';
 
 export default function BlockControls( { controls } ) {
 	return (

--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import IconButton from 'components/icon-button';
-import Toolbar from 'components/toolbar';
+import { IconButton } from 'components';
+import { Toolbar } from 'components';
 
 const FORMATTING_CONTROLS = [
 	{

--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { IconButton } from 'components';
-import { Toolbar } from 'components';
+import { IconButton, Toolbar } from 'components';
 
 const FORMATTING_CONTROLS = [
 	{

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -10,7 +10,7 @@ import 'element-closest';
 /**
  * WordPress dependencies
  */
-import Toolbar from 'components/toolbar';
+import { Toolbar } from 'components';
 
 /**
  * Internal dependencies

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import IconButton from 'components/icon-button';
+import { IconButton } from 'components';
 
 /**
  * Internal dependencies

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import Button from 'components/button';
-import Placeholder from 'components/placeholder';
+import { Button } from 'components';
+import { Placeholder } from 'components';
 
 /**
  * Internal dependencies

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button } from 'components';
-import { Placeholder } from 'components';
+import { Button, Placeholder } from 'components';
 
 /**
  * Internal dependencies

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import Placeholder from 'components/placeholder';
+import { Placeholder } from 'components';
 
 /**
  * Internal dependencies

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -3,7 +3,7 @@
  */
 import { Component } from 'element';
 import { __ } from 'i18n';
-import Button from 'components/button';
+import { Button } from 'components';
 
 class MediaUploadButton extends Component {
 	constructor( { multiple = false, type } ) {

--- a/components/README.md
+++ b/components/README.md
@@ -11,7 +11,7 @@ Within Gutenberg, these components can be accessed by importing from the `compon
 /**
  * WordPress dependencies
  */
-import Button from 'components/button';
+import { Button } from 'components';
 
 export default function MyButton() {
 	return <Button>Click Me!</Button>;

--- a/components/index.js
+++ b/components/index.js
@@ -1,0 +1,10 @@
+export { default as Button } from './button';
+export { default as Dashicon } from './dashicon';
+export { default as FormToggle } from './form-toggle';
+export { default as IconButton } from './icon-button';
+export { default as Panel } from './panel';
+export { default as Placeholder } from './placeholder';
+export { default as Spinner } from './spinner';
+export { default as Toolbar } from './toolbar';
+
+export { default as WithFocusReturn } from './higher-order/with-focus-return';

--- a/components/index.js
+++ b/components/index.js
@@ -7,4 +7,4 @@ export { default as Placeholder } from './placeholder';
 export { default as Spinner } from './spinner';
 export { default as Toolbar } from './toolbar';
 
-export { default as WithFocusReturn } from './higher-order/with-focus-return';
+export { default as withFocusReturn } from './higher-order/with-focus-return';

--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from 'element';
-import IconButton from 'components/icon-button';
+import { IconButton } from 'components';
 
 class PanelBody extends Component {
 	constructor( props ) {

--- a/components/placeholder/index.js
+++ b/components/placeholder/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import './style.scss';
-import Dashicon from 'components/dashicon';
+import { Dashicon } from 'components';
 
 function Placeholder( { icon, children, label, instructions, className, ...additionalProps } ) {
 	const classes = classnames( 'components-placeholder', className );

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import IconButton from 'components/icon-button';
+import { IconButton } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -8,8 +8,7 @@ import clickOutside from 'react-click-outside';
 /**
  * WordPress dependencies
  */
-import { IconButton } from 'components';
-import { Dashicon } from 'components';
+import { Dashicon, IconButton } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -8,8 +8,8 @@ import clickOutside from 'react-click-outside';
 /**
  * WordPress dependencies
  */
-import IconButton from 'components/icon-button';
-import Dashicon from 'components/dashicon';
+import { IconButton } from 'components';
+import { Dashicon } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import Dashicon from 'components/dashicon';
+import { Dashicon } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import Dashicon from 'components/dashicon';
+import { Dashicon } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import IconButton from 'components/icon-button';
+import { IconButton } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import IconButton from 'components/icon-button';
+import { IconButton } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import Button from 'components/button';
+import { Button } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import IconButton from 'components/icon-button';
+import { IconButton } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -8,8 +8,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Dashicon } from 'components';
-import { withFocusReturn } from 'components';
+import { Dashicon, withFocusReturn } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -8,8 +8,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import Dashicon from 'components/dashicon';
-import withFocusReturn from 'components/higher-order/with-focus-return';
+import { Dashicon } from 'components';
+import { withFocusReturn } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -11,7 +11,7 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
  * WordPress dependencies
  */
 import { Children } from 'element';
-import Toolbar from 'components/toolbar';
+import { Toolbar } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -6,9 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Panel } from 'components';
-import { PanelHeader } from 'components';
-import { PanelBody } from 'components';
+import { Panel, PanelHeader, PanelBody } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -6,9 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import Panel from 'components/panel';
-import PanelHeader from 'components/panel/header';
-import PanelBody from 'components/panel/body';
+import { Panel } from 'components';
+import { PanelHeader } from 'components';
+import { PanelBody } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/discussion-panel/index.js
+++ b/editor/sidebar/discussion-panel/index.js
@@ -8,8 +8,7 @@ import { connect } from 'react-redux';
  */
 import { __ } from 'i18n';
 import { Component } from 'element';
-import { PanelBody } from 'components';
-import { FormToggle } from 'components';
+import { PanelBody, FormToggle } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/discussion-panel/index.js
+++ b/editor/sidebar/discussion-panel/index.js
@@ -8,8 +8,8 @@ import { connect } from 'react-redux';
  */
 import { __ } from 'i18n';
 import { Component } from 'element';
-import PanelBody from 'components/panel/body';
-import FormToggle from 'components/form-toggle';
+import { PanelBody } from 'components';
+import { FormToggle } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/featured-image/index.js
+++ b/editor/sidebar/featured-image/index.js
@@ -8,10 +8,10 @@ import { connect } from 'react-redux';
  */
 import { Component } from 'element';
 import { __ } from 'i18n';
-import Button from 'components/button';
-import PanelBody from 'components/panel/body';
-import MediaUploadButton from 'blocks/media-upload-button';
-import Spinner from 'components/spinner';
+import { Button } from 'components';
+import { PanelBody } from 'components';
+import { MediaUploadButton } from 'blocks';
+import { Spinner } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/featured-image/index.js
+++ b/editor/sidebar/featured-image/index.js
@@ -8,10 +8,8 @@ import { connect } from 'react-redux';
  */
 import { Component } from 'element';
 import { __ } from 'i18n';
-import { Button } from 'components';
-import { PanelBody } from 'components';
+import { Button, PanelBody, Spinner } from 'components';
 import { MediaUploadButton } from 'blocks';
-import { Spinner } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress Dependencies
  */
-import withFocusReturn from 'components/higher-order/with-focus-return';
+import { withFocusReturn } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-excerpt/index.js
+++ b/editor/sidebar/post-excerpt/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import PanelBody from 'components/panel/body';
+import { PanelBody } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-schedule/clock.js
+++ b/editor/sidebar/post-schedule/clock.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import Button from 'components/button';
+import { Button } from 'components';
 
 function PostScheduleClock( { is12Hour, selected, onChange } ) {
 	const minutes = selected.format( 'mm' );

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -7,9 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Panel } from 'components';
-import { PanelHeader } from 'components';
-import { IconButton } from 'components';
+import { Panel, PanelHeader, IconButton } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -7,9 +7,9 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import Panel from 'components/panel';
-import PanelHeader from 'components/panel/header';
-import IconButton from 'components/icon-button';
+import { Panel } from 'components';
+import { PanelHeader } from 'components';
+import { IconButton } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -8,8 +8,7 @@ import { connect } from 'react-redux';
  */
 import { __ } from 'i18n';
 import { Component } from 'element';
-import { PanelBody } from 'components';
-import { FormToggle } from 'components';
+import { PanelBody, FormToggle } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -8,8 +8,8 @@ import { connect } from 'react-redux';
  */
 import { __ } from 'i18n';
 import { Component } from 'element';
-import PanelBody from 'components/panel/body';
-import FormToggle from 'components/form-toggle';
+import { PanelBody } from 'components';
+import { FormToggle } from 'components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-trash/index.js
+++ b/editor/sidebar/post-trash/index.js
@@ -7,8 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Button } from 'components';
-import { Dashicon } from 'components';
+import { Button, Dashicon } from 'components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-trash/index.js
+++ b/editor/sidebar/post-trash/index.js
@@ -7,8 +7,8 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import Button from 'components/button';
-import Dashicon from 'components/dashicon';
+import { Button } from 'components';
+import { Dashicon } from 'components';
 
 /**
  * Internal dependencies

--- a/index.php
+++ b/index.php
@@ -178,8 +178,6 @@ function gutenberg_register_scripts() {
 		'https://unpkg.com/moment@2.18.1/' . $moment_script,
 		array( 'react' )
 	);
-
-	// Editor Scripts.
 	gutenberg_register_vendor_script(
 		'tinymce-nightly',
 		'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce' . $suffix . '.js'
@@ -189,6 +187,8 @@ function gutenberg_register_scripts() {
 		'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin' . $suffix . '.js',
 		array( 'tinymce-nightly' )
 	);
+
+	// Editor Scripts.
 	wp_register_script(
 		'wp-date',
 		plugins_url( 'date/build/index.js', __FILE__ ),
@@ -232,6 +232,12 @@ function gutenberg_register_scripts() {
 		plugins_url( 'element/build/index.js', __FILE__ ),
 		array( 'react', 'react-dom', 'react-dom-server' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'element/build/index.js' )
+	);
+	wp_register_script(
+		'wp-components',
+		plugins_url( 'components/build/index.js', __FILE__ ),
+		array( 'wp-element' ),
+		filemtime( plugin_dir_path( __FILE__ ) . 'components/build/index.js' )
 	);
 	wp_register_script(
 		'wp-blocks',
@@ -473,7 +479,7 @@ function gutenberg_scripts_and_styles( $hook ) {
 	wp_enqueue_script(
 		'wp-editor',
 		plugins_url( 'editor/build/index.js', __FILE__ ),
-		array( 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element' ),
+		array( 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'editor/build/index.js' ),
 		true // enqueue in the footer.
 	);

--- a/index.php
+++ b/index.php
@@ -242,11 +242,17 @@ function gutenberg_register_scripts() {
 	wp_register_script(
 		'wp-blocks',
 		plugins_url( 'blocks/build/index.js', __FILE__ ),
-		array( 'wp-element', 'tinymce-nightly', 'tinymce-nightly-lists' ),
+		array( 'wp-element', 'wp-components', 'tinymce-nightly', 'tinymce-nightly-lists' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'blocks/build/index.js' )
 	);
 
 	// Editor Styles.
+	wp_register_style(
+		'wp-components',
+		plugins_url( 'components/build/style.css', __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . 'components/build/style.css' )
+	);
 	wp_register_style(
 		'wp-blocks',
 		plugins_url( 'blocks/build/style.css', __FILE__ ),
@@ -536,7 +542,7 @@ function gutenberg_scripts_and_styles( $hook ) {
 	wp_enqueue_style(
 		'wp-editor',
 		plugins_url( 'editor/build/style.css', __FILE__ ),
-		array( 'wp-blocks' ),
+		array( 'wp-components', 'wp-blocks' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'editor/build/style.css' )
 	);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,12 @@ const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
 const config = {
 	entry: {
-		date: './date/index.js',
-		i18n: './i18n/index.js',
 		blocks: './blocks/index.js',
+		components: './components/index.js',
+		date: './date/index.js',
 		editor: './editor/index.js',
 		element: './element/index.js',
+		i18n: './i18n/index.js',
 	},
 	output: {
 		filename: '[name]/build/index.js',
@@ -102,21 +103,29 @@ switch ( process.env.NODE_ENV ) {
 			__dirname: true,
 		};
 		config.module.rules = [
-			...[ 'date', 'i18n', 'element', 'blocks', 'editor' ].map( ( entry ) => ( {
+			...[
+				'blocks',
+				'components',
+				'date',
+				'editor',
+				'element',
+				'i18n',
+			].map( ( entry ) => ( {
 				test: require.resolve( './' + entry + '/index.js' ),
 				use: 'expose-loader?wp.' + entry,
 			} ) ),
 			...config.module.rules,
 		];
 		const testFiles = glob.sync(
-			'./{' + Object.keys( config.entry ).concat( 'components' ).sort() + '}/**/test/*.js'
+			'./{' + Object.keys( config.entry ).sort() + '}/**/test/*.js'
 		);
 		config.entry = [
-			'./date/index.js',
-			'./i18n/index.js',
-			'./element/index.js',
 			'./blocks/index.js',
+			'./components/index.js',
+			'./date/index.js',
 			'./editor/index.js',
+			'./element/index.js',
+			'./i18n/index.js',
 			...testFiles.filter( f => /full-content\.js$/.test( f ) ),
 			...testFiles.filter( f => ! /full-content\.js$/.test( f ) ),
 		];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,20 @@ const entryPointNames = [
 	'i18n',
 ];
 
+const externals = {
+	react: 'React',
+	'react-dom': 'ReactDOM',
+	'react-dom/server': 'ReactDOMServer',
+	tinymce: 'tinymce',
+	moment: 'moment',
+};
+
+entryPointNames.forEach( entryPointName => {
+	externals[ entryPointName ] = {
+		'this': [ 'wp', entryPointName ],
+	};
+} );
+
 const config = {
 	entry: entryPointNames.reduce( ( memo, entryPointName ) => {
 		memo[ entryPointName ] = './' + entryPointName + '/index.js';
@@ -26,13 +40,7 @@ const config = {
 		library: [ 'wp', '[name]' ],
 		libraryTarget: 'this',
 	},
-	externals: {
-		react: 'React',
-		'react-dom': 'ReactDOM',
-		'react-dom/server': 'ReactDOMServer',
-		tinymce: 'tinymce',
-		moment: 'moment',
-	},
+	externals,
 	resolve: {
 		modules: [
 			__dirname,
@@ -126,7 +134,7 @@ switch ( process.env.NODE_ENV ) {
 		];
 		config.externals = [
 			...config.externals,
-			require( 'webpack-node-externals' )()
+			require( 'webpack-node-externals' )(),
 		];
 		config.output = {
 			filename: 'build/test.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,12 +7,12 @@ const webpack = require( 'webpack' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
 const entryPointNames = [
-	'blocks',
-	'components',
-	'date',
-	'editor',
 	'element',
+	'date',
 	'i18n',
+	'components',
+	'blocks',
+	'editor',
 ];
 
 const externals = {
@@ -132,10 +132,7 @@ switch ( process.env.NODE_ENV ) {
 			...testFiles.filter( f => /full-content\.js$/.test( f ) ),
 			...testFiles.filter( f => ! /full-content\.js$/.test( f ) ),
 		];
-		config.externals = [
-			...config.externals,
-			require( 'webpack-node-externals' )(),
-		];
+		config.externals = [ require( 'webpack-node-externals' )() ];
 		config.output = {
 			filename: 'build/test.js',
 			path: __dirname,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,11 +120,11 @@ switch ( process.env.NODE_ENV ) {
 			'./{' + Object.keys( config.entry ).sort() + '}/**/test/*.js'
 		);
 		config.entry = [
+			'./element/index.js',
 			'./blocks/index.js',
 			'./components/index.js',
 			'./date/index.js',
 			'./editor/index.js',
-			'./element/index.js',
 			'./i18n/index.js',
 			...testFiles.filter( f => /full-content\.js$/.test( f ) ),
 			...testFiles.filter( f => ! /full-content\.js$/.test( f ) ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,15 +6,20 @@ const glob = require( 'glob' );
 const webpack = require( 'webpack' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
+const entryPointNames = [
+	'blocks',
+	'components',
+	'date',
+	'editor',
+	'element',
+	'i18n',
+];
+
 const config = {
-	entry: {
-		blocks: './blocks/index.js',
-		components: './components/index.js',
-		date: './date/index.js',
-		editor: './editor/index.js',
-		element: './element/index.js',
-		i18n: './i18n/index.js',
-	},
+	entry: entryPointNames.reduce( ( memo, entryPointName ) => {
+		memo[ entryPointName ] = './' + entryPointName + '/index.js';
+		return memo;
+	}, {} ),
 	output: {
 		filename: '[name]/build/index.js',
 		path: __dirname,
@@ -103,14 +108,7 @@ switch ( process.env.NODE_ENV ) {
 			__dirname: true,
 		};
 		config.module.rules = [
-			...[
-				'blocks',
-				'components',
-				'date',
-				'editor',
-				'element',
-				'i18n',
-			].map( ( entry ) => ( {
+			...entryPointNames.map( ( entry ) => ( {
 				test: require.resolve( './' + entry + '/index.js' ),
 				use: 'expose-loader?wp.' + entry,
 			} ) ),
@@ -120,16 +118,16 @@ switch ( process.env.NODE_ENV ) {
 			'./{' + Object.keys( config.entry ).sort() + '}/**/test/*.js'
 		);
 		config.entry = [
-			'./element/index.js',
-			'./blocks/index.js',
-			'./components/index.js',
-			'./date/index.js',
-			'./editor/index.js',
-			'./i18n/index.js',
+			...entryPointNames.map(
+				entryPointName => './' + entryPointName + '/index.js'
+			),
 			...testFiles.filter( f => /full-content\.js$/.test( f ) ),
 			...testFiles.filter( f => ! /full-content\.js$/.test( f ) ),
 		];
-		config.externals = [ require( 'webpack-node-externals' )() ];
+		config.externals = [
+			...config.externals,
+			require( 'webpack-node-externals' )()
+		];
 		config.output = {
 			filename: 'build/test.js',
 			path: __dirname,


### PR DESCRIPTION
While looking at #926 I noticed that we are probably duplicating some code in the `components/` directory across built files.  For example, we import `IconButton` in both [`editor/header/tools/preview-button.js`](https://github.com/WordPress/gutenberg/blob/739ae9808932b02c92e770033a1c2f7e2db4c5dc/editor/header/tools/preview-button.js#L9) and [`blocks/editable/format-toolbar.js`](https://github.com/WordPress/gutenberg/blob/d3c4425d4fa15ff4781f46de5fb925767e2b0d5e/blocks/editable/format-toolbar.js#L4).

If we split `components/` out into a separate build + entry point, we should be able to resolve this issue, and also make our common components available via `wp.components`, which seems good for reusability.

This PR is an attempt at doing this, but it's not working for some reason.  Here are the build sizes before this PR:

```
$ ls -la */build/*.js
271232 blocks/build/index.js
  3119 date/build/index.js
466975 editor/build/index.js
 14447 element/build/index.js
 17481 i18n/build/index.js
```

and after:

```
$ ls -la */build/*.js
271230 blocks/build/index.js
118012 components/build/index.js
  3119 date/build/index.js
467031 editor/build/index.js
 14389 element/build/index.js
 17481 i18n/build/index.js
```