### PR TITLE
Detect focus leaving wpbody-content to clear selected block

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -57,6 +57,7 @@ class VisualEditorBlock extends wp.element.Component {
 		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.onFocus = this.onFocus.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
+		this.stopClickPropagation = this.stopClickPropagation.bind( this );
 		this.previousOffset = null;
 	}
 
@@ -112,7 +113,6 @@ class VisualEditorBlock extends wp.element.Component {
 
 	bindBlockNode( node ) {
 		this.node = node;
-		this.props.blockRef( node );
 	}
 
 	setAttributes( attributes ) {
@@ -214,6 +214,12 @@ class VisualEditorBlock extends wp.element.Component {
 		this.props.onSelect();
 	}
 
+	stopClickPropagation( event ) {
+		// If parent visual editor receives a bubbled click event, it infers as
+		// click outside to clear selected block, so stop bubbling on click.
+		event.stopPropagation();
+	}
+
 	render() {
 		const { block, multiSelectedBlockUids } = this.props;
 		const blockType = wp.blocks.getBlockType( block.name );
@@ -255,6 +261,7 @@ class VisualEditorBlock extends wp.element.Component {
 		return (
 			<div
 				ref={ this.bindBlockNode }
+				onClick={ this.stopClickPropagation }
 				onKeyDown={ this.removeOrDeselect }
 				onFocus={ this.onFocus }
 				onMouseMove={ this.maybeHover }


### PR DESCRIPTION
Related: #1079

This pull request seeks to improve block clearing by detecting focus having left the `#wpbody-content` element. Notably, this preserves existing behavior of preserving the selected block while adjusting its settings from the Post Settings drawer, but clearing the selected block when clicking elsewhere in the admin chrome (admin bar, sidebar) or below post content (especially noticeable for new posts with few blocks).

__Implementation notes:__

A bit of hypocrisy here in making assumptions about ancestor DOM elements from the context of `VisualEditor`. I debated where best this logic should exist, since it's fairly specific to the visual editing mode. I'm open to suggestions here, and in the meantime have documented the expected behavior inline.

I'd hoped that by detecting focus leaving `#wpbody-content`, we could remove [the logic for detecting and clearing on Escape](https://github.com/WordPress/gutenberg/blob/c7ee1880996bda85f51116c88f7d88e297b2777c/editor/modes/visual-editor/block.js#L182-L185) since Escape should cause focus to move to the top-level `body` element. However, in my testing this did not work correctly. It may be that we'd have to force TinyMCE to blur on Escape (from Editable), but even for other block types such as Image, this behavior was not working. I might spend some more time investigating this.

Related to #1079, "canvas click" has been changed from detecting click target as one of two assigned `ref` nodes to an implementation where propagation is stopped from the `Block` component on click. I don't feel great about either of these implementations personally.

Unfortunately, this new implementation reverts to a behavior where the selected block is cleared when moving from the page to the browser Developer Tools inspector.

__Testing instructions:__

Verify that a selected block can be cleared by clicking above the editor column, on its sides, below the editor column, in the dashboard admin bar, or in the dashboard sidebar.

Verify that a selected block is **not** cleared by clicking between blocks, clicking in the editor header, or clicking in the Post Settings sidebar.