### PR TITLE
Rewire patterns plugin

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -21,6 +21,7 @@ import { BACKSPACE, DELETE, ENTER } from 'utils/keycodes';
 import './style.scss';
 import FormatToolbar from './format-toolbar';
 import TinyMCE from './tinymce';
+import patterns from './patterns';
 
 function createTinyMCEElement( type, props, ...children ) {
 	if ( props[ 'data-mce-bogus' ] === 'all' ) {
@@ -80,6 +81,8 @@ export default class Editable extends Component {
 		editor.on( 'keyup', this.onKeyUp );
 		editor.on( 'selectionChange', this.onSelectionChange );
 		editor.on( 'PastePostProcess', this.onPastePostProcess );
+
+		patterns.apply( this, [ editor ] );
 
 		if ( this.props.onSetup ) {
 			this.props.onSetup( editor );

--- a/blocks/editable/patterns.js
+++ b/blocks/editable/patterns.js
@@ -1,0 +1,321 @@
+/* eslint-disable */
+
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce';
+import { find, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getBlockTypes } from '../api/registration';
+
+/**
+ * Browser dependencies
+ */
+const { setTimeout } = window;
+
+/**
+ * Escapes characters for use in a Regular Expression.
+ *
+ * @param  {String} string Characters to escape
+ *
+ * @return {String}        Escaped characters
+ */
+function escapeRegExp( string ) {
+	return string.replace( /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&' );
+}
+
+export default function( editor ) {
+	const getContent = this.getContent.bind( this );
+	const { onReplace } = this.props;
+
+	var VK = tinymce.util.VK;
+	var settings = editor.settings.wptextpattern || {};
+
+	const spacePatterns = getBlockTypes().reduce( ( acc, blockType ) => {
+		const transformsFrom = get( blockType, 'transforms.from', [] );
+		const transforms = transformsFrom.filter( ( { type } ) => type === 'pattern' );
+		return [ ...acc, ...transforms ];
+	}, [] );
+
+	var enterPatterns = settings.enter || [
+		// { start: '##', format: 'h2' },
+		// { start: '###', format: 'h3' },
+		// { start: '####', format: 'h4' },
+		// { start: '#####', format: 'h5' },
+		// { start: '######', format: 'h6' },
+		// { start: '>', format: 'blockquote' },
+		// { regExp: /^(-){3,}$/, element: 'hr' }
+	];
+
+	var inlinePatterns = settings.inline || [
+		{ delimiter: '`', format: 'code' }
+	];
+
+	var canUndo;
+
+	editor.on( 'selectionchange', function() {
+		canUndo = null;
+	} );
+
+	editor.on( 'keydown', function( event ) {
+		if ( ( canUndo && event.keyCode === 27 /* ESCAPE */ ) || ( canUndo === 'space' && event.keyCode === VK.BACKSPACE ) ) {
+			editor.undoManager.undo();
+			event.preventDefault();
+			event.stopImmediatePropagation();
+		}
+
+		if ( VK.metaKeyPressed( event ) ) {
+			return;
+		}
+
+		if ( event.keyCode === VK.ENTER ) {
+			enter();
+		// Wait for the browser to insert the character.
+		} else if ( event.keyCode === VK.SPACEBAR ) {
+			setTimeout( space );
+		} else if ( event.keyCode > 47 && ! ( event.keyCode >= 91 && event.keyCode <= 93 ) ) {
+			setTimeout( inline );
+		}
+	}, true );
+
+	function inline() {
+		var rng = editor.selection.getRng();
+		var node = rng.startContainer;
+		var offset = rng.startOffset;
+		var startOffset;
+		var endOffset;
+		var pattern;
+		var format;
+		var zero;
+
+		// We need a non empty text node with an offset greater than zero.
+		if ( ! node || node.nodeType !== 3 || ! node.data.length || ! offset ) {
+			return;
+		}
+
+		var string = node.data.slice( 0, offset );
+		var lastChar = node.data.charAt( offset - 1 );
+
+		tinymce.each( inlinePatterns, function( p ) {
+			// Character before selection should be delimiter.
+			if ( lastChar !== p.delimiter.slice( -1 ) ) {
+				return;
+			}
+
+			var escDelimiter = escapeRegExp( p.delimiter );
+			var delimiterFirstChar = p.delimiter.charAt( 0 );
+			var regExp = new RegExp( '(.*)' + escDelimiter + '.+' + escDelimiter + '$' );
+			var match = string.match( regExp );
+
+			if ( ! match ) {
+				return;
+			}
+
+			startOffset = match[1].length;
+			endOffset = offset - p.delimiter.length;
+
+			var before = string.charAt( startOffset - 1 );
+			var after = string.charAt( startOffset + p.delimiter.length );
+
+			// test*test* => format applied
+			// test *test* => applied
+			// test* test* => not applied
+			if ( startOffset && /\S/.test( before ) ) {
+				if ( /\s/.test( after ) || before === delimiterFirstChar ) {
+					return;
+				}
+			}
+
+			// Do not replace when only whitespace and delimiter characters.
+			if ( ( new RegExp( '^[\\s' + escapeRegExp( delimiterFirstChar ) + ']+$' ) ).test( string.slice( startOffset, endOffset ) ) ) {
+				return;
+			}
+
+			pattern = p;
+
+			return false;
+		} );
+
+		if ( ! pattern ) {
+			return;
+		}
+
+		format = editor.formatter.get( pattern.format );
+
+		if ( format && format[0].inline ) {
+			editor.undoManager.add();
+
+			editor.undoManager.transact( function() {
+				node.insertData( offset, '\uFEFF' );
+
+				node = node.splitText( startOffset );
+				zero = node.splitText( offset - startOffset );
+
+				node.deleteData( 0, pattern.delimiter.length );
+				node.deleteData( node.data.length - pattern.delimiter.length, pattern.delimiter.length );
+
+				editor.formatter.apply( pattern.format, {}, node );
+
+				editor.selection.setCursorLocation( zero, 1 );
+			} );
+
+			// We need to wait for native events to be triggered.
+			setTimeout( function() {
+				canUndo = 'space';
+
+				editor.once( 'selectionchange', function() {
+					var offset;
+
+					if ( zero ) {
+						offset = zero.data.indexOf( '\uFEFF' );
+
+						if ( offset !== -1 ) {
+							zero.deleteData( offset, offset + 1 );
+						}
+					}
+				} );
+			} );
+		}
+	}
+
+	function firstTextNode( node ) {
+		var parent = editor.dom.getParent( node, 'p' ),
+			child;
+
+		if ( ! parent ) {
+			return;
+		}
+
+		while ( child = parent.firstChild ) {
+			if ( child.nodeType !== 3 ) {
+				parent = child;
+			} else {
+				break;
+			}
+		}
+
+		if ( ! child ) {
+			return;
+		}
+
+		if ( ! child.data ) {
+			if ( child.nextSibling && child.nextSibling.nodeType === 3 ) {
+				child = child.nextSibling;
+			} else {
+				child = null;
+			}
+		}
+
+		return child;
+	}
+
+	function space() {
+		var rng = editor.selection.getRng(),
+			node = rng.startContainer,
+			parent,
+			text;
+
+		if ( ! node || firstTextNode( node ) !== node ) {
+			return;
+		}
+
+		parent = node.parentNode;
+		text = node.data;
+
+		tinymce.each( spacePatterns, function( pattern ) {
+			var match = text.match( pattern.regExp );
+
+			if ( ! match || rng.startOffset !== match[0].length ) {
+				return;
+			}
+
+			editor.undoManager.add();
+
+			editor.undoManager.transact( function() {
+				node.deleteData( 0, match[0].length );
+
+				if ( ! parent.innerHTML ) {
+					parent.appendChild( document.createElement( 'br' ) );
+				}
+
+				editor.selection.setCursorLocation( parent );
+
+				const block = pattern.transform( { content: getContent() } );
+
+				onReplace( [ block ] );
+			} );
+
+			// We need to wait for native events to be triggered.
+			setTimeout( function() {
+				canUndo = 'space';
+			} );
+
+			return false;
+		} );
+	}
+
+	function enter() {
+		var rng = editor.selection.getRng(),
+			start = rng.startContainer,
+			node = firstTextNode( start ),
+			i = enterPatterns.length,
+			text, pattern, parent;
+
+		if ( ! node ) {
+			return;
+		}
+
+		text = node.data;
+
+		while ( i-- ) {
+			if ( enterPatterns[ i ].start ) {
+				if ( text.indexOf( enterPatterns[ i ].start ) === 0 ) {
+					pattern = enterPatterns[ i ];
+					break;
+				}
+			} else if ( enterPatterns[ i ].regExp ) {
+				if ( enterPatterns[ i ].regExp.test( text ) ) {
+					pattern = enterPatterns[ i ];
+					break;
+				}
+			}
+		}
+
+		if ( ! pattern ) {
+			return;
+		}
+
+		if ( node === start && tinymce.trim( text ) === pattern.start ) {
+			return;
+		}
+
+		editor.once( 'keyup', function() {
+			editor.undoManager.add();
+
+			editor.undoManager.transact( function() {
+				if ( pattern.format ) {
+					editor.formatter.apply( pattern.format, {}, node );
+					node.replaceData( 0, node.data.length, ltrim( node.data.slice( pattern.start.length ) ) );
+				} else if ( pattern.element ) {
+					parent = node.parentNode && node.parentNode.parentNode;
+
+					if ( parent ) {
+						parent.replaceChild( document.createElement( pattern.element ), node.parentNode );
+					}
+				}
+			} );
+
+			// We need to wait for native events to be triggered.
+			setTimeout( function() {
+				canUndo = 'enter';
+			} );
+		} );
+	}
+
+	function ltrim( text ) {
+		return text ? text.replace( /^\s+/, '' ) : '';
+	}
+}

--- a/blocks/editable/patterns.js
+++ b/blocks/editable/patterns.js
@@ -232,26 +232,15 @@ export default function( editor ) {
 				return;
 			}
 
-			editor.undoManager.add();
+			node.deleteData( 0, match[0].length );
 
-			editor.undoManager.transact( function() {
-				node.deleteData( 0, match[0].length );
+			if ( ! parent.innerHTML ) {
+				parent.appendChild( document.createElement( 'br' ) );
+			}
 
-				if ( ! parent.innerHTML ) {
-					parent.appendChild( document.createElement( 'br' ) );
-				}
+			const block = pattern.transform( { content: getContent() } );
 
-				editor.selection.setCursorLocation( parent );
-
-				const block = pattern.transform( { content: getContent() } );
-
-				onReplace( [ block ] );
-			} );
-
-			// We need to wait for native events to be triggered.
-			setTimeout( function() {
-				canUndo = 'space';
-			} );
+			onReplace( [ block ] );
 
 			return false;
 		} );

--- a/blocks/editable/patterns.js
+++ b/blocks/editable/patterns.js
@@ -1,10 +1,8 @@
-/* eslint-disable */
-
 /**
  * External dependencies
  */
 import tinymce from 'tinymce';
-import { find, get, escapeRegExp, trimStart, partition, drop } from 'lodash';
+import { find, get, escapeRegExp, partition, drop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -40,7 +38,7 @@ export default function( editor ) {
 	);
 
 	const inlinePatterns = settings.inline || [
-		{ delimiter: '`', format: 'code' }
+		{ delimiter: '`', format: 'code' },
 	];
 
 	let canUndo;
@@ -73,22 +71,21 @@ export default function( editor ) {
 	}, true );
 
 	function inline() {
-		var rng = editor.selection.getRng();
-		var node = rng.startContainer;
-		var offset = rng.startOffset;
-		var startOffset;
-		var endOffset;
-		var pattern;
-		var format;
-		var zero;
+		const rng = editor.selection.getRng();
+		const node = rng.startContainer;
+		const offset = rng.startOffset;
+		let startOffset;
+		let endOffset;
+		let pattern;
+		let zero;
 
 		// We need a non empty text node with an offset greater than zero.
 		if ( ! node || node.nodeType !== 3 || ! node.data.length || ! offset ) {
 			return;
 		}
 
-		var string = node.data.slice( 0, offset );
-		var lastChar = node.data.charAt( offset - 1 );
+		const string = node.data.slice( 0, offset );
+		const lastChar = node.data.charAt( offset - 1 );
 
 		tinymce.each( inlinePatterns, function( p ) {
 			// Character before selection should be delimiter.
@@ -96,20 +93,20 @@ export default function( editor ) {
 				return;
 			}
 
-			var escDelimiter = escapeRegExp( p.delimiter );
-			var delimiterFirstChar = p.delimiter.charAt( 0 );
-			var regExp = new RegExp( '(.*)' + escDelimiter + '.+' + escDelimiter + '$' );
-			var match = string.match( regExp );
+			const escDelimiter = escapeRegExp( p.delimiter );
+			const delimiterFirstChar = p.delimiter.charAt( 0 );
+			const regExp = new RegExp( '(.*)' + escDelimiter + '.+' + escDelimiter + '$' );
+			const match = string.match( regExp );
 
 			if ( ! match ) {
 				return;
 			}
 
-			startOffset = match[1].length;
+			startOffset = match[ 1 ].length;
 			endOffset = offset - p.delimiter.length;
 
-			var before = string.charAt( startOffset - 1 );
-			var after = string.charAt( startOffset + p.delimiter.length );
+			const before = string.charAt( startOffset - 1 );
+			const after = string.charAt( startOffset + p.delimiter.length );
 
 			// test*test* => format applied
 			// test *test* => applied
@@ -134,21 +131,21 @@ export default function( editor ) {
 			return;
 		}
 
-		format = editor.formatter.get( pattern.format );
+		const format = editor.formatter.get( pattern.format );
 
-		if ( format && format[0].inline ) {
+		if ( format && format[ 0 ].inline ) {
 			editor.undoManager.add();
 
 			editor.undoManager.transact( function() {
 				node.insertData( offset, '\uFEFF' );
 
-				node = node.splitText( startOffset );
-				zero = node.splitText( offset - startOffset );
+				const newNode = node.splitText( startOffset );
+				zero = newNode.splitText( offset - startOffset );
 
-				node.deleteData( 0, pattern.delimiter.length );
-				node.deleteData( node.data.length - pattern.delimiter.length, pattern.delimiter.length );
+				newNode.deleteData( 0, pattern.delimiter.length );
+				newNode.deleteData( newNode.data.length - pattern.delimiter.length, pattern.delimiter.length );
 
-				editor.formatter.apply( pattern.format, {}, node );
+				editor.formatter.apply( pattern.format, {}, newNode );
 
 				editor.selection.setCursorLocation( zero, 1 );
 			} );
@@ -158,13 +155,13 @@ export default function( editor ) {
 				canUndo = 'space';
 
 				editor.once( 'selectionchange', function() {
-					var offset;
+					let offset2;
 
 					if ( zero ) {
-						offset = zero.data.indexOf( '\uFEFF' );
+						offset2 = zero.data.indexOf( '\uFEFF' );
 
-						if ( offset !== -1 ) {
-							zero.deleteData( offset, offset + 1 );
+						if ( offset2 !== -1 ) {
+							zero.deleteData( offset2, offset2 + 1 );
 						}
 					}
 				} );
@@ -188,10 +185,12 @@ export default function( editor ) {
 
 		const firstText = content[ 0 ];
 
-		const { result, pattern } = spacePatterns.reduce( ( acc, pattern ) => {
-			const result = pattern.regExp.exec( firstText );
-			return result ? { result, pattern } : acc;
-		}, null );
+		const { result, pattern } = spacePatterns.reduce( ( acc, item ) => {
+			return acc.result ? acc : {
+				result: item.regExp.exec( firstText ),
+				pattern: item,
+			};
+		}, {} );
 
 		if ( ! result ) {
 			return;
@@ -228,7 +227,7 @@ export default function( editor ) {
 			return;
 		}
 
-		const pattern = find( enterPatterns, ( { regExp } ) => regExp.test( content[ 0 ] ) )
+		const pattern = find( enterPatterns, ( { regExp } ) => regExp.test( content[ 0 ] ) );
 
 		if ( ! pattern ) {
 			return;

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -12,7 +12,7 @@ import { __ } from 'i18n';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlockType, query } from '../../api';
+import { registerBlockType, query, createBlock } from '../../api';
 
 const { prop } = query;
 
@@ -25,6 +25,16 @@ registerBlockType( 'core/code', {
 
 	attributes: {
 		content: prop( 'code', 'textContent' ),
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'pattern',
+				regExp: /^```$/,
+				transform: () => createBlock( 'core/code' ),
+			},
+		],
 	},
 
 	edit( { attributes, setAttributes, className } ) {

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -81,6 +81,18 @@ registerBlockType( 'core/heading', {
 					nodeName: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
 				},
 			},
+			{
+				type: 'pattern',
+				regExp: /^(#{2,6})\s/,
+				transform: ( { content, match } ) => {
+					const level = match[ 1 ].length;
+
+					return createBlock( 'core/heading', {
+						nodeName: `H${ level }`,
+						content,
+					} );
+				},
+			},
 		],
 		to: [
 			{

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -110,6 +110,26 @@ registerBlockType( 'core/list', {
 					values: children( 'ol,ul' ),
 				},
 			},
+			{
+				type: 'pattern',
+				regExp: /^[*-]\s/,
+				transform: ( { content } ) => {
+					return createBlock( 'core/list', {
+						nodeName: 'ul',
+						values: fromBrDelimitedContent( content ),
+					} );
+				},
+			},
+			{
+				type: 'pattern',
+				regExp: /^1[.)]\s/,
+				transform: ( { content } ) => {
+					return createBlock( 'core/list', {
+						nodeName: 'ol',
+						values: fromBrDelimitedContent( content ),
+					} );
+				},
+			},
 		],
 		to: [
 			{

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -54,6 +54,15 @@ registerBlockType( 'core/quote', {
 					} );
 				},
 			},
+			{
+				type: 'pattern',
+				regExp: /^>\s/,
+				transform: ( { content } ) => {
+					return createBlock( 'core/quote', {
+						value: content,
+					} );
+				},
+			},
 		],
 		to: [
 			{

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -7,7 +7,7 @@ import { __ } from 'i18n';
  * Internal dependencies
  */
 import './block.scss';
-import { registerBlockType } from '../../api';
+import { registerBlockType, createBlock } from '../../api';
 
 registerBlockType( 'core/separator', {
 	title: __( 'Separator' ),
@@ -15,6 +15,16 @@ registerBlockType( 'core/separator', {
 	icon: 'minus',
 
 	category: 'layout',
+
+	transforms: {
+		from: [
+			{
+				type: 'pattern',
+				regExp: /^-{3,}$/,
+				transform: () => createBlock( 'core/separator' ),
+			},
+		],
+	},
 
 	edit( { className } ) {
 		return <hr className={ className } />;

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -53,7 +53,7 @@ registerBlockType( 'core/text', {
 		};
 	},
 
-	edit( { attributes, setAttributes, insertBlocksAfter, focus, setFocus, mergeBlocks } ) {
+	edit( { attributes, setAttributes, insertBlocksAfter, focus, setFocus, mergeBlocks, onReplace } ) {
 		const { align, content, dropCap, placeholder } = attributes;
 		const toggleDropCap = () => setAttributes( { dropCap: ! dropCap } );
 		return [
@@ -99,6 +99,7 @@ registerBlockType( 'core/text', {
 					] );
 				} }
 				onMerge={ mergeBlocks }
+				onReplace={ onReplace }
 				style={ { textAlign: align } }
 				className={ dropCap && 'has-drop-cap' }
 				placeholder={ placeholder || __( 'New Paragraph' ) }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -32,6 +32,7 @@ import {
 	clearSelectedBlock,
 	startTyping,
 	stopTyping,
+	replaceBlocks,
 } from '../../actions';
 import {
 	getPreviousBlock,
@@ -335,7 +336,7 @@ class VisualEditorBlock extends Component {
 			'is-showing-mobile-controls': showMobileControls,
 		} );
 
-		const { onMouseLeave, onFocus, onInsertBlocksAfter } = this.props;
+		const { onMouseLeave, onFocus, onInsertBlocksAfter, onReplace } = this.props;
 
 		// Determine whether the block has props to apply to the wrapper.
 		let wrapperProps;
@@ -408,6 +409,7 @@ class VisualEditorBlock extends Component {
 							attributes={ block.attributes }
 							setAttributes={ this.setAttributes }
 							insertBlocksAfter={ onInsertBlocksAfter }
+							onReplace={ onReplace }
 							setFocus={ partial( onFocus, block.uid ) }
 							mergeBlocks={ this.mergeBlocks }
 							className={ className }
@@ -496,6 +498,10 @@ export default connect(
 
 		onMerge( ...args ) {
 			dispatch( mergeBlocks( ...args ) );
+		},
+
+		onReplace( blocks ) {
+			dispatch( replaceBlocks( [ ownProps.uid ], blocks ) );
 		},
 	} )
 )( VisualEditorBlock );

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -2,6 +2,7 @@ export const BACKSPACE = 8;
 export const TAB = 9;
 export const ENTER = 13;
 export const ESCAPE = 27;
+export const SPACE = 32;
 export const LEFT = 37;
 export const UP = 38;
 export const RIGHT = 39;


### PR DESCRIPTION
This PR aims to bring the core patterns plugin to Gutenberg. It's still a WIP, but some patterns already work:

* Create a new text block and type `* `. You get a list.
* Prepend `* ` to a text block. It will be converted into a list.
* Write `` `something` `` and it will be wrapped in `<code>`.
* Wrap a word in `` ` `` and it will be wrapped in `<code>`.