### PR TITLE
If it looks like Gutenberg needs a `npm run build` alert the user.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -41,6 +41,13 @@ function gutenberg_url( $path ) {
  * @since 0.1.0
  */
 function gutenberg_register_scripts_and_styles() {
+	// If this file doesn't exist yet, we need a `npm run build`
+	if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'gutenberg', 'gutenberg-demo' ) ) && ! file_exists( gutenberg_dir_path() . 'blocks/build/edit-blocks.css' ) ) {
+		$error = esc_html__( 'Gutenberg is installed, but some assets still need to be built.  On the command line, run the following:' );
+		$error .= sprintf( "\r\n\r\n<code>cd %s\r\nnpm install\r\nnpm run build</code>", escapeshellarg( gutenberg_dir_path() ) );
+		wp_die( nl2br( $error ) );
+	}
+
 	gutenberg_register_vendor_scripts();
 
 	// Editor Scripts.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -43,7 +43,7 @@ function gutenberg_url( $path ) {
 function gutenberg_register_scripts_and_styles() {
 	// If this file doesn't exist yet, we need a `npm run build`.
 	if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'gutenberg', 'gutenberg-demo' ) ) && ! file_exists( gutenberg_dir_path() . 'blocks/build/edit-blocks.css' ) ) {
-		$error = esc_html__( 'Gutenberg is installed, but some assets still need to be built.  On the command line, run the following:' );
+		$error = esc_html__( 'Gutenberg is installed, but some assets still need to be built.  On the command line, run the following:', 'gutenberg' );
 		$error .= sprintf( "\r\n\r\n<code>cd %s\r\nnpm install\r\nnpm run build</code>", escapeshellarg( gutenberg_dir_path() ) );
 		wp_die( nl2br( $error ) );
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -41,7 +41,7 @@ function gutenberg_url( $path ) {
  * @since 0.1.0
  */
 function gutenberg_register_scripts_and_styles() {
-	// If this file doesn't exist yet, we need a `npm run build`
+	// If this file doesn't exist yet, we need a `npm run build`.
 	if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'gutenberg', 'gutenberg-demo' ) ) && ! file_exists( gutenberg_dir_path() . 'blocks/build/edit-blocks.css' ) ) {
 		$error = esc_html__( 'Gutenberg is installed, but some assets still need to be built.  On the command line, run the following:' );
 		$error .= sprintf( "\r\n\r\n<code>cd %s\r\nnpm install\r\nnpm run build</code>", escapeshellarg( gutenberg_dir_path() ) );


### PR DESCRIPTION
This should handle issues where error messages like this show up
following installation from GitHub or a Git Pull:

```
<b>Warning</b>:  filemtime(): stat failed for /mnt/c/Users/George
Stephanis/Code/wp.dev/src/wp-content/plugins/gutenberg/blocks/build/edit-blocks.css
in <b>/mnt/c/Users/George
Stephanis/Code/wp.dev/src/wp-content/plugins/gutenberg/lib/client-assets.php</b>
on line <b>127</b><br />
```

May be wiser to test for each built file, but I'm not sure if there's a
better way to enumerate those.  Suggestions welcome.