### PR TITLE
Hide gallery display settings in the media modal

### DIFF
--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -42,6 +42,7 @@ const getGalleryDetailsMediaFrame = () => {
 					library: this.options.selection,
 					editing: this.options.editing,
 					menu: 'gallery',
+					displaySettings: false,
 				} ),
 
 				new wp.media.controller.GalleryAdd(),


### PR DESCRIPTION
Following #1820, this hides the display settings in the media modal when the frame is in the gallery-edit state, since the settings aren't being used by Gutenberg anyway.

Before:
<img width="1270" alt="screen shot 2017-07-22 at 11 59 55 am" src="https://user-images.githubusercontent.com/801097/28493081-70d312c2-6ed5-11e7-9774-d694cb4abd20.png">

After:
<img width="1267" alt="screen shot 2017-07-22 at 11 58 58 am" src="https://user-images.githubusercontent.com/801097/28493082-781aaa72-6ed5-11e7-84e8-7b04102e27f3.png">
