### PR TITLE
Try old hover design

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -30,8 +30,8 @@
 	margin-bottom: 5px;
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
 	position: relative;
-
 	padding: $block-padding;
+	transition: 0.2s border;
 
 	@include break-small {
 		// The block mover needs to stay inside the block to allow clicks when hovering the block
@@ -42,8 +42,8 @@
 		z-index: z-index( '.editor-visual-editor__block:before' );
 		content: '';
 		position: absolute;
-		outline: 1px solid transparent;
-		transition: 0.2s outline;
+		border: 2px solid transparent;
+		transition: 0.2s border;
 		top: 0;
 		bottom: 0;
 
@@ -74,13 +74,11 @@
 	}
 
 	&.is-hovered:before {
-		outline: 1px solid $light-gray-500;
-		transition: 0.2s outline;
+		border-left: 2px solid $light-gray-500;
 	}
 
 	&.is-selected:before {
-		outline: 2px solid $light-gray-500;
-		transition: 0.2s outline;
+		border: 2px solid $light-gray-500;
 	}
 
 	&.is-showing-mobile-controls {


### PR DESCRIPTION
There has been discussion on the heaviness of the blocks. Initially this led us to having only the left border on hover. We added a full outline so as to better portray that a paragraph is a block.

However multi selection across blocks works well. If we can get it to work as well with keyboard shortcuts (and show list and quote options in a toolbar), aside from this addressing #539, it seems like there's less of a need for the block outlines to look so heavy.

Screenshot:

![screen shot 2017-08-02 at 13 47 24](https://user-images.githubusercontent.com/1204802/28872376-2d2c927a-7789-11e7-81ba-53d361a4ac15.png)
