### PR TITLE
Accessibility: Rename the "withA11yMessages" into "withSpokenMessages"

### DIFF
--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -8,7 +8,7 @@ import { isUndefined } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { IconButton, Toolbar, withA11yMessages } from '@wordpress/components';
+import { IconButton, Toolbar, withSpokenMessages } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -193,4 +193,4 @@ class FormatToolbar extends Component {
 	}
 }
 
-export default withA11yMessages( FormatToolbar );
+export default withSpokenMessages( FormatToolbar );

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -11,7 +11,7 @@ import scrollIntoView from 'dom-scroll-into-view';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
-import { Spinner, withInstanceId, withA11yMessages } from '@wordpress/components';
+import { Spinner, withInstanceId, withSpokenMessages } from '@wordpress/components';
 
 const { UP, DOWN, ENTER } = keycodes;
 
@@ -214,4 +214,4 @@ class UrlInput extends Component {
 	}
 }
 
-export default withA11yMessages( withInstanceId( UrlInput ) );
+export default withSpokenMessages( withInstanceId( UrlInput ) );

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -18,7 +18,7 @@ import Token from './token';
 import TokenInput from './token-input';
 import SuggestionsList from './suggestions-list';
 import withInstanceId from '../higher-order/with-instance-id';
-import withA11yMessages from '../higher-order/with-a11y-messages';
+import withSpokenMessages from '../higher-order/with-spoken-messages';
 
 const initialState = {
 	incompleteTokenValue: '',
@@ -564,4 +564,4 @@ FormTokenField.defaultProps = {
 	},
 };
 
-export default withA11yMessages( withInstanceId( FormTokenField ) );
+export default withSpokenMessages( withInstanceId( FormTokenField ) );

--- a/components/higher-order/with-spoken-messages/index.js
+++ b/components/higher-order/with-spoken-messages/index.js
@@ -15,7 +15,7 @@ import { Component } from 'element';
  *
  * @return {Component}                   Component with an instanceId prop.
  */
-function withA11yMessages( WrappedComponent ) {
+function withSpokenMessages( WrappedComponent ) {
 	return class extends Component {
 		constructor() {
 			super( ...arguments );
@@ -41,4 +41,4 @@ function withA11yMessages( WrappedComponent ) {
 	};
 }
 
-export default withA11yMessages;
+export default withSpokenMessages;

--- a/components/higher-order/with-spoken-messages/test/index.js
+++ b/components/higher-order/with-spoken-messages/test/index.js
@@ -7,13 +7,13 @@ import { isFunction } from 'lodash';
 /**
  * Internal dependencies
  */
-import withA11yMessages from '../';
+import withSpokenMessages from '../';
 
-describe( 'withA11yMessages', () => {
+describe( 'withSpokenMessages', () => {
 	it( 'should generate speak and debouncedSpeak props', () => {
 		const testSpeak = jest.fn();
 		const testDebouncedSpeak = jest.fn();
-		const DumpComponent = withA11yMessages( ( { speak, debouncedSpeak } ) => {
+		const DumpComponent = withSpokenMessages( ( { speak, debouncedSpeak } ) => {
 			testSpeak( isFunction( speak ) );
 			testDebouncedSpeak( isFunction( debouncedSpeak ) );
 			return <div />;

--- a/components/index.js
+++ b/components/index.js
@@ -25,4 +25,4 @@ export { default as Popover } from './popover';
 // Higher-Order Components
 export { default as withFocusReturn } from './higher-order/with-focus-return';
 export { default as withInstanceId } from './higher-order/with-instance-id';
-export { default as withA11yMessages } from './higher-order/with-a11y-messages';
+export { default as withSpokenMessages } from './higher-order/with-spoken-messages';

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Popover, withFocusReturn, withInstanceId, withA11yMessages } from '@wordpress/components';
+import { Popover, withFocusReturn, withInstanceId, withSpokenMessages } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
 import { getCategories, getBlockTypes, BlockIcon } from '@wordpress/blocks';
 
@@ -440,7 +440,7 @@ const connectComponent = connect(
 
 export default flow(
 	withInstanceId,
-	withA11yMessages,
+	withSpokenMessages,
 	withFocusReturn,
 	connectComponent
 )( InserterMenu );


### PR DESCRIPTION
cc https://github.com/WordPress/gutenberg/pull/2107#issuecomment-320284346