### PR TITLE
Themes: Add the wideImages theme support config

### DIFF
--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -28,11 +28,14 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 };
 
 const DEFAULT_CONTROLS = [ 'left', 'center', 'right' ];
+const WIDE_CONTROLS = [ 'wide', 'full' ];
 
-export default function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CONTROLS } ) {
+export default function BlockAlignmentToolbar( { value, onChange, wideControlsEnabled = false } ) {
 	function applyOrUnset( align ) {
 		return () => onChange( value === align ? undefined : align );
 	}
+
+	const controls = DEFAULT_CONTROLS.concat( wideControlsEnabled ? WIDE_CONTROLS : [] );
 
 	return (
 		<Toolbar

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -56,7 +56,7 @@ registerBlockType( 'core/cover-image', {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
+						wideControlsEnabled={ settings.wideImages }
 					/>
 
 					<Toolbar>

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -45,7 +45,7 @@ registerBlockType( 'core/cover-image', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, className } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className, settings } ) {
 		const { url, title, align, id, hasParallax, hasBackgroundDim } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const onSelectImage = ( media ) => setAttributes( { url: media.url, id: media.id } );
@@ -56,7 +56,7 @@ registerBlockType( 'core/cover-image', {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-						controls={ validAlignments }
+						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
 					/>
 
 					<Toolbar>

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -112,7 +112,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 			render() {
 				const { html, type, error, fetching } = this.state;
 				const { align, url, caption } = this.props.attributes;
-				const { setAttributes, focus, setFocus } = this.props;
+				const { setAttributes, focus, setFocus, settings } = this.props;
 				const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
 				const controls = (
@@ -121,7 +121,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 							<BlockAlignmentToolbar
 								value={ align }
 								onChange={ updateAlignment }
-								controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
+								controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
 							/>
 						</BlockControls>
 					)

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -121,7 +121,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 							<BlockAlignmentToolbar
 								value={ align }
 								onChange={ updateAlignment }
-								controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
+								wideControlsEnabled={ settings.wideImages }
 							/>
 						</BlockControls>
 					)

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -77,7 +77,7 @@ registerBlockType( 'core/gallery', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, className } ) {
+	edit( { attributes, setAttributes, focus, className, settings } ) {
 		const { images = [], columns = defaultColumnsNumber( attributes ), align = 'none' } = attributes;
 		const setColumnsNumber = ( event ) => setAttributes( { columns: event.target.value } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
@@ -90,7 +90,7 @@ registerBlockType( 'core/gallery', {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
+						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
 					/>
 					{ !! images.length && (
 						<Toolbar controls={ [ {

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -90,7 +90,7 @@ registerBlockType( 'core/gallery', {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
+						wideControlsEnabled={ settings.wideImages }
 					/>
 					{ !! images.length && (
 						<Toolbar controls={ [ {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -79,7 +79,7 @@ registerBlockType( 'core/image', {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
+						wideControlsEnabled={ settings.wideImages }
 					/>
 
 					<Toolbar>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -63,7 +63,7 @@ registerBlockType( 'core/image', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, className } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className, settings } ) {
 		const { url, alt, caption, align, id, href } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
@@ -79,7 +79,7 @@ registerBlockType( 'core/image', {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
+						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
 					/>
 
 					<Toolbar>

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -143,7 +143,7 @@ registerBlockType( 'core/latest-posts', {
 							onChange={ ( nextAlign ) => {
 								setAttributes( { align: nextAlign } );
 							} }
-							controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
+							wideControlsEnabled={ settings.wideImages }
 						/>
 						<Toolbar controls={ layoutControls } />
 					</BlockControls>

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -118,7 +118,7 @@ registerBlockType( 'core/latest-posts', {
 				latestPosts.splice( this.props.attributes.postsToShow, postsDifference );
 			}
 
-			const { focus } = this.props;
+			const { focus, settings } = this.props;
 			const { displayPostDate, align, layout, columns } = this.props.attributes;
 			const layoutControls = [
 				{
@@ -143,7 +143,7 @@ registerBlockType( 'core/latest-posts', {
 							onChange={ ( nextAlign ) => {
 								setAttributes( { align: nextAlign } );
 							} }
-							controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
+							controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
 						/>
 						<Toolbar controls={ layoutControls } />
 					</BlockControls>

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -40,7 +40,7 @@ registerBlockType( 'core/pullquote', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, className } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className, settings } ) {
 		const { value, citation, align } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
@@ -50,7 +50,7 @@ registerBlockType( 'core/pullquote', {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
+						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
 					/>
 				</BlockControls>
 			),

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -50,7 +50,7 @@ registerBlockType( 'core/pullquote', {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
+						wideControlsEnabled={ settings.wideImages }
 					/>
 				</BlockControls>
 			),

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -43,7 +43,7 @@ registerBlockType( 'core/table', {
 					<BlockAlignmentToolbar
 						value={ attributes.align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
+						wideControlsEnabled={ settings.wideImages }
 					/>
 				</BlockControls>
 			),

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -34,7 +34,7 @@ registerBlockType( 'core/table', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, className } ) {
+	edit( { attributes, setAttributes, focus, setFocus, className, settings } ) {
 		const { content } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		return [
@@ -43,7 +43,7 @@ registerBlockType( 'core/table', {
 					<BlockAlignmentToolbar
 						value={ attributes.align }
 						onChange={ updateAlignment }
-						controls={ [ 'left', 'center', 'right', 'wide', 'full' ] }
+						controls={ [ 'left', 'center', 'right' ].concat( settings.wideImages ? [ 'wide', 'full' ] : [] ) }
 					/>
 				</BlockControls>
 			),

--- a/docs/index.js
+++ b/docs/index.js
@@ -59,6 +59,13 @@ addStory( {
 
 addStory( {
 	parents: [ 'reference' ],
+	name: 'theme-support',
+	title: 'Theme Support',
+	markdown: require( './themes.md' ),
+} );
+
+addStory( {
+	parents: [ 'reference' ],
 	name: 'glossary',
 	title: 'Glossary',
 	markdown: require( './glossary.md' ),

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -11,5 +11,7 @@ Some advanced block features require opt-in support in the theme itself as it's 
 Some blocks such as the image block have the possibility to define a "wide" or "full" alignment by adding the corresponding classname to the block's wrapper ( `alignwide` or `alignfull` ). A theme can opt-in for this feature by calling:
 
 ```php
-add_theme_support( 'wide-images' );
+add_theme_support( 'gutenberg', array(
+   'wide-images' => true,
+) );
 ```

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,15 @@
+# Blocks support by themes
+
+By default, blocks provide their styles to enable basic support for blocks in themes without any change. Themes can add/override these styles, or they can provide no styles at all, and rely fully on what the theme provides.
+
+Some advanced block features require opt-in support in the theme itself as it's difficult for the block to provide these styles, they may require some architecting of the theme itself, in order to work well.
+
+## Opt-in features
+
+### Wide Images:
+
+Some blocks such as the image block have the possibility to define a "wide" or "full" alignment by adding the corresponding classname to the block's wrapper ( `alignwide` or `alignfull` ). A theme can opt-in for this feature by calling:
+
+```php
+add_theme_support( 'wide-images' );
+```

--- a/editor/index.js
+++ b/editor/index.js
@@ -22,6 +22,10 @@ import Layout from './layout';
 import { createReduxStore } from './state';
 import { undo } from './actions';
 
+const defaultSettings = {
+	wideImages: false,
+};
+
 // Configure moment globally
 moment.locale( settings.l10n.locale );
 if ( settings.timezone.string ) {
@@ -73,14 +77,16 @@ function preparePostState( store, post ) {
 /**
  * Initializes and returns an instance of Editor.
  *
- * @param {String} id   Unique identifier for editor instance
- * @param {Object} post API entity for post to edit  (type required)
+ * @param {String} id              Unique identifier for editor instance
+ * @param {Object} post            API entity for post to edit  (type required)
+ * @param {Object} editorSettings  Editor settings object
  */
-export function createEditorInstance( id, post ) {
+export function createEditorInstance( id, post, editorSettings = defaultSettings ) {
 	const store = createReduxStore();
 
 	store.dispatch( {
-		type: 'LOAD_USER_DATA',
+		type: 'SETUP_EDITOR',
+		settings: editorSettings,
 	} );
 
 	preparePostState( store, post );
@@ -93,7 +99,7 @@ export function createEditorInstance( id, post ) {
 						onUndo: undo,
 					}, store.dispatch ) }
 				>
-					<Layout />
+					<Layout settings={ editorSettings } />
 				</EditableProvider>
 			</SlotFillProvider>
 		</ReduxProvider>,

--- a/editor/index.js
+++ b/editor/index.js
@@ -22,7 +22,15 @@ import Layout from './layout';
 import { createReduxStore } from './state';
 import { undo } from './actions';
 
-const defaultSettings = {
+/**
+ * The default editor settings
+ * You can override any default settings when calling createEditorInstance
+ *
+ *  wideImages   boolean   Enable/Disable Wide/Full Alignments
+ *
+ * @var {Object} DEFAULT_SETTINGS
+ */
+const DEFAULT_SETTINGS = {
 	wideImages: false,
 };
 
@@ -81,7 +89,7 @@ function preparePostState( store, post ) {
  * @param {Object} post            API entity for post to edit  (type required)
  * @param {Object} editorSettings  Editor settings object
  */
-export function createEditorInstance( id, post, editorSettings = defaultSettings ) {
+export function createEditorInstance( id, post, editorSettings = DEFAULT_SETTINGS ) {
 	const store = createReduxStore();
 
 	store.dispatch( {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -45,6 +45,7 @@ import {
 	isBlockMultiSelected,
 	isFirstMultiSelectedBlock,
 	isTyping,
+	getEditorSettings,
 } from '../../selectors';
 
 function FirstChild( { children } ) {
@@ -308,7 +309,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	render() {
-		const { block, multiSelectedBlockUids } = this.props;
+		const { block, multiSelectedBlockUids, settings } = this.props;
 		const { name: blockName, isValid } = block;
 		const blockType = getBlockType( blockName );
 		// translators: %s: Type of block (i.e. Text, Image etc)
@@ -418,6 +419,7 @@ class VisualEditorBlock extends Component {
 							setFocus={ partial( onFocus, block.uid ) }
 							mergeBlocks={ this.mergeBlocks }
 							className={ className }
+							settings={ settings }
 							id={ block.uid }
 						/>
 					) }
@@ -448,6 +450,7 @@ export default connect(
 			focus: getBlockFocus( state, ownProps.uid ),
 			isTyping: isTyping( state ),
 			order: getBlockIndex( state, ownProps.uid ),
+			settings: getEditorSettings( state ),
 		};
 	},
 	( dispatch, ownProps ) => ( {

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -715,3 +715,13 @@ export function getRecentlyUsedBlocks( state ) {
 	// resolves the block names in the state to the block type settings
 	return state.userData.recentlyUsedBlocks.map( blockType => getBlockType( blockType ) );
 }
+
+/**
+ * Get the editor settings.
+ *
+ * @param {Object} state Global application state
+ * @return {Object}      The editor settings
+ */
+export function getEditorSettings( state ) {
+	return state.settings;
+}

--- a/editor/state.js
+++ b/editor/state.js
@@ -240,7 +240,7 @@ export const userData = combineReducers( {
 	recentlyUsedBlocks( state = [], action ) {
 		const maxRecent = 8;
 		switch ( action.type ) {
-			case 'LOAD_USER_DATA':
+			case 'SETUP_EDITOR':
 				// This is where we initially populate the recently used blocks,
 				// for now this inserts blocks from the common category, but will
 				// load this from an API in the future.
@@ -529,6 +529,15 @@ export function notices( state = {}, action ) {
 	return state;
 }
 
+export function settings( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SETUP_EDITOR':
+			return action.settings;
+	}
+
+	return state;
+}
+
 /**
  * Creates a new instance of a Redux store.
  *
@@ -549,6 +558,7 @@ export function createReduxStore() {
 		saving,
 		notices,
 		userData,
+		settings,
 	} ) );
 
 	const enhancers = [ applyMiddleware( refx( effects ) ) ];

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -53,6 +53,7 @@ import {
 	didPostSaveRequestFail,
 	getSuggestedPostFormat,
 	getNotices,
+	getEditorSettings,
 } from '../selectors';
 
 /**
@@ -1333,6 +1334,20 @@ describe( 'selectors', () => {
 				state.notices.b,
 				state.notices.a,
 			] );
+		} );
+	} );
+
+	describe( 'getEditorSettings', () => {
+		it( 'should return the settings object', () => {
+			const state = {
+				settings: {
+					wideImages: true,
+				},
+			};
+
+			expect( getEditorSettings( state ) ).toEqual( {
+				wideImages: true,
+			} );
 		} );
 	} );
 } );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -26,6 +26,7 @@ import {
 	showInsertionPoint,
 	createReduxStore,
 	userData,
+	settings,
 } from '../state';
 
 describe( 'state', () => {
@@ -1081,10 +1082,21 @@ describe( 'state', () => {
 
 		it( 'should populate recently used blocks with the common category', () => {
 			const initial = userData( undefined, {
-				type: 'LOAD_USER_DATA',
+				type: 'SETUP_EDITOR',
 			} );
 
 			expect( initial.recentlyUsedBlocks ).toEqual( expect.arrayContaining( [ 'core/test-block', 'core/text' ] ) );
+		} );
+	} );
+
+	describe( 'settings', () => {
+		it( 'should populate the editor settings', () => {
+			const state = settings( {}, {
+				type: 'SETUP_EDITOR',
+				settings: { wideImages: true },
+			} );
+
+			expect( state ).toEqual( { wideImages: true } );
 		} );
 	} );
 } );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -611,7 +611,13 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	);
 
 	// Initialize the editor.
-	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() { wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost ); } );' );
+	$editor_settings = array(
+		'wideImages' => get_theme_support( 'wide-images' ),
+	);
+	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() {'
+		. 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
+		.'} );'
+	);
 
 	/**
 	 * Scripts

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -611,8 +611,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	);
 
 	// Initialize the editor.
+	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
 	$editor_settings = array(
-		'wideImages' => get_theme_support( 'wide-images' ),
+		'wideImages' => $gutenberg_theme_support ? $gutenberg_theme_support[0]['wide-images'] : false,
 	);
 	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() {'
 		. 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -616,7 +616,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	);
 	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() {'
 		. 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
-		.'} );'
+		. '} );'
 	);
 
 	/**


### PR DESCRIPTION
closes #1724 

The backend passes an `editorSettings` variable when initializing the editor. This object could contain any global editor setting such as the `wideImages` flag for now.

I'm storing these settings in the editor's store but we could decide to pass it as prop down to where it's being used.

By default, the `wideImages` is disabled and we could opt-in by calling `add_theme_support( 'wide-images' );`