### PR TITLE
Add aria-expanded and aria-label to the sidebar section toggles.

### DIFF
--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from 'element';
+import { __, sprintf } from 'i18n';
 
 /**
  * Internal dependencies
@@ -33,6 +34,8 @@ class PanelBody extends Component {
 						className="components-panel__body-toggle"
 						onClick={ this.toggle }
 						icon={ this.state.opened ? 'arrow-down' : 'arrow-right' }
+						aria-expanded={ this.state.opened }
+						label={ sprintf( __( 'Open section: %s' ), title ) }
 					>
 						{ title }
 					</IconButton>


### PR DESCRIPTION
This PR tries to improve the accessibility of the expandable section toggle buttons in the sidebar:
- adds an `aria-expanded` attribute
- adds an `aria-label`: `sprintf( __( 'Open section: %s' ), title )`

I'm intentionally avoiding to use the word "Toggle" because it's terribly difficult to translate in some languages, see core Trac ticket: https://core.trac.wordpress.org/ticket/34753

Also, one interesting consideration about the label: it's a bit controversial if the label text should be updated depending on the expanded/collapsed state. I've seen recommendations and examples for both ways. I think the best option depends on a case by case basis. In this specific case I'd say it makes perfectly sense to not change the label because `aria-expanded` already complements the label text; screen readers will announce the label + the state, for example:

`Open section: Featured image, collapsed`
`Open section: Featured image, expanded`
in this case, changing the label to 
`Close section: Featured image, expanded`
could be even confusing.

Screenshots:

![screen shot 2017-06-10 at 15 36 16](https://user-images.githubusercontent.com/1682452/27003278-e4d4b23c-4df3-11e7-971c-50a0d60cf1c6.png)

![screen shot 2017-06-10 at 15 36 23](https://user-images.githubusercontent.com/1682452/27003277-e4cf93c4-4df3-11e7-8b0e-8792e0a499e1.png)

Note: safari displays the icons a bit misaligned, that's unrelated and already addressed in a separate issue see #1103 

Fixes #1112 