### PR TITLE
Blocks: Adding the block's classname as prop to use in the `edit`

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -6,7 +6,7 @@ import * as query from './query';
 export { query };
 export { createBlock, switchToBlockType } from './factory';
 export { default as parse } from './parser';
-export { default as serialize } from './serializer';
+export { default as serialize, getBlockDefaultClassname } from './serializer';
 export { getCategories } from './categories';
 export {
 	registerBlockType,

--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -3,6 +3,7 @@
  */
 import tinymce from 'tinymce';
 import { isEqual } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -77,7 +78,7 @@ export default class TinyMCE extends Component {
 	}
 
 	render() {
-		const { tagName = 'div', style, defaultValue, label } = this.props;
+		const { tagName = 'div', style, defaultValue, label, className } = this.props;
 
 		// If a default value is provided, render it into the DOM even before
 		// TinyMCE finishes initializing. This avoids a short delay by allowing
@@ -91,7 +92,7 @@ export default class TinyMCE extends Component {
 			ref: ( node ) => this.editorNode = node,
 			contentEditable: true,
 			suppressContentEditableWarning: true,
-			className: 'blocks-editable__tinymce',
+			className: classnames( className, 'blocks-editable__tinymce' ),
 			style,
 			'aria-label': label,
 		}, children );

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -35,7 +35,7 @@ registerBlockType( 'core/button', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { text, url, title, align } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
@@ -45,7 +45,7 @@ registerBlockType( 'core/button', {
 					<BlockAlignmentToolbar value={ align } onChange={ updateAlignment } />
 				</BlockControls>
 			),
-			<span key="button" className="blocks-button" title={ title }>
+			<span key="button" className={ className } title={ title }>
 				<Editable
 					tagName="span"
 					placeholder={ __( 'Write label…' ) }

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -1,6 +1,6 @@
 $blocks-button__height: 46px;
 
-.blocks-button {
+.wp-block-button {
 	font-family: $default-font;
 	display: inline-block;
 	text-decoration: none;

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -27,9 +27,10 @@ registerBlockType( 'core/code', {
 		content: prop( 'code', 'textContent' ),
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		return (
 			<TextareaAutosize
+				className={ className }
 				value={ attributes.content }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
 				placeholder={ __( 'Write code…' ) }

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -39,7 +39,7 @@ registerBlockType( 'core/cover-image', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { url, title, align, id, hasParallax } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const onSelectImage = ( media ) => setAttributes( { url: media.url, id: media.id } );
@@ -78,7 +78,7 @@ registerBlockType( 'core/cover-image', {
 					instructions={ __( 'Drag image here or insert from media library' ) }
 					icon="format-image"
 					label={ __( 'Image' ) }
-					className="blocks-image">
+					className={ className }>
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }
 						onSelect={ onSelectImage }
@@ -109,7 +109,7 @@ registerBlockType( 'core/cover-image', {
 					/>
 				</InspectorControls>
 			),
-			<section key="cover-image" className="blocks-cover-image">
+			<section key="cover-image" className={ className }>
 				<section className={ sectionClasses } data-url={ url } style={ style }>
 					{ title || !! focus ? (
 						<Editable
@@ -139,7 +139,7 @@ registerBlockType( 'core/cover-image', {
 		} );
 
 		return (
-			<section className="blocks-cover-image">
+			<section>
 				<section className={ sectionClasses } style={ style }>
 					<h2>{ title }</h2>
 				</section>

--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -3,7 +3,7 @@
 		position: inherit;
 	}
 
-	.blocks-cover-image {
+	.wp-block-cover-image {
 		margin: 0;
 
 		h2 {
@@ -11,7 +11,6 @@
 			font-size: 24pt;
 			line-height: 1em;
 		}
-
 	}
 
 	.cover-image {

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -130,7 +130,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 				if ( fetching ) {
 					return [
 						controls,
-						<div key="loading" className="blocks-embed is-loading">
+						<div key="loading" className="wp-block-embed is-loading">
 							<Spinner />
 							<p>{ __( 'Embedding…' ) }</p>
 						</div>,
@@ -140,7 +140,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 				if ( ! html ) {
 					return [
 						controls,
-						<Placeholder key="placeholder" icon={ icon } label={ sprintf( __( '%s URL' ), title ) } className="blocks-embed">
+						<Placeholder key="placeholder" icon={ icon } label={ sprintf( __( '%s URL' ), title ) } className="wp-block-embed">
 							<form onSubmit={ this.doServerSideRender }>
 								<input
 									type="url"
@@ -162,10 +162,9 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 				const parsedUrl = parse( url );
 				const cannotPreview = includes( HOSTS_NO_PREVIEWS, parsedUrl.host.replace( /^www\./, '' ) );
 				const iframeTitle = 'Embedded content from ' + parsedUrl.host;
-				let typeClassName = 'blocks-embed';
-
+				let typeClassName = 'wp-block-embed';
 				if ( 'video' === type ) {
-					typeClassName = 'blocks-embed-video';
+					typeClassName += ' is-video';
 				}
 
 				return [

--- a/blocks/library/embed/style.scss
+++ b/blocks/library/embed/style.scss
@@ -1,5 +1,4 @@
-.blocks-embed,
-.blocks-embed-video {
+.wp-block-embed {
 	margin: 0;
 	clear: both; // necessary because we use responsive trickery to set width/height, and therefore the video doesn't intrinsically clear floats like an img does
 
@@ -17,19 +16,19 @@
 			font-size: $default-font-size;
 		}
 	}
-}
 
-.blocks-embed-video > div:first-child {
-	position: relative;
-	width: 100%;
-	height: 0;
-	padding-bottom: 56.25%; /* 16:9 */
-}
+	&.is-video > div:first-child {
+		position: relative;
+		width: 100%;
+		height: 0;
+		padding-bottom: 56.25%; /* 16:9 */
+	}
 
-.blocks-embed-video > div > iframe {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
+	&.is-video > div > iframe {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+	}
 }

--- a/blocks/library/freeform/freeform-block.js
+++ b/blocks/library/freeform/freeform-block.js
@@ -376,7 +376,7 @@ export default class FreeformBlock extends Component {
 	}
 
 	render() {
-		const { content, focus } = this.props;
+		const { content, focus, className } = this.props;
 		const { expandDown, showMore } = this.state;
 		const moreDrawerClasses = classnames( 'more-drawer', expandDown ? 'down' : 'up' );
 		return [
@@ -405,6 +405,7 @@ export default class FreeformBlock extends Component {
 			</BlockControls>,
 			<TinyMCE
 				key="editor"
+				className={ className }
 				getSettings={ this.getSettings }
 				onSetup={ this.onSetup }
 				defaultValue={ content }

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -27,11 +27,12 @@ registerBlockType( 'core/freeform', {
 		content: <p />,
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { content } = attributes;
 
 		return (
 			<FreeformBlock
+				className={ className }
 				content={ content }
 				onChange={ ( nextContent ) => {
 					setAttributes( {

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -58,7 +58,7 @@ registerBlockType( 'core/gallery', {
 
 	attributes: {
 		images:
-			query( 'div.blocks-gallery figure.blocks-gallery-image img', {
+			query( 'div.wp-block-gallery figure.blocks-gallery-image img', {
 				url: attr( 'src' ),
 				alt: attr( 'alt' ),
 			} ) || [],
@@ -71,7 +71,7 @@ registerBlockType( 'core/gallery', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus } ) {
+	edit( { attributes, setAttributes, focus, className } ) {
 		const { images = [], columns = defaultColumnsNumber( attributes ), align = 'none' } = attributes;
 		const setColumnsNumber = ( event ) => setAttributes( { columns: event.target.value } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
@@ -104,7 +104,7 @@ registerBlockType( 'core/gallery', {
 					instructions={ __( 'Drag images here or insert from media library' ) }
 					icon="format-gallery"
 					label={ __( 'Gallery' ) }
-					className="blocks-gallery">
+					className={ className }>
 					<MediaUploadButton
 						onSelect={ setMediaUrl }
 						type="image"
@@ -130,7 +130,7 @@ registerBlockType( 'core/gallery', {
 					/>
 				</InspectorControls>
 			),
-			<div key="gallery" className={ `blocks-gallery align${ align } columns-${ columns }` }>
+			<div key="gallery" className={ `${ className } align${ align } columns-${ columns }` }>
 				{ images.map( ( img ) => (
 					<GalleryImage key={ img.url } img={ img } />
 				) ) }
@@ -141,7 +141,7 @@ registerBlockType( 'core/gallery', {
 	save( { attributes } ) {
 		const { images, columns = defaultColumnsNumber( attributes ), align = 'none' } = attributes;
 		return (
-			<div className={ `blocks-gallery align${ align } columns-${ columns }` } >
+			<div className={ `align${ align } columns-${ columns }` } >
 				{ images.map( ( img ) => (
 					<GalleryImage key={ img.url } img={ img } />
 				) ) }

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -1,11 +1,11 @@
 
-.blocks-gallery {
+.wp-block-gallery {
 	display: flex;
 	flex-wrap: wrap;
 
 	&:not( .components-placeholder ) {
 		margin-right: -16px;
-		margin-bottom: -16px;	
+		margin-bottom: -16px;
 	}
 
 	.blocks-gallery-image {
@@ -43,7 +43,7 @@
 	}
 }
 
-.blocks-gallery.is-placeholder {
+.wp-block-gallery.is-placeholder {
 	margin: -15px;
 	padding: 6em 0;
 	border: 2px solid $light-gray-500;

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -38,7 +38,7 @@ registerBlockType( 'core/image', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { url, alt, caption, align, id } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
@@ -80,7 +80,7 @@ registerBlockType( 'core/image', {
 					instructions={ __( 'Drag image here or insert from media library' ) }
 					icon="format-image"
 					label={ __( 'Image' ) }
-					className="blocks-image">
+					className={ className }>
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }
 						onSelect={ onSelectImage }
@@ -105,7 +105,7 @@ registerBlockType( 'core/image', {
 					<TextControl label={ __( 'Alternate Text' ) } value={ alt } onChange={ updateAlt } />
 				</InspectorControls>
 			),
-			<figure key="image" className="blocks-image">
+			<figure key="image" className={ className }>
 				<img src={ url } alt={ alt } onClick={ setFocus } />
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -1,4 +1,4 @@
-.blocks-image {
+.wp-block-image {
 	margin: 0;
 
 	img {

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -52,7 +52,7 @@ registerBlockType( 'core/latestposts', {
 			}
 
 			return (
-				<div className="blocks-latest-posts">
+				<div className={ this.props.className }>
 					<ul>
 						{ latestPosts.map( ( post, i ) =>
 							<li key={ i }><a href={ post.link }>{ post.title.rendered }</a></li>

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -42,7 +42,7 @@ registerBlockType( 'core/preformatted', {
 		],
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { content } = attributes;
 
 		return (
@@ -58,6 +58,7 @@ registerBlockType( 'core/preformatted', {
 				onFocus={ setFocus }
 				placeholder={ __( 'Write preformatted text…' ) }
 				inline
+				className={ className }
 			/>
 		);
 	},

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -34,7 +34,7 @@ registerBlockType( 'core/pullquote', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { value, citation, align } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
@@ -48,7 +48,7 @@ registerBlockType( 'core/pullquote', {
 					/>
 				</BlockControls>
 			),
-			<blockquote key="quote" className="blocks-pullquote">
+			<blockquote key="quote" className={ className }>
 				<Editable
 					value={ value }
 					onChange={
@@ -84,7 +84,7 @@ registerBlockType( 'core/pullquote', {
 		const { value, citation, align = 'none' } = attributes;
 
 		return (
-			<blockquote className={ `blocks-pullquote align${ align }` }>
+			<blockquote className={ `align${ align }` }>
 				{ value && value.map( ( paragraph, i ) => (
 					<p key={ i }>{ paragraph }</p>
 				) ) }

--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -1,4 +1,4 @@
-.blocks-pullquote {
+.wp-block-pullquote {
 	color: $light-gray-900;
 	padding: 2em;
 	text-align: center;
@@ -21,7 +21,7 @@
 	}
 }
 
-.editor-visual-editor .blocks-pullquote {
+.editor-visual-editor .wp-block-pullquote {
 	& > .blocks-pullquote__content .blocks-editable__tinymce[data-is-empty="true"]:before,
 	& > .blocks-editable p {
 		font-family: $default-font;

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -113,7 +113,7 @@ registerBlockType( 'core/quote', {
 		],
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks } ) {
+	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, className } ) {
 		const { align, value, citation, style = 1 } = attributes;
 		const focusedEditable = focus ? focus.editable || 'value' : null;
 
@@ -139,7 +139,7 @@ registerBlockType( 'core/quote', {
 			),
 			<blockquote
 				key="quote"
-				className={ `blocks-quote blocks-quote-style-${ style }` }
+				className={ `${ className } blocks-quote-style-${ style }` }
 			>
 				<Editable
 					value={ value }

--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -1,4 +1,4 @@
-.blocks-quote {
+.wp-block-quote {
 	margin: 0;
 	box-shadow: inset 0px 0px 0px 0px $light-gray-500;
 

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -16,8 +16,8 @@ registerBlockType( 'core/separator', {
 
 	category: 'layout',
 
-	edit() {
-		return <hr className="blocks-separator" />;
+	edit( { className } ) {
+		return <hr className={ className } />;
 	},
 
 	save() {

--- a/blocks/library/separator/style.scss
+++ b/blocks/library/separator/style.scss
@@ -1,4 +1,4 @@
-.blocks-separator {
+.wp-block-separator {
 	border: none;
 	border-bottom: 2px solid $dark-gray-100;
 	max-width: 100px;

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -37,7 +37,7 @@ registerBlockType( 'core/table', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const focussedKey = focus ? focus.editable || 'body.0.0' : null;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
@@ -51,7 +51,7 @@ registerBlockType( 'core/table', {
 					/>
 				</BlockControls>
 			),
-			<table key="table">
+			<table key="table" className={ className }>
 				{ [ 'head', 'body', 'foot' ].map( ( part ) =>
 					attributes[ part ] && attributes[ part ].length
 						? createElement( 't' + part, { key: part },

--- a/blocks/test/fixtures/core-cover-image.html
+++ b/blocks/test/fixtures/core-cover-image.html
@@ -1,5 +1,5 @@
 <!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg"} -->
-<section class="blocks-cover-image">
+<section class="wp-block-cover-image">
 	<section class="cover-image" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg);">
 		<h2>Guten Berg!</h2>
 	</section>

--- a/blocks/test/fixtures/core-cover-image.serialized.html
+++ b/blocks/test/fixtures/core-cover-image.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg"} -->
-<section class="blocks-cover-image wp-block-cover-image">
+<section class="wp-block-cover-image">
     <section class="cover-image" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg);">
         <h2>Guten Berg!</h2>
     </section>

--- a/blocks/test/fixtures/core-gallery.html
+++ b/blocks/test/fixtures/core-gallery.html
@@ -1,5 +1,5 @@
 <!-- wp:core/gallery -->
-<div class="blocks-gallery wp-block-gallery">
+<div class="wp-block-gallery">
 	<figure class="blocks-gallery-image">
 		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
 	</figure>

--- a/blocks/test/fixtures/core-gallery.serialized.html
+++ b/blocks/test/fixtures/core-gallery.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/gallery -->
-<div class="blocks-gallery alignnone columns-2 wp-block-gallery">
+<div class="alignnone columns-2 wp-block-gallery">
     <figure class="blocks-gallery-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
     <figure class="blocks-gallery-image"><img src="http://google.com/hi.png" alt="title" /></figure>
 </div>

--- a/blocks/test/fixtures/core-pullquote.html
+++ b/blocks/test/fixtures/core-pullquote.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
-<blockquote class="blocks-pullquote wp-block-pullquote">
+<blockquote class="wp-block-pullquote">
 <p>Testing pullquote block...</p><footer>...with a caption</footer>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core-pullquote.serialized.html
+++ b/blocks/test/fixtures/core-pullquote.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
-<blockquote class="blocks-pullquote alignnone wp-block-pullquote">
+<blockquote class="alignnone wp-block-pullquote">
     <p>Testing pullquote block...</p>
     <footer>...with a caption</footer>
 </blockquote>

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -12,7 +12,7 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
  */
 import { Children, Component } from 'element';
 import { BACKSPACE, ESCAPE, DELETE } from 'utils/keycodes';
-import { getBlockType } from 'blocks';
+import { getBlockType, getBlockDefaultClassname } from 'blocks';
 
 /**
  * Internal dependencies
@@ -236,6 +236,7 @@ class VisualEditorBlock extends Component {
 	render() {
 		const { block, multiSelectedBlockUids } = this.props;
 		const blockType = getBlockType( block.name );
+		const { className = getBlockDefaultClassname( block.name ) } = blockType;
 		// The block as rendered in the editor is composed of general block UI
 		// (mover, toolbar, wrapper) and the display of the block content, which
 		// is referred to as <BlockEdit />.
@@ -255,7 +256,7 @@ class VisualEditorBlock extends Component {
 		// Generate the wrapper class names handling the different states of the block.
 		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, isTyping, focus } = this.props;
 		const showUI = isSelected && ( ! isTyping || ! focus.collapsed );
-		const className = classnames( 'editor-visual-editor__block', {
+		const wrapperClassname = classnames( 'editor-visual-editor__block', {
 			'is-selected': showUI,
 			'is-multi-selected': isMultiSelected,
 			'is-hovered': isHovered,
@@ -279,7 +280,7 @@ class VisualEditorBlock extends Component {
 				onMouseMove={ this.maybeHover }
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
-				className={ className }
+				className={ wrapperClassname }
 				data-type={ block.name }
 				tabIndex="0"
 				{ ...wrapperProps }
@@ -317,6 +318,7 @@ class VisualEditorBlock extends Component {
 						insertBlockAfter={ onInsertAfter }
 						setFocus={ partial( onFocus, block.uid ) }
 						mergeBlocks={ this.mergeBlocks }
+						className={ className }
 						id={ block.uid }
 					/>
 				</div>


### PR DESCRIPTION
In this PR, I explore the idea of passing the block's className as prop to the edit function.
I'm starting to think we should drop the automatically added className in favor of explicit classNames added in the `edit` and `save` and some guidelines. Sometimes guidelines are better than adding complexity.