### PR TITLE
Consider a new order and grouping for the toolbar controlsTry/toolbar controls order grouping

### DIFF
--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -13,8 +13,6 @@ import { IconButton } from 'components';
  * Internal dependencies
  */
 import './style.scss';
-import ModeSwitcher from './mode-switcher';
-import SavedState from './saved-state';
 import Tools from './tools';
 import { getMultiSelectedBlockUids } from '../selectors';
 import { clearSelectedBlock } from '../actions';
@@ -51,8 +49,6 @@ function Header( { multiSelectedBlockUids, onRemove, onDeselect } ) {
 
 	return (
 		<header className="editor-header">
-			<ModeSwitcher />
-			<SavedState />
 			<Tools />
 		</header>
 	);

--- a/editor/header/mode-switcher/style.scss
+++ b/editor/header/mode-switcher/style.scss
@@ -1,11 +1,10 @@
 #wpbody .editor-mode-switcher {	/* #wpbody for extra specificity */
 	position: relative;
+	margin-left: auto;
 	margin-right: $item-spacing;
-	padding-right: $item-spacing;
 	color: $dark-gray-500;
 	align-items: center;
 	cursor: pointer;
-	border-right: 1px solid $light-gray-500;
 	outline: none;
 	display: flex;
 	align-items: center;

--- a/editor/header/mode-switcher/style.scss
+++ b/editor/header/mode-switcher/style.scss
@@ -13,35 +13,39 @@
 		background: transparent;
 		line-height: 1;
 		border: 0;
-		border-radius: 0;
-		-webkit-appearance: none;
-		outline: none;
+		border-radius: 4px;
+		appearance: none;
 		cursor: pointer;
 		box-shadow: none;
-		padding-right: 0;
+		padding: 10px 8px;
 		font-size: $default-font-size;
+		line-height: 16px;
 		height: auto;
 
-		@include break-small {
-			padding-right: 24px;
+		/* IE10+ */
+		&::-ms-expand {
+			display: none;
 		}
+
+		@include break-small {
+			padding-right: 26px;
+		}
+
+		&:focus {
+			outline: none;
+			box-shadow: 0 0 0 1px $blue-medium-400, 0 0 2px 1px $blue-medium-400;
+  		}
 	}
 
 	.dashicon {
 		position: relative;
-		z-index: z-index( '.editor-mode-switcher .dashicon' );
-		margin-left: -24px;
-		margin-top: -1px;
-
+		left: -26px;
+		margin-right: -20px;
+		pointer-events: none;
 		display: none;
 
 		@include break-small {
 			display: block;
 		}
-	}
-
-	&:hover,
-	select:hover {
-		color: $dark-gray-900;
 	}
 }

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Dashicon, Button, IconButton } from 'components';
+import { IconButton } from 'components';
 
 /**
  * Internal dependencies
@@ -43,7 +43,6 @@ export function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onSt
 	}
 
 	const onClick = () => {
-		console.log( "clicked" );
 		onStatusChange( status || 'draft' );
 		onSave();
 	};

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { __ } from 'i18n';
-import { Dashicon, Button } from 'components';
+import { Dashicon, Button, IconButton } from 'components';
 
 /**
  * Internal dependencies
@@ -26,37 +25,38 @@ import {
 
 export function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
 	const className = 'editor-saved-state';
-
-	if ( isSaving ) {
-		return (
-			<span className={ className }>
-				{ __( 'Saving' ) }
-			</span>
-		);
-	}
+	let buttonLabel = __( 'Save' );
+	let isDisabled = false;
 
 	if ( ! isSaveable ) {
-		return null;
+		isDisabled = true;
+	}
+
+	if ( isSaving ) {
+		buttonLabel = __( 'Saving' );
+		isDisabled = true;
 	}
 
 	if ( ! isNew && ! isDirty ) {
-		return (
-			<span className={ className }>
-				<Dashicon icon="saved" />
-				{ __( 'Saved' ) }
-			</span>
-		);
+		buttonLabel = __( 'Saved' );
+		isDisabled = true;
 	}
 
 	const onClick = () => {
+		console.log( "clicked" );
 		onStatusChange( status || 'draft' );
 		onSave();
 	};
 
 	return (
-		<Button className={ classnames( className, 'button-link' ) } onClick={ onClick }>
-			{ __( 'Save' ) }
-		</Button>
+		<IconButton
+			className={ className }
+			onClick={ onClick }
+			icon="saved"
+			disabled={ isDisabled }
+		>
+			{ buttonLabel }
+		</IconButton>
 	);
 }
 

--- a/editor/header/saved-state/style.scss
+++ b/editor/header/saved-state/style.scss
@@ -1,24 +1,9 @@
 .editor-saved-state {
-	display: flex;
-	align-items: center;
+	width: auto;
 	margin-right: $item-spacing;
 	color: $dark-gray-500;
 
 	.dashicon {
 		margin-right: 4px;
-	}
-
-	&.button-link {
-		text-decoration: underline;
-		color: $blue-wordpress;
-
-		&:focus {
-			box-shadow: none;
-			outline: none;
-		}
-
-		&:hover {
-			color: $blue-medium-500;
-		}
 	}
 }

--- a/editor/header/saved-state/test/index.js
+++ b/editor/header/saved-state/test/index.js
@@ -18,10 +18,10 @@ describe( 'SavedState', () => {
 				isSaveable={ false } />
 		);
 
-		expect( wrapper.text() ).toBe( 'Saving' );
+		expect( wrapper.childAt( 0 ).text() ).toBe( 'Saving' );
 	} );
 
-	it( 'returns null if the post is not saveable', () => {
+	it( 'returns disabled button if the post is not saveable', () => {
 		const wrapper = shallow(
 			<SavedState
 				isNew
@@ -30,7 +30,7 @@ describe( 'SavedState', () => {
 				isSaveable={ false } />
 		);
 
-		expect( wrapper.type() ).toBeNull();
+		expect( wrapper.prop( 'disabled' ) ).toEqual( true );
 	} );
 
 	it( 'should return Saved text if not new and not dirty', () => {
@@ -42,8 +42,7 @@ describe( 'SavedState', () => {
 				isSaveable={ true } />
 		);
 
-		expect( wrapper.childAt( 0 ).name() ).toBe( 'Dashicon' );
-		expect( wrapper.childAt( 1 ).text() ).toBe( 'Saved' );
+		expect( wrapper.childAt( 0 ).text() ).toBe( 'Saved' );
 	} );
 
 	it( 'should return Save button if edits to be saved', () => {
@@ -59,7 +58,7 @@ describe( 'SavedState', () => {
 				onSave={ saveSpy } />
 		);
 
-		expect( wrapper.name() ).toBe( 'Button' );
+		expect( wrapper.name() ).toBe( 'IconButton' );
 		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save' );
 		wrapper.simulate( 'click' );
 		expect( statusSpy ).toHaveBeenCalledWith( 'draft' );

--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -3,9 +3,6 @@
 	padding: $item-spacing;
 	border-bottom: 1px solid $light-gray-500;
 	background: $white;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
 	z-index: z-index( '.editor-header' );
 	left: 0;
 	right: 0;

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -26,6 +26,9 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 			<PublishButton />
 			<SavedState />
 			<PreviewButton />
+			<Inserter position="bottom">
+				{ __( 'Insert' ) }
+			</Inserter>
 			<IconButton
 				className="editor-tools__undo"
 				icon="undo"
@@ -38,9 +41,6 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 				label={ __( 'Redo' ) }
 				disabled={ ! hasRedo }
 				onClick={ redo } />
-			<Inserter position="bottom">
-				{ __( 'Insert' ) }
-			</Inserter>
 			<ModeSwitcher />
 			<div className="editor-tools__tabs">
 				<IconButton icon="admin-generic" onClick={ toggleSidebar } isToggled={ isSidebarOpened }>

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -13,6 +13,8 @@ import { IconButton } from 'components';
  * Internal dependencies
  */
 import './style.scss';
+import ModeSwitcher from '../mode-switcher';
+import SavedState from '../saved-state';
 import Inserter from '../../inserter';
 import PublishButton from './publish-button';
 import PreviewButton from './preview-button';
@@ -21,6 +23,9 @@ import { isEditorSidebarOpened, hasEditorUndo, hasEditorRedo } from '../../selec
 function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar } ) {
 	return (
 		<div className="editor-tools">
+			<PublishButton />
+			<SavedState />
+			<PreviewButton />
 			<IconButton
 				className="editor-tools__undo"
 				icon="undo"
@@ -36,13 +41,12 @@ function Tools( { undo, redo, hasUndo, hasRedo, isSidebarOpened, toggleSidebar }
 			<Inserter position="bottom">
 				{ __( 'Insert' ) }
 			</Inserter>
-			<PreviewButton />
+			<ModeSwitcher />
 			<div className="editor-tools__tabs">
 				<IconButton icon="admin-generic" onClick={ toggleSidebar } isToggled={ isSidebarOpened }>
 					{ __( 'Settings' ) }
 				</IconButton>
 			</div>
-			<PublishButton />
 		</div>
 	);
 }

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -15,12 +16,15 @@ import { _x } from 'i18n';
 import { getEditedPostPreviewLink } from '../../selectors';
 
 function PreviewButton( { link, postId } ) {
+	const className = 'editor-preview-button';
+
 	return (
 		<IconButton
 			href={ link }
 			target={ `wp-preview-${ postId }` }
 			icon="visibility"
 			disabled={ ! link }
+			className={ className }
 		>
 			{ _x( 'Preview', 'imperative verb' ) }
 		</IconButton>

--- a/editor/header/tools/style.scss
+++ b/editor/header/tools/style.scss
@@ -4,6 +4,7 @@
 	align-items: center;
 }
 
+.editor-preview-button,
 .editor-tools__undo,
 .editor-tools__redo {
 	display: none;
@@ -22,14 +23,15 @@
 }
 
 .editor-tools__tabs {
-	margin: 0 $item-spacing;
-	padding: 0;
+	width: auto;
 	border-left: 1px solid $light-gray-500;
-	border-right: 1px solid $light-gray-500;
+	margin: 0;
+	padding: 0;
 	display: flex;
 	align-items: center;
 
 	@include break-medium {
+		width: 270px;
 		padding: 0 0 0 $item-spacing;
 	}
 
@@ -41,7 +43,6 @@
 		border: none;
 		background: none;
 		color: $dark-gray-500;
-		margin-right: 0;
 		cursor: pointer;
 		height: 30px;
 		padding: 0 10px;
@@ -55,7 +56,7 @@
 
 		@include break-medium() {
 			width: auto;
-			margin-right: $item-spacing;
+			margin-left: auto;
 		}
 	}
 
@@ -79,6 +80,7 @@
 // Needs specificity to override bleed
 .wp-core-ui .button.button-large.editor-tools__publish-button {
 	margin-bottom: 0;
+	margin-right: $item-spacing;
 }
 
 .editor-tools__publish-button.is-saving,
@@ -110,4 +112,8 @@
 		z-index: -1;
 		@include move_background;
 	}
+}
+
+.editor-preview-button {
+	margin-right: $item-spacing;
 }


### PR DESCRIPTION
This PR is a first try to experiment the design proposal in #467. Before moving on and refine things, it would be great to have some testing and feedback.

Gains:

- Publishing is the main goal here, so that should be the first action.
- Previewing is related to achieving that goal, and to preview you need to save, so grouping those actions together will eliminate some confusion. The icon for saving can also display a spinner (and then a checkmark) while (auto)saving.
- In order of 'user needs', adding blocks to the page is next up, followed by undo-ing and re-do-ing what you do in those blocks. This also groups the icon + text buttons, which brings some calm to the toolbar.
- Switching from visual to text is something you do a limited amount of times per post edit, so it should be clearly findable, but not a blocking higher-order element.
- The settings toggle should be directly next to the sidebar, as it will 'spawn' something coming from that side of the screen. Making it stick to that side will make it more intuitive if somebody is searching for it. When the sidebar is hidden, the mode switcher could move next to the settings button.

Screenshot on the issue.

Note: the save buttons would need a new icon.

Minor glitches to address noticed so far:
- when saving, the Save button text changes and thus the button width changes: all the following elements get moved horizontally
- when closing the sidebar, the "Mode Switcher" hangs in a awkward position :)

The responsive view has some pre-existing issues, unrelated to this PR. However, now also the Preview link gets hidden on very small screens, this improves things a bit.

Personally, I think this goes in the right direction even if maybe it's not still there. Grouping together Publish, Saved state, and Preview makes a lot of sense to me. 
Considering plugins might want to add their controls in the toolbar, the space is very limited especially on small screens. Maybe worth considering to split the Inserter, Undo/Redo and move them elsewhere...