### PR TITLE
Fix missing script file due to changes in React build process

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -45,7 +45,17 @@ exec 3< <(
 while IFS='|' read -u 3 url filename; do
 	echo "$url"
 	echo -n " > vendor/$filename ... "
-	curl --location --silent "$url" --output "vendor/_download.tmp.js"
+	http_status=$( curl \
+		--location \
+		--silent \
+		"$url" \
+		--output "vendor/_download.tmp.js" \
+		--write-out "%{http_code}"
+	)
+	if [ "$http_status" != 200 ]; then
+		echo "error - HTTP $http_status"
+		exit 1
+	fi
 	mv -f "vendor/_download.tmp.js" "vendor/$filename"
 	echo "done!"
 	vendor_scripts="$vendor_scripts vendor/$filename"

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -194,7 +194,7 @@ function gutenberg_register_vendor_scripts() {
 	);
 	gutenberg_register_vendor_script(
 		'react-dom-server',
-		'https://unpkg.com/react-dom@next/umd/react-dom-server' . $react_suffix . '.js',
+		'https://unpkg.com/react-dom@next/umd/react-dom-server.browser' . $react_suffix . '.js',
 		array( 'react' )
 	);
 	$moment_script = SCRIPT_DEBUG ? 'moment.js' : 'min/moment.min.js';


### PR DESCRIPTION
Currently, Gutenberg will fail to load with the following error:

> <img src="https://user-images.githubusercontent.com/227022/28948120-bd983e4c-7881-11e7-8680-b143fb273d0c.png" width="500">

It may be necessary to `rm vendor/*.js` in order to see this error, because by default these vendor JS files are cached for one day.

This failure occurs because we attempt to load https://unpkg.com/react-dom@next/umd/react-dom-server.production.min.js, which currently redirects to https://unpkg.com/react-dom@16.0.0-beta.3/umd/react-dom-server.production.min.js, which is not found.

As seen in the directory listing at https://unpkg.com/react-dom@16.0.0-beta.3/umd/ and the [related React change](https://github.com/facebook/react/commit/fc86ef0f3d5c3b93121d245512eb686617e47527#diff-6c6554c881731a0c8ac33c8ddba3876eL182) (https://github.com/facebook/react/pull/10362), the correct path to this file now includes a `.browser` suffix.

The first commit in this PR adds error handling to detect this condition (and any other such failures) when building a plugin zip file:

```
$ bin/build-plugin-zip.sh 
WARNING: You should probably be running this script against the
         'master' branch (current: 'fix/build-error-react-dom-server')

https://unpkg.com/react@next/umd/react.production.min.js
 > vendor/react.min.c7397a88.js ... done!
https://unpkg.com/react-dom@next/umd/react-dom.production.min.js
 > vendor/react-dom.min.912dc6cf.js ... done!
https://unpkg.com/react-dom@next/umd/react-dom-server.production.min.js
 > vendor/react-dom-server.min.538e07c8.js ... error - HTTP 404
```

The second commit fixes the load issue (and the plugin zip build) by fixing the path.