### PR TITLE
Fix update block attributes shallow clone comparison

### DIFF
--- a/editor/state.js
+++ b/editor/state.js
@@ -102,8 +102,8 @@ export const editor = combineUndoableReducers( {
 				const nextAttributes = reduce( action.attributes, ( result, value, key ) => {
 					if ( value !== result[ key ] ) {
 						// Avoid mutating original block by creating shallow clone
-						if ( result === state[ action.uid ] ) {
-							result = { ...state[ action.uid ] };
+						if ( result === state[ action.uid ].attributes ) {
+							result = { ...result };
 						}
 
 						result[ key ] = value;

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -509,13 +509,13 @@ describe( 'state', () => {
 
 		describe( 'blocksByUid', () => {
 			it( 'should return with attribute block updates', () => {
-				const original = editor( undefined, {
+				const original = deepFreeze( editor( undefined, {
 					type: 'RESET_BLOCKS',
 					blocks: [ {
 						uid: 'kumquat',
 						attributes: {},
 					} ],
-				} );
+				} ) );
 				const state = editor( original, {
 					type: 'UPDATE_BLOCK_ATTRIBUTES',
 					uid: 'kumquat',
@@ -527,11 +527,35 @@ describe( 'state', () => {
 				expect( state.blocksByUid.kumquat.attributes.updated ).toBe( true );
 			} );
 
+			it( 'should accumulate attribute block updates', () => {
+				const original = deepFreeze( editor( undefined, {
+					type: 'RESET_BLOCKS',
+					blocks: [ {
+						uid: 'kumquat',
+						attributes: {
+							updated: true,
+						},
+					} ],
+				} ) );
+				const state = editor( original, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					uid: 'kumquat',
+					attributes: {
+						moreUpdated: true,
+					},
+				} );
+
+				expect( state.blocksByUid.kumquat.attributes ).toEqual( {
+					updated: true,
+					moreUpdated: true,
+				} );
+			} );
+
 			it( 'should ignore updates to non-existant block', () => {
-				const original = editor( undefined, {
+				const original = deepFreeze( editor( undefined, {
 					type: 'RESET_BLOCKS',
 					blocks: [],
-				} );
+				} ) );
 				const state = editor( original, {
 					type: 'UPDATE_BLOCK_ATTRIBUTES',
 					uid: 'kumquat',
@@ -544,7 +568,7 @@ describe( 'state', () => {
 			} );
 
 			it( 'should return with same reference if no changes in updates', () => {
-				const original = editor( undefined, {
+				const original = deepFreeze( editor( undefined, {
 					type: 'RESET_BLOCKS',
 					blocks: [ {
 						uid: 'kumquat',
@@ -552,7 +576,7 @@ describe( 'state', () => {
 							updated: true,
 						},
 					} ],
-				} );
+				} ) );
 				const state = editor( original, {
 					type: 'UPDATE_BLOCK_ATTRIBUTES',
 					uid: 'kumquat',


### PR DESCRIPTION
This pull request seeks to resolve an issue where block attributes were not correctly considering strict equality of current vs. previous attribute sets. This resulted in the reducer mutating state directly, which did not have an immediately noticeable effect, except uncovered in an in-progress pull request which relied on immutability of state.

Tests have been revised to apply `deepFreeze` to original state, which reveals the original error. Further, a new test case has been added to ensure that the shallow clone is performed correctly when accumulating (merging) attributes.

__Testing instructions:__

Ensure that unit tests pass:

```
npm test
```

Verify with [Redux DevTools Extension](https://github.com/zalmoxisus/redux-devtools-extension) that when changing then blurring a Classic Text block, the Diff tab includes the updated `content` attribute for the `UPDATE_BLOCK_ATTRIBUTES` action.