### PR TITLE
Pullquote: Fix parsing/serializing multi-paragraphs in pullquotes

### DIFF
--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -13,7 +13,7 @@ import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-const { children, query } = hpq;
+const { children, query, node } = hpq;
 
 registerBlockType( 'core/pullquote', {
 
@@ -24,7 +24,7 @@ registerBlockType( 'core/pullquote', {
 	category: 'formatting',
 
 	attributes: {
-		value: query( 'blockquote > p', children() ),
+		value: query( 'blockquote > p', node() ),
 		citation: children( 'footer' ),
 	},
 
@@ -86,9 +86,7 @@ registerBlockType( 'core/pullquote', {
 
 		return (
 			<blockquote className={ `align${ align }` }>
-				{ value && value.map( ( paragraph, i ) => (
-					<p key={ i }>{ paragraph }</p>
-				) ) }
+				{ value }
 
 				{ citation && citation.length > 0 && (
 					<footer>{ citation }</footer>

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isString } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from 'i18n';
@@ -86,7 +91,11 @@ registerBlockType( 'core/pullquote', {
 
 		return (
 			<blockquote className={ `align${ align }` }>
-				{ value }
+				{ value && value.map( ( paragraph, i ) => (
+					<p key={ i }>
+						{ isString( paragraph ) ? paragraph : paragraph.props.children }
+					</p>
+				) ) }
 
 				{ citation && citation.length > 0 && (
 					<footer>{ citation }</footer>

--- a/blocks/test/fixtures/core__pullquote.json
+++ b/blocks/test/fixtures/core__pullquote.json
@@ -5,9 +5,10 @@
         "isValid": false,
         "attributes": {
             "value": [
-                [
-                    "Testing pullquote block..."
-                ]
+                {
+                    "type": "p",
+                    "children": "Testing pullquote block..."
+                }
             ],
             "citation": [
                 "...with a caption"

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.html
@@ -1,0 +1,7 @@
+<!-- wp:core/pullquote -->
+<blockquote class="wp-block-pullquote alignnone">
+    <p>Paragraph one</p>
+    <p>Paragraph two</p>
+    <footer>by whoever</footer>
+</blockquote>
+<!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.html
@@ -1,7 +1,7 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-    <p>Paragraph one</p>
+    <p>Paragraph <strong>one</strong></p>
     <p>Paragraph two</p>
-    <footer>by whoever</footer>
+    <footer>by whomever</footer>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -1,0 +1,21 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/pullquote",
+        "attributes": {
+            "value": [
+                {
+                    "type": "p",
+                    "children": "Paragraph one"
+                },
+                {
+                    "type": "p",
+                    "children": "Paragraph two"
+                }
+            ],
+            "citation": [
+                "by whoever"
+            ]
+        }
+    }
+]

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -2,11 +2,18 @@
     {
         "uid": "_uid_0",
         "name": "core/pullquote",
+        "isValid": true,
         "attributes": {
             "value": [
                 {
                     "type": "p",
-                    "children": "Paragraph one"
+                    "children": [
+                        "Paragraph ",
+                        {
+                            "type": "strong",
+                            "children": "one"
+                        }
+                    ]
                 },
                 {
                     "type": "p",
@@ -14,7 +21,7 @@
                 }
             ],
             "citation": [
-                "by whoever"
+                "by whomever"
             ]
         }
     }

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -1,0 +1,11 @@
+[
+    {
+        "blockName": "core/pullquote",
+        "attrs": null,
+        "rawContent": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph one</p>\n    <p>Paragraph two</p>\n    <footer>by whoever</footer>\n</blockquote>\n"
+    },
+    {
+        "attrs": {},
+        "rawContent": "\n"
+    }
+]

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -2,7 +2,7 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "rawContent": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph one</p>\n    <p>Paragraph two</p>\n    <footer>by whoever</footer>\n</blockquote>\n"
+        "rawContent": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>by whomever</footer>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,0 +1,7 @@
+<!-- wp:core/pullquote -->
+<blockquote class="wp-block-pullquote alignnone">
+    <p>Paragraph one</p>
+    <p>Paragraph two</p>
+    <footer>by whoever</footer>
+</blockquote>
+<!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,7 +1,7 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
-    <p>Paragraph one</p>
+    <p>Paragraph <strong>one</strong></p>
     <p>Paragraph two</p>
-    <footer>by whoever</footer>
+    <footer>by whomever</footer>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/full-content.js
+++ b/blocks/test/full-content.js
@@ -172,7 +172,7 @@ describe( 'full post content fixture', () => {
 
 			if ( ! serializedExpected ) {
 				if ( process.env.GENERATE_MISSING_FIXTURES ) {
-					serializedExpected = serializedActual;
+					serializedExpected = serializedActual + '\n';
 					writeFixtureFile( f + '.serialized.html', serializedExpected );
 				} else {
 					throw new Error(


### PR DESCRIPTION
closes #1982 

This PR seeks to solve the parsing/serializing issues we were experiencing when typing multiple paragraphs in pullquotes.

**Testing instructions**

 - Create a multi-p pullquote
 - Check the markup in the text editor (no nested paragraphs
 - Save and refresh, the markup should stay the same