### PR TITLE
Chrome: Enhance the publish button flow (and the saved state component)

### DIFF
--- a/components/panel/test/body.js
+++ b/components/panel/test/body.js
@@ -7,7 +7,7 @@ import { shallow, mount } from 'enzyme';
 /**
  * Internal dependencies
  */
-import PanelBody from '../body.js';
+import PanelBody from '../body';
 
 describe( 'PanelBody', () => {
 	describe( 'basic rendering', () => {

--- a/editor/assets/stylesheets/_animations.scss
+++ b/editor/assets/stylesheets/_animations.scss
@@ -13,3 +13,18 @@
 		transform: translateY( 0px );
 	}
 }
+
+
+@mixin move_background {
+	background-size: 28px 28px;
+	animation: move_background .5s linear infinite;
+}
+
+@keyframes move_background {
+	from {
+    background-position: 0 0;
+	}
+	to {
+    background-position: 28px 0;
+	}
+}

--- a/editor/assets/stylesheets/_animations.scss
+++ b/editor/assets/stylesheets/_animations.scss
@@ -22,9 +22,9 @@
 
 @keyframes move_background {
 	from {
-    background-position: 0 0;
+		background-position: 0 0;
 	}
 	to {
-    background-position: 28px 0;
+		background-position: 28px 0;
 	}
 }

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -20,12 +20,14 @@ export default {
 		const { dispatch } = store;
 		const { postId, edits } = action;
 		const toSend = postId ? { id: postId, ...edits } : edits;
+		const isNew = ! postId;
 
 		dispatch( { type: 'CLEAR_POST_EDITS' } );
 		new wp.api.models.Post( toSend ).save().done( ( newPost ) => {
 			dispatch( {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				post: newPost,
+				isNew,
 			} );
 		} ).fail( ( err ) => {
 			dispatch( {

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -26,7 +26,6 @@ export default {
 			dispatch( {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				post: newPost,
-				isNew,
 			} );
 		} ).fail( ( err ) => {
 			dispatch( {

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -19,7 +19,6 @@ export default {
 	REQUEST_POST_UPDATE( action, store ) {
 		const { dispatch } = store;
 		const { postId, edits } = action;
-		const isNew = ! postId;
 		const toSend = postId ? { id: postId, ...edits } : edits;
 
 		new wp.api.models.Post( toSend ).save().done( ( newPost ) => {
@@ -36,7 +35,6 @@ export default {
 					message: __( 'An unknown error occurred.' ),
 				} ),
 				edits,
-				isNew,
 			} );
 		} );
 	},

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -21,6 +21,7 @@ export default {
 		const { postId, edits } = action;
 		const toSend = postId ? { id: postId, ...edits } : edits;
 
+		dispatch( { type: 'CLEAR_POST_EDITS' } );
 		new wp.api.models.Post( toSend ).save().done( ( newPost ) => {
 			dispatch( {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -21,10 +21,10 @@ import {
 	getCurrentPost,
 	getPostEdits,
 	getBlocks,
-	isEditedPostAlreadyPublished,
+	getEditedPostStatus,
 } from '../../selectors';
 
-function SavedState( { isNew, isDirty, isSaving, isPublished, edits, blocks, post, onSave } ) {
+function SavedState( { isNew, isDirty, isSaving, edits, blocks, post, status, onSave } ) {
 	const className = 'editor-saved-state';
 
 	if ( isSaving ) {
@@ -43,8 +43,7 @@ function SavedState( { isNew, isDirty, isSaving, isPublished, edits, blocks, pos
 		);
 	}
 
-	const statusEdits = isPublished ? {} : { status: 'draft' };
-	const onClick = () => onSave( post, { ...edits, ...statusEdits }, blocks );
+	const onClick = () => onSave( post, { ...edits, status: status || 'draft' }, blocks );
 
 	return (
 		<Button className={ classnames( className, 'button-link' ) } onClick={ onClick }>
@@ -61,7 +60,7 @@ export default connect(
 		isNew: isEditedPostNew( state ),
 		isDirty: isEditedPostDirty( state ),
 		isSaving: isSavingPost( state ),
-		isPublished: isEditedPostAlreadyPublished( state ),
+		status: getEditedPostStatus( state ),
 	} ),
 	( dispatch ) => ( {
 		onSave( post, edits, blocks ) {

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -22,7 +22,7 @@ import {
 	getCurrentPost,
 	getPostEdits,
 	getBlocks,
-	getEditedPostStatus,
+	getEditedPostAttribute,
 } from '../../selectors';
 
 function SavedState( { isNew, isDirty, isSaving, edits, blocks, post, status, onSave } ) {
@@ -61,7 +61,7 @@ export default connect(
 		isNew: isEditedPostNew( state ),
 		isDirty: isEditedPostDirty( state ),
 		isSaving: isSavingPost( state ),
-		status: getEditedPostStatus( state ),
+		status: getEditedPostAttribute( state, 'status' ),
 	} ),
 	( dispatch ) => ( {
 		onSave( post, edits, blocks ) {

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -2,51 +2,73 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-import { Dashicon } from 'components';
+import { Dashicon, Button } from 'components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { isEditedPostNew, isEditedPostDirty } from '../../selectors';
+import { savePost } from '../../actions';
+import {
+	isEditedPostNew,
+	isEditedPostDirty,
+	isSavingPost,
+	getCurrentPost,
+	getPostEdits,
+	getBlocks,
+	isEditedPostAlreadyPublished,
+} from '../../selectors';
 
-function SavedState( { isNew, isDirty } ) {
-	const classes = classNames( 'editor-saved-state', {
-		'is-new': isNew,
-		'is-dirty': isDirty,
-	} );
+function SavedState( { isNew, isDirty, isSaving, isPublished, edits, blocks, post, onSave } ) {
+	const className = 'editor-saved-state';
 
-	let icon, text;
-	if ( isNew && isDirty ) {
-		icon = 'warning';
-		text = wp.i18n.__( 'New post with changes' );
-	} else if ( isNew ) {
-		icon = 'edit';
-		text = wp.i18n.__( 'New post' );
-	} else if ( isDirty ) {
-		icon = 'warning';
-		text = wp.i18n.__( 'Unsaved changes' );
-	} else {
-		icon = 'saved';
-		text = wp.i18n.__( 'Saved' );
+	if ( isSaving ) {
+		return (
+			<div className={ className }>
+				Saving
+			</div>
+		);
+	}
+	if ( ! isNew && ! isDirty ) {
+		return (
+			<div className={ className }>
+				<Dashicon icon={ 'saved' } />
+				{ wp.i18n.__( 'Saved' ) }
+			</div>
+		);
 	}
 
+	const statusEdits = isPublished ? {} : { status: 'draft' };
+	const onClick = () => onSave( post, { ...edits, ...statusEdits }, blocks );
+
 	return (
-		<div className={ classes }>
-			<Dashicon icon={ icon } />
-			{ text }
-		</div>
+		<Button className={ classnames( className, 'button-link' ) } onClick={ onClick }>
+			{ wp.i18n.__( 'Save' ) }
+		</Button>
 	);
 }
 
 export default connect(
 	( state ) => ( {
+		post: getCurrentPost( state ),
+		edits: getPostEdits( state ),
+		blocks: getBlocks( state ),
 		isNew: isEditedPostNew( state ),
 		isDirty: isEditedPostDirty( state ),
+		isSaving: isSavingPost( state ),
+		isPublished: isEditedPostAlreadyPublished( state ),
+	} ),
+	( dispatch ) => ( {
+		onSave( post, edits, blocks ) {
+			dispatch( savePost( post.id, {
+				content: wp.blocks.serialize( blocks ),
+				...edits,
+			} ) );
+		},
 	} )
 )( SavedState );

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
 import { Dashicon, Button } from 'components';
 
 /**
@@ -29,17 +30,17 @@ function SavedState( { isNew, isDirty, isSaving, edits, blocks, post, status, on
 
 	if ( isSaving ) {
 		return (
-			<div className={ className }>
-				Saving
-			</div>
+			<span className={ className }>
+				{ __( 'Saving' ) }
+			</span>
 		);
 	}
 	if ( ! isNew && ! isDirty ) {
 		return (
-			<div className={ className }>
-				<Dashicon icon={ 'saved' } />
-				{ wp.i18n.__( 'Saved' ) }
-			</div>
+			<span className={ className }>
+				<Dashicon icon="saved" />
+				{ __( 'Saved' ) }
+			</span>
 		);
 	}
 
@@ -47,7 +48,7 @@ function SavedState( { isNew, isDirty, isSaving, edits, blocks, post, status, on
 
 	return (
 		<Button className={ classnames( className, 'button-link' ) } onClick={ onClick }>
-			{ wp.i18n.__( 'Save' ) }
+			{ __( 'Save' ) }
 		</Button>
 	);
 }

--- a/editor/header/saved-state/style.scss
+++ b/editor/header/saved-state/style.scss
@@ -7,4 +7,18 @@
 	.dashicon {
 		margin-right: 4px;
 	}
+
+	&.button-link {
+		text-decoration: underline;
+		color: $blue-wordpress;
+
+		&:focus {
+			box-shadow: none;
+			outline: none;
+		}
+
+		&:hover {
+			color: $blue-medium;
+	}
+	}
 }

--- a/editor/header/saved-state/style.scss
+++ b/editor/header/saved-state/style.scss
@@ -18,7 +18,7 @@
 		}
 
 		&:hover {
-			color: $blue-medium;
-	}
+			color: $blue-medium-500;
+		}
 	}
 }

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -81,7 +81,7 @@ export default connect(
 		dirty: isEditedPostDirty( state ),
 		isSaving: isSavingPost( state ),
 		isPublished: isEditedPostAlreadyPublished( state ),
-		isBeingScheduled: isEditedPostBeingScheduled( state, 'date' ),
+		isBeingScheduled: isEditedPostBeingScheduled( state ),
 	} ),
 	( dispatch ) => ( {
 		onSave( post, edits, blocks ) {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -21,6 +21,7 @@ import {
 	isSavingPost,
 	isEditedPostAlreadyPublished,
 	isEditedPostBeingScheduled,
+	getEditedPostVisibility,
 } from '../../selectors';
 
 function PublishButton( {
@@ -32,6 +33,7 @@ function PublishButton( {
 	isPublished,
 	onSave,
 	isBeingScheduled,
+	visibility,
 } ) {
 	const buttonEnabled = ! isSaving &&
 		( dirty || ( ! isPublished && ! isBeingScheduled )
@@ -44,16 +46,14 @@ function PublishButton( {
 	} else {
 		buttonText = wp.i18n.__( 'Publish' );
 	}
-	let publishStatus;
-	if ( isPublished ) {
-		publishStatus = post.status;
-	} else if ( isBeingScheduled ) {
+	let publishStatus = 'publish';
+	if ( isBeingScheduled ) {
 		publishStatus = 'future';
-	} else {
-		publishStatus = 'publish';
+	} else if ( visibility === 'private' ) {
+		publishStatus = 'private';
 	}
 	const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
-	const onClick = () => onSave( post, { status: publishStatus, ...edits }, blocks );
+	const onClick = () => onSave( post, { ...edits, status: publishStatus }, blocks );
 
 	const buttonDisabledHint = process.env.NODE_ENV === 'production'
 		? wp.i18n.__( 'The Save button is disabled during early alpha releases.' )
@@ -82,6 +82,7 @@ export default connect(
 		isSaving: isSavingPost( state ),
 		isPublished: isEditedPostAlreadyPublished( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
+		visibility: getEditedPostVisibility( state ),
 	} ),
 	( dispatch ) => ( {
 		onSave( post, edits, blocks ) {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -14,30 +14,28 @@ import { Button } from 'components';
  */
 import { savePost } from '../../actions';
 import {
-	isEditedPostDirty,
 	getCurrentPost,
 	getPostEdits,
 	getBlocks,
 	isSavingPost,
-	isEditedPostAlreadyPublished,
+	isEditedPostPublished,
 	isEditedPostBeingScheduled,
 	getEditedPostVisibility,
+	isEditedPostPublishable,
 } from '../../selectors';
 
 function PublishButton( {
 	post,
 	edits,
-	dirty,
 	blocks,
 	isSaving,
 	isPublished,
 	onSave,
 	isBeingScheduled,
 	visibility,
+	isPublishable,
 } ) {
-	const buttonEnabled = ! isSaving &&
-		( dirty || ( ! isPublished && ! isBeingScheduled )
-	);
+	const buttonEnabled = ! isSaving && isPublishable;
 	let buttonText;
 	if ( isPublished ) {
 		buttonText = wp.i18n.__( 'Update' );
@@ -78,11 +76,11 @@ export default connect(
 		post: getCurrentPost( state ),
 		edits: getPostEdits( state ),
 		blocks: getBlocks( state ),
-		dirty: isEditedPostDirty( state ),
 		isSaving: isSavingPost( state ),
-		isPublished: isEditedPostAlreadyPublished( state ),
+		isPublished: isEditedPostPublished( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		visibility: getEditedPostVisibility( state ),
+		isPublishable: isEditedPostPublishable( state ),
 	} ),
 	( dispatch ) => ( {
 		onSave( post, edits, blocks ) {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -18,9 +19,8 @@ import {
 	getPostEdits,
 	getBlocks,
 	isSavingPost,
-	didPostSaveRequestSucceed,
-	didPostSaveRequestFail,
-	isSavingNewPost,
+	isEditedPostAlreadyPublished,
+	isEditedPostBeingScheduled,
 } from '../../selectors';
 
 function PublishButton( {
@@ -28,32 +28,32 @@ function PublishButton( {
 	edits,
 	dirty,
 	blocks,
-	isSuccessful,
-	isRequesting,
-	isError,
-	requestIsNewPost,
+	isSaving,
+	isPublished,
 	onSave,
+	isBeingScheduled,
 } ) {
-	const buttonEnabled = ! isRequesting;
-
+	const buttonEnabled = ! isSaving &&
+		( dirty || ( ! isPublished && ! isBeingScheduled )
+	);
 	let buttonText;
-	if ( isRequesting ) {
-		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Saving…' )
-			: wp.i18n.__( 'Updating…' );
-	} else if ( ! dirty && isSuccessful ) {
-		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Saved!' )
-			: wp.i18n.__( 'Updated!' );
-	} else if ( ! dirty && isError ) {
-		buttonText = requestIsNewPost
-			? wp.i18n.__( 'Save failed' )
-			: wp.i18n.__( 'Update failed' );
-	} else if ( post && post.id ) {
+	if ( isPublished ) {
 		buttonText = wp.i18n.__( 'Update' );
+	} else if ( isBeingScheduled ) {
+		buttonText = wp.i18n.__( 'Schedule' );
 	} else {
-		buttonText = wp.i18n.__( 'Save draft' );
+		buttonText = wp.i18n.__( 'Publish' );
 	}
+	let publishStatus;
+	if ( isPublished ) {
+		publishStatus = post.status;
+	} else if ( isBeingScheduled ) {
+		publishStatus = 'future';
+	} else {
+		publishStatus = 'publish';
+	}
+	const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
+	const onClick = () => onSave( post, { status: publishStatus, ...edits }, blocks );
 
 	const buttonDisabledHint = process.env.NODE_ENV === 'production'
 		? wp.i18n.__( 'The Save button is disabled during early alpha releases.' )
@@ -63,9 +63,10 @@ function PublishButton( {
 		<Button
 			isPrimary
 			isLarge
-			onClick={ () => onSave( post, edits, blocks ) }
+			onClick={ onClick }
 			disabled={ ! buttonEnabled || process.env.NODE_ENV === 'production' }
 			title={ buttonDisabledHint }
+			className={ className }
 		>
 			{ buttonText }
 		</Button>
@@ -76,12 +77,11 @@ export default connect(
 	( state ) => ( {
 		post: getCurrentPost( state ),
 		edits: getPostEdits( state ),
-		dirty: isEditedPostDirty( state ),
 		blocks: getBlocks( state ),
-		isRequesting: isSavingPost( state ),
-		isSuccessful: didPostSaveRequestSucceed( state ),
-		isError: !! didPostSaveRequestFail( state ),
-		requestIsNewPost: isSavingNewPost( state ),
+		dirty: isEditedPostDirty( state ),
+		isSaving: isSavingPost( state ),
+		isPublished: isEditedPostAlreadyPublished( state ),
+		isBeingScheduled: isEditedPostBeingScheduled( state, 'date' ),
 	} ),
 	( dispatch ) => ( {
 		onSave( post, edits, blocks ) {

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -75,3 +75,34 @@
 		}
 	}
 }
+
+.editor-tools__publish-button.is-saving,
+.editor-tools__publish-button.is-saving:disabled {
+	position: relative;
+
+	// These styles overrides the disabled state with the button primary styles
+	background: none !important;
+	border-color: #0073aa #006799 #006799 !important;
+	box-shadow: 0 1px 0 #006799 !important;
+	color: #fff !important;
+	text-decoration: none !important;
+	text-shadow: 0 -1px 1px #006799, 1px 0 1px #006799, 0 1px 1px #006799, -1px 0 1px #006799 !important;
+	opacity: 1;
+	// End of the overriding
+
+	&:hover {
+		background: none;
+	}
+
+	&:before {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		content: '';
+    background-image: repeating-linear-gradient( -45deg, $blue-wordpress-700, $blue-wordpress-700 11px, $blue-wordpress 10px, $blue-wordpress 20px );
+		z-index: -1;
+		@include move_background;
+	}
+}

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -101,7 +101,7 @@
 		right: 0;
 		bottom: 0;
 		content: '';
-    background-image: repeating-linear-gradient( -45deg, $blue-wordpress-700, $blue-wordpress-700 11px, $blue-wordpress 10px, $blue-wordpress 20px );
+		background-image: repeating-linear-gradient( -45deg, $blue-wordpress-700, $blue-wordpress-700 11px, $blue-wordpress 10px, $blue-wordpress 20px );
 		z-index: -1;
 		@include move_background;
 	}

--- a/editor/index.js
+++ b/editor/index.js
@@ -4,8 +4,8 @@
 import { Provider as ReduxProvider } from 'react-redux';
 import { Provider as SlotFillProvider } from 'react-slot-fill';
 import { omit } from 'lodash';
-import moment from 'moment';
-import 'moment-timezone';
+import moment from 'moment-timezone';
+import 'moment-timezone/moment-timezone-utils';
 
 /**
  * WordPress dependencies
@@ -21,7 +21,19 @@ import { createReduxStore } from './state';
 
 // Configure moment globally
 moment.locale( settings.l10n.locale );
-moment.tz.setDefault( settings.timezone.string );
+if ( settings.timezone.string ) {
+	moment.tz.setDefault( settings.timezone.string );
+} else {
+	const momentTimezone = {
+		name: 'WP',
+		abbrs: [ 'WP' ],
+		untils: [ null ],
+		offsets: [ -settings.timezone.offset * 60 ],
+	};
+	const unpackedTimezone = moment.tz.pack( momentTimezone );
+	moment.tz.add( unpackedTimezone );
+	moment.tz.setDefault( 'WP' );
+}
 
 /**
  * Initializes and returns an instance of Editor.

--- a/editor/index.js
+++ b/editor/index.js
@@ -4,6 +4,13 @@
 import { Provider as ReduxProvider } from 'react-redux';
 import { Provider as SlotFillProvider } from 'react-slot-fill';
 import { omit } from 'lodash';
+import moment from 'moment';
+import 'moment-timezone';
+
+/**
+ * WordPress dependencies
+ */
+import { settings } from 'date';
 
 /**
  * Internal dependencies
@@ -11,6 +18,10 @@ import { omit } from 'lodash';
 import './assets/stylesheets/main.scss';
 import Layout from './layout';
 import { createReduxStore } from './state';
+
+// Configure moment globally
+moment.locale( settings.l10n.locale );
+moment.tz.setDefault( settings.timezone.string );
 
 /**
  * Initializes and returns an instance of Editor.

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import moment from 'moment';
 import { first, last, get } from 'lodash';
 
 /**
@@ -127,6 +128,31 @@ export function getEditedPostVisibility( state ) {
 		return 'password';
 	}
 	return 'public';
+}
+
+/**
+ * Return true if the post being edited has already been published.
+ *
+ * @param  {Object}   state Global application state
+ * @return {Boolearn}       Whether the post has been bublished
+ */
+export function isEditedPostAlreadyPublished( state ) {
+	const post = getCurrentPost( state );
+
+	return [ 'publish', 'private' ].indexOf( post.status ) !== -1 ||
+		( post.status === 'future' && moment( post.date ).isBefore( moment() ) );
+}
+
+/**
+ * Return true if the post being edited is being scheduled. Preferring the
+ * unsaved status values.
+ *
+ * @param  {Object}   state Global application state
+ * @return {Boolearn}       Whether the post has been bublished
+ */
+export function isEditedPostBeingScheduled( state ) {
+	const date = getEditedPostAttribute( state, 'date' );
+	return moment( date ).isAfter( moment() );
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -500,16 +500,6 @@ export function didPostSaveRequestFail( state ) {
 }
 
 /**
- * Returns true if the post being saved is a new draft, or false otherwise.
- *
- * @param  {Object}  state Global application state
- * @return {Boolean}       Whether post being saved is a new draft
- */
-export function isSavingNewPost( state ) {
-	return state.saving.isNew;
-}
-
-/**
  * Returns a suggested post format for the current post, inferred only if there
  * is a single block within the post and it is of a type known to match a
  * default post format. Returns null if the format cannot be determined.

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -136,11 +136,22 @@ export function getEditedPostVisibility( state ) {
  * @param  {Object}   state Global application state
  * @return {Boolearn}       Whether the post has been bublished
  */
-export function isEditedPostAlreadyPublished( state ) {
+export function isEditedPostPublished( state ) {
 	const post = getCurrentPost( state );
 
 	return [ 'publish', 'private' ].indexOf( post.status ) !== -1 ||
 		( post.status === 'future' && moment( post.date ).isBefore( moment() ) );
+}
+
+/**
+ * Return true if the post being edited can be published
+ *
+ * @param  {Object}   state Global application state
+ * @return {Boolearn}       Whether the post can been bublished
+ */
+export function isEditedPostPublishable( state ) {
+	const post = getCurrentPost( state );
+	return isEditedPostDirty( state ) || [ 'publish', 'private', 'future' ].indexOf( post.status ) === -1;
 }
 
 /**

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -20,7 +20,7 @@ import PostSchedule from '../post-schedule';
 import {
 	getEditedPostAttribute,
 	getSuggestedPostFormat,
-	isEditedPostAlreadyPublished,
+	isEditedPostPublished,
 } from '../../selectors';
 import { editPost } from '../../actions';
 
@@ -82,7 +82,7 @@ export default connect(
 	( state ) => ( {
 		status: getEditedPostAttribute( state, 'status' ),
 		suggestedFormat: getSuggestedPostFormat( state ),
-		isPublished: isEditedPostAlreadyPublished( state ),
+		isPublished: isEditedPostPublished( state ),
 	} ),
 	( dispatch ) => {
 		return {

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -17,7 +17,7 @@ import './style.scss';
 import PostVisibility from '../post-visibility';
 import PostTrash from '../post-trash';
 import PostSchedule from '../post-schedule';
-import { getEditedPostAttribute, getSuggestedPostFormat } from '../../selectors';
+import { getEditedPostAttribute, getSuggestedPostFormat, getCurrentPost } from '../../selectors';
 import { editPost } from '../../actions';
 
 class PostStatus extends Component {
@@ -27,9 +27,14 @@ class PostStatus extends Component {
 	}
 
 	render() {
-		const { status, onUpdateStatus, suggestedFormat } = this.props;
+		const { status, onUpdateStatus, suggestedFormat, post } = this.props;
 		const onToggle = () => {
-			const updatedStatus = status === 'pending' ? 'draft' : 'pending';
+			let updatedStatus;
+			if ( status !== 'pending' ) {
+				updatedStatus = 'pending';
+			} else {
+				updatedStatus = post.status && post.status !== 'pending' ? post.status : 'publish';
+			}
 			onUpdateStatus( updatedStatus );
 		};
 
@@ -72,6 +77,7 @@ PostStatus.instances = 1;
 export default connect(
 	( state ) => ( {
 		status: getEditedPostAttribute( state, 'status' ),
+		post: getCurrentPost( state ),
 		suggestedFormat: getSuggestedPostFormat( state ),
 	} ),
 	( dispatch ) => {

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -44,7 +44,7 @@ class PostVisibility extends Component {
 		const { status, visibility, password, onUpdateVisibility } = this.props;
 
 		const setPublic = () => {
-			onUpdateVisibility( visibility === 'private' ? 'draft' : status );
+			onUpdateVisibility( visibility === 'private' ? 'publish' : status );
 			this.setState( { hasPassword: false } );
 		};
 		const setPrivate = () => {
@@ -52,7 +52,7 @@ class PostVisibility extends Component {
 			this.setState( { hasPassword: false } );
 		};
 		const setPasswordProtected = () => {
-			onUpdateVisibility( visibility === 'private' ? 'draft' : status, password || '' );
+			onUpdateVisibility( visibility === 'private' ? 'publish' : status, password || '' );
 			this.setState( { hasPassword: true } );
 		};
 		const updatePassword = ( event ) => onUpdateVisibility( status, event.target.value );

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -104,7 +104,7 @@ class PostVisibility extends Component {
 						</div>
 						{ visibilityOptions.map( ( { value, label, info, changeHandler, checked } ) => (
 							<label key={ value } className="editor-post-visibility__dialog-label">
-								<input type="radio" value={ value } onChange={ changeHandler } checked={ checked } />
+								<input type="radio" value={ value } onClick={ changeHandler } onChange={ changeHandler } checked={ checked } />
 								{ label }
 								{ <div className="editor-post-visibility__dialog-info">{ info }</div> }
 							</label>

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -47,7 +47,7 @@ class PostVisibility extends Component {
 		const { status, visibility, password, post, blocks, edits, onUpdateVisibility, onSave } = this.props;
 
 		const setPublic = () => {
-			onUpdateVisibility( visibility === 'private' ? 'publish' : status );
+			onUpdateVisibility( visibility === 'private' ? 'draft' : status );
 			this.setState( { hasPassword: false } );
 		};
 		const setPrivate = () => {
@@ -57,7 +57,7 @@ class PostVisibility extends Component {
 			}
 		};
 		const setPasswordProtected = () => {
-			onUpdateVisibility( visibility === 'private' ? 'publish' : status, password || '' );
+			onUpdateVisibility( visibility === 'private' ? 'draft' : status, password || '' );
 			this.setState( { hasPassword: true } );
 		};
 		const updatePassword = ( event ) => onUpdateVisibility( status, event.target.value );

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -18,8 +18,11 @@ import './style.scss';
 import {
 	getEditedPostAttribute,
 	getEditedPostVisibility,
+	getCurrentPost,
+	getPostEdits,
+	getBlocks,
 } from '../../selectors';
-import { editPost } from '../../actions';
+import { editPost, savePost } from '../../actions';
 
 class PostVisibility extends Component {
 	constructor( props ) {
@@ -41,15 +44,17 @@ class PostVisibility extends Component {
 	}
 
 	render() {
-		const { status, visibility, password, onUpdateVisibility } = this.props;
+		const { status, visibility, password, post, blocks, edits, onUpdateVisibility, onSave } = this.props;
 
 		const setPublic = () => {
 			onUpdateVisibility( visibility === 'private' ? 'publish' : status );
 			this.setState( { hasPassword: false } );
 		};
 		const setPrivate = () => {
-			onUpdateVisibility( 'private' );
-			this.setState( { hasPassword: false } );
+			if ( window.confirm( __( 'Would you like to privately publish this post now?' ) ) ) { // eslint-disable-line no-alert
+				onSave( post, { ...edits, status: 'private' }, blocks );
+				this.setState( { opened: false } );
+			}
 		};
 		const setPasswordProtected = () => {
 			onUpdateVisibility( visibility === 'private' ? 'publish' : status, password || '' );
@@ -126,11 +131,20 @@ export default connect(
 		status: getEditedPostAttribute( state, 'status' ),
 		visibility: getEditedPostVisibility( state ),
 		password: getEditedPostAttribute( state, 'password' ),
+		post: getCurrentPost( state ),
+		edits: getPostEdits( state ),
+		blocks: getBlocks( state ),
 	} ),
 	( dispatch ) => {
 		return {
 			onUpdateVisibility( status, password = null ) {
 				dispatch( editPost( { status, password } ) );
+			},
+			onSave( post, edits, blocks ) {
+				dispatch( savePost( post.id, {
+					content: wp.blocks.serialize( blocks ),
+					...edits,
+				} ) );
 			},
 		};
 	}

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -104,7 +104,7 @@ class PostVisibility extends Component {
 						</div>
 						{ visibilityOptions.map( ( { value, label, info, changeHandler, checked } ) => (
 							<label key={ value } className="editor-post-visibility__dialog-label">
-								<input type="radio" value={ value } onClick={ changeHandler } onChange={ changeHandler } checked={ checked } />
+								<input type="radio" value={ value } onClick={ changeHandler } checked={ checked } />
 								{ label }
 								{ <div className="editor-post-visibility__dialog-info">{ info }</div> }
 							</label>

--- a/editor/state.js
+++ b/editor/state.js
@@ -34,7 +34,7 @@ export const editor = combineUndoableReducers( {
 					...state,
 					...action.edits,
 				};
-			case 'REQUEST_POST_UPDATE':
+			case 'CLEAR_POST_EDITS':
 				return {};
 		}
 

--- a/editor/state.js
+++ b/editor/state.js
@@ -34,6 +34,8 @@ export const editor = combineUndoableReducers( {
 					...state,
 					...action.edits,
 				};
+			case 'REQUEST_POST_UPDATE':
+				return {};
 		}
 
 		return state;

--- a/editor/state.js
+++ b/editor/state.js
@@ -392,7 +392,6 @@ export function saving( state = {}, action ) {
 				requesting: true,
 				successful: false,
 				error: null,
-				isNew: action.isNew,
 			};
 
 		case 'REQUEST_POST_UPDATE_SUCCESS':
@@ -400,7 +399,6 @@ export function saving( state = {}, action ) {
 				requesting: false,
 				successful: true,
 				error: null,
-				isNew: false,
 			};
 
 		case 'REQUEST_POST_UPDATE_FAILURE':
@@ -408,7 +406,6 @@ export function saving( state = {}, action ) {
 				requesting: false,
 				successful: false,
 				error: action.error,
-				isNew: action.isNew,
 			};
 	}
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -44,7 +44,6 @@ import {
 	isSavingPost,
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
-	isSavingNewPost,
 	getSuggestedPostFormat,
 } from '../selectors';
 
@@ -905,28 +904,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( didPostSaveRequestFail( state ) ).to.be.false();
-		} );
-	} );
-
-	describe( 'isSavingNewPost', () => {
-		it( 'should return true if the post being saved is new', () => {
-			const state = {
-				saving: {
-					isNew: true,
-				},
-			};
-
-			expect( isSavingNewPost( state ) ).to.be.true();
-		} );
-
-		it( 'should return false if the post being saved is not new', () => {
-			const state = {
-				saving: {
-					isNew: false,
-				},
-			};
-
-			expect( isSavingNewPost( state ) ).to.be.false();
 		} );
 	} );
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -19,7 +19,8 @@ import {
 	getEditedPostTitle,
 	getEditedPostExcerpt,
 	getEditedPostVisibility,
-	isEditedPostAlreadyPublished,
+	isEditedPostPublished,
+	isEditedPostPublishable,
 	isEditedPostBeingScheduled,
 	getEditedPostPreviewLink,
 	getBlock,
@@ -311,7 +312,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isEditedPostAlreadyPublished', () => {
+	describe( 'isEditedPostPublished', () => {
 		it( 'should return true for public posts', () => {
 			const state = {
 				currentPost: {
@@ -319,7 +320,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostAlreadyPublished( state ) ).to.be.true();
+			expect( isEditedPostPublished( state ) ).to.be.true();
 		} );
 
 		it( 'should return true for private posts', () => {
@@ -329,7 +330,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostAlreadyPublished( state ) ).to.be.true();
+			expect( isEditedPostPublished( state ) ).to.be.true();
 		} );
 
 		it( 'should return false for draft posts', () => {
@@ -339,7 +340,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostAlreadyPublished( state ) ).to.be.false();
+			expect( isEditedPostPublished( state ) ).to.be.false();
 		} );
 
 		it( 'should return true for old scheduled posts', () => {
@@ -350,7 +351,87 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostAlreadyPublished( state ) ).to.be.true();
+			expect( isEditedPostPublished( state ) ).to.be.true();
+		} );
+	} );
+
+	describe( 'isEditedPostPublishable', () => {
+		it( 'should return true for pending posts', () => {
+			const state = {
+				currentPost: {
+					status: 'pending',
+				},
+				editor: {
+					dirty: false,
+				},
+			};
+
+			expect( isEditedPostPublishable( state ) ).to.be.true();
+		} );
+
+		it( 'should return true for draft posts', () => {
+			const state = {
+				currentPost: {
+					status: 'draft',
+				},
+				editor: {
+					dirty: false,
+				},
+			};
+
+			expect( isEditedPostPublishable( state ) ).to.be.true();
+		} );
+
+		it( 'should return false for published posts', () => {
+			const state = {
+				currentPost: {
+					status: 'publish',
+				},
+				editor: {
+					dirty: false,
+				},
+			};
+
+			expect( isEditedPostPublishable( state ) ).to.be.false();
+		} );
+
+		it( 'should return false for private posts', () => {
+			const state = {
+				currentPost: {
+					status: 'private',
+				},
+				editor: {
+					dirty: false,
+				},
+			};
+
+			expect( isEditedPostPublishable( state ) ).to.be.false();
+		} );
+
+		it( 'should return false for scheduled posts', () => {
+			const state = {
+				currentPost: {
+					status: 'private',
+				},
+				editor: {
+					dirty: false,
+				},
+			};
+
+			expect( isEditedPostPublishable( state ) ).to.be.false();
+		} );
+
+		it( 'should return true for dirty posts', () => {
+			const state = {
+				currentPost: {
+					status: 'private',
+				},
+				editor: {
+					dirty: true,
+				},
+			};
+
+			expect( isEditedPostPublishable( state ) ).to.be.true();
 		} );
 	} );
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -18,6 +19,8 @@ import {
 	getEditedPostTitle,
 	getEditedPostExcerpt,
 	getEditedPostVisibility,
+	isEditedPostAlreadyPublished,
+	isEditedPostBeingScheduled,
 	getEditedPostPreviewLink,
 	getBlock,
 	getBlocks,
@@ -306,6 +309,71 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditedPostVisibility( state ) ).to.equal( 'private' );
+		} );
+	} );
+
+	describe( 'isEditedPostAlreadyPublished', () => {
+		it( 'should return true for public posts', () => {
+			const state = {
+				currentPost: {
+					status: 'publish',
+				},
+			};
+
+			expect( isEditedPostAlreadyPublished( state ) ).to.be.true();
+		} );
+
+		it( 'should return true for private posts', () => {
+			const state = {
+				currentPost: {
+					status: 'private',
+				},
+			};
+
+			expect( isEditedPostAlreadyPublished( state ) ).to.be.true();
+		} );
+
+		it( 'should return false for draft posts', () => {
+			const state = {
+				currentPost: {
+					status: 'draft',
+				},
+			};
+
+			expect( isEditedPostAlreadyPublished( state ) ).to.be.false();
+		} );
+
+		it( 'should return true for old scheduled posts', () => {
+			const state = {
+				currentPost: {
+					status: 'future',
+					date: '2016-05-30T17:21:39',
+				},
+			};
+
+			expect( isEditedPostAlreadyPublished( state ) ).to.be.true();
+		} );
+	} );
+
+	describe( 'isEditedPostBeingScheduled', () => {
+		it( 'should return true for posts with a future date', () => {
+			const state = {
+				editor: {
+					edits: { date: moment().add( 7, 'days' ).format( '' ) },
+				},
+			};
+
+			expect( isEditedPostBeingScheduled( state ) ).to.be.true();
+		} );
+
+		it( 'should return false for posts with an old date', () => {
+			const state = {
+				editor: {
+					edits: { date: '2016-05-30T17:21:39' },
+				},
+			};
+
+			expect( isEditedPostBeingScheduled( state ) ).to.be.false();
 		} );
 	} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -388,6 +388,23 @@ describe( 'state', () => {
 				} );
 			} );
 
+			it( 'should reset modified properties', () => {
+				const original = editor( undefined, {
+					type: 'EDIT_POST',
+					edits: {
+						status: 'draft',
+						title: 'post title',
+						tags: [ 1 ],
+					},
+				} );
+
+				const state = editor( original, {
+					type: 'REQUEST_POST_UPDATE',
+				} );
+
+				expect( state.edits ).to.eql( {} );
+			} );
+
 			it( 'should save initial post state', () => {
 				const state = editor( undefined, {
 					type: 'SETUP_NEW_POST',

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -399,7 +399,7 @@ describe( 'state', () => {
 				} );
 
 				const state = editor( original, {
-					type: 'REQUEST_POST_UPDATE',
+					type: 'CLEAR_POST_EDITS',
 				} );
 
 				expect( state.edits ).to.eql( {} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -853,33 +853,28 @@ describe( 'state', () => {
 		it( 'should update when a request is started', () => {
 			const state = saving( null, {
 				type: 'REQUEST_POST_UPDATE',
-				isNew: true,
 			} );
 			expect( state ).to.eql( {
 				requesting: true,
 				successful: false,
 				error: null,
-				isNew: true,
 			} );
 		} );
 
 		it( 'should update when a request succeeds', () => {
 			const state = saving( null, {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
-				isNew: true,
 			} );
 			expect( state ).to.eql( {
 				requesting: false,
 				successful: true,
 				error: null,
-				isNew: false,
 			} );
 		} );
 
 		it( 'should update when a request fails', () => {
 			const state = saving( null, {
 				type: 'REQUEST_POST_UPDATE_FAILURE',
-				isNew: true,
 				error: {
 					code: 'pretend_error',
 					message: 'update failed',
@@ -892,7 +887,6 @@ describe( 'state', () => {
 					code: 'pretend_error',
 					message: 'update failed',
 				},
-				isNew: true,
 			} );
 		} );
 	} );

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "js-beautify": "^1.6.12",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
+    "moment-timezone": "^0.5.13",
     "react": "^15.5.4",
     "react-autosize-textarea": "^0.4.2",
     "react-click-outside": "^2.3.0",

--- a/post-content.js
+++ b/post-content.js
@@ -5,10 +5,6 @@ window._wpGutenbergPost = {
 	title: {
 		raw: 'Welcome to the Gutenberg Editor',
 	},
-	// TODO `status` and any other initial attributes other than content and
-	// title need to move somewhere else when this file goes away.  See:
-	// https://github.com/WordPress/gutenberg/pull/848#issuecomment-302836177
-	status: 'draft',
 	content: {
 		raw: [
 			'<!-- wp:core/text -->',


### PR DESCRIPTION
closes #945  

Several things in this PR:

 - We need a way to match the server's timezone in the frontend in order to compare dates properly. I'm using moment-timezone for this and setting the server timezone globally in moment
 - When publishing a post (publish button), the status applied to the button 'publish' if no date or date in the past, 'future' if date in the future but this status can be overridden when the edits (pending, private, ...)
 - When clicking the "save" link, we always save a draft unless the post is already saved, we'll keep the same status in this case.

I'd appreciate help in testing this PR because there's so many use-cases. It's easy to miss one.

Auto-saving is not implemented yet.