### PR TITLE
Chrome: Use a fixed position for the notices

### DIFF
--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -3,8 +3,7 @@
 }
 
 .editor-layout .components-notice-list {
-	position: absolute;
-	top: 10px;
-	left: 0;
+	position: fixed;
+	top: 100px;
 	right: auto;
 }


### PR DESCRIPTION
Use fixed positioning for the notices list (it's hidden right now if you scroll)