### PR TITLE
Export getEmbedBlockSettings function

### DIFF
--- a/blocks/index.js
+++ b/blocks/index.js
@@ -19,3 +19,4 @@ export { default as BlockDescription } from './block-description';
 export { default as Editable } from './editable';
 export { default as InspectorControls } from './inspector-controls';
 export { default as MediaUploadButton } from './media-upload-button';
+export { default as getEmbedBlockSettings } from './library/embed';

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -210,6 +210,8 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 	};
 }
 
+export default getEmbedBlockSettings;
+
 registerBlockType(
 	'core/embed',
 	getEmbedBlockSettings( {


### PR DESCRIPTION
This will be useful for plugin developers to easily register an 'Embed' block with Gutenberg.

eg.
```js
( function( blocks ) {
	blocks.registerBlockType(
		'my-id/embed',
		blocks.getEmbedBlockSettings( {
			title: 'My Embed',
			icon: 'video-alt3',
		} )
	);
} )(
	window.wp.blocks
);
```

Edit: Whoops! Sorry for not prefixing my PR branch with `update/`.  Let me know if you want me to resubmit the PR.