### PR TITLE
Chrome: Fix empty post placeholder hover effect

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -174,6 +174,8 @@ class VisualEditorBlockList extends wp.element.Component {
 			<div>
 				{ ! blocks.length && (
 					<input
+						type="text"
+						readOnly
 						className="editor-visual-editor__placeholder"
 						value={ __( 'Write your story' ) }
 						onFocus={ this.appendDefaultBlock }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -256,38 +256,26 @@ $sticky-bottom-offset: 20px;
 	}
 }
 
-.editor-visual-editor__placeholder {
+.editor-visual-editor__placeholder[type=text] {
 	margin-left: auto;
 	margin-right: auto;
 	max-width: $visual-editor-max-width;
 	position: relative;
 	padding: $block-padding;
-	border: none;
+	border: 2px solid transparent;
 	background: none;
+	box-shadow: none;
 	display: block;
 	transition: 0.2s border-color;
 	text-align: left;
 	width: 100%;
 	color: inherit;
 	opacity: 0.5;
-	line-height: $editor-line-height;
 	font-size: $editor-font-size;
 	cursor: text;
+	left: -2px;
 
-	&:before {
-		z-index: z-index( '.editor-visual-editor__block:before' );
-		content: '';
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		border: 2px solid transparent;
-		transition: 0.2s border-color;
-	}
-
-	&:hover:before {
+	&:hover {
 		border-left-color: $light-gray-500;
-		@include animate_fade;
 	}
 }


### PR DESCRIPTION
Addresses the comment here https://github.com/WordPress/gutenberg/pull/1195#issuecomment-308810477

The input has not before content area which caused a regression in the hover effect.