### PR TITLE
Add missing headers in the Table of Contents

### DIFF
--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -17,27 +17,83 @@ import { PanelBody } from 'components';
 import './style.scss';
 import { getBlocks } from '../../selectors';
 
+const headingToInt = ( heading ) => {
+	switch ( heading.toUpperCase() ) {
+		case 'H1': return 1;
+		case 'H2': return 2;
+		case 'H3': return 3;
+		case 'H4': return 4;
+		case 'H5': return 5;
+		case 'H6': return 6;
+	}
+};
+
+const headingsInit = () => [ [], 1, 0 ];
+
+const headingsReducer = ( [ hs, previousLevel, index ], heading ) => {
+	const nodeName = heading.attributes.nodeName;
+	const headingLevel = headingToInt( nodeName );
+
+	let valid = heading.attributes.content && heading.attributes.content.length > 0;
+
+	// Headings can go up by one or down by any amount. Otherwise there are missing levels.
+	if ( headingLevel > previousLevel + 1 ) {
+		valid = false;
+		let i = previousLevel + 1;
+		while ( i < headingLevel ) {
+			hs.push(
+				<MissingTocItem key={ index++ } nodeName={ `H${ i }` } />
+			);
+			i++;
+		}
+	}
+
+	return [
+		hs.concat(
+			<TocItem
+				key={ index++ }
+				nodeName={ heading.attributes.nodeName }
+				valid={ valid }
+			>
+				{ heading.attributes.content.length
+					? heading.attributes.content
+					: <em>{ __( '(Empty header)' ) }</em>
+				}
+			</TocItem>
+		),
+		headingLevel,
+		index,
+	];
+};
+
+const TocItem = ( { valid, nodeName, children } ) => (
+	<div
+		className={ classnames(
+			'table-of-contents__item',
+			`is-${ nodeName }`,
+			{
+				'is-invalid': ! valid,
+			}
+		) }
+	>
+		<strong>{ nodeName }</strong>
+		{ children }
+	</div>
+);
+
+const MissingTocItem = ( { nodeName } ) => (
+	<TocItem nodeName={ nodeName }>
+		<em>{ __( '(Missing header level)' ) }</em>
+	</TocItem>
+);
+
 const TableOfContents = ( { blocks } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
-
 	return (
 		<PanelBody title={ __( 'Table of Contents (experimental)' ) } initialOpen={ false }>
 			<div className="table-of-contents__items">
 				{ headings.length > 1 && <p><strong>{ sprintf( '%d Headings', headings.length ) }</strong></p> }
-				{ headings.map( ( heading, index ) =>
-					<div
-						key={ `heading-${ index }` }
-						className={ classnames( 'table-of-contents__item', `is-${ heading.attributes.nodeName }`, {
-							'is-invalid': ! heading.attributes.content || heading.attributes.content.length === 0,
-						} ) }
-					>
-						<strong>{ heading.attributes.nodeName }</strong>
-						{ heading.attributes.content && heading.attributes.content.length > 0
-							? heading.attributes.content
-							: <em>{ __( '(Missing header text)' ) }</em>
-						}
-					</div>
-				) }
+				{ headings.reduce( headingsReducer, headingsInit() )[ 0 ] }
 			</div>
 		</PanelBody>
 	);

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -54,10 +54,9 @@ const isEmptyHeading = heading => ! heading.attributes.content || heading.attrib
 const TableOfContents = ( { blocks } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
 
-	const tocItems = [];
 	let prevHeadingLevel = 1;
 
-	headings.forEach( ( heading, index ) => {
+	const tocItems = headings.map( ( heading, index ) => {
 		const headingLevel = getHeadingLevel( heading );
 		const isEmpty = isEmptyHeading( heading );
 
@@ -71,9 +70,11 @@ const TableOfContents = ( { blocks } ) => {
 			headingLevel
 		);
 
-		tocItems.push(
+		prevHeadingLevel = headingLevel;
+
+		return (
 			<TableOfContentsItem
-				key={ index++ }
+				key={ index }
 				level={ headingLevel }
 				isValid={ isValid }
 			>
@@ -81,8 +82,6 @@ const TableOfContents = ( { blocks } ) => {
 				{ isIncorrectLevel && incorrectLevelContent }
 			</TableOfContentsItem>
 		);
-
-		prevHeadingLevel = headingLevel;
 	} );
 
 	return (

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -1,9 +1,8 @@
 /**
- * External dependencies
+ * External Dependencies
  */
 import { connect } from 'react-redux';
 import { filter } from 'lodash';
-import classnames from 'classnames';
 
 /**
  * WordPress Dependencies
@@ -15,6 +14,7 @@ import { PanelBody } from 'components';
  * Internal Dependencies
  */
 import './style.scss';
+import TableOfContentsItem from './item';
 import { getBlocks } from '../../selectors';
 
 const headingToInt = ( heading ) => {
@@ -42,7 +42,12 @@ const headingsReducer = ( [ hs, previousLevel, index ], heading ) => {
 		let i = previousLevel + 1;
 		while ( i < headingLevel ) {
 			hs.push(
-				<MissingTocItem key={ index++ } nodeName={ `H${ i }` } />
+				<TableOfContentsItem
+					key={ index++ }
+					level={ i }
+				>
+					<em>{ __( '(Missing header level)' ) }</em>
+				</TableOfContentsItem>
 			);
 			i++;
 		}
@@ -50,42 +55,21 @@ const headingsReducer = ( [ hs, previousLevel, index ], heading ) => {
 
 	return [
 		hs.concat(
-			<TocItem
+			<TableOfContentsItem
 				key={ index++ }
-				nodeName={ heading.attributes.nodeName }
+				level={ headingLevel }
 				valid={ valid }
 			>
 				{ heading.attributes.content.length
 					? heading.attributes.content
 					: <em>{ __( '(Empty header)' ) }</em>
 				}
-			</TocItem>
+			</TableOfContentsItem>
 		),
 		headingLevel,
 		index,
 	];
 };
-
-const TocItem = ( { valid, nodeName, children } ) => (
-	<div
-		className={ classnames(
-			'table-of-contents__item',
-			`is-${ nodeName }`,
-			{
-				'is-invalid': ! valid,
-			}
-		) }
-	>
-		<strong>{ nodeName }</strong>
-		{ children }
-	</div>
-);
-
-const MissingTocItem = ( { nodeName } ) => (
-	<TocItem nodeName={ nodeName }>
-		<em>{ __( '(Missing header level)' ) }</em>
-	</TocItem>
-);
 
 const TableOfContents = ( { blocks } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -17,67 +17,77 @@ import './style.scss';
 import TableOfContentsItem from './item';
 import { getBlocks } from '../../selectors';
 
-const headingToInt = ( heading ) => {
-	switch ( heading.toUpperCase() ) {
-		case 'H1': return 1;
-		case 'H2': return 2;
-		case 'H3': return 3;
-		case 'H4': return 4;
-		case 'H5': return 5;
-		case 'H6': return 6;
+/**
+ * Module Constants
+ */
+const missingHeadingContent = <em>{ __( '(Missing header level)' ) }</em>;
+const emptyHeadingContent = <em>{ __( '(Empty header)' ) }</em>;
+
+const getHeadingLevel = heading => {
+	switch ( heading.attributes.nodeName ) {
+		case 'h1':
+		case 'H1':
+			return 1;
+		case 'h2':
+		case 'H2':
+			return 2;
+		case 'h3':
+		case 'H3':
+			return 3;
+		case 'h4':
+		case 'H4':
+			return 4;
+		case 'h5':
+		case 'H5':
+			return 5;
+		case 'h6':
+		case 'H6':
+			return 6;
 	}
 };
 
-const headingsInit = () => [ [], 1, 0 ];
-
-const headingsReducer = ( [ hs, previousLevel, index ], heading ) => {
-	const nodeName = heading.attributes.nodeName;
-	const headingLevel = headingToInt( nodeName );
-
-	let valid = heading.attributes.content && heading.attributes.content.length > 0;
-
-	// Headings can go up by one or down by any amount. Otherwise there are missing levels.
-	if ( headingLevel > previousLevel + 1 ) {
-		valid = false;
-		let i = previousLevel + 1;
-		while ( i < headingLevel ) {
-			hs.push(
-				<TableOfContentsItem
-					key={ index++ }
-					level={ i }
-				>
-					<em>{ __( '(Missing header level)' ) }</em>
-				</TableOfContentsItem>
-			);
-			i++;
-		}
-	}
-
-	return [
-		hs.concat(
-			<TableOfContentsItem
-				key={ index++ }
-				level={ headingLevel }
-				valid={ valid }
-			>
-				{ heading.attributes.content.length
-					? heading.attributes.content
-					: <em>{ __( '(Empty header)' ) }</em>
-				}
-			</TableOfContentsItem>
-		),
-		headingLevel,
-		index,
-	];
-};
+const isEmptyHeading = heading => ! heading.attributes.content || heading.attributes.content.length === 0;
 
 const TableOfContents = ( { blocks } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
+
+	const tocItems = [];
+	let prevHeadingLevel = 1;
+
+	headings.forEach( ( heading, index ) => {
+		const headingLevel = getHeadingLevel( heading );
+		const isEmpty = isEmptyHeading( heading );
+		let isValid = ! isEmpty && headingLevel;
+		// Headings can go up by one or down by any amount. Otherwise there are missing levels.
+		if ( headingLevel > prevHeadingLevel + 1 ) {
+			isValid = false;
+			for ( let missingLevel = prevHeadingLevel + 1; headingLevel > missingLevel; missingLevel++ ) {
+				tocItems.push(
+					<TableOfContentsItem key={ `${ index }.${ missingLevel }` } level={ missingLevel }>
+						{ missingHeadingContent }
+					</TableOfContentsItem>
+				);
+			}
+		}
+
+		tocItems.push(
+			<TableOfContentsItem
+				key={ index++ }
+				level={ headingLevel }
+				isValid={ isValid }
+			>
+				{ isEmpty ? emptyHeadingContent : heading.attributes.content }
+			</TableOfContentsItem>
+		);
+
+		prevHeadingLevel = headingLevel;
+	} );
+
 	return (
 		<PanelBody title={ __( 'Table of Contents (experimental)' ) } initialOpen={ false }>
 			<div className="table-of-contents__items">
 				{ headings.length > 1 && <p><strong>{ sprintf( '%d Headings', headings.length ) }</strong></p> }
-				{ headings.reduce( headingsReducer, headingsInit() )[ 0 ] }
+				{ tocItems }
 			</div>
 		</PanelBody>
 	);

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -21,7 +21,10 @@ import { getBlocks } from '../../selectors';
  * Module Constants
  */
 const emptyHeadingContent = <em>{ __( '(Empty heading)' ) }</em>;
-const incorrectLevelContent = [ <br />, <em>{ __( '(Incorrect heading level)' ) }</em> ];
+const incorrectLevelContent = [
+	<br key="incorrect-break" />,
+	<em key="incorrect-message">{ __( '(Incorrect heading level)' ) }</em>,
+];
 
 const getHeadingLevel = heading => {
 	switch ( heading.attributes.nodeName ) {

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -20,8 +20,8 @@ import { getBlocks } from '../../selectors';
 /**
  * Module Constants
  */
-const missingHeadingContent = <em>{ __( '(Missing header level)' ) }</em>;
-const emptyHeadingContent = <em>{ __( '(Empty header)' ) }</em>;
+const missingHeadingContent = <em>{ __( '(Missing heading level)' ) }</em>;
+const emptyHeadingContent = <em>{ __( '(Empty heading)' ) }</em>;
 
 const getHeadingLevel = heading => {
 	switch ( heading.attributes.nodeName ) {

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -20,8 +20,8 @@ import { getBlocks } from '../../selectors';
 /**
  * Module Constants
  */
-const missingHeadingContent = <em>{ __( '(Missing heading level)' ) }</em>;
 const emptyHeadingContent = <em>{ __( '(Empty heading)' ) }</em>;
+const incorrectLevelContent = [ <br />, <em>{ __( '(Incorrect heading level)' ) }</em> ];
 
 const getHeadingLevel = heading => {
 	switch ( heading.attributes.nodeName ) {
@@ -57,18 +57,16 @@ const TableOfContents = ( { blocks } ) => {
 	headings.forEach( ( heading, index ) => {
 		const headingLevel = getHeadingLevel( heading );
 		const isEmpty = isEmptyHeading( heading );
-		let isValid = ! isEmpty && headingLevel;
-		// Headings can go up by one or down by any amount. Otherwise there are missing levels.
-		if ( headingLevel > prevHeadingLevel + 1 ) {
-			isValid = false;
-			for ( let missingLevel = prevHeadingLevel + 1; headingLevel > missingLevel; missingLevel++ ) {
-				tocItems.push(
-					<TableOfContentsItem key={ `${ index }.${ missingLevel }` } level={ missingLevel }>
-						{ missingHeadingContent }
-					</TableOfContentsItem>
-				);
-			}
-		}
+
+		// Headings remain the same, go up by one, or down by any amount.
+		// Otherwise there are missing levels.
+		const isIncorrectLevel = headingLevel > prevHeadingLevel + 1;
+
+		const isValid = (
+			! isEmpty &&
+			! isIncorrectLevel &&
+			headingLevel
+		);
 
 		tocItems.push(
 			<TableOfContentsItem
@@ -77,6 +75,7 @@ const TableOfContents = ( { blocks } ) => {
 				isValid={ isValid }
 			>
 				{ isEmpty ? emptyHeadingContent : heading.attributes.content }
+				{ isIncorrectLevel && incorrectLevelContent }
 			</TableOfContentsItem>
 		);
 

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -85,7 +85,7 @@ const TableOfContents = ( { blocks } ) => {
 	} );
 
 	return (
-		<PanelBody title={ __( 'Table of Contents (experimental)' ) } initialOpen={ false }>
+		<PanelBody title={ __( 'Table of Contents' ) } initialOpen={ false }>
 			<div className="table-of-contents__items">
 				{ headings.length > 1 && <p><strong>{ sprintf( '%d Headings', headings.length ) }</strong></p> }
 				{ tocItems }

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -1,24 +1,24 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { connect } from 'react-redux';
 import { filter } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { __, sprintf } from 'i18n';
 import { PanelBody } from 'components';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import './style.scss';
 import TableOfContentsItem from './item';
 import { getBlocks } from '../../selectors';
 
 /**
- * Module Constants
+ * Module constants
  */
 const emptyHeadingContent = <em>{ __( '(Empty heading)' ) }</em>;
 const incorrectLevelContent = [
@@ -54,6 +54,10 @@ const isEmptyHeading = heading => ! heading.attributes.content || heading.attrib
 const TableOfContents = ( { blocks } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
 
+	if ( headings.length <= 1 ) {
+		return null;
+	}
+
 	let prevHeadingLevel = 1;
 
 	const tocItems = headings.map( ( heading, index ) => {
@@ -87,8 +91,8 @@ const TableOfContents = ( { blocks } ) => {
 	return (
 		<PanelBody title={ __( 'Table of Contents' ) } initialOpen={ false }>
 			<div className="table-of-contents__items">
-				{ headings.length > 1 && <p><strong>{ sprintf( '%d Headings', headings.length ) }</strong></p> }
-				{ tocItems }
+				<p><strong>{ sprintf( '%d Headings', headings.length ) }</strong></p>
+				<ul>{ tocItems }</ul>
 			</div>
 		</PanelBody>
 	);

--- a/editor/sidebar/table-of-contents/item.js
+++ b/editor/sidebar/table-of-contents/item.js
@@ -3,13 +3,17 @@
  */
 import classnames from 'classnames';
 
-const TableOfContentsItem = ( { valid, level, children } ) => (
+const TableOfContentsItem = ( {
+	children,
+	isValid,
+	level,
+} ) => (
 	<div
 		className={ classnames(
 			'table-of-contents__item',
 			`is-H${ level }`,
 			{
-				'is-invalid': ! valid,
+				'is-invalid': ! isValid,
 			}
 		) }
 	>

--- a/editor/sidebar/table-of-contents/item.js
+++ b/editor/sidebar/table-of-contents/item.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+const TableOfContentsItem = ( { valid, level, children } ) => (
+	<div
+		className={ classnames(
+			'table-of-contents__item',
+			`is-H${ level }`,
+			{
+				'is-invalid': ! valid,
+			}
+		) }
+	>
+		<strong>H{ level }</strong>
+		{ children }
+	</div>
+);
+
+export default TableOfContentsItem;

--- a/editor/sidebar/table-of-contents/item.js
+++ b/editor/sidebar/table-of-contents/item.js
@@ -10,15 +10,19 @@ const TableOfContentsItem = ( {
 } ) => (
 	<div
 		className={ classnames(
-			'table-of-contents__item',
+			'table-of-contents-item',
 			`is-h${ level }`,
 			{
 				'is-invalid': ! isValid,
 			}
 		) }
 	>
-		<strong>H{ level }</strong>
-		{ children }
+		<strong className="table-of-contents-item__level">
+			H{ level }
+		</strong>
+		<div className="table-of-contents-item__content">
+			{ children }
+		</div>
 	</div>
 );
 

--- a/editor/sidebar/table-of-contents/item.js
+++ b/editor/sidebar/table-of-contents/item.js
@@ -11,7 +11,7 @@ const TableOfContentsItem = ( {
 	<div
 		className={ classnames(
 			'table-of-contents__item',
-			`is-H${ level }`,
+			`is-h${ level }`,
 			{
 				'is-invalid': ! isValid,
 			}

--- a/editor/sidebar/table-of-contents/item.js
+++ b/editor/sidebar/table-of-contents/item.js
@@ -8,7 +8,7 @@ const TableOfContentsItem = ( {
 	isValid,
 	level,
 } ) => (
-	<div
+	<li
 		className={ classnames(
 			'table-of-contents-item',
 			`is-h${ level }`,
@@ -17,13 +17,14 @@ const TableOfContentsItem = ( {
 			}
 		) }
 	>
+		<span className="table-of-contents-item__emdash" aria-hidden="true"></span>
 		<strong className="table-of-contents-item__level">
 			H{ level }
 		</strong>
-		<div className="table-of-contents-item__content">
+		<span className="table-of-contents-item__content">
 			{ children }
-		</div>
-	</div>
+		</span>
+	</li>
 );
 
 export default TableOfContentsItem;

--- a/editor/sidebar/table-of-contents/style.scss
+++ b/editor/sidebar/table-of-contents/style.scss
@@ -2,21 +2,9 @@
 	margin: 20px 0;
 }
 
-.table-of-contents__item {
+.table-of-contents-item {
+	display: flex;
 	margin: 4px 0;
-
-	strong {
-		background: $light-gray-500;
-		color: $dark-gray-800;
-		border-radius: 3px;
-		font-size: 12px;
-		padding: 2px 6px;
-		margin-right: 4px;
-	}
-
-	&.is-invalid strong {
-		background: $alert-yellow;
-	}
 
 	&::before {
 		color: $light-gray-500;
@@ -41,5 +29,19 @@
 
 	&.is-h6::before {
 		content: '—————';
+	}
+}
+
+.table-of-contents-item__level {
+	align-self: start;
+	background: $light-gray-500;
+	color: $dark-gray-800;
+	border-radius: 3px;
+	font-size: 12px;
+	padding: 2px 6px;
+	margin-right: 4px;
+
+	.is-invalid & {
+		background: $alert-yellow;
 	}
 }

--- a/editor/sidebar/table-of-contents/style.scss
+++ b/editor/sidebar/table-of-contents/style.scss
@@ -23,23 +23,23 @@
 		margin-right: 4px;
 	}
 
-	&.is-H2::before {
+	&.is-h2::before {
 		content: '—';
 	}
 
-	&.is-H3::before {
+	&.is-h3::before {
 		content: '——';
 	}
 
-	&.is-H4::before {
+	&.is-h4::before {
 		content: '———';
 	}
 
-	&.is-H5::before {
+	&.is-h5::before {
 		content: '————';
 	}
 
-	&.is-H6::before {
+	&.is-h6::before {
 		content: '—————';
 	}
 }

--- a/editor/sidebar/table-of-contents/style.scss
+++ b/editor/sidebar/table-of-contents/style.scss
@@ -4,36 +4,36 @@
 
 .table-of-contents-item {
 	display: flex;
+	align-items: flex-start;
 	margin: 4px 0;
 
-	&::before {
+	.table-of-contents-item__emdash::before {
 		color: $light-gray-500;
 		margin-right: 4px;
 	}
 
-	&.is-h2::before {
+	&.is-h2 .table-of-contents-item__emdash::before {
 		content: '—';
 	}
 
-	&.is-h3::before {
+	&.is-h3 .table-of-contents-item__emdash::before {
 		content: '——';
 	}
 
-	&.is-h4::before {
+	&.is-h4 .table-of-contents-item__emdash::before {
 		content: '———';
 	}
 
-	&.is-h5::before {
+	&.is-h5 .table-of-contents-item__emdash::before {
 		content: '————';
 	}
 
-	&.is-h6::before {
+	&.is-h6 .table-of-contents-item__emdash::before {
 		content: '—————';
 	}
 }
 
 .table-of-contents-item__level {
-	align-self: start;
 	background: $light-gray-500;
 	color: $dark-gray-800;
 	border-radius: 3px;


### PR DESCRIPTION
Add missing headers to the Table of Contents.
Separate `TableOfContentsItem` into independent component.

![toc](https://user-images.githubusercontent.com/841763/28407844-e9ccceee-6d35-11e7-9f9e-6743d9e0822d.png)

Closes #1903 