### PR TITLE
Restrict width of oEmbeds to max possible width of iframe

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -84,7 +84,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 					event.preventDefault();
 				}
 				const { url } = this.props.attributes;
-				const apiURL = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&_wpnonce=' + wpApiSettings.nonce;
+				const apiURL = wpApiSettings.root + 'oembed/1.0/proxy?url=' + encodeURIComponent( url ) + '&maxwidth=608&_wpnonce=' + wpApiSettings.nonce;
 
 				this.setState( { error: false, fetching: true } );
 				window.fetch( apiURL, {


### PR DESCRIPTION
The max width of a sandbox iframe containing embeds is 608px. Nevertheless, the oEmbeds being fetched for the iframe are getting the default width of 660px. The result is:

![image](https://user-images.githubusercontent.com/134745/28137104-ee4c51a0-6700-11e7-93b2-c1bbc50fdd4e.png)

Note that even with this fix applied, no effect will be noticed because there is _also_ a bug in core that prevents the `maxwidth` param from being passed along to the oEmbed provider. For the fix, which I think will be part of 4.8.1, see https://github.com/xwp/wordpress-develop/pull/239.

Also, it feels not right to hard-code the width of `608` especially since the block editing UI is responsive. It would seem preferable to use the `offsetWidth` of the containing element instead to compute this dynamically. Advise on how to best to get this width and to pass it along in the request would be appreciated.

Closely related to making videos responsive: #1658.