### PR TITLE
Strip whitespace on inserter search term.

### DIFF
--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -21,7 +21,7 @@ import { getBlocks, getRecentlyUsedBlocks } from '../selectors';
 import { showInsertionPoint, hideInsertionPoint } from '../actions';
 
 export const searchBlocks = ( blocks, searchTerm ) => {
-	const normalizedSearchTerm = searchTerm.toLowerCase();
+	const normalizedSearchTerm = searchTerm.toLowerCase().trim();
 	const matchSearch = ( string ) => string.toLowerCase().indexOf( normalizedSearchTerm ) !== -1;
 
 	return blocks.filter( ( block ) =>

--- a/editor/inserter/test/menu.js
+++ b/editor/inserter/test/menu.js
@@ -196,6 +196,26 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 1 ).childAt( 1 ).text() ).toBe( 'Advanced Text' );
 		expect( visibleBlocks.at( 2 ).childAt( 1 ).text() ).toBe( 'A Text Embed' );
 	} );
+
+	it( 'should trim whitespace of search terms', () => {
+		const wrapper = shallow(
+			<InserterMenu
+				instanceId={ 1 }
+				blocks={ [] }
+				recentlyUsedBlocks={ [] }
+			/>
+		);
+		wrapper.setState( { filterValue: ' text' } );
+
+		const tabs = wrapper.find( '.editor-inserter__tab' );
+		expect( tabs.length ).toBe( 0 );
+
+		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
+		expect( visibleBlocks.length ).toBe( 3 );
+		expect( visibleBlocks.at( 0 ).childAt( 1 ).text() ).toBe( 'Text' );
+		expect( visibleBlocks.at( 1 ).childAt( 1 ).text() ).toBe( 'Advanced Text' );
+		expect( visibleBlocks.at( 2 ).childAt( 1 ).text() ).toBe( 'A Text Embed' );
+	} );
 } );
 
 describe( 'searchBlocks', () => {


### PR DESCRIPTION
While testing #2164 I accidentally entered in ` gallery` ( note the space before ) when searching for the gallery block to test - and no results were returned.  This PR `trim()`s the search value prior to searching to fix this.

I have added a test case, but could not figure out how to run it locally :)

__Steps To Test__
- Open block inserter
- type ` gallery` or `text ` and validate the results are shown as expected