### PR TITLE
Update freeform block to apply focus/blur fix

### DIFF
--- a/blocks/library/freeform/freeform-block.js
+++ b/blocks/library/freeform/freeform-block.js
@@ -92,6 +92,7 @@ export default class FreeformBlock extends wp.element.Component {
 		this.onSelectionChange = this.onSelectionChange.bind( this );
 		this.onChange = this.onChange.bind( this );
 		this.onFocus = this.onFocus.bind( this );
+		this.isEndOfEditor = this.isEndOfEditor.bind( this );
 		this.updateFocus = this.updateFocus.bind( this );
 		this.updateContent = this.updateContent.bind( this );
 		this.setContent = this.setContent.bind( this );
@@ -200,16 +201,39 @@ export default class FreeformBlock extends wp.element.Component {
 		}
 	}
 
+	isEndOfEditor() {
+		const range = this.editor.selection.getRng();
+		if ( range.endOffset !== range.endContainer.textContent.length || ! range.collapsed ) {
+			return false;
+		}
+		const start = range.endContainer;
+		const body = this.editor.getBody();
+		let element = start;
+		while ( element !== body ) {
+			const child = element;
+			element = element.parentNode;
+			if ( element.lastChild !== child ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	updateFocus() {
 		const { focus } = this.props;
+		const isActive = this.isActive();
+
 		if ( focus ) {
-			this.editor.focus();
+			if ( ! isActive ) {
+				this.editor.focus();
+			}
+
 			// Offset = -1 means we should focus the end of the editable
-			if ( focus.offset === -1 ) {
+			if ( focus.offset === -1 && ! this.isEndOfEditor() ) {
 				this.editor.selection.select( this.editor.getBody(), true );
 				this.editor.selection.collapse( false );
 			}
-		} else {
+		} else if ( isActive ) {
 			this.editor.getBody().blur();
 		}
 	}


### PR DESCRIPTION
The pull request applies a fix to the freeform block that was previously applied to editable in
43b85f3cb2ed0ddd17781f54202b0fca78e51d27

My understanding of the fix is that it prevents focus or blur being called when unneeded.