### PR TITLE
Add CSS classes to the Gallery insert from media library button.

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -97,6 +97,8 @@ registerBlockType( 'core/gallery', {
 
 		if ( images.length === 0 ) {
 			const setMediaUrl = ( imgs ) => setAttributes( { images: imgs } );
+			const uploadButtonProps = { isLarge: true };
+
 			return [
 				controls,
 				<Placeholder
@@ -106,6 +108,7 @@ registerBlockType( 'core/gallery', {
 					label={ __( 'Gallery' ) }
 					className={ className }>
 					<MediaUploadButton
+						buttonProps={ uploadButtonProps }
 						onSelect={ setMediaUrl }
 						type="image"
 						autoOpen


### PR DESCRIPTION
Makes the Gallery block placeholder button look like a button (same as the Image block one).

Fixes #1478 

![screen shot 2017-06-29 at 12 03 08](https://user-images.githubusercontent.com/1682452/27682539-3f509338-5cc3-11e7-9cf9-a0a57c73db3f.png)
