### PR TITLE
Inspector: Bootstrapping the block inspector API (Slot & Fill)

### DIFF
--- a/blocks/inspector-controls/index.js
+++ b/blocks/inspector-controls/index.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { Fill } from 'react-slot-fill';
+
+export default function InspectorControls( { children } ) {
+	return (
+		<Fill name="Inspector.Controls">
+			{ children }
+		</Fill>
+	);
+}

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -12,17 +12,21 @@ class TextControl extends Component {
 	constructor() {
 		super( ...arguments );
 		this.instanceId = this.constructor.instances++;
+		this.onChange = this.onChange.bind( this );
+	}
+
+	onChange( event ) {
+		this.props.onChange( event.target.value );
 	}
 
 	render() {
-		const { label, value, onChange } = this.props;
+		const { label, value } = this.props;
 		const id = 'inspector-text-control-' + this.instanceId;
-		const updateValue = ( event ) => onChange( event.target.value );
 
 		return (
 			<div className="blocks-text-control">
 				<label className="blocks-text-control__label" htmlFor={ id }>{ label }</label>
-				<input className="blocks-text-control__input" id={ id } value={ value } onChange={ updateValue } />
+				<input className="blocks-text-control__input" id={ id } value={ value } onChange={ this.onChange } />
 			</div>
 		);
 	}

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class TextControl extends Component {
+	constructor() {
+		super( ...arguments );
+		this.instanceId = this.constructor.instances++;
+	}
+
+	render() {
+		const { label, value, onChange } = this.props;
+		const id = 'inspector-text-control-' + this.instanceId;
+		const updateValue = ( event ) => onChange( event.target.value );
+
+		return (
+			<div className="blocks-text-control">
+				<label className="blocks-text-control__label" htmlFor={ id }>{ label }</label>
+				<input className="blocks-text-control__input" id={ id } value={ value } onChange={ updateValue } />
+			</div>
+		);
+	}
+}
+
+TextControl.instances = 0;
+
+export default TextControl;

--- a/blocks/inspector-controls/text-control/style.scss
+++ b/blocks/inspector-controls/text-control/style.scss
@@ -1,0 +1,14 @@
+.blocks-text-control {
+	margin-bottom: 10px;
+}
+
+.blocks-text-control__label {
+	display: block;
+	font-weight: 500;
+	margin-bottom: 5px;
+}
+
+.blocks-text-control__input {
+	width: 100%;
+	padding: 6px 10px;
+}

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
 import { Placeholder } from 'components';
 
 /**
@@ -10,6 +11,8 @@ import './style.scss';
 import { registerBlockType, query } from '../../api';
 import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
+import InspectorControls from '../../inspector-controls';
+import TextControl from '../../inspector-controls/text-control';
 
 const { attr, children } = query;
 
@@ -28,7 +31,7 @@ function toggleAlignment( align ) {
 }
 
 registerBlockType( 'core/image', {
-	title: wp.i18n.__( 'Image' ),
+	title: __( 'Image' ),
 
 	icon: 'format-image',
 
@@ -43,31 +46,31 @@ registerBlockType( 'core/image', {
 	controls: [
 		{
 			icon: 'align-left',
-			title: wp.i18n.__( 'Align left' ),
+			title: __( 'Align left' ),
 			isActive: ( { align } ) => 'left' === align,
 			onClick: toggleAlignment( 'left' ),
 		},
 		{
 			icon: 'align-center',
-			title: wp.i18n.__( 'Align center' ),
+			title: __( 'Align center' ),
 			isActive: ( { align } ) => ! align || 'center' === align,
 			onClick: toggleAlignment( 'center' ),
 		},
 		{
 			icon: 'align-right',
-			title: wp.i18n.__( 'Align right' ),
+			title: __( 'Align right' ),
 			isActive: ( { align } ) => 'right' === align,
 			onClick: toggleAlignment( 'right' ),
 		},
 		{
-			icon: 'align-wide',
-			title: wp.i18n.__( 'Wide width' ),
+			icon: 'align-width',
+			title: __( 'Wide width' ),
 			isActive: ( { align } ) => 'wide' === align,
 			onClick: toggleAlignment( 'wide' ),
 		},
 		{
 			icon: 'align-full-width',
-			title: wp.i18n.__( 'Full width' ),
+			title: __( 'Full width' ),
 			isActive: ( { align } ) => 'full' === align,
 			onClick: toggleAlignment( 'full' ),
 		},
@@ -82,15 +85,24 @@ registerBlockType( 'core/image', {
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { url, alt, caption } = attributes;
+		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
+
+		const inspector = focus && (
+			<InspectorControls key="inspector">
+				<TextControl label={ __( 'Alternate Text' ) } value={ alt } onChange={ updateAlt } />
+			</InspectorControls>
+		);
 
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
 			const setMediaURL = ( media ) => setAttributes( { url: media.url } );
-			return (
+			return [
+				inspector,
 				<Placeholder
-					instructions={ wp.i18n.__( 'Drag image here or insert from media library' ) }
+					key="placeholder"
+					instructions={ __( 'Drag image here or insert from media library' ) }
 					icon="format-image"
-					label={ wp.i18n.__( 'Image' ) }
+					label={ __( 'Image' ) }
 					className="blocks-image">
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }
@@ -98,10 +110,10 @@ registerBlockType( 'core/image', {
 						type="image"
 						auto-open
 					>
-						{ wp.i18n.__( 'Insert from Media Library' ) }
+						{ __( 'Insert from Media Library' ) }
 					</MediaUploadButton>
-				</Placeholder>
-			);
+				</Placeholder>,
+			];
 		}
 
 		const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );
@@ -109,13 +121,14 @@ registerBlockType( 'core/image', {
 		// Disable reason: Each block can be selected by clicking on it
 
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-		return (
-			<figure className="blocks-image">
+		return [
+			inspector,
+			<figure key="image" className="blocks-image">
 				<img src={ url } alt={ alt } onClick={ setFocus } />
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
-						placeholder={ wp.i18n.__( 'Write caption…' ) }
+						placeholder={ __( 'Write caption…' ) }
 						value={ caption }
 						focus={ focus && focus.editable === 'caption' ? focus : undefined }
 						onFocus={ focusCaption }
@@ -124,8 +137,8 @@ registerBlockType( 'core/image', {
 						inlineToolbar
 					/>
 				) : null }
-			</figure>
-		);
+			</figure>,
+		];
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 	},
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -63,7 +63,7 @@ registerBlockType( 'core/image', {
 			onClick: toggleAlignment( 'right' ),
 		},
 		{
-			icon: 'align-width',
+			icon: 'align-wide',
 			title: __( 'Wide width' ),
 			isActive: ( { align } ) => 'wide' === align,
 			onClick: toggleAlignment( 'wide' ),
@@ -87,17 +87,10 @@ registerBlockType( 'core/image', {
 		const { url, alt, caption } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
 
-		const inspector = focus && (
-			<InspectorControls key="inspector">
-				<TextControl label={ __( 'Alternate Text' ) } value={ alt } onChange={ updateAlt } />
-			</InspectorControls>
-		);
-
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
 			const setMediaURL = ( media ) => setAttributes( { url: media.url } );
 			return [
-				inspector,
 				<Placeholder
 					key="placeholder"
 					instructions={ __( 'Drag image here or insert from media library' ) }
@@ -122,7 +115,11 @@ registerBlockType( 'core/image', {
 
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return [
-			inspector,
+			focus && (
+				<InspectorControls key="inspector">
+					<TextControl label={ __( 'Alternate Text' ) } value={ alt } onChange={ updateAlt } />
+				</InspectorControls>
+			),
 			<figure key="image" className="blocks-image">
 				<img src={ url } alt={ alt } onClick={ setFocus } />
 				{ ( caption && caption.length > 0 ) || !! focus ? (

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -59,7 +59,6 @@ body.toplevel_page_gutenberg {
 	}
 }
 
-.editor-sidebar,
 .editor-post-title,
 .editor-visual-editor__block {
 	input,

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { Slot } from 'react-slot-fill';
 
 /**
  * WordPress dependencies
@@ -35,12 +36,7 @@ const BlockInspector = ( { selectedBlock, ...props } ) => {
 		<Panel>
 			<PanelHeader label={ header } />
 			<PanelBody>
-				<div>{ selectedBlock.name } settings...</div>
-				<ul>
-					{ Object.keys( selectedBlock.attributes ).map( ( attribute, index ) => (
-						<li key={ index }>{ attribute }: { selectedBlock.attributes[ attribute ] }</li>
-					) ) }
-				</ul>
+				<Slot name="Inspector.Controls" />
 			</PanelBody>
 		</Panel>
 	);

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -7,7 +7,9 @@ import { Slot } from 'react-slot-fill';
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
 import { Panel, PanelHeader, PanelBody } from 'components';
+import { getBlockType } from 'blocks';
 
 /**
  * Internal Dependencies
@@ -21,6 +23,8 @@ const BlockInspector = ( { selectedBlock, ...props } ) => {
 		return null;
 	}
 
+	const blockType = getBlockType( selectedBlock.name );
+
 	const onDeselect = ( event ) => {
 		event.preventDefault();
 		props.deselectBlock( selectedBlock.uid );
@@ -28,7 +32,11 @@ const BlockInspector = ( { selectedBlock, ...props } ) => {
 
 	const header = (
 		<strong>
-			<a href="" onClick={ onDeselect } className="editor-block-inspector__deselect-post">Post</a> → Block
+			<a href="" onClick={ onDeselect } className="editor-block-inspector__deselect-post">
+				{ __( 'Post' ) }
+			</a>
+			{ ' → ' }
+			{ blockType.title }
 		</strong>
 	);
 


### PR DESCRIPTION
Closes #672 

- In this PR, I'm bootstraping the block inspector API.
- It works in the exact same way as the Controls API. We have a "Insepector.Controls" slot that can be filled inside the `edit` function of the blocks using the `InspectorControls` wrapper.
- We'll probably provide a bunch of inspector controls, in this PR I'm creating the `TextControl`.
- As an example, I'm adding the image "alt" control to the inspector.

Once this merged, we'll have to create separate issues to implement the inspector for each block.