### PR TITLE
Create separate paragraph and text blocks

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -6,8 +6,18 @@
 	margin: 0;
 	position: relative;
 
-	> p:empty {
-		min-height: $editor-font-size * $editor-line-height;
+	> p {
+		&:empty {
+			min-height: $editor-font-size * $editor-line-height;
+		}
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	&:focus {

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -7,6 +7,7 @@ import './embed';
 import './list';
 import './separator';
 import './button';
+import './paragraph';
 import './pullquote';
 import './table';
 import './preformatted';

--- a/blocks/library/paragraph/block.scss
+++ b/blocks/library/paragraph/block.scss
@@ -1,0 +1,16 @@
+p.has-drop-cap {
+	&:first-letter {
+		float: left;
+		font-size: 4.1em;
+		line-height: 0.7;
+		font-family: serif;
+		font-weight: bold;
+		margin: .07em .23em 0 0;
+		text-transform: uppercase;
+		font-style: normal;
+	}
+}
+
+p.has-drop-cap:not( :focus )  {
+	overflow: hidden;
+}

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -8,7 +8,7 @@ import { concatChildren } from 'element';
  * Internal dependencies
  */
 import './block.scss';
-import { registerBlockType, createBlock, query as hpq, setDefaultBlock } from '../../api';
+import { registerBlockType, createBlock, query as hpq } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import Editable from '../../editable';
@@ -18,8 +18,8 @@ import BlockDescription from '../../block-description';
 
 const { children, query } = hpq;
 
-registerBlockType( 'core/text', {
-	title: __( 'Text' ),
+registerBlockType( 'core/paragraph', {
+	title: __( 'Paragraph' ),
 
 	icon: 'text',
 
@@ -81,7 +81,7 @@ registerBlockType( 'core/text', {
 				</InspectorControls>
 			),
 			<Editable
-				multiline="p"
+				tagName="p"
 				key="editable"
 				value={ content }
 				onChange={ ( nextContent ) => {
@@ -95,13 +95,13 @@ registerBlockType( 'core/text', {
 					setAttributes( { content: before } );
 					insertBlocksAfter( [
 						...blocks,
-						createBlock( 'core/text', { content: after } ),
+						createBlock( 'core/paragraph', { content: after } ),
 					] );
 				} }
 				onMerge={ mergeBlocks }
 				style={ { textAlign: align } }
 				className={ dropCap && 'has-drop-cap' }
-				placeholder={ placeholder || __( 'Write your story' ) }
+				placeholder={ placeholder || __( 'New Paragraph' ) }
 			/>,
 		];
 	},
@@ -117,5 +117,3 @@ registerBlockType( 'core/text', {
 		return <p style={ { textAlign: align } } className={ className }>{ content }</p>;
 	},
 } );
-
-setDefaultBlock( 'core/text' );

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -21,7 +21,7 @@ const { children, query } = hpq;
 registerBlockType( 'core/paragraph', {
 	title: __( 'Paragraph' ),
 
-	icon: 'text',
+	icon: 'editor-paragraph',
 
 	category: 'common',
 

--- a/blocks/test/fixtures/core__paragraph__align-right.html
+++ b/blocks/test/fixtures/core__paragraph__align-right.html
@@ -1,0 +1,3 @@
+<!-- wp:core/paragraph {"align":"right"} -->
+<p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
+<!-- /wp:core/paragraph -->

--- a/blocks/test/fixtures/core__paragraph__align-right.json
+++ b/blocks/test/fixtures/core__paragraph__align-right.json
@@ -1,0 +1,14 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/paragraph",
+        "attributes": {
+            "align": "right",
+            "content": [
+                [
+                    "... like this one, which is separate from the above and right aligned."
+                ]
+            ]
+        }
+    }
+]

--- a/blocks/test/fixtures/core__paragraph__align-right.parsed.json
+++ b/blocks/test/fixtures/core__paragraph__align-right.parsed.json
@@ -1,0 +1,13 @@
+[
+    {
+        "blockName": "core/paragraph",
+        "attrs": {
+            "align": "right"
+        },
+        "rawContent": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n"
+    },
+    {
+        "attrs": {},
+        "rawContent": "\n"
+    }
+]

--- a/blocks/test/fixtures/core__paragraph__align-right.serialized.html
+++ b/blocks/test/fixtures/core__paragraph__align-right.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:core/paragraph {"align":"right"} -->
+<p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
+<!-- /wp:core/paragraph -->

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -1060,7 +1060,7 @@ describe( 'state', () => {
 				type: 'LOAD_USER_DATA',
 			} );
 
-			expect( initial.recentlyUsedBlocks ).toEqual( expect.arrayContaining( [ 'core/test-block', 'core/text' ] ) );
+			expect( initial.recentlyUsedBlocks.length ).toBeGreaterThanOrEqual( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/1078#issuecomment-308888277
Related: https://github.com/WordPress/gutenberg/issues/374#issuecomment-303049354
Slack discussion: https://wordpress.slack.com/archives/C02QB2JS7/p1500483704729747

This pull request seeks to create two separate blocks for text behavior, for the purpose of testing and iterating improvements on each in parallel. The intention is not necessarily that both of these blocks would exist in a merged editor, reflected in lack of effort to reduce duplicate logic between the two implementations.

The text block has been reverted back to the behavior where a single Enter press creates a new paragraph within the same text block. The current behavior (single Enter press creates a line break) is preserved in a separate "Paragraph" block.

__Testing instructions:__

Verify that single enter and multiple enter behavior matches expectation for Text and Paragraph blocks:

- Single enter
   - Text: New paragraph in same block
   - Paragraph: Linebreak in same block
- Multiple enter
   - Text: Splits to new Text block
   - Paragraph: Splits to new Paragraph block