### PR TITLE
Blocks: Fix scrolling to the image and gallery blocks on Insert

### DIFF
--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -28,7 +28,7 @@ class MediaUploadButton extends Component {
 
 	componentDidMount() {
 		if ( !! this.props.autoOpen ) {
-			this.frame.open();
+			setTimeout( () => this.frame.open() );
 		}
 	}
 


### PR DESCRIPTION
closes #1048 Alternative to #1139

The downside of this approach is that we could notice the scrolling happening before the modal being opened, but this solution has the advantage of simplicity and genericity. 