### PR TITLE
Block API: Adding a `useOnce` property in the block settings to forbid using it multiple times

### DIFF
--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -282,8 +282,8 @@ class InserterMenu extends Component {
 				onClick={ this.selectBlock( block.name ) }
 				ref={ this.bindReferenceNode( block.name ) }
 				tabIndex="-1"
-				onMouseEnter={ this.props.showInsertionPoint }
-				onMouseLeave={ this.props.hideInsertionPoint }
+				onMouseEnter={ ! disabled && this.props.showInsertionPoint }
+				onMouseLeave={ ! disabled && this.props.hideInsertionPoint }
 				disabled={ disabled }
 			>
 				<Dashicon icon={ block.icon } />

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -139,9 +139,19 @@ class InserterMenu extends Component {
 
 	findByIncrement( blockTypes, increment = 1 ) {
 		const currentIndex = findIndex( blockTypes, ( blockType ) => this.state.currentFocus === blockType.name );
-		const nextIndex = currentIndex + increment;
 		const highestIndex = blockTypes.length - 1;
 		const lowestIndex = 0;
+
+		let nextIndex = currentIndex;
+		let blockType;
+		do {
+			nextIndex += increment;
+			// Return the name of the next block type.
+			blockType = blockTypes[ nextIndex ];
+			if ( blockType && ! this.isDisabledBlock( blockType ) ) {
+				return blockType.name;
+			}
+		} while ( blockType );
 
 		if ( nextIndex > highestIndex ) {
 			return 'search';
@@ -150,14 +160,6 @@ class InserterMenu extends Component {
 		if ( nextIndex < lowestIndex ) {
 			return 'search';
 		}
-
-		// Return the name of the next block type.
-		const blockType = blockTypes[ nextIndex ];
-		if ( this.isDisabledBlock( blockType ) ) {
-			return this.findByIncrement( blockTypes, increment > 0 ? increment + 1 : increment - 1 );
-		}
-
-		return blockType.name;
 	}
 
 	findNext( blockTypes ) {

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, groupBy, sortBy, findIndex, filter, debounce } from 'lodash';
+import { flow, groupBy, sortBy, findIndex, filter, debounce, find } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -63,8 +63,8 @@ class InserterMenu extends Component {
 		}
 	}
 
-	isDisabledBlock( block ) {
-		return block.useOnce && find( this.props.blocks, ( { name } ) => block.name === name );
+	isDisabledBlock( blockType ) {
+		return blockType.useOnce && find( this.props.blocks, ( { name } ) => blockType.name === name );
 	}
 
 	bindReferenceNode( nodeName ) {
@@ -152,12 +152,12 @@ class InserterMenu extends Component {
 		}
 
 		// Return the name of the next block type.
-		const block = blockTypes[ nextIndex ];
-		if ( this.isDisabledBlock( block ) ) {
+		const blockType = blockTypes[ nextIndex ];
+		if ( this.isDisabledBlock( blockType ) ) {
 			return this.findByIncrement( blockTypes, increment > 0 ? increment + 1 : increment - 1 );
 		}
 
-		return block.name;
+		return blockType.name;
 	}
 
 	findNext( blockTypes ) {

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -88,8 +88,14 @@ input[type="search"].editor-inserter__search {
 	background: none;
 	line-height: 20px;
 
-	&:hover,
-	&:focus {
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+
+	&:hover:not(:disabled),
+	&:focus:not(:disabled) {
 		color: $blue-medium-500;
 		outline: none;
 		position: relative;


### PR DESCRIPTION
closes #1465 

While doing this, I noticed some errors while navigating using arrows in the inserter, it should be fixed now. (The warning has been reported in #1606)

**Testing instructions**

 - We don't have any block like that for now, you'll have to add `useOnce: true` to one of the current block settings to try it.