### PR TITLE
Editable: Fix empty editable

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -3,6 +3,10 @@
 }
 
 .blocks-editable__tinymce {
+	> p:empty {
+		min-height: $editor-font-size * $editor-line-height;
+	}
+
 	> p:first-child {
 		margin-top: 0;
 	}


### PR DESCRIPTION
closes #1053 

When clearing the content of the text editable, we were having an empty `p` as the content of the editable, and empty paragraphs without any text have a height equal to 0. this was preventing us from editing the content again.