### PR TITLE
Add "Archives" block

### DIFF
--- a/blocks/library/archives/index.js
+++ b/blocks/library/archives/index.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+import { Placeholder } from 'components';
+import { __ } from 'i18n';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '../../api';
+import InspectorControls from '../../inspector-controls';
+import ToggleControl from '../../inspector-controls/toggle-control';
+
+registerBlockType( 'core/archives', {
+	title: __( 'Archives' ),
+
+	icon: 'calendar-alt',
+
+	category: 'widgets',
+
+	defaultAttributes: {
+		count: true,
+		dropdown: false,
+	},
+
+	edit( { attributes, setAttributes, focus } ) {
+		const { count, dropdown } = attributes;
+		const toggleCount = () => setAttributes( { count: ! count } );
+		const toggleDropdown = () => setAttributes( { dropdown: ! dropdown } );
+		return [
+			focus && (
+				<InspectorControls key="inspector">
+					<ToggleControl
+						label={ __( 'Show post counts' ) }
+						checked={ !! count }
+						onChange={ toggleCount }
+					/>
+					<ToggleControl
+						label={ __( 'Display as dropdown' ) }
+						checked={ !! dropdown }
+						onChange={ toggleDropdown }
+					/>
+				</InspectorControls>
+			),
+			<Placeholder
+				icon="update"
+				key="placeholder"
+				label={ __( 'Loading archives, please wait' ) }
+			>
+			</Placeholder>,
+		];
+	},
+
+	save() {
+		return null;
+	},
+} );

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -15,3 +15,4 @@ import './html';
 import './freeform';
 import './latest-posts';
 import './cover-image';
+import './archives';

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -23,4 +23,5 @@ if ( gutenberg_can_init() ) {
 
 	// Register server-side code for individual blocks.
 	require_once dirname( __FILE__ ) . '/lib/blocks/latest-posts.php';
+	require_once dirname( __FILE__ ) . '/lib/blocks/archives.php';
 }

--- a/lib/blocks/archives.php
+++ b/lib/blocks/archives.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Server-side rendering of the `core/archives` block.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Renders the `core/archives` block on server.
+ *
+ * @see WP_Widget_Archives
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string Returns the post content with archives added.
+ */
+function gutenberg_render_block_core_archives( $attributes ) {
+	$count = ! empty( $attributes['count'] ) ? '1' : '0';
+	$dropdown = ! empty( $attributes['dropdown'] ) ? '1' : '0';
+
+	if ( $dropdown ) {
+		// Todo: 123 should be a unique number, see WP_Widget_Archives class.
+		$dropdown_id = esc_attr( 'archives-dropdown-123' );
+		$title = __( 'Archives' );
+
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
+		$dropdown_args = apply_filters( 'widget_archives_dropdown_args', array(
+			'type'            => 'monthly',
+			'format'          => 'option',
+			'show_post_count' => $count,
+		) );
+
+		$dropdown_args['echo'] = 0;
+
+		$archives = wp_get_archives( $dropdown_args );
+
+		switch ( $dropdown_args['type'] ) {
+			case 'yearly':
+				$label = __( 'Select Year' );
+				break;
+			case 'monthly':
+				$label = __( 'Select Month' );
+				break;
+			case 'daily':
+				$label = __( 'Select Day' );
+				break;
+			case 'weekly':
+				$label = __( 'Select Week' );
+				break;
+			default:
+				$label = __( 'Select Post' );
+				break;
+		}
+
+		$label = esc_attr( $label );
+
+		$block_content = <<<CONTENT
+<div class="blocks-archives">
+	<label class="screen-reader-text" for="{$dropdown_id}">{$title}</label>
+	<select id="{$dropdown_id}" name="archive-dropdown" onchange='document.location.href=this.options[this.selectedIndex].value;'>
+	<option value="">{$label}</option>
+	{$archives}
+</div>
+CONTENT;
+	} else {
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
+		$archives_args = apply_filters( 'widget_archives_args', array(
+			'type'            => 'monthly',
+			'show_post_count' => $count,
+		) );
+
+		$archives_args['echo'] = 0;
+
+		$archives = wp_get_archives( $archives_args );
+
+		$block_content = <<<CONTENT
+<div class="blocks-archives">
+	{$archives}
+</div>
+CONTENT;
+	}
+
+	return $block_content;
+}
+
+register_block_type( 'core/archives', array(
+	'render' => 'gutenberg_render_block_core_archives',
+) );


### PR DESCRIPTION
This is a possible implementation for an archives block that uses the same code as the archives widget currently in code. The same code and filters are used for output on the front end, so there shouldn't be any BC concerns.

**Todo:**

* Add server-side rendering, either through a custom REST API endpoint or something like #780.
  Right now, a fake loading screen is shown in the editor.
* Testing
* Styling
* Accessibility improvements
  Probably something to happen in core directly, see https://github.com/WordPress/gutenberg/issues/1464#issuecomment-311331634). Not really a blocker for this implementation
* Maybe implement alignment options

**Screenshots:**

<img width="286" alt="screen shot 2017-06-27 at 13 34 39" src="https://user-images.githubusercontent.com/841956/27607019-cdb2d498-5b82-11e7-8897-a9800d2e5437.png">

<img width="662" alt="screen shot 2017-06-27 at 13 07 45" src="https://user-images.githubusercontent.com/841956/27607028-d58b58a2-5b82-11e7-89ca-25992b461b4d.png">

<img width="357" alt="screen shot 2017-06-27 at 21 54 45" src="https://user-images.githubusercontent.com/841956/27607173-44fef694-5b83-11e7-94d8-9eee63dccbcf.png">

---------------

Fixes #1464.