### PR TITLE
Plugin: Enable publishing and saving in production

### DIFF
--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { __ } from 'i18n';
 import { Button } from 'components';
 
 /**
@@ -33,11 +34,11 @@ function PublishButton( {
 	const buttonEnabled = ! isSaving && isPublishable;
 	let buttonText;
 	if ( isPublished ) {
-		buttonText = wp.i18n.__( 'Update' );
+		buttonText = __( 'Update' );
 	} else if ( isBeingScheduled ) {
-		buttonText = wp.i18n.__( 'Schedule' );
+		buttonText = __( 'Schedule' );
 	} else {
-		buttonText = wp.i18n.__( 'Publish' );
+		buttonText = __( 'Publish' );
 	}
 	let publishStatus = 'publish';
 	if ( isBeingScheduled ) {
@@ -47,8 +48,13 @@ function PublishButton( {
 	}
 	const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
 	const onClick = () => {
-		onStatusChange( publishStatus );
-		onSave();
+		const doSave = isPublished ||
+			! process.env.NODE_ENV === 'production' ||
+			window.confirm( __( 'Keep in mind this is in Beta and may not display correctly on your theme' ) ); // eslint-disable-line no-alert
+		if ( doSave ) {
+			onStatusChange( publishStatus );
+			onSave();
+		}
 	};
 
 	return (

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -51,17 +51,12 @@ function PublishButton( {
 		onSave();
 	};
 
-	const buttonDisabledHint = process.env.NODE_ENV === 'production'
-		? wp.i18n.__( 'The Save button is disabled during early alpha releases.' )
-		: null;
-
 	return (
 		<Button
 			isPrimary
 			isLarge
 			onClick={ onClick }
-			disabled={ ! buttonEnabled || process.env.NODE_ENV === 'production' }
-			title={ buttonDisabledHint }
+			disabled={ ! buttonEnabled }
 			className={ className }
 		>
 			{ buttonText }

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -50,7 +50,7 @@ function PublishButton( {
 	const onClick = () => {
 		const doSave = isPublished ||
 			! process.env.NODE_ENV === 'production' ||
-			window.confirm( __( 'Keep in mind this is in Beta and may not display correctly on your theme' ) ); // eslint-disable-line no-alert
+			window.confirm( __( 'Keep in mind this plugin is a beta version and will not display correctly on your theme.' ) ); // eslint-disable-line no-alert
 		if ( doSave ) {
 			onStatusChange( publishStatus );
 			onSave();


### PR DESCRIPTION
closes #1036 

The new post link is live, we can now enable publishing and saving in production.