### PR TITLE
Preview Button: Allow autosave for clean, unsaved post

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -223,7 +223,11 @@ export default {
 	AUTOSAVE( action, store ) {
 		const { getState, dispatch } = store;
 		const state = getState();
-		if ( ! isEditedPostSaveable( state ) || ! isEditedPostDirty( state ) ) {
+		if ( ! isEditedPostSaveable( state ) ) {
+			return;
+		}
+
+		if ( ! isEditedPostNew( state ) && ! isEditedPostDirty( state ) ) {
 			return;
 		}
 

--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -17,6 +17,7 @@ import {
 	getEditedPostPreviewLink,
 	getEditedPostAttribute,
 	isEditedPostDirty,
+	isEditedPostNew,
 } from '../../selectors';
 import { autosave } from '../../actions';
 
@@ -51,8 +52,9 @@ export class PreviewButton extends Component {
 	}
 
 	saveForPreview( event ) {
-		// Let default link behavior occur if no changes to be saved
-		if ( ! this.props.isDirty ) {
+		const { isDirty, isNew } = this.props;
+		// Let default link behavior occur if no changes to saved post
+		if ( ! isDirty && ! isNew ) {
 			return;
 		}
 
@@ -93,6 +95,7 @@ export default connect(
 		postId: state.currentPost.id,
 		link: getEditedPostPreviewLink( state ),
 		isDirty: isEditedPostDirty( state ),
+		isNew: isEditedPostNew( state ),
 		modified: getEditedPostAttribute( state, 'modified' ),
 	} ),
 	{ autosave }

--- a/editor/header/tools/test/preview-button.js
+++ b/editor/header/tools/test/preview-button.js
@@ -48,50 +48,55 @@ describe( 'PreviewButton', () => {
 	} );
 
 	describe( 'saveForPreview()', () => {
-		it( 'should do nothing if not dirty', () => {
+		function assertForSave( props, isExpectingSave ) {
 			const autosave = jest.fn();
 			const preventDefault = jest.fn();
 			const windowOpen = window.open;
 			window.open = jest.fn();
 
 			const wrapper = shallow(
-				<PreviewButton
-					postId={ 1 }
-					isDirty={ false }
-					autosave={ autosave } />
+				<PreviewButton { ...props } autosave={ autosave } />
 			);
 
 			wrapper.simulate( 'click', { preventDefault } );
 
-			expect( autosave ).not.toHaveBeenCalled();
-			expect( preventDefault ).not.toHaveBeenCalled();
-			expect( wrapper.state( 'isAwaitingSave' ) ).not.toBe( true );
-			expect( window.open ).not.toHaveBeenCalled();
+			if ( isExpectingSave ) {
+				expect( autosave ).toHaveBeenCalled();
+				expect( preventDefault ).toHaveBeenCalled();
+				expect( wrapper.state( 'isAwaitingSave' ) ).toBe( true );
+				expect( window.open ).toHaveBeenCalled();
+			} else {
+				expect( autosave ).not.toHaveBeenCalled();
+				expect( preventDefault ).not.toHaveBeenCalled();
+				expect( wrapper.state( 'isAwaitingSave' ) ).not.toBe( true );
+				expect( window.open ).not.toHaveBeenCalled();
+			}
 
 			window.open = windowOpen;
+		}
+
+		it( 'should do nothing if not dirty for saved post', () => {
+			assertForSave( {
+				postId: 1,
+				isNew: false,
+				isDirty: false,
+			}, false );
+		} );
+
+		it( 'should save if not dirty for new post', () => {
+			assertForSave( {
+				postId: 1,
+				isNew: true,
+				isDirty: false,
+			}, true );
 		} );
 
 		it( 'should open a popup window', () => {
-			const autosave = jest.fn();
-			const preventDefault = jest.fn();
-			const windowOpen = window.open;
-			window.open = jest.fn();
-
-			const wrapper = shallow(
-				<PreviewButton
-					postId={ 1 }
-					isDirty
-					autosave={ autosave } />
-			);
-
-			wrapper.simulate( 'click', { preventDefault } );
-
-			expect( autosave ).toHaveBeenCalled();
-			expect( preventDefault ).toHaveBeenCalled();
-			expect( wrapper.state( 'isAwaitingSave' ) ).toBe( true );
-			expect( window.open ).toHaveBeenCalledWith( 'about:blank', 'wp-preview-1' );
-
-			window.open = windowOpen;
+			assertForSave( {
+				postId: 1,
+				isNew: false,
+				isDirty: true,
+			}, true );
 		} );
 	} );
 

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -169,9 +169,22 @@ describe( 'effects', () => {
 			selectors.isEditedPostSaveable.mockReturnValue( true );
 			selectors.isEditedPostDirty.mockReturnValue( false );
 			selectors.isCurrentPostPublished.mockReturnValue( false );
-			selectors.isEditedPostNew.mockReturnValue( true );
+			selectors.isEditedPostNew.mockReturnValue( false );
 
 			expect( dispatch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should return autosave action for clean, new, saveable post', () => {
+			selectors.isEditedPostSaveable.mockReturnValue( true );
+			selectors.isEditedPostDirty.mockReturnValue( false );
+			selectors.isCurrentPostPublished.mockReturnValue( false );
+			selectors.isEditedPostNew.mockReturnValue( true );
+
+			handler( {}, store );
+
+			expect( dispatch ).toHaveBeenCalledTimes( 2 );
+			expect( dispatch ).toHaveBeenCalledWith( editPost( { status: 'draft' } ) );
+			expect( dispatch ).toHaveBeenCalledWith( savePost() );
 		} );
 
 		it( 'should return autosave action for saveable, dirty, published post', () => {


### PR DESCRIPTION
Related: #2225, #2193

This pull request seeks to resolve the case where pressing "Preview" after immediately visiting the Demo page does not allow you to preview the post. The current logic assumes that a clean post can be previewed without a save, but this is not the case for posts which have yet to be saved (new posts). With these changes, if the user clicks Preview for a post which hasn't yet been saved, even if the post is new, a save will be triggered before navigating to the post preview.

__Testing instructions:__

1. Navigate to Gutenberg > Demo
2. Press Preview
3. Note that you are shown the demo preview

Repeat testing instructions from #2225
Repeat testing instructions from #2193