### PR TITLE
Chrome: Adding a post author dropdown

### DIFF
--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+import { PanelRow, withInstanceId } from 'components';
+import { Component } from 'element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { getEditedPostAttribute } from '../../selectors';
+import { editPost } from '../../actions';
+
+class PostAuthor extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			authors: [],
+		};
+	}
+
+	fetchAuthors() {
+		this.fetchAuthorsRequest = new wp.api.collections.Users().fetch( { data: {
+			roles: 'author,editor,administrator',
+			per_page: 100,
+		} } );
+		this.fetchAuthorsRequest.then( ( authors ) => {
+			this.setState( { authors } );
+		} );
+	}
+
+	componentDidMount() {
+		this.fetchAuthors();
+	}
+
+	componentWillUnmount() {
+		if ( this.fetchAuthorsRequest ) {
+			return this.fetchAuthorsRequest.abort();
+		}
+	}
+
+	render() {
+		const { onUpdateAuthor, postAuthor, instanceId } = this.props;
+		const { authors } = this.state;
+		const selectId = 'post-author-selector-' + instanceId;
+
+		if ( authors.length < 2 ) {
+			return null;
+		}
+
+		// Disable reason: A select with an onchange throws a warning
+
+		/* eslint-disable jsx-a11y/no-onchange */
+		return (
+			<PanelRow>
+				<label htmlFor={ selectId }>{ __( 'Author' ) }</label>
+				<select
+					id={ selectId }
+					value={ postAuthor }
+					onChange={ ( event ) => onUpdateAuthor( event.target.value ) }
+					className="editor-post-author__select"
+				>
+					{ authors.map( ( author ) => (
+						<option key={ author.id } value={ author.id }>{ author.name }</option>
+					) ) }
+				</select>
+			</PanelRow>
+		);
+		/* eslint-enable jsx-a11y/no-onchange */
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			postAuthor: getEditedPostAttribute( state, 'author' ),
+		};
+	},
+	{
+		onUpdateAuthor( author ) {
+			return editPost( { author } );
+		},
+	},
+)( withInstanceId( PostAuthor ) );

--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -27,7 +27,6 @@ class PostAuthor extends Component {
 
 	fetchAuthors() {
 		this.fetchAuthorsRequest = new wp.api.collections.Users().fetch( { data: {
-			roles: 'author,editor,administrator',
 			per_page: 100,
 		} } );
 		this.fetchAuthorsRequest.then( ( authors ) => {
@@ -40,9 +39,7 @@ class PostAuthor extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this.fetchAuthorsRequest ) {
-			return this.fetchAuthorsRequest.abort();
-		}
+		this.fetchAuthorsRequest.abort();
 	}
 
 	render() {

--- a/editor/sidebar/post-author/style.scss
+++ b/editor/sidebar/post-author/style.scss
@@ -1,0 +1,3 @@
+.editor-post-author__select {
+	margin: -5px 0;
+}

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -17,6 +17,7 @@ import PostVisibility from '../post-visibility';
 import PostTrash from '../post-trash';
 import PostSchedule from '../post-schedule';
 import PostSticky from '../post-sticky';
+import PostAuthor from '../post-author';
 import {
 	getEditedPostAttribute,
 	getSuggestedPostFormat,
@@ -64,6 +65,7 @@ class PostStatus extends Component {
 					<span>{ format }</span>
 				</PanelRow>
 				<PostSticky />
+				<PostAuthor />
 				<PostTrash />
 			</PanelBody>
 		);


### PR DESCRIPTION
closes #968 

A simple PR adding a select allowing us to select the post author dropdown in case the "user" request for authors, editors and administrators returns more than one result.