### PR TITLE
Fix multi select behaviours

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { throttle, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -32,10 +33,20 @@ class VisualEditorBlockList extends wp.element.Component {
 		this.onSelectionEnd = this.onSelectionEnd.bind( this );
 		this.onCopy = this.onCopy.bind( this );
 		this.onCut = this.onCut.bind( this );
+		this.setBlockRef = this.setBlockRef.bind( this );
+		this.onPointerMove = throttle( this.onPointerMove.bind( this ), 250 );
+		// Browser does not fire `*move` event when the pointer position changes
+		// relative to the document, so fire it with the last known position.
+		this.onScroll = () => this.onPointerMove( { clientY: this.lastClientY } );
 
 		this.state = {
 			selectionAtStart: null,
 		};
+
+		this.coordMap = {};
+		this.coordMapKeys = [];
+		this.lastClientY = 0;
+		this.refs = {};
 	}
 
 	componentDidMount() {
@@ -46,6 +57,28 @@ class VisualEditorBlockList extends wp.element.Component {
 	componentWillUnmount() {
 		document.removeEventListener( 'copy', this.onCopy );
 		document.removeEventListener( 'cut', this.onCut );
+
+		// Cancel throttled calls.
+		this.onPointerMove.cancel();
+	}
+
+	setBlockRef( ref, uid ) {
+		if ( ref === null ) {
+			delete this.refs[ uid ];
+		} else {
+			this.refs = {
+				...this.refs,
+				[ uid ]: ref,
+			};
+		}
+	}
+
+	onPointerMove( { clientY } ) {
+		const y = clientY + window.pageYOffset;
+		const key = this.coordMapKeys.reduce( ( acc, topY ) => y > topY ? topY : acc );
+
+		this.lastClientY = clientY;
+		this.onSelectionChange( this.coordMap[ key ] );
 	}
 
 	onCopy( event ) {
@@ -71,7 +104,22 @@ class VisualEditorBlockList extends wp.element.Component {
 	}
 
 	onSelectionStart( uid ) {
+		const { pageYOffset } = window;
+
+		// Create a Y coödinate map to unique block IDs.
+		this.coordMap = reduce( this.refs, ( acc, node, blockUid ) => ( {
+			...acc,
+			[ pageYOffset + node.getBoundingClientRect().top ]: blockUid,
+		} ), {} );
+		// Cache an array of the Y coödrinates for use in `onPointerMove`.
+		this.coordMapKeys = Object.keys( this.coordMap );
 		this.setState( { selectionAtStart: uid } );
+
+		window.addEventListener( 'mousemove', this.onPointerMove );
+		window.addEventListener( 'touchmove', this.onPointerMove );
+		window.addEventListener( 'scroll', this.onScroll );
+		window.addEventListener( 'mouseup', this.onSelectionEnd );
+		window.addEventListener( 'touchend', this.onSelectionEnd );
 	}
 
 	onSelectionChange( uid ) {
@@ -94,6 +142,12 @@ class VisualEditorBlockList extends wp.element.Component {
 
 	onSelectionEnd() {
 		this.setState( { selectionAtStart: null } );
+
+		window.removeEventListener( 'mousemove', this.onPointerMove );
+		window.removeEventListener( 'touchmove', this.onPointerMove );
+		window.removeEventListener( 'scroll', this.onScroll );
+		window.removeEventListener( 'mouseup', this.onSelectionEnd );
+		window.removeEventListener( 'touchend', this.onSelectionEnd );
 	}
 
 	render() {
@@ -123,9 +177,8 @@ class VisualEditorBlockList extends wp.element.Component {
 						<VisualEditorBlock
 							key={ uid }
 							uid={ uid }
+							blockRef={ ( ref ) => this.setBlockRef( ref, uid ) }
 							onSelectionStart={ () => this.onSelectionStart( uid ) }
-							onSelectionChange={ () => this.onSelectionChange( uid ) }
-							onSelectionEnd={ this.onSelectionEnd }
 							multiSelectedBlockUids={ multiSelectedBlockUids }
 						/>
 					);

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -54,13 +54,12 @@ class VisualEditorBlock extends wp.element.Component {
 		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.onFocus = this.onFocus.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
-		this.onPointerMove = this.onPointerMove.bind( this );
-		this.onPointerUp = this.onPointerUp.bind( this );
 		this.previousOffset = null;
 	}
 
 	bindBlockNode( node ) {
 		this.node = node;
+		this.props.blockRef( node );
 	}
 
 	componentWillReceiveProps( newProps ) {
@@ -185,15 +184,6 @@ class VisualEditorBlock extends wp.element.Component {
 		this.props.onSelectionStart();
 	}
 
-	onPointerMove() {
-		this.props.onSelectionChange();
-		this.maybeHover();
-	}
-
-	onPointerUp() {
-		this.props.onSelectionEnd();
-	}
-
 	render() {
 		const { block, multiSelectedBlockUids } = this.props;
 		const blockType = wp.blocks.getBlockType( block.name );
@@ -239,10 +229,7 @@ class VisualEditorBlock extends wp.element.Component {
 				onFocus={ this.onFocus }
 				onMouseDown={ this.onPointerDown }
 				onTouchStart={ this.onPointerDown }
-				onMouseMove={ this.onPointerMove }
-				onTouchMove={ this.onPointerMove }
-				onMouseUp={ this.onPointerUp }
-				onTouchEnd={ this.onPointerUp }
+				onMouseMove={ this.maybeHover }
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
 				className={ className }


### PR DESCRIPTION
* Selection is continued after releasing the mouse outside the block list or window.
* Selection does not adjust when the pointer goes outside the  block list area, but still horizontally next to unselected blocks.
* Selection does not adjust on scroll when the pointer does not move.

First commit addresses the first issue.