### PR TITLE
Fix backspacing in text blocks

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -164,8 +164,8 @@ class VisualEditorBlock extends wp.element.Component {
 
 		// Remove block on backspace.
 		if ( BACKSPACE === keyCode ) {
-			event.preventDefault();
 			if ( target === this.node ) {
+				event.preventDefault();
 				onRemove( [ uid ] );
 
 				if ( previousBlock ) {
@@ -174,6 +174,7 @@ class VisualEditorBlock extends wp.element.Component {
 			}
 
 			if ( multiSelectedBlockUids.length ) {
+				event.preventDefault();
 				onRemove( multiSelectedBlockUids );
 			}
 		}


### PR DESCRIPTION
context: https://github.com/WordPress/gutenberg/pull/1257#issuecomment-309422011
Tks for caching that @aduth 

**Testing instructions**

- Try clicking backspace in a text block
- Try clicking on an image and hitting backspace, it should remove only the image.