### PR TITLE
Switch code coverage from coveralls to codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  status:
+    project:
+      diff-change:
+        enabled: true
+        target: auto
+        threshold: 1
+
+comment: false

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-traverse": "^6.24.1",
+    "codecov": "^2.2.0",
     "concurrently": "^3.4.0",
-    "coveralls": "^2.13.1",
     "cross-env": "^3.2.4",
     "deep-freeze": "0.0.1",
     "enzyme": "^2.8.2",
@@ -132,7 +132,7 @@
     "docs-build": "./docutron/bin/cli.js build",
     "test-unit": "jest",
     "test-unit:coverage": "jest --coverage",
-    "test-unit:coverage-ci": "jest --coverage --maxWorkers 1 && coveralls < coverage/lcov.info",
+    "test-unit:coverage-ci": "jest --coverage --maxWorkers 1 && codecov",
     "test-unit:watch": "jest --watch"
   }
 }


### PR DESCRIPTION
After a rebase, this should fix the build failures on #2018, #2050, and perhaps others.

Codecov.io looks like a more polished service than coveralls.io, and provides really nice reporting.  Example:  https://github.com/facebook/jest/pull/4122#issuecomment-318229759, https://codecov.io/gh/facebook/jest