### PR TITLE
Linting: Restrict WordPress import path access

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -74,6 +74,13 @@
 		"no-negated-in-lhs": "error",
 		"no-nested-ternary": "error",
 		"no-redeclare": "error",
+		"no-restricted-syntax": [
+			"error",
+			{
+				"selector": "ImportDeclaration[source.value=/^@wordpress\\u002F.+\\u002F/]",
+				"message": "Path access on WordPress dependencies is not allowed."
+			}
+		],
 		"no-shadow": "error",
 		"no-undef-init": "error",
 		"no-unreachable": "error",


### PR DESCRIPTION
Related: #941, #929

This pull request seeks to add a lint rule restricting path access for WordPress dependencies. For example:

```js
// Good:
import { keycodes } from '@wordpress/utils';

// Bad:
import { ENTER } from '@wordpress/utils/keycodes';
```

__Implementation notes:__

See also:

 - http://eslint.org/docs/developer-guide/selectors
 - http://eslint.org/docs/rules/no-restricted-syntax
- http://astexplorer.net/#/gist/d349d521ab8ddeaa092db7374af72e42/1aa94d1abe644d79da1c8ebd08aae08d43141e59

I found the selectors syntax to not be particularly happy with escaping slashes (`\\/`) except when using the unicode escape (`\\u002F`).

__Testing instructions:__

Verify there are currently no lint issues:

```
npm run lint
```

Introduce a lint issue by finding a WordPress dependency and suffixing a path, then re-run the command above and verify the lint issue is surfaced as an error.