### PR TITLE
Add Perl script to list JS dependencies and suggest a load order

### DIFF
--- a/bin/list-js-dependencies.pl
+++ b/bin/list-js-dependencies.pl
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+
+use File::Basename;
+
+chdir dirname dirname $0;
+
+my $files = qx( git ls-files );
+my %deps = ();
+
+my $entry_points = 'blocks|components|date|editor|element|i18n|utils';
+
+foreach my $file ( split /[\r\n]+/, $files ) {
+	next if $file !~ /^($entry_points)\/.*\.js$/;
+	my $entry_point = $1;
+
+	open JSFILE, '<', $file or die;
+	while ( <JSFILE> ) {
+		if ( /from '($entry_points)[\/']/ ) {
+			my $imported_entry = $1;
+			if ( $entry_point ne $imported_entry ) {
+				$deps{ $entry_point }{ $imported_entry } = 1;
+			}
+		}
+	}
+	close JSFILE or die;
+}
+
+foreach my $dest ( sort keys %deps ) {
+	foreach my $source ( sort keys %{ $deps{ $dest } } ) {
+		print "'$dest' depends on '$source'\n";
+	}
+}
+print "\n";
+
+my @loaded = ();
+
+sub load_deps {
+	my $entry_point = shift;
+	my $stack = shift;
+	my $loaded = shift;
+	for my $ancestor ( @$stack ) {
+		if ( $entry_point eq $ancestor ) {
+			push @$stack, $entry_point;
+			my $msg = join ' -> ', @$stack;
+			die "Circular dependency: $msg\n";
+		}
+	}
+	my @new_stack = @$stack;
+	push @new_stack, $entry_point;
+	unshift @loaded, \@new_stack;
+	foreach my $dep ( reverse sort keys %{ $deps{ $entry_point } } ) {
+		load_deps( $dep, \@new_stack );
+	}
+}
+
+load_deps 'editor', [];
+
+sub uniq {
+	my %seen;
+	return grep {
+		my $seen_this = $seen{ $_ };
+		$seen{ $_ } = 1;
+		! $seen_this;
+	} @_;
+}
+
+print "Suggested load order:\n\n";
+foreach my $load ( uniq map { @$_[-1] } @loaded ) {
+	print "$load\n";
+}


### PR DESCRIPTION
I wrote this script while I was working on #929 to better understand the dependencies between our various Webpack bundles.  I'm not sure that we want to add this to the repo or not, but it was useful to me to determine the needed order of these modules [in our Webpack config](https://github.com/WordPress/gutenberg/blob/62552a9/webpack.config.js#L9-L17).  (This is mainly important for the test build, as in the actual plugin this is handled via WP's script dependency resolution mechanism).

It's a bit unfortunate that we have to do this twice (once on the client side and once on the server side).  However, I'm also thinking that this script (or something like it) will come in handy to calculate actual dependencies when we start adding more Webpack-built files to WP core.