### PR TITLE
Parser: Introduce <p>-as-text-block and soup block

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -18,12 +18,13 @@ Document
   = WP_Block_List
 
 WP_Block_List
-  = WP_Block*
+  = blocks:(WP_Block / Whitespace / WP_Block_Freeform)*
+  { return blocks.filter( function( block ) { return typeof block.blockName === 'string' } ) }
 
 WP_Block
   = WP_Block_Void
   / WP_Block_Balanced
-  / WP_Block_Html
+  / WP_Block_P_Text
 
 WP_Block_Void
   = "<!--" __ "wp:" blockName:WP_Block_Name attrs:HTML_Attribute_List _? "/-->"
@@ -33,22 +34,30 @@ WP_Block_Void
     rawContent: ''
   } }
 
+WP_Block_P_Text
+  = p:HTML_Tag_Balanced
+  & { return p.name === 'p' }
+  { return {
+    blockType: 'core/text',
+    attrs: p.attrs,
+    rawContent: p.rawContent
+  } }
+
 WP_Block_Balanced
-  = s:WP_Block_Start ts:(!WP_Block_End c:Any { return c })* e:WP_Block_End & { return s.blockName === e.blockName }
+  = s:WP_Block_Start ts:(!WP_Block_End c:. { return c })* e:WP_Block_End & { return s.blockName === e.blockName }
   { return {
     blockName: s.blockName,
     attrs: s.attrs,
     rawContent: ts.join( '' ),
   } }
 
-WP_Block_Html
-  = ts:(!WP_Block_Balanced c:Any { return c })+
-  {
-    return {
+WP_Block_Freeform
+  = ts:$((!WP_Block c:. { return c })+)
+  { return {
+      blockType: 'core/freeform',
       attrs: {},
-      rawContent: ts.join( '' )
-    }
-  }
+      rawContent: ts
+  } }
 
 WP_Block_Start
   = "<!--" __ "wp:" blockName:WP_Block_Name attrs:HTML_Attribute_List __ "-->"
@@ -65,6 +74,36 @@ WP_Block_End
 
 WP_Block_Name
   = $(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
+
+HTML_Tag_Balanced
+  = s:HTML_Tag_Open
+    rawContent:$((!(ct:HTML_Tag_Close & { return s.name === ct.name } ) c:. { return c })*)
+    e:HTML_Tag_Close
+  & { return s.name === e.name }
+  { return {
+    type: 'HTML_Tag',
+    name: s.name,
+    attrs: s.attrs,
+    rawContent
+  } }
+
+HTML_Tag_Open
+  = "<" name:HTML_Tag_Name attrs:HTML_Attribute_List _* ">"
+  { return {
+    type: 'HTML_Tag_Open',
+    name,
+    attrs
+  } }
+
+HTML_Tag_Close
+  = "</" name:HTML_Tag_Name _* ">"
+  { return {
+    type: 'HTML_Tag_Close',
+    name
+  } }
+  
+HTML_Tag_Name
+  = $(ASCII_Letter ASCII_AlphaNumeric*)
 
 HTML_Attribute_List
   = as:(_+ a:HTML_Attribute_Item { return a })*
@@ -109,11 +148,16 @@ Special_Chars
 Newline
   = [\r\n]
 
+/**
+ * Match JS `[\s]`
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+ */
+Whitespace
+  = [ \f\n\r\t\v\u00a0\u1680\u180e\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+
+
 _
   = [ \t]
 
 __
   = _+
-
-Any
-  = .

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -230,11 +230,11 @@ describe( 'block parser', () => {
 			setUnknownTypeHandler( 'core/unknown-block' );
 
 			const parsed = parse(
-				'<p>Cauliflower</p>' +
+				'<span>Cauliflower</span>' +
 				'<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
 				'\n<p>Broccoli</p>\n' +
 				'<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
-				'<p>Romanesco</p>'
+				'<div>Romanesco</div>'
 			);
 
 			expect( parsed ).to.have.lengthOf( 5 );
@@ -245,9 +245,9 @@ describe( 'block parser', () => {
 				'core/test-block',
 				'core/unknown-block',
 			] );
-			expect( parsed[ 0 ].attributes.content ).to.eql( '<p>Cauliflower</p>' );
-			expect( parsed[ 2 ].attributes.content ).to.eql( '<p>Broccoli</p>' );
-			expect( parsed[ 4 ].attributes.content ).to.eql( '<p>Romanesco</p>' );
+			expect( parsed[ 0 ].attributes.content ).to.eql( '<span>Cauliflower</span>' );
+			expect( parsed[ 2 ].attributes.content ).to.eql( 'Broccoli' );
+			expect( parsed[ 4 ].attributes.content ).to.eql( '<div>Romanesco</div>' );
 		} );
 
 		it( 'should parse blocks with empty content', () => {

--- a/post-content.js
+++ b/post-content.js
@@ -18,6 +18,15 @@ window._wpGutenbergPost = {
 
 			'<!-- wp:core/more /-->',
 
+			'<p class="fancy important">This is just a plain <em>old</em> block in a <pre><code>&lt;p&gt;</code></pre> tag.</p>',
+
+			'\nBlarg!\n',
+
+			'<ul>',
+			'	<li>One</li>',
+			'	<li>Two</li>',
+			'</ul>',
+
 			'<!-- wp:core/text -->',
 			'<p>Headings are separate blocks as well, which helps with the outline and organization of your content.</p>',
 			'<!-- /wp:core/text -->',


### PR DESCRIPTION
Basic text blocks don't need much indication of what they are. In this
patch we augment the parser to treat a top-level `<p>` tag as a text
block (if it has a matching closing `</p>`).

Further, anything that isn't one of these or a well-formed block is
going into a new freeform block.

Finally, to support this work I have allowed for the parser to ignore
interblock characters since they shouldn't indicate separate blocks.