### PR TITLE
Remove array of paragraphs structure from the text block

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isObject } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -46,28 +41,7 @@ registerBlockType( 'core/heading', {
 			{
 				type: 'block',
 				blocks: [ 'core/paragraph' ],
-				transform: ( { content, ...attrs } ) => {
-					const isMultiParagraph = Array.isArray( content ) && isObject( content[ 0 ] ) && content[ 0 ].type === 'p';
-					if ( isMultiParagraph ) {
-						const headingContent = isObject( content[ 0 ] ) && content[ 0 ].type === 'p'
-							? content[ 0 ].props.children
-							: content[ 0 ];
-						const heading = createBlock( 'core/heading', {
-							content: headingContent,
-						} );
-						const blocks = [ heading ];
-
-						const remainingContent = content.slice( 1 );
-						if ( remainingContent.length ) {
-							const text = createBlock( 'core/paragraph', {
-								...attrs,
-								content: remainingContent,
-							} );
-							blocks.push( text );
-						}
-
-						return blocks;
-					}
+				transform: ( { content } ) => {
 					return createBlock( 'core/heading', {
 						content,
 					} );

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -16,7 +16,7 @@ import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import BlockDescription from '../../block-description';
 
-const { children, query } = hpq;
+const { children } = hpq;
 
 registerBlockType( 'core/paragraph', {
 	title: __( 'Paragraph' ),
@@ -32,7 +32,7 @@ registerBlockType( 'core/paragraph', {
 	className: false,
 
 	attributes: {
-		content: query( 'p', children() ),
+		content: children( 'p' ),
 	},
 
 	transforms: {
@@ -45,7 +45,7 @@ registerBlockType( 'core/paragraph', {
 					! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
 				),
 				attributes: {
-					content: query( 'p', children() ),
+					content: children( 'p' ),
 				},
 			},
 		],

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isString } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -90,12 +85,7 @@ registerBlockType( 'core/pullquote', {
 
 		return (
 			<blockquote className={ `align${ align }` }>
-				{ value && value.map( ( paragraph, i ) => (
-					<p key={ i }>
-						{ isString( paragraph ) ? paragraph : paragraph.props.children }
-					</p>
-				) ) }
-
+				{ value.map( ( paragraph, i ) => <p key={ i }>{ paragraph.props.children }</p> ) }
 				{ citation && citation.length > 0 && (
 					<footer>{ citation }</footer>
 				) }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -41,7 +41,9 @@ registerBlockType( 'core/quote', {
 				blocks: [ 'core/paragraph' ],
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
-						value: content,
+						value: [
+							<p key="1">{ content }</p>,
+						],
 					} );
 				},
 			},
@@ -50,7 +52,9 @@ registerBlockType( 'core/quote', {
 				blocks: [ 'core/heading' ],
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
-						value: content,
+						value: [
+							<p key="1">{ content }</p>,
+						],
 					} );
 				},
 			},
@@ -59,7 +63,9 @@ registerBlockType( 'core/quote', {
 				regExp: /^>\s/,
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
-						value: content,
+						value: [
+							<p key="1">{ content }</p>,
+						],
 					} );
 				},
 			},
@@ -185,15 +191,11 @@ registerBlockType( 'core/quote', {
 		const { align, value, citation, style = 1 } = attributes;
 
 		return (
-			<blockquote className={ `blocks-quote-style-${ style }` }>
-				{ value && value.map( ( paragraph, i ) => (
-					<p
-						key={ i }
-						style={ { textAlign: align ? align : null } }
-					>
-						{ isString( paragraph ) ? paragraph : paragraph.props.children }
-					</p>
-				) ) }
+			<blockquote
+				className={ `blocks-quote-style-${ style }` }
+				style={ { textAlign: align ? align : null } }
+			>
+				{ value.map( ( paragraph, i ) => <p key={ i }>{ paragraph.props.children }</p> ) }
 				{ citation && citation.length > 0 && (
 					<footer>{ citation }</footer>
 				) }

--- a/blocks/test/fixtures/core__paragraph__align-right.json
+++ b/blocks/test/fixtures/core__paragraph__align-right.json
@@ -7,9 +7,7 @@
             "dropCap": false,
             "align": "right",
             "content": [
-                [
-                    "... like this one, which is separate from the above and right aligned."
-                ]
+                "... like this one, which is separate from the above and right aligned."
             ]
         }
     }

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.json
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.json
@@ -6,14 +6,12 @@
         "attributes": {
             "dropCap": false,
             "content": [
-                [
-                    "This is an old-style text block.  Changed to ",
-                    {
-                        "type": "code",
-                        "children": "core/paragraph"
-                    },
-                    " in #2135."
-                ]
+                "This is an old-style text block.  Changed to ",
+                {
+                    "type": "code",
+                    "children": "core/paragraph"
+                },
+                " in #2135."
             ]
         }
     }


### PR DESCRIPTION
This seems to be a remainder from the multi paragraph structure. Currently this causes a bug with the placeholders as well when initialising the editor:

```js
this.state = {
	empty: ! props.value || ! props.value.length,
};
```