### PR TITLE
Editable: Prevent the link input from being cleared when we move the mouse

### DIFF
--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isUndefined } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from 'i18n';
@@ -69,17 +74,19 @@ class FormatToolbar extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const newState = {
-			linkValue: nextProps.formats.link ? nextProps.formats.link.value : '',
-		};
+		// Update the link value if the focused link node changes
 		if (
-			! this.props.formats.link ||
-			! nextProps.formats.link ||
-			this.props.formats.link.node !== nextProps.formats.link.node
+			isUndefined( nextProps.formats.link ) !== isUndefined( this.props.formats.link ) ||
+			(
+				nextProps.formats.link && this.props.formats.link &&
+				nextProps.formats.link.node !== this.props.formats.link.node
+			)
 		) {
-			newState.isEditingLink = false;
+			this.setState( {
+				linkValue: nextProps.formats.link ? nextProps.formats.link.value : '',
+				isEditingLink: false,
+			} );
 		}
-		this.setState( newState );
 	}
 
 	toggleFormat( format ) {

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -337,7 +337,7 @@ export default class Editable extends Component {
 		const formats = {};
 		const link = find( parents, ( node ) => node.nodeName.toLowerCase() === 'a' );
 		if ( link ) {
-			formats.link = { value: link.getAttribute( 'href' ) || '', link };
+			formats.link = { value: link.getAttribute( 'href' ) || '', node: link };
 		}
 		const activeFormats = this.editor.formatter.matchAll( [	'bold', 'italic', 'strikethrough' ] );
 		activeFormats.forEach( ( activeFormat ) => formats[ activeFormat ] = true );


### PR DESCRIPTION
When inserting a link, the input value was being cleared each time new props were provided to the `FormatToolbar` component (for example when moving the mouse).

This PR fixes this bug by checking that the focused linked actually changed before reverting the linkValue.

