### PR TITLE
Announce the blocks search results to assistive technologies

### DIFF
--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -50,14 +50,14 @@ class InserterMenu extends Component {
 	}
 
 	componentDidUpdate() {
-		const visibleBlocks = this.getVisibleBlocks( getBlockTypes() );
+		const searchResults = this.searchBlocks( getBlockTypes() );
 		// Announce the blocks search results to screen readers.
-		if ( !! visibleBlocks.length ) {
+		if ( !! searchResults.length ) {
 			this.debouncedSpeakAssertive( sprintf( _n(
 				'%d result found',
 				'%d results found',
-				visibleBlocks.length
-			), visibleBlocks.length ) );
+				searchResults.length
+			), searchResults.length ) );
 		} else {
 			this.debouncedSpeakAssertive( __( 'No results.' ) );
 		}


### PR DESCRIPTION
This PR tries to make the Inserter blocks search results available to assistive technologies users.
I've based this on the work already done for the Tags suggestion. With one notable difference:
- it uses lodash debounce instead of throttle
- not sure about this part `if ( !! visibleBlocks.length ) ` seems a bit excessive to me but I've done it this way for consistency with the Tags suggestion, feedback welcome

Todo:
some strings could be improved, for example:
instead of `No results.` use `No results found.` for consistency with similar string already used in core (one string less to translate)

We could also evaluate to use different strings based on other core conventions, for example the core Themes search uses:
`Number of Themes found: %d` <-- maybe easier for translators and doesn't need singular/plural
`No themes found. Try a different search.`

Or, keep it simple and leave as is. Feedback welcome!

Note: I'll open an issue for the Tags suggestion, to clarify if it's better to use debounce or throttle.

Fixes #1505 