### PR TITLE
Add hr description

### DIFF
--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -8,6 +8,8 @@ import { __ } from '@wordpress/i18n';
  */
 import './block.scss';
 import { registerBlockType, createBlock } from '../../api';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/separator', {
 	title: __( 'Separator' ),
@@ -27,8 +29,17 @@ registerBlockType( 'core/separator', {
 		],
 	},
 
-	edit( { className } ) {
-		return <hr className={ className } />;
+	edit( { className, focus } ) {
+		return [
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'The horizontal rule represents a paragraph-level thematic break, e.g. a scene change in a story, or a transition to another topic within an article.' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
+			),
+			<hr key="hr" className={ className } />,
+		];
 	},
 
 	save() {

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -34,7 +34,7 @@ registerBlockType( 'core/separator', {
 			focus && (
 				<InspectorControls key="inspector">
 					<BlockDescription>
-						<p>{ __( 'The horizontal rule represents a paragraph-level thematic break, e.g. a scene change in a story, or a transition to another topic within an article.' ) }</p>
+						<p>{ __( 'The separator represents a paragraph-level thematic break, e.g. a scene change in a story, or a transition to another topic within an article.' ) }</p>
 					</BlockDescription>
 				</InspectorControls>
 			),


### PR DESCRIPTION
This PR adds a description to the horizontal rule block, similar to the one from W3:

> The hr element represents a paragraph-level thematic break, e.g. a scene change in a story, or a transition to another topic within a section of a reference book.

https://www.w3.org/TR/html5/grouping-content.html#the-hr-element