### PR TITLE
Improve keyboard interaction of the DropdownMenu

### DIFF
--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -20,7 +20,8 @@ import './style.scss';
 class DropdownMenu extends wp.element.Component {
 	constructor() {
 		super( ...arguments );
-		this.bindMenuReferenceNode = this.bindMenuReferenceNode.bind( this );
+
+		this.bindReferenceNode = this.bindReferenceNode.bind( this );
 		this.closeMenu = this.closeMenu.bind( this );
 		this.toggleMenu = this.toggleMenu.bind( this );
 		this.findActiveIndex = this.findActiveIndex.bind( this );
@@ -29,7 +30,9 @@ class DropdownMenu extends wp.element.Component {
 		this.focusNext = this.focusNext.bind( this );
 		this.handleKeyDown = this.handleKeyDown.bind( this );
 		this.handleKeyUp = this.handleKeyUp.bind( this );
+
 		this.nodes = {};
+
 		this.state = {
 			open: false,
 		};

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -59,7 +59,7 @@ class DropdownMenu extends wp.element.Component {
 
 		this.maybeCloseMenuOnBlur = setTimeout( () => {
 			this.closeMenu();
-		}, 200 );
+		}, 100 );
 	}
 
 	closeMenu() {
@@ -114,13 +114,18 @@ class DropdownMenu extends wp.element.Component {
 		this.focusIndex( nextI );
 	}
 
-	handleKeyUp( event) {
-		/*
-		 * VisualEditorBlock uses keyup to deselect the block. We need to stop
-		 * propagation of keyup after Escape has been pressed to close the menu
-		 * otherwise the whole block toolbar will disappear.
-		 */
-		event.stopPropagation();
+	handleKeyUp( event ) {
+		// TODO: find a better way to isolate events on nested components see GH issue #1973.
+		if ( this.state.open ) {
+			/*
+			 * VisualEditorBlock uses keyup to deselect the block. When the menu is
+			 * open we need to stop propagation of keyup after Escape has been pressed
+			 * to close the menu, otherwise the whole block toolbar will disappear.
+			 * When the menu is closed, Escape will make the toolbar disappear as intended.
+			 */
+			event.stopPropagation();
+		}
+
 	}
 
 	handleKeyDown( keydown ) {
@@ -176,6 +181,13 @@ class DropdownMenu extends wp.element.Component {
 		clearTimeout( this.maybeCloseMenuOnBlur );
 		const node = findDOMNode( this );
 		node.removeEventListener( 'keydown', this.handleKeyDown, false );
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		// Focus the first item when the menu opens.
+		if ( ! prevState.open && this.state.open ) {
+			this.focusIndex( 0 );
+		}
 	}
 
 	render() {

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -11,7 +11,7 @@ import { findIndex } from 'lodash';
 import IconButton from 'components/icon-button';
 import Dashicon from 'components/dashicon';
 import { findDOMNode } from 'element';
-import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
+import { ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ import './style.scss';
 class DropdownMenu extends wp.element.Component {
 	constructor() {
 		super( ...arguments );
-		this.bindMenuRef = this.bindMenuRef.bind( this );
+		this.bindMenuReferenceNode = this.bindMenuReferenceNode.bind( this );
 		this.closeMenu = this.closeMenu.bind( this );
 		this.toggleMenu = this.toggleMenu.bind( this );
 		this.findActiveIndex = this.findActiveIndex.bind( this );
@@ -32,14 +32,14 @@ class DropdownMenu extends wp.element.Component {
 		this.handleKeyUp = this.handleKeyUp.bind( this );
 		this.handleFocus = this.handleFocus.bind( this );
 		this.handleBlur = this.handleBlur.bind( this );
-		this.menuRef = null;
+		this.menuNode = null;
 		this.state = {
 			open: false,
 		};
 	}
 
-	bindMenuRef( node ) {
-		this.menuRef = node;
+	bindMenuReferenceNode( node ) {
+		this.menuNode = node;
 	}
 
 	handleClickOutside() {
@@ -79,23 +79,21 @@ class DropdownMenu extends wp.element.Component {
 	}
 
 	findActiveIndex() {
-		if ( this.menuRef ) {
-			const menu = findDOMNode( this.menuRef );
+		if ( this.menuNode ) {
 			const menuItem = document.activeElement;
-			if ( menuItem.parentNode === menu ) {
-				return findIndex( menu.children, ( child ) => child === menuItem );
+			if ( menuItem.parentNode === this.menuNode ) {
+				return findIndex( this.menuNode.children, ( child ) => child === menuItem );
 			}
 			return -1;
 		}
 	}
 
 	focusIndex( index ) {
-		if ( this.menuRef ) {
-			const menu = findDOMNode( this.menuRef );
+		if ( this.menuNode ) {
 			if ( index < 0 ) {
-				menu.previousElementSibling.focus();
+				this.menuNode.previousElementSibling.focus();
 			} else {
-				menu.children[ index ].focus();
+				this.menuNode.children[ index ].focus();
 			}
 		}
 	}
@@ -125,7 +123,6 @@ class DropdownMenu extends wp.element.Component {
 			 */
 			event.stopPropagation();
 		}
-
 	}
 
 	handleKeyDown( keydown ) {
@@ -172,15 +169,8 @@ class DropdownMenu extends wp.element.Component {
 		}
 	}
 
-	componentDidMount() {
-		const node = findDOMNode( this );
-		node.addEventListener( 'keydown', this.handleKeyDown, false );
-	}
-
 	componentWillUnmount() {
 		clearTimeout( this.maybeCloseMenuOnBlur );
-		const node = findDOMNode( this );
-		node.removeEventListener( 'keydown', this.handleKeyDown, false );
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
@@ -203,8 +193,13 @@ class DropdownMenu extends wp.element.Component {
 			return null;
 		}
 
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
-			<div className="components-dropdown-menu" onKeyUp={ this.handleKeyUp }>
+			<div
+				className="components-dropdown-menu"
+				onKeyDown={ this.handleKeyDown }
+				onKeyUp={ this.handleKeyUp }
+			>
 				<IconButton
 					className={
 						classnames( 'components-dropdown-menu__toggle', {
@@ -224,7 +219,7 @@ class DropdownMenu extends wp.element.Component {
 						className="components-dropdown-menu__menu"
 						role="menu"
 						aria-label={ menuLabel }
-						ref={ this.bindMenuRef }
+						ref={ this.bindMenuReferenceNode }
 						onFocus={ this.handleFocus }
 						onBlur={ this.handleBlur }
 						tabIndex="-1"
@@ -254,6 +249,7 @@ class DropdownMenu extends wp.element.Component {
 				}
 			</div>
 		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
 

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -10,7 +10,7 @@ import { findIndex } from 'lodash';
  */
 import IconButton from 'components/icon-button';
 import Dashicon from 'components/dashicon';
-import { findDOMNode } from 'element';
+import { Component, findDOMNode } from 'element';
 import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
 
 /**
@@ -18,7 +18,7 @@ import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
  */
 import './style.scss';
 
-class DropdownMenu extends wp.element.Component {
+class DropdownMenu extends Component {
 	constructor() {
 		super( ...arguments );
 

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -10,7 +10,6 @@ import { findIndex } from 'lodash';
  */
 import IconButton from 'components/icon-button';
 import Dashicon from 'components/dashicon';
-import { findDOMNode } from 'element';
 import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
 
 /**
@@ -30,14 +29,16 @@ class DropdownMenu extends wp.element.Component {
 		this.focusNext = this.focusNext.bind( this );
 		this.handleKeyDown = this.handleKeyDown.bind( this );
 		this.handleKeyUp = this.handleKeyUp.bind( this );
-		this.menuNode = null;
+		this.nodes = {};
 		this.state = {
 			open: false,
 		};
 	}
 
-	bindMenuReferenceNode( node ) {
-		this.menuNode = node;
+	bindReferenceNode( name ) {
+		return ( node ) => {
+			this.nodes[ name ] = node;
+		};
 	}
 
 	handleClickOutside() {
@@ -61,18 +62,18 @@ class DropdownMenu extends wp.element.Component {
 	}
 
 	findActiveIndex() {
-		if ( this.menuNode ) {
+		if ( this.nodes.menu ) {
 			const menuItem = document.activeElement;
-			if ( menuItem.parentNode === this.menuNode ) {
-				return findIndex( this.menuNode.children, ( child ) => child === menuItem );
+			if ( menuItem.parentNode === this.nodes.menu ) {
+				return findIndex( this.nodes.menu.children, ( child ) => child === menuItem );
 			}
 			return -1;
 		}
 	}
 
 	focusIndex( index ) {
-		if ( this.menuNode ) {
-			this.menuNode.children[ index ].focus();
+		if ( this.nodes.menu ) {
+			this.nodes.menu.children[ index ].focus();
 		}
 	}
 
@@ -101,9 +102,7 @@ class DropdownMenu extends wp.element.Component {
 		if ( event.keyCode === ESCAPE && this.state.open ) {
 			event.preventDefault();
 			event.stopPropagation();
-			const node = findDOMNode( this );
-			const toggle = node.querySelector( '.components-dropdown-menu__toggle' );
-			toggle.focus();
+			this.nodes.toggle.focus();
 			this.closeMenu();
 			if ( this.props.onSelect ) {
 				this.props.onSelect( null );
@@ -188,6 +187,7 @@ class DropdownMenu extends wp.element.Component {
 					aria-haspopup="true"
 					aria-expanded={ this.state.open }
 					label={ label }
+					ref={ this.bindReferenceNode( 'toggle' ) }
 				>
 					<Dashicon icon="arrow-down" />
 				</IconButton>
@@ -196,7 +196,7 @@ class DropdownMenu extends wp.element.Component {
 						className="components-dropdown-menu__menu"
 						role="menu"
 						aria-label={ menuLabel }
-						ref={ this.bindMenuReferenceNode }
+						ref={ this.bindReferenceNode( 'menu' ) }
 					>
 						{ controls.map( ( control, index ) => (
 							<IconButton

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -10,6 +10,7 @@ import { findIndex } from 'lodash';
  */
 import IconButton from 'components/icon-button';
 import Dashicon from 'components/dashicon';
+import { findDOMNode } from 'element';
 import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
 
 /**
@@ -105,7 +106,8 @@ class DropdownMenu extends wp.element.Component {
 		if ( event.keyCode === ESCAPE && this.state.open ) {
 			event.preventDefault();
 			event.stopPropagation();
-			this.nodes.toggle.focus();
+			// eslint-disable-next-line react/no-find-dom-node
+			findDOMNode( this.nodes.toggle ).focus();
 			this.closeMenu();
 			if ( this.props.onSelect ) {
 				this.props.onSelect( null );

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -4,21 +4,31 @@
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 import Button from '../button';
 import Dashicon from '../dashicon';
 
-function IconButton( { icon, children, label, className, focus, ...additionalProps } ) {
-	const classes = classnames( 'components-icon-button', className );
+// This is intentionally a Component class, not a function component because it
+// is common to apply a ref to the button element (only supported in class)
+class IconButton extends Component {
+	render() {
+		const { icon, children, label, className, focus, ...additionalProps } = this.props;
+		const classes = classnames( 'components-icon-button', className );
 
-	return (
-		<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
-			<Dashicon icon={ icon } />
-			{ children }
-		</Button>
-	);
+		return (
+			<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
+				<Dashicon icon={ icon } />
+				{ children }
+			</Button>
+		);
+	}
 }
 
 export default IconButton;


### PR DESCRIPTION
This PR tries to improve the accessibility and keyboard interaction of the DropdownMenu following the model described in the ARIA Authoring Practices.

The DropdownMenu is, in ARIA terms, a composite widget made of a [Menu button](https://www.w3.org/TR/wai-aria-practices/#menubutton) and a [Menu](https://www.w3.org/TR/wai-aria-practices/#menu). To get how the expected keyboard interaction should work I'd recommend to jump directly to the W3C examples for the standalone Menu:
https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-actions.html
and the same example in the context of a Toolbar:
https://www.w3.org/TR/wai-aria-practices/examples/toolbar/toolbar.html

Navigation through the menu items should work with arrow keys only, while tabbing should close the menu (same for Escape). Optionally, items navigation should "loop" continuously. 

Worth reminding ARIA widgets replicate common, established patterns already used in our operating systems and keyboard users are used to them. For example, the macOS Finder menu works this way: it uses arrow keys to navigate the drop-down items:

<img width="326" alt="screen shot 2017-07-21 at 19 17 36" src="https://user-images.githubusercontent.com/1682452/28476310-e994f6e8-6e4f-11e7-8ef9-bd40d2ea9313.png">

The mixed use of the Tab key and arrow keys is a great way to reduce the amount of Tab key presses necessary to navigate through content, as it allows to open a menu just if that's really needed.

As mentioned in the issue, it would be great to consider to extend this behavior to other components too.

Fixes #1880 