### PR TITLE
Blocks: Don't show the block toolbar if we press ctrl, shift... on Safari

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -52,7 +52,7 @@ class VisualEditorBlock extends Component {
 		this.setAttributes = this.setAttributes.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
-		this.stopTyping = this.stopTyping.bind( this );
+		this.stopTypingOnMouseMove = this.stopTypingOnMouseMove.bind( this );
 		this.removeOrDeselect = this.removeOrDeselect.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.onFocus = this.onFocus.bind( this );
@@ -95,7 +95,7 @@ class VisualEditorBlock extends Component {
 		const { isTyping } = this.props;
 		if ( isTyping !== prevProps.isTyping ) {
 			if ( isTyping ) {
-				document.addEventListener( 'mousemove', this.stopTyping );
+				document.addEventListener( 'mousemove', this.stopTypingOnMouseMove );
 			} else {
 				this.removeStopTypingListener();
 			}
@@ -107,7 +107,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	removeStopTypingListener() {
-		document.removeEventListener( 'mousemove', this.stopTyping );
+		document.removeEventListener( 'mousemove', this.stopTypingOnMouseMove );
 	}
 
 	bindBlockNode( node ) {
@@ -147,8 +147,21 @@ class VisualEditorBlock extends Component {
 		}
 	}
 
-	stopTyping() {
-		this.props.onStopTyping();
+	stopTypingOnMouseMove( { clientX, clientY } ) {
+		const { lastClientX, lastClientY } = this;
+
+		// We need to check that the mouse really moved
+		// Because Safari trigger mousemove event when we press shift, ctrl...
+		if (
+			lastClientX &&
+			lastClientY &&
+			( lastClientX !== clientX || lastClientY !== clientY )
+		) {
+			this.props.onStopTyping();
+		}
+
+		this.lastClientX = clientX;
+		this.lastClientY = clientY;
 	}
 
 	removeOrDeselect( event ) {


### PR DESCRIPTION
closes #1349 

It appears that safari trigger an "mousemove" event when we click on the meta keys (shift, ctrl...) even if the mouse didn't move. Some details on the weird mousemove event in Safari here https://transitory.technology/mouse-move-in-safari/

The workaround here is to check that the mouse position effectively changed before showing the toolbar.