### PR TITLE
Consolidate visibility handling to instance functions

### DIFF
--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -102,7 +102,7 @@ class PostVisibility extends Component {
 						</div>
 						{ visibilityOptions.map( ( { value, label, info, changeHandler, checked } ) => (
 							<label key={ value } className="editor-post-visibility__dialog-label">
-								<input type="radio" value={ value } onClick={ changeHandler } checked={ checked } />
+								<input type="radio" value={ value } onChange={ changeHandler } checked={ checked } />
 								{ label }
 								{ <div className="editor-post-visibility__dialog-info">{ info }</div> }
 							</label>

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -24,11 +24,16 @@ import { editPost, savePost } from '../../actions';
 class PostVisibility extends Component {
 	constructor( props ) {
 		super( ...arguments );
+
+		this.toggleDialog = this.toggleDialog.bind( this );
+		this.setPublic = this.setPublic.bind( this );
+		this.setPrivate = this.setPrivate.bind( this );
+		this.setPasswordProtected = this.setPasswordProtected.bind( this );
+
 		this.state = {
 			opened: false,
 			hasPassword: !! props.password,
 		};
-		this.toggleDialog = this.toggleDialog.bind( this );
 	}
 
 	toggleDialog( event ) {
@@ -36,28 +41,39 @@ class PostVisibility extends Component {
 		this.setState( { opened: ! this.state.opened } );
 	}
 
+	setPublic() {
+		const { visibility, onUpdateVisibility, status } = this.props;
+
+		onUpdateVisibility( visibility === 'private' ? 'draft' : status );
+		this.setState( { hasPassword: false } );
+	}
+
+	setPrivate() {
+		if ( ! window.confirm( __( 'Would you like to privately publish this post now?' ) ) ) { // eslint-disable-line no-alert
+			return;
+		}
+
+		const { onUpdateVisibility, onSave } = this.props;
+
+		onUpdateVisibility( 'private' );
+		onSave();
+		this.setState( { opened: false } );
+	}
+
+	setPasswordProtected() {
+		const { visibility, onUpdateVisibility, status, password } = this.props;
+
+		onUpdateVisibility( visibility === 'private' ? 'draft' : status, password || '' );
+		this.setState( { hasPassword: true } );
+	}
+
 	handleClickOutside() {
 		this.setState( { opened: false } );
 	}
 
 	render() {
-		const { status, visibility, password, onUpdateVisibility, onSave } = this.props;
+		const { status, visibility, password, onUpdateVisibility } = this.props;
 
-		const setPublic = () => {
-			onUpdateVisibility( visibility === 'private' ? 'draft' : status );
-			this.setState( { hasPassword: false } );
-		};
-		const setPrivate = () => {
-			if ( window.confirm( __( 'Would you like to privately publish this post now?' ) ) ) { // eslint-disable-line no-alert
-				onUpdateVisibility( 'private' );
-				onSave();
-				this.setState( { opened: false } );
-			}
-		};
-		const setPasswordProtected = () => {
-			onUpdateVisibility( visibility === 'private' ? 'draft' : status, password || '' );
-			this.setState( { hasPassword: true } );
-		};
 		const updatePassword = ( event ) => onUpdateVisibility( status, event.target.value );
 
 		const visibilityOptions = [
@@ -65,21 +81,21 @@ class PostVisibility extends Component {
 				value: 'public',
 				label: __( 'Public' ),
 				info: __( 'Visible to everyone.' ),
-				changeHandler: setPublic,
+				onSelect: this.setPublic,
 				checked: visibility === 'public' && ! this.state.hasPassword,
 			},
 			{
 				value: 'private',
 				label: __( 'Private' ),
 				info: __( 'Only visible to site admins and editors.' ),
-				changeHandler: setPrivate,
+				onSelect: this.setPrivate,
 				checked: visibility === 'private',
 			},
 			{
 				value: 'password',
 				label: __( 'Password Protected' ),
 				info: __( 'Protected with a password you choose. Only those with the password can view this post.' ),
-				changeHandler: setPasswordProtected,
+				onSelect: this.setPasswordProtected,
 				checked: this.state.hasPassword,
 			},
 		];
@@ -100,9 +116,13 @@ class PostVisibility extends Component {
 						<div className="editor-post-visibility__dialog-legend">
 							{ __( 'Post Visibility' ) }
 						</div>
-						{ visibilityOptions.map( ( { value, label, info, changeHandler, checked } ) => (
+						{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
 							<label key={ value } className="editor-post-visibility__dialog-label">
-								<input type="radio" value={ value } onChange={ changeHandler } checked={ checked } />
+								<input
+									type="radio"
+									value={ value }
+									onChange={ onSelect }
+									checked={ checked } />
 								{ label }
 								{ <div className="editor-post-visibility__dialog-info">{ info }</div> }
 							</label>


### PR DESCRIPTION
This pull request seeks to...

1. Resolve an error which occurs when toggling the visibility dialog because we bind change handling to `onClick` instead of `onChange`
2. Refactor to consolidate change handling to a single `setVisibility` component instance function

The benefit of the latter approach is that we avoid creating three functions on every render call and instead defer the handling to be determined at the time that the change occurs.

__Testing instructions:__

Verify that there are no regressions in toggling post visibility.