### PR TITLE
Fix invalid block warning text overflow in IE11

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -473,6 +473,7 @@ $sticky-bottom-offset: 20px;
 	box-shadow: $shadow-popover;
 
 	p {
+		width: 100%;
 		font-family: $default-font;
 		font-size: $default-font-size;
 	}


### PR DESCRIPTION
Fixes #2073 
See: https://stackoverflow.com/a/35113633

This pull request seeks to resolve a styling issue which occurs in the invalid block warning, affecting IE11 only.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/28720218-83bc85a4-737a-11e7-8013-aa3d175b69f6.png)|![After](https://user-images.githubusercontent.com/1779930/28720876-6044abfe-737c-11e7-9a2f-fa2dc031aeaf.png)

__Testing instructions:__

Repeat steps to reproduce from #2073, verifying that an invalid block warning displays correctly in IE11.