### PR TITLE
Allow the use of tabs for list indents and outdents 

### DIFF
--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -188,7 +188,7 @@ registerBlockType( 'core/list', {
 			return {
 				...settings,
 				plugins: ( settings.plugins || [] ).concat( 'lists' ),
-				lists_indent_on_tab: false,
+				lists_indent_on_tab: true,
 			};
 		}
 


### PR DESCRIPTION
## PR Overview

Allow `tab` to be used to indent list items. As well, allow `shift` + `tab` to outdent tabs.

### Preview

![2017-07-01_17-19-30](https://user-images.githubusercontent.com/1571635/27766333-913186d4-5e81-11e7-8b1f-5c03b444a21e.gif)

Ref: #1552 and #1640 
