### PR TITLE
Add actions for plugins to register frontend and editor assets

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -113,11 +113,13 @@ function gutenberg_frontend_scripts_and_styles() {
 	wp_enqueue_style( 'wp-blocks' );
 
 	// Enqueue block styles built through plugins.  This lives in a separate
-	// action because one day we may need to be smarter about whether assets
-	// are included based on whether blocks are actually present on the page.
+	// action for a couple of reasons: (1) we want to load these assets
+	// (usually stylesheets) in *both* frontend and editor contexts, and (2)
+	// one day we may need to be smarter about whether assets are included
+	// based on whether blocks are actually present on the page.
 
 	/**
-	 * Fires after block assets have been enqueued for the front-end.
+	 * Fires after enqueuing block assets for both editor and front-end.
 	 *
 	 * Call `add_action` on any hook before 'wp_enqueue_scripts'.
 	 *
@@ -126,6 +128,7 @@ function gutenberg_frontend_scripts_and_styles() {
 	 *
 	 * @since 0.4.0
 	 */
-	do_action( 'enqueue_block_frontend_assets' );
+	do_action( 'enqueue_block_assets' );
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_frontend_scripts_and_styles' );
+add_action( 'admin_enqueue_scripts', 'gutenberg_frontend_scripts_and_styles' );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -108,7 +108,7 @@ add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode() and wpauto
  *
  * @since 0.3.0
  */
-function gutenberg_frontend_scripts_and_styles() {
+function gutenberg_common_scripts_and_styles() {
 	// Enqueue basic styles built out of Gutenberg through `npm build`.
 	wp_enqueue_style( 'wp-blocks' );
 
@@ -130,5 +130,5 @@ function gutenberg_frontend_scripts_and_styles() {
 	 */
 	do_action( 'enqueue_block_assets' );
 }
-add_action( 'wp_enqueue_scripts', 'gutenberg_frontend_scripts_and_styles' );
-add_action( 'admin_enqueue_scripts', 'gutenberg_frontend_scripts_and_styles' );
+add_action( 'wp_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
+add_action( 'admin_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -103,32 +103,3 @@ function do_blocks( $content ) {
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode() and wpautop().
 
-/**
- * Handles the enqueueing of front end scripts and styles from Gutenberg.
- *
- * @since 0.3.0
- */
-function gutenberg_common_scripts_and_styles() {
-	// Enqueue basic styles built out of Gutenberg through `npm build`.
-	wp_enqueue_style( 'wp-blocks' );
-
-	// Enqueue block styles built through plugins.  This lives in a separate
-	// action for a couple of reasons: (1) we want to load these assets
-	// (usually stylesheets) in *both* frontend and editor contexts, and (2)
-	// one day we may need to be smarter about whether assets are included
-	// based on whether blocks are actually present on the page.
-
-	/**
-	 * Fires after enqueuing block assets for both editor and front-end.
-	 *
-	 * Call `add_action` on any hook before 'wp_enqueue_scripts'.
-	 *
-	 * In the function call you supply, simply use `wp_enqueue_script` and
-	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
-	 *
-	 * @since 0.4.0
-	 */
-	do_action( 'enqueue_block_assets' );
-}
-add_action( 'wp_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
-add_action( 'admin_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -102,4 +102,3 @@ function do_blocks( $content ) {
 	return $content_after_blocks;
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode() and wpautop().
-

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -102,3 +102,30 @@ function do_blocks( $content ) {
 	return $content_after_blocks;
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode() and wpautop().
+
+/**
+ * Handles the enqueueing of front end scripts and styles from Gutenberg.
+ *
+ * @since 0.3.0
+ */
+function gutenberg_frontend_scripts_and_styles() {
+	// Enqueue basic styles built out of Gutenberg through `npm build`.
+	wp_enqueue_style( 'wp-blocks' );
+
+	// Enqueue block styles built through plugins.  This lives in a separate
+	// action because one day we may need to be smarter about whether assets
+	// are included based on whether blocks are actually present on the page.
+
+	/**
+	 * Fires after block assets have been enqueued for the front-end.
+	 *
+	 * Call `add_action` on any hook before 'wp_enqueue_scripts'.
+	 *
+	 * In the function call you supply, simply use `wp_enqueue_script` and
+	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
+	 *
+	 * @since 0.4.0
+	 */
+	do_action( 'enqueue_block_frontend_assets' );
+}
+add_action( 'wp_enqueue_scripts', 'gutenberg_frontend_scripts_and_styles' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -365,6 +365,41 @@ function gutenberg_get_post_to_edit( $post_id ) {
 }
 
 /**
+ * Handles the enqueueing of block scripts and styles that are common to both
+ * the editor and the front-end.
+ *
+ * Note: This function must remain *before*
+ * `gutenberg_editor_scripts_and_styles` so that editor-specific stylesheets
+ * are loaded last.
+ *
+ * @since 0.3.0
+ */
+function gutenberg_common_scripts_and_styles() {
+	// Enqueue basic styles built out of Gutenberg through `npm build`.
+	wp_enqueue_style( 'wp-blocks' );
+
+	// Enqueue block styles built through plugins.  This lives in a separate
+	// action for a couple of reasons: (1) we want to load these assets
+	// (usually stylesheets) in *both* frontend and editor contexts, and (2)
+	// one day we may need to be smarter about whether assets are included
+	// based on whether blocks are actually present on the page.
+
+	/**
+	 * Fires after enqueuing block assets for both editor and front-end.
+	 *
+	 * Call `add_action` on any hook before 'wp_enqueue_scripts'.
+	 *
+	 * In the function call you supply, simply use `wp_enqueue_script` and
+	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
+	 *
+	 * @since 0.4.0
+	 */
+	do_action( 'enqueue_block_assets' );
+}
+add_action( 'wp_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
+add_action( 'admin_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
+
+/**
  * Scripts & Styles.
  *
  * Enqueues the needed scripts and styles when visiting the top-level page of
@@ -374,7 +409,7 @@ function gutenberg_get_post_to_edit( $post_id ) {
  *
  * @param string $hook Screen name.
  */
-function gutenberg_scripts_and_styles( $hook ) {
+function gutenberg_editor_scripts_and_styles( $hook ) {
 	if ( ! preg_match( '/(toplevel|gutenberg)_page_gutenberg(-demo)?/', $hook, $page_match ) ) {
 		return;
 	}
@@ -480,4 +515,4 @@ function gutenberg_scripts_and_styles( $hook ) {
 	 */
 	do_action( 'enqueue_block_editor_assets' );
 }
-add_action( 'admin_enqueue_scripts', 'gutenberg_scripts_and_styles' );
+add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -481,4 +481,3 @@ function gutenberg_scripts_and_styles( $hook ) {
 	do_action( 'enqueue_block_editor_assets' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_scripts_and_styles' );
-

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -372,7 +372,7 @@ function gutenberg_get_post_to_edit( $post_id ) {
  * `gutenberg_editor_scripts_and_styles` so that editor-specific stylesheets
  * are loaded last.
  *
- * @since 0.3.0
+ * @since 0.4.0
  */
 function gutenberg_common_scripts_and_styles() {
 	// Enqueue basic styles built out of Gutenberg through `npm build`.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -378,11 +378,13 @@ function gutenberg_common_scripts_and_styles() {
 	// Enqueue basic styles built out of Gutenberg through `npm build`.
 	wp_enqueue_style( 'wp-blocks' );
 
-	// Enqueue block styles built through plugins.  This lives in a separate
-	// action for a couple of reasons: (1) we want to load these assets
-	// (usually stylesheets) in *both* frontend and editor contexts, and (2)
-	// one day we may need to be smarter about whether assets are included
-	// based on whether blocks are actually present on the page.
+	/*
+	 * Enqueue block styles built through plugins.  This lives in a separate
+	 * action for a couple of reasons: (1) we want to load these assets
+	 * (usually stylesheets) in *both* frontend and editor contexts, and (2)
+	 * one day we may need to be smarter about whether assets are included
+	 * based on whether blocks are actually present on the page.
+	 */
 
 	/**
 	 * Fires after enqueuing block assets for both editor and front-end.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -467,14 +467,18 @@ function gutenberg_scripts_and_styles( $hook ) {
 		array( 'wp-components', 'wp-blocks', 'wp-edit-blocks' ),
 		filemtime( gutenberg_dir_path() . 'editor/build/style.css' )
 	);
+
+	/**
+	 * Fires after block assets have been enqueued for the editing interface.
+	 *
+	 * Call `add_action` on any hook before 'admin_enqueue_scripts'.
+	 *
+	 * In the function call you supply, simply use `wp_enqueue_script` and
+	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
+	 *
+	 * @since 0.4.0
+	 */
+	do_action( 'enqueue_block_editor_assets' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_scripts_and_styles' );
 
-/**
- * Handles the enqueueing of front end scripts and styles from Gutenberg.
- */
-function gutenberg_frontend_scripts_and_styles() {
-	// Enqueue basic styles built out of Gutenberg through npm build.
-	wp_enqueue_style( 'wp-blocks' );
-}
-add_action( 'wp_enqueue_scripts', 'gutenberg_frontend_scripts_and_styles' );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,7 +25,7 @@
 	</rule>
 
 	<!-- How about no -->
-	<rule ref="Squiz.Commenting.LongConditionClosingComment.Missing">
+	<rule ref="Squiz.Commenting.InlineComment.SpacingAfter">
 		<exclude-pattern>*</exclude-pattern>
 	</rule>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,11 +24,6 @@
 		<exclude-pattern>gutenberg.php</exclude-pattern>
 	</rule>
 
-	<!-- How about no -->
-	<rule ref="Squiz.Commenting.InlineComment.SpacingAfter">
-		<exclude-pattern>*</exclude-pattern>
-	</rule>
-
 	<!-- Do not require docblocks for unit tests -->
 	<rule ref="Squiz.Commenting.FunctionComment.Missing">
 		<exclude-pattern>phpunit/*</exclude-pattern>


### PR DESCRIPTION
Adds actions so that someone can hook into where Gutenberg styles and scripts are loaded and bring in styles and scripts of their own, for both the frontend and the editor.

This modifies functionality added in #1418, adding a Gutenberg-specific action intended for plugin use in enqueuing front-end assets.  It also adds a corresponding action for plugins to enqueue editor assets.

See also #422, #514, and #1420.