### PR TITLE
Post visibility panel better keyboard interaction.

### DIFF
--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -139,54 +139,57 @@ class PostVisibility extends Component {
 						<Popover
 							position="bottom left"
 							className="editor-post-visibility__dialog"
-							onKeyDown={ this.handleKeyDown }
-							onBlur={ this.handleBlur }
-							ref={ dialog => this.dialog = dialog }
 						>
-							<fieldset>
-								<legend className="editor-post-visibility__dialog-legend">
-									{ __( 'Post Visibility' ) }
-								</legend>
-								{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
-									<div key={ value } className="editor-post-visibility__choice">
-										<input
-											type="radio"
-											name={ `editor-post-visibility__setting-${ instanceId }` }
-											value={ value }
-											onChange={ onSelect }
-											checked={ checked }
-											id={ `editor-post-${ value }-${ instanceId }` }
-											aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
-											className="editor-post-visibility__dialog-radio"
-										/>
+							<div
+								onKeyDown={ this.handleKeyDown }
+								onBlur={ this.handleBlur }
+								ref={ dialog => this.dialog = dialog }
+							>
+								<fieldset>
+									<legend className="editor-post-visibility__dialog-legend">
+										{ __( 'Post Visibility' ) }
+									</legend>
+									{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
+										<div key={ value } className="editor-post-visibility__choice">
+											<input
+												type="radio"
+												name={ `editor-post-visibility__setting-${ instanceId }` }
+												value={ value }
+												onChange={ onSelect }
+												checked={ checked }
+												id={ `editor-post-${ value }-${ instanceId }` }
+												aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
+												className="editor-post-visibility__dialog-radio"
+											/>
+											<label
+												htmlFor={ `editor-post-${ value }-${ instanceId }` }
+												className="editor-post-visibility__dialog-label"
+											>
+												{ label }
+											</label>
+											{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
+										</div>
+									) ) }
+								</fieldset>
+								{ this.state.hasPassword &&
+									<div className="editor-post-visibility__dialog-password">
 										<label
-											htmlFor={ `editor-post-${ value }-${ instanceId }` }
-											className="editor-post-visibility__dialog-label"
+											htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+											className="screen-reader-text"
 										>
-											{ label }
+											{ __( 'Create password' ) }
 										</label>
-										{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
+										<input
+											className="editor-post-visibility__dialog-password-input"
+											id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+											type="text"
+											onChange={ updatePassword }
+											value={ password || '' }
+											placeholder={ __( 'Use a secure password' ) }
+										/>
 									</div>
-								) ) }
-							</fieldset>
-							{ this.state.hasPassword &&
-								<div className="editor-post-visibility__dialog-password">
-									<label
-										htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
-										className="screen-reader-text"
-									>
-										{ __( 'Create password' ) }
-									</label>
-									<input
-										className="editor-post-visibility__dialog-password-input"
-										id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
-										type="text"
-										onChange={ updatePassword }
-										value={ password || '' }
-										placeholder={ __( 'Use a secure password' ) }
-									/>
-								</div>
-							}
+								}
+							</div>
 						</Popover>
 					}
 				</span>

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -182,7 +182,7 @@ class PostVisibility extends Component {
 										id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
 										type="text"
 										onChange={ updatePassword }
-										value={ password }
+										value={ password || '' }
 										placeholder={ __( 'Use a secure password' ) }
 									/>
 								</div>

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -9,7 +9,7 @@ import { find } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, findDOMNode } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { PanelRow, Popover, withInstanceId } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
 
@@ -77,42 +77,18 @@ class PostVisibility extends Component {
 	}
 
 	handleBlur( event ) {
-		if ( this.state.opened && event.relatedTarget !== null ) {
-			const wrapper = findDOMNode( this );
-			const toggle = wrapper.querySelector( '.editor-post-visibility__toggle' );
-			const dialog = wrapper.querySelector( '.editor-post-visibility__dialog' );
-
-			if ( ! dialog.contains( event.relatedTarget ) ) {
-				this.setState( { opened: false } );
-				toggle.focus();
-			}
+		if ( this.state.opened && event.relatedTarget !== null && ! this.dialog.contains( event.relatedTarget ) ) {
+			this.setState( { opened: false } );
 		}
 	}
 
 	handleKeyDown( event ) {
 		if ( this.state.opened && event.keyCode === ESCAPE ) {
-			const wrapper = findDOMNode( this );
-			const toggle = wrapper.querySelector( '.editor-post-visibility__toggle' );
-
-			if ( event.target === toggle ) {
-				return;
-			}
-
 			event.preventDefault();
 			event.stopPropagation();
 			this.setState( { opened: false } );
-			toggle.focus();
+			this.toggle.focus();
 		}
-	}
-
-	componentDidMount() {
-		const node = findDOMNode( this );
-		node.addEventListener( 'keydown', this.handleKeyDown, false );
-	}
-
-	componentWillUnmount() {
-		const node = findDOMNode( this );
-		node.removeEventListener( 'keydown', this.handleKeyDown, false );
 	}
 
 	render() {
@@ -154,12 +130,19 @@ class PostVisibility extends Component {
 						aria-expanded={ this.state.opened }
 						className="editor-post-visibility__toggle button-link"
 						onClick={ this.toggleDialog }
+						ref={ toggle => this.toggle = toggle }
 					>
 						{ getVisibilityLabel( visibility ) }
 					</button>
 
 					{ this.state.opened &&
-						<Popover position="bottom left" className="editor-post-visibility__dialog">
+						<Popover
+							position="bottom left"
+							className="editor-post-visibility__dialog"
+							onKeyDown={ this.handleKeyDown }
+							onBlur={ this.handleBlur }
+							ref={ dialog => this.dialog = dialog }
+						>
 							<fieldset>
 								<legend className="editor-post-visibility__dialog-legend">
 									{ __( 'Post Visibility' ) }


### PR DESCRIPTION
This PR is a POC to try to address keyboard interaction on the Post Visibility panel:

To my understanding, `PostVisibility` is mounted when the sidebar opens so I'm not sure `withFocusReturn` can be used here. If only something similar to `react-click-outside` existed also for `focusOut`, things would be simpler. Any feedback for a better approach very welcome.

- adds a keydown event to close the panel when pressing Escape
- adds an blur event to close the panel when tabbing away (uses `event.relatedTarget`)
- moves focus back to the toggle when closing the panel

The code here is mainly to share and discuss better approaches. I haven't found better ways to do this, so any help would be greatly appreciated 🙂 

Also to note: seems it doesn't work very well when using Safari+VoiceOver, while it works nicely with Firefox+NVDA.

I also get a warning `A component is changing an uncontrolled input of type text to be controlled...` but this seems to happen also on master.

Fixes #1885 