### PR TITLE
Block mover: Position under header

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -13,10 +13,10 @@ $z-layers: (
 	'.editor-inserter__tabs': 1,
 	'.editor-inserter__tab.is-active': 1,
 	'.components-panel__header': 1,
-	'.editor-header': 20,
-	'.editor-post-visibility__dialog': 30,
-	'.editor-post-schedule__dialog': 30,
-	'.editor-block-mover': 30,
+	'.editor-block-mover': 20,
+	'.editor-header': 30,
+	'.editor-post-visibility__dialog': 40,
+	'.editor-post-schedule__dialog': 40,
 
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,


### PR DESCRIPTION
Modify z-indices to position the editor header above the block mover.

**Before**

<img width="209" alt="before" src="https://user-images.githubusercontent.com/841763/28239858-d4eac436-6975-11e7-802d-a2ed4dc1c0da.png">

**After**

<img width="188" alt="after" src="https://user-images.githubusercontent.com/841763/28239859-d8e150d2-6975-11e7-9a67-3b73340c7c5b.png">

Fixes #1860 