### PR TITLE
Remove `RUN_PARSER_TESTS` flag from PHPUnit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
       # Check parser syntax
       php lib/parser.php || exit 1
       # Run PHPUnit tests
-      RUN_PARSER_TESTS=1 phpunit || exit 1
+      phpunit || exit 1
       WP_MULTISITE=1 phpunit || exit 1
     fi
   - |

--- a/phpunit/class-parsing-test.php
+++ b/phpunit/class-parsing-test.php
@@ -5,65 +5,58 @@
  * @package Gutenberg
  */
 
-// To run these tests, set the RUN_PARSER_TESTS environment variable to a
-// truthy value.
-if ( getenv( 'RUN_PARSER_TESTS' ) ) {
+class Parsing_Test extends WP_UnitTestCase {
+	protected static $fixtures_dir;
+
+	function parsing_test_filenames() {
+		self::$fixtures_dir = dirname( dirname( __FILE__ ) ) . '/blocks/test/fixtures';
+
+		require_once dirname( dirname( __FILE__ ) ) . '/lib/parser.php';
+
+		$fixture_filenames = glob( self::$fixtures_dir . '/*.{json,html}', GLOB_BRACE );
+		$fixture_filenames = array_values( array_unique( array_map(
+			array( $this, 'clean_fixture_filename' ),
+			$fixture_filenames
+		) ) );
+
+		return array_map(
+			array( $this, 'pass_parser_fixture_filenames' ),
+			$fixture_filenames
+		);
+	}
+
+	function clean_fixture_filename( $filename ) {
+		$filename = basename( $filename );
+		$filename = preg_replace( '/\..+$/', '', $filename );
+		return $filename;
+	}
+
+	function pass_parser_fixture_filenames( $filename ) {
+		return array(
+			"$filename.html",
+			"$filename.parsed.json",
+		);
+	}
+
 	/**
-	 * Tests for the PHP parser generated from our PEG grammar by `phpegjs`.
+	 * @dataProvider parsing_test_filenames
 	 */
-	class Parsing_Test extends WP_UnitTestCase {
-		protected static $fixtures_dir;
+	function test_parser_output( $html_filename, $parsed_json_filename ) {
+		$html_filename        = self::$fixtures_dir . '/' . $html_filename;
+		$parsed_json_filename = self::$fixtures_dir . '/' . $parsed_json_filename;
 
-		function parsing_test_filenames() {
-			self::$fixtures_dir = dirname( dirname( __FILE__ ) ) . '/blocks/test/fixtures';
-
-			require_once dirname( dirname( __FILE__ ) ) . '/lib/parser.php';
-
-			$fixture_filenames = glob( self::$fixtures_dir . '/*.{json,html}', GLOB_BRACE );
-			$fixture_filenames = array_values( array_unique( array_map(
-				array( $this, 'clean_fixture_filename' ),
-				$fixture_filenames
-			) ) );
-
-			return array_map(
-				array( $this, 'pass_parser_fixture_filenames' ),
-				$fixture_filenames
-			);
-		}
-
-		function clean_fixture_filename( $filename ) {
-			$filename = basename( $filename );
-			$filename = preg_replace( '/\..+$/', '', $filename );
-			return $filename;
-		}
-
-		function pass_parser_fixture_filenames( $filename ) {
-			return array(
-				"$filename.html",
-				"$filename.parsed.json",
-			);
-		}
-
-		/**
-		 * @dataProvider parsing_test_filenames
-		 */
-		function test_parser_output( $html_filename, $parsed_json_filename ) {
-			$html_filename        = self::$fixtures_dir . '/' . $html_filename;
-			$parsed_json_filename = self::$fixtures_dir . '/' . $parsed_json_filename;
-
-			foreach ( array( $html_filename, $parsed_json_filename ) as $filename ) {
-				if ( ! file_exists( $filename ) ) {
-					throw new Exception( "Missing fixture file: '$filename'" );
-				}
+		foreach ( array( $html_filename, $parsed_json_filename ) as $filename ) {
+			if ( ! file_exists( $filename ) ) {
+				throw new Exception( "Missing fixture file: '$filename'" );
 			}
-
-			$html            = file_get_contents( $html_filename );
-			$expected_parsed = json_decode( file_get_contents( $parsed_json_filename ), true );
-
-			$parser = new Gutenberg_PEG_Parser;
-			$result = $parser->parse( $html );
-
-			$this->assertEquals( $expected_parsed, $result );
 		}
+
+		$html            = file_get_contents( $html_filename );
+		$expected_parsed = json_decode( file_get_contents( $parsed_json_filename ), true );
+
+		$parser = new Gutenberg_PEG_Parser;
+		$result = $parser->parse( $html );
+
+		$this->assertEquals( $expected_parsed, $result );
 	}
 }


### PR DESCRIPTION
Quick follow-up to #1152.  I originally added this flag because the generated PHP parser was not part of the repository, and this would mean you have to generate it before running `phpunit`.  Later, I added the parser to the repository to make things easier, so we can get rid of this now.

Review this PR with [`?w=1`](https://github.com/WordPress/gutenberg/pull/1605/files?w=1) to ignore indentation changes.