### PR TITLE
PostSchedule toggle button: add aria-expanded and remove preventDefault

### DIFF
--- a/editor/sidebar/post-schedule/index.js
+++ b/editor/sidebar/post-schedule/index.js
@@ -30,8 +30,7 @@ class PostSchedule extends Component {
 		this.toggleDialog = this.toggleDialog.bind( this );
 	}
 
-	toggleDialog( event ) {
-		event.preventDefault();
+	toggleDialog() {
 		this.setState( ( state ) => ( { opened: ! state.opened } ) );
 	}
 
@@ -61,7 +60,12 @@ class PostSchedule extends Component {
 		return (
 			<div className="editor-post-schedule">
 				<span>{ __( 'Publish' ) }</span>
-				<button className="editor-post-schedule__toggle button-link" onClick={ this.toggleDialog }>
+				<button
+					type="button"
+					className="editor-post-schedule__toggle button-link"
+					onClick={ this.toggleDialog }
+					aria-expanded={ this.state.opened }
+				>
 					{ label }
 				</button>
 


### PR DESCRIPTION
This PR tries to improve a bit the PostSchedule toggle button:
- adds an `aria-expanded` attribute
- add a `type="button"` attribute
- removes `event.preventDefault()` as buttons with a `type="button"` attribute don't have any default action to prevent

Fixes #1363 