### PR TITLE
Editor: Try a fixed block toolbar

### DIFF
--- a/blocks/block-controls/index.js
+++ b/blocks/block-controls/index.js
@@ -10,7 +10,7 @@ import { Toolbar } from '@wordpress/components';
 
 export default function BlockControls( { controls, children } ) {
 	return (
-		<Fill name="Formatting.Toolbar">
+		<Fill name="Block.Toolbar">
 			<Toolbar controls={ controls } />
 			{ children }
 		</Fill>

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -568,7 +568,7 @@ export default class Editable extends Component {
 		return (
 			<div className={ classes }>
 				{ focus &&
-					<Fill name="Formatting.Toolbar">
+					<Fill name="Block.Toolbar">
 						{ ! inlineToolbar && formatToolbar }
 					</Fill>
 				}

--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -93,5 +93,6 @@
 
 	ul.components-toolbar {
 		box-shadow: $shadow-toolbar;
+		background: $white;
 	}
 }

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -1,8 +1,6 @@
 .components-toolbar {
-	margin: 0;
-	border: 1px solid $light-gray-500;
-	background-color: $white;
 	display: inline-flex;
+	border-right: 1px solid $light-gray-500;
 }
 
 ul.components-toolbar {

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -18,6 +18,7 @@ $z-layers: (
 	'.editor-block-switcher__menu': 2,
 	'.editor-block-mover': 10,
 	'.editor-header': 20,
+	'.editor-visual-editor__block-toolbar': 20,
 	'.editor-post-schedule__dialog': 30,
 
 	// Show drop zone above most standard content, but below any overlays

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -19,6 +19,9 @@ import { isFirstBlock, isLastBlock, getBlockIndex, getBlock } from '../selectors
 import { getBlockMoverLabel } from './mover-label';
 
 function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex } ) {
+	if ( ! blockType ) {
+		return null;
+	}
 	// We emulate a disabled state because forcefully applying the `disabled`
 	// attribute on the button while it has focus causes the screen to change
 	// to an unfocused state (body as active element) without firing blur on,
@@ -60,12 +63,15 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, f
 }
 
 export default connect(
-	( state, ownProps ) => ( {
-		isFirst: isFirstBlock( state, first( ownProps.uids ) ),
-		isLast: isLastBlock( state, last( ownProps.uids ) ),
-		firstIndex: getBlockIndex( state, first( ownProps.uids ) ),
-		blockType: getBlockType( getBlock( state, first( ownProps.uids ) ).name ),
-	} ),
+	( state, ownProps ) => {
+		const block = getBlock( state, first( ownProps.uids ) );
+		return {
+			isFirst: isFirstBlock( state, first( ownProps.uids ) ),
+			isLast: isLastBlock( state, last( ownProps.uids ) ),
+			firstIndex: getBlockIndex( state, first( ownProps.uids ) ),
+			blockType: block && getBlockType( block.name ),
+		};
+	},
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {
 			dispatch( {

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -53,6 +53,9 @@ class BlockSwitcher extends Component {
 	}
 
 	render() {
+		if ( ! this.props.block ) {
+			return null;
+		}
 		const blockType = getBlockType( this.props.block.name );
 		const blocksToBeTransformedFrom = reduce( getBlockTypes(), ( memo, block ) => {
 			const transformFrom = get( block, 'transforms.from', [] );

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -1,10 +1,9 @@
 .editor-block-switcher {
-	border: 1px solid $light-gray-500;
-	background-color: $white;
+	display: inline-block;
+	border-right: 1px solid $light-gray-500;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	line-height: $default-line-height;
-	margin-right: -1px;
 }
 
 .editor-block-switcher__toggle {

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { first, last } from 'lodash';
+import { Slot } from 'react-slot-fill';
 
 /**
  * WordPress dependencies
@@ -91,6 +92,9 @@ class VisualEditor extends Component {
 				onKeyDown={ this.onKeyDown }
 				ref={ this.bindContainer }
 			>
+				<div className="editor-visual-editor__block-toolbar">
+					<Slot name="Block.Toolbar" />
+				</div>
 				<KeyboardShortcuts shortcuts={ {
 					'mod+a': this.selectAll,
 					'mod+z': this.undoOrRedo,

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -1,7 +1,6 @@
 .editor-visual-editor {
 	position: relative;
 	margin: 0 auto;
-	padding: 50px 0;	// Floating up/down arrows invisible
 
 	&,
 	& p {
@@ -73,47 +72,13 @@
 		background-color: rgba( $white, 0.6 );
 	}
 
-	&.is-hovered:before {
+	&.is-selected:before {
+		outline: 1px solid $light-gray-200;
+	}
+
+	&.has-visible-ui:before {
 		outline: 1px solid $light-gray-500;
 		transition: 0.2s outline;
-	}
-
-	&.is-selected:before {
-		outline: 2px solid $light-gray-500;
-		transition: 0.2s outline;
-	}
-
-	&.is-showing-mobile-controls {
-		.editor-visual-editor__group > :not( .editor-visual-editor__mobile-tools ) {
-			display: none;
-		}
-		.editor-visual-editor__mobile-tools {
-			align-items: baseline;
-			display: flex;
-			width: 100%;
-
-			@include break-small {
-				display: none;
-			}
-
-			.editor-block-mover,
-			.editor-block-settings-menu {
-				display: block;
-				display: flex;
-				position: static;
-				.components-button {
-					margin: 0 5px;
-				}
-			}
-
-			.editor-block-settings-menu {
-				left: 80px;
-				right: auto;
-			}
-			.editor-visual-editor__mobile-toggle {
-				margin-left: auto;
-			}
-		}
 	}
 
 	&.is-multi-selected *::selection {
@@ -287,9 +252,39 @@
 	}
 }
 
+.editor-visual-editor__mobile-menu {
+	float: right;
+	@include break-small {
+		display: none;
+	}
+}
+
+.editor-visual-editor__mobile-tools {
+	align-items: baseline;
+	display: flex;
+	width: 100%;
+
+	.editor-block-mover,
+	.editor-block-settings-menu {
+		display: block;
+		display: flex;
+		position: static;
+		.components-button {
+			margin: 0 5px;
+		}
+	}
+
+	.editor-block-settings-menu {
+		left: 80px;
+		right: auto;
+	}
+	.editor-visual-editor__mobile-toggle {
+		margin-left: auto;
+	}
+}
+
 .editor-visual-editor__block-controls {
 	display: flex;
-	position: sticky;
 	z-index: z-index( '.editor-visual-editor__block-controls' );
 	margin-top: -$block-controls-height - $item-spacing;
 	margin-bottom: $item-spacing + 20px;	// 20px is the offset from the bottom of the selected block where it stops sticking
@@ -331,23 +326,6 @@
 
 	@include break-small() {
 		width: auto;
-	}
-}
-
-$sticky-bottom-offset: 20px;
-.editor-visual-editor__block-controls + div {
-	// prevent collapsing margins between block and toolbar, matches the 20px bottom offset
- 	margin-top: -$sticky-bottom-offset - 1px;
-	padding-top: 1px;
- }
-
-.editor-visual-editor__block-controls .components-toolbar {
-	margin-right: -1px;
-
-	&.editor-visual-editor__mobile-tools {
-		margin-left: auto;
-		margin-top: -1px;
-		margin-bottom: -1px;
 	}
 }
 
@@ -459,16 +437,6 @@ $sticky-bottom-offset: 20px;
 	}
 }
 
-.editor-visual-editor__mobile-tools {
-	@include break-small {
-		display: none;
-	}
-	.editor-block-mover,
-	.editor-block-settings-menu {
-		display: none;
-	}
-}
-
 .editor-visual-editor__block-warning {
 	z-index: z-index( '.editor-visual-editor__block-warning' );
 	position: absolute;
@@ -497,4 +465,68 @@ $sticky-bottom-offset: 20px;
 	.button + .button {
 		margin-left: $item-spacing;
 	}
+}
+
+.editor-visual-editor__block-toolbar {
+	z-index: z-index( '.editor-visual-editor__block-toolbar' );
+	background: $white;
+	border-bottom: 1px solid $light-gray-500;
+	top: $header-height;
+	left: 0;
+	right: 0;
+	position: sticky;
+
+	@include break-small() {
+		top: $admin-bar-height-big + $header-height;
+		position: fixed;
+	}
+
+	@include break-medium() {
+		top: $admin-bar-height + $header-height;
+	}
+}
+
+.sticky-menu .editor-visual-editor__block-toolbar {	/* Sticky is when on smaller breakpoints, nav menu is manually opened */
+	@include break-medium() {
+		left: $admin-sidebar-width;
+	}
+}
+
+.auto-fold .editor-visual-editor__block-toolbar {		/* Auto fold is when on smaller breakpoints, nav menu auto colllapses */
+	@include break-medium() {
+		left: $admin-sidebar-width-collapsed;
+	}
+
+	@include break-large() {
+		left: $admin-sidebar-width;
+	}
+}
+
+/* Sidebar manually collapsed */
+.folded .editor-visual-editor__block-toolbar {
+	left: $admin-sidebar-width-collapsed;
+}
+
+/* Mobile menu opened */
+.auto-fold .wp-responsive-open .editor-visual-editor__block-toolbar {
+	left: $admin-sidebar-width-big;
+	right: -$admin-sidebar-width-big;
+}
+
+/* RTL */
+.rtl.auto-fold .editor-visual-editor__block-toolbar {
+	@include break-medium() {
+		left: 0;
+		right: $admin-sidebar-width-collapsed;
+	}
+
+	@include break-large() {
+		left: 0;
+		right: $admin-sidebar-width;
+	}
+}
+
+.rtl.auto-fold .wp-responsive-open .editor-visual-editor__block-toolbar {
+	left: -$admin-sidebar-width-big;
+	right: $admin-sidebar-width-big;
 }

--- a/editor/post-permalink/style.scss
+++ b/editor/post-permalink/style.scss
@@ -1,16 +1,10 @@
 .editor-post-permalink {
 	display: inline-flex;
 	align-items: center;
-	position: absolute;
-	top: -34px;
-	box-shadow: $shadow-popover;
-	border: 1px solid $light-gray-500;
 	background: $white;
 	padding: 5px;
 	font-family: $default-font;
 	font-size: $default-font-size;
-	left: 0;
-	right: 0;
 
 	@include break-small() {
 		left: $block-padding + $block-mover-padding-visible - 2px;
@@ -30,8 +24,4 @@
 	overflow: hidden;
 	position: relative;
 	white-space: nowrap;
-
-	&:after {
-		@include long-content-fade( $size: 20% );
-	}
 }

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -12,6 +12,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
+import { BlockControls } from 'blocks';
 
 /**
  * Internal dependencies
@@ -91,9 +92,10 @@ class PostTitle extends Component {
 		const { isSelected } = this.state;
 		const className = classnames( 'editor-post-title', { 'is-selected': isSelected } );
 
+
 		return (
 			<div className={ className }>
-				{ isSelected && <PostPermalink /> }
+				{ isSelected && <BlockControls><PostPermalink /></BlockControls> }
 				<h1>
 					<Textarea
 						ref={ this.bindTextarea }

--- a/editor/post-title/style.scss
+++ b/editor/post-title/style.scss
@@ -24,13 +24,13 @@
 		}
 	}
 
-	&:hover h1 {
-		outline: 1px solid $light-gray-500;
+	&.is-selected h1 {
+		outline: 1px solid $light-gray-200;
 		transition: 0.2s outline;
 	}
 
-	&.is-selected h1 {
-		outline: 2px solid $light-gray-500;
+	&:hover h1 {
+		outline: 1px solid $light-gray-500;
 		transition: 0.2s outline;
 	}
 

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -13,7 +13,6 @@
 
 	@include break-small() {
 		top: $admin-bar-height-big + $header-height;
-		z-index: auto;
 		height: auto;
 		overflow: auto;
 	}

--- a/editor/state.js
+++ b/editor/state.js
@@ -392,7 +392,6 @@ export function hoveredBlock( state = null, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_BLOCK_HOVERED':
 			return action.hovered ? action.uid : null;
-		case 'SELECT_BLOCK':
 		case 'START_TYPING':
 		case 'MULTI_SELECT':
 			return null;

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -584,15 +584,6 @@ describe( 'state', () => {
 			expect( state ).toBe( 'kumquat' );
 		} );
 
-		it( 'should return null when a block is selected', () => {
-			const state = hoveredBlock( 'kumquat', {
-				type: 'SELECT_BLOCK',
-				uid: 'kumquat',
-			} );
-
-			expect( state ).toBeNull();
-		} );
-
 		it( 'should replace the hovered block', () => {
 			const state = hoveredBlock( 'chicken', {
 				type: 'REPLACE_BLOCKS',


### PR DESCRIPTION
People are complaining about the block toolbar showing up constantly and disturbing their writing flow, this PR explores the possibility to use a fixed a block toolbar at the top. And its content change depending on the selected block.

<img width="1219" alt="screen shot 2017-08-02 at 10 39 24" src="https://user-images.githubusercontent.com/272444/28867717-e16f1232-776e-11e7-989a-4a2aed6c29e3.png">

Not done yet:

 - The freeform block shows the toolbar differently, we need to tackle it separately
 - Hide this toolbar when the blocks are deselected or when a block doesn't have any control (or maybe show the permalink like shown when focusing the post title)
 - Use this same toolbar for the multiselection toolbar