### PR TITLE
Render inspector controls only if options exist

### DIFF
--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { Slot } from 'react-slot-fill';
+import { Provider, Slot } from 'react-slot-fill';
 
 /**
  * WordPress dependencies
  */
 import { __ } from 'i18n';
+import { Component } from 'element';
 import { Panel, PanelHeader, PanelBody } from 'components';
 import { getBlockType } from 'blocks';
 
@@ -18,36 +19,76 @@ import './style.scss';
 import { deselectBlock } from '../../actions';
 import { getSelectedBlock } from '../../selectors';
 
-const BlockInspector = ( { selectedBlock, ...props } ) => {
-	if ( ! selectedBlock ) {
-		return null;
+class BlockInspector extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.forceUpdateIfSelected = this.forceUpdateIfSelected.bind( this );
 	}
 
-	const blockType = getBlockType( selectedBlock.name );
+	componentWillMount() {
+		const { manager: rsfManager } = this.context;
+		rsfManager.onComponentsChange( 'Inspector.Controls', this.forceUpdateIfSelected );
+	}
 
-	const onDeselect = ( event ) => {
-		event.preventDefault();
-		props.deselectBlock( selectedBlock.uid );
-	};
+	componentWillUnmount() {
+		const { manager: rsfManager } = this.context;
+		rsfManager.removeOnComponentsChange( 'Inspector.Controls', this.forceUpdateIfSelected );
+	}
 
-	const header = (
-		<strong>
-			<a href="" onClick={ onDeselect } className="editor-block-inspector__deselect-post">
-				{ __( 'Post' ) }
-			</a>
-			{ ' → ' }
-			{ blockType.title }
-		</strong>
-	);
+	forceUpdateIfSelected() {
+		// We must bind to the React-Slot-Fill Provider manager to re-render if
+		// slots change after the initial render. This can occur when focus
+		// changes between blocks, where control fills may only update after
+		// change in selected block (and subsequent render) already occurred.
+		if ( this.props.selectedBlock ) {
+			this.forceUpdate();
+		}
+	}
 
-	return (
-		<Panel>
-			<PanelHeader label={ header } />
-			<PanelBody>
-				<Slot name="Inspector.Controls" />
-			</PanelBody>
-		</Panel>
-	);
+	render() {
+		const { selectedBlock, ...props } = this.props;
+		const { manager: rsfManager } = this.context;
+		if ( ! selectedBlock ) {
+			return null;
+		}
+
+		// Don't show inspector controls if slot is empty
+		const hasFills = rsfManager.getFillsByName( 'Inspector.Controls' ).length > 0;
+		if ( ! hasFills ) {
+			return null;
+		}
+
+		const blockType = getBlockType( selectedBlock.name );
+
+		const onDeselect = ( event ) => {
+			event.preventDefault();
+			props.deselectBlock( selectedBlock.uid );
+		};
+
+		const header = (
+			<strong>
+				<a href="" onClick={ onDeselect } className="editor-block-inspector__deselect-post">
+					{ __( 'Post' ) }
+				</a>
+				{ ' → ' }
+				{ blockType.title }
+			</strong>
+		);
+
+		return (
+			<Panel className="editor-block-inspector">
+				<PanelHeader label={ header } />
+				<PanelBody>
+					<Slot name="Inspector.Controls" />
+				</PanelBody>
+			</Panel>
+		);
+	}
+}
+
+BlockInspector.contextTypes = {
+	manager: Provider.childContextTypes.manager,
 };
 
 export default connect(

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress Dependencies
  */
 import { withFocusReturn } from 'components';
@@ -14,21 +9,12 @@ import { withFocusReturn } from 'components';
 import './style.scss';
 import PostSettings from './post-settings';
 import BlockInspector from './block-inspector';
-import { getSelectedBlock } from '../selectors';
 
-const Sidebar = ( { selectedBlock } ) => {
-	return (
-		<div className="editor-sidebar">
-			{ ! selectedBlock && <PostSettings /> }
-			{ selectedBlock && <BlockInspector /> }
-		</div>
-	);
-};
+const sidebar = (
+	<div className="editor-sidebar">
+		<BlockInspector />
+		<PostSettings />
+	</div>
+);
 
-export default connect(
-	( state ) => {
-		return {
-			selectedBlock: getSelectedBlock( state ),
-		};
-	}
-)( withFocusReturn( Sidebar ) );
+export default withFocusReturn( () => sidebar );

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -22,7 +22,7 @@ import LastRevision from '../last-revision';
 
 const PostSettings = ( { toggleSidebar } ) => {
 	return (
-		<Panel>
+		<Panel className="editor-post-settings">
 			<PanelHeader label={ __( 'Post Settings' ) } >
 				<div className="editor-sidebar-post-settings__icons">
 					<IconButton

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -30,6 +30,10 @@
 	}
 }
 
+.editor-sidebar .editor-block-inspector + .editor-post-settings {
+	display: none;
+}
+
 /* Visual and Text editor both */
 .editor-layout.is-sidebar-opened .editor-layout__content {
 	margin-left: -200%;


### PR DESCRIPTION
Closes #1100 

This pull request seeks to show the block inspector controls only in the case that controls exist, otherwise continuing to show the Post Settings sidebar.

![Settings](https://user-images.githubusercontent.com/1779930/27394538-8a5f2744-567a-11e7-989a-84d219b988ff.gif)

__Implementation notes:__

The challenge here is knowing whether any [fills](https://github.com/camwest/react-slot-fill) occupy the inspector slot. The implementation here achieves this using the React-Slot-Fill Provider `manager` context to retrieve all fills for the inspector slot. Further, it must bind directly to its internal event emitter to capture changes to fills after the initial render of BlockInspector.

__Testing instructions:__

1. Navigate to Gutenberg Demo editor
2. Select blocks
3. Note that Inspector controls are only shown for the selected block if at least one Inspector control option exists