### PR TITLE
Framework: Set/Get default block slug

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -13,6 +13,8 @@ export {
 	unregisterBlockType,
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
+	setDefaultBlock,
+	getDefaultBlock,
 	getBlockType,
 	getBlockTypes,
 } from './registration';

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -15,6 +15,13 @@ const blocks = {};
 let unknownTypeHandler;
 
 /**
+ * Name of the default block.
+ *
+ * @type {?string}
+ */
+let defaultBlockName;
+
+/**
  * Registers a new block provided a unique name and an object defining its
  * behavior. Once registered, the block is made available as an option to any
  * editor interface where blocks are implemented.
@@ -84,6 +91,24 @@ export function setUnknownTypeHandler( name ) {
  */
 export function getUnknownTypeHandler() {
 	return unknownTypeHandler;
+}
+
+/**
+ * Assigns the default block name
+ *
+ * @param {string} name Block name
+ */
+export function setDefaultBlock( name ) {
+	defaultBlockName = name;
+}
+
+/**
+ * Retrieves the default block name
+ *
+ * @return {?string} Blog name
+ */
+export function getDefaultBlock() {
+	return defaultBlockName;
 }
 
 /**

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -14,6 +14,8 @@ import {
 	unregisterBlockType,
 	setUnknownTypeHandler,
 	getUnknownTypeHandler,
+	setDefaultBlock,
+	getDefaultBlock,
 	getBlockType,
 	getBlockTypes,
 } from '../registration';
@@ -29,6 +31,7 @@ describe( 'blocks', () => {
 			unregisterBlockType( block.name );
 		} );
 		setUnknownTypeHandler( undefined );
+		setDefaultBlock( undefined );
 		console.error.restore();
 	} );
 
@@ -105,6 +108,20 @@ describe( 'blocks', () => {
 	describe( 'getUnknownTypeHandler()', () => {
 		it( 'defaults to undefined', () => {
 			expect( getUnknownTypeHandler() ).to.be.undefined();
+		} );
+	} );
+
+	describe( 'setDefaultBlock()', () => {
+		it( 'assigns default block name', () => {
+			setDefaultBlock( 'core/test-block' );
+
+			expect( getDefaultBlock() ).to.equal( 'core/test-block' );
+		} );
+	} );
+
+	describe( 'getDefaultBlock()', () => {
+		it( 'defaults to undefined', () => {
+			expect( getDefaultBlock() ).to.be.undefined();
 		} );
 	} );
 

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -6,7 +6,7 @@ import { Children, cloneElement } from 'element';
 /**
  * Internal dependencies
  */
-import { registerBlockType, createBlock, query } from '../../api';
+import { registerBlockType, createBlock, query, setDefaultBlock } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import Editable from '../../editable';
@@ -78,3 +78,5 @@ registerBlockType( 'core/text', {
 		) );
 	},
 } );
+
+setDefaultBlock( 'core/text' );


### PR DESCRIPTION
closes #798 

In this PR, I'm adding two functions `setDefaultBlockSlug` and `getDefaultBlockSlug` in the same way we have `setUnknownTypeHandler`.

I'm hoping to use this default block as an automatic block appended to newly created blocks. #1082