### PR TITLE
Use development version of wpcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "require-dev": {
     "squizlabs/php_codesniffer": "2.9.x",
-    "wp-coding-standards/wpcs": "^0.11.0"
+    "wp-coding-standards/wpcs": "dev-develop"
   },
   "scripts": {
     "lint": "phpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a5dd686e18346fa4dbc564b7b90f4a1",
+    "content-hash": "32ce56503bf0964a5c611d6f0dba56dd",
     "packages": [],
     "packages-dev": [
         {
@@ -87,20 +87,20 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.11.0",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "407e4b85f547a5251185f89ceae6599917343388"
+                "reference": "0999ed3fcf74acf9ed7ed047f8f159b7fa93e9b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/407e4b85f547a5251185f89ceae6599917343388",
-                "reference": "407e4b85f547a5251185f89ceae6599917343388",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/0999ed3fcf74acf9ed7ed047f8f159b7fa93e9b6",
+                "reference": "0999ed3fcf74acf9ed7ed047f8f159b7fa93e9b6",
                 "shasum": ""
             },
             "require": {
-                "squizlabs/php_codesniffer": "^2.8.1"
+                "squizlabs/php_codesniffer": "^2.9.0"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -119,12 +119,14 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-03-20T23:17:58+00:00"
+            "time": "2017-06-25T21:13:08+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "wp-coding-standards/wpcs": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],


### PR DESCRIPTION
The development version of the WP coding standards for PHP_CodeSniffer contain many recent updates to the available sniffs.

In https://core.trac.wordpress.org/ticket/41057, core is aiming to update its coding standards and apply these throughout the code base. During that process, the coding standards have changed a bit and WPCS has quickly adapted to that. For example, there's now [no longer](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/965) a rule about blocks longer than 35 characters.

Gutenberg should adopt these changes as well.