### PR TITLE
Inserter: Fix the insertion point

### DIFF
--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -13,7 +13,7 @@ import { IconButton } from 'components';
  * Internal dependencies
  */
 import InserterMenu from './menu';
-import { getSelectedBlock } from '../selectors';
+import { getBlockSelectionEnd, getSelectedBlock } from '../selectors';
 import { insertBlock, clearInsertionPoint } from '../actions';
 
 class Inserter extends wp.element.Component {
@@ -41,10 +41,17 @@ class Inserter extends wp.element.Component {
 
 	insertBlock( slug ) {
 		if ( slug ) {
-			const { selectedBlock, onInsertBlock } = this.props;
+			const { selectedBlock, lastMultiSelectedBlock, onInsertBlock } = this.props;
+			let insertionPoint = null;
+			if ( lastMultiSelectedBlock ) {
+				insertionPoint = lastMultiSelectedBlock;
+			} else if ( selectedBlock ) {
+				insertionPoint = selectedBlock.uid;
+			}
+
 			onInsertBlock(
 				slug,
-				selectedBlock ? selectedBlock.uid : null
+				insertionPoint
 			);
 		}
 
@@ -90,6 +97,7 @@ export default connect(
 	( state ) => {
 		return {
 			selectedBlock: getSelectedBlock( state ),
+			lastMultiSelectedBlock: getBlockSelectionEnd( state ),
 		};
 	},
 	( dispatch ) => ( {

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -15,7 +15,7 @@ import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
  * Internal dependencies
  */
 import './style.scss';
-import { getSelectedBlock } from '../selectors';
+import { getBlockSelectionEnd, getSelectedBlock } from '../selectors';
 import { setInsertionPoint, clearInsertionPoint } from '../actions';
 
 class InserterMenu extends wp.element.Component {
@@ -68,10 +68,15 @@ class InserterMenu extends wp.element.Component {
 	}
 
 	hoverBlock() {
+		const { lastMultiSelectedBlock, selectedBlock } = this.props;
+		let insertionPoint = null;
+		if ( lastMultiSelectedBlock ) {
+			insertionPoint = lastMultiSelectedBlock;
+		} else if ( selectedBlock ) {
+			insertionPoint = selectedBlock.uid;
+		}
 		return () => {
-			this.props.setInsertionPoint(
-				this.props.selectedBlock ? this.props.selectedBlock.uid : null
-			);
+			this.props.setInsertionPoint( insertionPoint );
 		};
 	}
 
@@ -306,6 +311,7 @@ export default connect(
 	( state ) => {
 		return {
 			selectedBlock: getSelectedBlock( state ),
+			lastMultiSelectedBlock: getBlockSelectionEnd( state ),
 		};
 	},
 	{ setInsertionPoint, clearInsertionPoint }

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import clickOutside from 'react-click-outside';
 
 /**
  * Internal dependencies
@@ -56,10 +55,6 @@ class VisualEditorBlockList extends wp.element.Component {
 		this.setState( { selectionAtStart: null } );
 	}
 
-	handleClickOutside() {
-		this.props.clearSelectedBlock();
-	}
-
 	render() {
 		const { blocks, insertionPoint } = this.props;
 		const insertionPointIndex = blocks.indexOf( insertionPoint );
@@ -106,9 +101,8 @@ export default connect(
 		selectionEnd: getBlockSelectionEnd( state ),
 	} ),
 	( dispatch ) => ( {
-		clearSelectedBlock: () => dispatch( { type: 'CLEAR_SELECTED_BLOCK' } ),
 		onMultiSelect( { start, end } ) {
 			dispatch( { type: 'MULTI_SELECT', start, end } );
 		},
 	} )
-)( clickOutside( VisualEditorBlockList ) );
+)( VisualEditorBlockList );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -52,7 +52,6 @@ class VisualEditorBlock extends wp.element.Component {
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
 		this.removeOrDeselect = this.removeOrDeselect.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
-		this.selectAndStopPropagation = this.selectAndStopPropagation.bind( this );
 		this.previousOffset = null;
 	}
 
@@ -149,13 +148,6 @@ class VisualEditorBlock extends wp.element.Component {
 		} else {
 			onMerge( previousBlock, block );
 		}
-	}
-
-	selectAndStopPropagation( event ) {
-		this.props.onSelect();
-		// Visual editor infers click as intent to clear the selected block, so
-		// prevent bubbling when occurring on block where selection is intended
-		event.stopPropagation();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -280,7 +272,7 @@ class VisualEditorBlock extends wp.element.Component {
 				<div
 					onKeyPress={ this.maybeStartTyping }
 					onFocus={ onSelect }
-					onClick={ this.selectAndStopPropagation }
+					onClick={ onSelect }
 				>
 					<BlockEdit
 						focus={ focus }

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
  * WordPress dependencies
  */
 import { __ } from 'i18n';
+import { Component } from 'element';
 
 /**
  * Internal dependencies
@@ -11,16 +17,48 @@ import Inserter from '../../inserter';
 import VisualEditorBlockList from './block-list';
 import PostTitle from '../../post-title';
 
-export default function VisualEditor() {
-	return (
-		<div
-			role="region"
-			aria-label={ __( 'Visual Editor' ) }
-			className="editor-visual-editor"
-		>
-			<PostTitle />
-			<VisualEditorBlockList />
-			<Inserter position="top right" />
-		</div>
-	);
+class VisualEditor extends Component {
+	constructor() {
+		super( ...arguments );
+		this.bindContainer = this.bindContainer.bind( this );
+		this.onClick = this.onClick.bind( this );
+	}
+
+	bindContainer( ref ) {
+		this.container = ref;
+	}
+
+	onClick( event ) {
+		if ( event.target === this.container ) {
+			this.props.clearSelectedBlock();
+		}
+	}
+
+	render() {
+		// Disable reason: Clicking the canvas should clear the selection
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		return (
+			<div
+				role="region"
+				aria-label={ __( 'Visual Editor' ) }
+				className="editor-visual-editor"
+				onClick={ this.onClick }
+				ref={ this.bindContainer }
+			>
+				<PostTitle />
+				<VisualEditorBlockList />
+				<Inserter position="top right" />
+			</div>
+		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+	}
 }
+
+export default connect(
+	undefined,
+	( dispatch ) => ( {
+		clearSelectedBlock() {
+			dispatch( { type: 'CLEAR_SELECTED_BLOCK' } );
+		},
+	} )
+)( VisualEditor );

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -125,15 +125,16 @@
 	margin: $item-spacing $item-spacing $item-spacing calc( 50% - #{ $visual-editor-max-width / 2 } );	// account for full-width trick
 }
 
-.editor-visual-editor > .editor-visual-editor__insertion-point {
+.editor-visual-editor .editor-visual-editor__insertion-point {
 	position: relative;
+	margin-right: #{ ( $block-padding + $block-mover-margin) * 2 };
 
 	&:before {
 		position: absolute;
 		top: 6px;
-		right: #{ $block-padding + $block-mover-margin };
-		left: 0;
 		height: 3px;
+		left: 0;
+		right: 0;
 		background: $blue-medium-500;
 		content: '';
 	}

--- a/editor/state.js
+++ b/editor/state.js
@@ -279,6 +279,7 @@ export function multiSelectedBlocks( state = { start: null, end: null }, action 
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK':
 		case 'TOGGLE_BLOCK_SELECTED':
+		case 'INSERT_BLOCK':
 			return {
 				start: null,
 				end: null,

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -786,6 +786,16 @@ describe( 'state', () => {
 			} );
 
 			expect( state2 ).to.eql( { start: null, end: null } );
+
+			const state3 = multiSelectedBlocks( original, {
+				type: 'INSERT_BLOCK',
+				block: {
+					uid: 'ribs',
+					name: 'core/freeform',
+				},
+			} );
+
+			expect( state3 ).to.eql( { start: null, end: null } );
 		} );
 	} );
 


### PR DESCRIPTION
There were some regressions to the insertion point feature due to multi-selection #896 

The behaviour of this PR:

 - When we have a multi-selection, the block is inserted after the multi-selection
 - When clicking outside the editor, the selection is not cleared (multi or mono). I thought it's good to keep a consistent behaviour (Though we can decide to clear the multi-selection only)

Open questions:

I think we should unify the concept of selected block and multi-selection into a unique state