### PR TITLE
Image Block: Adding an edit image button for the image and cover image blocks

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Placeholder } from 'components';
+import { Placeholder, Toolbar, Dashicon } from 'components';
 import { __ } from 'i18n';
 
 /**
@@ -37,8 +37,10 @@ registerBlockType( 'core/cover-image', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
-		const { url, title, align } = attributes;
+		const { url, title, align, id } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
+		const onSelectImage = ( media ) => setAttributes( { url: media.url, id: media.id } );
+
 		const controls = (
 			focus && (
 				<BlockControls key="controls">
@@ -47,13 +49,25 @@ registerBlockType( 'core/cover-image', {
 						onChange={ updateAlignment }
 						controls={ validAlignments }
 					/>
+
+					<Toolbar>
+						<li>
+							<MediaUploadButton
+								buttonProps={ { className: 'components-icon-button components-toolbar__control' } }
+								onSelect={ onSelectImage }
+								type="image"
+								value={ id }
+							>
+								<Dashicon icon="format-image" />
+							</MediaUploadButton>
+						</li>
+					</Toolbar>
 				</BlockControls>
 			)
 		);
 
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
-			const setMediaUrl = ( media ) => setAttributes( { url: media.url } );
 			return [
 				controls,
 				<Placeholder
@@ -64,7 +78,7 @@ registerBlockType( 'core/cover-image', {
 					className="blocks-image">
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }
-						onSelect={ setMediaUrl }
+						onSelect={ onSelectImage }
 						type="image"
 						autoOpen
 					>

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -58,7 +58,7 @@ registerBlockType( 'core/cover-image', {
 								type="image"
 								value={ id }
 							>
-								<Dashicon icon="format-image" />
+								<Dashicon icon="edit" />
 							</MediaUploadButton>
 						</li>
 					</Toolbar>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Placeholder } from 'components';
+import { Placeholder, Dashicon, Toolbar } from 'components';
 
 /**
  * Internal dependencies
@@ -39,9 +39,13 @@ registerBlockType( 'core/image', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus } ) {
-		const { url, alt, caption, align } = attributes;
+		const { url, alt, caption, align, id } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
+		const onSelectImage = ( media ) => {
+			setAttributes( { url: media.url, alt: media.alt, caption: media.caption, id: media.id } );
+		};
+		const uploadButtonProps = { isLarge: true };
 
 		const controls = (
 			focus && (
@@ -51,15 +55,24 @@ registerBlockType( 'core/image', {
 						onChange={ updateAlignment }
 						controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
 					/>
+
+					<Toolbar>
+						<li>
+							<MediaUploadButton
+								buttonProps={ { className: 'components-icon-button components-toolbar__control' } }
+								onSelect={ onSelectImage }
+								type="image"
+								value={ id }
+							>
+								<Dashicon icon="format-image" />
+							</MediaUploadButton>
+						</li>
+					</Toolbar>
 				</BlockControls>
 			)
 		);
 
 		if ( ! url ) {
-			const uploadButtonProps = { isLarge: true };
-			const onSelectImage = ( media ) => {
-				setAttributes( { url: media.url, alt: media.alt, caption: media.caption } );
-			};
 			return [
 				controls,
 				<Placeholder
@@ -71,7 +84,7 @@ registerBlockType( 'core/image', {
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }
 						onSelect={ onSelectImage }
-						type="image"
+						type="format-image"
 						autoOpen
 					>
 						{ __( 'Insert from Media Library' ) }

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -64,7 +64,7 @@ registerBlockType( 'core/image', {
 								type="image"
 								value={ id }
 							>
-								<Dashicon icon="format-image" />
+								<Dashicon icon="edit" />
 							</MediaUploadButton>
 						</li>
 					</Toolbar>

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -10,6 +10,7 @@ class MediaUploadButton extends Component {
 		super( ...arguments );
 		this.openModal = this.openModal.bind( this );
 		this.onSelect = this.onSelect.bind( this );
+		this.onOpen = this.onOpen.bind( this );
 		const frameConfig = {
 			title: __( 'Select or Upload a media' ),
 			button: {
@@ -24,6 +25,7 @@ class MediaUploadButton extends Component {
 
 		// When an image is selected in the media frame...
 		this.frame.on( 'select', this.onSelect );
+		this.frame.on( 'open', this.onOpen );
 	}
 
 	componentDidMount() {
@@ -41,6 +43,25 @@ class MediaUploadButton extends Component {
 		// Get media attachment details from the frame state
 		const attachment = this.frame.state().get( 'selection' ).toJSON();
 		onSelect( multiple ? attachment : attachment[ 0 ] );
+	}
+
+	onOpen() {
+		const selection = this.frame.state().get( 'selection' );
+		const addMedia = ( id ) => {
+			const attachment = wp.media.attachment( id );
+			attachment.fetch();
+			selection.add( attachment );
+		};
+
+		if ( ! this.props.value ) {
+			return;
+		}
+
+		if ( this.props.multiple ) {
+			this.props.value.map( addMedia );
+		} else {
+			addMedia( this.props.value );
+		}
 	}
 
 	openModal() {

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -9,8 +9,11 @@ import classNames from 'classnames';
 import './style.scss';
 import IconButton from '../icon-button';
 
-function Toolbar( { controls, focus } ) {
-	if ( ! controls || ! controls.length ) {
+function Toolbar( { controls = [], children } ) {
+	if (
+		( ! controls || ! controls.length ) &&
+		! children
+	) {
 		return null;
 	}
 
@@ -41,13 +44,13 @@ function Toolbar( { controls, focus } ) {
 								'is-active': control.isActive,
 							} ) }
 							aria-pressed={ control.isActive }
-							focus={ focus && setIndex === 0 && controlIndex === 0 }
 							disabled={ control.isDisabled }
 						/>
 						{ control.children }
 					</li>
 				) ),
 			], [] ) }
+			{ children }
 		</ul>
 	);
 }

--- a/components/toolbar/test/index.js
+++ b/components/toolbar/test/index.js
@@ -42,7 +42,6 @@ describe( 'Toolbar', () => {
 				'data-subscript': 'wp',
 				'aria-pressed': false,
 				className: 'components-toolbar__control',
-				focus: undefined,
 			} );
 		} );
 
@@ -100,20 +99,6 @@ describe( 'Toolbar', () => {
 			listItem.simulate( 'click', event );
 			expect( clickHandler ).to.have.been.calledOnce();
 			expect( clickHandler ).to.have.been.calledWith();
-		} );
-
-		it( 'should have a focus property of true.', () => {
-			const controls = [
-				{
-					icon: 'wordpress',
-					title: 'WordPress',
-					subscript: 'wp',
-					isActive: true,
-				},
-			];
-			const toolbar = shallow( <Toolbar controls={ controls } focus={ true } /> );
-			const listItem = toolbar.find( 'IconButton' );
-			expect( listItem.prop( 'focus' ) ).to.be.true();
 		} );
 	} );
 } );


### PR DESCRIPTION
closes #1412 

 - Adding a "value" prop for the MediaUploadButton component
 - Adding the edit image control to the cover image and image blocks.
 - Storing the image id in the image block metadata (same for cover)
 - Dropping unused focus prop from the Toolbar component