### PR TITLE
Localize schema for wp api client

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -373,6 +373,18 @@ function gutenberg_extend_wp_api_backbone_client() {
 		};
 JS;
 	wp_add_inline_script( 'wp-api', $script );
+
+	// Localize the wp-api settings and schema.
+	$schema_response = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2' ) );
+	if ( ! $schema_response->is_error() ) {
+		wp_localize_script( 'wp-api', 'wpApiSettings', array(
+			'root'          => esc_url_raw( get_rest_url() ),
+			'nonce'         => wp_create_nonce( 'wp_rest' ),
+			'versionString' => 'wp/v2/',
+			'schema'        => $schema_response->get_data(),
+			'cacheSchema'   => true,
+		) );
+	}
 }
 
 /**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -377,13 +377,10 @@ JS;
 	// Localize the wp-api settings and schema.
 	$schema_response = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2' ) );
 	if ( ! $schema_response->is_error() ) {
-		wp_localize_script( 'wp-api', 'wpApiSettings', array(
-			'root'          => esc_url_raw( get_rest_url() ),
-			'nonce'         => wp_create_nonce( 'wp_rest' ),
-			'versionString' => 'wp/v2/',
-			'schema'        => $schema_response->get_data(),
-			'cacheSchema'   => true,
-		) );
+		wp_add_inline_script( 'wp-api', sprintf(
+			'wpApiSettings.cacheSchema = true; wpApiSettings.schema = %s;',
+			wp_json_encode( $schema_response->get_data() )
+		), 'before' );
 	}
 }
 


### PR DESCRIPTION
Supersedes #1498
Fixes #1298 

This pull request seeks to bootstrap the REST API schema to prevent an unusable editor screen from being shown while the schema is fetched from the REST API.

__Implementation notes:__

Ideally one could hook into and append data to the default set (`schema`, `cacheSchema`), but to my knowledge the script loader provides no such opportunities.

https://github.com/WordPress/WordPress/blob/89fa297/wp-includes/script-loader.php#L510-L514
https://github.com/WordPress/WordPress/blob/89fa297/wp-includes/class.wp-scripts.php#L403-L440

It may be the case that we want to revise the above core logic to be filterable, or inject the schema by default.

__Testing instructions:__

Verify in your browser's Developer Tools Network tab that no request is issued for the `/wp/v2` root API route when navigating to the Gutenberg editor.