### PR TITLE
Editor: Open the sidebar by default on desktops

### DIFF
--- a/editor/state.js
+++ b/editor/state.js
@@ -12,6 +12,8 @@ import { reduce, keyBy, first, last, omit, without, flowRight } from 'lodash';
 import { combineUndoableReducers } from './utils/undoable-reducer';
 import effects from './effects';
 
+const isMobile = window.innerWidth < 782;
+
 /**
  * Undoable reducer returning the editor post state, including blocks parsed
  * from current HTML markup.
@@ -407,7 +409,7 @@ export function mode( state = 'visual', action ) {
 	return state;
 }
 
-export function isSidebarOpened( state = false, action ) {
+export function isSidebarOpened( state = ! isMobile, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_SIDEBAR':
 			return ! state;

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -893,10 +893,10 @@ describe( 'state', () => {
 	} );
 
 	describe( 'isSidebarOpened()', () => {
-		it( 'should be closed by default', () => {
+		it( 'should be opened by default', () => {
 			const state = isSidebarOpened( undefined, {} );
 
-			expect( state ).to.be.false();
+			expect( state ).to.be.true();
 		} );
 
 		it( 'should toggle the sidebar open flag', () => {


### PR DESCRIPTION
closes #1045 

Open the sidebar by default except for mobile.
We have different options to check if we're on a mobile or not, I'm using a simple one here: checking the width of the browser window. (And I'm not watching for changes), I think it's sufficient for this specific feature.