### PR TITLE
Add/image alt attributes

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -57,7 +57,9 @@ registerBlockType( 'core/image', {
 
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
-			const setMediaURL = ( media ) => setAttributes( { url: media.url } );
+			const onSelectImage = ( media ) => {
+				setAttributes( { url: media.url, alt: media.alt, caption: media.caption } );
+			};
 			return [
 				controls,
 				<Placeholder
@@ -68,7 +70,7 @@ registerBlockType( 'core/image', {
 					className="blocks-image">
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }
-						onSelect={ setMediaURL }
+						onSelect={ onSelectImage }
 						type="image"
 						autoOpen
 					>

--- a/post-content.js
+++ b/post-content.js
@@ -34,7 +34,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/image align="center" -->',
-			'<figure><img src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>',
+			'<figure><img alt="Beautiful landscape" src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
@@ -106,7 +106,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/image -->',
-			'<figure><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>',
+			'<figure><img alt="Accessibility is important don\'t forget image alt attribute" src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
@@ -124,11 +124,11 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/code -->',
 
 			'<!-- wp:core/image -->',
-			'<figure><img src="https://cldup.com/GCwahb3aOb.jpg" /></figure>',
+			'<figure><img alt="Yet another image block" src="https://cldup.com/GCwahb3aOb.jpg" /></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/image -->',
-			'<figure><img src="https://cldup.com/lUUQPv6w9c.jpg" /></figure>',
+			'<figure><img alt="Yet another image block" src="https://cldup.com/lUUQPv6w9c.jpg" /></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/preformatted -->',


### PR DESCRIPTION
closes #1309 

This PR does two things:

 - Adding alt attributes to the demo content
 - Setting alt and caption when inserting an image from the media modal

