### PR TITLE
Fix multi-select flickering

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -137,7 +137,10 @@ export default class Editable extends wp.element.Component {
 			empty: ! content || ! content.length,
 		} );
 
-		if ( this.props.focus.collapsed !== collapsed ) {
+		if (
+			this.props.focus && this.props.onFocus &&
+			this.props.focus.collapsed !== collapsed
+		) {
 			this.props.onFocus( {
 				...this.props.focus,
 				collapsed,
@@ -344,7 +347,7 @@ export default class Editable extends wp.element.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.focus !== prevProps.focus ) {
+		if ( ! isEqual( this.props.focus, prevProps.focus ) ) {
 			this.updateFocus();
 		}
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -52,6 +52,10 @@ class VisualEditorBlock extends wp.element.Component {
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
 		this.removeOrDeselect = this.removeOrDeselect.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
+		this.onFocus = this.onFocus.bind( this );
+		this.onPointerDown = this.onPointerDown.bind( this );
+		this.onPointerMove = this.onPointerMove.bind( this );
+		this.onPointerUp = this.onPointerUp.bind( this );
 		this.previousOffset = null;
 	}
 
@@ -171,6 +175,26 @@ class VisualEditorBlock extends wp.element.Component {
 		}
 	}
 
+	onFocus( event ) {
+		if ( event.target === this.node ) {
+			this.props.onSelect();
+		}
+	}
+
+	onPointerDown() {
+		this.props.onSelect();
+		this.props.onSelectionStart();
+	}
+
+	onPointerMove() {
+		this.props.onSelectionChange();
+		this.maybeHover();
+	}
+
+	onPointerUp() {
+		this.props.onSelectionEnd();
+	}
+
 	render() {
 		const { block, selectedBlocks } = this.props;
 		const blockType = wp.blocks.getBlockType( block.name );
@@ -199,7 +223,7 @@ class VisualEditorBlock extends wp.element.Component {
 			'is-hovered': isHovered,
 		} );
 
-		const { onSelect, onMouseLeave, onFocus, onInsertAfter } = this.props;
+		const { onMouseLeave, onFocus, onInsertAfter } = this.props;
 
 		// Determine whether the block has props to apply to the wrapper.
 		let wrapperProps;
@@ -213,15 +237,13 @@ class VisualEditorBlock extends wp.element.Component {
 			<div
 				ref={ this.bindBlockNode }
 				onKeyDown={ this.removeOrDeselect }
-				onMouseDown={ this.props.onSelectionStart }
-				onTouchStart={ this.props.onSelectionStart }
-				onMouseMove={ () => {
-					this.props.onSelectionChange();
-					this.maybeHover();
-				} }
-				onTouchMove={ this.props.onSelectionChange }
-				onMouseUp={ this.props.onSelectionEnd }
-				onTouchEnd={ this.props.onSelectionEnd }
+				onFocus={ this.onFocus }
+				onMouseDown={ this.onPointerDown }
+				onTouchStart={ this.onPointerDown }
+				onMouseMove={ this.onPointerMove }
+				onTouchMove={ this.onPointerMove }
+				onMouseUp={ this.onPointerUp }
+				onTouchEnd={ this.onPointerUp }
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
 				className={ className }
@@ -258,8 +280,6 @@ class VisualEditorBlock extends wp.element.Component {
 				) }
 				<div
 					onKeyPress={ this.maybeStartTyping }
-					onFocus={ onSelect }
-					onClick={ onSelect }
 					onDragStart={ ( event ) => event.preventDefault() }
 				>
 					<BlockEdit


### PR DESCRIPTION
To reproduce the issue, try to start selecting a block containing an `Editable` region, but not from inside that region, then move up or down to multi-select. The state will bounce between having no multi-selection (as it toggles the selected block) and having multi-selection (as you move the mouse). This results in the flickering selection colour.

I'm still not sure what is causing the multiple set focus calls in the scenario above, while not when starting from inside the Editable... 