### PR TITLE
Do not download vendor JS files in released plugin versions

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit if any command fails
 set -e
@@ -7,6 +7,50 @@ set -e
 cd "$(dirname "$0")"
 cd ..
 
+# Make sure there are no changes in the working tree.  Release builds should be
+# traceable to a particular commit and reliably reproducible.  (This is not
+# totally true at the moment because we download nightly vendor scripts).
+changed=
+if ! git diff --exit-code > /dev/null; then
+	changed="file(s) modified"
+elif ! git diff --cached --exit-code > /dev/null; then
+	changed="file(s) staged"
+fi
+if [ ! -z "$changed" ]; then
+	git status
+	echo "ERROR: Cannot build plugin zip with dirty working tree."
+	echo "       Commit your changes and try again."
+	exit 1
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != 'master' ]; then
+	echo "WARNING: You should probably be running this script against the"
+	echo "         'master' branch (current: '$branch')"
+	echo
+	sleep 2
+fi
+
+# Download all vendor scripts
+vendor_scripts=""
+# Using `command | while read...` is more typical, but the inside of the while
+# loop will run under a separate process this way, meaning that it cannot
+# modify $vendor_scripts.  See:  https://stackoverflow.com/a/16855194
+exec 3< <(
+	# minified versions of vendor scripts
+	php bin/get-vendor-scripts.php
+	# non-minified versions of vendor scripts (for SCRIPT_DEBUG)
+	php bin/get-vendor-scripts.php debug
+)
+while IFS='|' read -u 3 url filename; do
+	echo "$url"
+	echo -n " > vendor/$filename ... "
+	curl --location --silent "$url" --output "vendor/_download.tmp.js"
+	mv -f "vendor/_download.tmp.js" "vendor/$filename"
+	echo "done!"
+	vendor_scripts="$vendor_scripts vendor/$filename"
+done
+
 # Run the build
 npm install
 npm run build
@@ -14,17 +58,31 @@ npm run build
 # Remove any existing zip file
 rm -f gutenberg.zip
 
+# Temporarily modify `gutenberg.php` with production constants defined.  Use a
+# temp file because `bin/generate-gutenberg-php.php` reads from `gutenberg.php`
+# so we need to avoid writing to that file at the same time.
+php bin/generate-gutenberg-php.php > gutenberg.tmp.php
+mv gutenberg.tmp.php gutenberg.php
+
 # Generate the plugin zip file
 zip -r gutenberg.zip \
 	gutenberg.php \
+	index.php \
 	lib/*.php \
 	lib/blocks/*.php \
 	post-content.js \
-	blocks/build \
-	components/build \
-	date/build \
-	editor/build \
-	element/build \
-	i18n/build \
-	utils/build \
+	$vendor_scripts \
+	blocks/build/*.{js,map} \
+	components/build/*.{js,map} \
+	date/build/*.{js,map} \
+	editor/build/*.{js,map} \
+	element/build/*.{js,map} \
+	i18n/build/*.{js,map} \
+	utils/build/*.{js,map} \
+	blocks/build/*.css \
+	components/build/*.css \
+	editor/build/*.css \
 	README.md
+
+# Reset `gutenberg.php`
+git checkout gutenberg.php

--- a/bin/generate-gutenberg-php.php
+++ b/bin/generate-gutenberg-php.php
@@ -1,0 +1,62 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Generates the production (plugin build) version of `gutenberg.php`,
+ * containing alternate `define` statements from the development version.
+ *
+ * @package gutenberg-build
+ */
+
+$f = fopen( dirname( dirname( __FILE__ ) ) . '/gutenberg.php', 'r' );
+
+$plugin_version = null;
+$inside_defines = false;
+
+/**
+ * Prints `define` statements for the production version of `gutenberg.php`
+ * (the plugin entry point).
+ */
+function print_production_defines() {
+	global $plugin_version;
+
+	echo "define( 'GUTENBERG_VERSION', '$plugin_version' );\n";
+
+	$git_commit = trim( shell_exec( 'git rev-parse HEAD' ) );
+
+	echo "define( 'GUTENBERG_GIT_COMMIT', '$git_commit' );\n";
+}
+
+while ( true ) {
+	$line = fgets( $f );
+	if ( false === $line ) {
+		break;
+	}
+
+	if (
+		! $plugin_version &&
+		preg_match( '@^\s*\*\s*Version:\s*([0-9.]+)@', $line, $matches )
+	) {
+		$plugin_version = $matches[1];
+	}
+
+	switch ( trim( $line ) ) {
+		case '### BEGIN AUTO-GENERATED DEFINES':
+			$inside_defines = true;
+			echo $line;
+			print_production_defines();
+			break;
+
+		case '### END AUTO-GENERATED DEFINES':
+			$inside_defines = false;
+			echo $line;
+			break;
+
+		default:
+			if ( ! $inside_defines ) {
+				echo $line;
+			}
+			break;
+	}
+}
+
+fclose( $f );

--- a/bin/get-vendor-scripts.php
+++ b/bin/get-vendor-scripts.php
@@ -1,0 +1,24 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Loads the minimum amount of the Gutenberg PHP code possible and lists vendor
+ * JavaScript URLs and filenames.
+ *
+ * @package gutenberg-build
+ */
+
+define( 'SCRIPT_DEBUG', $argc > 1 && 'debug' === strtolower( $argv[1] ) );
+
+// Hacks to get lib/client-assets.php to load.
+define( 'ABSPATH', dirname( dirname( __FILE__ ) ) );
+/**
+ * Hi, phpcs
+ */
+function add_action() {}
+
+// Instead of loading script files, just show how they need to be loaded.
+define( 'GUTENBERG_LIST_VENDOR_ASSETS', true );
+
+require_once dirname( dirname( __FILE__ ) ) . '/lib/client-assets.php';
+
+gutenberg_register_vendor_scripts();

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -9,6 +9,10 @@
  * @package gutenberg
  */
 
+### BEGIN AUTO-GENERATED DEFINES
+define( 'GUTENBERG_DEVELOPMENT_MODE', true );
+### END AUTO-GENERATED DEFINES
+
 // Load API functions.
 require_once dirname( __FILE__ ) . '/lib/blocks.php';
 require_once dirname( __FILE__ ) . '/lib/client-assets.php';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,9 +10,15 @@
 
 	<file>gutenberg.php</file>
 	<file>./phpunit</file>
+	<file>./bin</file>
 
 	<!-- The plugin entry point already has a file comment, I promise -->
 	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>gutenberg.php</exclude-pattern>
+	</rule>
+
+	<!-- These special comments are markers for the build process -->
+	<rule ref="Squiz.Commenting.InlineComment.WrongStyle">
 		<exclude-pattern>gutenberg.php</exclude-pattern>
 	</rule>
 


### PR DESCRIPTION
This PR introduces the first example of logic needing to vary between the development and release versions of the plugin.  In development mode, we download and cache "nightly" vendor JavaScript files, but this isn't appropriate for release - we should bundle these with the plugin instead.

This is accomplished by generating a slightly different `gutenberg.php` file during the plugin release process, then only downloading vendor files if the `GUTENBERG_DEVELOPMENT_MODE` constant is truthy.

We respect the `SCRIPT_DEBUG` constant for these vendor scripts, but not yet for our own JavaScript.  I'll create a separate issue for this (#1026).

Follow-up to #985.

Addresses https://github.com/WordPress/gutenberg/issues/953#issuecomment-305183177, after this we should be ready to release Gutenberg to the WP plugins directory.

Fixes #921 at the same time, since I was making changes in that area.