### PR TITLE
Create typing reducer and keep flag on inserting blocks

### DIFF
--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -101,7 +101,7 @@ registerBlockType( 'core/text', {
 				onMerge={ mergeBlocks }
 				style={ { textAlign: align } }
 				className={ dropCap && 'has-drop-cap' }
-				placeholder={ placeholder || __( 'Write…' ) }
+				placeholder={ placeholder || __( 'New Paragraph' ) }
 			/>,
 		];
 	},

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -111,30 +111,24 @@ export function mergeBlocks( blockA, blockB ) {
 }
 
 /**
- * Returns an action object used in signalling that the user has begun to type
- * within a block's editable field.
+ * Returns an action object used in signalling that the user has begun to type.
  *
- * @param  {String} uid Block UID
  * @return {Object}     Action object
  */
-export function startTypingInBlock( uid ) {
+export function startTyping() {
 	return {
 		type: 'START_TYPING',
-		uid,
 	};
 }
 
 /**
- * Returns an action object used in signalling that the user has stopped typing
- * within a block's editable field.
+ * Returns an action object used in signalling that the user has stopped typing.
  *
- * @param  {String} uid Block UID
  * @return {Object}     Action object
  */
-export function stopTypingInBlock( uid ) {
+export function stopTyping() {
 	return {
 		type: 'STOP_TYPING',
-		uid,
 	};
 }
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -28,8 +28,8 @@ import {
 	mergeBlocks,
 	insertBlocks,
 	clearSelectedBlock,
-	startTypingInBlock,
-	stopTypingInBlock,
+	startTyping,
+	stopTyping,
 } from '../../actions';
 import {
 	getPreviousBlock,
@@ -41,7 +41,7 @@ import {
 	isBlockSelected,
 	isBlockMultiSelected,
 	isFirstMultiSelectedBlock,
-	isTypingInBlock,
+	isTypingInEditor,
 } from '../../selectors';
 
 function FirstChild( { children } ) {
@@ -325,7 +325,7 @@ class VisualEditorBlock extends Component {
 
 		// Generate the wrapper class names handling the different states of the block.
 		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, isTyping, focus } = this.props;
-		const showUI = isSelected && ( ! isTyping || ! focus.collapsed );
+		const showUI = isSelected && ( ! isTyping || focus.collapsed === false );
 		const { showMobileControls } = this.state;
 		const wrapperClassname = classnames( 'editor-visual-editor__block', {
 			'is-selected': showUI,
@@ -424,7 +424,7 @@ export default connect(
 			isFirstMultiSelected: isFirstMultiSelectedBlock( state, ownProps.uid ),
 			isHovered: isBlockHovered( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
-			isTyping: isTypingInBlock( state, ownProps.uid ),
+			isTyping: isTypingInEditor( state ),
 			order: getBlockIndex( state, ownProps.uid ),
 		};
 	},
@@ -445,11 +445,11 @@ export default connect(
 		},
 
 		onStartTyping() {
-			dispatch( startTypingInBlock( ownProps.uid ) );
+			dispatch( startTyping() );
 		},
 
 		onStopTyping() {
-			dispatch( stopTypingInBlock( ownProps.uid ) );
+			dispatch( stopTyping() );
 		},
 
 		onHover() {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -41,7 +41,7 @@ import {
 	isBlockSelected,
 	isBlockMultiSelected,
 	isFirstMultiSelectedBlock,
-	isTypingInEditor,
+	isTyping,
 } from '../../selectors';
 
 function FirstChild( { children } ) {
@@ -103,9 +103,8 @@ class VisualEditorBlock extends Component {
 		}
 
 		// Bind or unbind mousemove from page when user starts or stops typing
-		const { isTyping } = this.props;
-		if ( isTyping !== prevProps.isTyping ) {
-			if ( isTyping ) {
+		if ( this.props.isTyping !== prevProps.isTyping ) {
+			if ( this.props.isTyping ) {
 				document.addEventListener( 'mousemove', this.stopTypingOnMouseMove );
 			} else {
 				this.removeStopTypingListener();
@@ -147,9 +146,8 @@ class VisualEditorBlock extends Component {
 		//  - The current block is not selected (e.g. after a split occurs,
 		//    we'll still receive the keyDown event, but the focus has since
 		//    shifted to the newly created block)
-		const { isTyping, isSelected, onStartTyping } = this.props;
-		if ( ! isTyping && isSelected ) {
-			onStartTyping();
+		if ( ! this.props.isTyping && this.props.isSelected ) {
+			this.props.onStartTyping();
 		}
 	}
 
@@ -324,8 +322,8 @@ class VisualEditorBlock extends Component {
 		}
 
 		// Generate the wrapper class names handling the different states of the block.
-		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, isTyping, focus } = this.props;
-		const showUI = isSelected && ( ! isTyping || focus.collapsed === false );
+		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, focus } = this.props;
+		const showUI = isSelected && ( ! this.props.isTyping || focus.collapsed === false );
 		const { showMobileControls } = this.state;
 		const wrapperClassname = classnames( 'editor-visual-editor__block', {
 			'is-selected': showUI,
@@ -424,7 +422,7 @@ export default connect(
 			isFirstMultiSelected: isFirstMultiSelectedBlock( state, ownProps.uid ),
 			isHovered: isBlockHovered( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
-			isTyping: isTypingInEditor( state ),
+			isTyping: isTyping( state ),
 			order: getBlockIndex( state, ownProps.uid ),
 		};
 	},

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -559,12 +559,8 @@ export function getBlockFocus( state, uid ) {
  * @param  {Object}  uid   Block unique ID
  * @return {Boolean}       Whether user is typing within block
  */
-export function isTypingInBlock( state, uid ) {
-	if ( ! isBlockSelected( state, uid ) ) {
-		return false;
-	}
-
-	return state.selectedBlock.typing;
+export function isTypingInEditor( state ) {
+	return state.isTyping;
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -552,14 +552,12 @@ export function getBlockFocus( state, uid ) {
 }
 
 /**
- * Returns true if the user is typing within the block corresponding to the
- * specified unique ID, or false otherwise.
+ * Returns true if the user is typing, or false otherwise.
  *
  * @param  {Object}  state Global application state
- * @param  {Object}  uid   Block unique ID
- * @return {Boolean}       Whether user is typing within block
+ * @return {Boolean}       Whether user is typing
  */
-export function isTypingInEditor( state ) {
+export function isTyping( state ) {
 	return state.isTyping;
 }
 

--- a/editor/state.js
+++ b/editor/state.js
@@ -286,7 +286,6 @@ export function selectedBlock( state = {}, action ) {
 				? state
 				: {
 					uid: action.uid,
-					typing: false,
 					focus: action.uid === state.uid ? state.focus : {},
 				};
 
@@ -298,45 +297,19 @@ export function selectedBlock( state = {}, action ) {
 			const firstUid = first( action.uids );
 			return firstUid === state.uid
 				? state
-				: { uid: firstUid, typing: false, focus: {} };
+				: { uid: firstUid, focus: {} };
 		}
 
 		case 'INSERT_BLOCKS':
 			return {
 				uid: action.blocks[ 0 ].uid,
-				typing: false,
 				focus: {},
 			};
 
 		case 'UPDATE_FOCUS':
 			return {
 				uid: action.uid,
-				typing: state.uid === action.uid ? state.typing : false,
 				focus: action.config || {},
-			};
-
-		case 'START_TYPING':
-			if ( action.uid !== state.uid ) {
-				return {
-					uid: action.uid,
-					typing: true,
-					focus: {},
-				};
-			}
-
-			return {
-				...state,
-				typing: true,
-			};
-
-		case 'STOP_TYPING':
-			if ( action.uid !== state.uid ) {
-				return state;
-			}
-
-			return {
-				...state,
-				typing: false,
 			};
 
 		case 'REPLACE_BLOCKS':
@@ -346,9 +319,27 @@ export function selectedBlock( state = {}, action ) {
 
 			return {
 				uid: action.blocks[ 0 ].uid,
-				typing: false,
 				focus: {},
 			};
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning typing state.
+ *
+ * @param  {Boolean} state  Current state
+ * @param  {Object}  action Dispatched action
+ * @return {Boolean}        Updated state
+ */
+export function isTyping( state = false, action ) {
+	switch ( action.type ) {
+		case 'START_TYPING':
+			return true;
+
+		case 'STOP_TYPING':
+			return false;
 	}
 
 	return state;
@@ -528,6 +519,7 @@ export function createReduxStore() {
 		editor,
 		currentPost,
 		selectedBlock,
+		isTyping,
 		multiSelectedBlocks,
 		hoveredBlock,
 		showInsertionPoint,

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -4,8 +4,8 @@
 import {
 	focusBlock,
 	replaceBlocks,
-	startTypingInBlock,
-	stopTypingInBlock,
+	startTyping,
+	stopTyping,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -37,20 +37,18 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'startTypingInBlock', () => {
+	describe( 'startTyping', () => {
 		it( 'should return the START_TYPING action', () => {
-			expect( startTypingInBlock( 'chicken' ) ).toEqual( {
+			expect( startTyping() ).toEqual( {
 				type: 'START_TYPING',
-				uid: 'chicken',
 			} );
 		} );
 	} );
 
-	describe( 'stopTypingInBlock', () => {
+	describe( 'stopTyping', () => {
 		it( 'should return the STOP_TYPING action', () => {
-			expect( stopTypingInBlock( 'chicken' ) ).toEqual( {
+			expect( stopTyping() ).toEqual( {
 				type: 'STOP_TYPING',
-				uid: 'chicken',
 			} );
 		} );
 	} );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -43,7 +43,7 @@ import {
 	isFirstMultiSelectedBlock,
 	isBlockHovered,
 	getBlockFocus,
-	isTypingInEditor,
+	isTyping,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
 	isSavingPost,
@@ -966,13 +966,13 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isTypingInEditor', () => {
+	describe( 'isTyping', () => {
 		it( 'should return the isTyping flag if the block is selected', () => {
 			const state = {
 				isTyping: true,
 			};
 
-			expect( isTypingInEditor( state ) ).toBe( true );
+			expect( isTyping( state ) ).toBe( true );
 		} );
 
 		it( 'should return false if the block is not selected', () => {
@@ -980,7 +980,7 @@ describe( 'selectors', () => {
 				isTyping: false,
 			};
 
-			expect( isTypingInEditor( state ) ).toBe( false );
+			expect( isTyping( state ) ).toBe( false );
 		} );
 	} );
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -43,7 +43,7 @@ import {
 	isFirstMultiSelectedBlock,
 	isBlockHovered,
 	getBlockFocus,
-	isTypingInBlock,
+	isTypingInEditor,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
 	isSavingPost,
@@ -966,29 +966,21 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isTypingInBlock', () => {
+	describe( 'isTypingInEditor', () => {
 		it( 'should return the isTyping flag if the block is selected', () => {
 			const state = {
-				selectedBlock: {
-					uid: 123,
-					typing: true,
-				},
-				multiSelectedBlocks: {},
+				isTyping: true,
 			};
 
-			expect( isTypingInBlock( state, 123 ) ).toBe( true );
+			expect( isTypingInEditor( state ) ).toBe( true );
 		} );
 
 		it( 'should return false if the block is not selected', () => {
 			const state = {
-				selectedBlock: {
-					uid: 123,
-					typing: true,
-				},
-				multiSelectedBlocks: {},
+				isTyping: false,
 			};
 
-			expect( isTypingInBlock( state, 23 ) ).toBe( false );
+			expect( isTypingInEditor( state ) ).toBe( false );
 		} );
 	} );
 
@@ -998,7 +990,6 @@ describe( 'selectors', () => {
 				mode: 'visual',
 				selectedBlock: {
 					uid: 2,
-					typing: true,
 				},
 				multiSelectedBlocks: {},
 				editor: {
@@ -1046,7 +1037,6 @@ describe( 'selectors', () => {
 				mode: 'text',
 				selectedBlock: {
 					uid: 2,
-					typing: true,
 				},
 				multiSelectedBlocks: {},
 				editor: {

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -17,6 +17,7 @@ import {
 	currentPost,
 	hoveredBlock,
 	selectedBlock,
+	isTyping,
 	multiSelectedBlocks,
 	mode,
 	isSidebarOpened,
@@ -707,11 +708,11 @@ describe( 'state', () => {
 				selected: true,
 			} );
 
-			expect( state ).toEqual( { uid: 'kumquat', typing: false, focus: {} } );
+			expect( state ).toEqual( { uid: 'kumquat', focus: {} } );
 		} );
 
 		it( 'returns an empty object when clearing selected block', () => {
-			const original = deepFreeze( { uid: 'kumquat', typing: false, focus: {} } );
+			const original = deepFreeze( { uid: 'kumquat', focus: {} } );
 			const state = selectedBlock( original, {
 				type: 'CLEAR_SELECTED_BLOCK',
 			} );
@@ -719,8 +720,8 @@ describe( 'state', () => {
 			expect( state ).toEqual( {} );
 		} );
 
-		it( 'should not update the state if already selected and not typing', () => {
-			const original = deepFreeze( { uid: 'kumquat', typing: false, focus: {} } );
+		it( 'should not update the state if already selected', () => {
+			const original = deepFreeze( { uid: 'kumquat', focus: {} } );
 			const state = selectedBlock( original, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
@@ -730,23 +731,8 @@ describe( 'state', () => {
 			expect( state ).toBe( original );
 		} );
 
-		it( 'should update the state if already selected and typing', () => {
-			const original = deepFreeze( { uid: 'kumquat', typing: true, focus: { editable: 'content' } } );
-			const state = selectedBlock( original, {
-				type: 'TOGGLE_BLOCK_SELECTED',
-				uid: 'kumquat',
-				selected: true,
-			} );
-
-			expect( state ).toEqual( {
-				uid: 'kumquat',
-				typing: false,
-				focus: { editable: 'content' },
-			} );
-		} );
-
 		it( 'should unselect the block if currently selected', () => {
-			const original = deepFreeze( { uid: 'kumquat', typing: true, focus: {} } );
+			const original = deepFreeze( { uid: 'kumquat', focus: {} } );
 			const state = selectedBlock( original, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
@@ -757,7 +743,7 @@ describe( 'state', () => {
 		} );
 
 		it( 'should not unselect the block if another block is selected', () => {
-			const original = deepFreeze( { uid: 'loquat', typing: true, focus: {} } );
+			const original = deepFreeze( { uid: 'loquat', focus: {} } );
 			const state = selectedBlock( original, {
 				type: 'TOGGLE_BLOCK_SELECTED',
 				uid: 'kumquat',
@@ -776,7 +762,7 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( state ).toEqual( { uid: 'ribs', typing: false, focus: {} } );
+			expect( state ).toEqual( { uid: 'ribs', focus: {} } );
 		} );
 
 		it( 'should return with block moved up', () => {
@@ -785,7 +771,7 @@ describe( 'state', () => {
 				uids: [ 'ribs' ],
 			} );
 
-			expect( state ).toEqual( { uid: 'ribs', typing: false, focus: {} } );
+			expect( state ).toEqual( { uid: 'ribs', focus: {} } );
 		} );
 
 		it( 'should return with block moved down', () => {
@@ -794,11 +780,11 @@ describe( 'state', () => {
 				uids: [ 'chicken' ],
 			} );
 
-			expect( state ).toEqual( { uid: 'chicken', typing: false, focus: {} } );
+			expect( state ).toEqual( { uid: 'chicken', focus: {} } );
 		} );
 
 		it( 'should not update the state if the block moved is already selected', () => {
-			const original = deepFreeze( { uid: 'ribs', typing: true, focus: {} } );
+			const original = deepFreeze( { uid: 'ribs', focus: {} } );
 			const state = selectedBlock( original, {
 				type: 'MOVE_BLOCKS_UP',
 				uids: [ 'ribs' ],
@@ -814,64 +800,22 @@ describe( 'state', () => {
 				config: { editable: 'citation' },
 			} );
 
-			expect( state ).toEqual( { uid: 'chicken', typing: false, focus: { editable: 'citation' } } );
+			expect( state ).toEqual( { uid: 'chicken', focus: { editable: 'citation' } } );
 		} );
 
 		it( 'should update the focus and merge the existing state', () => {
-			const original = deepFreeze( { uid: 'ribs', typing: true, focus: {} } );
+			const original = deepFreeze( { uid: 'ribs', focus: {} } );
 			const state = selectedBlock( original, {
 				type: 'UPDATE_FOCUS',
 				uid: 'ribs',
 				config: { editable: 'citation' },
 			} );
 
-			expect( state ).toEqual( { uid: 'ribs', typing: true, focus: { editable: 'citation' } } );
-		} );
-
-		it( 'should set the typing flag and selects the block', () => {
-			const state = selectedBlock( undefined, {
-				type: 'START_TYPING',
-				uid: 'chicken',
-			} );
-
-			expect( state ).toEqual( { uid: 'chicken', typing: true, focus: {} } );
-		} );
-
-		it( 'should do nothing if typing stopped not within selected block', () => {
-			const original = selectedBlock( undefined, {} );
-			const state = selectedBlock( original, {
-				type: 'STOP_TYPING',
-				uid: 'chicken',
-			} );
-
-			expect( state ).toBe( original );
-		} );
-
-		it( 'should reset typing flag if typing stopped within selected block', () => {
-			const original = selectedBlock( undefined, {
-				type: 'START_TYPING',
-				uid: 'chicken',
-			} );
-			const state = selectedBlock( original, {
-				type: 'STOP_TYPING',
-				uid: 'chicken',
-			} );
-
-			expect( state ).toEqual( { uid: 'chicken', typing: false, focus: {} } );
-		} );
-
-		it( 'should set the typing flag and merge the existing state', () => {
-			const original = deepFreeze( { uid: 'ribs', typing: false, focus: { editable: 'citation' } } );
-			const state = selectedBlock( original, {
-				type: 'START_TYPING',
-				uid: 'ribs',
-			} );
-
-			expect( state ).toEqual( { uid: 'ribs', typing: true, focus: { editable: 'citation' } } );
+			expect( state ).toEqual( { uid: 'ribs', focus: { editable: 'citation' } } );
 		} );
 
 		it( 'should replace the selected block', () => {
-			const original = deepFreeze( { uid: 'chicken', typing: false, focus: { editable: 'citation' } } );
+			const original = deepFreeze( { uid: 'chicken', focus: { editable: 'citation' } } );
 			const state = selectedBlock( original, {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
@@ -881,11 +825,11 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( state ).toEqual( { uid: 'wings', typing: false, focus: {} } );
+			expect( state ).toEqual( { uid: 'wings', focus: {} } );
 		} );
 
 		it( 'should keep the selected block', () => {
-			const original = deepFreeze( { uid: 'chicken', typing: false, focus: { editable: 'citation' } } );
+			const original = deepFreeze( { uid: 'chicken', focus: { editable: 'citation' } } );
 			const state = selectedBlock( original, {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'ribs' ],
@@ -896,6 +840,24 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toBe( original );
+		} );
+	} );
+
+	describe( 'isTyping()', () => {
+		it( 'should set the typing flag to true', () => {
+			const state = isTyping( false, {
+				type: 'START_TYPING',
+			} );
+
+			expect( state ).toBe( true );
+		} );
+
+		it( 'should set the typing flag to false', () => {
+			const state = isTyping( false, {
+				type: 'STOP_TYPING',
+			} );
+
+			expect( state ).toBe( false );
 		} );
 	} );
 
@@ -1079,6 +1041,7 @@ describe( 'state', () => {
 				'editor',
 				'currentPost',
 				'selectedBlock',
+				'isTyping',
 				'multiSelectedBlocks',
 				'hoveredBlock',
 				'mode',


### PR DESCRIPTION
See #1561.

To test: type in a text block and press enter twice to create a new text block. No UI should appear.