### PR TITLE
Polish controls, floats, switches and headings

### DIFF
--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -72,6 +72,7 @@ $toggle-border-width: 2px;
 
 .components-form-toggle__hint {
 	display: inline-block;
+	min-width: 24px;	// This prevents a position jog when the control is right aligned, and the width of the label changes
 	margin-left: 10px;
 	font-weight: 500;
 }

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -94,14 +94,18 @@
 		color: $white;
 	}
 
+	&[data-subscript] svg {
+		padding: 4px 8px 4px 0px;
+	}
+
 	&[data-subscript]:after {
 		content: attr( data-subscript );
 		font-family: $default-font;
-		font-size: 10px;
+		font-size: $default-font-size;
 		font-weight: bold;
 		position: relative;
-		top: -6px;
-		left: -9px;
+		top: -5px;
+		left: -12px;
 	}
 }
 

--- a/editor/assets/stylesheets/_mixins.scss
+++ b/editor/assets/stylesheets/_mixins.scss
@@ -107,4 +107,6 @@
 		@content;
 	}
 }
-$float-margin: calc( 50% - #{ $visual-editor-max-width / 2 } );
+
+$visual-editor-max-width-padding: $visual-editor-max-width + $block-mover-padding-visible + $block-mover-padding-visible;
+$float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -58,7 +58,7 @@ $text-editor-max-width: 760px;
 
 /* Editor */
 $text-editor-max-width: 760px;
-$visual-editor-max-width: 636px;	// previously 700
+$visual-editor-max-width: 636px;
 $block-controls-height: 38px;
 $icon-button-size: 36px;
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -175,12 +175,23 @@
 
 		&:before {
 			left: 0;
+			right: 0;
 			border-left-width: 0;
 			border-right-width: 0;
 		}
 
 		.editor-block-mover {
 			display: none;
+		}
+
+		.editor-block-settings-menu {
+			top: -24px;
+			right: 10px;
+		}
+
+		.editor-block-settings-menu__control {
+			float: left;
+			margin-right: 8px;
 		}
 	}
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -29,7 +29,7 @@
 	margin-bottom: 5px;
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
 	position: relative;
-	 // The block mover needs to stay inside the block to allow clicks when hovering the block
+	// The block mover needs to stay inside the block to allow clicks when hovering the block
 	padding: $block-padding $block-padding + $block-mover-padding-visible;
 
 	&:before {


### PR DESCRIPTION
This PR addresses a couple of issues.

It fixes floats:

![screen shot 2017-06-23 at 11 43 40](https://user-images.githubusercontent.com/1204802/27476490-4468c75a-5809-11e7-9e5a-220dab274e4d.png)

It fixes an issue with full wide:

![screen shot 2017-06-23 at 11 44 20](https://user-images.githubusercontent.com/1204802/27476506-4f7aee98-5809-11e7-88e6-4034da7f7b31.png)

It fixes a pixel jog that happened on On/Off switches due to "On" being a shorter word than "Off".

![screen shot 2017-06-23 at 11 47 20](https://user-images.githubusercontent.com/1204802/27476624-bde4b058-5809-11e7-8e7d-9c5f5111fec9.png)


It also improves heading icons. I finally feel like they're in a good place:

![screen shot 2017-06-23 at 11 42 07](https://user-images.githubusercontent.com/1204802/27476527-66037158-5809-11e7-82b7-ef3176cfc583.png)
