### PR TITLE
Beef up the padding on component panel titles.

### DIFF
--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -52,21 +52,20 @@
 .components-panel__body-title {
 	display: block;
 	padding: 0;
-	margin: 0;
+	margin: -15px;
 	font-size: inherit;
 }
 
 .components-panel__body-toggle.components-icon-button {
 	position: relative;
-	padding: 0;
-	padding-right: 20px;
+	padding: 15px;
 	outline: none;
 	width: 100%;
 	font-weight: 600;
 
 	.dashicon {
 		position: absolute;
-		right: 0;
+		right: 10px;
 		top: 50%;
 		transform: translateY( -50% );
 	}


### PR DESCRIPTION
This increases the size of the clickable target area for component panel titles by 30px in each direction, making them easier to click open & closed.

Fixes #1335.