### PR TITLE
Render "normal" metaboxes created by Advanced Custom Fields

### DIFF
--- a/editor/index.js
+++ b/editor/index.js
@@ -6,6 +6,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { Provider as SlotFillProvider } from 'react-slot-fill';
 import moment from 'moment-timezone';
 import 'moment-timezone/moment-timezone-utils';
+import { partial } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -85,6 +86,24 @@ function preparePostState( store, post ) {
 }
 
 /**
+ * Initializes Redux state with metaboxes for the current post.
+ *
+ * @param {Redux.Store} store Redux store instance
+ * @param {Object}     metaboxes  Metabox data for the current post.
+ */
+function prepareMetaboxesState( store, metaboxes ) {
+	if ( ! metaboxes ) {
+		// eslint-disable-next-line no-console
+		console.error( 'No data about post metaboxes!' );
+		return;
+	}
+	store.dispatch( {
+		type: 'RESET_METABOXES',
+		metaboxes,
+	} );
+}
+
+/**
  * Initializes and returns an instance of Editor.
  *
  * @param {String} id              Unique identifier for editor instance
@@ -124,4 +143,8 @@ export function createEditorInstance( id, post, editorSettings = DEFAULT_SETTING
 		</ReduxProvider>,
 		document.getElementById( id )
 	);
+
+	return {
+		setPostMetaboxes: partial( prepareMetaboxesState, store ),
+	};
 }

--- a/editor/index.js
+++ b/editor/index.js
@@ -109,6 +109,8 @@ function prepareMetaboxesState( store, metaboxes ) {
  * @param {String} id              Unique identifier for editor instance
  * @param {Object} post            API entity for post to edit  (type required)
  * @param {Object} editorSettings  Editor settings object
+ * @return {Object}                Object containing functions that can be
+ *                                 called to manipulate the editor instance.
  */
 export function createEditorInstance( id, post, editorSettings = DEFAULT_SETTINGS ) {
 	const store = createReduxStore();

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -19,6 +19,7 @@ import TextEditor from '../modes/text-editor';
 import VisualEditor from '../modes/visual-editor';
 import UnsavedChangesWarning from '../unsaved-changes-warning';
 import DocumentTitle from '../document-title';
+import NormalMetaboxes from '../metaboxes/normal';
 import { removeNotice } from '../actions';
 import {
 	getEditorMode,
@@ -40,6 +41,7 @@ function Layout( { mode, isSidebarOpened, notices, ...props } ) {
 			<div className="editor-layout__content">
 				{ mode === 'text' && <TextEditor /> }
 				{ mode === 'visual' && <VisualEditor /> }
+				<NormalMetaboxes />
 			</div>
 			{ isSidebarOpened && <Sidebar /> }
 		</div>

--- a/editor/metaboxes/index.js
+++ b/editor/metaboxes/index.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { sprintf, __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+export class Metaboxes extends Component {
+	render() {
+		const classes = classnames(
+			'gutenberg-metaboxes',
+			'gutenberg-metaboxes__' + this.props.context
+		);
+
+		return (
+			<div className={ classes }>
+				<h2>{ this.props.headingText }</h2>
+				{ this.renderBody() }
+			</div>
+		);
+	}
+
+	renderBody() {
+		const { metaboxes, context } = this.props;
+		if ( ! metaboxes || ! metaboxes[ context ] ) {
+			const noMetaboxesMessage =
+				/* translators: %s: metabox context ('normal', 'advanced', 'side') */
+				sprintf( __( 'No metaboxes for context: %s' ), context );
+			return (
+				<div>
+					{ noMetaboxesMessage }
+				</div>
+			);
+		}
+
+		return (
+			<div
+				dangerouslySetInnerHTML={ { __html: metaboxes[ context ] } }
+			/>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			metaboxes: state.currentPostMetaboxes,
+		};
+	}
+)( Metaboxes );

--- a/editor/metaboxes/normal.js
+++ b/editor/metaboxes/normal.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from 'i18n';
+
+/**
+ * Internal dependencies
+ */
+import Metaboxes from './index';
+
+export default function MetaboxesNormal() {
+	return (
+		<Metaboxes
+			context="normal"
+			headingText={ __( 'Metaboxes: Below Content' ) }
+		/>
+	);
+}

--- a/editor/metaboxes/style.scss
+++ b/editor/metaboxes/style.scss
@@ -1,0 +1,4 @@
+.gutenberg-metaboxes {
+	margin: 0 auto;
+	max-width: 700px;
+}

--- a/editor/state.js
+++ b/editor/state.js
@@ -290,6 +290,22 @@ export function currentPost( state = {}, action ) {
 }
 
 /**
+ * Reducer returning information about the metaboxes for the current post.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {Object}        Updated state
+ */
+export function currentPostMetaboxes( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RESET_METABOXES':
+			return action.metaboxes;
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning selected block state.
  *
  * @param  {Object} state  Current state
@@ -538,6 +554,7 @@ export function createReduxStore() {
 	const reducer = optimist( combineReducers( {
 		editor,
 		currentPost,
+		currentPostMetaboxes,
 		selectedBlock,
 		isTyping,
 		multiSelectedBlocks,

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -16,6 +16,7 @@ define( 'GUTENBERG_DEVELOPMENT_MODE', true );
 require_once dirname( __FILE__ ) . '/lib/init-checks.php';
 if ( gutenberg_can_init() ) {
 	// Load API functions, register scripts and actions, etc.
+	require_once dirname( __FILE__ ) . '/lib/api/class-gutenberg-metaboxes-controller.php';
 	require_once dirname( __FILE__ ) . '/lib/class-wp-block-type.php';
 	require_once dirname( __FILE__ ) . '/lib/class-wp-block-type-registry.php';
 	require_once dirname( __FILE__ ) . '/lib/blocks.php';

--- a/lib/api/class-gutenberg-metaboxes-controller.php
+++ b/lib/api/class-gutenberg-metaboxes-controller.php
@@ -9,18 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-__local_log( 'load gutenberg', substr( __FILE__, strlen( ABSPATH ) ) );
-
-add_action( 'init', function() {
-	__local_log( 'init' );
-} );
-add_action( 'plugins_loaded', function() {
-	__local_log( 'plugins_loaded' );
-} );
-add_action( 'rest_api_init', function() {
-	__local_log( 'rest_api_init' );
-} );
-
 /**
  * Controller class for metaboxes API endpoint.
  */

--- a/lib/api/class-gutenberg-metaboxes-controller.php
+++ b/lib/api/class-gutenberg-metaboxes-controller.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * REST API endpoint to render and (eventually) update metabox content.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+__local_log( 'load gutenberg', substr( __FILE__, strlen( ABSPATH ) ) );
+
+add_action( 'init', function() {
+	__local_log( 'init' );
+} );
+add_action( 'plugins_loaded', function() {
+	__local_log( 'plugins_loaded' );
+} );
+add_action( 'rest_api_init', function() {
+	__local_log( 'rest_api_init' );
+} );
+
+/**
+ * Controller class for metaboxes API endpoint.
+ */
+class Gutenberg_Metaboxes_Controller {
+	/**
+	 * Register REST API routes.
+	 */
+	public static function register_routes() {
+		register_rest_route( 'gutenberg/v1', '/metaboxes', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'permission_callback' => array( __CLASS__, 'get_items_permissions_check' ),
+				'callback'            => array( __CLASS__, 'get_items' ),
+				'args'                => array(
+					'post_id' => array(
+						'description' => __(
+							'The ID of the post for which to fetch metaboxes.',
+							'gutenberg'
+						),
+						'type'        => 'integer',
+					),
+				),
+			),
+		) );
+	}
+
+	/**
+	 * Check permissions for reading metaboxes.  Requires `edit_post` for the
+	 * requested post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public static function get_items_permissions_check( $request ) {
+		$post = get_post( $request['post_id'] );
+		if ( ! $post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.', 'gutenberg' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		$post_type = get_post_type_object( $post->post_type );
+		$allowed_post_types = get_post_types( array(
+			'show_in_rest' => true,
+		) );
+		if ( ! in_array( $post_type->name, $allowed_post_types, true ) ) {
+			return new WP_Error(
+				'rest_post_invalid_type',
+				__( 'Invalid post type.', 'gutenberg' ),
+				array(
+					'status' => 404,
+				)
+			);
+		}
+
+		if ( current_user_can( $post_type->cap->edit_post, $post->ID ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns information about metaboxes for the requested post.
+	 *
+	 * Plugins that add metaboxes along with their timing:
+	 *
+	 * advanced-custom-fields
+	 * ======================
+	 * An 'admin_enqueue_scripts' callback (priority 10) verifies that `$pagenow`
+	 * is `post.php` or `post-new.php`, then adds an 'admin_head' callback which
+	 * calls add_meta_box().
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return array Information about metaboxes for the requested post.
+	 */
+	public static function get_items( $request ) {
+		$post = get_post( $request['post_id'] );
+		$output = array();
+
+		// advanced-custom-fields doesn't do anything unless is_admin().
+		define( 'WP_ADMIN', true );
+
+		// advanced-custom-fields doesn't register metaboxes without these.
+		$GLOBALS['pagenow'] = 'post.php';
+		$GLOBALS['typenow'] = $post->post_type;
+
+		// Load wp-admin APIs and functions.  This shouldn't produce any
+		// output, but we can collect it just in case and verify during
+		// testing.
+		ob_start();
+		require_once ABSPATH . 'wp-admin/includes/admin.php';
+		$output['include_admin'] = ob_get_clean();
+
+		// Capture output produced by the following actions.
+		// TODO: Collect more specific info about enqueued assets.
+		ob_start();
+
+		/*
+		 * Normally called via wp-admin/post.php ->
+		 * wp-admin/edit-form-advanced.php -> wp-admin/admin-header.php
+		 */
+		do_action( 'admin_enqueue_scripts', 'post.php' );
+		do_action( 'admin_print_styles-post.php' );
+		do_action( 'admin_print_styles' );
+		do_action( 'admin_print_scripts-post.php' );
+		do_action( 'admin_print_scripts' );
+		do_action( 'admin_head-post.php' );
+		do_action( 'admin_head' );
+
+		$output['admin_head'] = ob_get_clean();
+
+		/*
+		 * Adapted from code in wp-admin/edit-form-advanced.php:
+		 * do_action( 'do_meta_boxes', $post_type, {'normal','advanced','side'}, $post );
+		 * do_meta_boxes( $post_type, 'side', $post );
+		 * do_meta_boxes( null, 'normal', $post );
+		 * do_meta_boxes( null, 'advanced', $post );
+		 */
+		foreach ( array( 'normal', 'advanced', 'side' ) as $location ) {
+			ob_start();
+			do_action(
+				'do_meta_boxes',
+				$post->post_type,
+				$location,
+				$post
+			);
+			do_meta_boxes(
+				'side' === $location ? $post->post_type : null,
+				$location,
+				$post
+			);
+			$output[ $location ] = ob_get_clean();
+		}
+
+		// TODO wp-admin/post.php -> wp-admin/admin-footer.php ?
+		; // Just for you, phpcs.
+
+		return array(
+			'html' => $output,
+		);
+	}
+}
+
+add_action(
+	'rest_api_init',
+	array( 'Gutenberg_Metaboxes_Controller', 'register_routes' )
+);

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -615,6 +615,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	if ( is_wp_error( $post_to_edit ) ) {
 		wp_die( $post_to_edit->get_error_message() );
 	}
+	$GLOBALS['_gutenberg_post_id'] = $post_id; // TODO something other than this.
 
 	// Set initial title to empty string for auto draft for duration of edit.
 	$is_new_post = 'auto-draft' === $post_to_edit['status'];
@@ -661,10 +662,17 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'colors' => $color_palette,
 	);
 
-	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() {'
-		. 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
-		. '} );'
+	$editor_settings_encoded = json_encode( $editor_settings );
+	$create_editor_instance_script = <<<JS
+wp.api.init().done( function() {
+	window._wpGutenbergInstance = wp.editor.createEditorInstance(
+		'editor',
+		window._wpGutenbergPost,
+		$editor_settings_encoded
 	);
+} );
+JS;
+	wp_add_inline_script( 'wp-editor', $create_editor_instance_script );
 
 	/**
 	 * Scripts

--- a/lib/metabox-api.php
+++ b/lib/metabox-api.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Initialization and wp-admin integration for the Gutenberg editor plugin.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+function gutenberg_meta_box_api() {
+	/**
+	 * The metabox param as long as it is set on the wp-admin/post.php request
+	 * will trigger this API.
+	 *
+	 * Essentially all that happens is we try to load in the scripts from admin_head
+	 * and admin_footer to mimic the assets for a typical post.php.
+	 *
+	 * @in_the_future Hopefully the metabox param can be changed to a location,
+	 * or contenxt, so that we can use this API to render metaboxes that appear,
+	 * in the sidebar vs. regular content, or core metaboxes vs others. For now
+	 * a request like http://local.wordpress.dev/wp-admin/post.php?post=40007&action=edit&metabox=taco
+	 * works just fine! Will only work on existing posts so far. Need to handle
+	 * this differently for new posts.
+	 */
+	if ( isset( $_REQUEST['metabox'] ) && $GLOBALS['pagenow'] === 'post.php' ) {
+		/* Scripts and styles that metaboxes can potentially be using */
+		wp_enqueue_style( 'common' );
+		wp_enqueue_style( 'buttons' );
+		wp_enqueue_style( 'colors' );
+		wp_enqueue_style( 'ie' );
+		wp_enqueue_script( 'utils' );
+		wp_enqueue_script( 'svg-painter' );
+
+		// Grab the admin body class.
+		$admin_body_class = preg_replace('/[^a-z0-9_-]+/i', '-', $hook_suffix);
+		?>
+		<!-- Add in JavaScript variables that some meta box plugins make use of. -->
+		<script type="text/javascript">
+		addLoadEvent = function( func ){ if( typeof jQuery!="undefined" )jQuery( document ).ready( func );else if(typeof wpOnload!='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
+		var ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>',
+			pagenow = '<?php echo $current_screen->id; ?>',
+			typenow = '<?php echo $current_screen->post_type; ?>',
+			adminpage = '<?php echo $admin_body_class; ?>',
+			thousandsSeparator = '<?php echo addslashes( $wp_locale->number_format['thousands_sep'] ); ?>',
+			decimalPoint = '<?php echo addslashes( $wp_locale->number_format['decimal_point'] ); ?>',
+			isRtl = <?php echo (int) is_rtl(); ?>;
+		</script>
+		<meta name="viewport" content="width=device-width,initial-scale=1.0">
+		<?php
+
+		// More scripts.
+		wp_enqueue_script( 'post' );
+		wp_enqueue_script( 'editor-expand' );
+
+		global $post, $wp_meta_boxes, $hook_suffix;
+
+		/**
+		 * Enqueue scripts for all admin pages.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param string $hook_suffix The current admin page.
+		 */
+		do_action( 'admin_enqueue_scripts', $hook_suffix );
+
+		/**
+		 * Fires when styles are printed for a specific admin page based on $hook_suffix.
+		 *
+		 * @since 2.6.0
+		 */
+		do_action( "admin_print_styles-{$hook_suffix}" );
+
+		/**
+		 * Fires when styles are printed for all admin pages.
+		 *
+		 * @since 2.6.0
+		 */
+		do_action( 'admin_print_styles' );
+
+		/**
+		 * Fires when scripts are printed for a specific admin page based on $hook_suffix.
+		 *
+		 * @since 2.1.0
+		 */
+		do_action( "admin_print_scripts-{$hook_suffix}" );
+
+		/**
+		 * Fires when scripts are printed for all admin pages.
+		 *
+		 * @since 2.1.0
+		 */
+		do_action( 'admin_print_scripts' );
+
+		/**
+		 * Fires in head section for a specific admin page.
+		 *
+		 * The dynamic portion of the hook, `$hook_suffix`, refers to the hook suffix
+		 * for the admin page.
+		 *
+		 * @since 2.1.0
+		 */
+		do_action( "admin_head-{$hook_suffix}" );
+
+		/**
+		 * Fires in head section for all admin pages.
+		 *
+		 * @since 2.1.0
+		 */
+		do_action( 'admin_head' );
+
+		$locations = array( 'normal', 'advanced', 'side' );
+		//foreach( $locations as $location ) {
+			do_meta_boxes(
+				null,
+				'normal',
+				$post
+			);
+		//}
+		echo '<pre>', var_dump( $wp_meta_boxes ), '</pre>';
+
+		/**
+		 * Prints scripts or data before the default footer scripts.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param string $data The data to print.
+		 */
+		do_action( 'admin_footer', '' );
+
+		/**
+		 * Prints scripts and data queued for the footer.
+		 *
+		 * The dynamic portion of the hook name, `$hook_suffix`,
+		 * refers to the global hook suffix of the current page.
+		 *
+		 * @since 4.6.0
+		 */
+		do_action( "admin_print_footer_scripts-{$hook_suffix}" );
+
+		/**
+		 * Prints any scripts and data queued for the footer.
+		 *
+		 * @since 2.8.0
+		 */
+		do_action( 'admin_print_footer_scripts' );
+
+		/**
+		 * Prints scripts or data after the default footer scripts.
+		 *
+		 * The dynamic portion of the hook name, `$hook_suffix`,
+		 * refers to the global hook suffix of the current page.
+		 *
+		 * @since 2.8.0
+		 */
+		do_action( "admin_footer-{$hook_suffix}" );
+
+		exit( 'YOLO' );
+
+		/**
+		 * Shutdown hooks potentially firing.
+		 *
+		 * Try Query Monitor plugin to make sure the output isn't janky.
+		 */
+	}
+}
+
+add_action( 'do_meta_boxes', 'gutenberg_meta_box_api' );
+
+?>

--- a/lib/register.php
+++ b/lib/register.php
@@ -18,10 +18,23 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.1.0
  */
 function the_gutenberg_project() {
+	// Somehow get post ID.
+	global $post;
+	$post_id = $post->ID;
+	$meta_box_api_url = get_admin_url();
+	$meta_box_api_url = $meta_box_api_url . 'post.php';
+	$meta_box_api_url = add_query_arg( array(
+		'post'    => $post_id,
+		'metabox' => 'some-location',
+		'action'  => 'edit',
+	), $meta_box_api_url );
 	?>
 	<div class="gutenberg">
 		<section id="editor" class="gutenberg__editor"></section>
 	</div>
+	<!-- HERE is an iframe -->
+	<h1>Meta Boxes: Wait for iFrame to load!</h1>
+	<iframe style="width: 100%; height: 1000px;" src="<?php echo esc_url_raw( $meta_box_api_url ); ?>"></iframe>
 	<?php
 }
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -25,10 +25,12 @@ function the_gutenberg_project() {
 	<?php
 }
 
-// Plugins that add metaboxes along with their timing:
-//
-//  - advanced-custom-fields : admin_enqueue_scripts (priority 10) adds an
-//                             'admin_head' action which calls add_meta_box()
+/*
+ * Plugins that add metaboxes along with their timing:
+ *
+ *  - advanced-custom-fields : admin_enqueue_scripts (priority 10) adds an
+ *                             'admin_head' action which calls add_meta_box()
+ */
 
 /**
  * Set up global variables so that plugins will add metaboxes as if we were
@@ -59,13 +61,15 @@ add_action(
 function gutenberg_collect_metabox_data() {
 	global $_gutenberg_post_id, $_gutenberg_restore_globals_after_metaboxes;
 
-	// WIP: Collect and send information needed to render metaboxes.
-	// From wp-admin/edit-form-advanced.php
-	// Relevant code there:
-	// do_action( 'do_meta_boxes', $post_type, {'normal','advanced','side'}, $post );
-	// do_meta_boxes( $post_type, 'side', $post );
-	// do_meta_boxes( null, 'normal', $post );
-	// do_meta_boxes( null, 'advanced', $post );
+	/*
+	 * WIP: Collect and send information needed to render metaboxes.
+	 * From wp-admin/edit-form-advanced.php
+	 * Relevant code there:
+	 * do_action( 'do_meta_boxes', $post_type, {'normal','advanced','side'}, $post );
+	 * do_meta_boxes( $post_type, 'side', $post );
+	 * do_meta_boxes( null, 'normal', $post );
+	 * do_meta_boxes( null, 'advanced', $post );
+	 */
 	$meta_boxes_output = array();
 
 	$post = get_post( $_gutenberg_post_id );

--- a/lib/register.php
+++ b/lib/register.php
@@ -25,6 +25,77 @@ function the_gutenberg_project() {
 	<?php
 }
 
+// Plugins that add metaboxes along with their timing:
+//
+//  - advanced-custom-fields : admin_enqueue_scripts (priority 10) adds an
+//                             'admin_head' action which calls add_meta_box()
+
+/**
+ * Set up global variables so that plugins will add metaboxes as if we were
+ * using the main editor.
+ *
+ * @since ???
+ */
+function gutenberg_trick_plugins_into_registering_metaboxes() {
+	global $pagenow;
+	$GLOBALS['_gutenberg_restore_globals_after_metaboxes'] = array(
+		'pagenow' => $pagenow,
+	);
+	$pagenow = 'post.php';
+	// As early as possible, but after any logic that adds metaboxes.
+	add_action( 'admin_head', 'gutenberg_collect_metabox_data', 99 );
+}
+// As late as possible, but before any logic that adds metaboxes.
+add_action(
+	'load-toplevel_page_gutenberg',
+	'gutenberg_trick_plugins_into_registering_metaboxes'
+);
+
+/**
+ * Collect information about metaboxes registered for the current post.
+ *
+ * @since ???
+ */
+function gutenberg_collect_metabox_data() {
+	global $_gutenberg_post_id, $_gutenberg_restore_globals_after_metaboxes;
+
+	// WIP: Collect and send information needed to render metaboxes.
+	// From wp-admin/edit-form-advanced.php
+	// Relevant code there:
+	// do_action( 'do_meta_boxes', $post_type, {'normal','advanced','side'}, $post );
+	// do_meta_boxes( $post_type, 'side', $post );
+	// do_meta_boxes( null, 'normal', $post );
+	// do_meta_boxes( null, 'advanced', $post );
+	$meta_boxes_output = array();
+
+	$post = get_post( $_gutenberg_post_id );
+	foreach ( array( 'normal', 'advanced', 'side' ) as $location ) {
+		ob_start();
+		do_action(
+			'do_meta_boxes',
+			$post->post_type,
+			$location,
+			$post
+		);
+		do_meta_boxes(
+			'side' === $location ? $post->post_type : null,
+			$location,
+			$post
+		);
+		$meta_boxes_output[ $location ] = ob_get_clean();
+	}
+	wp_add_inline_script(
+		'wp-editor',
+		'window._wpGutenbergMetaboxes = ' . wp_json_encode( $meta_boxes_output ) . ';'
+		. "\nwindow._wpGutenbergInstance.setPostMetaboxes( window._wpGutenbergMetaboxes );"
+	);
+
+	// Restore any global variables that we temporarily modified above.
+	foreach ( $_gutenberg_restore_globals_after_metaboxes as $name => $value ) {
+		$GLOBALS[ $name ] = $value;
+	}
+}
+
 /**
  * Gutenberg's Menu.
  *


### PR DESCRIPTION
This PR is an initial exploration of rendering PHP metaboxes in the Gutenberg editor.  See #952.

A fairly basic metabox configuration added by the [Advanced Custom Fields plugin](https://wordpress.org/plugins/advanced-custom-fields/) looks like this in the wp-admin editor:

> <img src="https://user-images.githubusercontent.com/227022/29005602-7d7fcf0a-7aac-11e7-89fa-b07888b734c3.gif" width="500">

This PR **renders the HTML** for this field group in the Gutenberg editor.  It **does not attempt to handle** saving, JavaScript attached to the field boxes, or any number of other things that can and will go wrong when attempting to implement this feature.

Here's what it looks like currently:

> <img src="https://user-images.githubusercontent.com/227022/29005611-bc1df8f4-7aac-11e7-85fe-595224dbef48.gif" width="500">

## Technical details

As noted in the PHP comments, Advanced Custom Fields adds its metaboxes by registering a hook against `admin_enqueue_scripts`.  This hook verifies that the current page load is either `post.php` or `post-new.php`, and if so, adds an `admin_head` action which calls `add_meta_box`.  WP core does its `do_meta_boxes` calls shortly after that action, [in `edit-form-advanced.php`](https://github.com/WordPress/wordpress-develop/blob/4.8.1/src/wp-admin/edit-form-advanced.php#L336-L726).

This PR works by modifying the `$pagenow` variable during the appropriate portion of the Gutenberg page load so that Advanced Custom Fields will register its metaboxes and inject its scripts.

This is not even close to an acceptable approach.  It is already having a lot of unintended side effects.  For example, it doesn't seem to be breaking the Gutenberg editor when using Advanced Custom Fields, but here are the console errors that result from this "unorthodox" loading process:

> <img src="https://user-images.githubusercontent.com/227022/29005653-b463964a-7aad-11e7-85a4-6983e1e7340f.png" width="500">

Also, the way this PR renders the metabox HTML is unacceptable because any malformed markup will probably completely break the React app, and any scripts that expect to manipulate the traditional editor page structure will fail and probably break things along the way.

From the extensive modification of the WP load process needed to get this initial example working, and from the resulting issues, it's clear that we will need to create an API endpoint to render and return metabox HTML.  This API endpoint would then be called in a separate request after the Gutenberg editor has loaded, where it can do whatever horrible things it wants to the WP load process.

To avoid concerns about rendering unfiltered HTML inside a React app, we had previously discussed rendering metaboxes in a separate element not managed by React.  We can try this next; however, based on the number and type of errors I am already seeing, and the likely difficulties in managing the load-save lifecycle of the metabox content, I'm skeptical that it will work well.