### PR TITLE
Refactor: Use filter and map instead of reduce

### DIFF
--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -71,7 +71,7 @@ describe( 'block serializer', () => {
 				fruit: 'bananas',
 			} );
 
-			expect( attributes ).to.equal( 'category="food" ripeness="ripe" ' );
+			expect( attributes ).to.equal( 'category="food" ripeness="ripe"' );
 		} );
 
 		it( 'should not append an undefined attribute value', () => {
@@ -83,7 +83,7 @@ describe( 'block serializer', () => {
 				fruit: 'bananas',
 			} );
 
-			expect( attributes ).to.equal( 'category="food" ' );
+			expect( attributes ).to.equal( 'category="food"' );
 		} );
 	} );
 


### PR DESCRIPTION
Just curious on the choice of the reduce. Seems like a filter and map
are more appropriate when joined with a space.

@aduth any particular reason for the reduce approach? seemed to stick out when I saw it, mainly because of the extra ` ` it leaves at the end.

granted, the reduce only has a single iteration while this has two, but I assumed you hadn't chosen what you did for speed reasons