### PR TITLE
Paragraph Block: Add a "text" keyword to the paragraph block

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -25,6 +25,8 @@ registerBlockType( 'core/paragraph', {
 
 	category: 'common',
 
+	keywords: [ 'text' ],
+
 	defaultAttributes: {
 		dropCap: false,
 	},


### PR DESCRIPTION
I have a tendency to search for "text" when trying to inserter a "paragraph" block, this PR adds a "text" keyword to the paragraph block to allow this.