### PR TITLE
State: Optimistically update the saved post

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -50,8 +50,8 @@ export default {
 				optimist: { type: COMMIT, id: transactionId },
 			} );
 			dispatch( {
-				type: 'UPDATE_POST',
-				edits: newPost,
+				type: 'RESET_POST',
+				post: newPost,
 			} );
 		} ).fail( ( err ) => {
 			dispatch( {

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -46,6 +46,7 @@ export default {
 		new wp.api.models.Post( toSend ).save().done( ( newPost ) => {
 			dispatch( {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
+				post: newPost,
 				isNew,
 				optimist: { type: COMMIT, id: transactionId },
 			} );

--- a/editor/index.js
+++ b/editor/index.js
@@ -47,8 +47,11 @@ function preparePostState( store, post ) {
 	}
 
 	store.dispatch( {
-		type: 'RESET_BLOCKS',
+		type: 'RESET_POST',
 		post,
+	} );
+	store.dispatch( {
+		type: 'RESET_BLOCKS',
 		blocks: wp.blocks.parse( post.content.raw ),
 	} );
 

--- a/editor/state.js
+++ b/editor/state.js
@@ -228,8 +228,8 @@ export const editor = combineUndoableReducers( {
  */
 export function currentPost( state = {}, action ) {
 	switch ( action.type ) {
-		case 'RESET_BLOCKS':
-			return action.post || state;
+		case 'RESET_POST':
+			return action.post;
 
 		case 'UPDATE_POST':
 			return { ...state, ...action.edits };

--- a/editor/state.js
+++ b/editor/state.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import optimist from 'redux-optimist';
 import { combineReducers, applyMiddleware, createStore } from 'redux';
 import refx from 'refx';
 import { reduce, keyBy, first, last, omit, without, flowRight } from 'lodash';
@@ -230,8 +231,8 @@ export function currentPost( state = {}, action ) {
 		case 'RESET_BLOCKS':
 			return action.post || state;
 
-		case 'REQUEST_POST_UPDATE_SUCCESS':
-			return action.post;
+		case 'UPDATE_POST':
+			return { ...state, ...action.edits };
 	}
 
 	return state;
@@ -460,7 +461,7 @@ export function saving( state = {}, action ) {
  * @return {Redux.Store} Redux store
  */
 export function createReduxStore() {
-	const reducer = combineReducers( {
+	const reducer = optimist( combineReducers( {
 		editor,
 		currentPost,
 		selectedBlock,
@@ -470,7 +471,7 @@ export function createReduxStore() {
 		mode,
 		isSidebarOpened,
 		saving,
-	} );
+	} ) );
 
 	const enhancers = [ applyMiddleware( refx( effects ) ) ];
 	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -588,18 +588,19 @@ describe( 'state', () => {
 			expect( state ).to.equal( original );
 		} );
 
-		it( 'should remember a post object sent with REQUEST_POST_UPDATE_SUCCESS', () => {
-			const original = deepFreeze( { title: 'unmodified' } );
+		it( 'should update the post object with UPDATE_POST', () => {
+			const original = deepFreeze( { title: 'unmodified', status: 'publish' } );
 
 			const state = currentPost( original, {
-				type: 'REQUEST_POST_UPDATE_SUCCESS',
-				post: {
+				type: 'UPDATE_POST',
+				edits: {
 					title: 'updated post object from server',
 				},
 			} );
 
 			expect( state ).to.eql( {
 				title: 'updated post object from server',
+				status: 'publish',
 			} );
 		} );
 	} );
@@ -979,6 +980,7 @@ describe( 'state', () => {
 			const state = store.getState();
 
 			expect( Object.keys( state ) ).to.have.members( [
+				'optimist',
 				'editor',
 				'currentPost',
 				'selectedBlock',

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -562,11 +562,11 @@ describe( 'state', () => {
 	} );
 
 	describe( 'currentPost()', () => {
-		it( 'should remember a post object sent with RESET_BLOCKS', () => {
+		it( 'should reset a post object', () => {
 			const original = deepFreeze( { title: 'unmodified' } );
 
 			const state = currentPost( original, {
-				type: 'RESET_BLOCKS',
+				type: 'RESET_POST',
 				post: {
 					title: 'new post',
 				},
@@ -575,17 +575,6 @@ describe( 'state', () => {
 			expect( state ).to.eql( {
 				title: 'new post',
 			} );
-		} );
-
-		it( 'should ignore RESET_BLOCKS without a post object', () => {
-			const original = deepFreeze( { title: 'unmodified' } );
-
-			const state = currentPost( original, {
-				type: 'RESET_BLOCKS',
-				post: null,
-			} );
-
-			expect( state ).to.equal( original );
 		} );
 
 		it( 'should update the post object with UPDATE_POST', () => {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-slot-fill": "^1.0.0-alpha.11",
     "react-transition-group": "^1.1.3",
     "redux": "^3.6.0",
+    "redux-optimist": "0.0.2",
     "refx": "^2.0.0",
     "uuid": "^3.0.1"
   },


### PR DESCRIPTION
alternative to #1092 

Two things:

 - I'm using redux-optimist to optimistically save the current post when we trigger the request and revert in case of failure.

 - I'm adding a `UPDATE_POST` action to separate network actions from data actions (which could allow offline mode.)