### PR TITLE
Pass content to dynamic block render functions

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -90,9 +90,16 @@ function do_blocks( $content ) {
 		$block_name = isset( $block['blockName'] ) ? $block['blockName'] : null;
 		$attributes = is_array( $block['attrs'] ) ? $block['attrs'] : array();
 		if ( $block_name && isset( $wp_registered_blocks[ $block_name ] ) ) {
+
+			$content = null;
+			if ( isset( $block['rawContent'] ) ) {
+				$content = $block['rawContent'];
+			}
+
 			$content_after_blocks .= call_user_func(
 				$wp_registered_blocks[ $block_name ]['render'],
-				$attributes
+				$attributes,
+				$content
 			);
 		} else {
 			$content_after_blocks .= $block['rawContent'];

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -21,12 +21,13 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * Dummy block rendering function.
 	 *
 	 * @param  array $attributes Block attributes.
+	 * @param  array $content    Content.
 	 *
 	 * @return string             Block output.
 	 */
-	function render_dummy_block( $attributes ) {
+	function render_dummy_block( $attributes, $content ) {
 		$this->dummy_block_instance_number += 1;
-		return $this->dummy_block_instance_number . ':' . $attributes['value'];
+		return $this->dummy_block_instance_number . ':' . $attributes['value'] . ":$content";
 	}
 
 	/**
@@ -64,11 +65,11 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$updated_post_content = do_blocks( $post_content );
 		$this->assertEquals( $updated_post_content,
 			'before' .
-			'1:b1' .
-			'2:b1' .
+			'1:b1:' .
+			'2:b1:' .
 			'between' .
-			'3:b2' .
-			'4:b2' .
+			'3:b2:' .
+			'4:b2:' .
 			'after'
 		);
 	}
@@ -88,17 +89,17 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		register_block_type( 'core/dummy', $settings );
 		$post_content =
 			'before' .
-			'<!-- wp:core/dummy {"value":"b1"} -->this\nshould\n\nbe\nignored<!-- /wp:core/dummy -->' .
+			"<!-- wp:core/dummy {\"value\":\"b1\"} -->this\ncontent\n\nshould\nbe\npassed<!-- /wp:core/dummy -->" .
 			'between' .
-			'<!-- wp:core/dummy {"value":"b2"} -->this should also be ignored<!-- /wp:core/dummy -->' .
+			'<!-- wp:core/dummy {"value":"b2"} -->content2<!-- /wp:core/dummy -->' .
 			'after';
 
 		$updated_post_content = do_blocks( $post_content );
 		$this->assertEquals( $updated_post_content,
 			'before' .
-			'1:b1' .
+			"1:b1:this\ncontent\n\nshould\nbe\npassed" .
 			'between' .
-			'2:b2' .
+			'2:b2:content2' .
 			'after'
 		);
 	}


### PR DESCRIPTION
Currently only the attributes are passed to the PHP render function. This PR changes that to allow the contents of the block also to be passed. This brings blocks closer aligned with shortcodes, for which the callback functions take two arguments, the attributes and the content.