### PR TITLE
Handle undo / redo keyboard events

### DIFF
--- a/blocks/editable/provider.js
+++ b/blocks/editable/provider.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { pick, noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+
+/**
+ * The Editable Provider allows a rendering context to define global behaviors
+ * without requiring intermediate props to be passed through to the Editable.
+ * The provider accepts as props its `childContextTypes` which are passed to
+ * any Editable instance.
+ */
+class EditableProvider extends Component {
+	getChildContext() {
+		return pick(
+			this.props,
+			Object.keys( this.constructor.childContextTypes )
+		);
+	}
+
+	render() {
+		return this.props.children;
+	}
+}
+
+EditableProvider.childContextTypes = {
+	onUndo: noop,
+};
+
+export default EditableProvider;

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -18,5 +18,6 @@ export { default as BlockControls } from './block-controls';
 export { default as BlockDescription } from './block-description';
 export { default as BlockIcon } from './block-icon';
 export { default as Editable } from './editable';
+export { default as EditableProvider } from './editable/provider';
 export { default as InspectorControls } from './inspector-controls';
 export { default as MediaUploadButton } from './media-upload-button';

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -134,6 +134,25 @@ export function queueAutosave() {
 }
 
 /**
+ * Returns an action object used in signalling that undo history should
+ * restore last popped state.
+ *
+ * @return {Object} Action object
+ */
+export function redo() {
+	return { type: 'REDO' };
+}
+
+/**
+ * Returns an action object used in signalling that undo history should pop.
+ *
+ * @return {Object} Action object
+ */
+export function undo() {
+	return { type: 'UNDO' };
+}
+
+/**
  * Returns an action object used in signalling that the blocks
  * corresponding to the specified UID set are to be removed.
  *

--- a/editor/index.js
+++ b/editor/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { bindActionCreators } from 'redux';
 import { Provider as ReduxProvider } from 'react-redux';
 import { Provider as SlotFillProvider } from 'react-slot-fill';
 import moment from 'moment-timezone';
@@ -9,7 +10,7 @@ import 'moment-timezone/moment-timezone-utils';
 /**
  * WordPress dependencies
  */
-import { parse } from 'blocks';
+import { EditableProvider, parse } from 'blocks';
 import { render } from 'element';
 import { settings } from 'date';
 
@@ -19,6 +20,7 @@ import { settings } from 'date';
 import './assets/stylesheets/main.scss';
 import Layout from './layout';
 import { createReduxStore } from './state';
+import { undo } from './actions';
 
 // Configure moment globally
 moment.locale( settings.l10n.locale );
@@ -86,7 +88,13 @@ export function createEditorInstance( id, post ) {
 	render(
 		<ReduxProvider store={ store }>
 			<SlotFillProvider>
-				<Layout />
+				<EditableProvider {
+					...bindActionCreators( {
+						onUndo: undo,
+					}, store.dispatch ) }
+				>
+					<Layout />
+				</EditableProvider>
 			</SlotFillProvider>
 		</ReduxProvider>,
 		document.getElementById( id )

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -18,7 +18,7 @@ import './style.scss';
 import VisualEditorBlockList from './block-list';
 import PostTitle from '../../post-title';
 import { getBlockUids } from '../../selectors';
-import { clearSelectedBlock, multiSelect } from '../../actions';
+import { clearSelectedBlock, multiSelect, redo, undo } from '../../actions';
 
 class VisualEditor extends Component {
 	constructor() {
@@ -27,6 +27,7 @@ class VisualEditor extends Component {
 		this.bindBlocksContainer = this.bindBlocksContainer.bind( this );
 		this.onClick = this.onClick.bind( this );
 		this.selectAll = this.selectAll.bind( this );
+		this.undoOrRedo = this.undoOrRedo.bind( this );
 	}
 
 	componentDidMount() {
@@ -52,9 +53,20 @@ class VisualEditor extends Component {
 	}
 
 	selectAll( event ) {
-		const { uids } = this.props;
+		const { uids, onMultiSelect } = this.props;
 		event.preventDefault();
-		this.props.multiSelect( first( uids ), last( uids ) );
+		onMultiSelect( first( uids ), last( uids ) );
+	}
+
+	undoOrRedo( event ) {
+		const { onRedo, onUndo } = this.props;
+		if ( event.shiftKey ) {
+			onRedo();
+		} else {
+			onUndo();
+		}
+
+		event.preventDefault();
 	}
 
 	render() {
@@ -72,6 +84,8 @@ class VisualEditor extends Component {
 			>
 				<KeyboardShortcuts shortcuts={ {
 					'mod+a': this.selectAll,
+					'mod+z': this.undoOrRedo,
+					'mod+shift+z': this.undoOrRedo,
 				} } />
 				<PostTitle />
 				<VisualEditorBlockList ref={ this.bindBlocksContainer } />
@@ -89,6 +103,8 @@ export default connect(
 	},
 	{
 		clearSelectedBlock,
-		multiSelect,
+		onMultiSelect: multiSelect,
+		onRedo: redo,
+		onUndo: undo,
 	}
 )( VisualEditor );

--- a/editor/utils/test/undoable-reducer.js
+++ b/editor/utils/test/undoable-reducer.js
@@ -49,6 +49,21 @@ describe( 'undoableReducer', () => {
 			} );
 		} );
 
+		it( 'should not perform undo on empty past', () => {
+			const reducer = undoable( counter );
+
+			let state;
+			state = reducer( undefined, {} );
+			state = reducer( state, { type: 'INCREMENT' } );
+			state = reducer( state, { type: 'UNDO' } );
+
+			expect( state ).toEqual( {
+				past: [],
+				present: 0,
+				future: [ 1 ],
+			} );
+		} );
+
 		it( 'should perform redo', () => {
 			const reducer = undoable( counter );
 
@@ -56,6 +71,21 @@ describe( 'undoableReducer', () => {
 			state = reducer( undefined, {} );
 			state = reducer( state, { type: 'INCREMENT' } );
 			state = reducer( state, { type: 'UNDO' } );
+			state = reducer( state, { type: 'UNDO' } );
+
+			expect( state ).toEqual( {
+				past: [],
+				present: 0,
+				future: [ 1 ],
+			} );
+		} );
+
+		it( 'should not perform redo on empty future', () => {
+			const reducer = undoable( counter );
+
+			let state;
+			state = reducer( undefined, {} );
+			state = reducer( state, { type: 'INCREMENT' } );
 			state = reducer( state, { type: 'REDO' } );
 
 			expect( state ).toEqual( {

--- a/editor/utils/undoable-reducer.js
+++ b/editor/utils/undoable-reducer.js
@@ -25,6 +25,11 @@ export function undoable( reducer, options = {} ) {
 
 		switch ( action.type ) {
 			case 'UNDO':
+				// Can't undo if no past
+				if ( ! past.length ) {
+					break;
+				}
+
 				return {
 					past: past.slice( 0, past.length - 1 ),
 					present: past[ past.length - 1 ],
@@ -32,6 +37,11 @@ export function undoable( reducer, options = {} ) {
 				};
 
 			case 'REDO':
+				// Can't redo if no future
+				if ( ! future.length ) {
+					break;
+				}
+
 				return {
 					past: [ ...past, present ],
 					present: future[ 0 ],


### PR DESCRIPTION
Closes #627

This pull request seeks to implement Cmd/Ctrl+Z (undo) and Cmd/Ctrl+Shift+Z (redo) behaviors.

__Implementation notes:__

The implementation is similar to the compromise proposed by @youknowriad at https://github.com/WordPress/gutenberg/issues/627#issuecomment-312650346 with some modification. Because we do not sync the TinyMCE value to state until a change event occurs, we allow TinyMCE to handle undo history while the Editable field is focused. If there is no TinyMCE undo history, we propagate the event to be handled by the editor's `UNDO` action behavior. This works largely because we call [`editor.save`](https://www.tinymce.com/docs/api/tinymce/tinymce.editor/#save) during the change event handler to reset undo history.

Included in these changes is a proposed EditorProvider component which leverages [React context](https://facebook.github.io/react/docs/context.html) (like `react-redux`) to allow the Editable to communicate with its wrapping editor render hierarchy. This allows Editable to continue to be unaware of the editor or any specific editor instance, while allowing it to propagate the Undo callback without block implementer intervention. I'm curious to apply this pattern to other behaviors as well, such as focus handling.

__Testing instructions:__

Verify that global Undo handler works as expected:

1. Navigate to Gutenberg > New Post
2. Add a new text block with some content
3. Unfocus the block editable
4. Press Cmd/Ctrl+Z to undo
5. Note block is removed
5. Press Cmd/Ctrl+Shift+Z to redo
6. Note block is restored

Verify that TinyMCE undo handler works as expected:

1. Navigate to Gutenberg > New Post
2. Add a new text block with some content
3. While text block is still focused, press Cmd/Ctrl+Z to undo
4. Note that TinyMCE's internal undo history resets text
5. Continue to undo until there is no text remaining in text block
6. Undo once more
7. Note that global editor history handles undo and removes block