### PR TITLE
Parser: Store attributes in unescaped JSON format

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -1,15 +1,11 @@
 {
 
-function untransformValue( value ) {
-	return 'string' === typeof value
-		? value.replace( /\\-/g, '-' )
-		: value;
-}
-
-function keyValue( key, value ) {
-  const o = {};
-  o[ key ] = untransformValue( value );
-  return o;
+function maybeJSON( s ) {
+	try {
+		return JSON.parse( s );
+	} catch (e) {
+		return null;
+	}
 }
 
 }
@@ -26,7 +22,7 @@ WP_Block
   / WP_Block_Html
 
 WP_Block_Void
-  = "<!--" __ "wp:" blockName:WP_Block_Name attrs:HTML_Attribute_List _? "/-->"
+  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ { return a })? "/-->"
   { return {
     blockName: blockName,
     attrs: attrs,
@@ -34,7 +30,8 @@ WP_Block_Void
   } }
 
 WP_Block_Balanced
-  = s:WP_Block_Start ts:(!WP_Block_End c:Any { return c })* e:WP_Block_End & { return s.blockName === e.blockName }
+  = s:WP_Block_Start ts:(!WP_Block_End c:Any { return c })* e:WP_Block_End
+  & { return s.blockName === e.blockName }
   { return {
     blockName: s.blockName,
     attrs: s.attrs,
@@ -51,14 +48,14 @@ WP_Block_Html
   }
 
 WP_Block_Start
-  = "<!--" __ "wp:" blockName:WP_Block_Name attrs:HTML_Attribute_List __ "-->"
+  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ { return a })? "-->"
   { return {
     blockName: blockName,
     attrs: attrs
   } }
 
 WP_Block_End
-  = "<!--" __ "/wp:" blockName:WP_Block_Name __ "-->"
+  = "<!--" WS+ "/wp:" blockName:WP_Block_Name WS+ "-->"
   { return {
     blockName: blockName
   } }
@@ -66,31 +63,9 @@ WP_Block_End
 WP_Block_Name
   = $(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
 
-HTML_Attribute_List
-  = as:(_+ a:HTML_Attribute_Item { return a })*
-  { return as.reduce( function( attrs, attr ) { return Object.assign( attrs, attr ) }, {} ) }
-
-HTML_Attribute_Item
-  = HTML_Attribute_Quoted
-  / HTML_Attribute_Unquoted
-  / HTML_Attribute_Empty
-
-HTML_Attribute_Empty
-  = name:HTML_Attribute_Name
-  { return keyValue( name, true ) }
-
-HTML_Attribute_Unquoted
-  = name:HTML_Attribute_Name _* "=" _* value:$([a-zA-Z0-9]+)
-  { return keyValue( name, value ) }
-
-HTML_Attribute_Quoted
-  = name:HTML_Attribute_Name _* "=" _* '"' value:$(('\\"' . / !'"' .)*) '"'
-  { return keyValue( name, value ) }
-  / name:HTML_Attribute_Name _* "=" _* "'" value:$(("\\'" . / !"'" .)*) "'"
-  { return keyValue( name, value ) }
-
-HTML_Attribute_Name
-  = $([a-zA-Z0-9:.]+)
+WP_Block_Attributes
+  = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")
+  { return maybeJSON( attrs ) }
 
 ASCII_AlphaNumeric
   = ASCII_Letter
@@ -105,6 +80,9 @@ ASCII_Digit
 
 Special_Chars
   = [\-\_]
+
+WS
+  = [ \t\r\n]
 
 Newline
   = [\r\n]

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -119,16 +119,12 @@ export function getCommentAttributes( allAttributes, attributesFromContent ) {
 	);
 }
 
-/**
- * Lodash iterator which transforms a key: value
- * pair into a string of `key="value"`
- *
- * @param {*}        value value to be stringified
- * @param {String}   key   name of value
- * @returns {string}       stringified equality pair
- */
-function asNameValuePair( value, key ) {
-	return `${ key }="${ serializeValue( value ) }"`;
+export function serializeAttributes( attrs ) {
+	return JSON.stringify( attrs )
+		.replace( /--/g, '\\u002d\\u002d' ) // don't break HTML comments
+		.replace( /</g, '\\u003c' ) // don't break standard-non-compliant tools
+		.replace( />/g, '\\u003e' ) // ibid
+		.replace( /&/g, '\\u0026' ); // ibid
 }
 
 export function serializeBlock( block ) {
@@ -138,7 +134,7 @@ export function serializeBlock( block ) {
 	const saveAttributes = getCommentAttributes( block.attributes, parseBlockAttributes( saveContent, blockType ) );
 
 	const serializedAttributes = ! isEmpty( saveAttributes )
-		? map( saveAttributes, asNameValuePair ).join( ' ' ) + ' '
+		? serializeAttributes( saveAttributes ) + ' '
 		: '';
 
 	if ( ! saveContent ) {

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, map, reduce, kebabCase, isObject } from 'lodash';
+import { isEmpty, reduce, kebabCase, isObject } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 import classnames from 'classnames';
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -68,24 +68,6 @@ export function getSaveContent( blockType, attributes ) {
 	return renderToString( contentWithClassname );
 }
 
-const escapeDoubleQuotes = value => value.replace( /"/g, '\"' );
-const escapeHyphens = value => value.replace( /-/g, '\\-' );
-
-/**
- * Transform value for storage in block comment
- *
- * Some special characters and sequences should not
- * appear in a block comment header. This transformer
- * will guarantee that we store the data safely.
- *
- * @param {*}   value attribute value to serialize
- * @returns {*}       transformed value
- */
-export const serializeValue = value =>
-	'string' === typeof value
-		? escapeHyphens( escapeDoubleQuotes( value ) )
-		: value;
-
 /**
  * Returns attributes which ought to be saved
  * and serialized into the block comment header

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -152,7 +152,7 @@ describe( 'block parser', () => {
 			} );
 
 			const parsed = parse(
-				'<!-- wp:core/test-block smoked="yes" url="http://google.com" chicken="ribs & \'wings\'" -->' +
+				'<!-- wp:core/test-block {"smoked":"yes","url":"http://google.com","chicken":"ribs & \'wings\'"} -->' +
 				'Brisket' +
 				'<!-- /wp:core/test-block -->'
 			);

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -11,7 +11,7 @@ import { createElement, Component } from 'element';
 /**
  * Internal dependencies
  */
-import serialize, { getCommentAttributes, getSaveContent, serializeValue } from '../serializer';
+import serialize, { getCommentAttributes, getSaveContent } from '../serializer';
 import { getBlockTypes, registerBlockType, unregisterBlockType } from '../registration';
 
 describe( 'block serializer', () => {
@@ -134,18 +134,6 @@ describe( 'block serializer', () => {
 			}, {} );
 
 			expect( attributes ).to.eql( { fruit: 'bananas' } );
-		} );
-	} );
-
-	describe( 'serializeValue()', () => {
-		it( 'should escape double-quotes', () => {
-			expect( serializeValue( 'a"b' ) ).to.equal( 'a\"b' );
-		} );
-
-		it( 'should escape hyphens', () => {
-			expect( serializeValue( '-' ) ).to.equal( '\u{5c}-' );
-			expect( serializeValue( '--' ) ).to.equal( '\u{5c}-\u{5c}-' );
-			expect( serializeValue( '\\-' ) ).to.equal( '\u{5c}\u{5c}-' );
 		} );
 	} );
 

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -171,7 +171,7 @@ describe( 'block serializer', () => {
 					},
 				},
 			];
-			const expectedPostContent = '<!-- wp:core/test-block align="left" -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
+			const expectedPostContent = '<!-- wp:core/test-block {"align":"left"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
 
 			expect( serialize( blockList ) ).to.eql( expectedPostContent );
 		} );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -11,7 +11,7 @@ import { createElement, Component } from 'element';
 /**
  * Internal dependencies
  */
-import serialize, { getCommentAttributes, getSaveContent } from '../serializer';
+import serialize, { getCommentAttributes, getSaveContent, serializeAttributes } from '../serializer';
 import { getBlockTypes, registerBlockType, unregisterBlockType } from '../registration';
 
 describe( 'block serializer', () => {
@@ -137,6 +137,21 @@ describe( 'block serializer', () => {
 		} );
 	} );
 
+	describe( 'serializeAttributes()', () => {
+		it( 'should not break HTML comments', () => {
+			expect( serializeAttributes( { a: '-- and --' } ) ).to.equal( '{"a":"\\u002d\\u002d and \\u002d\\u002d"}' );
+		} );
+		it( 'should not break standard-non-compliant tools for "<"', () => {
+			expect( serializeAttributes( { a: '< and <' } ) ).to.equal( '{"a":"\\u003c and \\u003c"}' );
+		} );
+		it( 'should not break standard-non-compliant tools for ">"', () => {
+			expect( serializeAttributes( { a: '> and >' } ) ).to.equal( '{"a":"\\u003e and \\u003e"}' );
+		} );
+		it( 'should not break standard-non-compliant tools for "&"', () => {
+			expect( serializeAttributes( { a: '& and &' } ) ).to.equal( '{"a":"\\u0026 and \\u0026"}' );
+		} );
+	} );
+
 	describe( 'serialize()', () => {
 		it( 'should serialize the post content properly', () => {
 			const blockType = {
@@ -155,11 +170,11 @@ describe( 'block serializer', () => {
 					name: 'core/test-block',
 					attributes: {
 						content: 'Ribs & Chicken',
-						align: 'left',
+						stuff: 'left & right -- but <not>',
 					},
 				},
 			];
-			const expectedPostContent = '<!-- wp:core/test-block {"align":"left"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
+			const expectedPostContent = '<!-- wp:core/test-block {"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
 
 			expect( serialize( blockList ) ).to.eql( expectedPostContent );
 		} );

--- a/blocks/test/fixtures/core-button-center.html
+++ b/blocks/test/fixtures/core-button-center.html
@@ -1,3 +1,3 @@
-<!-- wp:core/button align="center" -->
+<!-- wp:core/button {"align":"center"} -->
 <div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->

--- a/blocks/test/fixtures/core-button-center.serialized.html
+++ b/blocks/test/fixtures/core-button-center.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/button align="center" -->
+<!-- wp:core/button {"align":"center"} -->
 <div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->
 

--- a/blocks/test/fixtures/core-cover-image.html
+++ b/blocks/test/fixtures/core-cover-image.html
@@ -1,4 +1,4 @@
-<!-- wp:core/cover-image url="https://cldup.com/uuUqE_dXzy.jpg" -->
+<!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg"} -->
 <section class="blocks-cover-image">
 	<section class="cover-image" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg);">
 		<h2>Guten Berg!</h2>

--- a/blocks/test/fixtures/core-cover-image.serialized.html
+++ b/blocks/test/fixtures/core-cover-image.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/cover-image url="https://cldup.com/uuUqE_dXzy.jpg" -->
+<!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg"} -->
 <section class="blocks-cover-image wp-block-cover-image">
     <section class="cover-image" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg);">
         <h2>Guten Berg!</h2>

--- a/blocks/test/fixtures/core-embed.html
+++ b/blocks/test/fixtures/core-embed.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embed url="https://example.com/" -->
+<!-- wp:core/embed {"url":"https://example.com/"} -->
 <figure class="wp-block-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>

--- a/blocks/test/fixtures/core-embed.serialized.html
+++ b/blocks/test/fixtures/core-embed.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embed url="https://example.com/" -->
+<!-- wp:core/embed {"url":"https://example.com/"} -->
 <figure class="wp-block-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>

--- a/blocks/test/fixtures/core-embedanimoto.html
+++ b/blocks/test/fixtures/core-embedanimoto.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedanimoto url="https://animoto.com/" -->
+<!-- wp:core/embedanimoto {"url":"https://animoto.com/"} -->
 <figure class="wp-block-embedanimoto">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>

--- a/blocks/test/fixtures/core-embedanimoto.serialized.html
+++ b/blocks/test/fixtures/core-embedanimoto.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedanimoto url="https://animoto.com/" -->
+<!-- wp:core/embedanimoto {"url":"https://animoto.com/"} -->
 <figure class="wp-block-embedanimoto">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>

--- a/blocks/test/fixtures/core-embedcloudup.html
+++ b/blocks/test/fixtures/core-embedcloudup.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedcloudup url="https://cloudup.com/" -->
+<!-- wp:core/embedcloudup {"url":"https://cloudup.com/"} -->
 <figure class="wp-block-embedcloudup">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>

--- a/blocks/test/fixtures/core-embedcloudup.serialized.html
+++ b/blocks/test/fixtures/core-embedcloudup.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedcloudup url="https://cloudup.com/" -->
+<!-- wp:core/embedcloudup {"url":"https://cloudup.com/"} -->
 <figure class="wp-block-embedcloudup">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>

--- a/blocks/test/fixtures/core-embedcollegehumor.html
+++ b/blocks/test/fixtures/core-embedcollegehumor.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedcollegehumor url="https://collegehumor.com/" -->
+<!-- wp:core/embedcollegehumor {"url":"https://collegehumor.com/"} -->
 <figure class="wp-block-embedcollegehumor">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>

--- a/blocks/test/fixtures/core-embedcollegehumor.serialized.html
+++ b/blocks/test/fixtures/core-embedcollegehumor.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedcollegehumor url="https://collegehumor.com/" -->
+<!-- wp:core/embedcollegehumor {"url":"https://collegehumor.com/"} -->
 <figure class="wp-block-embedcollegehumor">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>

--- a/blocks/test/fixtures/core-embeddailymotion.html
+++ b/blocks/test/fixtures/core-embeddailymotion.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embeddailymotion url="https://dailymotion.com/" -->
+<!-- wp:core/embeddailymotion {"url":"https://dailymotion.com/"} -->
 <figure class="wp-block-embeddailymotion">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>

--- a/blocks/test/fixtures/core-embeddailymotion.serialized.html
+++ b/blocks/test/fixtures/core-embeddailymotion.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embeddailymotion url="https://dailymotion.com/" -->
+<!-- wp:core/embeddailymotion {"url":"https://dailymotion.com/"} -->
 <figure class="wp-block-embeddailymotion">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>

--- a/blocks/test/fixtures/core-embedfacebook.html
+++ b/blocks/test/fixtures/core-embedfacebook.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedfacebook url="https://facebook.com/" -->
+<!-- wp:core/embedfacebook {"url":"https://facebook.com/"} -->
 <figure class="wp-block-embedfacebook">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>

--- a/blocks/test/fixtures/core-embedfacebook.serialized.html
+++ b/blocks/test/fixtures/core-embedfacebook.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedfacebook url="https://facebook.com/" -->
+<!-- wp:core/embedfacebook {"url":"https://facebook.com/"} -->
 <figure class="wp-block-embedfacebook">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>

--- a/blocks/test/fixtures/core-embedflickr.html
+++ b/blocks/test/fixtures/core-embedflickr.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedflickr url="https://flickr.com/" -->
+<!-- wp:core/embedflickr {"url":"https://flickr.com/"} -->
 <figure class="wp-block-embedflickr">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>

--- a/blocks/test/fixtures/core-embedflickr.serialized.html
+++ b/blocks/test/fixtures/core-embedflickr.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedflickr url="https://flickr.com/" -->
+<!-- wp:core/embedflickr {"url":"https://flickr.com/"} -->
 <figure class="wp-block-embedflickr">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>

--- a/blocks/test/fixtures/core-embedfunnyordie.html
+++ b/blocks/test/fixtures/core-embedfunnyordie.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedfunnyordie url="https://funnyordie.com/" -->
+<!-- wp:core/embedfunnyordie {"url":"https://funnyordie.com/"} -->
 <figure class="wp-block-embedfunnyordie">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>

--- a/blocks/test/fixtures/core-embedfunnyordie.serialized.html
+++ b/blocks/test/fixtures/core-embedfunnyordie.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedfunnyordie url="https://funnyordie.com/" -->
+<!-- wp:core/embedfunnyordie {"url":"https://funnyordie.com/"} -->
 <figure class="wp-block-embedfunnyordie">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>

--- a/blocks/test/fixtures/core-embedhulu.html
+++ b/blocks/test/fixtures/core-embedhulu.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedhulu url="https://hulu.com/" -->
+<!-- wp:core/embedhulu {"url":"https://hulu.com/"} -->
 <figure class="wp-block-embedhulu">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>

--- a/blocks/test/fixtures/core-embedhulu.serialized.html
+++ b/blocks/test/fixtures/core-embedhulu.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedhulu url="https://hulu.com/" -->
+<!-- wp:core/embedhulu {"url":"https://hulu.com/"} -->
 <figure class="wp-block-embedhulu">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>

--- a/blocks/test/fixtures/core-embedimgur.html
+++ b/blocks/test/fixtures/core-embedimgur.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedimgur url="https://imgur.com/" -->
+<!-- wp:core/embedimgur {"url":"https://imgur.com/"} -->
 <figure class="wp-block-embedimgur">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>

--- a/blocks/test/fixtures/core-embedimgur.serialized.html
+++ b/blocks/test/fixtures/core-embedimgur.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedimgur url="https://imgur.com/" -->
+<!-- wp:core/embedimgur {"url":"https://imgur.com/"} -->
 <figure class="wp-block-embedimgur">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>

--- a/blocks/test/fixtures/core-embedinstagram.html
+++ b/blocks/test/fixtures/core-embedinstagram.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedinstagram url="https://instagram.com/" -->
+<!-- wp:core/embedinstagram {"url":"https://instagram.com/"} -->
 <figure class="wp-block-embedinstagram">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>

--- a/blocks/test/fixtures/core-embedinstagram.serialized.html
+++ b/blocks/test/fixtures/core-embedinstagram.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedinstagram url="https://instagram.com/" -->
+<!-- wp:core/embedinstagram {"url":"https://instagram.com/"} -->
 <figure class="wp-block-embedinstagram">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>

--- a/blocks/test/fixtures/core-embedissuu.html
+++ b/blocks/test/fixtures/core-embedissuu.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedissuu url="https://issuu.com/" -->
+<!-- wp:core/embedissuu {"url":"https://issuu.com/"} -->
 <figure class="wp-block-embedissuu">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>

--- a/blocks/test/fixtures/core-embedissuu.serialized.html
+++ b/blocks/test/fixtures/core-embedissuu.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedissuu url="https://issuu.com/" -->
+<!-- wp:core/embedissuu {"url":"https://issuu.com/"} -->
 <figure class="wp-block-embedissuu">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>

--- a/blocks/test/fixtures/core-embedkickstarter.html
+++ b/blocks/test/fixtures/core-embedkickstarter.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedkickstarter url="https://kickstarter.com/" -->
+<!-- wp:core/embedkickstarter {"url":"https://kickstarter.com/"} -->
 <figure class="wp-block-embedkickstarter">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>

--- a/blocks/test/fixtures/core-embedkickstarter.serialized.html
+++ b/blocks/test/fixtures/core-embedkickstarter.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedkickstarter url="https://kickstarter.com/" -->
+<!-- wp:core/embedkickstarter {"url":"https://kickstarter.com/"} -->
 <figure class="wp-block-embedkickstarter">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>

--- a/blocks/test/fixtures/core-embedmeetupcom.html
+++ b/blocks/test/fixtures/core-embedmeetupcom.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedmeetupcom url="https://meetupcom.com/" -->
+<!-- wp:core/embedmeetupcom {"url":"https://meetupcom.com/"} -->
 <figure class="wp-block-embedmeetupcom">
     https://meetupcom.com/
     <figcaption>Embedded content from meetupcom</figcaption>

--- a/blocks/test/fixtures/core-embedmeetupcom.serialized.html
+++ b/blocks/test/fixtures/core-embedmeetupcom.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedmeetupcom url="https://meetupcom.com/" -->
+<!-- wp:core/embedmeetupcom {"url":"https://meetupcom.com/"} -->
 <figure class="wp-block-embedmeetupcom">
     https://meetupcom.com/
     <figcaption>Embedded content from meetupcom</figcaption>

--- a/blocks/test/fixtures/core-embedmixcloud.html
+++ b/blocks/test/fixtures/core-embedmixcloud.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedmixcloud url="https://mixcloud.com/" -->
+<!-- wp:core/embedmixcloud {"url":"https://mixcloud.com/"} -->
 <figure class="wp-block-embedmixcloud">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>

--- a/blocks/test/fixtures/core-embedmixcloud.serialized.html
+++ b/blocks/test/fixtures/core-embedmixcloud.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedmixcloud url="https://mixcloud.com/" -->
+<!-- wp:core/embedmixcloud {"url":"https://mixcloud.com/"} -->
 <figure class="wp-block-embedmixcloud">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>

--- a/blocks/test/fixtures/core-embedphotobucket.html
+++ b/blocks/test/fixtures/core-embedphotobucket.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedphotobucket url="https://photobucket.com/" -->
+<!-- wp:core/embedphotobucket {"url":"https://photobucket.com/"} -->
 <figure class="wp-block-embedphotobucket">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>

--- a/blocks/test/fixtures/core-embedphotobucket.serialized.html
+++ b/blocks/test/fixtures/core-embedphotobucket.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedphotobucket url="https://photobucket.com/" -->
+<!-- wp:core/embedphotobucket {"url":"https://photobucket.com/"} -->
 <figure class="wp-block-embedphotobucket">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>

--- a/blocks/test/fixtures/core-embedpolldaddy.html
+++ b/blocks/test/fixtures/core-embedpolldaddy.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedpolldaddy url="https://polldaddy.com/" -->
+<!-- wp:core/embedpolldaddy {"url":"https://polldaddy.com/"} -->
 <figure class="wp-block-embedpolldaddy">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>

--- a/blocks/test/fixtures/core-embedpolldaddy.serialized.html
+++ b/blocks/test/fixtures/core-embedpolldaddy.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedpolldaddy url="https://polldaddy.com/" -->
+<!-- wp:core/embedpolldaddy {"url":"https://polldaddy.com/"} -->
 <figure class="wp-block-embedpolldaddy">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>

--- a/blocks/test/fixtures/core-embedreddit.html
+++ b/blocks/test/fixtures/core-embedreddit.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedreddit url="https://reddit.com/" -->
+<!-- wp:core/embedreddit {"url":"https://reddit.com/"} -->
 <figure class="wp-block-embedreddit">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>

--- a/blocks/test/fixtures/core-embedreddit.serialized.html
+++ b/blocks/test/fixtures/core-embedreddit.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedreddit url="https://reddit.com/" -->
+<!-- wp:core/embedreddit {"url":"https://reddit.com/"} -->
 <figure class="wp-block-embedreddit">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>

--- a/blocks/test/fixtures/core-embedreverbnation.html
+++ b/blocks/test/fixtures/core-embedreverbnation.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedreverbnation url="https://reverbnation.com/" -->
+<!-- wp:core/embedreverbnation {"url":"https://reverbnation.com/"} -->
 <figure class="wp-block-embedreverbnation">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>

--- a/blocks/test/fixtures/core-embedreverbnation.serialized.html
+++ b/blocks/test/fixtures/core-embedreverbnation.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedreverbnation url="https://reverbnation.com/" -->
+<!-- wp:core/embedreverbnation {"url":"https://reverbnation.com/"} -->
 <figure class="wp-block-embedreverbnation">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>

--- a/blocks/test/fixtures/core-embedscreencast.html
+++ b/blocks/test/fixtures/core-embedscreencast.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedscreencast url="https://screencast.com/" -->
+<!-- wp:core/embedscreencast {"url":"https://screencast.com/"} -->
 <figure class="wp-block-embedscreencast">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>

--- a/blocks/test/fixtures/core-embedscreencast.serialized.html
+++ b/blocks/test/fixtures/core-embedscreencast.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedscreencast url="https://screencast.com/" -->
+<!-- wp:core/embedscreencast {"url":"https://screencast.com/"} -->
 <figure class="wp-block-embedscreencast">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>

--- a/blocks/test/fixtures/core-embedscribd.html
+++ b/blocks/test/fixtures/core-embedscribd.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedscribd url="https://scribd.com/" -->
+<!-- wp:core/embedscribd {"url":"https://scribd.com/"} -->
 <figure class="wp-block-embedscribd">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>

--- a/blocks/test/fixtures/core-embedscribd.serialized.html
+++ b/blocks/test/fixtures/core-embedscribd.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedscribd url="https://scribd.com/" -->
+<!-- wp:core/embedscribd {"url":"https://scribd.com/"} -->
 <figure class="wp-block-embedscribd">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>

--- a/blocks/test/fixtures/core-embedslideshare.html
+++ b/blocks/test/fixtures/core-embedslideshare.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedslideshare url="https://slideshare.com/" -->
+<!-- wp:core/embedslideshare {"url":"https://slideshare.com/"} -->
 <figure class="wp-block-embedslideshare">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>

--- a/blocks/test/fixtures/core-embedslideshare.serialized.html
+++ b/blocks/test/fixtures/core-embedslideshare.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedslideshare url="https://slideshare.com/" -->
+<!-- wp:core/embedslideshare {"url":"https://slideshare.com/"} -->
 <figure class="wp-block-embedslideshare">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>

--- a/blocks/test/fixtures/core-embedsmugmug.html
+++ b/blocks/test/fixtures/core-embedsmugmug.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedsmugmug url="https://smugmug.com/" -->
+<!-- wp:core/embedsmugmug {"url":"https://smugmug.com/"} -->
 <figure class="wp-block-embedsmugmug">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>

--- a/blocks/test/fixtures/core-embedsmugmug.serialized.html
+++ b/blocks/test/fixtures/core-embedsmugmug.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedsmugmug url="https://smugmug.com/" -->
+<!-- wp:core/embedsmugmug {"url":"https://smugmug.com/"} -->
 <figure class="wp-block-embedsmugmug">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>

--- a/blocks/test/fixtures/core-embedsoundcloud.html
+++ b/blocks/test/fixtures/core-embedsoundcloud.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedsoundcloud url="https://soundcloud.com/" -->
+<!-- wp:core/embedsoundcloud {"url":"https://soundcloud.com/"} -->
 <figure class="wp-block-embedsoundcloud">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>

--- a/blocks/test/fixtures/core-embedsoundcloud.serialized.html
+++ b/blocks/test/fixtures/core-embedsoundcloud.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedsoundcloud url="https://soundcloud.com/" -->
+<!-- wp:core/embedsoundcloud {"url":"https://soundcloud.com/"} -->
 <figure class="wp-block-embedsoundcloud">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>

--- a/blocks/test/fixtures/core-embedspeaker.html
+++ b/blocks/test/fixtures/core-embedspeaker.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedspeaker url="https://speaker.com/" -->
+<!-- wp:core/embedspeaker {"url":"https://speaker.com/"} -->
 <figure class="wp-block-embedspeaker">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>

--- a/blocks/test/fixtures/core-embedspeaker.serialized.html
+++ b/blocks/test/fixtures/core-embedspeaker.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedspeaker url="https://speaker.com/" -->
+<!-- wp:core/embedspeaker {"url":"https://speaker.com/"} -->
 <figure class="wp-block-embedspeaker">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>

--- a/blocks/test/fixtures/core-embedspotify.html
+++ b/blocks/test/fixtures/core-embedspotify.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedspotify url="https://spotify.com/" -->
+<!-- wp:core/embedspotify {"url":"https://spotify.com/"} -->
 <figure class="wp-block-embedspotify">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>

--- a/blocks/test/fixtures/core-embedspotify.serialized.html
+++ b/blocks/test/fixtures/core-embedspotify.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedspotify url="https://spotify.com/" -->
+<!-- wp:core/embedspotify {"url":"https://spotify.com/"} -->
 <figure class="wp-block-embedspotify">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>

--- a/blocks/test/fixtures/core-embedted.html
+++ b/blocks/test/fixtures/core-embedted.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedted url="https://ted.com/" -->
+<!-- wp:core/embedted {"url":"https://ted.com/"} -->
 <figure class="wp-block-embedted">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>

--- a/blocks/test/fixtures/core-embedted.serialized.html
+++ b/blocks/test/fixtures/core-embedted.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedted url="https://ted.com/" -->
+<!-- wp:core/embedted {"url":"https://ted.com/"} -->
 <figure class="wp-block-embedted">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>

--- a/blocks/test/fixtures/core-embedtumblr.html
+++ b/blocks/test/fixtures/core-embedtumblr.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedtumblr url="https://tumblr.com/" -->
+<!-- wp:core/embedtumblr {"url":"https://tumblr.com/"} -->
 <figure class="wp-block-embedtumblr">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>

--- a/blocks/test/fixtures/core-embedtumblr.serialized.html
+++ b/blocks/test/fixtures/core-embedtumblr.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedtumblr url="https://tumblr.com/" -->
+<!-- wp:core/embedtumblr {"url":"https://tumblr.com/"} -->
 <figure class="wp-block-embedtumblr">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>

--- a/blocks/test/fixtures/core-embedtwitter.html
+++ b/blocks/test/fixtures/core-embedtwitter.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedtwitter url="https://twitter.com/automattic" -->
+<!-- wp:core/embedtwitter {"url":"https://twitter.com/automattic"} -->
 <figure class="wp-block-embedtwitter">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>

--- a/blocks/test/fixtures/core-embedtwitter.serialized.html
+++ b/blocks/test/fixtures/core-embedtwitter.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedtwitter url="https://twitter.com/automattic" -->
+<!-- wp:core/embedtwitter {"url":"https://twitter.com/automattic"} -->
 <figure class="wp-block-embedtwitter">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>

--- a/blocks/test/fixtures/core-embedvideopress.html
+++ b/blocks/test/fixtures/core-embedvideopress.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedvideopress url="https://videopress.com/" -->
+<!-- wp:core/embedvideopress {"url":"https://videopress.com/"} -->
 <figure class="wp-block-embedvideopress">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>

--- a/blocks/test/fixtures/core-embedvideopress.serialized.html
+++ b/blocks/test/fixtures/core-embedvideopress.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedvideopress url="https://videopress.com/" -->
+<!-- wp:core/embedvideopress {"url":"https://videopress.com/"} -->
 <figure class="wp-block-embedvideopress">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>

--- a/blocks/test/fixtures/core-embedvimeo.html
+++ b/blocks/test/fixtures/core-embedvimeo.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedvimeo url="https://vimeo.com/" -->
+<!-- wp:core/embedvimeo {"url":"https://vimeo.com/"} -->
 <figure class="wp-block-embedvimeo">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>

--- a/blocks/test/fixtures/core-embedvimeo.serialized.html
+++ b/blocks/test/fixtures/core-embedvimeo.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedvimeo url="https://vimeo.com/" -->
+<!-- wp:core/embedvimeo {"url":"https://vimeo.com/"} -->
 <figure class="wp-block-embedvimeo">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>

--- a/blocks/test/fixtures/core-embedvine.html
+++ b/blocks/test/fixtures/core-embedvine.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedvine url="https://vine.com/" -->
+<!-- wp:core/embedvine {"url":"https://vine.com/"} -->
 <figure class="wp-block-embedvine">
     https://vine.com/
     <figcaption>Embedded content from vine</figcaption>

--- a/blocks/test/fixtures/core-embedvine.serialized.html
+++ b/blocks/test/fixtures/core-embedvine.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedvine url="https://vine.com/" -->
+<!-- wp:core/embedvine {"url":"https://vine.com/"} -->
 <figure class="wp-block-embedvine">
     https://vine.com/
     <figcaption>Embedded content from vine</figcaption>

--- a/blocks/test/fixtures/core-embedwordpress.html
+++ b/blocks/test/fixtures/core-embedwordpress.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedwordpress url="https://wordpress.com/" -->
+<!-- wp:core/embedwordpress {"url":"https://wordpress.com/"} -->
 <figure class="wp-block-embedwordpress">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>

--- a/blocks/test/fixtures/core-embedwordpress.serialized.html
+++ b/blocks/test/fixtures/core-embedwordpress.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedwordpress url="https://wordpress.com/" -->
+<!-- wp:core/embedwordpress {"url":"https://wordpress.com/"} -->
 <figure class="wp-block-embedwordpress">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>

--- a/blocks/test/fixtures/core-embedwordpresstv.html
+++ b/blocks/test/fixtures/core-embedwordpresstv.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedwordpresstv url="https://wordpresstv.com/" -->
+<!-- wp:core/embedwordpresstv {"url":"https://wordpresstv.com/"} -->
 <figure class="wp-block-embedwordpresstv">
     https://wordpresstv.com/
     <figcaption>Embedded content from wordpresstv</figcaption>

--- a/blocks/test/fixtures/core-embedwordpresstv.serialized.html
+++ b/blocks/test/fixtures/core-embedwordpresstv.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedwordpresstv url="https://wordpresstv.com/" -->
+<!-- wp:core/embedwordpresstv {"url":"https://wordpresstv.com/"} -->
 <figure class="wp-block-embedwordpresstv">
     https://wordpresstv.com/
     <figcaption>Embedded content from wordpresstv</figcaption>

--- a/blocks/test/fixtures/core-embedyoutube.html
+++ b/blocks/test/fixtures/core-embedyoutube.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedyoutube url="https://youtube.com/" -->
+<!-- wp:core/embedyoutube {"url":"https://youtube.com/"} -->
 <figure class="wp-block-embedyoutube">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>

--- a/blocks/test/fixtures/core-embedyoutube.serialized.html
+++ b/blocks/test/fixtures/core-embedyoutube.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/embedyoutube url="https://youtube.com/" -->
+<!-- wp:core/embedyoutube {"url":"https://youtube.com/"} -->
 <figure class="wp-block-embedyoutube">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>

--- a/blocks/test/fixtures/core-image-center-caption.html
+++ b/blocks/test/fixtures/core-image-center-caption.html
@@ -1,3 +1,3 @@
-<!-- wp:core/image align="center" -->
+<!-- wp:core/image {"align":"center"} -->
 <figure class="wp-block-image"><img src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core-image-center-caption.serialized.html
+++ b/blocks/test/fixtures/core-image-center-caption.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/image align="center" -->
+<!-- wp:core/image {"align":"center"} -->
 <figure class="aligncenter wp-block-image"><img src="https://cldup.com/YLYhpou2oq.jpg" />
     <figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-latestposts.html
+++ b/blocks/test/fixtures/core-latestposts.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latestposts poststoshow="5" /-->
+<!-- wp:core/latestposts {"poststoshow":5} /-->

--- a/blocks/test/fixtures/core-latestposts.json
+++ b/blocks/test/fixtures/core-latestposts.json
@@ -3,7 +3,7 @@
         "uid": "_uid_0",
         "name": "core/latestposts",
         "attributes": {
-            "poststoshow": "5"
+            "poststoshow": 5
         }
     }
 ]

--- a/blocks/test/fixtures/core-latestposts.serialized.html
+++ b/blocks/test/fixtures/core-latestposts.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latestposts poststoshow="5" /-->
+<!-- wp:core/latestposts {"poststoshow":5} /-->

--- a/blocks/test/fixtures/core-quote-style-1.html
+++ b/blocks/test/fixtures/core-quote-style-1.html
@@ -1,3 +1,3 @@
-<!-- wp:core/quote style="1" -->
+<!-- wp:core/quote {"style":"1"} -->
 <blockquote class="blocks-quote-style-1 wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core-quote-style-1.serialized.html
+++ b/blocks/test/fixtures/core-quote-style-1.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/quote style="1" -->
+<!-- wp:core/quote {"style":"1"} -->
 <blockquote class="blocks-quote-style-1 wp-block-quote">
     <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
     <footer>Matt Mullenweg, 2017</footer>

--- a/blocks/test/fixtures/core-quote-style-2.html
+++ b/blocks/test/fixtures/core-quote-style-2.html
@@ -1,3 +1,3 @@
-<!-- wp:core/quote style="2" -->
+<!-- wp:core/quote {"style":"2"} -->
 <blockquote class="blocks-quote-style-2 wp-block-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core-quote-style-2.serialized.html
+++ b/blocks/test/fixtures/core-quote-style-2.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/quote style="2" -->
+<!-- wp:core/quote {"style":"2"} -->
 <blockquote class="blocks-quote-style-2 wp-block-quote">
     <p>There is no greater agony than bearing an untold story inside you.</p>
     <footer>Maya Angelou</footer>

--- a/blocks/test/fixtures/core-text-align-right.html
+++ b/blocks/test/fixtures/core-text-align-right.html
@@ -1,3 +1,3 @@
-<!-- wp:core/text align="right" -->
+<!-- wp:core/text {"align":"right"} -->
 <p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
 <!-- /wp:core/text -->

--- a/blocks/test/fixtures/core-text-align-right.serialized.html
+++ b/blocks/test/fixtures/core-text-align-right.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/text align="right" -->
+<!-- wp:core/text {"align":"right"} -->
 <p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
 <!-- /wp:core/text -->
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -104,7 +104,7 @@ function do_blocks( $content ) {
 			$block_attributes_string = trim( $matches['attributes'][ $index ][0] );
 			$block_attributes = json_decode( $block_attributes_string, true );
 			if ( ! is_array( $block_attributes ) ) {
-				$block_attributes = arraty();
+				$block_attributes = array();
 			}
 
 			// Call the block's render function to generate the dynamic output.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -70,27 +70,6 @@ function unregister_block_type( $name ) {
 }
 
 /**
- * Extract the block attributes from the block's attributes string
- *
- * @since 0.1.0
- * @deprecated No longer used since block attributes are stored as JSON.
- *
- * @param string $attr_string Attributes string.
-
- * @return array
- */
-function parse_block_attributes( $attr_string ) {
-	$attributes_matcher = '/([^\s]+)="([^"]+)"\s*/';
-	preg_match_all( $attributes_matcher, $attr_string, $matches );
-	$attributes = array();
-	foreach ( $matches[1] as $index => $attribute_match ) {
-		$attributes[ $attribute_match ] = $matches[2][ $index ];
-	}
-
-	return $attributes;
-}
-
-/**
  * Renders the dynamic blocks into the post content
  *
  * @since 0.1.0
@@ -123,10 +102,9 @@ function do_blocks( $content ) {
 		$output = '';
 		if ( isset( $wp_registered_blocks[ $block_name ] ) ) {
 			$block_attributes_string = trim( $matches['attributes'][ $index ][0] );
-			if ( '{' === substr( $block_attributes_string, 0, 1 ) ) {
-				$block_attributes = json_decode( $block_attributes_string, true );
-			} else {
-				$block_attributes = parse_block_attributes( $block_attributes_string ); // @todo Remove later once block attributes have been migrated to JSON.
+			$block_attributes = json_decode( $block_attributes_string, true );
+			if ( ! is_array( $block_attributes ) ) {
+				$block_attributes = arraty();
 			}
 
 			// Call the block's render function to generate the dynamic output.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -105,7 +105,7 @@ function do_blocks( $content ) {
 	$matcher = '#' . join( '', array(
 		'(?P<opener><!--\s*',
 		'wp:(?P<block_name>[a-z](?:[a-z0-9/]+)*)\s+',
-		'(?P<attributes>(?:(?!-->).)*)',
+		'(?P<attributes>(?:(?!-->).)*?)',
 		'\s*/?-->\n?)',
 		'(?:',
 		'(?P<content>.*?)',

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -73,6 +73,7 @@ function unregister_block_type( $name ) {
  * Extract the block attributes from the block's attributes string
  *
  * @since 0.1.0
+ * @deprecated No longer used since block attributes are stored as JSON.
  *
  * @param string $attr_string Attributes string.
 
@@ -121,8 +122,12 @@ function do_blocks( $content ) {
 
 		$output = '';
 		if ( isset( $wp_registered_blocks[ $block_name ] ) ) {
-			$block_attributes_string = $matches['attributes'][ $index ][0];
-			$block_attributes = parse_block_attributes( $block_attributes_string );
+			$block_attributes_string = trim( $matches['attributes'][ $index ][0] );
+			if ( '{' === substr( $block_attributes_string, 0, 1 ) ) {
+				$block_attributes = json_decode( $block_attributes_string, true );
+			} else {
+				$block_attributes = parse_block_attributes( $block_attributes_string ); // @todo Remove later once block attributes have been migrated to JSON.
+			}
 
 			// Call the block's render function to generate the dynamic output.
 			$output = call_user_func( $wp_registered_blocks[ $block_name ]['render'], $block_attributes );

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -54,11 +54,11 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		// The duplicated dynamic blocks below are there to ensure that do_blocks() replaces each one-by-one.
 		$post_content =
 			'before' .
-			'<!-- wp:core/dummy value="b1" --><!-- /wp:core/dummy -->' .
-			'<!-- wp:core/dummy value="b1" --><!-- /wp:core/dummy -->' .
+			'<!-- wp:core/dummy {"value":"b1"} --><!-- /wp:core/dummy -->' .
+			'<!-- wp:core/dummy {"value":"b1"} --><!-- /wp:core/dummy -->' .
 			'between' .
-			'<!-- wp:core/dummy value="b2" /-->' .
-			'<!-- wp:core/dummy value="b2" /-->' .
+			'<!-- wp:core/dummy {"value":"b2"} /-->' .
+			'<!-- wp:core/dummy {"value":"b2"} /-->' .
 			'after';
 
 		$updated_post_content = do_blocks( $post_content );
@@ -88,9 +88,9 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		register_block_type( 'core/dummy', $settings );
 		$post_content =
 			'before' .
-			"<!-- wp:core/dummy value=\"b1\" -->this\nshould\n\nbe\nignored<!-- /wp:core/dummy -->" .
+			'<!-- wp:core/dummy {"value":"b1"} -->this\nshould\n\nbe\nignored<!-- /wp:core/dummy -->' .
 			'between' .
-			'<!-- wp:core/dummy value="b2" -->this should also be ignored<!-- /wp:core/dummy -->' .
+			'<!-- wp:core/dummy {"value":"b2"} -->this should also be ignored<!-- /wp:core/dummy -->' .
 			'after';
 
 		$updated_post_content = do_blocks( $post_content );

--- a/post-content.js
+++ b/post-content.js
@@ -12,7 +12,7 @@ window._wpGutenbergPost = {
 			'<section className="cover-image wp-block-cover-image" style={ { backgroundImage: \'url("https://cldup.com/GCwahb3aOb.jpg");\' } }><h2>Gutenberg Editor</h2></section>',
 			'<!-- /wp:core/cover-image -->',
 
-			'<!-- wp:core/text { "projectName": "gutenberg", "isAwesome": true } -->',
+			'<!-- wp:core/text { "project": { "name": "gutenberg", "for": "WordPress" }, "isAwesome": true } -->',
 			'<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you\'ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>',
 			'<!-- /wp:core/text -->',
 

--- a/post-content.js
+++ b/post-content.js
@@ -8,7 +8,7 @@ window._wpGutenbergPost = {
 	},
 	content: {
 		raw: [
-			'<!-- wp:core/cover-image url="https://cldup.com/GCwahb3aOb.jpg" -->',
+			'<!-- wp:core/cover-image { "url": "https://cldup.com/GCwahb3aOb.jpg" } -->',
 			'<section className="cover-image wp-block-cover-image" style={ { backgroundImage: \'url("https://cldup.com/GCwahb3aOb.jpg");\' } }><h2>Gutenberg Editor</h2></section>',
 			'<!-- /wp:core/cover-image -->',
 

--- a/post-content.js
+++ b/post-content.js
@@ -12,7 +12,7 @@ window._wpGutenbergPost = {
 			'<section className="cover-image wp-block-cover-image" style={ { backgroundImage: \'url("https://cldup.com/GCwahb3aOb.jpg");\' } }><h2>Gutenberg Editor</h2></section>',
 			'<!-- /wp:core/cover-image -->',
 
-			'<!-- wp:core/text data="{\\"projectName\\":\\"gutenberg\\",\\"isAwesome\\":true}" -->',
+			'<!-- wp:core/text { "projectName": "gutenberg", "isAwesome": true } -->',
 			'<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you\'ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>',
 			'<!-- /wp:core/text -->',
 
@@ -20,7 +20,7 @@ window._wpGutenbergPost = {
 			'<p>What you are reading now is a <strong>text block</strong>, the most basic block of all. The text block has its own controls to be moved freely around the post...</p>',
 			'<!-- /wp:core/text -->',
 
-			'<!-- wp:core/text align="right" -->',
+			'<!-- wp:core/text { "align": "right" } -->',
 			'<p style="text-align:right;">... like this one, which is right aligned.</p>',
 			'<!-- /wp:core/text -->',
 
@@ -38,7 +38,7 @@ window._wpGutenbergPost = {
 			'<p>Handling images and media with the utmost care is a primary focus of the new editor. Hopefully you\'ll find aspects like adding captions or going full-width with your pictures much easier and robust than before.</p>',
 			'<!-- /wp:core/text -->',
 
-			'<!-- wp:core/image align="center" -->',
+			'<!-- wp:core/image { "align": "center" } -->',
 			'<figure class="wp-block-image"><img alt="Beautiful landscape" src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>',
 			'<!-- /wp:core/image -->',
 
@@ -66,7 +66,7 @@ window._wpGutenbergPost = {
 			'<p>If you want to learn more about how to build additional blocks, or if you are interested in helping with the project, head over to the <a href="https://github.com/WordPress/gutenberg">GitHub repository</a>.</p>',
 			'<!-- /wp:core/text -->',
 
-			'<!-- wp:core/button align="center" -->',
+			'<!-- wp:core/button { "align": "center" } -->',
 			'<div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>',
 			'<!-- /wp:core/button -->',
 
@@ -82,7 +82,7 @@ window._wpGutenbergPost = {
 			'<p>A huge benefit of blocks is that you can edit them in place and manipulate you content directly. Instead of having fields for editing things like the source of a quote, or the text of a button, you can directly change the content. Try editing the following quote:</p>',
 			'<!-- /wp:core/text -->',
 
-			'<!-- wp:core/quote style="1" -->',
+			'<!-- wp:core/quote { "style": 1 } -->',
 			'<blockquote class="blocks-quote-style-1 wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>',
 			'<!-- /wp:core/quote -->',
 
@@ -94,7 +94,7 @@ window._wpGutenbergPost = {
 			'<p>Blocks can be anything you need. For instance, you may want to insert a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>',
 			'<!-- /wp:core/text -->',
 
-			'<!-- wp:core/quote style="2" -->',
+			'<!-- wp:core/quote { "style": 2 } -->',
 			'<blockquote class="blocks-quote-style-2 wp-block-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>',
 			'<!-- /wp:core/quote -->',
 
@@ -168,15 +168,15 @@ window._wpGutenbergPost = {
 			'<h2>All that you can embed!</h2>',
 			'<!-- /wp:core/heading -->',
 
-			'<!-- wp:core/embed url="https://www.youtube.com/watch?v=Nl6U7UotA-M" -->',
+			'<!-- wp:core/embed { "url": "https://www.youtube.com/watch?v=Nl6U7UotA-M" } -->',
 			'<figure class="wp-block-embed">https://www.youtube.com/watch?v=Nl6U7UotA-M<figcaption>State of the Word 2016</figcaption></figure>',
 			'<!-- /wp:core/embed -->',
 
-			'<!-- wp:core/embed url="https://twitter.com/photomatt/status/868657763970404352" -->',
+			'<!-- wp:core/embed { "url": "https://twitter.com/photomatt/status/868657763970404352" } -->',
 			'https://twitter.com/photomatt/status/868657763970404352',
 			'<!-- /wp:core/embed -->',
 
-			'<!-- wp:core/embed url="https://make.wordpress.org/core/2017/01/17/editor-technical-overview/" -->',
+			'<!-- wp:core/embed { "url": "https://make.wordpress.org/core/2017/01/17/editor-technical-overview/" } -->',
 			'https://make.wordpress.org/core/2017/01/17/editor-technical-overview/',
 			'<!-- /wp:core/embed -->',
 


### PR DESCRIPTION
@see #1088 

Previously we borrowed the `name="value"` format of tag attributes from
HTML. This caused some headache with blocks because of the different
ways we are wanting to save data in the block comment headers, not the
least of which reason is due to how data must or need not be escaped.

In this change we overhaul the format of the data to allow for (mostly)
unescaped JSON data in the block comment headers. Minimal escaping
exists to prevent breaking the HTML comment and to prevent
poorly-implemented tools from messing up the comments as well.