### PR TITLE
Configure codecov.io to ignore PRs that do not change coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  require_changes: true


### PR DESCRIPTION
Tried this first on #2069 and #2086; seems to work as intended (for PRs that do not change code coverage, like CSS-only changes, the codecov bot should not comment).