### PR TITLE
Initialize demo content only for new posts

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -535,7 +535,8 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	}
 
 	// Set initial title to empty string for auto draft for duration of edit.
-	if ( 'auto-draft' === $post_to_edit['status'] ) {
+	$is_new_post = 'auto-draft' === $post_to_edit['status'];
+	if ( $is_new_post ) {
 		$default_title = apply_filters( 'default_title', '' );
 		$post_to_edit['title'] = array(
 			'raw'      => $default_title,
@@ -550,7 +551,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	);
 
 	// Prepopulate with some test content in demo.
-	if ( $is_demo ) {
+	if ( $is_new_post && $is_demo ) {
 		wp_add_inline_script(
 			'wp-editor',
 			file_get_contents( gutenberg_dir_path() . 'post-content.js' )


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/1929#issuecomment-318118967
Related: #1984 (cc @westonruter)

This pull request seeks to resolve an issue where saving an edited Demo post and proceeding to refresh the page will not reflect edits made to the Demo.

The cause is two-fold:

- We don't change the URL from `?page=gutenberg-demo` to `?page=gutenberg` when saving a demo post
- We don't ensure that the demo initialization is not triggered when editing an existing post

The changes herein address the second of these two issues, which fixes the behavior. Ideally we should still seek to remedy the first of these points.

__Testing instructions:__

1. Navigate to Gutenberg > Demo
2. Edit the post (title or content)
3. Save the post
4. Refresh
5. Note that edits are reflected