### PR TITLE
Front end styling for blocks.

### DIFF
--- a/blocks/library/gallery/blocks.scss
+++ b/blocks/library/gallery/blocks.scss
@@ -1,0 +1,44 @@
+/**
+ * any blocks.scss will be split out into a seperate blocks/build/blocks.css
+ *
+ * This split is useful for enqueing onto the front end.
+ */
+
+.blocks-gallery {
+	display: flex;
+	flex-wrap: wrap;
+
+	.blocks-gallery-image {
+		flex-grow: 1;
+		margin: 8px;
+
+		img {
+			max-width: 100%;
+		}
+	}
+
+	&.columns-1 figure {
+		width: calc(100% / 1 - 2 * 8px);
+	}
+	&.columns-2 figure {
+		width: calc(100% / 2 - 3 * 8px);
+	}
+	&.columns-3 figure {
+		width: calc(100% / 3 - 4 * 8px);
+	}
+	&.columns-4 figure {
+		width: calc(100% / 4 - 5 * 8px);
+	}
+	&.columns-5 figure {
+		width: calc(100% / 5 - 6 * 8px);
+	}
+	&.columns-6 figure {
+		width: calc(100% / 6 - 7 * 8px);
+	}
+	&.columns-7 figure {
+		width: calc(100% / 7 - 8 * 8px);
+	}
+	&.columns-8 figure {
+		width: calc(100% / 8 - 9 * 8px);
+	}
+}

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -2,7 +2,9 @@
  * Internal dependencies
  */
 import { __ } from 'i18n';
+import './blocks.scss';
 import './style.scss';
+
 import { registerBlockType, query as hpq } from '../../api';
 import { Fill } from 'react-slot-fill';
 

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -1,43 +1,4 @@
 
-.blocks-gallery {
-	display: flex;
-	flex-wrap: wrap;
-
-	.blocks-gallery-image {
-		flex-grow: 1;
-		margin: 8px;
-
-		img {
-			max-width: 100%;
-		}
-	}
-
-	&.columns-1 figure {
-		width: calc(100% / 1 - 2 * 8px);
-	}
-	&.columns-2 figure {
-		width: calc(100% / 2 - 3 * 8px);
-	}
-	&.columns-3 figure {
-		width: calc(100% / 3 - 4 * 8px);
-	}
-	&.columns-4 figure {
-		width: calc(100% / 4 - 5 * 8px);
-	}
-	&.columns-5 figure {
-		width: calc(100% / 5 - 6 * 8px);
-	}
-	&.columns-6 figure {
-		width: calc(100% / 6 - 7 * 8px);
-	}
-	&.columns-7 figure {
-		width: calc(100% / 7 - 8 * 8px);
-	}
-	&.columns-8 figure {
-		width: calc(100% / 8 - 9 * 8px);
-	}
-}
-
 .blocks-gallery.is-placeholder {
 	margin: -15px;
 	padding: 6em 0;

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -20,4 +20,5 @@ require_once dirname( __FILE__ ) . '/lib/i18n.php';
 require_once dirname( __FILE__ ) . '/lib/register.php';
 
 // Register server-side code for individual blocks.
+require_once dirname( __FILE__ ) . '/lib/blocks/quote.php';
 require_once dirname( __FILE__ ) . '/lib/blocks/latest-posts.php';

--- a/lib/blocks/quote.php
+++ b/lib/blocks/quote.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Server-side rendering of the `core/quote` block.
+ *
+ * @package gutenberg
+ */
+
+register_block_type( 'core/quote', array() );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -115,10 +115,16 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'components/build/style.css' )
 	);
 	wp_register_style(
-		'wp-blocks',
+		'wp-editor-blocks',
 		gutenberg_url( 'blocks/build/style.css' ),
 		array(),
 		filemtime( gutenberg_dir_path() . 'blocks/build/style.css' )
+	);
+	wp_register_style(
+		'wp-blocks',
+		gutenberg_url( 'blocks/build/blocks.css' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'blocks/build/blocks.css' )
 	);
 }
 add_action( 'init', 'gutenberg_register_scripts_and_styles' );
@@ -366,10 +372,64 @@ function gutenberg_scripts_and_styles( $hook ) {
 		'https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i'
 	);
 	wp_enqueue_style(
+		'wp-blocks'
+	);
+	wp_enqueue_style(
+		'wp-editor-blocks'
+	);
+	wp_enqueue_style(
 		'wp-editor',
 		gutenberg_url( 'editor/build/style.css' ),
 		array( 'wp-components', 'wp-blocks' ),
 		filemtime( gutenberg_dir_path() . 'editor/build/style.css' )
 	);
+
+	// Enqueue any special theme editor styles and scripts.
+	global $wp_registered_blocks;
+	gutenberg_load_custom_assets_by_location( $wp_registered_blocks, 'editor' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_scripts_and_styles' );
+
+/**
+ * Handles the enqueueing of front end scripts and styles from Gutenberg.
+ */
+function gutenberg_frontend_scripts_and_styles() {
+	// Enqueue basic styles built out of Gutenberg through npm build.
+	wp_enqueue_style( 'wp-blocks' );
+
+	// Enqueue any special theme front-end styles and scripts.
+	global $wp_registered_blocks;
+	gutenberg_load_custom_assets_by_location( $wp_registered_blocks, 'theme' );
+}
+add_action( 'wp_enqueue_scripts', 'gutenberg_frontend_scripts_and_styles' );
+
+/**
+ * Loads custom assets based on the location provided.
+ *
+ * Use 'theme' for front end and 'editor' for the editor itself.
+ *
+ * @param array  $blocks   Should be the $wp_registered_blocks global.
+ * @param string $location A string to check for assets for a location.
+ */
+function gutenberg_load_custom_assets_by_location( $blocks, $location ) {
+	foreach ( $blocks as $name => $settings ) {
+		// If there are assets registered see if any theme assets are registered.
+		if ( isset( $settings['assets'] ) && isset( $settings['assets'][ $location ] ) ) {
+			$location_assets = $settings['assets'][ $location ];
+
+			// Handle scripts.
+			if ( isset( $location_assets['scripts'] ) && is_array( $location_assets['scripts'] ) ) {
+				foreach ( $location_assets['scripts'] as $script ) {
+					wp_enqueue_style( $script['handle'], $script['src'], $script['deps'], $script['ver'], $script['in_footer'] );
+				}
+			}
+
+			// Handle styles.
+			if ( isset( $location_assets['styles'] ) && is_array( $location_assets['styles'] ) ) {
+				foreach ( $location_assets['styles'] as $style ) {
+					wp_enqueue_style( $style['handle'], $style['src'], $style['deps'], $style['ver'], $style['media'] );
+				}
+			}
+		}
+	}
+}

--- a/phpunit/class-asset-registration-test.php
+++ b/phpunit/class-asset-registration-test.php
@@ -1,0 +1,492 @@
+<?php
+/**
+ * Blocks asset registration tests
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Test registering scripts and styles, for theme view and editor view.
+ */
+class Asset_Registration_Test extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+
+		register_block_type( 'core/text', array() );
+	}
+
+	function tearDown() {
+		$GLOBALS['wp_registered_blocks'] = array();
+	}
+
+	/**
+	 * Should reject blocks that are not registered.
+	 *
+	 * @expectedIncorrectUsage register_block_assets
+	 */
+	function test_registering_to_unregistered_block() {
+		$result = register_block_assets( 'core/does-not-exist', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test registering to a block with empty assets.
+	 */
+	function test_registering_assets_to_registered_block_without_assets() {
+		$assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$result = register_block_assets( 'core/text', $assets );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $assets, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Test registering to a block with already existing assets.
+	 */
+	function test_registering_assets_to_registered_block_with_existing_assets() {
+		$assets_1 = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		register_block_assets( 'core/text', $assets_1 );
+
+		$assets_2 = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$result = register_block_assets( 'core/text', $assets_2 );
+
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Should add an editor style asset for the block.
+	 */
+	function test_gutenberg_add_block_editor_style() {
+		$expected = array(
+			'editor' => array(
+				'styles' => array(
+					array(
+						'handle' => 'my-handle',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => false,
+						'media'  => 'all',
+					),
+				),
+			),
+		);
+		gutenberg_add_block_editor_style( 'core/text', 'my-handle', 'https://wordpress.org/is-the-best' );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $expected, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Should add an editor style asset for the block.
+	 */
+	function test_gutenberg_add_block_theme_style() {
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'my-handle',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => false,
+						'media'  => 'all',
+					),
+				),
+			),
+		);
+		gutenberg_add_block_theme_style( 'core/text', 'my-handle', 'https://wordpress.org/is-the-best' );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $expected, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Should add an editor script asset for the block.
+	 */
+	function test_gutenberg_add_block_editor_script() {
+		$expected = array(
+			'editor' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'my-handle',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => false,
+						'in_footer'  => false,
+					),
+				),
+			),
+		);
+		gutenberg_add_block_editor_script( 'core/text', 'my-handle', 'https://wordpress.org/is-the-best' );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $expected, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Should add an editor script asset for the block.
+	 */
+	function test_gutenberg_add_block_theme_script() {
+		$expected = array(
+			'theme' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'my-handle',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => false,
+						'in_footer'  => false,
+					),
+				),
+			),
+		);
+		gutenberg_add_block_theme_script( 'core/text', 'my-handle', 'https://wordpress.org/is-the-best' );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $expected, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Should merge asset data into array.
+	 */
+	function test_merging_to_empty_assets() {
+		$current_assets = array();
+		$assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$result = gutenberg_merge_assets( $current_assets, $assets );
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Should merge asset data into existing data, creating multiple styles to be enqueued.
+	 */
+	function test_merging_to_existing_assets() {
+		$current_assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$result = gutenberg_merge_assets( $current_assets, $assets );
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Should merge scripts and style assets to match the expected output.
+	 */
+	function test_merging_new_scripts_and_styles() {
+		$current_assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$assets = array(
+			'theme' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'script 1',
+						'src'    => 'https://wordpress.org/is-neat',
+						'deps'   => array(),
+						'ver'    => null,
+						'in_footer'  => null,
+					),
+				),
+				'styles' => array(
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$result = gutenberg_merge_assets( $current_assets, $assets );
+		$expected = array(
+			'theme' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'script 1',
+						'src'    => 'https://wordpress.org/is-neat',
+						'deps'   => array(),
+						'ver'    => null,
+						'in_footer'  => null,
+					),
+				),
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Should merge scripts and style assets across multiple calls to match the expected output.
+	 */
+	function test_merging_across_multiple_calls() {
+		$current_assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$assets_1 = array(
+			'theme' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'script 1',
+						'src'    => 'https://wordpress.org/is-neat',
+						'deps'   => array(),
+						'ver'    => null,
+						'in_footer'  => null,
+					),
+				),
+				'styles' => array(
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$assets_2 = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 3',
+						'src'    => 'https://wordpress.org/is-goofy',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+			'editor' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 4',
+						'src'    => 'https://wordpress.org/is-free',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$first_merge = gutenberg_merge_assets( $current_assets, $assets_1 );
+		$result = gutenberg_merge_assets( $first_merge, $assets_2 );
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'style 3',
+						'src'    => 'https://wordpress.org/is-goofy',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+				'scripts' => array(
+					array(
+						'handle' => 'script 1',
+						'src'    => 'https://wordpress.org/is-neat',
+						'deps'   => array(),
+						'ver'    => null,
+						'in_footer'  => null,
+					),
+				),
+			),
+			'editor' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 4',
+						'src'    => 'https://wordpress.org/is-free',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,16 @@ entryPointNames.forEach( entryPointName => {
 	};
 } );
 
+// Main CSS loader.
+const MainCSSExtractTextPlugin = new ExtractTextPlugin( {
+	filename: './[name]/build/style.css',
+} );
+
+// CSS loader for front end style building.
+const BlockCSSExtractTextPlugin = new ExtractTextPlugin( {
+	filename: './blocks/build/blocks.css',
+} );
+
 const config = {
 	entry: entryPointNames.reduce( ( memo, entryPointName ) => {
 		memo[ entryPointName ] = './' + entryPointName + '/index.js';
@@ -65,8 +75,30 @@ const config = {
 				use: 'babel-loader',
 			},
 			{
+				test: /blocks\.s?css$/,
+				include: [
+					/blocks/,
+				],
+				use: BlockCSSExtractTextPlugin.extract( {
+					use: [
+						{ loader: 'raw-loader' },
+						{ loader: 'postcss-loader' },
+						{
+							loader: 'sass-loader',
+							query: {
+								outputStyle: 'production' === process.env.NODE_ENV ?
+									'compressed' : 'nested',
+							},
+						},
+					],
+				} ),
+			},
+			{
 				test: /\.s?css$/,
-				use: ExtractTextPlugin.extract( {
+				exclude: [
+					/blocks\.s?css$/,
+				],
+				use: MainCSSExtractTextPlugin.extract( {
 					use: [
 						{ loader: 'raw-loader' },
 						{ loader: 'postcss-loader' },
@@ -88,9 +120,8 @@ const config = {
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV || 'development' ),
 		} ),
-		new ExtractTextPlugin( {
-			filename: './[name]/build/style.css',
-		} ),
+		BlockCSSExtractTextPlugin,
+		MainCSSExtractTextPlugin,
 		new webpack.LoaderOptionsPlugin( {
 			minimize: process.env.NODE_ENV === 'production',
 			debug: process.env.NODE_ENV !== 'production',


### PR DESCRIPTION
Closes #963

Came across some interesting hurdles:

Block names most likely need to be registered server side in addition
to client side.

I forgot to write down the other ones lol.

This PR seeks to add two different features and maybe should be split
into two seperate PRs.

Function 1:

Dynamically break any blocks.scss files into a seperate
file, so any default blocks styles which need to be displayed in both
the editor and the theme, can be used. This is only currently used for
adding gallery columns.

Function 2:

Adds an api for registering additional styles and scripts
for blocks, to the theme, as well as to the editor itself. A low level
API `register_block_assets()` is introduced as the backbone to some of
the easier to use functions like: `gutenberg_add_block_editor_style()`,
which mirrors the use of enqueue styles. The loading of these scripts
and styles is handle automatically, and I think the end developer
experience is already pretty good.

Currently scripts can be only registered to blocks that have been
previously registered. If the block is not present, a `_doing_it_wrong()`
is thrown to help guide the programmer.

_mock implementation_

In this PR I am registering the quote block server side so the API can be tested out.

Create a css file in your active theme like this:

quote.css:
```css
.blocks-quote-style-1 {
    background-color: red;
    color: white;
}

.blocks-quote-style-2 {
    background-color: blue;
    color: orange;
}
```

Then somewhere in that themes functions php, preferably on the after_setup_theme hook, add this line:
```php
gutenberg_add_block_theme_style( 'core/quote', 'quote-colors', get_template_directory_uri() . '/quote.css' );
```
This will register the special stylesheet to be loaded by the theme. Make sure you have added a quote block to your post, and on the front end you should now see a hideous red quote with white text. Click to block style two in the editor and you should see the blue bg with orange text. This should not apply in the editor. To add these styles to the editor as well simply add this line right after:
```php
gutenberg_add_block_editor_style( 'core/quote', 'quote-colors', get_template_directory_uri() . '/quote.css' );
```

**Testing Instructions**

Create a gallery block on the backend with two columns. Verify that
the columns display correctly, while still in the editor. Go to the front end view of that post.
Verify that the same gallery columns style applies.

Use the block style registry for testing additional styles being
added. For ease, you can use the example provided above, but I recommend
taking everything for a spin.