### PR TITLE
Polish gallery inspector, inspector headings, slider

### DIFF
--- a/blocks/inspector-controls/base-control/style.scss
+++ b/blocks/inspector-controls/base-control/style.scss
@@ -1,5 +1,5 @@
 .blocks-base-control {
-	margin: 1em 0 1.5em 0;
+	margin: 0 0 1.5em 0;
 }
 
 .blocks-base-control__label {

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -12,6 +12,7 @@
 	background: $dark-gray-500;
 	border: 4px solid transparent;
 	background-clip: padding-box;
+	box-sizing: border-box;
 }
 
 @mixin range-track() {
@@ -23,23 +24,18 @@
 
 .blocks-range-control__input {
 	width: 100%;
-	margin-top: -3px;
 	margin-left: $item-spacing;
-
+	padding: 0;
 	-webkit-appearance: none;
 	background: transparent;
-
 
 	/**
  	 * Thumb
  	 */
 
-	&::-webkit-slider-thumb {
-		-webkit-appearance: none;
-	}
-
 	// webkit
 	&::-webkit-slider-thumb {
+		-webkit-appearance: none;
 		@include range-thumb();
 		margin-top: -7px;	// necessary for chrome
 	}
@@ -49,11 +45,31 @@
 		@include range-thumb();
 	}
 
+	// ie
+	&::-ms-thumb {
+		@include range-thumb();
+		margin-top: 0;	// necessary because edge inherits from chrome
+		height: 14px;
+		width: 14px;
+		border: 2px solid transparent;
+	}
+
 	&:focus {
 		outline: none;
 	}
 
+	// webkit
 	&:focus::-webkit-slider-thumb {
+		box-shadow: $button-focus-style;;
+	}
+
+	// moz
+	&:focus::-moz-range-thumb {
+		box-shadow: $button-focus-style;;
+	}
+
+	// ie
+	&:focus::-ms-thumb {
 		box-shadow: $button-focus-style;;
 	}
 
@@ -61,11 +77,23 @@
  	 * Track
  	 */
 
+	 // webkit
 	&::-webkit-slider-runnable-track {
+		@include range-track();
+		margin-top: -4px;
+	}
+
+	// moz
+	&::-moz-range-track {
 		@include range-track();
 	}
 
-	&::-moz-range-track {
+	// ie
+	&::-ms-track {
+		margin-top: -4px;
+		background: transparent;
+		border-color: transparent;
+		color: transparent;
 		@include range-track();
 	}
 }

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -3,12 +3,75 @@
 	justify-content: center;
 }
 
+// creating mixin because we can't do multiline variables, and we can't comma-group the selectors for styling the range slider
+@mixin range-thumb() {
+	height: 18px;
+	width: 18px;
+	border-radius: 50%;
+	cursor: pointer;
+	background: $dark-gray-500;
+	border: 4px solid transparent;
+	background-clip: padding-box;
+}
+
+@mixin range-track() {
+	height: 3px;
+	cursor: pointer;
+	background: $light-gray-500;
+	border-radius: 1.5px;
+}
+
 .blocks-range-control__input {
 	width: 100%;
+	margin-top: -3px;
+	margin-left: $item-spacing;
+
+	-webkit-appearance: none;
+	background: transparent;
+
+
+	/**
+ 	 * Thumb
+ 	 */
+
+	&::-webkit-slider-thumb {
+		-webkit-appearance: none;
+	}
+
+	// webkit
+	&::-webkit-slider-thumb {
+		@include range-thumb();
+		margin-top: -7px;	// necessary for chrome
+	}
+
+	// moz
+	&::-moz-range-thumb {
+		@include range-thumb();
+	}
+
+	&:focus {
+		outline: none;
+	}
+
+	&:focus::-webkit-slider-thumb {
+		box-shadow: $button-focus-style;;
+	}
+
+	/**
+ 	 * Track
+ 	 */
+
+	&::-webkit-slider-runnable-track {
+		@include range-track();
+	}
+
+	&::-moz-range-track {
+		@include range-track();
+	}
 }
 
 .blocks-range-control__hint {
 	display: inline-block;
-	margin-left: 10px;
+	margin-left: $item-spacing;
 	font-weight: 500;
 }

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -59,7 +59,7 @@ export function SavedState( { isNew, isPublished, isDirty, isSaving, isSaveable,
 
 	return (
 		<Button className={ classnames( className, 'button-link' ) } onClick={ onClick }>
-			{ __( 'Save' ) }
+			{ __( 'Save Draft' ) }
 		</Button>
 	);
 }

--- a/editor/header/saved-state/test/index.js
+++ b/editor/header/saved-state/test/index.js
@@ -67,7 +67,7 @@ describe( 'SavedState', () => {
 		);
 
 		expect( wrapper.name() ).toBe( 'Button' );
-		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save' );
+		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save Draft' );
 		wrapper.simulate( 'click' );
 		expect( statusSpy ).toHaveBeenCalledWith( 'draft' );
 		expect( saveSpy ).toHaveBeenCalled();
@@ -87,7 +87,7 @@ describe( 'SavedState', () => {
 		);
 
 		expect( wrapper.name() ).toBe( 'Button' );
-		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save' );
+		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save Draft' );
 		wrapper.simulate( 'click' );
 		expect( statusSpy ).not.toHaveBeenCalled();
 		expect( saveSpy ).toHaveBeenCalled();

--- a/editor/sidebar/block-inspector/class-name.js
+++ b/editor/sidebar/block-inspector/class-name.js
@@ -36,10 +36,13 @@ class BlockInspectorClassName extends Component {
 		}
 
 		return (
-			<InspectorControls.TextControl
-				label={ __( 'Additional CSS Class' ) }
-				value={ selectedBlock.attributes.className }
-				onChange={ this.setClassName } />
+			<div>
+				<h3>{ __( 'Block Settings' ) }</h3>
+				<InspectorControls.TextControl
+					label={ __( 'Additional CSS Class' ) }
+					value={ selectedBlock.attributes.className }
+					onChange={ this.setClassName } />
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
Another sort of polish kitchen sink PR. This PR changes:

- The lavel of the "Save" button to say "Save Draft". This reads better when editing a published post, and will be further improved when autosave kicks in.
- Inspector headings were polished a bit, and I added a "Block Settings" heading to the global CSS class option.
- The range slider was styled to almost fix #1523 

With regards to the slider, it has a focus style, so it should be accessible. It suffers from that same annoying issue that any other styled elements do -- that is, the focus lingers even when you click, which it doesn't do if the component itself is unstyled. But this is discussed separtely in #904.

Slider screenshot:

![screen shot 2017-07-26 at 13 13 10](https://user-images.githubusercontent.com/1204802/28618785-eae4d70c-7205-11e7-9635-5ec3cbee0040.png)
