### PR TITLE
Always pass focus props to setFocus

### DIFF
--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -26,7 +26,7 @@ registerBlockType( 'core/code', {
 		return (
 			<TextareaAutosize
 				value={ attributes.content }
-				onFocus={ setFocus }
+				onFocus={ () => setFocus( {} ) }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
 			/>
 		);

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -22,11 +22,10 @@ registerBlockType( 'core/code', {
 		content: prop( 'code', 'textContent' ),
 	},
 
-	edit( { attributes, setAttributes, setFocus } ) {
+	edit( { attributes, setAttributes } ) {
 		return (
 			<TextareaAutosize
 				value={ attributes.content }
-				onFocus={ () => setFocus( {} ) }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
 			/>
 		);

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -33,7 +33,7 @@ registerBlockType( 'core/pullquote', {
 						} )
 					}
 					focus={ focus && focus.editable === 'value' ? focus : null }
-					onFocus={ () => setFocus( { editable: 'value' } ) }
+					onFocus={ ( props ) => setFocus( { ...props, editable: 'value' } ) }
 				/>
 				{ ( citation || !! focus ) && (
 					<Editable
@@ -45,7 +45,7 @@ registerBlockType( 'core/pullquote', {
 							} )
 						}
 						focus={ focus && focus.editable === 'citation' ? focus : null }
-						onFocus={ () => setFocus( { editable: 'citation' } ) }
+						onFocus={ ( props ) => setFocus( { ...props, editable: 'citation' } ) }
 						inline
 					/>
 				) }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -124,7 +124,7 @@ registerBlockType( 'core/quote', {
 						} )
 					}
 					focus={ focusedEditable === 'value' ? focus : null }
-					onFocus={ () => setFocus( { editable: 'value' } ) }
+					onFocus={ ( props ) => setFocus( { ...props, editable: 'value' } ) }
 					onMerge={ mergeBlocks }
 					showAlignments
 				/>
@@ -139,7 +139,7 @@ registerBlockType( 'core/quote', {
 							} )
 						}
 						focus={ focusedEditable === 'citation' ? focus : null }
-						onFocus={ () => setFocus( { editable: 'citation' } ) }
+						onFocus={ ( props ) => setFocus( { ...props, editable: 'citation' } ) }
 						inline
 					/>
 				) }

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -90,7 +90,7 @@ registerBlockType( 'core/table', {
 													inline
 													value={ value }
 													focus={ focussedKey === key ? focus : null }
-													onFocus={ () => setFocus( { editable: key } ) }
+													onFocus={ ( props ) => setFocus( { ...props, editable: key } ) }
 													onChange={ ( nextValue ) => {
 														const nextPart = [ ...attributes[ part ] ];
 


### PR DESCRIPTION
This fixes an issue where the toolbar does not hide when typing in a quote block or table. Somehow I don't like that this is the responsibility of the block implementor but yeah. :)