### PR TITLE
Add "display post date" and "number of posts to show" Inspector options for Latest Posts block

### DIFF
--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -5,6 +5,7 @@ import { Component } from 'element';
 import { Placeholder, FormToggle } from 'components';
 import { __ } from 'i18n';
 import moment from 'moment';
+import { withInstanceId } from 'components';
 
 /**
  * Internal dependencies
@@ -26,7 +27,7 @@ registerBlockType( 'core/latestposts', {
 		displayPostDate: false,
 	},
 
-	edit: class extends Component {
+	edit: withInstanceId( class extends Component {
 		constructor() {
 			super( ...arguments );
 
@@ -64,10 +65,10 @@ registerBlockType( 'core/latestposts', {
 				);
 			}
 
-			const { focus } = this.props;
+			const { focus, instanceId } = this.props;
 			const { displayPostDate } = this.props.attributes;
 
-			const displayPostDateId = 'post-date-toggle';
+			const displayPostDateId = `post-date-toggle-${ instanceId }`;
 
 			return [
 				focus && (
@@ -107,7 +108,7 @@ registerBlockType( 'core/latestposts', {
 				this.latestPostsRequest.abort();
 			}
 		}
-	},
+	} ),
 
 	save() {
 		return null;

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -14,6 +14,9 @@ import { registerBlockType } from '../../api';
 import { getLatestPosts } from './data.js';
 import InspectorControls from '../../inspector-controls';
 
+const MIN_POSTS = 1;
+const MAX_POSTS = 100;
+
 registerBlockType( 'core/latestposts', {
 	title: __( 'Latest Posts' ),
 
@@ -54,16 +57,14 @@ registerBlockType( 'core/latestposts', {
 
 		componentWillReceiveProps( nextProps ) {
 			const { poststoshow: postToShowCurrent } = this.props.attributes;
-			let { poststoshow: postToShowNext } = nextProps.attributes;
+			const { poststoshow: postToShowNext } = nextProps.attributes;
 			const { setAttributes } = this.props;
-
-			postToShowNext = parseInt( postToShowNext );
 
 			if ( postToShowCurrent === postToShowNext ) {
 				return;
 			}
 
-			if ( ! isNaN( postToShowNext ) && postToShowNext > 0 && postToShowNext <= 100 ) {
+			if ( postToShowNext >= MIN_POSTS && postToShowNext <= MAX_POSTS ) {
 				this.latestPostsRequest = getLatestPosts( postToShowNext );
 
 				this.latestPostsRequest
@@ -76,7 +77,7 @@ registerBlockType( 'core/latestposts', {
 		changePostsToShow( postsToShow ) {
 			const { setAttributes } = this.props;
 
-			setAttributes( { poststoshow: postsToShow } );
+			setAttributes( { poststoshow: parseInt( postsToShow, 10 ) || 0 } );
 		}
 
 		render() {
@@ -113,7 +114,9 @@ registerBlockType( 'core/latestposts', {
 						<div className="editor-latest-posts__row">
 							<label htmlFor={ postToShowId }>{ __( 'Number of posts to show' ) } </label>
 							<input
-								type="text"
+								type="number"
+								min={ MIN_POSTS }
+								max={ MAX_POSTS }
 								value={ this.props.attributes.poststoshow }
 								ref={ postToShowId }
 								id={ postToShowId }

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -110,14 +110,17 @@ registerBlockType( 'core/latestposts', {
 								showHint={ false }
 							/>
 						</div>
-						<label htmlFor={ postToShowId }>Number of posts to show:</label>
-						<input
-							type="text"
-							value={ this.props.attributes.poststoshow }
-							ref={ postToShowId }
-							id={ postToShowId }
-							onChange={ () => this.changePostsToShow( this.refs[ postToShowId ].value ) }
-						/>
+						<div className="editor-latest-posts__row">
+							<label htmlFor={ postToShowId }>{ __( 'Number of posts to show' ) } </label>
+							<input
+								type="text"
+								value={ this.props.attributes.poststoshow }
+								ref={ postToShowId }
+								id={ postToShowId }
+								className="editor-latest-posts__input"
+								onChange={ () => this.changePostsToShow( this.refs[ postToShowId ].value ) }
+							/>
+						</div>
 					</InspectorControls>
 				),
 				<div className={ this.props.className } key="latest-posts">

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -73,7 +73,7 @@ registerBlockType( 'core/latestposts', {
 				focus && (
 					<InspectorControls key="inspector">
 						<div className="editor-latest-posts__row">
-							<label htmlFor={ displayPostDateId }>{ __( 'Display post date?' ) }</label>
+							<label htmlFor={ displayPostDateId }>{ __( 'Display post date' ) }</label>
 							<FormToggle
 								id={ displayPostDateId }
 								checked={ displayPostDate }

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -4,6 +4,7 @@
 import { Component } from 'element';
 import { Placeholder, FormToggle } from 'components';
 import { __ } from 'i18n';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -29,13 +30,13 @@ registerBlockType( 'core/latestposts', {
 		constructor() {
 			super( ...arguments );
 
-			const { poststoshow, displayPostDate } = this.props.attributes;
+			const { poststoshow } = this.props.attributes;
 
 			this.state = {
 				latestPosts: [],
 			};
 
-			this.latestPostsRequest = getLatestPosts( poststoshow, displayPostDate );
+			this.latestPostsRequest = getLatestPosts( poststoshow );
 
 			this.latestPostsRequest
 				.then( latestPosts => this.setState( { latestPosts } ) );
@@ -83,9 +84,18 @@ registerBlockType( 'core/latestposts', {
 					</InspectorControls>
 				),
 				<div className={ this.props.className } key="latest-posts">
-					<ul>
+					<ul className="blocks-latest-posts__list">
 						{ latestPosts.map( ( post, i ) =>
-							<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>
+							<li key={ i }>
+								<a href={ post.link }>{ post.title.rendered }</a>
+								{ displayPostDate && post.date_gmt &&
+									(
+										<span className="blocks-latest-posts__post-date">
+											{ moment( post.date_gmt ).local().format( 'MMM DD h:mm A' ) }
+										</span>
+									)
+								}
+							</li>
 						) }
 					</ul>
 				</div>,

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -2,12 +2,13 @@
  * WordPress dependencies
  */
 import { Component } from 'element';
-import { Placeholder } from 'components';
+import { Placeholder, FormToggle } from 'components';
 import { __ } from 'i18n';
 
 /**
  * Internal dependencies
  */
+import './style.scss';
 import { registerBlockType } from '../../api';
 import { getLatestPosts } from './data.js';
 import InspectorControls from '../../inspector-controls';
@@ -21,22 +22,32 @@ registerBlockType( 'core/latestposts', {
 
 	defaultAttributes: {
 		poststoshow: 5,
+		displayPostDate: false,
 	},
 
 	edit: class extends Component {
 		constructor() {
 			super( ...arguments );
 
-			const { poststoshow } = this.props.attributes;
+			const { poststoshow, displayPostDate } = this.props.attributes;
 
 			this.state = {
 				latestPosts: [],
 			};
 
-			this.latestPostsRequest = getLatestPosts( poststoshow );
+			this.latestPostsRequest = getLatestPosts( poststoshow, displayPostDate );
 
 			this.latestPostsRequest
 				.then( latestPosts => this.setState( { latestPosts } ) );
+
+			this.toggleDisplayPostDate = this.toggleDisplayPostDate.bind( this );
+		}
+
+		toggleDisplayPostDate() {
+			const { displayPostDate } = this.props.attributes;
+			const { setAttributes } = this.props;
+
+			setAttributes( { displayPostDate: ! displayPostDate } );
 		}
 
 		render() {
@@ -53,11 +64,22 @@ registerBlockType( 'core/latestposts', {
 			}
 
 			const { focus } = this.props;
+			const { displayPostDate } = this.props.attributes;
+
+			const displayPostDateId = 'post-date-toggle';
 
 			return [
 				focus && (
 					<InspectorControls key="inspector">
-
+						<div className="editor-latest-posts__row">
+							<label htmlFor={ displayPostDateId }>{ __( 'Display post date?' ) }</label>
+							<FormToggle
+								id={ displayPostDateId }
+								checked={ displayPostDate }
+								onChange={ this.toggleDisplayPostDate }
+								showHint={ false }
+							/>
+						</div>
 					</InspectorControls>
 				),
 				<div className={ this.props.className } key="latest-posts">

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -2,10 +2,9 @@
  * WordPress dependencies
  */
 import { Component } from 'element';
-import { Placeholder, FormToggle } from 'components';
+import { Placeholder, FormToggle, withInstanceId } from 'components';
 import { __ } from 'i18n';
 import moment from 'moment';
-import { withInstanceId } from 'components';
 
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ registerBlockType( 'core/latestposts', {
 	edit: withInstanceId( class extends Component {
 		constructor() {
 			super( ...arguments );
-			this.changePostsToShow = this.changePostsToShow.bind(this);
+			this.changePostsToShow = this.changePostsToShow.bind( this );
 
 			const { poststoshow } = this.props.attributes;
 
@@ -53,18 +52,18 @@ registerBlockType( 'core/latestposts', {
 			setAttributes( { displayPostDate: ! displayPostDate } );
 		}
 
-		componentWillReceiveProps(nextProps) {
+		componentWillReceiveProps( nextProps ) {
 			const { poststoshow: postToShowCurrent } = this.props.attributes;
 			let { poststoshow: postToShowNext } = nextProps.attributes;
 			const { setAttributes } = this.props;
 
 			postToShowNext = parseInt( postToShowNext );
 
-			if( postToShowCurrent === postToShowNext ) {
+			if ( postToShowCurrent === postToShowNext ) {
 				return;
 			}
 
-			if( !isNaN(postToShowNext) && postToShowNext > 0 && postToShowNext <= 100 ) {
+			if ( ! isNaN( postToShowNext ) && postToShowNext > 0 && postToShowNext <= 100 ) {
 				this.latestPostsRequest = getLatestPosts( postToShowNext );
 
 				this.latestPostsRequest
@@ -77,7 +76,7 @@ registerBlockType( 'core/latestposts', {
 		changePostsToShow( postsToShow ) {
 			const { setAttributes } = this.props;
 
-			setAttributes( { poststoshow: postsToShow  } );
+			setAttributes( { poststoshow: postsToShow } );
 		}
 
 		render() {
@@ -97,6 +96,7 @@ registerBlockType( 'core/latestposts', {
 			const { displayPostDate } = this.props.attributes;
 
 			const displayPostDateId = `post-date-toggle-${ instanceId }`;
+			const postToShowId = `post-to-show-${ instanceId }`;
 
 			return [
 				focus && (
@@ -110,12 +110,13 @@ registerBlockType( 'core/latestposts', {
 								showHint={ false }
 							/>
 						</div>
-						<label>Number of posts to show:</label>
+						<label htmlFor={ postToShowId }>Number of posts to show:</label>
 						<input
 							type="text"
-							value={this.props.attributes.poststoshow}
-							ref="poststoshow"
-							onChange={ () => this.changePostsToShow( this.refs.poststoshow.value ) }
+							value={ this.props.attributes.poststoshow }
+							ref={ postToShowId }
+							id={ postToShowId }
+							onChange={ () => this.changePostsToShow( this.refs[ postToShowId ].value ) }
 						/>
 					</InspectorControls>
 				),

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -30,6 +30,7 @@ registerBlockType( 'core/latestposts', {
 	edit: withInstanceId( class extends Component {
 		constructor() {
 			super( ...arguments );
+			this.changePostsToShow = this.changePostsToShow.bind(this);
 
 			const { poststoshow } = this.props.attributes;
 
@@ -50,6 +51,33 @@ registerBlockType( 'core/latestposts', {
 			const { setAttributes } = this.props;
 
 			setAttributes( { displayPostDate: ! displayPostDate } );
+		}
+
+		componentWillReceiveProps(nextProps) {
+			const { poststoshow: postToShowCurrent } = this.props.attributes;
+			let { poststoshow: postToShowNext } = nextProps.attributes;
+			const { setAttributes } = this.props;
+
+			postToShowNext = parseInt( postToShowNext );
+
+			if( postToShowCurrent === postToShowNext ) {
+				return;
+			}
+
+			if( !isNaN(postToShowNext) && postToShowNext > 0 && postToShowNext <= 100 ) {
+				this.latestPostsRequest = getLatestPosts( postToShowNext );
+
+				this.latestPostsRequest
+					.then( latestPosts => this.setState( { latestPosts } ) );
+
+				setAttributes( { poststoshow: postToShowNext } );
+			}
+		}
+
+		changePostsToShow( postsToShow ) {
+			const { setAttributes } = this.props;
+
+			setAttributes( { poststoshow: postsToShow  } );
 		}
 
 		render() {
@@ -82,6 +110,13 @@ registerBlockType( 'core/latestposts', {
 								showHint={ false }
 							/>
 						</div>
+						<label>Number of posts to show:</label>
+						<input
+							type="text"
+							value={this.props.attributes.poststoshow}
+							ref="poststoshow"
+							onChange={ () => this.changePostsToShow( this.refs.poststoshow.value ) }
+						/>
 					</InspectorControls>
 				),
 				<div className={ this.props.className } key="latest-posts">

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from 'element';
-import { Placeholder, FormToggle, withInstanceId } from 'components';
+import { Placeholder } from 'components';
 import { __ } from 'i18n';
 import moment from 'moment';
 
@@ -13,6 +13,8 @@ import './style.scss';
 import { registerBlockType } from '../../api';
 import { getLatestPosts } from './data.js';
 import InspectorControls from '../../inspector-controls';
+import TextControl from '../../inspector-controls/text-control';
+import ToggleControl from '../../inspector-controls/toggle-control';
 
 const MIN_POSTS = 1;
 const MAX_POSTS = 100;
@@ -29,7 +31,7 @@ registerBlockType( 'core/latestposts', {
 		displayPostDate: false,
 	},
 
-	edit: withInstanceId( class extends Component {
+	edit: class extends Component {
 		constructor() {
 			super( ...arguments );
 			this.changePostsToShow = this.changePostsToShow.bind( this );
@@ -93,37 +95,25 @@ registerBlockType( 'core/latestposts', {
 				);
 			}
 
-			const { focus, instanceId } = this.props;
+			const { focus } = this.props;
 			const { displayPostDate } = this.props.attributes;
-
-			const displayPostDateId = `post-date-toggle-${ instanceId }`;
-			const postToShowId = `post-to-show-${ instanceId }`;
 
 			return [
 				focus && (
 					<InspectorControls key="inspector">
-						<div className="editor-latest-posts__row">
-							<label htmlFor={ displayPostDateId }>{ __( 'Display post date' ) }</label>
-							<FormToggle
-								id={ displayPostDateId }
-								checked={ displayPostDate }
-								onChange={ this.toggleDisplayPostDate }
-								showHint={ false }
-							/>
-						</div>
-						<div className="editor-latest-posts__row">
-							<label htmlFor={ postToShowId }>{ __( 'Number of posts to show' ) } </label>
-							<input
-								type="number"
-								min={ MIN_POSTS }
-								max={ MAX_POSTS }
-								value={ this.props.attributes.poststoshow }
-								ref={ postToShowId }
-								id={ postToShowId }
-								className="editor-latest-posts__input"
-								onChange={ () => this.changePostsToShow( this.refs[ postToShowId ].value ) }
-							/>
-						</div>
+						<ToggleControl
+							label={ __( 'Display post date' ) }
+							checked={ displayPostDate }
+							onChange={ this.toggleDisplayPostDate }
+						/>
+						<TextControl
+							label={ __( 'Number of posts to show' ) }
+							type="number"
+							min={ MIN_POSTS }
+							max={ MAX_POSTS }
+							value={ this.props.attributes.poststoshow }
+							onChange={ ( value ) => this.changePostsToShow( value ) }
+						/>
 					</InspectorControls>
 				),
 				<div className={ this.props.className } key="latest-posts">
@@ -150,7 +140,7 @@ registerBlockType( 'core/latestposts', {
 				this.latestPostsRequest.abort();
 			}
 		}
-	} ),
+	},
 
 	save() {
 		return null;

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -116,22 +116,18 @@ registerBlockType( 'core/latestposts', {
 						/>
 					</InspectorControls>
 				),
-				<div className={ this.props.className } key="latest-posts">
-					<ul className="blocks-latest-posts__list">
-						{ latestPosts.map( ( post, i ) =>
-							<li key={ i }>
-								<a href={ post.link }>{ post.title.rendered }</a>
-								{ displayPostDate && post.date_gmt &&
-									(
-										<span className="blocks-latest-posts__post-date">
-											{ moment( post.date_gmt ).local().format( 'MMM DD h:mm A' ) }
-										</span>
-									)
-								}
-							</li>
-						) }
-					</ul>
-				</div>,
+				<ul className={ this.props.className } key="latest-posts">
+					{ latestPosts.map( ( post, i ) =>
+						<li key={ i }>
+							<a href={ post.link }>{ post.title.rendered }</a>
+							{ displayPostDate && post.date_gmt &&
+								<span className={ `${ this.props.className }__post-date` }>
+									{ moment( post.date_gmt ).local().format( 'MMM DD h:mm A' ) }
+								</span>
+							}
+						</li>
+					) }
+				</ul>,
 			];
 		}
 

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -10,6 +10,7 @@ import { __ } from 'i18n';
  */
 import { registerBlockType } from '../../api';
 import { getLatestPosts } from './data.js';
+import InspectorControls from '../../inspector-controls';
 
 registerBlockType( 'core/latestposts', {
 	title: __( 'Latest Posts' ),
@@ -51,15 +52,22 @@ registerBlockType( 'core/latestposts', {
 				);
 			}
 
-			return (
-				<div className={ this.props.className }>
+			const { focus } = this.props;
+
+			return [
+				focus && (
+					<InspectorControls key="inspector">
+
+					</InspectorControls>
+				),
+				<div className={ this.props.className } key="latest-posts">
 					<ul>
 						{ latestPosts.map( ( post, i ) =>
 							<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>
 						) }
 					</ul>
-				</div>
-			);
+				</div>,
+			];
 		}
 
 		componentWillUnmount() {

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -1,0 +1,6 @@
+.editor-latest-posts__row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-top: 20px;
+}

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -12,7 +12,9 @@
 }
 
 .blocks-latest-posts__post-date {
-	padding-left: 1em;
+	display: block;
+	color: $dark-gray-100;
+	font-size: $default-font-size;
 }
 
 .editor-latest-posts__input {

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -1,12 +1,3 @@
-.editor-latest-posts__row {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding-top: 20px;
-
-	margin-bottom: 1em;
-}
-
 .blocks-latest-posts .blocks-latest-posts__list {
 	padding-left: 1em;
 }
@@ -15,11 +6,4 @@
 	display: block;
 	color: $dark-gray-100;
 	font-size: $default-font-size;
-}
-
-.editor-latest-posts__input {
-	width: 3em;
-	-webkit-border-radius: 0.3em;
-	-moz-border-radius: 0.3em;
-	border-radius: 0.3em;
 }

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -3,4 +3,14 @@
 	justify-content: space-between;
 	align-items: center;
 	padding-top: 20px;
+
+	margin-bottom: 1em;
+}
+
+.blocks-latest-posts .blocks-latest-posts__list {
+	padding-left: 1em;
+}
+
+.blocks-latest-posts__post-date {
+	padding-left: 1em;
 }

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -14,3 +14,10 @@
 .blocks-latest-posts__post-date {
 	padding-left: 1em;
 }
+
+.editor-latest-posts__input {
+	width: 3em;
+	-webkit-border-radius: 0.3em;
+	-moz-border-radius: 0.3em;
+	border-radius: 0.3em;
+}

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -1,8 +1,8 @@
-.blocks-latest-posts .blocks-latest-posts__list {
-	padding-left: 1em;
+div[data-type="core/latestposts"] .wp-block-latestposts {
+	padding-left: 2.5em;
 }
 
-.blocks-latest-posts__post-date {
+.wp-block-latestposts__post-date {
 	display: block;
 	color: $dark-gray-100;
 	font-size: $default-font-size;

--- a/blocks/test/fixtures/core-latestposts.html
+++ b/blocks/test/fixtures/core-latestposts.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latestposts {"poststoshow":5} /-->
+<!-- wp:core/latestposts {"poststoshow":5,"displayPostDate":false} /-->

--- a/blocks/test/fixtures/core-latestposts.json
+++ b/blocks/test/fixtures/core-latestposts.json
@@ -3,7 +3,8 @@
         "uid": "_uid_0",
         "name": "core/latestposts",
         "attributes": {
-            "poststoshow": 5
+            "poststoshow": 5,
+            "displayPostDate": false
         }
     }
 ]

--- a/blocks/test/fixtures/core-latestposts.serialized.html
+++ b/blocks/test/fixtures/core-latestposts.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latestposts {"poststoshow":5} /-->
+<!-- wp:core/latestposts {"poststoshow":5,"displayPostDate":false} /-->


### PR DESCRIPTION
When [building the Latest Posts block](https://github.com/WordPress/gutenberg/pull/870), @jasmussen did [a great design](https://github.com/WordPress/gutenberg/pull/870#issuecomment-303326566) of some initial Inspector options. In this PR, we are implementing parts of it.

## Testing
1. In a post, add the latest posts block and click on it;
2. On the left of the screen, the Gutenberg Inspector should show the "display post date" and "number of posts to show" options;
3. Play with the options -- do they work as expected?

Looking like this as of now:

![selection_359](https://user-images.githubusercontent.com/4988512/27188546-bbdd3332-51ee-11e7-8b0e-c5dd2da1efcb.png)

## TODO
- [ ] Add display post date to server-side rendering
- [ ] Possibly debounce the change in number of posts to show input