### PR TITLE
Disable drag on images to enable multi-select

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -273,6 +273,7 @@ class VisualEditorBlock extends wp.element.Component {
 					onKeyPress={ this.maybeStartTyping }
 					onFocus={ onSelect }
 					onClick={ onSelect }
+					onDragStart={ ( event ) => event.preventDefault() }
 				>
 					<BlockEdit
 						focus={ focus }


### PR DESCRIPTION
This may be a bit controversial, but in order to enable multi-select starting at image blocks with the current behaviour, we need to disable dragging them. Dragging in the current WP core editor is used to move the image. We now have the block movers for this, and it make be better to find a solution for drag-and-drop for all blocks that is consistent rather than images alone. (Also note that dragging the images will not work to move them at the moment, it would have to be implemented. You _can_ drag it in an Editable region though...)