### PR TITLE
Explicitly define prop-types as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.13",
+    "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-autosize-textarea": "^0.4.2",
     "react-click-outside": "^2.3.0",


### PR DESCRIPTION
This pull request seeks to define `prop-types` as a dependency. The intent is not to encourage assigning prop types for components, but instead to satisfy the [peer dependency of `react-slot-fill`](https://github.com/camwest/react-slot-fill/blob/f23ba95c0d0286d985cab8fb040984533305707d/package.json#L54). Currently we rely on this module having been installed by other dependencies (e.g. `react-redux`), which is very prone to breakage.

__Testing instructions:__

There are no observable effects from this change. Ensure that installing dependencies from a clean repository clone (or `rm -rf node_modules`) and building (`npm run build`) runs without errors.