### PR TITLE
Avoid overlapping button block controls

### DIFF
--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -54,7 +54,6 @@ registerBlockType( 'core/button', {
 					onFocus={ setFocus }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					inline
-					inlineToolbar
 					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
 				/>
 				{ focus &&


### PR DESCRIPTION
Fixes #1111.

<img width="475" alt="screenshot 2017-06-22 23 13 01" src="https://user-images.githubusercontent.com/4710635/27456176-5fcdfa42-57a0-11e7-90ab-360558c8bbe0.png">
