### PR TITLE
Avoid creating new state references if unchanged

### DIFF
--- a/editor/state.js
+++ b/editor/state.js
@@ -3,7 +3,7 @@
  */
 import { combineReducers, applyMiddleware, createStore } from 'redux';
 import refx from 'refx';
-import { keyBy, first, last, omit, without, flowRight } from 'lodash';
+import { reduce, keyBy, first, last, omit, without, flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,11 +30,27 @@ export const editor = combineUndoableReducers( {
 		switch ( action.type ) {
 			case 'EDIT_POST':
 			case 'SETUP_NEW_POST':
-				return {
-					...state,
-					...action.edits,
-				};
+				return reduce( action.edits, ( result, value, key ) => {
+					// Only assign into result if not already same value
+					if ( value !== state[ key ] ) {
+						// Avoid mutating original state by creating shallow
+						// clone. Should only occur once per reduce.
+						if ( result === state ) {
+							result = { ...state };
+						}
+
+						result[ key ] = value;
+					}
+
+					return result;
+				}, state );
+
 			case 'CLEAR_POST_EDITS':
+				// Don't return a new object if there's not any edits
+				if ( ! Object.keys( state ).length ) {
+					return state;
+				}
+
 				return {};
 		}
 
@@ -66,6 +82,32 @@ export const editor = combineUndoableReducers( {
 				return keyBy( action.blocks, 'uid' );
 
 			case 'UPDATE_BLOCK':
+				// Ignore updates if block isn't known
+				if ( ! state[ action.uid ] ) {
+					return state;
+				}
+
+				// Consider as updates only changed values
+				const nextBlock = reduce( action.updates, ( result, value, key ) => {
+					if ( value !== result[ key ] ) {
+						// Avoid mutating original block by creating shallow clone
+						if ( result === state[ action.uid ] ) {
+							result = { ...state[ action.uid ] };
+						}
+
+						result[ key ] = value;
+					}
+
+					return result;
+				}, state[ action.uid ] );
+
+				// Skip update if nothing has been changed. The reference will
+				// match the original block if `reduce` had no changed values.
+				if ( nextBlock === state[ action.uid ] ) {
+					return state;
+				}
+
+				// Otherwise merge updates into state
 				return {
 					...state,
 					[ action.uid ]: {

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -51,27 +51,6 @@ describe( 'state', () => {
 			expect( state.blockOrder ).to.eql( [ 'bananas' ] );
 		} );
 
-		it( 'should return with block updates', () => {
-			const original = editor( undefined, {
-				type: 'RESET_BLOCKS',
-				blocks: [ {
-					uid: 'kumquat',
-					attributes: {},
-				} ],
-			} );
-			const state = editor( original, {
-				type: 'UPDATE_BLOCK',
-				uid: 'kumquat',
-				updates: {
-					attributes: {
-						updated: true,
-					},
-				},
-			} );
-
-			expect( state.blocksByUid.kumquat.attributes.updated ).to.be.true();
-		} );
-
 		it( 'should insert block', () => {
 			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
@@ -363,6 +342,25 @@ describe( 'state', () => {
 				} );
 			} );
 
+			it( 'should return same reference if no changed properties', () => {
+				const original = editor( undefined, {
+					type: 'EDIT_POST',
+					edits: {
+						status: 'draft',
+						title: 'post title',
+					},
+				} );
+
+				const state = editor( original, {
+					type: 'EDIT_POST',
+					edits: {
+						status: 'draft',
+					},
+				} );
+
+				expect( state.edits ).to.equal( original.edits );
+			} );
+
 			it( 'should save modified properties', () => {
 				const original = editor( undefined, {
 					type: 'EDIT_POST',
@@ -403,6 +401,19 @@ describe( 'state', () => {
 				} );
 
 				expect( state.edits ).to.eql( {} );
+			} );
+
+			it( 'should return same reference if clearing non-edited', () => {
+				const original = editor( undefined, {
+					type: 'EDIT_POST',
+					edits: {},
+				} );
+
+				const state = editor( original, {
+					type: 'CLEAR_POST_EDITS',
+				} );
+
+				expect( state.edits ).to.equal( original.edits );
 			} );
 
 			it( 'should save initial post state', () => {
@@ -482,6 +493,70 @@ describe( 'state', () => {
 				} );
 
 				expect( state.dirty ).to.be.false();
+			} );
+		} );
+
+		describe( 'blocksByUid', () => {
+			it( 'should return with block updates', () => {
+				const original = editor( undefined, {
+					type: 'RESET_BLOCKS',
+					blocks: [ {
+						uid: 'kumquat',
+						attributes: {},
+					} ],
+				} );
+				const state = editor( original, {
+					type: 'UPDATE_BLOCK',
+					uid: 'kumquat',
+					updates: {
+						attributes: {
+							updated: true,
+						},
+					},
+				} );
+
+				expect( state.blocksByUid.kumquat.attributes.updated ).to.be.true();
+			} );
+
+			it( 'should ignore updates to non-existant block', () => {
+				const original = editor( undefined, {
+					type: 'RESET_BLOCKS',
+					blocks: [],
+				} );
+				const state = editor( original, {
+					type: 'UPDATE_BLOCK',
+					uid: 'kumquat',
+					updates: {
+						attributes: {
+							updated: true,
+						},
+					},
+				} );
+
+				expect( state.blocksByUid ).to.equal( original.blocksByUid );
+			} );
+
+			it( 'should return with same reference if no changes in updates', () => {
+				const original = editor( undefined, {
+					type: 'RESET_BLOCKS',
+					blocks: [ {
+						uid: 'kumquat',
+						attributes: {
+							updated: true,
+						},
+					} ],
+				} );
+				const state = editor( original, {
+					type: 'UPDATE_BLOCK',
+					uid: 'kumquat',
+					updates: {
+						attributes: {
+							updated: true,
+						},
+					},
+				} );
+
+				expect( state.blocksByUid ).to.equal( state.blocksByUid );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Related: #916

This pull request seeks to improve Redux state behavior for keys handling post updates, to ensure that a new object reference is only returned if in-fact a change has occurred. The effect is two-fold: It avoids unnecessary re-renders by allowing `react-redux`'s [default pure render behavior](https://github.com/reactjs/react-redux/blob/master/docs/api.md#optimizing-connect-when-optionspure-is-true) to be effective, and may be used toward a goal of considering dirtiness as the presence of an undo history, since both [`combineUndoableReducers`](https://github.com/WordPress/gutenberg/blob/73bd4ab0659897c9f710eaf2d888dce635e72bf4/editor/utils/undoable-reducer.js#L52-L54) and [`combineReducers`](https://github.com/reactjs/redux/blob/bf3a557a4ab93ebfc3f9648e88941bb734471c80/src/combineReducers.js#L158) disregard unchanged state.

__Testing instructions:__

Ensure unit tests pass:

```
npm test
```