### PR TITLE
Add ability to set custom placeholders in text and headings.

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -98,7 +98,7 @@ registerBlockType( 'core/heading', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlocksAfter } ) {
-		const { align, content, nodeName = 'H2' } = attributes;
+		const { align, content, nodeName = 'H2', placeholder } = attributes;
 
 		return [
 			focus && (
@@ -158,7 +158,7 @@ registerBlockType( 'core/heading', {
 					] );
 				} }
 				style={ { textAlign: align } }
-				placeholder={ __( 'Write heading…' ) }
+				placeholder={ placeholder || __( 'Write heading…' ) }
 			/>,
 		];
 	},

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -54,7 +54,7 @@ registerBlockType( 'core/text', {
 	},
 
 	edit( { attributes, setAttributes, insertBlocksAfter, focus, setFocus, mergeBlocks } ) {
-		const { align, content, dropCap } = attributes;
+		const { align, content, dropCap, placeholder } = attributes;
 		const toggleDropCap = () => setAttributes( { dropCap: ! dropCap } );
 		return [
 			focus && (
@@ -101,7 +101,7 @@ registerBlockType( 'core/text', {
 				onMerge={ mergeBlocks }
 				style={ { textAlign: align } }
 				className={ dropCap && 'has-drop-cap' }
-				placeholder={ __( 'Write…' ) }
+				placeholder={ placeholder || __( 'Write…' ) }
 			/>,
 		];
 	},


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/548849/28187990-dc42e4e4-6820-11e7-80bb-93908a18301d.png)

Example: `<!-- wp:core/heading { "placeholder": "Enter your name" } -->`