### PR TITLE
Perform dirty detection as diff against saved post

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -85,7 +85,6 @@
 		"no-undef-init": "error",
 		"no-unreachable": "error",
 		"no-unsafe-negation": "error",
-		"no-use-before-define": [ "error", "nofunc" ],
 		"no-useless-computed-key": "error",
 		"no-useless-constructor": "error",
 		"no-useless-return": "error",

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -5,6 +5,21 @@ import uuid from 'uuid/v4';
 import { partial } from 'lodash';
 
 /**
+ * Returns an action object used in signalling that blocks state should be
+ * reset to the specified array of blocks, taking precedence over any other
+ * content reflected as an edit in state.
+ *
+ * @param  {Array}  blocks Array of blocks
+ * @return {Object}        Action object
+ */
+export function resetBlocks( blocks ) {
+	return {
+		type: 'RESET_BLOCKS',
+		blocks,
+	};
+}
+
+/**
  * Returns an action object used in signalling that the block with the
  * specified UID has been updated.
  *
@@ -117,18 +132,6 @@ export function mergeBlocks( blockA, blockB ) {
 export function autosave() {
 	return {
 		type: 'AUTOSAVE',
-	};
-}
-
-/**
- * Returns an action object used in signalling that the post should be queued
- * for autosave after a delay.
- *
- * @return {Object} Action object
- */
-export function queueAutosave() {
-	return {
-		type: 'QUEUE_AUTOSAVE',
 	};
 }
 

--- a/editor/autosave-monitor/index.js
+++ b/editor/autosave-monitor/index.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { autosave } from '../actions';
+import {
+	isEditedPostDirty,
+	isEditedPostSaveable,
+} from '../selectors';
+
+export class AutosaveMonitor extends Component {
+	componentDidUpdate( prevProps ) {
+		const { isDirty, isSaveable } = this.props;
+		if ( prevProps.isDirty !== isDirty ||
+				prevProps.isSaveable !== isSaveable ) {
+			this.toggleTimer( isDirty && isSaveable );
+		}
+	}
+
+	componentWillUnmount() {
+		this.toggleTimer( false );
+	}
+
+	toggleTimer( isPendingSave ) {
+		clearTimeout( this.pendingSave );
+
+		if ( isPendingSave ) {
+			this.pendingSave = setTimeout(
+				() => this.props.autosave(),
+				10000
+			);
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			isDirty: isEditedPostDirty( state ),
+			isSaveable: isEditedPostSaveable( state ),
+		};
+	},
+	{ autosave }
+)( AutosaveMonitor );

--- a/editor/autosave-monitor/test/index.js
+++ b/editor/autosave-monitor/test/index.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { AutosaveMonitor } from '../';
+
+describe( 'AutosaveMonitor', () => {
+	const toggleTimer = jest.fn();
+	let wrapper;
+	beforeEach( () => {
+		toggleTimer.mockClear();
+		wrapper = shallow(
+			<AutosaveMonitor />,
+			{ lifecycleExperimental: true }
+		);
+
+		wrapper.instance().toggleTimer = toggleTimer;
+	} );
+
+	describe( '#componentDidUpdate()', () => {
+		it( 'should start autosave timer when having become dirty and saveable', () => {
+			wrapper.setProps( { isDirty: true, isSaveable: true } );
+
+			expect( toggleTimer ).toHaveBeenCalledWith( true );
+		} );
+
+		it( 'should stop autosave timer when having become dirty but not saveable', () => {
+			wrapper.setProps( { isDirty: true, isSaveable: false } );
+
+			expect( toggleTimer ).toHaveBeenCalledWith( false );
+		} );
+
+		it( 'should stop autosave timer when having become not dirty', () => {
+			wrapper.setProps( { isDirty: true } );
+			toggleTimer.mockClear();
+			wrapper.setProps( { isDirty: false } );
+
+			expect( toggleTimer ).toHaveBeenCalledWith( false );
+		} );
+
+		it( 'should stop autosave timer when having become not saveable', () => {
+			wrapper.setProps( { isDirty: true } );
+			toggleTimer.mockClear();
+			wrapper.setProps( { isSaveable: false } );
+
+			expect( toggleTimer ).toHaveBeenCalledWith( false );
+		} );
+	} );
+
+	describe( '#componentWillUnmount()', () => {
+		it( 'should stop autosave timer', () => {
+			wrapper.unmount();
+
+			expect( toggleTimer ).toHaveBeenCalledWith( false );
+		} );
+	} );
+
+	describe( '#render()', () => {
+		it( 'should render nothing', () => {
+			expect( wrapper.type() ).toBe( null );
+		} );
+	} );
+} );

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, uniqueId, debounce } from 'lodash';
+import { get, uniqueId } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { serialize, getBlockType, switchToBlockType } from '@wordpress/blocks';
+import { parse, getBlockType, switchToBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -15,19 +15,18 @@ import { __ } from '@wordpress/i18n';
  */
 import { getGutenbergURL, getWPAdminURL } from './utils/url';
 import {
+	resetBlocks,
 	focusBlock,
 	replaceBlocks,
 	createSuccessNotice,
 	createErrorNotice,
-	autosave,
-	queueAutosave,
 	savePost,
 	editPost,
 } from './actions';
 import {
 	getCurrentPost,
 	getCurrentPostType,
-	getBlocks,
+	getEditedPostContent,
 	getPostEdits,
 	isCurrentPostPublished,
 	isEditedPostDirty,
@@ -43,19 +42,15 @@ export default {
 		const edits = getPostEdits( state );
 		const toSend = {
 			...edits,
-			content: serialize( getBlocks( state ) ),
+			content: getEditedPostContent( state ),
 			id: post.id,
 		};
 		const transactionId = uniqueId();
 
 		dispatch( {
-			type: 'CLEAR_POST_EDITS',
-			optimist: { type: BEGIN, id: transactionId },
-		} );
-		dispatch( {
 			type: 'UPDATE_POST',
 			edits: toSend,
-			optimist: { id: transactionId },
+			optimist: { type: BEGIN, id: transactionId },
 		} );
 		const Model = wp.api.getPostTypeModel( getCurrentPostType( state ) );
 		new Model( toSend ).save().done( ( newPost ) => {
@@ -243,15 +238,10 @@ export default {
 
 		dispatch( savePost() );
 	},
-	QUEUE_AUTOSAVE: debounce( ( action, store ) => {
-		store.dispatch( autosave() );
-	}, 10000 ),
-	UPDATE_BLOCK_ATTRIBUTES: () => queueAutosave(),
-	INSERT_BLOCKS: () => queueAutosave(),
-	MOVE_BLOCKS_DOWN: () => queueAutosave(),
-	MOVE_BLOCKS_UP: () => queueAutosave(),
-	REPLACE_BLOCKS: () => queueAutosave(),
-	REMOVE_BLOCKS: () => queueAutosave(),
-	EDIT_POST: () => queueAutosave(),
-	MARK_DIRTY: () => queueAutosave(),
+	RESET_POST( action ) {
+		const { post } = action;
+		if ( post.content ) {
+			return resetBlocks( parse( post.content.raw ) );
+		}
+	},
 };

--- a/editor/index.js
+++ b/editor/index.js
@@ -10,7 +10,7 @@ import 'moment-timezone/moment-timezone-utils';
 /**
  * WordPress dependencies
  */
-import { EditableProvider, parse } from '@wordpress/blocks';
+import { EditableProvider } from '@wordpress/blocks';
 import { render } from '@wordpress/element';
 import { settings } from '@wordpress/date';
 
@@ -64,14 +64,6 @@ function preparePostState( store, post ) {
 		type: 'RESET_POST',
 		post,
 	} );
-
-	// Parse content as blocks
-	if ( post.content.raw ) {
-		store.dispatch( {
-			type: 'RESET_BLOCKS',
-			blocks: parse( post.content.raw ),
-		} );
-	}
 
 	// Include auto draft title in edits while not flagging post as dirty
 	if ( post.status === 'auto-draft' ) {

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -19,6 +19,7 @@ import TextEditor from '../modes/text-editor';
 import VisualEditor from '../modes/visual-editor';
 import UnsavedChangesWarning from '../unsaved-changes-warning';
 import DocumentTitle from '../document-title';
+import AutosaveMonitor from '../autosave-monitor';
 import { removeNotice } from '../actions';
 import {
 	getEditorMode,
@@ -36,6 +37,7 @@ function Layout( { mode, isSidebarOpened, notices, ...props } ) {
 			<DocumentTitle />
 			<NoticeList onRemove={ props.removeNotice } notices={ notices } />
 			<UnsavedChangesWarning />
+			<AutosaveMonitor />
 			<Header />
 			<div className="editor-layout__content">
 				{ mode === 'text' && <TextEditor /> }

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import moment from 'moment';
-import { first, last, get, values } from 'lodash';
+import { first, last, values, some, isEqual } from 'lodash';
 import createSelector from 'rememo';
 
 /**
  * WordPress dependencies
  */
-import { getBlockType } from '@wordpress/blocks';
+import { serialize, getBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -85,9 +85,44 @@ export function isEditedPostNew( state ) {
  * @param  {Object}  state Global application state
  * @return {Boolean}       Whether unsaved values exist
  */
-export function isEditedPostDirty( state ) {
-	return state.editor.dirty;
-}
+export const isEditedPostDirty = createSelector(
+	( state ) => {
+		const edits = getPostEdits( state );
+		const currentPost = getCurrentPost( state );
+		const hasEditedAttributes = some( edits, ( value, key ) => {
+			return ! isEqual( value, currentPost[ key ] );
+		} );
+
+		if ( hasEditedAttributes ) {
+			return true;
+		}
+
+		// This is a cheaper operation that still must occur after checking
+		// attributes, because a post initialized with attributes different
+		// from its saved copy should be considered dirty.
+		if ( ! hasEditorUndo( state ) ) {
+			return false;
+		}
+
+		// Check whether there are differences between editor from its original
+		// state (when history was last reset) and currently. Any difference in
+		// attributes, block type, order should consistute needing save.
+		const { history } = state.editor;
+		const originalEditor = history.past[ 0 ];
+		const currentEditor = history.present;
+		return some( [
+			'blocksByUid',
+			'blockOrder',
+		], ( key ) => ! isEqual(
+			originalEditor[ key ],
+			currentEditor[ key ]
+		) );
+	},
+	( state ) => [
+		state.editor,
+		state.currentPost,
+	]
+);
 
 /**
  * Returns true if there are no unsaved values for the current edit session and if
@@ -212,7 +247,7 @@ export function isEditedPostPublishable( state ) {
  */
 export function isEditedPostSaveable( state ) {
 	return (
-		getBlockCount( state ) > 0 ||
+		!! getEditedPostContent( state ) ||
 		!! getEditedPostTitle( state ) ||
 		!! getEditedPostExcerpt( state )
 	);
@@ -243,8 +278,8 @@ export function getEditedPostTitle( state ) {
 		return editedTitle;
 	}
 	const currentPost = getCurrentPost( state );
-	if ( currentPost.title && currentPost.title.raw ) {
-		return currentPost.title.raw;
+	if ( currentPost.title && currentPost.title ) {
+		return currentPost.title;
 	}
 	return '';
 }
@@ -273,7 +308,7 @@ export function getDocumentTitle( state ) {
  */
 export function getEditedPostExcerpt( state ) {
 	return state.editor.edits.excerpt === undefined
-		? get( state.currentPost, 'excerpt.raw' )
+		? state.currentPost.excerpt
 		: state.editor.edits.excerpt;
 }
 
@@ -695,6 +730,29 @@ export function getSuggestedPostFormat( state ) {
 
 	return null;
 }
+
+/**
+ * Returns the content of the post being edited, preferring raw string edit
+ * before falling back to serialization of block state.
+ *
+ * @param  {Object} state Global application state
+ * @return {String}       Post content
+ */
+export const getEditedPostContent = createSelector(
+	( state ) => {
+		const edits = getPostEdits( state );
+		if ( 'content' in edits ) {
+			return edits.content;
+		}
+
+		return serialize( getBlocks( state ) );
+	},
+	( state ) => [
+		state.editor.edits.content,
+		state.editor.blocksByUid,
+		state.editor.blockOrder,
+	],
+);
 
 /**
  * Returns the user notices array


### PR DESCRIPTION
Closes #916

This pull request seeks to refactor dirty detection not as a property of state, but instead as a selector whose return value is determined by a difference between state and the last saved copy of the post.

__Implementation notes:__

This one turned out to be more of a sprawling refactor than I would have liked, particularly around:

- Flattening rendered post attributes into their raw value
- Changing `editor.edits` reducer to omit values matching the reset post
- Modifying `TextEditor` to operate without an explicit `markDirty` action creator

It may be worth splitting these into smaller pull requests.

Some remaining tasks include:

- Verify edits made while save in-flight are respected
- Update unit tests for `editor/tests/state.js`

__Testing instructions:__

Verify that the "Save" option is only presented when changes exist to be saved. Notably:

- Shown on the Demo screen by default
- Shown when changing content in Visual and Text modes
- Shown when changing attributes (e.g. title)
- **NOT** Shown when changing content or attributes, then reverting back to the original value

Demonstration of the last item:

![dirty](https://user-images.githubusercontent.com/1779930/28545341-a949edd6-7094-11e7-8dcd-379f15563dc5.gif)

__Caveats:__

Editable values are only reflected in state after blurring the editable fields. Dirtiness detection will only update at these intervals.