### PR TITLE
Fixes #1472: Block mover isn't clickable

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -10,6 +10,7 @@ $z-layers: (
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
+	'.editor-block-mover': 30,
 	'.components-popover': 100000,
 );
 

--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -3,8 +3,8 @@
 	top: 10px;
 	left: 0;
 	padding: 0 14px 20px 0; // handles hover area
-	z-index: 100;
-	
+	z-index: z-index( '.editor-block-mover' );
+
 	// Mobile, to be revisited
 	display: none;
 

--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -3,7 +3,8 @@
 	top: 10px;
 	left: 0;
 	padding: 0 14px 20px 0; // handles hover area
-
+	z-index: 100;
+	
 	// Mobile, to be revisited
 	display: none;
 


### PR DESCRIPTION
When block goes behind an image that is left aligned, the image block covers block mover buttons so we can't move the block.