### PR TITLE
Include paste as default Editable TinyMCE plugin

### DIFF
--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -48,10 +48,13 @@ export default class TinyMCE extends wp.element.Component {
 			browser_spellcheck: true,
 			entity_encoding: 'raw',
 			convert_urls: false,
+			plugins: [],
 			formats: {
 				strikethrough: { inline: 'del' },
 			},
 		} );
+
+		settings.plugins.push( 'paste' );
 
 		tinymce.init( {
 			...settings,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -103,7 +103,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'tinymce-nightly', 'tinymce-nightly-lists' ),
+		array( 'wp-element', 'wp-components', 'wp-utils', 'tinymce-nightly', 'tinymce-nightly-lists', 'tinymce-nightly-paste' ),
 		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 
@@ -164,6 +164,11 @@ function gutenberg_register_vendor_scripts() {
 	gutenberg_register_vendor_script(
 		'tinymce-nightly-lists',
 		'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin' . $suffix . '.js',
+		array( 'tinymce-nightly' )
+	);
+	gutenberg_register_vendor_script(
+		'tinymce-nightly-paste',
+		'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/paste/plugin' . $suffix . '.js',
 		array( 'tinymce-nightly' )
 	);
 }


### PR DESCRIPTION
Closes #1041 

This pull request seeks to specify the [`paste` plugin](https://www.tinymce.com/docs/plugins/paste/) as a default plugin for the `Editable` control. The paste plugin performs a number of clean-up tasks for pasting content, but notably includes the usability feature of pasting a URL to be applied as a link to the selected text.

__Implementation notes / Open questions:__

Previously we'd encouraged TinyMCE plugins to be specified by individual blocks to reflect the fact that Editable should be left as minimal as possible, with blocks individually adding functionality in an isolated way. In this case, paste is argued to be a "global" behavior for any Editable and is enabled for all Editable elements.

The paste plugin is appended regardless of whether the block implements its own `getSettings` prop for the `Editable` component, meaning that it is not possible for a block to disable the `paste` plugin. This was chosen instead of the alternative where a block implementer would be required to merge their additional plugins with the default set of plugins. I'm open to considering this alternative though, since it would only affect blocks which include their own additional plugins.

__Testing instructions:__

Repeat steps described at #1041, observing that pasting a URL applies a link to the selected text.