### PR TITLE
Fix toolbars, polish inserter, inspector, lots of blocks

### DIFF
--- a/blocks/block-description/style.scss
+++ b/blocks/block-description/style.scss
@@ -8,5 +8,6 @@
 
 	p {
 		font-style: italic;
+		margin-top: 0;
 	}
 }

--- a/blocks/inspector-controls/base-control/style.scss
+++ b/blocks/inspector-controls/base-control/style.scss
@@ -1,9 +1,8 @@
-.blocks-base-control:not(:last-child) {
-	margin-bottom: 15px;
+.blocks-base-control {
+	margin: 1em 0 1.5em 0;
 }
 
 .blocks-base-control__label {
 	display: block;
-	font-weight: 500;
 	margin-bottom: 5px;
 }

--- a/blocks/library/cover-image/block.scss
+++ b/blocks/library/cover-image/block.scss
@@ -7,6 +7,9 @@
 		font-size: 24pt;
 		line-height: 1em;
 		z-index: 1;
+		max-width: $visual-editor-max-width;
+		padding: $block-padding;
+		text-align: center;
 	}
 
 	.cover-image {
@@ -22,7 +25,7 @@
 		background-attachment: fixed;
 	}
 
-	.cover-image:before {
+	.has-background-dim.cover-image:before {
 		content: '';
 		position: absolute;
 		top: 0;

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -17,6 +17,7 @@ import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
+import BlockDescription from '../../block-description';
 
 const { text } = query;
 
@@ -105,8 +106,9 @@ registerBlockType( 'core/cover-image', {
 			controls,
 			focus && (
 				<InspectorControls key="inspector">
-					<p className="editor-block-inspector__description">Image galleries are a great way to share groups of pictures on your site.</p>
-					<hr />
+					<BlockDescription>
+						<p>{ __( 'Cover Image is a bold image block with an optional title.' ) }</p>
+					</BlockDescription>
 					<h3>{ __( 'Cover Image Settings' ) }</h3>
 					<ToggleControl
 						label={ __( 'Fixed Background' ) }

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -142,13 +142,14 @@ registerBlockType( 'core/cover-image', {
 	},
 
 	save( { attributes } ) {
-		const { url, title, hasParallax } = attributes;
+		const { url, title, hasParallax, hasBackgroundDim } = attributes;
 		const style = {
 			backgroundImage: `url(${ url })`,
 		};
 		const sectionClasses = classnames( {
 			'cover-image': true,
 			'has-parallax': hasParallax,
+			'has-background-dim': hasBackgroundDim,
 		} );
 
 		return (

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -41,7 +41,7 @@ registerBlockType( 'core/cover-image', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus, className } ) {
-		const { url, title, align, id, hasParallax } = attributes;
+		const { url, title, align, id, hasParallax, hasBackgroundDim = true } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const onSelectImage = ( media ) => setAttributes( { url: media.url, id: media.id } );
 
@@ -96,17 +96,27 @@ registerBlockType( 'core/cover-image', {
 		const sectionClasses = classnames( {
 			'cover-image': true,
 			'has-parallax': hasParallax,
+			'has-background-dim': hasBackgroundDim,
 		} );
 		const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
+		const toggleBackgroundDim = () => setAttributes( { hasBackgroundDim: ! hasBackgroundDim } );
 
 		return [
 			controls,
 			focus && (
 				<InspectorControls key="inspector">
+					<p className="editor-block-inspector__description">Image galleries are a great way to share groups of pictures on your site.</p>
+					<hr />
+					<h3>{ __( 'Cover Image Settings' ) }</h3>
 					<ToggleControl
-						label={ __( 'Fixed Position' ) }
+						label={ __( 'Fixed Background' ) }
 						checked={ !! hasParallax }
 						onChange={ toggleParallax }
+					/>
+					<ToggleControl
+						label={ __( 'Dim Background' ) }
+						checked={ !! hasBackgroundDim }
+						onChange={ toggleBackgroundDim }
 					/>
 				</InspectorControls>
 			),

--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -32,9 +32,9 @@
 	.cover-image.has-background-dim::before {
 		content: '';
 		position: absolute;
-		top: $block-padding;
+		top: 0;
 		right: $block-padding * 2 + $block-mover-margin;
-		bottom: $block-padding;
+		bottom: 0;
 		left: $block-padding * 2 + $block-mover-margin;
 		background: rgba( 0,0,0,.5 );
 	}

--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -10,6 +10,9 @@
 			color: white;
 			font-size: 24pt;
 			line-height: 1em;
+			max-width: $visual-editor-max-width;
+			padding: $block-padding;
+			text-align: center;
 		}
 	}
 

--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -1,3 +1,47 @@
+.editor-visual-editor__block[data-type="core/cover-image"] {
+	.blocks-editable__tinymce[data-is-empty="true"]:before {
+		position: inherit;
+	}
+
+	.wp-block-cover-image {
+		margin: 0;
+
+		h2 {
+			color: white;
+			font-size: 24pt;
+			line-height: 1em;
+		}
+	}
+
+	.cover-image {
+		background-size: cover;
+		height: 430px;
+		width: 100%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.has-parallax {
+		background-attachment: fixed;
+	}
+
+	.cover-image.has-background-dim::before {
+		content: '';
+		position: absolute;
+		top: $block-padding;
+		right: $block-padding * 2 + $block-mover-margin;
+		bottom: $block-padding;
+		left: $block-padding * 2 + $block-mover-margin;
+		background: rgba( 0,0,0,.5 );
+	}
+
+	&[data-align="full"] .cover-image::before {
+		right: 0;
+		left: 0;
+	}
+}
+
 .cover-image {
 	.blocks-editable__tinymce a {
 		color: white;

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -17,6 +17,7 @@ import ToggleControl from '../../inspector-controls/toggle-control';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import GalleryImage from './gallery-image';
+import BlockDescription from '../../block-description';
 
 const { query, attr } = hpq;
 
@@ -128,8 +129,9 @@ registerBlockType( 'core/gallery', {
 			controls,
 			focus && images.length > 1 && (
 				<InspectorControls key="inspector">
-					<p className="editor-block-inspector__description">Image galleries are a great way to share groups of pictures on your site.</p>
-					<hr />
+					<BlockDescription>
+						<p>{ __( 'Image galleries are a great way to share groups of pictures on your site.' ) }</p>
+					</BlockDescription>
 					<h3>{ __( 'Gallery Settings' ) }</h3>
 					<RangeControl
 						label={ __( 'Columns' ) }

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -19,6 +19,7 @@ import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import InspectorControls from '../../inspector-controls';
 import AlignmentToolbar from '../../alignment-toolbar';
+import BlockDescription from '../../block-description';
 
 const { children, prop } = query;
 
@@ -108,7 +109,11 @@ registerBlockType( 'core/heading', {
 			),
 			focus && (
 				<InspectorControls key="inspector">
-					<h3>{ __( 'Heading Size' ) }</h3>
+					<BlockDescription>
+						<p>{ __( 'Search engines use the headings to index the structure and content of your web pages.' ) }</p>
+					</BlockDescription>
+					<h3>{ __( 'Heading Settings' ) }</h3>
+					<p>{ __( 'Size' ) }</p>
 					<Toolbar
 						controls={
 							'123456'.split( '' ).map( ( level ) => ( {
@@ -120,7 +125,7 @@ registerBlockType( 'core/heading', {
 							} ) )
 						}
 					/>
-					<h3>{ __( 'Text Alignment' ) }</h3>
+					<p>{ __( 'Text Alignment' ) }</p>
 					<AlignmentToolbar
 						value={ align }
 						onChange={ ( nextAlign ) => {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -15,6 +15,7 @@ import InspectorControls from '../../inspector-controls';
 import TextControl from '../../inspector-controls/text-control';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import BlockDescription from '../../block-description';
 
 const { attr, children } = query;
 
@@ -102,6 +103,10 @@ registerBlockType( 'core/image', {
 			controls,
 			focus && (
 				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Worth a thousand words.' ) }</p>
+					</BlockDescription>
+					<h3>{ __( 'Image Settings' ) }</h3>
 					<TextControl label={ __( 'Alternate Text' ) } value={ alt } onChange={ updateAlt } />
 				</InspectorControls>
 			),

--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -12,8 +12,7 @@
 
 	& > .blocks-pullquote__content .blocks-editable__tinymce[data-is-empty="true"]:before,
 	& > .blocks-editable p {
-		font-family: $default-font;
 		font-size: 48px;
-		font-weight: 900;
+		font-weight: bold;
 	}
 }

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -14,6 +14,7 @@ import BlockControls from '../../block-controls';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
+import BlockDescription from '../../block-description';
 
 const { children, query } = hpq;
 
@@ -52,6 +53,10 @@ registerBlockType( 'core/text', {
 			),
 			focus && (
 				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Text. Great things start here.' ) }</p>
+					</BlockDescription>
+					<h3>{ __( 'Text Settings' ) }</h3>
 					<ToggleControl
 						label={ __( 'Drop Cap' ) }
 						checked={ !! dropCap }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -268,13 +268,13 @@ $sticky-bottom-offset: 20px;
 .editor-visual-editor .editor-inserter {
 	margin: $item-spacing;
 
-	@include break-small {
+	/*@include break-small {
 		margin: $item-spacing $item-spacing $item-spacing calc( 50% - #{ $visual-editor-max-width / 2 } );	// account for full-width trick
-	}
+	}*/
 
 	.editor-inserter__toggle {
 		color: $dark-gray-300;
-		margin: 4px 0 0 4px;	// align better with text blocks
+		margin: 4px 0 0 -4px;	// align better with text blocks
 	}
 
 	.editor-inserter__toggle.components-icon-button:not(:disabled):hover {
@@ -327,6 +327,8 @@ $sticky-bottom-offset: 20px;
 .editor-visual-editor__continue-writing {
 	display: flex;
 	align-items: baseline;
+	max-width: $visual-editor-max-width;
+	margin: 0 auto;
 
 	> .editor-inserter__block {
 		opacity: 0;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -224,6 +224,7 @@
 	margin-bottom: $item-spacing + 20px;	// 20px is the offset from the bottom of the selected block where it stops sticking
 	width: 0;
 	white-space: nowrap;
+	height: $block-controls-height;
 
 	// Mobile viewport
 	top: $header-height - 1px;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -268,10 +268,6 @@ $sticky-bottom-offset: 20px;
 .editor-visual-editor .editor-inserter {
 	margin: $item-spacing;
 
-	/*@include break-small {
-		margin: $item-spacing $item-spacing $item-spacing calc( 50% - #{ $visual-editor-max-width / 2 } );	// account for full-width trick
-	}*/
-
 	.editor-inserter__toggle {
 		color: $dark-gray-300;
 		margin: 4px 0 0 -4px;	// align better with text blocks

--- a/editor/post-permalink/style.scss
+++ b/editor/post-permalink/style.scss
@@ -3,7 +3,8 @@
 	align-items: center;
 	position: absolute;
 	top: -36px;
-	left: 15px;
+	left: $block-padding;
+	right: $block-padding;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;
@@ -20,7 +21,7 @@
 	color: $dark-gray-200;
 	text-decoration: underline;
 	margin-right: 10px;
-	width: 300px;
+	width: 100%;
 	overflow: hidden;
 	position: relative;
 	white-space: nowrap;

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -7,6 +7,7 @@
 	width: $sidebar-width;
 	border-left: 1px solid $light-gray-500;
 	background: $light-gray-300;
+	color: $dark-gray-500;
 
 	@include break-small() {
 		position: fixed;
@@ -29,9 +30,14 @@
 		}
 	}
 
+	p {
+		margin-top: 0;
+	}
+
 	h3 {
 		font-size: $default-font-size;
 		color: $dark-gray-500;
+		margin-bottom: 1.5em;
 	}
 
 	hr {
@@ -42,7 +48,11 @@
 
 	ul.components-toolbar {
 		box-shadow: none;
-		margin-bottom: $panel-padding;
+		margin-bottom: 1.5em;
+	}
+
+	p + ul.components-toolbar {
+		margin-top: -1em;
 	}
 }
 

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -31,6 +31,7 @@
 
 	h3 {
 		font-size: $default-font-size;
+		color: $dark-gray-500;
 	}
 
 	hr {

--- a/post-content.js
+++ b/post-content.js
@@ -9,7 +9,7 @@ window._wpGutenbergPost = {
 	content: {
 		raw: [
 			'<!-- wp:core/cover-image { "url": "https://cldup.com/GCwahb3aOb.jpg", "align": "full", "hasParallax": true } -->',
-			'<section className="cover-image wp-block-cover-image" style={ { backgroundImage: \'url("https://cldup.com/GCwahb3aOb.jpg");\' } }><h2>A tale of mountains and the printing press</h2></section>',
+			'<section className="cover-image wp-block-cover-image" style={ { backgroundImage: \'url("https://cldup.com/GCwahb3aOb.jpg");\' } }><h2>Of mountains & printing presses</h2></section>',
 			'<!-- /wp:core/cover-image -->',
 
 			'<!-- wp:core/text { "project": { "name": "gutenberg", "for": "WordPress" }, "isAwesome": true } -->',


### PR DESCRIPTION
This is sort of a "trash pickup" PR, and polishes a lot of small things:

- It fixes an issue where blocks with no toolbar would collapse on select
- Fixes a responsive issue with the in-text inserter, and polishes
- Adds toggle for Cover Image dimming
- Adds max width and centering to Cover Image text
- Makes permalink container go full width
- Uses the new `BlockDescription` component by @swissspidy and applies it to all blocks with inspector controls
- Polishes and normalizes inspector styles
- Tweaks the pullquote

Screenshots:

![screen shot 2017-06-30 at 11 09 09](https://user-images.githubusercontent.com/1204802/27729095-bb714220-5d84-11e7-86a3-b89e55d5c5cc.png)

![screen shot 2017-06-30 at 11 09 35](https://user-images.githubusercontent.com/1204802/27729098-bd67fd3a-5d84-11e7-84f3-bc0dc86918b8.png)

![screen shot 2017-06-30 at 11 10 21](https://user-images.githubusercontent.com/1204802/27729112-c661326c-5d84-11e7-8bcb-fd9227c6841c.png)

![screen shot 2017-06-30 at 11 09 50](https://user-images.githubusercontent.com/1204802/27729102-c06868da-5d84-11e7-89ce-038b32d04696.png)

![screen shot 2017-06-30 at 11 09 54](https://user-images.githubusercontent.com/1204802/27729110-c418cb1e-5d84-11e7-8696-1f8e1001519b.png)