### PR TITLE
Do not select block on pressing UI, only content

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -182,7 +182,6 @@ class VisualEditorBlock extends wp.element.Component {
 	}
 
 	onPointerDown() {
-		this.props.onSelect();
 		this.props.onSelectionStart();
 	}
 
@@ -281,6 +280,7 @@ class VisualEditorBlock extends wp.element.Component {
 				<div
 					onKeyPress={ this.maybeStartTyping }
 					onDragStart={ ( event ) => event.preventDefault() }
+					onMouseDown={ this.props.onSelect }
 				>
 					<BlockEdit
 						focus={ focus }


### PR DESCRIPTION
To test, make sure that the block movers work. Also make sure that there are no regressions of 3f65f3c632646c2cee83639c6efc1455fea217bf:

> Fix onFocus and onClick handling on block wrapper (#1024)
> Fixes:
> 
> * Multi-select flickering.
> * Horizontal rule selection.
> * Input and text area that cannot be focussed immediately (fixes #1005).
> * Tabbing into block without inputs (focus on block wrapper did not select block).