### PR TITLE
Remove obsolete poststoshow attribute from latest-posts block and dead code

### DIFF
--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -15,22 +15,15 @@
 function gutenberg_render_block_core_latest_posts( $attributes ) {
 	$posts_to_show = 5;
 
-	$posts_to_show_attr = null;
 	if ( array_key_exists( 'postsToShow', $attributes ) ) {
-		$posts_to_show_attr = $attributes['postsToShow'];
-	} elseif ( array_key_exists( 'poststoshow', $attributes ) ) {
-		$posts_to_show_attr = $attributes['poststoshow'];
-	}
-	if ( null !== $posts_to_show_attr ) {
-		$posts_to_show_attr = $attributes['postsToShow'];
 
 		// Basic attribute validation.
 		if (
-			is_numeric( $posts_to_show_attr ) &&
-			$posts_to_show_attr > 0 &&
-			$posts_to_show_attr < 100
+			is_numeric( $attributes['postsToShow'] ) &&
+			$attributes['postsToShow'] > 0 &&
+			$attributes['postsToShow'] < 100
 		) {
-			$posts_to_show = intval( $posts_to_show_attr );
+			$posts_to_show = intval( $attributes['postsToShow'] );
 		}
 	}
 


### PR DESCRIPTION
Follow up on #1992.

I had originally added support for the `poststoshow` prop because before JSON block attributes, the attributes were lowercase. But no need to keep back-compat. Anyway, the logic was such that `$attributes['poststoshow']` was overridden regardless. So it was dead code.