### PR TITLE
Regenerate fixture JSON files

### DIFF
--- a/blocks/test/fixtures/core-embed__animoto.json
+++ b/blocks/test/fixtures/core-embed__animoto.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/animoto",
+        "isValid": true,
         "attributes": {
             "url": "https://animoto.com/",
             "caption": [
                 "Embedded content from animoto"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__cloudup.json
+++ b/blocks/test/fixtures/core-embed__cloudup.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/cloudup",
+        "isValid": true,
         "attributes": {
             "url": "https://cloudup.com/",
             "caption": [
                 "Embedded content from cloudup"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__collegehumor.json
+++ b/blocks/test/fixtures/core-embed__collegehumor.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/collegehumor",
+        "isValid": true,
         "attributes": {
             "url": "https://collegehumor.com/",
             "caption": [
                 "Embedded content from collegehumor"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__dailymotion.json
+++ b/blocks/test/fixtures/core-embed__dailymotion.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/dailymotion",
+        "isValid": true,
         "attributes": {
             "url": "https://dailymotion.com/",
             "caption": [
                 "Embedded content from dailymotion"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__facebook.json
+++ b/blocks/test/fixtures/core-embed__facebook.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/facebook",
+        "isValid": true,
         "attributes": {
             "url": "https://facebook.com/",
             "caption": [
                 "Embedded content from facebook"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__flickr.json
+++ b/blocks/test/fixtures/core-embed__flickr.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/flickr",
+        "isValid": true,
         "attributes": {
             "url": "https://flickr.com/",
             "caption": [
                 "Embedded content from flickr"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__funnyordie.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/funnyordie",
+        "isValid": true,
         "attributes": {
             "url": "https://funnyordie.com/",
             "caption": [
                 "Embedded content from funnyordie"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__hulu.json
+++ b/blocks/test/fixtures/core-embed__hulu.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/hulu",
+        "isValid": true,
         "attributes": {
             "url": "https://hulu.com/",
             "caption": [
                 "Embedded content from hulu"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__imgur.json
+++ b/blocks/test/fixtures/core-embed__imgur.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/imgur",
+        "isValid": true,
         "attributes": {
             "url": "https://imgur.com/",
             "caption": [
                 "Embedded content from imgur"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__instagram.json
+++ b/blocks/test/fixtures/core-embed__instagram.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/instagram",
+        "isValid": true,
         "attributes": {
             "url": "https://instagram.com/",
             "caption": [
                 "Embedded content from instagram"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__issuu.json
+++ b/blocks/test/fixtures/core-embed__issuu.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/issuu",
+        "isValid": true,
         "attributes": {
             "url": "https://issuu.com/",
             "caption": [
                 "Embedded content from issuu"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__kickstarter.json
+++ b/blocks/test/fixtures/core-embed__kickstarter.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/kickstarter",
+        "isValid": true,
         "attributes": {
             "url": "https://kickstarter.com/",
             "caption": [
                 "Embedded content from kickstarter"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__meetup-com.json
+++ b/blocks/test/fixtures/core-embed__meetup-com.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/meetup-com",
+        "isValid": true,
         "attributes": {
             "url": "https://meetup.com/",
             "caption": [
                 "Embedded content from meetup-com"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__mixcloud.json
+++ b/blocks/test/fixtures/core-embed__mixcloud.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/mixcloud",
+        "isValid": true,
         "attributes": {
             "url": "https://mixcloud.com/",
             "caption": [
                 "Embedded content from mixcloud"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__photobucket.json
+++ b/blocks/test/fixtures/core-embed__photobucket.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/photobucket",
+        "isValid": true,
         "attributes": {
             "url": "https://photobucket.com/",
             "caption": [
                 "Embedded content from photobucket"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__polldaddy.json
+++ b/blocks/test/fixtures/core-embed__polldaddy.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/polldaddy",
+        "isValid": true,
         "attributes": {
             "url": "https://polldaddy.com/",
             "caption": [
                 "Embedded content from polldaddy"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__reddit.json
+++ b/blocks/test/fixtures/core-embed__reddit.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/reddit",
+        "isValid": true,
         "attributes": {
             "url": "https://reddit.com/",
             "caption": [
                 "Embedded content from reddit"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__reverbnation.json
+++ b/blocks/test/fixtures/core-embed__reverbnation.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/reverbnation",
+        "isValid": true,
         "attributes": {
             "url": "https://reverbnation.com/",
             "caption": [
                 "Embedded content from reverbnation"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__screencast.json
+++ b/blocks/test/fixtures/core-embed__screencast.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/screencast",
+        "isValid": true,
         "attributes": {
             "url": "https://screencast.com/",
             "caption": [
                 "Embedded content from screencast"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__scribd.json
+++ b/blocks/test/fixtures/core-embed__scribd.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/scribd",
+        "isValid": true,
         "attributes": {
             "url": "https://scribd.com/",
             "caption": [
                 "Embedded content from scribd"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__slideshare.json
+++ b/blocks/test/fixtures/core-embed__slideshare.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/slideshare",
+        "isValid": true,
         "attributes": {
             "url": "https://slideshare.com/",
             "caption": [
                 "Embedded content from slideshare"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__smugmug.json
+++ b/blocks/test/fixtures/core-embed__smugmug.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/smugmug",
+        "isValid": true,
         "attributes": {
             "url": "https://smugmug.com/",
             "caption": [
                 "Embedded content from smugmug"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__soundcloud.json
+++ b/blocks/test/fixtures/core-embed__soundcloud.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/soundcloud",
+        "isValid": true,
         "attributes": {
             "url": "https://soundcloud.com/",
             "caption": [
                 "Embedded content from soundcloud"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__speaker.json
+++ b/blocks/test/fixtures/core-embed__speaker.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/speaker",
+        "isValid": true,
         "attributes": {
             "url": "https://speaker.com/",
             "caption": [
                 "Embedded content from speaker"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__spotify.json
+++ b/blocks/test/fixtures/core-embed__spotify.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/spotify",
+        "isValid": true,
         "attributes": {
             "url": "https://spotify.com/",
             "caption": [
                 "Embedded content from spotify"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__ted.json
+++ b/blocks/test/fixtures/core-embed__ted.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/ted",
+        "isValid": true,
         "attributes": {
             "url": "https://ted.com/",
             "caption": [
                 "Embedded content from ted"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__tumblr.json
+++ b/blocks/test/fixtures/core-embed__tumblr.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/tumblr",
+        "isValid": true,
         "attributes": {
             "url": "https://tumblr.com/",
             "caption": [
                 "Embedded content from tumblr"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__twitter.json
+++ b/blocks/test/fixtures/core-embed__twitter.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/twitter",
+        "isValid": true,
         "attributes": {
             "url": "https://twitter.com/automattic",
             "caption": [
                 "We are Automattic"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__videopress.json
+++ b/blocks/test/fixtures/core-embed__videopress.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/videopress",
+        "isValid": true,
         "attributes": {
             "url": "https://videopress.com/",
             "caption": [
                 "Embedded content from videopress"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__vimeo.json
+++ b/blocks/test/fixtures/core-embed__vimeo.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/vimeo",
+        "isValid": true,
         "attributes": {
             "url": "https://vimeo.com/",
             "caption": [
                 "Embedded content from vimeo"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__vine.json
+++ b/blocks/test/fixtures/core-embed__vine.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/vine",
+        "isValid": true,
         "attributes": {
             "url": "https://vine.com/",
             "caption": [
                 "Embedded content from vine"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress-tv.json
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/wordpress-tv",
+        "isValid": true,
         "attributes": {
             "url": "https://wordpress.tv/",
             "caption": [
                 "Embedded content from wordpress-tv"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress.json
+++ b/blocks/test/fixtures/core-embed__wordpress.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/wordpress",
+        "isValid": true,
         "attributes": {
             "url": "https://wordpress.com/",
             "caption": [
                 "Embedded content from WordPress"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core-embed__youtube.json
+++ b/blocks/test/fixtures/core-embed__youtube.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core-embed/youtube",
+        "isValid": true,
         "attributes": {
             "url": "https://youtube.com/",
             "caption": [
                 "Embedded content from youtube"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__button__center.json
+++ b/blocks/test/fixtures/core__button__center.json
@@ -2,13 +2,13 @@
     {
         "uid": "_uid_0",
         "name": "core/button",
+        "isValid": true,
         "attributes": {
             "align": "center",
             "url": "https://github.com/WordPress/gutenberg",
             "text": [
                 "Help build Gutenberg"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__code.json
+++ b/blocks/test/fixtures/core__code.json
@@ -2,9 +2,9 @@
     {
         "uid": "_uid_0",
         "name": "core/code",
+        "isValid": true,
         "attributes": {
             "content": "export default function MyButton() {\n\treturn <Button>Click Me!</Button>;\n}"
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__cover-image.json
+++ b/blocks/test/fixtures/core__cover-image.json
@@ -2,10 +2,10 @@
     {
         "uid": "_uid_0",
         "name": "core/cover-image",
+        "isValid": true,
         "attributes": {
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "title": "Guten Berg!"
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__embed.json
+++ b/blocks/test/fixtures/core__embed.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core/embed",
+        "isValid": true,
         "attributes": {
             "url": "https://example.com/",
             "caption": [
                 "Embedded content from an example URL"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__freeform.json
+++ b/blocks/test/fixtures/core__freeform.json
@@ -2,9 +2,9 @@
     {
         "uid": "_uid_0",
         "name": "core/freeform",
+        "isValid": true,
         "attributes": {
             "content": "Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__gallery.json
+++ b/blocks/test/fixtures/core__gallery.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/gallery",
+        "isValid": false,
         "attributes": {
             "images": [
                 {
@@ -38,7 +39,6 @@
                 }
             ]
         },
-        "isValid": false,
         "originalContent": "<div class=\"wp-block-gallery\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>"
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2-em.json
+++ b/blocks/test/fixtures/core__heading__h2-em.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/heading",
+        "isValid": true,
         "attributes": {
             "nodeName": "H2",
             "content": [
@@ -12,7 +13,6 @@
                 },
                 " Tool"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2.json
+++ b/blocks/test/fixtures/core__heading__h2.json
@@ -2,12 +2,12 @@
     {
         "uid": "_uid_0",
         "name": "core/heading",
+        "isValid": true,
         "attributes": {
             "nodeName": "H2",
             "content": [
                 "A picture is worth a thousand words, or so the saying goes"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__html.json
+++ b/blocks/test/fixtures/core__html.json
@@ -2,9 +2,9 @@
     {
         "uid": "_uid_0",
         "name": "core/html",
+        "isValid": true,
         "attributes": {
             "content": "<h1>Some HTML code</h1>\n<marquee>This text will scroll from right to left</marquee>"
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__image.json
+++ b/blocks/test/fixtures/core__image.json
@@ -2,10 +2,10 @@
     {
         "uid": "_uid_0",
         "name": "core/image",
+        "isValid": true,
         "attributes": {
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "caption": []
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__image__center-caption.json
+++ b/blocks/test/fixtures/core__image__center-caption.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/image",
+        "isValid": false,
         "attributes": {
             "align": "center",
             "url": "https://cldup.com/YLYhpou2oq.jpg",
@@ -9,7 +10,6 @@
                 "Give it a try. Press the \"really wide\" button on the image toolbar."
             ]
         },
-        "isValid": false,
         "originalContent": "<figure class=\"wp-block-image\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" class=\"aligncenter\"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>"
     }
 ]

--- a/blocks/test/fixtures/core__latest-posts.json
+++ b/blocks/test/fixtures/core__latest-posts.json
@@ -2,11 +2,11 @@
     {
         "uid": "_uid_0",
         "name": "core/latest-posts",
+        "isValid": true,
         "attributes": {
             "postsToShow": 5,
             "displayPostDate": false,
             "layout": "list"
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__list__ul.json
+++ b/blocks/test/fixtures/core__list__ul.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/list",
+        "isValid": false,
         "attributes": {
             "nodeName": "UL",
             "values": [
@@ -38,7 +39,6 @@
                 }
             ]
         },
-        "isValid": false,
         "originalContent": "<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>"
     }
 ]

--- a/blocks/test/fixtures/core__preformatted.json
+++ b/blocks/test/fixtures/core__preformatted.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/preformatted",
+        "isValid": false,
         "attributes": {
             "content": [
                 "Some ",
@@ -16,7 +17,6 @@
                 "And more!"
             ]
         },
-        "isValid": false,
         "originalContent": "<pre class=\"wp-block-preformatted\">Some <em>preformatted</em> text...<br>And more!</pre>"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote.json
+++ b/blocks/test/fixtures/core__pullquote.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/pullquote",
+        "isValid": false,
         "attributes": {
             "value": [
                 [
@@ -12,7 +13,6 @@
                 "...with a caption"
             ]
         },
-        "isValid": false,
         "originalContent": "<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><footer>...with a caption</footer>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/quote",
+        "isValid": true,
         "attributes": {
             "value": [
                 {
@@ -13,7 +14,6 @@
             "citation": [
                 "Matt Mullenweg, 2017"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/quote",
+        "isValid": true,
         "attributes": {
             "value": [
                 {
@@ -13,7 +14,6 @@
             "citation": [
                 "Maya Angelou"
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__separator.json
+++ b/blocks/test/fixtures/core__separator.json
@@ -2,7 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/separator",
-        "attributes": {},
-        "isValid": true
+        "isValid": true,
+        "attributes": {}
     }
 ]

--- a/blocks/test/fixtures/core__table.json
+++ b/blocks/test/fixtures/core__table.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/table",
+        "isValid": false,
         "attributes": {
             "content": [
                 {
@@ -195,7 +196,6 @@
                 }
             ]
         },
-        "isValid": false,
         "originalContent": "<table><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>"
     }
 ]

--- a/blocks/test/fixtures/core__text__align-right.json
+++ b/blocks/test/fixtures/core__text__align-right.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/text",
+        "isValid": true,
         "attributes": {
             "align": "right",
             "content": [
@@ -9,7 +10,6 @@
                     "... like this one, which is separate from the above and right aligned."
                 ]
             ]
-        },
-        "isValid": true
+        }
     }
 ]

--- a/blocks/test/fixtures/core__verse.json
+++ b/blocks/test/fixtures/core__verse.json
@@ -2,6 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/verse",
+        "isValid": false,
         "attributes": {
             "content": [
                 "A ",
@@ -16,7 +17,6 @@
                 "And more!"
             ]
         },
-        "isValid": false,
         "originalContent": "<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"
     }
 ]


### PR DESCRIPTION
Quick follow-up to #2033

The changes in 1a2e011db0b26f8a94accc37579fbdba60f4771e result in new property ordering when regenerating JSON fixtures and should have been regenerated in #2033. This pull request simply updates to the expected output.

__Testing instructions:__

Verify that `master` has changes when regenerating fixtures.
Verify that `update/regenerate-fixtures` has no changes when regenerating fixtures.

Regenerate fixtures via:

```
./node_modules/.bin/rimraf blocks/test/fixtures/*.json && GENERATE_MISSING_FIXTURES=y npm run test-unit
```