### PR TITLE
Open the gallery from placeholder in the initial creation state

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -120,6 +120,7 @@ registerBlockType( 'core/gallery', {
 						onSelect={ setMediaUrl }
 						type="image"
 						multiple="true"
+						gallery="true"
 					>
 						{ __( 'Insert from Media Library' ) }
 					</MediaUploadButton>

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -4,6 +4,7 @@
 import { Component } from 'element';
 import { __ } from 'i18n';
 import { Button } from 'components';
+import { pick } from 'lodash';
 
 // Getter for the sake of unit tests.
 const getGalleryDetailsMediaFrame = () => {
@@ -47,6 +48,13 @@ const getGalleryDetailsMediaFrame = () => {
 			] );
 		},
 	} );
+};
+
+// the media library image object contains numerous attributes
+// we only need this set to display the image in the library
+const slimImageObjects = ( imgs ) => {
+	const attrSet = [ 'sizes', 'mime', 'type', 'subtype', 'id', 'url', 'alt' ];
+	return imgs.map( ( img ) => pick( img, attrSet ) );
 };
 
 class MediaUploadButton extends Component {
@@ -99,7 +107,7 @@ class MediaUploadButton extends Component {
 			return;
 		}
 		if ( multiple ) {
-			onSelect( selectedImages.models.map( ( model ) => model.toJSON() ) );
+			onSelect( slimImageObjects( selectedImages.models.map( ( model ) => model.toJSON() ) ) );
 		} else {
 			onSelect( selectedImages.models[ 0 ].toJSON() );
 		}

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -5,11 +5,56 @@ import { Component } from 'element';
 import { __ } from 'i18n';
 import { Button } from 'components';
 
+// Getter for the sake of unit tests.
+const getGalleryDetailsMediaFrame = () => {
+	/**
+	 * Custom gallery details frame.
+	 *
+	 * @link https://github.com/xwp/wp-core-media-widgets/blob/905edbccfc2a623b73a93dac803c5335519d7837/wp-admin/js/widgets/media-gallery-widget.js
+	 * @class GalleryDetailsMediaFrame
+	 * @constructor
+	 */
+	return wp.media.view.MediaFrame.Post.extend( {
+
+		/**
+		 * Create the default states.
+		 *
+		 * @returns {void}
+		 */
+		createStates: function createStates() {
+			this.states.add( [
+				new wp.media.controller.Library( {
+					id: 'gallery',
+					title: wp.media.view.l10n.createGalleryTitle,
+					priority: 40,
+					toolbar: 'main-gallery',
+					filterable: 'uploaded',
+					multiple: 'add',
+					editable: false,
+
+					library: wp.media.query( _.defaults( {
+						type: 'image',
+					}, this.options.library ) ),
+				} ),
+
+				new wp.media.controller.GalleryEdit( {
+					library: this.options.selection,
+					editing: this.options.editing,
+					menu: 'gallery',
+				} ),
+
+				new wp.media.controller.GalleryAdd(),
+			] );
+		},
+	} );
+};
+
 class MediaUploadButton extends Component {
-	constructor( { multiple = false, type } ) {
+	constructor( { multiple = false, type, gallery = false } ) {
 		super( ...arguments );
 		this.openModal = this.openModal.bind( this );
 		this.onSelect = this.onSelect.bind( this );
+		this.onUpdate = this.onUpdate.bind( this );
 		this.onOpen = this.onOpen.bind( this );
 		const frameConfig = {
 			title: __( 'Select or Upload a media' ),
@@ -17,19 +62,47 @@ class MediaUploadButton extends Component {
 				text: __( 'Select' ),
 			},
 			multiple,
+			selection: new wp.media.model.Selection( [] ),
 		};
 		if ( !! type ) {
 			frameConfig.library = { type };
 		}
-		this.frame = wp.media( frameConfig );
+
+		if ( gallery ) {
+			const GalleryDetailsMediaFrame = getGalleryDetailsMediaFrame();
+			this.frame = new GalleryDetailsMediaFrame( {
+				frame: 'select',
+				mimeType: type,
+				state: 'gallery',
+			} );
+			wp.media.frame = this.frame;
+		} else {
+			this.frame = wp.media( frameConfig );
+		}
 
 		// When an image is selected in the media frame...
 		this.frame.on( 'select', this.onSelect );
+		this.frame.on( 'update', this.onUpdate );
 		this.frame.on( 'open', this.onOpen );
 	}
 
 	componentWillUnmount() {
 		this.frame.remove();
+	}
+
+	onUpdate( selections ) {
+		const { onSelect, multiple = false } = this.props;
+		const state = this.frame.state();
+		const selectedImages = selections || state.get( 'selection' );
+
+		if ( ! selectedImages || ! selectedImages.models.length ) {
+			return;
+		}
+		if ( multiple ) {
+			onSelect( selectedImages.models.map( ( model ) => model.toJSON() ) );
+		} else {
+			onSelect( selectedImages.models[ 0 ].toJSON() );
+		}
 	}
 
 	onSelect() {

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -57,10 +57,6 @@ const slimImageObject = ( img ) => {
 	return pick( img, attrSet );
 };
 
-const slimImageObjects = ( imgs ) => {
-	return imgs.map( ( img ) => slimImageObject( img ) );
-};
-
 class MediaUploadButton extends Component {
 	constructor( { multiple = false, type, gallery = false } ) {
 		super( ...arguments );
@@ -111,7 +107,7 @@ class MediaUploadButton extends Component {
 			return;
 		}
 		if ( multiple ) {
-			onSelect( slimImageObjects( selectedImages.models.map( ( model ) => model.toJSON() ) ) );
+			onSelect( selectedImages.models.map( ( model ) => slimImageObject( model.toJSON() ) ) );
 		} else {
 			onSelect( slimImageObject( selectedImages.models[ 0 ].toJSON() ) );
 		}

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -52,9 +52,13 @@ const getGalleryDetailsMediaFrame = () => {
 
 // the media library image object contains numerous attributes
 // we only need this set to display the image in the library
-const slimImageObjects = ( imgs ) => {
+const slimImageObject = ( img ) => {
 	const attrSet = [ 'sizes', 'mime', 'type', 'subtype', 'id', 'url', 'alt' ];
-	return imgs.map( ( img ) => pick( img, attrSet ) );
+	return pick( img, attrSet );
+};
+
+const slimImageObjects = ( imgs ) => {
+	return imgs.map( ( img ) => slimImageObject( img ) );
 };
 
 class MediaUploadButton extends Component {
@@ -109,7 +113,7 @@ class MediaUploadButton extends Component {
 		if ( multiple ) {
 			onSelect( slimImageObjects( selectedImages.models.map( ( model ) => model.toJSON() ) ) );
 		} else {
-			onSelect( selectedImages.models[ 0 ].toJSON() );
+			onSelect( slimImageObject( selectedImages.models[ 0 ].toJSON() ) );
 		}
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -103,7 +103,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'tinymce-nightly', 'tinymce-nightly-lists', 'tinymce-nightly-paste', 'tinymce-nightly-table' ),
+		array( 'wp-element', 'wp-components', 'wp-utils', 'tinymce-nightly', 'tinymce-nightly-lists', 'tinymce-nightly-paste', 'tinymce-nightly-table', 'media-views', 'media-models' ),
 		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 


### PR DESCRIPTION
Adds the initial multi-select mode without having to shift-click to select multiple images, as well as the “interstitial” state to re-order the images as desired. This adds functional parity with the classic post editor.

Props @obenland for his work on Gallery widget which was adapted into this PR: https://github.com/xwp/wp-core-media-widgets/pull/120

Fixes #1401.