### PR TITLE
Add contextually aware title for block mover control (#557)

### DIFF
--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -15,7 +15,7 @@ import { getBlockType } from 'blocks';
  */
 import './style.scss';
 import { isFirstBlock, isLastBlock, getBlockOrder, getBlock } from '../selectors';
-import { blockMoverLabel } from './mover-label';
+import { getBlockMoverLabel } from './mover-label';
 
 function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex } ) {
 	// We emulate a disabled state because forcefully applying the `disabled`
@@ -28,7 +28,7 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, f
 				className="editor-block-mover__control"
 				onClick={ isFirst ? null : onMoveUp }
 				icon="arrow-up-alt2"
-				label={ blockMoverLabel( uids.length, {
+				label={ getBlockMoverLabel( uids.length, {
 					type: blockType && blockType.title,
 					isFirst,
 					isLast,
@@ -41,7 +41,7 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, f
 				className="editor-block-mover__control"
 				onClick={ isLast ? null : onMoveDown }
 				icon="arrow-down-alt2"
-				label={ blockMoverLabel( uids.length, {
+				label={ getBlockMoverLabel( uids.length, {
 					type: blockType && blockType.title,
 					isFirst,
 					isLast,

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -17,7 +17,7 @@ import { isFirstBlock, isLastBlock, getBlockOrder, getBlock } from '../selectors
 import { blockMoverLabel } from './mover-label';
 import { getBlockType } from 'blocks';
 
-function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block, firstPosition } ) {
+function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block, firstIndex } ) {
 	// We emulate a disabled state because forcefully applying the `disabled`
 	// attribute on the button while it has focus causes the screen to change
 	// to an unfocused state (body as active element) without firing blur on,
@@ -38,7 +38,7 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block, first
 					type: blockType && blockType.title,
 					isFirst,
 					isLast,
-					firstPosition,
+					firstIndex,
 					dir: -1,
 				} ) }
 				aria-disabled={ isFirst }
@@ -51,7 +51,7 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block, first
 					type: blockType && blockType.title,
 					isFirst,
 					isLast,
-					firstPosition,
+					firstIndex,
 					dir: 1,
 				} ) }
 				aria-disabled={ isLast }
@@ -64,8 +64,8 @@ export default connect(
 	( state, ownProps ) => ( {
 		isFirst: isFirstBlock( state, first( ownProps.uids ) ),
 		isLast: isLastBlock( state, last( ownProps.uids ) ),
-		firstPosition: getBlockOrder( state, first( ownProps.uids ) ),
 		block: getBlock( state, first( ownProps.uids ) ),
+		firstIndex: getBlockOrder( state, first( ownProps.uids ) ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -17,17 +17,11 @@ import { isFirstBlock, isLastBlock, getBlockOrder, getBlock } from '../selectors
 import { blockMoverLabel } from './mover-label';
 import { getBlockType } from 'blocks';
 
-function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block, firstIndex } ) {
+function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex } ) {
 	// We emulate a disabled state because forcefully applying the `disabled`
 	// attribute on the button while it has focus causes the screen to change
 	// to an unfocused state (body as active element) without firing blur on,
 	// the rendering parent, leaving it unable to react to focus out.
-	let blockType;
-
-	if ( uids.length === 1 && block ) {
-		blockType = getBlockType( block.name );
-	}
-
 	return (
 		<div className="editor-block-mover">
 			<IconButton
@@ -64,8 +58,8 @@ export default connect(
 	( state, ownProps ) => ( {
 		isFirst: isFirstBlock( state, first( ownProps.uids ) ),
 		isLast: isLastBlock( state, last( ownProps.uids ) ),
-		block: getBlock( state, first( ownProps.uids ) ),
 		firstIndex: getBlockOrder( state, first( ownProps.uids ) ),
+		blockType: getBlockType( getBlock( state, first( ownProps.uids ) ).name ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -8,6 +8,7 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { IconButton } from 'components';
+import { getBlockType } from 'blocks';
 
 /**
  * Internal dependencies
@@ -15,7 +16,6 @@ import { IconButton } from 'components';
 import './style.scss';
 import { isFirstBlock, isLastBlock, getBlockOrder, getBlock } from '../selectors';
 import { blockMoverLabel } from './mover-label';
-import { getBlockType } from 'blocks';
 
 function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex } ) {
 	// We emulate a disabled state because forcefully applying the `disabled`

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -28,26 +28,28 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, f
 				className="editor-block-mover__control"
 				onClick={ isFirst ? null : onMoveUp }
 				icon="arrow-up-alt2"
-				label={ getBlockMoverLabel( uids.length, {
-					type: blockType && blockType.title,
+				label={ getBlockMoverLabel(
+					uids.length,
+					blockType && blockType.title,
+					firstIndex,
 					isFirst,
 					isLast,
-					firstIndex,
-					dir: -1,
-				} ) }
+					-1,
+				) }
 				aria-disabled={ isFirst }
 			/>
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ isLast ? null : onMoveDown }
 				icon="arrow-down-alt2"
-				label={ getBlockMoverLabel( uids.length, {
-					type: blockType && blockType.title,
+				label={ getBlockMoverLabel(
+					uids.length,
+					blockType && blockType.title,
+					firstIndex,
 					isFirst,
 					isLast,
-					firstIndex,
-					dir: 1,
-				} ) }
+					1,
+				) }
 				aria-disabled={ isLast }
 			/>
 		</div>

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -13,13 +13,20 @@ import { IconButton } from 'components';
  * Internal dependencies
  */
 import './style.scss';
-import { isFirstBlock, isLastBlock } from '../selectors';
+import { isFirstBlock, isLastBlock, getBlockOrder, getBlock } from '../selectors';
+import { blockMoverLabel } from './mover-label';
+import { getBlockType } from 'blocks';
 
-function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
+function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block, firstPosition } ) {
 	// We emulate a disabled state because forcefully applying the `disabled`
 	// attribute on the button while it has focus causes the screen to change
 	// to an unfocused state (body as active element) without firing blur on,
 	// the rendering parent, leaving it unable to react to focus out.
+	let blockType;
+
+	if ( uids.length === 1 && block ) {
+		blockType = getBlockType( block.name );
+	}
 
 	return (
 		<div className="editor-block-mover">
@@ -27,12 +34,26 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast } ) {
 				className="editor-block-mover__control"
 				onClick={ isFirst ? null : onMoveUp }
 				icon="arrow-up-alt2"
+				label={ blockMoverLabel( uids.length, {
+					type: blockType && blockType.title,
+					isFirst,
+					isLast,
+					firstPosition,
+					dir: -1,
+				} ) }
 				aria-disabled={ isFirst }
 			/>
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ isLast ? null : onMoveDown }
 				icon="arrow-down-alt2"
+				label={ blockMoverLabel( uids.length, {
+					type: blockType && blockType.title,
+					isFirst,
+					isLast,
+					firstPosition,
+					dir: 1,
+				} ) }
 				aria-disabled={ isLast }
 			/>
 		</div>
@@ -43,6 +64,8 @@ export default connect(
 	( state, ownProps ) => ( {
 		isFirst: isFirstBlock( state, first( ownProps.uids ) ),
 		isLast: isLastBlock( state, last( ownProps.uids ) ),
+		firstPosition: getBlockOrder( state, first( ownProps.uids ) ),
+		block: getBlock( state, first( ownProps.uids ) ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {

--- a/editor/block-mover/mover-label.js
+++ b/editor/block-mover/mover-label.js
@@ -1,24 +1,4 @@
 /**
- * @typedef blockMoverLabelOptions
- * @property {string}  type       Block type - in the case of a single block, should
- *                                define its 'type'. I.e. 'Text', 'Heading', 'Image' etc.
- * @property {number}  firstIndex The index (position - 1) of the first block selected.
- * @property {boolean} isFirst    This is the first block.
- * @property {boolean} isLast     This is the last block.
- * @property {number}  dir        Direction of movement (> 0 is considered to be going
- *                                down, < 0 is up).
- */
-
-/**
- * @typedef multiBlockMoverLabelOptions
- * @property {number}  firstIndex The index (position - 1) of the first block selected.
- * @property {boolean} isFirst    This is the first block.
- * @property {boolean} isLast     This is the last block.
- * @property {number}  dir        Direction of movement (> 0 is considered to be going
- *                                down, < 0 is up).
- */
-
-/**
  * Wordpress dependencies
  */
 import { __, sprintf } from 'i18n';
@@ -26,15 +6,21 @@ import { __, sprintf } from 'i18n';
 /**
  * Return a label for the block movement controls depending on block position.
  *
- * @param  {number}                 selectedCount Number of blocks selected.
- * @param  {blockMoverLabelOptions} options       Object options.
- * @return {string}                               Label for the block movement controls.
+ * @param  {number}  selectedCount Number of blocks selected.
+ * @param  {string}  type          Block type - in the case of a single block, should
+ *                                 define its 'type'. I.e. 'Text', 'Heading', 'Image' etc.
+ * @param  {number}  firstIndex    The index (position - 1) of the first block selected.
+ * @param  {boolean} isFirst       This is the first block.
+ * @param  {boolean} isLast        This is the last block.
+ * @param  {number}  dir           Direction of movement (> 0 is considered to be going
+ *                                 down, < 0 is up).
+ * @return {string}                Label for the block movement controls.
  */
-export function getBlockMoverLabel( selectedCount, { type, firstIndex, isFirst, isLast, dir } ) {
+export function getBlockMoverLabel( selectedCount, type, firstIndex, isFirst, isLast, dir ) {
 	const position = ( firstIndex + 1 );
 
 	if ( selectedCount > 1 ) {
-		return getMultiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } );
+		return getMultiBlockMoverLabel( selectedCount, firstIndex, isFirst, isLast, dir );
 	}
 
 	if ( isFirst && isLast ) {
@@ -75,11 +61,15 @@ export function getBlockMoverLabel( selectedCount, { type, firstIndex, isFirst, 
 /**
  * Return a label for the block movement controls depending on block position.
  *
- * @param  {number}                      selectedCount Number of blocks selected.
- * @param  {multiBlockMoverLabelOptions} options       Object options.
- * @return {string}                                    Label for the block movement controls.
+ * @param  {number}  selectedCount Number of blocks selected.
+ * @param  {number}  firstIndex    The index (position - 1) of the first block selected.
+ * @param  {boolean} isFirst       This is the first block.
+ * @param  {boolean} isLast        This is the last block.
+ * @param  {number}  dir           Direction of movement (> 0 is considered to be going
+ *                                 down, < 0 is up).
+ * @return {string}                Label for the block movement controls.
  */
-export function getMultiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } ) {
+export function getMultiBlockMoverLabel( selectedCount, firstIndex, isFirst, isLast, dir ) {
 	const position = ( firstIndex + 1 );
 
 	if ( dir < 0 && isFirst ) {

--- a/editor/block-mover/mover-label.js
+++ b/editor/block-mover/mover-label.js
@@ -1,0 +1,73 @@
+import { __, sprintf } from 'i18n';
+
+export function blockMoverLabel( selectedCount, { type, firstPosition, isFirst, isLast, dir } ) {
+	const position = ( firstPosition + 1 );
+
+	if ( selectedCount > 1 ) {
+		return multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstPosition, dir } );
+	}
+
+	if ( isFirst && isLast ) {
+		return sprintf( __( 'Block "%s" is the only block, and cannot be moved' ), type );
+	}
+
+	if ( dir > 0 && ! isLast ) {
+		// moving down
+		return sprintf(
+			__( 'Move "%s" block from position %s down to position %s' ),
+			type,
+			position,
+			( position + 1 )
+		);
+	}
+
+	if ( dir > 0 && isLast ) {
+		// moving down, and is the last item
+		return sprintf( __( 'Block "%s" is at the end of the content and can’t be moved down' ), type );
+	}
+
+	if ( dir < 0 && ! isFirst ) {
+		// moving up
+		return sprintf(
+			__( 'Move "%s" block from position %s up to position %s' ),
+			type,
+			position,
+			( position - 1 )
+		);
+	}
+
+	if ( dir < 0 && isFirst ) {
+		// moving up, and is the first item
+		return sprintf( __( 'Block "%s" is at the beginning of the content and can’t be moved up' ), type );
+	}
+
+	return '';
+}
+
+export function multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstPosition, dir } ) {
+	const position = ( firstPosition + 1 );
+
+	if ( dir < 0 && isFirst ) {
+		return __( 'Blocks cannot be moved up as they are already at the top' );
+	}
+
+	if ( dir > 0 && isLast ) {
+		return __( 'Blocks cannot be moved down as they are already at the bottom' );
+	}
+
+	if ( dir < 0 && ! isFirst ) {
+		return sprintf(
+			__( 'Move %s blocks from position %s up by one place' ),
+			selectedCount,
+			position
+		);
+	}
+
+	if ( dir > 0 && ! isLast ) {
+		return sprintf(
+			__( 'Move %s blocks from position %s down by one place' ),
+			selectedCount,
+			position
+		);
+	}
+}

--- a/editor/block-mover/mover-label.js
+++ b/editor/block-mover/mover-label.js
@@ -30,11 +30,11 @@ import { __, sprintf } from 'i18n';
  * @param  {blockMoverLabelOptions} options       Object options.
  * @return {string}                               Label for the block movement controls.
  */
-export function blockMoverLabel( selectedCount, { type, firstIndex, isFirst, isLast, dir } ) {
+export function getBlockMoverLabel( selectedCount, { type, firstIndex, isFirst, isLast, dir } ) {
 	const position = ( firstIndex + 1 );
 
 	if ( selectedCount > 1 ) {
-		return multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } );
+		return getMultiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } );
 	}
 
 	if ( isFirst && isLast ) {
@@ -81,7 +81,7 @@ export function blockMoverLabel( selectedCount, { type, firstIndex, isFirst, isL
  * @param  {multiBlockMoverLabelOptions} options       Object options.
  * @return {string}                                    Label for the block movement controls.
  */
-export function multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } ) {
+export function getMultiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } ) {
 	const position = ( firstIndex + 1 );
 
 	if ( dir < 0 && isFirst ) {

--- a/editor/block-mover/mover-label.js
+++ b/editor/block-mover/mover-label.js
@@ -24,36 +24,43 @@ export function getBlockMoverLabel( selectedCount, type, firstIndex, isFirst, is
 	}
 
 	if ( isFirst && isLast ) {
+		// translators: %s: Type of block (i.e. Text, Image etc)
 		return sprintf( __( 'Block "%s" is the only block, and cannot be moved' ), type );
 	}
 
 	if ( dir > 0 && ! isLast ) {
 		// moving down
 		return sprintf(
-			__( 'Move "%s" block from position %s down to position %s' ),
-			type,
-			position,
-			( position + 1 )
+			__( 'Move "%(type)s" block from position %(position)d down to position %(newPosition)d' ),
+			{
+				type,
+				position,
+				newPosition: ( position + 1 ),
+			}
 		);
 	}
 
 	if ( dir > 0 && isLast ) {
 		// moving down, and is the last item
+		// translators: %s: Type of block (i.e. Text, Image etc)
 		return sprintf( __( 'Block "%s" is at the end of the content and can’t be moved down' ), type );
 	}
 
 	if ( dir < 0 && ! isFirst ) {
 		// moving up
 		return sprintf(
-			__( 'Move "%s" block from position %s up to position %s' ),
-			type,
-			position,
-			( position - 1 )
+			__( 'Move "%(type)s" block from position %(position)d up to position %(newPosition)d' ),
+			{
+				type,
+				position,
+				newPosition: ( position - 1 ),
+			}
 		);
 	}
 
 	if ( dir < 0 && isFirst ) {
 		// moving up, and is the first item
+		// translators: %s: Type of block (i.e. Text, Image etc)
 		return sprintf( __( 'Block "%s" is at the beginning of the content and can’t be moved up' ), type );
 	}
 }
@@ -82,17 +89,21 @@ export function getMultiBlockMoverLabel( selectedCount, firstIndex, isFirst, isL
 
 	if ( dir < 0 && ! isFirst ) {
 		return sprintf(
-			__( 'Move %s blocks from position %s up by one place' ),
-			selectedCount,
-			position
+			__( 'Move %(selectedCount)d blocks from position %(position)d up by one place' ),
+			{
+				selectedCount,
+				position,
+			}
 		);
 	}
 
 	if ( dir > 0 && ! isLast ) {
 		return sprintf(
-			__( 'Move %s blocks from position %s down by one place' ),
-			selectedCount,
-			position
+			__( 'Move %(selectedCount)d blocks from position %(position)s down by one place' ),
+			{
+				selectedCount,
+				position,
+			}
 		);
 	}
 }

--- a/editor/block-mover/mover-label.js
+++ b/editor/block-mover/mover-label.js
@@ -70,8 +70,6 @@ export function getBlockMoverLabel( selectedCount, { type, firstIndex, isFirst, 
 		// moving up, and is the first item
 		return sprintf( __( 'Block "%s" is at the beginning of the content and can’t be moved up' ), type );
 	}
-
-	return '';
 }
 
 /**

--- a/editor/block-mover/mover-label.js
+++ b/editor/block-mover/mover-label.js
@@ -1,5 +1,35 @@
+/**
+ * @typedef blockMoverLabelOptions
+ * @property {string}  type       Block type - in the case of a single block, should
+ *                                define its 'type'. I.e. 'Text', 'Heading', 'Image' etc.
+ * @property {number}  firstIndex The index (position - 1) of the first block selected.
+ * @property {boolean} isFirst    This is the first block.
+ * @property {boolean} isLast     This is the last block.
+ * @property {number}  dir        Direction of movement (> 0 is considered to be going
+ *                                down, < 0 is up).
+ */
+
+/**
+ * @typedef multiBlockMoverLabelOptions
+ * @property {number}  firstIndex The index (position - 1) of the first block selected.
+ * @property {boolean} isFirst    This is the first block.
+ * @property {boolean} isLast     This is the last block.
+ * @property {number}  dir        Direction of movement (> 0 is considered to be going
+ *                                down, < 0 is up).
+ */
+
+/**
+ * Wordpress dependencies
+ */
 import { __, sprintf } from 'i18n';
 
+/**
+ * Return a label for the block movement controls depending on block position.
+ *
+ * @param  {number}                 selectedCount Number of blocks selected.
+ * @param  {blockMoverLabelOptions} options       Object options.
+ * @return {string}                               Label for the block movement controls.
+ */
 export function blockMoverLabel( selectedCount, { type, firstIndex, isFirst, isLast, dir } ) {
 	const position = ( firstIndex + 1 );
 
@@ -44,6 +74,13 @@ export function blockMoverLabel( selectedCount, { type, firstIndex, isFirst, isL
 	return '';
 }
 
+/**
+ * Return a label for the block movement controls depending on block position.
+ *
+ * @param  {number}                      selectedCount Number of blocks selected.
+ * @param  {multiBlockMoverLabelOptions} options       Object options.
+ * @return {string}                                    Label for the block movement controls.
+ */
 export function multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } ) {
 	const position = ( firstIndex + 1 );
 

--- a/editor/block-mover/mover-label.js
+++ b/editor/block-mover/mover-label.js
@@ -1,10 +1,10 @@
 import { __, sprintf } from 'i18n';
 
-export function blockMoverLabel( selectedCount, { type, firstPosition, isFirst, isLast, dir } ) {
-	const position = ( firstPosition + 1 );
+export function blockMoverLabel( selectedCount, { type, firstIndex, isFirst, isLast, dir } ) {
+	const position = ( firstIndex + 1 );
 
 	if ( selectedCount > 1 ) {
-		return multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstPosition, dir } );
+		return multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } );
 	}
 
 	if ( isFirst && isLast ) {
@@ -44,8 +44,8 @@ export function blockMoverLabel( selectedCount, { type, firstPosition, isFirst, 
 	return '';
 }
 
-export function multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstPosition, dir } ) {
-	const position = ( firstPosition + 1 );
+export function multiBlockMoverLabel( selectedCount, { isFirst, isLast, firstIndex, dir } ) {
+	const position = ( firstIndex + 1 );
 
 	if ( dir < 0 && isFirst ) {
 		return __( 'Blocks cannot be moved up as they are already at the top' );

--- a/editor/block-mover/test/mover-label.js
+++ b/editor/block-mover/test/mover-label.js
@@ -9,8 +9,8 @@ import { expect } from 'chai';
 import { getBlockMoverLabel, getMultiBlockMoverLabel } from '../mover-label';
 
 describe( 'block mover', () => {
-	const dir_up = -1,
-		dir_down = 1;
+	const dirUp = -1,
+		dirDown = 1;
 
 	describe( 'getBlockMoverLabel', () => {
 		const type = 'TestType';
@@ -22,7 +22,7 @@ describe( 'block mover', () => {
 				0,
 				true,
 				false,
-				dir_up,
+				dirUp,
 			) ).to.equal(
 				`Block "${ type }" is at the beginning of the content and can’t be moved up`
 			);
@@ -35,7 +35,7 @@ describe( 'block mover', () => {
 				3,
 				false,
 				true,
-				dir_down,
+				dirDown,
 			) ).to.equal(
 				`Block "${ type }" is at the end of the content and can’t be moved down`
 			);
@@ -48,7 +48,7 @@ describe( 'block mover', () => {
 				1,
 				false,
 				false,
-				dir_up,
+				dirUp,
 			) ).to.equal(
 				`Move "${ type }" block from position 2 up to position 1`
 			);
@@ -61,7 +61,7 @@ describe( 'block mover', () => {
 				1,
 				false,
 				false,
-				dir_down,
+				dirDown,
 			) ).to.equal(
 				`Move "${ type }" block from position 2 down to position 3`
 			);
@@ -74,7 +74,7 @@ describe( 'block mover', () => {
 				0,
 				true,
 				true,
-				dir_down,
+				dirDown,
 			) ).to.equal(
 				`Block "${ type }" is the only block, and cannot be moved`
 			);
@@ -88,7 +88,7 @@ describe( 'block mover', () => {
 				1,
 				false,
 				true,
-				dir_up,
+				dirUp,
 			) ).to.equal(
 				'Move 4 blocks from position 2 up by one place'
 			);
@@ -100,7 +100,7 @@ describe( 'block mover', () => {
 				0,
 				true,
 				false,
-				dir_down,
+				dirDown,
 			) ).to.equal(
 				'Move 4 blocks from position 1 down by one place'
 			);
@@ -112,7 +112,7 @@ describe( 'block mover', () => {
 				1,
 				true,
 				true,
-				dir_up,
+				dirUp,
 			) ).to.equal(
 				'Blocks cannot be moved up as they are already at the top'
 			);
@@ -124,7 +124,7 @@ describe( 'block mover', () => {
 				2,
 				false,
 				true,
-				dir_down,
+				dirDown,
 			) ).to.equal(
 				'Blocks cannot be moved down as they are already at the bottom'
 			);

--- a/editor/block-mover/test/mover-label.js
+++ b/editor/block-mover/test/mover-label.js
@@ -9,65 +9,73 @@ import { expect } from 'chai';
 import { getBlockMoverLabel, getMultiBlockMoverLabel } from '../mover-label';
 
 describe( 'block mover', () => {
+	const dir_up = -1,
+		dir_down = 1;
+
 	describe( 'getBlockMoverLabel', () => {
 		const type = 'TestType';
 
 		it( 'Should generate a title for the first item moving up', () => {
-			expect( getBlockMoverLabel( 1, {
+			expect( getBlockMoverLabel(
+				1,
 				type,
-				firstIndex: 0,
-				isFirst: true,
-				isLast: false,
-				dir: -1,
-			} ) ).to.equal(
+				0,
+				true,
+				false,
+				dir_up,
+			) ).to.equal(
 				`Block "${ type }" is at the beginning of the content and can’t be moved up`
 			);
 		} );
 
 		it( 'Should generate a title for the last item moving down', () => {
-			expect( getBlockMoverLabel( 1, {
+			expect( getBlockMoverLabel(
+				1,
 				type,
-				firstIndex: 3,
-				isFirst: false,
-				isLast: true,
-				dir: 1,
-			} ) ).to.equal(
+				3,
+				false,
+				true,
+				dir_down,
+			) ).to.equal(
 				`Block "${ type }" is at the end of the content and can’t be moved down`
 			);
 		} );
 
 		it( 'Should generate a title for the second item moving up', () => {
-			expect( getBlockMoverLabel( 1, {
+			expect( getBlockMoverLabel(
+				1,
 				type,
-				firstIndex: 1,
-				isFirst: false,
-				isLast: false,
-				dir: -1,
-			} ) ).to.equal(
+				1,
+				false,
+				false,
+				dir_up,
+			) ).to.equal(
 				`Move "${ type }" block from position 2 up to position 1`
 			);
 		} );
 
 		it( 'Should generate a title for the second item moving down', () => {
-			expect( getBlockMoverLabel( 1, {
+			expect( getBlockMoverLabel(
+				1,
 				type,
-				firstIndex: 1,
-				isFirst: false,
-				isLast: false,
-				dir: 1,
-			} ) ).to.equal(
+				1,
+				false,
+				false,
+				dir_down,
+			) ).to.equal(
 				`Move "${ type }" block from position 2 down to position 3`
 			);
 		} );
 
 		it( 'Should generate a title for the only item in the list', () => {
-			expect( getBlockMoverLabel( 1, {
+			expect( getBlockMoverLabel(
+				1,
 				type,
-				firstIndex: 0,
-				isFirst: true,
-				isLast: true,
-				dir: 1,
-			} ) ).to.equal(
+				0,
+				true,
+				true,
+				dir_down,
+			) ).to.equal(
 				`Block "${ type }" is the only block, and cannot be moved`
 			);
 		} );
@@ -75,45 +83,49 @@ describe( 'block mover', () => {
 
 	describe( 'getMultiBlockMoverLabel', () => {
 		it( 'Should generate a title moving multiple blocks up', () => {
-			expect( getMultiBlockMoverLabel( 4, {
-				firstIndex: 1,
-				isFirst: false,
-				isLast: true,
-				dir: -1,
-			} ) ).to.equal(
+			expect( getMultiBlockMoverLabel(
+				4,
+				1,
+				false,
+				true,
+				dir_up,
+			) ).to.equal(
 				'Move 4 blocks from position 2 up by one place'
 			);
 		} );
 
 		it( 'Should generate a title moving multiple blocks down', () => {
-			expect( getMultiBlockMoverLabel( 4, {
-				firstIndex: 0,
-				isFirst: true,
-				isLast: false,
-				dir: 1,
-			} ) ).to.equal(
+			expect( getMultiBlockMoverLabel(
+				4,
+				0,
+				true,
+				false,
+				dir_down,
+			) ).to.equal(
 				'Move 4 blocks from position 1 down by one place'
 			);
 		} );
 
 		it( 'Should generate a title for a selection of blocks at the top', () => {
-			expect( getMultiBlockMoverLabel( 4, {
-				firstIndex: 1,
-				isFirst: true,
-				isLast: true,
-				dir: -1,
-			} ) ).to.equal(
+			expect( getMultiBlockMoverLabel(
+				4,
+				1,
+				true,
+				true,
+				dir_up,
+			) ).to.equal(
 				'Blocks cannot be moved up as they are already at the top'
 			);
 		} );
 
 		it( 'Should generate a title for a selection of blocks at the bottom', () => {
-			expect( getMultiBlockMoverLabel( 4, {
-				firstIndex: 2,
-				isFirst: false,
-				isLast: true,
-				dir: 1,
-			} ) ).to.equal(
+			expect( getMultiBlockMoverLabel(
+				4,
+				2,
+				false,
+				true,
+				dir_down,
+			) ).to.equal(
 				'Blocks cannot be moved down as they are already at the bottom'
 			);
 		} );

--- a/editor/block-mover/test/mover-label.js
+++ b/editor/block-mover/test/mover-label.js
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { blockMoverLabel, multiBlockMoverLabel } from '../mover-label';
+
+describe( 'block mover', () => {
+	describe( 'blockMoverLabel', () => {
+		const type = 'TestType';
+
+		it( 'Should generate a title for the first item moving up', () => {
+			expect( blockMoverLabel( 1, {
+				type,
+				firstPosition: 0,
+				isFirst: true,
+				isLast: false,
+				dir: -1,
+			} ) ).to.equal(
+				`Block "${ type }" is at the beginning of the content and can’t be moved up`
+			);
+		} );
+
+		it( 'Should generate a title for the last item moving down', () => {
+			expect( blockMoverLabel( 1, {
+				type,
+				firstPosition: 3,
+				isFirst: false,
+				isLast: true,
+				dir: 1,
+			} ) ).to.equal(
+				`Block "${ type }" is at the end of the content and can’t be moved down`
+			);
+		} );
+
+		it( 'Should generate a title for the second item moving up', () => {
+			expect( blockMoverLabel( 1, {
+				type,
+				firstPosition: 1,
+				isFirst: false,
+				isLast: false,
+				dir: -1,
+			} ) ).to.equal(
+				`Move "${ type }" block from position 2 up to position 1`
+			);
+		} );
+
+		it( 'Should generate a title for the second item moving down', () => {
+			expect( blockMoverLabel( 1, {
+				type,
+				firstPosition: 1,
+				isFirst: false,
+				isLast: false,
+				dir: 1,
+			} ) ).to.equal(
+				`Move "${ type }" block from position 2 down to position 3`
+			);
+		} );
+
+		it( 'Should generate a title for the only item in the list', () => {
+			expect( blockMoverLabel( 1, {
+				type,
+				firstPosition: 0,
+				isFirst: true,
+				isLast: true,
+				dir: 1,
+			} ) ).to.equal(
+				`Block "${ type }" is the only block, and cannot be moved`
+			);
+		} );
+	} );
+
+	describe( 'multiBlockMoverLabel', () => {
+		it( 'Should generate a title moving multiple blocks up', () => {
+			expect( multiBlockMoverLabel( 4, {
+				firstPosition: 1,
+				isFirst: false,
+				isLast: true,
+				dir: -1,
+			} ) ).to.equal(
+				'Move 4 blocks from position 2 up by one place'
+			);
+		} );
+
+		it( 'Should generate a title moving multiple blocks down', () => {
+			expect( multiBlockMoverLabel( 4, {
+				firstPosition: 0,
+				isFirst: true,
+				isLast: false,
+				dir: 1,
+			} ) ).to.equal(
+				'Move 4 blocks from position 1 down by one place'
+			);
+		} );
+
+		it( 'Should generate a title for a selection of blocks at the top', () => {
+			expect( multiBlockMoverLabel( 4, {
+				firstPosition: 1,
+				isFirst: true,
+				isLast: true,
+				dir: -1,
+			} ) ).to.equal(
+				'Blocks cannot be moved up as they are already at the top'
+			);
+		} );
+
+		it( 'Should generate a title for a selection of blocks at the bottom', () => {
+			expect( multiBlockMoverLabel( 4, {
+				firstPosition: 2,
+				isFirst: false,
+				isLast: true,
+				dir: 1,
+			} ) ).to.equal(
+				'Blocks cannot be moved down as they are already at the bottom'
+			);
+		} );
+	} );
+} );

--- a/editor/block-mover/test/mover-label.js
+++ b/editor/block-mover/test/mover-label.js
@@ -15,7 +15,7 @@ describe( 'block mover', () => {
 		it( 'Should generate a title for the first item moving up', () => {
 			expect( getBlockMoverLabel( 1, {
 				type,
-				firstPosition: 0,
+				firstIndex: 0,
 				isFirst: true,
 				isLast: false,
 				dir: -1,
@@ -27,7 +27,7 @@ describe( 'block mover', () => {
 		it( 'Should generate a title for the last item moving down', () => {
 			expect( getBlockMoverLabel( 1, {
 				type,
-				firstPosition: 3,
+				firstIndex: 3,
 				isFirst: false,
 				isLast: true,
 				dir: 1,
@@ -39,7 +39,7 @@ describe( 'block mover', () => {
 		it( 'Should generate a title for the second item moving up', () => {
 			expect( getBlockMoverLabel( 1, {
 				type,
-				firstPosition: 1,
+				firstIndex: 1,
 				isFirst: false,
 				isLast: false,
 				dir: -1,
@@ -51,7 +51,7 @@ describe( 'block mover', () => {
 		it( 'Should generate a title for the second item moving down', () => {
 			expect( getBlockMoverLabel( 1, {
 				type,
-				firstPosition: 1,
+				firstIndex: 1,
 				isFirst: false,
 				isLast: false,
 				dir: 1,
@@ -63,7 +63,7 @@ describe( 'block mover', () => {
 		it( 'Should generate a title for the only item in the list', () => {
 			expect( getBlockMoverLabel( 1, {
 				type,
-				firstPosition: 0,
+				firstIndex: 0,
 				isFirst: true,
 				isLast: true,
 				dir: 1,
@@ -76,7 +76,7 @@ describe( 'block mover', () => {
 	describe( 'getMultiBlockMoverLabel', () => {
 		it( 'Should generate a title moving multiple blocks up', () => {
 			expect( getMultiBlockMoverLabel( 4, {
-				firstPosition: 1,
+				firstIndex: 1,
 				isFirst: false,
 				isLast: true,
 				dir: -1,
@@ -87,7 +87,7 @@ describe( 'block mover', () => {
 
 		it( 'Should generate a title moving multiple blocks down', () => {
 			expect( getMultiBlockMoverLabel( 4, {
-				firstPosition: 0,
+				firstIndex: 0,
 				isFirst: true,
 				isLast: false,
 				dir: 1,
@@ -98,7 +98,7 @@ describe( 'block mover', () => {
 
 		it( 'Should generate a title for a selection of blocks at the top', () => {
 			expect( getMultiBlockMoverLabel( 4, {
-				firstPosition: 1,
+				firstIndex: 1,
 				isFirst: true,
 				isLast: true,
 				dir: -1,
@@ -109,7 +109,7 @@ describe( 'block mover', () => {
 
 		it( 'Should generate a title for a selection of blocks at the bottom', () => {
 			expect( getMultiBlockMoverLabel( 4, {
-				firstPosition: 2,
+				firstIndex: 2,
 				isFirst: false,
 				isLast: true,
 				dir: 1,

--- a/editor/block-mover/test/mover-label.js
+++ b/editor/block-mover/test/mover-label.js
@@ -6,14 +6,14 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { blockMoverLabel, multiBlockMoverLabel } from '../mover-label';
+import { getBlockMoverLabel, getMultiBlockMoverLabel } from '../mover-label';
 
 describe( 'block mover', () => {
-	describe( 'blockMoverLabel', () => {
+	describe( 'getBlockMoverLabel', () => {
 		const type = 'TestType';
 
 		it( 'Should generate a title for the first item moving up', () => {
-			expect( blockMoverLabel( 1, {
+			expect( getBlockMoverLabel( 1, {
 				type,
 				firstPosition: 0,
 				isFirst: true,
@@ -25,7 +25,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for the last item moving down', () => {
-			expect( blockMoverLabel( 1, {
+			expect( getBlockMoverLabel( 1, {
 				type,
 				firstPosition: 3,
 				isFirst: false,
@@ -37,7 +37,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for the second item moving up', () => {
-			expect( blockMoverLabel( 1, {
+			expect( getBlockMoverLabel( 1, {
 				type,
 				firstPosition: 1,
 				isFirst: false,
@@ -49,7 +49,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for the second item moving down', () => {
-			expect( blockMoverLabel( 1, {
+			expect( getBlockMoverLabel( 1, {
 				type,
 				firstPosition: 1,
 				isFirst: false,
@@ -61,7 +61,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for the only item in the list', () => {
-			expect( blockMoverLabel( 1, {
+			expect( getBlockMoverLabel( 1, {
 				type,
 				firstPosition: 0,
 				isFirst: true,
@@ -73,9 +73,9 @@ describe( 'block mover', () => {
 		} );
 	} );
 
-	describe( 'multiBlockMoverLabel', () => {
+	describe( 'getMultiBlockMoverLabel', () => {
 		it( 'Should generate a title moving multiple blocks up', () => {
-			expect( multiBlockMoverLabel( 4, {
+			expect( getMultiBlockMoverLabel( 4, {
 				firstPosition: 1,
 				isFirst: false,
 				isLast: true,
@@ -86,7 +86,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title moving multiple blocks down', () => {
-			expect( multiBlockMoverLabel( 4, {
+			expect( getMultiBlockMoverLabel( 4, {
 				firstPosition: 0,
 				isFirst: true,
 				isLast: false,
@@ -97,7 +97,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for a selection of blocks at the top', () => {
-			expect( multiBlockMoverLabel( 4, {
+			expect( getMultiBlockMoverLabel( 4, {
 				firstPosition: 1,
 				isFirst: true,
 				isLast: true,
@@ -108,7 +108,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for a selection of blocks at the bottom', () => {
-			expect( multiBlockMoverLabel( 4, {
+			expect( getMultiBlockMoverLabel( 4, {
 				firstPosition: 2,
 				isFirst: false,
 				isLast: true,


### PR DESCRIPTION
After thinking about what would be best for the user in terms of accessibility and guidance, I’ve decided that trying to give them the “content” of a block wouldn’t very useful in a lot of contexts – especially non-text blocks.

Instead, I’ve opted for telling them where the block is, and where it’ll be moved to.

This is also the case for multiple selected blocks, where it will fall back to simpler language.