### PR TITLE
Fix undefined drop-cap class

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -50,7 +50,7 @@
 	}
 }
 
-.drop-cap-true .blocks-editable__tinymce:not( :focus )  {
+.drop-cap .blocks-editable__tinymce:not( :focus )  {
 	&:first-letter {
 		float: left;
 		font-size: 4.1em;
@@ -63,7 +63,7 @@
 	}
 }
 
-.drop-cap-true:not( :focus )  {
+.drop-cap:not( :focus )  {
 	overflow: hidden;
 }
 

--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -50,7 +50,7 @@
 	}
 }
 
-.drop-cap .blocks-editable__tinymce:not( :focus )  {
+.has-drop-cap .blocks-editable__tinymce:not( :focus )  {
 	&:first-letter {
 		float: left;
 		font-size: 4.1em;
@@ -63,7 +63,7 @@
 	}
 }
 
-.drop-cap:not( :focus )  {
+.has-drop-cap:not( :focus )  {
 	overflow: hidden;
 }
 

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -78,7 +78,7 @@ registerBlockType( 'core/text', {
 				} }
 				onMerge={ mergeBlocks }
 				style={ { textAlign: align } }
-				className={ `drop-cap-${ dropCap }` }
+				className={ dropCap && 'drop-cap' }
 				placeholder={ __( 'Write…' ) }
 			/>,
 		];

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -78,7 +78,7 @@ registerBlockType( 'core/text', {
 				} }
 				onMerge={ mergeBlocks }
 				style={ { textAlign: align } }
-				className={ dropCap && 'drop-cap' }
+				className={ dropCap && 'has-drop-cap' }
 				placeholder={ __( 'Write…' ) }
 			/>,
 		];


### PR DESCRIPTION
Right now when adding a new text block, it gets a `drop-cap-undefined` class because `dropCap` is not defined in the block (instead of `drop-cap-false` I guess). If the drop cap toggle is turned on, there will be a `drop-cap-true` class. 

It makes more sense to only add a `drop-cap` class if it's enabled and don't do anything else otherwise. You can target non-drop-cap blocks using the `:not()` CSS selector already.

Plus, `drop-cap` is more readable than `drop-cap-false` and `drop-cap-true`.