### PR TITLE
Block pointer events and focus in embedded content

### DIFF
--- a/components/html-embed/index.js
+++ b/components/html-embed/index.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 // When embedding HTML from the WP oEmbed proxy, we need to insert it
 // into a div and make sure any scripts get run. This component takes
 // HTML and puts it into a div element, and creates and adds new script
@@ -27,7 +32,11 @@ export default class HtmlEmbed extends wp.element.Component {
 
 	render() {
 		return (
-			<div ref={ ( node ) => this.node = node } />
+			<div
+				className="html-embed"
+				tabIndex="-1"
+				ref={ ( node ) => this.node = node }
+			/>
 		);
 	}
 }

--- a/components/html-embed/style.scss
+++ b/components/html-embed/style.scss
@@ -1,0 +1,3 @@
+.html-embed {
+	pointer-events: none;
+}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -60,24 +60,6 @@
 		border: 2px solid $blue-medium-200;
 	}
 
-	.iframe-overlay {
-		position: relative;
-	}
-
-	.iframe-overlay:before {
-		content: '';
-		display: block;
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-	}
-
-	&.is-selected .iframe-overlay:before {
-		display: none;
-	}
-
 	// Alignments
 	&[data-align="left"],
 	&[data-align="right"] {


### PR DESCRIPTION
Fixes #1002. Props @westonruter.

Testing: make sure no embedded content can be tabbed into or clicked.