### PR TITLE
Polish sidebar headings, quote buttons and gallery margins

### DIFF
--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -3,9 +3,14 @@
 	display: flex;
 	flex-wrap: wrap;
 
+	&:not( .components-placeholder ) {
+		margin-right: -16px;
+		margin-bottom: -16px;	
+	}
+
 	.blocks-gallery-image {
 		flex-grow: 1;
-		margin: 8px;
+		margin: 0 16px 16px 0;
 
 		img {
 			max-width: 100%;

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -21,6 +21,10 @@
 	padding: $panel-padding;
 	border-top: 1px solid $light-gray-500;
 	border-bottom: 1px solid $light-gray-500;
+
+	h3 {
+		margin: 0 0 .5em 0;
+	}
 }
 
 .components-panel__header {
@@ -47,7 +51,7 @@
 	margin-top: -1px;
 }
 
-.components-panel__body-title {
+.components-panel .components-panel__body-title {
 	display: block;
 	padding: 0;
 	margin: 0;

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -105,7 +105,7 @@ ul.components-toolbar {
 		font-weight: bold;
 		position: relative;
 		top: -5px;
-		left: -12px;
+		left: -11px;
 	}
 }
 

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -31,8 +31,6 @@
 
 	h3 {
 		font-size: $default-font-size;
-		margin-top: 0;
-		margin-bottom: .5em;
 	}
 
 	ul.components-toolbar {


### PR DESCRIPTION
A few tiny things here. Sidebar headings were too big. This fixes it:

![screen shot 2017-06-27 at 10 45 52](https://user-images.githubusercontent.com/1204802/27578908-e2f1468a-5b25-11e7-9a2e-b2910bce44b2.png)

Quote style buttons were a little tight. It's better now:

![screen shot 2017-06-27 at 10 46 56](https://user-images.githubusercontent.com/1204802/27578935-0468df12-5b26-11e7-9cff-ca56f9caebd9.png)

Tweaked the margins of galleries. This lets them align vertically to content next to it:

![screen shot 2017-06-27 at 10 38 56](https://user-images.githubusercontent.com/1204802/27579024-5df2441a-5b26-11e7-9334-33d1865bf6ac.png)
