### PR TITLE
Add an aria-label to the editor blocks.

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -237,7 +237,8 @@ class VisualEditorBlock extends Component {
 	render() {
 		const { block, multiSelectedBlockUids } = this.props;
 		const blockType = getBlockType( block.name );
-		const blockLabel = sprintf( __( 'Editor block: %s' ), blockType.title );
+		// translators: %s: Type of block (i.e. Text, Image etc)
+		const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
 		const { className = getBlockDefaultClassname( block.name ) } = blockType;
 		// The block as rendered in the editor is composed of general block UI
 		// (mover, toolbar, wrapper) and the display of the block content, which

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -13,6 +13,7 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { Children, Component } from 'element';
 import { BACKSPACE, ESCAPE, DELETE } from 'utils/keycodes';
 import { getBlockType, getBlockDefaultClassname } from 'blocks';
+import { __, sprintf } from 'i18n';
 
 /**
  * Internal dependencies
@@ -236,6 +237,7 @@ class VisualEditorBlock extends Component {
 	render() {
 		const { block, multiSelectedBlockUids } = this.props;
 		const blockType = getBlockType( block.name );
+		const blockLabel = sprintf( __( 'Editor block: %s' ), blockType.title );
 		const { className = getBlockDefaultClassname( block.name ) } = blockType;
 		// The block as rendered in the editor is composed of general block UI
 		// (mover, toolbar, wrapper) and the display of the block content, which
@@ -283,6 +285,7 @@ class VisualEditorBlock extends Component {
 				className={ wrapperClassname }
 				data-type={ block.name }
 				tabIndex="0"
+				aria-label={ blockLabel }
 				{ ...wrapperProps }
 			>
 				{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }


### PR DESCRIPTION
First pass to try to add an aria-label to the Editor blocks. Code and wording could be improved, any feedback welcome.

All the editor blocks need to be labeled to allow screen reader users to get `what` a block is.

Screenshots:

![screen shot 2017-06-30 at 17 55 40](https://user-images.githubusercontent.com/1682452/27744056-6da56ed8-5dbe-11e7-88c2-5096ddf04337.png)

![screen shot 2017-06-30 at 17 57 09](https://user-images.githubusercontent.com/1682452/27744057-6dababae-5dbe-11e7-8ff2-9e98cb6d64af.png)

Re: VoiceOver in the screenshot above:
- "group" is added by VoiceOver because blocks have no semantic role, so it announces them as generic "group"
- also the number of items in the group is added by VoiceOver


Fixes #562 