### PR TITLE
Improves arial-label attributes for unordered and ordered lists

### DIFF
--- a/blocks/library/freeform/freeform-block.js
+++ b/blocks/library/freeform/freeform-block.js
@@ -51,12 +51,12 @@ const FREEFORM_CONTROLS = [
 		{
 			id: 'bullist',
 			icon: 'editor-ul',
-			title: __( 'Convert to unordered list' ),
+			title: __( 'Convert to unordered' ),
 		},
 		{
 			id: 'numlist',
 			icon: 'editor-ol',
-			title: __( 'Convert to ordered list' ),
+			title: __( 'Convert to ordered' ),
 		},
 	],
 	[

--- a/blocks/library/freeform/freeform-block.js
+++ b/blocks/library/freeform/freeform-block.js
@@ -51,12 +51,12 @@ const FREEFORM_CONTROLS = [
 		{
 			id: 'bullist',
 			icon: 'editor-ul',
-			title: __( 'Convert to unordered' ),
+			title: __( 'Convert to unordered list' ),
 		},
 		{
 			id: 'numlist',
 			icon: 'editor-ol',
-			title: __( 'Convert to ordered' ),
+			title: __( 'Convert to ordered list' ),
 		},
 	],
 	[

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -227,13 +227,13 @@ registerBlockType( 'core/list', {
 						controls={ [
 							{
 								icon: 'editor-ul',
-								title: __( 'Convert to unordered' ),
+								title: __( 'Convert to unordered list' ),
 								isActive: this.isListActive( 'UL' ),
 								onClick: this.createSetListType( 'UL', 'InsertUnorderedList' ),
 							},
 							{
 								icon: 'editor-ol',
-								title: __( 'Convert to ordered' ),
+								title: __( 'Convert to ordered list' ),
 								isActive: this.isListActive( 'OL' ),
 								onClick: this.createSetListType( 'OL', 'InsertOrderedList' ),
 							},


### PR DESCRIPTION
Fixes #1882 

Improves arial-label attributes for unordered and ordered lists when inspecting the toolbar buttons.

<img width="1022" alt="screen shot 2017-07-14 at 14 13 23" src="https://user-images.githubusercontent.com/3812076/28211772-a9ae17aa-689e-11e7-9098-84354c490e11.png">


