### PR TITLE
Show Popovers above all other UI elements

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -1,16 +1,16 @@
 $z-layers: (
 	'.editor-mode-switcher .dashicon': -1,
 	'.editor-block-switcher__arrow': 1,
-	'.components-popover': 1,
 	'.editor-visual-editor__block:before': -1,
 	'.editor-visual-editor__block {core/image aligned left or right}': 10,
 	'.editor-visual-editor__block-controls': 1,
 	'.components-form-toggle__input': 1,
+	'.editor-format-list__menu': 1,
 	'.editor-sidebar': 19,
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
-	'.editor-format-list__menu': 1,
+	'.components-popover': 100000,
 );
 
 @function z-index( $key ) {


### PR DESCRIPTION
closes #1282 
closes #1279 

IMO Popovers should show up above all UI elements including the admin bar (That's why I'm using a really big number here).