### PR TITLE
Make auto-generated `wp-block*` classes consistent

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, kebabCase, isObject } from 'lodash';
+import { isEmpty, reduce, isObject } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 import classnames from 'classnames';
 
@@ -23,11 +23,8 @@ import { parseBlockAttributes } from './parser';
  * @return {string}             The block's default class
  */
 export function getBlockDefaultClassname( blockName ) {
-	// Drop the namespace "core/"" for core blocks only
-	const match = /^([a-z0-9-]+)\/([a-z0-9-]+)$/.exec( blockName );
-	const sanitizedBlockName = match[ 1 ] === 'core' ? match[ 2 ] : blockName;
-
-	return `wp-block-${ kebabCase( sanitizedBlockName ) }`;
+	// Drop common prefixes: 'core/' or 'core-' (in 'core-embed/')
+	return 'wp-block-' + blockName.replace( /\//, '-' ).replace( /^core-/, '' );
 }
 
 /**
@@ -59,7 +56,7 @@ export function getSaveContent( blockType, attributes ) {
 			return element;
 		}
 
-		const updatedClassName = classnames( element.props.className, className );
+		const updatedClassName = classnames( className, element.props.className );
 		return cloneElement( element, { className: updatedClassName } );
 	};
 	const contentWithClassname = Children.map( rawContent, addClassnameToElement );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -51,6 +51,12 @@ describe( 'blocks', () => {
 			expect( block ).to.be.undefined();
 		} );
 
+		it( 'should reject blocks with too many namespaces', () => {
+			const block = registerBlockType( 'doing/it/wrong' );
+			expect( console.error ).to.have.been.calledWith( 'Block names must contain a namespace prefix. Example: my-plugin/my-custom-block' );
+			expect( block ).to.be.undefined();
+		} );
+
 		it( 'should reject blocks with invalid characters', () => {
 			const block = registerBlockType( 'still/_doing_it_wrong' );
 			expect( console.error ).to.have.been.calledWith( 'Block names must contain a namespace prefix. Example: my-plugin/my-custom-block' );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -47,7 +47,7 @@ describe( 'block serializer', () => {
 				expect( saved ).to.equal( '<div class="wp-block-fruit">Bananas</div>' );
 			} );
 
-			it( 'should return use the namespace in the classname if it\' not a core block', () => {
+			it( 'should use the namespace in the classname for non-core blocks', () => {
 				const saved = getSaveContent(
 					{
 						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
@@ -59,7 +59,7 @@ describe( 'block serializer', () => {
 				expect( saved ).to.equal( '<div class="wp-block-myplugin-fruit">Bananas</div>' );
 			} );
 
-			it( 'should overrides the className', () => {
+			it( 'should allow overriding the className', () => {
 				const saved = getSaveContent(
 					{
 						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),

--- a/blocks/test/fixtures/core-embed__animoto.html
+++ b/blocks/test/fixtures/core-embed__animoto.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/animoto {"url":"https://animoto.com/"} -->
-<figure class="wp-block-core-embed-animoto">
+<figure class="wp-block-embed-animoto">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__animoto.parsed.json
+++ b/blocks/test/fixtures/core-embed__animoto.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://animoto.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-animoto\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-animoto\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__animoto.serialized.html
+++ b/blocks/test/fixtures/core-embed__animoto.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/animoto {"url":"https://animoto.com/"} -->
-<figure class="wp-block-core-embed-animoto">
+<figure class="wp-block-embed-animoto">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__cloudup.html
+++ b/blocks/test/fixtures/core-embed__cloudup.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/cloudup {"url":"https://cloudup.com/"} -->
-<figure class="wp-block-core-embed-cloudup">
+<figure class="wp-block-embed-cloudup">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__cloudup.parsed.json
+++ b/blocks/test/fixtures/core-embed__cloudup.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://cloudup.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-cloudup\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-cloudup\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__cloudup.serialized.html
+++ b/blocks/test/fixtures/core-embed__cloudup.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/cloudup {"url":"https://cloudup.com/"} -->
-<figure class="wp-block-core-embed-cloudup">
+<figure class="wp-block-embed-cloudup">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__collegehumor.html
+++ b/blocks/test/fixtures/core-embed__collegehumor.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/collegehumor {"url":"https://collegehumor.com/"} -->
-<figure class="wp-block-core-embed-collegehumor">
+<figure class="wp-block-embed-collegehumor">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__collegehumor.parsed.json
+++ b/blocks/test/fixtures/core-embed__collegehumor.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://collegehumor.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-collegehumor\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-collegehumor\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__collegehumor.serialized.html
+++ b/blocks/test/fixtures/core-embed__collegehumor.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/collegehumor {"url":"https://collegehumor.com/"} -->
-<figure class="wp-block-core-embed-collegehumor">
+<figure class="wp-block-embed-collegehumor">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__dailymotion.html
+++ b/blocks/test/fixtures/core-embed__dailymotion.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/dailymotion {"url":"https://dailymotion.com/"} -->
-<figure class="wp-block-core-embed-dailymotion">
+<figure class="wp-block-embed-dailymotion">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__dailymotion.parsed.json
+++ b/blocks/test/fixtures/core-embed__dailymotion.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://dailymotion.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-dailymotion\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-dailymotion\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__dailymotion.serialized.html
+++ b/blocks/test/fixtures/core-embed__dailymotion.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/dailymotion {"url":"https://dailymotion.com/"} -->
-<figure class="wp-block-core-embed-dailymotion">
+<figure class="wp-block-embed-dailymotion">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__facebook.html
+++ b/blocks/test/fixtures/core-embed__facebook.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/facebook {"url":"https://facebook.com/"} -->
-<figure class="wp-block-core-embed-facebook">
+<figure class="wp-block-embed-facebook">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__facebook.parsed.json
+++ b/blocks/test/fixtures/core-embed__facebook.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://facebook.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-facebook\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-facebook\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__facebook.serialized.html
+++ b/blocks/test/fixtures/core-embed__facebook.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/facebook {"url":"https://facebook.com/"} -->
-<figure class="wp-block-core-embed-facebook">
+<figure class="wp-block-embed-facebook">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__flickr.html
+++ b/blocks/test/fixtures/core-embed__flickr.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/flickr {"url":"https://flickr.com/"} -->
-<figure class="wp-block-core-embed-flickr">
+<figure class="wp-block-embed-flickr">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__flickr.parsed.json
+++ b/blocks/test/fixtures/core-embed__flickr.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://flickr.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-flickr\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-flickr\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__flickr.serialized.html
+++ b/blocks/test/fixtures/core-embed__flickr.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/flickr {"url":"https://flickr.com/"} -->
-<figure class="wp-block-core-embed-flickr">
+<figure class="wp-block-embed-flickr">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__funnyordie.html
+++ b/blocks/test/fixtures/core-embed__funnyordie.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/funnyordie {"url":"https://funnyordie.com/"} -->
-<figure class="wp-block-core-embed-funnyordie">
+<figure class="wp-block-embed-funnyordie">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__funnyordie.parsed.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://funnyordie.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-funnyordie\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-funnyordie\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__funnyordie.serialized.html
+++ b/blocks/test/fixtures/core-embed__funnyordie.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/funnyordie {"url":"https://funnyordie.com/"} -->
-<figure class="wp-block-core-embed-funnyordie">
+<figure class="wp-block-embed-funnyordie">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__hulu.html
+++ b/blocks/test/fixtures/core-embed__hulu.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/hulu {"url":"https://hulu.com/"} -->
-<figure class="wp-block-core-embed-hulu">
+<figure class="wp-block-embed-hulu">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__hulu.parsed.json
+++ b/blocks/test/fixtures/core-embed__hulu.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://hulu.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-hulu\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-hulu\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__hulu.serialized.html
+++ b/blocks/test/fixtures/core-embed__hulu.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/hulu {"url":"https://hulu.com/"} -->
-<figure class="wp-block-core-embed-hulu">
+<figure class="wp-block-embed-hulu">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__imgur.html
+++ b/blocks/test/fixtures/core-embed__imgur.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/imgur {"url":"https://imgur.com/"} -->
-<figure class="wp-block-core-embed-imgur">
+<figure class="wp-block-embed-imgur">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__imgur.parsed.json
+++ b/blocks/test/fixtures/core-embed__imgur.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://imgur.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-imgur\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-imgur\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__imgur.serialized.html
+++ b/blocks/test/fixtures/core-embed__imgur.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/imgur {"url":"https://imgur.com/"} -->
-<figure class="wp-block-core-embed-imgur">
+<figure class="wp-block-embed-imgur">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__instagram.html
+++ b/blocks/test/fixtures/core-embed__instagram.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/instagram {"url":"https://instagram.com/"} -->
-<figure class="wp-block-core-embed-instagram">
+<figure class="wp-block-embed-instagram">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__instagram.parsed.json
+++ b/blocks/test/fixtures/core-embed__instagram.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://instagram.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-instagram\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-instagram\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__instagram.serialized.html
+++ b/blocks/test/fixtures/core-embed__instagram.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/instagram {"url":"https://instagram.com/"} -->
-<figure class="wp-block-core-embed-instagram">
+<figure class="wp-block-embed-instagram">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__issuu.html
+++ b/blocks/test/fixtures/core-embed__issuu.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/issuu {"url":"https://issuu.com/"} -->
-<figure class="wp-block-core-embed-issuu">
+<figure class="wp-block-embed-issuu">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__issuu.parsed.json
+++ b/blocks/test/fixtures/core-embed__issuu.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://issuu.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-issuu\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-issuu\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__issuu.serialized.html
+++ b/blocks/test/fixtures/core-embed__issuu.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/issuu {"url":"https://issuu.com/"} -->
-<figure class="wp-block-core-embed-issuu">
+<figure class="wp-block-embed-issuu">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__kickstarter.html
+++ b/blocks/test/fixtures/core-embed__kickstarter.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/kickstarter {"url":"https://kickstarter.com/"} -->
-<figure class="wp-block-core-embed-kickstarter">
+<figure class="wp-block-embed-kickstarter">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__kickstarter.parsed.json
+++ b/blocks/test/fixtures/core-embed__kickstarter.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://kickstarter.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-kickstarter\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-kickstarter\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__kickstarter.serialized.html
+++ b/blocks/test/fixtures/core-embed__kickstarter.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/kickstarter {"url":"https://kickstarter.com/"} -->
-<figure class="wp-block-core-embed-kickstarter">
+<figure class="wp-block-embed-kickstarter">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__meetup-com.html
+++ b/blocks/test/fixtures/core-embed__meetup-com.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/meetup-com {"url":"https://meetup.com/"} -->
-<figure class="wp-block-core-embed-meetup-com">
+<figure class="wp-block-embed-meetup-com">
     https://meetup.com/
     <figcaption>Embedded content from meetup-com</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__meetup-com.parsed.json
+++ b/blocks/test/fixtures/core-embed__meetup-com.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://meetup.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-meetup-com\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-meetup-com\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__meetup-com.serialized.html
+++ b/blocks/test/fixtures/core-embed__meetup-com.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/meetup-com {"url":"https://meetup.com/"} -->
-<figure class="wp-block-core-embed-meetup-com">
+<figure class="wp-block-embed-meetup-com">
     https://meetup.com/
     <figcaption>Embedded content from meetup-com</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__mixcloud.html
+++ b/blocks/test/fixtures/core-embed__mixcloud.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/mixcloud {"url":"https://mixcloud.com/"} -->
-<figure class="wp-block-core-embed-mixcloud">
+<figure class="wp-block-embed-mixcloud">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__mixcloud.parsed.json
+++ b/blocks/test/fixtures/core-embed__mixcloud.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://mixcloud.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-mixcloud\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-mixcloud\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__mixcloud.serialized.html
+++ b/blocks/test/fixtures/core-embed__mixcloud.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/mixcloud {"url":"https://mixcloud.com/"} -->
-<figure class="wp-block-core-embed-mixcloud">
+<figure class="wp-block-embed-mixcloud">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__photobucket.html
+++ b/blocks/test/fixtures/core-embed__photobucket.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/photobucket {"url":"https://photobucket.com/"} -->
-<figure class="wp-block-core-embed-photobucket">
+<figure class="wp-block-embed-photobucket">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__photobucket.parsed.json
+++ b/blocks/test/fixtures/core-embed__photobucket.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://photobucket.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-photobucket\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-photobucket\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__photobucket.serialized.html
+++ b/blocks/test/fixtures/core-embed__photobucket.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/photobucket {"url":"https://photobucket.com/"} -->
-<figure class="wp-block-core-embed-photobucket">
+<figure class="wp-block-embed-photobucket">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__polldaddy.html
+++ b/blocks/test/fixtures/core-embed__polldaddy.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/polldaddy {"url":"https://polldaddy.com/"} -->
-<figure class="wp-block-core-embed-polldaddy">
+<figure class="wp-block-embed-polldaddy">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__polldaddy.parsed.json
+++ b/blocks/test/fixtures/core-embed__polldaddy.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://polldaddy.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-polldaddy\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-polldaddy\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__polldaddy.serialized.html
+++ b/blocks/test/fixtures/core-embed__polldaddy.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/polldaddy {"url":"https://polldaddy.com/"} -->
-<figure class="wp-block-core-embed-polldaddy">
+<figure class="wp-block-embed-polldaddy">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__reddit.html
+++ b/blocks/test/fixtures/core-embed__reddit.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/reddit {"url":"https://reddit.com/"} -->
-<figure class="wp-block-core-embed-reddit">
+<figure class="wp-block-embed-reddit">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__reddit.parsed.json
+++ b/blocks/test/fixtures/core-embed__reddit.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://reddit.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-reddit\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-reddit\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__reddit.serialized.html
+++ b/blocks/test/fixtures/core-embed__reddit.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/reddit {"url":"https://reddit.com/"} -->
-<figure class="wp-block-core-embed-reddit">
+<figure class="wp-block-embed-reddit">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__reverbnation.html
+++ b/blocks/test/fixtures/core-embed__reverbnation.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/reverbnation {"url":"https://reverbnation.com/"} -->
-<figure class="wp-block-core-embed-reverbnation">
+<figure class="wp-block-embed-reverbnation">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__reverbnation.parsed.json
+++ b/blocks/test/fixtures/core-embed__reverbnation.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://reverbnation.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-reverbnation\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-reverbnation\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__reverbnation.serialized.html
+++ b/blocks/test/fixtures/core-embed__reverbnation.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/reverbnation {"url":"https://reverbnation.com/"} -->
-<figure class="wp-block-core-embed-reverbnation">
+<figure class="wp-block-embed-reverbnation">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__screencast.html
+++ b/blocks/test/fixtures/core-embed__screencast.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/screencast {"url":"https://screencast.com/"} -->
-<figure class="wp-block-core-embed-screencast">
+<figure class="wp-block-embed-screencast">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__screencast.parsed.json
+++ b/blocks/test/fixtures/core-embed__screencast.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://screencast.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-screencast\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-screencast\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__screencast.serialized.html
+++ b/blocks/test/fixtures/core-embed__screencast.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/screencast {"url":"https://screencast.com/"} -->
-<figure class="wp-block-core-embed-screencast">
+<figure class="wp-block-embed-screencast">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__scribd.html
+++ b/blocks/test/fixtures/core-embed__scribd.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/scribd {"url":"https://scribd.com/"} -->
-<figure class="wp-block-core-embed-scribd">
+<figure class="wp-block-embed-scribd">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__scribd.parsed.json
+++ b/blocks/test/fixtures/core-embed__scribd.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://scribd.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-scribd\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-scribd\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__scribd.serialized.html
+++ b/blocks/test/fixtures/core-embed__scribd.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/scribd {"url":"https://scribd.com/"} -->
-<figure class="wp-block-core-embed-scribd">
+<figure class="wp-block-embed-scribd">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__slideshare.html
+++ b/blocks/test/fixtures/core-embed__slideshare.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/slideshare {"url":"https://slideshare.com/"} -->
-<figure class="wp-block-core-embed-slideshare">
+<figure class="wp-block-embed-slideshare">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__slideshare.parsed.json
+++ b/blocks/test/fixtures/core-embed__slideshare.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://slideshare.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-slideshare\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-slideshare\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__slideshare.serialized.html
+++ b/blocks/test/fixtures/core-embed__slideshare.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/slideshare {"url":"https://slideshare.com/"} -->
-<figure class="wp-block-core-embed-slideshare">
+<figure class="wp-block-embed-slideshare">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__smugmug.html
+++ b/blocks/test/fixtures/core-embed__smugmug.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/smugmug {"url":"https://smugmug.com/"} -->
-<figure class="wp-block-core-embed-smugmug">
+<figure class="wp-block-embed-smugmug">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__smugmug.parsed.json
+++ b/blocks/test/fixtures/core-embed__smugmug.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://smugmug.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-smugmug\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-smugmug\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__smugmug.serialized.html
+++ b/blocks/test/fixtures/core-embed__smugmug.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/smugmug {"url":"https://smugmug.com/"} -->
-<figure class="wp-block-core-embed-smugmug">
+<figure class="wp-block-embed-smugmug">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__soundcloud.html
+++ b/blocks/test/fixtures/core-embed__soundcloud.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/soundcloud {"url":"https://soundcloud.com/"} -->
-<figure class="wp-block-core-embed-soundcloud">
+<figure class="wp-block-embed-soundcloud">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__soundcloud.parsed.json
+++ b/blocks/test/fixtures/core-embed__soundcloud.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://soundcloud.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-soundcloud\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-soundcloud\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__soundcloud.serialized.html
+++ b/blocks/test/fixtures/core-embed__soundcloud.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/soundcloud {"url":"https://soundcloud.com/"} -->
-<figure class="wp-block-core-embed-soundcloud">
+<figure class="wp-block-embed-soundcloud">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__speaker.html
+++ b/blocks/test/fixtures/core-embed__speaker.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/speaker {"url":"https://speaker.com/"} -->
-<figure class="wp-block-core-embed-speaker">
+<figure class="wp-block-embed-speaker">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__speaker.parsed.json
+++ b/blocks/test/fixtures/core-embed__speaker.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://speaker.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-speaker\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-speaker\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__speaker.serialized.html
+++ b/blocks/test/fixtures/core-embed__speaker.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/speaker {"url":"https://speaker.com/"} -->
-<figure class="wp-block-core-embed-speaker">
+<figure class="wp-block-embed-speaker">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__spotify.html
+++ b/blocks/test/fixtures/core-embed__spotify.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/spotify {"url":"https://spotify.com/"} -->
-<figure class="wp-block-core-embed-spotify">
+<figure class="wp-block-embed-spotify">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__spotify.parsed.json
+++ b/blocks/test/fixtures/core-embed__spotify.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://spotify.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-spotify\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-spotify\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__spotify.serialized.html
+++ b/blocks/test/fixtures/core-embed__spotify.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/spotify {"url":"https://spotify.com/"} -->
-<figure class="wp-block-core-embed-spotify">
+<figure class="wp-block-embed-spotify">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__ted.html
+++ b/blocks/test/fixtures/core-embed__ted.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/ted {"url":"https://ted.com/"} -->
-<figure class="wp-block-core-embed-ted">
+<figure class="wp-block-embed-ted">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__ted.parsed.json
+++ b/blocks/test/fixtures/core-embed__ted.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://ted.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-ted\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-ted\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__ted.serialized.html
+++ b/blocks/test/fixtures/core-embed__ted.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/ted {"url":"https://ted.com/"} -->
-<figure class="wp-block-core-embed-ted">
+<figure class="wp-block-embed-ted">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__tumblr.html
+++ b/blocks/test/fixtures/core-embed__tumblr.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/tumblr {"url":"https://tumblr.com/"} -->
-<figure class="wp-block-core-embed-tumblr">
+<figure class="wp-block-embed-tumblr">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__tumblr.parsed.json
+++ b/blocks/test/fixtures/core-embed__tumblr.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://tumblr.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-tumblr\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-tumblr\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__tumblr.serialized.html
+++ b/blocks/test/fixtures/core-embed__tumblr.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/tumblr {"url":"https://tumblr.com/"} -->
-<figure class="wp-block-core-embed-tumblr">
+<figure class="wp-block-embed-tumblr">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__twitter.html
+++ b/blocks/test/fixtures/core-embed__twitter.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/twitter {"url":"https://twitter.com/automattic"} -->
-<figure class="wp-block-core-embed-twitter">
+<figure class="wp-block-embed-twitter">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__twitter.parsed.json
+++ b/blocks/test/fixtures/core-embed__twitter.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://twitter.com/automattic"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-twitter\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-twitter\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__twitter.serialized.html
+++ b/blocks/test/fixtures/core-embed__twitter.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/twitter {"url":"https://twitter.com/automattic"} -->
-<figure class="wp-block-core-embed-twitter">
+<figure class="wp-block-embed-twitter">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__videopress.html
+++ b/blocks/test/fixtures/core-embed__videopress.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/videopress {"url":"https://videopress.com/"} -->
-<figure class="wp-block-core-embed-videopress">
+<figure class="wp-block-embed-videopress">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__videopress.parsed.json
+++ b/blocks/test/fixtures/core-embed__videopress.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://videopress.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-videopress\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-videopress\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__videopress.serialized.html
+++ b/blocks/test/fixtures/core-embed__videopress.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/videopress {"url":"https://videopress.com/"} -->
-<figure class="wp-block-core-embed-videopress">
+<figure class="wp-block-embed-videopress">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__vimeo.html
+++ b/blocks/test/fixtures/core-embed__vimeo.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/vimeo {"url":"https://vimeo.com/"} -->
-<figure class="wp-block-core-embed-vimeo">
+<figure class="wp-block-embed-vimeo">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__vimeo.parsed.json
+++ b/blocks/test/fixtures/core-embed__vimeo.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://vimeo.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-vimeo\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-vimeo\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__vimeo.serialized.html
+++ b/blocks/test/fixtures/core-embed__vimeo.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/vimeo {"url":"https://vimeo.com/"} -->
-<figure class="wp-block-core-embed-vimeo">
+<figure class="wp-block-embed-vimeo">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__vine.html
+++ b/blocks/test/fixtures/core-embed__vine.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/vine {"url":"https://vine.com/"} -->
-<figure class="wp-block-core-embed-vine">
+<figure class="wp-block-embed-vine">
     https://vine.com/
     <figcaption>Embedded content from vine</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__vine.parsed.json
+++ b/blocks/test/fixtures/core-embed__vine.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://vine.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-vine\">\n    https://vine.com/\n    <figcaption>Embedded content from vine</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-vine\">\n    https://vine.com/\n    <figcaption>Embedded content from vine</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__vine.serialized.html
+++ b/blocks/test/fixtures/core-embed__vine.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/vine {"url":"https://vine.com/"} -->
-<figure class="wp-block-core-embed-vine">
+<figure class="wp-block-embed-vine">
     https://vine.com/
     <figcaption>Embedded content from vine</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__wordpress-tv.html
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/wordpress-tv {"url":"https://wordpress.tv/"} -->
-<figure class="wp-block-core-embed-wordpress-tv">
+<figure class="wp-block-embed-wordpress-tv">
     https://wordpress.tv/
     <figcaption>Embedded content from wordpress-tv</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__wordpress-tv.parsed.json
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://wordpress.tv/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-wordpress-tv\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-wordpress-tv\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__wordpress-tv.serialized.html
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/wordpress-tv {"url":"https://wordpress.tv/"} -->
-<figure class="wp-block-core-embed-wordpress-tv">
+<figure class="wp-block-embed-wordpress-tv">
     https://wordpress.tv/
     <figcaption>Embedded content from wordpress-tv</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__wordpress.html
+++ b/blocks/test/fixtures/core-embed__wordpress.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/wordpress {"url":"https://wordpress.com/"} -->
-<figure class="wp-block-core-embed-wordpress">
+<figure class="wp-block-embed-wordpress">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__wordpress.parsed.json
+++ b/blocks/test/fixtures/core-embed__wordpress.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://wordpress.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-wordpress\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-wordpress\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__wordpress.serialized.html
+++ b/blocks/test/fixtures/core-embed__wordpress.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/wordpress {"url":"https://wordpress.com/"} -->
-<figure class="wp-block-core-embed-wordpress">
+<figure class="wp-block-embed-wordpress">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__youtube.html
+++ b/blocks/test/fixtures/core-embed__youtube.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/youtube {"url":"https://youtube.com/"} -->
-<figure class="wp-block-core-embed-youtube">
+<figure class="wp-block-embed-youtube">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__youtube.parsed.json
+++ b/blocks/test/fixtures/core-embed__youtube.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "url": "https://youtube.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-core-embed-youtube\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>\n"
+        "rawContent": "\n<figure class=\"wp-block-embed-youtube\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__youtube.serialized.html
+++ b/blocks/test/fixtures/core-embed__youtube.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/youtube {"url":"https://youtube.com/"} -->
-<figure class="wp-block-core-embed-youtube">
+<figure class="wp-block-embed-youtube">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>
 </figure>

--- a/blocks/test/fixtures/core__button__center.html
+++ b/blocks/test/fixtures/core__button__center.html
@@ -1,3 +1,3 @@
 <!-- wp:core/button {"align":"center"} -->
-<div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->

--- a/blocks/test/fixtures/core__button__center.parsed.json
+++ b/blocks/test/fixtures/core__button__center.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "align": "center"
         },
-        "rawContent": "\n<div class=\"aligncenter wp-block-button\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
+        "rawContent": "\n<div class=\"wp-block-button aligncenter\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__button__center.serialized.html
+++ b/blocks/test/fixtures/core__button__center.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/button {"align":"center"} -->
-<div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->
 

--- a/blocks/test/fixtures/core__freeform.serialized.html
+++ b/blocks/test/fixtures/core__freeform.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core/freeform -->
 Testing freeform block with some
-<div class="wp-some-class wp-block-freeform">
+<div class="wp-block-freeform wp-some-class">
     HTML <span style="color:red;">content</span>
 </div>
 <!-- /wp:core/freeform -->

--- a/blocks/test/fixtures/core__gallery.serialized.html
+++ b/blocks/test/fixtures/core__gallery.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/gallery {"images":[{"sizes":{"full":{"url":"https://cldup.com/uuUqE_dXzy.jpg","height":1080,"width":810,"orientation":"portrait"}},"mime":"image/jpeg","type":"image","subtype":"jpeg","id":1,"url":"https://cldup.com/uuUqE_dXzy.jpg","alt":"title"},{"sizes":{"full":{"url":"http://google.com/hi.png","height":1080,"width":1440,"orientation":"landscape"}},"mime":"image/jpeg","type":"image","subtype":"jpeg","id":2,"url":"http://google.com/hi.png","alt":"title"}]} -->
-<div class="alignnone columns-2 is-cropped wp-block-gallery">
+<div class="wp-block-gallery alignnone columns-2 is-cropped">
     <figure class="blocks-gallery-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
     <figure class="blocks-gallery-image"><img src="http://google.com/hi.png" alt="title" /></figure>
 </div>

--- a/blocks/test/fixtures/core__image.serialized.html
+++ b/blocks/test/fixtures/core__image.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:core/image -->
-<img src="https://cldup.com/uuUqE_dXzy.jpg" class="alignnone wp-block-image" />
+<img src="https://cldup.com/uuUqE_dXzy.jpg" class="wp-block-image alignnone" />
 <!-- /wp:core/image -->
 

--- a/blocks/test/fixtures/core__image__center-caption.serialized.html
+++ b/blocks/test/fixtures/core__image__center-caption.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/image {"align":"center"} -->
-<figure class="aligncenter wp-block-image"><img src="https://cldup.com/YLYhpou2oq.jpg" />
+<figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" />
     <figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption>
 </figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core__pullquote.serialized.html
+++ b/blocks/test/fixtures/core__pullquote.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
-<blockquote class="alignnone wp-block-pullquote">
+<blockquote class="wp-block-pullquote alignnone">
     <p>Testing pullquote block...</p>
     <footer>...with a caption</footer>
 </blockquote>

--- a/blocks/test/fixtures/core__quote__style-1.html
+++ b/blocks/test/fixtures/core__quote__style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"style":"1"} -->
-<blockquote class="blocks-quote-style-1 wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
+<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "style": "1"
         },
-        "rawContent": "\n<blockquote class=\"blocks-quote-style-1 wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>\n"
+        "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/quote {"style":"1"} -->
-<blockquote class="blocks-quote-style-1 wp-block-quote">
+<blockquote class="wp-block-quote blocks-quote-style-1">
     <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
     <footer>Matt Mullenweg, 2017</footer>
 </blockquote>

--- a/blocks/test/fixtures/core__quote__style-2.html
+++ b/blocks/test/fixtures/core__quote__style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"style":"2"} -->
-<blockquote class="blocks-quote-style-2 wp-block-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
+<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "style": "2"
         },
-        "rawContent": "\n<blockquote class=\"blocks-quote-style-2 wp-block-quote\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>\n"
+        "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/quote {"style":"2"} -->
-<blockquote class="blocks-quote-style-2 wp-block-quote">
+<blockquote class="wp-block-quote blocks-quote-style-2">
     <p>There is no greater agony than bearing an untold story inside you.</p>
     <footer>Maya Angelou</footer>
 </blockquote>

--- a/blocks/test/fixtures/core__table2.serialized.html
+++ b/blocks/test/fixtures/core__table2.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core/table2 -->
-<table class="wp-block-table-2">
+<table class="wp-block-table2">
     <thead>
         <tr>
             <th>Version</th>


### PR DESCRIPTION
Follow-up to #1381 that modifies the generated classnames for blocks to improve consistency.

Mainly I don't think we should drop the `core` namespace from generated classnames for core blocks.  From [`docs/design.md`](https://github.com/WordPress/gutenberg/blob/1db9bb1e0ec546f149d8d90b9c58fa1e111df90f/docs/design.md#key-values):

> **Key Values**
> All blocks are created equal, ...

From https://github.com/WordPress/gutenberg/pull/1381#issuecomment-312042952:

> This special handling is a definitive way in which core blocks are not equal to plugin blocks; it imposes additional cognitive load; and anything related to how we handle block names should be super simple, consistent, and explicit.

> Also, the current structure breaks down a bit if, for example, a plugin registers a block named `text/poetry`.  Then you end up with classes `wp-block-text` for `core/text` and `wp-block-text-poetry` for `text/poetry`.

The last bit is probably more an issue if someone releases a plugin whose name overlaps with one of our embeds, then the class names will get a bit confusing.  We can fix this by making it really obvious how a block name maps to a class name, and making the different parts of the class name really clear.

Here are some example class names before and after this PR:

| Block name | Before | After |
|--|--|--|
| `core/text` | `wp-block-text` | `wp-block__core__text` |
| `core/image` | `wp-block-image` | `wp-block__core__image` |
| `core-embed/collegehumor` | `wp-block-core-embed-collegehumor` | `wp-block__core-embed__collegehumor` |
| `myplugin/someblock` | `wp-block-myplugin-someblock` | `wp-block__myplugin__someblock` |

As a first try, I've used `__` because then the parts of the classname are completely unambiguous.