### PR TITLE
Hide editable placeholders on focus

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -497,7 +497,7 @@ export default class Editable extends Component {
 		// changes, we unmount and destroy the previous TinyMCE element, then
 		// mount and initialize a new child element in its place.
 		const key = [ 'editor', Tagname ].join();
-		const isPlaceholderVisible = placeholder && this.state.empty;
+		const isPlaceholderVisible = placeholder && ! focus && this.state.empty;
 		const classes = classnames( className, 'blocks-editable' );
 
 		const formatToolbar = (


### PR DESCRIPTION
While it's unlike the behaviour of normal input fields, it's been suggested that we should hide placeholders on focus. This will prevent them from popping up while writing.