### PR TITLE
Allow console.error in registration, but not any other console logging

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
 
 /**
  * Block settings keyed by block slug.


### PR DESCRIPTION
Allows us to catch debug console.logs without having to hint every usage of console.error