### PR TITLE
Blocks: Dotted border on hover and always show the placeholder

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -172,15 +172,6 @@ class VisualEditorBlockList extends wp.element.Component {
 
 		return (
 			<div>
-				{ ! blocks.length && (
-					<input
-						type="text"
-						readOnly
-						className="editor-visual-editor__placeholder"
-						value={ __( 'Write your story' ) }
-						onFocus={ this.appendDefaultBlock }
-					/>
-				) }
 				{ !! blocks.length && blocksWithInsertionPoint.map( ( uid ) => {
 					if ( uid === INSERTION_POINT_PLACEHOLDER ) {
 						return (
@@ -201,6 +192,14 @@ class VisualEditorBlockList extends wp.element.Component {
 						/>
 					);
 				} ) }
+
+				<input
+					type="text"
+					readOnly
+					className="editor-visual-editor__placeholder"
+					value={ ! blocks.length ? __( 'Write your story' ) : __( 'Write' ) }
+					onFocus={ this.appendDefaultBlock }
+				/>
 			</div>
 		);
 	}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -26,11 +26,11 @@
 .editor-visual-editor__block {
 	margin-left: auto;
 	margin-right: auto;
+	margin-bottom: 5px;
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
 	position: relative;
 	 // The block mover needs to stay inside the block to allow clicks when hovering the block
 	padding: $block-padding $block-padding + $block-mover-padding-visible;
-	transition: 0.2s border-color;
 
 	&:before {
 		z-index: z-index( '.editor-visual-editor__block:before' );
@@ -40,16 +40,18 @@
 		bottom: 0;
 		left: $block-mover-padding-visible;
 		right: $block-mover-padding-visible;
-		border: 2px solid transparent;
-		transition: 0.2s border-color;
+		outline: 1px solid transparent;
+		transition: 0.2s outline;
 	}
 
 	&.is-hovered:before {
-		border-left-color: $light-gray-500;
+		outline: 1px dotted $light-gray-500;
+		transition: 0.2s outline;
 	}
 
 	&.is-selected:before {
-		border-color: $light-gray-500;
+		outline: 2px solid $light-gray-500;
+		transition: 0.2s outline;
 	}
 
 	&.is-multi-selected *::selection {
@@ -58,7 +60,8 @@
 
 	&.is-multi-selected:before {
 		background: $blue-medium-100;
-		border: 2px solid $blue-medium-200;
+		outline: 2px solid $blue-medium-200;
+		transition: 0.2s outline;
 	}
 
 	.iframe-overlay {
@@ -258,25 +261,26 @@ $sticky-bottom-offset: 20px;
 }
 
 .editor-visual-editor__placeholder[type=text] {
-	margin-left: auto;
-	margin-right: auto;
+	margin: 2px auto;
 	max-width: $visual-editor-max-width;
 	position: relative;
 	padding: $block-padding;
-	border: 2px solid transparent;
+	outline: 1px solid transparent;
+	border: none;
 	background: none;
 	box-shadow: none;
 	display: block;
-	transition: 0.2s border-color;
+	transition: 0.2s outline;
 	text-align: left;
 	width: 100%;
 	color: inherit;
 	opacity: 0.5;
 	font-size: $editor-font-size;
+	line-height: $editor-line-height;
 	cursor: text;
-	left: -2px;
+	left: -1px;
 
 	&:hover {
-		border-left-color: $light-gray-500;
+		outline: 1px dotted $light-gray-500;
 	}
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -45,7 +45,7 @@
 	}
 
 	&.is-hovered:before {
-		outline: 1px dotted $light-gray-500;
+		outline: 1px solid $light-gray-500;
 		transition: 0.2s outline;
 	}
 
@@ -273,14 +273,13 @@ $sticky-bottom-offset: 20px;
 	transition: 0.2s outline;
 	text-align: left;
 	width: 100%;
-	color: inherit;
-	opacity: 0.5;
+	color: $light-gray-700;
 	font-size: $editor-font-size;
 	line-height: $editor-line-height;
 	cursor: text;
 	left: -1px;
 
 	&:hover {
-		outline: 1px dotted $light-gray-500;
+		outline: 1px solid $light-gray-500;
 	}
 }

--- a/editor/post-title/style.scss
+++ b/editor/post-title/style.scss
@@ -15,7 +15,7 @@
 	}
 
 	&:hover h1 {
-		outline: 1px dotted $light-gray-500;
+		outline: 1px solid $light-gray-500;
 		transition: 0.2s outline;
 	}
 

--- a/editor/post-title/style.scss
+++ b/editor/post-title/style.scss
@@ -7,16 +7,21 @@
 	margin-bottom: 10px;
 
 	h1 {
-		border: 2px solid transparent;
+		outline: 1px solid transparent;
 		margin: 0;
 		padding: #{ $block-padding / 2 } #{ $block-padding - 2px };
 		font-size: $editor-font-size;
-		transition: 0.2s border-color;
+		transition: 0.2s outline;
+	}
+
+	&:hover h1 {
+		outline: 1px dotted $light-gray-500;
+		transition: 0.2s outline;
 	}
 
 	&.is-selected h1 {
-		border: 2px solid $light-gray-500;
-		transition: 0.2s border-color;
+		outline: 2px solid $light-gray-500;
+		transition: 0.2s outline;
 	}
 
 	.editor-text-editor & {


### PR DESCRIPTION
closes #1209 
closes #1250 

I've used "outline" instead of "border" for the block borders to avoid a flickering effect when the border size changes. 
I tried the other option (using a margin to compensate the border size, but I've found the outline method way simpler even if theoretically it's less performant).