### PR TITLE
Create gallery opens correct Media Library modal

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -11,7 +11,6 @@ import { pick } from 'lodash';
 import './style.scss';
 import './block.scss';
 import { registerBlockType } from '../../api';
-import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
 import RangeControl from '../../inspector-controls/range-control';
 import ToggleControl from '../../inspector-controls/toggle-control';
@@ -21,6 +20,13 @@ import GalleryImage from './gallery-image';
 import BlockDescription from '../../block-description';
 
 const MAX_COLUMNS = 8;
+
+// the media library image object contains numerous attributes
+// we only need this set to display the image in the library
+const slimImageObjects = ( imgs ) => {
+	const attrSet = [ 'sizes', 'mime', 'type', 'subtype', 'id', 'url', 'alt' ];
+	return imgs.map( ( img ) => pick( img, attrSet ) );
+};
 
 const createMediaLibrary = ( attributes, setAttributes ) => {
 	const frameConfig = {
@@ -44,9 +50,9 @@ const createMediaLibrary = ( attributes, setAttributes ) => {
 
 	function updateFn() {
 		setAttributes( {
-			images: this.frame.state().attributes.library.models.map( ( a ) => {
+			images: slimImageObjects( this.frame.state().attributes.library.models.map( ( a ) => {
 				return a.attributes;
-			} ),
+			} ) ),
 		} );
 	}
 
@@ -76,22 +82,15 @@ const editMediaLibrary = ( attributes, setAttributes ) => {
 
 	function updateFn() {
 		setAttributes( {
-			images: this.frame.state().attributes.library.models.map( ( a ) => {
+			images: slimImageObjects( this.frame.state().attributes.library.models.map( ( a ) => {
 				return a.attributes;
-			} ),
+			} ) ),
 		} );
 	}
 
 	editFrame.on( 'insert', updateFn );
 	editFrame.state( 'gallery-edit' ).on( 'update', updateFn );
 	editFrame.open( 'gutenberg-gallery' );
-};
-
-// the media library image object contains numerous attributes
-// we only need this set to display the image in the library
-const slimImageObjects = ( imgs ) => {
-	const attrSet = [ 'sizes', 'mime', 'type', 'subtype', 'id', 'url', 'alt' ];
-	return imgs.map( ( img ) => pick( img, attrSet ) );
 };
 
 function defaultColumnsNumber( attributes ) {
@@ -138,9 +137,6 @@ registerBlockType( 'core/gallery', {
 		);
 
 		if ( images.length === 0 ) {
-			const setMediaUrl = ( imgs ) => setAttributes( { images: slimImageObjects( imgs ) } );
-			const uploadButtonProps = { isLarge: true };
-
 			return [
 				controls,
 				<Placeholder
@@ -150,6 +146,7 @@ registerBlockType( 'core/gallery', {
 					label={ __( 'Gallery' ) }
 					className={ className }>
 					<Button
+						isLarge="true"
 						onClick={ () => createMediaLibrary( attributes, setAttributes ) }
 					>
 						{ __( 'Insert from Media Library' ) }

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -60,9 +60,9 @@ const openMediaLibrary = ( frameConfig, attributes, setAttributes ) => {
 
 	function updateFn() {
 		setAttributes( {
-			images: this.frame.state().attributes.library.models.map( ( a ) => {
+			images: slimImageObjects( this.frame.state().attributes.library.models.map( ( a ) => {
 				return a.attributes;
-			} ),
+			} ) ),
 		} );
 	}
 

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Toolbar, Placeholder } from 'components';
+import { Button, Toolbar, Placeholder } from 'components';
 import { pick } from 'lodash';
 
 /**
@@ -22,6 +22,39 @@ import BlockDescription from '../../block-description';
 
 const MAX_COLUMNS = 8;
 
+const createMediaLibrary = ( attributes, setAttributes ) => {
+	const frameConfig = {
+		frame: 'post',
+		title: __( 'Create Gallery' ),
+		button: {
+			text: __( 'Select' ),
+		},
+		multiple: 'add',
+		state: 'gallery',
+		toolbar: 'main-gallery',
+		menu: 'gallery',
+		selection: new wp.media.model.Selection( attributes.images, { multiple: true } ),
+	};
+
+	const createFrame = wp.media( frameConfig );
+
+	// the frameConfig settings dont carry to other state modals
+	// so requires setting this attribute directory to not show settings
+	createFrame.state( 'gallery' ).attributes.displaySettings = false;
+
+	function updateFn() {
+		setAttributes( {
+			images: this.frame.state().attributes.library.models.map( ( a ) => {
+				return a.attributes;
+			} ),
+		} );
+	}
+
+	createFrame.on( 'insert', updateFn );
+	createFrame.state( 'gallery-edit' ).on( 'update', updateFn );
+	createFrame.open( 'gutenberg-gallery' );
+};
+
 const editMediaLibrary = ( attributes, setAttributes ) => {
 	const frameConfig = {
 		frame: 'post',
@@ -31,6 +64,7 @@ const editMediaLibrary = ( attributes, setAttributes ) => {
 		},
 		multiple: true,
 		state: 'gallery-edit',
+
 		selection: new wp.media.model.Selection( attributes.images, { multiple: true } ),
 	};
 
@@ -115,14 +149,11 @@ registerBlockType( 'core/gallery', {
 					icon="format-gallery"
 					label={ __( 'Gallery' ) }
 					className={ className }>
-					<MediaUploadButton
-						buttonProps={ uploadButtonProps }
-						onSelect={ setMediaUrl }
-						type="image"
-						multiple="true"
+					<Button
+						onClick={ () => createMediaLibrary( attributes, setAttributes ) }
 					>
 						{ __( 'Insert from Media Library' ) }
-					</MediaUploadButton>
+					</Button>
 				</Placeholder>,
 			];
 		}

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -28,69 +28,47 @@ const slimImageObjects = ( imgs ) => {
 	return imgs.map( ( img ) => pick( img, attrSet ) );
 };
 
-const createMediaLibrary = ( attributes, setAttributes ) => {
-	const frameConfig = {
-		frame: 'post',
-		title: __( 'Create Gallery' ),
-		button: {
-			text: __( 'Select' ),
-		},
-		multiple: 'add',
-		state: 'gallery',
-		toolbar: 'main-gallery',
-		menu: 'gallery',
-		selection: new wp.media.model.Selection( attributes.images, { multiple: true } ),
-	};
-
-	const createFrame = wp.media( frameConfig );
-
-	// the frameConfig settings dont carry to other state modals
-	// so requires setting this attribute directory to not show settings
-	createFrame.state( 'gallery' ).attributes.displaySettings = false;
-
-	function updateFn() {
-		setAttributes( {
-			images: slimImageObjects( this.frame.state().attributes.library.models.map( ( a ) => {
-				return a.attributes;
-			} ) ),
-		} );
-	}
-
-	createFrame.on( 'insert', updateFn );
-	createFrame.state( 'gallery-edit' ).on( 'update', updateFn );
-	createFrame.open( 'gutenberg-gallery' );
+const createFrameConfig = {
+	frame: 'post',
+	title: __( 'Create Gallery' ),
+	button: {
+		text: __( 'Select' ),
+	},
+	multiple: true,
+	state: 'gallery',
+	toolbar: 'main-gallery',
+	menu: 'gallery',
 };
 
-const editMediaLibrary = ( attributes, setAttributes ) => {
-	const frameConfig = {
-		frame: 'post',
-		title: __( 'Update Gallery media' ),
-		button: {
-			text: __( 'Select' ),
-		},
-		multiple: true,
-		state: 'gallery-edit',
+const editFrameConfig = {
+	frame: 'post',
+	title: __( 'Update Gallery media' ),
+	button: {
+		text: __( 'Select' ),
+	},
+	multiple: true,
+	state: 'gallery-edit',
+};
 
-		selection: new wp.media.model.Selection( attributes.images, { multiple: true } ),
-	};
-
-	const editFrame = wp.media( frameConfig );
+const openMediaLibrary = ( frameConfig, attributes, setAttributes ) => {
+	frameConfig.selection = new wp.media.model.Selection( attributes.images, { multiple: true } );
+	const mediaFrame = wp.media( frameConfig );
 
 	// the frameConfig settings dont carry to other state modals
 	// so requires setting this attribute directory to not show settings
-	editFrame.state( 'gallery-edit' ).attributes.displaySettings = false;
+	mediaFrame.state( 'gallery' ).attributes.displaySettings = false;
 
 	function updateFn() {
 		setAttributes( {
-			images: slimImageObjects( this.frame.state().attributes.library.models.map( ( a ) => {
+			images: this.frame.state().attributes.library.models.map( ( a ) => {
 				return a.attributes;
-			} ) ),
+			} ),
 		} );
 	}
 
-	editFrame.on( 'insert', updateFn );
-	editFrame.state( 'gallery-edit' ).on( 'update', updateFn );
-	editFrame.open( 'gutenberg-gallery' );
+	mediaFrame.on( 'insert', updateFn );
+	mediaFrame.state( 'gallery-edit' ).on( 'update', updateFn );
+	mediaFrame.open( 'gutenberg-gallery' );
 };
 
 function defaultColumnsNumber( attributes ) {
@@ -129,7 +107,7 @@ registerBlockType( 'core/gallery', {
 						<Toolbar controls={ [ {
 							icon: 'edit',
 							title: __( 'Edit Gallery' ),
-							onClick: () => editMediaLibrary( attributes, setAttributes ),
+							onClick: () => openMediaLibrary( editFrameConfig, attributes, setAttributes ),
 						} ] } />
 					) }
 				</BlockControls>
@@ -147,7 +125,7 @@ registerBlockType( 'core/gallery', {
 					className={ className }>
 					<Button
 						isLarge="true"
-						onClick={ () => createMediaLibrary( attributes, setAttributes ) }
+						onClick={ () => openMediaLibrary( createFrameConfig, attributes, setAttributes ) }
 					>
 						{ __( 'Insert from Media Library' ) }
 					</Button>


### PR DESCRIPTION
When creating a new gallery, the initial open should use the "Create Gallery" media modal which automatically multi-selects images when clicked on them.

Fixes #1444 