### PR TITLE
Enable user-specified CSS classes via Inspector field

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -56,7 +56,12 @@ export function getSaveContent( blockType, attributes ) {
 			return element;
 		}
 
-		const updatedClassName = classnames( className, element.props.className );
+		const updatedClassName = classnames(
+			className,
+			element.props.className,
+			attributes.className
+		);
+
 		return cloneElement( element, { className: updatedClassName } );
 	};
 	const contentWithClassname = Children.map( rawContent, addClassnameToElement );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -67,6 +67,24 @@ describe( 'block serializer', () => {
 				expect( saved ).toBe( '<div class="apples">Bananas</div>' );
 			} );
 
+			it( 'should include additional classes in block attributes', () => {
+				const saved = getSaveContent(
+					{
+						save: ( { attributes } ) => createElement( 'div', {
+							className: 'fruit',
+						}, attributes.fruit ),
+						name: 'myplugin/fruit',
+						className: 'apples',
+					},
+					{
+						fruit: 'Bananas',
+						className: 'fresh',
+					}
+				);
+
+				expect( saved ).toBe( '<div class="apples fruit fresh">Bananas</div>' );
+			} );
+
 			it( 'should not add a className if falsy', () => {
 				const saved = getSaveContent(
 					{

--- a/blocks/inspector-controls/index.js
+++ b/blocks/inspector-controls/index.js
@@ -3,6 +3,18 @@
  */
 import { Fill } from 'react-slot-fill';
 
+/**
+ * Internal dependencies
+ */
+import BaseControl from './base-control';
+import CheckboxControl from './checkbox-control';
+import RadioControl from './radio-control';
+import RangeControl from './range-control';
+import SelectControl from './select-control';
+import TextControl from './text-control';
+import TextareaControl from './textarea-control';
+import ToggleControl from './toggle-control';
+
 export default function InspectorControls( { children } ) {
 	return (
 		<Fill name="Inspector.Controls">
@@ -10,3 +22,12 @@ export default function InspectorControls( { children } ) {
 		</Fill>
 	);
 }
+
+InspectorControls.BaseControl = BaseControl;
+InspectorControls.CheckboxControl = CheckboxControl;
+InspectorControls.RadioControl = RadioControl;
+InspectorControls.RangeControl = RangeControl;
+InspectorControls.SelectControl = SelectControl;
+InspectorControls.TextControl = TextControl;
+InspectorControls.TextareaControl = TextareaControl;
+InspectorControls.ToggleControl = ToggleControl;

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -4,6 +4,22 @@
 import uuid from 'uuid/v4';
 import { partial } from 'lodash';
 
+/**
+ * Returns an action object used in signalling that the block with the
+ * specified UID has been updated.
+ *
+ * @param  {String} uid        Block UID
+ * @param  {Object} attributes Block attributes to be merged
+ * @return {Object}            Action object
+ */
+export function updateBlockAttributes( uid, attributes ) {
+	return {
+		type: 'UPDATE_BLOCK_ATTRIBUTES',
+		uid,
+		attributes,
+	};
+}
+
 export function focusBlock( uid, config ) {
 	return {
 		type: 'UPDATE_FOCUS',

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -429,7 +429,9 @@ export default connect(
 		};
 	},
 	( dispatch, ownProps ) => ( {
-		onChange: updateBlockAttributes,
+		onChange( uid, attributes ) {
+			dispatch( updateBlockAttributes( uid, attributes ) );
+		},
 
 		onSelect() {
 			dispatch( {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -23,6 +23,7 @@ import BlockMover from '../../block-mover';
 import BlockRightMenu from '../../block-settings-menu';
 import BlockSwitcher from '../../block-switcher';
 import {
+	updateBlockAttributes,
 	focusBlock,
 	mergeBlocks,
 	insertBlocks,
@@ -127,12 +128,7 @@ class VisualEditorBlock extends Component {
 
 	setAttributes( attributes ) {
 		const { block, onChange } = this.props;
-		onChange( block.uid, {
-			attributes: {
-				...block.attributes,
-				...attributes,
-			},
-		} );
+		onChange( block.uid, attributes );
 	}
 
 	maybeHover() {
@@ -433,13 +429,8 @@ export default connect(
 		};
 	},
 	( dispatch, ownProps ) => ( {
-		onChange( uid, updates ) {
-			dispatch( {
-				type: 'UPDATE_BLOCK',
-				uid,
-				updates,
-			} );
-		},
+		onChange: updateBlockAttributes,
+
 		onSelect() {
 			dispatch( {
 				type: 'TOGGLE_BLOCK_SELECTED',

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -403,7 +403,7 @@ class VisualEditorBlock extends Component {
 						insertBlocksAfter={ onInsertBlocksAfter }
 						setFocus={ partial( onFocus, block.uid ) }
 						mergeBlocks={ this.mergeBlocks }
-						className={ className }
+						className={ classnames( className, block.attributes.className ) }
 						id={ block.uid }
 					/>
 				</div>

--- a/editor/sidebar/block-inspector/class-name.js
+++ b/editor/sidebar/block-inspector/class-name.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+import { getBlockType, InspectorControls } from 'blocks';
+import { __ } from 'i18n';
+
+/**
+ * Internal Dependencies
+ */
+import { updateBlockAttributes } from '../../actions';
+import { getSelectedBlock } from '../../selectors';
+
+class BlockInspectorClassName extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.setClassName = this.setClassName.bind( this );
+	}
+
+	setClassName( className ) {
+		const { selectedBlock, setAttributes } = this.props;
+		setAttributes( selectedBlock.uid, { className } );
+	}
+
+	render() {
+		const { selectedBlock } = this.props;
+		const blockType = getBlockType( selectedBlock.name );
+		if ( false === blockType.className ) {
+			return null;
+		}
+
+		return (
+			<InspectorControls.TextControl
+				label={ __( 'Additional CSS Class' ) }
+				value={ selectedBlock.attributes.className }
+				onChange={ this.setClassName } />
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			selectedBlock: getSelectedBlock( state ),
+		};
+	},
+	{
+		setAttributes: updateBlockAttributes,
+	}
+)( BlockInspectorClassName );

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -14,7 +14,6 @@ import { Panel, PanelBody } from 'components';
  * Internal Dependencies
  */
 import './style.scss';
-import { deselectBlock } from '../../actions';
 import { getSelectedBlock } from '../../selectors';
 
 const BlockInspector = ( { selectedBlock } ) => {
@@ -36,6 +35,5 @@ export default connect(
 		return {
 			selectedBlock: getSelectedBlock( state ),
 		};
-	},
-	{ deselectBlock }
+	}
 )( BlockInspector );

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -25,8 +25,8 @@ const BlockInspector = ( { selectedBlock } ) => {
 	return (
 		<Panel>
 			<PanelBody>
-				<BlockInspectorClassName />
 				<Slot name="Inspector.Controls" />
+				<BlockInspectorClassName />
 			</PanelBody>
 		</Panel>
 	);

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -14,6 +14,7 @@ import { Panel, PanelBody } from 'components';
  * Internal Dependencies
  */
 import './style.scss';
+import BlockInspectorClassName from './class-name';
 import { getSelectedBlock } from '../../selectors';
 
 const BlockInspector = ( { selectedBlock } ) => {
@@ -24,6 +25,7 @@ const BlockInspector = ( { selectedBlock } ) => {
 	return (
 		<Panel>
 			<PanelBody>
+				<BlockInspectorClassName />
 				<Slot name="Inspector.Controls" />
 			</PanelBody>
 		</Panel>

--- a/editor/state.js
+++ b/editor/state.js
@@ -72,7 +72,7 @@ export const editor = combineUndoableReducers( {
 			case 'TRASH_POST_SUCCESS':
 				return false;
 
-			case 'UPDATE_BLOCK':
+			case 'UPDATE_BLOCK_ATTRIBUTES':
 			case 'INSERT_BLOCKS':
 			case 'MOVE_BLOCKS_DOWN':
 			case 'MOVE_BLOCKS_UP':
@@ -91,14 +91,14 @@ export const editor = combineUndoableReducers( {
 			case 'RESET_BLOCKS':
 				return keyBy( action.blocks, 'uid' );
 
-			case 'UPDATE_BLOCK':
+			case 'UPDATE_BLOCK_ATTRIBUTES':
 				// Ignore updates if block isn't known
 				if ( ! state[ action.uid ] ) {
 					return state;
 				}
 
 				// Consider as updates only changed values
-				const nextBlock = reduce( action.updates, ( result, value, key ) => {
+				const nextAttributes = reduce( action.attributes, ( result, value, key ) => {
 					if ( value !== result[ key ] ) {
 						// Avoid mutating original block by creating shallow clone
 						if ( result === state[ action.uid ] ) {
@@ -109,20 +109,20 @@ export const editor = combineUndoableReducers( {
 					}
 
 					return result;
-				}, state[ action.uid ] );
+				}, state[ action.uid ].attributes );
 
 				// Skip update if nothing has been changed. The reference will
 				// match the original block if `reduce` had no changed values.
-				if ( nextBlock === state[ action.uid ] ) {
+				if ( nextAttributes === state[ action.uid ].attributes ) {
 					return state;
 				}
 
-				// Otherwise merge updates into state
+				// Otherwise merge attributes into state
 				return {
 					...state,
 					[ action.uid ]: {
 						...state[ action.uid ],
-						...action.updates,
+						attributes: nextAttributes,
 					},
 				};
 

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -542,7 +542,7 @@ describe( 'state', () => {
 		} );
 
 		describe( 'blocksByUid', () => {
-			it( 'should return with block updates', () => {
+			it( 'should return with attribute block updates', () => {
 				const original = editor( undefined, {
 					type: 'RESET_BLOCKS',
 					blocks: [ {
@@ -551,12 +551,10 @@ describe( 'state', () => {
 					} ],
 				} );
 				const state = editor( original, {
-					type: 'UPDATE_BLOCK',
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
 					uid: 'kumquat',
-					updates: {
-						attributes: {
-							updated: true,
-						},
+					attributes: {
+						updated: true,
 					},
 				} );
 
@@ -569,12 +567,10 @@ describe( 'state', () => {
 					blocks: [],
 				} );
 				const state = editor( original, {
-					type: 'UPDATE_BLOCK',
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
 					uid: 'kumquat',
-					updates: {
-						attributes: {
-							updated: true,
-						},
+					attributes: {
+						updated: true,
 					},
 				} );
 
@@ -592,12 +588,10 @@ describe( 'state', () => {
 					} ],
 				} );
 				const state = editor( original, {
-					type: 'UPDATE_BLOCK',
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
 					uid: 'kumquat',
-					updates: {
-						attributes: {
-							updated: true,
-						},
+					attributes: {
+						updated: true,
 					},
 				} );
 


### PR DESCRIPTION
Related: #887

This pull request seeks to add an "Additional CSS Class" field to the Block Inspector for all blocks which do not explicitly opt out from the `className` block type field. If the user provides a value fro this field, it is automatically applied to the serialized content for that block.

![Additional CSS Class](https://user-images.githubusercontent.com/1779930/28182116-f9d672f2-67d8-11e7-944a-23429b05cff0.png)

__Testing instructions:__

Verify that the "Additional CSS Class" field shows in the Block Inspector for all applicable block types, and that the value is included in the serialized content.

1. Insert a new block
2. In Settings > Block, note that...
   - If the block type opts out of the `className` field (e.g. text block), the "Additional CSS Class" field is not shown
   - Otherwise, the "Additional CSS Class" field is shown
3. Enter a value in "Additional CSS Class"
4. Change to Text editing mode
5. Note that the class value is included in the serialized content

__Caveats:__

The behavior of block description is such that the "Additional CSS Class" field is shown _before_ the description in the inspector. Per feedback at https://github.com/WordPress/gutenberg/pull/1555#issuecomment-312676860, I'd like to separately explore refactoring description to be a property of the block type itself.