### PR TITLE
Editable: Fix caret jumping on format change

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -435,12 +435,12 @@ export default class Editable extends Component {
 	}
 
 	changeFormats( formats ) {
-		if ( this.state.bookmark ) {
-			this.editor.selection.moveToBookmark( this.state.bookmark );
-		}
-
 		forEach( formats, ( formatValue, format ) => {
 			if ( format === 'link' ) {
+				if ( this.state.bookmark ) {
+					this.editor.selection.moveToBookmark( this.state.bookmark );
+				}
+
 				if ( formatValue !== undefined ) {
 					const anchor = this.editor.dom.getParent( this.editor.selection.getNode(), 'a' );
 					if ( ! anchor ) {


### PR DESCRIPTION
Correct caret jumping when changing formats.

Moves a call to `moveToBookmark` to only affect link formatting. It appears to be relevant only for these cases. It causes strange behavior for other formats.

**To test:**
1. All instructions apply to `Editable`.
1. Place the caret in text
1. Link format the text
1. When applying the link, the selection point should remain
1. Repeat with a highlighted selection
1. Place the caret in text
1. Toggle formats (bold, italics, etc.)
1. When applying the link, the selection point should remain
1. Repeat with a highlighted selection

Before:

![before](https://user-images.githubusercontent.com/841763/27996141-0610b352-64dc-11e7-896b-ce270589b9da.gif)

After:

![after](https://user-images.githubusercontent.com/841763/27996143-07d37c74-64dc-11e7-8c1a-1d9bd76ae903.gif)

Fixes #1814 