### PR TITLE
Reformat and correct `blocks/README.md`

### DIFF
--- a/blocks/README.md
+++ b/blocks/README.md
@@ -230,12 +230,6 @@ editor interface where blocks are implemented.
 - `save( { attributes: Object } ): WPElement | String` - Returns an element
   describing the markup of a block to be saved in the published content. This
   function is called before save and when switching to an editor's HTML view.
-- `encodeAttributes( attributes: Object ): Object` - Called when save markup is
-  generated, this function allows you to control which attributes are to be
-  encoded in the block comment metadata. By default, all attribute values not
-  defined in the block's `attributes` property are serialized to the comment
-  metadata. If defined, this function should return the subset of attributes to
-  encode, or `null` to bypass default behavior.
 
 ### `wp.blocks.getBlockType( name: string )`
 
@@ -319,18 +313,20 @@ behaves similarly to a
 except that `onChange` is triggered less frequently than would be expected from
 a traditional `input` field, usually when the user exits the field.
 
-The following props are made available:
+The following properties (non-exhaustive list) are made available:
 
-- `inline: boolean` - If true, only inline elements are allowed to be used in
-  inserted into the text, effectively disabling the behavior of the "Enter"
-  key.
-- `placeholder: string` - A text hint to be shown to the user when the field
-  value is empty, similar to the
-  [`input` and `textarea` attribute of the same name](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/HTML5_updates#The_placeholder_attribute).
 - `value: string` - Markup value of the editable field. Only valid markup is
   allowed, as determined by `inline` value and available controls.
 - `onChange: Function` - Callback handler when the value of the field changes,
   passing the new value as its only argument.
+- `placeholder: string` - A text hint to be shown to the user when the field
+  value is empty, similar to the
+  [`input` and `textarea` attribute of the same name](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/HTML5_updates#The_placeholder_attribute).
+- `multiline: String` - A tag name to use for the tag that should be inserted
+  when Enter is pressed.  For example: `li` in a list block, and `p` for a
+	block that can contain multiple paragraphs.  The default is that only inline
+	elements are allowed to be used in inserted into the text, effectively
+  disabling the behavior of the "Enter" key.
 
 Example:
 

--- a/blocks/README.md
+++ b/blocks/README.md
@@ -50,10 +50,15 @@ The following sections will describe what you'll need to include in `block.js`
 to describe the behavior of your custom block.
 
 Note that all JavaScript code samples in this document are enclosed in a
-function that is evaulated immediately afterwards.  This recommended practice
-ensures that your variables declared with `var` will not pollute the global
-`window` object, which could cause plugins with WordPress core or with other
-plugins.
+function that is evaluated immediately afterwards.  We recommend using either
+ES6 modules
+[as used in this project](docs/coding-guidelines.md#imports)
+(documentation on setting up a plugin with Webpack + ES6 modules coming soon)
+or these
+["immediately-invoked function expressions"](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
+as used in this document.  Both of these methods ensure that your plugin's
+variables will not pollute the global `window` object, which could cause
+incompatibilities with WordPress core or with other plugins.
 
 ## Example
 

--- a/blocks/README.md
+++ b/blocks/README.md
@@ -23,7 +23,7 @@ in the Theme Handbook.
 
 At a minimum, you will need to enqueue scripts for your block as part of a
 `enqueue_block_editor_assets` action callback, with a dependency on the
-`wp-blocks` script handle:
+`wp-blocks` and `wp-element` script handles:
 
 ```php
 <?php


### PR DESCRIPTION
Mostly fixing the hook names updated/added in #1717; also reformatting a few things for clarity and for readability of the source file.

Temporary fix pending a more complete documentation solution like #1786 - we should get this in first. 
 People will be reading this document more and more as it's linked from make/core posts, and perhaps more importantly, it's now actually possible to create plugins that register blocks.

It will be easiest to review this PR using GitHub's [markdown diff mode](https://github.com/WordPress/gutenberg/pull/1794/files?short_path=8973b2d#diff-8973b2df4ecb1bd89ade51059ee90658).