### PR TITLE
Create separate New Post / Demo submenus

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -1,4 +1,5 @@
-body.toplevel_page_gutenberg {
+body.toplevel_page_gutenberg,
+body.gutenberg_page_gutenberg-demo {
 	background: $white;
 
 	#update-nag, .update-nag {

--- a/editor/index.js
+++ b/editor/index.js
@@ -36,13 +36,16 @@ if ( settings.timezone.string ) {
 }
 
 /**
- * Initializes and returns an instance of Editor.
+ * Initializes Redux state with bootstrapped post, if provided.
  *
- * @param {String} id   Unique identifier for editor instance
- * @param {Object} post API entity for post to edit
+ * @param {Redux.Store} store Redux store instance
+ * @param {?Object}     post  Bootstrapped post object
  */
-export function createEditorInstance( id, post ) {
-	const store = createReduxStore();
+function preparePostState( store, post ) {
+	if ( ! post ) {
+		return;
+	}
+
 	store.dispatch( {
 		type: 'RESET_BLOCKS',
 		post,
@@ -62,6 +65,18 @@ export function createEditorInstance( id, post ) {
 			},
 		} );
 	}
+}
+
+/**
+ * Initializes and returns an instance of Editor.
+ *
+ * @param {String} id   Unique identifier for editor instance
+ * @param {Object} post API entity for post to edit
+ */
+export function createEditorInstance( id, post ) {
+	const store = createReduxStore();
+
+	preparePostState( store, post );
 
 	wp.element.render(
 		<ReduxProvider store={ store }>

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -273,9 +273,11 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
  * @param string $hook Screen name.
  */
 function gutenberg_scripts_and_styles( $hook ) {
-	if ( 'toplevel_page_gutenberg' !== $hook ) {
+	if ( ! preg_match( '/(toplevel|gutenberg)_page_gutenberg(-demo)?/', $hook, $page_match ) ) {
 		return;
 	}
+
+	$is_demo = isset( $page_match[ 2 ] );
 
 	/**
 	 * Scripts
@@ -312,13 +314,14 @@ function gutenberg_scripts_and_styles( $hook ) {
 			'wp-editor',
 			'window._wpGutenbergPost = ' . wp_json_encode( $post_to_edit ) . ';'
 		);
-	} else {
+	} else if ( $is_demo ) {
 		// ...with some test content
-		// TODO: replace this with error handling
 		wp_add_inline_script(
 			'wp-editor',
 			file_get_contents( gutenberg_dir_path() . 'post-content.js' )
 		);
+	} else {
+		// TODO: Error handling
 	}
 
 	// Prepare Jed locale data.
@@ -330,7 +333,7 @@ function gutenberg_scripts_and_styles( $hook ) {
 	);
 
 	// Initialize the editor.
-	wp_add_inline_script( 'wp-editor', 'wp.editor.createEditorInstance( \'editor\', _wpGutenbergPost );' );
+	wp_add_inline_script( 'wp-editor', 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost );' );
 
 	/**
 	 * Styles

--- a/lib/register.php
+++ b/lib/register.php
@@ -41,6 +41,24 @@ function gutenberg_menu() {
 		'the_gutenberg_project',
 		'dashicons-edit'
 	);
+
+	add_submenu_page(
+		'gutenberg',
+		__( 'New Post', 'gutenberg' ),
+		__( 'New Post', 'gutenberg' ),
+		'edit_posts',
+		'gutenberg',
+		'the_gutenberg_project'
+	);
+
+	add_submenu_page(
+		'gutenberg',
+		__( 'Demo', 'gutenberg' ),
+		__( 'Demo', 'gutenberg' ),
+		'edit_posts',
+		'gutenberg-demo',
+		'the_gutenberg_project'
+	);
 }
 add_action( 'admin_menu', 'gutenberg_menu' );
 


### PR DESCRIPTION
Closes #1000 

This pull request seeks to enable creating new posts, separating Demo to a submenu item of the top-level Gutenberg menu item.

![Menu](https://user-images.githubusercontent.com/1779930/26898900-760033c2-4b9b-11e7-9f05-65a05e2f46e5.png)

__Testing instructions:__

Verify that...

1. Clicking Gutenberg top-level menu takes you to a blank editor
2. Clicking on the New Post submenu again takes you to a blank editor
3. Clicking on the Demo submenu takes you to the editor prepopulated with demo content