### PR TITLE
Adds basic IconButton component tests.

### DIFF
--- a/components/icon-button/test/index.js
+++ b/components/icon-button/test/index.js
@@ -11,35 +11,35 @@ import IconButton from '../';
 
 describe( 'IconButton', () => {
 	describe( 'basic rendering', () => {
-		it( 'without modifiers', () => {
+		it( 'should render an top level element with only a class property', () => {
 			const iconButton = shallow( <IconButton /> );
 			expect( iconButton.hasClass( 'components-icon-button' ) ).to.be.true();
 			expect( iconButton.prop( 'aria-label' ) ).to.be.undefined();
 		} );
 
-		it( 'with icon', () => {
+		it( 'should render a Dashicon component matching the wordpress icon', () => {
 			const iconButton = shallow( <IconButton icon="wordpress" /> );
 			expect( iconButton.find( 'Dashicon' ).shallow().hasClass( 'dashicons-wordpress' ) ).to.be.true();
 		} );
 
-		it( 'with children', () => {
+		it( 'should render child elements when passed as children', () => {
 			const iconButton = shallow( <IconButton children={ <p className="test">Test</p> } /> );
 			expect( iconButton.find( '.test' ).shallow().text() ).to.equal( 'Test' );
 		} );
 
-		it( 'with label', () => {
+		it( 'should add an aria-label when the label property is used', () => {
 			const iconButton = shallow( <IconButton label="WordPress" /> );
 			expect( iconButton.prop( 'aria-label' ) ).to.equal( 'WordPress' );
 		} );
 
-		it( 'with additonal className', () => {
+		it( 'should add an additional className', () => {
 			const iconButton = shallow( <IconButton className="test" /> );
 			expect( iconButton.hasClass( 'test' ) ).to.be.true();
 		} );
 
-		it( 'with additonal properties', () => {
+		it( 'should add an additonal prop to the IconButton element', () => {
 			const iconButton = shallow( <IconButton test="test" /> );
-			expect( iconButton.node.props.test ).to.equal( 'test' );
+			expect( iconButton.props().test ).to.equal( 'test' );
 		} );
 	} );
 } );

--- a/components/icon-button/test/index.js
+++ b/components/icon-button/test/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import IconButton from '../';
+
+describe( 'IconButton', () => {
+	describe( 'basic rendering', () => {
+		it( 'without modifiers', () => {
+			const iconButton = shallow( <IconButton /> );
+			expect( iconButton.hasClass( 'components-icon-button' ) ).to.be.true();
+			expect( iconButton.prop( 'aria-label' ) ).to.be.undefined();
+		} );
+
+		it( 'with icon', () => {
+			const iconButton = shallow( <IconButton icon="wordpress" /> );
+			expect( iconButton.find( 'Dashicon' ).shallow().hasClass( 'dashicons-wordpress' ) ).to.be.true();
+		} );
+
+		it( 'with children', () => {
+			const iconButton = shallow( <IconButton children={ <p className="test">Test</p> } /> );
+			expect( iconButton.find( '.test' ).shallow().text() ).to.equal( 'Test' );
+		} );
+
+		it( 'with label', () => {
+			const iconButton = shallow( <IconButton label="WordPress" /> );
+			expect( iconButton.prop( 'aria-label' ) ).to.equal( 'WordPress' );
+		} );
+
+		it( 'with additonal className', () => {
+			const iconButton = shallow( <IconButton className="test" /> );
+			expect( iconButton.hasClass( 'test' ) ).to.be.true();
+		} );
+
+		it( 'with additonal properties', () => {
+			const iconButton = shallow( <IconButton test="test" /> );
+			expect( iconButton.node.props.test ).to.equal( 'test' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Adds basic IconButton component tests. Related to progress on #641.

Testing Instructions
Run npm i && npm run test-unit ensure tests pass. Change Dashicon logic
to ensure tests fail as they should.