### PR TITLE
Define root setup files as ignored test directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,9 @@
       "<rootDir>/test/setup-globals.js",
       "<rootDir>/test/setup-wp-aliases.js"
     ],
+    "testPathIgnorePatterns": [
+      "<rootDir>/test"
+    ],
     "setupTestFrameworkScriptFile": "<rootDir>/test/setup-test-framework.js",
     "testMatch": [
       "**/blocks/**/test/*.js",

--- a/package.json
+++ b/package.json
@@ -109,18 +109,9 @@
       "<rootDir>/test/setup-globals.js",
       "<rootDir>/test/setup-wp-aliases.js"
     ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/test"
-    ],
     "setupTestFrameworkScriptFile": "<rootDir>/test/setup-test-framework.js",
     "testMatch": [
-      "**/blocks/**/test/*.js",
-      "**/components/**/test/*.js",
-      "**/date/**/test/*.js",
-      "**/editor/**/test/*.js",
-      "**/element/**/test/*.js",
-      "**/i18n/**/test/*.js",
-      "**/utils/**/test/*.js"
+      "<rootDir>/(blocks|components|date|editor|element|i18n|utils)/**/test/*.js"
     ],
     "timers": "fake",
     "transform": {


### PR DESCRIPTION
This pull request seeks to resolve test failures which occur when running `npm test` locally, due to Jest attempting to treat files within the root `test/` directory as tests. Since none of these files define any test cases, the result of `npm test` is a failure. It's unclear to me why these tests fail locally, but not in CircleCI. The changes herein define an ignore pattern for the root `test/` directory in Jest's configuration.

__Testing instructions:__

Verify that expected tests run, and no test failures occur:

```
npm test
```