### PR TITLE
Add theme support for custom palettes and shared "ColorPalette" component

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { CirclePicker } from 'react-color';
+
+/**
+ * Internal dependencies
+ */
+import withEditorSettings from '../with-editor-settings';
+
+function ColorPalette( { colors, onChange, value } ) {
+	return (
+		<CirclePicker
+			color={ value }
+			colors={ colors }
+			onChangeComplete={ ( colorValue ) => onChange( colorValue ) }
+			style={ { marginBottom: '20px' } }
+		/>
+	);
+}
+
+export default withEditorSettings(
+	( settings ) => ( {
+		colors: settings.colors,
+	} )
+)( ColorPalette );

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -17,6 +17,7 @@ export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as BlockControls } from './block-controls';
 export { default as BlockDescription } from './block-description';
 export { default as BlockIcon } from './block-icon';
+export { default as ColorPalette } from './color-palette';
 export { default as Editable } from './editable';
 export { default as EditableProvider } from './editable/provider';
 export { default as InspectorControls } from './inspector-controls';

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { CirclePicker } from 'react-color';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -19,6 +14,7 @@ import Editable from '../../editable';
 import UrlInput from '../../url-input';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import ColorPalette from '../../color-palette';
 import InspectorControls from '../../inspector-controls';
 
 const { attr, children } = query;
@@ -76,9 +72,9 @@ registerBlockType( 'core/button', {
 				}
 				{ focus &&
 					<InspectorControls key="inspector">
-						<CirclePicker
+						<ColorPalette
 							color={ color }
-							onChangeComplete={ ( colorValue ) => setAttributes( { color: colorValue.hex } ) }
+							onChange={ ( colorValue ) => setAttributes( { color: colorValue.hex } ) }
 						/>
 						<InspectorControls.TextControl
 							label={ __( 'Hex Color' ) }

--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { CirclePicker } from 'react-color';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -17,29 +12,13 @@ import { registerBlockType, query as hpq } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import ColorPalette from '../../color-palette';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import BlockDescription from '../../block-description';
 
 const { children, query } = hpq;
-
-function palette() {
-	return [
-		'#f78da7',
-		'#eb144c',
-		'#ff6900',
-		'#fcb900',
-		'#7bdcb5',
-		'#00d084',
-		'#8ed1fc',
-		'#0693e3',
-		'#eee',
-		'#abb8c3',
-		'#444',
-		'#111',
-	];
-}
 
 registerBlockType( 'core/cover-text', {
 	title: __( 'Cover Text' ),
@@ -68,6 +47,7 @@ registerBlockType( 'core/cover-text', {
 	edit( { attributes, setAttributes, className, focus, setFocus, mergeBlocks } ) {
 		const { align, width, content, dropCap, placeholder, textColor, backgroundColor } = attributes;
 		const toggleDropCap = () => setAttributes( { dropCap: ! dropCap } );
+
 		return [
 			focus && (
 				<BlockControls key="controls">
@@ -94,17 +74,14 @@ registerBlockType( 'core/cover-text', {
 						onChange={ toggleDropCap }
 					/>
 					<h3>{ __( 'Background Color' ) }</h3>
-					<CirclePicker
+					<ColorPalette
 						color={ backgroundColor }
-						colors={ palette() }
-						onChangeComplete={ ( colorValue ) => setAttributes( { backgroundColor: colorValue.hex } ) }
-						style={ { marginBottom: '20px' } }
+						onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue.hex } ) }
 					/>
 					<h3>{ __( 'Text Color' ) }</h3>
-					<CirclePicker
+					<ColorPalette
 						color={ textColor }
-						colors={ palette() }
-						onChangeComplete={ ( colorValue ) => setAttributes( { textColor: colorValue.hex } ) }
+						onChange={ ( colorValue ) => setAttributes( { textColor: colorValue.hex } ) }
 					/>
 				</InspectorControls>
 			),

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -15,3 +15,20 @@ add_theme_support( 'gutenberg', array(
    'wide-images' => true,
 ) );
 ```
+
+### Colors:
+
+Different blocks have the possibility of customizing colors. Gutenberg provides a default palette, but a theme can overwrite it and provide its own:
+
+```php
+add_theme_support( 'gutenberg', array(
+   'colors' => array(
+		'#a156b4',
+		'#d0a5db',
+		'#eee',
+		'#444',
+	),
+) );
+```
+
+The colors will be shown in order on the palette, and there's no limit to how many can be specified.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -458,6 +458,13 @@ function gutenberg_common_scripts_and_styles() {
 add_action( 'wp_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
 add_action( 'admin_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
 
+/**
+ * Returns a default color palette.
+ *
+ * @return array Color strings in hex format.
+ *
+ * @since 0.7.0
+ */
 function gutenberg_color_palette() {
 	return array(
 		'#f78da7',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -458,6 +458,23 @@ function gutenberg_common_scripts_and_styles() {
 add_action( 'wp_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
 add_action( 'admin_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
 
+function gutenberg_color_palette() {
+	return array(
+		'#f78da7',
+		'#eb144c',
+		'#ff6900',
+		'#fcb900',
+		'#7bdcb5',
+		'#00d084',
+		'#8ed1fc',
+		'#0693e3',
+		'#eee',
+		'#abb8c3',
+		'#444',
+		'#111',
+	);
+}
+
 /**
  * Scripts & Styles.
  *
@@ -625,9 +642,17 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
+	$color_palette = gutenberg_color_palette();
+
+	if ( $gutenberg_theme_support && $gutenberg_theme_support[0]['colors'] ) {
+		$color_palette = $gutenberg_theme_support[0]['colors'];
+	}
+
 	$editor_settings = array(
 		'wideImages' => $gutenberg_theme_support ? $gutenberg_theme_support[0]['wide-images'] : false,
+		'colors' => $color_palette,
 	);
+
 	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() {'
 		. 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
 		. '} );'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/548849/28924449-14d6bff0-7862-11e7-8131-eaee8d148d0d.png)

Done via:

```php
add_theme_support( 'gutenberg', array(
	'colors' => array(
		'#A156B4',
		'#D0A5DB',
		'#EEE',
		'#444',
	),
) );
```