### PR TITLE
Go back to default codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-coverage:
-  status:
-    project:
-      diff_change:
-        enabled: true
-        target: auto
-        threshold: 1
-
-comment: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
-codecov:
+coverage:
   status:
     project:
-      diff-change:
+      diff_change:
         enabled: true
         target: auto
         threshold: 1


### PR DESCRIPTION
Follow-up to #2054.

`curl --data-binary @codecov.yml https://codecov.io/validate`

This command documented [here](https://github.com/codecov/support/wiki/Codecov-Yaml) revealed some errors.  The desired result for now is that Codecov.io shows up as a commit status like Travis but does not leave comments on PRs.