### PR TITLE
HTML Block: Fix parsing HTML blocks using `html` instead of `children`

### DIFF
--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -16,7 +16,7 @@ import './style.scss';
 import { registerBlockType, query } from '../../api';
 import BlockControls from '../../block-controls';
 
-const { children } = query;
+const { html } = query;
 
 registerBlockType( 'core/html', {
 	title: __( 'Custom HTML' ),
@@ -28,7 +28,7 @@ registerBlockType( 'core/html', {
 	className: false,
 
 	attributes: {
-		content: children(),
+		content: html(),
 	},
 
 	edit: class extends Component {

--- a/blocks/test/fixtures/core-html.json
+++ b/blocks/test/fixtures/core-html.json
@@ -3,17 +3,7 @@
         "uid": "_uid_0",
         "name": "core/html",
         "attributes": {
-            "content": [
-                {
-                    "children": "Some HTML code",
-                    "type": "h1"
-                },
-                "\n",
-                {
-                    "children": "This text will scroll from right to left",
-                    "type": "marquee"
-                }
-            ]
+            "content": "<h1>Some HTML code</h1>\n<marquee>This text will scroll from right to left</marquee>"
         }
     }
 ]


### PR DESCRIPTION
closes #1474 

This fixes saving and reloading a post containing an HTML block.
