### PR TITLE
Button: Add "Start on a new line" option (#1473)

### DIFF
--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -13,6 +13,7 @@ import { registerBlockType, source } from '../../api';
 import Editable from '../../editable';
 import UrlInput from '../../url-input';
 import BlockControls from '../../block-controls';
+import ToggleControl from '../../inspector-controls/toggle-control';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import ColorPalette from '../../color-palette';
 import InspectorControls from '../../inspector-controls';
@@ -50,15 +51,24 @@ registerBlockType( 'core/button', {
 	},
 
 	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
+		const { align, clear } = attributes;
+		const props = {};
+
 		if ( 'left' === align || 'right' === align || 'center' === align ) {
-			return { 'data-align': align };
+			props[ 'data-align' ] = align;
 		}
+
+		if ( clear ) {
+			props[ 'data-clear' ] = 'true';
+		}
+
+		return props;
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus, className } ) {
-		const { text, url, title, align, color } = attributes;
+		const { text, url, title, align, color, clear } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
+		const toggleClear = () => setAttributes( { clear: ! clear } );
 
 		return [
 			focus && (
@@ -93,6 +103,13 @@ registerBlockType( 'core/button', {
 						<BlockDescription>
 							<p>{ __( 'A nice little button. Call something out with it.' ) }</p>
 						</BlockDescription>
+
+						<ToggleControl
+							label={ __( 'Stand on a line' ) }
+							checked={ !! clear }
+							onChange={ toggleClear }
+						/>
+
 						<ColorPalette
 							value={ color }
 							onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -289,6 +289,10 @@
 		}
 	}
 
+	&[data-clear="true"] {
+		float: none;
+	}
+
 	& > .components-drop-zone {
 		border: none;
 		top: -4px;


### PR DESCRIPTION
There is no way to clear the float when using an align left or right button, the next text button always behinds the button. You can read more here: [#1473](https://github.com/WordPress/gutenberg/issues/1473)