### PR TITLE
SelectControl: display option name, not the select label

### DIFF
--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -28,11 +28,11 @@ function SelectControl( { label, selected, instanceId, onBlur, options = [], ...
 			>
 				{ options.map( ( option ) =>
 					<option
-						key={ option.value }
-						value={ option.value }
-						selected={ option.value === selected }
+						key={ option }
+						value={ option }
+						selected={ option === selected }
 					>
-						{ label }
+						{ option }
 					</option>
 				) }
 			</select>


### PR DESCRIPTION
Definitely don't want to display the select's `label` for each option.

Not too sure what is desired for the select though. Is just a flat array wanted (what this PR does), or an array of objects with a key/value property pair? Array of objects offers more built-in flexibility at the expense of added complexity. A flat array would just require that the component does it's own mapping outside of the select.

If the later, `onBlur` should probably just pass `event.target`: https://github.com/WPprodigy/gutenberg/blob/f191c6695f76867f6042230f668f4fde478e0703/blocks/inspector-controls/select-control/index.js#L19. And key + selected should map to `option.key`. Otherwise, you end up with an array of objects that just contain a single value property, which seems unnecessary.

Anyways, let me know what is wanted and I can revise the PR :)