### PR TITLE
Set thresholds for codecov build failures

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch: off
+
 comment:
   require_changes: true


### PR DESCRIPTION
Closes #2093.

I tested these changes by first making them on #2056 to verify that they have the intended effect (codecov.io will not report build failures for a PR unless it causes test coverage to decrease by 0.5% or more).