### PR TITLE
Blocks: Adding the frontend alignment classname

### DIFF
--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -106,13 +106,22 @@ registerBlockType( 'core/cover-text', {
 	},
 
 	save( { attributes } ) {
-		const { align, content, dropCap, backgroundColor, textColor } = attributes;
+		const { width, align, content, dropCap, backgroundColor, textColor } = attributes;
 		const className = dropCap && 'has-drop-cap';
+		const wrapperClassName = width && `align${ width }`;
 
 		if ( ! align ) {
-			return <div style={ { backgroundColor: backgroundColor, color: textColor } }><p className={ className }>{ content }</p></div>;
+			return (
+				<div className={ wrapperClassName } style={ { backgroundColor: backgroundColor, color: textColor } }>
+					<p className={ className }>{ content }</p>
+				</div>
+			);
 		}
 
-		return <div style={ { backgroundColor: backgroundColor, color: textColor } }><p style={ { textAlign: align } } className={ className }>{ content }</p></div>;
+		return (
+			<div className={ wrapperClassName } style={ { backgroundColor: backgroundColor, color: textColor } }>
+				<p style={ { textAlign: align } } className={ className }>{ content }</p>
+			</div>
+		);
 	},
 } );

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -61,9 +61,9 @@ registerBlockType( 'core/table', {
 	},
 
 	save( { attributes } ) {
-		const { content } = attributes;
+		const { content, align } = attributes;
 		return (
-			<table>
+			<table className={ align && `align${ align }` }>
 				{ content }
 			</table>
 		);


### PR DESCRIPTION
closes #2274 

This PR adds the missing alignment class names for the table block and the cover-text block.
AFAIK the class name is being added properly to the image block.