### PR TITLE
More embed block fixes

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { parse } from 'url';
+import { includes } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Button, Placeholder, HtmlEmbed, Spinner } from 'components';
@@ -10,12 +16,9 @@ import './style.scss';
 import { registerBlockType, query } from '../../api';
 import Editable from '../../editable';
 
-/**
- * External dependencies
- */
-import { parse } from 'url';
-
 const { attr, children } = query;
+
+const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 
 /**
  * Returns an attribute setter with behavior that if the target value is
@@ -81,16 +84,12 @@ registerBlockType( 'core/embed', {
 		constructor() {
 			super( ...arguments );
 			this.doServerSideRender = this.doServerSideRender.bind( this );
-			this.isPreviewBlacklisted = this.isPreviewBlacklisted.bind( this );
 			this.state = {
 				html: '',
 				type: '',
 				error: false,
 				fetching: false,
 			};
-			this.noPreview = [
-				'facebook.com',
-			];
 		}
 
 		componentWillMount() {
@@ -158,7 +157,7 @@ registerBlockType( 'core/embed', {
 				return (
 					<div className="blocks-embed__loading">
 						<Spinner />
-						<p className="blocks-embed__loading-text">{ wp.i18n.__( 'Embedding...' ) }</p>
+						<p className="blocks-embed__loading-text">{ wp.i18n.__( 'Embedding…' ) }</p>
 					</div>
 				);
 			}
@@ -171,7 +170,7 @@ registerBlockType( 'core/embed', {
 								type="url"
 								value={ url || '' }
 								className="components-placeholder__input"
-								placeholder={ wp.i18n.__( 'Enter URL to embed here...' ) }
+								placeholder={ wp.i18n.__( 'Enter URL to embed here…' ) }
 								onChange={ ( event ) => setAttributes( { url: event.target.value } ) } />
 							<Button
 								isLarge
@@ -184,8 +183,8 @@ registerBlockType( 'core/embed', {
 				);
 			}
 
-			const urlBits = parse( url );
-			const cannotPreview = this.isPreviewBlacklisted( urlBits.host );
+			const parsedUrl = parse( url );
+			const cannotPreview = includes( HOSTS_NO_PREVIEWS, parsedUrl.host.replace( /^www\./, '' ) );
 			let typeClassName = 'blocks-embed';
 
 			if ( 'video' === type ) {

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -142,9 +142,9 @@ registerBlockType( 'core/embed', {
 
 			if ( fetching ) {
 				return (
-					<div className="blocks-embed__loading">
+					<div className="blocks-embed is-loading">
 						<Spinner />
-						<p className="blocks-embed__loading-text">{ wp.i18n.__( 'Embedding…' ) }</p>
+						<p>{ wp.i18n.__( 'Embedding…' ) }</p>
 					</div>
 				);
 			}

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -87,7 +87,6 @@ registerBlockType( 'core/embed', {
 				type: '',
 				error: false,
 				fetching: false,
-				loadingFromSavedBlock: false,
 			};
 			this.noPreview = [
 				'facebook.com',
@@ -99,7 +98,7 @@ registerBlockType( 'core/embed', {
 				// if the url is already there, we're loading a saved block, so we need to render
 				// a different thing, which is why this doesn't use 'fetching', as that
 				// is for when the user is putting in a new url on the placeholder form
-				this.setState( { loadingFromSavedBlock: true } );
+				this.setState( { fetching: true } );
 				this.doServerSideRender();
 			}
 		}
@@ -144,19 +143,18 @@ registerBlockType( 'core/embed', {
 						} else {
 							this.setState( { error: true } );
 						}
-						this.setState( { fetching: false, loadingFromSavedBlock: false } );
+						this.setState( { fetching: false } );
 					} );
 				}
 			);
 		}
 
 		render() {
-			const { html, type, error, fetching, loadingFromSavedBlock } = this.state;
+			const { html, type, error, fetching } = this.state;
 			const { url, caption } = this.props.attributes;
 			const { setAttributes, focus, setFocus } = this.props;
 
-			if ( loadingFromSavedBlock ) {
-				// we're loading from a saved block, but haven't fetched the HTML yet...
+			if ( fetching ) {
 				return (
 					<div className="blocks-embed__loading">
 						<Spinner />
@@ -174,14 +172,11 @@ registerBlockType( 'core/embed', {
 								className="components-placeholder__input"
 								placeholder={ wp.i18n.__( 'Enter URL to embed here...' ) }
 								onChange={ ( event ) => setAttributes( { url: event.target.value } ) } />
-							{ ! fetching
-								? <Button
-									isLarge
-									type="submit">
-									{ wp.i18n.__( 'Embed' ) }
-								</Button>
-								: <Spinner />
-							}
+							<Button
+								isLarge
+								type="submit">
+								{ wp.i18n.__( 'Embed' ) }
+							</Button>
 							{ error && <p className="components-placeholder__error">{ wp.i18n.__( 'Sorry, we could not embed that content.' ) }</p> }
 						</form>
 					</Placeholder>

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -107,19 +107,6 @@ registerBlockType( 'core/embed', {
 			this.unmounting = true;
 		}
 
-		isPreviewBlacklisted( host ) {
-			if ( ! host ) {
-				return false;
-			}
-			host = host.replace( 'www.', '' );
-			for ( let i = 0; i < this.noPreview.length; i++ ) {
-				if ( host === this.noPreview[ i ] ) {
-					return true;
-				}
-			}
-			return false;
-		}
-
 		doServerSideRender( event ) {
 			if ( event ) {
 				event.preventDefault();

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -169,6 +169,7 @@ registerBlockType( 'core/embed', {
 						<form onSubmit={ this.doServerSideRender }>
 							<input
 								type="url"
+								value={ url || '' }
 								className="components-placeholder__input"
 								placeholder={ wp.i18n.__( 'Enter URL to embed here...' ) }
 								onChange={ ( event ) => setAttributes( { url: event.target.value } ) } />

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -158,7 +158,10 @@ registerBlockType( 'core/embed', {
 			if ( loadingFromSavedBlock ) {
 				// we're loading from a saved block, but haven't fetched the HTML yet...
 				return (
-					<p>{ url }</p>
+					<div className="blocks-embed__loading">
+						<Spinner />
+						<p className="blocks-embed__loading-text">{ wp.i18n.__( 'Embedding...' ) }</p>
+					</div>
 				);
 			}
 

--- a/blocks/library/embed/style.scss
+++ b/blocks/library/embed/style.scss
@@ -1,6 +1,20 @@
 .blocks-embed,
 .blocks-embed-video {
 	margin: 0;
+	&.is-loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 1em;
+		min-height: 200px;
+		text-align: center;
+		background: $light-gray-100;
+		p {
+			font-family: $default-font;
+			font-size: $default-font-size;
+		}
+	}
 }
 
 .blocks-embed-video > div:first-child {
@@ -16,22 +30,6 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-}
-
-.blocks-embed__loading {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	padding: 1em;
-	min-height: 200px;
-	text-align: center;
-	background: $light-gray-100;
-
-	.blocks-embed__loading-text {
-		font-family: $default-font;
-		font-size: $default-font-size;
-	}
 }
 
 div[data-type="core/embed"] {

--- a/blocks/library/embed/style.scss
+++ b/blocks/library/embed/style.scss
@@ -18,6 +18,22 @@
 	height: 100%;
 }
 
+.blocks-embed__loading {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 1em;
+	min-height: 200px;
+	text-align: center;
+	background: $light-gray-100;
+
+	.blocks-embed__loading-text {
+		font-family: $default-font;
+		font-size: $default-font-size;
+	}
+}
+
 div[data-type="core/embed"] {
 	&[data-align="left"],
 	&[data-align="right"] {


### PR DESCRIPTION
* Loading the rendered html on loading a saved block moved into componentWillMount
* Removed '.includes' usage, as it's not polyfilled
* Added a new rendering state for when we're loading a saved block
* Replaced string manipulation of urls to extract the host, with url.parse