### PR TITLE
Hide the "Continue writing" prompt if the last block is an empty text block

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -200,7 +200,7 @@ class VisualEditorBlockList extends Component {
 			hasTypedInLastBlock,
 			showInsertionPoint,
 			insertionPoint,
-			multiSelectedBlockUids
+			multiSelectedBlockUids,
 		} = this.props;
 		const insertionPointIndex = blockUids.indexOf( insertionPoint );
 		const blocksWithInsertionPoint = showInsertionPoint

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -21,6 +21,7 @@ import {
 	getBlock,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
+	hasTypedInSelectedBlock,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
 	getMultiSelectedBlocks,
@@ -196,6 +197,7 @@ class VisualEditorBlockList extends Component {
 		const {
 			blockUids,
 			lastBlock,
+			hasTypedInLastBlock,
 			showInsertionPoint,
 			insertionPoint,
 			multiSelectedBlockUids
@@ -212,7 +214,8 @@ class VisualEditorBlockList extends Component {
 		const showContinueWriting = (
 			! lastBlock ||
 			lastBlock.name !== getDefaultBlock() ||
-			!! lastBlock.attributes.content
+			!! lastBlock.attributes.content ||
+			hasTypedInLastBlock
 		);
 
 		return (
@@ -269,10 +272,16 @@ class VisualEditorBlockList extends Component {
 export default connect(
 	( state ) => {
 		const blockUids = getBlockUids( state );
+		const lastBlockUid = blockUids.length
+			? blockUids[ blockUids.length - 1 ]
+			: null;
 		return {
 			blockUids,
-			lastBlock: blockUids.length
-				? getBlock( state, blockUids[ blockUids.length - 1 ] )
+			lastBlock: lastBlockUid
+				? getBlock( state, lastBlockUid )
+				: null,
+			hasTypedInLastBlock: lastBlockUid
+				? hasTypedInSelectedBlock( state, lastBlockUid )
 				: null,
 			insertionPoint: getBlockInsertionPoint( state ),
 			showInsertionPoint: isBlockInsertionPointVisible( state ),

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -18,6 +18,7 @@ import { ENTER } from 'utils/keycodes';
 import VisualEditorBlock from './block';
 import {
 	getBlockUids,
+	getBlock,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
 	getMultiSelectedBlocksStartUid,
@@ -192,19 +193,31 @@ class VisualEditorBlockList extends Component {
 	}
 
 	render() {
-		const { blocks, showInsertionPoint, insertionPoint, multiSelectedBlockUids } = this.props;
-		const insertionPointIndex = blocks.indexOf( insertionPoint );
+		const {
+			blockUids,
+			lastBlock,
+			showInsertionPoint,
+			insertionPoint,
+			multiSelectedBlockUids
+		} = this.props;
+		const insertionPointIndex = blockUids.indexOf( insertionPoint );
 		const blocksWithInsertionPoint = showInsertionPoint
 			? [
-				...blocks.slice( 0, insertionPointIndex + 1 ),
+				...blockUids.slice( 0, insertionPointIndex + 1 ),
 				INSERTION_POINT_PLACEHOLDER,
-				...blocks.slice( insertionPointIndex + 1 ),
+				...blockUids.slice( insertionPointIndex + 1 ),
 			]
-			: blocks;
+			: blockUids;
+
+		const showContinueWriting = (
+			! lastBlock ||
+			lastBlock.name !== getDefaultBlock() ||
+			!! lastBlock.attributes.content
+		);
 
 		return (
 			<div>
-				{ !! blocks.length && blocksWithInsertionPoint.map( ( uid ) => {
+				{ !! blockUids.length && blocksWithInsertionPoint.map( ( uid ) => {
 					if ( uid === INSERTION_POINT_PLACEHOLDER ) {
 						return (
 							<div
@@ -225,30 +238,50 @@ class VisualEditorBlockList extends Component {
 					);
 				} ) }
 
-				<input
-					type="text"
-					readOnly
-					className="editor-visual-editor__placeholder"
-					value={ ! blocks.length ? __( 'Write your story' ) : __( 'Continue writing…' ) }
-					onFocus={ ! blocks.length ? this.appendDefaultBlock : noop }
-					onClick={ !! blocks.length ? this.appendDefaultBlock : noop }
-					onKeyDown={ !! blocks.length ? this.onPlaceholderKeyDown : noop }
-				/>
+				{ showContinueWriting && (
+					<input
+						type="text"
+						readOnly
+						className="editor-visual-editor__placeholder"
+						value={ ! blockUids.length
+							? __( 'Write your story' )
+							: __( 'Continue writing…' )
+						}
+						onFocus={ ! blockUids.length
+							? this.appendDefaultBlock
+							: noop
+						}
+						onClick={ !! blockUids.length
+							? this.appendDefaultBlock
+							: noop
+						}
+						onKeyDown={ !! blockUids.length
+							? this.onPlaceholderKeyDown
+							: noop
+						}
+					/>
+				) }
 			</div>
 		);
 	}
 }
 
 export default connect(
-	( state ) => ( {
-		blocks: getBlockUids( state ),
-		insertionPoint: getBlockInsertionPoint( state ),
-		showInsertionPoint: isBlockInsertionPointVisible( state ),
-		selectionStart: getMultiSelectedBlocksStartUid( state ),
-		selectionEnd: getMultiSelectedBlocksEndUid( state ),
-		multiSelectedBlocks: getMultiSelectedBlocks( state ),
-		multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
-	} ),
+	( state ) => {
+		const blockUids = getBlockUids( state );
+		return {
+			blockUids,
+			lastBlock: blockUids.length
+				? getBlock( state, blockUids[ blockUids.length - 1 ] )
+				: null,
+			insertionPoint: getBlockInsertionPoint( state ),
+			showInsertionPoint: isBlockInsertionPointVisible( state ),
+			selectionStart: getMultiSelectedBlocksStartUid( state ),
+			selectionEnd: getMultiSelectedBlocksEndUid( state ),
+			multiSelectedBlocks: getMultiSelectedBlocks( state ),
+			multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
+		};
+	},
 	( dispatch ) => ( {
 		onInsertBlock( block ) {
 			dispatch( insertBlock( block ) );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -553,6 +553,22 @@ export function isTypingInBlock( state, uid ) {
 }
 
 /**
+ * Returns true if the block corresponding to the specified unique ID is
+ * selected and the user has typed within it before, or false otherwise.
+ *
+ * @param  {Object}  state Global application state
+ * @param  {Object}  uid   Block unique ID
+ * @return {Boolean}       Whether user is typing within block
+ */
+export function hasTypedInSelectedBlock( state, uid ) {
+	if ( ! isBlockSelected( state, uid ) ) {
+		return false;
+	}
+
+	return state.selectedBlock.hasTypedBefore;
+}
+
+/**
  * Returns the unique ID of the block after which a new block insertion would
  * be placed, or null if the insertion point is not shown. Defaults to the
  * unique ID of the last block occurring in the post if not otherwise assigned.

--- a/editor/state.js
+++ b/editor/state.js
@@ -292,6 +292,7 @@ export function selectedBlock( state = {}, action ) {
 				return {
 					uid: action.uid,
 					typing: true,
+					hasTypedBefore: true,
 					focus: {},
 				};
 			}
@@ -299,6 +300,7 @@ export function selectedBlock( state = {}, action ) {
 			return {
 				...state,
 				typing: true,
+				hasTypedBefore: true,
 			};
 
 		case 'STOP_TYPING':

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -800,7 +800,12 @@ describe( 'state', () => {
 				uid: 'chicken',
 			} );
 
-			expect( state ).to.eql( { uid: 'chicken', typing: true, focus: {} } );
+			expect( state ).to.eql( {
+				uid: 'chicken',
+				typing: true,
+				hasTypedBefore: true,
+				focus: {},
+			} );
 		} );
 
 		it( 'should do nothing if typing stopped not within selected block', () => {
@@ -823,17 +828,31 @@ describe( 'state', () => {
 				uid: 'chicken',
 			} );
 
-			expect( state ).to.eql( { uid: 'chicken', typing: false, focus: {} } );
+			expect( state ).to.eql( {
+				uid: 'chicken',
+				typing: false,
+				hasTypedBefore: true,
+				focus: {},
+			} );
 		} );
 
 		it( 'should set the typing flag and merge the existing state', () => {
-			const original = deepFreeze( { uid: 'ribs', typing: false, focus: { editable: 'citation' } } );
+			const original = deepFreeze( {
+				uid: 'ribs',
+				typing: false,
+				focus: { editable: 'citation' },
+			} );
 			const state = selectedBlock( original, {
 				type: 'START_TYPING',
 				uid: 'ribs',
 			} );
 
-			expect( state ).to.eql( { uid: 'ribs', typing: true, focus: { editable: 'citation' } } );
+			expect( state ).to.eql( {
+				uid: 'ribs',
+				typing: true,
+				hasTypedBefore: true,
+				focus: { editable: 'citation' },
+			} );
 		} );
 
 		it( 'should replace the selected block', () => {


### PR DESCRIPTION
Partially fixes #1501 (apart from the post being marked dirty when the first text block is inserted).

The first commit handles the majority of the work: looking at the last block to determine whether it is an empty text block.  The empty detection using `!! lastBlock.attributes.content` works, but ideally the block list shouldn't be so aware of the internal details of the text block.

The second commit causes the "Continue writing" placeholder to appear again when you start typing inside an empty text block.  The `START_TYPING` action and the `isTypingInBlock` selector are _almost_ right for this, but the `STOP_TYPING` action triggers when you move the mouse away from the block, meaning that the placeholder would be hidden again.  I've added a new selector `hasTypedInSelectedBlock` which "remembers" this value for a bit longer.  I'm not very happy with this code either, but I think it is demonstrating the correct behavior.