### PR TITLE
Remove Gutenberg link from page row actions since pages are not yet supported

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -69,8 +69,6 @@ add_action( 'admin_menu', 'gutenberg_menu' );
  * @since 0.1.0
  */
 function gutenberg_add_edit_links_filters() {
-	// For hierarchical post types.
-	add_filter( 'page_row_actions', 'gutenberg_add_edit_links', 10, 2 );
 	// For non-hierarchical post types.
 	add_filter( 'post_row_actions', 'gutenberg_add_edit_links', 10, 2 );
 }


### PR DESCRIPTION
See #1272.

In a subsequent PR I'll add the support for pages. For now the link needs to be removed.