### PR TITLE
EmbedBlock: support all sets of widths.

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -72,11 +72,17 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 				isActive: ( { align } ) => 'wide' === align,
 				onClick: toggleAlignment( 'wide' ),
 			},
+			{
+				icon: 'align-full-width',
+				title: wp.i18n.__( 'Full width' ),
+				isActive: ( { align } ) => 'full' === align,
+				onClick: toggleAlignment( 'full' ),
+			},
 		],
 
 		getEditWrapperProps( attributes ) {
 			const { align } = attributes;
-			if ( 'left' === align || 'right' === align || 'wide' === align ) {
+			if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
 				return { 'data-align': align };
 			}
 		},


### PR DESCRIPTION
Supports `wide` and `full-width`.