### PR TITLE
Inserter scroll indicator

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -12,7 +12,6 @@ body.toplevel_page_gutenberg {
 	#wpfooter {
 		display: none;
 	}
-
 }
 
 .gutenberg {

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -108,12 +108,30 @@
 	z-index: z-index( '.editor-inserter__arrow' );
 }
 
+$scrollbar-width: 12px;
 .editor-inserter__content {
-	max-height: 50vh;
+	max-height: 10vh;	// fix me should be 50
 	overflow: auto;
+	box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
 
 	&:focus {
 		outline: none;
+	}
+
+	&::-webkit-scrollbar {
+		width: $scrollbar-width;
+		height: $scrollbar-width;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		border-radius: 10px;
+		background-color: $dark-gray-300;
+		border: 3px solid transparent;
+		background-clip: padding-box;
+
+		&:hover {
+			background-color: $dark-gray-900;
+		}
 	}
 }
 

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -108,30 +108,13 @@
 	z-index: z-index( '.editor-inserter__arrow' );
 }
 
-$scrollbar-width: 12px;
 .editor-inserter__content {
-	max-height: 10vh;	// fix me should be 50
+	max-height: 50vh;
 	overflow: auto;
 	box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
 
 	&:focus {
 		outline: none;
-	}
-
-	&::-webkit-scrollbar {
-		width: $scrollbar-width;
-		height: $scrollbar-width;
-	}
-
-	&::-webkit-scrollbar-thumb {
-		border-radius: 10px;
-		background-color: $dark-gray-300;
-		border: 3px solid transparent;
-		background-clip: padding-box;
-
-		&:hover {
-			background-color: $dark-gray-900;
-		}
 	}
 }
 


### PR DESCRIPTION
This PR adds a bottom box shadow to the scroll inserter, indicating you can scroll. This fixes #776.

Originally I also intended to look deeper into whether we could fix scroll bleed. I got far enough that if we add this CSS, we can prevent scrolling of the body content:

```
.toplevel_page_gutenberg {
	&.is-scroll-locked {
		overflow: hidden;

		.gutenberg {
			overflow: scroll;
		}
	}
}
```

That worked pretty well —  all you had to do with that is add the CSS class `is-scroll-locked` when mousing over something like the inserter, then remove it again when mousing off. Then scroll bleed solved. 

Problem is, it relies on creating a fake scrollbar to indent the page, so there isn't a jarring page "jog" when the scrollbar is locked away. This doesn't work with fixed position elements, beckoning hacks that I don't think we'll want to go into. 

As such, it seems if we want to address scroll bleed, we should probably look into https://codepen.io/joen/pen/dMEyjr or https://codepen.io/joen/pen/wGLjWG. 

In the mean time, no reason not to merge this in, right?