### PR TITLE
Add title attribute to icon-button component

### DIFF
--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -10,11 +10,12 @@ import './style.scss';
 import Button from '../button';
 import Dashicon from '../dashicon';
 
-function IconButton( { icon, children, label, className, focus, ...additionalProps } ) {
+function IconButton( { icon, children, label, className, focus, title, ...additionalProps } ) {
 	const classes = classnames( 'components-icon-button', className );
 
 	return (
-		<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
+		<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }
+			title={ title || label }>
 			<Dashicon icon={ icon } />
 			{ children }
 		</Button>

--- a/components/icon-button/test/index.js
+++ b/components/icon-button/test/index.js
@@ -41,5 +41,15 @@ describe( 'IconButton', () => {
 			const iconButton = shallow( <IconButton test="test" /> );
 			expect( iconButton.props().test ).to.equal( 'test' );
 		} );
+
+		it( 'should add a title attribute when the title property is used', () => {
+			const iconButton = shallow( <IconButton title="WordPress" /> );
+			expect( iconButton.props().title ).to.equal( 'WordPress' );
+		} );
+
+		it( 'should add a title attribute using the label property value in absence of the title property', () => {
+			const iconButton = shallow( <IconButton label="WordPress" /> );
+			expect( iconButton.props().title ).to.equal( 'WordPress' );
+		} );
 	} );
 } );

--- a/components/icon-button/test/index.js
+++ b/components/icon-button/test/index.js
@@ -15,6 +15,7 @@ describe( 'IconButton', () => {
 			const iconButton = shallow( <IconButton /> );
 			expect( iconButton.hasClass( 'components-icon-button' ) ).to.be.true();
 			expect( iconButton.prop( 'aria-label' ) ).to.be.undefined();
+			expect( iconButton.prop( 'title' ) ).to.be.undefined();
 		} );
 
 		it( 'should render a Dashicon component matching the wordpress icon', () => {
@@ -44,12 +45,12 @@ describe( 'IconButton', () => {
 
 		it( 'should add a title attribute when the title property is used', () => {
 			const iconButton = shallow( <IconButton title="WordPress" /> );
-			expect( iconButton.props().title ).to.equal( 'WordPress' );
+			expect( iconButton.prop( 'title' ) ).to.equal( 'WordPress' );
 		} );
 
 		it( 'should add a title attribute using the label property value in absence of the title property', () => {
 			const iconButton = shallow( <IconButton label="WordPress" /> );
-			expect( iconButton.props().title ).to.equal( 'WordPress' );
+			expect( iconButton.prop( 'title' ) ).to.equal( 'WordPress' );
 		} );
 	} );
 } );

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -35,6 +35,7 @@ function Toolbar( { controls = [], children } ) {
 						<IconButton
 							icon={ control.icon }
 							label={ control.title }
+							title={ control.title }
 							data-subscript={ control.subscript }
 							onClick={ ( event ) => {
 								event.stopPropagation();

--- a/components/toolbar/test/index.js
+++ b/components/toolbar/test/index.js
@@ -39,6 +39,7 @@ describe( 'Toolbar', () => {
 			expect( listItem.props() ).to.include( {
 				icon: 'wordpress',
 				label: 'WordPress',
+				title: 'WordPress',
 				'data-subscript': 'wp',
 				'aria-pressed': false,
 				className: 'components-toolbar__control',


### PR DESCRIPTION
The icon buttons don't show any hint or tooltip. I think, we can let browser show hints using title attribute until we add support for component tooltips.