### PR TITLE
Try Building a Template Block

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -97,3 +97,17 @@ export function switchToBlockType( block, name ) {
 		};
 	} );
 }
+
+/**
+ * Gives us a `to` transformation that renders the given component into a text block
+ *
+ * @param  {Object} Component The component to render, it must accept an `attributes` prop. It must include only inline elements, because the text block is a `p`.
+ * @return {Object}           The transformation
+ */
+export function transformComponentToText( Component ) {
+	return {
+		type: 'block',
+		blocks: [ 'core/text' ],
+		transform: ( attributes ) => createBlock( 'core/text', { content: <Component attributes={ attributes } /> } ),
+	};
+}

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -4,7 +4,7 @@
 import * as query from './query';
 
 export { query };
-export { createBlock, switchToBlockType } from './factory';
+export { createBlock, switchToBlockType, transformComponentToText } from './factory';
 export { default as parse } from './parser';
 export { default as pasteHandler } from './paste';
 export { default as serialize, getBlockDefaultClassname } from './serializer';

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -16,3 +16,4 @@ import './freeform';
 import './latest-posts';
 import './cover-image';
 import './verse';
+import './template';

--- a/blocks/library/template/index.js
+++ b/blocks/library/template/index.js
@@ -6,15 +6,16 @@ import { __ } from 'i18n';
 /**
  * Internal dependencies
  */
-import { registerBlockType, createBlock } from '../../api';
+import { registerBlockType, transformComponentToText } from '../../api';
+import AttributeInput from 'components/attribute-input';
 
 function template( mode ) {
 	return function( { attributes, setAttributes } ) {
 		return <span>
 			Hi, my name is {
 				'edit' === mode ?
-					<input type="text" placeholder="Peter" value={ attributes.name } onChange={ ( e ) => setAttributes( { name: e.target.value } ) } />
-					: <span>{ attributes.name }</span>
+					<AttributeInput type="text" placeholder="Peter" value={ attributes.name } attribute="name" setAttributes={ setAttributes } /> :
+					attributes.name
 			}! <br />
 			#intro { tagify( attributes.name ) }
 		</span>;
@@ -31,17 +32,10 @@ registerBlockType( 'core/template', {
 		name: '',
 	},
 	transforms: {
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/text' ],
-				transform: ( attributes ) => createBlock( 'core/text', { content: template( 'save' )( { attributes } ) } ),
-			},
-		],
+		to: [ transformComponentToText( template( 'save' ) ) ],
 	},
 
 	icon: 'list-view',
-
 	category: 'widgets',
 
 	edit: template( 'edit' ),

--- a/blocks/library/template/index.js
+++ b/blocks/library/template/index.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlockType, createBlock } from '../../api';
+
+function template( mode ) {
+	return function( { attributes, setAttributes } ) {
+		return <p>
+			Hi, my name is {
+				'edit' === mode ?
+					<input type="text" placeholder="Peter" value={ attributes.name } onChange={ ( e ) => setAttributes( { name: e.target.value } ) } />
+					: <span>{ attributes.name }</span>
+			}! <br />
+			#intro { tagify( attributes.name ) }
+		</p>;
+	};
+}
+
+function tagify( name ) {
+	return name ? '#' + name.toLowerCase().replace( /\s+/g, '-' ) : '';
+}
+
+registerBlockType( 'core/template', {
+	title: __( 'Template for Templates' ),
+	defaultAttributes: {
+		name: '',
+	},
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/text' ],
+				transform: ( attributes ) => createBlock( 'core/text', { content: template( 'save' )( { attributes } ) } ),
+			},
+		],
+	},
+
+	icon: 'list-view',
+
+	category: 'widgets',
+
+	edit: template( 'edit' ),
+	save: template( 'save' ),
+} );

--- a/blocks/library/template/index.js
+++ b/blocks/library/template/index.js
@@ -10,14 +10,14 @@ import { registerBlockType, createBlock } from '../../api';
 
 function template( mode ) {
 	return function( { attributes, setAttributes } ) {
-		return <p>
+		return <span>
 			Hi, my name is {
 				'edit' === mode ?
 					<input type="text" placeholder="Peter" value={ attributes.name } onChange={ ( e ) => setAttributes( { name: e.target.value } ) } />
 					: <span>{ attributes.name }</span>
 			}! <br />
 			#intro { tagify( attributes.name ) }
-		</p>;
+		</span>;
 	};
 }
 

--- a/components/attribute-input/README.md
+++ b/components/attribute-input/README.md
@@ -1,0 +1,24 @@
+The `AttributeInput` component can be used to add an `input` to a block, whose value is always synchronized with a certain attribute.
+
+#### Props
+
+The following props are used to tell us which attrbute to connect the `input` to and how to update the attribute value. Any additional props will be passed to the rendered `<input />`.
+
+* `attribute`: (string) the name of the block attribute to connect the `input` to.
+* `setAttribute`: (function) the block's `setAttribute` function, we need it to be able to set the attribute value when the input changes.
+
+#### Example:
+
+```javascript
+registerBlockType( 'example/hello', {
+	title: __( 'Hello' ),
+	icon: 'list-view',
+	category: 'widgets',
+	edit: ( { attributes, setAttributes } ) => (
+		<span>Enter your name: <AttributeInput type="text" value={ attributes.name } placeholder="Baba" attribute="name" setAttributes={ setAttributes } /></span>
+	),
+	save: ( { attributes } ) => (
+		<span>Hello, { attributes.name }!</span>
+	),
+} );
+```

--- a/components/attribute-input/index.js
+++ b/components/attribute-input/index.js
@@ -1,0 +1,3 @@
+export default function AttributeInput( { attribute, setAttributes, value = '', ...inputProps } ) {
+	return <input value={ value } onChange={ ( e ) => setAttributes( { [ attribute ]: e.target.value } ) } { ...inputProps } />;
+}


### PR DESCRIPTION
A super common use-case I‘ve found for blocks has been to build interactive templates users can insert into their post.

![template](https://user-images.githubusercontent.com/27954/28471238-264f898c-6e45-11e7-8a79-b1248377a63e.gif)

Few interesting learnings:

* It was shorter and more powerful than I though. Generating parts of the text based on others was trivial, see the `tagify` function.
* In order to not duplicate markup, we needed a higher-order function – something we need to make sure developers are familiar with as a pattern.
* It would’ve been a lot easier if I had a “connected” input, which syncs its value with an attribute.
* Building the transformation to a text block was harder than I thought – it required some level of understanding of how React renders components (and wild be harder if we weren't using functional components).

All in all if we provide some connected inputs and a shortcut to the text transform this could be an incredibly useful way of building a whole class of blocks and maybe a good introduction of both users and developers to Gutenberg.