### PR TITLE
Blocks: Adding a placeholder when the post has no blocks

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -79,7 +79,6 @@ figcaption.blocks-editable__tinymce {
 	}
 }
 
-
 .editable-format-toolbar {
 	display: inline-flex;
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -255,3 +255,39 @@ $sticky-bottom-offset: 20px;
 		content: '';
 	}
 }
+
+.editor-visual-editor__placeholder {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: $visual-editor-max-width;
+	position: relative;
+	padding: $block-padding;
+	border: none;
+	background: none;
+	display: block;
+	transition: 0.2s border-color;
+	text-align: left;
+	width: 100%;
+	color: inherit;
+	opacity: 0.5;
+	line-height: $editor-line-height;
+	font-size: $editor-font-size;
+	cursor: text;
+
+	&:before {
+		z-index: z-index( '.editor-visual-editor__block:before' );
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		border: 2px solid transparent;
+		transition: 0.2s border-color;
+	}
+
+	&:hover:before {
+		border-left-color: $light-gray-500;
+		@include animate_fade;
+	}
+}


### PR DESCRIPTION
closes #1082

This PR adds a placeholder to empty posts. It takes the approach proposed by @jasmussen here https://github.com/WordPress/gutenberg/issues/1082#issuecomment-308725257

<img width="631" alt="screen shot 2017-06-15 at 14 50 35" src="https://user-images.githubusercontent.com/272444/27184425-0e6c12f4-51da-11e7-848e-c78d3e79187c.png">




There's no default block selector for now. I guess this could be a global setting.