### PR TITLE
Use Lodash endsWith equivalent

### DIFF
--- a/blocks/editable/patterns.js
+++ b/blocks/editable/patterns.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import tinymce from 'tinymce';
-import { find, get, escapeRegExp, partition, drop } from 'lodash';
+import { endsWith, find, get, escapeRegExp, partition, drop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -34,7 +34,7 @@ export default function( editor ) {
 
 	const [ enterPatterns, spacePatterns ] = partition(
 		patterns,
-		( { regExp } ) => regExp.source.endsWith( '$' ),
+		( { regExp } ) => endsWith( regExp.source, '$' ),
 	);
 
 	const inlinePatterns = settings.inline || [


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/1674/files#r130091486
Related: #746

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Browser_compatibility

We do not use `babel-polyfill` or the like to polyfill ES2015+ base type prototype methods (e.g. `Array#includes`, `String#endsWith`), so we must be careful to use Lodash alternatives instead.

I'm not opposed to using a polyfill, though it introduces non-trivial bulk to the bundle size. This situation will improve in `babel-preset-env@2.x` (current alpha.16) with automatic feature detection.

https://github.com/babel/babel-preset-env/tree/2.0#usebuiltins-usage

__Testing instructions:__

Repeat testing instructions from #1674