### PR TITLE
Post visibility better html and a11y

### DIFF
--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -126,7 +126,7 @@ class PostVisibility extends Component {
 								<div key={ value } className="editor-post-visibility__choice">
 									<input
 										type="radio"
-										name="editor-post-visibility__setting"
+										name={ `editor-post-visibility__setting-${ instanceId }` }
 										value={ value }
 										onChange={ onSelect }
 										checked={ checked }

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -121,6 +121,7 @@ class PostVisibility extends Component {
 								<div key={ value } className="editor-post-visibility__choice">
 									<input
 										type="radio"
+										name="editor-post-visibility__setting"
 										value={ value }
 										onChange={ onSelect }
 										checked={ checked }

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -56,6 +56,7 @@ class PostVisibility extends Component {
 		const { onUpdateVisibility, onSave } = this.props;
 
 		onUpdateVisibility( 'private' );
+		this.setState( { hasPassword: false } );
 		onSave();
 	}
 

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -106,7 +106,12 @@ class PostVisibility extends Component {
 		return (
 			<div className="editor-post-visibility">
 				<span>{ __( 'Visibility' ) }</span>
-				<button type="button" aria-expanded={ this.state.opened } className="editor-post-visibility__toggle button-link" onClick={ this.toggleDialog }>
+				<button
+					type="button"
+					aria-expanded={ this.state.opened }
+					className="editor-post-visibility__toggle button-link"
+					onClick={ this.toggleDialog }
+				>
 					{ getVisibilityLabel( visibility ) }
 				</button>
 

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -164,4 +164,4 @@ export default connect(
 			return editPost( { status, password } );
 		},
 	}
-)( clickOutside( withInstanceId( PostVisibility ) ) );
+)( withInstanceId( clickOutside( PostVisibility ) ) );

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -137,7 +137,9 @@ class PostVisibility extends Component {
 									<label
 										htmlFor={ `editor-post-${ value }-${ instanceId }` }
 										className="editor-post-visibility__dialog-label"
-									>{ label }</label>
+									>
+										{ label }
+									</label>
 									{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
 								</div>
 							) ) }

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -126,6 +126,7 @@ class PostVisibility extends Component {
 										checked={ checked }
 										id={ `editor-post-${ value }-${ instanceId }` }
 										aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
+										className="editor-post-visibility__dialog-radio"
 									/>
 									<label
 										htmlFor={ `editor-post-${ value }-${ instanceId }` }

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -57,7 +57,6 @@ class PostVisibility extends Component {
 
 		onUpdateVisibility( 'private' );
 		onSave();
-		this.setState( { opened: false } );
 	}
 
 	setPasswordProtected() {
@@ -118,7 +117,7 @@ class PostVisibility extends Component {
 								{ __( 'Post Visibility' ) }
 							</legend>
 							{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
-								<span key={ value } className="editor-post-visibility__choice">
+								<div key={ value } className="editor-post-visibility__choice">
 									<input
 										type="radio"
 										value={ value }
@@ -133,17 +132,26 @@ class PostVisibility extends Component {
 										className="editor-post-visibility__dialog-label"
 									>{ label }</label>
 									{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
-								</span>
+								</div>
 							) ) }
 						</fieldset>
 						{ this.state.hasPassword &&
-							<input
-								className="editor-post-visibility__dialog-password-input"
-								type="text"
-								onChange={ updatePassword }
-								value={ password }
-								placeholder={ __( 'Create password' ) }
-							/>
+							<div className="editor-post-visibility__dialog-password">
+								<label
+									htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+									className="screen-reader-text"
+								>
+									{ __( 'Create password' ) }
+								</label>
+								<input
+									className="editor-post-visibility__dialog-password-input"
+									id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+									type="text"
+									onChange={ updatePassword }
+									value={ password }
+									placeholder={ __( 'Use a secure password' ) }
+								/>
+							</div>
 						}
 					</div>
 				}

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -4,6 +4,7 @@
 import { connect } from 'react-redux';
 import clickOutside from 'react-click-outside';
 import { find } from 'lodash';
+import { withInstanceId } from 'components';
 
 /**
  * WordPress dependencies
@@ -36,8 +37,7 @@ class PostVisibility extends Component {
 		};
 	}
 
-	toggleDialog( event ) {
-		event.preventDefault();
+	toggleDialog() {
 		this.setState( ( state ) => ( { opened: ! state.opened } ) );
 	}
 
@@ -72,7 +72,7 @@ class PostVisibility extends Component {
 	}
 
 	render() {
-		const { status, visibility, password, onUpdateVisibility } = this.props;
+		const { status, visibility, password, onUpdateVisibility, instanceId } = this.props;
 
 		const updatePassword = ( event ) => onUpdateVisibility( status, event.target.value );
 
@@ -106,27 +106,35 @@ class PostVisibility extends Component {
 		return (
 			<div className="editor-post-visibility">
 				<span>{ __( 'Visibility' ) }</span>
-				<button className="editor-post-visibility__toggle button-link" onClick={ this.toggleDialog }>
+				<button type="button" aria-expanded={ this.state.opened } className="editor-post-visibility__toggle button-link" onClick={ this.toggleDialog }>
 					{ getVisibilityLabel( visibility ) }
 				</button>
 
 				{ this.state.opened &&
 					<div className="editor-post-visibility__dialog">
 						<div className="editor-post-visibility__dialog-arrow" />
-						<div className="editor-post-visibility__dialog-legend">
-							{ __( 'Post Visibility' ) }
-						</div>
-						{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
-							<label key={ value } className="editor-post-visibility__dialog-label">
-								<input
-									type="radio"
-									value={ value }
-									onChange={ onSelect }
-									checked={ checked } />
-								{ label }
-								{ <div className="editor-post-visibility__dialog-info">{ info }</div> }
-							</label>
-						) ) }
+						<fieldset>
+							<legend className="editor-post-visibility__dialog-legend">
+								{ __( 'Post Visibility' ) }
+							</legend>
+							{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
+								<span key={ value } className="editor-post-visibility__choice">
+									<input
+										type="radio"
+										value={ value }
+										onChange={ onSelect }
+										checked={ checked }
+										id={ `editor-post-${ value }-${ instanceId }` }
+										aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
+									/>
+									<label
+										htmlFor={ `editor-post-${ value }-${ instanceId }` }
+										className="editor-post-visibility__dialog-label"
+									>{ label }</label>
+									{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
+								</span>
+							) ) }
+						</fieldset>
 						{ this.state.hasPassword &&
 							<input
 								className="editor-post-visibility__dialog-password-input"
@@ -156,5 +164,4 @@ export default connect(
 			return editPost( { status, password } );
 		},
 	}
-)( clickOutside( PostVisibility ) );
-
+)( clickOutside( withInstanceId( PostVisibility ) ) );

--- a/editor/sidebar/post-visibility/style.scss
+++ b/editor/sidebar/post-visibility/style.scss
@@ -65,7 +65,6 @@
 }
 
 .editor-post-visibility__choice {
-	display: block;
 	margin: 10px 0;
 }
 
@@ -83,5 +82,6 @@
 	color: $dark-gray-200;
 	padding-left: 20px;
 	font-style: italic;
-	margin-top: 4px;
+	margin: 4px 0 0;
+	line-height: 1.4;
 }

--- a/editor/sidebar/post-visibility/style.scss
+++ b/editor/sidebar/post-visibility/style.scss
@@ -62,12 +62,16 @@
 .editor-post-visibility__dialog-legend {
 	font-weight: 600;
 	font-size: 0.9em;
-
 }
 
 .editor-post-visibility__choice {
 	display: block;
 	margin: 10px 0;
+}
+
+.editor-post-visibility__dialog-radio,
+.editor-post-visibility__dialog-label {
+	vertical-align: top;
 }
 
 .editor-post-visibility__dialog-password-input {

--- a/editor/sidebar/post-visibility/style.scss
+++ b/editor/sidebar/post-visibility/style.scss
@@ -65,7 +65,7 @@
 
 }
 
-.editor-post-visibility__dialog-label {
+.editor-post-visibility__choice {
 	display: block;
 	margin: 10px 0;
 }


### PR DESCRIPTION
This PR tries to improve the Post Visibility "popover" HTML semantic and accessibility:
- valid HTML
- explicitly associated labels
- added fieldset and legend, see why this is important especially for radio buttons: https://accessibility.blog.gov.uk/2016/07/22/using-the-fieldset-and-legend-elements/
- the password protected field has now a proper label
- changed the password protected placeholder text to be more a "hint": placeholders shouldn't be used as replacement for labels, see https://core.trac.wordpress.org/ticket/40331
- the toggle button now uses an aria-expanded attribute
- don't close the panel when setting visibility to "Private", for consistency with the other 2 options

Not sure why `setPrivate()` uses `onSave()`, would need some feedback here since that seems to trigger a re-rendering of the "popover". /cc @aduth 

Todo:
- when closing the panel, focus should be moved back to the toggle button
- pressing Escape should close the panel (and move focus back)
- when setting visibility to "Private": interaction with the JS confirm: is it really needed?

These points should probably be addressed in #1204 as @aduth mentioned

Note: Needs to be tested in IE/Edge (I suspect the legend element would need some additional styling for those browsers)

Fixes #1312