### PR TITLE
Polish block UI, inspector, add contributors, fix quote styles

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -70,3 +70,13 @@ This list is manually curated to include valuable contributions by volunteers th
 | @shaunandrews | |
 | @hugobaeta | |
 | @mizejewski | |
+| @buzztone | |
+| @mathetos | |
+| @GaryJones | |
+| @jasonagnew | |
+| @brickbones | |
+| @iamgabrielma | |
+| @swissspidy | |
+| @dixitadusara | |
+| @ameeker | |
+| @StaggerLeee | |

--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -10,6 +10,14 @@
 		min-height: $editor-font-size * $editor-line-height;
 	}
 
+	> p:first-child {
+		margin-top: 0;
+	}
+
+	&.mce-content-body > p {	// needs specificity
+		line-height: inherit;
+	}
+
 	&:focus {
 		outline: none;
 	}

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -19,3 +19,7 @@
 .blocks-gallery__placeholder-instructions {
 	margin: 1.8em 0;
 }
+
+.editor-visual-editor__block[data-type="core/gallery"] .editor-visual-editor__block-edit {
+	overflow: hidden;
+}

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -13,10 +13,10 @@ $z-layers: (
 	'.editor-inserter__tabs': 1,
 	'.editor-inserter__tab.is-active': 1,
 	'.components-panel__header': 1,
+	'.editor-block-mover': 10,
 	'.editor-header': 20,
 	'.editor-post-visibility__dialog': 30,
 	'.editor-post-schedule__dialog': 30,
-	'.editor-block-mover': 30,
 
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,

--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -1,8 +1,9 @@
 .editor-block-mover {
 	position: absolute;
-	top: 10px;
+	top: 0;
 	left: 0;
-	padding: 0 14px 20px 0; // handles hover area
+	height: $text-editor-font-size * 4; // same height as an empty paragraph
+	padding: 6px 14px 6px 0; // handles hover area
 	z-index: z-index( '.editor-block-mover' );
 
 	// Mobile, to be revisited
@@ -33,5 +34,9 @@
 
 	.dashicon {
 		display: block;
+	}
+
+	&:first-child {
+		margin-bottom: 4px;
 	}
 }

--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -1,9 +1,11 @@
 .editor-block-settings-menu {
 	position: absolute;
-	top: 10px;
+	top: 0;
 	right: 0;
+	height: $text-editor-font-size * 4; // same height as an empty paragraph
+	padding: 6px 0 6px 14px; // handles hover area
 
-	// Mobile, to be revisited
+	// Mobile
 	display: none;
 
 	@include break-small {
@@ -22,7 +24,6 @@
 	width: 20px;
 	height: 20px;
 	border-radius: 50%;
-	margin-bottom: 8px;
 
 	&[aria-disabled="true"] {
 		cursor: default;
@@ -32,5 +33,9 @@
 
 	.dashicon {
 		display: block;
+	}
+
+	&:first-child {
+		margin-bottom: 4px;
 	}
 }

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -249,15 +249,16 @@ class VisualEditorBlockList extends Component {
 					);
 				} ) }
 				{ ! blocks.length &&
-					<input
-						type="text"
-						readOnly
-						className="editor-visual-editor__placeholder"
-						value={ __( 'Write your story' ) }
-						onFocus={ this.appendDefaultBlock }
-						onClick={ noop }
-						onKeyDown={ noop }
-					/>
+					<div className="editor-visual-editor__placeholder">
+						<input
+							type="text"
+							readOnly
+							value={ __( 'Write your story' ) }
+							onFocus={ this.appendDefaultBlock }
+							onClick={ noop }
+							onKeyDown={ noop }
+						/>
+					</div>
 				}
 				<div
 					className={ continueWritingClassname }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -243,7 +243,9 @@
 		}
 
 		.editor-block-mover {
-			display: none;
+			top: -30px;
+			left: 10px;
+			height: auto;
 		}
 
 		.editor-block-settings-menu {
@@ -252,6 +254,7 @@
 			height: auto;
 		}
 
+		.editor-block-mover__control,
 		.editor-block-settings-menu__control {
 			float: left;
 			margin-right: 8px;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -431,6 +431,10 @@ $sticky-bottom-offset: 20px;
 		font-family: $default-font;
 		font-size: $default-font-size;
 		box-shadow: none;
+
+		&:active {
+			background: none;
+		}
 	}
 
 	&:hover > .editor-inserter__block,

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -247,8 +247,9 @@
 		}
 
 		.editor-block-settings-menu {
-			top: -24px;
+			top: -30px;
 			right: 10px;
+			height: auto;
 		}
 
 		.editor-block-settings-menu__control {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -377,9 +377,14 @@ $sticky-bottom-offset: 20px;
 .editor-visual-editor__continue-writing {
 	display: flex;
 	align-items: baseline;
-	max-width: $visual-editor-max-width;
+	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
 	margin: 0 auto;
 	clear: both;
+
+	padding: 0;
+	@include break-small() {
+		padding: 0 ( $block-mover-padding-visible );
+	}
 
 	> .editor-inserter__block {
 		opacity: 0;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -349,28 +349,45 @@ $sticky-bottom-offset: 20px;
 	}
 }
 
-.editor-visual-editor__placeholder[type=text] {
+.editor-visual-editor__placeholder {
+	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
+	padding: 0;
 	clear: left;
-	margin: 2px auto;
-	max-width: $visual-editor-max-width;
+	margin: 0 auto;
 	position: relative;
-	padding: $block-padding;
-	outline: 1px solid transparent;
-	border: none;
-	background: none;
-	box-shadow: none;
-	display: block;
-	transition: 0.2s outline;
-	text-align: left;
-	width: 100%;
-	color: $dark-gray-300;
-	font-size: $editor-font-size;
-	line-height: $editor-line-height;
-	cursor: text;
-	left: -1px;
 
-	&:hover {
-		outline: 1px solid $light-gray-500;
+	@include break-small() {
+		padding: 0 ( $block-padding + $block-mover-padding-visible );
+	}
+
+	input[type=text] {
+		height: $text-editor-font-size * 4; // same height as an empty paragraph
+		margin-top: 0px;
+		margin-bottom: 5px;
+		outline: 1px solid transparent;
+		border: none;
+		background: none;
+		box-shadow: none;
+		display: block;
+		transition: 0.2s outline;
+		text-align: left;
+		width: 100%;
+		color: $dark-gray-300;
+		font-size: $editor-font-size;
+		line-height: $editor-line-height;
+		cursor: text;
+		left: -1px;
+
+		&:hover {
+			outline: 1px solid $light-gray-500;
+		}
+
+		padding: ( $block-padding - 2px ) $block-padding;
+
+		@include break-small() {
+			margin-left: -$block-padding;
+			margin-right: -$block-padding;
+		}
 	}
 }
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -243,9 +243,29 @@
 		}
 
 		.editor-block-mover {
-			top: -30px;
-			left: 10px;
-			height: auto;
+			display: none;
+		}
+
+		@include break-wide() {
+			.editor-block-mover {
+				display: block;
+			}
+
+			.editor-block-mover {
+				top: -30px;
+				left: 10px;
+				height: auto;
+			}
+
+			.editor-block-mover__control {
+				float: left;
+				margin-right: 8px;
+			}
+		}
+
+		.editor-block-settings-menu__control {
+			float: left;
+			margin-right: 8px;
 		}
 
 		.editor-block-settings-menu {
@@ -253,18 +273,14 @@
 			right: 10px;
 			height: auto;
 		}
-
-		.editor-block-mover__control,
-		.editor-block-settings-menu__control {
-			float: left;
-			margin-right: 8px;
-		}
 	}
 
 	&[data-align="full"],
 	&[data-align="wide"] {
 		.editor-visual-editor__block-controls {
-			width: $visual-editor-max-width - $block-padding - $block-padding;
+			@include break-small() {
+				width: $visual-editor-max-width - $block-padding - $block-padding;
+			}
 			margin-left: auto;
 			margin-right: auto;
 		}

--- a/editor/post-permalink/style.scss
+++ b/editor/post-permalink/style.scss
@@ -2,15 +2,20 @@
 	display: inline-flex;
 	align-items: center;
 	position: absolute;
-	top: -36px;
-	left: $block-padding;
-	right: $block-padding;
+	top: -34px;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;
 	padding: 5px;
 	font-family: $default-font;
 	font-size: $default-font-size;
+	left: 0;
+	right: 0;
+
+	@include break-small() {
+		left: $block-padding + $block-mover-padding-visible - 2px;
+		right: $block-padding + $block-mover-padding-visible - 2px;
+	}
 }
 
 .editor-post-permalink__label {

--- a/editor/post-title/style.scss
+++ b/editor/post-title/style.scss
@@ -3,19 +3,25 @@
 	margin-left: auto;
 	margin-right: auto;
 	position: relative;
-	margin-bottom: 10px;
-	max-width: $visual-editor-max-width - ( 2 * $block-mover-margin );
+	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
+	padding: 5px 0;
 
-	@include break-small {
-		max-width: $visual-editor-max-width;
+	@include break-small() {
+		padding: 5px ( $block-padding + $block-mover-padding-visible );
 	}
 
 	h1 {
 		outline: 1px solid transparent;
-		margin: 0;
-		padding: #{ $block-padding / 2 } #{ $block-padding - 2px };
 		font-size: $editor-font-size;
 		transition: 0.2s outline;
+		margin-top: 0;
+		margin-bottom: 0;
+		padding: $block-padding;
+
+		@include break-small() {
+			margin-left: -$block-padding;
+			margin-right: -$block-padding;
+		}
 	}
 
 	&:hover h1 {
@@ -38,7 +44,6 @@
 		}
 
 		@include break-large() {
-			max-width: $text-editor-max-width;
 			margin: 0 auto;
 			padding: 0;
 		}

--- a/editor/sidebar/block-inspector/style.scss
+++ b/editor/sidebar/block-inspector/style.scss
@@ -11,6 +11,8 @@
 .editor-block-inspector__no-blocks {
 	display: block;
 	font-size: $default-font-size;
-	margin: 32px 16px;
+	background: $white;
+	padding: ( $panel-padding * 2 ) $panel-padding;
+	border-bottom: 1px solid $light-gray-500;
 	text-align: center;
 }

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -28,19 +28,13 @@
 		overflow: auto;
 		height: 100%;
 		padding-top: $sidebar-panel-header-height;
+		margin-top: -1px;
+		margin-bottom: -1px;
 
 		@include break-small() {
 			overflow: inherit;
 			height: auto;
 			padding-top: 0;
-		}
-
-		&:first-child {
-			margin-top: -1px;
-		}
-
-		&:last-child {
-			margin-bottom: -1px;
 		}
 	}
 
@@ -111,6 +105,8 @@
 .components-panel__header.editor-sidebar__panel-tabs {
 	justify-content: flex-start;
 	padding-left: 0;
+	padding-right: $panel-padding / 2;
+	border-top: 0;
 
 	.components-icon-button {
 		margin-left: auto;


### PR DESCRIPTION
This is sort of a kitchen sink PR to fix a lot of lingering little issues.

# Normalization

The biggest issues fixed here are the normalization of block paddings and margins between the title, the empty placeholder, and the below the placeholder elements. These now share basically the same styles, which means they behave identically at responsive breakpoints (fixing issues), but the normalization also makes the code easier to maintain. 

Steps to test: View the editor at multiple responsive breakpoints (resize the window), and verify that

- new post writing prompt has the same width, hover and non hover, as the title and inserter
- insert a text block, then verify the inserter and title has the same width and sizes

# Other

Mover and cog/trash elements now have the same dimensions, and fit nicely within the smallest block (a single empty paragraph). This means the mover up/down arrows are spaced a little farther apart, but it gives some nice symmetry. Verify it looks good ;)

Quote styles were fixed, there was a CSS bleed regression from a recent tinymce update. To test, verify lineheights and margins for anything that uses the Editable component didn't regress from this fix. 

The inspector was polished a bit to remove double borders, tweak the close button padding, and add a white background when no block is selected.

The contributors document was updated with recent contributors. I know it's a bummer that this isn't automated, but it means we can give credit to contributors who test, mock up and other things. 