### PR TITLE
Improve absurd z-index values; put notices back under flyout menus

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -1,3 +1,7 @@
+// Stores a list of z-index values in a central location.  For clarity, when a
+// specific value is needed, add a comment explaining why (what other rules the
+// value is designed to work with).
+
 $z-layers: (
 	'.editor-mode-switcher .dashicon': -1,
 	'.editor-block-switcher__arrow': 1,
@@ -13,9 +17,18 @@ $z-layers: (
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
 	'.editor-block-mover': 30,
-	'.editor-sidebar': 100000,	// only used on mobile
-	'.components-notice-list': 100000,
-	'.components-popover': 100000,
+
+	// Show sidebar above wp-admin navigation bar for mobile viewports:
+	// #wpadminbar { z-index: 99999 }
+	'.editor-sidebar': 100000,
+
+	// Show notices below expanded wp-admin submenus:
+	// #adminmenuwrap { z-index: 9990 }
+	'.components-notice-list': 9989,
+
+	// Show popovers above wp-admin menus and submenus:
+	// #adminmenuwrap { z-index: 9990 }
+	'.components-popover': 9999,
 );
 
 @function z-index( $key ) {


### PR DESCRIPTION
Re-roll of #1630.

Follow-up to #1437 and #1691.

When we have to add large `z-index` values, we should leave comments explaining why.  We should also make sure we understand how the various `z-index` rules relate to each other, and ensure that the values we add are as large as necessary but no larger.