### PR TITLE
Chrome: Fix the inspector breadcrumb label

### DIFF
--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -33,7 +33,7 @@ const BlockInspector = ( { selectedBlock, ...props } ) => {
 	const header = (
 		<strong>
 			<a href="" onClick={ onDeselect } className="editor-block-inspector__deselect-post">
-				{ __( 'Post' ) }
+				{ __( 'Post Settings' ) }
 			</a>
 			{ ' → ' }
 			{ blockType.title }


### PR DESCRIPTION
"Post Settings" instead of "Post"

closes #1429