### PR TITLE
Blocks: Automatically generate a wrapper classname for blocks

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -44,7 +44,12 @@ export function getSaveContent( save, blockName, attributes ) {
 		if ( ! element || ! isObject( element ) ) {
 			return element;
 		}
-		const className = classnames( element.props.className, `wp-block-${ kebabCase( blockName ) }` );
+
+		// Drop the namespace "core/"" for core blocks only
+		const match = /^([a-z0-9-]+)\/([a-z0-9-]+)$/.exec( blockName );
+		const sanitizedBlockName = match[ 1 ] === 'core' ? match[ 2 ] : blockName;
+
+		const className = classnames( element.props.className, `wp-block-${ kebabCase( sanitizedBlockName ) }` );
 		return cloneElement( element, { className } );
 	};
 	const contentWithClassname = Children.map( rawContent, addClassnameToElement );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -40,7 +40,17 @@ describe( 'block serializer', () => {
 					{ fruit: 'Bananas' }
 				);
 
-				expect( saved ).to.equal( '<div class="wp-block-core-fruit">Bananas</div>' );
+				expect( saved ).to.equal( '<div class="wp-block-fruit">Bananas</div>' );
+			} );
+
+			it( 'should return use the namespace in the classname if it\' not a core block', () => {
+				const saved = getSaveContent(
+					( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+					'myplugin/fruit',
+					{ fruit: 'Bananas' }
+				);
+
+				expect( saved ).to.equal( '<div class="wp-block-myplugin-fruit">Bananas</div>' );
 			} );
 		} );
 
@@ -127,7 +137,7 @@ describe( 'block serializer', () => {
 					},
 				},
 			];
-			const expectedPostContent = '<!-- wp:core/test-block align="left" -->\n<p class="wp-block-core-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
+			const expectedPostContent = '<!-- wp:core/test-block align="left" -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
 
 			expect( serialize( blockList ) ).to.eql( expectedPostContent );
 		} );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -26,6 +26,7 @@ describe( 'block serializer', () => {
 			it( 'should return string verbatim', () => {
 				const saved = getSaveContent(
 					( { attributes } ) => attributes.fruit,
+					'core/fruit',
 					{ fruit: 'Bananas' }
 				);
 
@@ -35,10 +36,11 @@ describe( 'block serializer', () => {
 			it( 'should return element as string if save returns element', () => {
 				const saved = getSaveContent(
 					( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+					'core/fruit',
 					{ fruit: 'Bananas' }
 				);
 
-				expect( saved ).to.equal( '<div>Bananas</div>' );
+				expect( saved ).to.equal( '<div class="wp-block-core-fruit">Bananas</div>' );
 			} );
 		} );
 
@@ -50,6 +52,7 @@ describe( 'block serializer', () => {
 							return createElement( 'div', null, this.props.attributes.fruit );
 						}
 					},
+					'core/fruit',
 					{ fruit: 'Bananas' }
 				);
 
@@ -124,7 +127,7 @@ describe( 'block serializer', () => {
 					},
 				},
 			];
-			const expectedPostContent = '<!-- wp:core/test-block align="left" -->\n<p>Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
+			const expectedPostContent = '<!-- wp:core/test-block align="left" -->\n<p class="wp-block-core-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
 
 			expect( serialize( blockList ) ).to.eql( expectedPostContent );
 		} );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -25,8 +25,10 @@ describe( 'block serializer', () => {
 		context( 'function save', () => {
 			it( 'should return string verbatim', () => {
 				const saved = getSaveContent(
-					( { attributes } ) => attributes.fruit,
-					'core/fruit',
+					{
+						save: ( { attributes } ) => attributes.fruit,
+						name: 'core/fruit',
+					},
 					{ fruit: 'Bananas' }
 				);
 
@@ -35,8 +37,10 @@ describe( 'block serializer', () => {
 
 			it( 'should return element as string if save returns element', () => {
 				const saved = getSaveContent(
-					( { attributes } ) => createElement( 'div', null, attributes.fruit ),
-					'core/fruit',
+					{
+						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+						name: 'core/fruit',
+					},
 					{ fruit: 'Bananas' }
 				);
 
@@ -45,24 +49,54 @@ describe( 'block serializer', () => {
 
 			it( 'should return use the namespace in the classname if it\' not a core block', () => {
 				const saved = getSaveContent(
-					( { attributes } ) => createElement( 'div', null, attributes.fruit ),
-					'myplugin/fruit',
+					{
+						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+						name: 'myplugin/fruit',
+					},
 					{ fruit: 'Bananas' }
 				);
 
 				expect( saved ).to.equal( '<div class="wp-block-myplugin-fruit">Bananas</div>' );
+			} );
+
+			it( 'should overrides the className', () => {
+				const saved = getSaveContent(
+					{
+						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+						name: 'myplugin/fruit',
+						className: 'apples',
+					},
+					{ fruit: 'Bananas' }
+				);
+
+				expect( saved ).to.equal( '<div class="apples">Bananas</div>' );
+			} );
+
+			it( 'should not add a className if falsy', () => {
+				const saved = getSaveContent(
+					{
+						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+						name: 'myplugin/fruit',
+						className: false,
+					},
+					{ fruit: 'Bananas' }
+				);
+
+				expect( saved ).to.equal( '<div>Bananas</div>' );
 			} );
 		} );
 
 		context( 'component save', () => {
 			it( 'should return element as string', () => {
 				const saved = getSaveContent(
-					class extends Component {
-						render() {
-							return createElement( 'div', null, this.props.attributes.fruit );
-						}
+					{
+						save: class extends Component {
+							render() {
+								return createElement( 'div', null, this.props.attributes.fruit );
+							}
+						},
+						name: 'core/fruit',
 					},
-					'core/fruit',
 					{ fruit: 'Bananas' }
 				);
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -26,6 +26,8 @@ registerBlockType( 'core/heading', {
 
 	category: 'common',
 
+	className: false,
+
 	attributes: {
 		content: children( 'h1,h2,h3,h4,h5,h6' ),
 		nodeName: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -25,6 +25,8 @@ registerBlockType( 'core/html', {
 
 	category: 'formatting',
 
+	className: false,
+
 	attributes: {
 		content: children(),
 	},

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -74,6 +74,8 @@ registerBlockType( 'core/list', {
 		values: children( 'ol,ul' ),
 	},
 
+	className: false,
+
 	transforms: {
 		from: [
 			{

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -23,6 +23,8 @@ registerBlockType( 'core/text', {
 
 	category: 'common',
 
+	className: false,
+
 	attributes: {
 		content: query( 'p', children() ),
 	},

--- a/blocks/test/fixtures/core-button-center.html
+++ b/blocks/test/fixtures/core-button-center.html
@@ -1,3 +1,3 @@
 <!-- wp:core/button align="center" -->
-<div class="aligncenter"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="aligncenter wp-block-core-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->

--- a/blocks/test/fixtures/core-button-center.html
+++ b/blocks/test/fixtures/core-button-center.html
@@ -1,3 +1,3 @@
 <!-- wp:core/button align="center" -->
-<div class="aligncenter wp-block-core-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->

--- a/blocks/test/fixtures/core-button-center.serialized.html
+++ b/blocks/test/fixtures/core-button-center.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/button align="center" -->
-<div class="aligncenter"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="aligncenter wp-block-core-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->
 

--- a/blocks/test/fixtures/core-button-center.serialized.html
+++ b/blocks/test/fixtures/core-button-center.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/button align="center" -->
-<div class="aligncenter wp-block-core-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->
 

--- a/blocks/test/fixtures/core-code.html
+++ b/blocks/test/fixtures/core-code.html
@@ -1,5 +1,5 @@
 <!-- wp:core/code -->
-<pre class="wp-block-core-code"><code>export default function MyButton() {
+<pre class="wp-block-code"><code>export default function MyButton() {
 	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
 }</code></pre>
 <!-- /wp:core/code -->

--- a/blocks/test/fixtures/core-code.html
+++ b/blocks/test/fixtures/core-code.html
@@ -1,5 +1,5 @@
 <!-- wp:core/code -->
-<pre><code>export default function MyButton() {
+<pre class="wp-block-core-code"><code>export default function MyButton() {
 	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
 }</code></pre>
 <!-- /wp:core/code -->

--- a/blocks/test/fixtures/core-code.serialized.html
+++ b/blocks/test/fixtures/core-code.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/code -->
-<pre class="wp-block-core-code"><code>export default function MyButton() {
+<pre class="wp-block-code"><code>export default function MyButton() {
 	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
 }</code></pre>
 <!-- /wp:core/code -->

--- a/blocks/test/fixtures/core-code.serialized.html
+++ b/blocks/test/fixtures/core-code.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/code -->
-<pre><code>export default function MyButton() {
+<pre class="wp-block-core-code"><code>export default function MyButton() {
 	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
 }</code></pre>
 <!-- /wp:core/code -->

--- a/blocks/test/fixtures/core-cover-image.serialized.html
+++ b/blocks/test/fixtures/core-cover-image.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/cover-image url="https://cldup.com/uuUqE_dXzy.jpg" -->
-<section class="blocks-cover-image">
+<section class="blocks-cover-image wp-block-cover-image">
     <section class="cover-image" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg);">
         <h2>Guten Berg!</h2>
     </section>

--- a/blocks/test/fixtures/core-embed.html
+++ b/blocks/test/fixtures/core-embed.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embed url="https://example.com/" -->
-<figure class="wp-block-core-embed">
+<figure class="wp-block-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed.html
+++ b/blocks/test/fixtures/core-embed.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embed url="https://example.com/" -->
-<figure>
+<figure class="wp-block-core-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed.serialized.html
+++ b/blocks/test/fixtures/core-embed.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embed url="https://example.com/" -->
-<figure class="wp-block-core-embed">
+<figure class="wp-block-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed.serialized.html
+++ b/blocks/test/fixtures/core-embed.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embed url="https://example.com/" -->
-<figure>
+<figure class="wp-block-core-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedanimoto.html
+++ b/blocks/test/fixtures/core-embedanimoto.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedanimoto url="https://animoto.com/" -->
-<figure>
+<figure class="wp-block-core-embedanimoto">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedanimoto.html
+++ b/blocks/test/fixtures/core-embedanimoto.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedanimoto url="https://animoto.com/" -->
-<figure class="wp-block-core-embedanimoto">
+<figure class="wp-block-embedanimoto">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedanimoto.serialized.html
+++ b/blocks/test/fixtures/core-embedanimoto.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedanimoto url="https://animoto.com/" -->
-<figure>
+<figure class="wp-block-core-embedanimoto">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedanimoto.serialized.html
+++ b/blocks/test/fixtures/core-embedanimoto.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedanimoto url="https://animoto.com/" -->
-<figure class="wp-block-core-embedanimoto">
+<figure class="wp-block-embedanimoto">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedcloudup.html
+++ b/blocks/test/fixtures/core-embedcloudup.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedcloudup url="https://cloudup.com/" -->
-<figure class="wp-block-core-embedcloudup">
+<figure class="wp-block-embedcloudup">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedcloudup.html
+++ b/blocks/test/fixtures/core-embedcloudup.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedcloudup url="https://cloudup.com/" -->
-<figure>
+<figure class="wp-block-core-embedcloudup">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedcloudup.serialized.html
+++ b/blocks/test/fixtures/core-embedcloudup.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedcloudup url="https://cloudup.com/" -->
-<figure class="wp-block-core-embedcloudup">
+<figure class="wp-block-embedcloudup">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedcloudup.serialized.html
+++ b/blocks/test/fixtures/core-embedcloudup.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedcloudup url="https://cloudup.com/" -->
-<figure>
+<figure class="wp-block-core-embedcloudup">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedcollegehumor.html
+++ b/blocks/test/fixtures/core-embedcollegehumor.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedcollegehumor url="https://collegehumor.com/" -->
-<figure>
+<figure class="wp-block-core-embedcollegehumor">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedcollegehumor.html
+++ b/blocks/test/fixtures/core-embedcollegehumor.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedcollegehumor url="https://collegehumor.com/" -->
-<figure class="wp-block-core-embedcollegehumor">
+<figure class="wp-block-embedcollegehumor">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedcollegehumor.serialized.html
+++ b/blocks/test/fixtures/core-embedcollegehumor.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedcollegehumor url="https://collegehumor.com/" -->
-<figure>
+<figure class="wp-block-core-embedcollegehumor">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedcollegehumor.serialized.html
+++ b/blocks/test/fixtures/core-embedcollegehumor.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedcollegehumor url="https://collegehumor.com/" -->
-<figure class="wp-block-core-embedcollegehumor">
+<figure class="wp-block-embedcollegehumor">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embeddailymotion.html
+++ b/blocks/test/fixtures/core-embeddailymotion.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embeddailymotion url="https://dailymotion.com/" -->
-<figure class="wp-block-core-embeddailymotion">
+<figure class="wp-block-embeddailymotion">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embeddailymotion.html
+++ b/blocks/test/fixtures/core-embeddailymotion.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embeddailymotion url="https://dailymotion.com/" -->
-<figure>
+<figure class="wp-block-core-embeddailymotion">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embeddailymotion.serialized.html
+++ b/blocks/test/fixtures/core-embeddailymotion.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embeddailymotion url="https://dailymotion.com/" -->
-<figure class="wp-block-core-embeddailymotion">
+<figure class="wp-block-embeddailymotion">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embeddailymotion.serialized.html
+++ b/blocks/test/fixtures/core-embeddailymotion.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embeddailymotion url="https://dailymotion.com/" -->
-<figure>
+<figure class="wp-block-core-embeddailymotion">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedfacebook.html
+++ b/blocks/test/fixtures/core-embedfacebook.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedfacebook url="https://facebook.com/" -->
-<figure class="wp-block-core-embedfacebook">
+<figure class="wp-block-embedfacebook">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedfacebook.html
+++ b/blocks/test/fixtures/core-embedfacebook.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedfacebook url="https://facebook.com/" -->
-<figure>
+<figure class="wp-block-core-embedfacebook">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedfacebook.serialized.html
+++ b/blocks/test/fixtures/core-embedfacebook.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedfacebook url="https://facebook.com/" -->
-<figure class="wp-block-core-embedfacebook">
+<figure class="wp-block-embedfacebook">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedfacebook.serialized.html
+++ b/blocks/test/fixtures/core-embedfacebook.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedfacebook url="https://facebook.com/" -->
-<figure>
+<figure class="wp-block-core-embedfacebook">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedflickr.html
+++ b/blocks/test/fixtures/core-embedflickr.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedflickr url="https://flickr.com/" -->
-<figure>
+<figure class="wp-block-core-embedflickr">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedflickr.html
+++ b/blocks/test/fixtures/core-embedflickr.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedflickr url="https://flickr.com/" -->
-<figure class="wp-block-core-embedflickr">
+<figure class="wp-block-embedflickr">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedflickr.serialized.html
+++ b/blocks/test/fixtures/core-embedflickr.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedflickr url="https://flickr.com/" -->
-<figure>
+<figure class="wp-block-core-embedflickr">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedflickr.serialized.html
+++ b/blocks/test/fixtures/core-embedflickr.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedflickr url="https://flickr.com/" -->
-<figure class="wp-block-core-embedflickr">
+<figure class="wp-block-embedflickr">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedfunnyordie.html
+++ b/blocks/test/fixtures/core-embedfunnyordie.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedfunnyordie url="https://funnyordie.com/" -->
-<figure>
+<figure class="wp-block-core-embedfunnyordie">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedfunnyordie.html
+++ b/blocks/test/fixtures/core-embedfunnyordie.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedfunnyordie url="https://funnyordie.com/" -->
-<figure class="wp-block-core-embedfunnyordie">
+<figure class="wp-block-embedfunnyordie">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedfunnyordie.serialized.html
+++ b/blocks/test/fixtures/core-embedfunnyordie.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedfunnyordie url="https://funnyordie.com/" -->
-<figure>
+<figure class="wp-block-core-embedfunnyordie">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedfunnyordie.serialized.html
+++ b/blocks/test/fixtures/core-embedfunnyordie.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedfunnyordie url="https://funnyordie.com/" -->
-<figure class="wp-block-core-embedfunnyordie">
+<figure class="wp-block-embedfunnyordie">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedhulu.html
+++ b/blocks/test/fixtures/core-embedhulu.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedhulu url="https://hulu.com/" -->
-<figure>
+<figure class="wp-block-core-embedhulu">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedhulu.html
+++ b/blocks/test/fixtures/core-embedhulu.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedhulu url="https://hulu.com/" -->
-<figure class="wp-block-core-embedhulu">
+<figure class="wp-block-embedhulu">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedhulu.serialized.html
+++ b/blocks/test/fixtures/core-embedhulu.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedhulu url="https://hulu.com/" -->
-<figure>
+<figure class="wp-block-core-embedhulu">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedhulu.serialized.html
+++ b/blocks/test/fixtures/core-embedhulu.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedhulu url="https://hulu.com/" -->
-<figure class="wp-block-core-embedhulu">
+<figure class="wp-block-embedhulu">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedimgur.html
+++ b/blocks/test/fixtures/core-embedimgur.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedimgur url="https://imgur.com/" -->
-<figure>
+<figure class="wp-block-core-embedimgur">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedimgur.html
+++ b/blocks/test/fixtures/core-embedimgur.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedimgur url="https://imgur.com/" -->
-<figure class="wp-block-core-embedimgur">
+<figure class="wp-block-embedimgur">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedimgur.serialized.html
+++ b/blocks/test/fixtures/core-embedimgur.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedimgur url="https://imgur.com/" -->
-<figure>
+<figure class="wp-block-core-embedimgur">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedimgur.serialized.html
+++ b/blocks/test/fixtures/core-embedimgur.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedimgur url="https://imgur.com/" -->
-<figure class="wp-block-core-embedimgur">
+<figure class="wp-block-embedimgur">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedinstagram.html
+++ b/blocks/test/fixtures/core-embedinstagram.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedinstagram url="https://instagram.com/" -->
-<figure class="wp-block-core-embedinstagram">
+<figure class="wp-block-embedinstagram">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedinstagram.html
+++ b/blocks/test/fixtures/core-embedinstagram.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedinstagram url="https://instagram.com/" -->
-<figure>
+<figure class="wp-block-core-embedinstagram">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedinstagram.serialized.html
+++ b/blocks/test/fixtures/core-embedinstagram.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedinstagram url="https://instagram.com/" -->
-<figure class="wp-block-core-embedinstagram">
+<figure class="wp-block-embedinstagram">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedinstagram.serialized.html
+++ b/blocks/test/fixtures/core-embedinstagram.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedinstagram url="https://instagram.com/" -->
-<figure>
+<figure class="wp-block-core-embedinstagram">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedissuu.html
+++ b/blocks/test/fixtures/core-embedissuu.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedissuu url="https://issuu.com/" -->
-<figure>
+<figure class="wp-block-core-embedissuu">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedissuu.html
+++ b/blocks/test/fixtures/core-embedissuu.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedissuu url="https://issuu.com/" -->
-<figure class="wp-block-core-embedissuu">
+<figure class="wp-block-embedissuu">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedissuu.serialized.html
+++ b/blocks/test/fixtures/core-embedissuu.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedissuu url="https://issuu.com/" -->
-<figure>
+<figure class="wp-block-core-embedissuu">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedissuu.serialized.html
+++ b/blocks/test/fixtures/core-embedissuu.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedissuu url="https://issuu.com/" -->
-<figure class="wp-block-core-embedissuu">
+<figure class="wp-block-embedissuu">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedkickstarter.html
+++ b/blocks/test/fixtures/core-embedkickstarter.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedkickstarter url="https://kickstarter.com/" -->
-<figure>
+<figure class="wp-block-core-embedkickstarter">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedkickstarter.html
+++ b/blocks/test/fixtures/core-embedkickstarter.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedkickstarter url="https://kickstarter.com/" -->
-<figure class="wp-block-core-embedkickstarter">
+<figure class="wp-block-embedkickstarter">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedkickstarter.serialized.html
+++ b/blocks/test/fixtures/core-embedkickstarter.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedkickstarter url="https://kickstarter.com/" -->
-<figure>
+<figure class="wp-block-core-embedkickstarter">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedkickstarter.serialized.html
+++ b/blocks/test/fixtures/core-embedkickstarter.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedkickstarter url="https://kickstarter.com/" -->
-<figure class="wp-block-core-embedkickstarter">
+<figure class="wp-block-embedkickstarter">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedmeetupcom.html
+++ b/blocks/test/fixtures/core-embedmeetupcom.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedmeetupcom url="https://meetupcom.com/" -->
-<figure>
+<figure class="wp-block-core-embedmeetupcom">
     https://meetupcom.com/
     <figcaption>Embedded content from meetupcom</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedmeetupcom.html
+++ b/blocks/test/fixtures/core-embedmeetupcom.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedmeetupcom url="https://meetupcom.com/" -->
-<figure class="wp-block-core-embedmeetupcom">
+<figure class="wp-block-embedmeetupcom">
     https://meetupcom.com/
     <figcaption>Embedded content from meetupcom</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedmeetupcom.serialized.html
+++ b/blocks/test/fixtures/core-embedmeetupcom.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedmeetupcom url="https://meetupcom.com/" -->
-<figure>
+<figure class="wp-block-core-embedmeetupcom">
     https://meetupcom.com/
     <figcaption>Embedded content from meetupcom</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedmeetupcom.serialized.html
+++ b/blocks/test/fixtures/core-embedmeetupcom.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedmeetupcom url="https://meetupcom.com/" -->
-<figure class="wp-block-core-embedmeetupcom">
+<figure class="wp-block-embedmeetupcom">
     https://meetupcom.com/
     <figcaption>Embedded content from meetupcom</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedmixcloud.html
+++ b/blocks/test/fixtures/core-embedmixcloud.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedmixcloud url="https://mixcloud.com/" -->
-<figure class="wp-block-core-embedmixcloud">
+<figure class="wp-block-embedmixcloud">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedmixcloud.html
+++ b/blocks/test/fixtures/core-embedmixcloud.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedmixcloud url="https://mixcloud.com/" -->
-<figure>
+<figure class="wp-block-core-embedmixcloud">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedmixcloud.serialized.html
+++ b/blocks/test/fixtures/core-embedmixcloud.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedmixcloud url="https://mixcloud.com/" -->
-<figure class="wp-block-core-embedmixcloud">
+<figure class="wp-block-embedmixcloud">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedmixcloud.serialized.html
+++ b/blocks/test/fixtures/core-embedmixcloud.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedmixcloud url="https://mixcloud.com/" -->
-<figure>
+<figure class="wp-block-core-embedmixcloud">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedphotobucket.html
+++ b/blocks/test/fixtures/core-embedphotobucket.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedphotobucket url="https://photobucket.com/" -->
-<figure>
+<figure class="wp-block-core-embedphotobucket">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedphotobucket.html
+++ b/blocks/test/fixtures/core-embedphotobucket.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedphotobucket url="https://photobucket.com/" -->
-<figure class="wp-block-core-embedphotobucket">
+<figure class="wp-block-embedphotobucket">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedphotobucket.serialized.html
+++ b/blocks/test/fixtures/core-embedphotobucket.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedphotobucket url="https://photobucket.com/" -->
-<figure>
+<figure class="wp-block-core-embedphotobucket">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedphotobucket.serialized.html
+++ b/blocks/test/fixtures/core-embedphotobucket.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedphotobucket url="https://photobucket.com/" -->
-<figure class="wp-block-core-embedphotobucket">
+<figure class="wp-block-embedphotobucket">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedpolldaddy.html
+++ b/blocks/test/fixtures/core-embedpolldaddy.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedpolldaddy url="https://polldaddy.com/" -->
-<figure>
+<figure class="wp-block-core-embedpolldaddy">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedpolldaddy.html
+++ b/blocks/test/fixtures/core-embedpolldaddy.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedpolldaddy url="https://polldaddy.com/" -->
-<figure class="wp-block-core-embedpolldaddy">
+<figure class="wp-block-embedpolldaddy">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedpolldaddy.serialized.html
+++ b/blocks/test/fixtures/core-embedpolldaddy.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedpolldaddy url="https://polldaddy.com/" -->
-<figure>
+<figure class="wp-block-core-embedpolldaddy">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedpolldaddy.serialized.html
+++ b/blocks/test/fixtures/core-embedpolldaddy.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedpolldaddy url="https://polldaddy.com/" -->
-<figure class="wp-block-core-embedpolldaddy">
+<figure class="wp-block-embedpolldaddy">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedreddit.html
+++ b/blocks/test/fixtures/core-embedreddit.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedreddit url="https://reddit.com/" -->
-<figure>
+<figure class="wp-block-core-embedreddit">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedreddit.html
+++ b/blocks/test/fixtures/core-embedreddit.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedreddit url="https://reddit.com/" -->
-<figure class="wp-block-core-embedreddit">
+<figure class="wp-block-embedreddit">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedreddit.serialized.html
+++ b/blocks/test/fixtures/core-embedreddit.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedreddit url="https://reddit.com/" -->
-<figure>
+<figure class="wp-block-core-embedreddit">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedreddit.serialized.html
+++ b/blocks/test/fixtures/core-embedreddit.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedreddit url="https://reddit.com/" -->
-<figure class="wp-block-core-embedreddit">
+<figure class="wp-block-embedreddit">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedreverbnation.html
+++ b/blocks/test/fixtures/core-embedreverbnation.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedreverbnation url="https://reverbnation.com/" -->
-<figure>
+<figure class="wp-block-core-embedreverbnation">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedreverbnation.html
+++ b/blocks/test/fixtures/core-embedreverbnation.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedreverbnation url="https://reverbnation.com/" -->
-<figure class="wp-block-core-embedreverbnation">
+<figure class="wp-block-embedreverbnation">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedreverbnation.serialized.html
+++ b/blocks/test/fixtures/core-embedreverbnation.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedreverbnation url="https://reverbnation.com/" -->
-<figure>
+<figure class="wp-block-core-embedreverbnation">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedreverbnation.serialized.html
+++ b/blocks/test/fixtures/core-embedreverbnation.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedreverbnation url="https://reverbnation.com/" -->
-<figure class="wp-block-core-embedreverbnation">
+<figure class="wp-block-embedreverbnation">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedscreencast.html
+++ b/blocks/test/fixtures/core-embedscreencast.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedscreencast url="https://screencast.com/" -->
-<figure>
+<figure class="wp-block-core-embedscreencast">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedscreencast.html
+++ b/blocks/test/fixtures/core-embedscreencast.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedscreencast url="https://screencast.com/" -->
-<figure class="wp-block-core-embedscreencast">
+<figure class="wp-block-embedscreencast">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedscreencast.serialized.html
+++ b/blocks/test/fixtures/core-embedscreencast.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedscreencast url="https://screencast.com/" -->
-<figure>
+<figure class="wp-block-core-embedscreencast">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedscreencast.serialized.html
+++ b/blocks/test/fixtures/core-embedscreencast.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedscreencast url="https://screencast.com/" -->
-<figure class="wp-block-core-embedscreencast">
+<figure class="wp-block-embedscreencast">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedscribd.html
+++ b/blocks/test/fixtures/core-embedscribd.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedscribd url="https://scribd.com/" -->
-<figure>
+<figure class="wp-block-core-embedscribd">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedscribd.html
+++ b/blocks/test/fixtures/core-embedscribd.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedscribd url="https://scribd.com/" -->
-<figure class="wp-block-core-embedscribd">
+<figure class="wp-block-embedscribd">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedscribd.serialized.html
+++ b/blocks/test/fixtures/core-embedscribd.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedscribd url="https://scribd.com/" -->
-<figure>
+<figure class="wp-block-core-embedscribd">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedscribd.serialized.html
+++ b/blocks/test/fixtures/core-embedscribd.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedscribd url="https://scribd.com/" -->
-<figure class="wp-block-core-embedscribd">
+<figure class="wp-block-embedscribd">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedslideshare.html
+++ b/blocks/test/fixtures/core-embedslideshare.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedslideshare url="https://slideshare.com/" -->
-<figure>
+<figure class="wp-block-core-embedslideshare">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedslideshare.html
+++ b/blocks/test/fixtures/core-embedslideshare.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedslideshare url="https://slideshare.com/" -->
-<figure class="wp-block-core-embedslideshare">
+<figure class="wp-block-embedslideshare">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedslideshare.serialized.html
+++ b/blocks/test/fixtures/core-embedslideshare.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedslideshare url="https://slideshare.com/" -->
-<figure>
+<figure class="wp-block-core-embedslideshare">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedslideshare.serialized.html
+++ b/blocks/test/fixtures/core-embedslideshare.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedslideshare url="https://slideshare.com/" -->
-<figure class="wp-block-core-embedslideshare">
+<figure class="wp-block-embedslideshare">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedsmugmug.html
+++ b/blocks/test/fixtures/core-embedsmugmug.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedsmugmug url="https://smugmug.com/" -->
-<figure class="wp-block-core-embedsmugmug">
+<figure class="wp-block-embedsmugmug">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedsmugmug.html
+++ b/blocks/test/fixtures/core-embedsmugmug.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedsmugmug url="https://smugmug.com/" -->
-<figure>
+<figure class="wp-block-core-embedsmugmug">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedsmugmug.serialized.html
+++ b/blocks/test/fixtures/core-embedsmugmug.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedsmugmug url="https://smugmug.com/" -->
-<figure class="wp-block-core-embedsmugmug">
+<figure class="wp-block-embedsmugmug">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedsmugmug.serialized.html
+++ b/blocks/test/fixtures/core-embedsmugmug.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedsmugmug url="https://smugmug.com/" -->
-<figure>
+<figure class="wp-block-core-embedsmugmug">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedsoundcloud.html
+++ b/blocks/test/fixtures/core-embedsoundcloud.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedsoundcloud url="https://soundcloud.com/" -->
-<figure>
+<figure class="wp-block-core-embedsoundcloud">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedsoundcloud.html
+++ b/blocks/test/fixtures/core-embedsoundcloud.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedsoundcloud url="https://soundcloud.com/" -->
-<figure class="wp-block-core-embedsoundcloud">
+<figure class="wp-block-embedsoundcloud">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedsoundcloud.serialized.html
+++ b/blocks/test/fixtures/core-embedsoundcloud.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedsoundcloud url="https://soundcloud.com/" -->
-<figure>
+<figure class="wp-block-core-embedsoundcloud">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedsoundcloud.serialized.html
+++ b/blocks/test/fixtures/core-embedsoundcloud.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedsoundcloud url="https://soundcloud.com/" -->
-<figure class="wp-block-core-embedsoundcloud">
+<figure class="wp-block-embedsoundcloud">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedspeaker.html
+++ b/blocks/test/fixtures/core-embedspeaker.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedspeaker url="https://speaker.com/" -->
-<figure>
+<figure class="wp-block-core-embedspeaker">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedspeaker.html
+++ b/blocks/test/fixtures/core-embedspeaker.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedspeaker url="https://speaker.com/" -->
-<figure class="wp-block-core-embedspeaker">
+<figure class="wp-block-embedspeaker">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedspeaker.serialized.html
+++ b/blocks/test/fixtures/core-embedspeaker.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedspeaker url="https://speaker.com/" -->
-<figure>
+<figure class="wp-block-core-embedspeaker">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedspeaker.serialized.html
+++ b/blocks/test/fixtures/core-embedspeaker.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedspeaker url="https://speaker.com/" -->
-<figure class="wp-block-core-embedspeaker">
+<figure class="wp-block-embedspeaker">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedspotify.html
+++ b/blocks/test/fixtures/core-embedspotify.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedspotify url="https://spotify.com/" -->
-<figure>
+<figure class="wp-block-core-embedspotify">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedspotify.html
+++ b/blocks/test/fixtures/core-embedspotify.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedspotify url="https://spotify.com/" -->
-<figure class="wp-block-core-embedspotify">
+<figure class="wp-block-embedspotify">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedspotify.serialized.html
+++ b/blocks/test/fixtures/core-embedspotify.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedspotify url="https://spotify.com/" -->
-<figure>
+<figure class="wp-block-core-embedspotify">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedspotify.serialized.html
+++ b/blocks/test/fixtures/core-embedspotify.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedspotify url="https://spotify.com/" -->
-<figure class="wp-block-core-embedspotify">
+<figure class="wp-block-embedspotify">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedted.html
+++ b/blocks/test/fixtures/core-embedted.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedted url="https://ted.com/" -->
-<figure class="wp-block-core-embedted">
+<figure class="wp-block-embedted">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedted.html
+++ b/blocks/test/fixtures/core-embedted.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedted url="https://ted.com/" -->
-<figure>
+<figure class="wp-block-core-embedted">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedted.serialized.html
+++ b/blocks/test/fixtures/core-embedted.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedted url="https://ted.com/" -->
-<figure class="wp-block-core-embedted">
+<figure class="wp-block-embedted">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedted.serialized.html
+++ b/blocks/test/fixtures/core-embedted.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedted url="https://ted.com/" -->
-<figure>
+<figure class="wp-block-core-embedted">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedtumblr.html
+++ b/blocks/test/fixtures/core-embedtumblr.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedtumblr url="https://tumblr.com/" -->
-<figure>
+<figure class="wp-block-core-embedtumblr">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedtumblr.html
+++ b/blocks/test/fixtures/core-embedtumblr.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedtumblr url="https://tumblr.com/" -->
-<figure class="wp-block-core-embedtumblr">
+<figure class="wp-block-embedtumblr">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedtumblr.serialized.html
+++ b/blocks/test/fixtures/core-embedtumblr.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedtumblr url="https://tumblr.com/" -->
-<figure>
+<figure class="wp-block-core-embedtumblr">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedtumblr.serialized.html
+++ b/blocks/test/fixtures/core-embedtumblr.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedtumblr url="https://tumblr.com/" -->
-<figure class="wp-block-core-embedtumblr">
+<figure class="wp-block-embedtumblr">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedtwitter.html
+++ b/blocks/test/fixtures/core-embedtwitter.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedtwitter url="https://twitter.com/automattic" -->
-<figure class="wp-block-core-embedtwitter">
+<figure class="wp-block-embedtwitter">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedtwitter.html
+++ b/blocks/test/fixtures/core-embedtwitter.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedtwitter url="https://twitter.com/automattic" -->
-<figure>
+<figure class="wp-block-core-embedtwitter">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedtwitter.serialized.html
+++ b/blocks/test/fixtures/core-embedtwitter.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedtwitter url="https://twitter.com/automattic" -->
-<figure class="wp-block-core-embedtwitter">
+<figure class="wp-block-embedtwitter">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedtwitter.serialized.html
+++ b/blocks/test/fixtures/core-embedtwitter.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedtwitter url="https://twitter.com/automattic" -->
-<figure>
+<figure class="wp-block-core-embedtwitter">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvideopress.html
+++ b/blocks/test/fixtures/core-embedvideopress.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvideopress url="https://videopress.com/" -->
-<figure>
+<figure class="wp-block-core-embedvideopress">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvideopress.html
+++ b/blocks/test/fixtures/core-embedvideopress.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvideopress url="https://videopress.com/" -->
-<figure class="wp-block-core-embedvideopress">
+<figure class="wp-block-embedvideopress">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvideopress.serialized.html
+++ b/blocks/test/fixtures/core-embedvideopress.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvideopress url="https://videopress.com/" -->
-<figure>
+<figure class="wp-block-core-embedvideopress">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvideopress.serialized.html
+++ b/blocks/test/fixtures/core-embedvideopress.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvideopress url="https://videopress.com/" -->
-<figure class="wp-block-core-embedvideopress">
+<figure class="wp-block-embedvideopress">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvimeo.html
+++ b/blocks/test/fixtures/core-embedvimeo.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvimeo url="https://vimeo.com/" -->
-<figure>
+<figure class="wp-block-core-embedvimeo">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvimeo.html
+++ b/blocks/test/fixtures/core-embedvimeo.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvimeo url="https://vimeo.com/" -->
-<figure class="wp-block-core-embedvimeo">
+<figure class="wp-block-embedvimeo">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvimeo.serialized.html
+++ b/blocks/test/fixtures/core-embedvimeo.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvimeo url="https://vimeo.com/" -->
-<figure>
+<figure class="wp-block-core-embedvimeo">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvimeo.serialized.html
+++ b/blocks/test/fixtures/core-embedvimeo.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvimeo url="https://vimeo.com/" -->
-<figure class="wp-block-core-embedvimeo">
+<figure class="wp-block-embedvimeo">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvine.html
+++ b/blocks/test/fixtures/core-embedvine.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvine url="https://vine.com/" -->
-<figure class="wp-block-core-embedvine">
+<figure class="wp-block-embedvine">
     https://vine.com/
     <figcaption>Embedded content from vine</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvine.html
+++ b/blocks/test/fixtures/core-embedvine.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvine url="https://vine.com/" -->
-<figure>
+<figure class="wp-block-core-embedvine">
     https://vine.com/
     <figcaption>Embedded content from vine</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvine.serialized.html
+++ b/blocks/test/fixtures/core-embedvine.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvine url="https://vine.com/" -->
-<figure class="wp-block-core-embedvine">
+<figure class="wp-block-embedvine">
     https://vine.com/
     <figcaption>Embedded content from vine</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedvine.serialized.html
+++ b/blocks/test/fixtures/core-embedvine.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedvine url="https://vine.com/" -->
-<figure>
+<figure class="wp-block-core-embedvine">
     https://vine.com/
     <figcaption>Embedded content from vine</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedwordpress.html
+++ b/blocks/test/fixtures/core-embedwordpress.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedwordpress url="https://wordpress.com/" -->
-<figure>
+<figure class="wp-block-core-embedwordpress">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedwordpress.html
+++ b/blocks/test/fixtures/core-embedwordpress.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedwordpress url="https://wordpress.com/" -->
-<figure class="wp-block-core-embedwordpress">
+<figure class="wp-block-embedwordpress">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedwordpress.serialized.html
+++ b/blocks/test/fixtures/core-embedwordpress.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedwordpress url="https://wordpress.com/" -->
-<figure>
+<figure class="wp-block-core-embedwordpress">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedwordpress.serialized.html
+++ b/blocks/test/fixtures/core-embedwordpress.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedwordpress url="https://wordpress.com/" -->
-<figure class="wp-block-core-embedwordpress">
+<figure class="wp-block-embedwordpress">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedwordpresstv.html
+++ b/blocks/test/fixtures/core-embedwordpresstv.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedwordpresstv url="https://wordpresstv.com/" -->
-<figure>
+<figure class="wp-block-core-embedwordpresstv">
     https://wordpresstv.com/
     <figcaption>Embedded content from wordpresstv</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedwordpresstv.html
+++ b/blocks/test/fixtures/core-embedwordpresstv.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedwordpresstv url="https://wordpresstv.com/" -->
-<figure class="wp-block-core-embedwordpresstv">
+<figure class="wp-block-embedwordpresstv">
     https://wordpresstv.com/
     <figcaption>Embedded content from wordpresstv</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedwordpresstv.serialized.html
+++ b/blocks/test/fixtures/core-embedwordpresstv.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedwordpresstv url="https://wordpresstv.com/" -->
-<figure>
+<figure class="wp-block-core-embedwordpresstv">
     https://wordpresstv.com/
     <figcaption>Embedded content from wordpresstv</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedwordpresstv.serialized.html
+++ b/blocks/test/fixtures/core-embedwordpresstv.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedwordpresstv url="https://wordpresstv.com/" -->
-<figure class="wp-block-core-embedwordpresstv">
+<figure class="wp-block-embedwordpresstv">
     https://wordpresstv.com/
     <figcaption>Embedded content from wordpresstv</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedyoutube.html
+++ b/blocks/test/fixtures/core-embedyoutube.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedyoutube url="https://youtube.com/" -->
-<figure class="wp-block-core-embedyoutube">
+<figure class="wp-block-embedyoutube">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedyoutube.html
+++ b/blocks/test/fixtures/core-embedyoutube.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedyoutube url="https://youtube.com/" -->
-<figure>
+<figure class="wp-block-core-embedyoutube">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedyoutube.serialized.html
+++ b/blocks/test/fixtures/core-embedyoutube.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedyoutube url="https://youtube.com/" -->
-<figure class="wp-block-core-embedyoutube">
+<figure class="wp-block-embedyoutube">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embedyoutube.serialized.html
+++ b/blocks/test/fixtures/core-embedyoutube.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embedyoutube url="https://youtube.com/" -->
-<figure>
+<figure class="wp-block-core-embedyoutube">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-freeform.serialized.html
+++ b/blocks/test/fixtures/core-freeform.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core/freeform -->
 Testing freeform block with some
-<div class="wp-some-class wp-block-core-freeform">
+<div class="wp-some-class wp-block-freeform">
     HTML <span style="color:red;">content</span>
 </div>
 <!-- /wp:core/freeform -->

--- a/blocks/test/fixtures/core-freeform.serialized.html
+++ b/blocks/test/fixtures/core-freeform.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core/freeform -->
 Testing freeform block with some
-<div class="wp-some-class">
+<div class="wp-some-class wp-block-core-freeform">
     HTML <span style="color:red;">content</span>
 </div>
 <!-- /wp:core/freeform -->

--- a/blocks/test/fixtures/core-gallery.html
+++ b/blocks/test/fixtures/core-gallery.html
@@ -1,5 +1,5 @@
 <!-- wp:core/gallery -->
-<div class="blocks-gallery">
+<div class="blocks-gallery wp-block-core-gallery">
 	<figure class="blocks-gallery-image">
 		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
 	</figure>

--- a/blocks/test/fixtures/core-gallery.html
+++ b/blocks/test/fixtures/core-gallery.html
@@ -1,5 +1,5 @@
 <!-- wp:core/gallery -->
-<div class="blocks-gallery wp-block-core-gallery">
+<div class="blocks-gallery wp-block-gallery">
 	<figure class="blocks-gallery-image">
 		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
 	</figure>

--- a/blocks/test/fixtures/core-gallery.serialized.html
+++ b/blocks/test/fixtures/core-gallery.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/gallery -->
-<div class="blocks-gallery alignnone columns-2 wp-block-core-gallery">
+<div class="blocks-gallery alignnone columns-2 wp-block-gallery">
     <figure class="blocks-gallery-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
     <figure class="blocks-gallery-image"><img src="http://google.com/hi.png" alt="title" /></figure>
 </div>

--- a/blocks/test/fixtures/core-gallery.serialized.html
+++ b/blocks/test/fixtures/core-gallery.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/gallery -->
-<div class="blocks-gallery alignnone columns-2">
+<div class="blocks-gallery alignnone columns-2 wp-block-core-gallery">
     <figure class="blocks-gallery-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
     <figure class="blocks-gallery-image"><img src="http://google.com/hi.png" alt="title" /></figure>
 </div>

--- a/blocks/test/fixtures/core-heading-h2-em.html
+++ b/blocks/test/fixtures/core-heading-h2-em.html
@@ -1,3 +1,3 @@
 <!-- wp:core/heading -->
-<h2>The <em>Inserter</em> Tool</h2>
+<h2 class="wp-block-core-heading">The <em>Inserter</em> Tool</h2>
 <!-- /wp:core/heading -->

--- a/blocks/test/fixtures/core-heading-h2-em.html
+++ b/blocks/test/fixtures/core-heading-h2-em.html
@@ -1,3 +1,3 @@
 <!-- wp:core/heading -->
-<h2 class="wp-block-heading">The <em>Inserter</em> Tool</h2>
+<h2>The <em>Inserter</em> Tool</h2>
 <!-- /wp:core/heading -->

--- a/blocks/test/fixtures/core-heading-h2-em.html
+++ b/blocks/test/fixtures/core-heading-h2-em.html
@@ -1,3 +1,3 @@
 <!-- wp:core/heading -->
-<h2 class="wp-block-core-heading">The <em>Inserter</em> Tool</h2>
+<h2 class="wp-block-heading">The <em>Inserter</em> Tool</h2>
 <!-- /wp:core/heading -->

--- a/blocks/test/fixtures/core-heading-h2-em.serialized.html
+++ b/blocks/test/fixtures/core-heading-h2-em.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/heading -->
-<h2>The <em>Inserter</em> Tool</h2>
+<h2 class="wp-block-core-heading">The <em>Inserter</em> Tool</h2>
 <!-- /wp:core/heading -->
 

--- a/blocks/test/fixtures/core-heading-h2-em.serialized.html
+++ b/blocks/test/fixtures/core-heading-h2-em.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/heading -->
-<h2 class="wp-block-core-heading">The <em>Inserter</em> Tool</h2>
+<h2 class="wp-block-heading">The <em>Inserter</em> Tool</h2>
 <!-- /wp:core/heading -->
 

--- a/blocks/test/fixtures/core-heading-h2-em.serialized.html
+++ b/blocks/test/fixtures/core-heading-h2-em.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/heading -->
-<h2 class="wp-block-heading">The <em>Inserter</em> Tool</h2>
+<h2>The <em>Inserter</em> Tool</h2>
 <!-- /wp:core/heading -->
 

--- a/blocks/test/fixtures/core-heading-h2.html
+++ b/blocks/test/fixtures/core-heading-h2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/heading -->
-<h2 class="wp-block-heading">A picture is worth a thousand words, or so the saying goes</h2>
+<h2>A picture is worth a thousand words, or so the saying goes</h2>
 <!-- /wp:core/heading -->

--- a/blocks/test/fixtures/core-heading-h2.html
+++ b/blocks/test/fixtures/core-heading-h2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/heading -->
-<h2 class="wp-block-core-heading">A picture is worth a thousand words, or so the saying goes</h2>
+<h2 class="wp-block-heading">A picture is worth a thousand words, or so the saying goes</h2>
 <!-- /wp:core/heading -->

--- a/blocks/test/fixtures/core-heading-h2.html
+++ b/blocks/test/fixtures/core-heading-h2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/heading -->
-<h2>A picture is worth a thousand words, or so the saying goes</h2>
+<h2 class="wp-block-core-heading">A picture is worth a thousand words, or so the saying goes</h2>
 <!-- /wp:core/heading -->

--- a/blocks/test/fixtures/core-heading-h2.serialized.html
+++ b/blocks/test/fixtures/core-heading-h2.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/heading -->
-<h2 class="wp-block-heading">A picture is worth a thousand words, or so the saying goes</h2>
+<h2>A picture is worth a thousand words, or so the saying goes</h2>
 <!-- /wp:core/heading -->
 

--- a/blocks/test/fixtures/core-heading-h2.serialized.html
+++ b/blocks/test/fixtures/core-heading-h2.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/heading -->
-<h2>A picture is worth a thousand words, or so the saying goes</h2>
+<h2 class="wp-block-core-heading">A picture is worth a thousand words, or so the saying goes</h2>
 <!-- /wp:core/heading -->
 

--- a/blocks/test/fixtures/core-heading-h2.serialized.html
+++ b/blocks/test/fixtures/core-heading-h2.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/heading -->
-<h2 class="wp-block-core-heading">A picture is worth a thousand words, or so the saying goes</h2>
+<h2 class="wp-block-heading">A picture is worth a thousand words, or so the saying goes</h2>
 <!-- /wp:core/heading -->
 

--- a/blocks/test/fixtures/core-image-center-caption.html
+++ b/blocks/test/fixtures/core-image-center-caption.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image align="center" -->
-<figure><img src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
+<figure class="wp-block-core-image"><img src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core-image-center-caption.html
+++ b/blocks/test/fixtures/core-image-center-caption.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image align="center" -->
-<figure class="wp-block-core-image"><img src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core-image-center-caption.serialized.html
+++ b/blocks/test/fixtures/core-image-center-caption.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/image align="center" -->
-<figure class="aligncenter wp-block-core-image"><img src="https://cldup.com/YLYhpou2oq.jpg" />
+<figure class="aligncenter wp-block-image"><img src="https://cldup.com/YLYhpou2oq.jpg" />
     <figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption>
 </figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core-image-center-caption.serialized.html
+++ b/blocks/test/fixtures/core-image-center-caption.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/image align="center" -->
-<figure class="aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" />
+<figure class="aligncenter wp-block-core-image"><img src="https://cldup.com/YLYhpou2oq.jpg" />
     <figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption>
 </figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core-image.html
+++ b/blocks/test/fixtures/core-image.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image -->
-<figure class="wp-block-core-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core-image.html
+++ b/blocks/test/fixtures/core-image.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image -->
-<figure><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
+<figure class="wp-block-core-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core-image.serialized.html
+++ b/blocks/test/fixtures/core-image.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/image -->
-<img src="https://cldup.com/uuUqE_dXzy.jpg" class="alignnone" />
+<img src="https://cldup.com/uuUqE_dXzy.jpg" class="alignnone wp-block-core-image" />
 <!-- /wp:core/image -->
 

--- a/blocks/test/fixtures/core-image.serialized.html
+++ b/blocks/test/fixtures/core-image.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/image -->
-<img src="https://cldup.com/uuUqE_dXzy.jpg" class="alignnone wp-block-core-image" />
+<img src="https://cldup.com/uuUqE_dXzy.jpg" class="alignnone wp-block-image" />
 <!-- /wp:core/image -->
 

--- a/blocks/test/fixtures/core-list-ul.html
+++ b/blocks/test/fixtures/core-list-ul.html
@@ -1,3 +1,3 @@
 <!-- wp:core/list -->
-<ul class="wp-block-core-list"><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
+<ul class="wp-block-list"><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
 <!-- /wp:core/list -->

--- a/blocks/test/fixtures/core-list-ul.html
+++ b/blocks/test/fixtures/core-list-ul.html
@@ -1,3 +1,3 @@
 <!-- wp:core/list -->
-<ul class="wp-block-list"><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
+<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
 <!-- /wp:core/list -->

--- a/blocks/test/fixtures/core-list-ul.html
+++ b/blocks/test/fixtures/core-list-ul.html
@@ -1,3 +1,3 @@
 <!-- wp:core/list -->
-<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
+<ul class="wp-block-core-list"><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
 <!-- /wp:core/list -->

--- a/blocks/test/fixtures/core-list-ul.serialized.html
+++ b/blocks/test/fixtures/core-list-ul.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/list -->
-<ul class="wp-block-list">
+<ul>
     <li>Text &amp; Headings</li>
     <li>Images &amp; Videos</li>
     <li>Galleries</li>

--- a/blocks/test/fixtures/core-list-ul.serialized.html
+++ b/blocks/test/fixtures/core-list-ul.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/list -->
-<ul class="wp-block-core-list">
+<ul class="wp-block-list">
     <li>Text &amp; Headings</li>
     <li>Images &amp; Videos</li>
     <li>Galleries</li>

--- a/blocks/test/fixtures/core-list-ul.serialized.html
+++ b/blocks/test/fixtures/core-list-ul.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/list -->
-<ul>
+<ul class="wp-block-core-list">
     <li>Text &amp; Headings</li>
     <li>Images &amp; Videos</li>
     <li>Galleries</li>

--- a/blocks/test/fixtures/core-preformatted.html
+++ b/blocks/test/fixtures/core-preformatted.html
@@ -1,3 +1,3 @@
 <!-- wp:core/preformatted -->
-<pre class="wp-block-core-preformatted">Some <em>preformatted</em> text...<br>And more!</pre>
+<pre class="wp-block-preformatted">Some <em>preformatted</em> text...<br>And more!</pre>
 <!-- /wp:core/preformatted -->

--- a/blocks/test/fixtures/core-preformatted.html
+++ b/blocks/test/fixtures/core-preformatted.html
@@ -1,3 +1,3 @@
 <!-- wp:core/preformatted -->
-<pre>Some <em>preformatted</em> text...<br>And more!</pre>
+<pre class="wp-block-core-preformatted">Some <em>preformatted</em> text...<br>And more!</pre>
 <!-- /wp:core/preformatted -->

--- a/blocks/test/fixtures/core-preformatted.serialized.html
+++ b/blocks/test/fixtures/core-preformatted.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/preformatted -->
-<pre class="wp-block-core-preformatted">Some <em>preformatted</em> text...<br/>And more!</pre>
+<pre class="wp-block-preformatted">Some <em>preformatted</em> text...<br/>And more!</pre>
 <!-- /wp:core/preformatted -->
 

--- a/blocks/test/fixtures/core-preformatted.serialized.html
+++ b/blocks/test/fixtures/core-preformatted.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/preformatted -->
-<pre>Some <em>preformatted</em> text...<br/>And more!</pre>
+<pre class="wp-block-core-preformatted">Some <em>preformatted</em> text...<br/>And more!</pre>
 <!-- /wp:core/preformatted -->
 

--- a/blocks/test/fixtures/core-pullquote.html
+++ b/blocks/test/fixtures/core-pullquote.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
-<blockquote class="blocks-pullquote">
+<blockquote class="blocks-pullquote wp-block-core-pullquote">
 <p>Testing pullquote block...</p><footer>...with a caption</footer>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core-pullquote.html
+++ b/blocks/test/fixtures/core-pullquote.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
-<blockquote class="blocks-pullquote wp-block-core-pullquote">
+<blockquote class="blocks-pullquote wp-block-pullquote">
 <p>Testing pullquote block...</p><footer>...with a caption</footer>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core-pullquote.serialized.html
+++ b/blocks/test/fixtures/core-pullquote.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
-<blockquote class="blocks-pullquote alignnone">
+<blockquote class="blocks-pullquote alignnone wp-block-core-pullquote">
     <p>Testing pullquote block...</p>
     <footer>...with a caption</footer>
 </blockquote>

--- a/blocks/test/fixtures/core-pullquote.serialized.html
+++ b/blocks/test/fixtures/core-pullquote.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
-<blockquote class="blocks-pullquote alignnone wp-block-core-pullquote">
+<blockquote class="blocks-pullquote alignnone wp-block-pullquote">
     <p>Testing pullquote block...</p>
     <footer>...with a caption</footer>
 </blockquote>

--- a/blocks/test/fixtures/core-quote-style-1.html
+++ b/blocks/test/fixtures/core-quote-style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote style="1" -->
-<blockquote class="blocks-quote-style-1 wp-block-core-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
+<blockquote class="blocks-quote-style-1 wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core-quote-style-1.html
+++ b/blocks/test/fixtures/core-quote-style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote style="1" -->
-<blockquote class="blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
+<blockquote class="blocks-quote-style-1 wp-block-core-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core-quote-style-1.serialized.html
+++ b/blocks/test/fixtures/core-quote-style-1.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/quote style="1" -->
-<blockquote class="blocks-quote-style-1 wp-block-core-quote">
+<blockquote class="blocks-quote-style-1 wp-block-quote">
     <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
     <footer>Matt Mullenweg, 2017</footer>
 </blockquote>

--- a/blocks/test/fixtures/core-quote-style-1.serialized.html
+++ b/blocks/test/fixtures/core-quote-style-1.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/quote style="1" -->
-<blockquote class="blocks-quote-style-1">
+<blockquote class="blocks-quote-style-1 wp-block-core-quote">
     <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
     <footer>Matt Mullenweg, 2017</footer>
 </blockquote>

--- a/blocks/test/fixtures/core-quote-style-2.html
+++ b/blocks/test/fixtures/core-quote-style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote style="2" -->
-<blockquote class="blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
+<blockquote class="blocks-quote-style-2 wp-block-core-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core-quote-style-2.html
+++ b/blocks/test/fixtures/core-quote-style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote style="2" -->
-<blockquote class="blocks-quote-style-2 wp-block-core-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
+<blockquote class="blocks-quote-style-2 wp-block-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core-quote-style-2.serialized.html
+++ b/blocks/test/fixtures/core-quote-style-2.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/quote style="2" -->
-<blockquote class="blocks-quote-style-2 wp-block-core-quote">
+<blockquote class="blocks-quote-style-2 wp-block-quote">
     <p>There is no greater agony than bearing an untold story inside you.</p>
     <footer>Maya Angelou</footer>
 </blockquote>

--- a/blocks/test/fixtures/core-quote-style-2.serialized.html
+++ b/blocks/test/fixtures/core-quote-style-2.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/quote style="2" -->
-<blockquote class="blocks-quote-style-2">
+<blockquote class="blocks-quote-style-2 wp-block-core-quote">
     <p>There is no greater agony than bearing an untold story inside you.</p>
     <footer>Maya Angelou</footer>
 </blockquote>

--- a/blocks/test/fixtures/core-separator.html
+++ b/blocks/test/fixtures/core-separator.html
@@ -1,3 +1,3 @@
 <!-- wp:core/separator -->
-<hr class="wp-block-core-separator" />
+<hr class="wp-block-separator" />
 <!-- /wp:core/separator -->

--- a/blocks/test/fixtures/core-separator.html
+++ b/blocks/test/fixtures/core-separator.html
@@ -1,3 +1,3 @@
 <!-- wp:core/separator -->
-<hr/>
+<hr class="wp-block-core-separator" />
 <!-- /wp:core/separator -->

--- a/blocks/test/fixtures/core-separator.serialized.html
+++ b/blocks/test/fixtures/core-separator.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/separator -->
-<hr/>
+<hr class="wp-block-core-separator" />
 <!-- /wp:core/separator -->
 

--- a/blocks/test/fixtures/core-separator.serialized.html
+++ b/blocks/test/fixtures/core-separator.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/separator -->
-<hr class="wp-block-core-separator" />
+<hr class="wp-block-separator" />
 <!-- /wp:core/separator -->
 

--- a/blocks/test/fixtures/core-table.html
+++ b/blocks/test/fixtures/core-table.html
@@ -1,5 +1,5 @@
 <!-- wp:core/table -->
-<table class="wp-block-core-table">
+<table class="wp-block-table">
     <thead>
         <tr>
             <th>Version</th>

--- a/blocks/test/fixtures/core-table.html
+++ b/blocks/test/fixtures/core-table.html
@@ -1,5 +1,5 @@
 <!-- wp:core/table -->
-<table>
+<table class="wp-block-core-table">
     <thead>
         <tr>
             <th>Version</th>

--- a/blocks/test/fixtures/core-table.serialized.html
+++ b/blocks/test/fixtures/core-table.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/table -->
-<table class="wp-block-core-table">
+<table class="wp-block-table">
     <thead>
         <tr>
             <th>Version</th>

--- a/blocks/test/fixtures/core-table.serialized.html
+++ b/blocks/test/fixtures/core-table.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/table -->
-<table>
+<table class="wp-block-core-table">
     <thead>
         <tr>
             <th>Version</th>

--- a/blocks/test/fixtures/core-text-align-right.html
+++ b/blocks/test/fixtures/core-text-align-right.html
@@ -1,3 +1,3 @@
 <!-- wp:core/text align="right" -->
-<p class="wp-block-core-text" style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
+<p class="wp-block-text" style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
 <!-- /wp:core/text -->

--- a/blocks/test/fixtures/core-text-align-right.html
+++ b/blocks/test/fixtures/core-text-align-right.html
@@ -1,3 +1,3 @@
 <!-- wp:core/text align="right" -->
-<p class="wp-block-text" style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
+<p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
 <!-- /wp:core/text -->

--- a/blocks/test/fixtures/core-text-align-right.html
+++ b/blocks/test/fixtures/core-text-align-right.html
@@ -1,3 +1,3 @@
 <!-- wp:core/text align="right" -->
-<p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
+<p class="wp-block-core-text" style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
 <!-- /wp:core/text -->

--- a/blocks/test/fixtures/core-text-align-right.serialized.html
+++ b/blocks/test/fixtures/core-text-align-right.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/text align="right" -->
-<p style="text-align:right;" class="wp-block-text">... like this one, which is separate from the above and right aligned.</p>
+<p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
 <!-- /wp:core/text -->
 

--- a/blocks/test/fixtures/core-text-align-right.serialized.html
+++ b/blocks/test/fixtures/core-text-align-right.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/text align="right" -->
-<p style="text-align:right;" class="wp-block-core-text">... like this one, which is separate from the above and right aligned.</p>
+<p style="text-align:right;" class="wp-block-text">... like this one, which is separate from the above and right aligned.</p>
 <!-- /wp:core/text -->
 

--- a/blocks/test/fixtures/core-text-align-right.serialized.html
+++ b/blocks/test/fixtures/core-text-align-right.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/text align="right" -->
-<p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
+<p style="text-align:right;" class="wp-block-core-text">... like this one, which is separate from the above and right aligned.</p>
 <!-- /wp:core/text -->
 

--- a/post-content.js
+++ b/post-content.js
@@ -9,7 +9,7 @@ window._wpGutenbergPost = {
 	content: {
 		raw: [
 			'<!-- wp:core/cover-image url="https://cldup.com/GCwahb3aOb.jpg" -->',
-			'<section className="cover-image" style={ { backgroundImage: \'url("https://cldup.com/GCwahb3aOb.jpg");\' } }><h2>Gutenberg Editor</h2></section>',
+			'<section className="cover-image wp-block-cover-image" style={ { backgroundImage: \'url("https://cldup.com/GCwahb3aOb.jpg");\' } }><h2>Gutenberg Editor</h2></section>',
 			'<!-- /wp:core/cover-image -->',
 
 			'<!-- wp:core/text data="{\\"projectName\\":\\"gutenberg\\",\\"isAwesome\\":true}" -->',
@@ -39,7 +39,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/image align="center" -->',
-			'<figure><img alt="Beautiful landscape" src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>',
+			'<figure class="wp-block-image"><img alt="Beautiful landscape" src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
@@ -67,11 +67,11 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/button align="center" -->',
-			'<div class="aligncenter"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>',
+			'<div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>',
 			'<!-- /wp:core/button -->',
 
 			'<!-- wp:core/separator -->',
-			'<hr/>',
+			'<hr class="wp-block-separator" />',
 			'<!-- /wp:core/separator -->',
 
 			'<!-- wp:core/heading -->',
@@ -83,7 +83,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/quote style="1" -->',
-			'<blockquote class="blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>',
+			'<blockquote class="blocks-quote-style-1 wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>',
 			'<!-- /wp:core/quote -->',
 
 			'<!-- wp:core/text -->',
@@ -95,11 +95,11 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/quote style="2" -->',
-			'<blockquote class="blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>',
+			'<blockquote class="blocks-quote-style-2 wp-block-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>',
 			'<!-- /wp:core/quote -->',
 
 			'<!-- wp:core/separator -->',
-			'<hr/>',
+			'<hr class="wp-block-separator" />',
 			'<!-- /wp:core/separator -->',
 
 			'<!-- wp:core/heading -->',
@@ -111,7 +111,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/image -->',
-			'<figure><img alt="Accessibility is important don\'t forget image alt attribute" src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>',
+			'<figure class="wp-block-image"><img alt="Accessibility is important don\'t forget image alt attribute" src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/text -->',
@@ -123,21 +123,21 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/text -->',
 
 			'<!-- wp:core/code -->',
-			'<pre><code>export default function MyButton() {\n\
+			'<pre class="wp-block-code"><code>export default function MyButton() {\n\
 	return &lt;Button&gt;Click Me!&lt;/Button&gt;;\n\
 }</code></pre>',
 			'<!-- /wp:core/code -->',
 
 			'<!-- wp:core/image -->',
-			'<figure><img alt="Yet another image block" src="https://cldup.com/GCwahb3aOb.jpg" /></figure>',
+			'<figure class="wp-block-image"><img alt="Yet another image block" src="https://cldup.com/GCwahb3aOb.jpg" /></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/image -->',
-			'<figure><img alt="Yet another image block" src="https://cldup.com/lUUQPv6w9c.jpg" /></figure>',
+			'<figure class="wp-block-image"><img alt="Yet another image block" src="https://cldup.com/lUUQPv6w9c.jpg" /></figure>',
 			'<!-- /wp:core/image -->',
 
 			'<!-- wp:core/preformatted -->',
-			'<pre>An old silent pond...<br>A frog jumps into the pond,<br>splash! Silence again.</pre>',
+			'<pre class="wp-block-preformatted">An old silent pond...<br>A frog jumps into the pond,<br>splash! Silence again.</pre>',
 			'<!-- /wp:core/preformatted -->',
 
 			'<!-- wp:core/text -->',
@@ -153,15 +153,15 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/list -->',
 
 			'<!-- wp:core/pullquote -->',
-			'<blockquote class="blocks-pullquote"><p>Code is Poetry</p><footer>The WordPress community</footer></blockquote>',
+			'<blockquote class="blocks-pullquote wp-block-pullquote"><p>Code is Poetry</p><footer>The WordPress community</footer></blockquote>',
 			'<!-- /wp:core/pullquote -->',
 
 			'<!-- wp:core/separator -->',
-			'<hr/>',
+			'<hr class="wp-block-separator" />',
 			'<!-- /wp:core/separator -->',
 
 			'<!-- wp:core/table -->',
-			'<table class="widefat"><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><th><a href="https://wordpress.org/news/2015/12/clifford/">4.4</a></th><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr class="alt"><th><a href="https://wordpress.org/news/2016/04/coleman/">4.5</a></th><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><th><a href="https://wordpress.org/news/2016/08/pepper/">4.6</a></th><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr class="alt"><th><a href="https://wordpress.org/news/2016/12/vaughan/">4.7</a></th><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>',
+			'<table class="widefat wp-block-table"><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><th><a href="https://wordpress.org/news/2015/12/clifford/">4.4</a></th><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr class="alt"><th><a href="https://wordpress.org/news/2016/04/coleman/">4.5</a></th><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><th><a href="https://wordpress.org/news/2016/08/pepper/">4.6</a></th><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr class="alt"><th><a href="https://wordpress.org/news/2016/12/vaughan/">4.7</a></th><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>',
 			'<!-- /wp:core/table -->',
 
 			'<!-- wp:core/heading -->',
@@ -169,7 +169,7 @@ window._wpGutenbergPost = {
 			'<!-- /wp:core/heading -->',
 
 			'<!-- wp:core/embed url="https://www.youtube.com/watch?v=Nl6U7UotA-M" -->',
-			'<figure>https://www.youtube.com/watch?v=Nl6U7UotA-M<figcaption>State of the Word 2016</figcaption></figure>',
+			'<figure class="wp-block-embed">https://www.youtube.com/watch?v=Nl6U7UotA-M<figcaption>State of the Word 2016</figcaption></figure>',
 			'<!-- /wp:core/embed -->',
 
 			'<!-- wp:core/embed url="https://twitter.com/photomatt/status/868657763970404352" -->',


### PR DESCRIPTION
try to close #1362 

**Glitches:**

 - Doesn't work for blocks with save function returning strings (like embed links) 
 - Doesn't work for block with save function returning a component (instead of an element) but IMO we should drop this because we don't need a Component in the save function (we don't need any local state, ref or something it's just a serialization)

**Notes:**

We may need the same thing on the backend for dynamically rendered blocks but it's harder to implement because we only have strings (and not element) in the backend.