### PR TITLE
Text Editor: Fix inserting blocks

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -36,16 +36,15 @@ export function insertBlock( block, after ) {
 	};
 }
 
-export function setInsertionPoint( uid ) {
+export function showInsertionPoint() {
 	return {
-		type: 'SET_INSERTION_POINT',
-		uid,
+		type: 'SHOW_INSERTION_POINT',
 	};
 }
 
-export function clearInsertionPoint() {
+export function hideInsertionPoint() {
 	return {
-		type: 'CLEAR_INSERTION_POINT',
+		type: 'HIDE_INSERTION_POINT',
 	};
 }
 

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -13,8 +13,8 @@ import { IconButton } from 'components';
  * Internal dependencies
  */
 import InserterMenu from './menu';
-import { getLastMultiSelectedBlockUid, getSelectedBlock } from '../selectors';
-import { insertBlock, clearInsertionPoint } from '../actions';
+import { getBlockInsertionPoint, getEditorMode } from '../selectors';
+import { insertBlock, hideInsertionPoint } from '../actions';
 
 class Inserter extends wp.element.Component {
 	constructor() {
@@ -41,14 +41,7 @@ class Inserter extends wp.element.Component {
 
 	insertBlock( slug ) {
 		if ( slug ) {
-			const { selectedBlock, lastMultiSelectedBlock, onInsertBlock } = this.props;
-			let insertionPoint = null;
-			if ( lastMultiSelectedBlock ) {
-				insertionPoint = lastMultiSelectedBlock;
-			} else if ( selectedBlock ) {
-				insertionPoint = selectedBlock.uid;
-			}
-
+			const { insertionPoint, onInsertBlock } = this.props;
 			onInsertBlock(
 				slug,
 				insertionPoint
@@ -96,13 +89,13 @@ class Inserter extends wp.element.Component {
 export default connect(
 	( state ) => {
 		return {
-			selectedBlock: getSelectedBlock( state ),
-			lastMultiSelectedBlock: getLastMultiSelectedBlockUid( state ),
+			insertionPoint: getBlockInsertionPoint( state ),
+			mode: getEditorMode( state ),
 		};
 	},
 	( dispatch ) => ( {
 		onInsertBlock( slug, after ) {
-			dispatch( clearInsertionPoint() );
+			dispatch( hideInsertionPoint() );
 			dispatch( insertBlock(
 				wp.blocks.createBlock( slug ),
 				after

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -15,8 +15,7 @@ import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
  * Internal dependencies
  */
 import './style.scss';
-import { getLastMultiSelectedBlockUid, getSelectedBlock } from '../selectors';
-import { setInsertionPoint, clearInsertionPoint } from '../actions';
+import { showInsertionPoint, hideInsertionPoint } from '../actions';
 
 class InserterMenu extends wp.element.Component {
 	constructor() {
@@ -65,23 +64,6 @@ class InserterMenu extends wp.element.Component {
 				currentFocus: null,
 			} );
 		};
-	}
-
-	hoverBlock() {
-		const { lastMultiSelectedBlock, selectedBlock } = this.props;
-		let insertionPoint = null;
-		if ( lastMultiSelectedBlock ) {
-			insertionPoint = lastMultiSelectedBlock;
-		} else if ( selectedBlock ) {
-			insertionPoint = selectedBlock.uid;
-		}
-		return () => {
-			this.props.setInsertionPoint( insertionPoint );
-		};
-	}
-
-	unhoverBlock() {
-		return () => this.props.clearInsertionPoint();
 	}
 
 	getVisibleBlocks( blockTypes ) {
@@ -275,8 +257,8 @@ class InserterMenu extends wp.element.Component {
 											onClick={ this.selectBlock( slug ) }
 											ref={ this.bindReferenceNode( slug ) }
 											tabIndex="-1"
-											onMouseEnter={ this.hoverBlock() }
-											onMouseLeave={ this.unhoverBlock() }
+											onMouseEnter={ this.props.showInsertionPoint }
+											onMouseLeave={ this.props.hideInsertionPoint }
 										>
 											<Dashicon icon={ icon } />
 											{ title }
@@ -308,11 +290,6 @@ class InserterMenu extends wp.element.Component {
 InserterMenu.instances = 0;
 
 export default connect(
-	( state ) => {
-		return {
-			selectedBlock: getSelectedBlock( state ),
-			lastMultiSelectedBlock: getLastMultiSelectedBlockUid( state ),
-		};
-	},
-	{ setInsertionPoint, clearInsertionPoint }
+	undefined,
+	{ showInsertionPoint, hideInsertionPoint }
 )( withFocusReturn( InserterMenu ) );

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -20,9 +20,11 @@ import { getBlocks } from '../../selectors';
 class TextEditor extends Component {
 	constructor( { blocks } ) {
 		super( ...arguments );
+		const value = serialize( blocks );
 		this.state = {
 			blocks,
-			value: serialize( blocks ),
+			persistedValue: value,
+			value,
 		};
 		this.onChange = this.onChange.bind( this );
 		this.onBlur = this.onBlur.bind( this );
@@ -36,6 +38,9 @@ class TextEditor extends Component {
 	}
 
 	onBlur() {
+		if ( this.state.value === this.state.persistedValue ) {
+			return;
+		}
 		const blocks = parse( this.state.value );
 		this.setState( {
 			blocks,
@@ -46,9 +51,11 @@ class TextEditor extends Component {
 
 	componentWillReceiveProps( newProps ) {
 		if ( newProps.blocks !== this.state.blocks ) {
+			const value = serialize( newProps.blocks );
 			this.setState( {
 				blocks: newProps.blocks,
-				value: serialize( newProps.blocks ),
+				persistedValue: value,
+				value,
 			} );
 		}
 	}

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -5,55 +5,106 @@ import { connect } from 'react-redux';
 import Textarea from 'react-autosize-textarea';
 
 /**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+import { serialize, parse } from 'blocks';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 import PostTitle from '../../post-title';
 import { getBlocks } from '../../selectors';
 
-function TextEditor( { blocks, onChange } ) {
-	return (
-		<div className="editor-text-editor">
-			<header className="editor-text-editor__formatting">
-				<div className="editor-text-editor__formatting-group">
-					<button className="editor-text-editor__bold">b</button>
-					<button className="editor-text-editor__italic">i</button>
-					<button className="editor-text-editor__link">link</button>
-					<button>b-quote</button>
-					<button className="editor-text-editor__del">del</button>
-					<button>ins</button>
-					<button>img</button>
-					<button>ul</button>
-					<button>ol</button>
-					<button>li</button>
-					<button>code</button>
-					<button>more</button>
-					<button>close tags</button>
+class TextEditor extends Component {
+	constructor( { blocks } ) {
+		super( ...arguments );
+		this.state = {
+			blocks,
+			value: serialize( blocks ),
+		};
+		this.onChange = this.onChange.bind( this );
+		this.onBlur = this.onBlur.bind( this );
+	}
+
+	onChange( event ) {
+		this.setState( {
+			value: event.target.value,
+		} );
+		this.props.markDirty();
+	}
+
+	onBlur() {
+		const blocks = parse( this.state.value );
+		this.setState( {
+			blocks,
+		} );
+		this.props.onChange( blocks );
+		this.props.markDirty();
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.blocks !== this.state.blocks ) {
+			this.setState( {
+				blocks: newProps.blocks,
+				value: serialize( newProps.blocks ),
+			} );
+		}
+	}
+
+	render() {
+		const { value } = this.state;
+
+		return (
+			<div className="editor-text-editor">
+				<header className="editor-text-editor__formatting">
+					<div className="editor-text-editor__formatting-group">
+						<button className="editor-text-editor__bold">b</button>
+						<button className="editor-text-editor__italic">i</button>
+						<button className="editor-text-editor__link">link</button>
+						<button>b-quote</button>
+						<button className="editor-text-editor__del">del</button>
+						<button>ins</button>
+						<button>img</button>
+						<button>ul</button>
+						<button>ol</button>
+						<button>li</button>
+						<button>code</button>
+						<button>more</button>
+						<button>close tags</button>
+					</div>
+				</header>
+				<div className="editor-text-editor__body">
+					<PostTitle />
+					<Textarea
+						autoComplete="off"
+						value={ value }
+						onChange={ this.onChange }
+						onBlur={ this.onBlur }
+						className="editor-text-editor__textarea"
+					/>
 				</div>
-			</header>
-			<div className="editor-text-editor__body">
-				<PostTitle />
-				<Textarea
-					autoComplete="off"
-					defaultValue={ wp.blocks.serialize( blocks ) }
-					onBlur={ ( event ) => onChange( event.target.value ) }
-					className="editor-text-editor__textarea"
-				/>
 			</div>
-		</div>
-	);
+		);
+	}
 }
 
 export default connect(
 	( state ) => ( {
 		blocks: getBlocks( state ),
 	} ),
-	( dispatch ) => ( {
-		onChange( value ) {
-			dispatch( {
+	{
+		onChange( blocks ) {
+			return {
 				type: 'RESET_BLOCKS',
-				blocks: wp.blocks.parse( value ),
-			} );
+				blocks,
+			};
 		},
-	} )
+		markDirty() {
+			return {
+				type: 'MARK_DIRTY',
+			};
+		},
+	}
 )( TextEditor );

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -15,6 +15,7 @@ import VisualEditorBlock from './block';
 import {
 	getBlockUids,
 	getBlockInsertionPoint,
+	isBlockInsertionPointVisible,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
 	getMultiSelectedBlocks,
@@ -97,9 +98,9 @@ class VisualEditorBlockList extends wp.element.Component {
 	}
 
 	render() {
-		const { blocks, insertionPoint, multiSelectedBlockUids } = this.props;
+		const { blocks, showInsertionPoint, insertionPoint, multiSelectedBlockUids } = this.props;
 		const insertionPointIndex = blocks.indexOf( insertionPoint );
-		const blocksWithInsertionPoint = insertionPoint
+		const blocksWithInsertionPoint = showInsertionPoint
 			? [
 				...blocks.slice( 0, insertionPointIndex + 1 ),
 				INSERTION_POINT_PLACEHOLDER,
@@ -139,6 +140,7 @@ export default connect(
 	( state ) => ( {
 		blocks: getBlockUids( state ),
 		insertionPoint: getBlockInsertionPoint( state ),
+		showInsertionPoint: isBlockInsertionPointVisible( state ),
 		selectionStart: getMultiSelectedBlocksStartUid( state ),
 		selectionEnd: getMultiSelectedBlocksEndUid( state ),
 		multiSelectedBlocks: getMultiSelectedBlocks( state ),

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -3,7 +3,7 @@
  */
 import moment from 'moment';
 import { first, last, get } from 'lodash';
-import { createSelector } from 'reselect';
+import createSelector from 'rememo';
 
 /**
  * Internal dependencies
@@ -242,15 +242,15 @@ export function getBlock( state, uid ) {
  * @return {Object[]}       Post blocks
  */
 export const getBlocks = createSelector(
-	[
-		state => state.editor.blockOrder,
-		state => state.editor.blocksByUid,
-	],
-	( blockOrder, blocksByUid ) => {
-		return blockOrder.map( ( uid ) => (
-			blocksByUid[ uid ]
+	( state ) => {
+		return state.editor.blockOrder.map( ( uid ) => (
+			state.editor.blocksByUid[ uid ]
 		) );
-	}
+	},
+	( state ) => [
+		state.editor.blockOrder,
+		state.editor.blocksByUid,
+	]
 );
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -3,6 +3,7 @@
  */
 import moment from 'moment';
 import { first, last, get } from 'lodash';
+import { createSelector } from 'reselect';
 
 /**
  * Internal dependencies
@@ -235,13 +236,22 @@ export function getBlock( state, uid ) {
 /**
  * Returns all block objects for the current post being edited as an array in
  * the order they appear in the post.
+ * Note: It's important to memoize this selector to avoid return a new instance on each call
  *
  * @param  {Object}   state Global application state
  * @return {Object[]}       Post blocks
  */
-export function getBlocks( state ) {
-	return state.editor.blockOrder.map( ( uid ) => getBlock( state, uid ) );
-}
+export const getBlocks = createSelector(
+	[
+		state => state.editor.blockOrder,
+		state => state.editor.blocksByUid,
+	],
+	( blockOrder, blocksByUid ) => {
+		return blockOrder.map( ( uid ) => (
+			blocksByUid[ uid ]
+		) );
+	}
+);
 
 /**
  * Returns the currently selected block, or null if there is no selected block.

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -243,9 +243,7 @@ export function getBlock( state, uid ) {
  */
 export const getBlocks = createSelector(
 	( state ) => {
-		return state.editor.blockOrder.map( ( uid ) => (
-			state.editor.blocksByUid[ uid ]
-		) );
+		return state.editor.blockOrder.map( ( uid ) => getBlock( state, uid ) );
 	},
 	( state ) => [
 		state.editor.blockOrder,
@@ -528,12 +526,31 @@ export function isTypingInBlock( state, uid ) {
  * @return {?String}       Unique ID after which insertion will occur
  */
 export function getBlockInsertionPoint( state ) {
-	if ( ! state.insertionPoint.show ) {
-		return null;
+	if ( getEditorMode( state ) !== 'visual' ) {
+		return last( state.editor.blockOrder );
 	}
-	const blockToInsertAfter = state.insertionPoint.uid;
 
-	return blockToInsertAfter || last( state.editor.blockOrder );
+	const lastMultiSelectedBlock = getLastMultiSelectedBlockUid( state );
+	if ( lastMultiSelectedBlock ) {
+		return lastMultiSelectedBlock;
+	}
+
+	const selectedBlock = getSelectedBlock( state );
+	if ( selectedBlock ) {
+		return selectedBlock.uid;
+	}
+
+	return last( state.editor.blockOrder );
+}
+
+/**
+ * Returns true if we should show the block insertion point
+ *
+ * @param  {Object}  state Global application state
+ * @return {?Boolean}      Whether the insertion point is visible or not
+ */
+export function isBlockInsertionPointVisible( state ) {
+	return state.showInsertionPoint;
 }
 
 /**

--- a/editor/state.js
+++ b/editor/state.js
@@ -379,17 +379,12 @@ export function hoveredBlock( state = null, action ) {
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function insertionPoint( state = { show: false }, action ) {
+export function showInsertionPoint( state = false, action ) {
 	switch ( action.type ) {
-		case 'SET_INSERTION_POINT':
-			return {
-				show: true,
-				uid: action.uid,
-			};
-		case 'CLEAR_INSERTION_POINT':
-			return {
-				show: false,
-			};
+		case 'SHOW_INSERTION_POINT':
+			return true;
+		case 'HIDE_INSERTION_POINT':
+			return false;
 	}
 
 	return state;
@@ -467,7 +462,7 @@ export function createReduxStore() {
 		selectedBlock,
 		multiSelectedBlocks,
 		hoveredBlock,
-		insertionPoint,
+		showInsertionPoint,
 		mode,
 		isSidebarOpened,
 		saving,

--- a/editor/state.js
+++ b/editor/state.js
@@ -70,6 +70,7 @@ export const editor = combineUndoableReducers( {
 			case 'REPLACE_BLOCKS':
 			case 'REMOVE_BLOCKS':
 			case 'EDIT_POST':
+			case 'MARK_DIRTY':
 				return true;
 		}
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -43,6 +43,7 @@ import {
 	getBlockFocus,
 	isTypingInBlock,
 	getBlockInsertionPoint,
+	isBlockInsertionPointVisible,
 	isSavingPost,
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
@@ -905,39 +906,78 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getBlockInsertionPoint', () => {
-		it( 'should return the uid of the insertion point', () => {
+		it( 'should return the uid of the selected block', () => {
 			const state = {
-				insertionPoint: {
-					show: true,
-					uid: 123,
+				mode: 'visual',
+				selectedBlock: {
+					uid: 2,
+					typing: true,
+				},
+				multiSelectedBlocks: {},
+				editor: {
+					blocksByUid: {
+						2: { uid: 2 },
+					},
+					blockOrder: [ 1, 2, 3 ],
 				},
 			};
 
-			expect( getBlockInsertionPoint( state ) ).to.equal( 123 );
+			expect( getBlockInsertionPoint( state ) ).to.equal( 2 );
 		} );
 
-		it( 'should return return the last block uid if the insertion point is null', () => {
+		it( 'should return the last multi selected uid', () => {
 			const state = {
-				insertionPoint: {
-					show: true,
-					uid: null,
+				mode: 'visual',
+				selectedBlock: {},
+				multiSelectedBlocks: {
+					start: 1,
+					end: 2,
 				},
 				editor: {
-					blockOrder: [ 34, 23 ],
+					blockOrder: [ 1, 2, 3 ],
 				},
 			};
 
-			expect( getBlockInsertionPoint( state ) ).to.equal( 23 );
+			expect( getBlockInsertionPoint( state ) ).to.equal( 2 );
 		} );
 
-		it( 'should return null if the insertion point is not shown', () => {
+		it( 'should return the last block if no selection', () => {
 			const state = {
-				insertionPoint: {
-					show: false,
+				mode: 'visual',
+				selectedBlock: {},
+				multiSelectedBlocks: {},
+				editor: {
+					blockOrder: [ 1, 2, 3 ],
 				},
 			};
 
-			expect( getBlockInsertionPoint( state, 23 ) ).to.be.null();
+			expect( getBlockInsertionPoint( state ) ).to.equal( 3 );
+		} );
+
+		it( 'should return the last block for the text mode', () => {
+			const state = {
+				mode: 'text',
+				selectedBlock: {
+					uid: 2,
+					typing: true,
+				},
+				multiSelectedBlocks: {},
+				editor: {
+					blockOrder: [ 1, 2, 3 ],
+				},
+			};
+
+			expect( getBlockInsertionPoint( state ) ).to.equal( 3 );
+		} );
+	} );
+
+	describe( 'isBlockInsertionPointVisible', () => {
+		it( 'should return the value in state', () => {
+			const state = {
+				showInsertionPoint: true,
+			};
+
+			expect( isBlockInsertionPointVisible( state ) ).to.be.true();
 		} );
 	} );
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -17,7 +17,7 @@ import {
 	mode,
 	isSidebarOpened,
 	saving,
-	insertionPoint,
+	showInsertionPoint,
 	createReduxStore,
 } from '../state';
 
@@ -652,27 +652,21 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'insertionPoint', () => {
-		it( 'should set the insertion point', () => {
-			const state = insertionPoint( {}, {
-				type: 'SET_INSERTION_POINT',
-				uid: 'kumquat',
+	describe( 'showInsertionPoint', () => {
+		it( 'should show the insertion point', () => {
+			const state = showInsertionPoint( undefined, {
+				type: 'SHOW_INSERTION_POINT',
 			} );
 
-			expect( state ).to.eql( {
-				show: true,
-				uid: 'kumquat',
-			} );
+			expect( state ).to.be.true();
 		} );
 
 		it( 'should clear the insertion point', () => {
-			const state = insertionPoint( {}, {
-				type: 'CLEAR_INSERTION_POINT',
+			const state = showInsertionPoint( {}, {
+				type: 'HIDE_INSERTION_POINT',
 			} );
 
-			expect( state ).to.eql( {
-				show: false,
-			} );
+			expect( state ).to.be.false();
 		} );
 	} );
 
@@ -987,7 +981,7 @@ describe( 'state', () => {
 				'mode',
 				'isSidebarOpened',
 				'saving',
-				'insertionPoint',
+				'showInsertionPoint',
 			] );
 		} );
 	} );

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-transition-group": "^1.1.3",
     "redux": "^3.6.0",
     "refx": "^2.0.0",
-    "reselect": "^3.0.1",
+    "rememo": "^1.1.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-transition-group": "^1.1.3",
     "redux": "^3.6.0",
     "refx": "^2.0.0",
+    "reselect": "^3.0.1",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
closes #1072 

This bug is way harder to solve than it seems because for performance reasons, we want to avoid calling parse/serialize as much as we can.

The solution here involves:

 - Making the text editor controlled 
 - Tracking blocks prop updates and serialize the new content each time the prop change
 - Make sure the `getBlocks` selector returns the same array instance if the state didn't change
 - Trigger a "MARK_DIRTY" action each time we change the text editor value (to enable the publish button) even if the blocks value is not dispatched to the store.