### PR TITLE
Add mark formatting button to quote block

### DIFF
--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -35,6 +35,11 @@ const FORMATTING_CONTROLS = [
 		title: __( 'Strikethrough' ),
 		format: 'strikethrough',
 	},
+	{
+		icon: 'admin-customizer',
+		title: __( 'Mark' ),
+		format: 'mark',
+	},
 ];
 
 // Default controls shown if no `enabledControls` prop provided

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -105,6 +105,11 @@ export default class Editable extends Component {
 
 	onInit() {
 		this.updateFocus();
+
+		this.editor.formatter.register( 'mark', {
+			inline: 'mark',
+			remove: 'all',
+		} );
 	}
 
 	onFocus() {
@@ -409,7 +414,7 @@ export default class Editable extends Component {
 		if ( link ) {
 			formats.link = { value: link.getAttribute( 'href' ) || '', node: link };
 		}
-		const activeFormats = this.editor.formatter.matchAll( [	'bold', 'italic', 'strikethrough' ] );
+		const activeFormats = this.editor.formatter.matchAll( [	'bold', 'italic', 'strikethrough', 'mark' ] );
 		activeFormats.forEach( ( activeFormat ) => formats[ activeFormat ] = true );
 
 		const focusPosition = this.getRelativePosition( element );

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -168,6 +168,7 @@ registerBlockType( 'core/quote', {
 					onMerge={ mergeBlocks }
 					style={ { textAlign: align } }
 					placeholder={ __( 'Write quote…' ) }
+					formattingControls={ [ 'bold', 'italic', 'strikethrough', 'link', 'mark' ] }
 				/>
 				{ ( ( citation && citation.length > 0 ) || !! focus ) && (
 					<Editable


### PR DESCRIPTION
Discussion: https://core.trac.wordpress.org/ticket/38315

Gutenberg is a good opportunity to add this button. The way I see it, this button should only be added for use within the `<blockquote>` tag. It is very useful there if you want to emphasise something in a quoted document, but do not want to change the document's formatting (which should be preserved when quoting).

In other words, using this tag means "emphasis mine".

https://www.w3.org/TR/html5/text-level-semantics.html#the-mark-element

> The mark element represents a run of text in one document marked or highlighted for reference purposes, <mark>due to its relevance in another context</mark>. When used in a quotation or other block of text referred to from the prose, it indicates a highlight that was not originally present but which has been added to bring the reader's attention to a part of the text that might not have been considered important by the original author when the block was originally written, but which is now under previously unexpected scrutiny. When used in the main prose of a document, it indicates a part of the document that has been highlighted due to its likely relevance to the user's current activity.

Note: wanted to highlight something in the above quote, but GitHub doesn't support it. :/ We should! :)