### PR TITLE
Test saved post status in evaluating post as new

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -79,7 +79,7 @@ export function hasEditorRedo( state ) {
  * @return {Boolean}       Whether the post is new
  */
 export function isEditedPostNew( state ) {
-	return getEditedPostAttribute( state, 'status' ) === 'auto-draft';
+	return getCurrentPost( state ).status === 'auto-draft';
 }
 
 /**


### PR DESCRIPTION
Fixes #2022 

This pull request seeks to resolve an issue where toggling a new post as Pending Review would cause the "Move to Trash" button to display, even before the post had been saved.

__Testing instructions:__

Repeat steps to reproduce from #2022, verifying expected result.