### PR TITLE
Prevent TinyMCE table block from breaking placeholders in other blocks

### DIFF
--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -52,6 +52,12 @@ export default class TableBlock extends wp.element.Component {
 		};
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.focus && ! this.props.focus && this.editor ) {
+			this.editor.plugins.table.cellSelection.clear();
+		}
+	}
+
 	handleSetup( editor, focus ) {
 		// select the end of the first table cell
 		editor.on( 'init', () => {

--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -1,3 +1,11 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import { Toolbar, DropdownMenu } from 'components';
@@ -52,20 +60,31 @@ export default class TableBlock extends wp.element.Component {
 		};
 	}
 
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.focus && ! this.props.focus && this.editor ) {
-			this.editor.plugins.table.cellSelection.clear();
+	clearSelectionHandling() {
+		const cellSelectionPlugin = get(
+			this.state,
+			'editor.plugins.table.cellSelection'
+		);
+		if ( cellSelectionPlugin && cellSelectionPlugin.clear ) {
+			cellSelectionPlugin.clear();
 		}
 	}
 
 	handleSetup( editor, focus ) {
-		// select the end of the first table cell
 		editor.on( 'init', () => {
 			const cell = editor.getBody().querySelector( 'td,th' );
 			if ( cell && focus ) {
+				// Select the end of the first table cell.
 				cell.focus();
 				editor.selection.select( cell, true );
 				editor.selection.collapse( false );
+			} else if ( ! focus ) {
+				// Work around a bug in the TinyMCE table plugin that leaves
+				// selection handling enabled when it shouldn't.  Unfortunately
+				// we need a `setTimeout` here because the `cellSelection`
+				// plugin is not initialized until a later TinyMCE `init` event
+				// callback.
+				setTimeout( () => this.clearSelectionHandling(), 0 );
 			}
 		} );
 		this.setState( { editor } );


### PR DESCRIPTION
Fixes #1795.

The TinyMCE table plugin contains this code:

```js
editor.on('SelectionChange', function (e) { 
  if (hasCellSelection) { 
    e.stopImmediatePropagation();
  } 
}, true);
```

It looks like `hasCellSelection` is left as `true` when the table block loses focus.  Fortunately this is something we can fix outside of the table plugin, by calling this function inside the plugin:

```js
function clear(force) {
  // Restore selection possibilities
  editor.getBody().style.webkitUserSelect = '';

  if (force || hasCellSelection) {
    editor.$('td[data-mce-selected],th[data-mce-selected]').removeAttr('data-mce-selected');
    hasCellSelection = false;
  }
}
```

Adding the "Needs Tests" label to indicate that this will be a good candidate for an integration test once we have a framework set up to run them.