### PR TITLE
Handle ENTER on block focus

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -242,7 +242,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	onKeyDown( event ) {
-		const { keyCode } = event;
+		const { keyCode, target } = event;
 
 		this.handleArrowKey( event );
 
@@ -251,7 +251,7 @@ class VisualEditorBlock extends Component {
 			this.lastRange = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 		}
 
-		if ( ENTER === keyCode ) {
+		if ( ENTER === keyCode && target === this.node ) {
 			event.preventDefault();
 
 			this.props.onInsertBlocksAfter( [

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -13,7 +13,7 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { Children, Component } from '@wordpress/element';
 import { IconButton, Toolbar } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
-import { getBlockType, getBlockDefaultClassname } from '@wordpress/blocks';
+import { getBlockType, getBlockDefaultClassname, createBlock } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -48,7 +48,7 @@ import {
 	getMultiSelectedBlockUids,
 } from '../../selectors';
 
-const { BACKSPACE, ESCAPE, DELETE, UP, DOWN, LEFT, RIGHT } = keycodes;
+const { BACKSPACE, ESCAPE, DELETE, UP, DOWN, LEFT, RIGHT, ENTER } = keycodes;
 
 function FirstChild( { children } ) {
 	const childrenArray = Children.toArray( children );
@@ -249,6 +249,14 @@ class VisualEditorBlock extends Component {
 		if ( keyCode === UP || keyCode === LEFT || keyCode === DOWN || keyCode === RIGHT ) {
 			const selection = window.getSelection();
 			this.lastRange = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+		}
+
+		if ( ENTER === keyCode ) {
+			event.preventDefault();
+
+			this.props.onInsertBlocksAfter( [
+				createBlock( 'core/paragraph' ),
+			] );
 		}
 	}
 


### PR DESCRIPTION
Currently pressing ENTER is not handled when the outer block wrapper is focussed. Try for example an image, HR, read more, locked block, widget... 