### PR TITLE
Resolve IE11 error caused by memoization library

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "redux": "^3.6.0",
     "redux-optimist": "0.0.2",
     "refx": "^2.0.0",
-    "rememo": "^1.1.0",
+    "rememo": "^1.1.1",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request seeks to bump the `rememo` dependency from `1.1.0` to `1.1.1`, which resolves an issue where attempting to load the editor in IE11 results in an error. The details of the error cause are outlined in the corresponding changelog entry for the dependency (specifically, assumption of a `Promise` global):

https://github.com/aduth/rememo/blob/master/CHANGELOG.md#v111-2017-06-13
https://github.com/aduth/rememo/commit/52e5407caa09988ba19b9338330fdbdd28bf97a0

Because this is a patch bump, it should be picked up automatically by new installs (behavior of `^` in npm dependencies). This change is merely to be explicit about the version we intend to target.

This is a minor change and I'm likely to merge later today assuming there's no objections.