### PR TITLE
Improve mobile inserter and post settings

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -7,6 +7,7 @@ $z-layers: (
 	'.editor-visual-editor__block {core/image aligned left or right}': 10,
 	'.editor-visual-editor__block-controls': 1,
 	'.components-form-toggle__input': 1,
+	'.editor-sidebar': 19,
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,

--- a/editor/header/mode-switcher/style.scss
+++ b/editor/header/mode-switcher/style.scss
@@ -33,6 +33,12 @@
 		z-index: z-index( '.editor-mode-switcher .dashicon' );
 		margin-left: -24px;
 		margin-top: -1px;
+
+		display: none;
+
+		@include break-small {
+			display: block;
+		}
 	}
 
 	&:hover,

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -41,7 +41,6 @@
 
 	left: 0;
 	right: 0;
-	//height: calc( 100vh - #{ $admin-bar-height-big + $header-height } );
 
 	// inserter becomes popup
 	@include break-medium {

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -1,6 +1,5 @@
 .editor-inserter {
 	display: inline-block;
-	position: relative;
 	background: none;
 	border: none;
 	padding: 0;
@@ -8,6 +7,10 @@
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 	z-index: z-index( '.editor-inserter' );
+
+	@include break-medium {
+		position: relative;
+	}
 }
 
 .editor-inserter__toggle {
@@ -31,12 +34,22 @@
 }
 
 .editor-inserter__menu {
-	width: 280px;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	position: absolute;
-	left: -122px;
 	background: $white;
+
+	left: 0;
+	right: 0;
+	//height: calc( 100vh - #{ $admin-bar-height-big + $header-height } );
+
+	// inserter becomes popup
+	@include break-medium {
+		width: 280px;
+		left: -122px;
+		right: auto;
+		height: auto;
+	}
 
 	&.is-top {
 		bottom: 42px;
@@ -66,7 +79,11 @@
 	}
 
 	&.is-bottom {
-		top: 42px;
+		top: $admin-bar-height-big + $item-spacing -1px;
+
+		@include break-medium {
+			top: $admin-bar-height + $item-spacing;
+		}
 
 		.editor-inserter__arrow {
 			top: -10px;
@@ -110,10 +127,22 @@
 	position: absolute;
 	width: 0;
 	z-index: z-index( '.editor-inserter__arrow' );
+
+	display: none;
+
+	@include break-medium {
+		display: block;
+	}
 }
 
 .editor-inserter__content {
-	max-height: 50vh;
+	height: calc( 100vh - #{ $admin-bar-height-big + $header-height + $icon-button-size } );
+
+	@include break-medium {
+		height: auto;
+		max-height: 50vh;
+	}
+
 	overflow: auto;
 	box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
 

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -33,7 +33,7 @@
 /* Visual and Text editor both */
 .editor-layout.is-sidebar-opened .editor-layout__content {
 	margin-left: -200%;
-    float: left;
+	float: left;
 	height: 0;
 
 	@include break-small() {

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -1,5 +1,6 @@
 .editor-sidebar {
 	position: fixed;
+	z-index: z-index( '.editor-sidebar' );
 	right: 0;
 	top: $admin-bar-height-big + $header-height;
 	bottom: 0;

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -1,5 +1,5 @@
 .editor-sidebar {
-	position: fixed;
+	position: sticky;
 	z-index: z-index( '.editor-sidebar' );
 	right: 0;
 	top: $admin-bar-height-big + $header-height;
@@ -7,6 +7,10 @@
 	width: $sidebar-width;
 	border-left: 1px solid $light-gray-500;
 	background: $light-gray-300;
+
+	@include break-small() {
+		position: fixed;
+	}
 
 	@include break-medium() {
 		top: $admin-bar-height + $header-height;
@@ -28,7 +32,27 @@
 
 /* Visual and Text editor both */
 .editor-layout.is-sidebar-opened .editor-layout__content {
-	margin-right: $sidebar-width;
+	margin-left: -200%;
+    float: left;
+	height: 0;
+
+	@include break-small() {
+		margin-left: auto;
+		float: none;
+		height: auto;
+	}
+
+	@include break-medium() {
+		margin-right: $sidebar-width;
+	}
+}
+
+.editor-layout.is-sidebar-opened {
+	overflow: hidden;
+
+	@include break-small() {
+		overflow: auto;
+	}
 }
 
 .editor-layout.is-sidebar-opened .editor-sidebar {


### PR DESCRIPTION
This PR does a number of things:

- It fixes an issue where floated images would overlap the modal sidebar on mobile
- It makes the inserter completely full size and modal on mobile, this fixes #859 
- It hides the little mode switcher dropdown on mobile. We'll need to do more work on this one regardless
- It let's you open the post settings sidebar on mobile, and not experience scroll bleed. Additionally the positioning is tuned, there was a gap before.

The only downside to this PR is that if you are on mobile, and are editing a long document, then open post settings, you lose your place (i.e. you are scrolled to the top). This is actually the same behavior that's on WordPress.com, and it's not really a regression from the current editor where you'd have to scroll to the bottom where the metaboxes live regardless. 

But depending on how we deal with the inspector on mobile, we might want to separately address this positioning issue using JS. Potentially we could do that as part of fixing #656. 
