### PR TITLE
Try scrolling individual containers instead of the page

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -84,3 +84,27 @@ body.gutenberg_page_gutenberg-demo {
 		}
 	}
 }
+
+/**
+ * Scroll individual containers instead
+ */
+
+body.toplevel_page_gutenberg,
+body.gutenberg_page_gutenberg-demo {
+	overflow: hidden;
+
+	#wpwrap,
+	#wpbody,
+	#wpbody-content,
+	.gutenberg,
+	.gutenberg__editor,
+	.editor-layout {
+		height: 100%;
+	}
+
+	.editor-layout__content {
+		height: 100%;
+		overflow: auto;
+		-webkit-overflow-scrolling: touch;
+	}
+}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -307,7 +307,8 @@
 	}
 
 	@include break-medium() {
-		top: $header-height + $admin-bar-height + $item-spacing;
+		//top: $header-height + $admin-bar-height + $item-spacing;
+		top: 3px;
 	}
 
 	&.is-appearing-active {

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -26,6 +26,7 @@
 		border-left: none;
 		border-right: none;
 		overflow: auto;
+		-webkit-overflow-scrolling: touch;
 		height: 100%;
 		padding-top: $sidebar-panel-header-height;
 		margin-top: -1px;


### PR DESCRIPTION
This is an experiment. Instead of scrolling the `body` element, it scrolls the editor and sidebar individually. This has a number of benefits:

1. It fixes scroll bleed entirely (see #656)

Scroll bleed is when you scroll to the end of an individually scrolling container, and start scrolling the content below it.

Scroll bleed is particularly a problem on mobile, and if we can refactor to use this type of layout, we can have a vastly improved mobile experience in one fell swoop.

2. It drastically simplifies fixed position elements.

The header, for example, no longer has to be fixed position at all. It can just sit there. This also has benefits on the responsive stuff, since we now get this for free, as opposed to have to make advanced edgecases for every `left` and `right` value.

3. It fixes the issue of "double scrollbars" (see ##1899)

Because the scrollbar is now contextual to the element being scrolled, everything visually works as expected.

There are downsides too. We initially avoided this approach because scrolling on mobile just couldn't be made to behave in a good way. For example, on an iPhone you could "drag down" (to scroll) on the fixed top bar, and scroll the _page itself_, and invoke that overflow bounce that iOS is famous for, looking jarring. The expected behavior here would be that dragging on the fixed top bar wouldn't do anything at all, since it's not part of a scrollable element. However recent changes in mobile safari appear to have fixed this, that's why it's seems worth revisiting.

I'm also unsure of what possible accesibility implications are of this, so @afercia please chime in if you have thoughts here.

One final downside is that if you are viewing the editor in an iPad in landscape mode, and expect to be able to scroll the page by dragging on the left hand navigation menu (the one with Dashboard, Posts, Media, Pages, etc.) you won't be scrolling the page. Because again, this is not a scrollable element anymore.

It feels like there are a ton of upsides to this approach, but it needs a _lot_ of testing, so don't anyone celebrate. But it seems really really worth trying.

Screenshot with scrollbars:

![screen shot 2017-07-28 at 10 16 54](https://user-images.githubusercontent.com/1204802/28709019-ba527f16-737e-11e7-8579-8e710f324e8c.png)
