### PR TITLE
Fix splitting editable without child nodes

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -301,20 +301,25 @@ export default class Editable extends Component {
 		const afterRange = dom.createRng();
 		const selectionRange = this.editor.selection.getRng();
 
-		beforeRange.setStart( rootNode, 0 );
-		beforeRange.setEnd( selectionRange.startContainer, selectionRange.startOffset );
+		if ( rootNode.childNodes.length ) {
+			beforeRange.setStart( rootNode, 0 );
+			beforeRange.setEnd( selectionRange.startContainer, selectionRange.startOffset );
 
-		afterRange.setStart( selectionRange.endContainer, selectionRange.endOffset );
-		afterRange.setEnd( rootNode, dom.nodeIndex( rootNode.lastChild ) + 1 );
+			afterRange.setStart( selectionRange.endContainer, selectionRange.endOffset );
+			afterRange.setEnd( rootNode, dom.nodeIndex( rootNode.lastChild ) + 1 );
 
-		const beforeFragment = beforeRange.extractContents();
-		const afterFragment = afterRange.extractContents();
+			const beforeFragment = beforeRange.extractContents();
+			const afterFragment = afterRange.extractContents();
 
-		const beforeElement = nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
-		const afterElement = nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
+			const beforeElement = nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
+			const afterElement = nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
 
-		this.setContent( beforeElement );
-		this.props.onSplit( beforeElement, afterElement, ...blocks );
+			this.setContent( beforeElement );
+			this.props.onSplit( beforeElement, afterElement, ...blocks );
+		} else {
+			this.setContent( [] );
+			this.props.onSplit( [], [], ...blocks );
+		}
 	}
 
 	onNewBlock() {


### PR DESCRIPTION
Fixes #2112.

To reproduce: create a new paragraph, type a letter, and delete it again. The editor will have no child nodes now. Press enter, and observe a range error. Alternatively, delete all child nodes manually and press enter.

You can see that the code doesn't take this case into account.