### PR TITLE
Try: Components decorator extensibility pattern

### DIFF
--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -60,13 +60,6 @@ registerBlockType( 'core/button', {
 		},
 	],
 
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( 'left' === align || 'right' === align || 'center' === align ) {
-			return { 'data-align': align };
-		}
-	},
-
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { text, url, title } = attributes;
 

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -65,13 +65,6 @@ registerBlockType( 'core/embed', {
 		},
 	],
 
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( 'left' === align || 'right' === align || 'wide' === align ) {
-			return { 'data-align': align };
-		}
-	},
-
 	edit: class extends wp.element.Component {
 		constructor() {
 			super( ...arguments );

--- a/blocks/library/embed/style.scss
+++ b/blocks/library/embed/style.scss
@@ -35,26 +35,4 @@ div[data-type="core/embed"] {
 		float: right;
 		margin-left: $block-padding;
 	}
-
-	&[data-align="wide"] {
-		padding-left: 0;
-		padding-right: 0;
-		margin-right: -#{ $block-padding + $block-mover-margin };	/* Compensate for .editor-visual-editor centering padding */
-
-		&:before {
-			left: 0;
-			border-left-width: 0;
-			border-right-width: 0;
-		}
-
-		.editor-block-mover {
-			display: none;
-		}
-
-		.editor-visual-editor__block-controls {
-			max-width: #{ $visual-editor-max-width - $block-padding - ( $block-padding * 2 + $block-mover-margin ) };
-			margin-left: auto;
-			margin-right: auto;
-		}
-	}
 }

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -67,13 +67,6 @@ registerBlockType( 'core/image', {
 		},
 	],
 
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( 'left' === align || 'right' === align || 'wide' === align ) {
-			return { 'data-align': align };
-		}
-	},
-
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { url, alt, caption } = attributes;
 

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -15,29 +15,6 @@
 		float: right;
 		margin-left: $block-padding;
 	}
-
-	&[data-align="wide"] {
-		padding-left: 0;
-		padding-right: 0;
-		margin-right: -#{ $block-padding + $block-mover-margin };	/* Compensate for .editor-visual-editor centering padding */
-
-		&:before {
-			left: 0;
-			border-left-width: 0;
-			border-right-width: 0;
-		}
-
-		.editor-block-mover {
-			display: none;
-		}
-
-		.editor-visual-editor__block-controls {
-			max-width: #{ $visual-editor-max-width - $block-padding - ( $block-padding * 2 + $block-mover-margin ) };
-			margin-left: auto;
-			margin-right: auto;
-		}
-
-	}
 }
 
 .blocks-image {

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -63,13 +63,6 @@ registerBlockType( 'core/table', {
 		},
 	],
 
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( 'left' === align || 'right' === align || 'wide' === align ) {
-			return { 'data-align': align };
-		}
-	},
-
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const focussedKey = focus ? focus.editable || 'body.0.0' : null;
 

--- a/editor/extensions/wide-align/index.js
+++ b/editor/extensions/wide-align/index.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { registerExtension } from 'extensions';
+import { Component, cloneElement } from 'element';
+
+/**
+ * Internal dependencies
+ */
+import VisualEditorBlock from '../../modes/visual-editor/block';
+import Layout from '../../layout';
+
+registerExtension( 'wide-align', {
+	decorators: [
+		[ Layout, ( WrappedComponent ) => (
+			class extends Component {
+				componentDidMount() {
+					this.props.setExtensionState( {
+						layoutWidth: this.node.clientWidth,
+					} );
+				}
+
+				render() {
+					return (
+						<div ref={ ( node ) => this.node = node }>
+							<WrappedComponent { ...this.props } />
+						</div>
+					);
+				}
+			}
+		) ],
+		[ VisualEditorBlock, ( WrappedComponent ) => (
+			class extends Component {
+				render() {
+					const { block, extensionState } = this.props;
+					const { align } = block.attributes;
+					const element = <WrappedComponent { ...this.props } />;
+					if ( 'wide' !== align ) {
+						return element;
+					}
+
+					const { layoutWidth } = extensionState;
+					const offset = ( ( layoutWidth / -2 ) + ( 668 / 2 ) );
+					return cloneElement( element, {
+						style: {
+							marginLeft: offset,
+							marginRight: offset,
+						},
+					} );
+				}
+			}
+		) ],
+	],
+} );

--- a/editor/index.js
+++ b/editor/index.js
@@ -9,6 +9,7 @@ import { omit } from 'lodash';
  * Internal dependencies
  */
 import './assets/stylesheets/main.scss';
+import './extensions/wide-align';
 import Layout from './layout';
 import { createReduxStore } from './state';
 

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -3,6 +3,12 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { flow } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { applyComponentDecorators } from 'extensions';
 
 /**
  * Internal dependencies
@@ -30,7 +36,10 @@ function Layout( { mode, isSidebarOpened } ) {
 	);
 }
 
-export default connect( ( state ) => ( {
-	mode: getEditorMode( state ),
-	isSidebarOpened: isEditorSidebarOpened( state ),
-} ) )( Layout );
+export default flow(
+	applyComponentDecorators,
+	connect( ( state ) => ( {
+		mode: getEditorMode( state ),
+		isSidebarOpened: isEditorSidebarOpened( state ),
+	} ) )
+)( Layout );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { Slot } from 'react-slot-fill';
-import { partial } from 'lodash';
+import { partial, flow } from 'lodash';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
@@ -12,6 +12,7 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
  */
 import { Children } from 'element';
 import { Toolbar } from 'components';
+import { applyComponentDecorators } from 'extensions';
 import { BACKSPACE, ESCAPE } from 'utils/keycodes';
 
 /**
@@ -201,12 +202,6 @@ class VisualEditorBlock extends wp.element.Component {
 
 		const { onSelect, onMouseLeave, onFocus, onInsertAfter } = this.props;
 
-		// Determine whether the block has props to apply to the wrapper.
-		let wrapperProps;
-		if ( blockType.getEditWrapperProps ) {
-			wrapperProps = blockType.getEditWrapperProps( block.attributes );
-		}
-
 		// Disable reason: Each block can be selected by clicking on it
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
@@ -227,7 +222,7 @@ class VisualEditorBlock extends wp.element.Component {
 				className={ className }
 				data-type={ block.name }
 				tabIndex="0"
-				{ ...wrapperProps }
+				style={ this.props.style }
 			>
 				{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }
 				{ showUI &&
@@ -276,78 +271,81 @@ class VisualEditorBlock extends wp.element.Component {
 	}
 }
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			previousBlock: getPreviousBlock( state, ownProps.uid ),
-			nextBlock: getNextBlock( state, ownProps.uid ),
-			block: getBlock( state, ownProps.uid ),
-			isSelected: isBlockSelected( state, ownProps.uid ),
-			isMultiSelected: isBlockMultiSelected( state, ownProps.uid ),
-			isFirstSelected: isFirstSelectedBlock( state, ownProps.uid ),
-			selectedBlocks: getSelectedBlocks( state ),
-			isHovered: isBlockHovered( state, ownProps.uid ),
-			focus: getBlockFocus( state, ownProps.uid ),
-			isTyping: isTypingInBlock( state, ownProps.uid ),
-			order: getBlockIndex( state, ownProps.uid ),
-		};
-	},
-	( dispatch, ownProps ) => ( {
-		onChange( uid, updates ) {
-			dispatch( {
-				type: 'UPDATE_BLOCK',
-				uid,
-				updates,
-			} );
+export default flow(
+	applyComponentDecorators,
+	connect(
+		( state, ownProps ) => {
+			return {
+				previousBlock: getPreviousBlock( state, ownProps.uid ),
+				nextBlock: getNextBlock( state, ownProps.uid ),
+				block: getBlock( state, ownProps.uid ),
+				isSelected: isBlockSelected( state, ownProps.uid ),
+				isMultiSelected: isBlockMultiSelected( state, ownProps.uid ),
+				isFirstSelected: isFirstSelectedBlock( state, ownProps.uid ),
+				selectedBlocks: getSelectedBlocks( state ),
+				isHovered: isBlockHovered( state, ownProps.uid ),
+				focus: getBlockFocus( state, ownProps.uid ),
+				isTyping: isTypingInBlock( state, ownProps.uid ),
+				order: getBlockIndex( state, ownProps.uid ),
+			};
 		},
-		onSelect() {
-			dispatch( {
-				type: 'TOGGLE_BLOCK_SELECTED',
-				selected: true,
-				uid: ownProps.uid,
-			} );
-		},
-		onDeselect() {
-			dispatch( { type: 'CLEAR_SELECTED_BLOCK' } );
-		},
-		onStartTyping() {
-			dispatch( {
-				type: 'START_TYPING',
-				uid: ownProps.uid,
-			} );
-		},
-		onHover() {
-			dispatch( {
-				type: 'TOGGLE_BLOCK_HOVERED',
-				hovered: true,
-				uid: ownProps.uid,
-			} );
-		},
-		onMouseLeave() {
-			dispatch( {
-				type: 'TOGGLE_BLOCK_HOVERED',
-				hovered: false,
-				uid: ownProps.uid,
-			} );
-		},
+		( dispatch, ownProps ) => ( {
+			onChange( uid, updates ) {
+				dispatch( {
+					type: 'UPDATE_BLOCK',
+					uid,
+					updates,
+				} );
+			},
+			onSelect() {
+				dispatch( {
+					type: 'TOGGLE_BLOCK_SELECTED',
+					selected: true,
+					uid: ownProps.uid,
+				} );
+			},
+			onDeselect() {
+				dispatch( { type: 'CLEAR_SELECTED_BLOCK' } );
+			},
+			onStartTyping() {
+				dispatch( {
+					type: 'START_TYPING',
+					uid: ownProps.uid,
+				} );
+			},
+			onHover() {
+				dispatch( {
+					type: 'TOGGLE_BLOCK_HOVERED',
+					hovered: true,
+					uid: ownProps.uid,
+				} );
+			},
+			onMouseLeave() {
+				dispatch( {
+					type: 'TOGGLE_BLOCK_HOVERED',
+					hovered: false,
+					uid: ownProps.uid,
+				} );
+			},
 
-		onInsertAfter( block ) {
-			dispatch( insertBlock( block, ownProps.uid ) );
-		},
+			onInsertAfter( block ) {
+				dispatch( insertBlock( block, ownProps.uid ) );
+			},
 
-		onFocus( ...args ) {
-			dispatch( focusBlock( ...args ) );
-		},
+			onFocus( ...args ) {
+				dispatch( focusBlock( ...args ) );
+			},
 
-		onRemove( uids ) {
-			dispatch( {
-				type: 'REMOVE_BLOCKS',
-				uids,
-			} );
-		},
+			onRemove( uids ) {
+				dispatch( {
+					type: 'REMOVE_BLOCKS',
+					uids,
+				} );
+			},
 
-		onMerge( ...args ) {
-			dispatch( mergeBlocks( ...args ) );
-		},
-	} )
+			onMerge( ...args ) {
+				dispatch( mergeBlocks( ...args ) );
+			},
+		} )
+	)
 )( VisualEditorBlock );

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -18,8 +18,7 @@
 	}
 }
 
-/* "Hassle-free full bleed" from CSS Tricks */
-.editor-visual-editor > *:not( [data-align="wide"] ) {
+.editor-visual-editor > * {
 	max-width: $visual-editor-max-width;
 	margin-left: auto;
 	margin-right: auto;

--- a/editor/state.js
+++ b/editor/state.js
@@ -6,6 +6,11 @@ import refx from 'refx';
 import { keyBy, first, last, omit, without, flowRight } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { extensionsReducer } from 'extensions';
+
+/**
  * Internal dependencies
  */
 import { combineUndoableReducers } from './utils/undoable-reducer';
@@ -429,6 +434,7 @@ export function createReduxStore() {
 		mode,
 		isSidebarOpened,
 		saving,
+		extensions: extensionsReducer,
 	} );
 
 	const enhancers = [ applyMiddleware( refx( effects ) ) ];

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -902,6 +902,7 @@ describe( 'state', () => {
 				'isSidebarOpened',
 				'saving',
 				'insertionPoint',
+				'extensions',
 			] );
 		} );
 	} );

--- a/extensions/index.js
+++ b/extensions/index.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { forEach, flowRight, without } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { createElement, Component } from 'element';
+
+function connectExtensionState( name ) {
+	return connect(
+		( state ) => ( {
+			extensionState: state.extensions[ name ] || {},
+		} ),
+		{
+			setExtensionState: ( state ) => {
+				return {
+					type: '@@EXTENSIONS/SET_EXTENSION_STATE',
+					name,
+					state,
+				};
+			},
+		}
+	);
+}
+
+export function applyComponentDecorators( WrappedComponent ) {
+	class DecoratedComponent extends Component {
+		static addDecorator( name, decorator ) {
+			const { instances, decorators } = this._extensions;
+
+			decorators.push( flowRight( connectExtensionState( name ), decorator ) );
+
+			this._extensions.DecoratedComponent = flowRight( ...decorators )( WrappedComponent );
+			instances.forEach( ( instance ) => instance.forceUpdate() );
+		}
+
+		componentDidMount() {
+			this.constructor._extensions.instances.push( this );
+		}
+
+		componentWillUnmount() {
+			this.constructor._extensions.instances = without(
+				this.constructor._extensions.instances,
+				this
+			);
+		}
+
+		render() {
+			return createElement(
+				this.constructor._extensions.DecoratedComponent,
+				this.props
+			);
+		}
+	}
+
+	DecoratedComponent._extensions = {
+		decorators: [],
+		instances: [],
+		DecoratedComponent: WrappedComponent,
+	};
+
+	return DecoratedComponent;
+}
+
+export function decorateComponent( DecoratedComponent, name, decorator ) {
+	if ( ! DecoratedComponent.addDecorator ) {
+		throw new TypeError( 'The provided component has not enabled decorators' );
+	}
+
+	DecoratedComponent.addDecorator( name, decorator );
+}
+
+export function registerExtension( name, settings ) {
+	forEach( settings.decorators, ( [ DecoratedComponent, decorator ] ) => {
+		decorateComponent( DecoratedComponent, name, decorator );
+	} );
+}
+
+export function extensionsReducer( state = {}, action ) {
+	switch ( action.type ) {
+		case '@@EXTENSIONS/SET_EXTENSION_STATE':
+			state = {
+				...state,
+				[ action.name ]: {
+					...state[ action.name ],
+					...action.state,
+				},
+			};
+	}
+
+	return state;
+}
+
+export default {
+	applyComponentDecorators,
+	decorateComponent,
+	extensionsReducer,
+};

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -126,6 +126,12 @@ function gutenberg_register_scripts() {
 		filemtime( gutenberg_dir_path() . 'element/build/index.js' )
 	);
 	wp_register_script(
+		'wp-extensions',
+		gutenberg_url( 'extensions/build/index.js' ),
+		array( 'wp-element' ),
+		filemtime( gutenberg_dir_path() . 'extensions/build/index.js' )
+	);
+	wp_register_script(
 		'wp-components',
 		gutenberg_url( 'components/build/index.js' ),
 		array( 'wp-element' ),
@@ -286,7 +292,7 @@ function gutenberg_scripts_and_styles( $hook ) {
 	wp_enqueue_script(
 		'wp-editor',
 		gutenberg_url( 'editor/build/index.js' ),
-		array( 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils' ),
+		array( 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-extensions', 'wp-components', 'wp-utils' ),
 		filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
 		true // enqueue in the footer.
 	);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
 const entryPointNames = [
 	'element',
+	'extensions',
 	'i18n',
 	'components',
 	'utils',


### PR DESCRIPTION
_Experimental:_ These changes are highly incomplete, unpolished, and break nearly as much functionality as they introduce.

This pull request seeks to explore a decorator pattern for extensibility. It is primarily composed of two parts:

- `applyDecorators`, a higher-order component that flags a component as being enabled to accept decorators, responsible for managing the extensions during render.
- `registerExtension`, the API by which extensions can hook to component rendering via a `decorators` property, an array of tuples where the first entry is the component to hook and the second entry a higher-order component to dynamically introduce to the wrapped component's rendering flow

[See included `wide-align` usage](https://github.com/WordPress/gutenberg/blob/92c5039fbcceda5f8bd6b3b4e84044e259d262d5/editor/extensions/wide-align/index.js)

The use-case explored was that of wide image rendering, which is unique in that it depends on a relationship between two components: The `Layout` component for accessing the available width of the editor canvas, and the `VisualEditorBlock` component for applying the margin offsets. To achieve this I'd first explored using React `context` to pass information from the Layout decorator to the VisualEditorBlock component, but found that React-Redux's pure-by-default nature had the undesirable side-effect of preventing context changes from being reflected in the descendant component (#2517).

Instead I landed on the idea of namespaced extension state to be shared between all component decorators registered by `registerExtension`. A component decorator can interact with it using `extensionState` and `setExtensionState` from props (similar in usage to `setState` or `setAttributes`).

The approach differs from [react-slot-fill](https://github.com/camwest/react-slot-fill) in that a slot can be occupied by one or more fill to be rendered as a child, whereas a decorator wraps the original component and has power to replace or augment the original render behavior. I've not yet settled on whether the decorator pattern could serve as a complete replacement for slot/fill, or if the two complement each other in their own independent purpose. If slots were to remain, I think it could fit well within the existing API via `registerExtension( { slots: { slotName: [ fillOne, fillTwo ] } } );`.

__Testing instructions:__

As noted, there is breakage resulting from these changes, notably floated content. Observe though that Wide alignment (image, video, etc) stretches to occupy the full width.