### PR TITLE
Create new blocks as valid

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -31,6 +31,7 @@ export function createBlock( name, attributes = {} ) {
 	return {
 		uid: uuid(),
 		name,
+		isValid: true,
 		attributes: {
 			...defaultAttributes,
 			...attributes,

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -36,6 +36,7 @@ describe( 'block factory', () => {
 				includesDefault: true,
 				align: 'left',
 			} );
+			expect( block.isValid ).toBe( true );
 			expect( typeof block.uid ).toBe( 'string' );
 		} );
 	} );


### PR DESCRIPTION
Regression introduced in #1929

This pull request seeks to resolve a bug where creating a new block will flag it as corrupt, presenting the user with a warning.

The issue is that we check `! block.isValid` as considering a block to be corrupt, and this property was not assigned to newly created blocks.

We may want to refactor this behavior to explicitly check either `false === block.isValid` or `block.isInvalid` instead, but this change addresses the immediate breakage.

__Testing instructions:__

1. Navigate to Gutenberg > New Post
2. Click Write
3. Note you are not presented with corrupt warning
