### PR TITLE
Fix `.eslintrc.json` indentation, 2 spaces, not tabs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,110 +1,110 @@
 {
-	"root": true,
-	"parser": "babel-eslint",
-	"extends": [
-		"wordpress",
-		"plugin:react/recommended",
-		"plugin:jsx-a11y/recommended"
-	],
-	"env": {
-		"browser": false,
-		"node": true,
-		"mocha": true
-	},
-	"parserOptions": {
-		"sourceType": "module",
-		"ecmaFeatures": {
-			"jsx": true
-		}
-	},
-	"globals": {
-		"wp": true,
-		"wpApiSettings": true,
-		"window": true,
-		"document": true
-	},
-	"plugins": [
-		"react",
-		"jsx-a11y"
-	],
-	"settings": {
-		"react": {
-			"pragma": "wp"
-		}
-	},
-	"rules": {
-		"array-bracket-spacing": [ "error", "always" ],
-		"brace-style": [ "error", "1tbs" ],
-		"comma-dangle": [ "error", "always-multiline" ],
-		"comma-spacing": "error",
-		"comma-style": "error",
-		"computed-property-spacing": [ "error", "always" ],
-		"constructor-super": "error",
-		"dot-notation": "error",
-		"eol-last": "error",
-		"func-call-spacing": "error",
-		"indent": [ "error", "tab", { "SwitchCase": 1 } ],
-		"jsx-quotes": "error",
-		"key-spacing": "error",
-		"keyword-spacing": "error",
-		"no-alert": "error",
-		"no-bitwise": "error",
-		"no-console": "error",
-		"no-const-assign": "error",
-		"no-debugger": "error",
-		"no-dupe-args": "error",
-		"no-dupe-class-members": "error",
-		"no-dupe-keys": "error",
-		"no-duplicate-case": "error",
-		"no-duplicate-imports": "error",
-		"no-else-return": "error",
-		"no-eval": "error",
-		"no-extra-semi": "error",
-		"no-fallthrough": "error",
-		"no-lonely-if": "error",
-		"no-mixed-operators": "error",
-		"no-mixed-spaces-and-tabs": "error",
-		"no-multiple-empty-lines": [ "error", { "max": 1 } ],
-		"no-multi-spaces": "error",
-		"no-negated-in-lhs": "error",
-		"no-nested-ternary": "error",
-		"no-redeclare": "error",
-		"no-shadow": "error",
-		"no-undef-init": "error",
-		"no-unreachable": "error",
-		"no-unsafe-negation": "error",
-		"no-use-before-define": [ "error", "nofunc" ],
-		"no-useless-computed-key": "error",
-		"no-useless-constructor": "error",
-		"no-useless-return": "error",
-		"no-var": "error",
-		"no-whitespace-before-property": "error",
-		"object-curly-spacing": [ "error", "always" ],
-		"one-var": "off",
-		"padded-blocks": [ "error", "never" ],
-		"prefer-const": "error",
-		"quote-props": [ "error", "as-needed", { "keywords": true } ],
-		"react/display-name": "off",
-		"react/jsx-curly-spacing": [ "error", "always" ],
-		"react/jsx-equals-spacing": "error",
-		"react/jsx-indent": [ "error", "tab" ],
-		"react/jsx-indent-props": [ "error", "tab" ],
-		"react/jsx-key": "error",
-		"react/jsx-space-before-closing": "error",
-		"react/prop-types": "off",
-		"semi": "error",
-		"semi-spacing": "error",
-		"space-before-blocks": [ "error", "always" ],
-		"space-before-function-paren": [ "error", "never" ],
-		"space-in-parens": [ "error", "always" ],
-		"space-infix-ops": [ "error", { "int32Hint": false } ],
-		"space-unary-ops": [ "error", {
-			"overrides": {
-				"!": true
-			}
-		} ],
-		"template-curly-spacing": [ "error", "always" ],
-		"valid-jsdoc": [ "error", { "requireReturn": false } ],
-		"valid-typeof": "error"
-	}
+  "root": true,
+  "parser": "babel-eslint",
+  "extends": [
+    "wordpress",
+    "plugin:react/recommended",
+    "plugin:jsx-a11y/recommended"
+  ],
+  "env": {
+    "browser": false,
+    "node": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "globals": {
+    "wp": true,
+    "wpApiSettings": true,
+    "window": true,
+    "document": true
+  },
+  "plugins": [
+    "react",
+    "jsx-a11y"
+  ],
+  "settings": {
+    "react": {
+      "pragma": "wp"
+    }
+  },
+  "rules": {
+    "array-bracket-spacing": [ "error", "always" ],
+    "brace-style": [ "error", "1tbs" ],
+    "comma-dangle": [ "error", "always-multiline" ],
+    "comma-spacing": "error",
+    "comma-style": "error",
+    "computed-property-spacing": [ "error", "always" ],
+    "constructor-super": "error",
+    "dot-notation": "error",
+    "eol-last": "error",
+    "func-call-spacing": "error",
+    "indent": [ "error", "tab", { "SwitchCase": 1 } ],
+    "jsx-quotes": "error",
+    "key-spacing": "error",
+    "keyword-spacing": "error",
+    "no-alert": "error",
+    "no-bitwise": "error",
+    "no-console": "error",
+    "no-const-assign": "error",
+    "no-debugger": "error",
+    "no-dupe-args": "error",
+    "no-dupe-class-members": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-duplicate-imports": "error",
+    "no-else-return": "error",
+    "no-eval": "error",
+    "no-extra-semi": "error",
+    "no-fallthrough": "error",
+    "no-lonely-if": "error",
+    "no-mixed-operators": "error",
+    "no-mixed-spaces-and-tabs": "error",
+    "no-multiple-empty-lines": [ "error", { "max": 1 } ],
+    "no-multi-spaces": "error",
+    "no-negated-in-lhs": "error",
+    "no-nested-ternary": "error",
+    "no-redeclare": "error",
+    "no-shadow": "error",
+    "no-undef-init": "error",
+    "no-unreachable": "error",
+    "no-unsafe-negation": "error",
+    "no-use-before-define": [ "error", "nofunc" ],
+    "no-useless-computed-key": "error",
+    "no-useless-constructor": "error",
+    "no-useless-return": "error",
+    "no-var": "error",
+    "no-whitespace-before-property": "error",
+    "object-curly-spacing": [ "error", "always" ],
+    "one-var": "off",
+    "padded-blocks": [ "error", "never" ],
+    "prefer-const": "error",
+    "quote-props": [ "error", "as-needed", { "keywords": true } ],
+    "react/display-name": "off",
+    "react/jsx-curly-spacing": [ "error", "always" ],
+    "react/jsx-equals-spacing": "error",
+    "react/jsx-indent": [ "error", "tab" ],
+    "react/jsx-indent-props": [ "error", "tab" ],
+    "react/jsx-key": "error",
+    "react/jsx-space-before-closing": "error",
+    "react/prop-types": "off",
+    "semi": "error",
+    "semi-spacing": "error",
+    "space-before-blocks": [ "error", "always" ],
+    "space-before-function-paren": [ "error", "never" ],
+    "space-in-parens": [ "error", "always" ],
+    "space-infix-ops": [ "error", { "int32Hint": false } ],
+    "space-unary-ops": [ "error", {
+      "overrides": {
+        "!": true
+      }
+    } ],
+    "template-curly-spacing": [ "error", "always" ],
+    "valid-jsdoc": [ "error", { "requireReturn": false } ],
+    "valid-typeof": "error"
+  }
 }


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/1022#discussion_r120242848