### PR TITLE
chore: Try Ubuntu Trusty for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.2
       env: WP_VERSION=latest
+      sudo: required
       dist: precise
     - php: 5.6
       env: TRAVISCI=phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: php
 
@@ -23,6 +24,7 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.2
       env: WP_VERSION=latest
+      dist: precise
     - php: 5.6
       env: TRAVISCI=phpcs
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.2
       env: WP_VERSION=latest
-      sudo: required
       dist: precise
     - php: 5.6
       env: TRAVISCI=phpcs


### PR DESCRIPTION
Currently Travis CI uses Ubuntu Precise 12.x, lets try Ubuntu Trusty 14.x to see if there is any performance benefit

cc @nylen 

Related: #1808 