### PR TITLE
Preview Button: Load link normally if no unsaved changes

### DIFF
--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -16,6 +16,7 @@ import { _x } from '@wordpress/i18n';
 import {
 	getEditedPostPreviewLink,
 	getEditedPostAttribute,
+	isEditedPostDirty,
 } from '../../selectors';
 import { autosave } from '../../actions';
 
@@ -50,6 +51,11 @@ export class PreviewButton extends Component {
 	}
 
 	saveForPreview( event ) {
+		// Let default link behavior occur if no changes to be saved
+		if ( ! this.props.isDirty ) {
+			return;
+		}
+
 		// Save post prior to opening window
 		this.props.autosave();
 		this.setState( {
@@ -86,6 +92,7 @@ export default connect(
 	( state ) => ( {
 		postId: state.currentPost.id,
 		link: getEditedPostPreviewLink( state ),
+		isDirty: isEditedPostDirty( state ),
 		modified: getEditedPostAttribute( state, 'modified' ),
 	} ),
 	{ autosave }

--- a/editor/header/tools/test/preview-button.js
+++ b/editor/header/tools/test/preview-button.js
@@ -48,6 +48,29 @@ describe( 'PreviewButton', () => {
 	} );
 
 	describe( 'saveForPreview()', () => {
+		it( 'should do nothing if not dirty', () => {
+			const autosave = jest.fn();
+			const preventDefault = jest.fn();
+			const windowOpen = window.open;
+			window.open = jest.fn();
+
+			const wrapper = shallow(
+				<PreviewButton
+					postId={ 1 }
+					isDirty={ false }
+					autosave={ autosave } />
+			);
+
+			wrapper.simulate( 'click', { preventDefault } );
+
+			expect( autosave ).not.toHaveBeenCalled();
+			expect( preventDefault ).not.toHaveBeenCalled();
+			expect( wrapper.state( 'isAwaitingSave' ) ).not.toBe( true );
+			expect( window.open ).not.toHaveBeenCalled();
+
+			window.open = windowOpen;
+		} );
+
 		it( 'should open a popup window', () => {
 			const autosave = jest.fn();
 			const preventDefault = jest.fn();
@@ -57,6 +80,7 @@ describe( 'PreviewButton', () => {
 			const wrapper = shallow(
 				<PreviewButton
 					postId={ 1 }
+					isDirty
 					autosave={ autosave } />
 			);
 


### PR DESCRIPTION
Related: #2193

This pull request seeks to resolve an issue where clicking "Preview" on a post where no changes have been made will cause an `about:blank` popup to open, but never navigate to the preview. This is because autosave self-aborts if there are no changes, so the Preview Button is forever left waiting for save to complete.

Instead, if post has no changes, let the default `href="..." target="_blank"` behavior of the link continue unaffected.

__Testing instructions:__

1. Edit an existing post in Gutenberg
2. Click Preview
3. Note that a preview loads

Repeat testing instructions from #2193

Ensure unit tests pass:

```
npm test
```