### PR TITLE
Latest Posts Block: add column slider

### DIFF
--- a/blocks/library/latest-posts/block.scss
+++ b/blocks/library/latest-posts/block.scss
@@ -12,9 +12,27 @@
 		list-style: none;
 
 		li {
-			flex-grow: 1;
 			margin: 0 16px 16px 0;
 		}
+	}
+
+	&.columns-1 li {
+		width: calc( ( 100% / 1 ) - 16px );
+	}
+	&.columns-2 li {
+		width: calc( ( 100% / 2 ) - 16px );
+	}
+	&.columns-3 li {
+		width: calc( ( 100% / 3 ) - 16px );
+	}
+	&.columns-4 li {
+		width: calc( ( 100% / 4 ) - 16px );
+	}
+	&.columns-5 li {
+		width: calc( ( 100% / 5 ) - 16px );
+	}
+	&.columns-6 li {
+		width: calc( ( 100% / 6 ) - 16px );
 	}
 }
 

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -159,13 +159,15 @@ registerBlockType( 'core/latest-posts', {
 							checked={ displayPostDate }
 							onChange={ this.toggleDisplayPostDate }
 						/>
-						<RangeControl
-							label={ __( 'Columns' ) }
-							value={ columns }
-							onChange={ ( event ) => setAttributes( { columns: event.target.value } ) }
-							min="2"
-							max={ Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
-						/>
+						{ layout === 'grid' &&
+							<RangeControl
+								label={ __( 'Columns' ) }
+								value={ columns }
+								onChange={ ( event ) => setAttributes( { columns: event.target.value } ) }
+								min="2"
+								max={ Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
+							/>
+						}
 						<TextControl
 							label={ __( 'Number of posts to show' ) }
 							type="number"

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -17,12 +17,14 @@ import { getLatestPosts } from './data.js';
 import InspectorControls from '../../inspector-controls';
 import TextControl from '../../inspector-controls/text-control';
 import ToggleControl from '../../inspector-controls/toggle-control';
+import RangeControl from '../../inspector-controls/range-control';
 import BlockDescription from '../../block-description';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
 const MIN_POSTS = 1;
 const MAX_POSTS = 100;
+const MAX_POSTS_COLUMNS = 6;
 
 registerBlockType( 'core/latest-posts', {
 	title: __( 'Latest Posts' ),
@@ -35,6 +37,7 @@ registerBlockType( 'core/latest-posts', {
 		postsToShow: 5,
 		displayPostDate: false,
 		layout: 'list',
+		columns: 3,
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -116,7 +119,7 @@ registerBlockType( 'core/latest-posts', {
 			}
 
 			const { focus } = this.props;
-			const { displayPostDate, align, layout } = this.props.attributes;
+			const { displayPostDate, align, layout, columns } = this.props.attributes;
 			const layoutControls = [
 				{
 					icon: 'list-view',
@@ -151,11 +154,17 @@ registerBlockType( 'core/latest-posts', {
 							<p>{ __( 'Shows a list of your site\'s most recent posts.' ) }</p>
 						</BlockDescription>
 						<h3>{ __( 'Latest Posts Settings' ) }</h3>
-
 						<ToggleControl
 							label={ __( 'Display post date' ) }
 							checked={ displayPostDate }
 							onChange={ this.toggleDisplayPostDate }
+						/>
+						<RangeControl
+							label={ __( 'Columns' ) }
+							value={ columns }
+							onChange={ ( event ) => setAttributes( { columns: event.target.value } ) }
+							min="2"
+							max={ Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
 						/>
 						<TextControl
 							label={ __( 'Number of posts to show' ) }
@@ -168,7 +177,7 @@ registerBlockType( 'core/latest-posts', {
 					</InspectorControls>
 				),
 				<ul
-					className={ classnames( this.props.className, {
+					className={ classnames( this.props.className, 'columns-' + columns, {
 						'is-grid': layout === 'grid',
 					} ) }
 					key="latest-posts"

--- a/blocks/test/fixtures/core__latest-posts.json
+++ b/blocks/test/fixtures/core__latest-posts.json
@@ -3,6 +3,7 @@
         "uid": "_uid_0",
         "name": "core/latest-posts",
         "attributes": {
+            "columns": 3,
             "postsToShow": 5,
             "layout": "list",
             "displayPostDate": false

--- a/blocks/test/fixtures/core__latest-posts.serialized.html
+++ b/blocks/test/fixtures/core__latest-posts.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latest-posts {"postsToShow":5,"displayPostDate":false,"layout":"list"} /-->
+<!-- wp:core/latest-posts {"postsToShow":5,"displayPostDate":false,"layout":"list","columns":3} /-->

--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -75,6 +75,10 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 		$class .= ' is-grid';
 	}
 
+	if ( isset( $attributes['columns'] ) ) {
+		$class .= ' columns-' . $attributes['columns'];
+	}
+
 	$block_content = <<<CONTENT
 <ul class="{$class}">
 	{$posts_content}

--- a/lib/blocks/latest-posts.php
+++ b/lib/blocks/latest-posts.php
@@ -44,7 +44,7 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 		'post_status' => 'publish',
 	) );
 
-	$posts_content = '';
+	$list_items_markup = '';
 
 	foreach ( $recent_posts as $post ) {
 		$post_id = $post['ID'];
@@ -53,24 +53,24 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 		if ( ! $title ) {
 			$title = __( '(Untitled)', 'gutenberg' );
 		}
-		$posts_content .= sprintf(
+		$list_items_markup .= sprintf(
 			'<li><a href="%1$s">%2$s</a>',
 			esc_url( get_permalink( $post_id ) ),
 			esc_html( $title )
 		);
 
 		if ( $attributes['displayPostDate'] ) {
-			$posts_content .= sprintf(
+			$list_items_markup .= sprintf(
 				'<time datetime="%1$s" class="wp-block-latest-posts__post-date">%2$s</time>',
 				esc_attr( get_the_date( 'c', $post_id ) ),
 				esc_html( get_the_date( '', $post_id ) )
 			);
 		}
 
-		$posts_content .= "</li>\n";
+		$list_items_markup .= "</li>\n";
 	}
 
-	$class = 'wp-block-latest-posts ' . esc_attr( 'align' . $align );
+	$class = "wp-block-latest-posts align{$align}";
 	if ( isset( $attributes['layout'] ) && 'grid' === $attributes['layout'] ) {
 		$class .= ' is-grid';
 	}
@@ -79,11 +79,11 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 		$class .= ' columns-' . $attributes['columns'];
 	}
 
-	$block_content = <<<CONTENT
-<ul class="{$class}">
-	{$posts_content}
-</ul>
-CONTENT;
+	$block_content = sprintf(
+		'<ul class="%1$s">%2$s</ul>',
+		esc_attr( $class ),
+		$list_items_markup
+	);
 
 	return $block_content;
 }


### PR DESCRIPTION
Expands on #1992 providing a control for setting number of columns. Note that, different from galleries, we don't grow individual items and respect the sizing corresponding to the column divisions.

![latest-posts-columns](https://user-images.githubusercontent.com/548849/28630023-61c6fe72-7229-11e7-8625-a81e5792738e.gif)

The setting only shows if "grid" layout is selected, as it doesn't make sense for list display.