### PR TITLE
Blocks: Cover Text and Latest post shouldn't show left/right alignment options

### DIFF
--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -27,20 +27,22 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 	},
 };
 
-const DEFAULT_CONTROLS = [ 'left', 'center', 'right' ];
+const DEFAULT_CONTROLS = [ 'left', 'center', 'right', 'wide', 'full' ];
 const WIDE_CONTROLS = [ 'wide', 'full' ];
 
-export default function BlockAlignmentToolbar( { value, onChange, wideControlsEnabled = false } ) {
+export default function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CONTROLS, wideControlsEnabled = false } ) {
 	function applyOrUnset( align ) {
 		return () => onChange( value === align ? undefined : align );
 	}
 
-	const controls = DEFAULT_CONTROLS.concat( wideControlsEnabled ? WIDE_CONTROLS : [] );
+	const enabledControls = wideControlsEnabled
+		? controls
+		: controls.filter( ( control ) => WIDE_CONTROLS.indexOf( control ) === -1 );
 
 	return (
 		<Toolbar
 			controls={
-				controls.map( control => {
+				enabledControls.map( control => {
 					return {
 						...BLOCK_ALIGNMENTS_CONTROLS[ control ],
 						isActive: value === control,

--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -65,7 +65,7 @@ registerBlockType( 'core/cover-text', {
 		};
 	},
 
-	edit( { attributes, setAttributes, className, focus, setFocus, mergeBlocks } ) {
+	edit( { attributes, setAttributes, className, focus, setFocus, mergeBlocks, settings } ) {
 		const { align, width, content, dropCap, placeholder, textColor, backgroundColor } = attributes;
 		const toggleDropCap = () => setAttributes( { dropCap: ! dropCap } );
 		return [
@@ -75,6 +75,7 @@ registerBlockType( 'core/cover-text', {
 						value={ width }
 						onChange={ ( nextWidth ) => setAttributes( { width: nextWidth } ) }
 						controls={ [ 'center', 'wide', 'full' ] }
+						wideControlsEnabled={ settings.wideImages }
 					/>
 					<AlignmentToolbar
 						value={ align }

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -143,6 +143,7 @@ registerBlockType( 'core/latest-posts', {
 							onChange={ ( nextAlign ) => {
 								setAttributes( { align: nextAlign } );
 							} }
+							controls={ [ 'center', 'wide', 'full' ] }
 							wideControlsEnabled={ settings.wideImages }
 						/>
 						<Toolbar controls={ layoutControls } />


### PR DESCRIPTION
When the "wideAlignments" is supported by the them, they show, "center", wide" and "full" alignment options and only the "center" option if the theme doesn't support the wide alignments