### PR TITLE
Update tracking prompt accessibility

### DIFF
--- a/components/notice/index.js
+++ b/components/notice/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { isString, noop } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -13,14 +14,18 @@ import { __ } from '@wordpress/i18n';
  */
 import './style.scss';
 
-function Notice( { status, content, onRemove = noop } ) {
-	const className = `notice notice-alt is-dismissible notice-${ status }`;
+function Notice( { status, content, onRemove = noop, isDismissible = true } ) {
+	const className = classnames( 'notice notice-alt notice-' + status, {
+		'is-dismissible': isDismissible,
+	} );
 	return (
 		<div className={ className }>
 			{ isString( content ) ? <p>{ content }</p> : content }
-			<button className="notice-dismiss" type="button" onClick={ onRemove }>
-				<span className="screen-reader-text">{ __( 'Dismiss this notice' ) }</span>
-			</button>
+			{ isDismissible && (
+				<button className="notice-dismiss" type="button" onClick={ onRemove }>
+					<span className="screen-reader-text">{ __( 'Dismiss this notice' ) }</span>
+				</button>
+			) }
 		</div>
 	);
 }

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -204,17 +204,24 @@ export function stopTyping() {
  *
  * @param {String}     status   The notice status
  * @param {WPElement}  content  The notice content
- * @param {String}     id       The notice id
+ * @param {?Object}    options  The notice options.  Available options:
+ *                              `id` (string; default auto-generated)
+ *                              `isDismissible` (boolean; default `true`)
  *
  * @return {Object}             Action object
  */
-export function createNotice( status, content, id = uuid() ) {
+export function createNotice( status, content, options = {} ) {
+	const {
+		id = uuid(),
+		isDismissible = true,
+	} = options;
 	return {
 		type: 'CREATE_NOTICE',
 		notice: {
 			id,
 			status,
 			content,
+			isDismissible,
 		},
 	};
 }

--- a/editor/enable-tracking-prompt/index.js
+++ b/editor/enable-tracking-prompt/index.js
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import clickOutside from 'react-click-outside';
 
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, Popover } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -18,8 +20,18 @@ import { removeNotice } from '../actions';
 
 export const TRACKING_PROMPT_NOTICE_ID = 'notice:enable-tracking-prompt';
 
-export function EnableTrackingPrompt( props ) {
-	function dismissTrackingPrompt( enableTracking ) {
+export class EnableTrackingPrompt extends Component {
+	constructor() {
+		super();
+		this.state = {
+			showInfoPopover: false,
+		};
+		this.dismissTrackingPrompt = this.dismissTrackingPrompt.bind( this );
+		this.toggleInfoPopover = this.toggleInfoPopover.bind( this );
+		this.handleClickOutside = this.handleClickOutside.bind( this );
+	}
+
+	dismissTrackingPrompt( enableTracking ) {
 		window.setUserSetting(
 			'gutenberg_tracking',
 			enableTracking ? 'on' : 'off'
@@ -27,39 +39,70 @@ export function EnableTrackingPrompt( props ) {
 		if ( enableTracking ) {
 			bumpStat( 'tracking', 'opt-in' );
 		}
-		props.removeNotice( TRACKING_PROMPT_NOTICE_ID );
+		this.props.removeNotice( TRACKING_PROMPT_NOTICE_ID );
 	}
 
-	return (
-		<div className="enable-tracking-prompt">
-			<div className="enable-tracking-prompt__buttons">
-				<Button
-					isPrimary
-					isSmall
-					onClick={ () => dismissTrackingPrompt( true ) }
-				>
-					{ __( 'Yes' ) }
-				</Button>
-				<Button
-					isSecondary
-					isSmall
-					onClick={ () => dismissTrackingPrompt( false ) }
-				>
-					{ __( 'No' ) }
-				</Button>
+	toggleInfoPopover( event ) {
+		event.stopPropagation();
+		this.setState( {
+			showInfoPopover: ! this.state.showInfoPopover,
+		} );
+	}
+
+	handleClickOutside() {
+		this.setState( {
+			showInfoPopover: false,
+		} );
+	}
+
+	render() {
+		return (
+			// Ignore reason: This event handler exists only to catch click
+			// events in the notice but outside the "More info" popover.
+			// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role
+			<div
+				className="enable-tracking-prompt"
+				onClick={ this.handleClickOutside }
+			>
+				<p className="enable-tracking-prompt__message">
+					{ __( 'Can Gutenberg collect data about your usage of the editor?' ) }
+				</p>
+				<p className="enable-tracking-prompt__buttons">
+					<Button
+						isPrimary
+						isSmall
+						onClick={ () => this.dismissTrackingPrompt( true ) }
+					>
+						{ __( 'Yes' ) }
+					</Button>
+					<Button
+						isSecondary
+						isSmall
+						onClick={ () => this.dismissTrackingPrompt( false ) }
+					>
+						{ __( 'No' ) }
+					</Button>
+					<Button
+						className="enable-tracking-prompt__more-info"
+						onClick={ this.toggleInfoPopover }
+					>
+						<span>{ __( 'More info' ) }</span>
+						{ this.state.showInfoPopover && (
+							<Popover
+								position="bottom right"
+								className="enable-tracking-prompt__clarification"
+							>
+								{ __( 'Usage data is completely anonymous, does not include your post content, and will only be used to improve the editor.' ) }
+							</Popover>
+						) }
+					</Button>
+				</p>
 			</div>
-			<div className="enable-tracking-prompt__message">
-				{ __( 'Can Gutenberg collect data about your usage of the editor?' ) }
-			</div>
-			<div className="enable-tracking-prompt__clarification">
-				{ __( 'Usage data is completely anonymous, does not include your post content, and will only be used to improve the editor.' ) }
-			</div>
-		</div>
-	);
+		);
+	}
 }
 
 export default connect(
 	undefined,
 	{ removeNotice }
-)( EnableTrackingPrompt );
-
+)( clickOutside( EnableTrackingPrompt ) );

--- a/editor/enable-tracking-prompt/index.js
+++ b/editor/enable-tracking-prompt/index.js
@@ -83,7 +83,10 @@ export class EnableTrackingPrompt extends Component {
 						{ __( 'No' ) }
 					</Button>
 					<span className="enable-tracking-prompt__more-info">
-						<Button onClick={ this.toggleInfoPopover }>
+						<Button
+							onClick={ this.toggleInfoPopover }
+							aria-expanded={ this.state.showInfoPopover }
+						>
 							{ __( 'More info' ) }
 						</Button>
 						{ this.state.showInfoPopover && (

--- a/editor/enable-tracking-prompt/index.js
+++ b/editor/enable-tracking-prompt/index.js
@@ -67,7 +67,7 @@ export class EnableTrackingPrompt extends Component {
 				<p className="enable-tracking-prompt__message">
 					{ __( 'Can Gutenberg collect data about your usage of the editor?' ) }
 				</p>
-				<p className="enable-tracking-prompt__buttons">
+				<div className="enable-tracking-prompt__buttons">
 					<Button
 						isPrimary
 						isSmall
@@ -95,7 +95,7 @@ export class EnableTrackingPrompt extends Component {
 							</Popover>
 						) }
 					</span>
-				</p>
+				</div>
 			</div>
 		);
 	}

--- a/editor/enable-tracking-prompt/index.js
+++ b/editor/enable-tracking-prompt/index.js
@@ -82,11 +82,10 @@ export class EnableTrackingPrompt extends Component {
 					>
 						{ __( 'No' ) }
 					</Button>
-					<Button
-						className="enable-tracking-prompt__more-info"
-						onClick={ this.toggleInfoPopover }
-					>
-						<span>{ __( 'More info' ) }</span>
+					<span className="enable-tracking-prompt__more-info">
+						<Button onClick={ this.toggleInfoPopover }>
+							{ __( 'More info' ) }
+						</Button>
 						{ this.state.showInfoPopover && (
 							<Popover
 								position="bottom right"
@@ -95,7 +94,7 @@ export class EnableTrackingPrompt extends Component {
 								{ __( 'Usage data is completely anonymous, does not include your post content, and will only be used to improve the editor.' ) }
 							</Popover>
 						) }
-					</Button>
+					</span>
 				</p>
 			</div>
 		);

--- a/editor/enable-tracking-prompt/style.scss
+++ b/editor/enable-tracking-prompt/style.scss
@@ -10,13 +10,13 @@
 		}
 
 		.enable-tracking-prompt__more-info {
-			span {
-				cursor: pointer;
-			}
-			&:hover span {
-				color: $blue-wordpress-700;
-			}
 			position: relative; // for popover
+			.components-button {
+				cursor: pointer;
+				&:hover {
+					color: $blue-wordpress-700;
+				}
+			}
 		}
 	}
 

--- a/editor/enable-tracking-prompt/style.scss
+++ b/editor/enable-tracking-prompt/style.scss
@@ -1,10 +1,10 @@
 .enable-tracking-prompt {
 	.enable-tracking-prompt__message {
 		font-weight: bold;
-		margin-top: 8px;
 	}
 
 	.enable-tracking-prompt__buttons {
+		margin: 0.5em 0; // matches `.notice p` from core
 		.button {
 			margin-right: 6px;
 		}
@@ -12,6 +12,11 @@
 		.enable-tracking-prompt__more-info {
 			position: relative; // for popover
 			.components-button {
+				// Match selected `.button-small` styles from core
+				display: inline-block;
+				height: 24px;
+				line-height: 22px;
+
 				cursor: pointer;
 				&:hover {
 					color: $blue-wordpress-700;

--- a/editor/enable-tracking-prompt/style.scss
+++ b/editor/enable-tracking-prompt/style.scss
@@ -16,10 +16,16 @@
 				display: inline-block;
 				height: 24px;
 				line-height: 22px;
+				border-radius: 2px;
+				border: 1px solid transparent;
 
 				cursor: pointer;
-				&:hover {
+				&:hover, &:focus {
 					color: $blue-wordpress-700;
+				}
+				&:focus {
+					border-color: #5b9dd9;
+					box-shadow: 0 0 3px rgba( 0, 115, 170, .8 );
 				}
 			}
 		}

--- a/editor/enable-tracking-prompt/style.scss
+++ b/editor/enable-tracking-prompt/style.scss
@@ -4,17 +4,26 @@
 		margin-top: 8px;
 	}
 
-	.enable-tracking-prompt__clarification {
-		margin-bottom: 8px;
-		font-size: 90%;
-		font-style: italic;
+	.enable-tracking-prompt__buttons {
+		.button {
+			margin-right: 6px;
+		}
+
+		.enable-tracking-prompt__more-info {
+			span {
+				cursor: pointer;
+			}
+			&:hover span {
+				color: $blue-wordpress-700;
+			}
+			position: relative; // for popover
+		}
 	}
 
-	.enable-tracking-prompt__buttons {
-		float: right;
-
-		.button {
-			margin-left: 6px;
+	.enable-tracking-prompt__clarification {
+		text-align: left;
+		.components-popover__content {
+			padding: 6px;
 		}
 	}
 }

--- a/editor/index.js
+++ b/editor/index.js
@@ -100,10 +100,10 @@ export function createEditorInstance( id, post, editorSettings = DEFAULT_SETTING
 	} );
 
 	if ( window.getUserSetting( 'gutenberg_tracking' ) === '' ) {
-		store.dispatch( createInfoNotice(
-			<EnableTrackingPrompt />,
-			TRACKING_PROMPT_NOTICE_ID
-		) );
+		store.dispatch( createInfoNotice( <EnableTrackingPrompt />, {
+			id: TRACKING_PROMPT_NOTICE_ID,
+			isDismissible: false, // This notice has its own dismiss logic.
+		} ) );
 	}
 
 	preparePostState( store, post );


### PR DESCRIPTION
Fixes #2215.

- [x] Remove the default notice dismissal behavior for this notice
- [x] Move the control buttons in the editor tracking prompt to after the content
- [x] Move the clarification message behind a "More info" button and a `Popover` component
- [x] Add focus styles and any needed `aria` attributes for the "More info" button

_edit: outdated screenshots removed; see below_