### PR TITLE
Install `phpcs` using Composer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,.travis.yml}]
+[{package.json,.travis.yml,composer.json}]
 indent_style = space
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,.travis.yml,composer.json}]
+[{*.json,*.yml}]
 indent_style = space
 indent_size = 2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
     fi
   - |
     if [[ "$TRAVISCI" == "phpcs" ]] ; then
-      phpcs
+      ./vendor/bin/phpcs
     fi
   - |
     if [[ "$TRAVISCI" == "js" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,6 @@ before_script:
         composer global require "phpunit/phpunit=5.7.*"
       fi
     fi
-  - |
-    if [[ "$TRAVISCI" == "phpcs" ]] ; then
-      composer global require wp-coding-standards/wpcs
-      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
-    fi
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,10 @@ before_script:
         composer global require "phpunit/phpunit=5.7.*"
       fi
     fi
-  - composer install
+  - |
+    if [[ "$TRAVISCI" == "phpcs" ]] ; then
+      composer install
+    fi
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_script:
         composer global require "phpunit/phpunit=5.7.*"
       fi
     fi
+  - composer install
 
 script:
   - |

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "require-dev": {
-        "squizlabs/php_codesniffer": "2.9.x",
-        "wp-coding-standards/wpcs": "^0.11.0"
-    },
-	"scripts": {
-		"post-install-cmd": [
-			"phpcs --config-set installed_paths ../../wp-coding-standards/wpcs/"
-		]
-	}
+  "require-dev": {
+    "squizlabs/php_codesniffer": "2.9.x",
+    "wp-coding-standards/wpcs": "^0.11.0"
+  },
+  "scripts": {
+    "post-install-cmd": [
+      "phpcs --config-set installed_paths ../../wp-coding-standards/wpcs/"
+    ]
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "require-dev": {
+        "squizlabs/php_codesniffer": "2.9.x",
+        "wp-coding-standards/wpcs": "^0.11.0"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,10 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "2.9.x",
         "wp-coding-standards/wpcs": "^0.11.0"
-    }
+    },
+	"scripts": {
+		"post-install-cmd": [
+			"phpcs --config-set installed_paths ../../wp-coding-standards/wpcs/"
+		]
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,132 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1a5dd686e18346fa4dbc564b7b90f4a1",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-05-22T02:43:20+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "0.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "reference": "407e4b85f547a5251185f89ceae6599917343388"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/407e4b85f547a5251185f89ceae6599917343388",
+                "reference": "407e4b85f547a5251185f89ceae6599917343388",
+                "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "^2.8.1"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2017-03-20T23:17:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -95,14 +95,4 @@ build as well, but it is better to catch errors locally.
 The easiest way to do this is using `composer`.
 [Install `composer`](https://getcomposer.org/download/)
 on your computer, then run `composer install`.  This will install `phpcs` and
-`WordPress-Coding-Standards`.
-
-You need to tell `phpcs` where to find the WordPress coding standards rulesets.
-You can do that using the following command:
-
-```sh
-vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs/
-```
-
-You should now be able to run `vendor/bin/phpcs` from the root directory of
-this project.
+`WordPress-Coding-Standards` which you can the run via `vendor/bin/phpcs`.

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -92,28 +92,17 @@ When making any changes to the PHP code in this project, it's recommended to
 install and run `phpcs` on your computer.  This is a step in our Travis CI
 build as well, but it is better to catch errors locally.
 
-You will need to install `phpcs` version 2.9.x, because the 3.x versions are
-not yet compatible with the WordPress coding standards.  For more information see
-[this issue](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/718).
+The easiest way to do this is using `composer`.
+[Install `composer`](https://getcomposer.org/download/)
+on your computer, then run `composer install`.  This will install `phpcs` and
+`WordPress-Coding-Standards`.
 
-The easiest way to get `phpcs` is to download the .phar archive from the latest
-2.9.x release on GitHub:
-[PHP\_CodeSniffer releases](https://github.com/squizlabs/PHP_CodeSniffer/releases).
-
-For example:
+You need to tell `phpcs` where to find the WordPress coding standards rulesets.
+You can do that using the following command:
 
 ```sh
-wget \
-    https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.9.1/phpcs.phar \
-    -O ~/bin/phpcs
-chmod +x ~/bin/phpcs
+vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs/
 ```
 
-(If `~/bin` is not in your `$PATH`, pick another directory that is.)
-
-Then you must install the `WordPress-Coding-Standards` repository and tell
-`phpcs` where it lives.  See instructions here:
-
-https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#standalone
-
-You should now be able to run `phpcs` from the root directory of this project.
+You should now be able to run `vendor/bin/phpcs` from the root directory of
+this project.

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,1 +1,2 @@
-*.js
+*
+!.gitignore


### PR DESCRIPTION
From https://github.com/WordPress/gutenberg/pull/986#discussion_r119979875, another way to install `phpcs` and `WordPress-Coding-Standards` is via `composer`.  This PR explores this option.

Still left to do:

- [x] Get rid of the `phpcs --config-set` call, if possible
- [x] Simplify the Travis CI configuration accordingly