### PR TITLE
Omit serializing block attributes that match any default attribute values

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, isObject } from 'lodash';
+import { isEmpty, reduce, isObject, isEqual, pickBy } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 import classnames from 'classnames';
 
@@ -138,7 +138,12 @@ export function serializeBlock( block ) {
 		saveContent = block.originalContent;
 	}
 
-	const saveAttributes = getCommentAttributes( block.attributes, parseBlockAttributes( saveContent, blockType.attributes ) );
+	let saveAttributes = getCommentAttributes( block.attributes, parseBlockAttributes( saveContent, blockType.attributes ) );
+
+	// Remove attributes that are the same as the defaults.
+	if ( blockType.defaultAttributes ) {
+		saveAttributes = pickBy( saveAttributes, ( value, key ) => ! isEqual( value, blockType.defaultAttributes[ key ] ) );
+	}
 
 	if ( 'core/more' === blockName ) {
 		return `<!--more${ saveAttributes.text ? ` ${ saveAttributes.text }` : '' }-->${ saveAttributes.noTeaser ? '\n<!--noteaser-->' : '' }`;

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -13,6 +13,7 @@ import serialize, {
 	serializeAttributes,
 } from '../serializer';
 import { getBlockTypes, registerBlockType, unregisterBlockType } from '../registration';
+import { createBlock } from '../';
 
 describe( 'block serializer', () => {
 	afterEach( () => {
@@ -195,20 +196,15 @@ describe( 'block serializer', () => {
 				},
 			};
 			registerBlockType( 'core/test-block', blockType );
-			const blockList = [
-				{
-					name: 'core/test-block',
-					attributes: {
-						foo: false,
-						content: 'Ribs & Chicken',
-						stuff: 'left & right -- but <not>',
-					},
-					isValid: true,
-				},
-			];
+
+			const block = createBlock( 'core/test-block', {
+				foo: false,
+				content: 'Ribs & Chicken',
+				stuff: 'left & right -- but <not>',
+			} );
 			const expectedPostContent = '<!-- wp:core/test-block {"foo":false,"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
 
-			expect( serialize( blockList ) ).toEqual( expectedPostContent );
+			expect( serialize( [ block ] ) ).toEqual( expectedPostContent );
 		} );
 	} );
 } );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -181,6 +181,10 @@ describe( 'block serializer', () => {
 	describe( 'serialize()', () => {
 		it( 'should serialize the post content properly', () => {
 			const blockType = {
+				defaultAttributes: {
+					foo: true,
+					bar: false,
+				},
 				attributes: ( rawContent ) => {
 					return {
 						content: rawContent,
@@ -195,13 +199,14 @@ describe( 'block serializer', () => {
 				{
 					name: 'core/test-block',
 					attributes: {
+						foo: false,
 						content: 'Ribs & Chicken',
 						stuff: 'left & right -- but <not>',
 					},
 					isValid: true,
 				},
 			];
-			const expectedPostContent = '<!-- wp:core/test-block {"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
+			const expectedPostContent = '<!-- wp:core/test-block {"foo":false,"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
 
 			expect( serialize( blockList ) ).toEqual( expectedPostContent );
 		} );

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -25,6 +25,10 @@ registerBlockType( 'core/text', {
 
 	category: 'common',
 
+	defaultAttributes: {
+		dropCap: false,
+	},
+
 	className: false,
 
 	attributes: {

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -113,7 +113,7 @@ registerBlockType( 'core/text', {
 
 	save( { attributes } ) {
 		const { align, content, dropCap } = attributes;
-		const className = dropCap && 'has-drop-cap';
+		const className = dropCap ? 'has-drop-cap' : null;
 
 		if ( ! align ) {
 			return <p className={ className }>{ content }</p>;

--- a/blocks/test/fixtures/core__cover-image.serialized.html
+++ b/blocks/test/fixtures/core__cover-image.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/cover-image {"hasBackgroundDim":true,"url":"https://cldup.com/uuUqE_dXzy.jpg"} -->
+<!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg"} -->
 <section class="wp-block-cover-image has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg);">
     <h2>Guten Berg!</h2>
 </section>

--- a/blocks/test/fixtures/core__latest-posts.html
+++ b/blocks/test/fixtures/core__latest-posts.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latest-posts {"postsToShow":5,"displayPostDate":false} /-->
+<!-- wp:core/latest-posts {"postsToShow":5,"displayPostDate":true} /-->

--- a/blocks/test/fixtures/core__latest-posts.json
+++ b/blocks/test/fixtures/core__latest-posts.json
@@ -6,7 +6,7 @@
         "attributes": {
             "columns": 3,
             "postsToShow": 5,
-            "displayPostDate": false,
+            "displayPostDate": true,
             "layout": "list"
         }
     }

--- a/blocks/test/fixtures/core__latest-posts.parsed.json
+++ b/blocks/test/fixtures/core__latest-posts.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/latest-posts",
         "attrs": {
             "postsToShow": 5,
-            "displayPostDate": false
+            "displayPostDate": true
         },
         "rawContent": ""
     },

--- a/blocks/test/fixtures/core__latest-posts.serialized.html
+++ b/blocks/test/fixtures/core__latest-posts.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latest-posts {"postsToShow":5,"displayPostDate":false,"layout":"list","columns":3} /-->
+<!-- wp:core/latest-posts {"displayPostDate":true} /-->

--- a/blocks/test/fixtures/core__text__align-right.json
+++ b/blocks/test/fixtures/core__text__align-right.json
@@ -9,7 +9,8 @@
                 [
                     "... like this one, which is separate from the above and right aligned."
                 ]
-            ]
+            ],
+            "dropCap": false
         }
     }
 ]


### PR DESCRIPTION
Fixes #1768.

Before the patch, the Text block that gets `dropCap` toggled from `true` to `false` gets serialized as:

![image](https://user-images.githubusercontent.com/134745/28236873-a01e13b4-68e6-11e7-84bd-b7f6df629aa0.png)

With the changes, it gets serialized as (note the absence of the default value among the serialized attributes), and the fixed `class` in the Text block:

![image](https://user-images.githubusercontent.com/134745/28236880-dc422c5e-68e6-11e7-8e34-a0bfe9ae4929.png)

When dropCap is toggled back on, it gets serialized to:

![image](https://user-images.githubusercontent.com/134745/28236884-f76f0178-68e6-11e7-82b6-aa41cc491946.png)


