### PR TITLE
Chrome: Clear Post edits on save success

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -32,13 +32,13 @@ export default {
 			toSend.id = postId;
 		}
 
-		dispatch( { type: 'CLEAR_POST_EDITS' } );
 		new wp.api.models.Post( toSend ).save().done( ( newPost ) => {
 			dispatch( {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				post: newPost,
 				isNew,
 			} );
+			dispatch( { type: 'CLEAR_POST_EDITS', edits } );
 		} ).fail( ( err ) => {
 			dispatch( {
 				type: 'REQUEST_POST_UPDATE_FAILURE',

--- a/editor/state.js
+++ b/editor/state.js
@@ -46,12 +46,20 @@ export const editor = combineUndoableReducers( {
 				}, state );
 
 			case 'CLEAR_POST_EDITS':
-				// Don't return a new object if there's not any edits
-				if ( ! Object.keys( state ).length ) {
+				// if we made other edits while saving, these new edits are kept in the store.
+				const keysToClear = reduce( action.edits, ( memo, value, key ) => {
+					if ( value === state[ key ] ) {
+						memo.push( key );
+					}
+					return memo;
+				}, [] );
+
+				// Don't return a new object if there are no keys to clear
+				if ( ! keysToClear.length ) {
 					return state;
 				}
 
-				return {};
+				return omit( state, keysToClear );
 		}
 
 		return state;

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -398,15 +398,21 @@ describe( 'state', () => {
 
 				const state = editor( original, {
 					type: 'CLEAR_POST_EDITS',
+					edits: {
+						status: 'draft',
+						title: 'post title',
+					},
 				} );
 
-				expect( state.edits ).to.eql( {} );
+				expect( state.edits ).to.eql( { tags: [ 1 ] } );
 			} );
 
 			it( 'should return same reference if clearing non-edited', () => {
 				const original = editor( undefined, {
 					type: 'EDIT_POST',
-					edits: {},
+					edits: {
+						status: 'draft',
+					},
 				} );
 
 				const state = editor( original, {


### PR DESCRIPTION
Currently, we're clearing post edits when we trigger the post save request, this has the drawback of reverting the post state for a small period of time (try switching to private, you'll notice a flickering in the visibility while saving).

This PR moves clearing post edits to the save success handler, but at the same time, if we made other edits while saving, these new edits are kept in the store.

Related https://github.com/WordPress/gutenberg/pull/945#discussion_r120607125