### PR TITLE
Move Latest Posts’ `componentWillUnmount` to the React component

### DIFF
--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -60,11 +60,11 @@ registerBlockType( 'core/latestposts', {
 				</div>
 			);
 		}
-	},
 
-	componentWillUnmount() {
-		if ( this.latestPostsRequest.state() === 'pending' ) {
-			this.latestPostsRequest.abort();
+		componentWillUnmount() {
+			if ( this.latestPostsRequest.state() === 'pending' ) {
+				this.latestPostsRequest.abort();
+			}
 		}
 	},
 


### PR DESCRIPTION
It was in the block object and it wasn’t run at all.