### PR TITLE
Fixes js warning when using select control and change onBlur to onChange

### DIFF
--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -30,7 +30,6 @@ function SelectControl( { label, selected, instanceId, onBlur, options = [], ...
 					<option
 						key={ option.value }
 						value={ option.value }
-						selected={ option.value === selected }
 					>
 						{ option.label }
 					</option>


### PR DESCRIPTION
This PR fixes js warning `Use the defaultValue or value props on <select> instead of setting selected on <option>` when using select control, and change onBlur to onChange like other controls.