### PR TITLE
Fix sticky scrollbar with sidebar open.

### DIFF
--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -47,14 +47,6 @@
 	}
 }
 
-.editor-layout.is-sidebar-opened {
-	overflow: hidden;
-
-	@include break-small() {
-		overflow: auto;
-	}
-}
-
 .editor-layout.is-sidebar-opened .editor-sidebar {
 	/* Sidebar covers screen on mobile */
 	width: 100%;


### PR DESCRIPTION
This fixes a regression I introduced when I mobile optimized the sidebar. Essentially I wanted to fix scroll bleed. But the introduction of overflow hidden broke the sticky toolbars.

I will revisit fixing scroll bleed in the mobile inserter, but for now this basically reverts it.

See https://github.com/WordPress/gutenberg/commit/6991910962d60afb48ff52d611850c0b17a637cd