### PR TITLE
Rearrange package.json sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,27 @@
     "WordPress",
     "editor"
   ],
-  "scripts": {
-    "test-unit": "cross-env NODE_ENV=test webpack && mocha build --require bootstrap-test.js",
-    "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
-    "gettext-strings": "cross-env BABEL_ENV=gettext webpack",
-    "lint": "eslint .",
-    "dev": "cross-env BABEL_ENV=default webpack --watch",
-    "test": "npm run lint && npm run test-unit",
-    "ci": "concurrently \"npm run build\" \"npm test\"",
-    "package-plugin": "./bin/build-plugin-zip.sh"
+  "dependencies": {
+    "classnames": "^2.2.5",
+    "dom-react": "^2.2.0",
+    "dom-scroll-into-view": "^1.2.1",
+    "element-closest": "^2.0.2",
+    "hpq": "^1.2.0",
+    "jed": "^1.1.1",
+    "js-beautify": "^1.6.12",
+    "lodash": "^4.17.4",
+    "moment": "^2.18.1",
+    "react": "^15.5.4",
+    "react-autosize-textarea": "^0.4.2",
+    "react-click-outside": "^2.3.0",
+    "react-datepicker": "^0.46.0",
+    "react-dom": "^15.5.4",
+    "react-redux": "^5.0.4",
+    "react-slot-fill": "^1.0.0-alpha.11",
+    "react-transition-group": "^1.1.3",
+    "redux": "^3.6.0",
+    "refx": "^2.0.0",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",
@@ -61,26 +73,14 @@
     "webpack": "^2.2.1",
     "webpack-node-externals": "^1.5.4"
   },
-  "dependencies": {
-    "classnames": "^2.2.5",
-    "dom-react": "^2.2.0",
-    "dom-scroll-into-view": "^1.2.1",
-    "element-closest": "^2.0.2",
-    "hpq": "^1.2.0",
-    "jed": "^1.1.1",
-    "js-beautify": "^1.6.12",
-    "lodash": "^4.17.4",
-    "moment": "^2.18.1",
-    "react": "^15.5.4",
-    "react-autosize-textarea": "^0.4.2",
-    "react-click-outside": "^2.3.0",
-    "react-datepicker": "^0.46.0",
-    "react-dom": "^15.5.4",
-    "react-redux": "^5.0.4",
-    "react-slot-fill": "^1.0.0-alpha.11",
-    "react-transition-group": "^1.1.3",
-    "redux": "^3.6.0",
-    "refx": "^2.0.0",
-    "uuid": "^3.0.1"
+  "scripts": {
+    "test-unit": "cross-env NODE_ENV=test webpack && mocha build --require bootstrap-test.js",
+    "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
+    "gettext-strings": "cross-env BABEL_ENV=gettext webpack",
+    "lint": "eslint .",
+    "dev": "cross-env BABEL_ENV=default webpack --watch",
+    "test": "npm run lint && npm run test-unit",
+    "ci": "concurrently \"npm run build\" \"npm test\"",
+    "package-plugin": "./bin/build-plugin-zip.sh"
   }
 }


### PR DESCRIPTION
In package.json, the `scripts` section should come at the end of the file so that it's easy to see all of the available commands via `cat` or `tail` in the terminal.