### PR TITLE
Parser: Add "void" block signature

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -15,8 +15,17 @@ WP_Block_List
   = WP_Block*
 
 WP_Block
-  = WP_Block_Balanced
+  = WP_Block_Void
+  / WP_Block_Balanced
   / WP_Block_Html
+
+WP_Block_Void
+  = "<!--" __ "wp:" blockType:WP_Block_Type attrs:HTML_Attribute_List _? "/-->"
+  { return {
+    blockType: blockType,
+    attrs: attrs,
+    rawContent: ''
+  } }
 
 WP_Block_Balanced
   = s:WP_Block_Start ts:(!WP_Block_End c:Any { return c })* e:WP_Block_End & { return s.blockType === e.blockType }

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -82,17 +82,19 @@ export default function serialize( blocks ) {
 			indent_inner_html: true,
 			wrap_line_length: 0,
 		};
+		const blockAttributes = getCommentAttributes( block.attributes, parseBlockAttributes( saveContent, blockType ) );
+
+		if ( ! saveContent ) {
+			return memo + '<!-- wp:' + blockName + ' ' + blockAttributes + '/-->\n\n';
+		}
 
 		return memo + (
 			'<!-- wp:' +
 			blockName +
 			' ' +
-			getCommentAttributes(
-				block.attributes,
-				parseBlockAttributes( saveContent, blockType )
-			) +
+			blockAttributes +
 			'-->' +
-			( saveContent ? '\n' + beautifyHtml( saveContent, beautifyOptions ) + '\n' : '' ) +
+			'\n' + beautifyHtml( saveContent, beautifyOptions ) + '\n' +
 			'<!-- /wp:' +
 			blockName +
 			' -->'

--- a/blocks/test/fixtures/core-button-center.html
+++ b/blocks/test/fixtures/core-button-center.html
@@ -1,3 +1,3 @@
 <!-- wp:core/button align="center" -->
-<div class="aligncenter"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>
+<div class="aligncenter"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->

--- a/blocks/test/fixtures/core-freeform.json
+++ b/blocks/test/fixtures/core-freeform.json
@@ -4,13 +4,13 @@
         "name": "core/freeform",
         "attributes": {
             "content": [
-                "Testing freeform block with some",
+                "Testing freeform block with some\n",
                 {
                     "attributes": {
                         "className": "wp-some-class"
                     },
                     "children": [
-                        "HTML ",
+                        "\n\tHTML ",
                         {
                             "attributes": {
                                 "style": {
@@ -19,7 +19,8 @@
                             },
                             "children": "content",
                             "type": "span"
-                        }
+                        },
+                        "\n"
                     ],
                     "type": "div"
                 }

--- a/blocks/test/fixtures/core-freeform.serialized.html
+++ b/blocks/test/fixtures/core-freeform.serialized.html
@@ -1,5 +1,7 @@
 <!-- wp:core/freeform -->
 Testing freeform block with some
-<div class="wp-some-class">HTML <span style="color:red;">content</span></div>
+<div class="wp-some-class">
+    HTML <span style="color:red;">content</span>
+</div>
 <!-- /wp:core/freeform -->
 

--- a/blocks/test/fixtures/core-latestposts.html
+++ b/blocks/test/fixtures/core-latestposts.html
@@ -1,2 +1,2 @@
-<!-- wp:core/latestposts poststoshow="5" --><!-- /wp:core/latestposts -->
+<!-- wp:core/latestposts poststoshow="5" /-->
 

--- a/blocks/test/fixtures/core-latestposts.serialized.html
+++ b/blocks/test/fixtures/core-latestposts.serialized.html
@@ -1,2 +1,2 @@
-<!-- wp:core/latestposts poststoshow="5" --><!-- /wp:core/latestposts -->
+<!-- wp:core/latestposts poststoshow="5" /-->
 

--- a/blocks/test/fixtures/core-text-multi-paragraph.json
+++ b/blocks/test/fixtures/core-text-multi-paragraph.json
@@ -15,6 +15,7 @@
                         "—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you'll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting."
                     ]
                 },
+                "\n",
                 {
                     "type": "p",
                     "children": [

--- a/blocks/test/full-content.js
+++ b/blocks/test/full-content.js
@@ -10,10 +10,7 @@ import { format } from 'util';
 /**
  * Internal dependencies
  */
-import {
-	// parseWithGrammar,
-	parseWithTinyMCE,
-} from '../api/parser';
+import parse from '../api/parser';
 import serialize from '../api/serializer';
 import { getBlockTypes } from '../api/registration';
 
@@ -94,7 +91,7 @@ describe( 'full post content fixture', () => {
 		it( f, () => {
 			const content = readFixtureFile( f + '.html' );
 
-			const blocksActual = parseWithTinyMCE( content );
+			const blocksActual = parse( content );
 			const blocksActualNormalized = normalizeParsedBlocks( blocksActual );
 			let blocksExpectedString = readFixtureFile( f + '.json' );
 

--- a/post-content.js
+++ b/post-content.js
@@ -16,6 +16,8 @@ window._wpGutenbergPost = {
 			'<p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>',
 			'<!-- /wp:core/text -->',
 
+			'<!-- wp:core/more /-->',
+
 			'<!-- wp:core/text -->',
 			'<p>Headings are separate blocks as well, which helps with the outline and organization of your content.</p>',
 			'<!-- /wp:core/text -->',


### PR DESCRIPTION
Resolves #1085 

Sometimes a block doesn't need anything inside of the block comment tags
as children. One example of this is the traditional "more tag," which
only needs to indicate position.

These changes introduce a new syntax element, the "void block,"
borrowing from the HTML5 nomenclature for HTML void elements.

In this new element, there are no children.

Since nothing changes on the JavaScript size this could be considered an
optimization whereby any block with no children serializes to a
self-closing block comment tag, saving some space and improving
readability of the `post_content`.