### PR TITLE
Inserter: let the content be taller

### DIFF
--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -109,7 +109,7 @@
 }
 
 .editor-inserter__content {
-	max-height: 20vw;
+	max-height: 32vw;
 	overflow: auto;
 
 	&:focus {


### PR DESCRIPTION
The inserter window is too small on small screens especially. It was only fitting a couple rows. If a user clicks to insert we should give ample space so they can easily choose a block and get back to work, let's not get in their way.