### PR TITLE
Bump smallest font size.

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -116,7 +116,7 @@ figcaption.blocks-editable__tinymce {
 
 input.editable-format-toolbar__link-input {
 	padding: 10px;
-	font-size: 13px;
+	font-size: $default-font-size;
 	width: 100%;
 	border: none;
 	outline: none;

--- a/blocks/library/freeform/format-list.scss
+++ b/blocks/library/freeform/format-list.scss
@@ -51,7 +51,7 @@
 	z-index: z-index( '.editor-format-list__menu' );
 
 	input {
-		font-size: 13px;
+		font-size: $default-font-size;
 	}
 }
 

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -8,3 +8,7 @@
 		opacity: 0.6;
 	}
 }
+
+.wp-core-ui .button.components-button {	// needs specificity to override
+	font-size: $default-font-size;
+}

--- a/components/form-token-field/style.scss
+++ b/components/form-token-field/style.scss
@@ -176,7 +176,7 @@ input[type="text"].components-form-token-field__input {
 .components-form-token-field__suggestion {
 	color: $dark-gray-500;
 	display: block;
-	font-size: 13px;
+	font-size: $default-font-size;
 	padding: 4px 8px;
 	cursor: pointer;
 

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -37,7 +37,7 @@ $alert-green: #4ab866;
 
 /* Other */
 $default-font: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
-$default-font-size: 13px;
+$default-font-size: 14px;	// 13px default in core, but bumped for Gutenberg
 $default-line-height: 1.4;
 $editor-font: "Noto Serif", serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -1,6 +1,7 @@
 body.toplevel_page_gutenberg,
 body.gutenberg_page_gutenberg-demo {
 	background: $white;
+	font-size: $default-font-size;
 
 	#update-nag, .update-nag {
 		display: none;
@@ -39,7 +40,7 @@ body.gutenberg_page_gutenberg-demo {
 	}
 
 	select {
-		font-size: 13px;
+		font-size: $default-font-size;
 		color: $dark-gray-500;
 	}
 }

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -36,7 +36,7 @@
 	padding: 3px 3px 0 3px;
 
 	input {
-		font-size: 13px;
+		font-size: $default-font-size;
 	}
 }
 

--- a/editor/header/mode-switcher/style.scss
+++ b/editor/header/mode-switcher/style.scss
@@ -20,7 +20,7 @@
 		cursor: pointer;
 		box-shadow: none;
 		padding-right: 0;
-		font-size: 13px;
+		font-size: $default-font-size;
 		height: auto;
 
 		@include break-small {

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -55,7 +55,7 @@ input[type="search"].editor-inserter__search {
 	border: 1px solid transparent;
 	border-bottom: 1px solid $light-gray-500;
 	padding: 8px 11px;
-	font-size: 13px;
+	font-size: $default-font-size;
 	position: relative;
 	z-index: 1;
 

--- a/editor/post-permalink/style.scss
+++ b/editor/post-permalink/style.scss
@@ -10,7 +10,7 @@
 	background: $white;
 	padding: 5px;
 	font-family: $default-font;
-	font-size: 13px;
+	font-size: $default-font-size;
 }
 
 .editor-post-permalink__label {


### PR DESCRIPTION
This PR bumps the smallest font size, 13px, to 14px. To do this it overrides the default font size of core, which is 13px. This increases readibility.

We are now working with two primary font sizes: 14px and 16px (for content text).

Additionally this PR moves most font sizes to use variables.