### PR TITLE
Fix parsing in do_blocks() and rendering of blocks on frontend in the_content

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -115,6 +115,7 @@ function do_blocks( $content ) {
 	preg_match_all( $matcher, $content, $matches, PREG_OFFSET_CAPTURE );
 
 	$new_content = $content;
+	$offset_differential = 0;
 	foreach ( $matches[0] as $index => $block_match ) {
 		$block_name = $matches['block_name'][ $index ][0];
 
@@ -132,7 +133,15 @@ function do_blocks( $content ) {
 		}
 
 		// Replace the matched block with the static or dynamic output.
-		$new_content = str_replace( $block_match[0], $output, $new_content );
+		$new_content = substr_replace(
+			$new_content,
+			$output,
+			$block_match[1] - $offset_differential,
+			strlen( $block_match[0] )
+		);
+
+		// Update offset for the next replacement.
+		$offset_differential += strlen( $block_match[0] ) - strlen( $output );
 	}
 
 	return $new_content;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -120,16 +120,14 @@ function do_blocks( $content ) {
 		$block_name = $matches['block_name'][ $index ][0];
 
 		$output = '';
-		if ( ! isset( $wp_registered_blocks[ $block_name ] ) ) {
-			if ( isset( $matches['content'][ $index ][0] ) ) {
-				$output = $matches['content'][ $index ][0];
-			}
-		} else {
+		if ( isset( $wp_registered_blocks[ $block_name ] ) ) {
 			$block_attributes_string = $matches['attributes'][ $index ][0];
 			$block_attributes = parse_block_attributes( $block_attributes_string );
 
 			// Call the block's render function to generate the dynamic output.
 			$output = call_user_func( $wp_registered_blocks[ $block_name ]['render'], $block_attributes );
+		} elseif ( isset( $matches['content'][ $index ][0] ) ) {
+			$output = $matches['content'][ $index ][0];
 		}
 
 		// Replace the matched block with the static or dynamic output.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -126,4 +126,4 @@ function do_blocks( $content ) {
 
 	return $new_content;
 }
-add_filter( 'the_content', 'do_blocks', 10 ); // BEFORE do_shortcode().
+add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode() and wpautop().

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -88,7 +88,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		register_block_type( 'core/dummy', $settings );
 		$post_content =
 			'before' .
-			'<!-- wp:core/dummy value="b1" -->this should be ignored<!-- /wp:core/dummy -->' .
+			"<!-- wp:core/dummy value=\"b1\" -->this\nshould\n\nbe\nignored<!-- /wp:core/dummy -->" .
 			'between' .
 			'<!-- wp:core/dummy value="b2" -->this should also be ignored<!-- /wp:core/dummy -->' .
 			'after';

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -9,6 +9,14 @@
  * Test do_blocks
  */
 class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
+
+	/**
+	 * Dummy block instance number.
+	 *
+	 * @var int
+	 */
+	protected $dummy_block_instance_number = 0;
+
 	/**
 	 * Dummy block rendering function.
 	 *
@@ -17,13 +25,23 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * @return string             Block output.
 	 */
 	function render_dummy_block( $attributes ) {
-		return $attributes['value'];
+		$this->dummy_block_instance_number += 1;
+		return $this->dummy_block_instance_number . ':' . $attributes['value'];
 	}
 
+	/**
+	 * Tear down.
+	 */
 	function tearDown() {
+		$this->dummy_block_instance_number = 0;
 		$GLOBALS['wp_registered_blocks'] = array();
 	}
 
+	/**
+	 * Test dynamic blocks that lack content, including void blocks.
+	 *
+	 * @covers do_blocks
+	 */
 	function test_dynamic_block_rendering() {
 		$settings = array(
 			'render' => array(
@@ -32,23 +50,34 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			),
 		);
 		register_block_type( 'core/dummy', $settings );
+
+		// The duplicated dynamic blocks below are there to ensure that do_blocks() replaces each one-by-one.
 		$post_content =
 			'before' .
 			'<!-- wp:core/dummy value="b1" --><!-- /wp:core/dummy -->' .
+			'<!-- wp:core/dummy value="b1" --><!-- /wp:core/dummy -->' .
 			'between' .
-			'<!-- wp:core/dummy value="b2" --><!-- /wp:core/dummy -->' .
+			'<!-- wp:core/dummy value="b2" /-->' .
+			'<!-- wp:core/dummy value="b2" /-->' .
 			'after';
 
 		$updated_post_content = do_blocks( $post_content );
 		$this->assertEquals( $updated_post_content,
 			'before' .
-			'b1' .
+			'1:b1' .
+			'2:b1' .
 			'between' .
-			'b2' .
+			'3:b2' .
+			'4:b2' .
 			'after'
 		);
 	}
 
+	/**
+	 * Test dynamic blocks that contain content.
+	 *
+	 * @covers do_blocks
+	 */
 	function test_dynamic_block_rendering_with_content() {
 		$settings = array(
 			'render' => array(
@@ -67,9 +96,9 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$updated_post_content = do_blocks( $post_content );
 		$this->assertEquals( $updated_post_content,
 			'before' .
-			'b1' .
+			'1:b1' .
 			'between' .
-			'b2' .
+			'2:b2' .
 			'after'
 		);
 	}


### PR DESCRIPTION
* Change `do_blocks` to run as `the_content` filter at priority 9 instead of 10, to ensure it applies before `wpautop`. Blocks were getting processed after `wpautop` was being applied, causing problems with extra paragraphs being added erroneously (see below).
* Fix matcher regular expression which was failing to select the contents and end of the block.
* Improve regular expression readability since it was not broken up into its constituent parts, it lacked named capture groups and it needlessly escaped slashes. This will become irrelevant once https://github.com/WordPress/gutenberg/pull/1152 is merged.
* Blocks not registered on the server were not getting replaced, resulting in block delimiters leaking into the rendered frontend content.
* Blocks were getting replaced with a global search/replace as opposed to replacing the blocks one-by-one for each one as it is being processed.
* Adds missing tests for void blocks.

-------------

❌ Before:

```html
<p><div class="blocks-latest-posts">
	<ul>
		<li><a href='http://src.wordpress-develop.dev/2017/06/18/test-php-block-processing/'>Test PHP Block Processing</a></li>
<li><a href='http://src.wordpress-develop.dev/2017/06/15/test-latest-posts-block/'>Test latest posts block</a></li>

	</ul>
</div>
</p>
<p><!-- wp:core/text dropCap="false" --></p>
<p>Paragraph 1.</p>
<p><!-- /wp:core/text --></p>
<p><!-- wp:core/text dropCap="false" --></p>
<p>Paragraph 2.</p>
<p><!-- /wp:core/text --></p>
```

✅  After:

```html
<div class="blocks-latest-posts">
<ul>
<li><a href='http://src.wordpress-develop.dev/2017/06/18/test-php-block-processing/'>Test PHP Block Processing</a></li>
<li><a href='http://src.wordpress-develop.dev/2017/06/15/test-latest-posts-block/'>Test latest posts block</a></li>
</ul>
</div>
<p>Paragraph 1.</p>
<p>Paragraph 2.</p>
```