### PR TITLE
Link to attribute-matchers.md

### DIFF
--- a/docs/blocks-editable.md
+++ b/docs/blocks-editable.md
@@ -99,7 +99,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 ```
 {% end %}
 
-When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [matcher function]() to find the desired value from the markup of the block.
+When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [matcher function](attribute-matchers.md) to find the desired value from the markup of the block.
 
 In the code snippet above, when loading the editor, we will extract the `content` value as the children of the paragraph element in the saved post's markup.
 


### PR DESCRIPTION
Update the link to right file `attribute-matchers.md` in the Attributes and Editable Fields documentation.