### PR TITLE
Fix DropdownMenu arrows navigation and add missing aria-label.

### DIFF
--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -89,6 +89,7 @@ export default class TableBlock extends wp.element.Component {
 						<li>
 							<DropdownMenu
 								icon="editor-table"
+								label={ wp.i18n.__( 'Edit Table' ) }
 								controls={
 									TABLE_CONTROLS.map( ( control ) => ( {
 										...control,

--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -1,6 +1,7 @@
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import { Toolbar, DropdownMenu } from 'components';
+import { __ } from 'i18n';
 
 function execCommand( command ) {
 	return ( editor ) => {
@@ -13,32 +14,32 @@ function execCommand( command ) {
 const TABLE_CONTROLS = [
 	{
 		icon: 'table-row-before',
-		title: wp.i18n.__( 'Insert Row Before' ),
+		title: __( 'Insert Row Before' ),
 		onClick: execCommand( 'mceTableInsertRowBefore' ),
 	},
 	{
 		icon: 'table-row-after',
-		title: wp.i18n.__( 'Insert Row After' ),
+		title: __( 'Insert Row After' ),
 		onClick: execCommand( 'mceTableInsertRowAfter' ),
 	},
 	{
 		icon: 'table-row-delete',
-		title: wp.i18n.__( 'Delete Row' ),
+		title: __( 'Delete Row' ),
 		onClick: execCommand( 'mceTableDeleteRow' ),
 	},
 	{
 		icon: 'table-col-before',
-		title: wp.i18n.__( 'Insert Column Before' ),
+		title: __( 'Insert Column Before' ),
 		onClick: execCommand( 'mceTableInsertColBefore' ),
 	},
 	{
 		icon: 'table-col-after',
-		title: wp.i18n.__( 'Insert Column After' ),
+		title: __( 'Insert Column After' ),
 		onClick: execCommand( 'mceTableInsertColAfter' ),
 	},
 	{
 		icon: 'table-col-delete',
-		title: wp.i18n.__( 'Delete Column' ),
+		title: __( 'Delete Column' ),
 		onClick: execCommand( 'mceTableDeleteCol' ),
 	},
 ];
@@ -89,7 +90,7 @@ export default class TableBlock extends wp.element.Component {
 						<li>
 							<DropdownMenu
 								icon="editor-table"
-								label={ wp.i18n.__( 'Edit Table' ) }
+								label={ __( 'Edit Table' ) }
 								controls={
 									TABLE_CONTROLS.map( ( control ) => ( {
 										...control,

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -121,12 +121,14 @@ class DropdownMenu extends wp.element.Component {
 				case LEFT:
 				case UP:
 					keydown.preventDefault();
+					keydown.stopPropagation();
 					this.focusPrevious();
 					break;
 
 				case RIGHT:
 				case DOWN:
 					keydown.preventDefault();
+					keydown.stopPropagation();
 					this.focusNext();
 					break;
 


### PR DESCRIPTION
Fixes the DropdownMenu navigation with arrows. 
DOWN and RIGHT arrows were working, UP and LEFT weren't. Not sure why the difference, but this is probably related to the recent introduction of arrows navigation through blocks.
If so, there are probably more places where `stopPropagation()` will be needed.

Also, adds a missing label on the button that opens the drop down menu: it was completely empty... Uses `wp.i18n.__()` for consistency with what is already used in the file.

Todo: when one of the menu items is focused, pressing Escape should close the menu but it also makes the whole toolbar disappear. Will keep investigating and open a separate issue for this, probably together with other a11y improvements.

Fixes #1874 