### PR TITLE
Ignore `coverage` directory when running eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 build
+coverage
 docs
 vendor


### PR DESCRIPTION
If you do this:

```sh
npm run test-unit:coverage
npm run lint
```

`eslint` then reports several thousand errors, because running Jest code coverage creates a couple of JS files under the `coverage/` directory:

```sh
$ find coverage/ -iname '*.js'
coverage/lcov-report/sorter.js
coverage/lcov-report/prettify.js
```