### PR TITLE
Add all input inspector controls

### DIFF
--- a/blocks/inspector-controls/base-control/index.js
+++ b/blocks/inspector-controls/base-control/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function BaseControl( { id, label, type = 'base', children } ) {
+	return (
+		<div className={ classnames( 'blocks-base-control', `control-type-${ type }` ) }>
+			{ label && <label className="blocks-base-control__label" htmlFor={ id }>{ label }</label> }
+			{ children }
+		</div>
+	);
+}
+
+export default BaseControl;

--- a/blocks/inspector-controls/base-control/index.js
+++ b/blocks/inspector-controls/base-control/index.js
@@ -8,9 +8,9 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-function BaseControl( { id, label, type = 'base', children } ) {
+function BaseControl( { id, label, classes, children, ...props } ) {
 	return (
-		<div className={ classnames( 'blocks-base-control', `control-type-${ type }` ) }>
+		<div className={ classnames( 'blocks-base-control', classes ) } { ...props }>
 			{ label && <label className="blocks-base-control__label" htmlFor={ id }>{ label }</label> }
 			{ children }
 		</div>

--- a/blocks/inspector-controls/base-control/index.js
+++ b/blocks/inspector-controls/base-control/index.js
@@ -8,9 +8,9 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-function BaseControl( { id, label, className, children, ...props } ) {
+function BaseControl( { id, label, className, children } ) {
 	return (
-		<div className={ classnames( 'blocks-base-control', className ) } { ...props }>
+		<div className={ classnames( 'blocks-base-control', className ) }>
 			{ label && <label className="blocks-base-control__label" htmlFor={ id }>{ label }</label> }
 			{ children }
 		</div>

--- a/blocks/inspector-controls/base-control/index.js
+++ b/blocks/inspector-controls/base-control/index.js
@@ -8,9 +8,9 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-function BaseControl( { id, label, classes, children, ...props } ) {
+function BaseControl( { id, label, className, children, ...props } ) {
 	return (
-		<div className={ classnames( 'blocks-base-control', classes ) } { ...props }>
+		<div className={ classnames( 'blocks-base-control', className ) } { ...props }>
 			{ label && <label className="blocks-base-control__label" htmlFor={ id }>{ label }</label> }
 			{ children }
 		</div>

--- a/blocks/inspector-controls/base-control/style.scss
+++ b/blocks/inspector-controls/base-control/style.scss
@@ -1,0 +1,9 @@
+.blocks-base-control:not(:last-child) {
+	margin-bottom: 15px;
+}
+
+.blocks-base-control__label {
+	display: block;
+	font-weight: 500;
+	margin-bottom: 5px;
+}

--- a/blocks/inspector-controls/checkbox-control/index.js
+++ b/blocks/inspector-controls/checkbox-control/index.js
@@ -14,7 +14,7 @@ function CheckboxControl( { label, heading, checked, instanceId, onChange, ...pr
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl type="checkbox" label={ heading } id={ id }>
+		<BaseControl label={ heading } id={ id }>
 			<label className="blocks-checkbox-control__label" htmlFor={ id }>
 				<input
 					id={ id }

--- a/blocks/inspector-controls/checkbox-control/index.js
+++ b/blocks/inspector-controls/checkbox-control/index.js
@@ -6,6 +6,7 @@ import { withInstanceId } from 'components';
 /**
  * Internal dependencies
  */
+import BaseControl from './../base-control';
 import './style.scss';
 
 function CheckboxControl( { label, heading, checked, instanceId, onChange, ...props } ) {
@@ -13,8 +14,7 @@ function CheckboxControl( { label, heading, checked, instanceId, onChange, ...pr
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<div className="blocks-checkbox-control">
-			{ heading && <span className="blocks-checkbox-control__heading">{ heading }</span> }
+		<BaseControl type="checkbox" label={ heading } id={ id }>
 			<label className="blocks-checkbox-control__label" htmlFor={ id }>
 				<input
 					id={ id }
@@ -26,7 +26,7 @@ function CheckboxControl( { label, heading, checked, instanceId, onChange, ...pr
 					{ ...props } />
 				{ label }
 			</label>
-		</div>
+		</BaseControl>
 	);
 }
 

--- a/blocks/inspector-controls/checkbox-control/index.js
+++ b/blocks/inspector-controls/checkbox-control/index.js
@@ -23,7 +23,8 @@ function CheckboxControl( { label, heading, checked, instanceId, onChange, ...pr
 					value="1"
 					onChange={ onChangeValue }
 					checked={ checked }
-					{ ...props } />
+					{ ...props }
+				/>
 				{ label }
 			</label>
 		</BaseControl>

--- a/blocks/inspector-controls/checkbox-control/index.js
+++ b/blocks/inspector-controls/checkbox-control/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { withInstanceId } from 'components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function CheckboxControl( { label, heading, checked, instanceId, onChange, ...props } ) {
+	const id = 'inspector-checkbox-control-' + instanceId;
+	const onChangeValue = ( event ) => onChange( event.target.value );
+
+	return (
+		<div className="blocks-checkbox-control">
+			{ heading && <span className="blocks-checkbox-control__heading">{ heading }</span> }
+			<label className="blocks-checkbox-control__label" htmlFor={ id }>
+				<input
+					id={ id }
+					className="blocks-checkbox-control__input" 
+					type="checkbox"
+					value="1"
+					onChange= { onChangeValue }
+					checked={ checked }
+					{ ...props } />
+				{ label }
+			</label>
+		</div>
+	);
+}
+
+export default withInstanceId( CheckboxControl );

--- a/blocks/inspector-controls/checkbox-control/index.js
+++ b/blocks/inspector-controls/checkbox-control/index.js
@@ -18,10 +18,10 @@ function CheckboxControl( { label, heading, checked, instanceId, onChange, ...pr
 			<label className="blocks-checkbox-control__label" htmlFor={ id }>
 				<input
 					id={ id }
-					className="blocks-checkbox-control__input" 
+					className="blocks-checkbox-control__input"
 					type="checkbox"
 					value="1"
-					onChange= { onChangeValue }
+					onChange={ onChangeValue }
 					checked={ checked }
 					{ ...props } />
 				{ label }

--- a/blocks/inspector-controls/checkbox-control/style.scss
+++ b/blocks/inspector-controls/checkbox-control/style.scss
@@ -8,6 +8,6 @@
 	margin-bottom: 5px;
 }
 
-input.blocks-checkbox-control__input {
-	margin-right: 7px;
+.blocks-checkbox-control__input[type=checkbox] {
+	margin-right: 6px;
 }

--- a/blocks/inspector-controls/checkbox-control/style.scss
+++ b/blocks/inspector-controls/checkbox-control/style.scss
@@ -1,13 +1,3 @@
-.blocks-checkbox-control:not(:last-child) {
-	margin-bottom: 15px;
-}
-
-.blocks-checkbox-control__heading {
-	display: block;
-	font-weight: 500;
-	margin-bottom: 5px;
-}
-
 .blocks-checkbox-control__input[type=checkbox] {
 	margin-right: 6px;
 }

--- a/blocks/inspector-controls/checkbox-control/style.scss
+++ b/blocks/inspector-controls/checkbox-control/style.scss
@@ -1,0 +1,13 @@
+.blocks-checkbox-control:not(:last-child) {
+	margin-bottom: 15px;
+}
+
+.blocks-checkbox-control__heading {
+	display: block;
+	font-weight: 500;
+	margin-bottom: 5px;
+}
+
+input.blocks-checkbox-control__input {
+	margin-right: 7px;
+}

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -15,23 +15,23 @@ function RadioControl( { label, selected, instanceId, onChange, options = [] } )
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return ! isEmpty( options ) && (
-		<BaseControl label={ label } id={ id }>
-			<div className="blocks-radio-control">
-				{ options.map( ( option, i ) =>
-					<label key={ option.value } htmlFor={ ( id + '-' + i ) }>
-						<input
-							id={ ( id + '-' + i ) }
-							className="blocks-radio-control__input"
-							type="radio"
-							name={ id }
-							value={ option.value }
-							onChange={ onChangeValue }
-							selected={ option.value === selected }
-						/>
+		<BaseControl label={ label } id={ id } className={ [ 'blocks-radio-control' ] }>
+			{ options.map( ( option, index ) =>
+				<div className="blocks-radio-control__option">
+					<input
+						id={ ( id + '-' + index ) }
+						className="blocks-radio-control__input"
+						type="radio"
+						name={ id }
+						value={ option.value }
+						onChange={ onChangeValue }
+						selected={ option.value === selected }
+					/>
+					<label key={ option.value } htmlFor={ ( id + '-' + index ) }>
 						{ option.label }
 					</label>
-				) }
-			</div>
+				</div>
+			) }
 		</BaseControl>
 	);
 }

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { withInstanceId } from 'components';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function RadioControl( { label, selected, instanceId, options = [] } ) {
+	const id = 'inspector-radio-control-' + instanceId;
+	const onChangeValue = ( event ) => onChange( event.target.value );
+	
+	return ! isEmpty( options ) && (
+		<div className="blocks-radio-control">
+			<label className="blocks-radio-control__label">{ label }</label>
+			<div className="blocks-radio-control__inputs">
+				{ options.map( ( { value, label }, index ) =>
+					<label htmlFor={ ( id + '-' + index ) }>
+						<input
+							id={ ( id + '-' + index ) }
+							className="blocks-radio-control__input"
+							type="radio"
+							name={ id }
+							value={ value }
+							onChange={ onChangeValue }
+							selected={ value == selected }
+						/>
+						{ label }
+					</label>
+				) }
+			</div>
+		</div>
+	);
+}
+
+export default withInstanceId( RadioControl );

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -15,7 +15,7 @@ function RadioControl( { label, selected, instanceId, onChange, options = [] } )
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return ! isEmpty( options ) && (
-		<BaseControl label={ label } id={ id } className={ [ 'blocks-radio-control' ] }>
+		<BaseControl label={ label } id={ id } className="blocks-radio-control">
 			{ options.map( ( option, index ) =>
 				<div className="blocks-radio-control__option">
 					<input

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -7,6 +7,7 @@ import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
+import BaseControl from './../base-control';
 import './style.scss';
 
 function RadioControl( { label, selected, instanceId, options = [] } ) {
@@ -14,9 +15,8 @@ function RadioControl( { label, selected, instanceId, options = [] } ) {
 	const onChangeValue = ( event ) => onChange( event.target.value );
 	
 	return ! isEmpty( options ) && (
-		<div className="blocks-radio-control">
-			<label className="blocks-radio-control__label">{ label }</label>
-			<div className="blocks-radio-control__inputs">
+		<BaseControl type="radio" label={ label } id={ id }>
+			<div className="blocks-radio-control">
 				{ options.map( ( { value, label }, index ) =>
 					<label htmlFor={ ( id + '-' + index ) }>
 						<input
@@ -32,7 +32,7 @@ function RadioControl( { label, selected, instanceId, options = [] } ) {
 					</label>
 				) }
 			</div>
-		</div>
+		</BaseControl>
 	);
 }
 

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -10,25 +10,25 @@ import { isEmpty } from 'lodash';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function RadioControl( { label, selected, instanceId, options = [] } ) {
+function RadioControl( { label, selected, instanceId, onChange, options = [] } ) {
 	const id = 'inspector-radio-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
-	
+
 	return ! isEmpty( options ) && (
 		<BaseControl label={ label } id={ id }>
 			<div className="blocks-radio-control">
-				{ options.map( ( { value, label }, index ) =>
-					<label htmlFor={ ( id + '-' + index ) }>
+				{ options.map( ( option, i ) =>
+					<label key={ option.value } htmlFor={ ( id + '-' + i ) }>
 						<input
-							id={ ( id + '-' + index ) }
+							id={ ( id + '-' + i ) }
 							className="blocks-radio-control__input"
 							type="radio"
 							name={ id }
-							value={ value }
+							value={ option.value }
 							onChange={ onChangeValue }
-							selected={ value == selected }
+							selected={ option.value === selected }
 						/>
-						{ label }
+						{ option.label }
 					</label>
 				) }
 			</div>

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -15,7 +15,7 @@ function RadioControl( { label, selected, instanceId, options = [] } ) {
 	const onChangeValue = ( event ) => onChange( event.target.value );
 	
 	return ! isEmpty( options ) && (
-		<BaseControl type="radio" label={ label } id={ id }>
+		<BaseControl label={ label } id={ id }>
 			<div className="blocks-radio-control">
 				{ options.map( ( { value, label }, index ) =>
 					<label htmlFor={ ( id + '-' + index ) }>

--- a/blocks/inspector-controls/radio-control/style.scss
+++ b/blocks/inspector-controls/radio-control/style.scss
@@ -1,0 +1,23 @@
+.blocks-radio-control:not(:last-child) {
+	margin-bottom: 15px;
+}
+
+.blocks-radio-control__label {
+	display: block;
+	font-weight: 500;
+	margin-bottom: 5px;
+}
+
+.blocks-radio-control__inputs {
+	display: flex;
+	flex-direction: column;
+	
+	> label:not(:last-child) {
+		margin-bottom: 5px;
+	}
+}
+
+.blocks-radio-control__input[type=radio] {
+	margin-top: -3px;
+	margin-right: 6px;
+}

--- a/blocks/inspector-controls/radio-control/style.scss
+++ b/blocks/inspector-controls/radio-control/style.scss
@@ -1,13 +1,13 @@
 .blocks-radio-control {
 	display: flex;
 	flex-direction: column;
-	
-	> label:not(:last-child) {
-		margin-bottom: 5px;
-	}
+}
+
+.blocks-radio-control__option:not(:last-child) {
+	margin-bottom: 4px;
 }
 
 .blocks-radio-control__input[type=radio] {
-	margin-top: -3px;
+	margin-top: 0;
 	margin-right: 6px;
 }

--- a/blocks/inspector-controls/radio-control/style.scss
+++ b/blocks/inspector-controls/radio-control/style.scss
@@ -1,14 +1,4 @@
-.blocks-radio-control:not(:last-child) {
-	margin-bottom: 15px;
-}
-
-.blocks-radio-control__label {
-	display: block;
-	font-weight: 500;
-	margin-bottom: 5px;
-}
-
-.blocks-radio-control__inputs {
+.blocks-radio-control {
 	display: flex;
 	flex-direction: column;
 	

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -6,19 +6,19 @@ import { withInstanceId } from 'components';
 /**
  * Internal dependencies
  */
+import BaseControl from './../base-control';
 import './style.scss';
 
 function RangeControl( { label, value, instanceId, onChange, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
 
 	return (
-		<div className="blocks-range-control">
-			<label className="blocks-range-control__label" htmlFor={ id }>{ label }</label>
-			<div className="blocks-range-control__field">
+		<BaseControl type="range" label={ label } id={ id }>
+			<div className="blocks-range-control">
 				<input className="blocks-range-control__input" id={ id } type="range" value={ value } onChange={ onChange } { ...props } />
 				<span className="blocks-range-control__hint">{ value }</span>
 			</div>
-		</div>
+		</BaseControl>
 	);
 }
 

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -14,8 +14,10 @@ function RangeControl( { label, value, instanceId, onChange, ...props } ) {
 	return (
 		<div className="blocks-range-control">
 			<label className="blocks-range-control__label" htmlFor={ id }>{ label }</label>
-			<input className="blocks-range-control__input" id={ id } type="range" value={ value } onChange={ onChange } { ...props } />
-			<span>{ value }</span>
+			<div className="blocks-range-control__field">
+				<input className="blocks-range-control__input" id={ id } type="range" value={ value } onChange={ onChange } { ...props } />
+				<span>{ value }</span>
+			</div>
 		</div>
 	);
 }

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -13,7 +13,7 @@ function RangeControl( { label, value, instanceId, onChange, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
 
 	return (
-		<BaseControl type="range" label={ label } id={ id }>
+		<BaseControl label={ label } id={ id }>
 			<div className="blocks-range-control">
 				<input className="blocks-range-control__input" id={ id } type="range" value={ value } onChange={ onChange } { ...props } />
 				<span className="blocks-range-control__hint">{ value }</span>

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -16,7 +16,7 @@ function RangeControl( { label, value, instanceId, onChange, ...props } ) {
 			<label className="blocks-range-control__label" htmlFor={ id }>{ label }</label>
 			<div className="blocks-range-control__field">
 				<input className="blocks-range-control__input" id={ id } type="range" value={ value } onChange={ onChange } { ...props } />
-				<span>{ value }</span>
+				<span className="blocks-range-control__hint">{ value }</span>
 			</div>
 		</div>
 	);

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -1,5 +1,7 @@
 .blocks-range-control {
-	margin-bottom: 10px;
+	&:not(:last-child) {
+		margin-bottom: 10px;
+	}
 }
 
 .blocks-range-control__label {

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -16,8 +16,10 @@
 .blocks-range-control__field {
 	display: flex;
 	justify-content: center;
-	
-	> span {
-		margin-left: 10px;
-	}
+}
+
+.blocks-range-control__hint {
+	display: inline-block;
+	margin-left: 10px;
+	font-weight: 500;
 }

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -7,3 +7,17 @@
 	font-weight: 500;
 	margin-bottom: 5px;
 }
+
+.blocks-range-control__input {
+	width: 100%;
+	vertical-align: top;
+}
+
+.blocks-range-control__field {
+	display: flex;
+	justify-content: center;
+	
+	> span {
+		margin-left: 10px;
+	}
+}

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -1,21 +1,10 @@
-.blocks-range-control:not(:last-child) {
-	margin-bottom: 15px;
-}
-
-.blocks-range-control__label {
-	display: block;
-	font-weight: 500;
-	margin-bottom: 5px;
+.blocks-range-control {
+	display: flex;
+	justify-content: center;
 }
 
 .blocks-range-control__input {
 	width: 100%;
-	vertical-align: top;
-}
-
-.blocks-range-control__field {
-	display: flex;
-	justify-content: center;
 }
 
 .blocks-range-control__hint {

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -1,7 +1,5 @@
-.blocks-range-control {
-	&:not(:last-child) {
-		margin-bottom: 10px;
-	}
+.blocks-range-control:not(:last-child) {
+	margin-bottom: 15px;
 }
 
 .blocks-range-control__label {

--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -7,6 +7,7 @@ import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
+import BaseControl from './../base-control';
 import './style.scss';
 
 function SelectControl( { label, selected, instanceId, onChange, options = [], ...props } ) {
@@ -14,8 +15,7 @@ function SelectControl( { label, selected, instanceId, onChange, options = [], .
 	const onChangeValue = ( event ) => onChange( event.target.value );
 	
 	return ! isEmpty( options ) && (
-		<div className="blocks-select-control">
-			<label className="blocks-select-control__label" htmlFor={ id }>{ label }</label>
+		<BaseControl type="select" label={ label } id={ id }>
 			<select className="blocks-select-control__input" id={ id } onChange={ onChangeValue } { ...props }>
 				{ options.map( ( { value, label } ) =>
 					<option key={ value } value={ value } selected={ value == selected }>
@@ -23,7 +23,7 @@ function SelectControl( { label, selected, instanceId, onChange, options = [], .
 					</option>
 				) }
 			</select>
-		</div>
+		</BaseControl>
 	);
 }
 

--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -9,17 +9,16 @@ import { isEmpty } from 'lodash';
  */
 import './style.scss';
 
-function SelectControl( { label, value, instanceId, onChange, options = [], ...props } ) {
+function SelectControl( { label, selected, instanceId, onChange, options = [], ...props } ) {
 	const id = 'inspector-select-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
-	const selectedValue = value;
 	
 	return ! isEmpty( options ) && (
 		<div className="blocks-select-control">
 			<label className="blocks-select-control__label" htmlFor={ id }>{ label }</label>
 			<select className="blocks-select-control__input" id={ id } onChange={ onChangeValue } { ...props }>
 				{ options.map( ( { value, label } ) =>
-					<option key={ value } value={ value } selected={ value == selectedValue }>
+					<option key={ value } value={ value } selected={ value == selected }>
 						{ label }
 					</option>
 				) }

--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -15,7 +15,7 @@ function SelectControl( { label, selected, instanceId, onChange, options = [], .
 	const onChangeValue = ( event ) => onChange( event.target.value );
 	
 	return ! isEmpty( options ) && (
-		<BaseControl type="select" label={ label } id={ id }>
+		<BaseControl label={ label } id={ id }>
 			<select className="blocks-select-control__input" id={ id } onChange={ onChangeValue } { ...props }>
 				{ options.map( ( { value, label } ) =>
 					<option key={ value } value={ value } selected={ value == selected }>

--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { withInstanceId } from 'components';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function SelectControl( { label, value, instanceId, onChange, options = [], ...props } ) {
+	const id = 'inspector-select-control-' + instanceId;
+	const onChangeValue = ( event ) => onChange( event.target.value );
+	const selectedValue = value;
+	
+	return ! isEmpty( options ) && (
+		<div className="blocks-select-control">
+			<label className="blocks-select-control__label" htmlFor={ id }>{ label }</label>
+			<select className="blocks-select-control__input" id={ id } onChange={ onChangeValue } { ...props }>
+				{ options.map( ( { value, label } ) =>
+					<option key={ value } value={ value } selected={ value == selectedValue }>
+						{ label }
+					</option>
+				) }
+			</select>
+		</div>
+	);
+}
+
+export default withInstanceId( SelectControl );

--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -10,15 +10,24 @@ import { isEmpty } from 'lodash';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function SelectControl( { label, selected, instanceId, onChange, options = [], ...props } ) {
+function SelectControl( { label, selected, instanceId, onBlur, options = [], ...props } ) {
 	const id = 'inspector-select-control-' + instanceId;
-	const onChangeValue = ( event ) => onChange( event.target.value );
-	
+	const onBlurValue = ( event ) => onBlur( event.target.value );
+
 	return ! isEmpty( options ) && (
 		<BaseControl label={ label } id={ id }>
-			<select className="blocks-select-control__input" id={ id } onChange={ onChangeValue } { ...props }>
-				{ options.map( ( { value, label } ) =>
-					<option key={ value } value={ value } selected={ value == selected }>
+			<select
+				id={ id }
+				className="blocks-select-control__input"
+				onBlur={ onBlurValue }
+				{ ...props }
+			>
+				{ options.map( ( option ) =>
+					<option
+						key={ option.value }
+						value={ option.value }
+						selected={ option.value === selected }
+					>
 						{ label }
 					</option>
 				) }

--- a/blocks/inspector-controls/select-control/style.scss
+++ b/blocks/inspector-controls/select-control/style.scss
@@ -1,0 +1,13 @@
+.blocks-select-control:not(:last-child) {
+	margin-bottom: 15px;
+}
+
+.blocks-select-control__label {
+	display: block;
+	font-weight: 500;
+	margin-bottom: 5px;
+}
+
+.blocks-select-control__input {
+	width: 100%;
+}

--- a/blocks/inspector-controls/select-control/style.scss
+++ b/blocks/inspector-controls/select-control/style.scss
@@ -1,13 +1,3 @@
-.blocks-select-control:not(:last-child) {
-	margin-bottom: 15px;
-}
-
-.blocks-select-control__label {
-	display: block;
-	font-weight: 500;
-	margin-bottom: 5px;
-}
-
 .blocks-select-control__input {
 	width: 100%;
 }

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -14,7 +14,7 @@ function TextControl( { label, value, instanceId, onChange, type = 'text', ...pr
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl type="text" label={ label } id={ id }>
+		<BaseControl label={ label } id={ id }>
 			<input className="blocks-text-control__input" type={ type } id={ id } value={ value } onChange={ onChangeValue } { ...props } />
 		</BaseControl>
 	);

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -6,6 +6,7 @@ import { withInstanceId } from 'components';
 /**
  * Internal dependencies
  */
+import BaseControl from './../base-control';
 import './style.scss';
 
 function TextControl( { label, value, instanceId, onChange, type = 'text', ...props } ) {
@@ -13,10 +14,9 @@ function TextControl( { label, value, instanceId, onChange, type = 'text', ...pr
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<div className="blocks-text-control">
-			<label className="blocks-text-control__label" htmlFor={ id }>{ label }</label>
+		<BaseControl type="text" label={ label } id={ id }>
 			<input className="blocks-text-control__input" type={ type } id={ id } value={ value } onChange={ onChangeValue } { ...props } />
-		</div>
+		</BaseControl>
 	);
 }
 

--- a/blocks/inspector-controls/text-control/style.scss
+++ b/blocks/inspector-controls/text-control/style.scss
@@ -1,13 +1,3 @@
-.blocks-text-control:not(:last-child) {
-	margin-bottom: 15px;
-}
-
-.blocks-text-control__label {
-	display: block;
-	font-weight: 500;
-	margin-bottom: 5px;
-}
-
 .blocks-text-control__input {
 	width: 100%;
 	padding: 6px 8px;

--- a/blocks/inspector-controls/text-control/style.scss
+++ b/blocks/inspector-controls/text-control/style.scss
@@ -1,7 +1,5 @@
-.blocks-text-control {
-	&:not(:last-child) {
-		margin-bottom: 10px;
-	}
+.blocks-text-control:not(:last-child) {
+	margin-bottom: 15px;
 }
 
 .blocks-text-control__label {

--- a/blocks/inspector-controls/text-control/style.scss
+++ b/blocks/inspector-controls/text-control/style.scss
@@ -1,5 +1,7 @@
 .blocks-text-control {
-	margin-bottom: 10px;
+	&:not(:last-child) {
+		margin-bottom: 10px;
+	}
 }
 
 .blocks-text-control__label {

--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { withInstanceId } from 'components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function TextareaControl( { label, value, instanceId, onChange, rows = 3, ...props } ) {
+	const id = 'inspector-textarea-control-' + instanceId;
+	const onChangeValue = ( event ) => onChange( event.target.value );
+
+	return (
+		<div className="blocks-textarea-control">
+			<label className="blocks-textarea-control__label" htmlFor={ id }>{ label }</label>
+			<textarea className="blocks-textarea-control__input" id={ id } rows={ rows } onChange={ onChangeValue } { ...props }>
+				{ value }
+			</textarea>
+		</div>
+	);
+}
+
+export default withInstanceId( TextareaControl );

--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -6,6 +6,7 @@ import { withInstanceId } from 'components';
 /**
  * Internal dependencies
  */
+import BaseControl from './../base-control';
 import './style.scss';
 
 function TextareaControl( { label, value, instanceId, onChange, rows = 4, ...props } ) {
@@ -13,12 +14,11 @@ function TextareaControl( { label, value, instanceId, onChange, rows = 4, ...pro
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<div className="blocks-textarea-control">
-			<label className="blocks-textarea-control__label" htmlFor={ id }>{ label }</label>
+		<BaseControl type="textarea" label={ label } id={ id }>
 			<textarea className="blocks-textarea-control__input" id={ id } rows={ rows } onChange={ onChangeValue } { ...props }>
 				{ value }
 			</textarea>
-		</div>
+		</BaseControl>
 	);
 }
 

--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -14,7 +14,7 @@ function TextareaControl( { label, value, instanceId, onChange, rows = 4, ...pro
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl type="textarea" label={ label } id={ id }>
+		<BaseControl label={ label } id={ id }>
 			<textarea className="blocks-textarea-control__input" id={ id } rows={ rows } onChange={ onChangeValue } { ...props }>
 				{ value }
 			</textarea>

--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -8,7 +8,7 @@ import { withInstanceId } from 'components';
  */
 import './style.scss';
 
-function TextareaControl( { label, value, instanceId, onChange, rows = 3, ...props } ) {
+function TextareaControl( { label, value, instanceId, onChange, rows = 4, ...props } ) {
 	const id = 'inspector-textarea-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 

--- a/blocks/inspector-controls/textarea-control/style.scss
+++ b/blocks/inspector-controls/textarea-control/style.scss
@@ -1,13 +1,3 @@
-.blocks-textarea-control:not(:last-child) {
-	margin-bottom: 15px;
-}
-
-.blocks-textarea-control__label {
-	display: block;
-	font-weight: 500;
-	margin-bottom: 5px;
-}
-
 .blocks-textarea-control__input {
 	width: 100%;
 	padding: 6px 8px;

--- a/blocks/inspector-controls/textarea-control/style.scss
+++ b/blocks/inspector-controls/textarea-control/style.scss
@@ -1,14 +1,14 @@
-.blocks-text-control:not(:last-child) {
+.blocks-textarea-control:not(:last-child) {
 	margin-bottom: 15px;
 }
 
-.blocks-text-control__label {
+.blocks-textarea-control__label {
 	display: block;
 	font-weight: 500;
 	margin-bottom: 5px;
 }
 
-.blocks-text-control__input {
+.blocks-textarea-control__input {
 	width: 100%;
 	padding: 6px 8px;
 }

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -14,7 +14,7 @@ function ToggleControl( { label, checked, instanceId, onChange } ) {
 	const id = 'inspector-toggle-control-' + instanceId;
 
 	return (
-		<BaseControl label={ label } id={ id } classes={ [ 'blocks-toggle-control' ] }>
+		<BaseControl label={ label } id={ id } className={ [ 'blocks-toggle-control' ] }>
 			<Toggle id={ id } checked={ checked } onChange={ onChange } />
 		</BaseControl>
 	);

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -14,8 +14,8 @@ function ToggleControl( { label, checked, instanceId, onChange, ...props } ) {
 	const id = 'inspector-toggle-control-' + instanceId;
 
 	return (
-		<BaseControl type="toggle" label={ label } id={ id }>
-  			<Toggle id={ id } checked={ checked } onChange={ onChange } />
+		<BaseControl label={ label } id={ id } classes={ [ 'blocks-toggle-control' ] }>
+			<Toggle id={ id } checked={ checked } onChange={ onChange } />
 		</BaseControl>
 	);
 }

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -14,7 +14,7 @@ function ToggleControl( { label, checked, instanceId, onChange } ) {
 	const id = 'inspector-toggle-control-' + instanceId;
 
 	return (
-		<BaseControl label={ label } id={ id } className={ [ 'blocks-toggle-control' ] }>
+		<BaseControl label={ label } id={ id } className="blocks-toggle-control">
 			<Toggle id={ id } checked={ checked } onChange={ onChange } />
 		</BaseControl>
 	);

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -7,16 +7,16 @@ import Toggle from 'components/form-toggle';
 /**
  * Internal dependencies
  */
+import BaseControl from './../base-control';
 import './style.scss';
 
 function ToggleControl( { label, checked, instanceId, onChange, ...props } ) {
 	const id = 'inspector-toggle-control-' + instanceId;
 
 	return (
-		<div className="blocks-toggle-control">
-			<label className="blocks-toggle-control__label" htmlFor={ id }>{ label }</label>
-			<Toggle id={ id } checked={ checked } onChange={ onChange } />
-		</div>
+		<BaseControl type="toggle" label={ label } id={ id }>
+  			<Toggle id={ id } checked={ checked } onChange={ onChange } />
+		</BaseControl>
 	);
 }
 

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -10,7 +10,7 @@ import Toggle from 'components/form-toggle';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function ToggleControl( { label, checked, instanceId, onChange, ...props } ) {
+function ToggleControl( { label, checked, instanceId, onChange } ) {
 	const id = 'inspector-toggle-control-' + instanceId;
 
 	return (

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { withInstanceId } from 'components';
+import Toggle from 'components/form-toggle';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function ToggleControl( { label, checked, instanceId, onChange, ...props } ) {
+	const id = 'inspector-toggle-control-' + instanceId;
+
+	return (
+		<div className="blocks-toggle-control">
+			<label className="blocks-toggle-control__label" htmlFor={ id }>{ label }</label>
+			<Toggle id={ id } checked={ checked } onChange={ onChange } />
+		</div>
+	);
+}
+
+export default withInstanceId( ToggleControl );

--- a/blocks/inspector-controls/toggle-control/style.scss
+++ b/blocks/inspector-controls/toggle-control/style.scss
@@ -1,4 +1,4 @@
-.blocks-base-control.control-type-toggle {
+.blocks-toggle-control {
 	display: flex;
 	justify-content: space-between;
 }

--- a/blocks/inspector-controls/toggle-control/style.scss
+++ b/blocks/inspector-controls/toggle-control/style.scss
@@ -3,7 +3,7 @@
 	justify-content: space-between;
 	
 	&:not(:last-child) {
-		margin-bottom: 10px;
+		margin-bottom: 15px;
 	}
 }
 

--- a/blocks/inspector-controls/toggle-control/style.scss
+++ b/blocks/inspector-controls/toggle-control/style.scss
@@ -1,0 +1,15 @@
+.blocks-toggle-control {
+	display: flex;
+	justify-content: space-between;
+	
+	&:not(:last-child) {
+		margin-bottom: 10px;
+	}
+}
+
+.blocks-toggle-control__label {
+	display: block;
+	font-weight: 500;
+	margin-bottom: 5px;
+}
+

--- a/blocks/inspector-controls/toggle-control/style.scss
+++ b/blocks/inspector-controls/toggle-control/style.scss
@@ -1,15 +1,4 @@
-.blocks-toggle-control {
+.blocks-base-control.control-type-toggle {
 	display: flex;
 	justify-content: space-between;
-	
-	&:not(:last-child) {
-		margin-bottom: 15px;
-	}
 }
-
-.blocks-toggle-control__label {
-	display: block;
-	font-weight: 500;
-	margin-bottom: 5px;
-}
-

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from 'i18n';
 import { Children, cloneElement } from 'element';
-import Toggle from 'components/form-toggle';
 
 /**
  * Internal dependencies
@@ -13,6 +12,7 @@ import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
+import ToggleControl from '../../inspector-controls/toggle-control';
 
 const { children } = query;
 
@@ -49,14 +49,11 @@ registerBlockType( 'core/text', {
 			),
 			focus && (
 				<InspectorControls key="inspector">
-					<div className="blocks-text__drop-cap" style={ { display: 'flex', justifyContent: 'space-between' } }>
-						<label htmlFor="blocks-text__drop-cap">{ __( 'Drop Cap' ) }</label>
-						<Toggle
-							checked={ !! dropCap }
-							onChange={ toggleDropCap }
-							id="blocks-text__drop-cap-toggle"
-						/>
-					</div>
+					<ToggleControl 
+						label={ __( 'Drop Cap' ) }
+						checked={ !! dropCap }
+						onChange={ toggleDropCap }
+					/>
 				</InspectorControls>
 			),
 			<Editable


### PR DESCRIPTION
This is a followup to #1198, and adds all the basic controls (input field types).

In particular it adds:

- Textarea
- Radio
- Select
- Checkbox

I've also made a few style tweaks to existing controls for styling consistencies among all the control types.

Here is a screenshot of all the controls in action:

<img width="290" alt="screen shot 2017-06-15 at 19 07 58" src="https://user-images.githubusercontent.com/704594/27195369-6ab9a9ee-51fe-11e7-84ce-f6a05f1b3235.png">
