### PR TITLE
Preview Button: Disable if post is not saveable

### DIFF
--- a/editor/header/tools/preview-button.js
+++ b/editor/header/tools/preview-button.js
@@ -18,6 +18,7 @@ import {
 	getEditedPostAttribute,
 	isEditedPostDirty,
 	isEditedPostNew,
+	isEditedPostSaveable,
 } from '../../selectors';
 import { autosave } from '../../actions';
 
@@ -75,7 +76,7 @@ export class PreviewButton extends Component {
 	}
 
 	render() {
-		const { link } = this.props;
+		const { link, isSaveable } = this.props;
 
 		return (
 			<IconButton
@@ -83,6 +84,7 @@ export class PreviewButton extends Component {
 				onClick={ this.saveForPreview }
 				target={ this.getWindowTarget() }
 				icon="visibility"
+				disabled={ ! isSaveable }
 			>
 				{ _x( 'Preview', 'imperative verb' ) }
 			</IconButton>
@@ -96,6 +98,7 @@ export default connect(
 		link: getEditedPostPreviewLink( state ),
 		isDirty: isEditedPostDirty( state ),
 		isNew: isEditedPostNew( state ),
+		isSaveable: isEditedPostSaveable( state ),
 		modified: getEditedPostAttribute( state, 'modified' ),
 	} ),
 	{ autosave }

--- a/editor/header/tools/test/preview-button.js
+++ b/editor/header/tools/test/preview-button.js
@@ -33,6 +33,7 @@ describe( 'PreviewButton', () => {
 				<PreviewButton
 					postId={ 1 }
 					link="https://wordpress.org/?p=1"
+					isSaveable
 					modified="2017-08-03T15:05:50" />
 			);
 			wrapper.instance().previewWindow = {};
@@ -80,6 +81,7 @@ describe( 'PreviewButton', () => {
 				postId: 1,
 				isNew: false,
 				isDirty: false,
+				isSaveable: true,
 			}, false );
 		} );
 
@@ -88,14 +90,16 @@ describe( 'PreviewButton', () => {
 				postId: 1,
 				isNew: true,
 				isDirty: false,
+				isSaveable: true,
 			}, true );
 		} );
 
 		it( 'should open a popup window', () => {
 			assertForSave( {
 				postId: 1,
-				isNew: false,
+				isNew: true,
 				isDirty: true,
+				isSaveable: true,
 			}, true );
 		} );
 	} );
@@ -105,11 +109,23 @@ describe( 'PreviewButton', () => {
 			const wrapper = shallow(
 				<PreviewButton
 					postId={ 1 }
+					isSaveable
 					link="https://wordpress.org/?p=1" />
 			);
 
 			expect( wrapper.prop( 'href' ) ).toBe( 'https://wordpress.org/?p=1' );
+			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 			expect( wrapper.prop( 'target' ) ).toBe( 'wp-preview-1' );
+		} );
+
+		it( 'should be disabled if post is not saveable', () => {
+			const wrapper = shallow(
+				<PreviewButton
+					postId={ 1 }
+					link="https://wordpress.org/?p=1" />
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related: #2228, #2225, #2193 

This pull request seeks to resolve an issue where pressing Preview immediately upon starting a new post navigates the user to a 404 page. This is because a post cannot be saved until it has at least a title, content, or excerpt. Interestingly, this same bug exists in the current post editor. The changes here disable the Preview button if the post is not saveable.

__Testing instructions:__

Verify that the Preview button is disabled if the post cannot be saved (new post without title, content, or excerpt).

Repeat testing instructions from #2225
Repeat testing instructions from #2193