### PR TITLE
Popover: Refactor to render using React portals

### DIFF
--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -13,8 +13,14 @@ import { Popover } from '@wordpress/components';
 function ToggleButton( { isVisible, toggleVisible } ) {
 	return (
 		<button onClick={ toggleVisible }>
-			Toggle Me!
-			{ isVisible && <Popover>I am toggled!</Popover> }
+			Toggle Popover!
+			<Popover
+				isOpen={ isVisible }
+				onClose={ toggleVisible }
+				onClick={ ( event ) => event.stopPropagation() }
+			>
+				Popover is toggled!
+			</Popover>
 		</button>
 	);
 }

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -1,0 +1,47 @@
+Popover
+=======
+
+Popover is a React component to render a floating content modal. It is similar in purpose to a tooltip, but renders content of any sort, not only simple text. It anchors itself to its parent node, optionally by a specified direction. If the popover exceeds the bounds of the page in the direction it opens, its position will be flipped automatically.
+
+## Usage
+
+Render a Popover within the parent to which it should anchor:
+
+```jsx
+import { Popover } from '@wordpress/components';
+
+function ToggleButton( { isVisible, toggleVisible } ) {
+	return (
+		<button onClick={ toggleVisible }>
+			Toggle Me!
+			{ isVisible && <Popover>I am toggled!</Popover> }
+		</button>
+	);
+}
+```
+
+## Props
+
+The component accepts the following props:
+
+### position
+
+The direction in which the popover should open relative to its parent node. Specify y- and x-axis as a space-separated string. Supports `"top"`, `"bottom"` y axis, and `"left"`, `"center"`, `"right"` x axis.
+
+- Type: `String`
+- Required: No
+- Default: `"top center"`
+
+### children
+
+The content to be displayed within the popover.
+
+- Type: `Element`
+- Required: Yes
+
+### className
+
+An optional additional class name to apply to the rendered popover.
+
+- Type: `String`
+- Required: No

--- a/components/popover/detect-outside.js
+++ b/components/popover/detect-outside.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import clickOutside from 'react-click-outside';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+class PopoverDetectOutside extends Component {
+	handleClickOutside( event ) {
+		const { onClickOutside } = this.props;
+		if ( onClickOutside ) {
+			onClickOutside( event );
+		}
+	}
+
+	render() {
+		return this.props.children;
+	}
+}
+
+export default clickOutside( PopoverDetectOutside );

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEqual } from 'lodash';
+import { isEqual, pickBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +13,14 @@ import { createPortal, Component } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
+import PopoverDetectOutside from './detect-outside';
+
+/**
+ * Matches an event handler prop key
+ *
+ * @type {RegExp}
+ */
+const REGEXP_EVENT_PROP = /^on[A-Z]/;
 
 export class Popover extends Component {
 	constructor() {
@@ -31,11 +39,11 @@ export class Popover extends Component {
 	}
 
 	componentDidMount() {
-		this.setOffset();
-		this.setForcedPositions();
-
-		window.addEventListener( 'resize', this.throttledSetOffset );
-		window.addEventListener( 'scroll', this.throttledSetOffset );
+		if ( this.props.isOpen ) {
+			this.setOffset();
+			this.setForcedPositions();
+			this.toggleWindowEvents( true );
+		}
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -48,7 +56,17 @@ export class Popover extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		if ( this.props.position !== prevProps.position ) {
+		const { isOpen, position } = this.props;
+		const { isOpen: prevIsOpen, position: prevPosition } = prevProps;
+		if ( isOpen !== prevIsOpen ) {
+			this.toggleWindowEvents( isOpen );
+		}
+
+		if ( ! isOpen ) {
+			return;
+		}
+
+		if ( isOpen !== prevIsOpen || position !== prevPosition ) {
 			this.setOffset();
 			this.setForcedPositions();
 		} else if ( ! isEqual( this.state, prevState ) ) {
@@ -58,9 +76,15 @@ export class Popover extends Component {
 	}
 
 	componentWillUnmount() {
+		this.toggleWindowEvents( false );
+	}
+
+	toggleWindowEvents( isListening ) {
+		const handler = isListening ? 'addEventListener' : 'removeEventListener';
+
 		window.cancelAnimationFrame( this.rafHandle );
-		window.removeEventListener( 'resize', this.throttledSetOffset );
-		window.removeEventListener( 'scroll', this.throttledSetOffset );
+		window[ handler ]( 'resize', this.throttledSetOffset );
+		window[ handler ]( 'scroll', this.throttledSetOffset );
 	}
 
 	throttledSetOffset() {
@@ -118,8 +142,16 @@ export class Popover extends Component {
 	}
 
 	render() {
-		const { children, className } = this.props;
+		const { isOpen, onClose, children, className } = this.props;
 		const [ yAxis, xAxis ] = this.getPositions();
+
+		if ( ! isOpen ) {
+			return null;
+		}
+
+		const eventHandlers = pickBy( this.props, ( value, key ) => (
+			'onClose' !== key && REGEXP_EVENT_PROP.test( key )
+		) );
 
 		const classes = classnames(
 			'components-popover',
@@ -131,18 +163,21 @@ export class Popover extends Component {
 		return (
 			<span ref={ this.bindNode( 'anchor' ) }>
 				{ createPortal(
-					<div
-						ref={ this.bindNode( 'popover' ) }
-						className={ classes }
-						tabIndex="0"
-					>
+					<PopoverDetectOutside onClickOutside={ onClose }>
 						<div
-							ref={ this.bindNode( 'content' ) }
-							className="components-popover__content"
+							ref={ this.bindNode( 'popover' ) }
+							className={ classes }
+							tabIndex="0"
+							{ ...eventHandlers }
 						>
-							{ children }
+							<div
+								ref={ this.bindNode( 'content' ) }
+								className="components-popover__content"
+							>
+								{ children }
+							</div>
 						</div>
-					</div>,
+					</PopoverDetectOutside>,
 					document.body
 				) }
 			</span>

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -1,5 +1,9 @@
 .components-popover {
-	position: absolute;
+	&, * {
+		box-sizing: border-box;
+	}
+
+	position: fixed;
 	z-index: z-index( ".components-popover" );
 	left: 50%;
 
@@ -75,10 +79,6 @@
 
 	.components-popover.is-top & {
 		bottom: 100%;
-	}
-
-	.components-popover.is-bottom & {
-		top: 100%;
 	}
 
 	.components-popover.is-center & {

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -1,0 +1,158 @@
+/**
+ * Internal dependencies
+ */
+import { Popover } from '../';
+
+describe( 'Popover', () => {
+	describe( '#getPositions()', () => {
+		it( 'should default to top center', () => {
+			const instance = new Popover( {} );
+
+			expect( instance.getPositions() ).toEqual( [ 'top', 'center' ] );
+		} );
+
+		it( 'should use y axis', () => {
+			const instance = new Popover( { position: 'bottom' } );
+
+			expect( instance.getPositions() ).toEqual( [ 'bottom', 'center' ] );
+		} );
+
+		it( 'should use y and x axis', () => {
+			const instance = new Popover( { position: 'bottom right' } );
+
+			expect( instance.getPositions() ).toEqual( [ 'bottom', 'right' ] );
+		} );
+	} );
+
+	describe( '#setForcedPositions()', () => {
+		function getInstanceWithContentBounds( nodeBounds ) {
+			const instance = new Popover( {} );
+
+			instance.nodes.content = {
+				getBoundingClientRect() {
+					return {
+						top: 0,
+						right: 0,
+						bottom: 0,
+						left: 0,
+						...nodeBounds,
+					};
+				},
+			};
+
+			instance.setState = jest.fn();
+
+			return instance;
+		}
+
+		it( 'should do nothing if all is well', () => {
+			const instance = getInstanceWithContentBounds( {} );
+			instance.setForcedPositions();
+
+			expect( instance.setState ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should flip y axis to bottom if exceeding top', () => {
+			const instance = getInstanceWithContentBounds( { top: -1 } );
+			instance.setForcedPositions();
+
+			expect( instance.setState ).toHaveBeenCalledTimes( 1 );
+			expect( instance.setState ).toHaveBeenCalledWith( {
+				forcedYAxis: 'bottom',
+			} );
+		} );
+
+		it( 'should flip y axis to top if exceeding bottom', () => {
+			const instance = getInstanceWithContentBounds( { bottom: window.innerHeight + 1 } );
+			instance.setForcedPositions();
+
+			expect( instance.setState ).toHaveBeenCalledTimes( 1 );
+			expect( instance.setState ).toHaveBeenCalledWith( {
+				forcedYAxis: 'top',
+			} );
+		} );
+
+		it( 'should flip x axis to right if exceeding left', () => {
+			const instance = getInstanceWithContentBounds( { left: -1 } );
+			instance.setForcedPositions();
+
+			expect( instance.setState ).toHaveBeenCalledTimes( 1 );
+			expect( instance.setState ).toHaveBeenCalledWith( {
+				forcedXAxis: 'right',
+			} );
+		} );
+
+		it( 'should flip x axis to left if exceeding right', () => {
+			const instance = getInstanceWithContentBounds( { right: window.innerWidth + 1 } );
+			instance.setForcedPositions();
+
+			expect( instance.setState ).toHaveBeenCalledTimes( 1 );
+			expect( instance.setState ).toHaveBeenCalledWith( {
+				forcedXAxis: 'left',
+			} );
+		} );
+
+		it( 'should flip x and y axis', () => {
+			const instance = getInstanceWithContentBounds( { top: -1, left: -1 } );
+			instance.setForcedPositions();
+
+			expect( instance.setState ).toHaveBeenCalledTimes( 2 );
+			expect( instance.setState ).toHaveBeenCalledWith( {
+				forcedXAxis: 'right',
+			} );
+			expect( instance.setState ).toHaveBeenCalledWith( {
+				forcedYAxis: 'bottom',
+			} );
+		} );
+	} );
+
+	describe( '#setOffset()', () => {
+		function getInstanceWithParentNode() {
+			const instance = new Popover( {} );
+
+			instance.nodes.anchor = {
+				parentNode: {
+					getBoundingClientRect() {
+						return {
+							top: 200,
+							right: 400,
+							bottom: 400,
+							left: 200,
+							width: 50,
+							height: 50,
+						};
+					},
+				},
+			};
+
+			instance.nodes.popover = {
+				style: {},
+			};
+
+			return instance;
+		}
+
+		it( 'should position at parent node center', () => {
+			const instance = getInstanceWithParentNode();
+
+			instance.setOffset();
+
+			expect( instance.nodes.popover.style ).toEqual( {
+				left: '225px',
+				top: '200px',
+			} );
+		} );
+
+		it( 'should position at parent bottom', () => {
+			const instance = getInstanceWithParentNode();
+			instance.getPositions = jest.fn().mockReturnValue( [ 'bottom', 'center' ] );
+
+			instance.setOffset();
+
+			expect( instance.nodes.popover.style ).toEqual( {
+				left: '225px',
+				top: '400px',
+			} );
+		} );
+	} );
+} );

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -1,9 +1,73 @@
 /**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
  * Internal dependencies
  */
 import { Popover } from '../';
 
 describe( 'Popover', () => {
+	describe( '#componentDidUpdate()', () => {
+		let wrapper, mocks;
+		beforeEach( () => {
+			wrapper = shallow(
+				<Popover />,
+				{ lifecycleExperimental: true }
+			);
+
+			mocks = {
+				toggleWindowEvents: jest.fn(),
+				setOffset: jest.fn(),
+				setForcedPositions: jest.fn(),
+			};
+
+			Object.assign( wrapper.instance(), mocks );
+		} );
+
+		it( 'should add window events', () => {
+			wrapper.setProps( { isOpen: true } );
+
+			expect( mocks.toggleWindowEvents ).toHaveBeenCalledWith( true );
+			expect( mocks.setOffset ).toHaveBeenCalled();
+			expect( mocks.setForcedPositions ).toHaveBeenCalled();
+		} );
+
+		it( 'should remove window events', () => {
+			wrapper.setProps( { isOpen: true } );
+			jest.clearAllMocks();
+
+			wrapper.setProps( { isOpen: false } );
+
+			expect( mocks.toggleWindowEvents ).toHaveBeenCalledWith( false );
+			expect( mocks.setOffset ).not.toHaveBeenCalled();
+			expect( mocks.setForcedPositions ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should set offset and forced positions on changed position', () => {
+			wrapper.setProps( { isOpen: true } );
+			jest.clearAllMocks();
+
+			wrapper.setProps( { position: 'bottom right' } );
+
+			expect( mocks.toggleWindowEvents ).not.toHaveBeenCalled();
+			expect( mocks.setOffset ).toHaveBeenCalled();
+			expect( mocks.setForcedPositions ).toHaveBeenCalled();
+		} );
+
+		it( 'should set offset on changed forced positions', () => {
+			wrapper.setProps( { isOpen: true } );
+			jest.clearAllMocks();
+
+			wrapper.setState( { forcedXAxis: 'left' } );
+
+			expect( mocks.toggleWindowEvents ).not.toHaveBeenCalled();
+			expect( mocks.setOffset ).toHaveBeenCalled();
+			expect( mocks.setForcedPositions ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	describe( '#getPositions()', () => {
 		it( 'should default to top center', () => {
 			const instance = new Popover( {} );
@@ -153,6 +217,20 @@ describe( 'Popover', () => {
 				left: '225px',
 				top: '400px',
 			} );
+		} );
+	} );
+
+	describe( '#render()', () => {
+		it( 'should render nothing if popover is not open', () => {
+			const wrapper = shallow( <Popover /> );
+
+			expect( wrapper.type() ).toBeNull();
+		} );
+
+		it( 'should render content if popover is open', () => {
+			const wrapper = shallow( <Popover isOpen>Hello</Popover> );
+
+			expect( wrapper.type() ).not.toBeNull();
 		} );
 	} );
 } );

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -32,9 +32,9 @@ $z-layers: (
 	// #adminmenuwrap { z-index: 9990 }
 	'.components-notice-list': 9989,
 
-	// Show popovers above wp-admin menus and submenus:
+	// Show popovers above wp-admin menus and submenus and sidebar:
 	// #adminmenuwrap { z-index: 9990 }
-	'.components-popover': 9999,
+	'.components-popover': 1000000,
 	'.blocks-url-input__suggestions': 9999,
 );
 

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import clickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 
 /**
@@ -23,9 +22,13 @@ import { insertBlock, hideInsertionPoint } from '../actions';
 class Inserter extends Component {
 	constructor() {
 		super( ...arguments );
+
 		this.toggle = this.toggle.bind( this );
 		this.close = this.close.bind( this );
+		this.closeOnClickOutside = this.closeOnClickOutside.bind( this );
+		this.bindNode = this.bindNode.bind( this );
 		this.insertBlock = this.insertBlock.bind( this );
+
 		this.state = {
 			opened: false,
 		};
@@ -43,6 +46,16 @@ class Inserter extends Component {
 		} );
 	}
 
+	closeOnClickOutside( event ) {
+		if ( ! this.node.contains( event.target ) ) {
+			this.close();
+		}
+	}
+
+	bindNode( node ) {
+		this.node = node;
+	}
+
 	insertBlock( name ) {
 		if ( name ) {
 			const { insertionPoint, onInsertBlock } = this.props;
@@ -57,20 +70,12 @@ class Inserter extends Component {
 		this.close();
 	}
 
-	handleClickOutside() {
-		if ( ! this.state.opened ) {
-			return;
-		}
-
-		this.close();
-	}
-
 	render() {
 		const { opened } = this.state;
 		const { position, children } = this.props;
 
 		return (
-			<div className="editor-inserter">
+			<div ref={ this.bindNode } className="editor-inserter">
 				<IconButton
 					icon="insert"
 					label={ __( 'Insert block' ) }
@@ -85,6 +90,7 @@ class Inserter extends Component {
 					<InserterMenu
 						position={ position }
 						onSelect={ this.insertBlock }
+						onClose={ this.closeOnClickOutside }
 					/>
 				) }
 			</div>
@@ -108,4 +114,4 @@ export default connect(
 			) );
 		},
 	} )
-)( clickOutside( Inserter ) );
+)( Inserter );

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -314,13 +314,17 @@ export class InserterMenu extends Component {
 	}
 
 	render() {
-		const { position, instanceId } = this.props;
+		const { position, onClose, instanceId } = this.props;
 		const isSearching = this.state.filterValue;
 		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( this.getBlocksForCurrentTab() );
 
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
-			<Popover position={ position } className="editor-inserter__menu">
+			<Popover
+				position={ position }
+				isOpen
+				onClose={ onClose }
+				className="editor-inserter__menu">
 				<label htmlFor={ `editor-inserter__search-${ instanceId }` } className="screen-reader-text">
 					{ __( 'Search blocks' ) }
 				</label>

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -71,6 +71,18 @@ input[type="search"].editor-inserter__search {
 	padding: 8px;
 }
 
+.editor-inserter__menu.components-popover.is-center .components-popover__content {
+	@media ( max-width: #{ $break-medium - 1 } ) {
+		border-width: 0;
+		position: fixed;
+		left: 0;
+		right: 0;
+		top: $admin-bar-height-big + $header-height;
+		transform: none;
+		width: 100vw;
+	}
+}
+
 .editor-inserter__menu.is-bottom:after {
 	border-bottom-color: $white;
 }

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -33,7 +33,7 @@
 }
 
 .editor-inserter__content {
-	height: calc( 100vh - #{ $admin-bar-height-big + $header-height + $icon-button-size + $inserter-tabs-height } );
+	height: calc( 100vh - #{ $admin-bar-height-big + $header-height + 34 + $inserter-tabs-height } ); // 34 = search input height
 
 	@include break-medium {
 		height: 240px;

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -106,16 +106,13 @@ class PostVisibility extends Component {
 		return (
 			<PanelRow className="editor-post-visibility">
 				<span>{ __( 'Visibility' ) }</span>
-				<span className="editor-post-visibility__button-wrapper">
-					<button
-						type="button"
-						aria-expanded={ this.state.opened }
-						className="editor-post-visibility__toggle button-link"
-						onClick={ this.toggleDialog }
-					>
-						{ getVisibilityLabel( visibility ) }
-					</button>
-
+				<button
+					type="button"
+					aria-expanded={ this.state.opened }
+					className="editor-post-visibility__toggle button-link"
+					onClick={ this.toggleDialog }
+				>
+					{ getVisibilityLabel( visibility ) }
 					{ this.state.opened &&
 						<Popover position="bottom left" className="editor-post-visibility__dialog">
 							<fieldset>
@@ -164,7 +161,7 @@ class PostVisibility extends Component {
 							}
 						</Popover>
 					}
-				</span>
+				</button>
 			</PanelRow>
 		);
 		/* eslint-enable jsx-a11y/label-has-for */

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import clickOutside from 'react-click-outside';
 import { find } from 'lodash';
 
 /**
@@ -27,9 +26,12 @@ class PostVisibility extends Component {
 		super( ...arguments );
 
 		this.toggleDialog = this.toggleDialog.bind( this );
+		this.stopPropagation = this.stopPropagation.bind( this );
+		this.closeOnClickOutside = this.closeOnClickOutside.bind( this );
 		this.setPublic = this.setPublic.bind( this );
 		this.setPrivate = this.setPrivate.bind( this );
 		this.setPasswordProtected = this.setPasswordProtected.bind( this );
+		this.bindButtonNode = this.bindButtonNode.bind( this );
 
 		this.state = {
 			opened: false,
@@ -39,6 +41,17 @@ class PostVisibility extends Component {
 
 	toggleDialog() {
 		this.setState( ( state ) => ( { opened: ! state.opened } ) );
+	}
+
+	stopPropagation( event ) {
+		event.stopPropagation();
+	}
+
+	closeOnClickOutside( event ) {
+		const { opened } = this.state;
+		if ( opened && ! this.buttonNode.contains( event.target ) ) {
+			this.toggleDialog();
+		}
 	}
 
 	setPublic() {
@@ -67,8 +80,8 @@ class PostVisibility extends Component {
 		this.setState( { hasPassword: true } );
 	}
 
-	handleClickOutside() {
-		this.setState( { opened: false } );
+	bindButtonNode( node ) {
+		this.buttonNode = node;
 	}
 
 	render() {
@@ -111,56 +124,61 @@ class PostVisibility extends Component {
 					aria-expanded={ this.state.opened }
 					className="editor-post-visibility__toggle button-link"
 					onClick={ this.toggleDialog }
+					ref={ this.bindButtonNode }
 				>
 					{ getVisibilityLabel( visibility ) }
-					{ this.state.opened &&
-						<Popover position="bottom left" className="editor-post-visibility__dialog">
-							<fieldset>
-								<legend className="editor-post-visibility__dialog-legend">
-									{ __( 'Post Visibility' ) }
-								</legend>
-								{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
-									<div key={ value } className="editor-post-visibility__choice">
-										<input
-											type="radio"
-											name={ `editor-post-visibility__setting-${ instanceId }` }
-											value={ value }
-											onChange={ onSelect }
-											checked={ checked }
-											id={ `editor-post-${ value }-${ instanceId }` }
-											aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
-											className="editor-post-visibility__dialog-radio"
-										/>
-										<label
-											htmlFor={ `editor-post-${ value }-${ instanceId }` }
-											className="editor-post-visibility__dialog-label"
-										>
-											{ label }
-										</label>
-										{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
-									</div>
-								) ) }
-							</fieldset>
-							{ this.state.hasPassword &&
-								<div className="editor-post-visibility__dialog-password">
-									<label
-										htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
-										className="screen-reader-text"
-									>
-										{ __( 'Create password' ) }
-									</label>
+					<Popover
+						position="bottom left"
+						isOpen={ this.state.opened }
+						onClose={ this.closeOnClickOutside }
+						onClick={ this.stopPropagation }
+						className="editor-post-visibility__dialog"
+					>
+						<fieldset>
+							<legend className="editor-post-visibility__dialog-legend">
+								{ __( 'Post Visibility' ) }
+							</legend>
+							{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
+								<div key={ value } className="editor-post-visibility__choice">
 									<input
-										className="editor-post-visibility__dialog-password-input"
-										id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
-										type="text"
-										onChange={ updatePassword }
-										value={ password }
-										placeholder={ __( 'Use a secure password' ) }
+										type="radio"
+										name={ `editor-post-visibility__setting-${ instanceId }` }
+										value={ value }
+										onChange={ onSelect }
+										checked={ checked }
+										id={ `editor-post-${ value }-${ instanceId }` }
+										aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
+										className="editor-post-visibility__dialog-radio"
 									/>
+									<label
+										htmlFor={ `editor-post-${ value }-${ instanceId }` }
+										className="editor-post-visibility__dialog-label"
+									>
+										{ label }
+									</label>
+									{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
 								</div>
-							}
-						</Popover>
-					}
+							) ) }
+						</fieldset>
+						{ this.state.hasPassword &&
+							<div className="editor-post-visibility__dialog-password">
+								<label
+									htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+									className="screen-reader-text"
+								>
+									{ __( 'Create password' ) }
+								</label>
+								<input
+									className="editor-post-visibility__dialog-password-input"
+									id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+									type="text"
+									onChange={ updatePassword }
+									value={ password }
+									placeholder={ __( 'Use a secure password' ) }
+								/>
+							</div>
+						}
+					</Popover>
 				</button>
 			</PanelRow>
 		);
@@ -180,4 +198,4 @@ export default connect(
 			return editPost( { status, password } );
 		},
 	}
-)( withInstanceId( clickOutside( PostVisibility ) ) );
+)( withInstanceId( PostVisibility ) );

--- a/editor/sidebar/post-visibility/style.scss
+++ b/editor/sidebar/post-visibility/style.scss
@@ -2,10 +2,6 @@
 	width: 100%;
 }
 
-.editor-post-visibility__button-wrapper {
-	position: relative;
-}
-
 .editor-post-visibility__toggle.button-link {
 	text-decoration: underline;
 	color: $blue-wordpress;

--- a/element/index.js
+++ b/element/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createElement, Component, cloneElement, Children } from 'react';
-import { render, findDOMNode } from 'react-dom';
+import { render, findDOMNode, unstable_createPortal } from 'react-dom'; // eslint-disable-line camelcase
 import { renderToStaticMarkup } from 'react-dom/server';
 import { isString } from 'lodash';
 
@@ -50,6 +50,16 @@ export { cloneElement };
 export { findDOMNode };
 
 export { Children };
+
+/**
+ * Creates a portal into which a component can be rendered.
+ *
+ * @see https://github.com/facebook/react/issues/10309#issuecomment-318433235
+ *
+ * @param {Component} component Component
+ * @param {Element}   target    DOM node into which element should be rendered
+ */
+export { unstable_createPortal as createPortal }; // eslint-disable-line camelcase
 
 /**
  * Renders a given element into a string

--- a/test/setup-globals.js
+++ b/test/setup-globals.js
@@ -17,6 +17,8 @@ global.window.tinyMCEPreInit = {
 	// <script> tag where it was loaded from, which of course fails here.
 	baseURL: 'about:blank',
 };
+window.requestAnimationFrame = setTimeout;
+window.cancelAnimationFrame = clearTimeout;
 
 global.window._wpDateSettings = {
 	formats: {

--- a/test/setup-test-framework.js
+++ b/test/setup-test-framework.js
@@ -1,2 +1,9 @@
 // `babel-jest` should be doing this instead, but apparently it's not working.
 require( 'core-js/modules/es7.object.values' );
+
+// TODO: This is only necessary so long as we're running React 15.x in the Node
+// context, since createPortal is only available in 16.x
+jest.mock( '@wordpress/element', () => ( {
+	...require.requireActual( '@wordpress/element' ),
+	createPortal: ( x ) => x,
+} ) );


### PR DESCRIPTION
This pull request seeks to leverage React portals — a new (unstable) feature introduced in React 16 — to render the existing `Popover` component. The concept of portals has existed previously in the React ecosystem, through works such as [React-portal](https://github.com/tajo/react-portal) or [Calypso's `RootChild` component](https://github.com/Automattic/wp-calypso/tree/master/client/components/root-child). The idea is that the rendering of the component occurs elsewhere in the DOM, usually at the root (body) element. This has a few benefits:

- Styles from parent nodes will not cascade into the popover
- It is immune from [phrasing content restrictions](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content) (e.g. `div` cannot be a descendant of `button`)

See included changes to existing Popover usage in PostVisibility as an example of the simplification permitted by the second of these benefits.

__Testing instructions:__

Verify that there are no regressions in the behavior of Popover controls, currently present in:

- Header inserter
- Post settings visibility
- Content inserter

Of note, the content inserter should demonstrate "bounds flipping" behavior. It should try to open upwards (on Demo content where scroll exists), else downward if space does not permit (on New post without any content).

Ensure that unit tests pass:

```
npm test
```