### PR TITLE
Inserter: Taller/better the block menu height

### DIFF
--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -109,7 +109,7 @@
 }
 
 .editor-inserter__content {
-	max-height: 20vw;
+	max-height: 50vh;
 	overflow: auto;
 
 	&:focus {


### PR DESCRIPTION
Let the block menu be full size and use the height of the screen as a constraint. A max  of 50% the height of the screen.

This is related to #959 but this looks at it using vh rather than vw. I'm closing the other PR now. 