### PR TITLE
[WIP] Add alignment for latest posts block

### DIFF
--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -87,20 +87,23 @@ registerBlockType( 'core/latestposts', {
 
 			return (
 				<div>
-					{ 0 === latestPosts.length ?
-						<Placeholder
-							icon="update"
-							label={ __( 'Loading latest posts, please wait' ) }
-						>
-						</Placeholder>
-						:
-						<div className="blocks-latest-posts">
-							<ul>
-								{ latestPosts.map( ( post, i ) =>
-									<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>
-								) }
-							</ul>
-						</div>
+					{ 0 === latestPosts.length
+						? (
+							<Placeholder
+								icon="update"
+								label={ __( 'Loading latest posts, please wait' ) }
+							>
+							</Placeholder>
+						)
+						: (
+							<div className="blocks-latest-posts">
+								<ul>
+									{ latestPosts.map( ( post, i ) =>
+										<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>
+									) }
+								</ul>
+							</div>
+						)
 					}
 					{ focus &&
 						<InspectorControls>

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -104,7 +104,7 @@ registerBlockType( 'core/latestposts', {
 					{ /* focus && */
 						<InspectorControls>
 
-							<span>Alignment</span>
+							<h4>{ wp.i18n.__( 'Alignment' ) }</h4>
 							<div>
 								{ alignments.map( ( alignment, index ) => (
 									<IconButton

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -33,14 +33,13 @@ registerBlockType( 'core/latestposts', {
 	},
 
 	edit: class extends wp.element.Component {
-		constructor( { focus } ) {
+		constructor() {
 			super( ...arguments );
 
 			const { poststoshow } = this.props.attributes;
 
 			this.state = {
 				latestPosts: [],
-				focus,
 			};
 
 			this.latestPostsRequest = getLatestPosts( poststoshow );
@@ -50,7 +49,8 @@ registerBlockType( 'core/latestposts', {
 		}
 
 		render() {
-			const { latestPosts, focus } = this.state;
+			const { latestPosts } = this.state;
+			const { focus } = this.props;
 
 			const alignments = [
 				{
@@ -102,7 +102,7 @@ registerBlockType( 'core/latestposts', {
 							</ul>
 						</div>
 					}
-					{ /* focus && */
+					{ focus &&
 						<InspectorControls>
 
 							<h4>{ wp.i18n.__( 'Alignment' ) }</h4>

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -7,6 +7,7 @@ import { __ } from 'i18n';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import { registerBlockType } from '../../api';
 import { getLatestPosts } from './data.js';
 import InspectorControls from '../../inspector-controls';

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -99,7 +99,7 @@ registerBlockType( 'core/latestposts', {
 							<div className="blocks-latest-posts">
 								<ul>
 									{ latestPosts.map( ( post, i ) =>
-										<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>
+										<li key={ i } target="_blank"><a href={ post.link }>{ post.title.rendered }</a></li>
 									) }
 								</ul>
 							</div>

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -3,6 +3,7 @@
  */
 import { Placeholder } from 'components';
 import { __ } from 'i18n';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import { registerBlockType } from '../../api';
 import { getLatestPosts } from './data.js';
 import InspectorControls from '../../inspector-controls';
 import IconButton from '../../../components/icon-button';
-import classNames from 'classnames';
 
 registerBlockType( 'core/latestposts', {
 	title: __( 'Latest Posts' ),

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -111,7 +111,6 @@ registerBlockType( 'core/latestposts', {
 										key={ index }
 										icon={ alignment.icon }
 										label={ alignment.title }
-										data-subscript={ alignment.subscript }
 										onClick={ ( event ) => {
 											event.stopPropagation();
 											this.props.setAttributes( { align: alignment.value } );
@@ -119,7 +118,7 @@ registerBlockType( 'core/latestposts', {
 										className={ classNames( 'components-toolbar__control', {
 											'is-active': alignment.isActive( this.props.attributes ),
 										} ) }
-										aria-pressed={ alignment.isActive }
+										aria-pressed={ alignment.isActive( this.props.attributes ) }
 										focus={ focus && ! index }
 									/>
 								) ) }

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -1,0 +1,3 @@
+.blocks-latest-posts {
+	margin-left: 1em;
+}

--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -28,6 +28,11 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 		}
 	}
 
+	$align = 'center';
+	if ( isset( $attributes['align'] ) && in_array( $attributes['align'], array( 'left', 'right', 'wide', 'full' ), true ) ) {
+		$align = $attributes['align'];
+	}
+
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => $posts_to_show,
 		'post_status' => 'publish',
@@ -43,8 +48,10 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 		$posts_content .= "<li><a href='{$post_permalink}'>{$post_title}</a></li>\n";
 	}
 
+	$class = 'blocks-latest-posts ' . esc_attr( 'align' . $align );
+
 	$block_content = <<<CONTENT
-<div class="blocks-latest-posts">
+<div class="{$class}">
 	<ul>
 		{$posts_content}
 	</ul>


### PR DESCRIPTION
This is to implement part of #1011.

This is my very first hacking with blocks, so I'm sure I'm probably doing some things wrong. Advice appreciated.

The alignment buttons should get moved into a separate component that can be re-used across all widgets.

Also need to implement support for `align` in the server-side rendering.