### PR TITLE
Skip dynamic blocks parsing if `mbstring` PHP extension is missing

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -81,7 +81,7 @@ function unregister_block_type( $name ) {
 function do_blocks( $content ) {
 	global $wp_registered_blocks;
 
-	if ( ! function_exists( 'mb_ereg' ) ) {
+	if ( ! extension_loaded( 'mbstring' ) ) {
 		// Skip server-side rendering of blocks until WordPress/gutenberg#1611
 		// is properly fixed.
 		return $content;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -81,6 +81,12 @@ function unregister_block_type( $name ) {
 function do_blocks( $content ) {
 	global $wp_registered_blocks;
 
+	if ( ! function_exists( 'mb_ereg' ) ) {
+		// Skip server-side rendering of blocks until WordPress/gutenberg#1611
+		// is properly fixed.
+		return $content;
+	}
+
 	$parser = new Gutenberg_PEG_Parser;
 	$blocks = $parser->parse( $content );
 

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -44,6 +44,12 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * @covers do_blocks
 	 */
 	function test_dynamic_block_rendering() {
+		if ( ! function_exists( 'mb_ereg' ) ) {
+			$this->markTestSkipped(
+				'The mbstring PHP extension is not installed.'
+			);
+		}
+
 		$settings = array(
 			'render' => array(
 				$this,
@@ -80,6 +86,12 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * @covers do_blocks
 	 */
 	function test_dynamic_block_rendering_with_content() {
+		if ( ! function_exists( 'mb_ereg' ) ) {
+			$this->markTestSkipped(
+				'The mbstring PHP extension is not installed.'
+			);
+		}
+
 		$settings = array(
 			'render' => array(
 				$this,

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -44,7 +44,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * @covers do_blocks
 	 */
 	function test_dynamic_block_rendering() {
-		if ( ! function_exists( 'mb_ereg' ) ) {
+		if ( ! extension_loaded( 'mbstring' ) ) {
 			$this->markTestSkipped(
 				'The mbstring PHP extension is not installed.'
 			);
@@ -86,7 +86,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * @covers do_blocks
 	 */
 	function test_dynamic_block_rendering_with_content() {
-		if ( ! function_exists( 'mb_ereg' ) ) {
+		if ( ! extension_loaded( 'mbstring' ) ) {
 			$this->markTestSkipped(
 				'The mbstring PHP extension is not installed.'
 			);

--- a/phpunit/class-parsing-test.php
+++ b/phpunit/class-parsing-test.php
@@ -42,7 +42,7 @@ class Parsing_Test extends WP_UnitTestCase {
 	 * @dataProvider parsing_test_filenames
 	 */
 	function test_parser_output( $html_filename, $parsed_json_filename ) {
-		if ( ! function_exists( 'mb_ereg' ) ) {
+		if ( ! extension_loaded( 'mbstring' ) ) {
 			$this->markTestSkipped(
 				'The mbstring PHP extension is not installed.'
 			);

--- a/phpunit/class-parsing-test.php
+++ b/phpunit/class-parsing-test.php
@@ -42,6 +42,12 @@ class Parsing_Test extends WP_UnitTestCase {
 	 * @dataProvider parsing_test_filenames
 	 */
 	function test_parser_output( $html_filename, $parsed_json_filename ) {
+		if ( ! function_exists( 'mb_ereg' ) ) {
+			$this->markTestSkipped(
+				'The mbstring PHP extension is not installed.'
+			);
+		}
+
 		$html_path        = self::$fixtures_dir . '/' . $html_filename;
 		$parsed_json_path = self::$fixtures_dir . '/' . $parsed_json_filename;
 


### PR DESCRIPTION
Workaround for #1611 pending a full fix - to avoid fatals, this will disable dynamic blocks rendering (which we are not yet using very much).

This is a bit difficult to test - I used `phpbrew` as follows:

```sh
phpbrew install 7.0.19 +default +mysql -mbstring
phpbrew use 7.0.19
phpunit
```

PHPUnit results under this configuration before this change:

```
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 5.7.15 by Sebastian Bergmann and contributors.

EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE......... 65 / 76 ( 85%)
...........                                                       76 / 76 (100%)

Time: 899 ms, Memory: 28.00MB

There were 56 errors:

1) Dynamic_Blocks_Render_Test::test_dynamic_block_rendering
Error: Call to undefined function mb_regex_encoding()

.../gutenberg/lib/parser.php:1530
.../gutenberg/lib/blocks.php:85
.../gutenberg/phpunit/class-dynamic-blocks-render-test.php:65

2) Dynamic_Blocks_Render_Test::test_dynamic_block_rendering_with_content
Error: Call to undefined function mb_regex_encoding()

.../gutenberg/lib/parser.php:1530
.../gutenberg/lib/blocks.php:85
.../gutenberg/phpunit/class-dynamic-blocks-render-test.php:97

3) Parsing_Test::test_parser_output with data set #0 ('core-embed__animoto.html', 'core-embed__animoto.parsed.json')
Error: Call to undefined function mb_regex_encoding()

.../gutenberg/lib/parser.php:1530
.../gutenberg/phpunit/class-parsing-test.php:58

4) Parsing_Test::test_parser_output with data set #1 ('core-embed__cloudup.html', 'core-embed__cloudup.parsed.json')
Error: Call to undefined function mb_regex_encoding()

.../gutenberg/lib/parser.php:1530
.../gutenberg/phpunit/class-parsing-test.php:58

[...]

55) Parsing_Test::test_parser_output with data set #52 ('core__table.html', 'core__table.parsed.json')
Error: Call to undefined function mb_regex_encoding()

.../gutenberg/lib/parser.php:1530
.../gutenberg/phpunit/class-parsing-test.php:58

56) Parsing_Test::test_parser_output with data set #53 ('core__text__align-right.html', 'core__text__align-right.parsed.json')
Error: Call to undefined function mb_regex_encoding()

.../gutenberg/lib/parser.php:1530
.../gutenberg/phpunit/class-parsing-test.php:58

ERRORS!
Tests: 76, Assertions: 28, Errors: 56.
```

and after this change:

```
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 5.7.15 by Sebastian Bergmann and contributors.

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS........ 65 / 77 ( 84%)
............                                                      77 / 77 (100%)

Time: 999 ms, Memory: 28.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 77, Assertions: 28, Skipped: 57.
```