### PR TITLE
Avoid navigating outside the editor using the arrow keys

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -257,12 +257,13 @@ class VisualEditorBlock extends Component {
 		const { keyCode, target } = event;
 		const moveUp = ( keyCode === UP || keyCode === LEFT );
 		const moveDown = ( keyCode === DOWN || keyCode === RIGHT );
+		const wrapperClassname = '.editor-visual-editor';
 		const selectors = [
 			'*[contenteditable="true"]',
 			'*[tabindex]',
 			'textarea',
 			'input',
-		].join( ',' );
+		].map( ( selector ) => `${ wrapperClassname } ${ selector }` ).join( ',' );
 
 		if ( moveUp || moveDown ) {
 			const selection = window.getSelection();


### PR DESCRIPTION
closes #1997 

In this PR, I'm limiting the scope of the arrow navigation to the editor area only.