### PR TITLE
Freeform Block: Fix inserting the freeform block

### DIFF
--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -76,7 +76,7 @@ export default class TinyMCE extends Component {
 	}
 
 	render() {
-		const { tagName, style, defaultValue, label } = this.props;
+		const { tagName = 'div', style, defaultValue, label } = this.props;
 
 		// If a default value is provided, render it into the DOM even before
 		// TinyMCE finishes initializing. This avoids a short delay by allowing


### PR DESCRIPTION
Fix a small regression introduced in #1477 because the TinyMCE component is being used directly too.

closes #1533