### PR TITLE
Framework: Add notices

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -6,6 +6,8 @@ export { default as FormToggle } from './form-toggle';
 export { default as FormTokenField } from './form-token-field';
 export { default as HtmlEmbed } from './html-embed';
 export { default as IconButton } from './icon-button';
+export { default as Notice } from './notice';
+export { default as NoticeList } from './notice/list';
 export { default as Panel } from './panel';
 export { default as PanelHeader } from './panel/header';
 export { default as PanelBody } from './panel/body';

--- a/components/notice/index.js
+++ b/components/notice/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { isString, noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
+/**
+ * Internal Dependencies
+ */
+import './style.scss';
+
+function Notice( { status, content, onRemove = noop } ) {
+	const className = `notice notice-alt is-dismissible notice-${ status }`;
+	return (
+		<div className={ className }>
+			{ isString( content ) ? <p>{ content }</p> : content }
+			<button className="notice-dismiss" type="button" onClick={ onRemove }>
+				<span className="screen-reader-text">{ __( 'Dismiss this notice' ) }</span>
+			</button>
+		</div>
+	);
+}
+
+export default Notice;

--- a/components/notice/list.js
+++ b/components/notice/list.js
@@ -1,0 +1,23 @@
+/**
+ * External depednencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Notice from './';
+
+function NoticeList( { notices, onRemove = noop } ) {
+	const removeNotice = ( id ) => () => onRemove( id );
+
+	return (
+		<div className="components-notice-list">
+			{ notices.reverse().map( ( notice ) => (
+				<Notice { ...notice } key={ notice.id } onRemove={ removeNotice( notice.id ) } />
+			) ) }
+		</div>
+	);
+}
+
+export default NoticeList;

--- a/components/notice/style.scss
+++ b/components/notice/style.scss
@@ -1,0 +1,7 @@
+.components-notice-list {
+	position: fixed;
+	top: 40px;
+	right: 0;
+	width: 300px;
+	z-index: z-index( ".components-notice-list" );
+}

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -1,3 +1,9 @@
+/**
+ * External Dependencies
+ */
+import uuid from 'uuid/v4';
+import { partial } from 'lodash';
+
 export function focusBlock( uid, config ) {
 	return {
 		type: 'UPDATE_FOCUS',
@@ -111,3 +117,41 @@ export function stopTypingInBlock( uid ) {
 		uid,
 	};
 }
+
+/**
+ * Returns an action object used to create a notice
+ *
+ * @param {String}     status   The notice status
+ * @param {WPElement}  content  The notice content
+ * @param {String}     id       The notice id
+ *
+ * @return {Object}             Action object
+ */
+export function createNotice( status, content, id = uuid() ) {
+	return {
+		type: 'CREATE_NOTICE',
+		notice: {
+			id,
+			status,
+			content,
+		},
+	};
+}
+
+/**
+ * Returns an action object used to remove a notice
+ *
+ * @param {String}  id  The notice id
+ *
+ * @return {Object}     Action object
+ */
+export function removeNotice( id ) {
+	return {
+		type: 'REMOVE_NOTICE',
+		noticeId: id,
+	};
+}
+
+export const successNotice = partial( createNotice, 'success' );
+export const errorNotice = partial( createNotice, 'error' );
+export const warningNotice = partial( createNotice, 'warning' );

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -11,6 +11,7 @@ $z-layers: (
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
 	'.editor-block-mover': 30,
+	'.components-notice-list': 100000,
 	'.components-popover': 100000,
 );
 

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -51,14 +51,14 @@ export default {
 		const Model = wp.api.getPostTypeModel( getCurrentPostType( state ) );
 		new Model( toSend ).save().done( ( newPost ) => {
 			dispatch( {
+				type: 'RESET_POST',
+				post: newPost,
+			} );
+			dispatch( {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				post: newPost,
 				isNew,
 				optimist: { type: COMMIT, id: transactionId },
-			} );
-			dispatch( {
-				type: 'RESET_POST',
-				post: newPost,
 			} );
 		} ).fail( ( err ) => {
 			dispatch( {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -8,12 +8,18 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
+import { Component } from 'element';
 import { Button } from 'components';
 
 /**
  * Internal dependencies
  */
-import { editPost, savePost } from '../../actions';
+import {
+	editPost,
+	savePost,
+	successNotice,
+	errorNotice,
+} from '../../actions';
 import {
 	isSavingPost,
 	isEditedPostPublished,
@@ -21,68 +27,100 @@ import {
 	getEditedPostVisibility,
 	isEditedPostSaveable,
 	isEditedPostPublishable,
+	getCurrentPost,
+	didPostSaveRequestSucceed,
 } from '../../selectors';
 
-function PublishButton( {
-	isSaving,
-	isPublished,
-	onStatusChange,
-	onSave,
-	isBeingScheduled,
-	visibility,
-	isPublishable,
-	isSaveable,
-} ) {
-	const buttonEnabled = ! isSaving && isPublishable && isSaveable;
-	let buttonText;
-	if ( isPublished ) {
-		buttonText = __( 'Update' );
-	} else if ( isBeingScheduled ) {
-		buttonText = __( 'Schedule' );
-	} else {
-		buttonText = __( 'Publish' );
+class PublishButton extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onClick = this.onClick.bind( this );
 	}
-	let publishStatus = 'publish';
-	if ( isBeingScheduled ) {
-		publishStatus = 'future';
-	} else if ( visibility === 'private' ) {
-		publishStatus = 'private';
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.isSaving && ! this.props.isSaving && this.props.didSaveSuccessfully ) {
+			this.props.successNotice( (
+				<p>
+					<span>{ __( 'Post saved!' ) }</span>
+					{ ' ' }
+					<a href={ this.props.post.link } target="_blank">{ __( 'View post' ) }</a>
+				</p>
+			) );
+		}
+
+		if ( prevProps.isSaving && ! this.props.isSaving && ! this.props.didSaveSuccessfully ) {
+			this.props.errorNotice( __( 'Saving failed' ) );
+		}
 	}
-	const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
-	const onClick = () => {
+
+	onClick() {
+		const { isPublished, isBeingScheduled, visibility, onSave, onStatusChange } = this.props;
+		let publishStatus = 'publish';
+		if ( isBeingScheduled ) {
+			publishStatus = 'future';
+		} else if ( visibility === 'private' ) {
+			publishStatus = 'private';
+		}
 		const doSave = isPublished ||
 			! process.env.NODE_ENV === 'production' ||
-			window.confirm( __( 'Keep in mind this plugin is a beta version and will not display correctly on your theme.' ) ); // eslint-disable-line no-alert
+			window.confirm( // eslint-disable-line no-alert
+				__( 'Keep in mind this plugin is a beta version and will not display correctly on your theme.' )
+			);
 		if ( doSave ) {
 			onStatusChange( publishStatus );
 			onSave();
 		}
-	};
+	}
 
-	return (
-		<Button
-			isPrimary
-			isLarge
-			onClick={ onClick }
-			disabled={ ! buttonEnabled }
-			className={ className }
-		>
-			{ buttonText }
-		</Button>
-	);
+	render() {
+		const {
+			isSaving,
+			isPublished,
+			isBeingScheduled,
+			isPublishable,
+			isSaveable,
+		} = this.props;
+
+		const buttonEnabled = ! isSaving && isPublishable && isSaveable;
+		let buttonText;
+		if ( isPublished ) {
+			buttonText = __( 'Update' );
+		} else if ( isBeingScheduled ) {
+			buttonText = __( 'Schedule' );
+		} else {
+			buttonText = __( 'Publish' );
+		}
+		const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
+
+		return (
+			<Button
+				isPrimary
+				isLarge
+				onClick={ this.onClick }
+				disabled={ ! buttonEnabled }
+				className={ className }
+			>
+				{ buttonText }
+			</Button>
+		);
+	}
 }
 
 export default connect(
 	( state ) => ( {
 		isSaving: isSavingPost( state ),
+		didSaveSuccessfully: didPostSaveRequestSucceed( state ),
 		isPublished: isEditedPostPublished( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		visibility: getEditedPostVisibility( state ),
 		isSaveable: isEditedPostSaveable( state ),
 		isPublishable: isEditedPostPublishable( state ),
+		post: getCurrentPost( state ),
 	} ),
 	{
 		onStatusChange: ( status ) => editPost( { status } ),
 		onSave: savePost,
+		successNotice,
+		errorNotice,
 	}
 )( PublishButton );

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -8,18 +8,12 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Component } from 'element';
 import { Button } from 'components';
 
 /**
  * Internal dependencies
  */
-import {
-	editPost,
-	savePost,
-	successNotice,
-	errorNotice,
-} from '../../actions';
+import { editPost, savePost } from '../../actions';
 import {
 	isSavingPost,
 	isEditedPostPublished,
@@ -27,100 +21,68 @@ import {
 	getEditedPostVisibility,
 	isEditedPostSaveable,
 	isEditedPostPublishable,
-	getCurrentPost,
-	didPostSaveRequestSucceed,
 } from '../../selectors';
 
-class PublishButton extends Component {
-	constructor() {
-		super( ...arguments );
-		this.onClick = this.onClick.bind( this );
+function PublishButton( {
+	isSaving,
+	isPublished,
+	onStatusChange,
+	onSave,
+	isBeingScheduled,
+	visibility,
+	isPublishable,
+	isSaveable,
+} ) {
+	const buttonEnabled = ! isSaving && isPublishable && isSaveable;
+	let buttonText;
+	if ( isPublished ) {
+		buttonText = __( 'Update' );
+	} else if ( isBeingScheduled ) {
+		buttonText = __( 'Schedule' );
+	} else {
+		buttonText = __( 'Publish' );
 	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.isSaving && ! this.props.isSaving && this.props.didSaveSuccessfully ) {
-			this.props.successNotice( (
-				<p>
-					<span>{ __( 'Post saved!' ) }</span>
-					{ ' ' }
-					<a href={ this.props.post.link } target="_blank">{ __( 'View post' ) }</a>
-				</p>
-			) );
-		}
-
-		if ( prevProps.isSaving && ! this.props.isSaving && ! this.props.didSaveSuccessfully ) {
-			this.props.errorNotice( __( 'Saving failed' ) );
-		}
+	let publishStatus = 'publish';
+	if ( isBeingScheduled ) {
+		publishStatus = 'future';
+	} else if ( visibility === 'private' ) {
+		publishStatus = 'private';
 	}
-
-	onClick() {
-		const { isPublished, isBeingScheduled, visibility, onSave, onStatusChange } = this.props;
-		let publishStatus = 'publish';
-		if ( isBeingScheduled ) {
-			publishStatus = 'future';
-		} else if ( visibility === 'private' ) {
-			publishStatus = 'private';
-		}
+	const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
+	const onClick = () => {
 		const doSave = isPublished ||
 			! process.env.NODE_ENV === 'production' ||
-			window.confirm( // eslint-disable-line no-alert
-				__( 'Keep in mind this plugin is a beta version and will not display correctly on your theme.' )
-			);
+			window.confirm( __( 'Keep in mind this plugin is a beta version and will not display correctly on your theme.' ) ); // eslint-disable-line no-alert
 		if ( doSave ) {
 			onStatusChange( publishStatus );
 			onSave();
 		}
-	}
+	};
 
-	render() {
-		const {
-			isSaving,
-			isPublished,
-			isBeingScheduled,
-			isPublishable,
-			isSaveable,
-		} = this.props;
-
-		const buttonEnabled = ! isSaving && isPublishable && isSaveable;
-		let buttonText;
-		if ( isPublished ) {
-			buttonText = __( 'Update' );
-		} else if ( isBeingScheduled ) {
-			buttonText = __( 'Schedule' );
-		} else {
-			buttonText = __( 'Publish' );
-		}
-		const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
-
-		return (
-			<Button
-				isPrimary
-				isLarge
-				onClick={ this.onClick }
-				disabled={ ! buttonEnabled }
-				className={ className }
-			>
-				{ buttonText }
-			</Button>
-		);
-	}
+	return (
+		<Button
+			isPrimary
+			isLarge
+			onClick={ onClick }
+			disabled={ ! buttonEnabled }
+			className={ className }
+		>
+			{ buttonText }
+		</Button>
+	);
 }
 
 export default connect(
 	( state ) => ( {
 		isSaving: isSavingPost( state ),
-		didSaveSuccessfully: didPostSaveRequestSucceed( state ),
 		isPublished: isEditedPostPublished( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		visibility: getEditedPostVisibility( state ),
 		isSaveable: isEditedPostSaveable( state ),
 		isPublishable: isEditedPostPublishable( state ),
-		post: getCurrentPost( state ),
 	} ),
 	{
 		onStatusChange: ( status ) => editPost( { status } ),
 		onSave: savePost,
-		successNotice,
-		errorNotice,
 	}
 )( PublishButton );

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -5,21 +5,33 @@ import { connect } from 'react-redux';
 import classnames from 'classnames';
 
 /**
+ * WordPress Dependencie
+ */
+import { NoticeList } from 'components';
+
+/**
  * Internal dependencies
  */
+import './style.scss';
 import Header from '../header';
 import Sidebar from '../sidebar';
 import TextEditor from '../modes/text-editor';
 import VisualEditor from '../modes/visual-editor';
-import { getEditorMode, isEditorSidebarOpened } from '../selectors';
+import { removeNotice } from '../actions';
+import {
+	getEditorMode,
+	isEditorSidebarOpened,
+	getNotices,
+} from '../selectors';
 
-function Layout( { mode, isSidebarOpened } ) {
+function Layout( { mode, isSidebarOpened, notices, ...props } ) {
 	const className = classnames( 'editor-layout', {
 		'is-sidebar-opened': isSidebarOpened,
 	} );
 
 	return (
 		<div className={ className }>
+			<NoticeList onRemove={ props.removeNotice } notices={ notices } />
 			<Header />
 			<div className="editor-layout__content">
 				{ mode === 'text' && <TextEditor /> }
@@ -30,7 +42,11 @@ function Layout( { mode, isSidebarOpened } ) {
 	);
 }
 
-export default connect( ( state ) => ( {
-	mode: getEditorMode( state ),
-	isSidebarOpened: isEditorSidebarOpened( state ),
-} ) )( Layout );
+export default connect(
+	( state ) => ( {
+		mode: getEditorMode( state ),
+		isSidebarOpened: isEditorSidebarOpened( state ),
+		notices: getNotices( state ),
+	} ),
+	{ removeNotice }
+)( Layout );

--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -1,0 +1,7 @@
+.editor-layout .components-notice-list {
+	top: 100px;
+}
+
+.editor-layout.is-sidebar-opened .components-notice-list {
+	right: $sidebar-width;
+}

--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -1,7 +1,10 @@
-.editor-layout .components-notice-list {
-	top: 100px;
+.editor-layout {
+	position: relative;
 }
 
-.editor-layout.is-sidebar-opened .components-notice-list {
-	right: $sidebar-width;
+.editor-layout .components-notice-list {
+	position: absolute;
+	top: 10px;
+	left: 0;
+	right: auto;
 }

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import { first, last, get } from 'lodash';
+import { first, last, get, values } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -647,4 +647,14 @@ export function getSuggestedPostFormat( state ) {
 	}
 
 	return null;
+}
+
+/**
+ * Returns the user notices array
+ *
+ * @param {Object} state Global application state
+ * @return {Array}       List of notices
+ */
+export function getNotices( state ) {
+	return values( state.notices );
 }

--- a/editor/state.js
+++ b/editor/state.js
@@ -463,6 +463,24 @@ export function saving( state = {}, action ) {
 	return state;
 }
 
+export function notices( state = {}, action ) {
+	switch ( action.type ) {
+		case 'CREATE_NOTICE':
+			return {
+				...state,
+				[ action.notice.id ]: action.notice,
+			};
+		case 'REMOVE_NOTICE':
+			if ( ! state.hasOwnProperty( action.noticeId ) ) {
+				return state;
+			}
+
+			return omit( state, action.noticeId );
+	}
+
+	return state;
+}
+
 /**
  * Creates a new instance of a Redux store.
  *
@@ -479,6 +497,7 @@ export function createReduxStore() {
 		mode,
 		isSidebarOpened,
 		saving,
+		notices,
 	} ) );
 
 	const enhancers = [ applyMiddleware( refx( effects ) ) ];

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -51,6 +51,7 @@ import {
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
 	getSuggestedPostFormat,
+	getNotices,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -1188,6 +1189,22 @@ describe( 'selectors', () => {
 			};
 
 			expect( getSuggestedPostFormat( state ) ).to.equal( 'Quote' );
+		} );
+	} );
+
+	describe( 'getNotices', () => {
+		it( 'should return the notices array', () => {
+			const state = {
+				notices: {
+					b: { id: 'b', content: 'Post saved' },
+					a: { id: 'a', content: 'Error saving' },
+				},
+			};
+
+			expect( getNotices( state ) ).to.eql( [
+				state.notices.b,
+				state.notices.a,
+			] );
 		} );
 	} );
 } );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -22,6 +22,7 @@ import {
 	mode,
 	isSidebarOpened,
 	saving,
+	notices,
 	showInsertionPoint,
 	createReduxStore,
 } from '../state';
@@ -978,6 +979,56 @@ describe( 'state', () => {
 		} );
 	} );
 
+	describe( 'notices()', () => {
+		it( 'should create a notice', () => {
+			const originalState = {
+				b: {
+					id: 'b',
+					content: 'Error saving',
+					status: 'error',
+				},
+			};
+			const state = notices( originalState, {
+				type: 'CREATE_NOTICE',
+				notice: {
+					id: 'a',
+					content: 'Post saved',
+					status: 'success',
+				},
+			} );
+			expect( state ).to.eql( {
+				b: originalState.b,
+				a: {
+					id: 'a',
+					content: 'Post saved',
+					status: 'success',
+				},
+			} );
+		} );
+
+		it( 'should remove a notice', () => {
+			const originalState = {
+				a: {
+					id: 'a',
+					content: 'Post saved',
+					status: 'success',
+				},
+				b: {
+					id: 'b',
+					content: 'Error saving',
+					status: 'error',
+				},
+			};
+			const state = notices( originalState, {
+				type: 'REMOVE_NOTICE',
+				noticeId: 'a',
+			} );
+			expect( state ).to.eql( {
+				b: originalState.b,
+			} );
+		} );
+	} );
+
 	describe( 'createReduxStore()', () => {
 		it( 'should return a redux store', () => {
 			const store = createReduxStore();
@@ -1001,6 +1052,7 @@ describe( 'state', () => {
 				'isSidebarOpened',
 				'saving',
 				'showInsertionPoint',
+				'notices',
 			] );
 		} );
 	} );


### PR DESCRIPTION
refs #967 

This PR adds the notices "framework", I mean it answers these questions:

 - How to trigger a notice
 - Where do these notices show up
 - Provide reusable notices components
 - Dismiss notices

For this, I've implemented a "Post save success" and "Saving failed" notices, but don't take too much attention to the business logic. Showing more specific "Post published", "Post scheduled"... notices is left for a follow-up PR.

<img width="936" alt="screen shot 2017-06-26 at 11 49 20" src="https://user-images.githubusercontent.com/272444/27536237-3444b9d8-5a66-11e7-95d0-0db76c2958a7.png">


This probably needs some design/responsiveness polish. Feel free to polish :)