### PR TITLE
EmbedBlock: include align class in saved markup.

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -193,13 +193,13 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 		},
 
 		save( { attributes } ) {
-			const { url, caption } = attributes;
+			const { url, caption, align } = attributes;
 			if ( ! caption || ! caption.length ) {
 				return url;
 			}
 
 			return (
-				<figure>{ '\n' }
+				<figure className={ `align${ align }` }>{ '\n' }
 					{ url }
 					<figcaption>{ caption }</figcaption>
 				</figure>

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -199,7 +199,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 			}
 
 			return (
-				<figure className={ `align${ align }` }>{ '\n' }
+				<figure className={ align && `align${ align }` }>{ '\n' }
 					{ url }
 					<figcaption>{ caption }</figcaption>
 				</figure>


### PR DESCRIPTION
Fixes #1421.