### PR TITLE
i18n: Traverse through parent paths to find translator comment

### DIFF
--- a/i18n/test/babel-plugin.js
+++ b/i18n/test/babel-plugin.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { transform } from 'babel-core';
+import traverse from 'babel-traverse';
 
 /**
  * Internal dependencies
@@ -9,7 +11,11 @@ import { expect } from 'chai';
 import babelPlugin from '../babel-plugin';
 
 describe( 'babel-plugin', () => {
-	const { isValidTranslationKey, isSameTranslation } = babelPlugin;
+	const {
+		isValidTranslationKey,
+		isSameTranslation,
+		getTranslatorComment,
+	} = babelPlugin;
 
 	describe( '.isValidTranslationKey()', () => {
 		it( 'should return false if not one of valid keys', () => {
@@ -34,6 +40,49 @@ describe( 'babel-plugin', () => {
 			const b = { msgid: 'foo', comments: { reference: 'b' } };
 
 			expect( isSameTranslation( a, b ) ).to.be.true();
+		} );
+	} );
+
+	describe( '.getTranslatorComment()', () => {
+		function getCommentFromString( string ) {
+			let comment;
+			traverse( transform( string ).ast, {
+				CallExpression( path ) {
+					comment = getTranslatorComment( path );
+				},
+			} );
+
+			return comment;
+		}
+
+		it( 'should not return translator comment on same line but after call expression', () => {
+			const comment = getCommentFromString( '__( \'Hello world\' ); // translators: Greeting' );
+
+			expect( comment ).to.be.undefined();
+		} );
+
+		it( 'should return translator comment on leading comments', () => {
+			const comment = getCommentFromString( '// translators: Greeting\n__( \'Hello world\' );' );
+
+			expect( comment ).to.equal( 'Greeting' );
+		} );
+
+		it( 'should traverse up parents until it encounters comment', () => {
+			const comment = getCommentFromString( '// translators: Greeting\nconst string = __( \'Hello world\' );' );
+
+			expect( comment ).to.equal( 'Greeting' );
+		} );
+
+		it( 'should not consider comment if it does not end on same or previous line', () => {
+			const comment = getCommentFromString( '// translators: Greeting\n\n__( \'Hello world\' );' );
+
+			expect( comment ).to.be.undefined();
+		} );
+
+		it( 'should use multi-line comment starting many lines previous', () => {
+			const comment = getCommentFromString( '/* translators: Long comment\nspanning multiple \nlines */\nconst string = __( \'Hello world\' );' );
+
+			expect( comment ).to.equal( 'Long comment spanning multiple lines' );
 		} );
 	} );
 } );

--- a/i18n/test/babel-plugin.js
+++ b/i18n/test/babel-plugin.js
@@ -67,6 +67,12 @@ describe( 'babel-plugin', () => {
 			expect( comment ).to.equal( 'Greeting' );
 		} );
 
+		it( 'should be case insensitive to translator prefix', () => {
+			const comment = getCommentFromString( '// TrANslAtORs: Greeting\n__( \'Hello world\' );' );
+
+			expect( comment ).to.equal( 'Greeting' );
+		} );
+
 		it( 'should traverse up parents until it encounters comment', () => {
 			const comment = getCommentFromString( '// translators: Greeting\nconst string = __( \'Hello world\' );' );
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-plugin-transform-react-jsx": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
+    "babel-traverse": "^6.24.1",
     "chai": "^3.5.0",
     "concurrently": "^3.4.0",
     "cross-env": "^3.2.4",


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/984#discussion_r120464365

This pull request seeks to improve translation string extraction to traverse through parent paths in the AST to find any leading comment which occurs on the same or previous line.

__Testing instructions:__

Ensure tests pass:

```
npm test
```

Run `npm run gettext-strings` and check that strings observed at https://github.com/WordPress/gutenberg/pull/984#discussion_r120464365 are included in `languages/gutenberg.pot` output.

cc @njpanderson 