### PR TITLE
Add toggle for post sticky status on editor #1313

### DIFF
--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -17,6 +17,7 @@ import './style.scss';
 import PostVisibility from '../post-visibility';
 import PostTrash from '../post-trash';
 import PostSchedule from '../post-schedule';
+import PostSticky from '../post-sticky';
 import {
 	getEditedPostAttribute,
 	getSuggestedPostFormat,
@@ -67,6 +68,9 @@ class PostStatus extends Component {
 					<span>{ __( 'Post Format' ) }</span>
 					<span>{ format }</span>
 				</div>
+				
+				<PostSticky />
+			
 				<div className="editor-post-status__row">
 					<PostTrash />
 				</div>

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -68,9 +68,7 @@ class PostStatus extends Component {
 					<span>{ __( 'Post Format' ) }</span>
 					<span>{ format }</span>
 				</div>
-				
 				<PostSticky />
-			
 				<div className="editor-post-status__row">
 					<PostTrash />
 				</div>

--- a/editor/sidebar/post-sticky/index.js
+++ b/editor/sidebar/post-sticky/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+import { FormToggle, withInstanceId } from 'components';
+
+/**
+ * Internal dependencies
+ */
+import { getEditedPostAttribute } from '../../selectors';
+import { editPost } from '../../actions';
+
+function PostSticky( { postSticky = false, instanceId, ...props } ) {
+	const stickyToggleId = 'post-sticky-toggle-' + instanceId;
+
+	const onTogglePostSticky = () => props.editPost( { sticky: !postSticky } );
+
+	return ( 
+		<div className="editor-post-status__row">
+			<label htmlFor={ stickyToggleId }>{ __( 'Stick to the front page' ) }</label>
+			<FormToggle
+				checked={ postSticky }
+				onChange={ onTogglePostSticky }
+				showHint={ false }
+				id={ stickyToggleId }
+			/>
+		</div>
+	);
+}
+
+export default connect(
+	( state ) => {
+		return {
+			postSticky: getEditedPostAttribute( state, 'sticky' ),
+		};
+	},
+	{ editPost }
+)( withInstanceId( PostSticky ) );

--- a/editor/sidebar/post-sticky/index.js
+++ b/editor/sidebar/post-sticky/index.js
@@ -18,9 +18,9 @@ import { editPost } from '../../actions';
 function PostSticky( { postSticky = false, instanceId, ...props } ) {
 	const stickyToggleId = 'post-sticky-toggle-' + instanceId;
 
-	const onTogglePostSticky = () => props.editPost( { sticky: !postSticky } );
+	const onTogglePostSticky = () => props.editPost( { sticky: ! postSticky } );
 
-	return ( 
+	return (
 		<div className="editor-post-status__row">
 			<label htmlFor={ stickyToggleId }>{ __( 'Stick to the front page' ) }</label>
 			<FormToggle

--- a/editor/sidebar/post-sticky/index.js
+++ b/editor/sidebar/post-sticky/index.js
@@ -15,17 +15,19 @@ import { FormToggle, withInstanceId } from 'components';
 import { getEditedPostAttribute } from '../../selectors';
 import { editPost } from '../../actions';
 
-function PostSticky( { postSticky = false, instanceId, ...props } ) {
-	const stickyToggleId = 'post-sticky-toggle-' + instanceId;
+function PostSticky( { onTogglePostSticky, postType, postSticky = false, instanceId } ) {
+	if ( postType !== 'post' ) {
+		return false;
+	}
 
-	const onTogglePostSticky = () => props.editPost( { sticky: ! postSticky } );
+	const stickyToggleId = 'post-sticky-toggle-' + instanceId;
 
 	return (
 		<div className="editor-post-status__row">
 			<label htmlFor={ stickyToggleId }>{ __( 'Stick to the front page' ) }</label>
 			<FormToggle
 				checked={ postSticky }
-				onChange={ onTogglePostSticky }
+				onChange={ () => onTogglePostSticky( postSticky ) }
 				showHint={ false }
 				id={ stickyToggleId }
 			/>
@@ -36,8 +38,15 @@ function PostSticky( { postSticky = false, instanceId, ...props } ) {
 export default connect(
 	( state ) => {
 		return {
+			postType: getEditedPostAttribute( state, 'type' ),
 			postSticky: getEditedPostAttribute( state, 'sticky' ),
 		};
 	},
-	{ editPost }
+	( dispatch ) => {
+		return {
+			onTogglePostSticky( postSticky ) {
+				dispatch( editPost( { sticky: ! postSticky } ) );
+			},
+		};
+	},
 )( withInstanceId( PostSticky ) );

--- a/editor/sidebar/post-sticky/index.js
+++ b/editor/sidebar/post-sticky/index.js
@@ -12,10 +12,10 @@ import { FormToggle, withInstanceId } from 'components';
 /**
  * Internal dependencies
  */
-import { getEditedPostAttribute } from '../../selectors';
+import { getEditedPostAttribute, getCurrentPostType } from '../../selectors';
 import { editPost } from '../../actions';
 
-function PostSticky( { onTogglePostSticky, postType, postSticky = false, instanceId } ) {
+function PostSticky( { onUpdateSticky, postType, postSticky = false, instanceId } ) {
 	if ( postType !== 'post' ) {
 		return false;
 	}
@@ -27,7 +27,7 @@ function PostSticky( { onTogglePostSticky, postType, postSticky = false, instanc
 			<label htmlFor={ stickyToggleId }>{ __( 'Stick to the front page' ) }</label>
 			<FormToggle
 				checked={ postSticky }
-				onChange={ () => onTogglePostSticky( postSticky ) }
+				onChange={ () => onUpdateSticky( ! postSticky ) }
 				showHint={ false }
 				id={ stickyToggleId }
 			/>
@@ -38,14 +38,14 @@ function PostSticky( { onTogglePostSticky, postType, postSticky = false, instanc
 export default connect(
 	( state ) => {
 		return {
-			postType: getEditedPostAttribute( state, 'type' ),
+			postType: getCurrentPostType( state ),
 			postSticky: getEditedPostAttribute( state, 'sticky' ),
 		};
 	},
 	( dispatch ) => {
 		return {
-			onTogglePostSticky( postSticky ) {
-				dispatch( editPost( { sticky: ! postSticky } ) );
+			onUpdateSticky( postSticky ) {
+				dispatch( editPost( { sticky: postSticky } ) );
 			},
 		};
 	},


### PR DESCRIPTION
Added a toggle under Post Settings -> Status & Visibility for post sticky status.

http://share.agnew.co/lqC7JP

Should this option show if the post is not set to Public?
If the post is set to Private or Password Protected should we set Sticky back to false?

Fixes: #1313