### PR TITLE
Serialize: Escape quotes in attributes values

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -59,6 +59,10 @@ export function getCommentAttributes( realAttributes, expectedAttributes ) {
 			return memo;
 		}
 
+		if ( 'string' === typeof value ) {
+			return memo + `${ key }="${ value.replace( '"', '\"' ) }" `;
+		}
+
 		return memo + `${ key }="${ value }" `;
 	}, '' );
 }

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -85,6 +85,12 @@ describe( 'block serializer', () => {
 
 			expect( attributes ).to.equal( 'category="food" ' );
 		} );
+
+		it( 'should properly escape attributes with quotes in them', () => {
+			expect( getCommentAttributes( {
+				name: 'Kevin "The Yellow Dart" Smith',
+			}, {} ) ).to.equal( 'name="Kevin \"The Yellow Dart\" Smith" ' );
+		} );
 	} );
 
 	describe( 'serialize()', () => {


### PR DESCRIPTION
Necessary for #1130 

In #1130 we surfaced an issue where Gutenberg would mangle the attribute values on save such that strings with double quotes (in the test case, a JSON string) would break on parse. This PR fixes the issue which caused that problem.

---

Previously the `getCommentAttributes()` function was storing attributes
by wrapping them in double-quotes. This was fine for most values, but
when storing a string containing a double quote it would produce a value
which fails to parse. `name="This "is" wrong"`

Now we detect if the attribute is a string and if so escape the quotes
to produce a valid parse on load. `name="This \"is\" right"`