### PR TITLE
Handle pasted block content

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -6,6 +6,7 @@ import * as query from './query';
 export { query };
 export { createBlock, switchToBlockType } from './factory';
 export { default as parse } from './parser';
+export { default as pasteHandler } from './paste';
 export { default as serialize, getBlockDefaultClassname } from './serializer';
 export { getCategories } from './categories';
 export {

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -15,11 +15,10 @@ import { createBlock } from './factory';
  * Returns the block attributes parsed from raw content.
  *
  * @param  {String} rawContent    Raw block content
- * @param  {Object} blockType     Block type
+ * @param  {Object} attributes    Block attribute matchers
  * @return {Object}               Block attributes
  */
-export function parseBlockAttributes( rawContent, blockType ) {
-	const { attributes } = blockType;
+export function parseBlockAttributes( rawContent, attributes ) {
 	if ( 'function' === typeof attributes ) {
 		return attributes( rawContent );
 	} else if ( attributes ) {
@@ -53,7 +52,7 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
 		attributes = {
 			...blockType.defaultAttributes,
 			...attributes,
-			...parseBlockAttributes( rawContent, blockType ),
+			...parseBlockAttributes( rawContent, blockType.attributes ),
 		};
 	}
 

--- a/blocks/api/paste.js
+++ b/blocks/api/paste.js
@@ -38,25 +38,37 @@ export function normaliseToBlockLevelNodes( nodes ) {
 			}
 
 			accu.lastChild.appendChild( node );
-		// BR nodes: create a new paragraph on double, or append to previous.
-		} else if ( node.nodeName === 'BR' ) {
-			if ( node.nextSibling && node.nextSibling.nodeName === 'BR' ) {
-				accu.appendChild( document.createElement( 'P' ) );
-				decu.removeChild( node.nextSibling );
-			}
-
-			// Don't append to an empty paragraph.
-			if (
-				accu.lastChild &&
-				accu.lastChild.nodeName === 'P' &&
-				accu.lastChild.hasChildNodes()
-			) {
-				accu.lastChild.appendChild( node );
-			} else {
-				decu.removeChild( node );
-			}
+		// Element nodes.
 		} else if ( node.nodeType === 1 ) {
-			accu.appendChild( node );
+			// BR nodes: create a new paragraph on double, or append to previous.
+			if ( node.nodeName === 'BR' ) {
+				if ( node.nextSibling && node.nextSibling.nodeName === 'BR' ) {
+					accu.appendChild( document.createElement( 'P' ) );
+					decu.removeChild( node.nextSibling );
+				}
+
+				// Don't append to an empty paragraph.
+				if (
+					accu.lastChild &&
+					accu.lastChild.nodeName === 'P' &&
+					accu.lastChild.hasChildNodes()
+				) {
+					accu.lastChild.appendChild( node );
+				} else {
+					decu.removeChild( node );
+				}
+			} else if ( node.nodeName === 'P' ) {
+				// Only append non-empty paragraph nodes.
+				if ( /^(\s|&nbsp;)*$/.test( node.innerHTML ) ) {
+					decu.removeChild( node );
+				} else {
+					accu.appendChild( node );
+				}
+			} else {
+				accu.appendChild( node );
+			}
+		} else {
+			decu.removeChild( node );
 		}
 	}
 

--- a/blocks/api/paste.js
+++ b/blocks/api/paste.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { nodeListToReact } from 'dom-react';
+
+/**
+ * WordPress dependencies
+ */
+import { createElement } from 'element';
+
+/**
+ * Internal dependencies
+ */
+import { createBlock } from './factory';
+
+/**
+ * Normalises array nodes of any node type to an array of block level nodes.
+ * @param  {Array} nodes Array of Nodes.
+ * @return {Array}       Array of block level HTMLElements
+ */
+function normaliseToBlockLevelNodes( nodes ) {
+	return nodes.reduce( ( acc, node, index ) => {
+		// Text nodes: wrap in a paragraph, or append to previous.
+		if ( node.nodeType === 3 ) {
+			if ( ! acc.length || acc[ acc.length - 1 ].nodeName !== 'P' ) {
+				acc.push( document.createElement( 'P' ) );
+			}
+
+			acc[ acc.length - 1 ].appendChild( node );
+		// BR nodes: create a new paragraph on double, or append to
+		// previous.
+		} else if ( node.nodeName === 'BR' ) {
+			if ( nodes[ index + 1 ] && nodes[ index + 1 ].nodeName === 'BR' ) {
+				acc.push( document.createElement( 'P' ) );
+			}
+
+			// Don't append to an empty paragraph.
+			if ( acc[ acc.length - 1 ].hasChildNodes() ) {
+				acc[ acc.length - 1 ].appendChild( node );
+			}
+		} else if ( node.nodeType === 1 ) {
+			acc.push( node );
+		}
+
+		return acc;
+	}, [] );
+}
+
+export default function( nodes ) {
+	return normaliseToBlockLevelNodes( nodes ).map( ( node ) => {
+		// To do: move to block registration.
+		if ( node.nodeName === 'P' ) {
+			return createBlock( 'core/text', {
+				content: nodeListToReact( node.childNodes, createElement ),
+			} );
+		}
+
+		return createBlock( 'core/freeform', {
+			content: nodeListToReact( [ node ], createElement ),
+		} );
+	} );
+}

--- a/blocks/api/paste.js
+++ b/blocks/api/paste.js
@@ -18,32 +18,46 @@ import { createBlock } from './factory';
  * @param  {Array} nodes Array of Nodes.
  * @return {Array}       Array of block level HTMLElements
  */
-function normaliseToBlockLevelNodes( nodes ) {
-	return nodes.reduce( ( acc, node, index ) => {
+export function normaliseToBlockLevelNodes( nodes ) {
+	const decu = document.createDocumentFragment();
+	const accu = document.createDocumentFragment();
+
+	// A fragment is easier to work with.
+	nodes.forEach( node => decu.appendChild( node.cloneNode( true ) ) );
+
+	while ( decu.firstChild ) {
+		const node = decu.firstChild;
+
 		// Text nodes: wrap in a paragraph, or append to previous.
 		if ( node.nodeType === 3 ) {
-			if ( ! acc.length || acc[ acc.length - 1 ].nodeName !== 'P' ) {
-				acc.push( document.createElement( 'P' ) );
+			if ( ! accu.lastChild || accu.lastChild.nodeName !== 'P' ) {
+				accu.appendChild( document.createElement( 'P' ) );
 			}
 
-			acc[ acc.length - 1 ].appendChild( node );
-		// BR nodes: create a new paragraph on double, or append to
-		// previous.
+			accu.lastChild.appendChild( node );
+		// BR nodes: create a new paragraph on double, or append to previous.
 		} else if ( node.nodeName === 'BR' ) {
-			if ( nodes[ index + 1 ] && nodes[ index + 1 ].nodeName === 'BR' ) {
-				acc.push( document.createElement( 'P' ) );
+			if ( node.nextSibling && node.nextSibling.nodeName === 'BR' ) {
+				accu.appendChild( document.createElement( 'P' ) );
+				decu.removeChild( node.nextSibling );
 			}
 
 			// Don't append to an empty paragraph.
-			if ( acc[ acc.length - 1 ].hasChildNodes() ) {
-				acc[ acc.length - 1 ].appendChild( node );
+			if (
+				accu.lastChild &&
+				accu.lastChild.nodeName === 'P' &&
+				accu.lastChild.hasChildNodes()
+			) {
+				accu.lastChild.appendChild( node );
+			} else {
+				decu.removeChild( node );
 			}
 		} else if ( node.nodeType === 1 ) {
-			acc.push( node );
+			accu.appendChild( node );
 		}
+	}
 
-		return acc;
-	}, [] );
+	return Array.from( accu.childNodes );
 }
 
 export default function( nodes ) {

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -113,7 +113,7 @@ export function serializeBlock( block ) {
 	const blockName = block.name;
 	const blockType = getBlockType( blockName );
 	const saveContent = getSaveContent( blockType, block.attributes );
-	const saveAttributes = getCommentAttributes( block.attributes, parseBlockAttributes( saveContent, blockType ) );
+	const saveAttributes = getCommentAttributes( block.attributes, parseBlockAttributes( saveContent, blockType.attributes ) );
 
 	if ( 'wp:core/more' === blockName ) {
 		return `<!-- more ${ saveAttributes.customText ? `${ saveAttributes.customText } ` : '' }-->${ saveAttributes.noTeaser ? '\n<!--noteaser-->' : '' }`;

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -33,39 +33,35 @@ describe( 'block parser', () => {
 
 	describe( 'parseBlockAttributes()', () => {
 		it( 'should use the function implementation', () => {
-			const blockType = {
-				attributes: function( rawContent ) {
-					return {
-						content: rawContent + ' & Chicken',
-					};
-				},
+			const attributes = function( rawContent ) {
+				return {
+					content: rawContent + ' & Chicken',
+				};
 			};
 
-			expect( parseBlockAttributes( 'Ribs', blockType ) ).to.eql( {
+			expect( parseBlockAttributes( 'Ribs', attributes ) ).to.eql( {
 				content: 'Ribs & Chicken',
 			} );
 		} );
 
 		it( 'should use the query object implementation', () => {
-			const blockType = {
-				attributes: {
-					emphasis: text( 'strong' ),
-					ignoredDomMatcher: ( node ) => node.innerHTML,
-				},
+			const attributes = {
+				emphasis: text( 'strong' ),
+				ignoredDomMatcher: ( node ) => node.innerHTML,
 			};
 
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( parseBlockAttributes( rawContent, blockType ) ).to.eql( {
+			expect( parseBlockAttributes( rawContent, attributes ) ).to.eql( {
 				emphasis: '& Chicken',
 			} );
 		} );
 
 		it( 'should return an empty object if no attributes defined', () => {
-			const blockType = {};
+			const attributes = {};
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( parseBlockAttributes( rawContent, blockType ) ).to.eql( {} );
+			expect( parseBlockAttributes( rawContent, attributes ) ).to.eql( {} );
 		} );
 	} );
 

--- a/blocks/api/test/paste.js
+++ b/blocks/api/test/paste.js
@@ -38,5 +38,9 @@ describe( 'normaliseToBlockLevelNodes', () => {
 		const HTML = '<p>test</p><div>test<br>test</div>';
 		equal( transform( HTML ), HTML );
 	} );
+
+	it( 'should remove empty paragraphs', () => {
+		equal( transform( '<p>&nbsp;</p>' ), '' );
+	} );
 } );
 

--- a/blocks/api/test/paste.js
+++ b/blocks/api/test/paste.js
@@ -1,0 +1,42 @@
+import { describe, it } from 'mocha';
+import { equal } from 'assert';
+import { JSDOM } from 'jsdom';
+
+const { window } = new JSDOM();
+const { document } = window;
+
+import { normaliseToBlockLevelNodes } from '../paste';
+
+describe( 'normaliseToBlockLevelNodes', () => {
+	function createNodes( HTML ) {
+		document.body.innerHTML = HTML;
+		return Array.from( document.body.childNodes );
+	}
+
+	function outerHTML( nodes ) {
+		return nodes.map( node => node.outerHTML ).join( '' );
+	}
+
+	function transform( HTML ) {
+		return outerHTML( normaliseToBlockLevelNodes( createNodes( HTML ) ) );
+	}
+
+	it( 'should convert double line breaks to paragraphs', () => {
+		equal( transform( 'test<br><br>test' ), '<p>test</p><p>test</p>' );
+	} );
+
+	it( 'should not convert single line break to paragraphs', () => {
+		equal( transform( 'test<br>test' ), '<p>test<br>test</p>' );
+	} );
+
+	it( 'should not add extra line at the start', () => {
+		equal( transform( 'test<br><br><br>test' ), '<p>test</p><p>test</p>' );
+		equal( transform( '<br>test<br><br>test' ), '<p>test</p><p>test</p>' );
+	} );
+
+	it( 'should preserve non-inline content', () => {
+		const HTML = '<p>test</p><div>test<br>test</div>';
+		equal( transform( HTML ), HTML );
+	} );
+} );
+

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -127,13 +127,17 @@ export default class Editable extends Component {
 
 	onPastePostProcess( event ) {
 		const childNodes = Array.from( event.node.childNodes );
-		const isComment = ( node ) => node.nodeType === 8;
-		const mayBePartOfBlock = ( node ) => isComment( node ) || this.editor.dom.isBlock( node );
+		const isComment = ( node ) =>
+			node.nodeType === 8;
+		const isDoubleBR = ( node ) =>
+			node.nodeName === 'BR' && node.previousSibling && node.previousSibling.nodeName === 'BR';
+		const isBlockPart = ( node ) =>
+			isComment( node ) || isDoubleBR( node ) || this.editor.dom.isBlock( node );
 
 		// If we detect comments or block level elements, insert as blocks.
 		// If there's no `onSplit` prop, content will later be converted to
 		// inline content.
-		if ( this.props.onSplit && childNodes.some( mayBePartOfBlock ) ) {
+		if ( this.props.onSplit && childNodes.some( isBlockPart ) ) {
 			const HTML = event.node.innerHTML.replace( /<meta[^>]+>/, '' );
 			const blocks = wp.blocks.parse( HTML );
 

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -12,7 +12,7 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { createElement, Component, renderToString } from 'element';
-import { createBlock, parse } from '../api';
+import { parse, pasteHandler } from '../api';
 import { BACKSPACE, DELETE, ENTER } from 'utils/keycodes';
 
 /**
@@ -138,56 +138,18 @@ export default class Editable extends Component {
 		// If there's no `onSplit` prop, content will later be converted to
 		// inline content.
 		if ( this.props.onSplit ) {
+			let blocks = [];
+
 			// Internal paste, so parse.
 			if ( childNodes.some( isBlockDelimiter ) ) {
-				const blocks = parse( event.node.innerHTML.replace( /<meta[^>]+>/, '' ) );
-
-				// We must wait for TinyMCE to clean up paste containers after this
-				// event.
-				window.setTimeout( () => this.splitContent( blocks ), 0 );
-				event.preventDefault();
+				blocks = parse( event.node.innerHTML.replace( /<meta[^>]+>/, '' ) );
 			// External paste with block level content, so attempt to assign
 			// blocks.
 			} else if ( childNodes.some( isBlockPart ) ) {
-				// Handle BRs and text nodes.
-				const blockNodes = childNodes.reduce( ( acc, node, index ) => {
-					// Text nodes: wrap in a paragraph, or append to previous.
-					if ( node.nodeType === 3 ) {
-						if ( ! acc.length || acc[ acc.length - 1 ].nodeName !== 'P' ) {
-							acc.push( document.createElement( 'P' ) );
-						}
+				blocks = pasteHandler( childNodes );
+			}
 
-						acc[ acc.length - 1 ].appendChild( node );
-					// BR nodes: create a new paragraph on double, or append to
-					// previous.
-					} else if ( node.nodeName === 'BR' ) {
-						if ( childNodes[ index + 1 ] && childNodes[ index + 1 ].nodeName === 'BR' ) {
-							acc.push( document.createElement( 'P' ) );
-						}
-
-						// Don't append to an empty paragraph.
-						if ( acc[ acc.length - 1 ].hasChildNodes() ) {
-							acc[ acc.length - 1 ].appendChild( node );
-						}
-					} else {
-						acc.push( node );
-					}
-
-					return acc;
-				}, [] );
-
-				const blocks = blockNodes.map( ( node ) => {
-					if ( node.nodeName === 'P' ) {
-						return createBlock( 'core/text', {
-							content: nodeListToReact( node.childNodes, createElement ),
-						} );
-					}
-
-					return createBlock( 'core/freeform', {
-						content: nodeListToReact( [ node ], createElement ),
-					} );
-				} );
-
+			if ( blocks.length ) {
 				// We must wait for TinyMCE to clean up paste containers after this
 				// event.
 				window.setTimeout( () => this.splitContent( blocks ), 0 );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -89,7 +89,7 @@ registerBlockType( 'core/heading', {
 		};
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlockAfter } ) {
+	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlocksAfter } ) {
 		const { align, content, nodeName = 'H2' } = attributes;
 
 		return [
@@ -142,11 +142,12 @@ registerBlockType( 'core/heading', {
 				onFocus={ setFocus }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				onSplit={ ( before, after ) => {
+				onSplit={ ( before, after, ...blocks ) => {
 					setAttributes( { content: before } );
-					insertBlockAfter( createBlock( 'core/text', {
-						content: after,
-					} ) );
+					insertBlocksAfter( [
+						...blocks,
+						createBlock( 'core/text', { content: after } ),
+					] );
 				} }
 				style={ { textAlign: align } }
 				placeholder={ __( 'Write heading…' ) }

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -69,6 +69,14 @@ registerBlockType( 'core/heading', {
 					} );
 				},
 			},
+			{
+				type: 'raw',
+				matcher: ( node ) => /H\d/.test( node.nodeName ),
+				attributes: {
+					content: children( 'h1,h2,h3,h4,h5,h6' ),
+					nodeName: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
+				},
+			},
 		],
 		to: [
 			{

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -32,6 +32,23 @@ registerBlockType( 'core/image', {
 		caption: children( 'figcaption' ),
 	},
 
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				matcher: ( node ) => (
+					node.nodeName === 'IMG' ||
+					( ! node.textContent && node.querySelector( 'img' ) )
+				),
+				attributes: {
+					url: attr( 'img', 'src' ),
+					alt: attr( 'img', 'alt' ),
+					caption: children( 'figcaption' ),
+				},
+			},
+		],
+	},
+
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
 		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -102,7 +102,14 @@ registerBlockType( 'core/list', {
 					} );
 				},
 			},
-
+			{
+				type: 'raw',
+				matcher: ( node ) => node.nodeName === 'OL' || node.nodeName === 'UL',
+				attributes: {
+					nodeName: prop( 'ol,ul', 'nodeName' ),
+					values: children( 'ol,ul' ),
+				},
+			},
 		],
 		to: [
 			{

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -35,7 +35,11 @@ registerBlockType( 'core/text', {
 		from: [
 			{
 				type: 'raw',
-				matcher: ( node ) => node.nodeName === 'P',
+				matcher: ( node ) => (
+					node.nodeName === 'P' &&
+					// Do not allow embedded content.
+					! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
+				),
 				attributes: {
 					content: query( 'p', children() ),
 				},

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -31,7 +31,17 @@ registerBlockType( 'core/text', {
 		content: query( 'p', children() ),
 	},
 
-	pasteMatcher: ( node ) => node.nodeName === 'P',
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				matcher: ( node ) => node.nodeName === 'P',
+				attributes: {
+					content: query( 'p', children() ),
+				},
+			},
+		],
+	},
 
 	merge( attributes, attributesToMerge ) {
 		return {

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -37,7 +37,7 @@ registerBlockType( 'core/text', {
 		};
 	},
 
-	edit( { attributes, setAttributes, insertBlockAfter, focus, setFocus, mergeBlocks } ) {
+	edit( { attributes, setAttributes, insertBlocksAfter, focus, setFocus, mergeBlocks } ) {
 		const { align, content, dropCap } = attributes;
 		const toggleDropCap = () => setAttributes( { dropCap: ! dropCap } );
 		return [
@@ -75,11 +75,12 @@ registerBlockType( 'core/text', {
 				} }
 				focus={ focus }
 				onFocus={ setFocus }
-				onSplit={ ( before, after ) => {
+				onSplit={ ( before, after, ...blocks ) => {
 					setAttributes( { content: before } );
-					insertBlockAfter( createBlock( 'core/text', {
-						content: after,
-					} ) );
+					insertBlocksAfter( [
+						...blocks,
+						createBlock( 'core/text', { content: after } ),
+					] );
 				} }
 				onMerge={ mergeBlocks }
 				style={ { textAlign: align } }

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -31,6 +31,8 @@ registerBlockType( 'core/text', {
 		content: query( 'p', children() ),
 	},
 
+	pasteMatcher: ( node ) => node.nodeName === 'P',
+
 	merge( attributes, attributesToMerge ) {
 		return {
 			content: concatChildren( attributes.content, attributesToMerge.content ),

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -43,9 +43,13 @@ export function replaceBlocks( uids, blocks ) {
 }
 
 export function insertBlock( block, after ) {
+	return insertBlocks( [ block ], after );
+}
+
+export function insertBlocks( blocks, after ) {
 	return {
-		type: 'INSERT_BLOCK',
-		block,
+		type: 'INSERT_BLOCKS',
+		blocks,
 		after,
 	};
 }

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -56,7 +56,7 @@ class BlockSwitcher extends Component {
 		const blockType = getBlockType( this.props.block.name );
 		const blocksToBeTransformedFrom = reduce( getBlockTypes(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );
-			const transformation = find( transformFrom, t => t.blocks.indexOf( this.props.block.name ) !== -1 );
+			const transformation = find( transformFrom, t => t.type === 'block' && t.blocks.indexOf( this.props.block.name ) !== -1 );
 			return transformation ? memo.concat( [ block.name ] ) : memo;
 		}, [] );
 		const blocksToBeTransformedTo = get( blockType, 'transforms.to', [] )

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -24,7 +24,7 @@ import BlockSwitcher from '../../block-switcher';
 import {
 	focusBlock,
 	mergeBlocks,
-	insertBlock,
+	insertBlocks,
 	clearSelectedBlock,
 	startTypingInBlock,
 	stopTypingInBlock,
@@ -265,7 +265,7 @@ class VisualEditorBlock extends Component {
 			'is-hovered': isHovered,
 		} );
 
-		const { onMouseLeave, onFocus, onInsertAfter } = this.props;
+		const { onMouseLeave, onFocus, onInsertBlocksAfter } = this.props;
 
 		// Determine whether the block has props to apply to the wrapper.
 		let wrapperProps;
@@ -319,7 +319,7 @@ class VisualEditorBlock extends Component {
 						focus={ focus }
 						attributes={ block.attributes }
 						setAttributes={ this.setAttributes }
-						insertBlockAfter={ onInsertAfter }
+						insertBlocksAfter={ onInsertBlocksAfter }
 						setFocus={ partial( onFocus, block.uid ) }
 						mergeBlocks={ this.mergeBlocks }
 						className={ className }
@@ -389,8 +389,8 @@ export default connect(
 			} );
 		},
 
-		onInsertAfter( block ) {
-			dispatch( insertBlock( block, ownProps.uid ) );
+		onInsertBlocksAfter( blocks ) {
+			dispatch( insertBlocks( blocks, ownProps.uid ) );
 		},
 
 		onFocus( ...args ) {

--- a/editor/state.js
+++ b/editor/state.js
@@ -67,7 +67,7 @@ export const editor = combineUndoableReducers( {
 				return false;
 
 			case 'UPDATE_BLOCK':
-			case 'INSERT_BLOCK':
+			case 'INSERT_BLOCKS':
 			case 'MOVE_BLOCKS_DOWN':
 			case 'MOVE_BLOCKS_UP':
 			case 'REPLACE_BLOCKS':
@@ -120,10 +120,10 @@ export const editor = combineUndoableReducers( {
 					},
 				};
 
-			case 'INSERT_BLOCK':
+			case 'INSERT_BLOCKS':
 				return {
 					...state,
-					[ action.block.uid ]: action.block,
+					...keyBy( action.blocks, 'uid' ),
 				};
 
 			case 'REPLACE_BLOCKS':
@@ -149,11 +149,11 @@ export const editor = combineUndoableReducers( {
 			case 'RESET_BLOCKS':
 				return action.blocks.map( ( { uid } ) => uid );
 
-			case 'INSERT_BLOCK': {
+			case 'INSERT_BLOCKS': {
 				const position = action.after ? state.indexOf( action.after ) + 1 : state.length;
 				return [
 					...state.slice( 0, position ),
-					action.block.uid,
+					...action.blocks.map( block => block.uid ),
 					...state.slice( position ),
 				];
 			}
@@ -273,9 +273,9 @@ export function selectedBlock( state = {}, action ) {
 				: { uid: firstUid, typing: false, focus: {} };
 		}
 
-		case 'INSERT_BLOCK':
+		case 'INSERT_BLOCKS':
 			return {
-				uid: action.block.uid,
+				uid: action.blocks[ 0 ].uid,
 				typing: false,
 				focus: {},
 			};
@@ -337,7 +337,7 @@ export function multiSelectedBlocks( state = { start: null, end: null }, action 
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK':
 		case 'TOGGLE_BLOCK_SELECTED':
-		case 'INSERT_BLOCK':
+		case 'INSERT_BLOCKS':
 			return {
 				start: null,
 				end: null,

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -67,11 +67,11 @@ describe( 'state', () => {
 				} ],
 			} );
 			const state = editor( original, {
-				type: 'INSERT_BLOCK',
-				block: {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
 					uid: 'ribs',
 					name: 'core/freeform',
-				},
+				} ],
 			} );
 
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 2 );
@@ -312,12 +312,12 @@ describe( 'state', () => {
 			} );
 
 			const state = editor( original, {
-				type: 'INSERT_BLOCK',
+				type: 'INSERT_BLOCKS',
 				after: 'kumquat',
-				block: {
+				blocks: [ {
 					uid: 'persimmon',
 					name: 'core/freeform',
-				},
+				} ],
 			} );
 
 			expect( Object.keys( state.blocksByUid ) ).to.have.lengthOf( 3 );
@@ -736,11 +736,11 @@ describe( 'state', () => {
 
 		it( 'should return with inserted block', () => {
 			const state = selectedBlock( undefined, {
-				type: 'INSERT_BLOCK',
-				block: {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
 					uid: 'ribs',
 					name: 'core/freeform',
-				},
+				} ],
 			} );
 
 			expect( state ).to.eql( { uid: 'ribs', typing: false, focus: {} } );
@@ -893,11 +893,11 @@ describe( 'state', () => {
 			expect( state2 ).to.eql( { start: null, end: null } );
 
 			const state3 = multiSelectedBlocks( original, {
-				type: 'INSERT_BLOCK',
-				block: {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
 					uid: 'ribs',
 					name: 'core/freeform',
-				},
+				} ],
 			} );
 
 			expect( state3 ).to.eql( { start: null, end: null } );


### PR DESCRIPTION
Follow up from https://github.com/WordPress/gutenberg/pull/495#issuecomment-309714914.

> Redoing this a bit since the single paragraph approach was merged. This would allow us to do the following:
>
> * If the pasted content is inline, insert it at caret position. In other words, don't do anything special.
> * If the pasted content has blocks or block level content, split the text block at the caret, parse the content, and insert it between the split content.