### PR TITLE
Dropdown Menu: Document, test, refactor

### DIFF
--- a/components/dropdown-menu/README.md
+++ b/components/dropdown-menu/README.md
@@ -1,0 +1,75 @@
+Dropdown Menu
+=============
+
+Dropdown Menu is a React component to render an expandable menu of buttons. It is similar in purpose to a `<select>` element, with the distinction that it does not maintain a value. Instead, each option behaves as an action button.
+
+## Usage
+
+Render a Dropdown Menu with a set of controls:
+
+```jsx
+import { DropdownMenu } from '@wordpress/components';
+
+function DirectionMenu( { onMove } ) {
+	return (
+		<DropdownMenu
+			icon="move"
+			label="Select a direction"
+			controls={ [
+				{
+					title: 'Up',
+					icon: 'arrow-up-alt',
+					onClick: () => onMove( 'up' )
+				},
+				{
+					title: 'Right',
+					icon: 'arrow-right-alt',
+					onClick: () => onMove( 'right' )
+				},
+				{
+					title: 'Down',
+					icon: 'arrow-down-alt',
+					onClick: () => onMove( 'down' )
+				},
+				{
+					title: 'Left',
+					icon: 'arrow-left-alt',
+					onClick: () => onMove( 'left' )
+				},
+			] }
+		/>
+	);
+}
+```
+
+## Props
+
+The component accepts the following props:
+
+### icon
+
+The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug to be shown in the collapsed menu button.
+
+- Type: `String`
+- Required: No
+- Default: `"menu"`
+
+See also: [https://developer.wordpress.org/resource/dashicons/](https://developer.wordpress.org/resource/dashicons/)
+
+### label
+
+A human-readable label to present as accessibility text on the focused collapsed menu button.
+
+- Type: `String`
+- Required: Yes
+
+### controls
+
+An array of objects describing the options to be shown in the expanded menu.
+
+Each object should include an `icon` [Dashicon](https://developer.wordpress.org/resource/dashicons/) slug string, a human-readable `title` string, and an `onClick` function callback to invoke when the option is selected.
+
+- Type: `Array`
+- Required: Yes
+
+See also: [https://developer.wordpress.org/resource/dashicons/](https://developer.wordpress.org/resource/dashicons/)

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -87,8 +87,7 @@ export class DropdownMenu extends Component {
 			return;
 		}
 
-		const maxIndex = controls.length - 1;
-		const nextIndex = activeIndex >= maxIndex ? 0 : activeIndex + 1;
+		const nextIndex = ( activeIndex + 1 ) % controls.length;
 		this.focusIndex( nextIndex );
 	}
 

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -109,9 +109,6 @@ class DropdownMenu extends Component {
 			// eslint-disable-next-line react/no-find-dom-node
 			findDOMNode( this.nodes.toggle ).focus();
 			this.closeMenu();
-			if ( this.props.onSelect ) {
-				this.props.onSelect( null );
-			}
 		}
 	}
 
@@ -167,7 +164,6 @@ class DropdownMenu extends Component {
 			label,
 			menuLabel,
 			controls,
-			onSelect,
 		} = this.props;
 
 		if ( ! controls || ! controls.length ) {
@@ -211,9 +207,6 @@ class DropdownMenu extends Component {
 									this.closeMenu();
 									if ( control.onClick ) {
 										control.onClick();
-									}
-									if ( onSelect ) {
-										onSelect( index );
 									}
 								} }
 								className="components-dropdown-menu__menu-item"

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -3,7 +3,6 @@
  */
 import classnames from 'classnames';
 import clickOutside from 'react-click-outside';
-import { findIndex } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -25,7 +24,6 @@ class DropdownMenu extends Component {
 		this.bindReferenceNode = this.bindReferenceNode.bind( this );
 		this.closeMenu = this.closeMenu.bind( this );
 		this.toggleMenu = this.toggleMenu.bind( this );
-		this.findActiveIndex = this.findActiveIndex.bind( this );
 		this.focusIndex = this.focusIndex.bind( this );
 		this.focusPrevious = this.focusPrevious.bind( this );
 		this.focusNext = this.focusNext.bind( this );
@@ -35,6 +33,7 @@ class DropdownMenu extends Component {
 		this.nodes = {};
 
 		this.state = {
+			activeIndex: null,
 			open: false,
 		};
 	}
@@ -65,34 +64,32 @@ class DropdownMenu extends Component {
 		} );
 	}
 
-	findActiveIndex() {
-		if ( this.nodes.menu ) {
-			const menuItem = document.activeElement;
-			if ( menuItem.parentNode === this.nodes.menu ) {
-				return findIndex( this.nodes.menu.children, ( child ) => child === menuItem );
-			}
-			return -1;
-		}
-	}
-
-	focusIndex( index ) {
-		if ( this.nodes.menu ) {
-			this.nodes.menu.children[ index ].focus();
-		}
+	focusIndex( activeIndex ) {
+		this.setState( { activeIndex } );
 	}
 
 	focusPrevious() {
-		const i = this.findActiveIndex();
-		const maxI = this.props.controls.length - 1;
-		const prevI = i <= 0 ? maxI : i - 1;
-		this.focusIndex( prevI );
+		const { activeIndex } = this.state;
+		const { controls } = this.props;
+		if ( ! controls ) {
+			return;
+		}
+
+		const maxIndex = controls.length - 1;
+		const prevIndex = activeIndex <= 0 ? maxIndex : activeIndex - 1;
+		this.focusIndex( prevIndex );
 	}
 
 	focusNext() {
-		const i = this.findActiveIndex();
-		const maxI = this.props.controls.length - 1;
-		const nextI = i >= maxI ? 0 : i + 1;
-		this.focusIndex( nextI );
+		const { activeIndex } = this.state;
+		const { controls } = this.props;
+		if ( ! controls ) {
+			return;
+		}
+
+		const maxIndex = controls.length - 1;
+		const nextIndex = activeIndex >= maxIndex ? 0 : activeIndex + 1;
+		this.focusIndex( nextIndex );
 	}
 
 	handleKeyUp( event ) {
@@ -152,9 +149,19 @@ class DropdownMenu extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
+		const { open, activeIndex } = this.state;
+
 		// Focus the first item when the menu opens.
-		if ( ! prevState.open && this.state.open ) {
+		if ( ! prevState.open && open ) {
 			this.focusIndex( 0 );
+		}
+
+		// Change focus to active index
+		const { menu } = this.nodes;
+		if ( prevState.activeIndex !== activeIndex &&
+				Number.isInteger( activeIndex ) &&
+				menu && menu.children[ activeIndex ] ) {
+			menu.children[ activeIndex ].focus();
 		}
 	}
 

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -17,7 +17,7 @@ import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
  */
 import './style.scss';
 
-class DropdownMenu extends Component {
+export class DropdownMenu extends Component {
 	constructor() {
 		super( ...arguments );
 

--- a/components/dropdown-menu/test/index.js
+++ b/components/dropdown-menu/test/index.js
@@ -1,0 +1,184 @@
+/**
+ * External dependencies
+ */
+import { shallow, mount } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { DropdownMenu } from '../';
+
+describe( 'DropdownMenu', () => {
+	let controls;
+	beforeEach( () => {
+		controls = [
+			{
+				title: 'Up',
+				icon: 'arrow-up-alt',
+				onClick: jest.fn(),
+			},
+			{
+				title: 'Right',
+				icon: 'arrow-right-alt',
+				onClick: jest.fn(),
+			},
+			{
+				title: 'Down',
+				icon: 'arrow-down-alt',
+				onClick: jest.fn(),
+			},
+			{
+				title: 'Left',
+				icon: 'arrow-left-alt',
+				onClick: jest.fn(),
+			},
+		];
+	} );
+
+	describe( 'basic rendering', () => {
+		it( 'should render a null element when controls are not assigned', () => {
+			const wrapper = shallow( <DropdownMenu /> );
+
+			expect( wrapper.type() ).toBeNull();
+		} );
+
+		it( 'should render a null element when controls are empty', () => {
+			const wrapper = shallow( <DropdownMenu controls={ [] } /> );
+
+			expect( wrapper.type() ).toBeNull();
+		} );
+
+		it( 'should render a collapsed menu button', () => {
+			const wrapper = shallow(
+				<DropdownMenu
+					label="Select a direction"
+					controls={ controls }
+				/>
+			);
+
+			expect( wrapper.state( 'open' ) ).toBe( false );
+			expect( wrapper.state( 'activeIndex' ) ).toBeNull();
+			expect( wrapper.find( '> IconButton' ).prop( 'label' ) ).toBe( 'Select a direction' );
+			expect( wrapper.find( '> IconButton' ).prop( 'icon' ) ).toBe( 'menu' );
+			expect( wrapper.find( '.components-dropdown-menu__menu' ) ).toHaveLength( 0 );
+		} );
+
+		it( 'should render an expanded menu upon click', () => {
+			const wrapper = shallow( <DropdownMenu controls={ controls } /> );
+
+			// Open menu
+			wrapper.find( '> IconButton' ).simulate( 'click' );
+
+			const options = wrapper.find( '.components-dropdown-menu__menu > IconButton' );
+			expect( wrapper.state( 'open' ) ).toBe( true );
+			expect( wrapper.state( 'activeIndex' ) ).toBe( 0 );
+			expect( options ).toHaveLength( controls.length );
+			expect( options.at( 0 ).prop( 'icon' ) ).toBe( 'arrow-up-alt' );
+			expect( options.at( 0 ).children().text() ).toBe( 'Up' );
+		} );
+
+		it( 'should open menu on arrow down', () => {
+			const wrapper = shallow( <DropdownMenu controls={ controls } /> );
+
+			// Close menu by keyup
+			wrapper.simulate( 'keydown', {
+				stopPropagation: () => {},
+				preventDefault: () => {},
+				keyCode: DOWN,
+			} );
+
+			expect( wrapper.state( 'open' ) ).toBe( true );
+		} );
+
+		it( 'should call the control onClick callback and close menu', () => {
+			const wrapper = shallow( <DropdownMenu controls={ controls } /> );
+
+			// Open menu
+			wrapper.find( '> IconButton' ).simulate( 'click' );
+
+			// Select option
+			const options = wrapper.find( '.components-dropdown-menu__menu > IconButton' );
+			options.at( 0 ).simulate( 'click', { stopPropagation: () => {} } );
+
+			expect( controls[ 0 ].onClick ).toHaveBeenCalled();
+			expect( wrapper.state( 'open' ) ).toBe( false );
+		} );
+
+		it( 'should navigate by keypresses', () => {
+			const wrapper = shallow( <DropdownMenu controls={ controls } /> );
+
+			// Open menu
+			wrapper.find( '> IconButton' ).simulate( 'click' );
+
+			// Navigate options
+			function assertKeyDown( keyCode, expectedActiveIndex ) {
+				wrapper.simulate( 'keydown', {
+					stopPropagation: () => {},
+					preventDefault: () => {},
+					keyCode,
+				} );
+
+				const activeIndex = wrapper.state( 'activeIndex' );
+				expect( activeIndex ).toBe( expectedActiveIndex );
+			}
+
+			assertKeyDown( RIGHT, 1 );
+			assertKeyDown( DOWN, 2 );
+			assertKeyDown( DOWN, 3 );
+			assertKeyDown( DOWN, 0 ); // Reset to beginning
+			assertKeyDown( DOWN, 1 );
+			assertKeyDown( LEFT, 0 );
+			assertKeyDown( UP, 3 ); // Reset to end
+		} );
+
+		it( 'should close menu on escape', () => {
+			// Mount: We need to access DOM node of rendered menu IconButton
+			const wrapper = mount( <DropdownMenu controls={ controls } /> );
+
+			// Open menu
+			wrapper.find( '> IconButton' ).simulate( 'click' );
+
+			// Close menu by escape
+			wrapper.simulate( 'keyup', {
+				stopPropagation: () => {},
+				preventDefault: () => {},
+				keyCode: ESCAPE,
+			} );
+
+			expect( wrapper.state( 'open' ) ).toBe( false );
+		} );
+
+		it( 'should close menu on click outside', () => {
+			const wrapper = shallow( <DropdownMenu controls={ controls } /> );
+
+			// Open menu
+			wrapper.find( '> IconButton' ).simulate( 'click' );
+
+			// Close menu by click outside
+			wrapper.instance().handleClickOutside();
+
+			expect( wrapper.state( 'open' ) ).toBe( false );
+		} );
+
+		it( 'should close menu on tab', () => {
+			const wrapper = shallow( <DropdownMenu controls={ controls } /> );
+
+			// Open menu
+			wrapper.find( '> IconButton' ).simulate( 'click' );
+
+			// Close menu by tab
+			wrapper.simulate( 'keydown', {
+				stopPropagation: () => {},
+				preventDefault: () => {},
+				keyCode: TAB,
+			} );
+
+			expect( wrapper.state( 'open' ) ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
Related: #1975

This pull request seeks to...

- Add a README.md for the Dropdown Menu component
- Add unit tests for the Dropdown Menu component
- Perform some general refactoring:
  - Remove unused `onSelect` prop ([YAGNI](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it))
  - Manage active index by state transition
  - Ensure `controls` prop exists before calling on its `length` property (since not a required prop)
  - Use modulus `%` operator for "reset to beginning" logic

__Testing instructions:__

Verify that there are no regressions in the behavior of the Dropdown Menu, currently used only as the last control of the table block. Particularly with note of keyboard behaviors, recently refined in #1975.

Ensure that unit tests pass:

```
npm test
```