### PR TITLE
Pass 'image' instead of 'image-type' as type param for MediaUploadButton component

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -88,7 +88,7 @@ registerBlockType( 'core/image', {
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }
 						onSelect={ onSelectImage }
-						type="format-image"
+						type="image"
 						autoOpen
 					>
 						{ __( 'Insert from Media Library' ) }


### PR DESCRIPTION
It seems `image` was accidentally replaced with `format-image` in 255dbe5a9d12c775ce7fcda2beeaecd0cbca4237. The `MediaUploadButton` component takes a `type` prop which is the MIME type. 

Compare with the `gallery` and `cover-image` blocks:
* https://github.com/WordPress/gutenberg/blob/1fd55b20201e728cb8eb04321e09cbdb0848a363/blocks/library/gallery/index.js#L116
* https://github.com/WordPress/gutenberg/blob/1fd55b20201e728cb8eb04321e09cbdb0848a363/blocks/library/cover-image/index.js#L90

Fixes #1653.