### PR TITLE
Overlapping editor notifications over admin submenus.

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -13,8 +13,8 @@ $z-layers: (
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
 	'.editor-block-mover': 30,
-	'.components-notice-list': 100000,
-	'.components-popover': 100000,
+	'.components-notice-list': 9989,
+	'.components-popover': 9989,
 );
 
 @function z-index( $key ) {

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -13,8 +13,8 @@ $z-layers: (
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
 	'.editor-block-mover': 30,
-	'.components-notice-list': 9989,
-	'.components-popover': 9989,
+	'.components-notice-list': 9989, // Admin submenus (#adminmenu .wp-submenu) have z-index equal to 9999
+	'.components-popover': 9989, // Admin submenus (#adminmenu .wp-submenu) have z-index equal to 9999
 );
 
 @function z-index( $key ) {


### PR DESCRIPTION
<img src="https://image.ibb.co/fs1EiQ/Schermata_2017_07_01_alle_12_42_47.png">

As shown in the above screenshot, I think that having notifications to overlap admin submenus is bad user experience, since that would force the user to close the notification first, before being able to access the submenu content.

Bringing down the `z-index` value of the `.components-notice-list` and `.components-popover` to `9989` should fix this issue. On the other hand I don't know if the previous value of `100000` was there for a reason or just a randomly "high" number and this modification would break something else in the UI.