### PR TITLE
Let Gutenberg be default editor for posts with blocks; add links to classic editor

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -85,7 +85,7 @@ function gutenberg_add_admin_bar_edit_link( $wp_admin_bar ) {
 		return;
 	}
 
-	$classic_text = __( 'Classic Editor', 'gutenberg' );
+	$classic_text = __( 'Edit in Classic Editor', 'gutenberg' );
 	remove_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10 );
 	$classic_url = get_edit_post_link( $post->ID, 'raw' );
 	add_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10, 3 );
@@ -99,15 +99,13 @@ function gutenberg_add_admin_bar_edit_link( $wp_admin_bar ) {
 
 	$is_gutenberg_default = gutenberg_post_has_blocks( $post->ID );
 
-	// Update title for edit link to indicate it will link to Gutenberg.
-	if ( $is_gutenberg_default ) {
-		$wp_admin_bar->add_node( array_merge(
-			(array) $edit_node,
-			array(
-				'title' => $gutenberg_text,
-			)
-		) );
-	}
+	// Update title for edit link to indicate default editor.
+	$wp_admin_bar->add_node( array_merge(
+		(array) $edit_node,
+		array(
+			'title' => $is_gutenberg_default ? $gutenberg_text : $classic_text,
+		)
+	) );
 
 	// Add submenu item under link to go to Gutenberg editor or classic editor.
 	$wp_admin_bar->add_node( array(

--- a/lib/register.php
+++ b/lib/register.php
@@ -151,17 +151,16 @@ function gutenberg_add_edit_links( $actions, $post ) {
 		return $actions;
 	}
 
-	if ( gutenberg_post_has_blocks( $post->ID ) ) {
-		remove_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10 );
-		add_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10, 3 );
-	}
+	remove_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10 );
+	$classic_url = get_edit_post_link( $post->ID, 'raw' );
+	add_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10, 3 );
 
 	// Build the new edit actions. See also: WP_Posts_List_Table::handle_row_actions().
 	$title = _draft_or_post_title( $post->ID );
 	$edit_actions = array(
 		'classic hide-if-no-js' => sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
-			esc_url( get_edit_post_link( $post->ID, 'raw' ) ),
+			esc_url( $classic_url ),
 			esc_attr( sprintf(
 				/* translators: %s: post title */
 				__( 'Edit &#8220;%s&#8221; in the classic editor', 'gutenberg' ),

--- a/lib/register.php
+++ b/lib/register.php
@@ -264,5 +264,5 @@ function gutenberg_can_edit_post( $post_id ) {
  */
 function gutenberg_post_has_blocks( $post_id ) {
 	$post = get_post( $post_id );
-	return $post && preg_match( '#<!-- wp:\w+#', $post->post_content );
+	return $post && strpos( $post->post_content, '<!-- wp:' ) !== false;
 }

--- a/lib/register.php
+++ b/lib/register.php
@@ -90,7 +90,7 @@ function gutenberg_add_admin_bar_edit_link( $wp_admin_bar ) {
 	$classic_url = get_edit_post_link( $post->ID, 'raw' );
 	add_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10, 3 );
 
-	if ( empty( $classic_url ) ) {
+	if ( empty( $classic_url ) || ! post_type_supports( $post->post_type, 'editor' ) ) {
 		return;
 	}
 
@@ -146,7 +146,8 @@ add_action( 'admin_init', 'gutenberg_add_edit_links_filters' );
  * @return array          Updated post actions.
  */
 function gutenberg_add_edit_links( $actions, $post ) {
-	if ( ! gutenberg_can_edit_post( $post->ID ) ) {
+	if ( ! gutenberg_can_edit_post( $post->ID ) || ! post_type_supports( $post->post_type, 'editor' ) ||
+			! apply_filters( 'gutenberg_add_edit_link_for_post_type', true, $post->post_type, $post ) ) {
 		return $actions;
 	}
 
@@ -170,7 +171,7 @@ function gutenberg_add_edit_links( $actions, $post ) {
 		$link_class = 'classic';
 	}
 
-	if ( 'trash' !== $post->post_status && apply_filters( 'gutenberg_add_edit_link_for_post_type', true, $post_type, $post ) ) {
+	if ( 'trash' !== $post->post_status ) {
 		// Build the Gutenberg edit action. See also: WP_Posts_List_Table::handle_row_actions().
 		$gutenberg_action = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
@@ -222,7 +223,7 @@ function gutenberg_get_edit_post_url( $post_id ) {
  */
 function gutenberg_filter_edit_post_link( $url, $post_id, $context ) {
 	$post = get_post( $post_id );
-	if ( gutenberg_can_edit_post( $post_id ) && gutenberg_post_has_blocks( $post_id ) ) {
+	if ( gutenberg_can_edit_post( $post_id ) && gutenberg_post_has_blocks( $post_id ) && post_type_supports( get_post_type( $post_id ), 'editor' ) ) {
 		$gutenberg_url = gutenberg_get_edit_post_url( $post->ID );
 		if ( 'display' === $context ) {
 			$gutenberg_url = esc_url( $gutenberg_url );

--- a/lib/register.php
+++ b/lib/register.php
@@ -265,3 +265,19 @@ function gutenberg_post_has_blocks( $post_id ) {
 	$post = get_post( $post_id );
 	return $post && strpos( $post->post_content, '<!-- wp:' ) !== false;
 }
+
+/**
+ * Adds a "Gutenberg" post state for post tables, if the post contains blocks.
+ *
+ * @param  array   $post_states An array of post display states.
+ * @param  WP_Post $post        The current post object.
+ * @return array                A filtered array of post display states.
+ */
+function gutenberg_add_gutenberg_post_state( $post_states, $post ) {
+	if ( gutenberg_post_has_blocks( $post->ID ) ) {
+		$post_states[] = 'Gutenberg';
+	}
+
+	return $post_states;
+}
+add_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state', 10, 2 );

--- a/lib/register.php
+++ b/lib/register.php
@@ -140,8 +140,8 @@ add_action( 'admin_init', 'gutenberg_add_edit_links_filters' );
  *
  * @since 0.1.0
  *
- * @param  array $actions Post actions.
- * @param  array $post    Edited post.
+ * @param  array   $actions Post actions.
+ * @param  WP_Post $post    Edited post.
  *
  * @return array          Updated post actions.
  */
@@ -161,11 +161,13 @@ function gutenberg_add_edit_links( $actions, $post ) {
 		remove_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10 );
 		$edit_url = get_edit_post_link( $post->ID, 'raw' );
 		add_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10, 3 );
+		$link_class = 'gutenberg';
 	} else {
 		$text = __( 'Gutenberg', 'gutenberg' );
 		/* translators: %s: post title */
 		$label = __( 'Edit &#8220;%s&#8221; in the Gutenberg editor', 'gutenberg' );
 		$edit_url = gutenberg_get_edit_post_url( $post->ID );
+		$link_class = 'classic';
 	}
 
 	if ( 'trash' !== $post->post_status && apply_filters( 'gutenberg_add_edit_link_for_post_type', true, $post_type, $post ) ) {
@@ -184,7 +186,7 @@ function gutenberg_add_edit_links( $actions, $post ) {
 		$actions = array_merge(
 			array_slice( $actions, 0, $edit_offset + 1 ),
 			array(
-				'gutenberg hide-if-no-js' => $gutenberg_action,
+				"$link_class hide-if-no-js" => $gutenberg_action,
 			),
 			array_slice( $actions, $edit_offset + 1 )
 		);

--- a/lib/register.php
+++ b/lib/register.php
@@ -131,8 +131,6 @@ function gutenberg_add_edit_links_filters() {
 	add_filter( 'page_row_actions', 'gutenberg_add_edit_links', 10, 2 );
 	// For non-hierarchical post types.
 	add_filter( 'post_row_actions', 'gutenberg_add_edit_links', 10, 2 );
-
-	add_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10, 3 );
 }
 add_action( 'admin_init', 'gutenberg_add_edit_links_filters' );
 
@@ -231,6 +229,7 @@ function gutenberg_filter_edit_post_link( $url, $post_id, $context ) {
 	}
 	return $url;
 }
+add_filter( 'get_edit_post_link', 'gutenberg_filter_edit_post_link', 10, 3 );
 
 /**
  * Return whether the post can be edited in Gutenberg and by the current user.

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Admin Tests
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Test functions in register.php
+ */
+class Admin_Test extends WP_UnitTestCase {
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	protected static $editor_user_id;
+
+	/**
+	 * ID for a post containing blocks.
+	 *
+	 * @var int
+	 */
+	protected static $post_with_blocks;
+
+	/**
+	 * ID for a post without blocks.
+	 *
+	 * @var int
+	 */
+	protected static $post_without_blocks;
+
+	/**
+	 * Set up before class.
+	 */
+	public static function setUpBeforeClass() {
+
+		self::$editor_user_id = self::factory()->user->create( array(
+			'role' => 'editor',
+		) );
+		self::$post_with_blocks = self::factory()->post->create( array(
+			'post_title' => 'Example',
+			'post_content' => "<!-- wp:core/text {\"dropCap\":true} -->\n<p class=\"has-drop-cap\">Tester</p>\n<!-- /wp:core/text -->",
+		) );
+		self::$post_without_blocks = self::factory()->post->create( array(
+			'post_title' => 'Example',
+			'post_content' => 'Tester',
+		) );
+		return parent::setUpBeforeClass();
+	}
+
+	/**
+	 * Tests gutenberg_add_admin_bar_edit_link().
+	 *
+	 * @covers gutenberg_add_admin_bar_edit_link
+	 */
+	function test_gutenberg_add_admin_bar_edit_link() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Tests gutenberg_add_edit_links().
+	 *
+	 * @covers gutenberg_add_edit_links
+	 * @covers gutenberg_add_edit_links_filters
+	 */
+	function test_gutenberg_add_edit_links() {
+		gutenberg_add_edit_links_filters();
+
+		$original_actions = array(
+			'edit' => 'original',
+		);
+
+		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( self::$post_with_blocks ) );
+		$this->assertEquals( $original_actions, $actions, 'User not logged-in so no ability to edit.' );
+
+		wp_set_current_user( self::$editor_user_id );
+
+		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( self::$post_with_blocks ) );
+		$this->assertArrayHasKey( 'gutenberg hide-if-no-js', $actions );
+		$this->assertArrayNotHasKey( 'classic hide-if-no-js', $actions );
+
+		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( self::$post_without_blocks ) );
+		$this->assertArrayNotHasKey( 'gutenberg hide-if-no-js', $actions );
+		$this->assertArrayHasKey( 'classic hide-if-no-js', $actions );
+
+		$trashed_post = $this->factory()->post->create( array(
+			'post_status' => 'trash',
+		) );
+		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( $trashed_post ) );
+		$this->assertArrayNotHasKey( 'gutenberg hide-if-no-js', $actions );
+		$this->assertArrayNotHasKey( 'classic hide-if-no-js', $actions );
+	}
+
+	/**
+	 * Tests gutenberg_get_edit_post_url().
+	 *
+	 * @covers gutenberg_get_edit_post_url
+	 */
+	function test_gutenberg_get_edit_post_url() {
+		$url = gutenberg_get_edit_post_url( self::$post_with_blocks );
+		$this->assertContains( 'page=gutenberg', $url );
+		$this->assertContains( 'post_id=' . self::$post_with_blocks, $url );
+	}
+
+	/**
+	 * Tests gutenberg_filter_edit_post_link().
+	 *
+	 * @covers gutenberg_filter_edit_post_link
+	 */
+	function test_gutenberg_filter_edit_post_link() {
+		wp_set_current_user( self::$editor_user_id );
+		$this->assertContains( 'gutenberg', get_edit_post_link( self::$post_with_blocks ) );
+		$this->assertNotContains( 'gutenberg', get_edit_post_link( self::$post_without_blocks ) );
+	}
+
+	/**
+	 * Tests gutenberg_can_edit_post().
+	 *
+	 * @covers gutenberg_can_edit_post
+	 */
+	function test_gutenberg_can_edit_post() {
+		$this->assertFalse( gutenberg_can_edit_post( -1 ) );
+		$bogus_post_id = $this->factory()->post->create( array(
+			'post_type' => 'bogus',
+		) );
+		$this->assertFalse( gutenberg_can_edit_post( $bogus_post_id ) );
+
+		register_post_type( 'restless', array(
+			'show_in_rest' => false,
+		) );
+		$restless_post_id = $this->factory()->post->create( array(
+			'post_type' => 'restless',
+		) );
+		$this->assertFalse( gutenberg_can_edit_post( $restless_post_id ) );
+
+		$generic_post_id = $this->factory()->post->create();
+
+		wp_set_current_user( 0 );
+		$this->assertFalse( gutenberg_can_edit_post( $generic_post_id ) );
+
+		wp_set_current_user( self::$editor_user_id );
+		$this->assertTrue( gutenberg_can_edit_post( $generic_post_id ) );
+	}
+
+	/**
+	 * Tests gutenberg_post_has_blocks().
+	 *
+	 * @covers gutenberg_post_has_blocks
+	 */
+	function test_gutenberg_post_has_blocks() {
+		$this->assertTrue( gutenberg_post_has_blocks( self::$post_with_blocks ) );
+		$this->assertFalse( gutenberg_post_has_blocks( self::$post_without_blocks ) );
+	}
+}

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -79,10 +79,10 @@ class Admin_Test extends WP_UnitTestCase {
 
 		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( self::$post_with_blocks ) );
 		$this->assertArrayHasKey( 'gutenberg hide-if-no-js', $actions );
-		$this->assertArrayNotHasKey( 'classic hide-if-no-js', $actions );
+		$this->assertArrayHasKey( 'classic hide-if-no-js', $actions );
 
 		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( self::$post_without_blocks ) );
-		$this->assertArrayNotHasKey( 'gutenberg hide-if-no-js', $actions );
+		$this->assertArrayHasKey( 'gutenberg hide-if-no-js', $actions );
 		$this->assertArrayHasKey( 'classic hide-if-no-js', $actions );
 
 		$trashed_post = $this->factory()->post->create( array(

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -80,10 +80,12 @@ class Admin_Test extends WP_UnitTestCase {
 		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( self::$post_with_blocks ) );
 		$this->assertArrayHasKey( 'gutenberg hide-if-no-js', $actions );
 		$this->assertArrayHasKey( 'classic hide-if-no-js', $actions );
+		$this->assertContains( 'post.php', $actions['classic hide-if-no-js'] );
 
 		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( self::$post_without_blocks ) );
 		$this->assertArrayHasKey( 'gutenberg hide-if-no-js', $actions );
 		$this->assertArrayHasKey( 'classic hide-if-no-js', $actions );
+		$this->assertContains( 'post.php', $actions['classic hide-if-no-js'] );
 
 		$trashed_post = $this->factory()->post->create( array(
 			'post_status' => 'trash',

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -176,4 +176,19 @@ class Admin_Test extends WP_UnitTestCase {
 		$this->assertTrue( gutenberg_post_has_blocks( self::$post_with_blocks ) );
 		$this->assertFalse( gutenberg_post_has_blocks( self::$post_without_blocks ) );
 	}
+
+	/**
+	 * Tests gutenberg_add_gutenberg_post_state().
+	 *
+	 * @covers gutenberg_add_gutenberg_post_state
+	 */
+	function test_add_gutenberg_post_state() {
+		// With blocks.
+		$post_states = apply_filters( 'display_post_states', array(), get_post( self::$post_with_blocks ) );
+		$this->assertEquals( array( 'Gutenberg' ), $post_states );
+
+		// Without blocks.
+		$post_states = apply_filters( 'display_post_states', array(), get_post( self::$post_without_blocks ) );
+		$this->assertEquals( array(), $post_states );
+	}
 }

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -91,6 +91,29 @@ class Admin_Test extends WP_UnitTestCase {
 		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( $trashed_post ) );
 		$this->assertArrayNotHasKey( 'gutenberg hide-if-no-js', $actions );
 		$this->assertArrayNotHasKey( 'classic hide-if-no-js', $actions );
+
+		register_post_type( 'not_shown_in_rest', array(
+			'supports' => array( 'title', 'editor' ),
+			'show_in_rest' => false,
+		) );
+		$post_id = $this->factory()->post->create( array(
+			'post_type' => 'not_shown_in_rest',
+		) );
+		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( $post_id ) );
+		$this->assertArrayNotHasKey( 'gutenberg hide-if-no-js', $actions );
+		$this->assertArrayNotHasKey( 'classic hide-if-no-js', $actions );
+
+		register_post_type( 'not_supports_editor', array(
+			'show_in_rest' => true,
+			'supports' => array( 'title' ),
+		) );
+		$post_id = $this->factory()->post->create( array(
+			'post_type' => 'not_supports_editor',
+		) );
+		$actions = apply_filters( 'post_row_actions', $original_actions, get_post( $post_id ) );
+		$this->assertArrayNotHasKey( 'gutenberg hide-if-no-js', $actions );
+		$this->assertArrayNotHasKey( 'classic hide-if-no-js', $actions );
+
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1779, #1627.

When a post contains blocks, the main edit link becomes the link to Gutenberg whereas the row action link then goes to the Classic Editor:

![image](https://user-images.githubusercontent.com/134745/27978717-fd34e44a-6325-11e7-9443-2f21dfdb454e.png)

Any edit post link for a post with blocks becomes a link to the Gutenberg editor, including links on the frontend:

![image](https://user-images.githubusercontent.com/134745/27978976-8eb70618-6327-11e7-9796-27ee3a0cfef5.png)

If a post does not contain blocks, then the main link remains pointing to the classic editor and the Gutenberg link is in the row actions.

Likewise, if a post does have blocks then when the post is viewed on the frontend, the “Edit Post” link will link to Gutenberg and it will have a “Edit in Gutenberg” title. The classic editor will then be available via a submenu item:

![image](https://user-images.githubusercontent.com/134745/27978772-411f6a22-6326-11e7-827c-b3ae66e2a9f2.png)

Likewise, when the post does _not_ contain blocks, then the original Edit Post link is in place with a link to Gutenberg being in the submenu as the alternate edit mode:

![image](https://user-images.githubusercontent.com/134745/27978784-59c3e2a6-6326-11e7-9dea-8f4c751fc17f.png)

Lastly, if the post type is not registered with `show_in_rest` then the Gutenberg editor is not shown, since the REST API is a dependency for Gutenberg.

