### PR TITLE
KeyboardShortcuts: Don't provide the callback in Mousetrap.unbind

### DIFF
--- a/components/keyboard-shortcuts/README.md
+++ b/components/keyboard-shortcuts/README.md
@@ -36,8 +36,6 @@ class SelectAllDetection extends Component {
 }
 ```
 
-__Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
-
 __Note:__ The callback will not be invoked if the key combination occurs in an editable field.
 
 ## Props

--- a/components/keyboard-shortcuts/index.js
+++ b/components/keyboard-shortcuts/index.js
@@ -20,7 +20,11 @@ class KeyboardShortcuts extends Component {
 
 	toggleBindings( isActive ) {
 		forEach( this.props.shortcuts, ( callback, key ) => {
-			Mousetrap[ isActive ? 'bind' : 'unbind' ]( key, callback );
+			if ( isActive ) {
+				Mousetrap.bind( key, callback );
+				return;
+			}
+			Mousetrap.unbind( key );
 		} );
 	}
 


### PR DESCRIPTION
The [function signature](https://github.com/ccampbell/mousetrap/blob/825ce50c64cc2d9aaaddb453e6dc417aa64fdbbb/mousetrap.js#L915-L935) expects an `action` as the second param -- not a callback.

Since Mousetrap [doesn't support](https://github.com/ccampbell/mousetrap/issues/89#issuecomment-12391573) multiple bindings / namespacing and we're using default `action` behavior, only the first `key` param is needed.

Without this change, the callbacks are not being properly unbound when the visual editor [unmounts](https://github.com/WordPress/gutenberg/blob/03f8fe67929918036705bef4881925c27a516015/editor/modes/visual-editor/index.js#L85-L89).

## To Test

### Confirm Existing Behavior

* Run release or master
* Create a new post via: `/wp-admin/admin.php?page=gutenberg`
* Add some content
* Switch to `text` mode
* Issue a keyboard command...for example: <kbd>cmd</kbd>+<kbd>a</kbd> for "select all"
  **NOTE:** You may need to click the editor whitespace again to be able to kick this off
* Confirm the Visual Editor's select all callback is executed:
<img width="886" alt="screen shot 2017-07-29 at 1 29 05 pm" src="https://user-images.githubusercontent.com/1587282/28746924-f0079d74-7461-11e7-827c-e3d36bce60a4.png">

### Confirm the fix

* Run this branch
* Repeat the above
  * Callbacks should only be executed in the visual editor mode (none are currently registered via this component in text mode)