### PR TITLE
Specify fallback value for post visibility password

### DIFF
--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -157,7 +157,7 @@ class PostVisibility extends Component {
 									id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
 									type="text"
 									onChange={ updatePassword }
-									value={ password }
+									value={ password || '' }
 									placeholder={ __( 'Use a secure password' ) }
 								/>
 							</div>


### PR DESCRIPTION
This pull request resolve a warning which occurs when setting the post visibility to "Password protected".

>Warning: A component is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components

__Implementation notes:__

The issue occurs because when a post does not have a password, the `getEditedPostAttribute` selector returns `undefined`. React treats an `undefined` input value as an "uncontrolled" input, meaning it should never thereafter have a value explicitly assigned. Since the behavior of the input is otherwise controlled (has `onChange` specified to assign value into state) we should instead treat the input as controlled.

An alternate solution is to change the behavior of `getEditedPostAttribute` to return `null` if the value is not assigned. This may be preferable, as `null` is a more accurate representation of "explicitly no value" vs. "not assigned" (https://stackoverflow.com/a/5076962).

__Testing instructions:__

Verify that no warning is shown in the developer tools console when changing to Password Protected visibility:

1. Navigate to Gutenberg > New Post
2. In the sidebar, click Public (Visibility)
3. Select Password Protected
4. Note that no warning is logged in the developer tools console