### PR TITLE
Add checked attribute to FormToggle.

### DIFF
--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -28,6 +28,7 @@ function FormToggle( { className, checked, id, onChange = noop, showHint = true 
 				id={ id }
 				type="checkbox"
 				value={ checked }
+				checked={ checked }
 				onChange={ onChange }
 			/>
 			{ showHint &&

--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -27,7 +27,6 @@ function FormToggle( { className, checked, id, onChange = noop, showHint = true 
 				className="components-form-toggle__input"
 				id={ id }
 				type="checkbox"
-				value={ checked }
 				checked={ checked }
 				onChange={ onChange }
 			/>

--- a/components/form-toggle/test/index.js
+++ b/components/form-toggle/test/index.js
@@ -17,7 +17,6 @@ describe( 'FormToggle', () => {
 			expect( formToggle.hasClass( 'components-form-toggle' ) ).to.be.true();
 			expect( formToggle.hasClass( 'is-checked' ) ).to.be.false();
 			expect( formToggle.type() ).to.equal( 'span' );
-			expect( formToggle.find( '.components-form-toggle__input' ).prop( 'value' ) ).to.be.undefined();
 			expect( formToggle.find( '.components-form-toggle__hint' ).text() ).to.equal( 'Off' );
 			expect( formToggle.find( '.components-form-toggle__hint' ).prop( 'aria-hidden' ) ).to.be.true();
 		} );
@@ -25,7 +24,6 @@ describe( 'FormToggle', () => {
 		it( 'should render a checked checkbox and change the accessability text to On when providing checked prop', () => {
 			const formToggle = shallow( <FormToggle checked /> );
 			expect( formToggle.hasClass( 'is-checked' ) ).to.be.true();
-			expect( formToggle.find( '.components-form-toggle__input' ).prop( 'value' ) ).to.be.true();
 			expect( formToggle.find( '.components-form-toggle__hint' ).text() ).to.equal( 'On' );
 		} );
 

--- a/components/form-toggle/test/index.js
+++ b/components/form-toggle/test/index.js
@@ -17,13 +17,15 @@ describe( 'FormToggle', () => {
 			expect( formToggle.hasClass( 'components-form-toggle' ) ).to.be.true();
 			expect( formToggle.hasClass( 'is-checked' ) ).to.be.false();
 			expect( formToggle.type() ).to.equal( 'span' );
+			expect( formToggle.find( '.components-form-toggle__input' ).prop( 'checked' ) ).to.be.undefined();
 			expect( formToggle.find( '.components-form-toggle__hint' ).text() ).to.equal( 'Off' );
 			expect( formToggle.find( '.components-form-toggle__hint' ).prop( 'aria-hidden' ) ).to.be.true();
 		} );
 
-		it( 'should render a checked checkbox and change the accessability text to On when providing checked prop', () => {
+		it( 'should render a checked checkbox and change the accessibility text to On when providing checked prop', () => {
 			const formToggle = shallow( <FormToggle checked /> );
 			expect( formToggle.hasClass( 'is-checked' ) ).to.be.true();
+			expect( formToggle.find( '.components-form-toggle__input' ).prop( 'checked' ) ).to.be.true();
 			expect( formToggle.find( '.components-form-toggle__hint' ).text() ).to.equal( 'On' );
 		} );
 


### PR DESCRIPTION
Looks like screen readers, and presumably also other software, rely on the `checked` attribute to correctly announce the  checkboxes state. Please refer to the screenshots on the issue.

To test:
- use Safari + VoiceOver (or Firefox+NVDA, IE11+JAWS on Windows)
- focus the "Pending review" toggle, verify its state is reported correctly
- change the toggle state using Spacebar, verify each time its state is reported correctly
- repeat the previous steps on the 2 Discussions toggles (allow comments and pingbacks)

Fixes #1435 