### PR TITLE
Strip extra version identifier from wp_version in comparison

### DIFF
--- a/lib/init-checks.php
+++ b/lib/init-checks.php
@@ -31,7 +31,7 @@ function gutenberg_wordpress_version_notice() {
 function gutenberg_can_init() {
 	global $wp_version;
 
-	if ( version_compare( $wp_version, '4.8', '<' ) ) {
+	if ( version_compare( strtok( $wp_version, '-' ), '4.8', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
 		return false;
 	}


### PR DESCRIPTION
It seems `version_compare()` doesn't take kindly to the `-src` and `-beta` identifiers that we add to `$wp_version`. Case in point:

```php
true === version_compare( '4.8-src', '4.8', '<' )
```

When clearly we want this to be `false`. When I switch to `4.8` branch on `wordpress-develop` I get this:

![image](https://user-images.githubusercontent.com/134745/28297279-e365d944-6b21-11e7-9ade-a95a5de7c98a.png)

So this patch fixes that.