### PR TITLE
Defer until wp.api has initialized before attempting to use Backbone models

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -355,7 +355,7 @@ function gutenberg_scripts_and_styles( $hook ) {
 	);
 
 	// Initialize the editor.
-	wp_add_inline_script( 'wp-editor', 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost );' );
+	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() { wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost ); } );' );
 
 	/**
 	 * Styles


### PR DESCRIPTION
Fixes #1235.

The first time the WP-API Backbone client is loaded in the browser, the REST API schema is fetched from the server and then stored in `sessionStorage`. As such, the Backbone models and collections are not available for such initial loads. To ensure they are available, the `wp.api.init()` promise should first be resolved. Issue can be replicated by doing `sessionStorage.clear()` and then reloading the Gutenberg editor.