### PR TITLE
GalleryBlock: place edit button in separate toolbar.

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -4,8 +4,13 @@
 import { __ } from 'i18n';
 import './style.scss';
 import { registerBlockType, query as hpq } from '../../api';
+import { Fill } from 'react-slot-fill';
 
-import Placeholder from 'components/placeholder';
+/**
+ * WordPress dependencies
+ */
+import { Toolbar, Placeholder } from 'components';
+
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
 
@@ -104,11 +109,6 @@ registerBlockType( 'core/gallery', {
 			isActive: ( { align } ) => 'full' === align,
 			onClick: toggleAlignment( 'full' ),
 		},
-		{
-			icon: 'format-image',
-			title: wp.i18n.__( 'Edit Gallery' ),
-			onClick: editMediaLibrary,
-		},
 	],
 
 	getEditWrapperProps( attributes ) {
@@ -144,6 +144,13 @@ registerBlockType( 'core/gallery', {
 
 		return (
 			<div className={ `blocks-gallery align${ align } columns-${ columns }` }>
+				<Fill name="Formatting.Toolbar">
+					<Toolbar controls={ [ {
+						icon: 'format-image',
+						title: __( 'Edit Gallery' ),
+						onClick: () => editMediaLibrary( attributes, setAttributes ),
+					} ] } />
+				</Fill>
 				{ images.map( ( img ) => (
 					<GalleryImage key={ img.url } img={ img } />
 				) ) }

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -146,7 +146,7 @@ registerBlockType( 'core/gallery', {
 			<div className={ `blocks-gallery align${ align } columns-${ columns }` }>
 				<Fill name="Formatting.Toolbar">
 					<Toolbar controls={ [ {
-						icon: 'format-image',
+						icon: 'edit',
 						title: __( 'Edit Gallery' ),
 						onClick: () => editMediaLibrary( attributes, setAttributes ),
 					} ] } />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/548849/27015076-3c85139c-4f06-11e7-88e2-309bec2f5cc8.png)

Fixes #1129.

@jasmussen do you want to add the proper icon?

