### PR TITLE
Add focus style for the quicktags buttons.

### DIFF
--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -25,18 +25,16 @@
 		font-family: $editor-html-font;
 		color: $dark-gray-500;
 		border: 1px solid transparent;
-	}
 
-	button:first-child {
-		margin-left: 0;
-	}
+		&:first-child {
+			margin-left: 0;
+		}
 
-	button:hover {
-		border: 1px solid $dark-gray-500;
-	}
-
-	button:focus {
-		outline: none;
+		&:hover,
+		&:focus {
+			outline: none;
+			border: 1px solid $dark-gray-500;
+		}
 	}
 
 	@include break-small() {


### PR DESCRIPTION
Makes the quicktags buttons focus style same as the hover style.
Refactors a bit the related CSS.

Fixes #1835 