### PR TITLE
Revert "Plugin: use beta with YYMMDD date format."

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Prototyping since 1440. This is the development plugin for the new block editor in core. <strong>Meant for development, do not run on real sites.</strong>
- * Version: 1.0-beta0615
+ * Version: 0.1.0
  * Author: Gutenberg Team
  *
  * @package gutenberg


### PR DESCRIPTION
Reverts WordPress/gutenberg#1194

Going back to 0.1.0 as things are set up with that in mind and we won't have time to update all of them.

Release would look:
```
// Beta - weekly release
0.1.0
0.2.0
...
0.14.0

// Release candidate
1.0.0
1.1.0
...
```