### PR TITLE
Hide Save [Draft] button if post is published

### DIFF
--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -17,6 +17,7 @@ import './style.scss';
 import { editPost, savePost } from '../../actions';
 import {
 	isEditedPostNew,
+	isCurrentPostPublished,
 	isEditedPostDirty,
 	isSavingPost,
 	isEditedPostSaveable,
@@ -24,7 +25,7 @@ import {
 	getEditedPostAttribute,
 } from '../../selectors';
 
-export function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
+export function SavedState( { isNew, isPublished, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
 	const className = 'editor-saved-state';
 
 	if ( isSaving ) {
@@ -35,7 +36,7 @@ export function SavedState( { isNew, isDirty, isSaving, isSaveable, status, onSt
 		);
 	}
 
-	if ( ! isSaveable ) {
+	if ( ! isSaveable || isPublished ) {
 		return null;
 	}
 
@@ -67,6 +68,7 @@ export default connect(
 	( state ) => ( {
 		post: getCurrentPost( state ),
 		isNew: isEditedPostNew( state ),
+		isPublished: isCurrentPostPublished( state ),
 		isDirty: isEditedPostDirty( state ),
 		isSaving: isSavingPost( state ),
 		isSaveable: isEditedPostSaveable( state ),

--- a/editor/header/saved-state/test/index.js
+++ b/editor/header/saved-state/test/index.js
@@ -33,6 +33,12 @@ describe( 'SavedState', () => {
 		expect( wrapper.type() ).toBeNull();
 	} );
 
+	it( 'returns null if the post is published', () => {
+		const wrapper = shallow( <SavedState isPublished /> );
+
+		expect( wrapper.type() ).toBeNull();
+	} );
+
 	it( 'should return Saved text if not new and not dirty', () => {
 		const wrapper = shallow(
 			<SavedState


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/2020#issuecomment-318032568

This pull request seeks to omit the "Save" header button for published posts. Instead, the "Save" button is only offered as a means to save non-published posts with unsaved changes. A future revision will seek to add a "Revert to Draft" action.

__Testing instructions:__

Verify that Save is offered for drafts but not published posts:

1. Navigate to Gutenberg > New Post
2. Enter a title and/or content
3. Note that Save is shown
4. Press Publish
5. Note that Save is not shown
6. Make changes to the post
7. Note that Save is still not shown