### PR TITLE
Image Block: Adding image resizing handles

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,8 +24,7 @@
 		"wp": true,
 		"wpApiSettings": true,
 		"window": true,
-		"document": true,
-		"Image": true
+		"document": true
 	},
 	"plugins": [
 		"react",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,8 @@
 		"wp": true,
 		"wpApiSettings": true,
 		"window": true,
-		"document": true
+		"document": true,
+		"Image": true
 	},
 	"plugins": [
 		"react",

--- a/blocks/library/image/image-size.js
+++ b/blocks/library/image/image-size.js
@@ -16,6 +16,7 @@ class ImageSize extends Component {
 			height: undefined,
 		};
 		this.bindContainer = this.bindContainer.bind( this );
+		this.calculateSize = this.calculateSize.bind( this );
 	}
 
 	bindContainer( ref ) {
@@ -29,6 +30,10 @@ class ImageSize extends Component {
 				height: undefined,
 			} );
 			this.fetchImageSize();
+		}
+
+		if ( this.props.dirtynessTrigger !== prevProps.dirtynessTrigger ) {
+			this.calculateSize();
 		}
 	}
 
@@ -44,15 +49,17 @@ class ImageSize extends Component {
 
 	fetchImageSize() {
 		this.image = new window.Image();
-		this.image.onload = () => {
-			const maxWidth = this.container.clientWidth;
-			const exceedMaxWidth = this.image.width > maxWidth;
-			const ratio = this.image.height / this.image.width;
-			const width = exceedMaxWidth ? maxWidth : this.image.width;
-			const height = exceedMaxWidth ? maxWidth * ratio : this.image.height;
-			this.setState( { width, height } );
-		};
+		this.image.onload = this.calculateSize;
 		this.image.src = this.props.src;
+	}
+
+	calculateSize() {
+		const maxWidth = this.container.clientWidth;
+		const exceedMaxWidth = this.image.width > maxWidth;
+		const ratio = this.image.height / this.image.width;
+		const width = exceedMaxWidth ? maxWidth : this.image.width;
+		const height = exceedMaxWidth ? maxWidth * ratio : this.image.height;
+		this.setState( { width, height } );
 	}
 
 	render() {

--- a/blocks/library/image/image-size.js
+++ b/blocks/library/image/image-size.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+
+class ImageSize extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			width: undefined,
+			height: undefined,
+		};
+		this.bindContainer = this.bindContainer.bind( this );
+	}
+
+	bindContainer( ref ) {
+		this.container = ref;
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.src !== prevProps.src ) {
+			this.setState( {
+				width: undefined,
+				height: undefined,
+			} );
+			this.fetchImageSize();
+		}
+	}
+
+	componentDidMount() {
+		this.fetchImageSize();
+	}
+
+	componentWillUnmout() {
+		if ( this.image ) {
+			this.image.src = noop;
+		}
+	}
+
+	fetchImageSize() {
+		this.image = new Image();
+		this.image.onload = () => {
+			const maxWidth = this.container.clientWidth;
+			const ratio = this.image.height / this.image.width;
+			const width = this.image.width < maxWidth ? this.image.width : maxWidth;
+			const height = this.image.width < maxWidth ? this.image.height : maxWidth * ratio;
+			this.setState( { width, height } );
+		};
+		this.image.src = this.props.src;
+	}
+
+	render() {
+		return (
+			<div ref={ this.bindContainer }>
+				{ this.props.children( this.state.width, this.state.height ) }
+			</div>
+		);
+	}
+}
+
+export default ImageSize;

--- a/blocks/library/image/image-size.js
+++ b/blocks/library/image/image-size.js
@@ -36,9 +36,9 @@ class ImageSize extends Component {
 		this.fetchImageSize();
 	}
 
-	componentWillUnmout() {
+	componentWillUnmount() {
 		if ( this.image ) {
-			this.image.src = noop;
+			this.image.onload = noop;
 		}
 	}
 
@@ -46,9 +46,10 @@ class ImageSize extends Component {
 		this.image = new window.Image();
 		this.image.onload = () => {
 			const maxWidth = this.container.clientWidth;
+			const exceedMaxWidth = this.image.width > maxWidth;
 			const ratio = this.image.height / this.image.width;
-			const width = this.image.width < maxWidth ? this.image.width : maxWidth;
-			const height = this.image.width < maxWidth ? this.image.height : maxWidth * ratio;
+			const width = exceedMaxWidth ? maxWidth : this.image.width;
+			const height = exceedMaxWidth ? maxWidth * ratio : this.image.height;
 			this.setState( { width, height } );
 		};
 		this.image.src = this.props.src;

--- a/blocks/library/image/image-size.js
+++ b/blocks/library/image/image-size.js
@@ -43,7 +43,7 @@ class ImageSize extends Component {
 	}
 
 	fetchImageSize() {
-		this.image = new Image();
+		this.image = new window.Image();
 		this.image.onload = () => {
 			const maxWidth = this.container.clientWidth;
 			const ratio = this.image.height / this.image.width;

--- a/blocks/library/image/image-size.js
+++ b/blocks/library/image/image-size.js
@@ -63,9 +63,17 @@ class ImageSize extends Component {
 	}
 
 	render() {
+		const sizes = {
+			imageWidth: this.image && this.image.width,
+			imageHeight: this.image && this.image.height,
+			containerWidth: this.container && this.container.width,
+			containerHeight: this.container && this.container.height,
+			imageWidthWithinContainer: this.state.width,
+			imageHeightWithinContainer: this.state.height,
+		};
 		return (
 			<div ref={ this.bindContainer }>
-				{ this.props.children( this.state.width, this.state.height ) }
+				{ this.props.children( sizes ) }
 			</div>
 		);
 	}

--- a/blocks/library/image/image-size.js
+++ b/blocks/library/image/image-size.js
@@ -66,8 +66,8 @@ class ImageSize extends Component {
 		const sizes = {
 			imageWidth: this.image && this.image.width,
 			imageHeight: this.image && this.image.height,
-			containerWidth: this.container && this.container.width,
-			containerHeight: this.container && this.container.height,
+			containerWidth: this.container && this.container.clientWidth,
+			containerHeight: this.container && this.container.clientHeight,
 			imageWidthWithinContainer: this.state.width,
 			imageHeightWithinContainer: this.state.height,
 		};

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -86,10 +86,16 @@ registerBlockType( 'core/image', {
 	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { url, alt, caption, align, id, href, width, height } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
-		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
+		const updateAlignment = ( nextAlign ) => {
+			const extraUpdatedAttributes = [ 'wide', 'full' ].indexOf( nextAlign ) !== -1
+				? { width: undefined, height: undefined }
+				: {};
+			setAttributes( { ...extraUpdatedAttributes, align: nextAlign } );
+		};
 		const onSelectImage = ( media ) => {
 			setAttributes( { url: media.url, alt: media.alt, caption: media.caption, id: media.id } );
 		};
+		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1;
 		const uploadButtonProps = { isLarge: true };
 		const onSetHref = ( value ) => setAttributes( { href: value } );
 		const uploadFromFiles = ( files ) => {
@@ -207,7 +213,7 @@ registerBlockType( 'core/image', {
 				<ImageSize src={ url }>
 					{ ( originalWidth = width, originalHeight = height ) => {
 						const img = <img src={ url } alt={ alt } onClick={ setFocus } />;
-						if ( ! originalHeight || ! originalWidth ) {
+						if ( ! isResizable || ! originalHeight || ! originalWidth ) {
 							return img;
 						}
 						return (

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -15,6 +15,7 @@ import { Placeholder, Dashicon, Toolbar, DropZone, FormFileUpload } from '@wordp
  */
 import './style.scss';
 import { registerBlockType, source } from '../../api';
+import withEditorSettings from '../../with-editor-settings';
 import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
@@ -83,7 +84,7 @@ registerBlockType( 'core/image', {
 		}
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, className } ) {
+	edit: withEditorSettings()( ( { attributes, setAttributes, focus, setFocus, className, settings } ) => {
 		const { url, alt, caption, align, id, href, width, height } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
 		const updateAlignment = ( nextAlign ) => {
@@ -233,9 +234,9 @@ registerBlockType( 'core/image', {
 								width={ currentWidth }
 								height={ currentHeight }
 								minWidth={ minWidth }
-								maxWidth={ imageWidth }
+								maxWidth={ settings.maxWidth }
 								minHeight={ minHeight }
-								maxHeight={ imageHeight }
+								maxHeight={ settings.maxWidth / ratio }
 								lockAspectRatio
 								handlerClasses={ {
 									topRight: 'wp-block-image__resize-handler-top-right',
@@ -270,7 +271,7 @@ registerBlockType( 'core/image', {
 			</figure>,
 		];
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-	},
+	} ),
 
 	save( { attributes } ) {
 		const { url, alt, caption, align, href, width, height } = attributes;

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { ResizableBox } from 'react-resizable';
+import ResizableBox from 'react-resizable-box';
 
 /**
  * WordPress dependencies
@@ -232,11 +232,24 @@ registerBlockType( 'core/image', {
 							<ResizableBox
 								width={ currentWidth }
 								height={ currentHeight }
-								minConstraints={ [ minWidth, minHeight ] }
-								maxConstraints={ [ imageWidth, imageHeight ] }
-								handleSize={ [ 15, 15 ] }
+								minWidth={ minWidth }
+								maxWidth={ imageWidth }
+								minHeight={ minHeight }
+								maxHeight={ imageHeight }
 								lockAspectRatio
-								onResize={ ( event, { size } ) => setAttributes( size ) }
+								handlerClasses={ {
+									topRight: 'wp-block-image__resize-handler-top-right',
+									bottomRight: 'wp-block-image__resize-handler-bottom-right',
+									topLeft: 'wp-block-image__resize-handler-top-left',
+									bottomLeft: 'wp-block-image__resize-handler-bottom-left',
+								} }
+								enable={ { top: false, right: true, bottom: false, left: false, topRight: true, bottomRight: true, bottomLeft: true, topLeft: true } }
+								onResize={ ( event, direction, elt ) => {
+									setAttributes( {
+										width: elt.clientWidth,
+										height: elt.clientHeight,
+									} );
+								} }
 							>
 								{ img }
 							</ResizableBox>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -280,7 +280,7 @@ registerBlockType( 'core/image', {
 		return (
 			<figure className={ align && `align${ align }` }>
 				{ href ? <a href={ href }>{ image }</a> : image }
-				{ caption.length > 0 && <figcaption>{ caption }</figcaption> }
+				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 			</figure>
 		);
 	},

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -210,16 +210,18 @@ registerBlockType( 'core/image', {
 				</InspectorControls>
 			),
 			<figure key="image" className={ classes }>
-				<ImageSize src={ url }>
-					{ ( originalWidth = width, originalHeight = height ) => {
+				<ImageSize src={ url } dirtynessTrigger={ align }>
+					{ ( originalWidth, originalHeight ) => {
+						const currentWidth = width || originalWidth;
+						const currentHeight = height || originalHeight;
 						const img = <img src={ url } alt={ alt } onClick={ setFocus } />;
 						if ( ! isResizable || ! originalHeight || ! originalWidth ) {
 							return img;
 						}
 						return (
 							<ResizableBox
-								width={ originalWidth }
-								height={ originalHeight }
+								width={ currentWidth }
+								height={ currentHeight }
 								lockAspectRatio
 								onResize={ ( event, { size } ) => setAttributes( size ) }
 							>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -193,6 +193,7 @@ registerBlockType( 'core/image', {
 		const classes = classnames( className, {
 			'is-transient': 0 === url.indexOf( 'blob:' ),
 			'is-resized': !! width,
+			'is-focused': !! focus,
 		} );
 
 		// Disable reason: Each block can be selected by clicking on it

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { ResizableBox } from 'react-resizable';
 
 /**
  * WordPress dependencies
@@ -22,6 +23,7 @@ import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import BlockDescription from '../../block-description';
 import UrlInputButton from '../../url-input/button';
+import ImageSize from './image-size';
 
 const { attr, children } = source;
 
@@ -82,7 +84,7 @@ registerBlockType( 'core/image', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus, className } ) {
-		const { url, alt, caption, align, id, href } = attributes;
+		const { url, alt, caption, align, id, href, width, height } = attributes;
 		const updateAlt = ( newAlt ) => setAttributes( { alt: newAlt } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const onSelectImage = ( media ) => {
@@ -201,7 +203,23 @@ registerBlockType( 'core/image', {
 				</InspectorControls>
 			),
 			<figure key="image" className={ classes }>
-				<img src={ url } alt={ alt } onClick={ setFocus } />
+				<ImageSize src={ url }>
+					{ ( originalWidth = width, originalHeight = height ) => {
+						if ( ! originalHeight || ! originalWidth ) {
+							return <img src={ url } alt={ alt } onClick={ setFocus } />;
+						}
+						return (
+							<ResizableBox
+								width={ originalWidth }
+								height={ originalHeight }
+								lockAspectRatio
+								onResize={ ( event, { size } ) => setAttributes( size ) }
+							>
+								<img src={ url } alt={ alt } onClick={ setFocus } />
+							</ResizableBox>
+						);
+					} }
+				</ImageSize>
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
@@ -219,8 +237,9 @@ registerBlockType( 'core/image', {
 	},
 
 	save( { attributes } ) {
-		const { url, alt, caption, align, href } = attributes;
-		const image = <img src={ url } alt={ alt } />;
+		const { url, alt, caption, align, href, width, height } = attributes;
+		const extraImageProps = width || height ? { width, height } : {};
+		const image = <img src={ url } alt={ alt } { ...extraImageProps } />;
 
 		return (
 			<figure className={ align && `align${ align }` }>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -205,8 +205,9 @@ registerBlockType( 'core/image', {
 			<figure key="image" className={ classes }>
 				<ImageSize src={ url }>
 					{ ( originalWidth = width, originalHeight = height ) => {
+						const img = <img src={ url } alt={ alt } onClick={ setFocus } />;
 						if ( ! originalHeight || ! originalWidth ) {
-							return <img src={ url } alt={ alt } onClick={ setFocus } />;
+							return img;
 						}
 						return (
 							<ResizableBox
@@ -215,7 +216,7 @@ registerBlockType( 'core/image', {
 								lockAspectRatio
 								onResize={ ( event, { size } ) => setAttributes( size ) }
 							>
-								<img src={ url } alt={ alt } onClick={ setFocus } />
+								{ img }
 							</ResizableBox>
 						);
 					} }

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -211,17 +211,29 @@ registerBlockType( 'core/image', {
 			),
 			<figure key="image" className={ classes }>
 				<ImageSize src={ url } dirtynessTrigger={ align }>
-					{ ( originalWidth, originalHeight ) => {
-						const currentWidth = width || originalWidth;
-						const currentHeight = height || originalHeight;
+					{ ( sizes ) => {
+						const {
+							imageWidthWithinContainer,
+							imageHeightWithinContainer,
+							imageWidth,
+							imageHeight,
+						} = sizes;
+						const currentWidth = width || imageWidthWithinContainer;
+						const currentHeight = height || imageHeightWithinContainer;
 						const img = <img src={ url } alt={ alt } onClick={ setFocus } />;
-						if ( ! isResizable || ! originalHeight || ! originalWidth ) {
+						if ( ! isResizable || ! imageWidthWithinContainer ) {
 							return img;
 						}
+						const ratio = imageWidth / imageHeight;
+						const minWidth = imageWidth < imageHeight ? 10 : 10 * ratio;
+						const minHeight = imageHeight < imageWidth ? 10 : 10 / ratio;
 						return (
 							<ResizableBox
 								width={ currentWidth }
 								height={ currentHeight }
+								minConstraints={ [ minWidth, minHeight ] }
+								maxConstraints={ [ imageWidth, imageHeight ] }
+								handleSize={ [ 15, 15 ] }
 								lockAspectRatio
 								onResize={ ( event, { size } ) => setAttributes( size ) }
 							>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -77,9 +77,9 @@ registerBlockType( 'core/image', {
 	},
 
 	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
+		const { align, width } = attributes;
 		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
-			return { 'data-align': align };
+			return { 'data-align': align, 'data-resized': !! width };
 		}
 	},
 
@@ -186,6 +186,7 @@ registerBlockType( 'core/image', {
 		const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );
 		const classes = classnames( className, {
 			'is-transient': 0 === url.indexOf( 'blob:' ),
+			'is-resized': !! width,
 		} );
 
 		// Disable reason: Each block can be selected by clicking on it

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -10,6 +10,25 @@
 	&.is-transient img {
 		@include loading_fade;
 	}
+
+	.react-resizable {
+		position: relative;
+	}
+
+	.react-resizable-handle {
+		border-radius: 50%;
+		border: 2px solid white;
+		width: 15px;
+		height: 15px;
+		position: absolute;
+		right: -6px;
+		bottom: -6px;
+		background: $blue-medium-500;
+		padding: 0 3px 3px 0;
+		box-sizing: border-box;
+		cursor: se-resize;
+	}
+
 }
 
 .editor-visual-editor__block[data-type="core/image"] {

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -14,6 +14,11 @@
 	.react-resizable {
 		position: relative;
 		margin: 0 auto;
+
+		img {
+			width: 100%;
+			height: 100%;
+		}
 	}
 
 	.react-resizable-handle {
@@ -29,7 +34,6 @@
 		box-sizing: border-box;
 		cursor: se-resize;
 	}
-
 }
 
 .editor-visual-editor__block[data-type="core/image"] {

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -13,6 +13,7 @@
 
 	.react-resizable {
 		position: relative;
+		margin: 0 auto;
 	}
 
 	.react-resizable-handle {
@@ -49,5 +50,13 @@
 
 	&:hover {
 		color: $dark-gray-800;
+	}
+}
+
+.editor-visual-editor__block[data-align="right"],
+.editor-visual-editor__block[data-align="left"] {
+	max-width: none !important;
+	&[data-resized="false"] {
+		max-width: 370px !important;
 	}
 }

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -10,35 +10,47 @@
 	&.is-transient img {
 		@include loading_fade;
 	}
+}
 
-	.react-resizable {
-		position: relative;
-		margin: 0 auto;
 
-		img {
-			width: 100%;
-			height: 100%;
-		}
-	}
+.wp-block-image__resize-handler-top-right,
+.wp-block-image__resize-handler-bottom-right,
+.wp-block-image__resize-handler-top-left,
+.wp-block-image__resize-handler-bottom-left {
+	display: none;
+	border-radius: 50%;
+	border: 2px solid white;
+	width: 15px !important;
+	height: 15px !important;
+	position: absolute;
+	background: $blue-medium-500;
+	padding: 0 3px 3px 0;
+	box-sizing: border-box;
+	cursor: se-resize;
 
-	.react-resizable-handle {
-		display: none;
-		border-radius: 50%;
-		border: 2px solid white;
-		width: 15px;
-		height: 15px;
-		position: absolute;
-		right: -6px;
-		bottom: -6px;
-		background: $blue-medium-500;
-		padding: 0 3px 3px 0;
-		box-sizing: border-box;
-		cursor: se-resize;
-	}
-
-	&.is-focused .react-resizable-handle {
+	.wp-block-image.is-focused & {
 		display: block;
 	}
+}
+
+.wp-block-image__resize-handler-top-right {
+	top: -6px !important;
+	right: -6px !important;
+}
+
+.wp-block-image__resize-handler-top-left {
+	top: -6px !important;
+	left: -6px !important;
+}
+
+.wp-block-image__resize-handler-bottom-right {
+	bottom: -6px !important;
+	right: -6px !important;
+}
+
+.wp-block-image__resize-handler-bottom-left {
+	bottom: -6px !important;
+	left: -6px !important;
 }
 
 .editor-visual-editor__block[data-type="core/image"] {

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -22,6 +22,7 @@
 	}
 
 	.react-resizable-handle {
+		display: none;
 		border-radius: 50%;
 		border: 2px solid white;
 		width: 15px;
@@ -33,6 +34,10 @@
 		padding: 0 3px 3px 0;
 		box-sizing: border-box;
 		cursor: se-resize;
+	}
+
+	&.is-focused .react-resizable-handle {
+		display: block;
 	}
 }
 

--- a/blocks/with-editor-settings/index.js
+++ b/blocks/with-editor-settings/index.js
@@ -13,7 +13,7 @@ const withEditorSettings = ( mapSettingsToProps ) => ( OriginalComponent ) => {
 		render() {
 			const extraProps = mapSettingsToProps
 				? mapSettingsToProps( this.context.editor, this.props )
-				: this.context.editor;
+				: { settings: this.context.editor };
 
 			return (
 				<OriginalComponent

--- a/editor/index.js
+++ b/editor/index.js
@@ -34,6 +34,10 @@ import EditorSettingsProvider from './settings/provider';
  */
 const DEFAULT_SETTINGS = {
 	wideImages: false,
+
+	// This is current max width of the block inner area
+	// It's used to constraint image resizing and this value could be overriden later by themes
+	maxWidth: 608,
 };
 
 // Configure moment globally
@@ -81,9 +85,10 @@ function preparePostState( store, post ) {
  *
  * @param {String} id              Unique identifier for editor instance
  * @param {Object} post            API entity for post to edit  (type required)
- * @param {Object} editorSettings  Editor settings object
+ * @param {Object} userSettings  Editor settings object
  */
-export function createEditorInstance( id, post, editorSettings = DEFAULT_SETTINGS ) {
+export function createEditorInstance( id, post, userSettings ) {
+	const editorSettings = Object.assign( {}, DEFAULT_SETTINGS, userSettings );
 	const store = createReduxStore();
 
 	store.dispatch( {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-datepicker": "^0.46.0",
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.4",
+    "react-resizable": "^1.7.1",
     "react-slot-fill": "^1.0.0-alpha.11",
     "react-transition-group": "^1.1.3",
     "redux": "^3.6.0",
@@ -102,7 +103,7 @@
     ],
     "coverageDirectory": "coverage",
     "moduleNameMapper": {
-      "\\.scss$": "<rootDir>/test/style-mock.js",
+      "\\.(scss|css)$": "<rootDir>/test/style-mock.js",
       "@wordpress\\/(blocks|components|date|editor|element|i18n|utils)": "$1"
     },
     "modulePaths": [

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-datepicker": "^0.46.0",
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.4",
-    "react-resizable": "^1.7.1",
+    "react-resizable-box": "^2.0.6",
     "react-slot-fill": "^1.0.0-alpha.11",
     "react-transition-group": "^1.1.3",
     "redux": "^3.6.0",


### PR DESCRIPTION
closes #600 

**Implementation notes**

 - We need to know the original image width and height before allowing to resize the image, this is done by loading the image before showing it and limiting its width/height to the canvas size (see `ImageSize` component)

**Testing instructions**

 - Try inserting and resizing an image

**Questions**

Should we resize the container (image + caption) or just the image?