### PR TITLE
Do not trigger selection on right click

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -209,7 +209,12 @@ class VisualEditorBlock extends Component {
 		}
 	}
 
-	onPointerDown() {
+	onPointerDown( event ) {
+		// Not the main button (usually the left button on pointer device).
+		if ( event.buttons !== 1 ) {
+			return;
+		}
+
 		this.props.onSelectionStart();
 		this.props.onSelect();
 	}


### PR DESCRIPTION
To test, notice that in master, you'll trigger multi selection on right click, then moving the pointer a few blocks down to hide the context menu. This PR should fix this issue.