### PR TITLE
Inserter: Autofocus the Search input

### DIFF
--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -92,8 +92,8 @@ class InserterMenu extends Component {
 	}
 
 	findByIncrement( blockTypes, increment = 1 ) {
-		// Add on a fake search block to the list to cycle through.
-		const list = blockTypes.concat( { name: 'search' } );
+		// Prepend a fake search block to the list to cycle through.
+		const list = [ { name: 'search' }, ...blockTypes ];
 
 		const currentIndex = findIndex( list, ( blockType ) => this.state.currentFocus === blockType.name );
 		const nextIndex = currentIndex + increment;

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { __ } from 'i18n';
 import { Component } from 'element';
 import { Dashicon, Popover, withFocusReturn, withInstanceId } from 'components';
-import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN, isAlphaKeyCode } from 'utils/keycodes';
+import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
 import { getCategories, getBlockTypes } from 'blocks';
 
 /**
@@ -165,12 +165,6 @@ class InserterMenu extends Component {
 	}
 
 	onKeyDown( keydown ) {
-		// Focus the search input if an alpha key was pressed
-		if ( isAlphaKeyCode( keydown.keyCode ) ) {
-			this.setSearchFocus();
-			return;
-		}
-
 		switch ( keydown.keyCode ) {
 			case TAB:
 				if ( keydown.shiftKey ) {

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -236,6 +236,19 @@ class InserterMenu extends Component {
 
 		return (
 			<Popover position={ position } className="editor-inserter__menu">
+				<label htmlFor={ `editor-inserter__search-${ instanceId }` } className="screen-reader-text">
+					{ __( 'Search blocks' ) }
+				</label>
+				<input
+					id={ `editor-inserter__search-${ instanceId }` }
+					type="search"
+					placeholder={ __( 'Search…' ) }
+					className="editor-inserter__search"
+					onChange={ this.filter }
+					onClick={ this.setSearchFocus }
+					ref={ this.bindReferenceNode( 'search' ) }
+					tabIndex="-1"
+				/>
 				<div role="menu" className="editor-inserter__content">
 					{ getCategories()
 						.map( ( category ) => !! visibleBlocksByCategory[ category.slug ] && (
@@ -273,19 +286,6 @@ class InserterMenu extends Component {
 						) )
 					}
 				</div>
-				<label htmlFor={ `editor-inserter__search-${ instanceId }` } className="screen-reader-text">
-					{ __( 'Search blocks' ) }
-				</label>
-				<input
-					id={ `editor-inserter__search-${ instanceId }` }
-					type="search"
-					placeholder={ __( 'Search…' ) }
-					className="editor-inserter__search"
-					onChange={ this.filter }
-					onClick={ this.setSearchFocus }
-					ref={ this.bindReferenceNode( 'search' ) }
-					tabIndex="-1"
-				/>
 			</Popover>
 		);
 	}

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -228,6 +228,7 @@ class InserterMenu extends Component {
 		const { position, instanceId } = this.props;
 		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( getBlockTypes() );
 
+		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<Popover position={ position } className="editor-inserter__menu">
 				<label htmlFor={ `editor-inserter__search-${ instanceId }` } className="screen-reader-text">
@@ -283,6 +284,7 @@ class InserterMenu extends Component {
 				</div>
 			</Popover>
 		);
+		/* eslint-enable jsx-a11y/no-autofocus */
 	}
 }
 

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { __ } from 'i18n';
 import { Component } from 'element';
 import { Dashicon, Popover, withFocusReturn, withInstanceId } from 'components';
-import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
+import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN, isAlphaKeyCode } from 'utils/keycodes';
 import { getCategories, getBlockTypes } from 'blocks';
 
 /**
@@ -165,6 +165,12 @@ class InserterMenu extends Component {
 	}
 
 	onKeyDown( keydown ) {
+		// Focus the search input if an alpha key was pressed
+		if ( isAlphaKeyCode( keydown.keyCode ) ) {
+			this.setSearchFocus();
+			return;
+		}
+
 		switch ( keydown.keyCode ) {
 			case TAB:
 				if ( keydown.shiftKey ) {

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -25,7 +25,7 @@ class InserterMenu extends Component {
 		this.nodes = {};
 		this.state = {
 			filterValue: '',
-			currentFocus: null,
+			currentFocus: 'search',
 		};
 		this.filter = this.filter.bind( this );
 		this.isShownBlock = this.isShownBlock.bind( this );

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -240,6 +240,7 @@ class InserterMenu extends Component {
 					{ __( 'Search blocks' ) }
 				</label>
 				<input
+					autoFocus
 					id={ `editor-inserter__search-${ instanceId }` }
 					type="search"
 					placeholder={ __( 'Search…' ) }

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -8,3 +8,8 @@ export const RIGHT = 39;
 export const DOWN = 40;
 export const DELETE = 46;
 export const CHAR_A = 'A'.charCodeAt( 0 );
+
+export function isAlphaKeyCode( keyCode ) {
+	return ( keyCode >= 65 && keyCode <= 90 );
+}
+

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -8,8 +8,3 @@ export const RIGHT = 39;
 export const DOWN = 40;
 export const DELETE = 46;
 export const CHAR_A = 'A'.charCodeAt( 0 );
-
-export function isAlphaKeyCode( keyCode ) {
-	return ( keyCode >= 65 && keyCode <= 90 );
-}
-


### PR DESCRIPTION
Makes the inserter menu autofocus on the input search. We can autofocus if the search input is on the top as the first focusable item. 

Related to #1064

#### Testing instructions

1. Run this branch
1. Click the "Insert" button
1. Expect the focus to be set on the search input.