### PR TITLE
Detect Inserter bounds collision by generic Popover component

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -1,3 +1,4 @@
+// Components
 export { default as Button } from './button';
 export { default as ClipboardButton } from './clipboard-button';
 export { default as Dashicon } from './dashicon';
@@ -12,6 +13,8 @@ export { default as Placeholder } from './placeholder';
 export { default as ResponsiveWrapper } from './responsive-wrapper';
 export { default as Spinner } from './spinner';
 export { default as Toolbar } from './toolbar';
+export { default as Popover } from './popover';
 
+// Higher-Order Components
 export { default as withFocusReturn } from './higher-order/with-focus-return';
 export { default as withInstanceId } from './higher-order/with-instance-id';

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEqual, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,7 +20,8 @@ class Popover extends Component {
 		this.bindNode = this.bindNode.bind( this );
 
 		this.state = {
-			forcedPositions: {},
+			forcedYAxis: null,
+			forcedXAxis: null,
 		};
 	}
 
@@ -31,7 +31,10 @@ class Popover extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.position !== nextProps.position ) {
-			this.setState( { forcedPositions: {} } );
+			this.setState( {
+				forcedYAxis: null,
+				forcedXAxis: null,
+			} );
 		}
 	}
 
@@ -43,28 +46,19 @@ class Popover extends Component {
 
 	setForcedPositions() {
 		const rect = this.node.getBoundingClientRect();
-		const { forcedPositions } = this.state;
-
-		const nextForcedPositions = {};
 
 		// Check exceeding top or bottom of viewport
 		if ( rect.top < 0 ) {
-			nextForcedPositions.bottom = true;
+			this.setState( { forcedYAxis: 'bottom' } );
 		} else if ( rect.bottom > window.innerHeight ) {
-			nextForcedPositions.top = true;
+			this.setState( { forcedYAxis: 'top' } );
 		}
 
 		// Check exceeding left or right of viewport
 		if ( rect.left < 0 ) {
-			nextForcedPositions.right = true;
+			this.setState( { forcedXAxis: 'right' } );
 		} else if ( rect.right > window.innerWidth ) {
-			nextForcedPositions.left = true;
-		}
-
-		if ( ! isEqual( nextForcedPositions, forcedPositions ) ) {
-			this.setState( {
-				forcedPositions: nextForcedPositions,
-			} );
+			this.setState( { forcedXAxis: 'left' } );
 		}
 	}
 
@@ -74,26 +68,14 @@ class Popover extends Component {
 
 	render() {
 		const { position, children, className } = this.props;
-		const positions = position.split( ' ' );
-		const { forcedPositions } = this.state;
+		const { forcedYAxis, forcedXAxis } = this.state;
+		const [ yAxis = 'top', xAxis = 'center' ] = position.split( ' ' );
 
 		const classes = classnames(
 			'components-popover',
 			className,
-			...[ [ 'top', 'bottom' ], [ 'center', 'left', 'right' ] ].map( ( directions ) => {
-				// Consider first of directions set as the default
-				const defaultDirection = directions[ 0 ];
-
-				// Prefer the forced direction, but allow direction from props
-				// otherwise. Use default if neither forced nor prop value.
-				const direction = directions.reduce( ( result, dir ) => (
-					forcedPositions[ dir ] || ( ! result && includes( positions, dir ) )
-						? dir
-						: result
-				), null ) || defaultDirection;
-
-				return 'is-' + direction;
-			} )
+			'is-' + ( forcedYAxis || yAxis ),
+			'is-' + ( forcedXAxis || xAxis )
 		);
 
 		return (

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { isEqual, includes } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class Popover extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.bindNode = this.bindNode.bind( this );
+
+		this.state = {
+			forcedPositions: {},
+		};
+	}
+
+	componentDidMount() {
+		this.setForcedPositions();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.position !== nextProps.position ) {
+			this.setState( { forcedPositions: {} } );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.position !== prevProps.position ) {
+			this.setForcedPositions();
+		}
+	}
+
+	setForcedPositions() {
+		const rect = this.node.getBoundingClientRect();
+		const { forcedPositions } = this.state;
+
+		const nextForcedPositions = {};
+
+		// Check exceeding top or bottom of viewport
+		if ( rect.top < 0 ) {
+			nextForcedPositions.bottom = true;
+		} else if ( rect.bottom > window.innerHeight ) {
+			nextForcedPositions.top = true;
+		}
+
+		// Check exceeding left or right of viewport
+		if ( rect.left < 0 ) {
+			nextForcedPositions.right = true;
+		} else if ( rect.right > window.innerWidth ) {
+			nextForcedPositions.left = true;
+		}
+
+		if ( ! isEqual( nextForcedPositions, forcedPositions ) ) {
+			this.setState( {
+				forcedPositions: nextForcedPositions,
+			} );
+		}
+	}
+
+	bindNode( node ) {
+		this.node = node;
+	}
+
+	render() {
+		const { position, children, className } = this.props;
+		const positions = position.split( ' ' );
+		const { forcedPositions } = this.state;
+
+		const classes = classnames(
+			'components-popover',
+			className,
+			...[ [ 'top', 'bottom' ], [ 'center', 'left', 'right' ] ].map( ( directions ) => {
+				// Consider first of directions set as the default
+				const defaultDirection = directions[ 0 ];
+
+				// Prefer the forced direction, but allow direction from props
+				// otherwise. Use default if neither forced nor prop value.
+				const direction = directions.reduce( ( result, dir ) => (
+					forcedPositions[ dir ] || ( ! result && includes( positions, dir ) )
+						? dir
+						: result
+				), null ) || defaultDirection;
+
+				return 'is-' + direction;
+			} )
+		);
+
+		return (
+			<div
+				ref={ this.bindNode }
+				className={ classes }
+				tabIndex="0">
+				{ children }
+			</div>
+		);
+	}
+}
+
+export default Popover;

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -1,0 +1,102 @@
+.components-popover {
+	box-shadow: $shadow-popover;
+	border: 1px solid $light-gray-500;
+	position: absolute;
+	background: $white;
+	z-index: z-index( ".components-popover" );
+	left: 0;
+	right: 0;
+
+	@include break-medium {
+		width: 280px;
+		left: -122px;
+		right: auto;
+		height: auto;
+	}
+
+	&:before {
+		border: 10px dashed $light-gray-500;
+		display: none;
+
+		@include break-medium {
+			display: block;
+		}
+	}
+
+	&:after {
+		border: 10px solid $white;
+	}
+
+	&:before,
+	&:after {
+		content: "";
+		position: absolute;
+		left: 50%;
+		margin-left: -10px;
+		height: 0;
+		width: 0;
+		border-left-color: transparent;
+		border-right-color: transparent;
+		line-height: 0;
+	}
+
+	&.is-top {
+		bottom: 42px;
+
+		&:before {
+			bottom: -10px;
+		}
+
+		&:after {
+			bottom: -8px;
+		}
+
+		&:before,
+		&:after {
+			border-top-style: solid;
+			border-bottom: none;
+		}
+	}
+
+	&.is-bottom {
+		top: $admin-bar-height-big + $item-spacing -1px;
+
+		@include break-medium {
+			top: $admin-bar-height + $item-spacing;
+		}
+
+		&:before {
+			top: -10px;
+		}
+
+		&:after {
+			top: -8px;
+		}
+
+		&:before,
+		&:after {
+			border-bottom-style: solid;
+			border-top: none;
+		}
+	}
+
+	&.is-right {
+		left: -32px;
+
+		&:before,
+		&:after {
+			left: 49px;
+		}
+	}
+
+	&.is-left {
+		left: auto;
+		right: -42px;
+
+		&:before,
+		&:after {
+			left: auto;
+			right: 49px;
+		}
+	}
+}

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -3,6 +3,7 @@ $z-layers: (
 	'.editor-block-switcher__arrow': 1,
 	'.editor-inserter__arrow': 1,
 	'.editor-inserter__menu': 1,
+	'.components-popover': 1,
 	'.editor-visual-editor__block:before': -1,
 	'.editor-visual-editor__block {core/image aligned left or right}': 10,
 	'.editor-visual-editor__block-controls': 1,

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -1,8 +1,6 @@
 $z-layers: (
 	'.editor-mode-switcher .dashicon': -1,
 	'.editor-block-switcher__arrow': 1,
-	'.editor-inserter__arrow': 1,
-	'.editor-inserter__menu': 1,
 	'.components-popover': 1,
 	'.editor-visual-editor__block:before': -1,
 	'.editor-visual-editor__block {core/image aligned left or right}': 10,

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import { flow, groupBy, sortBy, findIndex, filter } from 'lodash';
-import classnames from 'classnames';
 import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
  */
-import { Dashicon, withFocusReturn, withInstanceId } from 'components';
+import { Dashicon, Popover, withFocusReturn, withInstanceId } from 'components';
 import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
 
 /**
@@ -223,14 +222,11 @@ class InserterMenu extends wp.element.Component {
 	}
 
 	render() {
-		const { position = 'top', instanceId } = this.props;
+		const { position, instanceId } = this.props;
 		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( wp.blocks.getBlockTypes() );
-		const positionClasses = position.split( ' ' ).map( ( pos ) => `is-${ pos }` );
-		const className = classnames( 'editor-inserter__menu', positionClasses );
 
 		return (
-			<div className={ className } tabIndex="0">
-				<div className="editor-inserter__arrow" />
+			<Popover position={ position } className="editor-inserter__menu">
 				<div role="menu" className="editor-inserter__content">
 					{ wp.blocks.getCategories()
 						.map( ( category ) => !! visibleBlocksByCategory[ category.slug ] && (
@@ -281,7 +277,7 @@ class InserterMenu extends wp.element.Component {
 					ref={ this.bindReferenceNode( 'search' ) }
 					tabIndex="-1"
 				/>
-			</div>
+			</Popover>
 		);
 	}
 }

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -32,108 +32,6 @@
 	}
 }
 
-.editor-inserter__menu {
-	box-shadow: $shadow-popover;
-	border: 1px solid $light-gray-500;
-	position: absolute;
-	background: $white;
-	z-index: z-index( '.editor-inserter__menu' );
-
-	left: 0;
-	right: 0;
-
-	// inserter becomes popup
-	@include break-medium {
-		width: 280px;
-		left: -122px;
-		right: auto;
-		height: auto;
-	}
-
-	&.is-top {
-		bottom: 42px;
-
-		.editor-inserter__arrow {
-			bottom: -10px;
-			left: 50%;
-			margin-left: -10px;
-			border-top-style: solid;
-			border-bottom: none;
-			border-left-color: transparent;
-			border-right-color: transparent;
-
-			&:before {
-				bottom: 2px;
-				border: 10px solid $white;
-				content: " ";
-				position: absolute;
-				left: 50%;
-				margin-left: -10px;
-				border-top-style: solid;
-				border-bottom: none;
-				border-left-color: transparent;
-				border-right-color: transparent;
-			}
-		}
-	}
-
-	&.is-bottom {
-		top: $admin-bar-height-big + $item-spacing -1px;
-
-		@include break-medium {
-			top: $admin-bar-height + $item-spacing;
-		}
-
-		.editor-inserter__arrow {
-			top: -10px;
-			left: 50%;
-			margin-left: -10px;
-			border-bottom-style: solid;
-			border-top: none;
-			border-left-color: transparent;
-			border-right-color: transparent;
-
-			&:before {
-				top: 2px;
-				border: 10px solid $light-gray-100;
-				content: " ";
-				position: absolute;
-				left: 50%;
-				margin-left: -10px;
-				border-bottom-style: solid;
-				border-top: none;
-				border-left-color: transparent;
-				border-right-color: transparent;
-			}
-		}
-	}
-
-	&.is-right {
-		left: -32px;
-		.editor-inserter__arrow {
-			left: 49px;
-			&:before {
-				left: 0;
-			}
-		}
-	}
-}
-
-.editor-inserter__arrow {
-	border: 10px dashed $light-gray-500;
-	height: 0;
-	line-height: 0;
-	position: absolute;
-	width: 0;
-	z-index: z-index( '.editor-inserter__arrow' );
-
-	display: none;
-
-	@include break-medium {
-		display: block;
-	}
-}
-
 .editor-inserter__content {
 	height: calc( 100vh - #{ $admin-bar-height-big + $header-height + $icon-button-size } );
 
@@ -169,6 +67,10 @@ input[type=search].editor-inserter__search {
 	display: flex;
 	flex-flow: row wrap;
 	padding: 3px;
+}
+
+.editor-inserter__menu.is-bottom:after {
+	border-bottom-color: $light-gray-100;
 }
 
 .editor-inserter__block {


### PR DESCRIPTION
Closes #1098 
Closes #1004

This pull request seeks to resolve an issue where the inserter is clipped by the editor bar when opened on a new post. A `Popover` component has been extracted from `InserterMenu` to provide a generic solution to tooltip-like behavior, including boundary collision detection. When the component mounts or its desired position changes, if it exceeds the viewport boundaries, its direction will be flipped.

__Implementation notes:__

Similar to as observed in #839, it is difficult to know from the context of the Popover component the bounds of the editor canvas. In this implementation I merely check whether it exceeds the bounds of the entire page (`top = 0`, `left = 0`). This could benefit from extensibility allowing the editor layout to override the default bounds (again, since the component is generic, we should not bind it to the editor use-case).

__Testing instructions:__

Verify that there are no regressions in inserter behavior.
Verify that the editor bar inserter continues to open downward.
Verify that in a post with sufficient content, the inserter opens upward.
Verify that if the inserter were to overlap with the editor bar, it opens downward instead.