### PR TITLE
Framework: Use WordPress dependencies in favor of globals

### DIFF
--- a/blocks/api/test/query.js
+++ b/blocks/api/test/query.js
@@ -50,7 +50,7 @@ describe( 'query', () => {
 			const html = '<blockquote><p>A delicious sundae dessert</p></blockquote>';
 			const match = parse( html, query.node() );
 
-			expect( wp.element.renderToString( match ) ).toBe( `<body>${ html }</body>` );
+			expect( renderToString( match ) ).toBe( `<body>${ html }</body>` );
 		} );
 	} );
 } );

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -8,7 +8,7 @@ import { includes } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, renderToString } from '@wordpress/element';
 import { Button, Placeholder, Spinner, SandBox } from '@wordpress/components';
 // TODO: This is a circular dependency between editor and blocks. This must be
 // updated, eventually to depend on published `@wordpress/url`
@@ -81,7 +81,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms } 
 				// 100% width for the preview so it fits nicely into the document, some "thumbnails" are
 				// acually the full size photo.
 				const photoPreview = <p><img src={ photo.thumbnail_url } alt={ photo.title } width="100%" /></p>;
-				return wp.element.renderToString( photoPreview );
+				return renderToString( photoPreview );
 			}
 
 			doServerSideRender( event ) {

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -11,7 +16,7 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 const { children } = hpq;
 
 registerBlockType( 'core/table', {
-	title: wp.i18n.__( 'Table' ),
+	title: __( 'Table' ),
 	icon: 'editor-table',
 	category: 'formatting',
 

--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -1,7 +1,15 @@
-import Editable from '../../editable';
-import BlockControls from '../../block-controls';
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
 import { Toolbar, DropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Editable from '../../editable';
+import BlockControls from '../../block-controls';
 
 function isTableSelected( editor ) {
 	return editor.dom.getParent(
@@ -64,7 +72,7 @@ const TABLE_CONTROLS = [
 	},
 ];
 
-export default class TableBlock extends wp.element.Component {
+export default class TableBlock extends Component {
 	constructor() {
 		super();
 		this.handleSetup = this.handleSetup.bind( this );

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -1,6 +1,9 @@
-import { renderToString } from '@wordpress/element';
+/**
+ * WordPress dependencies
+ */
+import { Component, renderToString } from '@wordpress/element';
 
-export default class Sandbox extends wp.element.Component {
+export default class Sandbox extends Component {
 
 	constructor() {
 		super( ...arguments );


### PR DESCRIPTION
Related: #1205
Related: #742

This pull request seeks to use WordPress dependencies consistently as imports within the codebase. It is a reattempt at #742, though happily I found that the overall number of occurrences has dropped significantly.

__Testing instructions:__

Ensure the build completes, tests pass, and editor initializes and appears without regressions. Specifically observe that no errors are logged to the console.