### PR TITLE
Add fallback to string if getAttribute returns null

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -321,7 +321,7 @@ export default class Editable extends Component {
 		const formats = {};
 		const link = find( parents, ( node ) => node.nodeName.toLowerCase() === 'a' );
 		if ( link ) {
-			formats.link = { value: link.getAttribute( 'href' ), link };
+			formats.link = { value: link.getAttribute( 'href' ) || '', link };
 		}
 		const activeFormats = this.editor.formatter.matchAll( [	'bold', 'italic', 'strikethrough' ] );
 		activeFormats.forEach( ( activeFormat ) => formats[ activeFormat ] = true );


### PR DESCRIPTION
I fixed the issue that reported on #680 
This `formats.link.value` passed to `value` attribute of `input`. but the value attribute is not accepting null value.

<img src="https://user-images.githubusercontent.com/8455/27513837-1a071940-59b1-11e7-949b-e8395f20cf05.gif" width=300>