### PR TITLE
Increase colour contrast on block mover buttons (#557)

### DIFF
--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -15,10 +15,6 @@
 	width: 20px;
 	height: 20px;
 
-	&:hover {
-		color: $dark-gray-500;
-	}
-
 	&[aria-disabled="true"] {
 		cursor: default;
 		color: $light-gray-300;

--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -10,13 +10,13 @@
 	border: none;
 	outline: none;
 	background: none;
-	color: $dark-gray-100;
+	color: $dark-gray-300;
 	cursor: pointer;
 	width: 20px;
 	height: 20px;
 
 	&:hover {
-		color: $dark-gray-900;
+		color: $dark-gray-500;
 	}
 
 	&[aria-disabled="true"] {


### PR DESCRIPTION
Have checked the new contrast meets WCAG AA using the following tool:

http://webaim.org/resources/contrastchecker/

If there’s a better checker you guys all use, do let me know in the comments!