### PR TITLE
Categories: call these widgets instead of REST API blocks.

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -16,7 +16,7 @@ const categories = [
 	{ slug: 'formatting', title: __( 'Formatting' ) },
 	{ slug: 'embed', title: __( 'Embed' ) },
 	{ slug: 'layout', title: __( 'Layout Blocks' ) },
-	{ slug: 'rest-api', title: __( 'REST API Blocks' ) },
+	{ slug: 'widgets', title: __( 'Widgets' ) },
 ];
 
 /**

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -15,7 +15,7 @@ registerBlockType( 'core/latestposts', {
 
 	icon: 'list-view',
 
-	category: 'rest-api',
+	category: 'widgets',
 
 	defaultAttributes: {
 		poststoshow: 5,


### PR DESCRIPTION
Not sure if we'll stick with this naming, but it's better than REST API blocks.

![image](https://user-images.githubusercontent.com/548849/26922695-203a8eba-4c40-11e7-8960-d4b5d9122c82.png)
