### PR TITLE
Validation: Detect block validity by tokenizing content

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,13 +13,12 @@
 					"last 1 Android version",
 					"last 1 ChromeAndroid version",
 					"ie 11",
-					"> 1%"				
+					"> 1%"
 				]
 			}
 		} ]
 	],
 	"plugins": [
-		"lodash",
 		"transform-object-rest-spread",
 		[ "transform-react-jsx", {
 			"pragma": "wp.element.createElement"
@@ -28,6 +27,7 @@
 	"env": {
 		"default": {
 			"plugins": [
+				"lodash",
 				"transform-runtime"
 			]
 		},

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -10,7 +10,7 @@ import { pickBy } from 'lodash';
 import { parse as grammarParse } from './post.pegjs';
 import { getBlockType, getUnknownTypeHandler } from './registration';
 import { createBlock } from './factory';
-import { getBeautifulContent, getSaveContent } from './serializer';
+import { isValidBlock } from './validation';
 
 /**
  * Returns the block attributes parsed from raw content.
@@ -107,38 +107,6 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
 
 		return block;
 	}
-}
-
-/**
- * Returns true if the parsed block is valid given the input content. A block
- * is considered valid if, when serialized with assumed attributes, the content
- * matches the original value.
- *
- * Logs to console in development environments when invalid.
- *
- * @param  {String}  rawContent Original block content
- * @param  {String}  blockType  Block type
- * @param  {Object}  attributes Parsed block attributes
- * @return {Boolean}            Whether block is valid
- */
-export function isValidBlock( rawContent, blockType, attributes ) {
-	const [ actual, expected ] = [
-		rawContent,
-		getSaveContent( blockType, attributes ),
-	].map( getBeautifulContent );
-
-	const isValid = ( actual === expected );
-
-	if ( ! isValid && 'development' === process.env.NODE_ENV ) {
-		// eslint-disable-next-line no-console
-		console.error(
-			'Invalid block parse\n' +
-				'\tExpected: ' + expected + '\n' +
-				'\tActual:   ' + actual
-		);
-	}
-
-	return isValid;
 }
 
 /**

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -10,7 +10,6 @@ import { text } from '../query';
 import {
 	getBlockAttributes,
 	parseBlockAttributes,
-	isValidBlock,
 	createBlockWithFallback,
 	default as parse,
 } from '../parser';
@@ -18,7 +17,6 @@ import {
 	registerBlockType,
 	unregisterBlockType,
 	getBlockTypes,
-	getBlockType,
 	setUnknownTypeHandler,
 } from '../registration';
 
@@ -90,28 +88,6 @@ describe( 'block parser', () => {
 				topic: 'none',
 				content: 'Ribs & Chicken',
 			} );
-		} );
-	} );
-
-	describe( 'isValidBlock()', () => {
-		it( 'returns false is block is not valid', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-
-			expect( isValidBlock(
-				'Apples',
-				getBlockType( 'core/test-block' ),
-				{ fruit: 'Bananas' }
-			) ).toBe( false );
-		} );
-
-		it( 'returns true is block is valid', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-
-			expect( isValidBlock(
-				'Bananas',
-				getBlockType( 'core/test-block' ),
-				{ fruit: 'Bananas' }
-			) ).toBe( true );
 		} );
 	} );
 

--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import { isValidBlock } from '../validation';
+import {
+	registerBlockType,
+	unregisterBlockType,
+	getBlockTypes,
+	getBlockType,
+	setUnknownTypeHandler,
+} from '../registration';
+
+describe( 'validation', () => {
+	const defaultBlockSettings = {
+		save: ( { attributes } ) => attributes.fruit,
+	};
+
+	afterEach( () => {
+		setUnknownTypeHandler( undefined );
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'isValidBlock()', () => {
+		it( 'returns false is block is not valid', () => {
+			registerBlockType( 'core/test-block', defaultBlockSettings );
+
+			expect( isValidBlock(
+				'Apples',
+				getBlockType( 'core/test-block' ),
+				{ fruit: 'Bananas' }
+			) ).toBe( false );
+		} );
+
+		it( 'returns true is block is valid', () => {
+			registerBlockType( 'core/test-block', defaultBlockSettings );
+
+			expect( isValidBlock(
+				'Bananas',
+				getBlockType( 'core/test-block' ),
+				{ fruit: 'Bananas' }
+			) ).toBe( true );
+		} );
+	} );
+} );

--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -1,7 +1,19 @@
 /**
  * Internal dependencies
  */
-import { isValidBlock } from '../validation';
+import {
+	getTextPiecesSplitOnWhitespace,
+	getTextWithCollapsedWhitespace,
+	isEqualTextTokensWithCollapsedWhitespace,
+	getNormalizedStyleValue,
+	getStyleProperties,
+	isEqualAttributesOfName,
+	isEqualTagAttributePairs,
+	isEqualTokensOfType,
+	getNextNonWhitespaceToken,
+	isEquivalentHTML,
+	isValidBlock,
+} from '../validation';
 import {
 	registerBlockType,
 	unregisterBlockType,
@@ -19,6 +31,282 @@ describe( 'validation', () => {
 		setUnknownTypeHandler( undefined );
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'getTextPiecesSplitOnWhitespace()', () => {
+		it( 'returns text pieces spilt on whitespace', () => {
+			const pieces = getTextPiecesSplitOnWhitespace( '  a \t  b \n c' );
+
+			expect( pieces ).toEqual( [ 'a', 'b', 'c' ] );
+		} );
+	} );
+
+	describe( 'getTextWithCollapsedWhitespace()', () => {
+		it( 'returns text with collapsed whitespace', () => {
+			const pieces = getTextWithCollapsedWhitespace( '  a \t  b \n c' );
+
+			expect( pieces ).toBe( 'a b c' );
+		} );
+	} );
+
+	describe( 'isEqualTextTokensWithCollapsedWhitespace()', () => {
+		it( 'should return false if not equal with collapsed whitespace', () => {
+			const isEqual = isEqualTextTokensWithCollapsedWhitespace(
+				{ chars: '  a \t  b \n c' },
+				{ chars: 'a \n c \t b  ' },
+			);
+
+			expect( isEqual ).toBe( false );
+		} );
+
+		it( 'should return true if equal with collapsed whitespace', () => {
+			const isEqual = isEqualTextTokensWithCollapsedWhitespace(
+				{ chars: '  a \t  b \n c' },
+				{ chars: 'a \n b \t c  ' },
+			);
+
+			expect( isEqual ).toBe( true );
+		} );
+	} );
+
+	describe( 'getNormalizedStyleValue()', () => {
+		it( 'omits whitespace and quotes from url value', () => {
+			const normalizedValue = getNormalizedStyleValue(
+				'url( "https://wordpress.org/img.png" )'
+			);
+
+			expect( normalizedValue ).toBe( 'url(https://wordpress.org/img.png)' );
+		} );
+	} );
+
+	describe( 'getStyleProperties()', () => {
+		it( 'returns style property pairs', () => {
+			const pairs = getStyleProperties(
+				'background-image: url( "https://wordpress.org/img.png" ); color: red;'
+			);
+
+			expect( pairs ).toEqual( {
+				'background-image': 'url(https://wordpress.org/img.png)',
+				color: 'red',
+			} );
+		} );
+	} );
+
+	describe( 'isEqualAttributesOfName', () => {
+		describe( '.class()', () => {
+			it( 'ignores ordering', () => {
+				const isEqual = isEqualAttributesOfName.class(
+					'a b c',
+					'b a c',
+				);
+
+				expect( isEqual ).toBe( true );
+			} );
+
+			it( 'ignores whitespace', () => {
+				const isEqual = isEqualAttributesOfName.class(
+					'a  b    c',
+					'b   a c',
+				);
+
+				expect( isEqual ).toBe( true );
+			} );
+
+			it( 'returns false if not equal', () => {
+				const isEqual = isEqualAttributesOfName.class(
+					'a b c',
+					'b a c d',
+				);
+
+				expect( isEqual ).toBe( false );
+			} );
+		} );
+
+		describe( '.style()', () => {
+			it( 'returns true if the same style', () => {
+				const isEqual = isEqualAttributesOfName.style(
+					'background-image: url( "https://wordpress.org/img.png" ); color: red;',
+					'color: red;   background-image: url(\'https://wordpress.org/img.png\n);'
+				);
+
+				expect( isEqual ).toBe( true );
+			} );
+
+			it( 'returns true if not same style', () => {
+				const isEqual = isEqualAttributesOfName.style(
+					'background-image: url( "https://wordpress.org/img.png" ); color: red;',
+					'color: red;  font-size: 13px; background-image: url(\'https://wordpress.org/img.png\');'
+				);
+
+				expect( isEqual ).toBe( false );
+			} );
+		} );
+	} );
+
+	describe( 'isEqualTagAttributePairs()', () => {
+		it( 'returns false if not equal pairs', () => {
+			const isEqual = isEqualTagAttributePairs(
+				[
+					[ 'class', 'b   a c' ],
+				],
+				[
+					[ 'class', 'c  a b' ],
+					[ 'style', 'background-image: url( "https://wordpress.org/img.png" ); color: red;' ],
+				]
+			);
+
+			expect( isEqual ).toBe( false );
+		} );
+
+		it( 'returns true if equal pairs', () => {
+			const isEqual = isEqualTagAttributePairs(
+				[
+					[ 'class', 'b   a c' ],
+					[ 'style', 'color: red;  background-image: url( "https://wordpress.org/img.png" );' ],
+				],
+				[
+					[ 'class', 'c  a b' ],
+					[ 'style', 'background-image: url( "https://wordpress.org/img.png" ); color: red;' ],
+				]
+			);
+
+			expect( isEqual ).toBe( true );
+		} );
+	} );
+
+	describe( 'isEqualTokensOfType', () => {
+		describe( '.StartTag()', () => {
+			it( 'returns false if tag name not the same', () => {
+				const isEqual = isEqualTokensOfType.StartTag(
+					{ tagName: 'p' },
+					{ tagName: 'section' }
+				);
+
+				expect( isEqual ).toBe( false );
+			} );
+
+			it( 'returns false if tag name the same but attributes not', () => {
+				const isEqual = isEqualTokensOfType.StartTag(
+					{
+						tagName: 'p',
+						attributes: [
+							[ 'class', 'b   a c' ],
+						],
+					},
+					{
+						tagName: 'p',
+						attributes: [
+							[ 'class', 'c  a b' ],
+							[ 'style', 'background-image: url( "https://wordpress.org/img.png" ); color: red;' ],
+						],
+					}
+				);
+
+				expect( isEqual ).toBe( false );
+			} );
+
+			it( 'returns true if tag name the same and attributes the same', () => {
+				const isEqual = isEqualTokensOfType.StartTag(
+					{
+						tagName: 'p',
+						attributes: [
+							[ 'class', 'b   a c' ],
+							[ 'style', 'color: red;  background-image: url( "https://wordpress.org/img.png" );' ],
+						],
+					},
+					{
+						tagName: 'p',
+						attributes: [
+							[ 'class', 'c  a b' ],
+							[ 'style', 'background-image: url( "https://wordpress.org/img.png" ); color: red;' ],
+						],
+					}
+				);
+
+				expect( isEqual ).toBe( true );
+			} );
+		} );
+	} );
+
+	describe( 'getNextNonWhitespaceToken()', () => {
+		it( 'returns the next non-whitespace token, mutating array', () => {
+			const tokens = [
+				{ type: 'Chars', chars: '   \n\t' },
+				{ type: 'StartTag', tagName: 'p' },
+			];
+
+			const token = getNextNonWhitespaceToken( tokens );
+
+			expect( token ).toEqual( { type: 'StartTag', tagName: 'p' } );
+			expect( tokens ).toHaveLength( 0 );
+		} );
+
+		it( 'returns undefined if token options exhausted', () => {
+			const tokens = [
+				{ type: 'Chars', chars: '   \n\t' },
+			];
+
+			const token = getNextNonWhitespaceToken( tokens );
+
+			expect( token ).toBeUndefined();
+			expect( tokens ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'isEquivalentHTML()', () => {
+		it( 'should return false for effectively inequivalent html', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div>Hello <span class="b">World!</span></div>',
+				'<div>Hello <span class="a">World!</span></div>'
+			);
+
+			expect( isEquivalent ).toBe( false );
+		} );
+
+		it( 'should return true for effectively equivalent html', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div>Hello<span   class="b a" id="foo"> World!</  span>  </div>',
+				'<div  >Hello\n<span id="foo" class="a  b">World!</span></div>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+		} );
+
+		it( 'should return false when more tokens in first', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div>Hello</div>',
+				'<div>Hello'
+			);
+
+			expect( isEquivalent ).toBe( false );
+		} );
+
+		it( 'should return false when more tokens in second', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div>Hello',
+				'<div>Hello</div>'
+			);
+
+			expect( isEquivalent ).toBe( false );
+		} );
+
+		it( 'should return true when first has trailing whitespace', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div>Hello</div>  ',
+				'<div>Hello</div>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+		} );
+
+		it( 'should return true when second has trailing whitespace', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div>Hello</div>',
+				'<div>Hello</div>  '
+			);
+
+			expect( isEquivalent ).toBe( true );
 		} );
 	} );
 

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -208,23 +208,16 @@ export function getNextNonWhitespaceToken( tokens ) {
 }
 
 /**
- * Returns true if the parsed block is valid given the input content. A block
- * is considered valid if, when serialized with assumed attributes, the content
- * matches the original value.
+ * Returns true if there is given HTML strings are effectively equivalent, or
+ * false otherwise.
  *
- * Logs to console in development environments when invalid.
- *
- * @param  {String}  rawContent Original block content
- * @param  {String}  blockType  Block type
- * @param  {Object}  attributes Parsed block attributes
- * @return {Boolean}            Whether block is valid
+ * @param  {String}  a First HTML string
+ * @param  {String}  b Second HTML string
+ * @return {Boolean}   Whether HTML strings are equivalent
  */
-export function isValidBlock( rawContent, blockType, attributes ) {
+export function isEquivalentHTML( a, b ) {
 	// Tokenize input content and reserialized save content
-	const [ actualTokens, expectedTokens ] = [
-		rawContent,
-		getSaveContent( blockType, attributes ),
-	].map( tokenize );
+	const [ actualTokens, expectedTokens ] = [ a, b ].map( tokenize );
 
 	let actualToken, expectedToken;
 	while ( ( actualToken = getNextNonWhitespaceToken( actualTokens ) ) ) {
@@ -255,4 +248,23 @@ export function isValidBlock( rawContent, blockType, attributes ) {
 	}
 
 	return true;
+}
+
+/**
+ * Returns true if the parsed block is valid given the input content. A block
+ * is considered valid if, when serialized with assumed attributes, the content
+ * matches the original value.
+ *
+ * Logs to console in development environments when invalid.
+ *
+ * @param  {String}  rawContent Original block content
+ * @param  {String}  blockType  Block type
+ * @param  {Object}  attributes Parsed block attributes
+ * @return {Boolean}            Whether block is valid
+ */
+export function isValidBlock( rawContent, blockType, attributes ) {
+	return isEquivalentHTML(
+		rawContent,
+		getSaveContent( blockType, attributes )
+	);
 }

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -1,0 +1,210 @@
+/**
+ * External dependencies
+ */
+import { tokenize } from 'simple-html-tokenizer';
+import { xor, fromPairs, isEqual } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSaveContent } from './serializer';
+
+/**
+ * Globally matches any consecutive whitespace
+ *
+ * @type {RegExp}
+ */
+const REGEXP_WHITESPACE = /[\t\n\r\v\f ]+/g;
+
+/**
+ * Matches a string containing only whitespace
+ *
+ * @type {RegExp}
+ */
+const REGEXP_ONLY_WHITESPACE = /^[\t\n\r\v\f ]*$/;
+
+/**
+ * Given a specified string, returns an array of strings split by consecutive
+ * whitespace, ignoring leading or trailing whitespace.
+ *
+ * @param  {String}   text Original text
+ * @return {String[]}      Text pieces split on whitespace
+ */
+function getTextPiecesSplitOnWhitespace( text ) {
+	return text.trim().split( REGEXP_WHITESPACE );
+}
+
+/**
+ * Given a specified string, returns a new trimmed string where all consecutive
+ * whitespace is collapsed to a single space.
+ *
+ * @param  {String} text Original text
+ * @return {String}      Trimmed text with consecutive whitespace collapsed
+ */
+function getTextWithCollapsedWhitespace( text ) {
+	return getTextPiecesSplitOnWhitespace( text ).join( ' ' );
+}
+
+/**
+ * Returns true if two text tokens (with `chars` property) are equivalent, or
+ * false otherwise.
+ *
+ * @param  {Object}  a First token
+ * @param  {Object}  b Second token
+ * @return {Boolean}   Whether two text tokens are equivalent
+ */
+function isEqualTextTokensWithCollapsedWhitespace( a, b ) {
+	// This is an overly simplified whitespace comparison. The specification is
+	// more prescriptive of whitespace behavior in inline and block contexts.
+	//
+	// See: https://medium.com/@patrickbrosset/when-does-white-space-matter-in-html-b90e8a7cdd33
+	return isEqual( ...[ a.chars, b.chars ].map( getTextWithCollapsedWhitespace ) );
+}
+
+/**
+ * Attribute-specific equality handlers
+ *
+ * @type {Object}
+ */
+const isEqualAttributesOfName = {
+	'class': ( a, b ) => {
+		// Class matches if members are the same, even if out of order or
+		// superfluous whitespace between.
+		return ! xor( ...[ a, b ].map( getTextPiecesSplitOnWhitespace ) ).length;
+	},
+};
+
+/**
+ * Given two sets of attribute tuples, returns true if the attribute sets are
+ * equivalent
+ *
+ * @param  {Array[]} a First attributes tuples
+ * @param  {Array[]} b Second attributes tuples
+ * @return {Boolean}   Whether attributes are equivalent
+ */
+function isEqualTagAttributes( a, b ) {
+	// Attributes is tokenized as tuples. Their lengths should match. This also
+	// avoids us needing to check both attributes sets, since if A has any keys
+	// which do not exist in B, we know the sets to be different.
+	if ( a.length !== b.length ) {
+		return false;
+	}
+
+	// Convert tuples to object for ease of lookup
+	const [ aAttributes, bAttributes ] = [ a, b ].map( fromPairs );
+
+	for ( const name in aAttributes ) {
+		// As noted above, if missing member in B, assume different
+		if ( ! bAttributes.hasOwnProperty( name ) ) {
+			return false;
+		}
+
+		const aValue = aAttributes[ name ];
+		const bValue = bAttributes[ name ];
+
+		const isEqualAttributes = isEqualAttributesOfName[ name ];
+		if ( isEqualAttributes ) {
+			// Defer custom attribute equality handling
+			if ( ! isEqualAttributes( aValue, bValue ) ) {
+				return false;
+			}
+		} else if ( aValue !== bValue ) {
+			// Otherwise strict inequality should bail
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Token-type-specific equality handlers
+ *
+ * @type {Object}
+ */
+export const isEqualTokensOfType = {
+	StartTag: ( a, b ) => {
+		if ( a.tagName !== b.tagName ) {
+			return false;
+		}
+
+		return isEqualTagAttributes(
+			a.attributes,
+			b.attributes,
+		);
+	},
+	Chars: isEqualTextTokensWithCollapsedWhitespace,
+	Comment: isEqualTextTokensWithCollapsedWhitespace,
+};
+
+/**
+ * Given an array of tokens, returns the first token which is not purely
+ * whitespace.
+ *
+ * Mutates the tokens array.
+ *
+ * @param  {Object[]} tokens Set of tokens to search
+ * @return {Object}          Next non-whitespace token
+ */
+export function getNextNonWhitespaceToken( tokens ) {
+	let token;
+	while ( ( token = tokens.shift() ) ) {
+		if ( token.type !== 'Chars' ) {
+			return token;
+		}
+
+		if ( ! REGEXP_ONLY_WHITESPACE.test( token.chars ) ) {
+			return token;
+		}
+	}
+}
+
+/**
+ * Returns true if the parsed block is valid given the input content. A block
+ * is considered valid if, when serialized with assumed attributes, the content
+ * matches the original value.
+ *
+ * Logs to console in development environments when invalid.
+ *
+ * @param  {String}  rawContent Original block content
+ * @param  {String}  blockType  Block type
+ * @param  {Object}  attributes Parsed block attributes
+ * @return {Boolean}            Whether block is valid
+ */
+export function isValidBlock( rawContent, blockType, attributes ) {
+	// Tokenize input content and reserialized save content
+	const [ actualTokens, expectedTokens ] = [
+		rawContent,
+		getSaveContent( blockType, attributes ),
+	].map( tokenize );
+
+	let actualToken, expectedToken;
+	while ( ( actualToken = getNextNonWhitespaceToken( actualTokens ) ) ) {
+		expectedToken = getNextNonWhitespaceToken( expectedTokens );
+
+		// Inequal if exhausted all expected tokens
+		if ( ! expectedToken ) {
+			return false;
+		}
+
+		// Inequal if next non-whitespace token of each set are not same type
+		if ( actualToken.type !== expectedToken.type ) {
+			return false;
+		}
+
+		// Defer custom token type equality handling, otherwise continue and
+		// assume as equal
+		const isEqualTokens = isEqualTokensOfType[ actualToken.type ];
+		if ( isEqualTokens && ! isEqualTokens( actualToken, expectedToken ) ) {
+			return false;
+		}
+	}
+
+	while ( ( expectedToken = getNextNonWhitespaceToken( expectedTokens ) ) ) {
+		// If any non-whitespace tokens remain in expected token set, this
+		// indicates inequality
+		return false;
+	}
+
+	return true;
+}

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -37,7 +37,7 @@ const REGEXP_STYLE_URL_TYPE = /^url\s*\(['"\s]*(.*?)['"\s]*\)$/;
  * @param  {String}   text Original text
  * @return {String[]}      Text pieces split on whitespace
  */
-function getTextPiecesSplitOnWhitespace( text ) {
+export function getTextPiecesSplitOnWhitespace( text ) {
 	return text.trim().split( REGEXP_WHITESPACE );
 }
 
@@ -48,7 +48,7 @@ function getTextPiecesSplitOnWhitespace( text ) {
  * @param  {String} text Original text
  * @return {String}      Trimmed text with consecutive whitespace collapsed
  */
-function getTextWithCollapsedWhitespace( text ) {
+export function getTextWithCollapsedWhitespace( text ) {
 	return getTextPiecesSplitOnWhitespace( text ).join( ' ' );
 }
 
@@ -60,7 +60,7 @@ function getTextWithCollapsedWhitespace( text ) {
  * @param  {Object}  b Second token
  * @return {Boolean}   Whether two text tokens are equivalent
  */
-function isEqualTextTokensWithCollapsedWhitespace( a, b ) {
+export function isEqualTextTokensWithCollapsedWhitespace( a, b ) {
 	// This is an overly simplified whitespace comparison. The specification is
 	// more prescriptive of whitespace behavior in inline and block contexts.
 	//
@@ -75,20 +75,20 @@ function isEqualTextTokensWithCollapsedWhitespace( a, b ) {
  * @param  {String} value Style value
  * @return {String}       Normalized style value
  */
-function getNormalizedStyleValue( value ) {
+export function getNormalizedStyleValue( value ) {
 	return value
 		// Normalize URL type to omit whitespace or quotes
 		.replace( REGEXP_STYLE_URL_TYPE, 'url($1)' );
 }
 
 /**
- * Given a style attribute string, returns an array of property-value pairs.
+ * Given a style attribute string, returns an object of style properties.
  *
- * @param  {String}  text Style attribute
- * @return {Array[]}      Style property-value pairs
+ * @param  {String} text Style attribute
+ * @return {Object}      Style properties
  */
-function getStylePropertyPairs( text ) {
-	return text
+export function getStyleProperties( text ) {
+	const pairs = text
 		// Trim ending semicolon (avoid including in split)
 		.replace( /;?\s*$/, '' )
 		// Split on property assignment
@@ -104,6 +104,8 @@ function getStylePropertyPairs( text ) {
 				getNormalizedStyleValue( value.trim() ),
 			];
 		} );
+
+	return fromPairs( pairs );
 }
 
 /**
@@ -111,14 +113,14 @@ function getStylePropertyPairs( text ) {
  *
  * @type {Object}
  */
-const isEqualAttributesOfName = {
+export const isEqualAttributesOfName = {
 	'class': ( a, b ) => {
 		// Class matches if members are the same, even if out of order or
 		// superfluous whitespace between.
 		return ! xor( ...[ a, b ].map( getTextPiecesSplitOnWhitespace ) ).length;
 	},
 	style: ( a, b ) => {
-		return isEqual( ...[ a, b ].map( getStylePropertyPairs ) );
+		return isEqual( ...[ a, b ].map( getStyleProperties ) );
 	},
 };
 
@@ -130,7 +132,7 @@ const isEqualAttributesOfName = {
  * @param  {Array[]} b Second attributes tuples
  * @return {Boolean}   Whether attributes are equivalent
  */
-function isEqualTagAttributePairs( a, b ) {
+export function isEqualTagAttributePairs( a, b ) {
 	// Attributes is tokenized as tuples. Their lengths should match. This also
 	// avoids us needing to check both attributes sets, since if A has any keys
 	// which do not exist in B, we know the sets to be different.

--- a/blocks/test/fixtures/core__list__ul.json
+++ b/blocks/test/fixtures/core__list__ul.json
@@ -2,7 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/list",
-        "isValid": false,
+        "isValid": true,
         "attributes": {
             "nodeName": "UL",
             "values": [
@@ -38,7 +38,6 @@
                     ]
                 }
             ]
-        },
-        "originalContent": "<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>"
+        }
     }
 ]

--- a/blocks/test/fixtures/core__list__ul.serialized.html
+++ b/blocks/test/fixtures/core__list__ul.serialized.html
@@ -1,7 +1,7 @@
 <!-- wp:core/list -->
 <ul>
-    <li>Text & Headings</li>
-    <li>Images & Videos</li>
+    <li>Text &amp; Headings</li>
+    <li>Images &amp; Videos</li>
     <li>Galleries</li>
     <li>Embeds, like YouTube, Tweets, or other WordPress posts.</li>
     <li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li>

--- a/blocks/test/fixtures/core__preformatted.json
+++ b/blocks/test/fixtures/core__preformatted.json
@@ -2,7 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/preformatted",
-        "isValid": false,
+        "isValid": true,
         "attributes": {
             "content": [
                 "Some ",
@@ -16,7 +16,6 @@
                 },
                 "And more!"
             ]
-        },
-        "originalContent": "<pre class=\"wp-block-preformatted\">Some <em>preformatted</em> text...<br>And more!</pre>"
+        }
     }
 ]

--- a/blocks/test/fixtures/core__preformatted.serialized.html
+++ b/blocks/test/fixtures/core__preformatted.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:core/preformatted -->
-<pre class="wp-block-preformatted">Some <em>preformatted</em> text...<br>And more!</pre>
+<pre class="wp-block-preformatted">Some <em>preformatted</em> text...<br/>And more!</pre>
 <!-- /wp:core/preformatted -->

--- a/blocks/test/fixtures/core__verse.json
+++ b/blocks/test/fixtures/core__verse.json
@@ -2,7 +2,7 @@
     {
         "uid": "_uid_0",
         "name": "core/verse",
-        "isValid": false,
+        "isValid": true,
         "attributes": {
             "content": [
                 "A ",
@@ -16,7 +16,6 @@
                 },
                 "And more!"
             ]
-        },
-        "originalContent": "<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"
+        }
     }
 ]

--- a/blocks/test/fixtures/core__verse.serialized.html
+++ b/blocks/test/fixtures/core__verse.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:core/verse -->
-<pre class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<pre class="wp-block-verse">A <em>verse</em>…<br/>And more!</pre>
 <!-- /wp:core/verse -->

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "redux-optimist": "0.0.2",
     "refx": "^2.0.0",
     "rememo": "^1.1.1",
+    "simple-html-tokenizer": "^0.4.1",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Related: #2197, #2132, #1929

This pull request seeks to try an alternate strategy to block validation. Previously we would compare a "beautified" copy of the block from post content when run again through its serialized using parsed attributes. The approach here instead tries to find whether there is an effective difference between two HTML strings by using an [HTML tokenizer](https://www.npmjs.com/package/simple-html-tokenizer) and comparing the token objects generated by each.

In general, this improves leniency of the comparison, particularly around whitespace, self-closing tags, whitespace within tag names, class attribute value ordering, style attribute values and value ordering.

Some false negatives can occur, largely around whitespace in HTML because [it is complicated](https://medium.com/@patrickbrosset/when-does-white-space-matter-in-html-b90e8a7cdd33).

The tokenizer is not a spec-compliant validator, nor do I think we need one. It is relatively light-weight (especially compared to other options like [parse5](https://www.npmjs.com/package/parse5)), and can be extended to [observe events while tokenizing](https://github.com/tildeio/simple-html-tokenizer/blob/master/src/evented-tokenizer.ts). Future refactoring could introduce optimizations such as early bailing on mismatched tokens (i.e. fail early).

__Testing instructions:__

Verify that all blocks in demo content are valid.

Verify that modifying `post-content.js` to cause a block to become invalid (e.g. adding/remove class or attribute) still causes "Invalid Block" warning to appear. See also #1929.

Verify that some previously erroneously-invalid content is now considered valid:

- https://wordpress.slack.com/archives/C02QB2JS7/p1501782622676845
- https://github.com/WordPress/gutenberg/issues/2132#issuecomment-319681444
- https://github.com/WordPress/gutenberg/issues/2197#issuecomment-320051088

Ensure unit tests pass:

```
npm test
```

__Caveats:__

Differences in content caused by `removep` ([`autop`](https://codex.wordpress.org/Function_Reference/wpautop)) behavior is still not accounted for. We may want to consider building this into the parser?