### PR TITLE
Block table: allow tabbing away from the table.

### DIFF
--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -77,6 +77,7 @@ export default class TableBlock extends wp.element.Component {
 				getSettings={ ( settings ) => ( {
 					...settings,
 					plugins: ( settings.plugins || [] ).concat( 'table' ),
+					table_tab_navigation: false,
 				} ) }
 				onSetup={ ( editor ) => this.handleSetup( editor, focus ) }
 				onChange={ onChange }


### PR DESCRIPTION
This PR sets the TinyMCE table plugin `table_tab_navigation` option to `false` to allow users to tab away from the table cells. Keyboard navigation through cells works with arrow keys only.

Worth noting, while working on this I've noticed _sometimes_ it isn't possible to set focus on the table cells using a keyboard. Couldn't reproduce consistently though and I _think_ it's something unrelated to this PR. I've also checked #1793 and #1751 but couldn't find any hint to investigate further.

Fixes #1839 