### PR TITLE
Make videos responsive

### DIFF
--- a/blocks/library/embed/style.scss
+++ b/blocks/library/embed/style.scss
@@ -17,18 +17,26 @@
 		}
 	}
 
-	&.is-video > div:first-child {
+	&.is-video {
 		position: relative;
 		width: 100%;
 		height: 0;
 		padding-bottom: 56.25%; /* 16:9 */
+		margin-bottom: 2em;
 	}
 
-	&.is-video > div > iframe {
+	&.is-video > iframe {
 		position: absolute;
 		top: 0;
 		left: 0;
 		width: 100%;
 		height: 100%;
+	}
+
+	&.is-video > .blocks-editable {
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
 	}
 }


### PR DESCRIPTION
Embeds are now sandboxed. This broke our responsive video trick. We should restore this in some way. This PR is a work in progress.

In order to finish the work here, we need to inject a few styles into the embed iframe. I could use help with this. 

The following CSS should be injected in all embeds:

```
body {
	margin: 0;
}
```

The following CSS should additionally be injected into all _video_ embeds:

```
body,
body > div,
body > div > iframe {
	width: 100%;
	height: 100%;
}
```

The CSS in the first commit assumes the above styles are present, and positions the caption accordingly:

![screen shot 2017-07-03 at 11 28 55](https://user-images.githubusercontent.com/1204802/27786961-80e41842-5fe3-11e7-9622-b287cee0495d.png)
