### PR TITLE
Remove MediaUploadButton autoOpen prop

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -88,7 +88,6 @@ registerBlockType( 'core/cover-image', {
 						buttonProps={ uploadButtonProps }
 						onSelect={ onSelectImage }
 						type="image"
-						autoOpen
 					>
 						{ __( 'Insert from Media Library' ) }
 					</MediaUploadButton>

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -119,7 +119,6 @@ registerBlockType( 'core/gallery', {
 						buttonProps={ uploadButtonProps }
 						onSelect={ setMediaUrl }
 						type="image"
-						autoOpen
 						multiple="true"
 					>
 						{ __( 'Insert from Media Library' ) }

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -110,7 +110,6 @@ registerBlockType( 'core/image', {
 						buttonProps={ uploadButtonProps }
 						onSelect={ onSelectImage }
 						type="image"
-						autoOpen
 					>
 						{ __( 'Insert from Media Library' ) }
 					</MediaUploadButton>

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -28,12 +28,6 @@ class MediaUploadButton extends Component {
 		this.frame.on( 'open', this.onOpen );
 	}
 
-	componentDidMount() {
-		if ( !! this.props.autoOpen ) {
-			setTimeout( () => this.frame.open() );
-		}
-	}
-
 	componentWillUnmount() {
 		this.frame.remove();
 	}


### PR DESCRIPTION
This pull request seeks to remove the `autoOpen` prop from the `MediaUploadButton` component, the intention being:

- Per suggestion from @mtias , removing automatic modal display as the default behavior, requiring the user to choose images (or in the future, drop images) explicitly
- To resolve a bug where the media modal is shown immediately when opening the demo screen

__Testing instructions:__

Verify that navigating to the Gutenberg > Demo screen does not display a modal immediately.

Verify that inserting a new image block does not display the media modal immediately, but functionality is otherwise unaffected.