### PR TITLE
Blocks: Select ALL on Ctrl+A outside editable DOM elements

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -14,6 +14,14 @@ export function deselectBlock( uid ) {
 	};
 }
 
+export function multiSelect( start, end ) {
+	return {
+		type: 'MULTI_SELECT',
+		start,
+		end,
+	};
+}
+
 export function clearSelectedBlock() {
 	return {
 		type: 'CLEAR_SELECTED_BLOCK',

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -23,7 +23,7 @@ import {
 	getMultiSelectedBlocks,
 	getMultiSelectedBlockUids,
 } from '../../selectors';
-import { insertBlock } from '../../actions';
+import { insertBlock, multiSelect } from '../../actions';
 
 const INSERTION_POINT_PLACEHOLDER = '[[insertion-point]]';
 
@@ -136,11 +136,11 @@ class VisualEditorBlockList extends wp.element.Component {
 		}
 
 		if ( isAtStart && selectionStart ) {
-			onMultiSelect( { start: null, end: null } );
+			onMultiSelect( null, null );
 		}
 
 		if ( ! isAtStart && selectionEnd !== uid ) {
-			onMultiSelect( { start: selectionAtStart, end: uid } );
+			onMultiSelect( selectionAtStart, uid );
 		}
 	}
 
@@ -220,8 +220,8 @@ export default connect(
 		onInsertBlock( block ) {
 			dispatch( insertBlock( block ) );
 		},
-		onMultiSelect( { start, end } ) {
-			dispatch( { type: 'MULTI_SELECT', start, end } );
+		onMultiSelect( start, end ) {
+			dispatch( multiSelect( start, end ) );
 		},
 		onRemove( uids ) {
 			dispatch( { type: 'REMOVE_BLOCKS', uids } );

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -20,6 +20,7 @@ import VisualEditorBlockList from './block-list';
 import PostTitle from '../../post-title';
 import { getBlockUids } from '../../selectors';
 import { clearSelectedBlock, multiSelect } from '../../actions';
+import { isEditableElement } from '../../utils/dom';
 
 class VisualEditor extends Component {
 	constructor() {
@@ -54,10 +55,8 @@ class VisualEditor extends Component {
 
 	onKeyDown( event ) {
 		const { uids } = this.props;
-		const isEditable = [ 'textarea', 'input', 'select' ].indexOf( document.activeElement.tagName.toLowerCase() ) !== -1
-			|| document.activeElement.isContentEditable;
 		if (
-			! isEditable &&
+			! isEditableElement( document.activeElement ) &&
 			( event.ctrlKey || event.metaKey ) &&
 			event.keyCode === CHAR_A
 		) {

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -9,7 +9,7 @@ import { first, last } from 'lodash';
  */
 import { __ } from 'i18n';
 import { Component, findDOMNode } from 'element';
-import { LETTER_A } from 'utils/keycodes';
+import { CHAR_A } from 'utils/keycodes';
 
 /**
  * Internal dependencies
@@ -59,7 +59,7 @@ class VisualEditor extends Component {
 		if (
 			! isEditable &&
 			( event.ctrlKey || event.metaKey ) &&
-			event.keyCode === LETTER_A
+			event.keyCode === CHAR_A
 		) {
 			event.preventDefault();
 			this.props.multiSelect( first( uids ), last( uids ) );

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -9,7 +9,7 @@ import { first, last } from 'lodash';
  */
 import { __ } from 'i18n';
 import { Component, findDOMNode } from 'element';
-import { LETTER_A, SMALL_LETTER_A } from 'utils/keycodes';
+import { LETTER_A } from 'utils/keycodes';
 
 /**
  * Internal dependencies
@@ -59,7 +59,7 @@ class VisualEditor extends Component {
 		if (
 			! isEditable &&
 			( event.ctrlKey || event.metaKey ) &&
-			[ LETTER_A, SMALL_LETTER_A ].indexOf( event.keyCode ) !== -1
+			event.keyCode === LETTER_A
 		) {
 			event.preventDefault();
 			this.props.multiSelect( first( uids ), last( uids ) );

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -1,0 +1,13 @@
+
+/**
+ * Utility function to check whether the domElement provided is editable or not
+ * An editable element means we can type in it to edit its content
+ * This includes inputs and contenteditables
+ *
+ * @param  {DomElement} domElement  DOM Element
+ * @return {Boolean}                Whether the DOM Element is editable or not
+ */
+export function isEditableElement( domElement ) {
+	return [ 'textarea', 'input', 'select' ].indexOf( domElement.tagName.toLowerCase() ) !== -1
+		|| !! domElement.isContentEditable;
+}

--- a/editor/utils/test/dom.js
+++ b/editor/utils/test/dom.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isEditableElement } from '../dom';
+
+describe.only( 'isEditableElement', () => {
+	it( 'should return false for non editable nodes', () => {
+		const div = document.createElement( 'div' );
+
+		expect( isEditableElement( div ) ).to.be.false();
+	} );
+
+	it( 'should return true for inputs', () => {
+		const input = document.createElement( 'input' );
+
+		expect( isEditableElement( input ) ).to.be.true();
+	} );
+
+	it( 'should return true for textareas', () => {
+		const textarea = document.createElement( 'textarea' );
+
+		expect( isEditableElement( textarea ) ).to.be.true();
+	} );
+
+	it( 'should return true for selects', () => {
+		const select = document.createElement( 'select' );
+
+		expect( isEditableElement( select ) ).to.be.true();
+	} );
+} );

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -7,3 +7,5 @@ export const UP = 38;
 export const RIGHT = 39;
 export const DOWN = 40;
 export const DELETE = 46;
+export const LETTER_A = 65;
+export const SMALL_LETTER_A = 97;

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -7,4 +7,4 @@ export const UP = 38;
 export const RIGHT = 39;
 export const DOWN = 40;
 export const DELETE = 46;
-export const LETTER_A = 65;
+export const CHAR_A = 'A'.charCodeAt( 0 );

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -8,4 +8,3 @@ export const RIGHT = 39;
 export const DOWN = 40;
 export const DELETE = 46;
 export const LETTER_A = 65;
-export const SMALL_LETTER_A = 97;


### PR DESCRIPTION
closes #3 

So basically, I'm listening to all Ctrl+A and Command+A events and if the active element is not editable (is not an input, textarea, select or contenteditable), I trigger a global multi selection.

