### PR TITLE
Add advanced alignment to inspector

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -93,18 +93,29 @@ registerBlockType( 'core/heading', {
 
 		return [
 			focus && (
-				<BlockControls
-					key="controls"
-					controls={
-						'234'.split( '' ).map( ( level ) => ( {
-							icon: 'heading',
-							title: sprintf( __( 'Heading %s' ), level ),
-							isActive: 'H' + level === nodeName,
-							onClick: () => setAttributes( { nodeName: 'H' + level } ),
-							subscript: level,
-						} ) )
-					}
-				/>
+				<BlockControls key="controls">
+					<Toolbar
+						controls={ [ {
+							icon: 'editor-aligncenter',
+							title: __( 'Align center' ),
+							isActive: align === 'center',
+							onClick: () => setAttributes( {
+								align: align === 'center' ? null : 'center',
+							} ),
+						} ] }
+					/>
+					<Toolbar
+						controls={
+							'234'.split( '' ).map( ( level ) => ( {
+								icon: 'heading',
+								title: sprintf( __( 'Heading %s' ), level ),
+								isActive: 'H' + level === nodeName,
+								onClick: () => setAttributes( { nodeName: 'H' + level } ),
+								subscript: level,
+							} ) )
+						}
+					/>
+				</BlockControls>
 			),
 			focus && (
 				<InspectorControls key="inspector">

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -14,6 +14,7 @@ import { registerBlockType, createBlock, query as hpq } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import Editable from '../../editable';
+import InspectorControls from '../../inspector-controls';
 
 const { children, query } = hpq;
 
@@ -90,6 +91,16 @@ registerBlockType( 'core/quote', {
 		return [
 			focus && (
 				<BlockControls key="controls">
+					<Toolbar
+						controls={ [ {
+							icon: 'editor-aligncenter',
+							title: __( 'Align center' ),
+							isActive: align === 'center',
+							onClick: () => setAttributes( {
+								align: align === 'center' ? null : 'center',
+							} ),
+						} ] }
+					/>
 					<Toolbar controls={ [ 1, 2 ].map( ( variation ) => ( {
 						icon: 'format-quote',
 						title: sprintf( __( 'Quote style %d' ), variation ),
@@ -99,13 +110,18 @@ registerBlockType( 'core/quote', {
 						},
 						subscript: variation,
 					} ) ) } />
+				</BlockControls>
+			),
+			focus && (
+				<InspectorControls key="inspector">
+					<h3>{ __( 'Text Alignment' ) }</h3>
 					<AlignmentToolbar
 						value={ align }
 						onChange={ ( nextAlign ) => {
 							setAttributes( { align: nextAlign } );
 						} }
 					/>
-				</BlockControls>
+				</InspectorControls>
 			),
 			<blockquote
 				key="quote"

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from 'i18n';
 import { concatChildren } from 'element';
+import { Toolbar } from 'components';
 
 /**
  * Internal dependencies
@@ -41,11 +42,15 @@ registerBlockType( 'core/text', {
 		return [
 			focus && (
 				<BlockControls key="controls">
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
+					<Toolbar
+						controls={ [ {
+							icon: 'editor-aligncenter',
+							title: __( 'Align center' ),
+							isActive: align === 'center',
+							onClick: () => setAttributes( {
+								align: align === 'center' ? null : 'center',
+							} ),
+						} ] }
 					/>
 				</BlockControls>
 			),
@@ -55,6 +60,13 @@ registerBlockType( 'core/text', {
 						label={ __( 'Drop Cap' ) }
 						checked={ !! dropCap }
 						onChange={ toggleDropCap }
+					/>
+					<h3>{ __( 'Text Alignment' ) }</h3>
+					<AlignmentToolbar
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
 					/>
 				</InspectorControls>
 			),


### PR DESCRIPTION
Alternatively I can remove the centre alignment from the inline toolbars as well. I'm fine with either.