### PR TITLE
Parser: Revert to PEG parser by default

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -232,4 +232,4 @@ export function parseWithGrammar( content ) {
 	}, [] );
 }
 
-export default parseWithTinyMCE;
+export default parseWithGrammar;

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -39,7 +39,7 @@ WP_Block_End
   } }
 
 WP_Block_Type
-  = $(ASCII_Letter WP_Block_Type_Char*)
+  = $(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
 
 HTML_Attribute_List
   = as:(_+ a:HTML_Attribute_Item { return a })*
@@ -73,10 +73,6 @@ HTML_Attribute_Quoted
 
 HTML_Attribute_Name
   = $([a-zA-Z0-9:.]+)
-
-WP_Block_Type_Char
- = ASCII_AlphaNumeric
- / [\/]
 
 ASCII_AlphaNumeric
   = ASCII_Letter


### PR DESCRIPTION
Fixes several small issues created with the TinyMCE parser.

Focuses efforts on building a declarative formal grammar to handle our
parsing needs.

@nylen how would you feel here about switching back to the PEG parser and then making our needed updates to the grammar and focusing on it?