### PR TITLE
Clean up empty links placeholders

### DIFF
--- a/blocks/editable/format-toolbar.js
+++ b/blocks/editable/format-toolbar.js
@@ -31,7 +31,7 @@ class FormatToolbar extends Component {
 	constructor( props ) {
 		super( ...arguments );
 		this.state = {
-			linkValue: props.formats.link ? props.formats.link.value : '',
+			linkValue: props.formats.link,
 			isEditingLink: false,
 		};
 		this.addLink = this.addLink.bind( this );
@@ -64,15 +64,21 @@ class FormatToolbar extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		const newState = {
-			linkValue: nextProps.formats.link ? nextProps.formats.link.value : '',
+			linkValue: nextProps.formats.link,
 		};
+
 		if (
-			! this.props.formats.link ||
-			! nextProps.formats.link ||
-			this.props.formats.link.node !== nextProps.formats.link.node
+			nextProps.formats.link !== '#' &&
+			this.props.formats.link !== nextProps.formats.link
 		) {
 			newState.isEditingLink = false;
+
+			// Clean up link placeholders.
+			if ( ! nextProps.formats.link ) {
+				this.props.onChange( { link: undefined } );
+			}
 		}
+
 		this.setState( newState );
 	}
 
@@ -86,10 +92,8 @@ class FormatToolbar extends Component {
 
 	addLink() {
 		if ( ! this.props.formats.link ) {
-			this.props.onChange( { link: { value: '' } } );
-
-			// Debounce the call to avoid the reset in willReceiveProps
-			this.editTimeout = setTimeout( () => this.setState( { isEditingLink: true } ) );
+			this.props.onChange( { link: '#' } );
+			this.setState( { isEditingLink: true } );
 		}
 	}
 
@@ -106,7 +110,7 @@ class FormatToolbar extends Component {
 
 	submitLink( event ) {
 		event.preventDefault();
-		this.props.onChange( { link: { value: this.state.linkValue } } );
+		this.props.onChange( { link: this.state.linkValue } );
 		this.setState( {
 			isEditingLink: false,
 		} );
@@ -141,12 +145,14 @@ class FormatToolbar extends Component {
 			} );
 		}
 
+		const isEditingLink = this.state.isEditingLink || this.state.linkValue === '#';
+
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<div className="editable-format-toolbar">
 				<Toolbar controls={ toolbarControls } />
 
-				{ !! formats.link && this.state.isEditingLink &&
+				{ !! formats.link && isEditingLink &&
 					<form
 						className="editable-format-toolbar__link-modal"
 						style={ linkStyle }
@@ -156,7 +162,7 @@ class FormatToolbar extends Component {
 							className="editable-format-toolbar__link-input"
 							type="url"
 							required
-							value={ this.state.linkValue }
+							value={ this.state.linkValue === '#' ? '' : this.state.linkValue }
 							onChange={ this.updateLinkValue }
 							placeholder={ __( 'Paste URL or type' ) }
 						/>
@@ -165,7 +171,7 @@ class FormatToolbar extends Component {
 					</form>
 				}
 
-				{ !! formats.link && ! this.state.isEditingLink &&
+				{ !! formats.link && ! isEditingLink &&
 					<div className="editable-format-toolbar__link-modal" style={ linkStyle }>
 						<a className="editable-format-toolbar__link-value" href="" onClick={ this.editLink }>
 							{ this.state.linkValue && decodeURI( this.state.linkValue ) }

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -318,16 +318,15 @@ export default class Editable extends Component {
 	}
 
 	onNodeChange( { element, parents } ) {
-		const formats = {};
-		const link = find( parents, ( node ) => node.nodeName.toLowerCase() === 'a' );
-		if ( link ) {
-			formats.link = { value: link.getAttribute( 'href' ) || '', link };
-		}
-		const activeFormats = this.editor.formatter.matchAll( [	'bold', 'italic', 'strikethrough' ] );
-		activeFormats.forEach( ( activeFormat ) => formats[ activeFormat ] = true );
-
 		const focusPosition = this.getRelativePosition( element );
 		const bookmark = this.editor.selection.getBookmark( 2, true );
+		const link = find( parents, ( node ) => node.nodeName === 'A' );
+		const formats = this.editor.formatter
+			.matchAll( [ 'bold', 'italic', 'strikethrough' ] )
+			.reduce( ( acc, format ) => ( { acc, [ format ]: true } ), {} );
+
+		formats.link = link ? link.getAttribute( 'href' ) || '' : '';
+
 		this.setState( { bookmark, formats, focusPosition } );
 	}
 
@@ -405,23 +404,29 @@ export default class Editable extends Component {
 		}
 
 		forEach( formats, ( formatValue, format ) => {
+			const isActive = this.isFormatActive( format );
+			const editor = this.editor;
+
 			if ( format === 'link' ) {
-				if ( formatValue !== undefined ) {
-					const anchor = this.editor.dom.getParent( this.editor.selection.getNode(), 'a' );
-					if ( ! anchor ) {
-						this.editor.formatter.remove( 'link' );
+				if ( ! formatValue ) {
+					if ( isActive ) {
+						editor.execCommand( 'Unlink' );
+					} else {
+						// Clean up link placeholders.
+						editor.$( 'a' ).each( function( i, element ) {
+							if ( element.getAttribute( 'href' ) === '#' ) {
+								editor.dom.remove( element, true );
+							}
+						} );
 					}
-					this.editor.formatter.apply( 'link', { href: formatValue.value }, anchor );
 				} else {
-					this.editor.execCommand( 'Unlink' );
+					const anchor = this.editor.dom.getParent( this.editor.selection.getNode(), 'a' );
+					this.editor.formatter.apply( 'link', { href: formatValue }, anchor );
 				}
-			} else {
-				const isActive = this.isFormatActive( format );
-				if ( isActive && ! formatValue ) {
-					this.editor.formatter.remove( format );
-				} else if ( ! isActive && formatValue ) {
-					this.editor.formatter.apply( format );
-				}
+			} else if ( isActive && ! formatValue ) {
+				this.editor.formatter.remove( format );
+			} else if ( ! isActive && formatValue ) {
+				this.editor.formatter.apply( format );
 			}
 		} );
 


### PR DESCRIPTION
* After dismissing the link dialog and not entering a link, clean up the placeholder.
* ~~Fix errors on link input: #680.~~ Fixed in 00c9bbeb7d43bcd7b5c21fc07e65bedb127916c5.
* Avoid passing link node through formats.