### PR TITLE
phpcs: scan `lib/` again and fix errors

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -277,7 +277,7 @@ function gutenberg_scripts_and_styles( $hook ) {
 		return;
 	}
 
-	$is_demo = isset( $page_match[ 2 ] );
+	$is_demo = isset( $page_match[2] );
 
 	/**
 	 * Scripts
@@ -314,14 +314,14 @@ function gutenberg_scripts_and_styles( $hook ) {
 			'wp-editor',
 			'window._wpGutenbergPost = ' . wp_json_encode( $post_to_edit ) . ';'
 		);
-	} else if ( $is_demo ) {
+	} elseif ( $is_demo ) {
 		// ...with some test content
 		wp_add_inline_script(
 			'wp-editor',
 			file_get_contents( gutenberg_dir_path() . 'post-content.js' )
 		);
 	} else {
-		// TODO: Error handling
+		// TODO: Error handling.
 	}
 
 	// Prepare Jed locale data.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,7 @@
 	<arg name="extensions" value="php"/>
 
 	<file>gutenberg.php</file>
+	<file>index.php</file>
 	<file>./lib</file>
 	<file>./phpunit</file>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,7 @@
 	<arg name="extensions" value="php"/>
 
 	<file>gutenberg.php</file>
+	<file>./lib</file>
 	<file>./phpunit</file>
 
 	<!-- The plugin entry point already has a file comment, I promise -->


### PR DESCRIPTION
Somehow `lib/*.php` (the majority of our PHP code) got excluded from `phpcs` scans.  This PR adds it back and fixes a couple of errors that had accumulated.