### PR TITLE
Set multi select copy content + better selector names

### DIFF
--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -16,11 +16,11 @@ import './style.scss';
 import ModeSwitcher from './mode-switcher';
 import SavedState from './saved-state';
 import Tools from './tools';
-import { getSelectedBlocks } from '../selectors';
+import { getMultiSelectedBlockUids } from '../selectors';
 import { clearSelectedBlock } from '../actions';
 
-function Header( { selectedBlocks, onRemove, onDeselect } ) {
-	const count = selectedBlocks.length;
+function Header( { multiSelectedBlockUids, onRemove, onDeselect } ) {
+	const count = multiSelectedBlockUids.length;
 
 	if ( count ) {
 		return (
@@ -32,7 +32,7 @@ function Header( { selectedBlocks, onRemove, onDeselect } ) {
 					<IconButton
 						icon="trash"
 						label={ __( 'Delete selected blocks' ) }
-						onClick={ () => onRemove( selectedBlocks ) }
+						onClick={ () => onRemove( multiSelectedBlockUids ) }
 						focus={ true }
 					>
 						{ __( 'Delete' ) }
@@ -60,7 +60,7 @@ function Header( { selectedBlocks, onRemove, onDeselect } ) {
 
 export default connect(
 	( state ) => ( {
-		selectedBlocks: getSelectedBlocks( state ),
+		multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
 	} ),
 	( dispatch ) => ( {
 		onDeselect: () => dispatch( clearSelectedBlock() ),

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -13,7 +13,7 @@ import { IconButton } from 'components';
  * Internal dependencies
  */
 import InserterMenu from './menu';
-import { getBlockSelectionEnd, getSelectedBlock } from '../selectors';
+import { getLastMultiSelectedBlockUid, getSelectedBlock } from '../selectors';
 import { insertBlock, clearInsertionPoint } from '../actions';
 
 class Inserter extends wp.element.Component {
@@ -97,7 +97,7 @@ export default connect(
 	( state ) => {
 		return {
 			selectedBlock: getSelectedBlock( state ),
-			lastMultiSelectedBlock: getBlockSelectionEnd( state ),
+			lastMultiSelectedBlock: getLastMultiSelectedBlockUid( state ),
 		};
 	},
 	( dispatch ) => ( {

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -15,7 +15,7 @@ import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
  * Internal dependencies
  */
 import './style.scss';
-import { getBlockSelectionEnd, getSelectedBlock } from '../selectors';
+import { getLastMultiSelectedBlockUid, getSelectedBlock } from '../selectors';
 import { setInsertionPoint, clearInsertionPoint } from '../actions';
 
 class InserterMenu extends wp.element.Component {
@@ -311,7 +311,7 @@ export default connect(
 	( state ) => {
 		return {
 			selectedBlock: getSelectedBlock( state ),
-			lastMultiSelectedBlock: getBlockSelectionEnd( state ),
+			lastMultiSelectedBlock: getLastMultiSelectedBlockUid( state ),
 		};
 	},
 	{ setInsertionPoint, clearInsertionPoint }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -34,8 +34,8 @@ import {
 	isBlockHovered,
 	isBlockSelected,
 	isBlockMultiSelected,
-	isFirstSelectedBlock,
-	getSelectedBlocks,
+	isFirstMultiSelectedBlock,
+	getMultiSelectedBlockUids,
 	isTypingInBlock,
 } from '../../selectors';
 
@@ -68,7 +68,7 @@ class VisualEditorBlock extends wp.element.Component {
 		if (
 			this.props.order !== newProps.order &&
 			( ( this.props.isSelected && newProps.isSelected ) ||
-			( this.props.isFirstSelected && newProps.isFirstSelected ) )
+			( this.props.isFirstMultiSelected && newProps.isFirstMultiSelected ) )
 		) {
 			this.previousOffset = this.node.getBoundingClientRect().top;
 		}
@@ -109,7 +109,7 @@ class VisualEditorBlock extends wp.element.Component {
 	removeOrDeselect( { keyCode, target } ) {
 		const {
 			uid,
-			selectedBlocks,
+			multiSelectedBlockUids,
 			previousBlock,
 			onRemove,
 			onFocus,
@@ -126,8 +126,8 @@ class VisualEditorBlock extends wp.element.Component {
 				}
 			}
 
-			if ( selectedBlocks.length ) {
-				onRemove( selectedBlocks );
+			if ( multiSelectedBlockUids.length ) {
+				onRemove( multiSelectedBlockUids );
 			}
 		}
 
@@ -196,7 +196,7 @@ class VisualEditorBlock extends wp.element.Component {
 	}
 
 	render() {
-		const { block, selectedBlocks } = this.props;
+		const { block, multiSelectedBlockUids } = this.props;
 		const blockType = wp.blocks.getBlockType( block.name );
 		// The block as rendered in the editor is composed of general block UI
 		// (mover, toolbar, wrapper) and the display of the block content, which
@@ -215,7 +215,7 @@ class VisualEditorBlock extends wp.element.Component {
 		}
 
 		// Generate the wrapper class names handling the different states of the block.
-		const { isHovered, isSelected, isMultiSelected, isFirstSelected, isTyping, focus } = this.props;
+		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, isTyping, focus } = this.props;
 		const showUI = isSelected && ( ! isTyping || ! focus.collapsed );
 		const className = classnames( 'editor-visual-editor__block', {
 			'is-selected': showUI,
@@ -275,8 +275,8 @@ class VisualEditorBlock extends wp.element.Component {
 						</div>
 					</CSSTransitionGroup>
 				}
-				{ isFirstSelected && (
-					<BlockMover uids={ selectedBlocks } />
+				{ isFirstMultiSelected && (
+					<BlockMover uids={ multiSelectedBlockUids } />
 				) }
 				<div
 					onKeyPress={ this.maybeStartTyping }
@@ -306,8 +306,8 @@ export default connect(
 			block: getBlock( state, ownProps.uid ),
 			isSelected: isBlockSelected( state, ownProps.uid ),
 			isMultiSelected: isBlockMultiSelected( state, ownProps.uid ),
-			isFirstSelected: isFirstSelectedBlock( state, ownProps.uid ),
-			selectedBlocks: getSelectedBlocks( state ),
+			isFirstMultiSelected: isFirstMultiSelectedBlock( state, ownProps.uid ),
+			multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
 			isHovered: isBlockHovered( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
 			isTyping: isTypingInBlock( state, ownProps.uid ),

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -35,7 +35,6 @@ import {
 	isBlockSelected,
 	isBlockMultiSelected,
 	isFirstMultiSelectedBlock,
-	getMultiSelectedBlockUids,
 	isTypingInBlock,
 } from '../../selectors';
 
@@ -307,7 +306,6 @@ export default connect(
 			isSelected: isBlockSelected( state, ownProps.uid ),
 			isMultiSelected: isBlockMultiSelected( state, ownProps.uid ),
 			isFirstMultiSelected: isFirstMultiSelectedBlock( state, ownProps.uid ),
-			multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
 			isHovered: isBlockHovered( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
 			isTyping: isTypingInBlock( state, ownProps.uid ),

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -240,9 +240,7 @@ export function getBlock( state, uid ) {
  * @return {Object[]}       Post blocks
  */
 export function getBlocks( state ) {
-	return state.editor.blockOrder.map( ( uid ) => (
-		state.editor.blocksByUid[ uid ]
-	) );
+	return state.editor.blockOrder.map( ( uid ) => getBlock( state, uid ) );
 }
 
 /**
@@ -259,17 +257,17 @@ export function getSelectedBlock( state ) {
 		return null;
 	}
 
-	return state.editor.blocksByUid[ uid ];
+	return getBlock( state, uid );
 }
 
 /**
- * Returns the current multi-selection set of blocks, or an empty array if
- * there is no multi-selection.
+ * Returns the current multi-selection set of blocks unique IDs, or an empty
+ * array if there is no multi-selection.
  *
  * @param  {Object} state Global application state
- * @return {Array}        Multi-selected block objects
+ * @return {Array}        Multi-selected block unique UDs
  */
-export function getSelectedBlocks( state ) {
+export function getMultiSelectedBlockUids( state ) {
 	const { blockOrder } = state.editor;
 	const { start, end } = state.multiSelectedBlocks;
 
@@ -288,24 +286,88 @@ export function getSelectedBlocks( state ) {
 }
 
 /**
+ * Returns the current multi-selection set of blocks, or an empty array if
+ * there is no multi-selection.
+ *
+ * @param  {Object} state Global application state
+ * @return {Array}        Multi-selected block objects
+ */
+export function getMultiSelectedBlocks( state ) {
+	return getMultiSelectedBlockUids( state ).map( ( uid ) => getBlock( state, uid ) );
+}
+
+/**
+ * Returns the unique ID of the first block in the multi-selection set, or null
+ * if there is no multi-selection.
+ *
+ * @param  {Object}  state Global application state
+ * @return {?String}       First unique block ID in the multi-selection set
+ */
+export function getFirstMultiSelectedBlockUid( state ) {
+	return first( getMultiSelectedBlockUids( state ) ) || null;
+}
+
+/**
+ * Returns the unique ID of the last block in the multi-selection set, or null
+ * if there is no multi-selection.
+ *
+ * @param  {Object}  state Global application state
+ * @return {?String}       Last unique block ID in the multi-selection set
+ */
+export function getLastMultiSelectedBlockUid( state ) {
+	return last( getMultiSelectedBlockUids( state ) ) || null;
+}
+
+/**
+ * Returns true if a multi-selection exists, and the block corresponding to the
+ * specified unique ID is the first block of the multi-selection set, or false
+ * otherwise.
+ *
+ * @param  {Object}  state Global application state
+ * @param  {Object}  uid   Block unique ID
+ * @return {Boolean}       Whether block is first in mult-selection
+ */
+export function isFirstMultiSelectedBlock( state, uid ) {
+	return getFirstMultiSelectedBlockUid( state ) === uid;
+}
+
+/**
+ * Returns true if the unique ID occurs within the block multi-selection, or
+ * false otherwise.
+ *
+ * @param  {Object} state Global application state
+ * @param  {Object} uid   Block unique ID
+ * @return {Boolean}      Whether block is in multi-selection set
+ */
+export function isBlockMultiSelected( state, uid ) {
+	return getMultiSelectedBlockUids( state ).indexOf( uid ) !== -1;
+}
+
+/**
  * Returns the unique ID of the block which begins the multi-selection set, or
- * null if there is no multi-selectino.
+ * null if there is no multi-selection.
+ *
+ * N.b.: This is not necessarily the first uid in the selection. See
+ * getFirstMultiSelectedBlockUid().
  *
  * @param  {Object}  state Global application state
  * @return {?String}       Unique ID of block beginning multi-selection
  */
-export function getBlockSelectionStart( state ) {
+export function getMultiSelectedBlocksStartUid( state ) {
 	return state.multiSelectedBlocks.start || null;
 }
 
 /**
  * Returns the unique ID of the block which ends the multi-selection set, or
- * null if there is no multi-selectino.
+ * null if there is no multi-selection.
+ *
+ * N.b.: This is not necessarily the last uid in the selection. See
+ * getLastMultiSelectedBlockUid().
  *
  * @param  {Object}  state Global application state
  * @return {?String}       Unique ID of block ending multi-selection
  */
-export function getBlockSelectionEnd( state ) {
+export function getMultiSelectedBlocksEndUid( state ) {
 	return state.multiSelectedBlocks.end || null;
 }
 
@@ -342,19 +404,6 @@ export function getBlockIndex( state, uid ) {
  */
 export function isFirstBlock( state, uid ) {
 	return first( state.editor.blockOrder ) === uid;
-}
-
-/**
- * Returns true if a multi-selection exists, and the block corresponding to the
- * specified unique ID is the first block of the multi-selection set, or false
- * otherwise.
- *
- * @param  {Object}  state Global application state
- * @param  {Object}  uid   Block unique ID
- * @return {Boolean}       Whether block is first in mult-selection
- */
-export function isFirstSelectedBlock( state, uid ) {
-	return first( getSelectedBlocks( state ) ) === uid;
 }
 
 /**
@@ -413,18 +462,6 @@ export function isBlockSelected( state, uid ) {
 	}
 
 	return state.selectedBlock.uid === uid;
-}
-
-/**
- * Returns true if the unique ID occurs within the block multi-selection, or
- * false otherwise.
- *
- * @param  {Object} state Global application state
- * @param  {Object} uid   Block unique ID
- * @return {Boolean}      Whether block is in multi-selection set
- */
-export function isBlockMultiSelected( state, uid ) {
-	return getSelectedBlocks( state ).indexOf( uid ) !== -1;
 }
 
 /**

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -27,9 +27,9 @@ import {
 	getBlock,
 	getBlocks,
 	getSelectedBlock,
-	getSelectedBlocks,
-	getBlockSelectionStart,
-	getBlockSelectionEnd,
+	getMultiSelectedBlockUids,
+	getMultiSelectedBlocksStartUid,
+	getMultiSelectedBlocksEndUid,
 	getBlockUids,
 	getBlockIndex,
 	isFirstBlock,
@@ -38,7 +38,7 @@ import {
 	getNextBlock,
 	isBlockSelected,
 	isBlockMultiSelected,
-	isFirstSelectedBlock,
+	isFirstMultiSelectedBlock,
 	isBlockHovered,
 	getBlockFocus,
 	isTypingInBlock,
@@ -576,7 +576,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getSelectedBlocks', () => {
+	describe( 'getMultiSelectedBlockUids', () => {
 		it( 'should return empty if there is no multi selection', () => {
 			const state = {
 				editor: {
@@ -585,7 +585,7 @@ describe( 'selectors', () => {
 				multiSelectedBlocks: { start: null, end: null },
 			};
 
-			expect( getSelectedBlocks( state ) ).to.eql( [] );
+			expect( getMultiSelectedBlockUids( state ) ).to.eql( [] );
 		} );
 
 		it( 'should return empty if there is no multi selection', () => {
@@ -596,11 +596,11 @@ describe( 'selectors', () => {
 				multiSelectedBlocks: { start: 2, end: 4 },
 			};
 
-			expect( getSelectedBlocks( state ) ).to.eql( [ 4, 3, 2 ] );
+			expect( getMultiSelectedBlockUids( state ) ).to.eql( [ 4, 3, 2 ] );
 		} );
 	} );
 
-	describe( 'getBlockSelectionStart', () => {
+	describe( 'getMultiSelectedBlocksStartUid', () => {
 		it( 'returns null if there is no multi selection', () => {
 			const state = {
 				editor: {
@@ -609,7 +609,7 @@ describe( 'selectors', () => {
 				multiSelectedBlocks: { start: null, end: null },
 			};
 
-			expect( getBlockSelectionStart( state ) ).to.be.null();
+			expect( getMultiSelectedBlocksStartUid( state ) ).to.be.null();
 		} );
 
 		it( 'returns multi selection start', () => {
@@ -620,11 +620,11 @@ describe( 'selectors', () => {
 				multiSelectedBlocks: { start: 2, end: 4 },
 			};
 
-			expect( getBlockSelectionStart( state ) ).to.equal( 2 );
+			expect( getMultiSelectedBlocksStartUid( state ) ).to.equal( 2 );
 		} );
 	} );
 
-	describe( 'getBlockSelectionEnd', () => {
+	describe( 'getMultiSelectedBlocksEndUid', () => {
 		it( 'returns null if there is no multi selection', () => {
 			const state = {
 				editor: {
@@ -633,7 +633,7 @@ describe( 'selectors', () => {
 				multiSelectedBlocks: { start: null, end: null },
 			};
 
-			expect( getBlockSelectionEnd( state ) ).to.be.null();
+			expect( getMultiSelectedBlocksEndUid( state ) ).to.be.null();
 		} );
 
 		it( 'returns multi selection end', () => {
@@ -644,7 +644,7 @@ describe( 'selectors', () => {
 				multiSelectedBlocks: { start: 2, end: 4 },
 			};
 
-			expect( getBlockSelectionEnd( state ) ).to.equal( 4 );
+			expect( getMultiSelectedBlocksEndUid( state ) ).to.equal( 4 );
 		} );
 	} );
 
@@ -817,7 +817,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isFirstSelectedBlock', () => {
+	describe( 'isFirstMultiSelectedBlock', () => {
 		const state = {
 			editor: {
 				blockOrder: [ 5, 4, 3, 2, 1 ],
@@ -826,11 +826,11 @@ describe( 'selectors', () => {
 		};
 
 		it( 'should return true if the block is first in multi selection', () => {
-			expect( isFirstSelectedBlock( state, 4 ) ).to.be.true();
+			expect( isFirstMultiSelectedBlock( state, 4 ) ).to.be.true();
 		} );
 
 		it( 'should return false if the block is not first in multi selection', () => {
-			expect( isFirstSelectedBlock( state, 3 ) ).to.be.false();
+			expect( isFirstMultiSelectedBlock( state, 3 ) ).to.be.false();
 		} );
 	} );
 


### PR DESCRIPTION
This PR enables copying content from a multi selection. To test, select some blocks, and verify that the clipboard data contains the serialised block content.

It also renames some selectors, which hopefully makes things clearer, and fixes a bug in the inserter where a block would be inserted at the wrong position for bottom-to-top selection.