### PR TITLE
Refactor serializer: rearrange code for clarity and introspection

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -78,9 +78,9 @@ HTML_Attribute_Unquoted
   { return keyValue( name, value ) }
 
 HTML_Attribute_Quoted
-  = name:HTML_Attribute_Name _* "=" _* '"' value:$(('\\"' . / !'"' .)*) '"'
+  = name:HTML_Attribute_Name _* "=" _* '"' value:$(("\\" '"' . / !'"' .)*) '"'
   { return keyValue( name, value ) }
-  / name:HTML_Attribute_Name _* "=" _* "'" value:$(("\\'" . / !"'" .)*) "'"
+  / name:HTML_Attribute_Name _* "=" _* "'" value:$(("\\" "'" . / !"'" .)*) "'"
   { return keyValue( name, value ) }
 
 HTML_Attribute_Name

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -45,7 +45,7 @@ WP_Block_Html
   }
 
 WP_Block_Start
-  = "<!--" __ "wp:" blockName:WP_Block_Name attrs:HTML_Attribute_List _? "-->"
+  = "<!--" __ "wp:" blockName:WP_Block_Name attrs:HTML_Attribute_List __ "-->"
   { return {
     blockName: blockName,
     attrs: attrs
@@ -78,9 +78,9 @@ HTML_Attribute_Unquoted
   { return keyValue( name, value ) }
 
 HTML_Attribute_Quoted
-  = name:HTML_Attribute_Name _* "=" _* '"' value:$(("\\" '"' . / !'"' .)*) '"'
+  = name:HTML_Attribute_Name _* "=" _* '"' value:$(('\\"' . / !'"' .)*) '"'
   { return keyValue( name, value ) }
-  / name:HTML_Attribute_Name _* "=" _* "'" value:$(("\\" "'" . / !"'" .)*) "'"
+  / name:HTML_Attribute_Name _* "=" _* "'" value:$(("\\'" . / !"'" .)*) "'"
   { return keyValue( name, value ) }
 
 HTML_Attribute_Name

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -1,8 +1,14 @@
 {
 
+function untransformValue( value ) {
+	return 'string' === typeof value
+		? value.replace( /\\-/g, '-' )
+		: value;
+}
+
 function keyValue( key, value ) {
   const o = {};
-  o[ key ] = value;
+  o[ key ] = untransformValue( value );
   return o;
 }
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -66,6 +66,7 @@ export function getCommentAttributes( allAttributes, attributesFromContent ) {
 			const allValue = allAttributes[ key ];
 			const contentValue = attributesFromContent[ key ];
 
+			// save only if attribute if not inferred from the content and if valued
 			return ! ( contentValue !== undefined || allValue === undefined )
 				? Object.assign( toSave, { [ key ]: escapeDoubleQuotes( allValue ) } )
 				: toSave;

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -84,27 +84,28 @@ export function getCommentAttributes( allAttributes, attributesFromContent ) {
 export default function serialize( blocks ) {
 	return blocks
 		.map( block => {
-		const blockName = block.name;
-		const blockType = getBlockType( blockName );
-		const saveContent = getSaveContent( blockType.save, block.attributes );
+			const blockName = block.name;
+			const blockType = getBlockType( blockName );
+			const saveContent = getSaveContent( blockType.save, block.attributes );
 			const saveAttributes = getCommentAttributes( block.attributes, parseBlockAttributes( saveContent, blockType ) );
-
-		const beautifyOptions = {
-			indent_inner_html: true,
-			wrap_line_length: 0,
-		};
 
 			const serializedAttributes = ! isEmpty( saveAttributes )
 				? map( saveAttributes, ( value, key ) => `${ key }="${ value }"` ).join( ' ' ) + ' '
 				: '';
 
-		if ( ! saveContent ) {
+			if ( ! saveContent ) {
 				return `<!-- wp:${ blockName } ${ serializedAttributes }--><!-- /wp:${ blockName } -->`;
-		}
+			}
 
 			return [
 				`<!-- wp:${ blockName } ${ serializedAttributes }-->`,
-				beautifyHtml( saveContent, beautifyOptions ),
+
+				/** make more readable - @see https://github.com/WordPress/gutenberg/pull/663 */
+				beautifyHtml( saveContent, {
+					indent_inner_html: true,
+					wrap_line_length: 0,
+				} ),
+
 				`<!-- /wp:${ blockName } -->`,
 			].join( '\n' );
 		} )

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -36,21 +36,9 @@ export function getSaveContent( save, attributes ) {
 	return wp.element.renderToString( rawContent );
 }
 
-// Reasons an attribute shouldn't be stored in the block header
-const canBeInferred = ( allValue, contentValue ) => undefined !== contentValue;
-const isUndefined = allValue => undefined === allValue;
-
-const isValidForHeader = ( allValue, contentValue ) => ! some( [
-	isUndefined,
-	canBeInferred,
-], f => f( allValue, contentValue ) );
-
-// Specific ways we need to transform attributes for storage in the block header
 const escapeDoubleQuotes = value => 'string' === typeof value
 	? value.replace( /"/g, '\"' )
 	: value;
-
-const transformAttributeValue = escapeDoubleQuotes;
 
 /**
  * Returns attributes which ought to be saved
@@ -75,8 +63,11 @@ export function getCommentAttributes( allAttributes, attributesFromContent ) {
 	return reduce(
 		Object.keys( allAttributes ),
 		( toSave, key ) => {
-			return isValidForHeader( allAttributes[ key ], attributesFromContent[ key ] )
-				? Object.assign( toSave, { [ key ]: transformAttributeValue( allAttributes[ key ] ) } )
+			const allValue = allAttributes[ key ];
+			const contentValue = attributesFromContent[ key ];
+
+			return ! ( contentValue !== undefined || allValue === undefined )
+				? Object.assign( toSave, { [ key ]: escapeDoubleQuotes( allValue ) } )
 				: toSave;
 		},
 		{},

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, map, reduce, some } from 'lodash';
+import { isEmpty, map, reduce } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -47,16 +47,14 @@ const escapeDoubleQuotes = value => 'string' === typeof value
  * When a block exists in memory it contains as its attributes
  * both those which come from the block comment header _and_
  * those which come from parsing the contents of the block.
- * Additionally they may live in a form fine for memory but
- * which isn't valid for serialization.
  *
- * This function returns a filtered set of attributes which are
- * the ones which need to be saved in order to ensure a full
- * serialization and they are in a form which is safe to store.
+ * This function returns only those attributes which are
+ * needed to persist and which cannot already be inferred
+ * from the block content.
  *
  * @param {Object<String,*>}   allAttributes         Attributes from in-memory block data
  * @param {Object<String,*>}   attributesFromContent Attributes which are inferred from block content
- * @returns {Object<String,*>} filtered set of attributes for minimum safe save/serialization
+ * @returns {Object<String,*>} filtered set of attributes for minimum save/serialization
  */
 export function getCommentAttributes( allAttributes, attributesFromContent ) {
 	// Iterate over attributes and produce the set to save
@@ -68,7 +66,7 @@ export function getCommentAttributes( allAttributes, attributesFromContent ) {
 
 			// save only if attribute if not inferred from the content and if valued
 			return ! ( contentValue !== undefined || allValue === undefined )
-				? Object.assign( toSave, { [ key ]: escapeDoubleQuotes( allValue ) } )
+				? Object.assign( toSave, { [ key ]: allValue } )
 				: toSave;
 		},
 		{},
@@ -84,7 +82,7 @@ export function getCommentAttributes( allAttributes, attributesFromContent ) {
  * @returns {string}       stringified equality pair
  */
 function asNameValuePair( value, key ) {
-	return `${ key }="${ value }`;
+	return `${ key }="${ escapeDoubleQuotes( value ) }"`;
 }
 
 export function serializeBlock( block ) {

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -37,7 +37,7 @@ export function getSaveContent( save, attributes ) {
 }
 
 const escapeDoubleQuotes = value => value.replace( /"/g, '\"' );
-const replaceHyphens = value => value.replace( /-/g, '\\-' );
+const escapeHyphens = value => value.replace( /-/g, '\\-' );
 
 /**
  * Transform value for storage in block comment
@@ -51,7 +51,7 @@ const replaceHyphens = value => value.replace( /-/g, '\\-' );
  */
 export const serializeValue = value =>
 	'string' === typeof value
-		? replaceHyphens( escapeDoubleQuotes( value ) )
+		? escapeHyphens( escapeDoubleQuotes( value ) )
 		: value;
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -49,7 +49,7 @@ const replaceHyphens = value => value.replace( /-/g, '\\-' );
  * @param {*}   value attribute value to serialize
  * @returns {*}       transformed value
  */
-const serializeValue = value =>
+export const serializeValue = value =>
 	'string' === typeof value
 		? replaceHyphens( escapeDoubleQuotes( value ) )
 		: value;
@@ -110,7 +110,7 @@ export function serializeBlock( block ) {
 		: '';
 
 	if ( ! saveContent ) {
-		return `<!-- wp:${ blockName } ${ serializedAttributes }--><!-- /wp:${ blockName } -->`;
+		return `<!-- wp:${ blockName } ${ serializedAttributes }/-->`;
 	}
 
 	return (

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -36,9 +36,23 @@ export function getSaveContent( save, attributes ) {
 	return wp.element.renderToString( rawContent );
 }
 
-const escapeDoubleQuotes = value => 'string' === typeof value
-	? value.replace( /"/g, '\"' )
-	: value;
+const escapeDoubleQuotes = value => value.replace( /"/g, '\"' );
+const replaceHyphens = value => value.replace( /-/g, '\\-' );
+
+/**
+ * Transform value for storage in block comment
+ *
+ * Some special characters and sequences should not
+ * appear in a block comment header. This transformer
+ * will guarantee that we store the data safely.
+ *
+ * @param {*}   value attribute value to serialize
+ * @returns {*}       transformed value
+ */
+const serializeValue = value =>
+	'string' === typeof value
+		? replaceHyphens( escapeDoubleQuotes( value ) )
+		: value;
 
 /**
  * Returns attributes which ought to be saved
@@ -82,7 +96,7 @@ export function getCommentAttributes( allAttributes, attributesFromContent ) {
  * @returns {string}       stringified equality pair
  */
 function asNameValuePair( value, key ) {
-	return `${ key }="${ escapeDoubleQuotes( value ) }"`;
+	return `${ key }="${ serializeValue( value ) }"`;
 }
 
 export function serializeBlock( block ) {

--- a/blocks/test/fixtures/core-latestposts.html
+++ b/blocks/test/fixtures/core-latestposts.html
@@ -1,2 +1,1 @@
 <!-- wp:core/latestposts poststoshow="5" /-->
-

--- a/blocks/test/fixtures/core-latestposts.serialized.html
+++ b/blocks/test/fixtures/core-latestposts.serialized.html
@@ -1,2 +1,1 @@
 <!-- wp:core/latestposts poststoshow="5" /-->
-

--- a/blocks/test/fixtures/core-text-multi-paragraph.serialized.html
+++ b/blocks/test/fixtures/core-text-multi-paragraph.serialized.html
@@ -2,4 +2,3 @@
 <p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you&#x27;ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>
 <p>What you are reading now is a <strong>text block</strong>, the most basic block of all. A text block can have multiple paragraphs, if that&#x27;s how you prefer to write your posts. But you can also split it by hitting enter twice. Once blocks are split they get their own controls to be moved freely around the post...</p>
 <!-- /wp:core/text -->
-

--- a/blocks/test/full-content.js
+++ b/blocks/test/full-content.js
@@ -127,7 +127,7 @@ describe( 'full post content fixture', () => {
 				}
 			}
 
-			expect( serializedActual ).to.eql( serializedExpected );
+			expect( serializedActual.trim() ).to.eql( serializedExpected.trim() );
 		} );
 	} );
 

--- a/post-content.js
+++ b/post-content.js
@@ -7,7 +7,7 @@ window._wpGutenbergPost = {
 	},
 	content: {
 		raw: [
-			'<!-- wp:core/text data="{\\"projectName\\":\\"gutenberg\\",\\"isAwesome\\":true}"-->',
+			'<!-- wp:core/text data="{\\"projectName\\":\\"gutenberg\\",\\"isAwesome\\":true}" -->',
 			'<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you\'ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>',
 			'<p>What you are reading now is a <strong>text block</strong>, the most basic block of all. A text block can have multiple paragraphs, if that\'s how you prefer to write your posts. But you can also split it by hitting enter twice. Once blocks are split they get their own controls to be moved freely around the post...</p>',
 			'<!-- /wp:core/text -->',


### PR DESCRIPTION
@see #948 for background exploration

These changes are intended to make the flow of transformation from
in-memory block data to serialized `post_content` clearer. Additionally
they are intended to ease testing and create points for easy trapping
and transformation of the data through the pipeline.

As I'm working in the serializer file to make harmonious updates with the parser changes I'm finding it unclear what _is_ and what _should_ be going on in serialization. Hopefully this PR will serve as a base for future work.

It makes subjective calls on style; I know. Please let me know if you don't like it. <del>Performance shouldn't be an issue and if you think it will please respond with data backing that up.</del> <ins>Unlike in #948 I tried to give a reasonable 👁 to performance in this incarnation and I don't anticipate it being reasonably less-performant than the current implementation in production.</ins>

My plans are to continue to augment this (and update the tests) so that we can have more control over the serialization process. This additional control might give us more ability to automatically detect if posts have been altered out of Gutenberg and if so, if they have been altered in a deleterious manner.