### PR TITLE
Display Saving label while save in progress

### DIFF
--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -24,7 +24,7 @@ import {
 	getEditedPostAttribute,
 } from '../../selectors';
 
-function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
+export function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
 	const className = 'editor-saved-state';
 
 	if ( isSaving ) {

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -25,10 +25,6 @@ import {
 } from '../../selectors';
 
 function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
-	if ( ! isSaveable ) {
-		return null;
-	}
-
 	const className = 'editor-saved-state';
 
 	if ( isSaving ) {
@@ -38,6 +34,11 @@ function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onStatusCha
 			</span>
 		);
 	}
+
+	if ( ! isSaveable ) {
+		return null;
+	}
+
 	if ( ! isNew && ! isDirty ) {
 		return (
 			<span className={ className }>

--- a/editor/header/saved-state/test/index.js
+++ b/editor/header/saved-state/test/index.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { SavedState } from '../';
+
+describe( 'SavedState', () => {
+	it( 'should display saving while save in progress, even if not saveable', () => {
+		const wrapper = shallow(
+			<SavedState
+				isNew
+				isDirty={ false }
+				isSaving={ true }
+				isSaveable={ false } />
+		);
+
+		expect( wrapper.text() ).to.equal( 'Saving' );
+	} );
+
+	it( 'returns null if the post is not saveable', () => {
+		const wrapper = shallow(
+			<SavedState
+				isNew
+				isDirty={ false }
+				isSaving={ false }
+				isSaveable={ false } />
+		);
+
+		expect( wrapper.type() ).to.be.null();
+	} );
+
+	it( 'should return Saved text if not new and not dirty', () => {
+		const wrapper = shallow(
+			<SavedState
+				isNew={ false }
+				isDirty={ false }
+				isSaving={ false }
+				isSaveable={ true } />
+		);
+
+		expect( wrapper.childAt( 0 ).name() ).to.equal( 'Dashicon' );
+		expect( wrapper.childAt( 1 ).text() ).to.equal( 'Saved' );
+	} );
+
+	it( 'should return Save button if edits to be saved', () => {
+		const statusSpy = sinon.spy();
+		const saveSpy = sinon.spy();
+		const wrapper = shallow(
+			<SavedState
+				isNew={ false }
+				isDirty={ true }
+				isSaving={ false }
+				isSaveable={ true }
+				onStatusChange={ statusSpy }
+				onSave={ saveSpy } />
+		);
+
+		expect( wrapper.name() ).to.equal( 'Button' );
+		expect( wrapper.childAt( 0 ).text() ).to.equal( 'Save' );
+		wrapper.simulate( 'click' );
+		expect( statusSpy ).to.have.been.calledWith( 'draft' );
+		expect( saveSpy ).to.have.been.called();
+	} );
+} );


### PR DESCRIPTION
Closes #707
Related: #1203

This pull request seeks to resolve a regression introduced in #1203 where the "Saving" label is no longer shown in the header while a save is in progress. The issue is due to the fact that when a save begins, [post edits are cleared](https://github.com/WordPress/gutenberg/blob/d80189e0c958fdd07e119572f9caf11ebd47de28/editor/effects.js#L37-L40), meaning that the post is considered un-saveable (no title, content, or excerpt). Due to the order of logic in `SavedState`, this resulted in nothing been shown, instead of the "Saving" label, despite a save being in progress.

__Implementation notes:__

Should we really be clearing post edits when a save is initiated? My thinking is that we should optimistically persist them as being the current state of the post. cc @youknowriad 

__Testing instructions:__

Verify that a Saving label is shown after clicking Save in the editor bar, while the request is in progress. Using [Chrome Developer Tools network throttling](https://developers.google.com/web/tools/chrome-devtools/network-performance/network-conditions) to emulate a slower connection can help identify the change in label.