### PR TITLE
Remove margin from sandbox iframe to fix size calculation

### DIFF
--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -80,8 +80,8 @@ export default class Sandbox extends wp.element.Component {
 				function sendResize() {
 					window.top.postMessage( {
 						action: 'resize',
-						width: document.body.offsetWidth,
-						height: document.body.offsetHeight
+						width: document.body.scrollWidth,
+						height: document.body.scrollHeight
 					}, '*' );
 				}
 

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -73,7 +73,7 @@ export default class Sandbox extends wp.element.Component {
 			( function() {
 				var observer;
 
-				if ( ! window.MutationObserver || ! document.body || ! window.top ) {
+				if ( ! window.MutationObserver || ! document.body || ! window.parent ) {
 					return;
 				}
 
@@ -81,7 +81,7 @@ export default class Sandbox extends wp.element.Component {
 					var clientBoundingRect, computedStyle;
 					clientBoundingRect = document.body.getBoundingClientRect();
 					computedStyle = getComputedStyle( document.body );
-					window.top.postMessage( {
+					window.parent.postMessage( {
 						action: 'resize',
 						width: clientBoundingRect.width + parseFloat( computedStyle.marginLeft ) + parseFloat( computedStyle.marginRight ),
 						height: clientBoundingRect.height + parseFloat( computedStyle.marginTop ) + parseFloat( computedStyle.marginBottom )

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -78,13 +78,11 @@ export default class Sandbox extends wp.element.Component {
 				}
 
 				function sendResize() {
-					var clientBoundingRect, computedStyle;
-					clientBoundingRect = document.body.getBoundingClientRect();
-					computedStyle = getComputedStyle( document.body );
+					var clientBoundingRect = document.body.getBoundingClientRect();
 					window.parent.postMessage( {
 						action: 'resize',
-						width: clientBoundingRect.width + parseFloat( computedStyle.marginLeft ) + parseFloat( computedStyle.marginRight ),
-						height: clientBoundingRect.height + parseFloat( computedStyle.marginTop ) + parseFloat( computedStyle.marginBottom )
+						width: clientBoundingRect.width,
+						height: clientBoundingRect.height
 					}, '*' );
 				}
 
@@ -129,7 +127,7 @@ export default class Sandbox extends wp.element.Component {
 				<head>
 					<title>{ this.props.title }</title>
 				</head>
-				<body data-resizable-iframe-connected="data-resizable-iframe-connected">
+				<body data-resizable-iframe-connected="data-resizable-iframe-connected" style={ { margin: 0 } }>
 					<div dangerouslySetInnerHTML={ { __html: this.props.html } } />
 					<script type="text/javascript" dangerouslySetInnerHTML={ { __html: observeAndResizeJS } } />
 				</body>

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -159,10 +159,8 @@ export default class Sandbox extends wp.element.Component {
 				scrolling="no"
 				sandbox="allow-scripts allow-same-origin allow-presentation"
 				onLoad={ this.trySandbox }
-				style={ {
-					width: this.state.width,
-					height: this.state.height,
-				} } />
+				width={ Math.ceil( this.state.width ) }
+				height={ Math.ceil( this.state.height ) } />
 		);
 	}
 }

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -78,10 +78,13 @@ export default class Sandbox extends wp.element.Component {
 				}
 
 				function sendResize() {
+					var clientBoundingRect, computedStyle;
+					clientBoundingRect = document.body.getBoundingClientRect();
+					computedStyle = getComputedStyle( document.body );
 					window.top.postMessage( {
 						action: 'resize',
-						width: document.body.scrollWidth,
-						height: document.body.scrollHeight
+						width: clientBoundingRect.width + parseFloat( computedStyle.marginLeft ) + parseFloat( computedStyle.marginRight ),
+						height: clientBoundingRect.height + parseFloat( computedStyle.marginTop ) + parseFloat( computedStyle.marginBottom )
 					}, '*' );
 				}
 

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -159,8 +159,10 @@ export default class Sandbox extends wp.element.Component {
 				scrolling="no"
 				sandbox="allow-scripts allow-same-origin allow-presentation"
 				onLoad={ this.trySandbox }
-				width={ this.state.width }
-				height={ this.state.height } />
+				style={ {
+					width: this.state.width,
+					height: this.state.height,
+				} } />
 		);
 	}
 }


### PR DESCRIPTION
The sandboxed `iframe` was not getting resized enough to account for the margins of the body inside the iframed window. The result, as I'm working on adding sandboxing to the Custom HTML block (#1625), is the content being cut off:

<img width="222" alt="screen shot 2017-07-03 at 22 50 53" src="https://user-images.githubusercontent.com/134745/27818471-9461eb08-604a-11e7-930e-26acd5ed2b1d.png">

With the fix, it looks like:

<img width="301" alt="screen shot 2017-07-03 at 22 54 34" src="https://user-images.githubusercontent.com/134745/27818489-ac0e3aae-604a-11e7-9dc7-2aacbf9428f2.png">

Amends #1392