### PR TITLE
Recent blocks

### DIFF
--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -269,7 +269,6 @@ class InserterMenu extends Component {
 
 	switchTab( tab ) {
 		this.setState( { tab: tab } );
-		this.setSearchFocus();
 	}
 
 	render() {

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -32,11 +32,10 @@ class InserterMenu extends Component {
 		this.filter = this.filter.bind( this );
 		this.setSearchFocus = this.setSearchFocus.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
-		this.applySearchFilter = this.applySearchFilter.bind( this );
+		this.searchBlocks = this.searchBlocks.bind( this );
 		this.getBlocksForCurrentTab = this.getBlocksForCurrentTab.bind( this );
 		this.sortBlocks = this.sortBlocks.bind( this );
 		this.addRecentBlocks = this.addRecentBlocks.bind( this );
-		this.filterRecentForSearch = this.filterRecentForSearch.bind( this );
 	}
 
 	componentDidMount() {
@@ -57,9 +56,9 @@ class InserterMenu extends Component {
 		} );
 	}
 
-	selectBlock( blockType ) {
+	selectBlock( name ) {
 		return () => {
-			this.props.onSelect( blockType.name );
+			this.props.onSelect( name );
 			this.setState( {
 				filterValue: '',
 				currentFocus: null,
@@ -67,7 +66,7 @@ class InserterMenu extends Component {
 		};
 	}
 
-	applySearchFilter( blockTypes ) {
+	searchBlocks( blockTypes ) {
 		const matchesSearch = ( block ) => block.title.toLowerCase().indexOf( this.state.filterValue.toLowerCase() ) !== -1;
 		return filter( blockTypes, matchesSearch );
 	}
@@ -104,22 +103,16 @@ class InserterMenu extends Component {
 		return blocksByCategory;
 	}
 
-	filterRecentForSearch( blocksByCategory ) {
-		blocksByCategory.recent = this.applySearchFilter( blocksByCategory.recent );
-		return blocksByCategory;
-	}
-
 	groupByCategory( blockTypes ) {
 		return groupBy( blockTypes, ( blockType ) => blockType.category );
 	}
 
 	getVisibleBlocksByCategory( blockTypes ) {
 		return flow(
-			this.applySearchFilter,
+			this.searchBlocks,
 			this.sortBlocks,
 			this.groupByCategory,
-			this.addRecentBlocks,
-			this.filterRecentForSearch
+			this.addRecentBlocks
 		)( blockTypes );
 	}
 
@@ -168,7 +161,7 @@ class InserterMenu extends Component {
 
 	focusNext() {
 		const sortedByCategory = flow(
-			this.applySearchFilter,
+			this.searchBlocks,
 			this.sortBlocks,
 		)( this.getBlocksForCurrentTab() );
 
@@ -183,7 +176,7 @@ class InserterMenu extends Component {
 
 	focusPrevious() {
 		const sortedByCategory = flow(
-			this.applySearchFilter,
+			this.searchBlocks,
 			this.sortBlocks,
 		)( this.getBlocksForCurrentTab() );
 
@@ -262,7 +255,7 @@ class InserterMenu extends Component {
 				role="menuitem"
 				key={ block.name }
 				className="editor-inserter__block"
-				onClick={ this.selectBlock( block ) }
+				onClick={ this.selectBlock( block.name ) }
 				ref={ this.bindReferenceNode( block.name ) }
 				tabIndex="-1"
 				onMouseEnter={ this.props.showInsertionPoint }

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import { first, last, get, values, sortBy } from 'lodash';
+import { first, last, get, values } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -677,10 +677,6 @@ export function getNotices( state ) {
  * @return {Array}       List of recently used blocks
  */
 export function getRecentlyUsedBlocks( state ) {
-	// resolves the block names in the state to the block type settings,
-	// and orders by title so they don't jump around as much in the recent tab
-	return sortBy(
-		state.editor.recentlyUsedBlocks.map( blockType => getBlockType( blockType ) ),
-		( blockType ) => blockType.title
-	);
+	// resolves the block names in the state to the block type settings
+	return state.editor.recentlyUsedBlocks.map( blockType => getBlockType( blockType ) );
 }

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -6,9 +6,13 @@ import { first, last, get, values } from 'lodash';
 import createSelector from 'rememo';
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
 import { getBlockType } from 'blocks';
+
+/**
+ * Internal dependencies
+ */
 import { addQueryArgs } from './utils/url';
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import moment from 'moment';
-import { first, last, get, values } from 'lodash';
+import { first, last, get, values, sortBy } from 'lodash';
 import createSelector from 'rememo';
 
 /**
  * Internal dependencies
  */
+import { getBlockType } from 'blocks';
 import { addQueryArgs } from './utils/url';
 
 /**
@@ -667,4 +668,19 @@ export function getSuggestedPostFormat( state ) {
  */
 export function getNotices( state ) {
 	return values( state.notices );
+}
+
+/**
+ * Resolves the list of recently used block names into a list of block type settings.
+ *
+ * @param {Object} state Global application state
+ * @return {Array}       List of recently used blocks
+ */
+export function getRecentlyUsedBlocks( state ) {
+	// resolves the block names in the state to the block type settings,
+	// and orders by title so they don't jump around as much in the recent tab
+	return sortBy(
+		state.editor.recentlyUsedBlocks.map( blockType => getBlockType( blockType ) ),
+		( blockType ) => blockType.title
+	);
 }

--- a/editor/state.js
+++ b/editor/state.js
@@ -7,6 +7,11 @@ import refx from 'refx';
 import { reduce, keyBy, first, last, omit, without, flowRight } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { getBlockTypes } from 'blocks';
+
+/**
  * Internal dependencies
  */
 import { combineUndoableReducers } from './utils/undoable-reducer';
@@ -217,6 +222,27 @@ export const editor = combineUndoableReducers( {
 				return without( state, ...action.uids );
 		}
 
+		return state;
+	},
+
+	recentlyUsedBlocks( state = [], action ) {
+		const maxRecent = 8;
+		switch ( action.type ) {
+			case 'SETUP_NEW_POST':
+				// This is where we initially populate the recently used blocks,
+				// for now this inserts blocks from the common category.
+				return getBlockTypes()
+					.filter( ( blockType ) => 'common' === blockType.category )
+					.slice( 0, maxRecent )
+					.map( ( blockType ) => blockType.name );
+			case 'INSERT_BLOCK':
+				// This is where we record the block usage so it can show up in
+				// the recent blocks.
+				return [
+					action.block.name,
+					...without( state, action.block.name ),
+				].slice( 0, maxRecent );
+		}
 		return state;
 	},
 }, { resetTypes: [ 'RESET_BLOCKS' ] } );

--- a/editor/state.js
+++ b/editor/state.js
@@ -235,13 +235,14 @@ export const editor = combineUndoableReducers( {
 					.filter( ( blockType ) => 'common' === blockType.category )
 					.slice( 0, maxRecent )
 					.map( ( blockType ) => blockType.name );
-			case 'INSERT_BLOCK':
+			case 'INSERT_BLOCKS':
 				// This is where we record the block usage so it can show up in
 				// the recent blocks.
-				return [
-					action.block.name,
-					...without( state, action.block.name ),
-				].slice( 0, maxRecent );
+				let newState = [ ...state ];
+				action.blocks.forEach( ( block ) => {
+					newState = [ block.name, ...without( newState, block.name ) ];
+				} );
+				return newState.slice( 0, maxRecent );
 		}
 		return state;
 	},

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -84,27 +84,26 @@ describe( 'state', () => {
 
 		it( 'should record recently used blocks', () => {
 			const original = editor( undefined, {} );
-			expect( original.recentlyUsedBlocks ).to.not.include( 'core-embed/twitter' );
-
 			const state = editor( original, {
-				type: 'INSERT_BLOCK',
-				block: {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
 					uid: 'bacon',
 					name: 'core-embed/twitter',
-				},
+				} ],
 			} );
 
-			expect( state.recentlyUsedBlocks ).to.eql( [ 'core-embed/twitter' ] );
+			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
 
 			const twoRecentBlocks = editor( state, {
-				type: 'INSERT_BLOCK',
-				block: {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
 					uid: 'eggs',
 					name: 'core-embed/youtube',
-				},
+				} ],
 			} );
 
-			expect( twoRecentBlocks.recentlyUsedBlocks ).to.eql( [ 'core-embed/youtube', 'core-embed/twitter' ] );
+			expect( twoRecentBlocks.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
+			expect( twoRecentBlocks.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/twitter' );
 		} );
 
 		it( 'should populate recently used blocks with the common category', () => {
@@ -116,7 +115,7 @@ describe( 'state', () => {
 				},
 			} );
 
-			expect( initial.recentlyUsedBlocks ).to.have.eql( [ 'core/test-block' ] );
+			expect( initial.recentlyUsedBlocks ).toEqual( expect.arrayContaining( [ 'core/test-block', 'core/text' ] ) );
 		} );
 
 		it( 'should replace the block', () => {


### PR DESCRIPTION
Refactored code that generates and sorts visible blocks so that
the order of recent blocks can be arbitrary, and recent blocks
appear in their own category.

Maximum of 8 recent blocks are shown, with most recently used
at the top. This is not persisted between editor sessions, there
is a TODO item in the usage module to highlight this needs to
be done.

The buttons in block-list which currently show core/text and core/image
have not been modified to use the recently used blocks yet,
this is to be looked at in the next iteration.