### PR TITLE
Blocks: Fix clicking on the block mover on hovered blocks

### DIFF
--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -1,7 +1,7 @@
 .editor-block-mover {
 	position: absolute;
 	top: 10px;
-	left: -$block-mover-padding-visible;
+	left: 0;
 	padding: 0 14px 20px 0; // handles hover area
 }
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -26,9 +26,10 @@
 .editor-visual-editor__block {
 	margin-left: auto;
 	margin-right: auto;
-	max-width: $visual-editor-max-width;
+	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
 	position: relative;
-	padding: $block-padding;
+	 // The block mover needs to stay inside the block to allow clicks when hovering the block
+	padding: $block-padding $block-padding + $block-mover-padding-visible;
 	transition: 0.2s border-color;
 
 	&:before {
@@ -37,8 +38,8 @@
 		position: absolute;
 		top: 0;
 		bottom: 0;
-		left: 0;
-		right: 0;
+		left: $block-mover-padding-visible;
+		right: $block-mover-padding-visible;
 		border: 2px solid transparent;
 		transition: 0.2s border-color;
 	}


### PR DESCRIPTION
closes #1090 

**Testing instructions**

 - Make sure clicking the block mover works on hovered blocks
 - Make sure the insertion point still works correctly
 - Make sure the wide alignment still works as expected