### PR TITLE
Change attribute serialization to explicit opt-in

### DIFF
--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { pick, identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,34 +57,34 @@ describe( 'block serializer', () => {
 	} );
 
 	describe( 'getCommentAttributes()', () => {
-		it( 'should return empty string if no difference', () => {
-			const attributes = getCommentAttributes( {}, {} );
-
-			expect( attributes ).to.equal( '' );
-		} );
-
-		it( 'should return joined string of key:value pairs by difference subset', () => {
-			const attributes = getCommentAttributes( {
-				fruit: 'bananas',
-				category: 'food',
-				ripeness: 'ripe',
-			}, {
+		it( 'should return empty string if no encodeAttributes implementation', () => {
+			const commentAttributes = getCommentAttributes( undefined, {
 				fruit: 'bananas',
 			} );
 
-			expect( attributes ).to.equal( 'category="food" ripeness="ripe" ' );
+			expect( commentAttributes ).to.equal( '' );
+		} );
+
+		it( 'should return joined string of `key="value"` pairs by difference subset', () => {
+			const commentAttributes = getCommentAttributes(
+				( attributes ) => pick( attributes, 'category', 'ripeness' ),
+				{
+					fruit: 'bananas',
+					category: 'food',
+					ripeness: 'ripe',
+				}
+			);
+
+			expect( commentAttributes ).to.equal( 'category="food" ripeness="ripe"' );
 		} );
 
 		it( 'should not append an undefined attribute value', () => {
-			const attributes = getCommentAttributes( {
-				fruit: 'bananas',
+			const commentAttributes = getCommentAttributes( identity, {
 				category: 'food',
 				ripeness: undefined,
-			}, {
-				fruit: 'bananas',
 			} );
 
-			expect( attributes ).to.equal( 'category="food" ' );
+			expect( commentAttributes ).to.equal( 'category="food"' );
 		} );
 	} );
 
@@ -94,6 +95,10 @@ describe( 'block serializer', () => {
 					return {
 						content: rawContent,
 					};
+				},
+				encodeAttributes( attributes ) {
+					const { align } = attributes;
+					return { align };
 				},
 				save( { attributes } ) {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -39,6 +39,11 @@ registerBlockType( 'core/button', {
 		text: children( 'a' ),
 	},
 
+	encodeAttributes( attributes ) {
+		const { align } = attributes;
+		return { align };
+	},
+
 	controls: [
 		{
 			icon: 'align-left',

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -40,6 +40,11 @@ registerBlockType( 'core/image', {
 		caption: children( 'figcaption' ),
 	},
 
+	encodeAttributes( attributes ) {
+		const { align } = attributes;
+		return { align };
+	},
+
 	controls: [
 		{
 			icon: 'align-left',

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -22,6 +22,11 @@ registerBlockType( 'core/quote', {
 		citation: children( 'footer' ),
 	},
 
+	encodeAttributes( attributes ) {
+		const { style } = attributes;
+		return { style };
+	},
+
 	controls: [ 1, 2 ].map( ( variation ) => ( {
 		icon: 'format-quote',
 		title: wp.i18n.sprintf( wp.i18n.__( 'Quote style %d' ), variation ),


### PR DESCRIPTION
Related: #865, #391

This pull request seeks to change attribute serialization behavior, currently inferred as the difference between a block's actual attributes at time of serialization and the `attributes` definition. With these changes, it will instead be required that a block explicitly control its comment encoding behavior by returning an object from an `encodeAttributes` function. This is implemented exactly as documented from the [`registerBlockType` documentation](https://github.com/WordPress/gutenberg/tree/master/blocks#wpblocksregisterblocktype-name-string-typedefinition-object-).

__Testing instructions:__

Ensure that tests pass:

```
npm test
```

Verify that block comment serialization continues to behave as expected for Button `align`, Image `align`, and Quote `style` blocks, when changing these values and switching to Text mode.