### PR TITLE
Text Block: Adding a placeholder

### DIFF
--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -79,6 +79,7 @@ registerBlockType( 'core/text', {
 				onMerge={ mergeBlocks }
 				style={ { textAlign: align } }
 				className={ `drop-cap-${ dropCap }` }
+				placeholder={ __( 'Write…' ) }
 			/>,
 		];
 	},

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -210,7 +210,7 @@ class VisualEditorBlockList extends Component {
 					type="text"
 					readOnly
 					className="editor-visual-editor__placeholder"
-					value={ ! blocks.length ? __( 'Write your story.' ) : __( 'Write…' ) }
+					value={ ! blocks.length ? __( 'Write your story.' ) : __( 'Continue writing…' ) }
 					onFocus={ ! blocks.length ? this.appendDefaultBlock : noop }
 					onClick={ !! blocks.length ? this.appendDefaultBlock : noop }
 					onKeyDown={ !! blocks.length ? this.onPlaceholderKeyDown : noop }


### PR DESCRIPTION
Clarifies the placeholders issue by following the pattern proposed here: https://github.com/WordPress/gutenberg/issues/1181#issuecomment-310069918

 - Renaming the end of post placeholder "Continue writing"
 - Adding a placeholder "Write" to all text blocks.

The placeholder colors should be addressed in #1439

Thoughts? I think I like it personally, it helps to surface empty texts.