### PR TITLE
Resolve empty gallery preview on demo post content

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -10,7 +10,7 @@ import { pick } from 'lodash';
  */
 import './style.scss';
 import './block.scss';
-import { registerBlockType } from '../../api';
+import { registerBlockType, query as hpq } from '../../api';
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
 import RangeControl from '../../inspector-controls/range-control';
@@ -19,6 +19,8 @@ import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import GalleryImage from './gallery-image';
 import BlockDescription from '../../block-description';
+
+const { query, attr } = hpq;
 
 const MAX_COLUMNS = 8;
 
@@ -69,6 +71,13 @@ registerBlockType( 'core/gallery', {
 	title: __( 'Gallery' ),
 	icon: 'format-gallery',
 	category: 'common',
+
+	attributes: {
+		images: query( '.blocks-gallery-image', {
+			url: attr( 'img', 'src' ),
+			alt: attr( 'img', 'alt' )
+		} )
+	},
 
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -10,7 +10,7 @@ import { pick } from 'lodash';
  */
 import './style.scss';
 import './block.scss';
-import { registerBlockType, query as hpq } from '../../api';
+import { registerBlockType } from '../../api';
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
 import RangeControl from '../../inspector-controls/range-control';
@@ -19,8 +19,6 @@ import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import GalleryImage from './gallery-image';
 import BlockDescription from '../../block-description';
-
-const { query, attr } = hpq;
 
 const MAX_COLUMNS = 8;
 
@@ -71,13 +69,6 @@ registerBlockType( 'core/gallery', {
 	title: __( 'Gallery' ),
 	icon: 'format-gallery',
 	category: 'common',
-
-	attributes: {
-		images: query( '.blocks-gallery-image', {
-			url: attr( 'img', 'src' ),
-			alt: attr( 'img', 'alt' )
-		} )
-	},
 
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;

--- a/post-content.js
+++ b/post-content.js
@@ -131,7 +131,7 @@ window._wpGutenbergPost = {
 }</code></pre>',
 			'<!-- /wp:core/code -->',
 
-			'<!-- wp:core/gallery {"align":"wide"} -->',
+			'<!-- wp:core/gallery {"align":"wide","images":[{"url":"https://cldup.com/GCwahb3aOb.jpg","alt":""},{"url":"https://cldup.com/lUUQPv6w9c.jpg","alt":""}]} -->',
 			'<div class="blocks-gallery alignwide columns-2 wp-block-gallery">',
 			'<figure class="blocks-gallery-image"><img src="https://cldup.com/GCwahb3aOb.jpg" alt="" /></figure>',
 			'<figure class="blocks-gallery-image"><img src="https://cldup.com/lUUQPv6w9c.jpg" alt="" /></figure>',


### PR DESCRIPTION
This pull request seeks to resolve an issue where the demo post content does not display the gallery preview correctly despite markup containing images. This is also the related cause of #1784. It appears `attributes` was removed in 118db19bcb89893984bf320e5de003761e079a7a, but we must be able to parse the initial attributes from saved content. Currently we're only assigning new attributes for a block added during the editor session.

I'm not sure restoring the previous parsing is necessarily the correct solution given 118db19bcb89893984bf320e5de003761e079a7a, but we will need attributes initialization.

__Testing instructions:__

Verify that the preview is shown correctly for the gallery block on Gutenberg > Demo.