### PR TITLE
Add Custom HTML block description and use sandbox for preview

### DIFF
--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -41,6 +41,9 @@ registerBlockType( 'core/html', {
 			this.state = {
 				preview: false,
 			};
+			const allowedHtmlTags = new Set( Object.keys( wp.editor.allowedPostHtml ) );
+			const unsafeHtmlTags = [ 'script', 'iframe', 'form', 'input', 'style' ];
+			this.disallowedHtmlTags = unsafeHtmlTags.filter( tag => ! allowedHtmlTags.has( tag ) );
 		}
 
 		preview() {
@@ -77,6 +80,17 @@ registerBlockType( 'core/html', {
 						<InspectorControls key="inspector">
 							<BlockDescription>
 								<p>{ __( 'Arbitrary HTML code.' ) }</p>
+								{ ! wp.editor.canUnfilteredHtml && this.disallowedHtmlTags.length > 0 &&
+									<p>
+										<span>{ __( 'Some HTML tags are not permitted, including:' ) }</span>
+										{ ' ' }
+										{ this.disallowedHtmlTags.map( ( tag, i ) => <span key={ i }>
+											{ 0 !== i && ', ' }
+											<code>{ tag }</code>
+										</span> ) }
+										{ '.' }
+									</p>
+								}
 							</BlockDescription>
 						</InspectorControls>
 					}

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -15,6 +15,8 @@ import { Component } from 'element';
 import './style.scss';
 import { registerBlockType, query } from '../../api';
 import BlockControls from '../../block-controls';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { html } = query;
 
@@ -70,6 +72,13 @@ registerBlockType( 'core/html', {
 								</li>
 							</ul>
 						</BlockControls>
+					}
+					{ focus &&
+						<InspectorControls key="inspector">
+							<BlockDescription>
+								<p>{ __( 'Arbitrary HTML code.' ) }</p>
+							</BlockDescription>
+						</InspectorControls>
 					}
 					{ preview
 						? <div dangerouslySetInnerHTML={ { __html: attributes.content } } />

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -8,6 +8,7 @@ import TextareaAutosize from 'react-autosize-textarea';
  */
 import { __ } from 'i18n';
 import { Component } from 'element';
+import { SandBox } from 'components';
 
 /**
  * Internal dependencies
@@ -95,7 +96,7 @@ registerBlockType( 'core/html', {
 						</InspectorControls>
 					}
 					{ preview
-						? <div dangerouslySetInnerHTML={ { __html: attributes.content } } />
+						? <SandBox html={ attributes.content } title={ __( 'Preview of custom HTML' ) } />
 						: <TextareaAutosize
 							value={ attributes.content }
 							onChange={ ( event ) => setAttributes( { content: event.target.value } ) }

--- a/blocks/library/html/style.scss
+++ b/blocks/library/html/style.scss
@@ -11,4 +11,7 @@ div[data-type="core/html"] {
 		overflow-x: auto;
 		width: 100%;
 	}
+	iframe {
+		display: block;
+	}
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -487,6 +487,10 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'before'
 	);
 
+	// Export data required by the Custom HTML block.
+	wp_add_inline_script( 'wp-editor', sprintf( 'wp.editor.canUnfilteredHtml = %s;', wp_json_encode( current_user_can( 'unfiltered_html' ) ) ) );
+	wp_add_inline_script( 'wp-editor', sprintf( 'wp.editor.allowedPostHtml = %s;', wp_json_encode( wp_kses_allowed_html( 'post' ) ) ) );
+
 	// Initialize the editor.
 	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() { wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost ); } );' );
 


### PR DESCRIPTION
For the Custom HTML block, see #1386.

Amends #1597 by adding a block description for the Custom HTML block to align with new Custom HTML widget in 4.8-alpha: https://github.com/WordPress/wordpress-develop/blob/2744e29fd3f0fb17485290d2bf827f21292a92c3/src/wp-includes/widgets/class-wp-widget-custom-html.php#L38

Also adds list of common HTML tags that are disallowed when the user cannot `unfiltered_html`, similar to the Custom HTML widget: https://github.com/WordPress/wordpress-develop/blob/2744e29fd3f0fb17485290d2bf827f21292a92c3/src/wp-includes/widgets/class-wp-widget-custom-html.php#L124-L135

<img width="283" alt="Custom HTML description" src="https://user-images.githubusercontent.com/134745/27759689-b83dc3aa-5deb-11e7-91df-9187d9c48e1c.png">

To test, try accessing Gutenberg with a user having an author role.

I'm not certain that exporting the allowed HTML tags and the current user's `unfiltered_html` capability by amending them to the `wp.editor` global is the best way to go about this.

Also, and this is probably for a separate issue, I should think that the preview should actually enforce the constraints to remove the disallowed HTML? This is probably also closely related to the need to sandbox the previewed HTML in an `iframe` so that `document.write()` calls can be previewed properly.