### PR TITLE
Add the balloon to the bottom instead of the top when there isn't much space available.

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -60,10 +60,6 @@ body.gutenberg_page_gutenberg-demo {
 	}
 }
 
-.editor-layout {
-	min-height: calc(100vh - 160px);
-}
-
 .editor-post-title,
 .editor-visual-editor__block {
 	input,

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -60,6 +60,10 @@ body.gutenberg_page_gutenberg-demo {
 	}
 }
 
+.editor-layout {
+	min-height: calc(100vh - 160px);
+}
+
 .editor-post-title,
 .editor-visual-editor__block {
 	input,

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -227,12 +227,12 @@ class InserterMenu extends wp.element.Component {
 		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getBlockTypes() );
 		const visualEditorHeight = document.querySelector( '.editor-visual-editor' ).clientHeight;
 		const minimumNeededHeight = 600;
-		let positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
+		const positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
 		if ( visualEditorHeight < minimumNeededHeight ) {
 			const isTopIndex = positionClasses.indexOf( 'is-top' );
 			if ( -1 !== isTopIndex ) {
-				positionClasses[isTopIndex] = 'is-bottom';
-			};
+				positionClasses[ isTopIndex ] = 'is-bottom';
+			}
 		}
 		const className = classnames( 'editor-inserter__menu', positionClasses );
 

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -226,7 +226,8 @@ class InserterMenu extends wp.element.Component {
 		const { position = 'top', instanceId } = this.props;
 		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getBlockTypes() );
 		const visualEditorHeight = document.querySelector( '.editor-visual-editor' ).clientHeight;
-		const minimumNeededHeight = 600;
+		const minimumNeededHeight = window.innerHeight - 124;
+		// 124 = $admin-bar-height-big + $header-height + $icon-button-size
 		const positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
 		if ( visualEditorHeight < minimumNeededHeight ) {
 			const isTopIndex = positionClasses.indexOf( 'is-top' );

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -226,7 +226,11 @@ class InserterMenu extends wp.element.Component {
 		const { position = 'top', instanceId } = this.props;
 		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getBlockTypes() );
 		const visualEditorHeight = document.querySelector( '.editor-visual-editor' ).clientHeight;
-		const minimumNeededHeight = window.innerHeight - 124;
+		const heightOccupied =
+			document.getElementById( 'wpadminbar' ).clientHeight +
+			document.querySelector( '.editor-header' ).clientHeight +
+			document.querySelector( '.editor-inserter__toggle' ).clientHeight;
+		const minimumNeededHeight = window.innerHeight - heightOccupied;
 		// 124 = $admin-bar-height-big + $header-height + $icon-button-size
 		const positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
 		if ( visualEditorHeight < minimumNeededHeight ) {

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -225,7 +225,15 @@ class InserterMenu extends wp.element.Component {
 	render() {
 		const { position = 'top', instanceId } = this.props;
 		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getBlockTypes() );
-		const positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
+		const visualEditorHeight = document.querySelector( '.editor-visual-editor' ).clientHeight;
+		const minimumNeededHeight = 600;
+		let positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
+		if ( visualEditorHeight < minimumNeededHeight ) {
+			const isTopIndex = positionClasses.indexOf( 'is-top' );
+			if ( -1 !== isTopIndex ) {
+				positionClasses[isTopIndex] = 'is-bottom';
+			};
+		}
 		const className = classnames( 'editor-inserter__menu', positionClasses );
 
 		return (


### PR DESCRIPTION
Fixes #1004 
I increased the minimum height of the overflow wrapper while avoiding adding an unnecessary vertical scrollbar (hence the calc).
Before showing the balloon, the height of the visual editor is checked and switches the position from top to bottom.