### PR TITLE
Improve PHP parser compatibility with different server configurations

### DIFF
--- a/bin/create-php-parser.js
+++ b/bin/create-php-parser.js
@@ -14,6 +14,7 @@ const parser = pegjs.generate(
 		phpegjs: {
 			parserNamespace: null,
 			parserGlobalNamePrefix: 'Gutenberg_PEG_',
+			mbstringAllowed: false,
 		},
 	}
 );

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -119,14 +119,13 @@ This also <a href="https://github.com/WordPress/gutenberg/issues/1516">gives us 
 In JS:
 
 ```js
-wp.blocks.parse( postContent );
+var blocks = wp.blocks.parse( postContent );
 ```
 
 In PHP:
 
 ```php
-$parser = new Gutenberg_PEG_Parser;
-$blocks = $parser->parse( $post_content );
+$blocks = gutenberg_parse_blocks( $post_content );
 ```
 ## Why should I start using this once released?
 Blocks are likely to become the main way users interact with content. Users are going to be discovering functionality in the new universal inserter tool, with a richer block interface that provides more layout opportunities.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -18,6 +18,7 @@ if ( gutenberg_can_init() ) {
 	// Load API functions, register scripts and actions, etc.
 	require_once dirname( __FILE__ ) . '/lib/blocks.php';
 	require_once dirname( __FILE__ ) . '/lib/client-assets.php';
+	require_once dirname( __FILE__ ) . '/lib/compat.php';
 	require_once dirname( __FILE__ ) . '/lib/i18n.php';
 	require_once dirname( __FILE__ ) . '/lib/parser.php';
 	require_once dirname( __FILE__ ) . '/lib/register.php';

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -81,12 +81,6 @@ function unregister_block_type( $name ) {
 function do_blocks( $content ) {
 	global $wp_registered_blocks;
 
-	if ( ! extension_loaded( 'mbstring' ) ) {
-		// Skip server-side rendering of blocks until WordPress/gutenberg#1611
-		// is properly fixed.
-		return $content;
-	}
-
 	$parser = new Gutenberg_PEG_Parser;
 	$blocks = $parser->parse( $content );
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -79,7 +79,7 @@ function unregister_block_type( $name ) {
  */
 function gutenberg_parse_blocks( $content ) {
 	$parser = new Gutenberg_PEG_Parser;
-	return $parser->parse( _gutenberg_utf8_split( $content, 100000 ) );
+	return $parser->parse( _gutenberg_utf8_split( $content ) );
 }
 
 /**

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -70,19 +70,30 @@ function unregister_block_type( $name ) {
 }
 
 /**
- * Renders the dynamic blocks into the post content
+ * Parses blocks out of a content string.
+ *
+ * @since 0.5.0
+ *
+ * @param  string $content Post content.
+ * @return array  Array of parsedblock objects.
+ */
+function gutenberg_parse_blocks( $content ) {
+	$parser = new Gutenberg_PEG_Parser;
+	return $parser->parse( _gutenberg_utf8_split( $content, 100000 ) );
+}
+
+/**
+ * Parses dynamic blocks out of `post_content` and re-renders them.
  *
  * @since 0.1.0
  *
  * @param  string $content Post content.
- *
  * @return string          Updated post content.
  */
 function do_blocks( $content ) {
 	global $wp_registered_blocks;
 
-	$parser = new Gutenberg_PEG_Parser;
-	$blocks = $parser->parse( $content );
+	$blocks = gutenberg_parse_blocks( $content );
 
 	$content_after_blocks = '';
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -17,11 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Based on WordPress' _mb_substr() compat function.
  *
  * @param string $str        The string to split.
- * @param int    $max_length Optional. The maximum number of array elements to
- *                           return. Default 1000.
  * @return array
  */
-function _gutenberg_utf8_split( $str, $max_length = 1000 ) {
+function _gutenberg_utf8_split( $str ) {
 	if ( _wp_can_use_pcre_u() ) {
 		// Use the regex unicode support to separate the UTF-8 characters into
 		// an array.
@@ -48,12 +46,12 @@ function _gutenberg_utf8_split( $str, $max_length = 1000 ) {
 		// in that last round.
 		array_pop( $chars );
 
-		// Split by UTF-8 character, limit to $max_length characters (last
-		// array element will contain the rest of the string).
+		// Split by UTF-8 character, limit to 1000 characters (last array
+		// element will contain the rest of the string).
 		$pieces = preg_split(
 			$regex,
 			$str,
-			$max_length,
+			1000,
 			PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
 		);
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -61,7 +61,7 @@ function _gutenberg_utf8_split( $str ) {
 		if ( count( $pieces ) > 1 ) {
 			$str = array_pop( $pieces );
 		} else {
-			$str = null;
+			break;
 		}
 	} while ( $str );
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * PHP configuration compatibility functions for the Gutenberg editor plugin.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Splits a UTF-8 string into an array of UTF-8-encoded codepoints.
+ *
+ * @since 0.5.0
+ *
+ * Based on WordPress' _mb_substr() compat function.
+ *
+ * @param string $str        The string to split.
+ * @param int    $max_length Optional. The maximum number of array elements to
+ *                           return. Default 1000.
+ * @return array
+ */
+function _gutenberg_utf8_split( $str, $max_length = 1000 ) {
+	if ( _wp_can_use_pcre_u() ) {
+		// Use the regex unicode support to separate the UTF-8 characters into
+		// an array.
+		preg_match_all( '/./us', $str, $match );
+		return $match[0];
+	}
+
+	$regex = '/(
+		  [\x00-\x7F]                  # single-byte sequences   0xxxxxxx
+		| [\xC2-\xDF][\x80-\xBF]       # double-byte sequences   110xxxxx 10xxxxxx
+		| \xE0[\xA0-\xBF][\x80-\xBF]   # triple-byte sequences   1110xxxx 10xxxxxx * 2
+		| [\xE1-\xEC][\x80-\xBF]{2}
+		| \xED[\x80-\x9F][\x80-\xBF]
+		| [\xEE-\xEF][\x80-\xBF]{2}
+		| \xF0[\x90-\xBF][\x80-\xBF]{2} # four-byte sequences   11110xxx 10xxxxxx * 3
+		| [\xF1-\xF3][\x80-\xBF]{3}
+		| \xF4[\x80-\x8F][\x80-\xBF]{2}
+	)/x';
+
+	// Start with 1 element instead of 0 since the first thing we do is pop.
+	$chars = array( '' );
+	do {
+		// We had some string left over from the last round, but we counted it
+		// in that last round.
+		array_pop( $chars );
+
+		// Split by UTF-8 character, limit to $max_length characters (last
+		// array element will contain the rest of the string).
+		$pieces = preg_split(
+			$regex,
+			$str,
+			$max_length,
+			PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+		);
+
+		$chars = array_merge( $chars, $pieces );
+
+		// If there's anything left over, repeat the loop.
+		if ( count( $pieces ) > 1 ) {
+			$str = array_pop( $pieces );
+		} else {
+			$str = null;
+		}
+	} while ( $str );
+
+	return $chars;
+}

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -6,38 +6,65 @@
  */
 
 
-/* Usefull functions: */
+/* Useful functions: */
 
 /* Gutenberg_PEG_chr_unicode - get unicode character from its char code */
-if (!function_exists('Gutenberg_PEG_chr_unicode')) { function Gutenberg_PEG_chr_unicode($code) { return mb_convert_encoding('&#' . $code . ';', 'UTF-8', 'HTML-ENTITIES');} }
-/* Gutenberg_PEG_peg_regex_test - multibyte regex test */
-if (!function_exists('Gutenberg_PEG_peg_regex_test')) { function Gutenberg_PEG_peg_regex_test($pattern, $string) { if (substr($pattern, -1) == 'i') return mb_eregi(substr($pattern, 1, -2), $string); else return mb_ereg(substr($pattern, 1, -1), $string);}}
+if (!function_exists("Gutenberg_PEG_chr_unicode")) {
+    function Gutenberg_PEG_chr_unicode($code) {
+        return html_entity_decode("&#$code;", ENT_QUOTES, "UTF-8");
+    }
+}
+/* Gutenberg_PEG_ord_unicode - get unicode char code from string */
+if (!function_exists("Gutenberg_PEG_ord_unicode")) {
+    function Gutenberg_PEG_ord_unicode($character) {
+        if (strlen($character) === 1) {
+            return ord($character);
+        }
+        $json = json_encode($character);
+        $utf16_1 = hexdec(substr($json, 3, 4));
+        if (substr($json, 7, 2) === "\u") {
+            $utf16_2 = hexdec(substr($json, 9, 4));
+            return 0x10000 + (($utf16_1 & 0x3ff) << 10) + ($utf16_2 & 0x3ff);
+        } else {
+            return $utf16_1;
+        }
+    }
+}
+/* Gutenberg_PEG_peg_char_class_test - simple character class test */
+if (!function_exists("Gutenberg_PEG_peg_char_class_test")) {
+    function Gutenberg_PEG_peg_char_class_test($class, $character) {
+        $code = Gutenberg_PEG_ord_unicode($character);
+        foreach ($class as $range) {
+            if ($code >= $range[0] && $code <= $range[1]) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
 
 /* Syntax error exception */
-if (!class_exists("Gutenberg_PEG_SyntaxError", false)){
-class Gutenberg_PEG_SyntaxError extends Exception
-{
-    public $expected;
-    public $found;
-    public $grammarOffset;
-    public $grammarLine;
-    public $grammarColumn;
-    public $name;
-    public function __construct($message, $expected, $found, $offset, $line, $column)
-    {
-        parent::__construct($message, 0);
-        $this->expected = $expected;
-        $this->found = $found;
-        $this->grammarOffset = $offset;
-        $this->grammarLine = $line;
-        $this->grammarColumn = $column;
-        $this->name = "Gutenberg_PEG_SyntaxError";
+if (!class_exists("Gutenberg_PEG_SyntaxError", false)) {
+    class Gutenberg_PEG_SyntaxError extends Exception {
+        public $expected;
+        public $found;
+        public $grammarOffset;
+        public $grammarLine;
+        public $grammarColumn;
+        public $name;
+        public function __construct($message, $expected, $found, $offset, $line, $column) {
+            parent::__construct($message, 0);
+            $this->expected = $expected;
+            $this->found = $found;
+            $this->grammarOffset = $offset;
+            $this->grammarLine = $line;
+            $this->grammarColumn = $column;
+            $this->name = "Gutenberg_PEG_SyntaxError";
+        }
     }
-};}
+}
 
 class Gutenberg_PEG_Parser {
-
-
     private $peg_currPos          = 0;
     private $peg_reportedPos      = 0;
     private $peg_cachedPos        = 0;
@@ -46,7 +73,7 @@ class Gutenberg_PEG_Parser {
     private $peg_maxFailExpected  = array();
     private $peg_silentFails      = 0;
     private $input                = array();
-
+    private $input_length         = 0;
 
     private function cleanup_state() {
       $this->peg_currPos          = 0;
@@ -62,7 +89,7 @@ class Gutenberg_PEG_Parser {
     }
 
     private function input_substr($start, $length) {
-      if ($length === 1) {
+      if ($length === 1 && $start < $this->input_length) {
         return $this->input[$start];
       }
       $substr = '';
@@ -158,7 +185,7 @@ class Gutenberg_PEG_Parser {
 
     private function peg_buildException($message, $expected, $pos) {
       $posDetails = $this->peg_computePosDetails($pos);
-      $found      = $pos < $this->input_length ? $this->input_substr($pos, 1) : null;
+      $found      = $pos < $this->input_length ? $this->input[$pos] : null;
 
       if ($expected !== null) {
         usort($expected, array($this, "peg_buildException_expectedComparator"));
@@ -327,7 +354,9 @@ class Gutenberg_PEG_Parser {
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c1); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c1);
+        }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
@@ -342,7 +371,9 @@ class Gutenberg_PEG_Parser {
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c3); }
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c3);
+            }
           }
           if ($s3 !== $this->peg_FAILED) {
             $s4 = $this->peg_currPos;
@@ -375,7 +406,9 @@ class Gutenberg_PEG_Parser {
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
-                  if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c5); }
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c5);
+                  }
                 }
                 if ($s12 !== $this->peg_FAILED) {
                   $s11 = array($s11, $s12);
@@ -401,7 +434,9 @@ class Gutenberg_PEG_Parser {
                   $this->peg_currPos++;
                 } else {
                   $s10 = $this->peg_FAILED;
-                  if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c6); }
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c6);
+                  }
                 }
                 if ($s10 !== $this->peg_FAILED) {
                   $s9 = array($s9, $s10);
@@ -433,7 +468,9 @@ class Gutenberg_PEG_Parser {
                       $this->peg_currPos += 3;
                     } else {
                       $s12 = $this->peg_FAILED;
-                      if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c5); }
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c5);
+                      }
                     }
                     if ($s12 !== $this->peg_FAILED) {
                       $s11 = array($s11, $s12);
@@ -459,7 +496,9 @@ class Gutenberg_PEG_Parser {
                       $this->peg_currPos++;
                     } else {
                       $s10 = $this->peg_FAILED;
-                      if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c6); }
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
                     }
                     if ($s10 !== $this->peg_FAILED) {
                       $s9 = array($s9, $s10);
@@ -509,7 +548,9 @@ class Gutenberg_PEG_Parser {
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
-                  if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c5); }
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c5);
+                  }
                 }
                 if ($s6 !== $this->peg_FAILED) {
                   $s7 = $this->peg_currPos;
@@ -525,7 +566,9 @@ class Gutenberg_PEG_Parser {
                       $this->peg_currPos += 15;
                     } else {
                       $s9 = $this->peg_FAILED;
-                      if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c8); }
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c8);
+                      }
                     }
                     if ($s9 !== $this->peg_FAILED) {
                       $s8 = array($s8, $s9);
@@ -585,7 +628,9 @@ class Gutenberg_PEG_Parser {
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c1); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c1);
+        }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
@@ -604,7 +649,9 @@ class Gutenberg_PEG_Parser {
             $this->peg_currPos += 3;
           } else {
             $s3 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c10); }
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c10);
+            }
           }
           if ($s3 !== $this->peg_FAILED) {
             $s4 = $this->peg_parseWP_Block_Name();
@@ -654,7 +701,9 @@ class Gutenberg_PEG_Parser {
                     $this->peg_currPos += 4;
                   } else {
                     $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c12); }
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c12);
+                    }
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
@@ -893,7 +942,9 @@ class Gutenberg_PEG_Parser {
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c1); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c1);
+        }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
@@ -912,7 +963,9 @@ class Gutenberg_PEG_Parser {
             $this->peg_currPos += 3;
           } else {
             $s3 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c10); }
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c10);
+            }
           }
           if ($s3 !== $this->peg_FAILED) {
             $s4 = $this->peg_parseWP_Block_Name();
@@ -962,7 +1015,9 @@ class Gutenberg_PEG_Parser {
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c5); }
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c5);
+                    }
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
@@ -1008,7 +1063,9 @@ class Gutenberg_PEG_Parser {
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c1); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c1);
+        }
       }
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
@@ -1027,7 +1084,9 @@ class Gutenberg_PEG_Parser {
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c14); }
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c14);
+            }
           }
           if ($s3 !== $this->peg_FAILED) {
             $s4 = $this->peg_parseWP_Block_Name();
@@ -1048,7 +1107,9 @@ class Gutenberg_PEG_Parser {
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
-                  if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c5); }
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c5);
+                  }
                 }
                 if ($s6 !== $this->peg_FAILED) {
                   $this->peg_reportedPos = $s0;
@@ -1097,7 +1158,9 @@ class Gutenberg_PEG_Parser {
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c16); }
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c16);
+            }
           }
           if ($s5 !== $this->peg_FAILED) {
             $s6 = $this->peg_parseASCII_AlphaNumeric();
@@ -1123,7 +1186,9 @@ class Gutenberg_PEG_Parser {
               $this->peg_currPos++;
             } else {
               $s5 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c16); }
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c16);
+              }
             }
             if ($s5 !== $this->peg_FAILED) {
               $s6 = $this->peg_parseASCII_AlphaNumeric();
@@ -1170,7 +1235,9 @@ class Gutenberg_PEG_Parser {
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c18); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c18);
+        }
       }
       if ($s3 !== $this->peg_FAILED) {
         $s4 = array();
@@ -1183,7 +1250,9 @@ class Gutenberg_PEG_Parser {
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
-          if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c20); }
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c20);
+          }
         }
         if ($s8 !== $this->peg_FAILED) {
           $s9 = array();
@@ -1204,7 +1273,9 @@ class Gutenberg_PEG_Parser {
                 $this->peg_currPos++;
               } else {
                 $s11 = $this->peg_FAILED;
-                if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c16); }
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c16);
+                }
               }
               if ($s11 === $this->peg_FAILED) {
                 $s11 = null;
@@ -1215,7 +1286,9 @@ class Gutenberg_PEG_Parser {
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
-                  if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c5); }
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c5);
+                  }
                 }
                 if ($s12 !== $this->peg_FAILED) {
                   $s8 = array($s8, $s9, $s10, $s11, $s12);
@@ -1253,7 +1326,9 @@ class Gutenberg_PEG_Parser {
             $this->peg_currPos++;
           } else {
             $s7 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c6); }
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c6);
+            }
           }
           if ($s7 !== $this->peg_FAILED) {
             $s6 = array($s6, $s7);
@@ -1277,7 +1352,9 @@ class Gutenberg_PEG_Parser {
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c20); }
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
+            }
           }
           if ($s8 !== $this->peg_FAILED) {
             $s9 = array();
@@ -1298,7 +1375,9 @@ class Gutenberg_PEG_Parser {
                   $this->peg_currPos++;
                 } else {
                   $s11 = $this->peg_FAILED;
-                  if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c16); }
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c16);
+                  }
                 }
                 if ($s11 === $this->peg_FAILED) {
                   $s11 = null;
@@ -1309,7 +1388,9 @@ class Gutenberg_PEG_Parser {
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
-                    if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c5); }
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c5);
+                    }
                   }
                   if ($s12 !== $this->peg_FAILED) {
                     $s8 = array($s8, $s9, $s10, $s11, $s12);
@@ -1347,7 +1428,9 @@ class Gutenberg_PEG_Parser {
               $this->peg_currPos++;
             } else {
               $s7 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c6); }
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c6);
+              }
             }
             if ($s7 !== $this->peg_FAILED) {
               $s6 = array($s6, $s7);
@@ -1367,7 +1450,9 @@ class Gutenberg_PEG_Parser {
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c20); }
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
+            }
           }
           if ($s5 !== $this->peg_FAILED) {
             $s3 = array($s3, $s4, $s5);
@@ -1413,12 +1498,14 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseASCII_Letter() {
 
-      if (Gutenberg_PEG_peg_regex_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c23); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c23);
+        }
       }
 
       return $s0;
@@ -1426,12 +1513,14 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseASCII_Digit() {
 
-      if (Gutenberg_PEG_peg_regex_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c25); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c25);
+        }
       }
 
       return $s0;
@@ -1439,12 +1528,14 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseSpecial_Chars() {
 
-      if (Gutenberg_PEG_peg_regex_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c27); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c27);
+        }
       }
 
       return $s0;
@@ -1452,12 +1543,14 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseWS() {
 
-      if (Gutenberg_PEG_peg_regex_test($this->peg_c28, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c28, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c29); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c29);
+        }
       }
 
       return $s0;
@@ -1465,12 +1558,14 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseNewline() {
 
-      if (Gutenberg_PEG_peg_regex_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c31); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c31);
+        }
       }
 
       return $s0;
@@ -1478,12 +1573,14 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parse_() {
 
-      if (Gutenberg_PEG_peg_regex_test($this->peg_c32, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c32, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c33); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c33);
+        }
       }
 
       return $s0;
@@ -1512,7 +1609,9 @@ class Gutenberg_PEG_Parser {
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) { $this->peg_fail($this->peg_c6); }
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c6);
+        }
       }
 
       return $s0;
@@ -1526,9 +1625,6 @@ class Gutenberg_PEG_Parser {
     preg_match_all("/./us", $input, $match);
     $this->input = $match[0];
     $this->input_length = count($this->input);
-
-    $old_regex_encoding = mb_regex_encoding();
-    mb_regex_encoding("UTF-8");
 
     $this->peg_FAILED = new stdClass;
     $this->peg_c0 = "<!--";
@@ -1553,17 +1649,17 @@ class Gutenberg_PEG_Parser {
     $this->peg_c19 = "}";
     $this->peg_c20 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
     $this->peg_c21 = "";
-    $this->peg_c22 = "/^[a-zA-Z]/";
+    $this->peg_c22 = array(array(97,122), array(65,90));
     $this->peg_c23 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
-    $this->peg_c24 = "/^[0-9]/";
+    $this->peg_c24 = array(array(48,57));
     $this->peg_c25 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c26 = "/^[-_]/";
+    $this->peg_c26 = array(array(45,45), array(95,95));
     $this->peg_c27 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c28 = "/^[ \\t\\r\\n]/";
+    $this->peg_c28 = array(array(32,32), array(9,9), array(13,13), array(10,10));
     $this->peg_c29 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c30 = "/^[\\r\\n]/";
+    $this->peg_c30 = array(array(13,13), array(10,10));
     $this->peg_c31 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c32 = "/^[ \\t]/";
+    $this->peg_c32 = array(array(32,32), array(9,9));
     $this->peg_c33 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
     $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
@@ -1585,7 +1681,6 @@ class Gutenberg_PEG_Parser {
 
     $peg_result = call_user_func($peg_startRuleFunction);
 
-    mb_regex_encoding($old_regex_encoding);
     if ($peg_result !== $this->peg_FAILED && $this->peg_currPos === $this->input_length) {
       $this->cleanup_state(); // Free up memory
       return $peg_result;

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -1622,8 +1622,12 @@ class Gutenberg_PEG_Parser {
     $options = count($arguments) > 1 ? $arguments[1] : array();
     $this->cleanup_state();
 
-    preg_match_all("/./us", $input, $match);
-    $this->input = $match[0];
+    if (is_array($input)) {
+        $this->input = $input;
+    } else {
+        preg_match_all("/./us", $input, $match);
+        $this->input = $match[0];
+    }
     $this->input_length = count($this->input);
 
     $this->peg_FAILED = new stdClass;

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node-sass": "^4.5.0",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.1",
-    "phpegjs": "1.0.0-beta5",
+    "phpegjs": "1.0.0-beta6",
     "postcss-loader": "^1.3.3",
     "prismjs": "^1.6.0",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node-sass": "^4.5.0",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.1",
-    "phpegjs": "1.0.0-beta6",
+    "phpegjs": "1.0.0-beta7",
     "postcss-loader": "^1.3.3",
     "prismjs": "^1.6.0",
     "raw-loader": "^0.5.1",

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -44,12 +44,6 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * @covers do_blocks
 	 */
 	function test_dynamic_block_rendering() {
-		if ( ! extension_loaded( 'mbstring' ) ) {
-			$this->markTestSkipped(
-				'The mbstring PHP extension is not installed.'
-			);
-		}
-
 		$settings = array(
 			'render' => array(
 				$this,
@@ -86,12 +80,6 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * @covers do_blocks
 	 */
 	function test_dynamic_block_rendering_with_content() {
-		if ( ! extension_loaded( 'mbstring' ) ) {
-			$this->markTestSkipped(
-				'The mbstring PHP extension is not installed.'
-			);
-		}
-
 		$settings = array(
 			'render' => array(
 				$this,

--- a/phpunit/class-parsing-test.php
+++ b/phpunit/class-parsing-test.php
@@ -42,12 +42,6 @@ class Parsing_Test extends WP_UnitTestCase {
 	 * @dataProvider parsing_test_filenames
 	 */
 	function test_parser_output( $html_filename, $parsed_json_filename ) {
-		if ( ! extension_loaded( 'mbstring' ) ) {
-			$this->markTestSkipped(
-				'The mbstring PHP extension is not installed.'
-			);
-		}
-
 		$html_path        = self::$fixtures_dir . '/' . $html_filename;
 		$parsed_json_path = self::$fixtures_dir . '/' . $parsed_json_filename;
 

--- a/phpunit/class-parsing-test.php
+++ b/phpunit/class-parsing-test.php
@@ -54,8 +54,7 @@ class Parsing_Test extends WP_UnitTestCase {
 		$html            = file_get_contents( $html_path );
 		$expected_parsed = json_decode( file_get_contents( $parsed_json_path ), true );
 
-		$parser = new Gutenberg_PEG_Parser;
-		$result = $parser->parse( $html );
+		$result = gutenberg_parse_blocks( $html );
 
 		$this->assertEquals(
 			$expected_parsed,

--- a/phpunit/class-performance-test.php
+++ b/phpunit/class-performance-test.php
@@ -13,12 +13,11 @@ if ( getenv( 'RUN_SLOW_TESTS' ) ) {
 			$html = file_get_contents(
 				dirname( __FILE__ ) . '/fixtures/long-content.html'
 			);
-			$parser = new Gutenberg_PEG_Parser;
 
 			$start = microtime( true );
 			$start_mem = memory_get_usage();
 
-			$parser->parse( $html );
+			$blocks = gutenberg_parse_blocks( $html );
 
 			$time = microtime( true ) - $start;
 			$mem = memory_get_usage() - $start_mem;


### PR DESCRIPTION
Fixes #1611.

The rest of WordPress does not depend on the presence of the `mbstring` extension or on the Unicode functionality of PCRE.  After this PR, our PHP parser doesn't either.

- Removes `mbstring` calls via https://github.com/nylen/phpegjs/commit/ab1dc14258c85663c813b477625accdfbec8d49a.
- Removes dependency on Unicode functionality of PCRE via https://github.com/nylen/phpegjs/commit/ff75facb321896e01adc3f2104d0262ae1490117 and adding code similar to [what already exists in WP core](https://core.trac.wordpress.org/browser/tags/4.8/src/wp-includes/compat.php?annotate=blame#L16).  During a core merge, I expect these functions would be refactored to avoid duplication and ensure good test coverage.

As compared to #1775, the first set of changes here yields a slight performance improvement:

```
JavaScript :  11ms
PHP 5.6    : 135ms (down from 150ms)
PHP 7.0    :  17ms (no significant change)
PHP 7.1    :  16ms (down from 19ms)
```

Under normal circumstances, the second set of changes will have no performance impact.  Forcing the code to use the alternative (non-PCRE-Unicode) method of splitting a string slows PHP 5.6 down by about 5ms, and does not appear to affect PHP 7 performance significantly.

For more details on the specific approaches taken here, see https://github.com/WordPress/gutenberg/issues/1611#issuecomment-314744610.