### PR TITLE
Add camelcase rule to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,7 @@
 	"rules": {
 		"array-bracket-spacing": [ "error", "always" ],
 		"brace-style": [ "error", "1tbs" ],
+		"camelcase": ["error", { "properties": "always" }],
 		"comma-dangle": [ "error", "always-multiline" ],
 		"comma-spacing": "error",
 		"comma-style": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,7 @@
 	"rules": {
 		"array-bracket-spacing": [ "error", "always" ],
 		"brace-style": [ "error", "1tbs" ],
-		"camelcase": ["error", { "properties": "always" }],
+		"camelcase": ["error", { "properties": "never" }],
 		"comma-dangle": [ "error", "always-multiline" ],
 		"comma-spacing": "error",
 		"comma-style": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,7 @@
 	"rules": {
 		"array-bracket-spacing": [ "error", "always" ],
 		"brace-style": [ "error", "1tbs" ],
-		"camelcase": ["error", { "properties": "never" }],
+		"camelcase": [ "error", { "properties": "never" } ],
 		"comma-dangle": [ "error", "always-multiline" ],
 		"comma-spacing": "error",
 		"comma-style": "error",

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -101,10 +101,10 @@ registerBlockType( 'core/embed', {
 				event.preventDefault();
 			}
 			const { url } = this.props.attributes;
-			const api_url = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce;
+			const apiURL = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce;
 
 			this.setState( { error: false, fetching: true } );
-			window.fetch( api_url, {
+			window.fetch( apiURL, {
 				credentials: 'include',
 			} ).then(
 				( response ) => {


### PR DESCRIPTION
This will catch uses of underscore_separated variables and recommend they be switched to camelCase as per the coding standards:

https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#naming-conventions

Feel free to ignore/close this if you have bigger/better plans for the eslint rules!