### PR TITLE
Editable: Fix splitting inline Editables using shift+enter

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -207,6 +207,8 @@ export default class Editable extends wp.element.Component {
 			event.stopImmediatePropagation();
 		}
 
+		// If we click shift+Enter on inline Editables, we should avoid creating `p` tags
+		// We should also split the content if splitting is allowed.
 		if ( event.keyCode === ENTER && event.shiftKey && this.props.inline ) {
 			event.preventDefault();
 

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -207,9 +207,12 @@ export default class Editable extends wp.element.Component {
 			event.stopImmediatePropagation();
 		}
 
-		if ( event.keyCode === ENTER && this.props.inline && this.props.onSplit && event.shiftKey ) {
+		if ( event.keyCode === ENTER && event.shiftKey && this.props.inline ) {
 			event.preventDefault();
-			this.splitContent();
+
+			if ( this.props.onSplit ) {
+				this.splitContent();
+			}
 		}
 	}
 

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -240,6 +240,7 @@ export default class Editable extends wp.element.Component {
 			}
 
 			this.editor.dom.remove( prevNode );
+			this.editor.dom.remove( endNode );
 			this.splitContent();
 		}
 	}

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -207,8 +207,8 @@ export default class Editable extends wp.element.Component {
 			event.stopImmediatePropagation();
 		}
 
-		// If we click shift+Enter on inline Editables, we should avoid creating `p` tags
-		// We should also split the content if splitting is allowed.
+		// If we click shift+Enter on inline Editables, we avoid creating two contenteditables
+		// We also split the content and call the onSplit prop if provided.
 		if ( event.keyCode === ENTER && event.shiftKey && this.props.inline ) {
 			event.preventDefault();
 

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -206,6 +206,11 @@ export default class Editable extends wp.element.Component {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 		}
+
+		if ( event.keyCode === ENTER && this.props.inline && this.props.onSplit && event.shiftKey ) {
+			event.preventDefault();
+			this.splitContent();
+		}
 	}
 
 	onKeyUp( { keyCode } ) {
@@ -229,28 +234,32 @@ export default class Editable extends wp.element.Component {
 				return;
 			}
 
-			const { dom } = this.editor;
-			const rootNode = this.editor.getBody();
-			const beforeRange = dom.createRng();
-			const afterRange = dom.createRng();
-
-			dom.remove( prevNode );
-
-			beforeRange.setStart( rootNode, 0 );
-			beforeRange.setEnd( endNode.parentNode, dom.nodeIndex( endNode ) );
-
-			afterRange.setStart( endNode.parentNode, dom.nodeIndex( endNode ) + 1 );
-			afterRange.setEnd( rootNode, dom.nodeIndex( rootNode.lastChild ) + 1 );
-
-			const beforeFragment = beforeRange.extractContents();
-			const afterFragment = afterRange.extractContents();
-
-			const beforeElement = nodeListToReact( beforeFragment.childNodes, createElement );
-			const afterElement = nodeListToReact( afterFragment.childNodes, createElement );
-
-			this.setContent( beforeElement );
-			this.props.onSplit( beforeElement, afterElement );
+			this.editor.dom.remove( prevNode );
+			this.splitContent();
 		}
+	}
+
+	splitContent() {
+		const { dom } = this.editor;
+		const rootNode = this.editor.getBody();
+		const beforeRange = dom.createRng();
+		const afterRange = dom.createRng();
+		const selectionRange = this.editor.selection.getRng();
+
+		beforeRange.setStart( rootNode, 0 );
+		beforeRange.setEnd( selectionRange.startContainer, selectionRange.startOffset );
+
+		afterRange.setStart( selectionRange.endContainer, selectionRange.endOffset );
+		afterRange.setEnd( rootNode, dom.nodeIndex( rootNode.lastChild ) + 1 );
+
+		const beforeFragment = beforeRange.extractContents();
+		const afterFragment = afterRange.extractContents();
+
+		const beforeElement = nodeListToReact( beforeFragment.childNodes, createElement );
+		const afterElement = nodeListToReact( afterFragment.childNodes, createElement );
+
+		this.setContent( beforeElement );
+		this.props.onSplit( beforeElement, afterElement );
 	}
 
 	onNewBlock() {


### PR DESCRIPTION
closes #1243 #1254 

In this PR, I'm proposing to split a text block if we hit shift+enter.
The current `shift+enter` behaviour is broken (see #1243 and #1254)

