### PR TITLE
Add "Text Columns" block.

### DIFF
--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -18,4 +18,5 @@ import './latest-posts';
 import './categories';
 import './cover-image';
 import './cover-text';
+import './text-columns';
 import './verse';

--- a/blocks/library/text-columns/block.scss
+++ b/blocks/library/text-columns/block.scss
@@ -1,0 +1,31 @@
+.wp-block-text-columns {
+	display: flex;
+
+	&.aligncenter {
+		display: flex;
+	}
+
+	.wp-block-text-columns__column {
+		box-sizing: border-box;
+		margin: 0 16px;
+		padding: 0;
+
+		&:first-child {
+			margin-left: 0;
+		}
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+
+	&.columns-2 .wp-block-text-columns__column {
+		width: calc( 100% / 2 );
+	}
+	&.columns-3 .wp-block-text-columns__column {
+		width: calc( 100% / 3 );
+	}
+	&.columns-4 .wp-block-text-columns__column {
+		width: calc( 100% / 4 );
+	}
+}

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { times } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
+/**
+ * Internal dependencies
+ */
+import './block.scss';
+import './style.scss';
+import { registerBlockType, query as hpq } from '../../api';
+import BlockControls from '../../block-controls';
+import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import RangeControl from '../../inspector-controls/range-control';
+import Editable from '../../editable';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
+
+const { children, query } = hpq;
+
+registerBlockType( 'core/text-columns', {
+	title: __( 'Text Columns' ),
+
+	icon: 'format-aside',
+
+	category: 'formatting',
+
+	attributes: {
+		content: query( 'p', children() ),
+	},
+
+	defaultAttributes: {
+		columns: 2,
+		content: [ [], [] ],
+	},
+
+	getEditWrapperProps( attributes ) {
+		const { width } = attributes;
+		if ( 'wide' === width || 'full' === width ) {
+			return { 'data-align': width };
+		}
+	},
+
+	edit( { attributes, setAttributes, className, focus, setFocus, settings } ) {
+		const { width, content, columns } = attributes;
+
+		return [
+			focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar
+						value={ width }
+						onChange={ ( nextWidth ) => setAttributes( { width: nextWidth } ) }
+						wideControlsEnabled={ settings.wideImages }
+					/>
+				</BlockControls>
+			),
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Text. Great things start here.' ) }</p>
+					</BlockDescription>
+					<RangeControl
+						label={ __( 'Columns' ) }
+						value={ columns }
+						onChange={ ( event ) => setAttributes( { columns: event.target.value } ) }
+						min="2"
+						max="4"
+					/>
+				</InspectorControls>
+			),
+			<div className={ `${ className } align${ width } columns-${ columns }` } key="block">
+				{ times( columns, ( index ) =>
+					<div className="wp-block-text-columns__column">
+						<Editable
+							key={ `editable-${ index }` }
+							tagName="p"
+							value={ content && content[ index ] }
+							onChange={ ( nextContent ) => {
+								setAttributes( {
+									content: [
+										...content.slice( 0, index ),
+										nextContent,
+										...content.slice( index + 1 ),
+									],
+								} );
+							} }
+							focus={ focus && focus.column === index }
+							onFocus={ () => setFocus( { column: index } ) }
+							placeholder={ __( 'New Column' ) }
+						/>
+					</div>
+				) }
+			</div>,
+		];
+	},
+
+	save( { attributes } ) {
+		const { width, content, columns } = attributes;
+		return (
+			<div className={ `align${ width } columns-${ columns }` }>
+				{ times( columns, ( index ) =>
+					<div className="wp-block-text-columns__column">
+						<p>{ content && content[ index ] }</p>
+					</div>
+				) }
+			</div>
+		);
+	},
+} );

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -26,7 +26,7 @@ const { children, query } = hpq;
 registerBlockType( 'core/text-columns', {
 	title: __( 'Text Columns' ),
 
-	icon: 'format-aside',
+	icon: 'columns',
 
 	category: 'formatting',
 

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -6,7 +6,7 @@ import { times } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ registerBlockType( 'core/text-columns', {
 
 	icon: 'columns',
 
-	category: 'formatting',
+	category: 'layout',
 
 	attributes: {
 		content: query( 'p', children() ),
@@ -46,7 +46,7 @@ registerBlockType( 'core/text-columns', {
 		}
 	},
 
-	edit( { attributes, setAttributes, className, focus, setFocus, settings } ) {
+	edit( { attributes, setAttributes, className, focus, setFocus } ) {
 		const { width, content, columns } = attributes;
 
 		return [
@@ -55,7 +55,7 @@ registerBlockType( 'core/text-columns', {
 					<BlockAlignmentToolbar
 						value={ width }
 						onChange={ ( nextWidth ) => setAttributes( { width: nextWidth } ) }
-						wideControlsEnabled={ settings.wideImages }
+						controls={ [ 'center', 'wide', 'full' ] }
 					/>
 				</BlockControls>
 			),
@@ -75,7 +75,7 @@ registerBlockType( 'core/text-columns', {
 			),
 			<div className={ `${ className } align${ width } columns-${ columns }` } key="block">
 				{ times( columns, ( index ) =>
-					<div className="wp-block-text-columns__column">
+					<div className="wp-block-text-columns__column" key={ `column-${ index }` }>
 						<Editable
 							key={ `editable-${ index }` }
 							tagName="p"

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -77,7 +77,6 @@ registerBlockType( 'core/text-columns', {
 				{ times( columns, ( index ) =>
 					<div className="wp-block-text-columns__column" key={ `column-${ index }` }>
 						<Editable
-							key={ `editable-${ index }` }
 							tagName="p"
 							value={ content && content[ index ] }
 							onChange={ ( nextContent ) => {
@@ -104,7 +103,7 @@ registerBlockType( 'core/text-columns', {
 		return (
 			<div className={ `align${ width } columns-${ columns }` }>
 				{ times( columns, ( index ) =>
-					<div className="wp-block-text-columns__column">
+					<div className="wp-block-text-columns__column" key={ `column-${ index }` }>
 						<p>{ content && content[ index ] }</p>
 					</div>
 				) }

--- a/blocks/library/text-columns/style.scss
+++ b/blocks/library/text-columns/style.scss
@@ -1,0 +1,5 @@
+.wp-block-text-columns {
+	.blocks-editable__tinymce:focus {
+		box-shadow: $button-focus-style;
+	}
+}

--- a/blocks/test/fixtures/core__text-columns.html
+++ b/blocks/test/fixtures/core__text-columns.html
@@ -1,0 +1,10 @@
+<!-- wp:core/text-columns {"width":"center"} -->
+<div class="wp-block-text-columns aligncenter columns-2">
+    <div class="wp-block-text-columns__column">
+        <p>One</p>
+    </div>
+    <div class="wp-block-text-columns__column">
+        <p>Two</p>
+    </div>
+</div>
+<!-- /wp:core/text-columns -->

--- a/blocks/test/fixtures/core__text-columns.json
+++ b/blocks/test/fixtures/core__text-columns.json
@@ -1,0 +1,19 @@
+[
+	{
+		"attributes": {
+			"columns": 2,
+			"content": [
+				[
+					"One"
+				],
+				[
+					"Two"
+				]
+			],
+			"width": "center"
+		},
+		"isValid": true,
+		"name": "core/text-columns",
+		"uid": "_uid_0"
+	}
+]

--- a/blocks/test/fixtures/core__text-columns.parsed.json
+++ b/blocks/test/fixtures/core__text-columns.parsed.json
@@ -1,0 +1,13 @@
+[
+    {
+        "blockName": "core/text-columns",
+        "attrs": {
+            "width": "center"
+        },
+        "rawContent": "\n<div class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-text-columns__column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-text-columns__column\">\n        <p>Two</p>\n    </div>\n</div>\n"
+    },
+    {
+        "attrs": {},
+        "rawContent": "\n"
+    }
+]

--- a/blocks/test/fixtures/core__text-columns.serialized.html
+++ b/blocks/test/fixtures/core__text-columns.serialized.html
@@ -1,0 +1,10 @@
+<!-- wp:core/text-columns {"width":"center"} -->
+<div class="wp-block-text-columns aligncenter columns-2">
+    <div class="wp-block-text-columns__column">
+        <p>One</p>
+    </div>
+    <div class="wp-block-text-columns__column">
+        <p>Two</p>
+    </div>
+</div>
+<!-- /wp:core/text-columns -->


### PR DESCRIPTION
![text-columns](https://user-images.githubusercontent.com/548849/28823284-16d38564-76bd-11e7-8241-9925368cc58e.gif)

This adds a new block for creating columns of text (serving as the basis for eventual generic columns).

@afercia wonder how you think we should announce navigating between columns.