### PR TITLE
Reveal the Continue Writing controls also on focus

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -11,7 +11,7 @@ import { throttle, reduce, noop } from 'lodash';
 import { __ } from 'i18n';
 import { Component } from 'element';
 import { serialize, getDefaultBlock, createBlock } from 'blocks';
-import { Dashicon } from 'components';
+import { IconButton, Dashicon } from 'components';
 import { ENTER } from 'utils/keycodes';
 
 /**
@@ -265,24 +265,22 @@ class VisualEditorBlockList extends Component {
 					onBlur={ this.toggleContinueWritingControls( false ) }
 				>
 					<Inserter position="top right" />
-					<button
-						type="button"
+					<IconButton
+						icon="text"
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( 'core/text' ) }
 						aria-label={ __( 'Insert text block' ) }
 					>
-						<Dashicon icon="text" />
 						{ __( 'Text' ) }
-					</button>
-					<button
-						type="button"
+					</IconButton>
+					<IconButton
+						icon="format-image"
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( 'core/image' ) }
 						aria-label={ __( 'Insert image block' ) }
 					>
-						<Dashicon icon="format-image" />
 						{ __( 'Image' ) }
-					</button>
+					</IconButton>
 				</div>
 			</div>
 		);

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 import { throttle, reduce, noop } from 'lodash';
 
 /**
@@ -34,7 +35,9 @@ const INSERTION_POINT_PLACEHOLDER = '[[insertion-point]]';
 class VisualEditorBlockList extends Component {
 	constructor( props ) {
 		super( props );
-
+		this.state = {
+			showContinueWritingControls: false,
+		};
 		this.onSelectionStart = this.onSelectionStart.bind( this );
 		this.onSelectionChange = this.onSelectionChange.bind( this );
 		this.onSelectionEnd = this.onSelectionEnd.bind( this );
@@ -45,6 +48,8 @@ class VisualEditorBlockList extends Component {
 		this.setLastClientY = this.setLastClientY.bind( this );
 		this.onPointerMove = throttle( this.onPointerMove.bind( this ), 250 );
 		this.onPlaceholderKeyDown = this.onPlaceholderKeyDown.bind( this );
+		this.onContinueWritingFocus = this.onContinueWritingFocus.bind( this );
+		this.onContinueWritingBlur = this.onContinueWritingBlur.bind( this );
 		// Browser does not fire `*move` event when the pointer position changes
 		// relative to the document, so fire it with the last known position.
 		this.onScroll = () => this.onPointerMove( { clientY: this.lastClientY } );
@@ -198,6 +203,18 @@ class VisualEditorBlockList extends Component {
 		this.props.onInsertBlock( newBlock );
 	}
 
+	onContinueWritingFocus() {
+		this.setState( {
+			showContinueWritingControls: true,
+		} );
+	}
+
+	onContinueWritingBlur() {
+		this.setState( {
+			showContinueWritingControls: false,
+		} );
+	}
+
 	render() {
 		const {
 			blocks,
@@ -214,6 +231,9 @@ class VisualEditorBlockList extends Component {
 				...blocks.slice( insertionPointIndex + 1 ),
 			]
 			: blocks;
+		const continueWritingClassname = classnames( 'editor-visual-editor__continue-writing', {
+			'show-controls': this.state.showContinueWritingControls,
+		} );
 
 		return (
 			<div>
@@ -248,11 +268,16 @@ class VisualEditorBlockList extends Component {
 						onKeyDown={ noop }
 					/>
 				}
-				<div className="editor-visual-editor__continue-writing">
+				<div
+					className={ continueWritingClassname }
+					onFocus={ this.onContinueWritingFocus }
+					onBlur={ this.onContinueWritingBlur }
+				>
 					<Inserter position="top right" />
 					<button
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( 'core/text' ) }
+						aria-label={ __( 'Insert text block' ) }
 					>
 						<Dashicon icon="text" />
 						{ __( 'Text' ) }
@@ -260,6 +285,7 @@ class VisualEditorBlockList extends Component {
 					<button
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( 'core/image' ) }
+						aria-label={ __( 'Insert image block' ) }
 					>
 						<Dashicon icon="format-image" />
 						{ __( 'Image' ) }

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -11,7 +11,7 @@ import { throttle, reduce, noop } from 'lodash';
 import { __ } from 'i18n';
 import { Component } from 'element';
 import { serialize, getDefaultBlock, createBlock } from 'blocks';
-import { IconButton, Dashicon } from 'components';
+import { IconButton } from 'components';
 import { ENTER } from 'utils/keycodes';
 
 /**

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -48,8 +48,7 @@ class VisualEditorBlockList extends Component {
 		this.setLastClientY = this.setLastClientY.bind( this );
 		this.onPointerMove = throttle( this.onPointerMove.bind( this ), 250 );
 		this.onPlaceholderKeyDown = this.onPlaceholderKeyDown.bind( this );
-		this.onContinueWritingFocus = this.onContinueWritingFocus.bind( this );
-		this.onContinueWritingBlur = this.onContinueWritingBlur.bind( this );
+		this.toggleContinueWritingControls = this.toggleContinueWritingControls.bind( this );
 		// Browser does not fire `*move` event when the pointer position changes
 		// relative to the document, so fire it with the last known position.
 		this.onScroll = () => this.onPointerMove( { clientY: this.lastClientY } );
@@ -203,16 +202,8 @@ class VisualEditorBlockList extends Component {
 		this.props.onInsertBlock( newBlock );
 	}
 
-	onContinueWritingFocus() {
-		this.setState( {
-			showContinueWritingControls: true,
-		} );
-	}
-
-	onContinueWritingBlur() {
-		this.setState( {
-			showContinueWritingControls: false,
-		} );
+	toggleContinueWritingControls( showContinueWritingControls ) {
+		return () => this.setState( { showContinueWritingControls } );
 	}
 
 	render() {
@@ -232,7 +223,7 @@ class VisualEditorBlockList extends Component {
 			]
 			: blocks;
 		const continueWritingClassname = classnames( 'editor-visual-editor__continue-writing', {
-			'show-controls': this.state.showContinueWritingControls,
+			'is-showing-controls': this.state.showContinueWritingControls,
 		} );
 
 		return (
@@ -270,11 +261,12 @@ class VisualEditorBlockList extends Component {
 				}
 				<div
 					className={ continueWritingClassname }
-					onFocus={ this.onContinueWritingFocus }
-					onBlur={ this.onContinueWritingBlur }
+					onFocus={ this.toggleContinueWritingControls( true ) }
+					onBlur={ this.toggleContinueWritingControls( false ) }
 				>
 					<Inserter position="top right" />
 					<button
+						type="button"
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( 'core/text' ) }
 						aria-label={ __( 'Insert text block' ) }
@@ -283,6 +275,7 @@ class VisualEditorBlockList extends Component {
 						{ __( 'Text' ) }
 					</button>
 					<button
+						type="button"
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( 'core/image' ) }
 						aria-label={ __( 'Insert image block' ) }

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -269,7 +269,7 @@ class VisualEditorBlockList extends Component {
 						icon="text"
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( 'core/text' ) }
-						aria-label={ __( 'Insert text block' ) }
+						label={ __( 'Insert text block' ) }
 					>
 						{ __( 'Text' ) }
 					</IconButton>
@@ -277,7 +277,7 @@ class VisualEditorBlockList extends Component {
 						icon="format-image"
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( 'core/image' ) }
-						aria-label={ __( 'Insert image block' ) }
+						label={ __( 'Insert image block' ) }
 					>
 						{ __( 'Image' ) }
 					</IconButton>

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -372,8 +372,9 @@ $sticky-bottom-offset: 20px;
 		font-family: $default-font;
 		font-size: $default-font-size;
 	}
+
 	&:hover > .editor-inserter__block,
-	&:focus > .editor-inserter__block {
+	&.show-controls > .editor-inserter__block {
 		opacity: 1;
 	}
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -371,6 +371,7 @@ $sticky-bottom-offset: 20px;
 		width: auto;
 		font-family: $default-font;
 		font-size: $default-font-size;
+		box-shadow: none;
 	}
 
 	&:hover > .editor-inserter__block,

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -374,7 +374,7 @@ $sticky-bottom-offset: 20px;
 	}
 
 	&:hover > .editor-inserter__block,
-	&.show-controls > .editor-inserter__block {
+	&.is-showing-controls > .editor-inserter__block {
 		opacity: 1;
 	}
 }


### PR DESCRIPTION
This PR tries to make the "Continue Writing" controls at the bottom of the editor...

![text image bottom](https://user-images.githubusercontent.com/1682452/28332457-29c01fac-6bf5-11e7-95ff-7bc9d6b944b2.png)

revealed also on focus when navigating content with a keyboard.

Also, adds an `aria-label` to the Text and Image button since they're out of the context of the inserter menu, they're announced by screen readers just as `button Text` and `button Image` and need to be clarified a bit.

Fixes #1939 