### PR TITLE
Blocks: Bind the isTyping event handler on component mount

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -78,6 +78,10 @@ class VisualEditorBlock extends Component {
 		if ( this.props.focus ) {
 			this.node.focus();
 		}
+
+		if ( this.props.isTyping ) {
+			document.addEventListener( 'mousemove', this.stopTypingOnMouseMove );
+		}
 	}
 
 	componentWillReceiveProps( newProps ) {


### PR DESCRIPTION
This fixes some issues where the block was creating directly with isTyping true hiding the block toolbar forever

Testing instructions:
 - start new post
 - click on “write your story”
 - add two `##` and a space
 - move the mouse, the block toolbar should appear