### PR TITLE
Fix a few full width issues

### DIFF
--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -58,7 +58,7 @@ $text-editor-max-width: 760px;
 
 /* Editor */
 $text-editor-max-width: 760px;
-$visual-editor-max-width: 700px;
+$visual-editor-max-width: 636px;	// previously 700
 $block-controls-height: 38px;
 $icon-button-size: 36px;
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -241,7 +241,9 @@ $sticky-bottom-offset: 20px;
 
 .editor-visual-editor .editor-visual-editor__insertion-point {
 	position: relative;
-	margin-right: #{ ( $block-padding + $block-mover-margin) * 2 };
+	width: $visual-editor-max-width - $block-padding - $block-padding;
+	margin-left: auto;
+	margin-right: auto;
 
 	&:before {
 		position: absolute;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -110,9 +110,16 @@
 			}
 		}
 
+		// sidebar (sticky) and post settings
+		.sticky-menu .editor-layout & {
+			@include editor-width( $admin-sidebar-width + $visual-editor-max-width + $sidebar-width - $block-padding ) {
+				margin-left: $float-margin;
+			}
+		}
+
 		// sidebar and post settings
 		.auto-fold .is-sidebar-opened & {
-			@include editor-width( $admin-sidebar-width + $visual-editor-max-width + $sidebar-width  ) {
+			@include editor-width( $admin-sidebar-width + $visual-editor-max-width + $sidebar-width ) {
 				margin-left: $float-margin;
 			}
 		}
@@ -138,9 +145,16 @@
 			}
 		}
 
+		// sidebar (sticky) and post settings
+		.sticky-menu .editor-layout & {
+			@include editor-width( $admin-sidebar-width + $visual-editor-max-width + $sidebar-width - $block-padding ) {
+				margin-right: $float-margin;
+			}
+		}
+
 		// sidebar and post settings
 		.auto-fold .is-sidebar-opened & {
-			@include editor-width( $admin-sidebar-width + $visual-editor-max-width + $sidebar-width  ) {
+			@include editor-width( $admin-sidebar-width + $visual-editor-max-width + $sidebar-width ) {
 				margin-right: $float-margin;
 			}
 		}

--- a/editor/post-title/style.scss
+++ b/editor/post-title/style.scss
@@ -4,13 +4,12 @@
 	margin-right: auto;
 	max-width: $visual-editor-max-width;
 	position: relative;
-	padding-right: 2 * ( $block-mover-margin + $block-padding );
 	margin-bottom: 10px;
 
 	h1 {
 		border: 2px solid transparent;
 		margin: 0;
-		padding: 0;
+		padding: #{ $block-padding / 2 } #{ $block-padding - 2px };
 		font-size: $editor-font-size;
 		transition: 0.2s border-color;
 	}
@@ -46,7 +45,7 @@ textarea.editor-post-title__input {
 	border: none;
 	box-shadow: none;
 	width: 100%;
-	padding: 5px;
+	padding: 5px 0;
 	margin: 0;
 
 	&:focus {


### PR DESCRIPTION
This PR addresses a few issues in the new full width setup:

- An edgecase where floated images would be off, when you stickied the left menu
- The inserter indicator is now better sized
- Fixed padding issues that created a discrepancy between the post title and blocks in the editor
- The main column width is reduced, because other issues in the full width branch changed how this was calculated