### PR TITLE
Replace text block on paste if empty

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -205,7 +205,13 @@ export default class Editable extends Component {
 				return;
 			}
 
-			this.splitContent( content );
+			const rootNode = this.editor.getBody();
+
+			if ( this.editor.dom.isEmpty( rootNode ) && this.props.onReplace ) {
+				this.props.onReplace( content );
+			} else {
+				this.splitContent( content );
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes pasting in an empty paragraph. At the moment this would "split" the empty paragraph and paste the blocks in between, resulting in an empty block above and below the pasted blocks. Instead, we should replace the current block.