### PR TITLE
Clear short dropcaps

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -63,6 +63,10 @@
 	}
 }
 
+.drop-cap-true:not( :focus )  {
+	overflow: hidden;
+}
+
 .block-editable__inline-toolbar {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
When a very short line has a dropcap, the inserter doesn't clear it. Because the inserter is fancily positioned, we can't just add a `clear: both;` to it. So this PR instead auto clears a block that has a dropcap. It seems to work with no side effects.

CC: @michaelarestad —  any tips?

Screenshot, before:

![screen shot 2017-06-19 at 10 24 22](https://user-images.githubusercontent.com/1204802/27276218-c5953b06-54da-11e7-9f66-8cc240ac52e2.png)

After:

![screen shot 2017-06-19 at 10 32 03](https://user-images.githubusercontent.com/1204802/27276223-ca047986-54da-11e7-9dd5-6d49f9223eb2.png)
