### PR TITLE
Add pagination block

### DIFF
--- a/blocks/api/raw-handling/special-comment-converter.js
+++ b/blocks/api/raw-handling/special-comment-converter.js
@@ -9,9 +9,9 @@ import { remove, replace } from '@wordpress/utils';
 const { COMMENT_NODE } = window.Node;
 
 /**
- * Looks for `<!--more-->` comments, as well as the `<!--more Some text-->`
- * variant and its `<!--noteaser-->` companion, and replaces them with a custom
- * element representing a future block.
+ * Looks for `<!--nextpage-->` and `<!--more-->` comments, as well as the
+ * `<!--more Some text-->` variant and its `<!--noteaser-->` companion,
+ * and replaces them with a custom element representing a future block.
  *
  * The custom element is a way to bypass the rest of the `raw-handling`
  * transforms, which would eliminate other kinds of node with which to carry
@@ -24,43 +24,39 @@ const { COMMENT_NODE } = window.Node;
  * @return {void}
  */
 export default function( node ) {
-	if (
-		node.nodeType !== COMMENT_NODE ||
-		node.nodeValue.indexOf( 'more' ) !== 0
-	) {
-		// We don't specificially look for `noteaser`, meaning that if one is
-		// found on its own (and not adjacent to `more`), it will be lost.
+	if ( node.nodeType !== COMMENT_NODE ) {
 		return;
 	}
 
-	// Grab any custom text in the comment
-	const customText = node.nodeValue.slice( 4 ).trim();
+	if ( node.nodeValue === 'nextpage' ) {
+		replace( node, createNextpage() );
+		return;
+	}
 
-	// When a `<!--more-->` comment is found, we need to look for any
-	// `<!--noteaser-->` sibling, but it may not be a direct sibling
-	// (whitespace typically lies in between)
-	let sibling = node;
-	let noTeaser = false;
-	while ( ( sibling = sibling.nextSibling ) ) {
-		if (
-			sibling.nodeType === COMMENT_NODE &&
-			sibling.nodeValue === 'noteaser'
-		) {
-			noTeaser = true;
-			remove( sibling );
-			break;
+	if ( node.nodeValue.indexOf( 'more' ) === 0 ) {
+		// Grab any custom text in the comment.
+		const customText = node.nodeValue.slice( 4 ).trim();
+
+		/*
+		 * When a `<!--more-->` comment is found, we need to look for any
+		 * `<!--noteaser-->` sibling, but it may not be a direct sibling
+		 * (whitespace typically lies in between)
+		 */
+		let sibling = node;
+		let noTeaser = false;
+		while ( ( sibling = sibling.nextSibling ) ) {
+			if (
+				sibling.nodeType === COMMENT_NODE &&
+				sibling.nodeValue === 'noteaser'
+			) {
+				noTeaser = true;
+				remove( sibling );
+				break;
+			}
 		}
-	}
 
-	// Conjure up a custom More element
-	const more = createMore( customText, noTeaser );
-
-	// Append it to the top level for later conversion to blocks
-	let parent = node.parentNode;
-	while ( parent.nodeName !== 'BODY' ) {
-		parent = parent.parentNode;
+		replace( node, createMore( customText, noTeaser ) );
 	}
-	replace( node, more );
 }
 
 function createMore( customText, noTeaser ) {
@@ -73,5 +69,12 @@ function createMore( customText, noTeaser ) {
 		// "Boolean" data attribute
 		node.dataset.noTeaser = '';
 	}
+	return node;
+}
+
+function createNextpage() {
+	const node = document.createElement( 'wp-block' );
+	node.dataset.block = 'core/nextpage';
+
 	return node;
 }

--- a/blocks/api/raw-handling/test/special-comment-converter.js
+++ b/blocks/api/raw-handling/test/special-comment-converter.js
@@ -10,13 +10,19 @@ import specialCommentConverter from '../special-comment-converter';
 import { deepFilterHTML } from '../utils';
 
 describe( 'specialCommentConverter', () => {
-	it( 'should convert a single comment into a basic block', () => {
+	it( 'should convert a single "more" comment into a basic block', () => {
 		equal(
 			deepFilterHTML(
 				'<p><!--more--></p>',
 				[ specialCommentConverter ]
 			),
 			'<p></p><wp-block data-block="core/more"></wp-block>'
+		);
+	} );
+	it( 'should convert a single "nextpage" comment into a basic block', () => {
+		equal(
+			deepFilterHTML( '<p><!--nextpage--></p>', [ specialCommentConverter ] ),
+			'<p></p><wp-block data-block="core/nextpage"></wp-block>'
 		);
 	} );
 	it( 'should convert two comments into a block', () => {
@@ -77,6 +83,24 @@ describe( 'specialCommentConverter', () => {
 				<p></p><wp-block data-block=\"core/more\"></wp-block>
 				<p>Second paragraph</p>
 				<p>Third paragraph</p>`
+			);
+		} );
+		it( 'should not break pagination order', () => {
+			const output = deepFilterHTML(
+				`<p>First page.</p>
+				<p><!--nextpage--></p>
+				<p>Second page</p>
+				<p><!--nextpage--></p>
+				<p>Third page</p>`,
+				[ specialCommentConverter ]
+			);
+			equal(
+				output,
+				`<p>First page.</p>
+				<p></p><wp-block data-block=\"core/nextpage\"></wp-block>
+				<p>Second page</p>
+				<p></p><wp-block data-block=\"core/nextpage\"></wp-block>
+				<p>Third page</p>`
 			);
 		} );
 	} );

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -23,6 +23,7 @@ import * as html from './html';
 import * as latestPosts from './latest-posts';
 import * as list from './list';
 import * as more from './more';
+import * as nextpage from './nextpage';
 import * as preformatted from './preformatted';
 import * as pullquote from './pullquote';
 import * as sharedBlock from './block';
@@ -60,6 +61,7 @@ export const registerCoreBlocks = () => {
 		html,
 		latestPosts,
 		more,
+		nextpage,
 		preformatted,
 		pullquote,
 		separator,

--- a/blocks/library/nextpage/editor.scss
+++ b/blocks/library/nextpage/editor.scss
@@ -1,0 +1,40 @@
+.editor-visual-editor__block[data-type="core/nextpage"] {
+	max-width: 100%;
+}
+
+.wp-block-nextpage {
+	display: block;
+	text-align: center;
+	overflow: hidden;
+	white-space: nowrap;
+}
+
+.wp-block-nextpage > span {
+	position: relative;
+	display: inline-block;
+	font-size: 12px;
+	text-transform: uppercase;
+	font-weight: 600;
+	font-family: $default-font;
+	color: $dark-gray-300;
+}
+
+.wp-block-nextpage > span:before,
+.wp-block-nextpage > span:after {
+	content: '';
+	position: absolute;
+	top: 50%;
+	width: 100vw;
+	border-top: 3px dashed $light-gray-700;
+	margin-top: -2px;
+}
+
+.wp-block-nextpage > span:before {
+	right: 100%;
+	margin-right: 20px;
+}
+
+.wp-block-nextpage > span:after {
+	left: 100%;
+	margin-left: 20px;
+}

--- a/blocks/library/nextpage/index.js
+++ b/blocks/library/nextpage/index.js
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { RawHTML } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import { createBlock } from '../../api';
+
+export const name = 'core/nextpage';
+
+export const settings = {
+	title: __( 'Page break' ),
+
+	description: __( 'This block allows you to set break points on your post. Visitors of your blog are then presented with content split into multiple pages.' ),
+
+	icon: 'admin-page',
+
+	category: 'layout',
+
+	keywords: [ __( 'next page' ), __( 'pagination' ) ],
+
+	supports: {
+		customClassName: false,
+		className: false,
+		html: false,
+	},
+
+	attributes: {},
+
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				isMatch: ( node ) => node.dataset && node.dataset.block === 'core/nextpage',
+				transform() {
+					return createBlock( 'core/nextpage', {} );
+				},
+			},
+		],
+	},
+
+	edit() {
+		return (
+			<div className="wp-block-nextpage">
+				<span>{ __( 'Page break' ) }</span>
+			</div>
+		);
+	},
+
+	save() {
+		return (
+			<RawHTML>
+				{ '<!--nextpage-->' }
+			</RawHTML>
+		);
+	},
+};

--- a/blocks/library/nextpage/test/__snapshots__/index.js.snap
+++ b/blocks/library/nextpage/test/__snapshots__/index.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/nextpage block edit matches snapshot 1`] = `
+<div
+  class="wp-block-nextpage"
+>
+  <span>
+    Page break
+  </span>
+</div>
+`;

--- a/blocks/library/nextpage/test/index.js
+++ b/blocks/library/nextpage/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { name, settings } from '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/nextpage', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( name, settings );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/test/fixtures/core__nextpage.html
+++ b/blocks/test/fixtures/core__nextpage.html
@@ -1,0 +1,3 @@
+<!-- wp:core/nextpage -->
+<!--nextpage-->
+<!-- /wp:core/nextpage -->

--- a/blocks/test/fixtures/core__nextpage.json
+++ b/blocks/test/fixtures/core__nextpage.json
@@ -1,0 +1,10 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/nextpage",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [],
+        "originalContent": "<!--nextpage-->"
+    }
+]

--- a/blocks/test/fixtures/core__nextpage.parsed.json
+++ b/blocks/test/fixtures/core__nextpage.parsed.json
@@ -1,0 +1,12 @@
+[
+    {
+        "blockName": "core/nextpage",
+        "attrs": null,
+        "innerBlocks": [],
+        "innerHTML": "\n<!--nextpage-->\n"
+    },
+    {
+        "attrs": {},
+        "innerHTML": "\n"
+    }
+]

--- a/blocks/test/fixtures/core__nextpage.serialized.html
+++ b/blocks/test/fixtures/core__nextpage.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:nextpage -->
+<!--nextpage-->
+<!-- /wp:nextpage -->


### PR DESCRIPTION
#1440 and #1460 inspired me to add a new block to support `<!--nextpage-->` in Gutenberg.

See #1328.

This PR does:

* add a new core/nextpage block
* update `special-comment-converter.js` to turn `<!--nexpage-->` into that new block
* add tests

Screenshots:

<img width="970" alt="screen shot 2017-06-26 at 21 46 53" src="https://user-images.githubusercontent.com/841956/27557497-1d9b0508-5aba-11e7-972a-5a1d9f665876.png">
<img width="337" alt="screen shot 2017-06-26 at 21 47 04" src="https://user-images.githubusercontent.com/841956/27557498-1dc066cc-5aba-11e7-9c8d-ce8fbd91bcc9.png">
<img width="267" alt="screen shot 2017-06-26 at 21 47 16" src="https://user-images.githubusercontent.com/841956/27557499-1dc290c8-5aba-11e7-9484-2919b4581915.png">
