### PR TITLE
PHPCS: Color Output & Show Progress

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,7 +5,12 @@
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />
 
+	<!-- Show sniff codes in all reports -->
 	<arg value="s"/>
+
+	<!-- Use colors in output -->
+	<arg value="-colors"/>
+	
 	<arg name="extensions" value="php"/>
 
 	<file>gutenberg.php</file>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,9 @@
 	<!-- Use colors in output -->
 	<arg value="-colors"/>
 	
+	<!-- Show Progress -->
+	<arg value="p"/>
+	
 	<arg name="extensions" value="php"/>
 
 	<file>gutenberg.php</file>


### PR DESCRIPTION
I like the colored output for PHPCS. Helps with the readability. As well as the progress! 
Also, this helps to keep the arguments list downsized to just what's needed.