### PR TITLE
Use post-specific window target for preview button instead of _blank

### DIFF
--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -13,11 +13,11 @@ import { IconButton } from 'components';
  */
 import { getEditedPostPreviewLink } from '../../selectors';
 
-function PreviewButton( { link } ) {
+function PreviewButton( { link, postId } ) {
 	return (
 		<IconButton
 			href={ link }
-			target="_blank"
+			target={ `wp-preview-${ postId }` }
 			icon="visibility"
 			disabled={ ! link }
 		>
@@ -28,6 +28,7 @@ function PreviewButton( { link } ) {
 
 export default connect(
 	( state ) => ( {
+		postId: state.currentPost.id,
 		link: getEditedPostPreviewLink( state ),
 	} )
 )( PreviewButton );


### PR DESCRIPTION
Fixes #1317.

Aligns `target` of preview button with core: https://github.com/WordPress/wordpress-develop/blob/4.8.0/src/wp-admin/includes/meta-boxes.php#L64