### PR TITLE
Build: Fix components exports after refactor

### DIFF
--- a/blocks/index.js
+++ b/blocks/index.js
@@ -14,3 +14,4 @@ import './library';
 // and then stored as objects in state, from which it is then rendered for editing.
 export * from './api';
 export { default as Editable } from './editable';
+export { default as MediaUploadButton } from './media-upload-button';

--- a/components/index.js
+++ b/components/index.js
@@ -3,6 +3,8 @@ export { default as Dashicon } from './dashicon';
 export { default as FormToggle } from './form-toggle';
 export { default as IconButton } from './icon-button';
 export { default as Panel } from './panel';
+export { default as PanelHeader } from './panel/header';
+export { default as PanelBody } from './panel/body';
 export { default as Placeholder } from './placeholder';
 export { default as Spinner } from './spinner';
 export { default as Toolbar } from './toolbar';

--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { Component } from 'element';
-import { IconButton } from 'components';
+
+/**
+ * Internal dependencies
+ */
+import IconButton from '../icon-button';
 
 class PanelBody extends Component {
 	constructor( props ) {


### PR DESCRIPTION
Refactoring the components module build, broke some components. (Try opening the sidebar)
This should fix it

See https://github.com/WordPress/gutenberg/pull/929#issuecomment-305154501
