### PR TITLE
Display block boundaries when cursor moves while typing

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -89,3 +89,17 @@ export function startTypingInBlock( uid ) {
 		uid,
 	};
 }
+
+/**
+ * Returns an action object used in signalling that the user has stopped typing
+ * within a block's editable field.
+ *
+ * @param  {String} uid Block UID
+ * @return {Object}     Action object
+ */
+export function stopTypingInBlock( uid ) {
+	return {
+		type: 'STOP_TYPING',
+		uid,
+	};
+}

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -75,3 +75,17 @@ export function mergeBlocks( blockA, blockB ) {
 		blocks: [ blockA, blockB ],
 	};
 }
+
+/**
+ * Returns an action object used in signalling that the user has begun to type
+ * within a block's editable field.
+ *
+ * @param  {String} uid Block UID
+ * @return {Object}     Action object
+ */
+export function startTypingInBlock( uid ) {
+	return {
+		type: 'START_TYPING',
+		uid,
+	};
+}

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -24,6 +24,7 @@ import {
 	mergeBlocks,
 	insertBlock,
 	clearSelectedBlock,
+	startTypingInBlock,
 } from '../../actions';
 import {
 	getPreviousBlock,
@@ -319,10 +320,7 @@ export default connect(
 			dispatch( clearSelectedBlock() );
 		},
 		onStartTyping() {
-			dispatch( {
-				type: 'START_TYPING',
-				uid: ownProps.uid,
-			} );
+			dispatch( startTypingInBlock( ownProps.uid ) );
 		},
 		onHover() {
 			dispatch( {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -52,6 +52,7 @@ class VisualEditorBlock extends wp.element.Component {
 		this.setAttributes = this.setAttributes.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
+		this.stopTyping = this.stopTyping.bind( this );
 		this.removeOrDeselect = this.removeOrDeselect.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.onFocus = this.onFocus.bind( this );
@@ -59,9 +60,10 @@ class VisualEditorBlock extends wp.element.Component {
 		this.previousOffset = null;
 	}
 
-	bindBlockNode( node ) {
-		this.node = node;
-		this.props.blockRef( node );
+	componentDidMount() {
+		if ( this.props.focus ) {
+			this.node.focus();
+		}
 	}
 
 	componentWillReceiveProps( newProps ) {
@@ -72,6 +74,45 @@ class VisualEditorBlock extends wp.element.Component {
 		) {
 			this.previousOffset = this.node.getBoundingClientRect().top;
 		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		// Preserve scroll prosition when block rearranged
+		if ( this.previousOffset ) {
+			window.scrollTo(
+				window.scrollX,
+				window.scrollY + this.node.getBoundingClientRect().top - this.previousOffset
+			);
+			this.previousOffset = null;
+		}
+
+		// Focus node when focus state is programmatically transferred.
+		if ( this.props.focus && ! prevProps.focus ) {
+			this.node.focus();
+		}
+
+		// Bind or unbind mousemove from page when user starts or stops typing
+		const { isTyping } = this.props;
+		if ( isTyping !== prevProps.isTyping ) {
+			if ( isTyping ) {
+				document.addEventListener( 'mousemove', this.stopTyping );
+			} else {
+				this.removeStopTypingListener();
+			}
+		}
+	}
+
+	componentWillUnmount() {
+		this.removeStopTypingListener();
+	}
+
+	removeStopTypingListener() {
+		document.removeEventListener( 'mousemove', this.stopTyping );
+	}
+
+	bindBlockNode( node ) {
+		this.node = node;
+		this.props.blockRef( node );
 	}
 
 	setAttributes( attributes ) {
@@ -85,17 +126,13 @@ class VisualEditorBlock extends wp.element.Component {
 	}
 
 	maybeHover() {
-		const { isHovered, isSelected, isTyping, isMultiSelected, onStopTyping, onHover } = this.props;
+		const { isHovered, isSelected, isMultiSelected, onHover } = this.props;
 
-		if ( isMultiSelected ) {
+		if ( isHovered || isSelected || isMultiSelected ) {
 			return;
 		}
 
-		if ( isSelected && isTyping ) {
-			onStopTyping();
-		} else if ( ! isSelected && ! isHovered ) {
-			onHover();
-		}
+		onHover();
 	}
 
 	maybeStartTyping() {
@@ -108,6 +145,10 @@ class VisualEditorBlock extends wp.element.Component {
 		if ( ! isTyping && isSelected ) {
 			onStartTyping();
 		}
+	}
+
+	stopTyping() {
+		this.props.onStopTyping();
 	}
 
 	removeOrDeselect( { keyCode, target } ) {
@@ -156,27 +197,6 @@ class VisualEditorBlock extends wp.element.Component {
 			onMerge( block, nextBlock );
 		} else {
 			onMerge( previousBlock, block );
-		}
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( this.previousOffset ) {
-			window.scrollTo(
-				window.scrollX,
-				window.scrollY + this.node.getBoundingClientRect().top - this.previousOffset
-			);
-			this.previousOffset = null;
-		}
-
-		// Focus node when focus state is programmatically transferred.
-		if ( this.props.focus && ! prevProps.focus ) {
-			this.node.focus();
-		}
-	}
-
-	componentDidMount() {
-		if ( this.props.focus ) {
-			this.node.focus();
 		}
 	}
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -25,6 +25,7 @@ import {
 	insertBlock,
 	clearSelectedBlock,
 	startTypingInBlock,
+	stopTypingInBlock,
 } from '../../actions';
 import {
 	getPreviousBlock,
@@ -84,13 +85,17 @@ class VisualEditorBlock extends wp.element.Component {
 	}
 
 	maybeHover() {
-		const { isHovered, isSelected, isMultiSelected, onHover } = this.props;
+		const { isHovered, isSelected, isTyping, isMultiSelected, onStopTyping, onHover } = this.props;
 
-		if ( isHovered || isSelected || isMultiSelected ) {
+		if ( isMultiSelected ) {
 			return;
 		}
 
-		onHover();
+		if ( isSelected && isTyping ) {
+			onStopTyping();
+		} else if ( ! isSelected && ! isHovered ) {
+			onHover();
+		}
 	}
 
 	maybeStartTyping() {
@@ -319,9 +324,15 @@ export default connect(
 		onDeselect() {
 			dispatch( clearSelectedBlock() );
 		},
+
 		onStartTyping() {
 			dispatch( startTypingInBlock( ownProps.uid ) );
 		},
+
+		onStopTyping() {
+			dispatch( stopTypingInBlock( ownProps.uid ) );
+		},
+
 		onHover() {
 			dispatch( {
 				type: 'TOGGLE_BLOCK_HOVERED',

--- a/editor/state.js
+++ b/editor/state.js
@@ -299,6 +299,16 @@ export function selectedBlock( state = {}, action ) {
 				typing: true,
 			};
 
+		case 'STOP_TYPING':
+			if ( action.uid !== state.uid ) {
+				return state;
+			}
+
+			return {
+				...state,
+				typing: false,
+			};
+
 		case 'REPLACE_BLOCKS':
 			if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.uid ) === -1 ) {
 				return state;

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -10,6 +10,7 @@ import {
 	focusBlock,
 	replaceBlocks,
 	startTypingInBlock,
+	stopTypingInBlock,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -45,6 +46,15 @@ describe( 'actions', () => {
 		it( 'should return the START_TYPING action', () => {
 			expect( startTypingInBlock( 'chicken' ) ).to.eql( {
 				type: 'START_TYPING',
+				uid: 'chicken',
+			} );
+		} );
+	} );
+
+	describe( 'stopTypingInBlock', () => {
+		it( 'should return the STOP_TYPING action', () => {
+			expect( stopTypingInBlock( 'chicken' ) ).to.eql( {
+				type: 'STOP_TYPING',
 				uid: 'chicken',
 			} );
 		} );

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -6,7 +6,11 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { focusBlock, replaceBlocks } from '../actions';
+import {
+	focusBlock,
+	replaceBlocks,
+	startTypingInBlock,
+} from '../actions';
 
 describe( 'actions', () => {
 	describe( 'focusBlock', () => {
@@ -33,6 +37,15 @@ describe( 'actions', () => {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks,
+			} );
+		} );
+	} );
+
+	describe( 'startTypingInBlock', () => {
+		it( 'should return the START_TYPING action', () => {
+			expect( startTypingInBlock( 'chicken' ) ).to.eql( {
+				type: 'START_TYPING',
+				uid: 'chicken',
 			} );
 		} );
 	} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -798,6 +798,29 @@ describe( 'state', () => {
 			expect( state ).to.eql( { uid: 'chicken', typing: true, focus: {} } );
 		} );
 
+		it( 'should do nothing if typing stopped not within selected block', () => {
+			const original = selectedBlock( undefined, {} );
+			const state = selectedBlock( original, {
+				type: 'STOP_TYPING',
+				uid: 'chicken',
+			} );
+
+			expect( state ).to.equal( original );
+		} );
+
+		it( 'should reset typing flag if typing stopped within selected block', () => {
+			const original = selectedBlock( undefined, {
+				type: 'START_TYPING',
+				uid: 'chicken',
+			} );
+			const state = selectedBlock( original, {
+				type: 'STOP_TYPING',
+				uid: 'chicken',
+			} );
+
+			expect( state ).to.eql( { uid: 'chicken', typing: false, focus: {} } );
+		} );
+
 		it( 'should set the typing flag and merge the existing state', () => {
 			const original = deepFreeze( { uid: 'ribs', typing: false, focus: { editable: 'citation' } } );
 			const state = selectedBlock( original, {


### PR DESCRIPTION
Closes #657 

This pull request seeks to redisplay block boundaries if the user is currently typing within a block and then moves their cursor within said block. This is the final remaining task noted in #657.

__Testing instruction:__

1. Navigate to Gutenberg Demo editor
2. Select a block using mouse
3. Begin typing
4. Note that boundaries fade
5. Move cursor
6. Note that block boundaries reappear