### PR TITLE
Update PHP “parser” to recognize shorthand block syntax

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -102,7 +102,7 @@ function do_blocks( $content ) {
 	global $wp_registered_blocks;
 
 	// Extract the blocks from the post content.
-	$open_matcher = '/<!--\s*wp:([a-z](?:[a-z0-9\/]+)*)\s+((?:(?!-->).)*)-->.*?<!--\s*\/wp:\g1\s+-->/';
+	$open_matcher = '/<!--\s*wp:([a-z](?:[a-z0-9\/]+)*)\s+((?:(?!-->).)*)\s*\/?-->(?:.*?<!--\s*\/wp:\g1\s+-->)?/';
 	preg_match_all( $open_matcher, $content, $matches, PREG_OFFSET_CAPTURE );
 
 	$new_content = $content;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -114,7 +114,6 @@ function do_blocks( $content ) {
 		}
 
 		$block_markup = $block_match[0];
-		$block_position = $block_match[1];
 		$block_attributes_string = $matches[2][ $index ][0];
 		$block_attributes = parse_block_attributes( $block_attributes_string );
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -102,8 +102,8 @@ function do_blocks( $content ) {
 	global $wp_registered_blocks;
 
 	// Extract the blocks from the post content.
-	$open_matcher = '/<!--\s*wp:([a-z](?:[a-z0-9\/]+)*)\s+((?:(?!-->).)*)\s*\/?-->(?:.*?<!--\s*\/wp:\g1\s+-->)?/';
-	preg_match_all( $open_matcher, $content, $matches, PREG_OFFSET_CAPTURE );
+	$matcher = '/<!--\s*wp:([a-z](?:[a-z0-9\/]+)*)\s+((?:(?!-->).)*)\s*\/?-->(?:.*?<!--\s*\/wp:\g1\s+-->)?/';
+	preg_match_all( $matcher, $content, $matches, PREG_OFFSET_CAPTURE );
 
 	$new_content = $content;
 	foreach ( $matches[0] as $index => $block_match ) {


### PR DESCRIPTION
I noticed that the Latest Posts block failed to render on the frontend at all. This is due to the block using the void syntax from #1134, which was not likewise implemented in PHP.

This change will be irrelevant once there is a proper PHP parser (see #1152 and #1086).