### PR TITLE
Add custom eslint rule for functional setState pattern.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
 	},
 	"plugins": [
 		"react",
+		"react-functional-set-state",
 		"jsx-a11y"
 	],
 	"settings": {
@@ -94,6 +95,7 @@
 		"react/jsx-key": "error",
 		"react/jsx-space-before-closing": "error",
 		"react/prop-types": "off",
+		"react-functional-set-state/no-this-state-props": "error",
 		"semi": "error",
 		"semi-spacing": "error",
 		"space-before-blocks": [ "error", "always" ],

--- a/blocks/library/freeform/freeform-block.js
+++ b/blocks/library/freeform/freeform-block.js
@@ -170,7 +170,7 @@ export default class FreeformBlock extends wp.element.Component {
 	}
 
 	toggleMoreDrawer() {
-		this.setState( { showMore: ! this.state.showMore } );
+		this.setState( state => ( { showMore: ! state.showMore } ) );
 	}
 
 	setToolbarRef( elem ) {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-config-wordpress": "^1.1.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
+    "eslint-plugin-react-functional-set-state": "1.0.0",
     "expose-loader": "^0.7.3",
     "extract-text-webpack-plugin": "^2.1.0",
     "gettext-parser": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-config-wordpress": "^1.1.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
-    "eslint-plugin-react-functional-set-state": "1.0.0",
+    "eslint-plugin-react-functional-set-state": "1.0.1",
     "expose-loader": "^0.7.3",
     "extract-text-webpack-plugin": "^2.1.0",
     "gettext-parser": "^1.2.2",


### PR DESCRIPTION
Related: #1158

This adds in a eslint rule for disallowing the access of this.props or
this.state from within a setState call. This is probably not going to
100% keep us in the clear. I believe you could set a variable in an upper
scope equal to this.state.something and pass that into the setState
call. This seems to work well though for the most part. First time
writing an eslint thing so feedback would be appreciated.

**Testing Instructions**
run `npm i && npm run lint` to hopefully see that we do not have any of
these errors.

Trigger the lint errors by accessing this.props, or this.state within a
this.setState call, and run the lint or use an IDE linting tool.