### PR TITLE
Generate edit payload in save effect handler

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -56,11 +56,9 @@ export function editPost( edits ) {
 	};
 }
 
-export function savePost( postId, edits ) {
+export function savePost() {
 	return {
 		type: 'REQUEST_POST_UPDATE',
-		edits,
-		postId,
 	};
 }
 

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -14,18 +14,16 @@ import { Dashicon, Button } from 'components';
  * Internal dependencies
  */
 import './style.scss';
-import { savePost } from '../../actions';
+import { editPost, savePost } from '../../actions';
 import {
 	isEditedPostNew,
 	isEditedPostDirty,
 	isSavingPost,
 	getCurrentPost,
-	getPostEdits,
-	getBlocks,
 	getEditedPostAttribute,
 } from '../../selectors';
 
-function SavedState( { isNew, isDirty, isSaving, edits, blocks, post, status, onSave } ) {
+function SavedState( { isNew, isDirty, isSaving, status, onStatusChange, onSave } ) {
 	const className = 'editor-saved-state';
 
 	if ( isSaving ) {
@@ -44,7 +42,10 @@ function SavedState( { isNew, isDirty, isSaving, edits, blocks, post, status, on
 		);
 	}
 
-	const onClick = () => onSave( post, { ...edits, status: status || 'draft' }, blocks );
+	const onClick = () => {
+		onStatusChange( status || 'draft' );
+		onSave();
+	};
 
 	return (
 		<Button className={ classnames( className, 'button-link' ) } onClick={ onClick }>
@@ -56,19 +57,13 @@ function SavedState( { isNew, isDirty, isSaving, edits, blocks, post, status, on
 export default connect(
 	( state ) => ( {
 		post: getCurrentPost( state ),
-		edits: getPostEdits( state ),
-		blocks: getBlocks( state ),
 		isNew: isEditedPostNew( state ),
 		isDirty: isEditedPostDirty( state ),
 		isSaving: isSavingPost( state ),
 		status: getEditedPostAttribute( state, 'status' ),
 	} ),
-	( dispatch ) => ( {
-		onSave( post, edits, blocks ) {
-			dispatch( savePost( post.id, {
-				content: wp.blocks.serialize( blocks ),
-				...edits,
-			} ) );
-		},
-	} )
+	{
+		onStatusChange: ( status ) => editPost( { status } ),
+		onSave: savePost,
+	}
 )( SavedState );

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -12,11 +12,8 @@ import { Button } from 'components';
 /**
  * Internal dependencies
  */
-import { savePost } from '../../actions';
+import { editPost, savePost } from '../../actions';
 import {
-	getCurrentPost,
-	getPostEdits,
-	getBlocks,
 	isSavingPost,
 	isEditedPostPublished,
 	isEditedPostBeingScheduled,
@@ -25,11 +22,9 @@ import {
 } from '../../selectors';
 
 function PublishButton( {
-	post,
-	edits,
-	blocks,
 	isSaving,
 	isPublished,
+	onStatusChange,
 	onSave,
 	isBeingScheduled,
 	visibility,
@@ -51,7 +46,10 @@ function PublishButton( {
 		publishStatus = 'private';
 	}
 	const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
-	const onClick = () => onSave( post, { ...edits, status: publishStatus }, blocks );
+	const onClick = () => {
+		onStatusChange( publishStatus );
+		onSave();
+	};
 
 	const buttonDisabledHint = process.env.NODE_ENV === 'production'
 		? wp.i18n.__( 'The Save button is disabled during early alpha releases.' )
@@ -73,21 +71,14 @@ function PublishButton( {
 
 export default connect(
 	( state ) => ( {
-		post: getCurrentPost( state ),
-		edits: getPostEdits( state ),
-		blocks: getBlocks( state ),
 		isSaving: isSavingPost( state ),
 		isPublished: isEditedPostPublished( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		visibility: getEditedPostVisibility( state ),
 		isPublishable: isEditedPostPublishable( state ),
 	} ),
-	( dispatch ) => ( {
-		onSave( post, edits, blocks ) {
-			dispatch( savePost( post.id, {
-				content: wp.blocks.serialize( blocks ),
-				...edits,
-			} ) );
-		},
-	} )
+	{
+		onStatusChange: ( status ) => editPost( { status } ),
+		onSave: savePost,
+	}
 )( PublishButton );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -85,6 +85,17 @@ export function getCurrentPost( state ) {
 }
 
 /**
+ * Returns the ID of the post currently being edited, or null if the post has
+ * not yet been saved.
+ *
+ * @param  {Object}  state Global application state
+ * @return {?Number}       ID of current post
+ */
+export function getCurrentPostId( state ) {
+	return getCurrentPost( state ).id || null;
+}
+
+/**
  * Returns any post values which have been changed in the editor but not yet
  * been saved.
  *

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -58,7 +58,7 @@ export function hasEditorRedo( state ) {
  * @return {Boolean}       Whether the post is new
  */
 export function isEditedPostNew( state ) {
-	return ! state.currentPost.id;
+	return ! getCurrentPostId( state );
 }
 
 /**

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -18,9 +18,6 @@ import './style.scss';
 import {
 	getEditedPostAttribute,
 	getEditedPostVisibility,
-	getCurrentPost,
-	getPostEdits,
-	getBlocks,
 } from '../../selectors';
 import { editPost, savePost } from '../../actions';
 
@@ -44,7 +41,7 @@ class PostVisibility extends Component {
 	}
 
 	render() {
-		const { status, visibility, password, post, blocks, edits, onUpdateVisibility, onSave } = this.props;
+		const { status, visibility, password, onUpdateVisibility, onSave } = this.props;
 
 		const setPublic = () => {
 			onUpdateVisibility( visibility === 'private' ? 'draft' : status );
@@ -52,7 +49,8 @@ class PostVisibility extends Component {
 		};
 		const setPrivate = () => {
 			if ( window.confirm( __( 'Would you like to privately publish this post now?' ) ) ) { // eslint-disable-line no-alert
-				onSave( post, { ...edits, status: 'private' }, blocks );
+				onUpdateVisibility( 'private' );
+				onSave();
 				this.setState( { opened: false } );
 			}
 		};
@@ -131,22 +129,12 @@ export default connect(
 		status: getEditedPostAttribute( state, 'status' ),
 		visibility: getEditedPostVisibility( state ),
 		password: getEditedPostAttribute( state, 'password' ),
-		post: getCurrentPost( state ),
-		edits: getPostEdits( state ),
-		blocks: getBlocks( state ),
 	} ),
-	( dispatch ) => {
-		return {
-			onUpdateVisibility( status, password = null ) {
-				dispatch( editPost( { status, password } ) );
-			},
-			onSave( post, edits, blocks ) {
-				dispatch( savePost( post.id, {
-					content: wp.blocks.serialize( blocks ),
-					...edits,
-				} ) );
-			},
-		};
+	{
+		onSave: savePost,
+		onUpdateVisibility( status, password = null ) {
+			return editPost( { status, password } );
+		},
 	}
 )( clickOutside( PostVisibility ) );
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -15,6 +15,7 @@ import {
 	isEditedPostNew,
 	isEditedPostDirty,
 	getCurrentPost,
+	getCurrentPostId,
 	getPostEdits,
 	getEditedPostTitle,
 	getEditedPostExcerpt,
@@ -178,10 +179,28 @@ describe( 'selectors', () => {
 	describe( 'getCurrentPost', () => {
 		it( 'should return the current post', () => {
 			const state = {
-				currentPost: { ID: 1 },
+				currentPost: { id: 1 },
 			};
 
-			expect( getCurrentPost( state ) ).to.eql( { ID: 1 } );
+			expect( getCurrentPost( state ) ).to.eql( { id: 1 } );
+		} );
+	} );
+
+	describe( 'getCurrentPostId', () => {
+		it( 'should return null if the post has not yet been saved', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( getCurrentPostId( state ) ).to.be.null();
+		} );
+
+		it( 'should return the current post ID', () => {
+			const state = {
+				currentPost: { id: 1 },
+			};
+
+			expect( getCurrentPostId( state ) ).to.equal( 1 );
 		} );
 	} );
 


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/945#issuecomment-306853211

This pull request seeks to defer save payload to be generated during the save effect handler, instead of making it the responsibility of each saving component to construct. Instead, the component can merely call `savePost`. There's a bit of uncomfortable magic in allowing the effect handler to make heavy use of the current state, but arguably outweighed by the usability benefit. I'd still like to consider further splitting the `REQUEST_POST_UPDATE` handler, e.g. standalone handlers for the actual network request, clearing edits.

__Testing instructions:__

Ensure unit tests pass:

```
npm test
```

(Will need to revisit #966 with updated effect tests)

Verify that there are no regressions in: saving, publishing, privately published, or changing status of an existing or new post and updating / saving said post.