### PR TITLE
Skip running TokenField tests by default

### DIFF
--- a/components/form-token-field/test/index.js
+++ b/components/form-token-field/test/index.js
@@ -32,6 +32,10 @@ const charCodes = {
 };
 
 describe( 'FormTokenField', function() {
+	if ( ! process.env.RUN_SLOW_TESTS ) {
+		return;
+	}
+
 	let wrapper, tokenFieldNode, textInputNode;
 
 	function setText( text ) {


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/924#issuecomment-305566868

Even though these tests use `enzyme`, they look more like "integration tests" than "unit tests" and perhaps should not be run on every build.  They might fit better in another category of tests (https://github.com/WordPress/gutenberg/issues/939#issuecomment-305260781), with a different strategy for running them (for example, executed every hour against the `master` branch).

However, `TokenField` has a long history of weird bugs and these tests are pretty important to keep around in some form.

Also worth noting that these tests execute far, far more quickly on my computer than they do on Travis.  The slowest test when running locally was 639ms; on Travis this is more like 3 seconds.