### PR TITLE
Add tests for refx REQUEST_POST_UPDATE effects network requests.

### DIFF
--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -406,10 +406,10 @@ describe( 'effects', () => {
 			};
 
 			expect( dispatch ).toHaveBeenCalledTimes( 4 );
-			expect( dispatch.mock.calls[ 0 ][ 0 ] ).toEqual( updatePost );
-			expect( dispatch.mock.calls[ 1 ][ 0 ] ).toEqual( removeNotice );
-			expect( dispatch.mock.calls[ 2 ][ 0 ] ).toEqual( resetPostAction );
-			expect( dispatch.mock.calls[ 3 ][ 0 ] ).toEqual( requestPostUpdateSuccess );
+			expect( dispatch ).toHaveBeenCalledWith( updatePost );
+			expect( dispatch ).toHaveBeenCalledWith( removeNotice );
+			expect( dispatch ).toHaveBeenCalledWith( resetPostAction );
+			expect( dispatch ).toHaveBeenCalledWith( requestPostUpdateSuccess );
 		} );
 
 		it( 'should dispatch three actions on failure post.', () => {
@@ -486,9 +486,9 @@ describe( 'effects', () => {
 			};
 
 			expect( dispatch ).toHaveBeenCalledTimes( 3 );
-			expect( dispatch.mock.calls[ 0 ][ 0 ] ).toEqual( updatePost );
-			expect( dispatch.mock.calls[ 1 ][ 0 ] ).toEqual( removeNotice );
-			expect( dispatch.mock.calls[ 2 ][ 0 ] ).toEqual( requestPostFailure );
+			expect( dispatch ).toHaveBeenCalledWith( updatePost );
+			expect( dispatch ).toHaveBeenCalledWith( removeNotice );
+			expect( dispatch ).toHaveBeenCalledWith( requestPostFailure );
 		} );
 	} );
 


### PR DESCRIPTION
These tests handle the network effects portion of unit testing our refx middleware. This makes use of stubs for testing the history API, and explicitly modifying the window.location object to be writable. For the network effects, these effects are broken out into seperate functions which use partial application to isolate the networkCallback. The postRequest function becomes a wrapper for wp.api.models.Post(). So the API remains consistent. Rather than doing a sinon mock, the wp.api.models.Post interface is manually mocked for easy future changing. As we change the actual implementation of the network requests these tests will fail, which is a good thing. If we use straight mocks we might get false positives instead.

**Testing Instructions**
Verify Trashing and Saving still works properly. Verify that tests pass.