### PR TITLE
Blocks: Merge parsed attributes on top of default attributes, instead of reverse

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -52,8 +52,8 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
 	attributes = attributes || {};
 	if ( blockType ) {
 		attributes = {
-			...attributes,
 			...blockType.defaultAttributes,
+			...attributes,
 			...parseBlockAttributes( rawContent, blockType ),
 		};
 	}

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -76,6 +76,7 @@ describe( 'block parser', () => {
 					};
 				},
 				defaultAttributes: {
+					content: '',
 					topic: 'none',
 				},
 			};

--- a/blocks/test/fixtures/core-latestposts.json
+++ b/blocks/test/fixtures/core-latestposts.json
@@ -3,7 +3,7 @@
         "uid": "_uid_0",
         "name": "core/latestposts",
         "attributes": {
-            "poststoshow": 5
+            "poststoshow": "5"
         }
     }
 ]


### PR DESCRIPTION
I was attempting to change the `postsToShow` in the Latest Posts block (#870) via manipulating the block's raw attributes (since there is no UI yet in the inspector), but each time I switched back to the Visual tab the number I entered would get reset to the default. It seems the order of `defaultAttributes` vs `attributes` is reversed in `getBlockAttributes`.