### PR TITLE
Order links suggestions by relevance

### DIFF
--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -63,7 +63,9 @@ class UrlInput extends Component {
 		this.suggestionsRequest = new wp.api.collections.Posts().fetch( { data: {
 			search: value,
 			per_page: 20,
+			orderby: 'relevance',
 		} } );
+
 		this.suggestionsRequest
 			.then(
 				( posts ) => {


### PR DESCRIPTION
This PR orders the link modal search suggestions by relevance, trying to get the same order as in the current core search (except pages and CPTs that can't be fetched all together right now). Looks like the order by relevance works pretty well (compare with the screenshots on the issue):

<img width="914" alt="co after" src="https://user-images.githubusercontent.com/1682452/28800599-a32b6b50-764d-11e7-8e9d-fc37a7f1d244.png">

<img width="843" alt="de after" src="https://user-images.githubusercontent.com/1682452/28800600-a32ef31a-764d-11e7-9063-535c9f5fdb84.png">

Fixes #2109 