### PR TITLE
Document testing workflow for JavaScript and PHP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,34 @@ For example, `add/gallery-block` means you're working on adding a new gallery bl
 
 You can pick among all the <a href="https://github.com/WordPress/gutenberg/issues">tickets</a>, or some of the ones labelled <a href="https://github.com/WordPress/gutenberg/labels/Good%20First%20Task">Good First Task</a>.
 
+## Testing
+
+Gutenberg contains both PHP and JavaScript code, and encourages testing and code style linting for both.
+
+### JavaScript Testing
+
+Tests for JavaScript use [Mocha](https://mochajs.org/) as the test runner and [Chai BDD](http://chaijs.com/api/bdd/) as an assertion library (with a [small variation](https://github.com/prodatakey/dirty-chai) on assertion properties). If needed, you can also use [Sinon](http://sinonjs.org/) for mocking and [Enzyme](https://github.com/airbnb/enzyme) for React component testing.
+
+Assuming you've followed the instructions above to install Node and project dependencies, tests can be run from the command-line with NPM:
+
+```
+npm test
+```
+
+To run unit tests only, use `npm run test-unit` instead.
+
+Code style in JavaScript is enforced using [ESLint](http://eslint.org/). The above `npm test` will execute both unit tests and code linting. Code linting can be verified independently by running `npm run lint`.
+
+### PHP Testing
+
+Tests for PHP use [PHPUnit](https://phpunit.de/) as the testing framework. Before starting, you should install PHPUnit and have a copy of [WordPress Develop](https://github.com/WordPress/wordpress-develop) available. If the Gutenberg plugin is installed in the context of a WordPress Develop site, you can run `phpunit` directly from the command-line. Otherwise, you will need to specify the path to WordPress Develop's test directory as an environment variable:
+
+```
+WP_TESTS_DIR=/path/to/wordpress-develop/tests/phpunit phpunit
+```
+
+Code style in PHP is enforced using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer). It is recommended that you install PHP_CodeSniffer and the WordPress-specific code standard ruleset using [Composer](https://getcomposer.org/). With Composer installed, run `composer install` from the project directory to install dependencies, then `composer run-script lint` to verify PHP code standards.
+
 ## How Designers Can Contribute
 
 If you'd like to contribute to the design or front-end, feel free to contribute to tickets labelled <a href="https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3ADesign">Design</a>. We could use your thoughtful replies, mockups, animatics, sketches, doodles. Proposed changes are best done as minimal and specific iterations on the work that precedes it so we can compare. If you use <a href="https://www.sketchapp.com/">Sketch</a>, you can grab <a href="https://cloudup.com/cMPXM8Va2cy">the source file for the mockups</a> (updated April 6th).

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "wp-coding-standards/wpcs": "^0.11.0"
   },
   "scripts": {
+    "lint": "phpcs",
     "post-install-cmd": [
       "phpcs --config-set installed_paths ../../wp-coding-standards/wpcs/"
     ]


### PR DESCRIPTION
This pull request seeks to enhance the `CONTRIBUTING.md` document with an additional section describing testing workflows. This was motivated by my own struggles with running PHP tests, in an effort to potentially save time for future maintainers. Included is a brief overview of the tools used in testing JavaScript and PHP, prerequisites for running tests, and the commands for tests themselves.

[See documentation](https://github.com/WordPress/gutenberg/blob/0cef954b4e6f98a34a007ae89eec29092e507480/CONTRIBUTING.md#testing)