### PR TITLE
Improve `core/latestposts` block PHP code

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -18,6 +18,7 @@ rm -f gutenberg.zip
 zip -r gutenberg.zip \
 	gutenberg.php \
 	lib/*.php \
+	lib/blocks/*.php \
 	post-content.js \
 	blocks/build \
 	components/build \

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -9,9 +9,11 @@
  * @package gutenberg
  */
 
-define( 'GUTENBERG__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-
+// Load API functions.
 require_once dirname( __FILE__ ) . '/lib/blocks.php';
 require_once dirname( __FILE__ ) . '/lib/client-assets.php';
 require_once dirname( __FILE__ ) . '/lib/i18n.php';
 require_once dirname( __FILE__ ) . '/lib/register.php';
+
+// Register server-side code for individual blocks.
+require_once dirname( __FILE__ ) . '/lib/blocks/latest-posts.php';

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -9,8 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-define( 'GUTENBERG__BLOCKS_LIBRARY_DIR', GUTENBERG__PLUGIN_DIR . 'blocks/library' );
-
 $wp_registered_blocks = array();
 
 /**
@@ -130,12 +128,3 @@ function do_blocks( $content ) {
 	return $new_content;
 }
 add_filter( 'the_content', 'do_blocks', 10 ); // BEFORE do_shortcode().
-
-/**
- * Loads the server-side rendering of blocks. If your block supports
- * server-side rendering, add it here.
- */
-function gutenberg_load_blocks_server_side_rendering() {
-	require_once GUTENBERG__BLOCKS_LIBRARY_DIR . '/latest-posts/index.php';
-}
-add_action( 'init', 'gutenberg_load_blocks_server_side_rendering' );

--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -12,7 +12,7 @@
  *
  * @return string Returns the post content with latest posts added.
  */
-function gutenberg_block_core_latest_posts( $attributes ) {
+function gutenberg_render_block_core_latest_posts( $attributes ) {
 	$posts_to_show = 5;
 
 	if ( array_key_exists( 'poststoshow', $attributes ) ) {
@@ -56,5 +56,5 @@ CONTENT;
 }
 
 register_block_type( 'core/latestposts', array(
-	'render' => 'gutenberg_block_core_latest_posts',
+	'render' => 'gutenberg_render_block_core_latest_posts',
 ) );


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/pull/870/files#r120894090 and https://github.com/WordPress/gutenberg/pull/870/files#r121213401:

- Removes unneeded PHP constants.
- Simplifies server-side block registration logic.  Currently there should be no need to defer this until `init`, at least in our main plugin.
- Moves the new PHP code for this block under the `lib/` directory so that it will be scanned by `phpcs` (also broken currently, another PR coming up for this).
- Adds the new PHP code to the plugin zip.  This fixes `npm run package-plugin` - currently it generates broken builds.

Placing PHP code inline with its block code in the `blocks/library` directory makes these last two steps in particular a good bit more difficult.  I think all PHP code should live under `lib/` and all JavaScript code should live elsewhere (under the already-defined Webpack entry points); given that we have to do path manipulation every time we mix the two, it doesn't seem like a good idea.