### PR TITLE
Blocks: Extract and factorize block alignment controls

### DIFF
--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+import { Toolbar } from 'components';
+
+const BLOCK_ALIGNMENTS_CONTROLS = {
+	left: {
+		icon: 'align-left',
+		title: __( 'Align left' ),
+	},
+	center: {
+		icon: 'align-center',
+		title: __( 'Align center' ),
+	},
+	right: {
+		icon: 'align-right',
+		title: __( 'Align right' ),
+	},
+	wide: {
+		icon: 'align-wide',
+		title: __( 'Wide width' ),
+	},
+	full: {
+		icon: 'align-full-width',
+		title: __( 'Full width' ),
+	},
+};
+
+const DEFAULT_CONTROLS = [ 'left', 'center', 'right' ];
+
+export default function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CONTROLS } ) {
+	function applyOrUnset( align ) {
+		return () => onChange( value === align ? undefined : align );
+	}
+
+	return (
+		<Toolbar
+			controls={
+				controls.map( control => {
+					return {
+						...BLOCK_ALIGNMENTS_CONTROLS[ control ],
+						isActive: value === control,
+						onClick: applyOrUnset( control ),
+					};
+				} )
+			}
+		/>
+	);
+}

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -9,22 +9,10 @@ import { IconButton } from 'components';
 import './style.scss';
 import { registerBlockType, query } from '../../api';
 import Editable from '../../editable';
+import BlockControls from '../../block-controls';
+import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
 const { attr, children } = query;
-
-/**
- * Returns an attribute setter with behavior that if the target value is
- * already the assigned attribute value, it will be set to undefined.
- *
- * @param  {string}   align Alignment value
- * @return {Function}       Attribute setter
- */
-function applyOrUnset( align ) {
-	return ( attributes, setAttributes ) => {
-		const nextAlign = attributes.align === align ? undefined : align;
-		setAttributes( { align: nextAlign } );
-	};
-}
 
 registerBlockType( 'core/button', {
 	title: wp.i18n.__( 'Button' ),
@@ -39,27 +27,6 @@ registerBlockType( 'core/button', {
 		text: children( 'a' ),
 	},
 
-	controls: [
-		{
-			icon: 'align-left',
-			title: wp.i18n.__( 'Align left' ),
-			isActive: ( { align } ) => 'left' === align,
-			onClick: applyOrUnset( 'left' ),
-		},
-		{
-			icon: 'align-center',
-			title: wp.i18n.__( 'Align center' ),
-			isActive: ( { align } ) => 'center' === align,
-			onClick: applyOrUnset( 'center' ),
-		},
-		{
-			icon: 'align-right',
-			title: wp.i18n.__( 'Align right' ),
-			isActive: ( { align } ) => 'right' === align,
-			onClick: applyOrUnset( 'right' ),
-		},
-	],
-
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
 		if ( 'left' === align || 'right' === align || 'center' === align ) {
@@ -68,10 +35,16 @@ registerBlockType( 'core/button', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
-		const { text, url, title } = attributes;
+		const { text, url, title, align } = attributes;
+		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
-		return (
-			<span className="blocks-button" title={ title }>
+		return [
+			focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar value={ align } onChange={ updateAlignment } />
+				</BlockControls>
+			),
+			<span key="button" className="blocks-button" title={ title }>
 				<Editable
 					tagName="span"
 					placeholder={ wp.i18n.__( 'Write label…' ) }
@@ -98,8 +71,8 @@ registerBlockType( 'core/button', {
 						<IconButton icon="editor-break" type="submit" />
 					</form>
 				}
-			</span>
-		);
+			</span>,
+		];
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -13,22 +13,10 @@ import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
 import TextControl from '../../inspector-controls/text-control';
+import BlockControls from '../../block-controls';
+import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
 const { attr, children } = query;
-
-/**
- * Returns an attribute setter with behavior that if the target value is
- * already the assigned attribute value, it will be set to undefined.
- *
- * @param  {string}   align Alignment value
- * @return {Function}       Attribute setter
- */
-function toggleAlignment( align ) {
-	return ( attributes, setAttributes ) => {
-		const nextAlign = attributes.align === align ? undefined : align;
-		setAttributes( { align: nextAlign } );
-	};
-}
 
 registerBlockType( 'core/image', {
 	title: __( 'Image' ),
@@ -43,39 +31,6 @@ registerBlockType( 'core/image', {
 		caption: children( 'figcaption' ),
 	},
 
-	controls: [
-		{
-			icon: 'align-left',
-			title: __( 'Align left' ),
-			isActive: ( { align } ) => 'left' === align,
-			onClick: toggleAlignment( 'left' ),
-		},
-		{
-			icon: 'align-center',
-			title: __( 'Align center' ),
-			isActive: ( { align } ) => ! align || 'center' === align,
-			onClick: toggleAlignment( 'center' ),
-		},
-		{
-			icon: 'align-right',
-			title: __( 'Align right' ),
-			isActive: ( { align } ) => 'right' === align,
-			onClick: toggleAlignment( 'right' ),
-		},
-		{
-			icon: 'align-wide',
-			title: __( 'Wide width' ),
-			isActive: ( { align } ) => 'wide' === align,
-			onClick: toggleAlignment( 'wide' ),
-		},
-		{
-			icon: 'align-full-width',
-			title: __( 'Full width' ),
-			isActive: ( { align } ) => 'full' === align,
-			onClick: toggleAlignment( 'full' ),
-		},
-	],
-
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
 		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
@@ -84,13 +39,27 @@ registerBlockType( 'core/image', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
-		const { url, alt, caption } = attributes;
+		const { url, alt, caption, align } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
+		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
+
+		const controls = (
+			focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar
+						value={ align }
+						onChange={ updateAlignment }
+						controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
+					/>
+				</BlockControls>
+			)
+		);
 
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
 			const setMediaURL = ( media ) => setAttributes( { url: media.url } );
 			return [
+				controls,
 				<Placeholder
 					key="placeholder"
 					instructions={ __( 'Drag image here or insert from media library' ) }
@@ -115,6 +84,7 @@ registerBlockType( 'core/image', {
 
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return [
+			controls,
 			focus && (
 				<InspectorControls key="inspector">
 					<TextControl label={ __( 'Alternate Text' ) } value={ alt } onChange={ updateAlt } />

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -4,22 +4,10 @@
 import './style.scss';
 import { registerBlockType, query as hpq } from '../../api';
 import Editable from '../../editable';
+import BlockControls from '../../block-controls';
+import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
 const { children, query } = hpq;
-
-/**
- * Returns an attribute setter with behavior that if the target value is
- * already the assigned attribute value, it will be set to undefined.
- *
- * @param  {string}   align Alignment value
- * @return {Function}       Attribute setter
- */
-function toggleAlignment( align ) {
-	return ( attributes, setAttributes ) => {
-		const nextAlign = attributes.align === align ? undefined : align;
-		setAttributes( { align: nextAlign } );
-	};
-}
 
 registerBlockType( 'core/table', {
 	title: wp.i18n.__( 'Table' ),
@@ -36,33 +24,6 @@ registerBlockType( 'core/table', {
 		body: [ [ [], [] ], [ [], [] ] ],
 	},
 
-	controls: [
-		{
-			icon: 'align-left',
-			title: wp.i18n.__( 'Align left' ),
-			isActive: ( { align } ) => 'left' === align,
-			onClick: toggleAlignment( 'left' ),
-		},
-		{
-			icon: 'align-center',
-			title: wp.i18n.__( 'Align center' ),
-			isActive: ( { align } ) => 'center' === align,
-			onClick: toggleAlignment( 'center' ),
-		},
-		{
-			icon: 'align-right',
-			title: wp.i18n.__( 'Align right' ),
-			isActive: ( { align } ) => 'right' === align,
-			onClick: toggleAlignment( 'right' ),
-		},
-		{
-			icon: 'align-full-width',
-			title: wp.i18n.__( 'Wide width' ),
-			isActive: ( { align } ) => 'wide' === align,
-			onClick: toggleAlignment( 'wide' ),
-		},
-	],
-
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
 		if ( 'left' === align || 'right' === align || 'wide' === align ) {
@@ -72,9 +33,19 @@ registerBlockType( 'core/table', {
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const focussedKey = focus ? focus.editable || 'body.0.0' : null;
+		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
-		return (
-			<table>
+		return [
+			focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar
+						value={ attributes.align }
+						onChange={ updateAlignment }
+						controls={ [ 'left', 'center', 'right', 'wide' ] }
+					/>
+				</BlockControls>
+			),
+			<table key="table">
 				{ [ 'head', 'body', 'foot' ].map( ( part ) =>
 					attributes[ part ] && attributes[ part ].length
 						? wp.element.createElement( 't' + part, { key: part },
@@ -107,8 +78,8 @@ registerBlockType( 'core/table', {
 						)
 						: null
 				) }
-			</table>
-		);
+			</table>,
+		];
 	},
 
 	save( { attributes } ) {


### PR DESCRIPTION
This PR continues our Refactoring to move the controls to the `edit` function. 

**Testing instructions**

 - Block Alignment controls for the button, image, embed and table block should continue the work the way they work on master.