### PR TITLE
Prevent unhandled action from returning new state reference

### DIFF
--- a/editor/utils/test/undoable-reducer.js
+++ b/editor/utils/test/undoable-reducer.js
@@ -84,10 +84,11 @@ describe( 'undoableReducer', () => {
 	} );
 
 	describe( 'combineUndoableReducers()', () => {
+		const reducer = combineUndoableReducers( {
+			count: ( state = 0 ) => state,
+		} );
+
 		it( 'should return a combined reducer with getters', () => {
-			const reducer = combineUndoableReducers( {
-				count: ( state = 0 ) => state,
-			} );
 			const state = reducer( undefined, {} );
 
 			expect( typeof reducer ).toBe( 'function' );
@@ -99,6 +100,13 @@ describe( 'undoableReducer', () => {
 				},
 				future: [],
 			} );
+		} );
+
+		it( 'should return same reference if state has not changed', () => {
+			const original = reducer( undefined, {} );
+			const state = reducer( original, {} );
+
+			expect( state ).toBe( original );
 		} );
 	} );
 } );

--- a/editor/utils/undoable-reducer.js
+++ b/editor/utils/undoable-reducer.js
@@ -96,7 +96,7 @@ export function combineUndoableReducers( reducers, options ) {
 
 	return ( state = initialState, action ) => {
 		const nextState = reducer( state.history, action );
-		if ( nextState === state.history.present ) {
+		if ( nextState === state.history ) {
 			return state;
 		}
 


### PR DESCRIPTION
This pull request seeks to (a) resolve an issue where unhandled actions were inadvertently creating a new state reference and (b) introduce a new test to guard against such cases in the future. A Redux reducer should ideally never return a new reference if no changes have occurred, and especially if the action is never handled. It was found that `combineUndoableReducers` was testing the incorrect property when deciding whether to return the same state reference and therefore returned a new reference every time the reducer was invoked. This has been resolved here, and a test case added to protect against future regressions.

__Testing instructions:__

There should be no behavioral changes in the editor.

Ensure tests pass:

```
npm test
```

cc @youknowriad , this was cause of issues described at https://github.com/WordPress/gutenberg/pull/1077#discussion_r120903922 (state _did_ in-fact change, or at least the reference did).