### PR TITLE
Render panel component icon as position absolute

### DIFF
--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -50,16 +50,18 @@
 }
 
 .components-panel__body-toggle.components-icon-button {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+	position: relative;
 	padding: 0;
+	padding-right: 20px;
 	outline: none;
 	width: 100%;
 	font-weight: 600;
 
 	.dashicon {
-		order: 2;
+		position: absolute;
+		right: 0;
+		top: 50%;
+		transform: translateY( -50% );
 	}
 }
 


### PR DESCRIPTION
Fixes #1103

This pull request seeks to resolve an alignment issue present in Safari browsers in which the `<Panel />` component's toggle button icon is misaligned due to a Flexbox bug affecting specific element types displayed as Flex containers:

https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers

With the changes included, the desired affect is achieved using absolute positioning. This also avoids the need to rearrange content via the `order` style. 

__Open questions:__

The tappable surface area of the toggle button is quite small (only the text's line height). It seems we may want to consider increasing this to encompass the entire collapsed area of the toggle.

__Testing instructions:__

Verify that button alignment appears correctly as in first screenshot of #1103 in Safari and your preferred browser.