### PR TITLE
Documentation: Gather all Gutenberg Documentation in Storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -14,6 +14,13 @@ import './style.scss';
 
 function loadStories() {
 	window.wp = { ...window.wp, element };
+	require( './stories/intro' );
+	require( './stories/contributing' );
+	require( './stories/coding-guidelines' );
+	require( '../i18n/story' );
+	require( '../element/story' );
+	require( '../blocks/story' );
+	require( '../editor/story' );
 	require( '../components/story' );
 	require( '../components/button/story' );
 	require( '../components/higher-order/story' );

--- a/.storybook/stories/coding-guidelines.js
+++ b/.storybook/stories/coding-guidelines.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import ReactMarkdown from 'react-markdown';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import readme from '../../docs/coding-guidelines.md';
+
+storiesOf( 'Gutenberg', module )
+	.addDecorator( withKnobs )
+	.add( 'Coding Guidelines', () => <ReactMarkdown source={ readme } /> );

--- a/.storybook/stories/contributing.js
+++ b/.storybook/stories/contributing.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import ReactMarkdown from 'react-markdown';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import readme from '../../CONTRIBUTING.md';
+
+storiesOf( 'Gutenberg', module )
+	.addDecorator( withKnobs )
+	.add( 'Contributing', () => <ReactMarkdown source={ readme } /> );

--- a/.storybook/stories/intro.js
+++ b/.storybook/stories/intro.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import ReactMarkdown from 'react-markdown';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import readme from '../../README.md';
+
+storiesOf( 'Gutenberg', module )
+	.addDecorator( withKnobs )
+	.add( 'Intro', () => <ReactMarkdown source={ readme } /> );

--- a/blocks/story/index.js
+++ b/blocks/story/index.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import ReactMarkdown from 'react-markdown';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import readme from '../README.md';
+
+storiesOf( 'Modules', module )
+	.addDecorator( withKnobs )
+	.add( 'Blocks', () => <ReactMarkdown source={ readme } /> );

--- a/editor/story/index.js
+++ b/editor/story/index.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import ReactMarkdown from 'react-markdown';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import readme from '../README.md';
+
+storiesOf( 'Modules', module )
+	.addDecorator( withKnobs )
+	.add( 'Editor', () => <ReactMarkdown source={ readme } /> );

--- a/element/story/index.js
+++ b/element/story/index.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import ReactMarkdown from 'react-markdown';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import readme from '../README.md';
+
+storiesOf( 'Modules', module )
+	.addDecorator( withKnobs )
+	.add( 'Element', () => <ReactMarkdown source={ readme } /> );

--- a/i18n/story/index.js
+++ b/i18n/story/index.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import ReactMarkdown from 'react-markdown';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import readme from '../README.md';
+
+storiesOf( 'Modules', module )
+	.addDecorator( withKnobs )
+	.add( 'i18n', () => <ReactMarkdown source={ readme } /> );


### PR DESCRIPTION
The idea of this PR is to provide a unique place to look for, for all Gutenberg's documentation enhancing discoverability. Instead of navigating the different folders looking for README's, this loads them into a clear navigable menu. I think this would facilitate contributing a lot.

<img width="1070" alt="screen shot 2017-06-13 at 11 53 41" src="https://user-images.githubusercontent.com/272444/27079309-04d660b6-502f-11e7-8ece-321d7ced5ce3.png">

**Drawbacks**

 - Relative README links are broken 
 - I wonder if we should keep the README's or replace them with Real Storybook documentation (At least, we may move them to a unique directory and drop relative links)