### PR TITLE
Add available page templates REST field and selector to sidebar

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  require_changes: true

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -24,6 +24,7 @@ if ( gutenberg_can_init() ) {
 	require_once dirname( __FILE__ ) . '/lib/i18n.php';
 	require_once dirname( __FILE__ ) . '/lib/parser.php';
 	require_once dirname( __FILE__ ) . '/lib/register.php';
+	require_once dirname( __FILE__ ) . '/lib/rest-api.php';
 
 	// Register server-side code for individual blocks.
 	require_once dirname( __FILE__ ) . '/lib/blocks/latest-posts.php';

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * REST API Extensions.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Registers REST field for `available_page_templates` on page resources.
+ *
+ * @since 0.7.0
+ *
+ * @return void
+ */
+function gutenberg_register_available_page_templates_field() {
+	register_rest_field( 'page', 'available_page_templates', array(
+		'get_callback' => 'gutenberg_get_available_page_templates',
+		'schema' => array(
+			'description' => __( 'Available templates for a given page.', 'gutenberg' ),
+			'type' => 'array',
+			'items' => array(
+				'type' => 'object',
+				'properties' => array(
+					'name' => array(
+						'type' => 'string',
+						'description' => __( 'Template name', 'gutenberg' ),
+					),
+					'template' => array(
+						'type' => 'string',
+						'description' => __( 'Template slug', 'gutenberg' ),
+					),
+				),
+			),
+			'readonly' => true,
+			'context' => array( 'edit' ),
+		),
+	) );
+}
+add_action( 'rest_api_init', 'gutenberg_register_available_page_templates_field' );
+
+/**
+ * Returns available page templates for a requested page..
+ *
+ * @since 0.7.0
+ * @see gutenberg_register_available_page_templates_field()
+ *
+ * @param array $page Page data.
+ * @return array Available page templates.
+ */
+function gutenberg_get_available_page_templates( $page ) {
+	$available_templates = array();
+
+	// No page templates are available if the post is the page on front. See page_attributes_meta_box().
+	if ( intval( get_option( 'page_for_posts' ) ) === $page['id'] ) {
+		return array();
+	}
+
+	$page_templates = wp_get_theme()->get_page_templates( $page['id'] );
+	foreach ( $page_templates as $template => $name ) {
+		$available_templates[] = compact( 'name', 'template' );
+	}
+	return $available_templates;
+}


### PR DESCRIPTION
See #991.

- [x] Add endpoint for returning the available page templates for a given page, along with their names for displaying in the UI. (There is another PR open for REST API extensions in #1948.) This should get merged into core with the Gutenberg code serving as a polyfill.
- [ ] Add page template selector to sidebar, following up on #1957.

Note that the reason for adding an entire new field on the `page` resource is explained in https://github.com/WordPress/gutenberg/issues/991#issuecomment-314930625. The page templates available for a page can vary from page to page due to the `theme_{$post_type}_templates` filter which is passed the page instance. This is the reason for adding a new field to the `page` itself. Note also that the list of page templates is already exposed on in the schema:

```json
                "template": {
                    "required": false,
                    "enum": [
                        "page-without-comments.php",
                        "page-without-footer.php",
                        "page-without-sidebar.php",
                        ""
                    ],
                    "description": "The theme file to use to display the object.",
                    "type": "string"
                }
```

However, the _name_ of the template is not included. Therefore, the names are then included in this new field:

```json
    "available_page_templates": [
        {
            "name": "No Comments",
            "template": "page-without-comments.php"
        },
        {
            "name": "No Footer",
            "template": "page-without-footer.php"
        },
        {
            "name": "No Sidebar",
            "template": "page-without-sidebar.php"
        }
    ],
```