### PR TITLE
Add basic Spinner component tests.

### DIFF
--- a/components/spinner/test/index.js
+++ b/components/spinner/test/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Spinner from '../';
+
+describe( 'Spinner', () => {
+	describe( 'basic rendering', () => {
+		it( 'should match the following element', () => {
+			const element = <span className="spinner is-active" />;
+			const spinner = shallow( <Spinner /> );
+			expect( spinner.matchesElement( element ) ).to.be.true();
+		} );
+	} );
+} );


### PR DESCRIPTION
Adds basic Spinner component tests. Related to progress on #641.
Testing Instructions
Run npm i && npm run test-unit ensure tests pass. Change component logic
to ensure tests fail as they should.