### PR TITLE
Enhance attributes to specify types and defaults

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -94,7 +94,7 @@
 		"one-var": "off",
 		"padded-blocks": [ "error", "never" ],
 		"prefer-const": "error",
-		"quote-props": [ "error", "as-needed", { "keywords": true } ],
+		"quote-props": [ "error", "as-needed" ],
 		"react/display-name": "off",
 		"react/jsx-curly-spacing": [ "error", "always" ],
 		"react/jsx-equals-spacing": "error",

--- a/blocks/README.md
+++ b/blocks/README.md
@@ -136,7 +136,10 @@ add_action( 'enqueue_block_editor_assets', 'random_image_enqueue_block_editor_as
 		category: 'media',
 
 		attributes: {
-			category: query.attr( 'img', 'alt' )
+			category: {
+				type: 'string',
+				source: query.attr( 'img', 'alt' )
+			}
 		},
 
 		edit: function( props ) {
@@ -231,11 +234,13 @@ editor interface where blocks are implemented.
   [Dashicon](https://developer.wordpress.org/resource/dashicons/#awards)
   to be shown in the control's button, or an element (or function returning an
   element) if you choose to render your own SVG.
-- `attributes: Object | Function` - An object of
-  [matchers](http://github.com/aduth/hpq) or a function which, when passed the
-  raw content of the block, returns block attributes as an object. When defined
-  as an object of matchers, the attributes object is generated with values
-  corresponding to the shape of the matcher object keys.
+- `attributes: Object | Function` - An object of attribute schemas, where the
+  keys of the object define the shape of attributes, and each value an object
+  schema describing the `type`, `default` (optional), and
+  [`source`](http://gutenberg-devdoc.surge.sh/reference/attribute-matchers/)
+  (optional) of the attribute. If `source` is omitted, the attribute is 
+  serialized into the block's comment delimiters. Alternatively, define 
+  `attributes` as a function which returns the attributes object.
 - `category: string` - Slug of the block's category. The category is used to
   organize the blocks in the block inserter.
 - `edit( { attributes: Object, setAttributes: Function } ): WPElement` -

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -14,7 +14,6 @@ import {
 /**
  * Internal dependencies
  */
-import { getNormalizedAttributeSource } from './parser';
 import { getBlockType } from './registration';
 
 /**
@@ -34,11 +33,8 @@ export function createBlock( name, attributes = {} ) {
 		const value = attributes[ key ];
 		if ( undefined !== value ) {
 			result[ key ] = value;
-		} else {
-			source = getNormalizedAttributeSource( source );
-			if ( source.defaultValue ) {
-				result[ key ] = source.defaultValue;
-			}
+		} else if ( source.default ) {
+			result[ key ] = source.default;
 		}
 
 		return result;

--- a/blocks/api/paste.js
+++ b/blocks/api/paste.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, mapValues, flowRight as compose } from 'lodash';
+import { find, get, flowRight as compose } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,7 +13,7 @@ import { nodetypes } from '@wordpress/utils';
  */
 import { createBlock } from './factory';
 import { getBlockTypes, getUnknownTypeHandlerName } from './registration';
-import { getMatcherAttributes, getNormalizedAttributeSource } from './parser';
+import { getSourcedAttributes } from './parser';
 import stripAttributes from './paste/strip-attributes';
 import removeSpans from './paste/remove-spans';
 
@@ -94,9 +94,9 @@ export default function( nodes ) {
 				return acc;
 			}
 
-			const attributes = getMatcherAttributes(
+			const attributes = getSourcedAttributes(
 				node.outerHTML,
-				mapValues( transform.attributes, getNormalizedAttributeSource )
+				transform.attributes,
 			);
 
 			return createBlock( blockType.name, attributes );

--- a/blocks/api/paste.js
+++ b/blocks/api/paste.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, flowRight as compose } from 'lodash';
+import { find, get, mapValues, flowRight as compose } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,7 +13,7 @@ import { nodetypes } from '@wordpress/utils';
  */
 import { createBlock } from './factory';
 import { getBlockTypes, getUnknownTypeHandlerName } from './registration';
-import { parseBlockAttributes } from './parser';
+import { getMatcherAttributes, getNormalizedAttributeSource } from './parser';
 import stripAttributes from './paste/strip-attributes';
 import removeSpans from './paste/remove-spans';
 
@@ -94,10 +94,12 @@ export default function( nodes ) {
 				return acc;
 			}
 
-			const { name, defaultAttributes = [] } = blockType;
-			const attributes = parseBlockAttributes( node.outerHTML, transform.attributes );
+			const attributes = getMatcherAttributes(
+				node.outerHTML,
+				mapValues( transform.attributes, getNormalizedAttributeSource )
+			);
 
-			return createBlock( name, { ...defaultAttributes, ...attributes } );
+			return createBlock( blockType.name, attributes );
 		}, null );
 
 		if ( block ) {

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -14,7 +14,6 @@ import { Component, createElement, renderToString, cloneElement, Children } from
  * Internal dependencies
  */
 import { getBlockType } from './registration';
-import { getNormalizedAttributeSource } from './parser';
 
 /**
  * Returns the block's default classname from its name
@@ -82,11 +81,11 @@ export function getSaveContent( blockType, attributes ) {
  * which cannot be matched from the block content.
  *
  * @param   {Object<String,*>} allAttributes Attributes from in-memory block data
- * @param   {Object<String,*>} sources       Block type attributes definition
+ * @param   {Object<String,*>} schema        Block type schema
  * @returns {Object<String,*>}               Subset of attributes for comment serialization
  */
-export function getCommentAttributes( allAttributes, sources ) {
-	return reduce( sources, ( result, source, key ) => {
+export function getCommentAttributes( allAttributes, schema ) {
+	return reduce( schema, ( result, attributeSchema, key ) => {
 		const value = allAttributes[ key ];
 
 		// Ignore undefined values
@@ -95,13 +94,12 @@ export function getCommentAttributes( allAttributes, sources ) {
 		}
 
 		// Ignore values sources from content
-		source = getNormalizedAttributeSource( source );
-		if ( source.matcher ) {
+		if ( attributeSchema.source ) {
 			return result;
 		}
 
 		// Ignore default value
-		if ( 'defaultValue' in source && source.defaultValue === value ) {
+		if ( 'default' in attributeSchema && attributeSchema.default === value ) {
 			return result;
 		}
 

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -10,7 +10,12 @@ import { createBlock, switchToBlockType } from '../factory';
 import { getBlockTypes, unregisterBlockType, setUnknownTypeHandlerName, registerBlockType } from '../registration';
 
 describe( 'block factory', () => {
-	const defaultBlockSettings = { save: noop };
+	const defaultBlockSettings = {
+		attributes: {
+			value: String,
+		},
+		save: noop,
+	};
 
 	afterEach( () => {
 		setUnknownTypeHandlerName( undefined );
@@ -22,8 +27,11 @@ describe( 'block factory', () => {
 	describe( 'createBlock()', () => {
 		it( 'should create a block given its blockType and attributes', () => {
 			registerBlockType( 'core/test-block', {
-				defaultAttributes: {
-					includesDefault: true,
+				attributes: {
+					align: String,
+					includesDefault: {
+						defaultValue: true,
+					},
 				},
 				save: noop,
 			} );
@@ -44,6 +52,9 @@ describe( 'block factory', () => {
 	describe( 'switchToBlockType()', () => {
 		it( 'should switch the blockType of a block using the "transform form"', () => {
 			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -76,6 +87,9 @@ describe( 'block factory', () => {
 		it( 'should switch the blockType of a block using the "transform to"', () => {
 			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 			registerBlockType( 'core/text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
@@ -119,6 +133,9 @@ describe( 'block factory', () => {
 
 		it( 'should reject transformations that return null', () => {
 			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -140,6 +157,9 @@ describe( 'block factory', () => {
 
 		it( 'should reject transformations that return an empty array', () => {
 			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -161,6 +181,9 @@ describe( 'block factory', () => {
 
 		it( 'should reject single transformations that do not include block types', () => {
 			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -188,6 +211,9 @@ describe( 'block factory', () => {
 
 		it( 'should reject array transformations that do not include block types', () => {
 			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
@@ -221,6 +247,9 @@ describe( 'block factory', () => {
 		it( 'should reject single transformations with unexpected block types', () => {
 			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 			registerBlockType( 'core/text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
@@ -246,6 +275,9 @@ describe( 'block factory', () => {
 		it( 'should reject array transformations with unexpected block types', () => {
 			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 			registerBlockType( 'core/text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
@@ -276,6 +308,9 @@ describe( 'block factory', () => {
 		it( 'should accept valid array transformations', () => {
 			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 			registerBlockType( 'core/text-block', {
+				attributes: {
+					value: String,
+				},
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -12,7 +12,9 @@ import { getBlockTypes, unregisterBlockType, setUnknownTypeHandlerName, register
 describe( 'block factory', () => {
 	const defaultBlockSettings = {
 		attributes: {
-			value: String,
+			value: {
+				type: 'string',
+			},
 		},
 		save: noop,
 	};
@@ -28,9 +30,12 @@ describe( 'block factory', () => {
 		it( 'should create a block given its blockType and attributes', () => {
 			registerBlockType( 'core/test-block', {
 				attributes: {
-					align: String,
+					align: {
+						type: 'string',
+					},
 					includesDefault: {
-						defaultValue: true,
+						type: 'boolean',
+						default: true,
 					},
 				},
 				save: noop,
@@ -53,7 +58,9 @@ describe( 'block factory', () => {
 		it( 'should switch the blockType of a block using the "transform form"', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					from: [ {
@@ -88,7 +95,9 @@ describe( 'block factory', () => {
 			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 			registerBlockType( 'core/text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					to: [ {
@@ -134,7 +143,9 @@ describe( 'block factory', () => {
 		it( 'should reject transformations that return null', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					from: [ {
@@ -158,7 +169,9 @@ describe( 'block factory', () => {
 		it( 'should reject transformations that return an empty array', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					from: [ {
@@ -182,7 +195,9 @@ describe( 'block factory', () => {
 		it( 'should reject single transformations that do not include block types', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					from: [ {
@@ -212,7 +227,9 @@ describe( 'block factory', () => {
 		it( 'should reject array transformations that do not include block types', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					from: [ {
@@ -248,7 +265,9 @@ describe( 'block factory', () => {
 			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 			registerBlockType( 'core/text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					to: [ {
@@ -276,7 +295,9 @@ describe( 'block factory', () => {
 			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 			registerBlockType( 'core/text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					to: [ {
@@ -309,7 +330,9 @@ describe( 'block factory', () => {
 			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
 			registerBlockType( 'core/text-block', {
 				attributes: {
-					value: String,
+					value: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					to: [ {

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -8,9 +8,9 @@ import { noop } from 'lodash';
  */
 import { text, attr, html } from '../query';
 import {
-	isValidMatcher,
+	isValidSource,
 	getBlockAttributes,
-	getMatcherAttributes,
+	getSourcedAttributes,
 	createBlockWithFallback,
 	default as parse,
 } from '../parser';
@@ -24,7 +24,9 @@ import {
 describe( 'block parser', () => {
 	const defaultBlockSettings = {
 		attributes: {
-			fruit: String,
+			fruit: {
+				type: 'string',
+			},
 		},
 		save: ( { attributes } ) => attributes.fruit,
 	};
@@ -36,32 +38,35 @@ describe( 'block parser', () => {
 		} );
 	} );
 
-	describe( 'isValidMatcher()', () => {
+	describe( 'isValidSource()', () => {
 		it( 'returns false if falsey argument', () => {
-			expect( isValidMatcher() ).toBe( false );
+			expect( isValidSource() ).toBe( false );
 		} );
 
-		it( 'returns true if valid matcher argument', () => {
-			expect( isValidMatcher( text() ) ).toBe( true );
+		it( 'returns true if valid source argument', () => {
+			expect( isValidSource( text() ) ).toBe( true );
 		} );
 
-		it( 'returns false if invalid matcher argument', () => {
-			expect( isValidMatcher( () => {} ) ).toBe( false );
+		it( 'returns false if invalid source argument', () => {
+			expect( isValidSource( () => {} ) ).toBe( false );
 		} );
 	} );
 
-	describe( 'getMatcherAttributes()', () => {
-		it( 'should return matched attributes from valid matchers', () => {
+	describe( 'getSourcedAttributes()', () => {
+		it( 'should return matched attributes from valid sources', () => {
 			const sources = {
-				number: Number,
+				number: {
+					type: 'number',
+				},
 				emphasis: {
-					matcher: text( 'strong' ),
+					type: 'string',
+					source: text( 'strong' ),
 				},
 			};
 
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( getMatcherAttributes( rawContent, sources ) ).toEqual( {
+			expect( getSourcedAttributes( rawContent, sources ) ).toEqual( {
 				emphasis: '& Chicken',
 			} );
 		} );
@@ -70,7 +75,7 @@ describe( 'block parser', () => {
 			const sources = {};
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( getMatcherAttributes( rawContent, sources ) ).toEqual( {} );
+			expect( getSourcedAttributes( rawContent, sources ) ).toEqual( {} );
 		} );
 	} );
 
@@ -78,18 +83,24 @@ describe( 'block parser', () => {
 		it( 'should merge attributes with the parsed and default attributes', () => {
 			const blockType = {
 				attributes: {
-					content: text( 'div' ),
+					content: {
+						type: 'string',
+						source: text( 'div' ),
+					},
 					number: {
-						type: Number,
-						matcher: attr( 'div', 'data-number' ),
+						type: 'number',
+						source: attr( 'div', 'data-number' ),
 					},
-					align: String,
+					align: {
+						type: 'string',
+					},
 					topic: {
-						type: String,
-						defaultValue: 'none',
+						type: 'string',
+						default: 'none',
 					},
-					ignoredDomMatcher: {
-						matcher: ( node ) => node.innerHTML,
+					ignoredDomSource: {
+						type: 'string',
+						source: ( node ) => node.innerHTML,
 					},
 				},
 			};
@@ -159,10 +170,13 @@ describe( 'block parser', () => {
 		it( 'should parse the post content, including block attributes', () => {
 			registerBlockType( 'core/test-block', {
 				attributes: {
-					content: text(),
-					smoked: String,
-					url: String,
-					chicken: String,
+					content: {
+						type: 'string',
+						source: text(),
+					},
+					smoked: { type: 'string' },
+					url: { type: 'string' },
+					chicken: { type: 'string' },
 				},
 				save: noop,
 			} );
@@ -193,7 +207,10 @@ describe( 'block parser', () => {
 		it( 'should parse the post content, ignoring unknown blocks', () => {
 			registerBlockType( 'core/test-block', {
 				attributes: {
-					content: text(),
+					content: {
+						type: 'string',
+						source: text(),
+					},
 				},
 				save: noop,
 			} );
@@ -236,7 +253,10 @@ describe( 'block parser', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 			registerBlockType( 'core/unknown-block', {
 				attributes: {
-					content: html(),
+					content: {
+						type: 'string',
+						source: html(),
+					},
 				},
 				save: noop,
 			} );

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -6,10 +6,11 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { text } from '../query';
+import { text, attr, html } from '../query';
 import {
+	isValidMatcher,
 	getBlockAttributes,
-	parseBlockAttributes,
+	getMatcherAttributes,
 	createBlockWithFallback,
 	default as parse,
 } from '../parser';
@@ -22,6 +23,9 @@ import {
 
 describe( 'block parser', () => {
 	const defaultBlockSettings = {
+		attributes: {
+			fruit: String,
+		},
 		save: ( { attributes } ) => attributes.fruit,
 	};
 
@@ -32,61 +36,72 @@ describe( 'block parser', () => {
 		} );
 	} );
 
-	describe( 'parseBlockAttributes()', () => {
-		it( 'should use the function implementation', () => {
-			const attributes = function( rawContent ) {
-				return {
-					content: rawContent + ' & Chicken',
-				};
-			};
-
-			expect( parseBlockAttributes( 'Ribs', attributes ) ).toEqual( {
-				content: 'Ribs & Chicken',
-			} );
+	describe( 'isValidMatcher()', () => {
+		it( 'returns false if falsey argument', () => {
+			expect( isValidMatcher() ).toBe( false );
 		} );
 
-		it( 'should use the query object implementation', () => {
-			const attributes = {
-				emphasis: text( 'strong' ),
-				ignoredDomMatcher: ( node ) => node.innerHTML,
+		it( 'returns true if valid matcher argument', () => {
+			expect( isValidMatcher( text() ) ).toBe( true );
+		} );
+
+		it( 'returns false if invalid matcher argument', () => {
+			expect( isValidMatcher( () => {} ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getMatcherAttributes()', () => {
+		it( 'should return matched attributes from valid matchers', () => {
+			const sources = {
+				number: Number,
+				emphasis: {
+					matcher: text( 'strong' ),
+				},
 			};
 
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( parseBlockAttributes( rawContent, attributes ) ).toEqual( {
+			expect( getMatcherAttributes( rawContent, sources ) ).toEqual( {
 				emphasis: '& Chicken',
 			} );
 		} );
 
-		it( 'should return an empty object if no attributes defined', () => {
-			const attributes = {};
+		it( 'should return an empty object if no sources defined', () => {
+			const sources = {};
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( parseBlockAttributes( rawContent, attributes ) ).toEqual( {} );
+			expect( getMatcherAttributes( rawContent, sources ) ).toEqual( {} );
 		} );
 	} );
 
 	describe( 'getBlockAttributes()', () => {
 		it( 'should merge attributes with the parsed and default attributes', () => {
 			const blockType = {
-				attributes: function( rawContent ) {
-					return {
-						content: rawContent + ' & Chicken',
-					};
-				},
-				defaultAttributes: {
-					content: '',
-					topic: 'none',
+				attributes: {
+					content: text( 'div' ),
+					number: {
+						type: Number,
+						matcher: attr( 'div', 'data-number' ),
+					},
+					align: String,
+					topic: {
+						type: String,
+						defaultValue: 'none',
+					},
+					ignoredDomMatcher: {
+						matcher: ( node ) => node.innerHTML,
+					},
 				},
 			};
 
-			const rawContent = 'Ribs';
-			const attrs = { align: 'left' };
+			const rawContent = '<div data-number="10">Ribs</div>';
+			const attrs = { align: 'left', invalid: true };
 
 			expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {
+				content: 'Ribs',
+				number: 10,
 				align: 'left',
 				topic: 'none',
-				content: 'Ribs & Chicken',
 			} );
 		} );
 	} );
@@ -98,10 +113,10 @@ describe( 'block parser', () => {
 			const block = createBlockWithFallback(
 				'core/test-block',
 				'content',
-				{ attr: 'value' }
+				{ fruit: 'Bananas' }
 			);
 			expect( block.name ).toEqual( 'core/test-block' );
-			expect( block.attributes ).toEqual( { attr: 'value' } );
+			expect( block.attributes ).toEqual( { fruit: 'Bananas' } );
 		} );
 
 		it( 'should create the requested block with no attributes if it exists', () => {
@@ -119,10 +134,10 @@ describe( 'block parser', () => {
 			const block = createBlockWithFallback(
 				'core/test-block',
 				'content',
-				{ attr: 'value' }
+				{ fruit: 'Bananas' }
 			);
 			expect( block.name ).toEqual( 'core/unknown-block' );
-			expect( block.attributes ).toEqual( { attr: 'value' } );
+			expect( block.attributes ).toEqual( { fruit: 'Bananas' } );
 		} );
 
 		it( 'should fall back to the unknown type handler if block type not specified', () => {
@@ -143,11 +158,11 @@ describe( 'block parser', () => {
 	describe( 'parse()', () => {
 		it( 'should parse the post content, including block attributes', () => {
 			registerBlockType( 'core/test-block', {
-				// Currently this is the only way to test block content parsing?
-				attributes: function( rawContent ) {
-					return {
-						content: rawContent,
-					};
+				attributes: {
+					content: text(),
+					smoked: String,
+					url: String,
+					chicken: String,
 				},
 				save: noop,
 			} );
@@ -177,10 +192,8 @@ describe( 'block parser', () => {
 
 		it( 'should parse the post content, ignoring unknown blocks', () => {
 			registerBlockType( 'core/test-block', {
-				attributes: function( rawContent ) {
-					return {
-						content: rawContent + ' & Chicken',
-					};
+				attributes: {
+					content: text(),
 				},
 				save: noop,
 			} );
@@ -194,7 +207,7 @@ describe( 'block parser', () => {
 			expect( parsed ).toHaveLength( 1 );
 			expect( parsed[ 0 ].name ).toBe( 'core/test-block' );
 			expect( parsed[ 0 ].attributes ).toEqual( {
-				content: 'Ribs & Chicken',
+				content: 'Ribs',
 			} );
 			expect( typeof parsed[ 0 ].uid ).toBe( 'string' );
 		} );
@@ -222,11 +235,8 @@ describe( 'block parser', () => {
 		it( 'should parse the post content, including raw HTML at each end', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 			registerBlockType( 'core/unknown-block', {
-				// Currently this is the only way to test block content parsing?
-				attributes: function( rawContent ) {
-					return {
-						content: rawContent,
-					};
+				attributes: {
+					content: html(),
 				},
 				save: noop,
 			} );

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -10,6 +10,7 @@ import { text, attr, html } from '../query';
 import {
 	isValidSource,
 	getBlockAttributes,
+	asType,
 	getSourcedAttributes,
 	createBlockWithFallback,
 	default as parse,
@@ -76,6 +77,44 @@ describe( 'block parser', () => {
 			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
 
 			expect( getSourcedAttributes( rawContent, sources ) ).toEqual( {} );
+		} );
+	} );
+
+	describe( 'asType()', () => {
+		it( 'gracefully handles undefined type', () => {
+			expect( asType( 5 ) ).toBe( 5 );
+		} );
+
+		it( 'gracefully handles unhandled type', () => {
+			expect( asType( 5, '__UNHANDLED__' ) ).toBe( 5 );
+		} );
+
+		it( 'returns expected coerced values', () => {
+			const arr = [];
+			const obj = {};
+
+			expect( asType( '5', 'string' ) ).toBe( '5' );
+			expect( asType( 5, 'string' ) ).toBe( '5' );
+
+			expect( asType( 5, 'integer' ) ).toBe( 5 );
+			expect( asType( '5', 'integer' ) ).toBe( 5 );
+
+			expect( asType( 5, 'number' ) ).toBe( 5 );
+			expect( asType( '5', 'number' ) ).toBe( 5 );
+
+			expect( asType( true, 'boolean' ) ).toBe( true );
+			expect( asType( false, 'boolean' ) ).toBe( false );
+			expect( asType( '5', 'boolean' ) ).toBe( true );
+			expect( asType( 0, 'boolean' ) ).toBe( false );
+
+			expect( asType( null, 'null' ) ).toBe( null );
+			expect( asType( 0, 'null' ) ).toBe( null );
+
+			expect( asType( arr, 'array' ) ).toBe( arr );
+			expect( asType( new Set( [ 1, 2, 3 ] ), 'array' ) ).toEqual( [ 1, 2, 3 ] );
+
+			expect( asType( obj, 'object' ) ).toBe( obj );
+			expect( asType( {}, 'object' ) ).toEqual( {} );
 		} );
 	} );
 

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -146,9 +146,16 @@ describe( 'block serializer', () => {
 				category: 'food',
 				ripeness: 'ripe',
 			}, {
-				fruit: text(),
-				category: String,
-				ripeness: String,
+				fruit: {
+					type: 'string',
+					source: text(),
+				},
+				category: {
+					type: 'string',
+				},
+				ripeness: {
+					type: 'string',
+				},
 			} );
 
 			expect( attributes ).toEqual( {
@@ -162,8 +169,12 @@ describe( 'block serializer', () => {
 				fruit: 'bananas',
 				ripeness: undefined,
 			}, {
-				fruit: String,
-				ripeness: String,
+				fruit: {
+					type: 'string',
+				},
+				ripeness: {
+					type: 'string',
+				},
 			} );
 
 			expect( attributes ).toEqual( { fruit: 'bananas' } );
@@ -190,15 +201,20 @@ describe( 'block serializer', () => {
 			const blockType = {
 				attributes: {
 					foo: {
-						type: String,
-						defaultValue: true,
+						type: 'string',
+						default: true,
 					},
 					bar: {
-						type: String,
-						defaultValue: false,
+						type: 'string',
+						default: false,
 					},
-					content: text(),
-					stuff: String,
+					content: {
+						type: 'string',
+						source: text(),
+					},
+					stuff: {
+						type: 'string',
+					},
 				},
 				save( { attributes } ) {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -6,6 +6,7 @@ import { createElement, Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { text } from '../query';
 import serialize, {
 	getCommentAttributes,
 	getBeautifulContent,
@@ -139,13 +140,15 @@ describe( 'block serializer', () => {
 			expect( attributes ).toEqual( {} );
 		} );
 
-		it( 'should only return attributes which cannot be inferred from the content', () => {
+		it( 'should only return attributes which are not matched from content', () => {
 			const attributes = getCommentAttributes( {
 				fruit: 'bananas',
 				category: 'food',
 				ripeness: 'ripe',
 			}, {
-				fruit: 'bananas',
+				fruit: text(),
+				category: String,
+				ripeness: String,
 			} );
 
 			expect( attributes ).toEqual( {
@@ -158,7 +161,10 @@ describe( 'block serializer', () => {
 			const attributes = getCommentAttributes( {
 				fruit: 'bananas',
 				ripeness: undefined,
-			}, {} );
+			}, {
+				fruit: String,
+				ripeness: String,
+			} );
 
 			expect( attributes ).toEqual( { fruit: 'bananas' } );
 		} );
@@ -182,14 +188,17 @@ describe( 'block serializer', () => {
 	describe( 'serialize()', () => {
 		it( 'should serialize the post content properly', () => {
 			const blockType = {
-				defaultAttributes: {
-					foo: true,
-					bar: false,
-				},
-				attributes: ( rawContent ) => {
-					return {
-						content: rawContent,
-					};
+				attributes: {
+					foo: {
+						type: String,
+						defaultValue: true,
+					},
+					bar: {
+						type: String,
+						defaultValue: false,
+					},
+					content: text(),
+					stuff: String,
 				},
 				save( { attributes } ) {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -114,7 +114,7 @@ export function getStyleProperties( text ) {
  * @type {Object}
  */
 export const isEqualAttributesOfName = {
-	'class': ( a, b ) => {
+	class: ( a, b ) => {
 		// Class matches if members are the same, even if out of order or
 		// superfluous whitespace between.
 		return ! xor( ...[ a, b ].map( getTextPiecesSplitOnWhitespace ) ).length;

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -27,15 +27,24 @@ registerBlockType( 'core/button', {
 	category: 'layout',
 
 	attributes: {
-		url: attr( 'a', 'href' ),
-		title: attr( 'a', 'title' ),
-		text: children( 'a' ),
+		url: {
+			type: 'string',
+			source: attr( 'a', 'href' ),
+		},
+		title: {
+			type: 'string',
+			source: attr( 'a', 'title' ),
+		},
+		text: {
+			type: 'array',
+			source: children( 'a' ),
+		},
 		align: {
-			type: String,
-			defaultValue: 'none',
+			type: 'string',
+			default: 'none',
 		},
 		color: {
-			type: String,
+			type: 'string',
 		},
 	},
 

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -30,6 +30,13 @@ registerBlockType( 'core/button', {
 		url: attr( 'a', 'href' ),
 		title: attr( 'a', 'title' ),
 		text: children( 'a' ),
+		align: {
+			type: String,
+			defaultValue: 'none',
+		},
+		color: {
+			type: String,
+		},
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -88,7 +95,7 @@ registerBlockType( 'core/button', {
 	},
 
 	save( { attributes } ) {
-		const { url, text, title, align = 'none', color } = attributes;
+		const { url, text, title, align, color } = attributes;
 
 		return (
 			<div className={ `align${ align }` } style={ { backgroundColor: color } }>

--- a/blocks/library/categories/index.js
+++ b/blocks/library/categories/index.js
@@ -28,18 +28,20 @@ registerBlockType( 'core/categories', {
 
 	attributes: {
 		showPostCounts: {
-			type: Boolean,
-			defaultValue: false,
+			type: 'boolean',
+			default: false,
 		},
 		displayAsDropdown: {
-			type: Boolean,
-			defaultValue: false,
+			type: 'boolean',
+			default: false,
 		},
 		showHierarchy: {
-			type: Boolean,
-			defaultValue: false,
+			type: 'boolean',
+			default: false,
 		},
-		align: String,
+		align: {
+			type: 'string',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/categories/index.js
+++ b/blocks/library/categories/index.js
@@ -26,10 +26,20 @@ registerBlockType( 'core/categories', {
 
 	category: 'widgets',
 
-	defaultAttributes: {
-		showPostCounts: false,
-		displayAsDropdown: false,
-		showHierarchy: false,
+	attributes: {
+		showPostCounts: {
+			type: Boolean,
+			defaultValue: false,
+		},
+		displayAsDropdown: {
+			type: Boolean,
+			defaultValue: false,
+		},
+		showHierarchy: {
+			type: Boolean,
+			defaultValue: false,
+		},
+		align: String,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -24,7 +24,10 @@ registerBlockType( 'core/code', {
 	category: 'formatting',
 
 	attributes: {
-		content: prop( 'code', 'textContent' ),
+		content: {
+			type: 'string',
+			source: prop( 'code', 'textContent' ),
+		},
 	},
 
 	transforms: {

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -32,10 +32,17 @@ registerBlockType( 'core/cover-image', {
 
 	attributes: {
 		title: text( 'h2' ),
-	},
-
-	defaultAttributes: {
-		hasBackgroundDim: true,
+		url: String,
+		align: String,
+		id: Number,
+		hasParallax: {
+			type: Boolean,
+			defaultValue: false,
+		},
+		hasBackgroundDim: {
+			type: Boolean,
+			defaultValue: true,
+		},
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -31,17 +31,26 @@ registerBlockType( 'core/cover-image', {
 	category: 'common',
 
 	attributes: {
-		title: text( 'h2' ),
-		url: String,
-		align: String,
-		id: Number,
+		title: {
+			type: 'string',
+			source: text( 'h2' ),
+		},
+		url: {
+			type: 'string',
+		},
+		align: {
+			type: 'string',
+		},
+		id: {
+			type: 'number',
+		},
 		hasParallax: {
-			type: Boolean,
-			defaultValue: false,
+			type: 'boolean',
+			default: false,
 		},
 		hasBackgroundDim: {
-			type: Boolean,
-			defaultValue: true,
+			type: 'boolean',
+			default: true,
 		},
 	},
 

--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -28,16 +28,29 @@ registerBlockType( 'core/cover-text', {
 	category: 'formatting',
 
 	attributes: {
-		align: String,
-		width: String,
-		content: query( 'p', children() ),
-		dropCap: {
-			type: Boolean,
-			defaultValue: false,
+		align: {
+			type: 'string',
 		},
-		placeholder: String,
-		textColor: String,
-		backgroundColor: String,
+		width: {
+			type: 'string',
+		},
+		content: {
+			type: 'array',
+			source: query( 'p', children() ),
+		},
+		dropCap: {
+			type: 'boolean',
+			default: false,
+		},
+		placeholder: {
+			type: 'string',
+		},
+		textColor: {
+			type: 'string',
+		},
+		backgroundColor: {
+			type: 'string',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -28,7 +28,16 @@ registerBlockType( 'core/cover-text', {
 	category: 'formatting',
 
 	attributes: {
+		align: String,
+		width: String,
 		content: query( 'p', children() ),
+		dropCap: {
+			type: Boolean,
+			defaultValue: false,
+		},
+		placeholder: String,
+		textColor: String,
+		backgroundColor: String,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -37,9 +37,16 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms } 
 		category,
 
 		attributes: {
-			url: String,
-			caption: children( 'figcaption' ),
-			align: String,
+			url: {
+				type: 'string',
+			},
+			caption: {
+				type: 'array',
+				source: children( 'figcaption' ),
+			},
+			align: {
+				type: 'string',
+			},
 		},
 
 		transforms,

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -23,7 +23,7 @@ import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-const { attr, children } = query;
+const { children } = query;
 
 // These embeds do not work in sandboxes
 const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
@@ -37,8 +37,9 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms } 
 		category,
 
 		attributes: {
-			title: attr( 'iframe', 'title' ),
+			url: String,
 			caption: children( 'figcaption' ),
+			align: String,
 		},
 
 		transforms,
@@ -207,7 +208,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms } 
 		},
 
 		save( { attributes } ) {
-			const { url, caption = [], align } = attributes;
+			const { url, caption, align } = attributes;
 
 			return (
 				<figure className={ align && `align${ align }` }>

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -20,7 +20,10 @@ registerBlockType( 'core/freeform', {
 	category: 'formatting',
 
 	attributes: {
-		content: prop( 'innerHTML' ),
+		content: {
+			type: 'string',
+			source: prop( 'innerHTML' ),
+		},
 	},
 
 	edit: OldEditor,

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -69,21 +69,23 @@ registerBlockType( 'core/gallery', {
 
 	attributes: {
 		align: {
-			type: String,
-			defaultValue: 'none',
+			type: 'string',
+			default: 'none',
 		},
 		images: {
-			type: Object, // Array
-			defaultValue: [],
+			type: 'array',
+			default: [],
 		},
-		columns: Number,
+		columns: {
+			type: 'number',
+		},
 		imageCrop: {
-			type: Boolean,
-			defaultValue: true,
+			type: 'boolean',
+			default: true,
 		},
 		linkTo: {
-			type: String,
-			defaultValue: 'none',
+			type: 'string',
+			default: 'none',
 		},
 	},
 

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -67,8 +67,24 @@ registerBlockType( 'core/gallery', {
 	icon: 'format-gallery',
 	category: 'common',
 
-	defaultAttributes: {
-		images: [],
+	attributes: {
+		align: {
+			type: String,
+			defaultValue: 'none',
+		},
+		images: {
+			type: Object, // Array
+			defaultValue: [],
+		},
+		columns: Number,
+		imageCrop: {
+			type: Boolean,
+			defaultValue: true,
+		},
+		linkTo: {
+			type: String,
+			defaultValue: 'none',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -79,12 +95,10 @@ registerBlockType( 'core/gallery', {
 	},
 
 	edit( { attributes, setAttributes, focus, className } ) {
-		const { images, columns = defaultColumnsNumber( attributes ), align = 'none' } = attributes;
+		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
 		const setLinkTo = ( value ) => setAttributes( { linkTo: value } );
 		const setColumnsNumber = ( event ) => setAttributes( { columns: event.target.value } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
-		const { imageCrop = true } = attributes;
-		const { linkTo = 'none' } = attributes;
 		const toggleImageCrop = () => setAttributes( { imageCrop: ! imageCrop } );
 
 		const controls = (
@@ -167,7 +181,7 @@ registerBlockType( 'core/gallery', {
 	},
 
 	save( { attributes } ) {
-		const { images, columns = defaultColumnsNumber( attributes ), align = 'none', imageCrop = true, linkTo = 'none' } = attributes;
+		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
 		return (
 			<div className={ `align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
 				{ images.map( ( img ) => (

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -28,13 +28,21 @@ registerBlockType( 'core/heading', {
 	className: false,
 
 	attributes: {
-		content: children( 'h1,h2,h3,h4,h5,h6' ),
-		nodeName: {
-			matcher: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
-			defaultValue: 'H2',
+		content: {
+			type: 'array',
+			source: children( 'h1,h2,h3,h4,h5,h6' ),
 		},
-		align: String,
-		placeholder: String,
+		nodeName: {
+			type: 'string',
+			source: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
+			default: 'H2',
+		},
+		align: {
+			type: 'string',
+		},
+		placeholder: {
+			type: 'string',
+		},
 	},
 
 	transforms: {

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -29,11 +29,12 @@ registerBlockType( 'core/heading', {
 
 	attributes: {
 		content: children( 'h1,h2,h3,h4,h5,h6' ),
-		nodeName: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
-	},
-
-	defaultAttributes: {
-		nodeName: 'H2',
+		nodeName: {
+			matcher: prop( 'h1,h2,h3,h4,h5,h6', 'nodeName' ),
+			defaultValue: 'H2',
+		},
+		align: String,
+		placeholder: String,
 	},
 
 	transforms: {

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -28,7 +28,10 @@ registerBlockType( 'core/html', {
 	className: false,
 
 	attributes: {
-		content: html(),
+		content: {
+			type: 'string',
+			source: html(),
+		},
 	},
 
 	edit: class extends Component {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -37,6 +37,8 @@ registerBlockType( 'core/image', {
 		alt: attr( 'img', 'alt' ),
 		caption: children( 'figcaption' ),
 		href: attr( 'a', 'href' ),
+		id: Number,
+		align: String,
 	},
 
 	transforms: {
@@ -201,7 +203,7 @@ registerBlockType( 'core/image', {
 	},
 
 	save( { attributes } ) {
-		const { url, alt, caption = [], align, href } = attributes;
+		const { url, alt, caption, align, href } = attributes;
 		const image = <img src={ url } alt={ alt } />;
 
 		return (

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -33,12 +33,28 @@ registerBlockType( 'core/image', {
 	category: 'common',
 
 	attributes: {
-		url: attr( 'img', 'src' ),
-		alt: attr( 'img', 'alt' ),
-		caption: children( 'figcaption' ),
-		href: attr( 'a', 'href' ),
-		id: Number,
-		align: String,
+		url: {
+			type: 'string',
+			source: attr( 'img', 'src' ),
+		},
+		alt: {
+			type: 'string',
+			source: attr( 'img', 'alt' ),
+		},
+		caption: {
+			type: 'array',
+			source: children( 'figcaption' ),
+		},
+		href: {
+			type: 'string',
+			source: attr( 'a', 'href' ),
+		},
+		id: {
+			type: 'number',
+		},
+		align: {
+			type: 'string',
+		},
 	},
 
 	transforms: {

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -35,22 +35,24 @@ registerBlockType( 'core/latest-posts', {
 
 	attributes: {
 		postsToShow: {
-			type: Number,
-			defaultValue: 5,
+			type: 'number',
+			default: 5,
 		},
 		displayPostDate: {
-			type: Boolean,
-			defaultValue: false,
+			type: 'boolean',
+			default: false,
 		},
 		layout: {
-			type: String,
-			defaultValue: 'list',
+			type: 'string',
+			default: 'list',
 		},
 		columns: {
-			type: Number,
-			defaultValue: 3,
+			type: 'number',
+			default: 3,
 		},
-		align: String,
+		align: {
+			type: 'string',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -33,11 +33,24 @@ registerBlockType( 'core/latest-posts', {
 
 	category: 'widgets',
 
-	defaultAttributes: {
-		postsToShow: 5,
-		displayPostDate: false,
-		layout: 'list',
-		columns: 3,
+	attributes: {
+		postsToShow: {
+			type: Number,
+			defaultValue: 5,
+		},
+		displayPostDate: {
+			type: Boolean,
+			defaultValue: false,
+		},
+		layout: {
+			type: String,
+			defaultValue: 'list',
+		},
+		columns: {
+			type: Number,
+			defaultValue: 3,
+		},
+		align: String,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -75,12 +75,14 @@ registerBlockType( 'core/list', {
 
 	attributes: {
 		nodeName: {
-			matcher: prop( 'ol,ul', 'nodeName' ),
-			defaultValue: 'UL',
+			type: 'string',
+			source: prop( 'ol,ul', 'nodeName' ),
+			default: 'UL',
 		},
 		values: {
-			matcher: children( 'ol,ul' ),
-			defaultValue: [],
+			type: 'array',
+			source: children( 'ol,ul' ),
+			default: [],
 		},
 	},
 

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -74,13 +74,14 @@ registerBlockType( 'core/list', {
 	category: 'common',
 
 	attributes: {
-		nodeName: prop( 'ol,ul', 'nodeName' ),
-		values: children( 'ol,ul' ),
-	},
-
-	defaultAttributes: {
-		nodeName: 'UL',
-		values: [],
+		nodeName: {
+			matcher: prop( 'ol,ul', 'nodeName' ),
+			defaultValue: 'UL',
+		},
+		values: {
+			matcher: children( 'ol,ul' ),
+			defaultValue: [],
+		},
 	},
 
 	className: false,

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -24,10 +24,12 @@ registerBlockType( 'core/more', {
 	className: false,
 
 	attributes: {
-		text: String,
+		text: {
+			type: 'string',
+		},
 		noTeaser: {
-			type: Boolean,
-			defaultValue: false,
+			type: 'boolean',
+			default: false,
 		},
 	},
 

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -23,6 +23,14 @@ registerBlockType( 'core/more', {
 
 	className: false,
 
+	attributes: {
+		text: String,
+		noTeaser: {
+			type: Boolean,
+			defaultValue: false,
+		},
+	},
+
 	edit( { attributes, setAttributes, focus, setFocus } ) {
 		const { text, noTeaser } = attributes;
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -30,13 +30,20 @@ registerBlockType( 'core/paragraph', {
 	className: false,
 
 	attributes: {
-		content: children( 'p' ),
-		align: String,
-		dropCap: {
-			type: Boolean,
-			defaultValue: false,
+		content: {
+			type: 'array',
+			source: children( 'p' ),
 		},
-		placeholder: String,
+		align: {
+			type: 'string',
+		},
+		dropCap: {
+			type: 'boolean',
+			default: false,
+		},
+		placeholder: {
+			type: 'string',
+		},
 	},
 
 	transforms: {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -27,14 +27,16 @@ registerBlockType( 'core/paragraph', {
 
 	keywords: [ __( 'text' ) ],
 
-	defaultAttributes: {
-		dropCap: false,
-	},
-
 	className: false,
 
 	attributes: {
 		content: children( 'p' ),
+		align: String,
+		dropCap: {
+			type: Boolean,
+			defaultValue: false,
+		},
+		placeholder: String,
 	},
 
 	transforms: {

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -20,7 +20,10 @@ registerBlockType( 'core/preformatted', {
 	category: 'formatting',
 
 	attributes: {
-		content: children( 'pre' ),
+		content: {
+			type: 'array',
+			source: children( 'pre' ),
+		},
 	},
 
 	transforms: {

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -26,6 +26,10 @@ registerBlockType( 'core/pullquote', {
 	attributes: {
 		value: query( 'blockquote > p', node() ),
 		citation: children( 'footer' ),
+		align: {
+			type: String,
+			defaultValue: 'none',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -81,7 +85,7 @@ registerBlockType( 'core/pullquote', {
 	},
 
 	save( { attributes } ) {
-		const { value, citation, align = 'none' } = attributes;
+		const { value, citation, align } = attributes;
 
 		return (
 			<blockquote className={ `align${ align }` }>

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -24,11 +24,17 @@ registerBlockType( 'core/pullquote', {
 	category: 'formatting',
 
 	attributes: {
-		value: query( 'blockquote > p', node() ),
-		citation: children( 'footer' ),
+		value: {
+			type: 'array',
+			source: query( 'blockquote > p', node() ),
+		},
+		citation: {
+			type: 'array',
+			source: children( 'footer' ),
+		},
 		align: {
-			type: String,
-			defaultValue: 'none',
+			type: 'string',
+			default: 'none',
 		},
 	},
 

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -26,12 +26,20 @@ registerBlockType( 'core/quote', {
 	category: 'common',
 
 	attributes: {
-		value: query( 'blockquote > p', node() ),
-		citation: children( 'footer' ),
-		align: String,
+		value: {
+			type: 'array',
+			source: query( 'blockquote > p', node() ),
+		},
+		citation: {
+			type: 'array',
+			source: children( 'footer' ),
+		},
+		align: {
+			type: 'string',
+		},
 		style: {
-			type: Number,
-			defaultValue: 1,
+			type: 'number',
+			default: 1,
 		},
 	},
 

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -28,10 +28,11 @@ registerBlockType( 'core/quote', {
 	attributes: {
 		value: query( 'blockquote > p', node() ),
 		citation: children( 'footer' ),
-	},
-
-	defaultAttributes: {
-		value: [],
+		align: String,
+		style: {
+			type: Number,
+			defaultValue: 1,
+		},
 	},
 
 	transforms: {
@@ -129,7 +130,7 @@ registerBlockType( 'core/quote', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, className } ) {
-		const { align, value, citation, style = 1 } = attributes;
+		const { align, value, citation, style } = attributes;
 		const focusedEditable = focus ? focus.editable || 'value' : null;
 
 		return [
@@ -188,7 +189,7 @@ registerBlockType( 'core/quote', {
 	},
 
 	save( { attributes } ) {
-		const { align, value, citation, style = 1 } = attributes;
+		const { align, value, citation, style } = attributes;
 
 		return (
 			<blockquote

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -22,15 +22,18 @@ registerBlockType( 'core/table', {
 
 	attributes: {
 		content: {
-			matcher: children( 'table' ),
-			defaultValue: [
+			type: 'array',
+			source: children( 'table' ),
+			default: [
 				<tbody key="1">
 					<tr><td><br /></td><td><br /></td></tr>
 					<tr><td><br /></td><td><br /></td></tr>
 				</tbody>,
 			],
 		},
-		align: String,
+		align: {
+			type: 'string',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -21,16 +21,16 @@ registerBlockType( 'core/table', {
 	category: 'formatting',
 
 	attributes: {
-		content: children( 'table' ),
-	},
-
-	defaultAttributes: {
-		content: [
-			<tbody key="1">
-				<tr><td><br /></td><td><br /></td></tr>
-				<tr><td><br /></td><td><br /></td></tr>
-			</tbody>,
-		],
+		content: {
+			matcher: children( 'table' ),
+			defaultValue: [
+				<tbody key="1">
+					<tr><td><br /></td><td><br /></td></tr>
+					<tr><td><br /></td><td><br /></td></tr>
+				</tbody>,
+			],
+		},
+		align: String,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -32,15 +32,17 @@ registerBlockType( 'core/text-columns', {
 
 	attributes: {
 		content: {
-			type: Object, // Array
-			matcher: query( 'p', children() ),
-			defaultValue: [ [], [] ],
+			type: 'array',
+			source: query( 'p', children() ),
+			default: [ [], [] ],
 		},
 		columns: {
-			type: Number,
-			defaultValue: 2,
+			type: 'number',
+			default: 2,
 		},
-		width: String,
+		width: {
+			type: 'string',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -31,12 +31,16 @@ registerBlockType( 'core/text-columns', {
 	category: 'layout',
 
 	attributes: {
-		content: query( 'p', children() ),
-	},
-
-	defaultAttributes: {
-		columns: 2,
-		content: [ [], [] ],
+		content: {
+			type: Object, // Array
+			matcher: query( 'p', children() ),
+			defaultValue: [ [], [] ],
+		},
+		columns: {
+			type: Number,
+			defaultValue: 2,
+		},
+		width: String,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -24,7 +24,10 @@ registerBlockType( 'core/verse', {
 	keywords: [ __( 'poetry' ) ],
 
 	attributes: {
-		content: children( 'pre' ),
+		content: {
+			type: 'array',
+			source: children( 'pre' ),
+		},
 	},
 
 	transforms: {

--- a/blocks/test/fixtures/core__button__center.json
+++ b/blocks/test/fixtures/core__button__center.json
@@ -4,11 +4,11 @@
         "name": "core/button",
         "isValid": true,
         "attributes": {
-            "align": "center",
             "url": "https://github.com/WordPress/gutenberg",
             "text": [
                 "Help build Gutenberg"
-            ]
+            ],
+            "align": "center"
         }
     }
 ]

--- a/blocks/test/fixtures/core__cover-image.json
+++ b/blocks/test/fixtures/core__cover-image.json
@@ -4,9 +4,10 @@
         "name": "core/cover-image",
         "isValid": true,
         "attributes": {
-            "hasBackgroundDim": true,
+            "title": "Guten Berg!",
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
-            "title": "Guten Berg!"
+            "hasParallax": false,
+            "hasBackgroundDim": true
         }
     }
 ]

--- a/blocks/test/fixtures/core__cover-text.json
+++ b/blocks/test/fixtures/core__cover-text.json
@@ -4,12 +4,13 @@
         "name": "core/cover-text",
         "isValid": false,
         "attributes": {
-            "backgroundColor": "#fcb900",
             "content": [
                 [
                     "Text with color."
                 ]
-            ]
+            ],
+            "dropCap": false,
+            "backgroundColor": "#fcb900"
         },
         "originalContent": "<div style=\"background-color:#fcb900\"><p>Text with color.</p></div>"
     }

--- a/blocks/test/fixtures/core__gallery.json
+++ b/blocks/test/fixtures/core__gallery.json
@@ -4,6 +4,7 @@
         "name": "core/gallery",
         "isValid": false,
         "attributes": {
+            "align": "none",
             "images": [
                 {
                     "sizes": {
@@ -37,7 +38,9 @@
                     "url": "http://google.com/hi.png",
                     "alt": "title"
                 }
-            ]
+            ],
+            "imageCrop": true,
+            "linkTo": "none"
         },
         "originalContent": "<div class=\"wp-block-gallery\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>"
     }

--- a/blocks/test/fixtures/core__heading__h2-em.json
+++ b/blocks/test/fixtures/core__heading__h2-em.json
@@ -4,7 +4,6 @@
         "name": "core/heading",
         "isValid": true,
         "attributes": {
-            "nodeName": "H2",
             "content": [
                 "The ",
                 {
@@ -12,7 +11,8 @@
                     "children": "Inserter"
                 },
                 " Tool"
-            ]
+            ],
+            "nodeName": "H2"
         }
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2.json
+++ b/blocks/test/fixtures/core__heading__h2.json
@@ -4,10 +4,10 @@
         "name": "core/heading",
         "isValid": true,
         "attributes": {
-            "nodeName": "H2",
             "content": [
                 "A picture is worth a thousand words, or so the saying goes"
-            ]
+            ],
+            "nodeName": "H2"
         }
     }
 ]

--- a/blocks/test/fixtures/core__image__center-caption.json
+++ b/blocks/test/fixtures/core__image__center-caption.json
@@ -4,11 +4,11 @@
         "name": "core/image",
         "isValid": false,
         "attributes": {
-            "align": "center",
             "url": "https://cldup.com/YLYhpou2oq.jpg",
             "caption": [
                 "Give it a try. Press the \"really wide\" button on the image toolbar."
-            ]
+            ],
+            "align": "center"
         },
         "originalContent": "<figure class=\"wp-block-image\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" class=\"aligncenter\"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>"
     }

--- a/blocks/test/fixtures/core__more.json
+++ b/blocks/test/fixtures/core__more.json
@@ -4,7 +4,6 @@
         "name": "core/more",
         "isValid": true,
         "attributes": {
-            "customText": null,
             "noTeaser": false
         }
     }

--- a/blocks/test/fixtures/core__more__custom-text-teaser.json
+++ b/blocks/test/fixtures/core__more__custom-text-teaser.json
@@ -4,7 +4,6 @@
         "name": "core/more",
         "isValid": true,
         "attributes": {
-            "customText": "Continue Reading",
             "noTeaser": true
         }
     }

--- a/blocks/test/fixtures/core__paragraph__align-right.json
+++ b/blocks/test/fixtures/core__paragraph__align-right.json
@@ -4,11 +4,11 @@
         "name": "core/paragraph",
         "isValid": true,
         "attributes": {
-            "dropCap": false,
-            "align": "right",
             "content": [
                 "... like this one, which is separate from the above and right aligned."
-            ]
+            ],
+            "align": "right",
+            "dropCap": false
         }
     }
 ]

--- a/blocks/test/fixtures/core__pullquote.json
+++ b/blocks/test/fixtures/core__pullquote.json
@@ -12,7 +12,8 @@
             ],
             "citation": [
                 "...with a caption"
-            ]
+            ],
+            "align": "none"
         },
         "originalContent": "<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><footer>...with a caption</footer>\n</blockquote>"
     }

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -22,7 +22,8 @@
             ],
             "citation": [
                 "by whomever"
-            ]
+            ],
+            "align": "none"
         }
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -10,10 +10,10 @@
                     "children": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
                 }
             ],
-            "style": "1",
             "citation": [
                 "Matt Mullenweg, 2017"
-            ]
+            ],
+            "style": 1
         }
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/quote {"style":"1"} -->
+<!-- wp:core/quote -->
 <blockquote class="wp-block-quote blocks-quote-style-1">
     <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
     <footer>Matt Mullenweg, 2017</footer>

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -10,10 +10,10 @@
                     "children": "There is no greater agony than bearing an untold story inside you."
                 }
             ],
-            "style": "2",
             "citation": [
                 "Maya Angelou"
-            ]
+            ],
+            "style": 2
         }
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/quote {"style":"2"} -->
+<!-- wp:core/quote {"style":2} -->
 <blockquote class="wp-block-quote blocks-quote-style-2">
     <p>There is no greater agony than bearing an untold story inside you.</p>
     <footer>Maya Angelou</footer>

--- a/blocks/test/fixtures/core__text-columns.json
+++ b/blocks/test/fixtures/core__text-columns.json
@@ -1,19 +1,19 @@
 [
-	{
-		"attributes": {
-			"columns": 2,
-			"content": [
-				[
-					"One"
-				],
-				[
-					"Two"
-				]
-			],
-			"width": "center"
-		},
-		"isValid": true,
-		"name": "core/text-columns",
-		"uid": "_uid_0"
-	}
+    {
+        "uid": "_uid_0",
+        "name": "core/text-columns",
+        "isValid": true,
+        "attributes": {
+            "content": [
+                [
+                    "One"
+                ],
+                [
+                    "Two"
+                ]
+            ],
+            "columns": 2,
+            "width": "center"
+        }
+    }
 ]

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.json
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.json
@@ -4,7 +4,6 @@
         "name": "core/paragraph",
         "isValid": true,
         "attributes": {
-            "dropCap": false,
             "content": [
                 "This is an old-style text block.  Changed to ",
                 {
@@ -12,7 +11,8 @@
                     "children": "core/paragraph"
                 },
                 " in #2135."
-            ]
+            ],
+            "dropCap": false
         }
     }
 ]

--- a/components/form-token-field/test/index.js
+++ b/components/form-token-field/test/index.js
@@ -21,7 +21,7 @@ const keyCodes = {
 	upArrow: 38,
 	rightArrow: 39,
 	downArrow: 40,
-	'delete': 46,
+	delete: 46,
 	comma: 188,
 };
 

--- a/docs/attribute-matchers.md
+++ b/docs/attribute-matchers.md
@@ -16,7 +16,9 @@ _Example_: Extract the `src` attribute from an image found in the block's markup
 
 ```js
 {
-	url: attr( 'img', 'src' )
+	url: {
+		source: attr( 'img', 'src' )
+	}
 }
 // { "url": "https://lorempixel.com/1200/800/" }
 ```
@@ -29,7 +31,9 @@ _Example_: Extract child nodes from a paragraph of rich text.
 
 ```js
 {
-	content: children( 'p' )	
+	content: {
+		source: children( 'p' )
+	}
 }
 // {
 //   "content": [
@@ -48,10 +52,12 @@ _Example_: Extract `src` and `alt` from each image element in the block's markup
 
 ```js
 {
-	images: query( 'img', {
-		url: attr( 'src' )
-		alt: attr( 'alt' )
-	} )
+	images: {
+		source: query( 'img', {
+			url: attr( 'src' )
+			alt: attr( 'alt' )
+		} )
+	}
 }
 // {
 //   "images": [ 

--- a/docs/blocks-controls.md
+++ b/docs/blocks-controls.md
@@ -28,7 +28,10 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 	category: 'layout',
 
 	attributes: {
-		content: children( 'p' ),
+		content: {
+			type: 'array',
+			source: children( 'p' )
+		}
 	},
 
 	edit: function( props ) {
@@ -98,7 +101,10 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 	category: 'layout',
 
 	attributes: {
-		content: children( 'p' ),
+		content: {
+			type: 'array',
+			source: children( 'p' ),
+		},
 	},
 
 	edit( { attributes, setAttributes, focus } ) {

--- a/docs/blocks-editable.md
+++ b/docs/blocks-editable.md
@@ -24,7 +24,10 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
 	category: 'layout',
 
 	attributes: {
-		content: children( 'p' ),
+		content: {
+			type: 'array',
+			source: children( 'p' )
+		}
 	},
 
 	edit: function( props ) {
@@ -68,7 +71,10 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 	category: 'layout',
 
 	attributes: {
-		content: children( 'p' ),
+		content: {
+			type: 'array',
+			children( 'p' ),
+		},
 	},
 
 	edit( { attributes, setAttributes, focus, className } ) {

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -85,7 +85,7 @@ export default {
 		const isPublished = publishStatus.indexOf( previousPost.status ) !== -1;
 		const messages = {
 			publish: __( 'Post published!' ),
-			'private': __( 'Post published privately!' ),
+			private: __( 'Post published privately!' ),
 			future: __( 'Post scheduled!' ),
 		};
 
@@ -125,7 +125,7 @@ export default {
 		// Unless we publish an "updating failed" message
 		const messages = {
 			publish: __( 'Publishing failed' ),
-			'private': __( 'Publishing failed' ),
+			private: __( 'Publishing failed' ),
 			future: __( 'Scheduling failed' ),
 		};
 		const noticeMessage = ! isPublished && publishStatus.indexOf( edits.status ) !== -1

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -108,7 +108,9 @@ describe( 'effects', () => {
 		it( 'should transform and merge the blocks', () => {
 			registerBlockType( 'core/test-block', {
 				attributes: {
-					content: String,
+					content: {
+						type: 'string',
+					},
 				},
 				merge( attributes, attributesToMerge ) {
 					return {
@@ -119,7 +121,9 @@ describe( 'effects', () => {
 			} );
 			registerBlockType( 'core/test-block-2', {
 				attributes: {
-					content: String,
+					content: {
+						type: 'string',
+					},
 				},
 				transforms: {
 					to: [ {

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -107,6 +107,9 @@ describe( 'effects', () => {
 
 		it( 'should transform and merge the blocks', () => {
 			registerBlockType( 'core/test-block', {
+				attributes: {
+					content: String,
+				},
 				merge( attributes, attributesToMerge ) {
 					return {
 						content: attributes.content + ' ' + attributesToMerge.content,
@@ -115,6 +118,9 @@ describe( 'effects', () => {
 				save: noop,
 			} );
 			registerBlockType( 'core/test-block-2', {
+				attributes: {
+					content: String,
+				},
 				transforms: {
 					to: [ {
 						type: 'blocks',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,7 @@ const externals = {
 
 entryPointNames.forEach( entryPointName => {
 	externals[ '@wordpress/' + entryPointName ] = {
-		'this': [ 'wp', entryPointName ],
+		this: [ 'wp', entryPointName ],
 	};
 } );
 


### PR DESCRIPTION
Closes #865
Closes #973
Supersedes #892, #988
Related: #391, #714

This pull request seeks to refactor the block type `attributes` property to specify not only attributes parsed from content, but also those also encoded in the block comment delimiter. Further, it optionally allows specifying type and default value of an attribute, replacing previous efforts including `defaultAttributes` and render-time destructuring.

The existing behavior of `attributes` matchers will continue to work as-is, but comment attributes are no longer inferred and must instead be explicitly defined. The value of each key in `attributes` can be a matcher, a constructor (type), or an object specifying any of `type`, `matcher`, and `defaultValue`.

See the following comment for the "kitchen sink" example: https://github.com/WordPress/gutenberg/pull/1905#issuecomment-320159018

<p><details>
<summary><strike>See original kitchen sink example</strike></summary>
<pre><code>it( 'should merge attributes with the parsed and default attributes', () => {
	const blockType = {
		attributes: {
			content: text( 'div' ),
			number: {
				type: Number,
				matcher: attr( 'div', 'data-number' ),
			},
			align: String,
			topic: {
				type: String,
				defaultValue: 'none',
			},
			ignoredDomMatcher: {
				matcher: ( node ) => node.innerHTML,
			},
		},
	};

	const rawContent = '<div data-number="10">Ribs</div>';
	const attrs = { align: 'left', invalid: true };

	expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {
		content: 'Ribs',
		number: 10,
		align: 'left',
		topic: 'none',
	} );
} );</code></pre>
</details></p>

~Block authors can potentially implement their own type coercion by specifying a constructor with `valueOf` implementation. There is some inspiration here from [Vue.js prop validation](https://vuejs.org/v2/guide/components.html#Prop-Validation) and [`prop-types`](https://www.npmjs.com/package/prop-types).~ (Removed)

__Testing instructions:__

Ensure that tests pass:

```
npm test
```

Verify that there is no regressions in block usage, particularly:

- Block default values
- Block transforms
- Block serialization of comment attributes