### PR TITLE
Ignore missing handle in registered script polyfill

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -47,6 +47,10 @@ function gutenberg_get_script_polyfill( $tests ) {
 
 	$polyfill = '';
 	foreach ( $tests as $test => $handle ) {
+		if ( ! array_key_exists( $handle, $wp_scripts->registered ) ) {
+			continue;
+		}
+
 		$polyfill .= (
 			// Test presence of feature...
 			'( ' . $test . ' ) || ' .

--- a/phpunit/class-polyfill-test.php
+++ b/phpunit/class-polyfill-test.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Test gutenberg_get_script_polyfill()
+ *
+ * @package Gutenberg
+ */
+
+class Polyfill_Test extends WP_UnitTestCase {
+
+	public function tearDown() {
+		wp_deregister_script( 'promise' );
+	}
+
+	function test_gutenberg_get_script_polyfill_ignores_missing_handle() {
+		$polyfill = gutenberg_get_script_polyfill( array(
+			'\'Promise\' in window' => 'promise',
+		) );
+
+		$this->assertEquals( '', $polyfill );
+	}
+
+	function test_gutenberg_get_script_polyfill_returns_inline_script() {
+		wp_register_script( 'promise', 'https://unpkg.com/promise-polyfill/promise.js' );
+
+		$polyfill = gutenberg_get_script_polyfill( array(
+			'\'Promise\' in window' => 'promise',
+		) );
+
+		$this->assertEquals(
+			'( \'Promise\' in window ) || document.write( \'<script src="https://unpkg.com/promise-polyfill/promise.js"></scr\' + \'ipt>\' );',
+			$polyfill
+		);
+	}
+
+}


### PR DESCRIPTION
Fixes #2137 

This pull request seeks to resolve a notice which can occur when trying to reference a polyfill script handle which may not be registered (for example, if `GUTENBERG_LOAD_VENDOR_SCRIPTS` is `false`).

__Testing instructions:__

Repeat testing instructions from #2041 to verify no regressions.

Run unit tests:

```
WP_TESTS_DIR=/path/to/wordpress-develop/tests/phpunit/ phpunit
```

(Substitute your own [wordpress-develop](https://github.com/WordPress/wordpress-develop) path)

__Open questions:__

Should we still allow the script handle to be registered even if the vendor loading is disabled?

https://github.com/WordPress/gutenberg/blob/85ba855/lib/client-assets.php#L288

What is the intent of this condition? If it's to prevent fetching, seems we could account for the constant in the `$needs_fetch` variable. cc @nylen 