### PR TITLE
Panel header a11y: heading and buttons aria-labels

### DIFF
--- a/components/panel/header.js
+++ b/components/panel/header.js
@@ -1,7 +1,7 @@
 function PanelHeader( { label, children } ) {
 	return (
 		<div className="components-panel__header">
-			{ label && <strong>{ label }</strong> }
+			{ label && <h2>{ label }</h2> }
 			{ children }
 		</div>
 	);

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -34,6 +34,12 @@
 	border: 1px solid $light-gray-500;
 	margin-left: -1px;
 	margin-right: -1px;
+
+	h2 {
+		margin: 0;
+		font-size: inherit;
+		color: inherit;
+	}
 }
 
 .components-panel__body + .components-panel__body,

--- a/components/panel/test/header.js
+++ b/components/panel/test/header.js
@@ -20,9 +20,9 @@ describe( 'PanelHeader', () => {
 
 		it( 'should render a label matching the text provided in the prop', () => {
 			const panelHeader = shallow( <PanelHeader label="Some Text" /> );
-			const label = panelHeader.find( 'strong' ).shallow();
+			const label = panelHeader.find( 'h2' ).shallow();
 			expect( label.text() ).to.equal( 'Some Text' );
-			expect( label.type() ).to.equal( 'strong' );
+			expect( label.type() ).to.equal( 'h2' );
 		} );
 
 		it( 'should render child elements in the panel header body when provided', () => {

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -25,10 +25,14 @@ const PostSettings = ( { toggleSidebar } ) => {
 		<Panel>
 			<PanelHeader label={ __( 'Post Settings' ) } >
 				<div className="editor-sidebar-post-settings__icons">
-					<IconButton icon="admin-settings" />
+					<IconButton
+						icon="admin-settings"
+						label={ __( 'WordPress settings' ) }
+					/>
 					<IconButton
 						onClick={ toggleSidebar }
 						icon="no-alt"
+						label={ __( 'Close post settings sidebar' ) }
 					/>
 				</div>
 			</PanelHeader>


### PR DESCRIPTION
This PR tries to improve a bit the sidebars (panels) header accessibility:
- changes the header label `<strong>` element in a `<h2>`
- adds aria-labels to the buttons

I'm not sure if you prefer to use a CSS class to target and style the `h2`.
About the "admin settings" button, please refer to the note on the issue.

Fixes #1099 