### PR TITLE
Preview Button: Save post before navigating to preview

### DIFF
--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -20,7 +20,6 @@ function PreviewButton( { link, postId } ) {
 			href={ link }
 			target={ `wp-preview-${ postId }` }
 			icon="visibility"
-			disabled={ ! link }
 		>
 			{ _x( 'Preview', 'imperative verb' ) }
 		</IconButton>

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -6,29 +6,86 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { getEditedPostPreviewLink } from '../../selectors';
+import {
+	getEditedPostPreviewLink,
+	getEditedPostAttribute,
+} from '../../selectors';
+import { autosave } from '../../actions';
 
-function PreviewButton( { link, postId } ) {
-	return (
-		<IconButton
-			href={ link }
-			target={ `wp-preview-${ postId }` }
-			icon="visibility"
-		>
-			{ _x( 'Preview', 'imperative verb' ) }
-		</IconButton>
-	);
+export class PreviewButton extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.saveForPreview = this.saveForPreview.bind( this );
+
+		this.state = {
+			isAwaitingSave: false,
+		};
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { modified, link } = this.props;
+		const { isAwaitingSave } = this.state;
+		const hasFinishedSaving = (
+			isAwaitingSave &&
+			modified !== prevProps.modified
+		);
+
+		if ( hasFinishedSaving && this.previewWindow ) {
+			this.previewWindow.location = link;
+		}
+	}
+
+	getWindowTarget() {
+		const { postId } = this.props;
+		return `wp-preview-${ postId }`;
+	}
+
+	saveForPreview( event ) {
+		// Save post prior to opening window
+		this.props.autosave();
+		this.setState( {
+			isAwaitingSave: true,
+		} );
+
+		// Open a popup, BUT: Set it to a blank page until save completes. This
+		// is necessary because popups can only be opened in response to user
+		// interaction (click), but we must still wait for the post to save.
+		event.preventDefault();
+		this.previewWindow = window.open(
+			'about:blank',
+			this.getWindowTarget()
+		);
+	}
+
+	render() {
+		const { link } = this.props;
+
+		return (
+			<IconButton
+				href={ link }
+				onClick={ this.saveForPreview }
+				target={ this.getWindowTarget() }
+				icon="visibility"
+			>
+				{ _x( 'Preview', 'imperative verb' ) }
+			</IconButton>
+		);
+	}
 }
 
 export default connect(
 	( state ) => ( {
 		postId: state.currentPost.id,
 		link: getEditedPostPreviewLink( state ),
-	} )
+		modified: getEditedPostAttribute( state, 'modified' ),
+	} ),
+	{ autosave }
 )( PreviewButton );

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -30,16 +30,17 @@ export class PreviewButton extends Component {
 		};
 	}
 
-	componentDidUpdate( prevProps ) {
-		const { modified, link } = this.props;
+	componentWillReceiveProps( nextProps ) {
+		const { modified, link } = nextProps;
 		const { isAwaitingSave } = this.state;
 		const hasFinishedSaving = (
 			isAwaitingSave &&
-			modified !== prevProps.modified
+			modified !== this.props.modified
 		);
 
 		if ( hasFinishedSaving && this.previewWindow ) {
 			this.previewWindow.location = link;
+			this.setState( { isAwaitingSave: false } );
 		}
 	}
 

--- a/editor/header/tools/test/preview-button.js
+++ b/editor/header/tools/test/preview-button.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PreviewButton } from '../preview-button';
+
+describe( 'PreviewButton', () => {
+	describe( 'constructor()', () => {
+		it( 'should initialize with non-awaiting-save', () => {
+			const instance = new PreviewButton( {} );
+
+			expect( instance.state.isAwaitingSave ).toBe( false );
+		} );
+	} );
+
+	describe( 'getWindowTarget()', () => {
+		it( 'returns a string unique to the post id', () => {
+			const instance = new PreviewButton( {
+				postId: 1,
+			} );
+
+			expect( instance.getWindowTarget() ).toBe( 'wp-preview-1' );
+		} );
+	} );
+
+	describe( 'componentDidUpdate()', () => {
+		it( 'should change popup location if save finishes', () => {
+			const wrapper = shallow(
+				<PreviewButton
+					postId={ 1 }
+					link="https://wordpress.org/?p=1"
+					modified="2017-08-03T15:05:50" />,
+				{ lifecycleExperimental: true }
+			);
+			wrapper.instance().previewWindow = {};
+			wrapper.setState( { isAwaitingSave: true } );
+
+			wrapper.setProps( { modified: '2017-08-03T15:05:52' } );
+
+			expect(
+				wrapper.instance().previewWindow.location
+			).toBe( 'https://wordpress.org/?p=1' );
+		} );
+	} );
+
+	describe( 'saveForPreview()', () => {
+		it( 'should open a popup window', () => {
+			const autosave = jest.fn();
+			const preventDefault = jest.fn();
+			const windowOpen = window.open;
+			window.open = jest.fn();
+
+			const wrapper = shallow(
+				<PreviewButton
+					postId={ 1 }
+					autosave={ autosave } />
+			);
+
+			wrapper.simulate( 'click', { preventDefault } );
+
+			expect( autosave ).toHaveBeenCalled();
+			expect( preventDefault ).toHaveBeenCalled();
+			expect( wrapper.state( 'isAwaitingSave' ) ).toBe( true );
+			expect( window.open ).toHaveBeenCalledWith( 'about:blank', 'wp-preview-1' );
+
+			window.open = windowOpen;
+		} );
+	} );
+
+	describe( 'render()', () => {
+		it( 'should render a link', () => {
+			const wrapper = shallow(
+				<PreviewButton
+					postId={ 1 }
+					link="https://wordpress.org/?p=1" />
+			);
+
+			expect( wrapper.prop( 'href' ) ).toBe( 'https://wordpress.org/?p=1' );
+			expect( wrapper.prop( 'target' ) ).toBe( 'wp-preview-1' );
+		} );
+	} );
+} );

--- a/editor/header/tools/test/preview-button.js
+++ b/editor/header/tools/test/preview-button.js
@@ -33,8 +33,7 @@ describe( 'PreviewButton', () => {
 				<PreviewButton
 					postId={ 1 }
 					link="https://wordpress.org/?p=1"
-					modified="2017-08-03T15:05:50" />,
-				{ lifecycleExperimental: true }
+					modified="2017-08-03T15:05:50" />
 			);
 			wrapper.instance().previewWindow = {};
 			wrapper.setState( { isAwaitingSave: true } );
@@ -44,6 +43,7 @@ describe( 'PreviewButton', () => {
 			expect(
 				wrapper.instance().previewWindow.location
 			).toBe( 'https://wordpress.org/?p=1' );
+			expect( wrapper.state( 'isAwaitingSave' ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Related: #1295 

This pull request seeks to address the need for a post autosave to occur before showing a preview, as otherwise the preview will not reflect unsaved changes applied to the post.

__Implementation notes:__

Because popup windows can only be opened in response to user interaction, the solution here is:

1. Open a popup at `about:blank` as soon as user clicks button, retaining reference to popup window
2. Autosave post
3. When autosave completes, update popup window reference location to saved post link

__Testing instructions:__

Verify that any unsaved changes are reflected in preview.

1. Navigate to Gutenberg > New Post
2. Add a title and/or content
3. Press Preview button in header
4. Note a popup window is shown, and after post is saved, you are navigated to a preview reflecting edits from your post

Ensure unit tests pass:

```
npm test
```

__Caveats:__

Published post autosave is not yet implemented. See https://github.com/WordPress/gutenberg/issues/1773#issuecomment-316434091.