### PR TITLE
Blocks: Dropping the controls property from blocks

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -4,7 +4,6 @@
 import { __ } from 'i18n';
 import './style.scss';
 import { registerBlockType, query as hpq } from '../../api';
-import { Fill } from 'react-slot-fill';
 
 /**
  * WordPress dependencies
@@ -14,6 +13,8 @@ import { Toolbar, Placeholder } from 'components';
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
 import RangeControl from '../../inspector-controls/range-control';
+import BlockControls from '../../block-controls';
+import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
 import GalleryImage from './gallery-image';
 
@@ -47,20 +48,6 @@ const editMediaLibrary = ( attributes, setAttributes ) => {
 	editFrame.open( 'gutenberg-gallery' );
 };
 
-/**
- * Returns an attribute setter with behavior that if the target value is
- * already the assigned attribute value, it will be set to undefined.
- *
- * @param  {string}   align Alignment value
- * @return {Function}       Attribute setter
- */
-function toggleAlignment( align ) {
-	return ( attributes, setAttributes ) => {
-		const nextAlign = attributes.align === align ? undefined : align;
-		setAttributes( { align: nextAlign } );
-	};
-}
-
 function defaultColumnsNumber( attributes ) {
 	attributes.images = attributes.images || [];
 	return Math.min( 3, attributes.images.length );
@@ -79,39 +66,6 @@ registerBlockType( 'core/gallery', {
 			} ) || [],
 	},
 
-	controls: [
-		{
-			icon: 'align-left',
-			title: wp.i18n.__( 'Align left' ),
-			isActive: ( { align } ) => 'left' === align,
-			onClick: toggleAlignment( 'left' ),
-		},
-		{
-			icon: 'align-center',
-			title: wp.i18n.__( 'Align center' ),
-			isActive: ( { align } ) => ! align || 'center' === align,
-			onClick: toggleAlignment( 'center' ),
-		},
-		{
-			icon: 'align-right',
-			title: wp.i18n.__( 'Align right' ),
-			isActive: ( { align } ) => 'right' === align,
-			onClick: toggleAlignment( 'right' ),
-		},
-		{
-			icon: 'align-wide',
-			title: __( 'Wide width' ),
-			isActive: ( { align } ) => 'wide' === align,
-			onClick: toggleAlignment( 'wide' ),
-		},
-		{
-			icon: 'align-full-width',
-			title: __( 'Full width' ),
-			isActive: ( { align } ) => 'full' === align,
-			onClick: toggleAlignment( 'full' ),
-		},
-	],
-
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
 		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
@@ -122,10 +76,33 @@ registerBlockType( 'core/gallery', {
 	edit( { attributes, setAttributes, focus } ) {
 		const { images = [], columns = defaultColumnsNumber( attributes ), align = 'none' } = attributes;
 		const setColumnsNumber = ( event ) => setAttributes( { columns: event.target.value } );
+		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
+
+		const controls = (
+			focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar
+						value={ align }
+						onChange={ updateAlignment }
+						controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
+					/>
+					{ !! images.length && (
+						<Toolbar controls={ [ {
+							icon: 'edit',
+							title: __( 'Edit Gallery' ),
+							onClick: () => editMediaLibrary( attributes, setAttributes ),
+						} ] } />
+					) }
+				</BlockControls>
+			)
+		);
+
 		if ( images.length === 0 ) {
 			const setMediaUrl = ( imgs ) => setAttributes( { images: imgs } );
-			return (
+			return [
+				controls,
 				<Placeholder
+					key="placeholder"
 					instructions={ wp.i18n.__( 'Drag images here or insert from media library' ) }
 					icon="format-gallery"
 					label={ wp.i18n.__( 'Gallery' ) }
@@ -138,28 +115,29 @@ registerBlockType( 'core/gallery', {
 					>
 						{ wp.i18n.__( 'Insert from Media Library' ) }
 					</MediaUploadButton>
-				</Placeholder>
-			);
+				</Placeholder>,
+			];
 		}
 
-		return (
-			<div className={ `blocks-gallery align${ align } columns-${ columns }` }>
-				<Fill name="Formatting.Toolbar">
-					<Toolbar controls={ [ {
-						icon: 'edit',
-						title: __( 'Edit Gallery' ),
-						onClick: () => editMediaLibrary( attributes, setAttributes ),
-					} ] } />
-				</Fill>
+		return [
+			controls,
+			focus && images.length > 1 && (
+				<InspectorControls>
+					<RangeControl
+						label={ __( 'Columns' ) }
+						value={ columns }
+						onChange={ setColumnsNumber }
+						min="1"
+						max={ Math.min( MAX_COLUMNS, images.length ) }
+					/>
+				</InspectorControls>
+			),
+			<div key="gallery" className={ `blocks-gallery align${ align } columns-${ columns }` }>
 				{ images.map( ( img ) => (
 					<GalleryImage key={ img.url } img={ img } />
 				) ) }
-				{ focus && images.length > 1 &&
-					<InspectorControls>
-						<RangeControl label={ __( 'Columns' ) } value={ columns } onChange={ setColumnsNumber } min="1" max={ Math.min( MAX_COLUMNS, images.length ) } />
-					</InspectorControls> }
-			</div>
-		);
+			</div>,
+		];
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -122,7 +122,7 @@ registerBlockType( 'core/gallery', {
 		return [
 			controls,
 			focus && images.length > 1 && (
-				<InspectorControls>
+				<InspectorControls key="inspector">
 					<RangeControl
 						label={ __( 'Columns' ) }
 						value={ columns }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { switchChildrenNodeName } from 'element';
+import { Toolbar } from 'components';
 
 /**
  * Internal dependencies
@@ -23,16 +24,6 @@ registerBlockType( 'core/quote', {
 		value: query( 'blockquote > p', children() ),
 		citation: children( 'footer' ),
 	},
-
-	controls: [ 1, 2 ].map( ( variation ) => ( {
-		icon: 'format-quote',
-		title: wp.i18n.sprintf( wp.i18n.__( 'Quote style %d' ), variation ),
-		isActive: ( { style = 1 } ) => Number( style ) === variation,
-		onClick( attributes, setAttributes ) {
-			setAttributes( { style: variation } );
-		},
-		subscript: variation,
-	} ) ),
 
 	transforms: {
 		from: [
@@ -119,6 +110,15 @@ registerBlockType( 'core/quote', {
 		return [
 			focus && (
 				<BlockControls key="controls">
+					<Toolbar controls={ [ 1, 2 ].map( ( variation ) => ( {
+						icon: 'format-quote',
+						title: wp.i18n.sprintf( wp.i18n.__( 'Quote style %d' ), variation ),
+						isActive: Number( style ) === variation,
+						onClick() {
+							setAttributes( { style: variation } );
+						},
+						subscript: variation,
+					} ) ) } />
 					<AlignmentToolbar
 						value={ align }
 						onChange={ ( nextAlign ) => {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -11,7 +11,6 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
  * WordPress dependencies
  */
 import { Children } from 'element';
-import { Toolbar } from 'components';
 import { BACKSPACE, ESCAPE } from 'utils/keycodes';
 
 /**
@@ -277,14 +276,6 @@ class VisualEditorBlock extends wp.element.Component {
 					>
 						<div className="editor-visual-editor__block-controls">
 							<BlockSwitcher uid={ block.uid } />
-							{ !! blockType.controls && (
-								<Toolbar
-									controls={ blockType.controls.map( ( control ) => ( {
-										...control,
-										onClick: () => control.onClick( block.attributes, this.setAttributes ),
-										isActive: control.isActive ? control.isActive( block.attributes ) : false,
-									} ) ) } />
-							) }
 							<Slot name="Formatting.Toolbar" />
 						</div>
 					</CSSTransitionGroup>


### PR DESCRIPTION
In this PR, I'm updating all the blocks to use `BlockControls` in `edit` instead of the `controls` property.

related #1205