### PR TITLE
KeyboardShortcuts: Use a separate Mousetrap instance per component instance

### DIFF
--- a/components/keyboard-shortcuts/index.js
+++ b/components/keyboard-shortcuts/index.js
@@ -11,17 +11,14 @@ import { Component } from 'element';
 
 class KeyboardShortcuts extends Component {
 	componentWillMount() {
-		this.toggleBindings( true );
+		this.mousetrap = new Mousetrap;
+		forEach( this.props.shortcuts, ( callback, key ) => {
+			this.mousetrap.bind( key, callback );
+		} );
 	}
 
 	componentWillUnmount() {
-		this.toggleBindings( false );
-	}
-
-	toggleBindings( isActive ) {
-		forEach( this.props.shortcuts, ( callback, key ) => {
-			Mousetrap[ isActive ? 'bind' : 'unbind' ]( key, callback );
-		} );
+		this.mousetrap.reset();
 	}
 
 	render() {


### PR DESCRIPTION
Fixes the same issue as #2085, but allows for multiple bindings per key command (props @aduth for the alternate approach).

Without this change, the callbacks are not being properly unbound when the visual editor [unmounts](https://github.com/WordPress/gutenberg/blob/03f8fe67929918036705bef4881925c27a516015/editor/modes/visual-editor/index.js#L85-L89).

## To Test

### Confirm Existing Behavior

* Run release or master
* Create a new post via: `/wp-admin/admin.php?page=gutenberg`
* Add some content
* Switch to `text` mode
* Issue a keyboard command...for example: <kbd>cmd</kbd>+<kbd>a</kbd> for "select all"
  **NOTE:** You may need to click the editor whitespace again to be able to kick this off
* Confirm the Visual Editor's select all callback is executed:
<img width="886" alt="screen shot 2017-07-29 at 1 29 05 pm" src="https://user-images.githubusercontent.com/1587282/28746924-f0079d74-7461-11e7-827c-e3d36bce60a4.png">

### Confirm the fix

* Run this branch
* Repeat the above
  * Callbacks should only be executed in the visual editor mode (none are currently registered via this component in text mode)
* Attempt to bind the same key command(s) as are already bound via a separately instantiated `KeyboardCommands` compoent
  * All bound callbacks should execute and unbind when the component unmounts.