### PR TITLE
Embed Block: Fix rendering the embed blocks (wideImage JS error)

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -116,7 +116,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 			render() {
 				const { html, type, error, fetching } = this.state;
 				const { align, url, caption } = this.props.attributes;
-				const { setAttributes, focus, setFocus, settings } = this.props;
+				const { setAttributes, focus, setFocus } = this.props;
 				const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
 				const controls = (
@@ -125,7 +125,6 @@ function getEmbedBlockSettings( { title, icon, category = 'embed' } ) {
 							<BlockAlignmentToolbar
 								value={ align }
 								onChange={ updateAlignment }
-								wideControlsEnabled={ settings.wideImages }
 							/>
 						</BlockControls>
 					)


### PR DESCRIPTION
with #2119 the editor settings are not provided as a prop to the blocks anymore. I somehow missed refactoring the embed blocks in this PR.
