### PR TITLE
Gracefully handle multiple installed copies of the Gutenberg plugin

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -9,6 +9,11 @@
  * @package gutenberg
  */
 
+require_once dirname( __FILE__ ) . '/lib/check-duplicate-plugins.php';
+if ( defined( 'GUTENBERG_MULTIPLE_COPIES' ) && GUTENBERG_MULTIPLE_COPIES ) {
+	return;
+}
+
 require_once dirname( __FILE__ ) . '/lib/blocks.php';
 require_once dirname( __FILE__ ) . '/lib/client-assets.php';
 require_once dirname( __FILE__ ) . '/lib/i18n.php';

--- a/lib/check-duplicate-plugins.php
+++ b/lib/check-duplicate-plugins.php
@@ -5,6 +5,10 @@
  * @package gutenberg
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
 if ( function_exists( 'the_gutenberg_project' ) ) {
 	if ( ! defined( 'GUTENBERG_MULTIPLE_COPIES' ) ) {
 		/**

--- a/lib/check-duplicate-plugins.php
+++ b/lib/check-duplicate-plugins.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Make sure we only have one copy of the Gutenberg plugin active.
+ *
+ * @package gutenberg
+ */
+
+if ( function_exists( 'the_gutenberg_project' ) ) {
+	if ( ! defined( 'GUTENBERG_MULTIPLE_COPIES' ) ) {
+		function gutenberg_multiple_copies_admin_notice() {
+			echo '<div class="notice notice-error"><p>';
+			_e(
+				'You have multiple copies of the Gutenberg plugin active.'
+				. ' Please deactivate or delete all but one copy.',
+				'gutenberg'
+			);
+			echo '</p></div>';
+		}
+		add_action( 'admin_notices', 'gutenberg_multiple_copies_admin_notice' );
+		define( 'GUTENBERG_MULTIPLE_COPIES', true );
+	}
+}

--- a/lib/check-duplicate-plugins.php
+++ b/lib/check-duplicate-plugins.php
@@ -7,11 +7,13 @@
 
 if ( function_exists( 'the_gutenberg_project' ) ) {
 	if ( ! defined( 'GUTENBERG_MULTIPLE_COPIES' ) ) {
+		/**
+		 * Displays an admin notice indicating a problem with the plugin.
+		 */
 		function gutenberg_multiple_copies_admin_notice() {
 			echo '<div class="notice notice-error"><p>';
 			_e(
-				'You have multiple copies of the Gutenberg plugin active.'
-				. ' Please deactivate or delete all but one copy.',
+				'You have multiple copies of the Gutenberg plugin active. Please deactivate or delete all but one copy.',
 				'gutenberg'
 			);
 			echo '</p></div>';


### PR DESCRIPTION
While finishing up #985 I discovered that installing multiple copies of the Gutenberg plugin on a site will cause the following error:

![2017-06-05t10 58 58-0400](https://cloud.githubusercontent.com/assets/227022/26789352/0c6da6f6-49de-11e7-9ca9-0964c7d18500.png)

This is likely to be a problem for some users because we did an early release in Slack with the filename `gutenberg-2017-05-24.zip`.  WordPress will install this plugin zip into a folder named `gutenberg-2017-05-24`.  Then, when a user installs an updated version of the Gutenberg plugin, whether from Slack, the plugin directory once it is released there, or somewhere else, they will see the above error.

We should detect this condition and handle it gracefully (have the duplicate version(s) of the plugin just bail out).  This is accomplished in this branch:

![2017-06-05t11 06 28-0400](https://cloud.githubusercontent.com/assets/227022/26789680/0ef2f948-49df-11e7-84c8-b6511ebcfca1.png)
