### PR TITLE
Fix conflict with Jetpack plugin when loading the `core/freeform` block

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -514,6 +514,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		true // enqueue in the footer.
 	);
 
+	gutenberg_fix_jetpack_freeform_block_conflict();
 	wp_localize_script( 'wp-editor', 'wpEditorL10n', array(
 		'tinymce' => array(
 			'baseURL' => includes_url( 'js/tinymce' ),

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * PHP configuration compatibility functions for the Gutenberg editor plugin.
+ * PHP and WordPress configuration compatibility functions for the Gutenberg
+ * editor plugin.
  *
  * @package gutenberg
  */
@@ -66,4 +67,23 @@ function _gutenberg_utf8_split( $str ) {
 	} while ( $str );
 
 	return $chars;
+}
+
+/**
+ * Fixes a conflict with the Jetpack plugin trying to read an undefined global
+ * variable `grunionEditorView` during the initialization of the
+ * `core/freeform` block.
+ *
+ * @since 0.7.1
+ */
+function gutenberg_fix_jetpack_freeform_block_conflict() {
+	if (
+		defined( 'JETPACK__VERSION' ) &&
+		version_compare( JETPACK__VERSION, '5.2.2', '<' )
+	) {
+		remove_filter(
+			'mce_external_plugins',
+			array( 'Grunion_Editor_View', 'mce_external_plugins' )
+		);
+	}
 }


### PR DESCRIPTION
When loading the `core/freeform` block with Jetpack enabled, [this line](https://github.com/Automattic/jetpack/blob/cf1a73c7b0670678d99d47d46519f2027a2fc5c7/modules/contact-form/js/tinymce-plugin-form-button.js#L7) throws an error and causes a white screen.  See https://github.com/Automattic/jetpack/pull/7490.

This PR works around the issue by unhooking the problematic script when loading Gutenberg.

The next version of Jetpack (5.2.2) should contain a fix for this; we should also try to catch errors like this as (sort of) described in #1743.