### PR TITLE
eslint: remove browser env

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
 		"plugin:jsx-a11y/recommended"
 	],
 	"env": {
-		"browser": true,
+		"browser": false,
 		"node": true,
 		"mocha": true
 	},
@@ -19,7 +19,9 @@
 	},
 	"globals": {
 		"wp": true,
-		"wpApiSettings": true
+		"wpApiSettings": true,
+		"window": true,
+		"document": true
 	},
 	"plugins": [
 		"react",

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -104,7 +104,7 @@ registerBlockType( 'core/embed', {
 			const api_url = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce;
 
 			this.setState( { error: false, fetching: true } );
-			fetch( api_url, {
+			window.fetch( api_url, {
 				credentials: 'include',
 			} ).then(
 				( response ) => {


### PR DESCRIPTION
To prevent bugs like #1007, I would suggest removing `browser` from eslint settings.