### PR TITLE
Added optional 'description' prop to inspector controls

### DIFF
--- a/blocks/inspector-controls/base-control/index.js
+++ b/blocks/inspector-controls/base-control/index.js
@@ -8,11 +8,12 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-function BaseControl( { id, label, className, children } ) {
+function BaseControl( { id, label, description, className, children } ) {
 	return (
 		<div className={ classnames( 'blocks-base-control', className ) }>
 			{ label && <label className="blocks-base-control__label" htmlFor={ id }>{ label }</label> }
 			{ children }
+			{ description && <p className="blocks-base-control__description">{ description }</p> }
 		</div>
 	);
 }

--- a/blocks/inspector-controls/base-control/index.js
+++ b/blocks/inspector-controls/base-control/index.js
@@ -13,7 +13,7 @@ function BaseControl( { id, label, description, className, children } ) {
 		<div className={ classnames( 'blocks-base-control', className ) }>
 			{ label && <label className="blocks-base-control__label" htmlFor={ id }>{ label }</label> }
 			{ children }
-			{ description && <p className="blocks-base-control__description">{ description }</p> }
+			{ description && <p className="blocks-base-control__description" aria-describedby={ id }>{ description }</p> }
 		</div>
 	);
 }

--- a/blocks/inspector-controls/base-control/style.scss
+++ b/blocks/inspector-controls/base-control/style.scss
@@ -7,3 +7,11 @@
 	font-weight: 500;
 	margin-bottom: 5px;
 }
+
+.blocks-base-control__description {
+	display: block;
+	margin-top: 5px;
+	margin-bottom: 0;
+	font-style: italic;
+	color: $dark-gray-300;
+}

--- a/blocks/inspector-controls/base-control/style.scss
+++ b/blocks/inspector-controls/base-control/style.scss
@@ -9,9 +9,8 @@
 }
 
 .blocks-base-control__description {
-	display: block;
+	min-width: 100%;
 	margin-top: 5px;
 	margin-bottom: 0;
-	font-style: italic;
 	color: $dark-gray-300;
 }

--- a/blocks/inspector-controls/checkbox-control/index.js
+++ b/blocks/inspector-controls/checkbox-control/index.js
@@ -9,12 +9,12 @@ import { withInstanceId } from 'components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function CheckboxControl( { label, heading, checked, instanceId, onChange, ...props } ) {
+function CheckboxControl( { label, description, heading, checked, instanceId, onChange, ...props } ) {
 	const id = 'inspector-checkbox-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ heading } id={ id }>
+		<BaseControl label={ heading } description={ description } id={ id }>
 			<input
 				id={ id }
 				className="blocks-checkbox-control__input"

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -14,12 +14,17 @@ import { withInstanceId } from 'components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function RadioControl( { label, selected, instanceId, onChange, options = [] } ) {
+function RadioControl( { label, description, selected, instanceId, onChange, options = [] } ) {
 	const id = 'inspector-radio-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return ! isEmpty( options ) && (
-		<BaseControl label={ label } id={ id } className="blocks-radio-control">
+		<BaseControl
+			id={ id }
+			label={ label }
+			description={ description }
+			className="blocks-radio-control"
+		>
 			{ options.map( ( option, index ) =>
 				<div
 					key={ ( id + '-' + index ) }

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -9,13 +9,22 @@ import { withInstanceId } from 'components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function RangeControl( { label, value, instanceId, onChange, ...props } ) {
+function RangeControl( { label, description, value, instanceId, onChange, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
 
 	return (
-		<BaseControl label={ label } id={ id } className="blocks-range-control">
-			<input className="blocks-range-control__input" id={ id } type="range" value={ value } onChange={ onChange } { ...props } />
-			<span className="blocks-range-control__hint">{ value }</span>
+		<BaseControl label={ label } description={ description } id={ id }>
+			<div className="blocks-range-control">
+				<input
+					id={ id }
+					type="range"
+					value={ value }
+					className="blocks-range-control__input"
+					onChange={ onChange }
+					{ ...props }
+				/>
+				<span className="blocks-range-control__hint">{ value }</span>
+			</div>
 		</BaseControl>
 	);
 }

--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -14,12 +14,12 @@ import { withInstanceId } from 'components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function SelectControl( { label, selected, instanceId, onBlur, options = [], ...props } ) {
+function SelectControl( { label, description, selected, instanceId, onBlur, options = [], ...props } ) {
 	const id = 'inspector-select-control-' + instanceId;
 	const onBlurValue = ( event ) => onBlur( event.target.value );
 
 	return ! isEmpty( options ) && (
-		<BaseControl label={ label } id={ id }>
+		<BaseControl label={ label } description={ description } id={ id }>
 			<select
 				id={ id }
 				className="blocks-select-control__input"

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -9,12 +9,12 @@ import { withInstanceId } from 'components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function TextControl( { label, value, instanceId, onChange, type = 'text', ...props } ) {
+function TextControl( { label, description, value, instanceId, onChange, type = 'text', ...props } ) {
 	const id = 'inspector-text-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ label } id={ id }>
+		<BaseControl label={ label } description={ description } id={ id }>
 			<input className="blocks-text-control__input" type={ type } id={ id } value={ value } onChange={ onChangeValue } { ...props } />
 		</BaseControl>
 	);

--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -9,12 +9,12 @@ import { withInstanceId } from 'components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function TextareaControl( { label, value, instanceId, onChange, rows = 4, ...props } ) {
+function TextareaControl( { label, description, value, instanceId, onChange, rows = 4, ...props } ) {
 	const id = 'inspector-textarea-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ label } id={ id }>
+		<BaseControl label={ label } description={ description } id={ id }>
 			<textarea className="blocks-textarea-control__input" id={ id } rows={ rows } onChange={ onChangeValue } { ...props }>
 				{ value }
 			</textarea>

--- a/blocks/inspector-controls/textarea-control/style.scss
+++ b/blocks/inspector-controls/textarea-control/style.scss
@@ -1,4 +1,5 @@
 .blocks-textarea-control__input {
+	vertical-align: top;
 	width: 100%;
 	padding: 6px 8px;
 }

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -9,11 +9,16 @@ import { withInstanceId, FormToggle } from 'components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function ToggleControl( { label, checked, instanceId, onChange } ) {
+function ToggleControl( { label, description, checked, instanceId, onChange } ) {
 	const id = 'inspector-toggle-control-' + instanceId;
 
 	return (
-		<BaseControl label={ label } id={ id } className="blocks-toggle-control">
+		<BaseControl
+			id={ id }
+			label={ label }
+			description={ description }
+			className="blocks-toggle-control"
+		>
 			<FormToggle id={ id } checked={ checked } onChange={ onChange } />
 		</BaseControl>
 	);

--- a/blocks/inspector-controls/toggle-control/style.scss
+++ b/blocks/inspector-controls/toggle-control/style.scss
@@ -1,4 +1,5 @@
 .blocks-toggle-control {
 	display: flex;
+	flex-wrap: wrap;
 	justify-content: space-between;
 }


### PR DESCRIPTION
This adds an optional prop to all inspector controls to add description text below. Useful for help text.

![screen shot 2017-06-28 at 21 20 45](https://user-images.githubusercontent.com/704594/27658773-02ffed2c-5c49-11e7-9381-61b3f2c15f85.png)
