### PR TITLE
Revert "Completely hide the meta boxes icons from screen readers"

### DIFF
--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -15,7 +15,7 @@ function IconButton( { icon, children, label, className, focus, ...additionalPro
 
 	return (
 		<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
-			<span aria-hidden="true"><Dashicon icon={ icon } /></span>
+			<Dashicon icon={ icon } />
 			{ children }
 		</Button>
 	);


### PR DESCRIPTION
Reverts WordPress/gutenberg#1388

I approved this prematurely. Seems it causes a number of issues with the icon button and we might want to try a different approach. 

Icons in the quick toolbar lost their styles:

![screen shot 2017-06-28 at 12 14 50](https://user-images.githubusercontent.com/1204802/27632633-82a0cc9c-5bfc-11e7-8151-398fc806bf23.png)

Icons in the editor bar are offset:

![screen shot 2017-06-28 at 12 23 14](https://user-images.githubusercontent.com/1204802/27632657-96be3b2e-5bfc-11e7-84af-3d780e6ac7de.png)

The quick toolbar appearing and disappearing when the block is selected causes a jump.