### PR TITLE
Support nested array of toolbar controls

### DIFF
--- a/blocks/README.md
+++ b/blocks/README.md
@@ -188,7 +188,8 @@ Alternatively, you can create your own toolbar controls by passing an array of `
 - `title: string` - A human-readable localized text to be shown as the tooltip label of the control's button
 - `subscript: ?string` - Optional text to be shown adjacent the button icon as subscript (for example, heading levels)
 - `isActive: ?boolean` - Whether the control should be considered active / selected. Defaults to `false`.
-- `leftDivider: ?boolean` - Whether a divider should be shown to the left of the control button. Defaults to `false`.
+
+To create divisions between sets of controls within the same `BlockControls` element, passing `controls` instead as a nested array (array of arrays of objects). A divider will be shown between each set of controls.
 
 ### `Editable`
 

--- a/blocks/library/freeform/freeform-block.js
+++ b/blocks/library/freeform/freeform-block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { nodeListToReact } from 'dom-react';
-import { isEqual, omitBy } from 'lodash';
+import { isEqual, flatten, omitBy } from 'lodash';
 import { Fill } from 'react-slot-fill';
 
 /**
@@ -32,37 +32,40 @@ const ALIGNMENT_CONTROLS = [
 ];
 
 const FREEFORM_CONTROLS = [
-	{
-		id: 'blockquote',
-		icon: 'editor-quote',
-		title: __( 'Quote' ),
-	},
-	{
-		id: 'bullist',
-		icon: 'editor-ul',
-		title: __( 'Convert to unordered' ),
-	},
-	{
-		id: 'numlist',
-		icon: 'editor-ol',
-		title: __( 'Convert to ordered' ),
-	},
-	{
-		leftDivider: true,
-		id: 'bold',
-		icon: 'editor-bold',
-		title: __( 'Bold' ),
-	},
-	{
-		id: 'italic',
-		icon: 'editor-italic',
-		title: __( 'Italic' ),
-	},
-	{
-		id: 'strikethrough',
-		icon: 'editor-strikethrough',
-		title: __( 'Strikethrough' ),
-	},
+	[
+		{
+			id: 'blockquote',
+			icon: 'editor-quote',
+			title: __( 'Quote' ),
+		},
+		{
+			id: 'bullist',
+			icon: 'editor-ul',
+			title: __( 'Convert to unordered' ),
+		},
+		{
+			id: 'numlist',
+			icon: 'editor-ol',
+			title: __( 'Convert to ordered' ),
+		},
+	],
+	[
+		{
+			id: 'bold',
+			icon: 'editor-bold',
+			title: __( 'Bold' ),
+		},
+		{
+			id: 'italic',
+			icon: 'editor-italic',
+			title: __( 'Italic' ),
+		},
+		{
+			id: 'strikethrough',
+			icon: 'editor-strikethrough',
+			title: __( 'Strikethrough' ),
+		},
+	],
 ];
 
 function createElement( type, props, ...children ) {
@@ -146,7 +149,7 @@ export default class FreeformBlock extends wp.element.Component {
 		this.handleFormatChange = formatselect.onselect;
 		this.forceUpdate();
 
-		[ ...ALIGNMENT_CONTROLS, ...FREEFORM_CONTROLS ].forEach( ( control ) => {
+		[ ...ALIGNMENT_CONTROLS, ...flatten( FREEFORM_CONTROLS ) ].forEach( ( control ) => {
 			if ( control.id ) {
 				const button = this.editor.buttons[ control.id ];
 				button.onPostRender.call( {
@@ -263,11 +266,17 @@ export default class FreeformBlock extends wp.element.Component {
 	}
 
 	mapControls( controls ) {
-		return controls.map( ( control ) => ( {
-			...control,
-			onClick: () => this.editor && this.editor.buttons[ control.id ].onclick(),
-			isActive: this.state.activeButtons[ control.id ],
-		} ) );
+		return controls.map( ( control ) => {
+			if ( Array.isArray( control ) ) {
+				return this.mapControls( control );
+			}
+
+			return {
+				...control,
+				onClick: () => this.editor && this.editor.buttons[ control.id ].onclick(),
+				isActive: this.state.activeButtons[ control.id ],
+			};
+		} );
 	}
 
 	componentWillUnmount() {

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -14,26 +14,35 @@ function Toolbar( { controls, focus } ) {
 		return null;
 	}
 
+	// Normalize controls to nested array of objects (sets of controls)
+	let controlSets = controls;
+	if ( ! Array.isArray( controlSets[ 0 ] ) ) {
+		controlSets = [ controlSets ];
+	}
+
 	return (
 		<ul className="components-toolbar">
-			{ controls.map( ( control, index ) => (
-				<IconButton
-					key={ index }
-					icon={ control.icon }
-					label={ control.title }
-					data-subscript={ control.subscript }
-					onClick={ ( event ) => {
-						event.stopPropagation();
-						control.onClick();
-					} }
-					className={ classNames( 'components-toolbar__control', {
-						'is-active': control.isActive,
-						'left-divider': control.leftDivider,
-					} ) }
-					aria-pressed={ control.isActive }
-					focus={ focus && ! index }
-				/>
-			) ) }
+			{ controlSets.reduce( ( result, controlSet, setIndex ) => [
+				...result,
+				...controlSet.map( ( control, controlIndex ) => (
+					<IconButton
+						key={ [ setIndex, controlIndex ].join() }
+						icon={ control.icon }
+						label={ control.title }
+						data-subscript={ control.subscript }
+						onClick={ ( event ) => {
+							event.stopPropagation();
+							control.onClick();
+						} }
+						className={ classNames( 'components-toolbar__control', {
+							'is-active': control.isActive,
+							'has-left-divider': setIndex > 0 && controlIndex === 0,
+						} ) }
+						aria-pressed={ control.isActive }
+						focus={ focus && setIndex === 0 && controlIndex === 0 }
+					/>
+				) ),
+			], [] ) }
 		</ul>
 	);
 }

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -65,13 +65,13 @@
 .components-toolbar__control.components-button + .components-toolbar__control.components-button {
 	margin-left: -3px;
 
-	&.left-divider {
+	&.has-left-divider {
 		margin-left: 6px;
 		position: relative;
 		overflow: visible;
 	}
 
-	&.left-divider:before {
+	&.has-left-divider:before {
 		display: inline-block;
 		content: '';
 		box-sizing: content-box;

--- a/components/toolbar/test/index.js
+++ b/components/toolbar/test/index.js
@@ -65,6 +65,24 @@ describe( 'Toolbar', () => {
 			} );
 		} );
 
+		it( 'should render a nested list of controls with separator between', () => {
+			const controls = [
+				[ {
+					icon: 'wordpress',
+					title: 'WordPress',
+				} ],
+				[ {
+					icon: 'wordpress',
+					title: 'WordPress',
+				} ],
+			];
+
+			const toolbar = shallow( <Toolbar controls={ controls } /> );
+			expect( toolbar.children() ).to.have.lengthOf( 2 );
+			expect( toolbar.childAt( 0 ).hasClass( 'has-left-divider' ) ).to.be.false();
+			expect( toolbar.childAt( 1 ).hasClass( 'has-left-divider' ) ).to.be.true();
+		} );
+
 		it( 'should call the clickHandler on click.', () => {
 			const clickHandler = spy();
 			const event = { stopPropagation: () => undefined };


### PR DESCRIPTION
Related: #1031

This pull request seeks to explore an alternative to assigning a `leftDivider` property on a control for displaying dividers, instead representing division between sets of controls by a nested array structure. With these changes, the `<Toolbar />` component now accepts `controls` as either an array of objects, or now also as an array of array of objects, where in the latter case each top-level array is considered a "set of controls" with dividers between sets.

__Testing instructions:__

Verify that unit tests pass:

```
npm test
```

Ensure that there are no regressions in the behavior of toolbar controls, both for non-nested controls (e.g. image) and also for nested controls (e.g. freeform block).