### PR TITLE
#1954 fixes z-index issue of block mover buttons

### DIFF
--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -3,7 +3,6 @@
 	top: 10px;
 	left: 0;
 	padding: 0 14px 20px 0; // handles hover area
-	z-index: z-index( '.editor-block-mover' );
 
 	// Mobile, to be revisited
 	display: none;


### PR DESCRIPTION
fixes #1954. Now, when scrolling past the focused block, the z-index is lower than the top of the toolbar, and so scrolling down looks more congruent without the mover buttons standing out.