### PR TITLE
Parser: Fix parsing void blocks

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -42,7 +42,7 @@ WP_Block_Balanced
   } }
 
 WP_Block_Html
-  = ts:(!WP_Block_Balanced c:Any { return c })+
+  = ts:(!WP_Block_Balanced !WP_Block_Void c:Any { return c })+
   {
     return {
       attrs: {},

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -262,5 +262,19 @@ describe( 'block parser', () => {
 				'core/test-block',
 			] );
 		} );
+
+		it( 'should parse void blocks', () => {
+			registerBlockType( 'core/test-block', {} );
+			registerBlockType( 'core/void-block', {} );
+			const parsed = parse(
+				'<!-- wp:core/test-block --><!-- /wp:core/test-block -->' +
+				'<!-- wp:core/void-block /-->'
+			);
+
+			expect( parsed ).to.have.lengthOf( 2 );
+			expect( parsed.map( ( { name } ) => name ) ).to.eql( [
+				'core/test-block', 'core/void-block',
+			] );
+		} );
 	} );
 } );


### PR DESCRIPTION
closes #1242 

This PRs fixes parsing void blocks when it's not the first block in the post content.

**Testing instructions**:

 - Insert a text block
 - Insert latest post block
 - Save and reload
 - You should still see the latest post block