### PR TITLE
Add sidebar tabs to switch between doc and block settings.

### DIFF
--- a/editor/block-settings-menu/index.js
+++ b/editor/block-settings-menu/index.js
@@ -15,10 +15,10 @@ import { IconButton } from 'components';
 import './style.scss';
 import { isEditorSidebarOpened } from 'editor/selectors';
 
-function BlockSettingsMenu( { onDelete, selectBlock, isSidebarOpened, toggleSidebar, setSidebarMode } ) {
+function BlockSettingsMenu( { onDelete, selectBlock, isSidebarOpened, toggleSidebar, setActivePanel } ) {
 	const toggleInspector = () => {
 		selectBlock();
-		setSidebarMode();
+		setActivePanel();
 		if ( ! isSidebarOpened ) {
 			toggleSidebar();
 		}
@@ -60,10 +60,10 @@ export default connect(
 				uid: ownProps.uid,
 			} );
 		},
-		setSidebarMode() {
+		setActivePanel() {
 			dispatch( {
-				type: 'SELECT_SIDEBAR_MODE',
-				sidebarMode: 'block',
+				type: 'SET_ACTIVE_PANEL',
+				panel: 'block',
 			} );
 		},
 		toggleSidebar() {

--- a/editor/block-settings-menu/index.js
+++ b/editor/block-settings-menu/index.js
@@ -15,9 +15,10 @@ import { IconButton } from 'components';
 import './style.scss';
 import { isEditorSidebarOpened } from 'editor/selectors';
 
-function BlockSettingsMenu( { onDelete, selectBlock, isSidebarOpened, toggleSidebar } ) {
+function BlockSettingsMenu( { onDelete, selectBlock, isSidebarOpened, toggleSidebar, setSidebarMode } ) {
 	const toggleInspector = () => {
 		selectBlock();
+		setSidebarMode();
 		if ( ! isSidebarOpened ) {
 			toggleSidebar();
 		}
@@ -57,6 +58,12 @@ export default connect(
 				type: 'TOGGLE_BLOCK_SELECTED',
 				selected: true,
 				uid: ownProps.uid,
+			} );
+		},
+		setSidebarMode() {
+			dispatch( {
+				type: 'SELECT_SIDEBAR_MODE',
+				sidebarMode: 'block',
 			} );
 		},
 		toggleSidebar() {

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -39,7 +39,7 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 			<PreviewButton />
 			<div className="editor-tools__tabs">
 				<IconButton icon="admin-generic" onClick={ toggleSidebar } isToggled={ isSidebarOpened }>
-					{ __( 'Post Settings' ) }
+					{ __( 'Settings' ) }
 				</IconButton>
 			</div>
 			<PublishButton />

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -21,6 +21,16 @@ export function getEditorMode( state ) {
 }
 
 /**
+ * Returns the current sidebar mode.
+ *
+ * @param  {Object}  state Global application state
+ * @return {String}        Sidebar mode
+ */
+export function getSidebarMode( state ) {
+	return state.sidebarMode;
+}
+
+/**
  * Returns true if the editor sidebar panel is open, or false otherwise.
  *
  * @param  {Object}  state Global application state

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -21,13 +21,13 @@ export function getEditorMode( state ) {
 }
 
 /**
- * Returns the current sidebar mode.
+ * Returns the current active panel for the sidebar.
  *
  * @param  {Object}  state Global application state
- * @return {String}        Sidebar mode
+ * @return {String}        Active sidebar panel
  */
-export function getSidebarMode( state ) {
-	return state.sidebarMode;
+export function getActivePanel( state ) {
+	return state.panel;
 }
 
 /**

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -20,7 +20,7 @@ import { getSelectedBlock } from '../../selectors';
 
 const BlockInspector = ( { selectedBlock, ...props } ) => {
 	if ( ! selectedBlock ) {
-		return null;
+		return <span>{ __( 'No block selected.' ) }</span>;
 	}
 
 	const blockType = getBlockType( selectedBlock.name );
@@ -42,7 +42,6 @@ const BlockInspector = ( { selectedBlock, ...props } ) => {
 
 	return (
 		<Panel>
-			<PanelHeader label={ header } />
 			<PanelBody>
 				<Slot name="Inspector.Controls" />
 			</PanelBody>

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -8,8 +8,7 @@ import { Slot } from 'react-slot-fill';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Panel, PanelHeader, PanelBody } from 'components';
-import { getBlockType } from 'blocks';
+import { Panel, PanelBody } from 'components';
 
 /**
  * Internal Dependencies
@@ -18,27 +17,10 @@ import './style.scss';
 import { deselectBlock } from '../../actions';
 import { getSelectedBlock } from '../../selectors';
 
-const BlockInspector = ( { selectedBlock, ...props } ) => {
+const BlockInspector = ( { selectedBlock } ) => {
 	if ( ! selectedBlock ) {
-		return <span>{ __( 'No block selected.' ) }</span>;
+		return <span className="editor-block-inspector__no-blocks">{ __( 'No block selected.' ) }</span>;
 	}
-
-	const blockType = getBlockType( selectedBlock.name );
-
-	const onDeselect = ( event ) => {
-		event.preventDefault();
-		props.deselectBlock( selectedBlock.uid );
-	};
-
-	const header = (
-		<strong>
-			<a href="" onClick={ onDeselect } className="editor-block-inspector__deselect-post">
-				{ __( 'Post Settings' ) }
-			</a>
-			{ ' → ' }
-			{ blockType.title }
-		</strong>
-	);
 
 	return (
 		<Panel>

--- a/editor/sidebar/block-inspector/style.scss
+++ b/editor/sidebar/block-inspector/style.scss
@@ -7,3 +7,10 @@
 		color: inherit;
 	}
 }
+
+.editor-block-inspector__no-blocks {
+	display: block;
+	font-size: $default-font-size;
+	margin: 32px 16px;
+	text-align: center;
+}

--- a/editor/sidebar/header.js
+++ b/editor/sidebar/header.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+import { IconButton } from 'components';
+
+/**
+ * Internal Dependencies
+ */
+import { getSidebarMode } from 'editor/selectors';
+
+const SidebarHeader = ( { mode, onSelectMode, toggleSidebar } ) => {
+	return (
+		<div className="components-panel__header">
+			<h2
+				onClick={ () => onSelectMode( 'document' ) }
+				className={ `editor-sidebar__mode-tab ${ mode === 'document' ? 'is-active' : '' }` }
+			>
+				{ __( 'Document' ) }
+			</h2>
+			<h2
+				onClick={ () => onSelectMode( 'block' ) }
+				className={ `editor-sidebar__mode-tab ${ mode === 'block' ? 'is-active' : '' }` }
+			>
+				{ __( 'Block' ) }
+			</h2>
+			<IconButton
+				onClick={ toggleSidebar }
+				icon="no-alt"
+				label={ __( 'Close post settings sidebar' ) }
+			/>
+		</div>
+	);
+};
+
+export default connect(
+	( state ) => ( {
+		mode: getSidebarMode( state ),
+	} ),
+	( dispatch ) => ( {
+		onSelectMode( mode ) {
+			dispatch( {
+				type: 'SELECT_SIDEBAR_MODE',
+				sidebarMode: mode,
+			} );
+		},
+		toggleSidebar: () => dispatch( { type: 'TOGGLE_SIDEBAR' } ),
+	} )
+)( SidebarHeader );

--- a/editor/sidebar/header.js
+++ b/editor/sidebar/header.js
@@ -12,20 +12,20 @@ import { IconButton } from 'components';
 /**
  * Internal Dependencies
  */
-import { getSidebarMode } from 'editor/selectors';
+import { getActivePanel } from 'editor/selectors';
 
-const SidebarHeader = ( { mode, onSelectMode, toggleSidebar } ) => {
+const SidebarHeader = ( { panel, onSetPanel, toggleSidebar } ) => {
 	return (
 		<div className="components-panel__header">
 			<h2
-				onClick={ () => onSelectMode( 'document' ) }
-				className={ `editor-sidebar__mode-tab ${ mode === 'document' ? 'is-active' : '' }` }
+				onClick={ () => onSetPanel( 'document' ) }
+				className={ `editor-sidebar__mode-tab ${ panel === 'document' ? 'is-active' : '' }` }
 			>
 				{ __( 'Document' ) }
 			</h2>
 			<h2
-				onClick={ () => onSelectMode( 'block' ) }
-				className={ `editor-sidebar__mode-tab ${ mode === 'block' ? 'is-active' : '' }` }
+				onClick={ () => onSetPanel( 'block' ) }
+				className={ `editor-sidebar__mode-tab ${ panel === 'block' ? 'is-active' : '' }` }
 			>
 				{ __( 'Block' ) }
 			</h2>
@@ -40,13 +40,13 @@ const SidebarHeader = ( { mode, onSelectMode, toggleSidebar } ) => {
 
 export default connect(
 	( state ) => ( {
-		mode: getSidebarMode( state ),
+		panel: getActivePanel( state ),
 	} ),
 	( dispatch ) => ( {
-		onSelectMode( mode ) {
+		onSetPanel( panel ) {
 			dispatch( {
-				type: 'SELECT_SIDEBAR_MODE',
-				sidebarMode: mode,
+				type: 'SET_ACTIVE_PANEL',
+				panel: panel,
 			} );
 		},
 		toggleSidebar: () => dispatch( { type: 'TOGGLE_SIDEBAR' } ),

--- a/editor/sidebar/header.js
+++ b/editor/sidebar/header.js
@@ -17,18 +17,18 @@ import { getActivePanel } from 'editor/selectors';
 const SidebarHeader = ( { panel, onSetPanel, toggleSidebar } ) => {
 	return (
 		<div className="components-panel__header editor-sidebar__panel-tabs">
-			<h2
+			<button
 				onClick={ () => onSetPanel( 'document' ) }
 				className={ `editor-sidebar__panel-tab ${ panel === 'document' ? 'is-active' : '' }` }
 			>
 				{ __( 'Document' ) }
-			</h2>
-			<h2
+			</button>
+			<button
 				onClick={ () => onSetPanel( 'block' ) }
 				className={ `editor-sidebar__panel-tab ${ panel === 'block' ? 'is-active' : '' }` }
 			>
 				{ __( 'Block' ) }
-			</h2>
+			</button>
 			<IconButton
 				onClick={ toggleSidebar }
 				icon="no-alt"

--- a/editor/sidebar/header.js
+++ b/editor/sidebar/header.js
@@ -16,16 +16,16 @@ import { getActivePanel } from 'editor/selectors';
 
 const SidebarHeader = ( { panel, onSetPanel, toggleSidebar } ) => {
 	return (
-		<div className="components-panel__header">
+		<div className="components-panel__header editor-sidebar__panel-tabs">
 			<h2
 				onClick={ () => onSetPanel( 'document' ) }
-				className={ `editor-sidebar__mode-tab ${ panel === 'document' ? 'is-active' : '' }` }
+				className={ `editor-sidebar__panel-tab ${ panel === 'document' ? 'is-active' : '' }` }
 			>
 				{ __( 'Document' ) }
 			</h2>
 			<h2
 				onClick={ () => onSetPanel( 'block' ) }
-				className={ `editor-sidebar__mode-tab ${ panel === 'block' ? 'is-active' : '' }` }
+				className={ `editor-sidebar__panel-tab ${ panel === 'block' ? 'is-active' : '' }` }
 			>
 				{ __( 'Block' ) }
 			</h2>

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -14,13 +14,15 @@ import { withFocusReturn } from 'components';
 import './style.scss';
 import PostSettings from './post-settings';
 import BlockInspector from './block-inspector';
-import { getSelectedBlock } from '../selectors';
+import Header from './header';
+import { getSelectedBlock, getSidebarMode } from '../selectors';
 
-const Sidebar = ( { selectedBlock } ) => {
+const Sidebar = ( { selectedBlock, sidebarMode } ) => {
 	return (
 		<div className="editor-sidebar">
-			{ ! selectedBlock && <PostSettings /> }
-			{ selectedBlock && <BlockInspector /> }
+			<Header />
+			{ sidebarMode === 'document' && <PostSettings /> }
+			{ sidebarMode === 'block' && <BlockInspector /> }
 		</div>
 	);
 };
@@ -29,6 +31,7 @@ export default connect(
 	( state ) => {
 		return {
 			selectedBlock: getSelectedBlock( state ),
+			sidebarMode: getSidebarMode( state ),
 		};
 	}
 )( withFocusReturn( Sidebar ) );

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -15,14 +15,14 @@ import './style.scss';
 import PostSettings from './post-settings';
 import BlockInspector from './block-inspector';
 import Header from './header';
-import { getSelectedBlock, getSidebarMode } from '../selectors';
+import { getSelectedBlock, getActivePanel } from '../selectors';
 
-const Sidebar = ( { selectedBlock, sidebarMode } ) => {
+const Sidebar = ( { selectedBlock, panel } ) => {
 	return (
 		<div className="editor-sidebar">
 			<Header />
-			{ sidebarMode === 'document' && <PostSettings /> }
-			{ sidebarMode === 'block' && <BlockInspector /> }
+			{ panel === 'document' && <PostSettings /> }
+			{ panel === 'block' && <BlockInspector /> }
 		</div>
 	);
 };
@@ -31,7 +31,7 @@ export default connect(
 	( state ) => {
 		return {
 			selectedBlock: getSelectedBlock( state ),
-			sidebarMode: getSidebarMode( state ),
+			panel: getActivePanel( state ),
 		};
 	}
 )( withFocusReturn( Sidebar ) );

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -15,9 +15,9 @@ import './style.scss';
 import PostSettings from './post-settings';
 import BlockInspector from './block-inspector';
 import Header from './header';
-import { getSelectedBlock, getActivePanel } from '../selectors';
+import { getActivePanel } from '../selectors';
 
-const Sidebar = ( { selectedBlock, panel } ) => {
+const Sidebar = ( { panel } ) => {
 	return (
 		<div className="editor-sidebar">
 			<Header />
@@ -30,7 +30,6 @@ const Sidebar = ( { selectedBlock, panel } ) => {
 export default connect(
 	( state ) => {
 		return {
-			selectedBlock: getSelectedBlock( state ),
 			panel: getActivePanel( state ),
 		};
 	}

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -6,8 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Panel, PanelHeader, IconButton } from 'components';
+import { Panel } from 'components';
 
 /**
  * Internal Dependencies
@@ -20,7 +19,7 @@ import FeaturedImage from '../featured-image';
 import DiscussionPanel from '../discussion-panel';
 import LastRevision from '../last-revision';
 
-const PostSettings = ( { toggleSidebar } ) => {
+const PostSettings = () => {
 	return (
 		<Panel>
 			<PostStatus />

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -23,19 +23,6 @@ import LastRevision from '../last-revision';
 const PostSettings = ( { toggleSidebar } ) => {
 	return (
 		<Panel>
-			<PanelHeader label={ __( 'Post Settings' ) } >
-				<div className="editor-sidebar-post-settings__icons">
-					<IconButton
-						icon="admin-settings"
-						label={ __( 'WordPress settings' ) }
-					/>
-					<IconButton
-						onClick={ toggleSidebar }
-						icon="no-alt"
-						label={ __( 'Close post settings sidebar' ) }
-					/>
-				</div>
-			</PanelHeader>
 			<PostStatus />
 			<LastRevision />
 			<PostTaxonomies />

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -118,6 +118,8 @@
 }
 
 .editor-sidebar__panel-tab {
+	background: transparent;
+	border: none;
 	border-bottom: 3px solid transparent;
 	cursor: pointer;
 	height: 50px;
@@ -129,5 +131,10 @@
 	&.is-active {
 		border-bottom-color: $blue-medium-500;
 		font-weight: 600;
+	}
+
+	&:focus {
+		box-shadow: $button-focus-style;
+		outline: none;
 	}
 }

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -124,8 +124,10 @@
 	line-height: 50px;
 	padding: 0 20px;
 	margin-left: 0;
+	font-weight: 400;
 
 	&.is-active {
 		border-bottom-color: $blue-medium-500;
+		font-weight: 600;
 	}
 }

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -107,3 +107,14 @@
 .editor-layout.is-sidebar-opened .editor-text-editor__formatting {
 	margin-right: $sidebar-width;
 }
+
+.editor-sidebar__mode-tab {
+	border-bottom: 3px solid transparent;
+	cursor: pointer;
+	height: 50px;
+	line-height: 50px;
+	padding: 0 20px;
+	&.is-active {
+		border-bottom-color: $blue-medium-500;
+	}
+}

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -108,12 +108,23 @@
 	margin-right: $sidebar-width;
 }
 
-.editor-sidebar__mode-tab {
+.components-panel__header.editor-sidebar__panel-tabs {
+	justify-content: flex-start;
+	padding-left: 0;
+
+	.components-icon-button {
+		margin-left: auto;
+	}
+}
+
+.editor-sidebar__panel-tab {
 	border-bottom: 3px solid transparent;
 	cursor: pointer;
 	height: 50px;
 	line-height: 50px;
 	padding: 0 20px;
+	margin-left: 0;
+
 	&.is-active {
 		border-bottom-color: $blue-medium-500;
 	}

--- a/editor/state.js
+++ b/editor/state.js
@@ -428,10 +428,10 @@ export function isSidebarOpened( state = ! isMobile, action ) {
 	return state;
 }
 
-export function sidebarMode( state = 'document', action ) {
+export function panel( state = 'document', action ) {
 	switch ( action.type ) {
-		case 'SELECT_SIDEBAR_MODE':
-			return action.sidebarMode;
+		case 'SET_ACTIVE_PANEL':
+			return action.panel;
 	}
 
 	return state;
@@ -505,7 +505,7 @@ export function createReduxStore() {
 		showInsertionPoint,
 		mode,
 		isSidebarOpened,
-		sidebarMode,
+		panel,
 		saving,
 		notices,
 	} ) );

--- a/editor/state.js
+++ b/editor/state.js
@@ -428,6 +428,15 @@ export function isSidebarOpened( state = ! isMobile, action ) {
 	return state;
 }
 
+export function sidebarMode( state = 'document', action ) {
+	switch ( action.type ) {
+		case 'SELECT_SIDEBAR_MODE':
+			return action.sidebarMode;
+	}
+
+	return state;
+}
+
 /**
  * Reducer returning current network request state (whether a request to the WP
  * REST API is in progress, successful, or failed).
@@ -496,6 +505,7 @@ export function createReduxStore() {
 		showInsertionPoint,
 		mode,
 		isSidebarOpened,
+		sidebarMode,
 		saving,
 		notices,
 	} ) );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/548849/28018096-d85c287c-6573-11e7-962d-507537ede9e2.png)

This simplifies the way the two sidebar mode are accessed. There are two layers now, selecting a mode, and selecting a block. This allows to have blocks selected while changing post settings, and avoids the switch of context whenever a block is selected with the sidebar open. This also means there's now a state in which "block" mode is selected, but no individual block is selected.

I'm showing a "No block selected" message, but we could get a bit more creative, maybe even showing the contents of the inserter. cc @jasmussen @melchoyce .

![image](https://user-images.githubusercontent.com/548849/28018235-5c89e0ee-6574-11e7-82aa-9cb8ed913daa.png)

It also look like we should create a reusable component called "Tabs" to reuse in the inserter and here, and provide good accessibility out of the box. cc @youknowriad .

Closes #1730.