### PR TITLE
Try hiding block toolbar under ellipsis

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -30,8 +30,8 @@
 	margin-bottom: 5px;
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
 	position: relative;
-
 	padding: $block-padding;
+	transition: 0.2s border;
 
 	@include break-small {
 		// The block mover needs to stay inside the block to allow clicks when hovering the block
@@ -42,11 +42,10 @@
 		z-index: z-index( '.editor-visual-editor__block:before' );
 		content: '';
 		position: absolute;
-		outline: 1px solid transparent;
-		transition: 0.2s outline;
+		border: 2px solid transparent;
+		transition: 0.2s border;
 		top: 0;
 		bottom: 0;
-
 		left: 0;
 		right: 0;
 
@@ -73,13 +72,19 @@
 		background-color: rgba( $white, 0.6 );
 	}
 
-	&.is-hovered:before {
-		outline: 1px solid $light-gray-500;
+	&.is-hovered:before,
+	&.is-selected:before {
+		border-left: 2px solid $light-gray-500;
 		transition: 0.2s outline;
 	}
 
-	&.is-selected:before {
-		outline: 2px solid $light-gray-500;
+	&.show-ui:before {
+		border: 2px solid $light-gray-500;
+		transition: 0.2s outline;
+	}
+
+	&.during-input:before {
+		border: 2px solid transparent;
 		transition: 0.2s outline;
 	}
 
@@ -284,6 +289,16 @@
 			margin-left: auto;
 			margin-right: auto;
 		}
+	}
+}
+
+ul.editor-visual-editor__toolbar-toggle {
+	height: 20px;
+	margin-top: 18px;
+	vertical-align: bottom;
+
+	button {
+		padding: 0 5px;
 	}
 }
 


### PR DESCRIPTION
This is an alternative to #2148 and tries to address the blocky feel/noisy UI feedback.

I'm not proposing to merge this, it's just a proof of concept.

Think of it a bit as the right-click of Gutenberg.

Here are the states:

* **Hover** and **select**. We could still trim down the hover state if needed, or just design it better.

<img width="761" alt="screenshot 2017-08-06 16 03 49" src="https://user-images.githubusercontent.com/4710635/29003979-ddebe054-7ac0-11e7-9abb-34197b6b79be.png">

* **Revealed toolbar** state. Maybe I'd also move the right icons under the toolbar for a cleaner look.

<img width="761" alt="screenshot 2017-08-06 16 04 47" src="https://user-images.githubusercontent.com/4710635/29004001-20aa7568-7ac1-11e7-8f26-08f53574b34a.png">

* **Typing** state. Moving the mouse brings you back to the selected state, which happens to be the same as hover. :)

<img width="761" alt="screenshot 2017-08-06 16 06 26" src="https://user-images.githubusercontent.com/4710635/29004009-3cc8597c-7ac1-11e7-8b98-c4516cf7df5e.png">

* **Text selection** state. Selecting some usually text implies a formatting action, so we should show the toolbar. It hides again when you remove the selection.

<img width="761" alt="screenshot 2017-08-06 16 08 15" src="https://user-images.githubusercontent.com/4710635/29004067-000af43a-7ac2-11e7-9e11-0b706378b0b3.png">

Things I like about this:

* Keyboard users are less likely to need the UI, so it's not there.
* When you're in the process of writing, you don't really need the toolbar. You only need it for editing (usually after you're done writing). So when you click around while writing (non heavy keyboard users), the toolbar doesn't pop in your face all the time. If you move the mouse, it's the same state as hover.
* When you are in an editing flow and need to move around text, format it, etc., you don't really need any more clicks. You can open the toolbar immediately from hovering the block. Formatting options become available as soon as you select some text, if you're a heavy mouse user.

Things I don't like about this:

* Hover state still feel strange to me, in general. Maybe it just needs a better design.

Maybe we need block setting for "object-like" blocks such as images. There it would make sense to show the toolbar all the time, though I don't mind it when I think about it as right-click for Gutenberg. It makes it feel less heavy overall.