### PR TITLE
Only run 2 tasks at once during Travis JS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,13 +133,13 @@
     "lint": "eslint . .storybook",
     "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "npm run lint && npm run test-unit",
-    "ci": "concurrently \"npm run build\" \"npm run lint\" \"npm run test-unit:coverage-ci\"",
+    "ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
     "package-plugin": "./bin/build-plugin-zip.sh",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "test-unit": "jest",
     "test-unit:coverage": "jest --coverage",
-    "test-unit:coverage-ci": "jest --coverage && coveralls < coverage/lcov.info",
+    "test-unit:coverage-ci": "jest --coverage --maxWorkers 1 && coveralls < coverage/lcov.info",
     "test-unit:watch": "jest --watch"
   }
 }


### PR DESCRIPTION
Recent Travis build times look highly variable:

<img src="https://user-images.githubusercontent.com/227022/27984772-761296ec-63de-11e7-987d-359f4bdf6259.png" width="450">

The change in pattern here coincides with switching to Jest in #1382.

After adding coverage reporting in #1783, we are putting even more stress on the Travis CI container that runs the JavaScript CI job.  It's effectively running 4 jobs at once:

- `npm run build`
- `npm run lint`
- Jest, worker 1
- Jest, worker 2

(Jest will use 2 workers because [our Travis containers have 2 cores](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments) and [Jest defaults to 1 worker per core](https://github.com/facebook/jest/blob/655a61c0c8c1d392c3963cf5465e91914477d444/docs/en/CLI.md#--maxworkersnum).)

This PR changes the CI job to run only two concurrent tasks:

- `npm run lint`, then `npm run build`
- Jest (only one worker)

I'll run a few builds against this PR and use the same [`travis-stats` app](http://scribu.github.io/travis-stats/#WordPress/gutenberg/update/travis-parallel-commands) to verify that build times are shorter and/or more consistent.