### PR TITLE
Prevent plugins from using core block namespaces

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -27,6 +27,13 @@ let unknownTypeHandler;
 let defaultBlockName;
 
 /**
+ * Flags that control the internal behavior of the block registration API.
+ */
+export const registrationFlags = {
+	ALLOW_CORE_NAMESPACES: false,
+};
+
+/**
  * Registers a new block provided a unique name and an object defining its
  * behavior. Once registered, the block is made available as an option to any
  * editor interface where blocks are implemented.
@@ -46,6 +53,12 @@ export function registerBlockType( name, settings ) {
 	if ( ! /^[a-z0-9-]+\/[a-z0-9-]+$/.test( name ) ) {
 		console.error(
 			'Block names must contain a namespace prefix. Example: my-plugin/my-custom-block'
+		);
+		return;
+	}
+	if ( ! registrationFlags.ALLOW_CORE_NAMESPACES && /^core[\/-]/.test( name ) ) {
+		console.error(
+			'Plugins may not register blocks in the "core" or "core-*" namespaces.'
 		);
 		return;
 	}

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -21,17 +21,17 @@ describe( 'block factory', () => {
 
 	describe( 'createBlock()', () => {
 		it( 'should create a block given its blockType and attributes', () => {
-			registerBlockType( 'core/test-block', {
+			registerBlockType( 'not-core/test-block', {
 				defaultAttributes: {
 					includesDefault: true,
 				},
 				save: noop,
 			} );
-			const block = createBlock( 'core/test-block', {
+			const block = createBlock( 'not-core/test-block', {
 				align: 'left',
 			} );
 
-			expect( block.name ).toEqual( 'core/test-block' );
+			expect( block.name ).toEqual( 'not-core/test-block' );
 			expect( block.attributes ).toEqual( {
 				includesDefault: true,
 				align: 'left',
@@ -43,12 +43,12 @@ describe( 'block factory', () => {
 
 	describe( 'switchToBlockType()', () => {
 		it( 'should switch the blockType of a block using the "transform form"', () => {
-			registerBlockType( 'core/updated-text-block', {
+			registerBlockType( 'not-core/updated-text-block', {
 				transforms: {
 					from: [ {
-						blocks: [ 'core/text-block' ],
+						blocks: [ 'not-core/text-block' ],
 						transform: ( { value } ) => {
-							return createBlock( 'core/updated-text-block', {
+							return createBlock( 'not-core/updated-text-block', {
 								value: 'chicken ' + value,
 							} );
 						},
@@ -56,17 +56,17 @@ describe( 'block factory', () => {
 				},
 				save: noop,
 			} );
-			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', defaultBlockSettings );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toHaveLength( 1 );
 			expect( transformedBlocks[ 0 ] ).toHaveProperty( 'uid' );
-			expect( transformedBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
+			expect( transformedBlocks[ 0 ].name ).toBe( 'not-core/updated-text-block' );
 			expect( transformedBlocks[ 0 ].isValid ).toBe( true );
 			expect( transformedBlocks[ 0 ].attributes ).toEqual( {
 				value: 'chicken ribs',
@@ -74,13 +74,13 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should switch the blockType of a block using the "transform to"', () => {
-			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
-			registerBlockType( 'core/text-block', {
+			registerBlockType( 'not-core/updated-text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', {
 				transforms: {
 					to: [ {
-						blocks: [ 'core/updated-text-block' ],
+						blocks: [ 'not-core/updated-text-block' ],
 						transform: ( { value } ) => {
-							return createBlock( 'core/updated-text-block', {
+							return createBlock( 'not-core/updated-text-block', {
 								value: 'chicken ' + value,
 							} );
 						},
@@ -89,15 +89,15 @@ describe( 'block factory', () => {
 				save: noop,
 			} );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toHaveLength( 1 );
 			expect( transformedBlocks[ 0 ] ).toHaveProperty( 'uid' );
-			expect( transformedBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
+			expect( transformedBlocks[ 0 ].name ).toBe( 'not-core/updated-text-block' );
 			expect( transformedBlocks[ 0 ].isValid ).toBe( true );
 			expect( transformedBlocks[ 0 ].attributes ).toEqual( {
 				value: 'chicken ribs',
@@ -105,65 +105,65 @@ describe( 'block factory', () => {
 		} );
 
 		it( 'should return null if no transformation is found', () => {
-			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
-			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/updated-text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', defaultBlockSettings );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toBeNull();
 		} );
 
 		it( 'should reject transformations that return null', () => {
-			registerBlockType( 'core/updated-text-block', {
+			registerBlockType( 'not-core/updated-text-block', {
 				transforms: {
 					from: [ {
-						blocks: [ 'core/text-block' ],
+						blocks: [ 'not-core/text-block' ],
 						transform: () => null,
 					} ],
 				},
 				save: noop,
 			} );
-			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', defaultBlockSettings );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toBeNull();
 		} );
 
 		it( 'should reject transformations that return an empty array', () => {
-			registerBlockType( 'core/updated-text-block', {
+			registerBlockType( 'not-core/updated-text-block', {
 				transforms: {
 					from: [ {
-						blocks: [ 'core/text-block' ],
+						blocks: [ 'not-core/text-block' ],
 						transform: () => [],
 					} ],
 				},
 				save: noop,
 			} );
-			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', defaultBlockSettings );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toBeNull();
 		} );
 
 		it( 'should reject single transformations that do not include block types', () => {
-			registerBlockType( 'core/updated-text-block', {
+			registerBlockType( 'not-core/updated-text-block', {
 				transforms: {
 					from: [ {
-						blocks: [ 'core/text-block' ],
+						blocks: [ 'not-core/text-block' ],
 						transform: ( { value } ) => {
 							return {
 								attributes: {
@@ -175,25 +175,25 @@ describe( 'block factory', () => {
 				},
 				save: noop,
 			} );
-			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', defaultBlockSettings );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toBeNull();
 		} );
 
 		it( 'should reject array transformations that do not include block types', () => {
-			registerBlockType( 'core/updated-text-block', {
+			registerBlockType( 'not-core/updated-text-block', {
 				transforms: {
 					from: [ {
-						blocks: [ 'core/text-block' ],
+						blocks: [ 'not-core/text-block' ],
 						transform: ( { value } ) => {
 							return [
-								createBlock( 'core/updated-text-block', {
+								createBlock( 'not-core/updated-text-block', {
 									value: 'chicken ' + value,
 								} ),
 								{
@@ -207,25 +207,25 @@ describe( 'block factory', () => {
 				},
 				save: noop,
 			} );
-			registerBlockType( 'core/text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', defaultBlockSettings );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toBeNull();
 		} );
 
 		it( 'should reject single transformations with unexpected block types', () => {
-			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
-			registerBlockType( 'core/text-block', {
+			registerBlockType( 'not-core/updated-text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', {
 				transforms: {
 					to: [ {
-						blocks: [ 'core/updated-text-block' ],
+						blocks: [ 'not-core/updated-text-block' ],
 						transform: ( { value } ) => {
-							return createBlock( 'core/text-block', {
+							return createBlock( 'not-core/text-block', {
 								value: 'chicken ' + value,
 							} );
 						},
@@ -234,27 +234,27 @@ describe( 'block factory', () => {
 				save: noop,
 			} );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toBeNull();
 		} );
 
 		it( 'should reject array transformations with unexpected block types', () => {
-			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
-			registerBlockType( 'core/text-block', {
+			registerBlockType( 'not-core/updated-text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', {
 				transforms: {
 					to: [ {
-						blocks: [ 'core/updated-text-block' ],
+						blocks: [ 'not-core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return [
-								createBlock( 'core/text-block', {
+								createBlock( 'not-core/text-block', {
 									value: 'chicken ' + value,
 								} ),
-								createBlock( 'core/text-block', {
+								createBlock( 'not-core/text-block', {
 									value: 'smoked ' + value,
 								} ),
 							];
@@ -264,27 +264,27 @@ describe( 'block factory', () => {
 				save: noop,
 			} );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			expect( transformedBlocks ).toEqual( null );
 		} );
 
 		it( 'should accept valid array transformations', () => {
-			registerBlockType( 'core/updated-text-block', defaultBlockSettings );
-			registerBlockType( 'core/text-block', {
+			registerBlockType( 'not-core/updated-text-block', defaultBlockSettings );
+			registerBlockType( 'not-core/text-block', {
 				transforms: {
 					to: [ {
-						blocks: [ 'core/updated-text-block' ],
+						blocks: [ 'not-core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return [
-								createBlock( 'core/text-block', {
+								createBlock( 'not-core/text-block', {
 									value: 'chicken ' + value,
 								} ),
-								createBlock( 'core/updated-text-block', {
+								createBlock( 'not-core/updated-text-block', {
 									value: 'smoked ' + value,
 								} ),
 							];
@@ -294,11 +294,11 @@ describe( 'block factory', () => {
 				save: noop,
 			} );
 
-			const block = createBlock( 'core/text-block', {
+			const block = createBlock( 'not-core/text-block', {
 				value: 'ribs',
 			} );
 
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+			const transformedBlocks = switchToBlockType( block, 'not-core/updated-text-block' );
 
 			// Make sure the block UIDs are set as expected: the first
 			// transformed block whose type matches the "destination" type gets
@@ -306,14 +306,14 @@ describe( 'block factory', () => {
 			expect( transformedBlocks ).toHaveLength( 2 );
 			expect( transformedBlocks[ 0 ] ).toHaveProperty( 'uid' );
 			expect( transformedBlocks[ 0 ].uid ).not.toBe( block.uid );
-			expect( transformedBlocks[ 0 ].name ).toBe( 'core/text-block' );
+			expect( transformedBlocks[ 0 ].name ).toBe( 'not-core/text-block' );
 			expect( transformedBlocks[ 0 ].isValid ).toBe( true );
 			expect( transformedBlocks[ 0 ].attributes ).toEqual( {
 				value: 'chicken ribs',
 			} );
 			expect( transformedBlocks[ 1 ].uid ).toBe( block.uid );
 			expect( transformedBlocks[ 1 ] ).toHaveProperty( 'uid' );
-			expect( transformedBlocks[ 1 ].name ).toBe( 'core/updated-text-block' );
+			expect( transformedBlocks[ 1 ].name ).toBe( 'not-core/updated-text-block' );
 			expect( transformedBlocks[ 1 ].isValid ).toBe( true );
 			expect( transformedBlocks[ 1 ].attributes ).toEqual( {
 				value: 'smoked ribs',

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -93,56 +93,56 @@ describe( 'block parser', () => {
 
 	describe( 'createBlockWithFallback', () => {
 		it( 'should create the requested block if it exists', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
 
 			const block = createBlockWithFallback(
-				'core/test-block',
+				'not-core/test-block',
 				'content',
 				{ attr: 'value' }
 			);
-			expect( block.name ).toEqual( 'core/test-block' );
+			expect( block.name ).toEqual( 'not-core/test-block' );
 			expect( block.attributes ).toEqual( { attr: 'value' } );
 		} );
 
 		it( 'should create the requested block with no attributes if it exists', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
 
-			const block = createBlockWithFallback( 'core/test-block', 'content' );
-			expect( block.name ).toEqual( 'core/test-block' );
+			const block = createBlockWithFallback( 'not-core/test-block', 'content' );
+			expect( block.name ).toEqual( 'not-core/test-block' );
 			expect( block.attributes ).toEqual( {} );
 		} );
 
 		it( 'should fall back to the unknown type handler for unknown blocks if present', () => {
-			registerBlockType( 'core/unknown-block', defaultBlockSettings );
-			setUnknownTypeHandler( 'core/unknown-block' );
+			registerBlockType( 'not-core/unknown-block', defaultBlockSettings );
+			setUnknownTypeHandler( 'not-core/unknown-block' );
 
 			const block = createBlockWithFallback(
-				'core/test-block',
+				'not-core/test-block',
 				'content',
 				{ attr: 'value' }
 			);
-			expect( block.name ).toEqual( 'core/unknown-block' );
+			expect( block.name ).toEqual( 'not-core/unknown-block' );
 			expect( block.attributes ).toEqual( { attr: 'value' } );
 		} );
 
 		it( 'should fall back to the unknown type handler if block type not specified', () => {
-			registerBlockType( 'core/unknown-block', defaultBlockSettings );
-			setUnknownTypeHandler( 'core/unknown-block' );
+			registerBlockType( 'not-core/unknown-block', defaultBlockSettings );
+			setUnknownTypeHandler( 'not-core/unknown-block' );
 
 			const block = createBlockWithFallback( null, 'content' );
-			expect( block.name ).toEqual( 'core/unknown-block' );
+			expect( block.name ).toEqual( 'not-core/unknown-block' );
 			expect( block.attributes ).toEqual( {} );
 		} );
 
 		it( 'should not create a block if no unknown type handler', () => {
-			const block = createBlockWithFallback( 'core/test-block', 'content' );
+			const block = createBlockWithFallback( 'not-core/test-block', 'content' );
 			expect( block ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'parse()', () => {
 		it( 'should parse the post content, including block attributes', () => {
-			registerBlockType( 'core/test-block', {
+			registerBlockType( 'not-core/test-block', {
 				// Currently this is the only way to test block content parsing?
 				attributes: function( rawContent ) {
 					return {
@@ -153,13 +153,13 @@ describe( 'block parser', () => {
 			} );
 
 			const parsed = parse(
-				'<!-- wp:core/test-block {"smoked":"yes","url":"http://google.com","chicken":"ribs & \'wings\'"} -->' +
+				'<!-- wp:not-core/test-block {"smoked":"yes","url":"http://google.com","chicken":"ribs & \'wings\'"} -->' +
 				'Brisket' +
-				'<!-- /wp:core/test-block -->'
+				'<!-- /wp:not-core/test-block -->'
 			);
 
 			expect( parsed ).toHaveLength( 1 );
-			expect( parsed[ 0 ].name ).toBe( 'core/test-block' );
+			expect( parsed[ 0 ].name ).toBe( 'not-core/test-block' );
 			expect( parsed[ 0 ].attributes ).toEqual( {
 				content: 'Brisket',
 				smoked: 'yes',
@@ -176,7 +176,7 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should parse the post content, ignoring unknown blocks', () => {
-			registerBlockType( 'core/test-block', {
+			registerBlockType( 'not-core/test-block', {
 				attributes: function( rawContent ) {
 					return {
 						content: rawContent + ' & Chicken',
@@ -186,13 +186,13 @@ describe( 'block parser', () => {
 			} );
 
 			const parsed = parse(
-				'<!-- wp:core/test-block -->\nRibs\n<!-- /wp:core/test-block -->' +
+				'<!-- wp:not-core/test-block -->\nRibs\n<!-- /wp:not-core/test-block -->' +
 				'<p>Broccoli</p>' +
-				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->'
+				'<!-- wp:not-core/unknown-block -->Ribs<!-- /wp:not-core/unknown-block -->'
 			);
 
 			expect( parsed ).toHaveLength( 1 );
-			expect( parsed[ 0 ].name ).toBe( 'core/test-block' );
+			expect( parsed[ 0 ].name ).toBe( 'not-core/test-block' );
 			expect( parsed[ 0 ].attributes ).toEqual( {
 				content: 'Ribs & Chicken',
 			} );
@@ -200,28 +200,28 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should parse the post content, using unknown block handler', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-			registerBlockType( 'core/unknown-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/unknown-block', defaultBlockSettings );
 
-			setUnknownTypeHandler( 'core/unknown-block' );
+			setUnknownTypeHandler( 'not-core/unknown-block' );
 
 			const parsed = parse(
-				'<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
+				'<!-- wp:not-core/test-block -->Ribs<!-- /wp:not-core/test-block -->' +
 				'<p>Broccoli</p>' +
-				'<!-- wp:core/unknown-block -->Ribs<!-- /wp:core/unknown-block -->'
+				'<!-- wp:not-core/unknown-block -->Ribs<!-- /wp:not-core/unknown-block -->'
 			);
 
 			expect( parsed ).toHaveLength( 3 );
 			expect( parsed.map( ( { name } ) => name ) ).toEqual( [
-				'core/test-block',
-				'core/unknown-block',
-				'core/unknown-block',
+				'not-core/test-block',
+				'not-core/unknown-block',
+				'not-core/unknown-block',
 			] );
 		} );
 
 		it( 'should parse the post content, including raw HTML at each end', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-			registerBlockType( 'core/unknown-block', {
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/unknown-block', {
 				// Currently this is the only way to test block content parsing?
 				attributes: function( rawContent ) {
 					return {
@@ -231,23 +231,23 @@ describe( 'block parser', () => {
 				save: noop,
 			} );
 
-			setUnknownTypeHandler( 'core/unknown-block' );
+			setUnknownTypeHandler( 'not-core/unknown-block' );
 
 			const parsed = parse(
 				'<p>Cauliflower</p>' +
-				'<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
+				'<!-- wp:not-core/test-block -->Ribs<!-- /wp:not-core/test-block -->' +
 				'\n<p>Broccoli</p>\n' +
-				'<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
+				'<!-- wp:not-core/test-block -->Ribs<!-- /wp:not-core/test-block -->' +
 				'<p>Romanesco</p>'
 			);
 
 			expect( parsed ).toHaveLength( 5 );
 			expect( parsed.map( ( { name } ) => name ) ).toEqual( [
-				'core/unknown-block',
-				'core/test-block',
-				'core/unknown-block',
-				'core/test-block',
-				'core/unknown-block',
+				'not-core/unknown-block',
+				'not-core/test-block',
+				'not-core/unknown-block',
+				'not-core/test-block',
+				'not-core/unknown-block',
 			] );
 			expect( parsed[ 0 ].attributes.content ).toEqual( '<p>Cauliflower</p>' );
 			expect( parsed[ 2 ].attributes.content ).toEqual( '<p>Broccoli</p>' );
@@ -255,28 +255,28 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should parse blocks with empty content', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
 			const parsed = parse(
-				'<!-- wp:core/test-block --><!-- /wp:core/test-block -->'
+				'<!-- wp:not-core/test-block --><!-- /wp:not-core/test-block -->'
 			);
 
 			expect( parsed ).toHaveLength( 1 );
 			expect( parsed.map( ( { name } ) => name ) ).toEqual( [
-				'core/test-block',
+				'not-core/test-block',
 			] );
 		} );
 
 		it( 'should parse void blocks', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-			registerBlockType( 'core/void-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/void-block', defaultBlockSettings );
 			const parsed = parse(
-				'<!-- wp:core/test-block --><!-- /wp:core/test-block -->' +
-				'<!-- wp:core/void-block /-->'
+				'<!-- wp:not-core/test-block --><!-- /wp:not-core/test-block -->' +
+				'<!-- wp:not-core/void-block /-->'
 			);
 
 			expect( parsed ).toHaveLength( 2 );
 			expect( parsed.map( ( { name } ) => name ) ).toEqual( [
-				'core/test-block', 'core/void-block',
+				'not-core/test-block', 'not-core/void-block',
 			] );
 		} );
 	} );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -69,9 +69,9 @@ describe( 'blocks', () => {
 		} );
 
 		it( 'should prohibit registering the same block twice', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-			const block = registerBlockType( 'core/test-block', defaultBlockSettings );
-			expect( console.error ).toHaveBeenCalledWith( 'Block "core/test-block" is already registered.' );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
+			const block = registerBlockType( 'not-core/test-block', defaultBlockSettings );
+			expect( console.error ).toHaveBeenCalledWith( 'Block "not-core/test-block" is already registered.' );
 			expect( block ).toBeUndefined();
 		} );
 
@@ -97,10 +97,10 @@ describe( 'blocks', () => {
 
 		it( 'should store a copy of block type', () => {
 			const blockType = { settingName: 'settingValue', save: noop };
-			registerBlockType( 'core/test-block-with-settings', blockType );
+			registerBlockType( 'not-core/test-block-with-settings', blockType );
 			blockType.mutated = true;
-			expect( getBlockType( 'core/test-block-with-settings' ) ).toEqual( {
-				name: 'core/test-block-with-settings',
+			expect( getBlockType( 'not-core/test-block-with-settings' ) ).toEqual( {
+				name: 'not-core/test-block-with-settings',
 				settingName: 'settingValue',
 				save: noop,
 			} );
@@ -109,28 +109,28 @@ describe( 'blocks', () => {
 
 	describe( 'unregisterBlockType()', () => {
 		it( 'should fail if a block is not registered', () => {
-			const oldBlock = unregisterBlockType( 'core/test-block' );
-			expect( console.error ).toHaveBeenCalledWith( 'Block "core/test-block" is not registered.' );
+			const oldBlock = unregisterBlockType( 'not-core/test-block' );
+			expect( console.error ).toHaveBeenCalledWith( 'Block "not-core/test-block" is not registered.' );
 			expect( oldBlock ).toBeUndefined();
 		} );
 
 		it( 'should unregister existing blocks', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
 			expect( getBlockTypes() ).toEqual( [
-				{ name: 'core/test-block', save: noop },
+				{ name: 'not-core/test-block', save: noop },
 			] );
-			const oldBlock = unregisterBlockType( 'core/test-block' );
+			const oldBlock = unregisterBlockType( 'not-core/test-block' );
 			expect( console.error ).not.toHaveBeenCalled();
-			expect( oldBlock ).toEqual( { name: 'core/test-block', save: noop } );
+			expect( oldBlock ).toEqual( { name: 'not-core/test-block', save: noop } );
 			expect( getBlockTypes() ).toEqual( [] );
 		} );
 	} );
 
 	describe( 'setUnknownTypeHandler()', () => {
 		it( 'assigns unknown type handler', () => {
-			setUnknownTypeHandler( 'core/test-block' );
+			setUnknownTypeHandler( 'not-core/test-block' );
 
-			expect( getUnknownTypeHandler() ).toBe( 'core/test-block' );
+			expect( getUnknownTypeHandler() ).toBe( 'not-core/test-block' );
 		} );
 	} );
 
@@ -142,9 +142,9 @@ describe( 'blocks', () => {
 
 	describe( 'setDefaultBlock()', () => {
 		it( 'assigns default block name', () => {
-			setDefaultBlock( 'core/test-block' );
+			setDefaultBlock( 'not-core/test-block' );
 
-			expect( getDefaultBlock() ).toBe( 'core/test-block' );
+			expect( getDefaultBlock() ).toBe( 'not-core/test-block' );
 		} );
 	} );
 
@@ -156,18 +156,18 @@ describe( 'blocks', () => {
 
 	describe( 'getBlockType()', () => {
 		it( 'should return { name, save } for blocks with minimum settings', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-			expect( getBlockType( 'core/test-block' ) ).toEqual( {
-				name: 'core/test-block',
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
+			expect( getBlockType( 'not-core/test-block' ) ).toEqual( {
+				name: 'not-core/test-block',
 				save: noop,
 			} );
 		} );
 
 		it( 'should return all block type elements', () => {
 			const blockType = { settingName: 'settingValue', save: noop };
-			registerBlockType( 'core/test-block-with-settings', blockType );
-			expect( getBlockType( 'core/test-block-with-settings' ) ).toEqual( {
-				name: 'core/test-block-with-settings',
+			registerBlockType( 'not-core/test-block-with-settings', blockType );
+			expect( getBlockType( 'not-core/test-block-with-settings' ) ).toEqual( {
+				name: 'not-core/test-block-with-settings',
 				settingName: 'settingValue',
 				save: noop,
 			} );
@@ -180,13 +180,13 @@ describe( 'blocks', () => {
 		} );
 
 		it( 'should return all registered blocks', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
 			const blockType = { settingName: 'settingValue', save: noop };
-			registerBlockType( 'core/test-block-with-settings', blockType );
+			registerBlockType( 'not-core/test-block-with-settings', blockType );
 			expect( getBlockTypes() ).toEqual( [
-				{ name: 'core/test-block', save: noop },
+				{ name: 'not-core/test-block', save: noop },
 				{
-					name: 'core/test-block-with-settings',
+					name: 'not-core/test-block-with-settings',
 					settingName: 'settingValue',
 					save: noop,
 				},

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -195,14 +195,14 @@ describe( 'block serializer', () => {
 					return <p dangerouslySetInnerHTML={ { __html: attributes.content } } />;
 				},
 			};
-			registerBlockType( 'core/test-block', blockType );
+			registerBlockType( 'not-core/test-block', blockType );
 
-			const block = createBlock( 'core/test-block', {
+			const block = createBlock( 'not-core/test-block', {
 				foo: false,
 				content: 'Ribs & Chicken',
 				stuff: 'left & right -- but <not>',
 			} );
-			const expectedPostContent = '<!-- wp:core/test-block {"foo":false,"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
+			const expectedPostContent = '<!-- wp:not-core/test-block {"foo":false,"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-not-core-test-block">Ribs & Chicken</p>\n<!-- /wp:not-core/test-block -->';
 
 			expect( serialize( [ block ] ) ).toEqual( expectedPostContent );
 		} );

--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -312,21 +312,21 @@ describe( 'validation', () => {
 
 	describe( 'isValidBlock()', () => {
 		it( 'returns false if block is not valid', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
 
 			expect( isValidBlock(
 				'Apples',
-				getBlockType( 'core/test-block' ),
+				getBlockType( 'not-core/test-block' ),
 				{ fruit: 'Bananas' }
 			) ).toBe( false );
 		} );
 
 		it( 'returns true if block is valid', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
 
 			expect( isValidBlock(
 				'Bananas',
-				getBlockType( 'core/test-block' ),
+				getBlockType( 'not-core/test-block' ),
 				{ fruit: 'Bananas' }
 			) ).toBe( true );
 		} );

--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -311,7 +311,7 @@ describe( 'validation', () => {
 	} );
 
 	describe( 'isValidBlock()', () => {
-		it( 'returns false is block is not valid', () => {
+		it( 'returns false if block is not valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
 			expect( isValidBlock(
@@ -321,7 +321,7 @@ describe( 'validation', () => {
 			) ).toBe( false );
 		} );
 
-		it( 'returns true is block is valid', () => {
+		it( 'returns true if block is valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
 			expect( isValidBlock(

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -1,20 +1,29 @@
-import './paragraph';
-import './image';
-import './gallery';
-import './heading';
-import './quote';
-import './embed';
-import './list';
-import './separator';
-import './more';
-import './button';
-import './pullquote';
-import './table';
-import './preformatted';
-import './code';
-import './html';
-import './freeform';
-import './latest-posts';
-import './cover-image';
-import './cover-text';
-import './verse';
+/**
+ * Internal dependencies
+ */
+import { registrationFlags } from '../api/registration';
+
+// Note - not using import statements here because they would be hoisted to the
+// top of the file, which would cause setting this flag to do nothing.
+registrationFlags.ALLOW_CORE_NAMESPACES = true;
+require( './paragraph' );
+require( './image' );
+require( './gallery' );
+require( './heading' );
+require( './quote' );
+require( './embed' );
+require( './list' );
+require( './separator' );
+require( './more' );
+require( './button' );
+require( './pullquote' );
+require( './table' );
+require( './preformatted' );
+require( './code' );
+require( './html' );
+require( './freeform' );
+require( './latest-posts' );
+require( './cover-image' );
+require( './cover-text' );
+require( './verse' );
+registrationFlags.ALLOW_CORE_NAMESPACES = false;

--- a/editor/inserter/test/menu.js
+++ b/editor/inserter/test/menu.js
@@ -15,7 +15,7 @@ import { registerBlockType, unregisterBlockType, getBlockTypes } from '@wordpres
 import { InserterMenu, searchBlocks } from '../menu';
 
 const textBlock = {
-	name: 'core/text-block',
+	name: 'not-core/text-block',
 	title: 'Text',
 	save: noop,
 	edit: noop,
@@ -23,7 +23,7 @@ const textBlock = {
 };
 
 const advancedTextBlock = {
-	name: 'core/advanced-text-block',
+	name: 'not-core/advanced-text-block',
 	title: 'Advanced Text',
 	save: noop,
 	edit: noop,
@@ -31,7 +31,7 @@ const advancedTextBlock = {
 };
 
 const someOtherBlock = {
-	name: 'core/some-other-block',
+	name: 'not-core/some-other-block',
 	title: 'Some Other Block',
 	save: noop,
 	edit: noop,
@@ -39,7 +39,7 @@ const someOtherBlock = {
 };
 
 const moreBlock = {
-	name: 'core/more-block',
+	name: 'not-core/more-block',
 	title: 'More',
 	save: noop,
 	edit: noop,
@@ -48,7 +48,7 @@ const moreBlock = {
 };
 
 const youtubeBlock = {
-	name: 'core-embed/youtube',
+	name: 'not-core-embed/youtube',
 	title: 'YouTube',
 	save: noop,
 	edit: noop,
@@ -57,7 +57,7 @@ const youtubeBlock = {
 };
 
 const textEmbedBlock = {
-	name: 'core-embed/a-text-embed',
+	name: 'not-core-embed/a-text-embed',
 	title: 'A Text Embed',
 	save: noop,
 	edit: noop,

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -32,14 +32,14 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should only focus the blockA if the blockA has no merge function', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block', defaultBlockSettings );
 			const blockA = {
 				uid: 'chicken',
-				name: 'core/test-block',
+				name: 'not-core/test-block',
 			};
 			const blockB = {
 				uid: 'ribs',
-				name: 'core/test-block',
+				name: 'not-core/test-block',
 			};
 			const dispatch = jest.fn();
 			handler( mergeBlocks( blockA, blockB ), { dispatch } );
@@ -49,7 +49,7 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should merge the blocks if blocks of the same type', () => {
-			registerBlockType( 'core/test-block', {
+			registerBlockType( 'not-core/test-block', {
 				merge( attributes, attributesToMerge ) {
 					return {
 						content: attributes.content + ' ' + attributesToMerge.content,
@@ -59,12 +59,12 @@ describe( 'effects', () => {
 			} );
 			const blockA = {
 				uid: 'chicken',
-				name: 'core/test-block',
+				name: 'not-core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				name: 'core/test-block',
+				name: 'not-core/test-block',
 				attributes: { content: 'ribs' },
 			};
 			const dispatch = jest.fn();
@@ -74,13 +74,13 @@ describe( 'effects', () => {
 			expect( dispatch ).toHaveBeenCalledWith( focusBlock( 'chicken', { offset: -1 } ) );
 			expect( dispatch ).toHaveBeenCalledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
 				uid: 'chicken',
-				name: 'core/test-block',
+				name: 'not-core/test-block',
 				attributes: { content: 'chicken ribs' },
 			} ] ) );
 		} );
 
 		it( 'should not merge the blocks have different types without transformation', () => {
-			registerBlockType( 'core/test-block', {
+			registerBlockType( 'not-core/test-block', {
 				merge( attributes, attributesToMerge ) {
 					return {
 						content: attributes.content + ' ' + attributesToMerge.content,
@@ -88,15 +88,15 @@ describe( 'effects', () => {
 				},
 				save: noop,
 			} );
-			registerBlockType( 'core/test-block-2', defaultBlockSettings );
+			registerBlockType( 'not-core/test-block-2', defaultBlockSettings );
 			const blockA = {
 				uid: 'chicken',
-				name: 'core/test-block',
+				name: 'not-core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				name: 'core/test-block2',
+				name: 'not-core/test-block2',
 				attributes: { content: 'ribs' },
 			};
 			const dispatch = jest.fn();
@@ -106,7 +106,7 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should transform and merge the blocks', () => {
-			registerBlockType( 'core/test-block', {
+			registerBlockType( 'not-core/test-block', {
 				merge( attributes, attributesToMerge ) {
 					return {
 						content: attributes.content + ' ' + attributesToMerge.content,
@@ -114,13 +114,13 @@ describe( 'effects', () => {
 				},
 				save: noop,
 			} );
-			registerBlockType( 'core/test-block-2', {
+			registerBlockType( 'not-core/test-block-2', {
 				transforms: {
 					to: [ {
 						type: 'blocks',
-						blocks: [ 'core/test-block' ],
+						blocks: [ 'not-core/test-block' ],
 						transform: ( { content2 } ) => {
-							return createBlock( 'core/test-block', {
+							return createBlock( 'not-core/test-block', {
 								content: content2,
 							} );
 						},
@@ -130,12 +130,12 @@ describe( 'effects', () => {
 			} );
 			const blockA = {
 				uid: 'chicken',
-				name: 'core/test-block',
+				name: 'not-core/test-block',
 				attributes: { content: 'chicken' },
 			};
 			const blockB = {
 				uid: 'ribs',
-				name: 'core/test-block-2',
+				name: 'not-core/test-block-2',
 				attributes: { content2: 'ribs' },
 			};
 			const dispatch = jest.fn();
@@ -145,7 +145,7 @@ describe( 'effects', () => {
 			expect( dispatch ).toHaveBeenCalledWith( focusBlock( 'chicken', { offset: -1 } ) );
 			expect( dispatch ).toHaveBeenCalledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
 				uid: 'chicken',
-				name: 'core/test-block',
+				name: 'not-core/test-block',
 				attributes: { content: 'chicken ribs' },
 			} ] ) );
 		} );

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -31,7 +31,7 @@ import {
 describe( 'state', () => {
 	describe( 'editor()', () => {
 		beforeAll( () => {
-			registerBlockType( 'core/test-block', {
+			registerBlockType( 'not-core/test-block', {
 				save: noop,
 				edit: noop,
 				category: 'common',
@@ -39,7 +39,7 @@ describe( 'state', () => {
 		} );
 
 		afterAll( () => {
-			unregisterBlockType( 'core/test-block' );
+			unregisterBlockType( 'not-core/test-block' );
 		} );
 
 		it( 'should return empty blocksByUid, blockOrder, history by default', () => {
@@ -67,7 +67,7 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -89,7 +89,7 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -113,11 +113,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -134,15 +134,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -159,11 +159,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -180,11 +180,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -201,15 +201,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -226,11 +226,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -247,11 +247,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -264,7 +264,7 @@ describe( 'state', () => {
 			expect( state.blocksByUid ).toEqual( {
 				ribs: {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				},
 			} );
@@ -275,15 +275,15 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'chicken',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'veggies',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -296,7 +296,7 @@ describe( 'state', () => {
 			expect( state.blocksByUid ).toEqual( {
 				ribs: {
 					uid: 'ribs',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				},
 			} );
@@ -307,11 +307,11 @@ describe( 'state', () => {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
 					uid: 'kumquat',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				}, {
 					uid: 'loquat',
-					name: 'core/test-block',
+					name: 'not-core/test-block',
 					attributes: {},
 				} ],
 			} );
@@ -1044,7 +1044,7 @@ describe( 'state', () => {
 
 	describe( 'userData()', () => {
 		beforeAll( () => {
-			registerBlockType( 'core/test-block', {
+			registerBlockType( 'not-core/test-block', {
 				save: noop,
 				edit: noop,
 				category: 'common',
@@ -1052,7 +1052,7 @@ describe( 'state', () => {
 		} );
 
 		afterAll( () => {
-			unregisterBlockType( 'core/test-block' );
+			unregisterBlockType( 'not-core/test-block' );
 		} );
 
 		it( 'should record recently used blocks', () => {
@@ -1084,7 +1084,7 @@ describe( 'state', () => {
 				type: 'SETUP_EDITOR',
 			} );
 
-			expect( initial.recentlyUsedBlocks ).toEqual( expect.arrayContaining( [ 'core/test-block', 'core/paragraph' ] ) );
+			expect( initial.recentlyUsedBlocks ).toEqual( expect.arrayContaining( [ 'not-core/test-block', 'core/paragraph' ] ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #333.

This PR prohibits plugins from registering blocks in the `core` or `core-*` namespaces (we currently use `core-embed`).

We should reserve these for future usage by core.

The PR works by setting an `ALLOW_CORE_NAMESPACES` flag when registering our core blocks, then unsetting it later.  Because this flag is completely internal to the `blocks` module, it is not accessible by third-party code.