### PR TITLE
Add npm org scope to WordPress dependencies

### DIFF
--- a/blocks/alignment-toolbar/index.js
+++ b/blocks/alignment-toolbar/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Toolbar } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Toolbar } from '@wordpress/components';
 
 const ALIGNMENT_CONTROLS = [
 	{

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Block categories.

--- a/blocks/api/paste.js
+++ b/blocks/api/paste.js
@@ -4,15 +4,21 @@
 import { find, get, flowRight as compose } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { nodetypes } from '@wordpress/utils';
+
+/**
  * Internal dependencies
  */
 import { createBlock } from './factory';
 import { getBlockTypes, getUnknownTypeHandler } from './registration';
 import { parseBlockAttributes } from './parser';
-import { ELEMENT_NODE, TEXT_NODE } from 'utils/nodetypes';
 import convertTables from './paste/convert-tables';
 import stripAttributes from './paste/strip-attributes';
 import removeSpans from './paste/remove-spans';
+
+const { ELEMENT_NODE, TEXT_NODE } = nodetypes;
 
 /**
  * Normalises array nodes of any node type to an array of block level nodes.

--- a/blocks/api/paste/remove-spans.js
+++ b/blocks/api/paste/remove-spans.js
@@ -1,4 +1,9 @@
-import { ELEMENT_NODE } from 'utils/nodetypes';
+/**
+ * WordPress dependencies
+ */
+import { nodetypes } from '@wordpress/utils';
+
+const { ELEMENT_NODE } = nodetypes;
 
 /**
  *

--- a/blocks/api/query.js
+++ b/blocks/api/query.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createElement } from 'element';
+import { createElement } from '@wordpress/element';
 
 /**
  * External dependencies

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, createElement, renderToString, cloneElement, Children } from 'element';
+import { Component, createElement, renderToString, cloneElement, Children } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/blocks/api/test/query.js
+++ b/blocks/api/test/query.js
@@ -6,7 +6,7 @@ import { parse } from 'hpq';
 /**
  * WordPress dependencies
  */
-import { renderToString } from 'element';
+import { renderToString } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createElement, Component } from 'element';
+import { createElement, Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Toolbar } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Toolbar } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/block-controls/index.js
+++ b/blocks/block-controls/index.js
@@ -6,7 +6,7 @@ import { Fill } from 'react-slot-fill';
 /**
  * WordPress dependencies
  */
-import { Toolbar } from 'components';
+import { Toolbar } from '@wordpress/components';
 
 export default function BlockControls( { controls, children } ) {
 	return (

--- a/blocks/block-icon/index.js
+++ b/blocks/block-icon/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import Dashicon from 'components/dashicon';
-import { createElement, Component } from 'element';
+import { Dashicon } from '@wordpress/components';
+import { createElement, Component } from '@wordpress/element';
 
 export default function BlockIcon( { icon } ) {
 	if ( 'string' === typeof icon ) {

--- a/blocks/block-icon/test/index.js
+++ b/blocks/block-icon/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -6,16 +6,18 @@ import { isUndefined } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { IconButton, Toolbar } from 'components';
-import { ESCAPE } from 'utils/keycodes';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { IconButton, Toolbar } from '@wordpress/components';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import UrlInput from '../../url-input';
+
+const { ESCAPE } = keycodes;
 
 const FORMATTING_CONTROLS = [
 	{

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -21,17 +21,19 @@ import 'element-closest';
 /**
  * WordPress dependencies
  */
-import { createElement, Component, renderToString } from 'element';
-import { parse, pasteHandler } from '../api';
-import { BACKSPACE, DELETE, ENTER } from 'utils/keycodes';
+import { createElement, Component, renderToString } from '@wordpress/element';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import { parse, pasteHandler } from '../api';
 import FormatToolbar from './format-toolbar';
 import TinyMCE from './tinymce';
 import patterns from './patterns';
+
+const { BACKSPACE, DELETE, ENTER } = keycodes;
 
 function createTinyMCEElement( type, props, ...children ) {
 	if ( props[ 'data-mce-bogus' ] === 'all' ) {

--- a/blocks/editable/patterns.js
+++ b/blocks/editable/patterns.js
@@ -7,7 +7,7 @@ import { endsWith, find, get, escapeRegExp, partition, drop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { ESCAPE, ENTER, SPACE, BACKSPACE } from 'utils/keycodes';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -18,6 +18,8 @@ import { getBlockTypes } from '../api/registration';
  * Browser dependencies
  */
 const { setTimeout } = window;
+
+const { ESCAPE, ENTER, SPACE, BACKSPACE } = keycodes;
 
 export default function( editor ) {
 	const getContent = this.getContent.bind( this );

--- a/blocks/editable/provider.js
+++ b/blocks/editable/provider.js
@@ -6,7 +6,7 @@ import { pick, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 /**
  * The Editable Provider allows a rendering context to define global behaviors

--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, Children, createElement } from 'element';
+import { Component, Children, createElement } from '@wordpress/element';
 
 export default class TinyMCE extends Component {
 	componentDidMount() {

--- a/blocks/inspector-controls/checkbox-control/index.js
+++ b/blocks/inspector-controls/checkbox-control/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from 'components';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -6,7 +6,7 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from 'components';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from 'components';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -6,7 +6,7 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from 'components';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from 'components';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from 'components';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withInstanceId, FormToggle } from 'components';
+import { withInstanceId, FormToggle } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -6,8 +6,8 @@ import { CirclePicker } from 'react-color';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { IconButton } from 'components';
+import { __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -6,7 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Placeholder, Toolbar, Dashicon } from 'components';
-import { __ } from 'i18n';
+import { Placeholder, Toolbar, Dashicon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 
 /**

--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -6,8 +6,8 @@ import { CirclePicker } from 'react-color';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { concatChildren } from 'element';
+import { __ } from '@wordpress/i18n';
+import { concatChildren } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -7,10 +7,12 @@ import { includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from 'i18n';
-import { Component } from 'element';
-import { Button, Placeholder, Spinner, SandBox } from 'components';
-import { addQueryArgs } from 'editor/utils/url';
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Button, Placeholder, Spinner, SandBox } from '@wordpress/components';
+// TODO: This is a circular dependency between editor and blocks. This must be
+// updated, eventually to depend on published `@wordpress/url`
+import { addQueryArgs } from '../../../editor/utils/url';
 
 /**
  * Internal dependencies

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { __ } from 'i18n';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 export default class OldEditor extends Component {
 	constructor( props ) {

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Toolbar, Placeholder } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Toolbar, Placeholder } from '@wordpress/components';
 import { pick } from 'lodash';
 
 /**

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -6,9 +6,9 @@ import { isObject } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from 'i18n';
-import { concatChildren } from 'element';
-import { Toolbar } from 'components';
+import { __, sprintf } from '@wordpress/i18n';
+import { concatChildren } from '@wordpress/element';
+import { Toolbar } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -6,8 +6,8 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -6,8 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Placeholder, Dashicon, Toolbar, DropZone } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Placeholder, Dashicon, Toolbar, DropZone } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { Placeholder, Toolbar, Spinner } from 'components';
-import { __ } from 'i18n';
+import { Component } from '@wordpress/element';
+import { Placeholder, Toolbar, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import classnames from 'classnames';
 

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -1,9 +1,13 @@
 /**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
  * WordPress dependencies
  */
-import { Component, createElement, Children, concatChildren } from 'element';
-import { find } from 'lodash';
-import { __ } from 'i18n';
+import { Component, createElement, Children, concatChildren } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -6,7 +6,7 @@ import { isString } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -6,8 +6,8 @@ import { isString, isObject } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from 'i18n';
-import { Toolbar } from 'components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Toolbar } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -1,7 +1,7 @@
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
-import { Toolbar, DropdownMenu } from 'components';
-import { __ } from 'i18n';
+import { Toolbar, DropdownMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 function execCommand( command ) {
 	return ( editor ) => {

--- a/blocks/library/text/index.js
+++ b/blocks/library/text/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { concatChildren } from 'element';
+import { __ } from '@wordpress/i18n';
+import { concatChildren } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { __ } from 'i18n';
-import { Button } from 'components';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import { pick } from 'lodash';
 
 // Getter for the sake of unit tests.

--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -7,9 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import './style.scss';
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { IconButton } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -8,10 +8,12 @@ import scrollIntoView from 'dom-scroll-into-view';
 /**
  * WordPress dependencies
  */
-import { __, sprintf, _n } from 'i18n';
-import { Component } from 'element';
-import { UP, DOWN, ENTER } from 'utils/keycodes';
-import { Spinner, withInstanceId } from 'components';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { keycodes } from '@wordpress/utils';
+import { Spinner, withInstanceId } from '@wordpress/components';
+
+const { UP, DOWN, ENTER } = keycodes;
 
 class UrlInput extends Component {
 	constructor() {

--- a/blocks/with-editor-settings/index.js
+++ b/blocks/with-editor-settings/index.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 const withEditorSettings = ( mapSettingsToProps ) => ( OriginalComponent ) => {
 	class WrappedComponent extends Component {

--- a/components/README.md
+++ b/components/README.md
@@ -11,7 +11,7 @@ Within Gutenberg, these components can be accessed by importing from the `compon
 /**
  * WordPress dependencies
  */
-import { Button } from 'components';
+import { Button } from '@wordpress/components';
 
 export default function MyButton() {
 	return <Button>Click Me!</Button>;

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, createElement } from 'element';
+import { Component, createElement } from '@wordpress/element';
 
 class Button extends Component {
 	constructor( props ) {

--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -8,7 +8,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { findDOMNode, Component } from 'element';
+import { findDOMNode, Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/components/drop-zone/index.js
+++ b/components/drop-zone/index.js
@@ -7,14 +7,14 @@ import { includes, without } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import Dashicon from 'components/dashicon';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import Dashicon from '../dashicon';
 
 class DropZone extends Component {
 	constructor() {

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -7,15 +7,17 @@ import clickOutside from 'react-click-outside';
 /**
  * WordPress dependencies
  */
-import IconButton from 'components/icon-button';
-import Dashicon from 'components/dashicon';
-import { Component, findDOMNode } from 'element';
-import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
+import { Component, findDOMNode } from '@wordpress/element';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import IconButton from '../icon-button';
+import Dashicon from '../dashicon';
+
+const { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } = keycodes;
 
 export class DropdownMenu extends Component {
 	constructor() {

--- a/components/dropdown-menu/test/index.js
+++ b/components/dropdown-menu/test/index.js
@@ -6,12 +6,14 @@ import { shallow, mount } from 'enzyme';
 /**
  * WordPress dependencies
  */
-import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import { DropdownMenu } from '../';
+
+const { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } = keycodes;
 
 describe( 'DropdownMenu', () => {
 	let controls;

--- a/components/external-link/index.js
+++ b/components/external-link/index.js
@@ -7,7 +7,7 @@ import { compact, uniq } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -7,8 +7,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf } from 'i18n';
-import { Component } from 'element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/components/form-token-field/suggestions-list.js
+++ b/components/form-token-field/suggestions-list.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 class SuggestionsList extends Component {
 	constructor() {

--- a/components/form-token-field/test/lib/token-field-wrapper.js
+++ b/components/form-token-field/test/lib/token-field-wrapper.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 import { unescape } from 'lodash';
 
 /**

--- a/components/form-token-field/token-input.js
+++ b/components/form-token-field/token-input.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 class TokenInput extends Component {
 	constructor() {

--- a/components/form-token-field/token.js
+++ b/components/form-token-field/token.js
@@ -7,8 +7,12 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { sprintf } from 'i18n';
-import IconButton from 'components/icon-button';
+import { sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import IconButton from '../icon-button';
 
 function Token( {
 	value,

--- a/components/higher-order/with-focus-return/index.js
+++ b/components/higher-order/with-focus-return/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component, findDOMNode } from 'element';
+import { Component, findDOMNode } from '@wordpress/element';
 
 /**
  * Higher Order Component used to be used to wrap disposable elements like Sidebars, modals, dropdowns.

--- a/components/higher-order/with-instance-id/README.md
+++ b/components/higher-order/with-instance-id/README.md
@@ -10,7 +10,7 @@ Wrapping a component with `withInstanceId` provides a unique `instanceId` to ser
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from 'components';
+import { withInstanceId } from '@wordpress/components';
 
 function MyCustomElement( { instanceId } ) {
 	return (

--- a/components/higher-order/with-instance-id/index.js
+++ b/components/higher-order/with-instance-id/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 /**
  * A Higher Order Component used to be provide a unique instance ID by component

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/components/keyboard-shortcuts/index.js
+++ b/components/keyboard-shortcuts/index.js
@@ -7,7 +7,7 @@ import { forEach } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 class KeyboardShortcuts extends Component {
 	componentWillMount() {

--- a/components/notice/index.js
+++ b/components/notice/index.js
@@ -6,7 +6,7 @@ import { isString, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal Dependencies

--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { __, sprintf } from 'i18n';
+import { Component } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/components/placeholder/test/index.js
+++ b/components/placeholder/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { Placeholder } from 'components';
+import Placeholder from '../';
 
 describe( 'Placeholder', () => {
 	describe( 'basic rendering', () => {

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/components/responsive-wrapper/index.js
+++ b/components/responsive-wrapper/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress Dependencies
  */
-import { cloneElement, Children } from 'element';
+import { cloneElement, Children } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -1,4 +1,4 @@
-import { renderToString } from 'element';
+import { renderToString } from '@wordpress/element';
 
 export default class Sandbox extends wp.element.Component {
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -72,7 +72,7 @@ Example:
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 ```
 
 #### Internal Dependencies

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -7,8 +7,8 @@ import { first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { IconButton } from 'components';
-import { getBlockType } from 'blocks';
+import { IconButton } from '@wordpress/components';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/block-mover/mover-label.js
+++ b/editor/block-mover/mover-label.js
@@ -1,7 +1,7 @@
 /**
  * Wordpress dependencies
  */
-import { __, sprintf } from 'i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Return a label for the block movement controls depending on block position.

--- a/editor/block-settings-menu/index.js
+++ b/editor/block-settings-menu/index.js
@@ -6,14 +6,14 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { IconButton } from 'components';
+import { __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { isEditorSidebarOpened } from 'editor/selectors';
+import { isEditorSidebarOpened } from '../selectors';
 
 function BlockSettingsMenu( { onDelete, selectBlock, isSidebarOpened, toggleSidebar, setActivePanel } ) {
 	const toggleInspector = () => {

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -8,10 +8,10 @@ import clickOutside from 'react-click-outside';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { Dashicon, IconButton } from 'components';
-import { getBlockType, getBlockTypes, switchToBlockType } from 'blocks';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Dashicon, IconButton } from '@wordpress/components';
+import { getBlockType, getBlockTypes, switchToBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -7,8 +7,8 @@ import { get, uniqueId, debounce } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { serialize, getBlockType, switchToBlockType } from 'blocks';
-import { __ } from 'i18n';
+import { serialize, getBlockType, switchToBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { sprintf, _n, __ } from 'i18n';
-import { IconButton } from 'components';
+import { sprintf, _n, __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __, _x } from 'i18n';
-import { Dashicon } from 'components';
+import { __, _x } from '@wordpress/i18n';
+import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -7,8 +7,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Dashicon, Button } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Dashicon, Button } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/header/tools/index.js
+++ b/editor/header/tools/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { IconButton } from 'components';
+import { __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -6,12 +6,12 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { IconButton } from 'components';
+import { IconButton } from '@wordpress/components';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { _x } from 'i18n';
 import { getEditedPostPreviewLink } from '../../selectors';
 
 function PreviewButton( { link, postId } ) {

--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -7,8 +7,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Button } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/index.js
+++ b/editor/index.js
@@ -10,9 +10,9 @@ import 'moment-timezone/moment-timezone-utils';
 /**
  * WordPress dependencies
  */
-import { EditableProvider, parse } from 'blocks';
-import { render } from 'element';
-import { settings } from 'date';
+import { EditableProvider, parse } from '@wordpress/blocks';
+import { render } from '@wordpress/element';
+import { settings } from '@wordpress/date';
 
 /**
  * Internal dependencies

--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -7,10 +7,10 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { IconButton } from 'components';
-import { createBlock } from 'blocks';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { IconButton } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -7,11 +7,11 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf } from 'i18n';
-import { Component } from 'element';
-import { Popover, withFocusReturn, withInstanceId } from 'components';
-import { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } from 'utils/keycodes';
-import { getCategories, getBlockTypes, BlockIcon } from 'blocks';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Popover, withFocusReturn, withInstanceId } from '@wordpress/components';
+import { keycodes } from '@wordpress/utils';
+import { getCategories, getBlockTypes, BlockIcon } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -19,6 +19,8 @@ import { getCategories, getBlockTypes, BlockIcon } from 'blocks';
 import './style.scss';
 import { getBlocks, getRecentlyUsedBlocks } from '../selectors';
 import { showInsertionPoint, hideInsertionPoint } from '../actions';
+
+const { TAB, ESCAPE, LEFT, UP, RIGHT, DOWN } = keycodes;
 
 export const searchBlocks = ( blocks, searchTerm ) => {
 	const normalizedSearchTerm = searchTerm.toLowerCase().trim();

--- a/editor/inserter/test/menu.js
+++ b/editor/inserter/test/menu.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { registerBlockType, unregisterBlockType, getBlockTypes } from 'blocks';
+import { registerBlockType, unregisterBlockType, getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { NoticeList } from 'components';
+import { NoticeList } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -7,8 +7,8 @@ import Textarea from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { serialize, parse } from 'blocks';
+import { Component } from '@wordpress/element';
+import { serialize, parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -8,11 +8,11 @@ import { throttle, reduce, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { serialize, getDefaultBlock, createBlock } from 'blocks';
-import { IconButton } from 'components';
-import { ENTER } from 'utils/keycodes';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { serialize, getDefaultBlock, createBlock } from '@wordpress/blocks';
+import { IconButton } from '@wordpress/components';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -31,6 +31,7 @@ import {
 import { insertBlock, multiSelect } from '../../actions';
 
 const INSERTION_POINT_PLACEHOLDER = '[[insertion-point]]';
+const { ENTER } = keycodes;
 
 class VisualEditorBlockList extends Component {
 	constructor( props ) {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -10,11 +10,11 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 /**
  * WordPress dependencies
  */
-import { Children, Component } from 'element';
-import { IconButton, Toolbar } from 'components';
-import { BACKSPACE, ESCAPE, DELETE, UP, DOWN, LEFT, RIGHT } from 'utils/keycodes';
-import { getBlockType, getBlockDefaultClassname } from 'blocks';
-import { __, sprintf } from 'i18n';
+import { Children, Component } from '@wordpress/element';
+import { IconButton, Toolbar } from '@wordpress/components';
+import { keycodes } from '@wordpress/utils';
+import { getBlockType, getBlockDefaultClassname } from '@wordpress/blocks';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -47,6 +47,8 @@ import {
 	isTyping,
 	getMultiSelectedBlockUids,
 } from '../../selectors';
+
+const { BACKSPACE, ESCAPE, DELETE, UP, DOWN, LEFT, RIGHT } = keycodes;
 
 function FirstChild( { children } ) {
 	const childrenArray = Children.toArray( children );

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -7,9 +7,9 @@ import { first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component, findDOMNode } from 'element';
-import { KeyboardShortcuts } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Component, findDOMNode } from '@wordpress/element';
+import { KeyboardShortcuts } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/modes/visual-editor/invalid-block-warning.js
+++ b/editor/modes/visual-editor/invalid-block-warning.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Dashicon } from 'components';
-import { __ } from 'i18n';
+import { Dashicon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 const warning = (
 	<div className="editor-visual-editor__invalid-block-warning">

--- a/editor/post-permalink/index.js
+++ b/editor/post-permalink/index.js
@@ -6,9 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { __ } from 'i18n';
-import { Dashicon, ClipboardButton, Button } from 'components';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Dashicon, ClipboardButton, Button } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -9,9 +9,9 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { ENTER } from 'utils/keycodes';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -25,6 +25,7 @@ import PostPermalink from '../post-permalink';
  * Constants
  */
 const REGEXP_NEWLINES = /[\r\n]+/g;
+const { ENTER } = keycodes;
 
 class PostTitle extends Component {
 	constructor() {

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -8,17 +8,13 @@ import createSelector from 'rememo';
 /**
  * WordPress dependencies
  */
-import { getBlockType } from 'blocks';
+import { getBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { addQueryArgs } from './utils/url';
-
-/**
- * WordPress dependencies
- */
-import { __ } from 'i18n';
 
 /**
  * Returns the current editing mode.

--- a/editor/settings/provider.js
+++ b/editor/settings/provider.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 /**
  * The Editor Settings Provider allows any compoent to access the editor settings

--- a/editor/sidebar/block-inspector/class-name.js
+++ b/editor/sidebar/block-inspector/class-name.js
@@ -6,9 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { getBlockType, InspectorControls } from 'blocks';
-import { __ } from 'i18n';
+import { Component } from '@wordpress/element';
+import { getBlockType, InspectorControls } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -7,8 +7,8 @@ import { Slot } from 'react-slot-fill';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Panel, PanelBody } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Panel, PanelBody } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/discussion-panel/index.js
+++ b/editor/sidebar/discussion-panel/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { PanelBody, PanelRow, FormToggle, withInstanceId } from 'components';
+import { __ } from '@wordpress/i18n';
+import { PanelBody, PanelRow, FormToggle, withInstanceId } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/featured-image/index.js
+++ b/editor/sidebar/featured-image/index.js
@@ -6,10 +6,10 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { __ } from 'i18n';
-import { Button, PanelBody, Spinner, ResponsiveWrapper } from 'components';
-import { MediaUploadButton } from 'blocks';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, PanelBody, Spinner, ResponsiveWrapper } from '@wordpress/components';
+import { MediaUploadButton } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/header.js
+++ b/editor/sidebar/header.js
@@ -6,13 +6,13 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { IconButton } from 'components';
+import { __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal Dependencies
  */
-import { getActivePanel } from 'editor/selectors';
+import { getActivePanel } from '../selectors';
 
 const SidebarHeader = ( { panel, onSetPanel, toggleSidebar } ) => {
 	return (

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress Dependencies
  */
-import { withFocusReturn } from 'components';
+import { withFocusReturn } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/last-revision/index.js
+++ b/editor/sidebar/last-revision/index.js
@@ -6,10 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
-import { sprintf, _n } from 'i18n';
-import IconButton from 'components/icon-button';
-import PanelBody from 'components/panel/body';
+import { Component } from '@wordpress/element';
+import { sprintf, _n } from '@wordpress/i18n';
+import { IconButton, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/page-attributes/index.js
+++ b/editor/sidebar/page-attributes/index.js
@@ -6,9 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { PanelBody, PanelRow, withInstanceId } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { PanelBody, PanelRow, withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -6,9 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { PanelRow, withInstanceId } from 'components';
-import { Component } from 'element';
+import { __ } from '@wordpress/i18n';
+import { PanelRow, withInstanceId } from '@wordpress/components';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-excerpt/index.js
+++ b/editor/sidebar/post-excerpt/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { ExternalLink, PanelBody } from 'components';
+import { __ } from '@wordpress/i18n';
+import { ExternalLink, PanelBody } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-schedule/clock.js
+++ b/editor/sidebar/post-schedule/clock.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Button } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 function PostScheduleClock( { is12Hour, selected, onChange } ) {
 	const minutes = selected.format( 'mm' );

--- a/editor/sidebar/post-schedule/index.js
+++ b/editor/sidebar/post-schedule/index.js
@@ -9,10 +9,10 @@ import moment from 'moment';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { dateI18n, settings } from 'date';
-import { PanelRow } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { dateI18n, settings } from '@wordpress/date';
+import { PanelRow } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Panel } from 'components';
+import { Panel } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -6,9 +6,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { PanelBody, PanelRow, FormToggle, withInstanceId } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { PanelBody, PanelRow, FormToggle, withInstanceId } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/post-sticky/index.js
+++ b/editor/sidebar/post-sticky/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { PanelRow, FormToggle, withInstanceId } from 'components';
+import { __ } from '@wordpress/i18n';
+import { PanelRow, FormToggle, withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-taxonomies/categories-selector.js
+++ b/editor/sidebar/post-taxonomies/categories-selector.js
@@ -7,8 +7,8 @@ import { unescape as unescapeString, without, groupBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-taxonomies/index.js
+++ b/editor/sidebar/post-taxonomies/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import PanelBody from 'components/panel/body';
+import { __ } from '@wordpress/i18n';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-taxonomies/tags-selector.js
+++ b/editor/sidebar/post-taxonomies/tags-selector.js
@@ -7,9 +7,9 @@ import { unescape, find, throttle } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { FormTokenField } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { FormTokenField } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-trash/index.js
+++ b/editor/sidebar/post-trash/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { PanelRow, Button, Dashicon } from 'components';
+import { __ } from '@wordpress/i18n';
+import { PanelRow, Button, Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -8,9 +8,9 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
-import { PanelRow, Popover, withInstanceId } from 'components';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { PanelRow, Popover, withInstanceId } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -8,8 +8,8 @@ import classnames from 'classnames';
 /**
  * WordPress Dependencies
  */
-import { __, sprintf } from 'i18n';
-import { PanelBody } from 'components';
+import { __, sprintf } from '@wordpress/i18n';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/editor/state.js
+++ b/editor/state.js
@@ -9,7 +9,7 @@ import { reduce, keyBy, first, last, omit, without, flowRight, forOwn } from 'lo
 /**
  * WordPress dependencies
  */
-import { getBlockTypes } from 'blocks';
+import { getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { getBlockTypes, unregisterBlockType, registerBlockType, createBlock } from 'blocks';
+import { getBlockTypes, unregisterBlockType, registerBlockType, createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -4,6 +4,11 @@
 import moment from 'moment';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import {
@@ -54,11 +59,6 @@ import {
 	getSuggestedPostFormat,
 	getNotices,
 } from '../selectors';
-
-/**
- * WordPress dependencies
- */
-import { __ } from 'i18n';
 
 describe( 'selectors', () => {
 	describe( 'getEditorMode', () => {

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -7,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * WordPress dependencies
  */
-import { registerBlockType, unregisterBlockType } from 'blocks';
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/editor/unsaved-changes-warning/index.js
+++ b/editor/unsaved-changes-warning/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
-import { Component } from 'element';
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -129,13 +129,13 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-components',
 		gutenberg_url( 'components/build/index.js' ),
-		array( 'wp-element', 'wp-a11y' ),
+		array( 'wp-element', 'wp-a11y', 'wp-i18n', 'wp-utils' ),
 		filemtime( gutenberg_dir_path() . 'components/build/index.js' )
 	);
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'tinymce-nightly', 'tinymce-nightly-lists', 'tinymce-nightly-paste', 'tinymce-nightly-table', 'media-views', 'media-models' ),
+		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-i18n', 'tinymce-nightly', 'tinymce-nightly-lists', 'tinymce-nightly-paste', 'tinymce-nightly-table', 'media-views', 'media-models' ),
 		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 	wp_add_inline_script(

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     ],
     "coverageDirectory": "coverage",
     "moduleNameMapper": {
-      "\\.scss$": "<rootDir>/test/style-mock.js"
+      "\\.scss$": "<rootDir>/test/style-mock.js",
+      "@wordpress\\/(blocks|components|date|editor|element|i18n|utils)": "$1"
     },
     "modulePaths": [
       "<rootDir>"

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,3 +1,5 @@
 import * as keycodes from './keycodes';
+import * as nodetypes from './nodetypes';
 
 export { keycodes };
+export { nodetypes };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,7 +55,7 @@ const externals = {
 };
 
 entryPointNames.forEach( entryPointName => {
-	externals[ entryPointName ] = {
+	externals[ '@wordpress/' + entryPointName ] = {
 		'this': [ 'wp', entryPointName ],
 	};
 } );


### PR DESCRIPTION
Related: #941
Related: #1205

This pull request seeks to add the [WordPress npm organization scope](https://www.npmjs.com/org/wordpress) to all [WordPress dependency](https://github.com/WordPress/gutenberg/blob/master/docs/coding-guidelines.md#wordpress-dependencies) imports. It is a further realization of the intent for these top-level folders to be distributed as independent packages.

Other side-benefits include:

- Surfaces pathed imports on WordPress dependencies
- Surfaces circular dependencies
- Surfaces incorrectly specified `wp_register_script` script dependencies
- Eliminates chance of naming conflicts between "WordPress dependencies" and other npm or built-in modules
- Reduces overall minified bundle size by 8.7% (1285kb -> 1124kb, related to first point and #941)

__Implementation notes:__

This will be hellish to rebase, so I'd prefer not to let this one linger.

__Testing instructions:__

This is difficult to test because it touches nearly every file in the application. Verify through `npm run build`, `npm run dev`, `npm test` that no errors occur, and that no regressions or console errors occur by thorough use of the application.