### PR TITLE
Do not focus or blur editor of it is already focussed or blurred

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -302,14 +302,19 @@ export default class Editable extends wp.element.Component {
 
 	updateFocus() {
 		const { focus } = this.props;
+		const isActive = this.isActive();
+
 		if ( focus ) {
-			this.editor.focus();
+			if ( ! isActive ) {
+				this.editor.focus();
+			}
+
 			// Offset = -1 means we should focus the end of the editable
-			if ( focus.offset === -1 ) {
+			if ( focus.offset === -1 && ! this.isEndOfEditor() ) {
 				this.editor.selection.select( this.editor.getBody(), true );
 				this.editor.selection.collapse( false );
 			}
-		} else {
+		} else if ( isActive ) {
 			this.editor.getBody().blur();
 		}
 	}


### PR DESCRIPTION
I am seeing some strange things with selection inside an Editable.

* Select a piece of text, then click in the Editable. Expected: caret moves to selected position. Actual result: selection is kept (though quickly disappears, then comes back).
* Sometimes, pressing to pointer to select text, and moving it, the caret moves with the pointer instead of starting a selection. I can't reproduce this consistently, but certainly happens when you try a few times.

Both if these issues seem to be caused by us continuously focussing the editor even though it is already focussed. To fix this, we should only update the focus/selection when it is necessary.