### PR TITLE
Add shortcut keys for indenting and outdenting lists to the list block

### DIFF
--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -165,6 +165,19 @@ registerBlockType( 'core/list', {
 				} );
 			} );
 
+			// this checks for languages that do not typically have square brackets on their keyboards
+			const lang = window.navigator.browserLanguage || window.navigator.language;
+			const keyboardHasSqBracket = ! /^(?:fr|nl|sv|ru|de|es|it)/.test( lang );
+
+			if ( keyboardHasSqBracket ) {
+				// keycode 219 = '[' and keycode 221 = ']'
+				editor.shortcuts.add( 'meta+219', 'Decrease indent', 'Outdent' );
+				editor.shortcuts.add( 'meta+221', 'Increase indent', 'Indent' );
+			} else {
+				editor.shortcuts.add( 'meta+shift+m', 'Decrease indent', 'Outdent' );
+				editor.shortcuts.add( 'meta+m', 'Increase indent', 'Indent' );
+			}
+
 			this.editor = editor;
 		}
 


### PR DESCRIPTION
By default TinyMCE overrides the tab key to provide list indentation but stops tab from being used for navigation and makes it impossible to escape from the list block. So for Gutenberg we disabled the tab key. 

For the list block this pull request enables `meta+[` for list outdent and `meta+]` for list indent where `meta` means control on windows/linux and command on mac.

**Edit**: For locales without `[` `meta+m` is used for indent and `meta+shift+m` is used for outdent.

This should resolve https://github.com/WordPress/gutenberg/issues/1640