### PR TITLE
Always wrap image and embed in figure

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -198,15 +198,12 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 		},
 
 		save( { attributes } ) {
-			const { url, caption, align } = attributes;
-			if ( ! caption || ! caption.length ) {
-				return url;
-			}
+			const { url, caption = [], align } = attributes;
 
 			return (
-				<figure className={ align && `align${ align }` }>{ '\n' }
-					{ url }
-					<figcaption>{ caption }</figcaption>
+				<figure className={ align && `align${ align }` }>
+					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+					{ caption.length > 0 && <figcaption>{ caption }</figcaption> }
 				</figure>
 			);
 		},

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -152,23 +152,13 @@ registerBlockType( 'core/image', {
 	},
 
 	save( { attributes } ) {
-		const { url, alt, caption, align = 'none', href } = attributes;
-		const needsWrapper = [ 'wide', 'full' ].indexOf( align ) !== -1;
-
-		// If there's no caption set only save the image element.
-		if ( ! needsWrapper && ( ! caption || ! caption.length ) ) {
-			const imageWithAlignment = <img src={ url } alt={ alt } className={ `align${ align }` } />;
-			return href
-				? <a href={ href }>{ imageWithAlignment }</a>
-				: imageWithAlignment;
-		}
-
+		const { url, alt, caption = [], align, href } = attributes;
 		const image = <img src={ url } alt={ alt } />;
 
 		return (
-			<figure className={ `align${ align }` }>
+			<figure className={ align && `align${ align }` }>
 				{ href ? <a href={ href }>{ image }</a> : image }
-				{ caption && !! caption.length && <figcaption>{ caption }</figcaption> }
+				{ caption.length > 0 && <figcaption>{ caption }</figcaption> }
 			</figure>
 		);
 	},

--- a/blocks/test/fixtures/core__image.serialized.html
+++ b/blocks/test/fixtures/core__image.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image -->
-<img src="https://cldup.com/uuUqE_dXzy.jpg" class="wp-block-image alignnone" />
+<figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
 <!-- /wp:core/image -->


### PR DESCRIPTION
Follow-up on https://github.com/WordPress/gutenberg/pull/1668#issuecomment-312671841.
See #1205.

* Simplifies `save` logic.
* Same semantic structure regardless of alignment or caption.
* Fixes front end rendering of aligned embed.