### PR TITLE
Add focus style to the switch toggle controls

### DIFF
--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -30,12 +30,13 @@ function FormToggle( { className, checked, id, onChange = noop, showHint = true 
 				checked={ checked }
 				onChange={ onChange }
 			/>
+			<span className="components-form-toggle__track"></span>
+			<span className="components-form-toggle__thumb"></span>
 			{ showHint &&
 				<span className="components-form-toggle__hint" aria-hidden>
 					{ checked ? __( 'On' ) : __( 'Off' ) }
 				</span>
 			}
-			<span className="components-form-toggle__thumb"></span>
 		</span>
 	);
 }

--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -35,6 +35,7 @@ function FormToggle( { className, checked, id, onChange = noop, showHint = true 
 					{ checked ? __( 'On' ) : __( 'Off' ) }
 				</span>
 			}
+			<span className="components-form-toggle__thumb"></span>
 		</span>
 	);
 }

--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -5,7 +5,7 @@ $toggle-border-width: 2px;
 .components-form-toggle {
 	position: relative;
 
-	&:before {
+	.components-form-toggle__track {
 		content: '';
 		display: inline-block;
 		vertical-align: top;
@@ -16,23 +16,18 @@ $toggle-border-width: 2px;
 		height: $toggle-height;
 		border-radius: $toggle-height / 2;
 		transition: 0.2s background ease;
-
-		.components-form-toggle.is-checked & {
-			background-color: $blue-medium-400;
-			border: $toggle-border-width solid $blue-medium-400;
-		}
 	}
 
-	&:hover:before {
+	&:hover .components-form-toggle__track {
 		background-color: $light-gray-500;
-
-		.components-form-toggle.is-checked & {
-			background-color: $blue-medium-500;
-			border: $toggle-border-width solid $blue-medium-500;
-		}
 	}
 
-	&__thumb {
+	&.is-checked .components-form-toggle__track {
+		background-color: $blue-medium-400;
+		border: $toggle-border-width solid $blue-medium-400;
+	}
+
+	.components-form-toggle__thumb {
 		display: block;
 		position: absolute;
 		top: $toggle-border-width * 2;
@@ -45,8 +40,14 @@ $toggle-border-width: 2px;
 		transition: 0.1s transform ease;
 	}
 
-	&__input:focus + &__thumb {
-		background: $dark-gray-500;
+	&__input:focus {
+		& + .components-form-toggle__track {
+			box-shadow: 0 0 0 1px $white, 0 0 0 2px $blue-medium-400, 0 0 2px 2px $blue-medium-400;
+
+			 & + .components-form-toggle__thumb {
+				 border-width: 5px;
+			 }
+		}
 	}
 
 	&.is-checked {
@@ -54,10 +55,6 @@ $toggle-border-width: 2px;
 			border: 2px solid $white;
 			background-color: $blue-medium-500;
 			transform: translateX( $toggle-width - ( $toggle-border-width * 4 ) - ( $toggle-height - ( $toggle-border-width * 4 ) ) );
-		}
-
-		.components-form-toggle__input:focus + .components-form-toggle__thumb {
-			background-color: $white;
 		}
 
 		&:before {

--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -32,8 +32,7 @@ $toggle-border-width: 2px;
 		}
 	}
 
-	&:after {
-		content: '';
+	&__thumb {
 		display: block;
 		position: absolute;
 		top: $toggle-border-width * 2;
@@ -41,14 +40,24 @@ $toggle-border-width: 2px;
 		width: $toggle-height - ( $toggle-border-width * 4 );
 		height: $toggle-height - ( $toggle-border-width * 4 );
 		border-radius: 50%;
-		background: $dark-gray-500;
+		border: 2px solid $dark-gray-500;
+		background: $white;
 		transition: 0.1s transform ease;
 	}
 
+	&__input:focus + &__thumb {
+		background: $dark-gray-500;
+	}
+
 	&.is-checked {
-		&:after {
-			background-color: $white;
+		.components-form-toggle__thumb {
+			border: 2px solid $white;
+			background-color: $blue-medium-500;
 			transform: translateX( $toggle-width - ( $toggle-border-width * 4 ) - ( $toggle-height - ( $toggle-border-width * 4 ) ) );
+		}
+
+		.components-form-toggle__input:focus + .components-form-toggle__thumb {
+			background-color: $white;
 		}
 
 		&:before {


### PR DESCRIPTION
This PR is a first try to add a focus style to the switch toggle UI control (FormToggle component).

It changes the CSS generated element (:after) previously used to style the switch "thumb" to a span element. This way it's trivial to target it when the input has focus and it is possible to use any style. For a11y reasons, it's better to use a border for the focus style, see the discussion on the issue about Windows High Contrast mode.

Pending design and a11y feedback. 

Fixes #1562 

<img width="301" alt="screen shot 2017-07-24 at 16 24 23" src="https://user-images.githubusercontent.com/1682452/28528600-783aa740-708e-11e7-9da1-7a557d7a46bf.png">
