### PR TITLE
Adds an API for enqueuing assets to the theme or editor of gutenberg.

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -22,5 +22,6 @@ if ( gutenberg_can_init() ) {
 	require_once dirname( __FILE__ ) . '/lib/register.php';
 
 	// Register server-side code for individual blocks.
+	require_once dirname( __FILE__ ) . '/lib/blocks/quote.php';
 	require_once dirname( __FILE__ ) . '/lib/blocks/latest-posts.php';
 }

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -145,3 +145,246 @@ function do_blocks( $content ) {
 	return $new_content;
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode() and wpautop().
+
+/**
+ * The low level API for registering assets to be loaded with a block.
+ *
+ * @param string $name   Name of already registered block you want to add assets to.
+ * @param array  $assets Array of asset data. It follows the following format:
+ *     array(
+ *       // Location to load.
+ *       'editor' => array(
+ *         'scripts' => array(
+ *           array(
+ *             'handle' => 'name of script to enqueue',
+ *             'src'    => 'url to resource',
+ *             'deps'   => array() of dependencies,
+ *             'ver'    => version of resource,
+ *             'in_footer'  => any specific media restrictions,
+ *           ),
+ *         ),
+ *         'styles' => array(
+ *           array(
+ *             'handle' => 'name of style to enqueue',
+ *             'src'    => 'url to resource',
+ *             'deps'   => array() of dependencies,
+ *             'ver'    => version of resource,
+ *             'media'  => any specific media restrictions,
+ *           ),
+ *         ),
+ *       ),
+ *       'theme'  => array(
+ *         // Same as above.
+ *       ),
+ *     );
+ *     Each individual asset is defined by an array matching the callback
+ *     parameters to the matching wp_enqueue_{ script|style } function.
+ * @return array Array of asset data for the block, after registering.
+ */
+function gutenberg_register_block_assets( $name, $assets ) {
+	global $wp_registered_blocks;
+	if ( ! isset( $wp_registered_blocks[ $name ] ) ) {
+		/* translators: 1: block name */
+		$message = sprintf( __( 'Block "%s" is not registered. It is possible you called this before it was registered.' ), $name );
+		_doing_it_wrong( __FUNCTION__, $message, '0.1.0' );
+		return false;
+	}
+
+	// Check to see if assets have not been registered.
+	if ( ! isset( $wp_registered_blocks[ $name ]['assets'] ) ) {
+		$wp_registered_blocks[ $name ]['assets'] = array();
+	}
+
+	$wp_registered_blocks[ $name ]['assets'] = gutenberg_merge_assets( $wp_registered_blocks[ $name ]['assets'], $assets );
+	return $wp_registered_blocks[ $name ]['assets'];
+}
+
+/**
+ * Currently a wrapper for array_merge_recursive().
+ *
+ * Lifted into a function so validation can be more easily added. Might not be
+ * needed at all though.
+ *
+ * @param array $current_assets Array of current assets.
+ * @param array $new_assets     Array of new assets.
+ * @return array Array of merged assets.
+ */
+function gutenberg_merge_assets( $current_assets, $new_assets ) {
+	return array_merge_recursive( $current_assets, $new_assets );
+}
+
+/**
+ * Adds a block style to the editor.
+ *
+ * @param string $name Block name to register to.
+ * @param array  $args Array of asset data related to wp_enqueue_style().
+ *
+ * @return array Array of asset data for block.
+ */
+function gutenberg_add_block_editor_style( $name, $args ) {
+	if ( ! isset( $args['handle'] ) ) {
+		/* translators: 1: block name */
+		$message = 'Registered styles must provide a handle in $args array.';
+		_doing_it_wrong( __FUNCTION__, $message, '0.2.0' );
+		return array();
+	}
+
+	$defaults = array(
+		'src'   => '',
+		'deps'  => array(),
+		'ver'   => false,
+		'media' => 'all',
+	);
+
+	$args = wp_parse_args( $args, $defaults );
+
+	$style = array(
+		'handle' => $args['handle'],
+		'src'    => $args['src'],
+		'deps'   => $args['deps'],
+		'ver'    => $args['ver'],
+		'media'  => $args['media'],
+	);
+
+	$assets = array(
+		'editor' => array(
+			'styles' => array(
+				$style,
+			),
+		),
+	);
+
+	return gutenberg_register_block_assets( $name, $assets );
+}
+
+/**
+ * Adds a block style to the theme.
+ *
+ * @param string $name Block name to register to.
+ * @param array  $args Array of asset data related to wp_enqueue_style().
+ *
+ * @return array Array of asset data for block.
+ */
+function gutenberg_add_block_theme_style( $name, $args ) {
+	if ( ! isset( $args['handle'] ) ) {
+		/* translators: 1: block name */
+		$message = 'Registered styles must provide a handle in $args array.';
+		_doing_it_wrong( __FUNCTION__, $message, '0.2.0' );
+		return array();
+	}
+
+	$defaults = array(
+		'src'   => '',
+		'deps'  => array(),
+		'ver'   => false,
+		'media' => 'all',
+	);
+
+	$args = wp_parse_args( $args, $defaults );
+
+	$style = array(
+		'handle' => $args['handle'],
+		'src'    => $args['src'],
+		'deps'   => $args['deps'],
+		'ver'    => $args['ver'],
+		'media'  => $args['media'],
+	);
+
+	$assets = array(
+		'theme' => array(
+			'styles' => array(
+				$style,
+			),
+		),
+	);
+
+	return gutenberg_register_block_assets( $name, $assets );
+}
+
+/**
+ * Adds a block script to the editor.
+ *
+ * @param string $name Block name to register to.
+ * @param array  $args Array of asset data related to wp_enqueue_script().
+ *
+ * @return array Array of asset data for block.
+ */
+function gutenberg_add_block_editor_script( $name, $args ) {
+	if ( ! isset( $args['handle'] ) ) {
+		/* translators: 1: block name */
+		$message = 'Registered scripts must provide a handle in $args array.';
+		_doing_it_wrong( __FUNCTION__, $message, '0.2.0' );
+		return array();
+	}
+
+	$defaults = array(
+		'src'   => '',
+		'deps'  => array(),
+		'ver'   => false,
+		'in_footer' => false,
+	);
+
+	$args = wp_parse_args( $args, $defaults );
+
+	$script = array(
+		'handle' => $args['handle'],
+		'src'    => $args['src'],
+		'deps'   => $args['deps'],
+		'ver'    => $args['ver'],
+		'in_footer'  => $args['in_footer'],
+	);
+
+	$assets = array(
+		'editor' => array(
+			'scripts' => array(
+				$script,
+			),
+		),
+	);
+
+	return gutenberg_register_block_assets( $name, $assets );
+}
+
+/**
+ * Adds a block script to the theme.
+ *
+ * @param string $name Block name to register to.
+ * @param array  $args Array of asset data related to wp_enqueue_script().
+ *
+ * @return array Array of asset data for block.
+ */
+function gutenberg_add_block_theme_script( $name, $args ) {
+	if ( ! isset( $args['handle'] ) ) {
+		/* translators: 1: block name */
+		$message = 'Registered scripts must provide a handle in $args array.';
+		_doing_it_wrong( __FUNCTION__, $message, '0.2.0' );
+		return array();
+	}
+
+	$defaults = array(
+		'src'   => '',
+		'deps'  => array(),
+		'ver'   => false,
+		'in_footer' => false,
+	);
+
+	$args = wp_parse_args( $args, $defaults );
+
+	$script = array(
+		'handle' => $args['handle'],
+		'src'    => $args['src'],
+		'deps'   => $args['deps'],
+		'ver'    => $args['ver'],
+		'in_footer'  => $args['in_footer'],
+	);
+
+	$assets = array(
+		'theme' => array(
+			'scripts' => array(
+				$script,
+			),
+		),
+	);
+
+	return gutenberg_register_block_assets( $name, $assets );
+}

--- a/lib/blocks/quote.php
+++ b/lib/blocks/quote.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Server-side rendering of the `core/quote` block.
+ *
+ * @package gutenberg
+ */
+
+register_block_type( 'core/quote', array() );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -449,5 +449,50 @@ function gutenberg_scripts_and_styles( $hook ) {
 		array( 'wp-components', 'wp-blocks' ),
 		filemtime( gutenberg_dir_path() . 'editor/build/style.css' )
 	);
+
+	// Enqueue any special theme editor styles and scripts.
+	global $wp_registered_blocks;
+	gutenberg_load_custom_assets_by_location( $wp_registered_blocks, 'editor' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_scripts_and_styles' );
+
+/**
+ * Handles the enqueueing of front end scripts and styles from Gutenberg.
+ */
+function gutenberg_frontend_scripts_and_styles() {
+	// Enqueue any special theme front-end styles and scripts.
+	global $wp_registered_blocks;
+	gutenberg_load_custom_assets_by_location( $wp_registered_blocks, 'theme' );
+}
+add_action( 'wp_enqueue_scripts', 'gutenberg_frontend_scripts_and_styles' );
+
+/**
+ * Loads custom assets based on the location provided.
+ *
+ * Use 'theme' for front end and 'editor' for the editor itself.
+ *
+ * @param array  $blocks   Should be the $wp_registered_blocks global.
+ * @param string $location A string to check for assets for a location.
+ */
+function gutenberg_load_custom_assets_by_location( $blocks, $location ) {
+	foreach ( $blocks as $name => $settings ) {
+		// If there are assets registered see if any theme assets are registered.
+		if ( isset( $settings['assets'] ) && isset( $settings['assets'][ $location ] ) ) {
+			$location_assets = $settings['assets'][ $location ];
+
+			// Handle scripts.
+			if ( isset( $location_assets['scripts'] ) && is_array( $location_assets['scripts'] ) ) {
+				foreach ( $location_assets['scripts'] as $script ) {
+					wp_enqueue_style( $script['handle'], $script['src'], $script['deps'], $script['ver'], $script['in_footer'] );
+				}
+			}
+
+			// Handle styles.
+			if ( isset( $location_assets['styles'] ) && is_array( $location_assets['styles'] ) ) {
+				foreach ( $location_assets['styles'] as $style ) {
+					wp_enqueue_style( $style['handle'], $style['src'], $style['deps'], $style['ver'], $style['media'] );
+				}
+			}
+		}
+	}
+}

--- a/phpunit/class-asset-registration-test.php
+++ b/phpunit/class-asset-registration-test.php
@@ -1,0 +1,555 @@
+<?php
+/**
+ * Blocks asset registration tests
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Test registering scripts and styles, for theme view and editor view.
+ */
+class Asset_Registration_Test extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+
+		register_block_type( 'core/text', array() );
+	}
+
+	function tearDown() {
+		$GLOBALS['wp_registered_blocks'] = array();
+	}
+
+	/**
+	 * Should reject blocks that are not registered.
+	 *
+	 * @expectedIncorrectUsage gutenberg_register_block_assets
+	 */
+	function test_registering_to_unregistered_block() {
+		$result = gutenberg_register_block_assets( 'core/does-not-exist', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Should error because an asset handle name was not provided.
+	 *
+	 * @expectedIncorrectUsage gutenberg_add_block_editor_style
+	 */
+	function test_gutenberg_add_block_editor_style_without_handle() {
+		$result = gutenberg_add_block_editor_style( 'core/text', array() );
+		$this->assertEquals( array(), $result );
+	}
+
+	/**
+	 * Should error because an asset handle name was not provided.
+	 *
+	 * @expectedIncorrectUsage gutenberg_add_block_theme_style
+	 */
+	function test_gutenberg_add_block_theme_style_without_handle() {
+		$result = gutenberg_add_block_theme_style( 'core/text', array() );
+		$this->assertEquals( array(), $result );
+	}
+
+	/**
+	 * Should error because an asset handle name was not provided.
+	 *
+	 * @expectedIncorrectUsage gutenberg_add_block_editor_script
+	 */
+	function test_gutenberg_add_block_editor_script_without_handle() {
+		$result = gutenberg_add_block_editor_script( 'core/text', array() );
+		$this->assertEquals( array(), $result );
+	}
+
+	/**
+	 * Should error because an asset handle name was not provided.
+	 *
+	 * @expectedIncorrectUsage gutenberg_add_block_theme_script
+	 */
+	function test_gutenberg_add_block_theme_script_without_handle() {
+		$result = gutenberg_add_block_theme_script( 'core/text', array() );
+		$this->assertEquals( array(), $result );
+	}
+
+	/**
+	 * Test registering to a block with empty assets.
+	 */
+	function test_registering_assets_to_registered_block_without_assets() {
+		$assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$result = gutenberg_register_block_assets( 'core/text', $assets );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $assets, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Test registering to a block with already existing assets.
+	 */
+	function test_registering_assets_to_registered_block_with_existing_assets() {
+		$assets_1 = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		gutenberg_register_block_assets( 'core/text', $assets_1 );
+
+		$assets_2 = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$result = gutenberg_register_block_assets( 'core/text', $assets_2 );
+
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Should add an editor style asset for the block.
+	 */
+	function test_gutenberg_add_block_editor_style() {
+		$expected = array(
+			'editor' => array(
+				'styles' => array(
+					array(
+						'handle' => 'my-handle',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => false,
+						'media'  => 'all',
+					),
+				),
+			),
+		);
+		gutenberg_add_block_editor_style( 'core/text', array(
+			'handle' => 'my-handle',
+			'src'    => 'https://wordpress.org/is-the-best',
+			'deps'   => array(),
+			'ver'    => false,
+			'media'  => 'all',
+		) );
+
+		global $wp_registered_blocks;
+		$this->assertEquals( $expected, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Should add an editor style asset for the block.
+	 */
+	function test_gutenberg_add_block_theme_style() {
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'my-handle',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => false,
+						'media'  => 'all',
+					),
+				),
+			),
+		);
+		gutenberg_add_block_theme_style( 'core/text', array(
+			'handle' => 'my-handle',
+			'src'    => 'https://wordpress.org/is-the-best',
+			'deps'   => array(),
+			'ver'    => false,
+			'media'  => 'all',
+		) );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $expected, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Should add an editor script asset for the block.
+	 */
+	function test_gutenberg_add_block_editor_script() {
+		$expected = array(
+			'editor' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'my-handle',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => false,
+						'in_footer'  => false,
+					),
+				),
+			),
+		);
+		gutenberg_add_block_editor_script( 'core/text', array(
+			'handle' => 'my-handle',
+			'src'    => 'https://wordpress.org/is-the-best',
+			'deps'   => array(),
+			'ver'    => false,
+			'in_footer'  => false,
+		) );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $expected, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Should add an editor script asset for the block.
+	 */
+	function test_gutenberg_add_block_theme_script() {
+		$expected = array(
+			'theme' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'my-handle',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => false,
+						'in_footer'  => false,
+					),
+				),
+			),
+		);
+		gutenberg_add_block_theme_script( 'core/text', array(
+			'handle' => 'my-handle',
+			'src'    => 'https://wordpress.org/is-the-best',
+			'deps'   => array(),
+			'ver'    => false,
+			'in_footer'  => false,
+		) );
+
+		global $wp_registered_blocks;
+
+		$this->assertEquals( $expected, $wp_registered_blocks['core/text']['assets'] );
+	}
+
+	/**
+	 * Should merge asset data into array.
+	 */
+	function test_merging_to_empty_assets() {
+		$current_assets = array();
+		$assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$result = gutenberg_merge_assets( $current_assets, $assets );
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'core/does-not-exist',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Should merge asset data into existing data, creating multiple styles to be enqueued.
+	 */
+	function test_merging_to_existing_assets() {
+		$current_assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$result = gutenberg_merge_assets( $current_assets, $assets );
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Should merge scripts and style assets to match the expected output.
+	 */
+	function test_merging_new_scripts_and_styles() {
+		$current_assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$assets = array(
+			'theme' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'script 1',
+						'src'    => 'https://wordpress.org/is-neat',
+						'deps'   => array(),
+						'ver'    => null,
+						'in_footer'  => null,
+					),
+				),
+				'styles' => array(
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$result = gutenberg_merge_assets( $current_assets, $assets );
+		$expected = array(
+			'theme' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'script 1',
+						'src'    => 'https://wordpress.org/is-neat',
+						'deps'   => array(),
+						'ver'    => null,
+						'in_footer'  => null,
+					),
+				),
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Should merge scripts and style assets across multiple calls to match the expected output.
+	 */
+	function test_merging_across_multiple_calls() {
+		$current_assets = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$assets_1 = array(
+			'theme' => array(
+				'scripts' => array(
+					array(
+						'handle' => 'script 1',
+						'src'    => 'https://wordpress.org/is-neat',
+						'deps'   => array(),
+						'ver'    => null,
+						'in_footer'  => null,
+					),
+				),
+				'styles' => array(
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+		$assets_2 = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 3',
+						'src'    => 'https://wordpress.org/is-goofy',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+			'editor' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 4',
+						'src'    => 'https://wordpress.org/is-free',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$first_merge = gutenberg_merge_assets( $current_assets, $assets_1 );
+		$result = gutenberg_merge_assets( $first_merge, $assets_2 );
+		$expected = array(
+			'theme' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 1',
+						'src'    => 'https://wordpress.org/is-the-best',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'style 2',
+						'src'    => 'https://wordpress.org/is-wonderful',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+					array(
+						'handle' => 'style 3',
+						'src'    => 'https://wordpress.org/is-goofy',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+				'scripts' => array(
+					array(
+						'handle' => 'script 1',
+						'src'    => 'https://wordpress.org/is-neat',
+						'deps'   => array(),
+						'ver'    => null,
+						'in_footer'  => null,
+					),
+				),
+			),
+			'editor' => array(
+				'styles' => array(
+					array(
+						'handle' => 'style 4',
+						'src'    => 'https://wordpress.org/is-free',
+						'deps'   => array(),
+						'ver'    => null,
+						'media'  => null,
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+}


### PR DESCRIPTION
4 top level functions can be used for adding extra assets.

`gutenberg_add_block_editor_style`
`gutenberg_add_block_theme_style`
`gutenberg_add_block_editor_script`
`gutenberg_add_block_theme_script`

Each of these will register the assets provided to the respective
location.

A quote block is registered server side so that we can register styles
to it.

_mock implementation_

In this PR I am registering the quote block server side so the API can be tested out.

Create a css file in your active theme like this:

quote.css:
```css
.blocks-quote-style-1 {
    background-color: red;
    color: white;
}

.blocks-quote-style-2 {
    background-color: blue;
    color: orange;
}
```

Then somewhere in that themes functions php, preferably on the after_setup_theme hook, add this line:
```php
gutenberg_add_block_theme_style( 'core/quote', array(
  'handle' => 'quote-colors',
  'src'    => get_template_directory_uri() . '/quote.css'
) );
```
This will register the special stylesheet to be loaded by the theme. Make sure you have added a quote block to your post, and on the front end you should now see a hideous red quote with white text. Click to block style two in the editor and you should see the blue bg with orange text. This should not apply in the editor.

To add these styles to the editor as well simply add this line right after:
```php
gutenberg_add_block_editor_style( 'core/quote', array(
  'handle' => 'quote-colors',
  'src'    => get_template_directory_uri() . '/quote.css'
) );
```

** Testing Instructions **
Verify PHPUnit tests pass.

Verify that you can add custom assets to the theme and editor views.
_NOTE_ Currently only registered blocks are supported, so you will need
to register styles to the quote block or latest posts block.