### PR TITLE
Chrome: Load more than 10 tags/categories

### DIFF
--- a/components/form-token-field/README.md
+++ b/components/form-token-field/README.md
@@ -41,6 +41,7 @@ The `value` property is handled in a manner similar to controlled form component
   Otherwise the REST API won't save them.)
 - `onChange` - Function to call when the tokens have changed. An array of new
   tokens is passed to the callback.
+- `onInputChange` - Function to call when the users types in the input field. It can be used to trigger autocomplete requests.
 - `onFocus` - Function to call when the TokenField has been focused on. The event is passed to the callback. Useful for analytics.
 - `suggestions` - An array of strings to present to the user as suggested
   tokens.

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -187,6 +187,8 @@ class FormTokenField extends Component {
 			selectedSuggestionScroll: false,
 		} );
 
+		this.props.onInputChange( tokenValue );
+
 		const showMessage = tokenValue.trim().length > 1;
 		if ( showMessage ) {
 			const matchingSuggestions = this.getMatchingSuggestions( tokenValue );
@@ -555,6 +557,7 @@ FormTokenField.defaultProps = {
 	displayTransform: identity,
 	saveTransform: ( token ) => token.trim(),
 	onChange: () => {},
+	onInputChange: () => {},
 	isBorderless: false,
 	disabled: false,
 	tokenizeOnSpace: false,

--- a/editor/sidebar/post-taxonomies/categories-selector.js
+++ b/editor/sidebar/post-taxonomies/categories-selector.js
@@ -17,9 +17,9 @@ import { getEditedPostAttribute } from '../../selectors';
 import { editPost } from '../../actions';
 
 const DEFAULT_CATEGORIES_QUERY = {
-	per_page: -1,
+	per_page: 100,
 	orderby: 'count',
-	order: 'DESC',
+	order: 'desc',
 };
 
 class CategoriesSelector extends Component {
@@ -50,7 +50,8 @@ class CategoriesSelector extends Component {
 	}
 
 	componentDidMount() {
-		this.fetchCategoriesRequest = new wp.api.collections.Categories().fetch( DEFAULT_CATEGORIES_QUERY )
+		this.fetchCategoriesRequest = new wp.api.collections.Categories()
+			.fetch( { data: DEFAULT_CATEGORIES_QUERY } )
 			.done( ( categories ) => {
 				const availableCategories = this.buildCategoriesTree( categories );
 


### PR DESCRIPTION
closes #1338 #1431 

The REST API can't return all the tags/categories in one request, this makes writing selectors very hard. So here are the fixed proposed in this branch:

 - When loading the tags selector, trigger a request for the selected tags
 - When typing, trigger a throttled request with the search parameter
 - Load 100 categories

For the categories selector, we'd have to rewrite completely (maybe with virtual scroll, something like Calypso) to load paginated categories but I think this is sufficient for now.