### PR TITLE
[WIP] Try: Use JSON to encode block attribute values

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -53,22 +53,15 @@ HTML_Attribute_List
 	}, {} ) }
 
 HTML_Attribute_Item
-  = HTML_Attribute_Quoted
-  / HTML_Attribute_Unquoted
+  = HTML_Attribute_JSON_Encoded
   / HTML_Attribute_Empty
 
 HTML_Attribute_Empty
   = name:HTML_Attribute_Name
   { return [ name, true ] }
 
-HTML_Attribute_Unquoted
-  = name:HTML_Attribute_Name _* "=" _* value:$([a-zA-Z0-9]+)
-  { return [ name, value ] }
-
-HTML_Attribute_Quoted
-  = name:HTML_Attribute_Name _* "=" _* '"' value:$((!'"' .)*) '"'
-  { return [ name, value ] }
-  / name:HTML_Attribute_Name _* "=" _* "'" value:$((!"'" .)*) "'"
+HTML_Attribute_JSON_Encoded
+  = name:HTML_Attribute_Name _* "=" _* value:JSON_text
   { return [ name, value ] }
 
 HTML_Attribute_Name
@@ -99,3 +92,155 @@ __
 
 Any
   = .
+
+// The following is copied from https://github.com/pegjs/pegjs/blob/624f87f66b18e29d93da8f5fcecac540cf214de8/examples/json.pegjs
+// JSON Grammar
+// ============
+//
+// Based on the grammar from RFC 7159 [1].
+//
+// Note that JSON is also specified in ECMA-262 [2], ECMA-404 [3], and on the
+// JSON website [4] (somewhat informally). The RFC seems the most authoritative
+// source, which is confirmed e.g. by [5].
+//
+// [1] http://tools.ietf.org/html/rfc7159
+// [2] http://www.ecma-international.org/publications/standards/Ecma-262.htm
+// [3] http://www.ecma-international.org/publications/standards/Ecma-404.htm
+// [4] http://json.org/
+// [5] https://www.tbray.org/ongoing/When/201x/2014/03/05/RFC7159-JSON
+
+// ----- 2. JSON Grammar -----
+
+JSON_text
+  = ws value:value ws { return value; }
+
+begin_array     = ws "[" ws
+begin_object    = ws "{" ws
+end_array       = ws "]" ws
+end_object      = ws "}" ws
+name_separator  = ws ":" ws
+value_separator = ws "," ws
+
+ws "whitespace" = [ \t\n\r]*
+
+// ----- 3. Values -----
+
+value
+  = false
+  / null
+  / true
+  / object
+  / array
+  / number
+  / string
+
+false = "false" { return false; }
+null  = "null"  { return null;  }
+true  = "true"  { return true;  }
+
+// ----- 4. Objects -----
+
+object
+  = begin_object
+    members:(
+      head:member
+      tail:(value_separator m:member { return m; })*
+      {
+        var result = {};
+
+        [head].concat(tail).forEach(function(element) {
+          result[element.name] = element.value;
+        });
+
+        return result;
+      }
+    )?
+    end_object
+    { return members !== null ? members: {}; }
+
+member
+  = name:string name_separator value:value {
+      return { name: name, value: value };
+    }
+
+// ----- 5. Arrays -----
+
+array
+  = begin_array
+    values:(
+      head:value
+      tail:(value_separator v:value { return v; })*
+      { return [head].concat(tail); }
+    )?
+    end_array
+    { return values !== null ? values : []; }
+
+// ----- 6. Numbers -----
+
+number "number"
+  = minus? int frac? exp? { return parseFloat(text()); }
+
+decimal_point
+  = "."
+
+digit1_9
+  = [1-9]
+
+e
+  = [eE]
+
+exp
+  = e (minus / plus)? DIGIT+
+
+frac
+  = decimal_point DIGIT+
+
+int
+  = zero / (digit1_9 DIGIT*)
+
+minus
+  = "-"
+
+plus
+  = "+"
+
+zero
+  = "0"
+
+// ----- 7. Strings -----
+
+string "string"
+  = quotation_mark chars:char* quotation_mark { return chars.join(""); }
+
+char
+  = unescaped
+  / escape
+    sequence:(
+        '"'
+      / "\\"
+      / "/"
+      / "b" { return "\b"; }
+      / "f" { return "\f"; }
+      / "n" { return "\n"; }
+      / "r" { return "\r"; }
+      / "t" { return "\t"; }
+      / "u" digits:$(HEXDIG HEXDIG HEXDIG HEXDIG) {
+          return String.fromCharCode(parseInt(digits, 16));
+        }
+    )
+    { return sequence; }
+
+escape
+  = "\\"
+
+quotation_mark
+  = '"'
+
+unescaped
+  = [^\0-\x1F\x22\x5C]
+
+// ----- Core ABNF Rules -----
+
+// See RFC 4234, Appendix B (http://tools.ietf.org/html/rfc4234).
+DIGIT  = [0-9]
+HEXDIG = [0-9a-f]i

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -59,7 +59,7 @@ export function getCommentAttributes( realAttributes, expectedAttributes ) {
 			return memo;
 		}
 
-		return memo + `${ key }="${ value }" `;
+		return memo + `${ key }=${ JSON.stringify( value ) } `;
 	}, '' );
 }
 

--- a/blocks/test/fixtures/core-latestposts.html
+++ b/blocks/test/fixtures/core-latestposts.html
@@ -1,2 +1,2 @@
-<!-- wp:core/latestposts poststoshow="5" --><!-- /wp:core/latestposts -->
+<!-- wp:core/latestposts poststoshow=5 --><!-- /wp:core/latestposts -->
 

--- a/blocks/test/fixtures/core-latestposts.serialized.html
+++ b/blocks/test/fixtures/core-latestposts.serialized.html
@@ -1,2 +1,2 @@
-<!-- wp:core/latestposts poststoshow="5" --><!-- /wp:core/latestposts -->
+<!-- wp:core/latestposts poststoshow=5 --><!-- /wp:core/latestposts -->
 


### PR DESCRIPTION
Depends on #1087, among many other things, including a PHP parser generator for the PEG.js grammar to be utilized in the `do_blocks` PHP function.

Fixes #1086.