### PR TITLE
Use `classnames` consistently for importing the classnames module

### DIFF
--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
 import { findIndex } from 'lodash';
 
@@ -173,7 +173,7 @@ class DropdownMenu extends wp.element.Component {
 			<div className="components-dropdown-menu">
 				<IconButton
 					className={
-						classNames( 'components-dropdown-menu__toggle', {
+						classnames( 'components-dropdown-menu__toggle', {
 							'is-active': this.state.open,
 						} )
 					}

--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { noop } from 'lodash';
 
 /**
@@ -15,7 +15,7 @@ import { __ } from 'i18n';
 import './style.scss';
 
 function FormToggle( { className, checked, id, onChange = noop, showHint = true } ) {
-	const wrapperClasses = classNames(
+	const wrapperClasses = classnames(
 		'components-form-toggle',
 		className,
 		{ 'is-checked': checked }

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -40,7 +40,7 @@ function Toolbar( { controls = [], children } ) {
 								event.stopPropagation();
 								control.onClick();
 							} }
-							className={ classNames( 'components-toolbar__control', {
+							className={ classnames( 'components-toolbar__control', {
 								'is-active': control.isActive,
 							} ) }
 							aria-pressed={ control.isActive }


### PR DESCRIPTION
closes #613 

It was suggested to write a custom eslint rule for this. I'm not sure it's worth it but it could be done separately anyway.