### PR TITLE
Try: Improve round-trip transformation of text and quote blocks

### DIFF
--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString, isObject } from 'lodash';
+import { isString, isObject, findIndex, flattenDeep } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -39,9 +39,26 @@ registerBlockType( 'core/quote', {
 			{
 				type: 'block',
 				blocks: [ 'core/text' ],
-				transform: ( { content } ) => {
+				transform: ( { content, ...attrs } ) => {
+					let value, citation = null;
+					if ( content && content.length > 0 ) {
+						content = flattenDeep( content );
+						const citationBreakPosition = findIndex( content, function( child ) {
+							return isObject( child ) && child.type === 'br' && child.props.className === 'citation-break';
+						} );
+
+						if ( citationBreakPosition !== -1 ) {
+							value = content.slice( 0, citationBreakPosition );
+							citation = content.slice( citationBreakPosition + 1 );
+						} else {
+							value = content;
+						}
+					}
+
 					return createBlock( 'core/quote', {
-						value: content,
+						value,
+						citation,
+						...attrs,
 					} );
 				},
 			},
@@ -60,27 +77,21 @@ registerBlockType( 'core/quote', {
 				type: 'block',
 				blocks: [ 'core/text' ],
 				transform: ( { value, citation, ...attrs } ) => {
-					const textElement = value[ 0 ];
-					if ( ! textElement ) {
+					// If quote value then the citation becomes the text content.
+					if ( ! value || value.length === 0 ) {
 						return createBlock( 'core/text', {
 							content: citation,
 						} );
 					}
-					const textContent = isString( textElement ) ? textElement : textElement.props.children;
-					if ( Array.isArray( value ) || citation ) {
-						const text = createBlock( 'core/text', {
-							content: textContent,
-						} );
-						const quote = createBlock( 'core/quote', {
-							...attrs,
-							citation,
-							value: Array.isArray( value ) ? value.slice( 1 ) : '',
-						} );
 
-						return [ text, quote ];
+					const content = value;
+					if ( citation && citation.length > 0 ) {
+						content.push( <br className="citation-break" key="citationBreak" /> );
+						content.push( ...citation );
 					}
 					return createBlock( 'core/text', {
-						content: textContent,
+						content,
+						...attrs,
 					} );
 				},
 			},


### PR DESCRIPTION
With this PR, given a quote block:

![image](https://user-images.githubusercontent.com/134745/27938700-93ab432c-6274-11e7-9945-30eb3b4f5009.png)

Converting it to a text block yields:

![image](https://user-images.githubusercontent.com/134745/27938714-ad6d898c-6274-11e7-8095-43f5115d7a8d.png)

This introduces a `<br class="citation-break">` element to delineate the original quotation from the citation so it can be converted back into a quote:

![image](https://user-images.githubusercontent.com/134745/27938751-ec662b8a-6274-11e7-8bec-abf605439bde.png)

There are two opening `p` tags there. So this is one known issue with the patch. It generates this in the console:

```
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
```

Fixes #1765.