### PR TITLE
Latest Posts: add grid option and improve front-end rendering

### DIFF
--- a/blocks/library/latest-posts/block.scss
+++ b/blocks/library/latest-posts/block.scss
@@ -1,6 +1,25 @@
-.wp-block-latest-posts.alignright {
-	margin-left: 2em;
+.wp-block-latest-posts {
+	&.alignleft {
+		margin-right: 2em;
+	}
+	&.alignright {
+		margin-left: 2em;
+	}
+	&.is-grid {
+		display: flex;
+		flex-wrap: wrap;
+		padding: 0;
+		list-style: none;
+
+		li {
+			flex-grow: 1;
+			margin: 0 16px 16px 0;
+		}
+	}
 }
-.wp-block-latest-posts.alignleft {
-	margin-right: 2em;
+
+.wp-block-latest-posts__post-date {
+	display: block;
+	color: $dark-gray-100;
 }
+

--- a/blocks/library/latest-posts/block.scss
+++ b/blocks/library/latest-posts/block.scss
@@ -21,5 +21,6 @@
 .wp-block-latest-posts__post-date {
 	display: block;
 	color: $dark-gray-100;
+	font-size: $default-font-size;
 }
 

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -5,6 +5,7 @@ import { Component } from 'element';
 import { Placeholder, Toolbar, Spinner } from 'components';
 import { __ } from 'i18n';
 import moment from 'moment';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -161,7 +162,12 @@ registerBlockType( 'core/latest-posts', {
 						/>
 					</InspectorControls>
 				),
-				<ul className={ this.props.className } key="latest-posts">
+				<ul
+					className={ classnames( this.props.className, {
+						'is-grid': layout === 'grid',
+					} ) }
+					key="latest-posts"
+				>
 					{ latestPosts.map( ( post, i ) =>
 						<li key={ i }>
 							<a href={ post.link } target="_blank">{ post.title.rendered }</a>

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from 'element';
-import { Placeholder, Spinner } from 'components';
+import { Placeholder, Toolbar, Spinner } from 'components';
 import { __ } from 'i18n';
 import moment from 'moment';
 
@@ -33,6 +33,7 @@ registerBlockType( 'core/latest-posts', {
 	defaultAttributes: {
 		postsToShow: 5,
 		displayPostDate: false,
+		layout: 'list',
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -109,7 +110,21 @@ registerBlockType( 'core/latest-posts', {
 			}
 
 			const { focus } = this.props;
-			const { displayPostDate, align } = this.props.attributes;
+			const { displayPostDate, align, layout } = this.props.attributes;
+			const layoutControls = [
+				{
+					icon: 'list-view',
+					title: __( 'List View' ),
+					onClick: () => setAttributes( { layout: 'list' } ),
+					isActive: layout === 'list',
+				},
+				{
+					icon: 'grid-view',
+					title: __( 'Grid View' ),
+					onClick: () => setAttributes( { layout: 'grid' } ),
+					isActive: layout === 'grid',
+				},
+			];
 
 			return [
 				focus && (
@@ -121,6 +136,7 @@ registerBlockType( 'core/latest-posts', {
 							} }
 							controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
 						/>
+						<Toolbar controls={ layoutControls } />
 					</BlockControls>
 				),
 				focus && (

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -178,7 +178,7 @@ registerBlockType( 'core/latest-posts', {
 							<a href={ post.link } target="_blank">{ post.title.rendered.trim() || __( '(Untitled)' ) }</a>
 							{ displayPostDate && post.date_gmt &&
 								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
-									{ moment( post.date_gmt ).local().format( 'MMM DD h:mm A' ) }
+									{ moment( post.date_gmt ).local().format( 'MMMM DD, Y' ) }
 								</time>
 							}
 						</li>

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -91,7 +91,6 @@ registerBlockType( 'core/latest-posts', {
 
 		changePostsToShow( postsToShow ) {
 			const { setAttributes } = this.props;
-
 			setAttributes( { postsToShow: parseInt( postsToShow, 10 ) || 0 } );
 		}
 
@@ -108,6 +107,12 @@ registerBlockType( 'core/latest-posts', {
 						<Spinner />
 					</Placeholder>
 				);
+			}
+
+			// Removing posts from display should be instant.
+			const postsDifference = latestPosts.length - this.props.attributes.postsToShow;
+			if ( postsDifference > 0 ) {
+				latestPosts.splice( this.props.attributes.postsToShow, postsDifference );
 			}
 
 			const { focus } = this.props;

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -170,7 +170,7 @@ registerBlockType( 'core/latest-posts', {
 				>
 					{ latestPosts.map( ( post, i ) =>
 						<li key={ i }>
-							<a href={ post.link } target="_blank">{ post.title.rendered }</a>
+							<a href={ post.link } target="_blank">{ post.title.rendered.trim() || __( '(Untitled)' ) }</a>
 							{ displayPostDate && post.date_gmt &&
 								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
 									{ moment( post.date_gmt ).local().format( 'MMM DD h:mm A' ) }

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -172,9 +172,9 @@ registerBlockType( 'core/latest-posts', {
 						<li key={ i }>
 							<a href={ post.link } target="_blank">{ post.title.rendered }</a>
 							{ displayPostDate && post.date_gmt &&
-								<span className={ `${ this.props.className }__post-date` }>
+								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
 									{ moment( post.date_gmt ).local().format( 'MMM DD h:mm A' ) }
-								</span>
+								</time>
 							}
 						</li>
 					) }

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -3,11 +3,12 @@
 
 	.wp-block-latest-posts {
 		padding-left: 2.5em;
+		&.is-grid {
+			padding-left: 0;
+		}
 	}
 
 	.wp-block-latest-posts__post-date {
-		display: block;
-		color: $dark-gray-100;
 		font-size: $default-font-size;
 	}
 }

--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -7,8 +7,4 @@
 			padding-left: 0;
 		}
 	}
-
-	.wp-block-latest-posts__post-date {
-		font-size: $default-font-size;
-	}
 }

--- a/blocks/test/fixtures/core__latest-posts.json
+++ b/blocks/test/fixtures/core__latest-posts.json
@@ -4,6 +4,7 @@
         "name": "core/latest-posts",
         "attributes": {
             "postsToShow": 5,
+            "layout": "list",
             "displayPostDate": false
         }
     }

--- a/blocks/test/fixtures/core__latest-posts.serialized.html
+++ b/blocks/test/fixtures/core__latest-posts.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latest-posts {"postsToShow":5,"displayPostDate":false} /-->
+<!-- wp:core/latest-posts {"postsToShow":5,"displayPostDate":false,"layout":"list"} /-->

--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -44,19 +44,25 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 		$post_id = $post['ID'];
 		$post_permalink = get_permalink( $post_id );
 		$post_title = get_the_title( $post_id );
+		$post_the_date = get_the_date( false, $post_id );
+		$post_date = '';
 
-		$posts_content .= "<li><a href='{$post_permalink}'>{$post_title}</a></li>\n";
+		if ( $attributes['displayPostDate'] ) {
+			$post_date = "<span class='wp-block-latest-posts__post-date'>{$post_the_date}</span>";
+		}
+
+		$posts_content .= "<li><a href='{$post_permalink}'>{$post_title}</a>{$post_date}</li>\n";
 	}
 
 	$class = 'wp-block-latest-posts ' . esc_attr( 'align' . $align );
+	if ( $attributes['layout'] === 'grid' ) {
+		$class .= ' is-grid';
+	}
 
 	$block_content = <<<CONTENT
-<div class="{$class}">
-	<ul>
-		{$posts_content}
-	</ul>
-</div>
-
+<ul class="{$class}">
+	{$posts_content}
+</ul>
 CONTENT;
 
 	return $block_content;

--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -49,10 +49,14 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 	foreach ( $recent_posts as $post ) {
 		$post_id = $post['ID'];
 
+		$title = get_the_title( $post_id );
+		if ( ! $title ) {
+			$title = __( '(Untitled)', 'gutenberg' );
+		}
 		$posts_content .= sprintf(
 			'<li><a href="%1$s">%2$s</a>',
 			esc_url( get_permalink( $post_id ) ),
-			esc_html( get_the_title( $post_id ) )
+			esc_html( $title )
 		);
 
 		if ( $attributes['displayPostDate'] ) {

--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -42,20 +42,26 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 
 	foreach ( $recent_posts as $post ) {
 		$post_id = $post['ID'];
-		$post_permalink = get_permalink( $post_id );
-		$post_title = get_the_title( $post_id );
-		$post_the_date = get_the_date( false, $post_id );
-		$post_date = '';
+
+		$posts_content .= sprintf(
+			'<li><a href="%1$s">%2$s</a>',
+			esc_url( get_permalink( $post_id ) ),
+			esc_html( get_the_title( $post_id ) )
+		);
 
 		if ( $attributes['displayPostDate'] ) {
-			$post_date = "<span class='wp-block-latest-posts__post-date'>{$post_the_date}</span>";
+			$posts_content .= sprintf(
+				'<time datetime="%1$s" class="wp-block-latest-posts__post-date">%2$s</time>',
+				esc_attr( get_the_date( 'c', $post_id ) ),
+				esc_html( get_the_date( '', $post_id ) )
+			);
 		}
 
-		$posts_content .= "<li><a href='{$post_permalink}'>{$post_title}</a>{$post_date}</li>\n";
+		$posts_content .= "</li>\n";
 	}
 
 	$class = 'wp-block-latest-posts ' . esc_attr( 'align' . $align );
-	if ( $attributes['layout'] === 'grid' ) {
+	if ( 'grid' === $attributes['layout'] ) {
 		$class .= ' is-grid';
 	}
 

--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -15,8 +15,14 @@
 function gutenberg_render_block_core_latest_posts( $attributes ) {
 	$posts_to_show = 5;
 
-	if ( array_key_exists( 'poststoshow', $attributes ) ) {
+	$posts_to_show_attr = null;
+	if ( array_key_exists( 'postsToShow', $attributes ) ) {
+		$posts_to_show_attr = $attributes['postsToShow'];
+	} elseif ( array_key_exists( 'poststoshow', $attributes ) ) {
 		$posts_to_show_attr = $attributes['poststoshow'];
+	}
+	if ( null !== $posts_to_show_attr ) {
+		$posts_to_show_attr = $attributes['postsToShow'];
 
 		// Basic attribute validation.
 		if (
@@ -24,7 +30,7 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 			$posts_to_show_attr > 0 &&
 			$posts_to_show_attr < 100
 		) {
-			$posts_to_show = $attributes['poststoshow'];
+			$posts_to_show = intval( $posts_to_show_attr );
 		}
 	}
 


### PR DESCRIPTION
This enhances the latest posts block adding a "grid" layout option.

![image](https://user-images.githubusercontent.com/548849/28537877-a4498a90-70ac-11e7-9acc-f27d806db6dc.png)

In the future, we'd want to add a columns slider like galleries have.

----

The front-end rendering seemed quite lackluster and wasn't rendering the date. This also fixes that.