### PR TITLE
Try removing abs position on placeholder text in button

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -38,15 +38,12 @@
 		background: $light-gray-400;
 	}
 
-	&[data-is-empty="true"] {
-		position: relative;
-	}
-
-	&[data-is-empty="true"]:before {
+	&[data-is-empty="true"]:after {
 		content: attr( data-placeholder );
+		display: block;
 		opacity: 0.5;
 		pointer-events: none;
-		position: absolute;
+		transform: translateY( -100% );
 	}
 }
 

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -27,6 +27,10 @@ $blocks-button__height: 46px;
 		left: 50%;
 		transform: translateX( -50% );
 	}
+
+	.blocks-editable__tinymce[data-is-empty="true"]:before {
+		position: inherit;
+	}
 }
 
 .editor-visual-editor__block[data-type="core/button"] {

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -27,10 +27,6 @@ $blocks-button__height: 46px;
 		left: 50%;
 		transform: translateX( -50% );
 	}
-
-	.blocks-editable__tinymce[data-is-empty="true"]:before {
-		position: inherit;
-	}
 }
 
 .editor-visual-editor__block[data-type="core/button"] {

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -147,7 +147,7 @@ registerBlockType( 'core/quote', {
 					<Editable
 						tagName="footer"
 						value={ citation }
-						placeholder={ wp.i18n.__( '— Add citation…' ) }
+						placeholder={ wp.i18n.__( 'Add citation…' ) }
 						onChange={
 							( nextCitation ) => setAttributes( {
 								citation: nextCitation,


### PR DESCRIPTION
This tries to address https://github.com/WordPress/gutenberg/issues/1168, specifically the concerns around letting the placeholder text scale the content.

Props @georgeolaru, https://github.com/WordPress/gutenberg/issues/1168#issuecomment-309125120

The downside is that the cursor is blinking at the end:

![placeholder](https://user-images.githubusercontent.com/1204802/27274604-531d186a-54d4-11e7-93b8-badfb452e90d.gif)

But as soon as you start typing, it works as intended. Can we address this? Can we set the caret at the beginning using some trick? Stacked textareas, one left floated? @iseulde any ideas?