### PR TITLE
Completely hide the meta boxes icons from screen readers

### DIFF
--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -15,7 +15,7 @@ function IconButton( { icon, children, label, className, focus, ...additionalPro
 
 	return (
 		<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
-			<Dashicon icon={ icon } />
+			<span aria-hidden="true"><Dashicon icon={ icon } /></span>
 			{ children }
 		</Button>
 	);


### PR DESCRIPTION
Fixes a Firefox/NVDA bug where the `aria-expanded` state change doesn't get announced when SVG icons are updated on the fly. To test:

- using Firefox and NVDA on master, tab to one of the metaboxes toggle buttons
- activate the button pressing Spacebar or Enter to toggle the meta box
- observe how NVDA doesn't announce "expanded" or "collapsed"
- switch to this branch and repeat the steps above
- observe how NVDA correctly announces "expanded" or "collapsed"

Screenshot:

![screenshot 109](https://user-images.githubusercontent.com/1682452/27475727-84769474-5806-11e7-8e8c-17cddf88fc43.png)


Fixes #1387.