### PR TITLE
Tags suggestions: Use debounce instead of throttle for the audible messages.

### DIFF
--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -64,6 +64,10 @@ class FormTokenField extends Component {
 		}
 	}
 
+	componentWillUnmount() {
+		this.debouncedSpeak.cancel();
+	}
+
 	bindInput( ref ) {
 		this.input = ref;
 	}
@@ -338,7 +342,7 @@ class FormTokenField extends Component {
 
 	addNewToken( token ) {
 		this.addNewTokens( [ token ] );
-		this.speak( this.props.messages.added );
+		this.speakAssertive( this.props.messages.added );
 
 		this.setState( {
 			incompleteTokenValue: '',
@@ -356,7 +360,7 @@ class FormTokenField extends Component {
 			return this.getTokenValue( item ) !== this.getTokenValue( token );
 		} );
 		this.props.onChange( newTokens );
-		this.speak( this.props.messages.removed );
+		this.speakAssertive( this.props.messages.removed );
 	}
 
 	getTokenValue( token ) {

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -46,7 +46,7 @@ class FormTokenField extends Component {
 		this.onInputChange = this.onInputChange.bind( this );
 		this.bindInput = this.bindInput.bind( this );
 		this.bindTokensAndInput = this.bindTokensAndInput.bind( this );
-		this.debouncedSpeak = debounce( this.speakAssertive.bind( this ), 500 );
+		this.debouncedSpeakAssertive = debounce( this.speakAssertive.bind( this ), 500 );
 	}
 
 	componentDidUpdate() {
@@ -65,7 +65,7 @@ class FormTokenField extends Component {
 	}
 
 	componentWillUnmount() {
-		this.debouncedSpeak.cancel();
+		this.debouncedSpeakAssertive.cancel();
 	}
 
 	bindInput( ref ) {
@@ -195,13 +195,13 @@ class FormTokenField extends Component {
 		if ( showMessage ) {
 			const matchingSuggestions = this.getMatchingSuggestions( tokenValue );
 			if ( !! matchingSuggestions.length ) {
-				this.debouncedSpeak( sprintf( _n(
+				this.debouncedSpeakAssertive( sprintf( _n(
 					'%d result found, use up and down arrow keys to navigate.',
 					'%d results found, use up and down arrow keys to navigate.',
 					matchingSuggestions.length
 				), matchingSuggestions.length ) );
 			} else {
-				this.debouncedSpeak( __( 'No results.' ) );
+				this.debouncedSpeakAssertive( __( 'No results.' ) );
 			}
 		}
 	}

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { last, take, clone, uniq, map, difference, each, identity, some, throttle } from 'lodash';
+import { last, take, clone, uniq, map, difference, each, identity, some, debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -46,7 +46,7 @@ class FormTokenField extends Component {
 		this.onInputChange = this.onInputChange.bind( this );
 		this.bindInput = this.bindInput.bind( this );
 		this.bindTokensAndInput = this.bindTokensAndInput.bind( this );
-		this.throlltedSpeak = throttle( this.speak.bind( this ), 1000 );
+		this.debouncedSpeak = debounce( this.speakAssertive.bind( this ), 500 );
 	}
 
 	componentDidUpdate() {
@@ -191,13 +191,13 @@ class FormTokenField extends Component {
 		if ( showMessage ) {
 			const matchingSuggestions = this.getMatchingSuggestions( tokenValue );
 			if ( !! matchingSuggestions.length ) {
-				this.throlltedSpeak( sprintf( _n(
+				this.debouncedSpeak( sprintf( _n(
 					'%d result found, use up and down arrow keys to navigate.',
 					'%d results found, use up and down arrow keys to navigate.',
 					matchingSuggestions.length
 				), matchingSuggestions.length ) );
 			} else {
-				this.throlltedSpeak( __( 'No results.' ) );
+				this.debouncedSpeak( __( 'No results.' ) );
 			}
 		}
 	}
@@ -400,7 +400,7 @@ class FormTokenField extends Component {
 		return take( suggestions, maxSuggestions );
 	}
 
-	speak( message ) {
+	speakAssertive( message ) {
 		wp.a11y.speak( message, 'assertive' );
 	}
 


### PR DESCRIPTION
This PR improves the `wp.a11y.speak()` messages for the Tags suggestions.
Please refer to the description (and video!) on the issue.

- uses lodash `debounce` instead of `throttle`
- reduces the delay to 500ms for consistency with #1508 
- renames `speak()` to `speakAssertive()` for clarity

This way, while the component is updated (which is equivalent to while users are typing), the call to speak is debounced.

Fixes #1510 