### PR TITLE
Reuse addQueryArgs function in getGutenbergURL and getWPAdminURL

### DIFF
--- a/editor/utils/test/url.js
+++ b/editor/utils/test/url.js
@@ -17,4 +17,20 @@ describe( 'addQueryArgs', () => {
 
 		expect( addQueryArgs( url, args ) ).toEqual( 'https://andalouses.com/beach?night=false&sun=true&sand=false' );
 	} );
+
+	it( 'should append args to an URL with query string and URL fragment', () => {
+		const url = 'https://andalouses.com/beach?night=false#foo=bar';
+		const args = { sun: 'true', sand: 'false' };
+
+		expect( addQueryArgs( url, args ) ).toEqual( 'https://andalouses.com/beach?night=false&sun=true&sand=false#foo=bar' );
+	} );
+} );
+
+describe( 'getWPAdminURL', () => {
+	it( 'should append args to an URL and account for fragment', () => {
+		const url = 'edit.php#content';
+		const args = { post_id: 123 };
+
+		expect( addQueryArgs( url, args ) ).toEqual( 'edit.php?post_id=123#content' );
+	} );
 } );

--- a/editor/utils/url.js
+++ b/editor/utils/url.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { parse, format } from 'url';
-import { parse as parseQueryString, stringify } from 'querystring';
 
 /**
  * Appends arguments to the query string of the url
@@ -28,12 +27,7 @@ export function addQueryArgs( url, args ) {
  * @return {String}        URL
  */
 export function getGutenbergURL( query = {} ) {
-	const [ baseURL, currentQuery = '' ] = window.location.href.split( '?' );
-	const qs = parseQueryString( currentQuery );
-	return baseURL + '?' + stringify( {
-		...qs,
-		...query,
-	} );
+	return addQueryArgs( window.location.href, query );
 }
 
 /**
@@ -45,6 +39,5 @@ export function getGutenbergURL( query = {} ) {
  * @return {String}        URL
  */
 export function getWPAdminURL( page, query ) {
-	const querystring = query ? '?' + stringify( query ) : '';
-	return page + querystring;
+	return addQueryArgs( page, query );
 }


### PR DESCRIPTION
It appears that the functions in the url module were written at different times and so they weren't all on the same page to re-use the same `addQueryArgs` function. The `getGutenbergURL` and `getWPAdminURL` methods were not properly parsing the URL.

Fixes #1976.