### PR TITLE
Add new function to register a new block category

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -33,41 +33,40 @@ export function getCategories() {
 }
 
 /**
- * Register a new block category
+ * Register a new block Category.
  *
  * @param {Array} category e.g {slug: 'custom', title: __('Custom Blocks')}
  *
- * @return {Array} Block categories
- *
+ * @return {Array} categories
  */
 export function registerCategory( category ) {
 	if ( ! category ) {
 		console.error(
-			'The Block category must be defined'
+			'The block Category must be defined'
 		);
 		return;
 	}
 	if ( ! category.slug ) {
 		console.error(
-			'The Block category slug must be defined'
+			'The block Category slug must be defined'
 		);
 		return;
 	}
 	if ( ! /^[a-z0-9-]+$/.test( category.slug ) ) {
 		console.error(
-			'Block category slug must not contain characters which are invalid for urls'
+			'The block Category slug must not contain characters which are invalid for urls'
 		);
 		return;
 	}
 	if ( categories.find( x => x.slug === category.slug ) ) {
 		console.error(
-			'Block category "' + category.slug + '" is already registered'
+			'The block Category "' + category.slug + '" is already registered'
 		);
 		return;
 	}
 	if ( ! category.title ) {
 		console.error(
-			'The Block category title must be defined'
+			'The block Category title must be defined'
 		);
 		return;
 	}
@@ -78,11 +77,11 @@ export function registerCategory( category ) {
 
 /**
  *
- * Get sorted categories by property
+ * Get sorted categories by property.
  *
  * @param {String} sortProperty The key to sort by
  *
- * @returns {Array} Block categories
+ * @returns {Array} categories
  */
 
 export function getSortedCategories( sortProperty ) {
@@ -103,12 +102,12 @@ export function getSortedCategories( sortProperty ) {
 }
 
 /**
- * Set the property 'order' for a category
+ * Set the property 'order' for a category.
  *
  * @param {String}    slug    The slug for the category
  * @param {Number}    order   The order for the category
  *
- * @returns {Array} Block categories
+ * @returns {Array} categories
  */
 export function setCategoryOrder( slug, order ) {
 	const category = find( categories, { slug: slug } );

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -14,7 +14,7 @@ import { sortBy, find } from 'lodash';
  *
  * @var {Array} categories
  */
-let categories = [
+const categories = [
 	{ slug: 'common', title: __( 'Common Blocks' ) },
 	{ slug: 'formatting', title: __( 'Formatting' ) },
 	{ slug: 'layout', title: __( 'Layout Blocks' ) },
@@ -22,6 +22,14 @@ let categories = [
 	{ slug: 'embed', title: __( 'Embed' ) },
 	{ slug: 'reusable-blocks', title: __( 'Saved Blocks' ) },
 ];
+
+/**
+ * @type {RegExp}
+ * @const
+ *
+ * Category names must be a combination of lower-case letters, numbers, and hypens
+ */
+const categoryNamePattern = /^[a-z0-9-]+$/;
 
 /**
  * Returns all the block categories.
@@ -52,13 +60,14 @@ export function registerCategory( category ) {
 		);
 		return;
 	}
-	if ( ! /^[a-z0-9-]+$/.test( category.slug ) ) {
+	if ( ! categoryNamePattern.test( category.slug ) ) {
 		console.error(
 			'The block Category slug must not contain characters which are invalid for urls'
 		);
 		return;
 	}
-	if ( categories.find( x => x.slug === category.slug ) ) {
+
+	if ( categories.some( x => x.slug === category.slug ) ) {
 		console.error(
 			'The block Category "' + category.slug + '" is already registered'
 		);
@@ -97,8 +106,9 @@ export function getSortedCategories( sortProperty ) {
 		);
 		return;
 	}
-	categories = sortBy( categories, sortProperty );
-	return categories;
+
+	const sortedCategories = sortBy( categories, sortProperty );
+	return sortedCategories;
 }
 
 /**

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -4,6 +4,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { sortBy, findIndex } from 'lodash';
 
 /**
  * Block categories.
@@ -13,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  *
  * @var {Array} categories
  */
-const categories = [
+let categories = [
 	{ slug: 'common', title: __( 'Common Blocks' ) },
 	{ slug: 'formatting', title: __( 'Formatting' ) },
 	{ slug: 'layout', title: __( 'Layout Blocks' ) },
@@ -60,7 +61,7 @@ export function registerCategory( cat ) {
 	}
 	if ( categories.find( x => x.slug === cat.slug ) ) {
 		console.error(
-			'Block category "' + cat.slug + '" is already registered.'
+			'Block category "' + cat.slug + '" is already registered'
 		);
 		return;
 	}
@@ -73,4 +74,54 @@ export function registerCategory( cat ) {
 
 	categories.push( cat );
 	return categories;
+}
+
+/**
+ * Sort categories by key
+ *
+ * @param {String} key The key to sort by
+ */
+export function sortCategoriesBy( key ) {
+	if ( ! key ) {
+		console.error(
+			'The key must be defined'
+		);
+		return;
+	}
+	if ( typeof key !== 'string' ) {
+		console.error(
+			'The key must be a string'
+		);
+		return;
+	}
+	categories = sortBy( categories, key );
+}
+
+/**
+ * Set the property 'order' for a category
+ *
+ * @param {String}    slug    The slug for the category
+ * @param {Number}    order   The order for the category
+ */
+export function setCategoryOrder( slug, order ) {
+	const pos = findIndex( categories, ( category ) => category.slug === slug );
+	if ( ! slug ) {
+		console.error(
+			'The slug must be defined'
+		);
+		return;
+	}
+	if ( typeof slug !== 'string' ) {
+		console.error(
+			'The slug must be a string'
+		);
+		return;
+	}
+	if ( ! ( order === parseInt( order, 10 ) ) ) {
+		console.error(
+			'The order must be an integer'
+		);
+		return;
+	}
+	categories[ pos ].order = order;
 }

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -28,3 +28,49 @@ const categories = [
 export function getCategories() {
 	return categories;
 }
+
+/**
+ * Register a new block category (e.g {slug: 'custom', title: __('Custom Blocks')})
+ *
+ * @return {Array} Block categories
+ */
+export function registerCategory( cat ) {
+
+	if ( ! cat ) {
+		console.error(
+			'The Block category must be defined'
+		);
+		return;
+	}
+
+	if ( ! cat.slug ) {
+		console.error(
+			'The Block category slug must be defined'
+		);
+		return;
+	}
+
+	if ( ! /^[a-z0-9-]+$/.test( cat.slug ) ) {
+		console.error(
+			'Block category slug must not contain characters which are invalid for urls'
+		);
+		return;
+	}
+
+	if ( categories.find( x => x.slug === cat.slug ) ) {
+		console.error(
+			'Block category "' + cat.slug + '" is already registered.'
+		);
+		return;
+	}
+
+	if ( ! cat.title ) {
+		console.error(
+			'The Block category title must be defined'
+		);
+		return;
+	}
+
+	categories.push(cat);
+	return categories;
+}

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -4,7 +4,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { sortBy, find } from 'lodash';
 
 /**
  * Block categories.
@@ -84,61 +83,3 @@ export function registerCategory( category ) {
 	return categories;
 }
 
-/**
- *
- * Get sorted categories by property.
- *
- * @param {String} sortProperty The key to sort by
- *
- * @returns {Array} categories
- */
-
-export function getSortedCategories( sortProperty ) {
-	if ( ! sortProperty ) {
-		console.error(
-			'The sortProperty must be defined'
-		);
-		return;
-	}
-	if ( typeof sortProperty !== 'string' ) {
-		console.error(
-			'The sortProperty must be a string'
-		);
-		return;
-	}
-
-	const sortedCategories = sortBy( categories, sortProperty );
-	return sortedCategories;
-}
-
-/**
- * Set the property 'order' for a category.
- *
- * @param {String}    slug    The slug for the category
- * @param {Number}    order   The order for the category
- *
- * @returns {Array} categories
- */
-export function setCategoryOrder( slug, order ) {
-	const category = find( categories, { slug: slug } );
-	if ( ! slug ) {
-		console.error(
-			'The slug must be defined'
-		);
-		return;
-	}
-	if ( typeof slug !== 'string' ) {
-		console.error(
-			'The slug must be a string'
-		);
-		return;
-	}
-	if ( ! ( order === parseInt( order, 10 ) ) ) {
-		console.error(
-			'The order must be an integer'
-		);
-		return;
-	}
-	category.order = order;
-	return categories;
-}

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -1,3 +1,5 @@
+/* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
+
 /**
  * WordPress dependencies
  */
@@ -30,40 +32,38 @@ export function getCategories() {
 }
 
 /**
- * Register a new block category (e.g {slug: 'custom', title: __('Custom Blocks')})
+ * Register a new block category
+ *
+ * @param {Array} cat e.g {slug: 'custom', title: __('Custom Blocks')}
  *
  * @return {Array} Block categories
+ *
  */
 export function registerCategory( cat ) {
-
 	if ( ! cat ) {
 		console.error(
 			'The Block category must be defined'
 		);
 		return;
 	}
-
 	if ( ! cat.slug ) {
 		console.error(
 			'The Block category slug must be defined'
 		);
 		return;
 	}
-
 	if ( ! /^[a-z0-9-]+$/.test( cat.slug ) ) {
 		console.error(
 			'Block category slug must not contain characters which are invalid for urls'
 		);
 		return;
 	}
-
 	if ( categories.find( x => x.slug === cat.slug ) ) {
 		console.error(
 			'Block category "' + cat.slug + '" is already registered.'
 		);
 		return;
 	}
-
 	if ( ! cat.title ) {
 		console.error(
 			'The Block category title must be defined'
@@ -71,6 +71,6 @@ export function registerCategory( cat ) {
 		return;
 	}
 
-	categories.push(cat);
+	categories.push( cat );
 	return categories;
 }

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -4,7 +4,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { sortBy, findIndex } from 'lodash';
+import { sortBy, find } from 'lodash';
 
 /**
  * Block categories.
@@ -35,69 +35,70 @@ export function getCategories() {
 /**
  * Register a new block category
  *
- * @param {Array} cat e.g {slug: 'custom', title: __('Custom Blocks')}
+ * @param {Array} category e.g {slug: 'custom', title: __('Custom Blocks')}
  *
  * @return {Array} Block categories
  *
  */
-export function registerCategory( cat ) {
-	if ( ! cat ) {
+export function registerCategory( category ) {
+	if ( ! category ) {
 		console.error(
 			'The Block category must be defined'
 		);
 		return;
 	}
-	if ( ! cat.slug ) {
+	if ( ! category.slug ) {
 		console.error(
 			'The Block category slug must be defined'
 		);
 		return;
 	}
-	if ( ! /^[a-z0-9-]+$/.test( cat.slug ) ) {
+	if ( ! /^[a-z0-9-]+$/.test( category.slug ) ) {
 		console.error(
 			'Block category slug must not contain characters which are invalid for urls'
 		);
 		return;
 	}
-	if ( categories.find( x => x.slug === cat.slug ) ) {
+	if ( categories.find( x => x.slug === category.slug ) ) {
 		console.error(
-			'Block category "' + cat.slug + '" is already registered'
+			'Block category "' + category.slug + '" is already registered'
 		);
 		return;
 	}
-	if ( ! cat.title ) {
+	if ( ! category.title ) {
 		console.error(
 			'The Block category title must be defined'
 		);
 		return;
 	}
 
-	categories.push( cat );
+	categories.push( category );
 	return categories;
 }
 
 /**
  *
- * Sort categories by key
+ * Get sorted categories by property
  *
- * @param {String} key The key to sort by
+ * @param {String} sortProperty The key to sort by
  *
  * @returns {Array} Block categories
  */
-export function sortCategoriesBy( key ) {
-	if ( ! key ) {
+
+export function getSortedCategories( sortProperty ) {
+	if ( ! sortProperty ) {
 		console.error(
-			'The key must be defined'
+			'The sortProperty must be defined'
 		);
 		return;
 	}
-	if ( typeof key !== 'string' ) {
+	if ( typeof sortProperty !== 'string' ) {
 		console.error(
-			'The key must be a string'
+			'The sortProperty must be a string'
 		);
 		return;
 	}
-	categories = sortBy( categories, key );
+	categories = sortBy( categories, sortProperty );
 	return categories;
 }
 
@@ -110,7 +111,7 @@ export function sortCategoriesBy( key ) {
  * @returns {Array} Block categories
  */
 export function setCategoryOrder( slug, order ) {
-	const pos = findIndex( categories, ( category ) => category.slug === slug );
+	const category = find( categories, { slug: slug } );
 	if ( ! slug ) {
 		console.error(
 			'The slug must be defined'
@@ -129,6 +130,6 @@ export function setCategoryOrder( slug, order ) {
 		);
 		return;
 	}
-	categories[ pos ].order = order;
+	category.order = order;
 	return categories;
 }

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -77,9 +77,12 @@ export function registerCategory( cat ) {
 }
 
 /**
+ *
  * Sort categories by key
  *
  * @param {String} key The key to sort by
+ *
+ * @returns {Array} Block categories
  */
 export function sortCategoriesBy( key ) {
 	if ( ! key ) {
@@ -95,6 +98,7 @@ export function sortCategoriesBy( key ) {
 		return;
 	}
 	categories = sortBy( categories, key );
+	return categories;
 }
 
 /**
@@ -102,6 +106,8 @@ export function sortCategoriesBy( key ) {
  *
  * @param {String}    slug    The slug for the category
  * @param {Number}    order   The order for the category
+ *
+ * @returns {Array} Block categories
  */
 export function setCategoryOrder( slug, order ) {
 	const pos = findIndex( categories, ( category ) => category.slug === slug );
@@ -124,4 +130,5 @@ export function setCategoryOrder( slug, order ) {
 		return;
 	}
 	categories[ pos ].order = order;
+	return categories;
 }

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -8,8 +8,6 @@ export {
 	getSaveElement,
 } from './serializer';
 export { isValidBlock } from './validation';
-export { getCategories } from './categories';
-export { default as serialize, getBlockDefaultClassname } from './serializer';
 export {
 	getCategories,
 	registerCategory,

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -13,7 +13,7 @@ export { default as serialize, getBlockDefaultClassname } from './serializer';
 export {
 	getCategories,
 	registerCategory,
-	sortCategoriesBy,
+	getSortedCategories,
 	setCategoryOrder,
 } from './categories';
 export {

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -11,8 +11,6 @@ export { isValidBlock } from './validation';
 export {
 	getCategories,
 	registerCategory,
-	getSortedCategories,
-	setCategoryOrder,
 } from './categories';
 export {
 	registerBlockType,

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -9,6 +9,11 @@ export {
 } from './serializer';
 export { isValidBlock } from './validation';
 export { getCategories } from './categories';
+export { default as serialize, getBlockDefaultClassname } from './serializer';
+export {
+	getCategories,
+	registerCategory,
+} from './categories';
 export {
 	registerBlockType,
 	unregisterBlockType,

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -13,6 +13,8 @@ export { default as serialize, getBlockDefaultClassname } from './serializer';
 export {
 	getCategories,
 	registerCategory,
+	sortCategoriesBy,
+	setCategoryOrder,
 } from './categories';
 export {
 	registerBlockType,

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -10,8 +10,6 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	registerCategory,
-	getSortedCategories,
-	setCategoryOrder,
 } from '../categories';
 
 describe( 'categories', () => {
@@ -66,58 +64,6 @@ describe( 'categories', () => {
 			const categories = registerCategory( { slug: 'custom-blocks', title: 'Custom Blocks' } );
 			expect( console.error ).toHaveBeenCalledWith( 'The block Category "custom-blocks" is already registered' );
 			expect( categories ).toBeUndefined();
-		} );
-	} );
-	describe( 'setCategoryOrder()', () => {
-		it( 'should reject slug not defined', () => {
-			const categories = setCategoryOrder();
-			expect( console.error ).toHaveBeenCalledWith( 'The slug must be defined' );
-			expect( categories ).toBeUndefined();
-		} );
-
-		it( 'should reject empty slug', () => {
-			const categories = setCategoryOrder( '', 2 );
-			expect( console.error ).toHaveBeenCalledWith( 'The slug must be defined' );
-			expect( categories ).toBeUndefined();
-		} );
-
-		it( 'should reject slug if it is not a string', () => {
-			const categories = setCategoryOrder( 2, 2 );
-			expect( console.error ).toHaveBeenCalledWith( 'The slug must be a string' );
-			expect( categories ).toBeUndefined();
-		} );
-
-		it( 'should reject order if it is not an integer', () => {
-			const categories = setCategoryOrder( 'custom-blocks', 2.5 );
-			expect( console.error ).toHaveBeenCalledWith( 'The order must be an integer' );
-			expect( categories ).toBeUndefined();
-		} );
-
-		it( 'should reject order if it is a string', () => {
-			const categories = setCategoryOrder( 'custom-blocks', '2' );
-			expect( console.error ).toHaveBeenCalledWith( 'The order must be an integer' );
-			expect( categories ).toBeUndefined();
-		} );
-
-		it( 'should set the category order and return an array', () => {
-			const categories = setCategoryOrder( 'custom-blocks', 1 );
-			expect( categories ).toEqual( jasmine.arrayContaining( [ { slug: 'custom-blocks', title: 'Custom Blocks', order: 1 } ] ) );
-		} );
-	} );
-	describe( 'getSortedCategories()', () => {
-		it( 'should reject empty sortProperty', () => {
-			const categories = getSortedCategories();
-			expect( console.error ).toHaveBeenCalledWith( 'The sortProperty must be defined' );
-			expect( categories ).toBeUndefined();
-		} );
-		it( 'should reject sortProperty if it is not a valid string', () => {
-			const categories = getSortedCategories( 12345 );
-			expect( console.error ).toHaveBeenCalledWith( 'The sortProperty must be a string' );
-			expect( categories ).toBeUndefined();
-		} );
-		it( 'should return the first element for the array', () => {
-			const categories = getSortedCategories( 'order' );
-			expect( categories[ 0 ] ).toEqual( { slug: 'custom-blocks', title: 'Custom Blocks', order: 1 } );
 		} );
 	} );
 } );

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -1,0 +1,69 @@
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { __ } from 'i18n';
+
+/**
+ * Internal dependencies
+ */
+
+import {
+	registerCategory,
+} from '../categories';
+
+describe( 'categories', () => {
+	// Reset block state before each tesclet.
+	beforeEach( () => {
+		sinon.stub( console, 'error' );
+	} );
+	afterEach( () => {
+		console.error.restore();
+	} );
+	describe( 'registerCategory()', () => {
+		it( 'should reject empty categories', () => {
+			const categories = registerCategory();
+			expect( console.error ).to.have.been.calledWith( 'The Block category must be defined' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject categories with empty slug', () => {
+			const categories = registerCategory( { slug: '', title: __( 'Custom Blocks' ) } );
+			expect( console.error ).to.have.been.calledWith( 'The Block category slug must be defined' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject categories with empty slug', () => {
+			const categories = registerCategory( { title: __( 'Custom Blocks' ) } );
+			expect( console.error ).to.have.been.calledWith( 'The Block category slug must be defined' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject categories with invalid slug', () => {
+			const categories = registerCategory( { slug: 'custom blocks', title: __( 'Custom Blocks' ) } );
+			expect( console.error ).to.have.been.calledWith( 'Block category slug must not contain characters which are invalid for urls' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject categories with empty title', () => {
+			const categories = registerCategory( { slug: 'custom-blocks', title: '' } );
+			expect( console.error ).to.have.been.calledWith( 'The Block category title must be defined' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should store the new category', () => {
+			const categories = registerCategory( { slug: 'custom-blocks', title: 'Custom Blocks' } );
+			expect( categories ).to.be.an( 'array' ).that.include( { slug: 'custom-blocks', title: 'Custom Blocks' } );
+		} );
+
+		it( 'should reject categories already registered', () => {
+			const categories = registerCategory( { slug: 'custom-blocks', title: 'Custom Blocks' } );
+			expect( console.error ).to.have.been.calledWith( 'Block category "custom-blocks" is already registered.' );
+			expect( categories ).to.be.undefined();
+		} );
+	} );
+} );

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -68,19 +68,6 @@ describe( 'categories', () => {
 			expect( categories ).toBeUndefined();
 		} );
 	} );
-	describe( 'sortCategoriesBy()', () => {
-		it( 'should reject empty key', () => {
-			const categories = sortCategoriesBy();
-			expect( console.error ).toHaveBeenCalledWith( 'The key must be defined' );
-			expect( categories ).toBeUndefined();
-		} );
-
-		it( 'should reject key if it is not a valid string', () => {
-			const categories = sortCategoriesBy( 12345 );
-			expect( console.error ).toHaveBeenCalledWith( 'The key must be a string' );
-			expect( categories ).toBeUndefined();
-		} );
-	} );
 	describe( 'setCategoryOrder()', () => {
 		it( 'should reject slug not defined', () => {
 			const categories = setCategoryOrder();
@@ -110,6 +97,27 @@ describe( 'categories', () => {
 			const categories = setCategoryOrder( 'custom-blocks', '2' );
 			expect( console.error ).toHaveBeenCalledWith( 'The order must be an integer' );
 			expect( categories ).toBeUndefined();
+		} );
+
+		it( 'should set the category order and return an array', () => {
+			const categories = setCategoryOrder( 'custom-blocks', 1 );
+			expect( categories ).toEqual( jasmine.arrayContaining( [ { slug: 'custom-blocks', title: 'Custom Blocks', order: 1 } ] ) );
+		} );
+	} );
+	describe( 'sortCategoriesBy()', () => {
+		it( 'should reject empty key', () => {
+			const categories = sortCategoriesBy();
+			expect( console.error ).toHaveBeenCalledWith( 'The key must be defined' );
+			expect( categories ).toBeUndefined();
+		} );
+		it( 'should reject key if it is not a valid string', () => {
+			const categories = sortCategoriesBy( 12345 );
+			expect( console.error ).toHaveBeenCalledWith( 'The key must be a string' );
+			expect( categories ).toBeUndefined();
+		} );
+		it( 'should return the first element for the array', () => {
+			const categories = sortCategoriesBy( 'order' );
+			expect( categories[ 0 ] ).toEqual( { slug: 'custom-blocks', title: 'Custom Blocks', order: 1 } );
 		} );
 	} );
 } );

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { __ } from 'i18n';
@@ -11,7 +10,6 @@ import { __ } from 'i18n';
 /**
  * Internal dependencies
  */
-
 import {
 	registerCategory,
 	sortCategoriesBy,

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -14,6 +14,8 @@ import { __ } from 'i18n';
 
 import {
 	registerCategory,
+	sortCategoriesBy,
+	setCategoryOrder,
 } from '../categories';
 
 describe( 'categories', () => {
@@ -62,7 +64,51 @@ describe( 'categories', () => {
 
 		it( 'should reject categories already registered', () => {
 			const categories = registerCategory( { slug: 'custom-blocks', title: 'Custom Blocks' } );
-			expect( console.error ).to.have.been.calledWith( 'Block category "custom-blocks" is already registered.' );
+			expect( console.error ).to.have.been.calledWith( 'Block category "custom-blocks" is already registered' );
+			expect( categories ).to.be.undefined();
+		} );
+	} );
+	describe( 'sortCategoriesBy()', () => {
+		it( 'should reject empty key', () => {
+			const categories = sortCategoriesBy();
+			expect( console.error ).to.have.been.calledWith( 'The key must be defined' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject key if it is not a valid string', () => {
+			const categories = sortCategoriesBy( 12345 );
+			expect( console.error ).to.have.been.calledWith( 'The key must be a string' );
+			expect( categories ).to.be.undefined();
+		} );
+	} );
+	describe( 'setCategoryOrder()', () => {
+		it( 'should reject empty slug', () => {
+			const categories = setCategoryOrder();
+			expect( console.error ).to.have.been.calledWith( 'The slug must be defined' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject empty slug', () => {
+			const categories = setCategoryOrder( '', 2 );
+			expect( console.error ).to.have.been.calledWith( 'The slug must be defined' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject slug if it is not a string', () => {
+			const categories = setCategoryOrder( 2, 2 );
+			expect( console.error ).to.have.been.calledWith( 'The slug must be a string' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject order if it is not an integer', () => {
+			const categories = setCategoryOrder( 'custom-blocks', 2.5 );
+			expect( console.error ).to.have.been.calledWith( 'The order must be an integer' );
+			expect( categories ).to.be.undefined();
+		} );
+
+		it( 'should reject order if it is not an integer', () => {
+			const categories = setCategoryOrder( 'custom-blocks', '2' );
+			expect( console.error ).to.have.been.calledWith( 'The order must be an integer' );
 			expect( categories ).to.be.undefined();
 		} );
 	} );

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -39,7 +39,7 @@ describe( 'categories', () => {
 			expect( categories ).to.be.undefined();
 		} );
 
-		it( 'should reject categories with empty slug', () => {
+		it( 'should reject categories with slug not defined', () => {
 			const categories = registerCategory( { title: __( 'Custom Blocks' ) } );
 			expect( console.error ).to.have.been.calledWith( 'The Block category slug must be defined' );
 			expect( categories ).to.be.undefined();
@@ -82,7 +82,7 @@ describe( 'categories', () => {
 		} );
 	} );
 	describe( 'setCategoryOrder()', () => {
-		it( 'should reject empty slug', () => {
+		it( 'should reject slug not defined', () => {
 			const categories = setCategoryOrder();
 			expect( console.error ).to.have.been.calledWith( 'The slug must be defined' );
 			expect( categories ).to.be.undefined();
@@ -106,7 +106,7 @@ describe( 'categories', () => {
 			expect( categories ).to.be.undefined();
 		} );
 
-		it( 'should reject order if it is not an integer', () => {
+		it( 'should reject order if it is a string', () => {
 			const categories = setCategoryOrder( 'custom-blocks', '2' );
 			expect( console.error ).to.have.been.calledWith( 'The order must be an integer' );
 			expect( categories ).to.be.undefined();

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import sinon from 'sinon';
 import { __ } from 'i18n';
 
 /**
@@ -17,97 +15,101 @@ import {
 } from '../categories';
 
 describe( 'categories', () => {
-	// Reset block state before each tesclet.
+	const error = console.error;
+
+	// Reset block state before each test.
 	beforeEach( () => {
-		sinon.stub( console, 'error' );
+		console.error = jest.fn();
 	} );
+
 	afterEach( () => {
-		console.error.restore();
+		console.error = error;
 	} );
+
 	describe( 'registerCategory()', () => {
 		it( 'should reject empty categories', () => {
 			const categories = registerCategory();
-			expect( console.error ).to.have.been.calledWith( 'The Block category must be defined' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The Block category must be defined' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject categories with empty slug', () => {
 			const categories = registerCategory( { slug: '', title: __( 'Custom Blocks' ) } );
-			expect( console.error ).to.have.been.calledWith( 'The Block category slug must be defined' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The Block category slug must be defined' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject categories with slug not defined', () => {
 			const categories = registerCategory( { title: __( 'Custom Blocks' ) } );
-			expect( console.error ).to.have.been.calledWith( 'The Block category slug must be defined' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The Block category slug must be defined' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject categories with invalid slug', () => {
 			const categories = registerCategory( { slug: 'custom blocks', title: __( 'Custom Blocks' ) } );
-			expect( console.error ).to.have.been.calledWith( 'Block category slug must not contain characters which are invalid for urls' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'Block category slug must not contain characters which are invalid for urls' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject categories with empty title', () => {
 			const categories = registerCategory( { slug: 'custom-blocks', title: '' } );
-			expect( console.error ).to.have.been.calledWith( 'The Block category title must be defined' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The Block category title must be defined' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should store the new category', () => {
 			const categories = registerCategory( { slug: 'custom-blocks', title: 'Custom Blocks' } );
-			expect( categories ).to.be.an( 'array' ).that.include( { slug: 'custom-blocks', title: 'Custom Blocks' } );
+			expect(categories).toEqual( jasmine.arrayContaining( [ { slug: 'custom-blocks', title: 'Custom Blocks' } ] ) );
 		} );
 
 		it( 'should reject categories already registered', () => {
 			const categories = registerCategory( { slug: 'custom-blocks', title: 'Custom Blocks' } );
-			expect( console.error ).to.have.been.calledWith( 'Block category "custom-blocks" is already registered' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'Block category "custom-blocks" is already registered' );
+			expect( categories ).toBeUndefined();
 		} );
 	} );
 	describe( 'sortCategoriesBy()', () => {
 		it( 'should reject empty key', () => {
 			const categories = sortCategoriesBy();
-			expect( console.error ).to.have.been.calledWith( 'The key must be defined' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The key must be defined' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject key if it is not a valid string', () => {
 			const categories = sortCategoriesBy( 12345 );
-			expect( console.error ).to.have.been.calledWith( 'The key must be a string' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The key must be a string' );
+			expect( categories ).toBeUndefined();
 		} );
 	} );
 	describe( 'setCategoryOrder()', () => {
 		it( 'should reject slug not defined', () => {
 			const categories = setCategoryOrder();
-			expect( console.error ).to.have.been.calledWith( 'The slug must be defined' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The slug must be defined' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject empty slug', () => {
 			const categories = setCategoryOrder( '', 2 );
-			expect( console.error ).to.have.been.calledWith( 'The slug must be defined' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The slug must be defined' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject slug if it is not a string', () => {
 			const categories = setCategoryOrder( 2, 2 );
-			expect( console.error ).to.have.been.calledWith( 'The slug must be a string' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The slug must be a string' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject order if it is not an integer', () => {
 			const categories = setCategoryOrder( 'custom-blocks', 2.5 );
-			expect( console.error ).to.have.been.calledWith( 'The order must be an integer' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The order must be an integer' );
+			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject order if it is a string', () => {
 			const categories = setCategoryOrder( 'custom-blocks', '2' );
-			expect( console.error ).to.have.been.calledWith( 'The order must be an integer' );
-			expect( categories ).to.be.undefined();
+			expect( console.error ).toHaveBeenCalledWith( 'The order must be an integer' );
+			expect( categories ).toBeUndefined();
 		} );
 	} );
 } );

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -59,7 +59,7 @@ describe( 'categories', () => {
 
 		it( 'should store the new category', () => {
 			const categories = registerCategory( { slug: 'custom-blocks', title: 'Custom Blocks' } );
-			expect(categories).toEqual( jasmine.arrayContaining( [ { slug: 'custom-blocks', title: 'Custom Blocks' } ] ) );
+			expect( categories ).toEqual( jasmine.arrayContaining( [ { slug: 'custom-blocks', title: 'Custom Blocks' } ] ) );
 		} );
 
 		it( 'should reject categories already registered', () => {

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -29,31 +29,31 @@ describe( 'categories', () => {
 	describe( 'registerCategory()', () => {
 		it( 'should reject empty categories', () => {
 			const categories = registerCategory();
-			expect( console.error ).toHaveBeenCalledWith( 'The Block category must be defined' );
+			expect( console.error ).toHaveBeenCalledWith( 'The block Category must be defined' );
 			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject categories with empty slug', () => {
 			const categories = registerCategory( { slug: '', title: __( 'Custom Blocks' ) } );
-			expect( console.error ).toHaveBeenCalledWith( 'The Block category slug must be defined' );
+			expect( console.error ).toHaveBeenCalledWith( 'The block Category slug must be defined' );
 			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject categories with slug not defined', () => {
 			const categories = registerCategory( { title: __( 'Custom Blocks' ) } );
-			expect( console.error ).toHaveBeenCalledWith( 'The Block category slug must be defined' );
+			expect( console.error ).toHaveBeenCalledWith( 'The block Category slug must be defined' );
 			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject categories with invalid slug', () => {
 			const categories = registerCategory( { slug: 'custom blocks', title: __( 'Custom Blocks' ) } );
-			expect( console.error ).toHaveBeenCalledWith( 'Block category slug must not contain characters which are invalid for urls' );
+			expect( console.error ).toHaveBeenCalledWith( 'The block Category slug must not contain characters which are invalid for urls' );
 			expect( categories ).toBeUndefined();
 		} );
 
 		it( 'should reject categories with empty title', () => {
 			const categories = registerCategory( { slug: 'custom-blocks', title: '' } );
-			expect( console.error ).toHaveBeenCalledWith( 'The Block category title must be defined' );
+			expect( console.error ).toHaveBeenCalledWith( 'The block Category title must be defined' );
 			expect( categories ).toBeUndefined();
 		} );
 
@@ -64,7 +64,7 @@ describe( 'categories', () => {
 
 		it( 'should reject categories already registered', () => {
 			const categories = registerCategory( { slug: 'custom-blocks', title: 'Custom Blocks' } );
-			expect( console.error ).toHaveBeenCalledWith( 'Block category "custom-blocks" is already registered' );
+			expect( console.error ).toHaveBeenCalledWith( 'The block Category "custom-blocks" is already registered' );
 			expect( categories ).toBeUndefined();
 		} );
 	} );

--- a/blocks/api/test/categories.js
+++ b/blocks/api/test/categories.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	registerCategory,
-	sortCategoriesBy,
+	getSortedCategories,
 	setCategoryOrder,
 } from '../categories';
 
@@ -104,19 +104,19 @@ describe( 'categories', () => {
 			expect( categories ).toEqual( jasmine.arrayContaining( [ { slug: 'custom-blocks', title: 'Custom Blocks', order: 1 } ] ) );
 		} );
 	} );
-	describe( 'sortCategoriesBy()', () => {
-		it( 'should reject empty key', () => {
-			const categories = sortCategoriesBy();
-			expect( console.error ).toHaveBeenCalledWith( 'The key must be defined' );
+	describe( 'getSortedCategories()', () => {
+		it( 'should reject empty sortProperty', () => {
+			const categories = getSortedCategories();
+			expect( console.error ).toHaveBeenCalledWith( 'The sortProperty must be defined' );
 			expect( categories ).toBeUndefined();
 		} );
-		it( 'should reject key if it is not a valid string', () => {
-			const categories = sortCategoriesBy( 12345 );
-			expect( console.error ).toHaveBeenCalledWith( 'The key must be a string' );
+		it( 'should reject sortProperty if it is not a valid string', () => {
+			const categories = getSortedCategories( 12345 );
+			expect( console.error ).toHaveBeenCalledWith( 'The sortProperty must be a string' );
 			expect( categories ).toBeUndefined();
 		} );
 		it( 'should return the first element for the array', () => {
-			const categories = sortCategoriesBy( 'order' );
+			const categories = getSortedCategories( 'order' );
 			expect( categories[ 0 ] ).toEqual( { slug: 'custom-blocks', title: 'Custom Blocks', order: 1 } );
 		} );
 	} );


### PR DESCRIPTION
The new function allows to add new block categories.
I think it's very useful in order to add new blocks and display them under a custom category.
I was inspired by the following ticket: https://github.com/WordPress/gutenberg/issues/1352