### PR TITLE
Prevent save if post has no saveable content

### DIFF
--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -19,11 +19,16 @@ import {
 	isEditedPostNew,
 	isEditedPostDirty,
 	isSavingPost,
+	isEditedPostSaveable,
 	getCurrentPost,
 	getEditedPostAttribute,
 } from '../../selectors';
 
-function SavedState( { isNew, isDirty, isSaving, status, onStatusChange, onSave } ) {
+function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
+	if ( ! isSaveable ) {
+		return null;
+	}
+
 	const className = 'editor-saved-state';
 
 	if ( isSaving ) {
@@ -60,6 +65,7 @@ export default connect(
 		isNew: isEditedPostNew( state ),
 		isDirty: isEditedPostDirty( state ),
 		isSaving: isSavingPost( state ),
+		isSaveable: isEditedPostSaveable( state ),
 		status: getEditedPostAttribute( state, 'status' ),
 	} ),
 	{

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -19,6 +19,7 @@ import {
 	isEditedPostPublished,
 	isEditedPostBeingScheduled,
 	getEditedPostVisibility,
+	isEditedPostSaveable,
 	isEditedPostPublishable,
 } from '../../selectors';
 
@@ -30,8 +31,9 @@ function PublishButton( {
 	isBeingScheduled,
 	visibility,
 	isPublishable,
+	isSaveable,
 } ) {
-	const buttonEnabled = ! isSaving && isPublishable;
+	const buttonEnabled = ! isSaving && isPublishable && isSaveable;
 	let buttonText;
 	if ( isPublished ) {
 		buttonText = __( 'Update' );
@@ -76,6 +78,7 @@ export default connect(
 		isPublished: isEditedPostPublished( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		visibility: getEditedPostVisibility( state ),
+		isSaveable: isEditedPostSaveable( state ),
 		isPublishable: isEditedPostPublishable( state ),
 	} ),
 	{

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -167,6 +167,21 @@ export function isEditedPostPublishable( state ) {
 }
 
 /**
+ * Returns true if the post can be saved, or false otherwise. A post must
+ * contain a title, an excerpt, or non-empty content to be valid for save.
+ *
+ * @param  {Object}  state Global application state
+ * @return {Boolean}       Whether the post can be saved
+ */
+export function isEditedPostSaveable( state ) {
+	return (
+		getBlockCount( state ) > 0 ||
+		!! getEditedPostTitle( state ) ||
+		!! getEditedPostExcerpt( state )
+	);
+}
+
+/**
  * Return true if the post being edited is being scheduled. Preferring the
  * unsaved status values.
  *
@@ -250,6 +265,16 @@ export const getBlocks = createSelector(
 		state.editor.blocksByUid,
 	]
 );
+
+/**
+ * Returns the number of blocks currently present in the post.
+ *
+ * @param  {Object} state Global application state
+ * @return {Object}       Number of blocks in the post
+ */
+export function getBlockCount( state ) {
+	return getBlockUids( state ).length;
+}
 
 /**
  * Returns the currently selected block, or null if there is no selected block.

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -22,10 +22,12 @@ import {
 	getEditedPostVisibility,
 	isEditedPostPublished,
 	isEditedPostPublishable,
+	isEditedPostSaveable,
 	isEditedPostBeingScheduled,
 	getEditedPostPreviewLink,
 	getBlock,
 	getBlocks,
+	getBlockCount,
 	getSelectedBlock,
 	getMultiSelectedBlockUids,
 	getMultiSelectedBlocksStartUid,
@@ -455,6 +457,66 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( 'isEditedPostSaveable', () => {
+		it( 'should return false if the post has no title, excerpt, content', () => {
+			const state = {
+				editor: {
+					blocksByUid: {},
+					blockOrder: [],
+					edits: {},
+				},
+				currentPost: {},
+			};
+
+			expect( isEditedPostSaveable( state ) ).to.be.false();
+		} );
+
+		it( 'should return true if the post has a title', () => {
+			const state = {
+				editor: {
+					blocksByUid: {},
+					blockOrder: [],
+					edits: {},
+				},
+				currentPost: {
+					title: { raw: 'sassel' },
+				},
+			};
+
+			expect( isEditedPostSaveable( state ) ).to.be.true();
+		} );
+
+		it( 'should return true if the post has an excerpt', () => {
+			const state = {
+				editor: {
+					blocksByUid: {},
+					blockOrder: [],
+					edits: {},
+				},
+				currentPost: {
+					excerpt: { raw: 'sassel' },
+				},
+			};
+
+			expect( isEditedPostSaveable( state ) ).to.be.true();
+		} );
+
+		it( 'should return true if the post has content', () => {
+			const state = {
+				editor: {
+					blocksByUid: {
+						123: { uid: 123, name: 'core/text' },
+					},
+					blockOrder: [ 123 ],
+					edits: {},
+				},
+				currentPost: {},
+			};
+
+			expect( isEditedPostSaveable( state ) ).to.be.true();
+		} );
+	} );
+
 	describe( 'isEditedPostBeingScheduled', () => {
 		it( 'should return true for posts with a future date', () => {
 			const state = {
@@ -527,6 +589,22 @@ describe( 'selectors', () => {
 				{ uid: 123, name: 'core/text' },
 				{ uid: 23, name: 'core/heading' },
 			] );
+		} );
+	} );
+
+	describe( 'getBlockCount', () => {
+		it( 'should return the number of blocks in the post', () => {
+			const state = {
+				editor: {
+					blocksByUid: {
+						23: { uid: 23, name: 'core/heading' },
+						123: { uid: 123, name: 'core/text' },
+					},
+					blockOrder: [ 123, 23 ],
+				},
+			};
+
+			expect( getBlockCount( state ) ).to.equal( 2 );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #1201 

This pull request seeks to hide the Save button and disable the Publish / Update button if the post does not have sufficient content (title, excerpt, content) to be saved.

__Testing instructions:__

Repeat testing instructions from #1201, noting that a new post cannot be saved.

Verify also that a post with content can be saved, whether that post is newly created or loaded from save.