### PR TITLE
Removed focus styles, moved outline property #1629

### DIFF
--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -134,16 +134,12 @@ input[type="search"].editor-inserter__search {
 	width: 100%;
 	margin: 0;
 	color: $dark-gray-500;
+	outline: none;
 
 	&.is-active {
 		background: $white;
 		border-bottom-color: $blue-medium-500;
 		position: relative;
 		z-index: z-index( '.editor-inserter__tab.is-active' );
-	}
-
-	&:focus {
-		box-shadow: $button-focus-style;
-		outline: none;
 	}
 }


### PR DESCRIPTION
## PR Overview
 
When the user clicked on a tab to insert a block there would be an outline like box-shadow as described in #1629.  I have updated the styles to remove this box-shadow.
 
### Before

 ![2017-07-01_15-33-02](https://user-images.githubusercontent.com/1571635/27765893-a67bc620-5e73-11e7-9522-a6b056e8683c.gif)
 
### After
 
 ![2017-07-01_15-34-04](https://user-images.githubusercontent.com/1571635/27765895-ae88f77a-5e73-11e7-8960-02d1a73782dc.gif)
