### PR TITLE
withFocusReturn: Get the document activeElement before the component mounts.

### DIFF
--- a/components/higher-order/with-focus-return/index.js
+++ b/components/higher-order/with-focus-return/index.js
@@ -14,7 +14,7 @@ import { Component, findDOMNode } from 'element';
  */
 function withFocusReturn( WrappedComponent ) {
 	return class extends Component {
-		componentDidMount() {
+		componentWillMount() {
 			this.activeElement = document.activeElement;
 		}
 


### PR DESCRIPTION
When components get mounted and focus is set on some element within the mounted component (like what happens for the Inserter menu search field with autoFocus), `withFocusReturn` will use that and will try to move focus back to the wrong element.

To correctly get the currently focused element before a component gets mounted, `document.activeElement` should be detected _before_ the new component mounts.

To test:

- open the inserter using the keyboard
- observe the search field gets auto-focused
- tab to some item in the inserter menu
- press Escape
- focus is not moved back to the inserter toggle button

Switch to this branch, and repeat the steps above:
- focus is correctly moved back to the inserter toggle button

Fixes #1917 