### PR TITLE
Suppress Gallery Settings Sidebar when editing gallery

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -35,6 +35,11 @@ const editMediaLibrary = ( attributes, setAttributes ) => {
 	};
 
 	const editFrame = wp.media( frameConfig );
+
+	// the frameConfig settings dont carry to other state modals
+	// so requires setting this attribute directory to not show settings
+	editFrame.state( 'gallery-edit' ).attributes.displaySettings = false;
+
 	function updateFn() {
 		setAttributes( {
 			images: this.frame.state().attributes.library.models.map( ( a ) => {


### PR DESCRIPTION
Fixes #1447 
Add attribute displaySettings=false to editFrame to suppress sidebar. The frameConfig settings did not pass forward to the different states of the modals, so it was required to set the attribute after creating the editFrame.