### PR TITLE
Fix the meta boxes toggle aria-expanded for Firefox+NVDA #2

### DIFF
--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -14,15 +14,22 @@ class PanelBody extends Component {
 		super( ...arguments );
 		this.state = {
 			opened: props.initialOpen === undefined ? true : props.initialOpen,
+			ariaExpanded: props.initialOpen === undefined ? true : props.initialOpen,
 		};
 		this.toggle = this.toggle.bind( this );
 	}
 
-	toggle( event ) {
-		event.preventDefault();
+	toggle() {
 		this.setState( ( state ) => ( {
 			opened: ! state.opened,
 		} ) );
+
+		// Workaround for Firefox+NVDA bug see issue 1556.
+		setTimeout( () => {
+			this.setState( ( state ) => ( {
+				ariaExpanded: ! state.ariaExpanded,
+			} ) );
+		}, 100 );
 	}
 
 	render() {
@@ -32,10 +39,11 @@ class PanelBody extends Component {
 				{ !! title && (
 					<h3 className="components-panel__body-title">
 						<IconButton
+							type="button"
 							className="components-panel__body-toggle"
 							onClick={ this.toggle }
 							icon={ this.state.opened ? 'arrow-down' : 'arrow-right' }
-							aria-expanded={ this.state.opened }
+							aria-expanded={ this.state.ariaExpanded }
 							label={ sprintf( __( 'Open section: %s' ), title ) }
 						>
 							{ title }


### PR DESCRIPTION
Second attempt to try a workaround to make Firefox+NVDA correctly report the aria-expanded state change on the meta boxes toggles in the sidebar.
See #1387 and #1388, then reverted in #1537.

I know this is a workaround, but I'd say it's simple enough and it is an improvement for NVDA users.
It is also very specific to this toggle button context so, in a certain sense, it's "isolated".

- no HTML/CSS changes, so no visual breakage
- adds `type="button"` to the button, so no need for `event.preventDefault()`
- uses a separate state property for the `aria-expanded` attribute
- this property gets updated with a slight delay (more details on the issue)

Note: yes, 100ms is a totally arbitrary value. I've tried with smaller values but it didn't work.

Alternatively, as last resort, we could consider to don't use aria-expanded at all and announce the collapsed/expanded state with `wp.a11y.speak` instead.

Fixes #1556