### PR TITLE
Add aria-hidden and role to SVGs.

### DIFF
--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -756,7 +756,7 @@ export default class Dashicon extends wp.element.Component {
 		const iconClass = [ 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
 
 		return (
-			<svg className={ iconClass } xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+			<svg aria-hidden="true" role="img" className={ iconClass } xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
 				<path d={ path } />
 			</svg>
 		);


### PR DESCRIPTION
This PR adds `aria-hidden="true"` and `role="img"` to the SVG files inside the dashicons component, addressing feedback here: https://github.com/WordPress/gutenberg/pull/1012#issuecomment-306137552

Upstream PR: https://github.com/WordPress/dashicons/pull/194

Test instructions:

- Build the plugin, then using the web inspector verify that the above mentioned attributes are present on the SVG icons.

CC: @afercia