### PR TITLE
Blocks: Capture and recover from block rendering runtime errors

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -8,7 +8,7 @@ $z-layers: (
 	'.editor-visual-editor__block .wp-block-more:before': -1,
 	'.editor-visual-editor__block {core/image aligned left or right}': 10,
 	'.editor-visual-editor__block-controls': 1,
-	'.editor-visual-editor__invalid-block-warning': 1,
+	'.editor-visual-editor__block-warning': 1,
 	'.components-form-toggle__input': 1,
 	'.editor-format-list__menu': 1,
 	'.editor-inserter__tabs': 1,

--- a/editor/modes/visual-editor/block-crash-boundary.js
+++ b/editor/modes/visual-editor/block-crash-boundary.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+class BlockCrashBoundary extends Component {
+	componentDidCatch( error ) {
+		this.props.onError( error );
+	}
+
+	render() {
+		return this.props.children;
+	}
+}
+
+export default BlockCrashBoundary;

--- a/editor/modes/visual-editor/block-crash-warning.js
+++ b/editor/modes/visual-editor/block-crash-warning.js
@@ -9,8 +9,7 @@ import { __ } from '@wordpress/i18n';
 import createBlockWarning from './create-block-warning';
 
 const warning = createBlockWarning( __(
-	'This block has been modified externally and has been locked to protect ' +
-	'against content loss.'
+	'This block has suffered from an unhandled error and cannot be previewed.'
 ) );
 
 export default () => warning;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -83,7 +83,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.focus ) {
+		if ( this.props.focus && this.node ) {
 			this.node.focus();
 		}
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -21,6 +21,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import InvalidBlockWarning from './invalid-block-warning';
 import BlockCrashWarning from './block-crash-warning';
+import BlockCrashBoundary from './block-crash-boundary';
 import BlockMover from '../../block-mover';
 import BlockRightMenu from '../../block-settings-menu';
 import BlockSwitcher from '../../block-switcher';
@@ -73,6 +74,7 @@ class VisualEditorBlock extends Component {
 		this.onKeyUp = this.onKeyUp.bind( this );
 		this.handleArrowKey = this.handleArrowKey.bind( this );
 		this.toggleMobileControls = this.toggleMobileControls.bind( this );
+		this.onBlockError = this.onBlockError.bind( this );
 
 		this.previousOffset = null;
 
@@ -83,7 +85,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.focus && this.node ) {
+		if ( this.props.focus ) {
 			this.node.focus();
 		}
 
@@ -125,10 +127,6 @@ class VisualEditorBlock extends Component {
 				this.removeStopTypingListener();
 			}
 		}
-	}
-
-	componentDidCatch( error ) {
-		this.setState( { error } );
 	}
 
 	componentWillUnmount() {
@@ -314,6 +312,10 @@ class VisualEditorBlock extends Component {
 		} );
 	}
 
+	onBlockError( error ) {
+		this.setState( { error } );
+	}
+
 	render() {
 		const { block, multiSelectedBlockUids } = this.props;
 		const { name: blockName, isValid } = block;
@@ -416,17 +418,19 @@ class VisualEditorBlock extends Component {
 					className="editor-visual-editor__block-edit"
 				>
 					{ isValid && ! error && (
-						<BlockEdit
-							focus={ focus }
-							attributes={ block.attributes }
-							setAttributes={ this.setAttributes }
-							insertBlocksAfter={ onInsertBlocksAfter }
-							onReplace={ onReplace }
-							setFocus={ partial( onFocus, block.uid ) }
-							mergeBlocks={ this.mergeBlocks }
-							className={ className }
-							id={ block.uid }
-						/>
+						<BlockCrashBoundary onError={ this.onBlockError }>
+							<BlockEdit
+								focus={ focus }
+								attributes={ block.attributes }
+								setAttributes={ this.setAttributes }
+								insertBlocksAfter={ onInsertBlocksAfter }
+								onReplace={ onReplace }
+								setFocus={ partial( onFocus, block.uid ) }
+								mergeBlocks={ this.mergeBlocks }
+								className={ className }
+								id={ block.uid }
+							/>
+						</BlockCrashBoundary>
 					) }
 					{ ! isValid && (
 						blockType.save( {

--- a/editor/modes/visual-editor/create-block-warning.js
+++ b/editor/modes/visual-editor/create-block-warning.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { Dashicon } from '@wordpress/components';
+
+export default ( text ) => (
+	<div className="editor-visual-editor__block-warning">
+		<Dashicon icon="warning" />
+		<p>{ text }</p>
+	</div>
+);

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -56,14 +56,14 @@
 		}
 	}
 
-	&.is-invalid .editor-visual-editor__block-edit {
+	&.has-warning .editor-visual-editor__block-edit {
 		position: relative;
 		min-height: 250px;
 		pointer-events: none;
 		user-select: none;
 	}
 
-	&.is-invalid .editor-visual-editor__block-edit::after {
+	&.has-warning .editor-visual-editor__block-edit::after {
 		content: '';
 		position: absolute;
 		top: 0;
@@ -453,8 +453,8 @@ $sticky-bottom-offset: 20px;
 	}
 }
 
-.editor-visual-editor__invalid-block-warning {
-	z-index: z-index( '.editor-visual-editor__invalid-block-warning' );
+.editor-visual-editor__block-warning {
+	z-index: z-index( '.editor-visual-editor__block-warning' );
 	position: absolute;
 	top: 50%;
 	left: 50%;


### PR DESCRIPTION
This pull request seeks to add error handling to block edit rendering. Error boundaries are a [new feature added in React 16](https://facebook.github.io/react/blog/2017/07/26/error-handling-in-react-16.html) which add a simple `componentDidCatch` lifecycle hook to capture errors which occur during a component's rendering. With these changes, an error boundary wraps rendering of each block and captures errors, presenting a warning message if one occurs, rather than allowing it to go unhandled and crash the entire application.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/29032101-442fdf26-7b5e-11e7-9fab-1b78df0934ba.png)|![After](https://user-images.githubusercontent.com/1779930/29032058-22ea2754-7b5e-11e7-8895-c80c80f93515.png)

__Implementation notes:__

The [original implementation attempt](https://github.com/WordPress/gutenberg/pull/2267/commits/7484237534a212b1d4c0b60106c856dd1ba691cc) applied `componentDidCatch` to `VisualEditorBlock` itself but this had some [odd effects on `componentDidMount` and refs](https://github.com/WordPress/gutenberg/pull/2267/commits/e94b21941ddf4528aaffae89bdcb3e66caba2849), so it was later [revised to create a separate wrapping error boundary component](https://github.com/WordPress/gutenberg/pull/2267/commits/29eeb432fa9f497d013ca0d9fca3c95063310ed7).

__Testing instructions:__

1. Navigate to Gutenberg > Demo, or Gutenberg > New Post
2. In your browser developer tools console, register the Mr. Crashy block:
   - `wp.blocks.registerBlockType( 'myplugin/mr-crashy', { title: 'Mr. Crashy', category: 'common', icon: 'warning', edit() { throw new Error(); }, save() { return ''; } } );`
3. From the inserter menu, select Mr. Crashy
4. Note that the block is inserted and displays a warning about failure

__Open questions:__

- What do we do about saved content? If an error occurs after making some revisions, the changed block attributes are still reflected in the saved output. To me, this seems reasonable, but is that expectation shared?
- How can we surface the actual error message that was captured? Might be better to be addressed in a subsequent pull request.