### PR TITLE
Add and aria-label to the embed url input fields

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -138,14 +138,17 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 				}
 
 				if ( ! html ) {
+					const label = sprintf( __( '%s URL' ), title );
+
 					return [
 						controls,
-						<Placeholder key="placeholder" icon={ icon } label={ sprintf( __( '%s URL' ), title ) } className="wp-block-embed">
+						<Placeholder key="placeholder" icon={ icon } label={ label } className="wp-block-embed">
 							<form onSubmit={ this.doServerSideRender }>
 								<input
 									type="url"
 									value={ url || '' }
 									className="components-placeholder__input"
+									aria-label={ label }
 									placeholder={ __( 'Enter URL to embed here…' ) }
 									onChange={ ( event ) => setAttributes( { url: event.target.value } ) } />
 								<Button

--- a/components/placeholder/index.js
+++ b/components/placeholder/index.js
@@ -13,7 +13,7 @@ function Placeholder( { icon, children, label, instructions, className, ...addit
 	const classes = classnames( 'components-placeholder', className );
 
 	return (
-		<div { ...additionalProps } aria-label={ label } className={ classes }>
+		<div { ...additionalProps } className={ classes }>
 			<div className="components-placeholder__label">
 				{ !! icon && <Dashicon icon={ icon } /> }
 				{ label }

--- a/components/placeholder/test/index.js
+++ b/components/placeholder/test/index.js
@@ -35,13 +35,12 @@ describe( 'Placeholder', () => {
 			expect( placeholderLabel.find( 'Dashicon' ).exists() ).to.be.true();
 		} );
 
-		it( 'should render a label section and add aria label', () => {
+		it( 'should render a label section', () => {
 			const label = 'WordPress';
 			const placeholder = shallow( <Placeholder label={ label } /> );
 			const placeholderLabel = placeholder.find( '.components-placeholder__label' );
 			const child = placeholderLabel.childAt( 0 );
 
-			expect( placeholder.prop( 'aria-label' ) ).to.equal( label );
 			expect( child.text() ).to.equal( label );
 		} );
 


### PR DESCRIPTION
All the embed blocks placeholders have an input field to insert the embed URL. The input field misses a label. This PR tries to address this in the simpler possible way, adding an `aria-label` attribute to the input field.

Maybe not 100% ideal but other solutions, for example making the visible "label" (which is just text) a real label element or using aria-labelledby, seem way more complicated to me.

Also removes an `aria-label` from the placeholder wrapper: `aria-label` attributes on a non-focusable div are a bit pointless because they're not announced at all. Yes, blocks should be labeled but that should be done on the wrapper that receives focus, see #562 

Not super expert about tests, I'd appreciate some eyes on the adjustments made on the Placeholder test.

Fixes #1409 