### PR TITLE
Fix responsive issues & a dimming issue

### DIFF
--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -33,9 +33,9 @@
 		content: '';
 		position: absolute;
 		top: 0;
-		right: $block-padding * 2 + $block-mover-margin;
+		right: 0;
 		bottom: 0;
-		left: $block-padding * 2 + $block-mover-margin;
+		left: 0;
 		background: rgba( 0,0,0,.5 );
 	}
 

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -49,6 +49,7 @@ $item-spacing: 10px;
 $panel-padding: 16px;
 $header-height: 56px;
 $sidebar-width: 280px;
+$sidebar-panel-header-height: 50px;
 $admin-bar-height: 32px;
 $admin-bar-height-big: 46px;
 $admin-sidebar-width: 160px;

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -13,7 +13,7 @@ $z-layers: (
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
 	'.editor-block-mover': 30,
-	'.editor-sidebar': 100000,
+	'.editor-sidebar': 100000,	// only used on mobile
 	'.components-notice-list': 100000,
 	'.components-popover': 100000,
 );

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -8,6 +8,7 @@ $z-layers: (
 	'.editor-format-list__menu': 1,
 	'.editor-inserter__tabs': 1,
 	'.editor-inserter__tab.is-active': 1,
+	'.components-panel__header': 1,
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -8,11 +8,11 @@ $z-layers: (
 	'.editor-format-list__menu': 1,
 	'.editor-inserter__tabs': 1,
 	'.editor-inserter__tab.is-active': 1,
-	'.editor-sidebar': 19,
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
 	'.editor-block-mover': 30,
+	'.editor-sidebar': 100000,
 	'.components-notice-list': 100000,
 	'.components-popover': 100000,
 );

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -76,6 +76,11 @@
 	}
 }
 
+// Needs specificity to override bleed
+.wp-core-ui .button.button-large.editor-tools__publish-button {
+	margin-bottom: 0;
+}
+
 .editor-tools__publish-button.is-saving,
 .editor-tools__publish-button.is-saving:disabled {
 	position: relative;

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -1,17 +1,19 @@
 .editor-sidebar {
-	position: sticky;
+	position: fixed;
 	z-index: z-index( '.editor-sidebar' );
+	top: 0;
 	right: 0;
-	top: $admin-bar-height-big + $header-height;
 	bottom: 0;
 	width: $sidebar-width;
 	border-left: 1px solid $light-gray-500;
 	background: $light-gray-300;
 	color: $dark-gray-500;
+	height: 100vh;
+	overflow: auto;
 
 	@include break-small() {
-		position: fixed;
-		overflow: auto;
+		top: $admin-bar-height-big + $header-height;
+		height: auto;
 	}
 
 	@include break-medium() {
@@ -58,16 +60,6 @@
 
 /* Visual and Text editor both */
 .editor-layout.is-sidebar-opened .editor-layout__content {
-	margin-left: -200%;
-	float: left;
-	height: 0;
-
-	@include break-small() {
-		margin-left: auto;
-		float: none;
-		height: auto;
-	}
-
 	@include break-medium() {
 		margin-right: $sidebar-width;
 	}

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -9,11 +9,12 @@
 	background: $light-gray-300;
 	color: $dark-gray-500;
 	height: 100vh;
-	overflow: auto;
+	overflow: hidden;
 
 	@include break-small() {
 		top: $admin-bar-height-big + $header-height;
 		height: auto;
+		overflow: auto;
 	}
 
 	@include break-medium() {
@@ -23,12 +24,38 @@
 	> .components-panel {
 		border-left: none;
 		border-right: none;
+		overflow: auto;
+		height: 100%;
+		padding-top: $sidebar-panel-header-height;
+
+		@include break-small() {
+			overflow: inherit;
+			height: auto;
+			padding-top: 0;
+		}
+
 		&:first-child {
 			margin-top: -1px;
 		}
 
 		&:last-child {
 			margin-bottom: -1px;
+		}
+	}
+
+	> .components-panel .components-panel__header {
+		position: fixed;
+		z-index: z-index( '.components-panel__header' );
+		top: 0;
+		left: 0;
+		right: 0;
+		height: $sidebar-panel-header-height;
+
+		@include break-small() {
+			position: inherit;
+			top: auto;
+			left: auto;
+			right: auto;
 		}
 	}
 

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -13,6 +13,7 @@
 
 	@include break-small() {
 		top: $admin-bar-height-big + $header-height;
+		z-index: auto;
 		height: auto;
 		overflow: auto;
 	}


### PR DESCRIPTION
This PR fixes an issue with the dimming layer on the cover image, and then it does a fair bit of rewriting of the sidebar code to make it work better on mobile.

It's still a bit of a work in progress, but I'm assigning reviewers early because the CSS is sort of gnarly and I'd appreciate insights.

Also — while working on this, I discovered that WordPress has already solved CSS bleed with a class called `modal-open`. It's pretty magical, and I would love it if we can apply this to the sidebar when on mobile. See more info here: https://github.com/WordPress/gutenberg/issues/656#issuecomment-312826151 —  but this should probably be done in a separate PR. 

Steps to test:

- Verify that the dimming layer on cover image looks right on all alignments
- Verify that the sidebar works / looks well on desktop, including with all metaboxes open
- Verify that the sidebar works well as a modal on mobile, including with all metaboxes open