### PR TITLE
Fix issues with Escape key while editing link

### DIFF
--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { IconButton, Toolbar } from 'components';
+import { ESCAPE } from 'utils/keycodes';
 
 const FORMATTING_CONTROLS = [
 	{
@@ -51,7 +52,7 @@ class FormatToolbar extends wp.element.Component {
 	}
 
 	onKeyDown( event ) {
-		if ( event.key === 'Escape' ) {
+		if ( event.keyCode === ESCAPE ) {
 			if ( this.state.isEditingLink ) {
 				event.stopPropagation();
 				this.dropLink();

--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { IconButton, Toolbar } from 'components';
-import { ESCAPE } from 'utils/keycodes';
 
 const FORMATTING_CONTROLS = [
 	{
@@ -37,23 +36,24 @@ class FormatToolbar extends wp.element.Component {
 		this.dropLink = this.dropLink.bind( this );
 		this.submitLink = this.submitLink.bind( this );
 		this.updateLinkValue = this.updateLinkValue.bind( this );
-		this.onKeyPress = this.onKeyPress.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
 	}
 
 	componentDidMount() {
-		document.addEventListener( 'keypress', this.onKeyPress );
+		document.addEventListener( 'keydown', this.onKeyDown );
 	}
 
 	componentWillUnmout() {
 		if ( this.editTimeout ) {
 			clearTimeout( this.editTimeout );
 		}
+		document.removeEventListener( 'keydown', this.onKeyDown );
 	}
 
-	onKeyPress( event ) {
-		if ( event.keyCode === ESCAPE ) {
+	onKeyDown( event ) {
+		if ( event.key === 'Escape' ) {
 			if ( this.state.isEditingLink ) {
-				event.preventDefault();
+				event.stopPropagation();
 				this.dropLink();
 			}
 		}


### PR DESCRIPTION
* Switch to using event.key instead of event.keyCode which is deprecated
* Add event.stopPropagation() instead of default
* Add remove event listener on unmount
* Use keydown event not keypress - keypress doesnt work with Escape key