### PR TITLE
fixes publish button warning for development environment #1928

### DIFF
--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -51,7 +51,7 @@ function PublishButton( {
 	const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
 	const onClick = () => {
 		const doSave = isPublished ||
-			! process.env.NODE_ENV === 'production' ||
+			process.env.NODE_ENV !== 'production' ||
 			window.confirm( __( 'Keep in mind this plugin is a beta version and will not display correctly on your theme.' ) ); // eslint-disable-line no-alert
 		if ( doSave ) {
 			onStatusChange( publishStatus );


### PR DESCRIPTION
Fixes #1928. The window confirmation warning dialog is no longer called when in the development environment.