### PR TITLE
Extend .gitignore rules with IntelliJ editors family settings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ gutenberg.zip
 *.log
 phpcs.xml
 yarn.lock
+.idea


### PR DESCRIPTION
I didn't find any guidelines about editor related configurations created in the project directory, but in my opinion, it is nothing bad to have them ignored. Both PhpStorm and Idea uses the same folder, so added it to the configuration. If it is against any project rules I will fully understand rejection.