### PR TITLE
Allow navigation between blocks with arrow keys

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -198,32 +198,15 @@ export default class Editable extends Component {
 		const { keyCode } = event;
 		const moveUp = ( keyCode === UP || keyCode === LEFT ) && this.isStartOfEditor();
 		const moveDown = ( keyCode === DOWN || keyCode === RIGHT ) && this.isEndOfEditor();
-		const selectors = [
-			'*[contenteditable="true"]',
-			'*[tabindex]',
-			'textarea',
-			'input',
-		].join( ',' );
 
-		if ( moveUp || moveDown ) {
-			const rootNode = this.editor.getBody();
-			const focusableNodes = Array.from( document.querySelectorAll( selectors ) );
+		if ( moveUp && this.props.onFocusPrevious ) {
+			event.preventDefault();
+			this.props.onFocusPrevious();
+		}
 
-			if ( moveUp ) {
-				focusableNodes.reverse();
-			}
-
-			const targetNode = focusableNodes
-				.slice( focusableNodes.indexOf( rootNode ) )
-				.reduce( ( result, node ) => {
-					return result || ( node.contains( rootNode ) ? null : node );
-				}, null );
-
-			if ( targetNode ) {
-				targetNode.focus();
-				event.preventDefault();
-				event.stopImmediatePropagation();
-			}
+		if ( moveDown && this.props.onFocusPrevious ) {
+			event.preventDefault();
+			this.props.onFocusNext();
 		}
 
 		if (

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -12,7 +12,7 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { createElement, Component, renderToString } from 'element';
-import { BACKSPACE, DELETE, ENTER } from 'utils/keycodes';
+import { BACKSPACE, DELETE, ENTER, UP, DOWN, LEFT, RIGHT } from 'utils/keycodes';
 
 /**
  * Internal dependencies
@@ -195,10 +195,41 @@ export default class Editable extends Component {
 	}
 
 	onKeyDown( event ) {
+		const { keyCode } = event;
+		const moveUp = ( keyCode === UP || keyCode === LEFT ) && this.isStartOfEditor();
+		const moveDown = ( keyCode === DOWN || keyCode === RIGHT ) && this.isEndOfEditor();
+		const selectors = [
+			'*[contenteditable="true"]',
+			'*[tabindex]',
+			'textarea',
+			'input',
+		].join( ',' );
+
+		if ( moveUp || moveDown ) {
+			const rootNode = this.editor.getBody();
+			const focusableNodes = Array.from( document.querySelectorAll( selectors ) );
+
+			if ( moveUp ) {
+				focusableNodes.reverse();
+			}
+
+			const targetNode = focusableNodes
+				.slice( focusableNodes.indexOf( rootNode ) )
+				.reduce( ( result, node ) => {
+					return result || ( node.contains( rootNode ) ? null : node );
+				}, null );
+
+			if ( targetNode ) {
+				targetNode.focus();
+				event.preventDefault();
+				event.stopImmediatePropagation();
+			}
+		}
+
 		if (
 			this.props.onMerge && (
-				( event.keyCode === BACKSPACE && this.isStartOfEditor() ) ||
-				( event.keyCode === DELETE && this.isEndOfEditor() )
+				( keyCode === BACKSPACE && this.isStartOfEditor() ) ||
+				( keyCode === DELETE && this.isEndOfEditor() )
 			)
 		) {
 			const forward = event.keyCode === DELETE;

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -35,7 +35,7 @@ registerBlockType( 'core/button', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, onFocusPrevious, onFocusNext } ) {
 		const { text, url, title, align } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
@@ -52,6 +52,8 @@ registerBlockType( 'core/button', {
 					value={ text }
 					focus={ focus }
 					onFocus={ setFocus }
+					onFocusPrevious={ onFocusPrevious }
+					onFocusNext={ onFocusNext }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					inline
 					inlineToolbar

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -82,7 +82,10 @@ registerBlockType( 'core/heading', {
 		};
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlockAfter } ) {
+	edit( {
+		attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlockAfter,
+		onFocusPrevious, onFocusNext,
+	} ) {
 		const { content, nodeName = 'H2' } = attributes;
 
 		return [
@@ -106,6 +109,8 @@ registerBlockType( 'core/heading', {
 				value={ content }
 				focus={ focus }
 				onFocus={ setFocus }
+				onFocusPrevious={ onFocusPrevious }
+				onFocusNext={ onFocusNext }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
 				inline

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -195,7 +195,7 @@ registerBlockType( 'core/list', {
 		}
 
 		render() {
-			const { attributes, focus, setFocus } = this.props;
+			const { attributes, focus, setFocus, onFocusPrevious, onFocusNext } = this.props;
 			const { nodeName = 'OL', values = [] } = attributes;
 
 			return [
@@ -237,6 +237,8 @@ registerBlockType( 'core/list', {
 					value={ values }
 					focus={ focus }
 					onFocus={ setFocus }
+					onFocusPrevious={ onFocusPrevious }
+					onFocusNext={ onFocusNext }
 					className="blocks-list"
 				/>,
 			];

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -42,7 +42,7 @@ registerBlockType( 'core/preformatted', {
 		],
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, onFocusPrevious, onFocusNext } ) {
 		const { content } = attributes;
 
 		return (
@@ -56,6 +56,8 @@ registerBlockType( 'core/preformatted', {
 				} }
 				focus={ focus }
 				onFocus={ setFocus }
+				onFocusPrevious={ onFocusPrevious }
+				onFocusNext={ onFocusNext }
 			/>
 		);
 	},

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -34,7 +34,7 @@ registerBlockType( 'core/pullquote', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, onFocusPrevious, onFocusNext } ) {
 		const { value, citation, align } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
@@ -59,6 +59,8 @@ registerBlockType( 'core/pullquote', {
 					placeholder={ __( 'Write Quote…' ) }
 					focus={ focus && focus.editable === 'value' ? focus : null }
 					onFocus={ ( props ) => setFocus( { ...props, editable: 'value' } ) }
+					onFocusPrevious={ onFocusPrevious }
+					onFocusNext={ () => setFocus( { editable: 'citation' } ) }
 					className="blocks-pullquote__content"
 				/>
 				{ ( citation || !! focus ) && (
@@ -73,6 +75,8 @@ registerBlockType( 'core/pullquote', {
 						}
 						focus={ focus && focus.editable === 'citation' ? focus : null }
 						onFocus={ ( props ) => setFocus( { ...props, editable: 'citation' } ) }
+						onFocusPrevious={ () => setFocus( { editable: 'value' } ) }
+						onFocusNext={ onFocusNext }
 						inline
 					/>
 				) }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -81,7 +81,7 @@ registerBlockType( 'core/quote', {
 		],
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks } ) {
+	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, onFocusPrevious, onFocusNext } ) {
 		const { align, value, citation, style = 1 } = attributes;
 		const focusedEditable = focus ? focus.editable || 'value' : null;
 
@@ -118,6 +118,8 @@ registerBlockType( 'core/quote', {
 					}
 					focus={ focusedEditable === 'value' ? focus : null }
 					onFocus={ ( props ) => setFocus( { ...props, editable: 'value' } ) }
+					onFocusPrevious={ onFocusPrevious }
+					onFocusNext={ () => setFocus( { editable: 'citation' } ) }
 					onMerge={ mergeBlocks }
 					style={ { textAlign: align } }
 				/>
@@ -133,6 +135,8 @@ registerBlockType( 'core/quote', {
 						}
 						focus={ focusedEditable === 'citation' ? focus : null }
 						onFocus={ ( props ) => setFocus( { ...props, editable: 'citation' } ) }
+						onFocusPrevious={ () => setFocus( { editable: 'value' } ) }
+						onFocusNext={ onFocusNext }
 						inline
 					/>
 				) }

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -33,7 +33,10 @@ registerBlockType( 'core/text', {
 		};
 	},
 
-	edit( { attributes, setAttributes, insertBlockAfter, focus, setFocus, mergeBlocks } ) {
+	edit( {
+		attributes, setAttributes, insertBlockAfter, focus, setFocus, mergeBlocks,
+		onFocusPrevious, onFocusNext,
+	} ) {
 		const { align, content, dropCap } = attributes;
 		const toggleDropCap = () => setAttributes( { dropCap: ! dropCap } );
 		return [
@@ -71,6 +74,8 @@ registerBlockType( 'core/text', {
 				} }
 				focus={ focus }
 				onFocus={ setFocus }
+				onFocusPrevious={ onFocusPrevious }
+				onFocusNext={ onFocusNext }
 				onSplit={ ( before, after ) => {
 					setAttributes( { content: before } );
 					insertBlockAfter( createBlock( 'core/text', {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -11,7 +11,7 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
  * WordPress dependencies
  */
 import { Children, Component } from 'element';
-import { BACKSPACE, ESCAPE } from 'utils/keycodes';
+import { BACKSPACE, ESCAPE, UP, DOWN, LEFT, RIGHT } from 'utils/keycodes';
 import { getBlockType } from 'blocks';
 
 /**
@@ -157,6 +157,7 @@ class VisualEditorBlock extends Component {
 			uid,
 			multiSelectedBlockUids,
 			previousBlock,
+			nextBlock,
 			onRemove,
 			onFocus,
 			onDeselect,
@@ -177,6 +178,22 @@ class VisualEditorBlock extends Component {
 				event.preventDefault();
 				onRemove( multiSelectedBlockUids );
 			}
+		}
+
+		if (
+			( keyCode === UP || keyCode === LEFT ) &&
+			previousBlock && target === this.node
+		) {
+			event.preventDefault();
+			onFocus( previousBlock.uid );
+		}
+
+		if (
+			( keyCode === DOWN || keyCode === RIGHT ) &&
+			nextBlock && target === this.node
+		) {
+			event.preventDefault();
+			onFocus( nextBlock.uid );
 		}
 
 		// Deselect on escape.
@@ -215,7 +232,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	render() {
-		const { block, multiSelectedBlockUids } = this.props;
+		const { block, previousBlock, nextBlock, multiSelectedBlockUids } = this.props;
 		const blockType = getBlockType( block.name );
 		// The block as rendered in the editor is composed of general block UI
 		// (mover, toolbar, wrapper) and the display of the block content, which
@@ -296,6 +313,8 @@ class VisualEditorBlock extends Component {
 						setAttributes={ this.setAttributes }
 						insertBlockAfter={ onInsertAfter }
 						setFocus={ partial( onFocus, block.uid ) }
+						onFocusPrevious={ () => previousBlock && onFocus( previousBlock.uid ) }
+						onFocusNext={ () => nextBlock && onFocus( nextBlock.uid ) }
 						mergeBlocks={ this.mergeBlocks }
 						id={ block.uid }
 					/>


### PR DESCRIPTION
This PR adds arrow key navigation between blocks in a very basic way, just like tabs would work. I took the approach of looking at focusable nodes instead of passing props, so block implementors don't have to worry about this as well.