### PR TITLE
Add focus style to the Inserter search and improve alignments.

### DIFF
--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 1px $blue-medium-400, 0 0 2px 1px $blue-medium-400;
+		box-shadow: $button-focus-style;
 		outline: none;
 	}
 

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -23,6 +23,8 @@ $white: #fff;
 /* Extra colors, some from https://make.wordpress.org/design/handbook/foundations/colors/ */
 $blue-wordpress-700: #00669b;
 $blue-wordpress: #0073aa;
+$blue-focus: #5b9dd9;
+$shadow-focus: 0px 0px 2px rgba( #1e8cbe, .8 );
 
 $blue-medium-500: #00a0d2;
 $blue-medium-400: #33B3DB;

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -23,8 +23,6 @@ $white: #fff;
 /* Extra colors, some from https://make.wordpress.org/design/handbook/foundations/colors/ */
 $blue-wordpress-700: #00669b;
 $blue-wordpress: #0073aa;
-$blue-focus: #5b9dd9;
-$shadow-focus: 0px 0px 2px rgba( #1e8cbe, .8 );
 
 $blue-medium-500: #00a0d2;
 $blue-medium-400: #33B3DB;
@@ -57,6 +55,7 @@ $admin-sidebar-width-big: 190px;
 $admin-sidebar-width-collapsed: 36px;
 $shadow-popover: 0px 3px 20px rgba( $dark-gray-900, .1 ), 0px 1px 3px rgba( $dark-gray-900, .1 );
 $text-editor-max-width: 760px;
+$button-focus-style: 0 0 0 1px $blue-medium-400, 0 0 2px 1px $blue-medium-400;
 
 /* Editor */
 $text-editor-max-width: 760px;

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -48,25 +48,29 @@
 	}
 }
 
-input[type=search].editor-inserter__search {
+input[type="search"].editor-inserter__search {
 	display: block;
 	width: 100%;
-	border: none;
 	margin: 0;
 	box-shadow: none;
+	border: 1px solid transparent;
 	border-top: 1px solid $light-gray-500;
-	padding: 8px 16px;
+	padding: 8px 11px;
 	font-size: 13px;
+	position: relative;
+	z-index: 1;
 
 	&:focus {
 		outline: none;
+		border-color: $blue-focus;
+		box-shadow: $shadow-focus;
 	}
 }
 
 .editor-inserter__category-blocks {
 	display: flex;
 	flex-flow: row wrap;
-	padding: 3px;
+	padding: 4px;
 }
 
 .editor-inserter__menu.is-bottom:after {
@@ -108,7 +112,7 @@ input[type=search].editor-inserter__search {
 .editor-inserter__separator {
 	display: block;
 	margin: 0;
-	padding: 4px 8px;
+	padding: 4px 12px;
 	font-size: 11px;
 	font-weight: 600;
 	text-transform: uppercase;

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -62,8 +62,7 @@ input[type="search"].editor-inserter__search {
 
 	&:focus {
 		outline: none;
-		border-color: $blue-focus;
-		box-shadow: $shadow-focus;
+		box-shadow: $button-focus-style;
 	}
 }
 


### PR DESCRIPTION
This PR adds a focus style to the inserter search field. It uses the default WordPress style (border + box-shadow) and introduces two new colors in `_variables.scss`:

```
$blue-focus: #5b9dd9;
$shadow-focus: 0px 0px 2px rgba( #1e8cbe, .8 );
```

It also tries to improve the left alignments of the menu titles, icons, and search field. See the screenshot below, before and after:

<img width="982" alt="screen shot 2017-06-23 at 12 58 11" src="https://user-images.githubusercontent.com/1682452/27479521-88058a7e-5814-11e7-8939-fcb1c9e4fdd9.png">

Note 1: the left alignment can't be pixel-perfect because of the different SVG icons shapes.

Note 2: looks like the search field needs a `z-index` property otherwise the top border is not visible in some cases when scrolling the menu:

<img width="339" alt="screen shot 2017-06-23 at 12 32 25" src="https://user-images.githubusercontent.com/1682452/27479583-c4679052-5814-11e7-9e41-768342166c1c.png">

Note 3: in Safari, the search field is a bit taller than in other browsers. Not sure if we want to fix this:

<img width="329" alt="screen shot 2017-06-23 at 12 38 19" src="https://user-images.githubusercontent.com/1682452/27479616-e1d79646-5814-11e7-9ac0-30602ff4acf5.png">


Fixes #1378 