### PR TITLE
Polish responsive a bit

### DIFF
--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -2,10 +2,14 @@
 	border: 1px solid $light-gray-500;
 	box-shadow: $shadow-popover;
 	background-color: $white;
-	margin-right: 10px;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	line-height: $default-line-height;
+	margin-right: -1px;
+
+	@include break-small() {
+		margin-right: $item-spacing;
+	}
 }
 
 .editor-block-switcher__toggle {

--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -7,11 +7,14 @@
 	flex-direction: row;
 	align-items: center;
 	z-index: z-index( '.editor-header' );
-	top: $admin-bar-height-big;
 	left: 0;
 	right: 0;
 
+	top: 0;
+	position: sticky;
+
 	@include break-small() {
+		top: $admin-bar-height-big;
 		position: fixed;
 	}
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -90,7 +90,11 @@
 	width: 0;
 	white-space: nowrap;
 
-	top: $header-height + $admin-bar-height-big + $item-spacing;
+	top: $header-height + $item-spacing;
+
+	@include break-small() {
+		top: $header-height + $admin-bar-height-big + $item-spacing;
+	}
 
 	@include break-medium() {
 		top: $header-height + $admin-bar-height + $item-spacing;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -114,7 +114,11 @@
 
 .editor-visual-editor__block-controls .components-toolbar {
 	display: inline-flex;
-	margin-right: $item-spacing;
+	margin-right: -1px;
+
+	@include break-small() {
+		margin-right: $item-spacing;
+	}
 }
 
 .editor-visual-editor__block-controls .editor-block-switcher {


### PR DESCRIPTION
This is a smallish PR to improve the responsiveness of the editor toolbar, and the block quick toolbars. 

On the smallest breakpoint, the editor bar is now sticky, and the toolbars are packed tighter together.

![screen shot 2017-06-06 at 11 47 16](https://cloud.githubusercontent.com/assets/1204802/26823536/43c644ca-4aae-11e7-8a43-36d753acc0d7.png)

Some improvements to how the blocks are centered live in #812. Upon that being merged, as well as #945, I can do some last tweaks and we'll be in a pretty good place, mobile-wise. (Edit, that will fix the issue with the save status, the mode dropdown, and the width of the block being off).