### PR TITLE
Tests: Drop .only to run all unit tests

### DIFF
--- a/blocks/test/fixtures/core-image-center-caption.serialized.html
+++ b/blocks/test/fixtures/core-image-center-caption.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/image align="center" -->
-<figure><img src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter" />
+<figure class="aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" />
     <figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption>
 </figure>
 <!-- /wp:core/image -->

--- a/editor/utils/test/dom.js
+++ b/editor/utils/test/dom.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
  */
 import { isEditableElement } from '../dom';
 
-describe.only( 'isEditableElement', () => {
+describe( 'isEditableElement', () => {
 	it( 'should return false for non editable nodes', () => {
 		const div = document.createElement( 'div' );
 


### PR DESCRIPTION
As part of #1211 I accidentally merged a `describe.only` which limit running the unit tests to this closure only.