### PR TITLE
Autosave drafts after delay

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -111,6 +111,29 @@ export function mergeBlocks( blockA, blockB ) {
 }
 
 /**
+ * Returns an action object used in signalling that the post should autosave.
+ *
+ * @return {Object} Action object
+ */
+export function autosave() {
+	return {
+		type: 'AUTOSAVE',
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the post should be queued
+ * for autosave after a delay.
+ *
+ * @return {Object} Action object
+ */
+export function queueAutosave() {
+	return {
+		type: 'QUEUE_AUTOSAVE',
+	};
+}
+
+/**
  * Returns an action object used in signalling that the blocks
  * corresponding to the specified UID set are to be removed.
  *

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -22,6 +22,7 @@ import {
 	autosave,
 	queueAutosave,
 	savePost,
+	editPost,
 } from './actions';
 import {
 	getCurrentPost,
@@ -30,6 +31,7 @@ import {
 	getPostEdits,
 	isCurrentPostPublished,
 	isEditedPostDirty,
+	isEditedPostNew,
 	isEditedPostSaveable,
 } from './selectors';
 
@@ -219,7 +221,7 @@ export default {
 		) );
 	},
 	AUTOSAVE( action, store ) {
-		const { getState } = store;
+		const { getState, dispatch } = store;
 		const state = getState();
 		if ( ! isEditedPostSaveable( state ) || ! isEditedPostDirty( state ) ) {
 			return;
@@ -234,7 +236,12 @@ export default {
 			return;
 		}
 
-		return savePost();
+		// Change status from auto-draft to draft
+		if ( isEditedPostNew( state ) ) {
+			dispatch( editPost( { status: 'draft' } ) );
+		}
+
+		dispatch( savePost() );
 	},
 	QUEUE_AUTOSAVE: debounce( ( action, store ) => {
 		store.dispatch( autosave() );

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, uniqueId } from 'lodash';
+import { get, uniqueId, debounce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,12 +14,23 @@ import { __ } from 'i18n';
  * Internal dependencies
  */
 import { getGutenbergURL, getWPAdminURL } from './utils/url';
-import { focusBlock, replaceBlocks, createSuccessNotice, createErrorNotice } from './actions';
+import {
+	focusBlock,
+	replaceBlocks,
+	createSuccessNotice,
+	createErrorNotice,
+	autosave,
+	queueAutosave,
+	savePost,
+} from './actions';
 import {
 	getCurrentPost,
 	getCurrentPostType,
 	getBlocks,
 	getPostEdits,
+	isCurrentPostPublished,
+	isEditedPostDirty,
+	isEditedPostSaveable,
 } from './selectors';
 
 export default {
@@ -207,4 +218,33 @@ export default {
 			]
 		) );
 	},
+	AUTOSAVE( action, store ) {
+		const { getState } = store;
+		const state = getState();
+		if ( ! isEditedPostSaveable( state ) || ! isEditedPostDirty( state ) ) {
+			return;
+		}
+
+		if ( isCurrentPostPublished( state ) ) {
+			// TODO: Publish autosave.
+			//  - Autosaves are created as revisions for published posts, but
+			//    the necessary REST API behavior does not yet exist
+			//  - May need to check for whether the status of the edited post
+			//    has changed from the saved copy (i.e. published -> pending)
+			return;
+		}
+
+		return savePost();
+	},
+	QUEUE_AUTOSAVE: debounce( ( action, store ) => {
+		store.dispatch( autosave() );
+	}, 10000 ),
+	UPDATE_BLOCK_ATTRIBUTES: () => queueAutosave(),
+	INSERT_BLOCKS: () => queueAutosave(),
+	MOVE_BLOCKS_DOWN: () => queueAutosave(),
+	MOVE_BLOCKS_UP: () => queueAutosave(),
+	REPLACE_BLOCKS: () => queueAutosave(),
+	REMOVE_BLOCKS: () => queueAutosave(),
+	EDIT_POST: () => queueAutosave(),
+	MARK_DIRTY: () => queueAutosave(),
 };

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -16,7 +16,7 @@ import { Button } from 'components';
 import { editPost, savePost } from '../../actions';
 import {
 	isSavingPost,
-	isEditedPostPublished,
+	isCurrentPostPublished,
 	isEditedPostBeingScheduled,
 	getEditedPostVisibility,
 	isEditedPostSaveable,
@@ -75,7 +75,7 @@ function PublishButton( {
 export default connect(
 	( state ) => ( {
 		isSaving: isSavingPost( state ),
-		isPublished: isEditedPostPublished( state ),
+		isPublished: isCurrentPostPublished( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		visibility: getEditedPostVisibility( state ),
 		isSaveable: isEditedPostSaveable( state ),

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -184,12 +184,12 @@ export function getEditedPostVisibility( state ) {
 }
 
 /**
- * Return true if the post being edited has already been published.
+ * Return true if the current post has already been published.
  *
  * @param  {Object}   state Global application state
  * @return {Boolean}        Whether the post has been published
  */
-export function isEditedPostPublished( state ) {
+export function isCurrentPostPublished( state ) {
 	const post = getCurrentPost( state );
 
 	return [ 'publish', 'private' ].indexOf( post.status ) !== -1 ||

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -20,7 +20,7 @@ import PostSticky from '../post-sticky';
 import {
 	getEditedPostAttribute,
 	getSuggestedPostFormat,
-	isEditedPostPublished,
+	isCurrentPostPublished,
 } from '../../selectors';
 import { editPost } from '../../actions';
 
@@ -74,7 +74,7 @@ export default connect(
 	( state ) => ( {
 		status: getEditedPostAttribute( state, 'status' ),
 		suggestedFormat: getSuggestedPostFormat( state ),
-		isPublished: isEditedPostPublished( state ),
+		isPublished: isCurrentPostPublished( state ),
 	} ),
 	( dispatch ) => {
 		return {

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -22,7 +22,7 @@ import {
 	getDocumentTitle,
 	getEditedPostExcerpt,
 	getEditedPostVisibility,
-	isEditedPostPublished,
+	isCurrentPostPublished,
 	isEditedPostPublishable,
 	isEditedPostSaveable,
 	isEditedPostBeingScheduled,
@@ -490,7 +490,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isEditedPostPublished', () => {
+	describe( 'isCurrentPostPublished', () => {
 		it( 'should return true for public posts', () => {
 			const state = {
 				currentPost: {
@@ -498,7 +498,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostPublished( state ) ).toBe( true );
+			expect( isCurrentPostPublished( state ) ).toBe( true );
 		} );
 
 		it( 'should return true for private posts', () => {
@@ -508,7 +508,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostPublished( state ) ).toBe( true );
+			expect( isCurrentPostPublished( state ) ).toBe( true );
 		} );
 
 		it( 'should return false for draft posts', () => {
@@ -518,7 +518,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostPublished( state ) ).toBe( false );
+			expect( isCurrentPostPublished( state ) ).toBe( false );
 		} );
 
 		it( 'should return true for old scheduled posts', () => {
@@ -529,7 +529,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( isEditedPostPublished( state ) ).toBe( true );
+			expect( isCurrentPostPublished( state ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
Partial resolution for #1773

This pull request seeks to implement an incomplete autosave behavior, currently applied to drafts only. Published posts lack API endpoint requirements for creating autosaves (see https://github.com/WordPress/gutenberg/issues/1773#issuecomment-316434091) and will need to be implemented separately. Further improvements may be needed for handling autosave for private or scheduled posts, currently ignored as of these changes.

__Implementation notes:__

Autosave occurs on a 10 second debounce. The current post editor [hooks to heartbeat lock refresh](https://github.com/WordPress/WordPress/blob/a798266/wp-admin/js/post.js#L178-L213) to trigger an autosave. More consideration may be needed for autosave frequency and use of browser storage for locally saved copies of the post. Discussion may be better reserved for #1773, though this pull request seeks to start exploring a minimal solution.

__Testing instructions:__

Verify that autosave occurs for a draft 10 seconds after a change:

1. Navigate to Gutenberg > New Post
2. Enter a title
3. Wait 10 seconds
4. Note that the draft saves