### PR TITLE
Blocks: Fix quote block (parsing, serializing and transforming)

### DIFF
--- a/blocks/api/query.js
+++ b/blocks/api/query.js
@@ -6,7 +6,7 @@ import { createElement } from 'element';
 /**
  * External dependencies
  */
-import { nodeListToReact } from 'dom-react';
+import { nodeListToReact, nodeToReact } from 'dom-react';
 import { flow } from 'lodash';
 import {
 	attr as originalAttr,
@@ -36,11 +36,11 @@ export const html = withKnownMatcherFlag( originalHtml );
 export const text = withKnownMatcherFlag( originalText );
 export const query = withKnownMatcherFlag( originalQuery );
 export const children = withKnownMatcherFlag( ( selector ) => {
-	return ( node ) => {
-		let match = node;
+	return ( domNode ) => {
+		let match = domNode;
 
 		if ( selector ) {
-			match = node.querySelector( selector );
+			match = domNode.querySelector( selector );
 		}
 
 		if ( match ) {
@@ -48,5 +48,16 @@ export const children = withKnownMatcherFlag( ( selector ) => {
 		}
 
 		return [];
+	};
+} );
+export const node = withKnownMatcherFlag( ( selector ) => {
+	return ( domNode ) => {
+		let match = domNode;
+
+		if ( selector ) {
+			match = domNode.querySelector( selector );
+		}
+
+		return nodeToReact( match, wp.element.createElement );
 	};
 } );

--- a/blocks/api/query.js
+++ b/blocks/api/query.js
@@ -58,6 +58,6 @@ export const node = withKnownMatcherFlag( ( selector ) => {
 			match = domNode.querySelector( selector );
 		}
 
-		return nodeToReact( match, wp.element.createElement );
+		return nodeToReact( match, createElement );
 	};
 } );

--- a/blocks/api/test/query.js
+++ b/blocks/api/test/query.js
@@ -37,4 +37,21 @@ describe( 'query', () => {
 			expect( renderToString( match ) ).to.equal( html );
 		} );
 	} );
+
+	describe( 'node()', () => {
+		it( 'should return a matcher function', () => {
+			const matcher = query.node();
+
+			expect( matcher ).to.be.a( 'function' );
+		} );
+
+		it( 'should return HTML equivalent WPElement of matched element', () => {
+			// Assumption here is that we can cleanly convert back and forth
+			// between a string and WPElement representation
+			const html = '<blockquote><p>A delicious sundae dessert</p></blockquote>';
+			const match = parse( html, query.node() );
+
+			expect( wp.element.renderToString( match ) ).to.equal( `<body>${ html }</body>` );
+		} );
+	} );
 } );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString, isObject } from 'lodash';
+import { isObject } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -41,9 +41,9 @@ registerBlockType( 'core/heading', {
 				transform: ( { content, ...attrs } ) => {
 					const isMultiParagraph = Array.isArray( content ) && isObject( content[ 0 ] ) && content[ 0 ].type === 'p';
 					if ( isMultiParagraph ) {
-						const headingContent = isString( content[ 0 ] )
-							? content[ 0 ]
-							: content[ 0 ].props.children;
+						const headingContent = isObject( content[ 0 ] ) && content[ 0 ].type === 'p'
+							? content[ 0 ].props.children
+							: content[ 0 ];
 						const heading = createBlock( 'core/heading', {
 							content: headingContent,
 						} );

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -90,7 +90,9 @@ registerBlockType( 'core/quote', {
 				transform: ( { value, citation, ...attrs } ) => {
 					const isMultiParagraph = Array.isArray( value ) && isObject( value[ 0 ] ) && value[ 0 ].type === 'p';
 					const headingElement = isMultiParagraph ? value[ 0 ] : value;
-					const headingContent = isString( headingElement ) ? headingElement : headingElement.props.children;
+					const headingContent = isObject( headingElement ) && value[ 0 ].type === 'p'
+						? headingElement.props.children
+						: headingElement;
 					if ( isMultiParagraph || citation ) {
 						const heading = createBlock( 'core/heading', {
 							content: headingContent,

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -30,6 +30,10 @@ registerBlockType( 'core/quote', {
 		citation: children( 'footer' ),
 	},
 
+	defaultAttributes: {
+		value: [],
+	},
+
 	transforms: {
 		from: [
 			{

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -56,7 +56,12 @@ registerBlockType( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { value, citation, ...attrs } ) => {
-					const textElement = Array.isArray( value ) ? value[ 0 ] : value;
+					const textElement = value[ 0 ];
+					if ( ! textElement ) {
+						return createBlock( 'core/text', {
+							content: citation,
+						} );
+					}
 					const textContent = isString( textElement ) ? textElement : textElement.props.children;
 					if ( Array.isArray( value ) || citation ) {
 						const text = createBlock( 'core/text', {

--- a/blocks/test/fixtures/core-quote-style-1.json
+++ b/blocks/test/fixtures/core-quote-style-1.json
@@ -5,9 +5,10 @@
         "attributes": {
             "style": "1",
             "value": [
-                [
-                    "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
-                ]
+                {
+                    "children": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.",
+                    "type": "p"
+                }
             ],
             "citation": [
                 "Matt Mullenweg, 2017"

--- a/blocks/test/fixtures/core-quote-style-2.json
+++ b/blocks/test/fixtures/core-quote-style-2.json
@@ -5,9 +5,10 @@
         "attributes": {
             "style": "2",
             "value": [
-                [
-                    "There is no greater agony than bearing an untold story inside you."
-                ]
+                {
+                    "children": "There is no greater agony than bearing an untold story inside you.",
+                    "type": "p"
+                }
             ],
             "citation": [
                 "Maya Angelou"


### PR DESCRIPTION
closes #1255 

I've noticed several issues with the quote block:

 - We were dropping the `p` when parsing the quote content
 - We were serializing double `p`s
 - Transforming to text block was broken when we moved the text block to single p.

This PR adds a new parsing helper `node` which is similar to `children` but includes the wrapper node.