### PR TITLE
Add responsive CSS to the table out of the box

### DIFF
--- a/blocks/library/table/block.scss
+++ b/blocks/library/table/block.scss
@@ -1,0 +1,9 @@
+.wp-block-table {
+	overflow-x: auto;
+	display: block;
+
+	table {
+		border-collapse: collapse;
+		width: 100%;
+	}
+}

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import './style.scss';
+import './block.scss';
 import { registerBlockType, query as hpq } from '../../api';
 import TableBlock from './table-block';
 import BlockControls from '../../block-controls';

--- a/blocks/library/table/style.scss
+++ b/blocks/library/table/style.scss
@@ -22,12 +22,8 @@
 }
 
 .wp-block-table {
-	table {
-		border-collapse: collapse;
-		width: 100%;
-	}
-
-	td, th {
+	td,
+	th {
 		padding: 0.5em;
 		border: 1px solid currentColor;
 	}


### PR DESCRIPTION
This fixes #1742.

It is also extracted from #2151 because I should know better.

In this PR, if there isn't room for the table it scrolls horizontally. This works in the admin and the theme, and I think it works reasonably well. Still it might be controversial — what might be the challenges?