### PR TITLE
Editable: make inline default

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -63,7 +63,7 @@ export default class Editable extends Component {
 	getSettings( settings ) {
 		return ( this.props.getSettings || identity )( {
 			...settings,
-			forced_root_block: this.props.inline ? false : 'p',
+			forced_root_block: this.props.multiline || false,
 		} );
 	}
 
@@ -210,7 +210,7 @@ export default class Editable extends Component {
 
 		// If we click shift+Enter on inline Editables, we avoid creating two contenteditables
 		// We also split the content and call the onSplit prop if provided.
-		if ( event.keyCode === ENTER && event.shiftKey && this.props.inline ) {
+		if ( event.keyCode === ENTER && event.shiftKey && ! this.props.multiline ) {
 			event.preventDefault();
 
 			if ( this.props.onSplit ) {
@@ -224,7 +224,7 @@ export default class Editable extends Component {
 			this.onSelectionChange();
 		}
 
-		if ( keyCode === ENTER && this.props.inline && this.props.onSplit ) {
+		if ( keyCode === ENTER && ! this.props.multiline && this.props.onSplit ) {
 			const endNode = this.editor.selection.getEnd();
 
 			// Make sure the current selection is on a line break.
@@ -270,7 +270,7 @@ export default class Editable extends Component {
 	}
 
 	onNewBlock() {
-		if ( this.props.tagName || ! this.props.onSplit ) {
+		if ( this.props.multiline !== 'p' || ! this.props.onSplit ) {
 			return;
 		}
 
@@ -442,7 +442,7 @@ export default class Editable extends Component {
 			inlineToolbar = false,
 			formattingControls,
 			placeholder,
-			inline,
+			multiline: MultilineTag,
 		} = this.props;
 
 		// Generating a key that includes `tagName` ensures that if the tag
@@ -488,7 +488,7 @@ export default class Editable extends Component {
 						className="blocks-editable__tinymce"
 						style={ style }
 					>
-						{ inline ? placeholder : <p>{ placeholder }</p> }
+						{ MultilineTag ? <MultilineTag>{ placeholder }</MultilineTag> : placeholder }
 					</Tagname>
 				}
 			</div>

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -54,7 +54,6 @@ registerBlockType( 'core/button', {
 					focus={ focus }
 					onFocus={ setFocus }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
-					inline
 					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
 				/>
 				{ focus &&

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -132,7 +132,6 @@ registerBlockType( 'core/cover-image', {
 							focus={ focus }
 							onFocus={ setFocus }
 							onChange={ ( value ) => setAttributes( { title: value } ) }
-							inline
 							inlineToolbar
 						/>
 					) : null }

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -189,7 +189,6 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 								focus={ focus }
 								onFocus={ setFocus }
 								onChange={ ( value ) => setAttributes( { caption: value } ) }
-								inline
 								inlineToolbar
 							/>
 						) : null }

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -142,7 +142,6 @@ registerBlockType( 'core/heading', {
 				onFocus={ setFocus }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				inline
 				onSplit={ ( before, after ) => {
 					setAttributes( { content: before } );
 					insertBlockAfter( createBlock( 'core/text', {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -120,7 +120,6 @@ registerBlockType( 'core/image', {
 						focus={ focus && focus.editable === 'caption' ? focus : undefined }
 						onFocus={ focusCaption }
 						onChange={ ( value ) => setAttributes( { caption: value } ) }
-						inline
 						inlineToolbar
 					/>
 				) : null }

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -231,6 +231,7 @@ registerBlockType( 'core/list', {
 					/>
 				),
 				<Editable
+					multiline="li"
 					key="editable"
 					tagName={ nodeName.toLowerCase() }
 					getSettings={ this.getEditorSettings }
@@ -240,6 +241,7 @@ registerBlockType( 'core/list', {
 					focus={ focus }
 					onFocus={ setFocus }
 					className="blocks-list"
+					placeholder={ __( 'Write list…' ) }
 				/>,
 			];
 		}

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -57,7 +57,6 @@ registerBlockType( 'core/preformatted', {
 				focus={ focus }
 				onFocus={ setFocus }
 				placeholder={ __( 'Write preformatted text…' ) }
-				inline
 				className={ className }
 			/>
 		);

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -51,6 +51,7 @@ registerBlockType( 'core/pullquote', {
 			),
 			<blockquote key="quote" className={ className }>
 				<Editable
+					multiline="p"
 					value={ value }
 					onChange={
 						( nextValue ) => setAttributes( {
@@ -74,7 +75,6 @@ registerBlockType( 'core/pullquote', {
 						}
 						focus={ focus && focus.editable === 'citation' ? focus : null }
 						onFocus={ ( props ) => setFocus( { ...props, editable: 'citation' } ) }
-						inline
 					/>
 				) }
 			</blockquote>,

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -142,6 +142,7 @@ registerBlockType( 'core/quote', {
 				className={ `${ className } blocks-quote-style-${ style }` }
 			>
 				<Editable
+					multiline="p"
 					value={ value }
 					onChange={
 						( nextValue ) => setAttributes( {
@@ -166,7 +167,6 @@ registerBlockType( 'core/quote', {
 						}
 						focus={ focusedEditable === 'citation' ? focus : null }
 						onFocus={ ( props ) => setFocus( { ...props, editable: 'citation' } ) }
-						inline
 					/>
 				) }
 			</blockquote>,

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -64,7 +64,6 @@ registerBlockType( 'core/table', {
 										return (
 											<Cell key={ key }>
 												<Editable
-													inline
 													value={ value }
 													focus={ focussedKey === key ? focus : null }
 													onFocus={ ( props ) => setFocus( { ...props, editable: key } ) }

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -65,7 +65,6 @@ registerBlockType( 'core/text', {
 				</InspectorControls>
 			),
 			<Editable
-				inline
 				tagName="p"
 				key="editable"
 				value={ content }


### PR DESCRIPTION
This PR makes "inline" Editable the default. It's the most used version of the Editable now, and requires less configuration. Additionally I find "inline" a little bit misleading as it doesn't really generate an inline element, it's more like a single-line configuration. 