### PR TITLE
Paragraph block: Internationalize the text keyword

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -25,7 +25,7 @@ registerBlockType( 'core/paragraph', {
 
 	category: 'common',
 
-	keywords: [ 'text' ],
+	keywords: [ __( 'text' ) ],
 
 	defaultAttributes: {
 		dropCap: false,


### PR DESCRIPTION
Sorry! I forgot to "internationalize" the keyword introduced in #2280 