### PR TITLE
Remove slimImageObjects method since happening in MediaUploadButton

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Toolbar, Placeholder } from '@wordpress/components';
-import { pick } from 'lodash';
 
 /**
  * Internal dependencies

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -53,13 +53,6 @@ const editMediaLibrary = ( attributes, setAttributes ) => {
 	editFrame.open( 'gutenberg-gallery' );
 };
 
-// the media library image object contains numerous attributes
-// we only need this set to display the image in the library
-const slimImageObjects = ( imgs ) => {
-	const attrSet = [ 'sizes', 'mime', 'type', 'subtype', 'id', 'url', 'alt' ];
-	return imgs.map( ( img ) => pick( img, attrSet ) );
-};
-
 function defaultColumnsNumber( attributes ) {
 	attributes.images = attributes.images || [];
 	return Math.min( 3, attributes.images.length );
@@ -103,7 +96,7 @@ registerBlockType( 'core/gallery', {
 		);
 
 		if ( images.length === 0 ) {
-			const setMediaUrl = ( imgs ) => setAttributes( { images: slimImageObjects( imgs ) } );
+			const setMediaUrl = ( imgs ) => setAttributes( { images: imgs } );
 			const uploadButtonProps = { isLarge: true };
 
 			return [


### PR DESCRIPTION
A little bit of cleanup - the slimImageObjects method removes unneeded attributes from the image objects. This method was previous done within gallery but was refactored and moved into the MediaUploadButton so no longer needed here. This change removes the method.

See #1820 