### PR TITLE
Parser: Start tokenizing HTML within the blocks

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -76,7 +76,7 @@ WP_Block_Balanced
       /** <?php return $t; ?> **/
       return t
     })* {
-      /** <?php return array($ts, text()); ?> **/
+      /** <?php return array($ts, $this->text()); ?> **/
       return [ts, text()]
     })
     e:WP_Block_End & {
@@ -103,7 +103,7 @@ WP_Block_Balanced
 
 WP_Block_Html
   = html:(t:(!WP_Block_Start html:HTML_Token { /** <?php return $html; ?> **/ return html } ) {
-      /** <?php return array( $t, text() ); ?> **/
+      /** <?php return array( $t, $this->text() ); ?> **/
       return [ t, text() ]
     })
   {
@@ -197,7 +197,7 @@ HTML_Tag_Void
           'hr',
           'img',
           'input',
-        ) ) && $t->isVoid;
+        ) );
       ?> **/
       
       return undefined !== {
@@ -207,7 +207,7 @@ HTML_Tag_Void
         'hr': true,
         'img': true,
         'input': true
-      }[ t.name.toLowerCase() ] && t.isVoid
+      }[ t.name.toLowerCase() ]
     }
   {
     /** <?php

--- a/blocks/test/fixtures/core-embed__animoto.parsed.json
+++ b/blocks/test/fixtures/core-embed__animoto.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://animoto.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-animoto"
+                },
+                "children": [
+                    "\n    https://animoto.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from animoto"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-animoto\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__cloudup.parsed.json
+++ b/blocks/test/fixtures/core-embed__cloudup.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://cloudup.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-cloudup"
+                },
+                "children": [
+                    "\n    https://cloudup.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from cloudup"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-cloudup\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__collegehumor.parsed.json
+++ b/blocks/test/fixtures/core-embed__collegehumor.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://collegehumor.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-collegehumor"
+                },
+                "children": [
+                    "\n    https://collegehumor.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from collegehumor"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-collegehumor\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__dailymotion.parsed.json
+++ b/blocks/test/fixtures/core-embed__dailymotion.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://dailymotion.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-dailymotion"
+                },
+                "children": [
+                    "\n    https://dailymotion.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from dailymotion"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-dailymotion\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__facebook.parsed.json
+++ b/blocks/test/fixtures/core-embed__facebook.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://facebook.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-facebook"
+                },
+                "children": [
+                    "\n    https://facebook.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from facebook"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-facebook\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__flickr.parsed.json
+++ b/blocks/test/fixtures/core-embed__flickr.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://flickr.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-flickr"
+                },
+                "children": [
+                    "\n    https://flickr.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from flickr"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-flickr\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__funnyordie.parsed.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://funnyordie.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-funnyordie"
+                },
+                "children": [
+                    "\n    https://funnyordie.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from funnyordie"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-funnyordie\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__hulu.parsed.json
+++ b/blocks/test/fixtures/core-embed__hulu.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://hulu.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-hulu"
+                },
+                "children": [
+                    "\n    https://hulu.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from hulu"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-hulu\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__imgur.parsed.json
+++ b/blocks/test/fixtures/core-embed__imgur.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://imgur.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-imgur"
+                },
+                "children": [
+                    "\n    https://imgur.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from imgur"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-imgur\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__instagram.parsed.json
+++ b/blocks/test/fixtures/core-embed__instagram.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://instagram.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-instagram"
+                },
+                "children": [
+                    "\n    https://instagram.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from instagram"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-instagram\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__issuu.parsed.json
+++ b/blocks/test/fixtures/core-embed__issuu.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://issuu.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-issuu"
+                },
+                "children": [
+                    "\n    https://issuu.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from issuu"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-issuu\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__kickstarter.parsed.json
+++ b/blocks/test/fixtures/core-embed__kickstarter.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://kickstarter.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-kickstarter"
+                },
+                "children": [
+                    "\n    https://kickstarter.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from kickstarter"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-kickstarter\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__meetup-com.parsed.json
+++ b/blocks/test/fixtures/core-embed__meetup-com.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://meetup.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-meetup-com"
+                },
+                "children": [
+                    "\n    https://meetup.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from meetup-com"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-meetup-com\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__mixcloud.parsed.json
+++ b/blocks/test/fixtures/core-embed__mixcloud.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://mixcloud.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-mixcloud"
+                },
+                "children": [
+                    "\n    https://mixcloud.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from mixcloud"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-mixcloud\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__photobucket.parsed.json
+++ b/blocks/test/fixtures/core-embed__photobucket.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://photobucket.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-photobucket"
+                },
+                "children": [
+                    "\n    https://photobucket.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from photobucket"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-photobucket\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__polldaddy.parsed.json
+++ b/blocks/test/fixtures/core-embed__polldaddy.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://polldaddy.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-polldaddy"
+                },
+                "children": [
+                    "\n    https://polldaddy.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from polldaddy"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-polldaddy\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__reddit.parsed.json
+++ b/blocks/test/fixtures/core-embed__reddit.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://reddit.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-reddit"
+                },
+                "children": [
+                    "\n    https://reddit.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from reddit"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-reddit\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__reverbnation.parsed.json
+++ b/blocks/test/fixtures/core-embed__reverbnation.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://reverbnation.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-reverbnation"
+                },
+                "children": [
+                    "\n    https://reverbnation.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from reverbnation"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-reverbnation\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__screencast.parsed.json
+++ b/blocks/test/fixtures/core-embed__screencast.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://screencast.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-screencast"
+                },
+                "children": [
+                    "\n    https://screencast.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from screencast"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-screencast\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__scribd.parsed.json
+++ b/blocks/test/fixtures/core-embed__scribd.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://scribd.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-scribd"
+                },
+                "children": [
+                    "\n    https://scribd.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from scribd"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-scribd\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__slideshare.parsed.json
+++ b/blocks/test/fixtures/core-embed__slideshare.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://slideshare.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-slideshare"
+                },
+                "children": [
+                    "\n    https://slideshare.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from slideshare"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-slideshare\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__smugmug.parsed.json
+++ b/blocks/test/fixtures/core-embed__smugmug.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://smugmug.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-smugmug"
+                },
+                "children": [
+                    "\n    https://smugmug.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from smugmug"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-smugmug\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__soundcloud.parsed.json
+++ b/blocks/test/fixtures/core-embed__soundcloud.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://soundcloud.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-soundcloud"
+                },
+                "children": [
+                    "\n    https://soundcloud.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from soundcloud"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-soundcloud\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__speaker.parsed.json
+++ b/blocks/test/fixtures/core-embed__speaker.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://speaker.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-speaker"
+                },
+                "children": [
+                    "\n    https://speaker.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from speaker"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-speaker\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__spotify.parsed.json
+++ b/blocks/test/fixtures/core-embed__spotify.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://spotify.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-spotify"
+                },
+                "children": [
+                    "\n    https://spotify.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from spotify"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-spotify\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__ted.parsed.json
+++ b/blocks/test/fixtures/core-embed__ted.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://ted.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-ted"
+                },
+                "children": [
+                    "\n    https://ted.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from ted"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-ted\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__tumblr.parsed.json
+++ b/blocks/test/fixtures/core-embed__tumblr.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://tumblr.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-tumblr"
+                },
+                "children": [
+                    "\n    https://tumblr.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from tumblr"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-tumblr\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__twitter.parsed.json
+++ b/blocks/test/fixtures/core-embed__twitter.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://twitter.com/automattic"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-twitter"
+                },
+                "children": [
+                    "\n    https://twitter.com/automattic\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "We are Automattic"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-twitter\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__videopress.parsed.json
+++ b/blocks/test/fixtures/core-embed__videopress.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://videopress.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-videopress"
+                },
+                "children": [
+                    "\n    https://videopress.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from videopress"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-videopress\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__vimeo.parsed.json
+++ b/blocks/test/fixtures/core-embed__vimeo.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://vimeo.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-vimeo"
+                },
+                "children": [
+                    "\n    https://vimeo.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from vimeo"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-vimeo\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__vine.parsed.json
+++ b/blocks/test/fixtures/core-embed__vine.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://vine.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-vine"
+                },
+                "children": [
+                    "\n    https://vine.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from vine"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-vine\">\n    https://vine.com/\n    <figcaption>Embedded content from vine</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress-tv.parsed.json
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://wordpress.tv/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-wordpress-tv"
+                },
+                "children": [
+                    "\n    https://wordpress.tv/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from wordpress-tv"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-wordpress-tv\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress.parsed.json
+++ b/blocks/test/fixtures/core-embed__wordpress.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://wordpress.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-wordpress"
+                },
+                "children": [
+                    "\n    https://wordpress.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from WordPress"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-wordpress\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__youtube.parsed.json
+++ b/blocks/test/fixtures/core-embed__youtube.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://youtube.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed-youtube"
+                },
+                "children": [
+                    "\n    https://youtube.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from youtube"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed-youtube\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__button__center.parsed.json
+++ b/blocks/test/fixtures/core__button__center.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "align": "center"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "div",
+                "attrs": {
+                    "class": "wp-block-button aligncenter"
+                },
+                "children": [
+                    {
+                        "type": "HTML_Tag",
+                        "name": "a",
+                        "attrs": {
+                            "href": "https://github.com/WordPress/gutenberg"
+                        },
+                        "children": [
+                            "Help build Gutenberg"
+                        ]
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<div class=\"wp-block-button aligncenter\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__categories.parsed.json
+++ b/blocks/test/fixtures/core__categories.parsed.json
@@ -10,6 +10,7 @@
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__code.parsed.json
+++ b/blocks/test/fixtures/core__code.parsed.json
@@ -2,10 +2,32 @@
     {
         "blockName": "core/code",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "pre",
+                "attrs": {
+                    "class": "wp-block-code"
+                },
+                "children": [
+                    {
+                        "type": "HTML_Tag",
+                        "name": "code",
+                        "attrs": {},
+                        "children": [
+                            "export default function MyButton() {\n\treturn &lt;Button&gt;Click Me!&lt;/Button&gt;;\n}"
+                        ]
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<pre class=\"wp-block-code\"><code>export default function MyButton() {\n\treturn &lt;Button&gt;Click Me!&lt;/Button&gt;;\n}</code></pre>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__cover-image.parsed.json
+++ b/blocks/test/fixtures/core__cover-image.parsed.json
@@ -5,10 +5,35 @@
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "hasBackgroundDim": true
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "section",
+                "attrs": {
+                    "class": "wp-block-cover-image has-background-dim",
+                    "style": "background-image:url(https://cldup.com/uuUqE_dXzy.jpg);"
+                },
+                "children": [
+                    "\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "h2",
+                        "attrs": {},
+                        "children": [
+                            "Guten Berg!"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<section class=\"wp-block-cover-image has-background-dim\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg);\">\n    <h2>Guten Berg!</h2>\n</section>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__cover-text.parsed.json
+++ b/blocks/test/fixtures/core__cover-text.parsed.json
@@ -4,10 +4,32 @@
         "attrs": {
             "backgroundColor": "#fcb900"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "div",
+                "attrs": {
+                    "style": "background-color:#fcb900"
+                },
+                "children": [
+                    {
+                        "type": "HTML_Tag",
+                        "name": "p",
+                        "attrs": {},
+                        "children": [
+                            "Text with color."
+                        ]
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<div style=\"background-color:#fcb900\"><p>Text with color.</p></div>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__embed.parsed.json
+++ b/blocks/test/fixtures/core__embed.parsed.json
@@ -4,10 +4,34 @@
         "attrs": {
             "url": "https://example.com/"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-embed"
+                },
+                "children": [
+                    "\n    https://example.com/\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Embedded content from an example URL"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__freeform.parsed.json
+++ b/blocks/test/fixtures/core__freeform.parsed.json
@@ -2,10 +2,36 @@
     {
         "blockName": "core/freeform",
         "attrs": null,
+        "children": [
+            "\nTesting freeform block with some\n",
+            {
+                "type": "HTML_Tag",
+                "name": "div",
+                "attrs": {
+                    "class": "wp-some-class"
+                },
+                "children": [
+                    "\n\tHTML ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "span",
+                        "attrs": {
+                            "style": "color: red;"
+                        },
+                        "children": [
+                            "content"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__gallery.parsed.json
+++ b/blocks/test/fixtures/core__gallery.parsed.json
@@ -37,10 +37,65 @@
                 }
             ]
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "div",
+                "attrs": {
+                    "class": "wp-block-gallery"
+                },
+                "children": [
+                    "\n\t",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figure",
+                        "attrs": {
+                            "class": "blocks-gallery-image"
+                        },
+                        "children": [
+                            "\n\t\t",
+                            {
+                                "type": "HTML_Void_Tag",
+                                "name": "img",
+                                "attrs": {
+                                    "src": "https://cldup.com/uuUqE_dXzy.jpg",
+                                    "alt": "title"
+                                }
+                            },
+                            "\n\t"
+                        ]
+                    },
+                    "\n\t",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figure",
+                        "attrs": {
+                            "class": "blocks-gallery-image"
+                        },
+                        "children": [
+                            "\n\t\t",
+                            {
+                                "type": "HTML_Void_Tag",
+                                "name": "img",
+                                "attrs": {
+                                    "src": "http://google.com/hi.png",
+                                    "alt": "title"
+                                }
+                            },
+                            "\n\t"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<div class=\"wp-block-gallery\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2-em.parsed.json
+++ b/blocks/test/fixtures/core__heading__h2-em.parsed.json
@@ -2,10 +2,32 @@
     {
         "blockName": "core/heading",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "h2",
+                "attrs": {},
+                "children": [
+                    "The ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "em",
+                        "attrs": {},
+                        "children": [
+                            "Inserter"
+                        ]
+                    },
+                    " Tool"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<h2>The <em>Inserter</em> Tool</h2>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2.parsed.json
+++ b/blocks/test/fixtures/core__heading__h2.parsed.json
@@ -2,10 +2,23 @@
     {
         "blockName": "core/heading",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "h2",
+                "attrs": {},
+                "children": [
+                    "A picture is worth a thousand words, or so the saying goes"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<h2>A picture is worth a thousand words, or so the saying goes</h2>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__html.parsed.json
+++ b/blocks/test/fixtures/core__html.parsed.json
@@ -2,10 +2,32 @@
     {
         "blockName": "core/html",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "h1",
+                "attrs": {},
+                "children": [
+                    "Some HTML code"
+                ]
+            },
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "marquee",
+                "attrs": {},
+                "children": [
+                    "This text will scroll from right to left"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<h1>Some HTML code</h1>\n<marquee>This text will scroll from right to left</marquee>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__image.parsed.json
+++ b/blocks/test/fixtures/core__image.parsed.json
@@ -2,10 +2,31 @@
     {
         "blockName": "core/image",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-image"
+                },
+                "children": [
+                    {
+                        "type": "HTML_Void_Tag",
+                        "name": "img",
+                        "attrs": {
+                            "src": "https://cldup.com/uuUqE_dXzy.jpg"
+                        }
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" /></figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__image__center-caption.parsed.json
+++ b/blocks/test/fixtures/core__image__center-caption.parsed.json
@@ -4,10 +4,40 @@
         "attrs": {
             "align": "center"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "figure",
+                "attrs": {
+                    "class": "wp-block-image"
+                },
+                "children": [
+                    {
+                        "type": "HTML_Void_Tag",
+                        "name": "img",
+                        "attrs": {
+                            "src": "https://cldup.com/YLYhpou2oq.jpg",
+                            "class": "aligncenter"
+                        }
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "figcaption",
+                        "attrs": {},
+                        "children": [
+                            "Give it a try. Press the &quot;really wide&quot; button on the image toolbar."
+                        ]
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" class=\"aligncenter\"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__latest-posts.parsed.json
+++ b/blocks/test/fixtures/core__latest-posts.parsed.json
@@ -9,6 +9,7 @@
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__latest-posts__displayPostDate.parsed.json
+++ b/blocks/test/fixtures/core__latest-posts__displayPostDate.parsed.json
@@ -9,6 +9,7 @@
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__list__ul.parsed.json
+++ b/blocks/test/fixtures/core__list__ul.parsed.json
@@ -2,10 +2,79 @@
     {
         "blockName": "core/list",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "ul",
+                "attrs": {},
+                "children": [
+                    {
+                        "type": "HTML_Tag",
+                        "name": "li",
+                        "attrs": {},
+                        "children": [
+                            "Text & Headings"
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "li",
+                        "attrs": {},
+                        "children": [
+                            "Images & Videos"
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "li",
+                        "attrs": {},
+                        "children": [
+                            "Galleries"
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "li",
+                        "attrs": {},
+                        "children": [
+                            "Embeds, like YouTube, Tweets, or other WordPress posts."
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "li",
+                        "attrs": {},
+                        "children": [
+                            "Layout blocks, like Buttons, Hero Images, Separators, etc."
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "li",
+                        "attrs": {},
+                        "children": [
+                            "And ",
+                            {
+                                "type": "HTML_Tag",
+                                "name": "em",
+                                "attrs": {},
+                                "children": [
+                                    "Lists"
+                                ]
+                            },
+                            " like this one of course :)"
+                        ]
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__more.parsed.json
+++ b/blocks/test/fixtures/core__more.parsed.json
@@ -9,6 +9,7 @@
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__more__custom-text-teaser.parsed.json
+++ b/blocks/test/fixtures/core__more__custom-text-teaser.parsed.json
@@ -9,6 +9,7 @@
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__paragraph__align-right.parsed.json
+++ b/blocks/test/fixtures/core__paragraph__align-right.parsed.json
@@ -4,10 +4,25 @@
         "attrs": {
             "align": "right"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "p",
+                "attrs": {
+                    "style": "text-align:right;"
+                },
+                "children": [
+                    "... like this one, which is separate from the above and right aligned."
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__preformatted.parsed.json
+++ b/blocks/test/fixtures/core__preformatted.parsed.json
@@ -2,10 +2,40 @@
     {
         "blockName": "core/preformatted",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "pre",
+                "attrs": {
+                    "class": "wp-block-preformatted"
+                },
+                "children": [
+                    "Some ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "em",
+                        "attrs": {},
+                        "children": [
+                            "preformatted"
+                        ]
+                    },
+                    " text...",
+                    {
+                        "type": "HTML_Void_Tag",
+                        "name": "br",
+                        "attrs": {}
+                    },
+                    "And more!"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<pre class=\"wp-block-preformatted\">Some <em>preformatted</em> text...<br>And more!</pre>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote.parsed.json
+++ b/blocks/test/fixtures/core__pullquote.parsed.json
@@ -2,10 +2,42 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "blockquote",
+                "attrs": {
+                    "class": "wp-block-pullquote"
+                },
+                "children": [
+                    "\n",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "p",
+                        "attrs": {},
+                        "children": [
+                            "Testing pullquote block..."
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "footer",
+                        "attrs": {},
+                        "children": [
+                            "...with a caption"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><footer>...with a caption</footer>\n</blockquote>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -2,10 +2,60 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "blockquote",
+                "attrs": {
+                    "class": "wp-block-pullquote alignnone"
+                },
+                "children": [
+                    "\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "p",
+                        "attrs": {},
+                        "children": [
+                            "Paragraph ",
+                            {
+                                "type": "HTML_Tag",
+                                "name": "strong",
+                                "attrs": {},
+                                "children": [
+                                    "one"
+                                ]
+                            }
+                        ]
+                    },
+                    "\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "p",
+                        "attrs": {},
+                        "children": [
+                            "Paragraph two"
+                        ]
+                    },
+                    "\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "footer",
+                        "attrs": {},
+                        "children": [
+                            "by whomever"
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>by whomever</footer>\n</blockquote>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -4,10 +4,40 @@
         "attrs": {
             "style": "1"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "blockquote",
+                "attrs": {
+                    "class": "wp-block-quote blocks-quote-style-1"
+                },
+                "children": [
+                    {
+                        "type": "HTML_Tag",
+                        "name": "p",
+                        "attrs": {},
+                        "children": [
+                            "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "footer",
+                        "attrs": {},
+                        "children": [
+                            "Matt Mullenweg, 2017"
+                        ]
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -4,10 +4,40 @@
         "attrs": {
             "style": "2"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "blockquote",
+                "attrs": {
+                    "class": "wp-block-quote blocks-quote-style-2"
+                },
+                "children": [
+                    {
+                        "type": "HTML_Tag",
+                        "name": "p",
+                        "attrs": {},
+                        "children": [
+                            "There is no greater agony than bearing an untold story inside you."
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "footer",
+                        "attrs": {},
+                        "children": [
+                            "Maya Angelou"
+                        ]
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__separator.parsed.json
+++ b/blocks/test/fixtures/core__separator.parsed.json
@@ -2,10 +2,22 @@
     {
         "blockName": "core/separator",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Void_Tag",
+                "name": "hr",
+                "attrs": {
+                    "class": "wp-block-separator"
+                }
+            },
+            "\n"
+        ],
         "rawContent": "\n<hr class=\"wp-block-separator\" />\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__table.parsed.json
+++ b/blocks/test/fixtures/core__table.parsed.json
@@ -2,10 +2,348 @@
     {
         "blockName": "core/table",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "table",
+                "attrs": {},
+                "children": [
+                    {
+                        "type": "HTML_Tag",
+                        "name": "thead",
+                        "attrs": {},
+                        "children": [
+                            {
+                                "type": "HTML_Tag",
+                                "name": "tr",
+                                "attrs": {},
+                                "children": [
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "th",
+                                        "attrs": {},
+                                        "children": [
+                                            "Version"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "th",
+                                        "attrs": {},
+                                        "children": [
+                                            "Musician"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "th",
+                                        "attrs": {},
+                                        "children": [
+                                            "Date"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "type": "HTML_Tag",
+                        "name": "tbody",
+                        "attrs": {},
+                        "children": [
+                            {
+                                "type": "HTML_Tag",
+                                "name": "tr",
+                                "attrs": {},
+                                "children": [
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            {
+                                                "type": "HTML_Tag",
+                                                "name": "a",
+                                                "attrs": {
+                                                    "href": "https://wordpress.org/news/2003/05/wordpress-now-available/"
+                                                },
+                                                "children": [
+                                                    ".70"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "No musician chosen."
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "May 27, 2003"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "HTML_Tag",
+                                "name": "tr",
+                                "attrs": {},
+                                "children": [
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            {
+                                                "type": "HTML_Tag",
+                                                "name": "a",
+                                                "attrs": {
+                                                    "href": "https://wordpress.org/news/2004/01/wordpress-10/"
+                                                },
+                                                "children": [
+                                                    "1.0"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "Miles Davis"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "January 3, 2004"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "HTML_Tag",
+                                "name": "tr",
+                                "attrs": {},
+                                "children": [
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "Lots of versions skipped, see ",
+                                            {
+                                                "type": "HTML_Tag",
+                                                "name": "a",
+                                                "attrs": {
+                                                    "href": "https://codex.wordpress.org/WordPress_Versions"
+                                                },
+                                                "children": [
+                                                    "the full list"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "&hellip;"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "&hellip;"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "HTML_Tag",
+                                "name": "tr",
+                                "attrs": {},
+                                "children": [
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            {
+                                                "type": "HTML_Tag",
+                                                "name": "a",
+                                                "attrs": {
+                                                    "href": "https://wordpress.org/news/2015/12/clifford/"
+                                                },
+                                                "children": [
+                                                    "4.4"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "Clifford Brown"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "December 8, 2015"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "HTML_Tag",
+                                "name": "tr",
+                                "attrs": {},
+                                "children": [
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            {
+                                                "type": "HTML_Tag",
+                                                "name": "a",
+                                                "attrs": {
+                                                    "href": "https://wordpress.org/news/2016/04/coleman/"
+                                                },
+                                                "children": [
+                                                    "4.5"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "Coleman Hawkins"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "April 12, 2016"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "HTML_Tag",
+                                "name": "tr",
+                                "attrs": {},
+                                "children": [
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            {
+                                                "type": "HTML_Tag",
+                                                "name": "a",
+                                                "attrs": {
+                                                    "href": "https://wordpress.org/news/2016/08/pepper/"
+                                                },
+                                                "children": [
+                                                    "4.6"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "Pepper Adams"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "August 16, 2016"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "HTML_Tag",
+                                "name": "tr",
+                                "attrs": {},
+                                "children": [
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            {
+                                                "type": "HTML_Tag",
+                                                "name": "a",
+                                                "attrs": {
+                                                    "href": "https://wordpress.org/news/2016/12/vaughan/"
+                                                },
+                                                "children": [
+                                                    "4.7"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "Sarah Vaughan"
+                                        ]
+                                    },
+                                    {
+                                        "type": "HTML_Tag",
+                                        "name": "td",
+                                        "attrs": {},
+                                        "children": [
+                                            "December 6, 2016"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<table><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>\n"
     },
     {
         "attrs": {},
+        "children": "\n\n",
         "rawContent": "\n\n"
     }
 ]

--- a/blocks/test/fixtures/core__text-columns.json
+++ b/blocks/test/fixtures/core__text-columns.json
@@ -1,19 +1,19 @@
 [
-	{
-		"attributes": {
-			"columns": 2,
-			"content": [
-				[
-					"One"
-				],
-				[
-					"Two"
-				]
-			],
-			"width": "center"
-		},
-		"isValid": true,
-		"name": "core/text-columns",
-		"uid": "_uid_0"
-	}
+    {
+        "uid": "_uid_0",
+        "name": "core/text-columns",
+        "isValid": true,
+        "attributes": {
+            "columns": 2,
+            "content": [
+                [
+                    "One"
+                ],
+                [
+                    "Two"
+                ]
+            ],
+            "width": "center"
+        }
+    }
 ]

--- a/blocks/test/fixtures/core__text-columns.parsed.json
+++ b/blocks/test/fixtures/core__text-columns.parsed.json
@@ -4,10 +4,65 @@
         "attrs": {
             "width": "center"
         },
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "div",
+                "attrs": {
+                    "class": "wp-block-text-columns aligncenter columns-2"
+                },
+                "children": [
+                    "\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "div",
+                        "attrs": {
+                            "class": "wp-block-text-columns__column"
+                        },
+                        "children": [
+                            "\n        ",
+                            {
+                                "type": "HTML_Tag",
+                                "name": "p",
+                                "attrs": {},
+                                "children": [
+                                    "One"
+                                ]
+                            },
+                            "\n    "
+                        ]
+                    },
+                    "\n    ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "div",
+                        "attrs": {
+                            "class": "wp-block-text-columns__column"
+                        },
+                        "children": [
+                            "\n        ",
+                            {
+                                "type": "HTML_Tag",
+                                "name": "p",
+                                "attrs": {},
+                                "children": [
+                                    "Two"
+                                ]
+                            },
+                            "\n    "
+                        ]
+                    },
+                    "\n"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<div class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-text-columns__column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-text-columns__column\">\n        <p>Two</p>\n    </div>\n</div>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.parsed.json
@@ -2,10 +2,32 @@
     {
         "blockName": "core/text",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "p",
+                "attrs": {},
+                "children": [
+                    "This is an old-style text block.  Changed to ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "code",
+                        "attrs": {},
+                        "children": [
+                            "core/paragraph"
+                        ]
+                    },
+                    " in #2135."
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<p>This is an old-style text block.  Changed to <code>core/paragraph</code> in #2135.</p>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__verse.parsed.json
+++ b/blocks/test/fixtures/core__verse.parsed.json
@@ -2,10 +2,40 @@
     {
         "blockName": "core/verse",
         "attrs": null,
+        "children": [
+            "\n",
+            {
+                "type": "HTML_Tag",
+                "name": "pre",
+                "attrs": {
+                    "class": "wp-block-verse"
+                },
+                "children": [
+                    "A ",
+                    {
+                        "type": "HTML_Tag",
+                        "name": "em",
+                        "attrs": {},
+                        "children": [
+                            "verse"
+                        ]
+                    },
+                    "…",
+                    {
+                        "type": "HTML_Void_Tag",
+                        "name": "br",
+                        "attrs": {}
+                    },
+                    "And more!"
+                ]
+            },
+            "\n"
+        ],
         "rawContent": "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n"
     },
     {
         "attrs": {},
+        "children": "\n",
         "rawContent": "\n"
     }
 ]

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -262,6 +262,24 @@ class Gutenberg_PEG_Parser {
     private $peg_c31;
     private $peg_c32;
     private $peg_c33;
+    private $peg_c34;
+    private $peg_c35;
+    private $peg_c36;
+    private $peg_c37;
+    private $peg_c38;
+    private $peg_c39;
+    private $peg_c40;
+    private $peg_c41;
+    private $peg_c42;
+    private $peg_c43;
+    private $peg_c44;
+    private $peg_c45;
+    private $peg_c46;
+    private $peg_c47;
+    private $peg_c48;
+    private $peg_c49;
+    private $peg_c50;
+    private $peg_c51;
 
     private function peg_f0($text) { return $text; }
     private function peg_f1($customText, $noTeaser) {
@@ -282,34 +300,92 @@ class Gutenberg_PEG_Parser {
           'rawContent' => '',
         );
         }
-    private function peg_f4($s, $c) { return $c; }
-    private function peg_f5($s, $ts, $e) { return $s['blockName'] === $e['blockName']; }
-    private function peg_f6($s, $ts, $e) {
+    private function peg_f4($s, $t) { return $t; }
+    private function peg_f5($s, $ts) { return array($ts, text()); }
+    private function peg_f6($s, $html, $e) { return $s['blockName'] === $e['blockName']; }
+    private function peg_f7($s, $html, $e) {
         return array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
-          'rawContent' => implode( '', $ts ),
+          'children'   => $html[0],
+          'rawContent' => $html[1],
         );
         }
-    private function peg_f7($c) { return $c; }
-    private function peg_f8($ts) {
+    private function peg_f8($html) { return $html; }
+    private function peg_f9($t) { return array( $t, text() ); }
+    private function peg_f10($html) {
         return array(
           'attrs'      => array(),
-          'rawContent' => implode( '', $ts ),
+          'children'   => $html[0],
+          'rawContent' => $html[1],
         );
         }
-    private function peg_f9($blockName, $attrs) {
+    private function peg_f11($blockName, $attrs) {
         return array(
           'blockName' => $blockName,
           'attrs'     => $attrs,
         );
         }
-    private function peg_f10($blockName) {
+    private function peg_f12($blockName) {
         return array(
           'blockName' => $blockName,
         );
         }
-    private function peg_f11($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f13($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f14($innerText) { return array(
+          'type'      => 'HTML_Comment',
+          'innerText' => $innerText,
+        ); }
+    private function peg_f15($t) {
+            return in_array( strtolower( $t->name ), array(
+              'br',
+              'col',
+              'embed',
+              'hr',
+              'img',
+              'input',
+            ) ) && $t->isVoid;
+          }
+    private function peg_f16($t) {
+        return array(
+          'type'  => 'HTML_Void_Tag',
+          'name'  => $t->name,
+          'attrs' => $t->attrs,
+        );
+        }
+    private function peg_f17($s, $children, $e) { return $s->name === $e->name; }
+    private function peg_f18($s, $children, $e) {
+        return array(
+          'type'     => 'HTML_Tag',
+          'name'     => $s->name,
+          'attrs'    => $s->attrs,
+          'children' => $children,
+        );
+        }
+    private function peg_f19($name, $attrs, $isVoid) {
+        return array(
+          'type'   => 'HTML_Tag_Open',
+          'isVoid' => (bool) $isVoid,
+          'name'   => $name,
+          'attrs'  => $attrs,
+        );
+        }
+    private function peg_f20($name) {
+        return array(
+          'type' => 'HTML_Tag_Close',
+          'name' => $name,
+        );
+        }
+    private function peg_f21($a) { return $a; }
+    private function peg_f22($as) {
+        $attrs = array();
+        foreach ( $as as $attr ) {
+          $attrs[ $attr[0] ] = $attr[1];
+        }
+        return $attrs;
+        }
+    private function peg_f23($name) { return array( $name, true ); }
+    private function peg_f24($name, $value) { return array( $name, $value ); }
 
     private function peg_parseDocument() {
 
@@ -746,65 +822,71 @@ class Gutenberg_PEG_Parser {
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_parseWP_Block_Start();
       if ($s1 !== $this->peg_FAILED) {
-        $s2 = array();
-        $s3 = $this->peg_currPos;
+        $s2 = $this->peg_currPos;
+        $s3 = array();
         $s4 = $this->peg_currPos;
+        $s5 = $this->peg_currPos;
         $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_End();
+        $s6 = $this->peg_parseWP_Block_End();
         $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
+        if ($s6 === $this->peg_FAILED) {
+          $s5 = null;
         } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
+          $this->peg_currPos = $s5;
+          $s5 = $this->peg_FAILED;
         }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s3;
-            $s4 = $this->peg_f4($s1, $s5);
-            $s3 = $s4;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
-          $s3 = $this->peg_currPos;
-          $s4 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s5 = $this->peg_parseWP_Block_End();
-          $this->peg_silentFails--;
-          if ($s5 === $this->peg_FAILED) {
-            $s4 = null;
+        if ($s5 !== $this->peg_FAILED) {
+          $s6 = $this->peg_parseHTML_Token();
+          if ($s6 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s4;
+            $s5 = $this->peg_f4($s1, $s6);
+            $s4 = $s5;
           } else {
             $this->peg_currPos = $s4;
             $s4 = $this->peg_FAILED;
           }
-          if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseAny();
-            if ($s5 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s3;
-              $s4 = $this->peg_f4($s1, $s5);
-              $s3 = $s4;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        while ($s4 !== $this->peg_FAILED) {
+          $s3[] = $s4;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s6 = $this->peg_parseWP_Block_End();
+          $this->peg_silentFails--;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
+          } else {
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $s6 = $this->peg_parseHTML_Token();
+            if ($s6 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s4;
+              $s5 = $this->peg_f4($s1, $s6);
+              $s4 = $s5;
             } else {
-              $this->peg_currPos = $s3;
-              $s3 = $this->peg_FAILED;
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
             }
           } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
           }
         }
+        if ($s3 !== $this->peg_FAILED) {
+          $this->peg_reportedPos = $s2;
+          $s3 = $this->peg_f5($s1, $s3);
+        }
+        $s2 = $s3;
         if ($s2 !== $this->peg_FAILED) {
           $s3 = $this->peg_parseWP_Block_End();
           if ($s3 !== $this->peg_FAILED) {
             $this->peg_reportedPos = $this->peg_currPos;
-            $s4 = $this->peg_f5($s1, $s2, $s3);
+            $s4 = $this->peg_f6($s1, $s2, $s3);
             if ($s4) {
               $s4 = null;
             } else {
@@ -812,7 +894,7 @@ class Gutenberg_PEG_Parser {
             }
             if ($s4 !== $this->peg_FAILED) {
               $this->peg_reportedPos = $s0;
-              $s1 = $this->peg_f6($s1, $s2, $s3);
+              $s1 = $this->peg_f7($s1, $s2, $s3);
               $s0 = $s1;
             } else {
               $this->peg_currPos = $s0;
@@ -837,11 +919,11 @@ class Gutenberg_PEG_Parser {
     private function peg_parseWP_Block_Html() {
 
       $s0 = $this->peg_currPos;
-      $s1 = array();
+      $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
       $s3 = $this->peg_currPos;
       $this->peg_silentFails++;
-      $s4 = $this->peg_parseWP_Block_Balanced();
+      $s4 = $this->peg_parseWP_Block_Start();
       $this->peg_silentFails--;
       if ($s4 === $this->peg_FAILED) {
         $s3 = null;
@@ -850,41 +932,11 @@ class Gutenberg_PEG_Parser {
         $s3 = $this->peg_FAILED;
       }
       if ($s3 !== $this->peg_FAILED) {
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_Void();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
+        $s4 = $this->peg_parseHTML_Token();
         if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s6 = $this->peg_parseWP_Tag_More();
-          $this->peg_silentFails--;
-          if ($s6 === $this->peg_FAILED) {
-            $s5 = null;
-          } else {
-            $this->peg_currPos = $s5;
-            $s5 = $this->peg_FAILED;
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseAny();
-            if ($s6 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s2;
-              $s3 = $this->peg_f7($s6);
-              $s2 = $s3;
-            } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
+          $this->peg_reportedPos = $s2;
+          $s3 = $this->peg_f8($s4);
+          $s2 = $s3;
         } else {
           $this->peg_currPos = $s2;
           $s2 = $this->peg_FAILED;
@@ -894,70 +946,13 @@ class Gutenberg_PEG_Parser {
         $s2 = $this->peg_FAILED;
       }
       if ($s2 !== $this->peg_FAILED) {
-        while ($s2 !== $this->peg_FAILED) {
-          $s1[] = $s2;
-          $s2 = $this->peg_currPos;
-          $s3 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s4 = $this->peg_parseWP_Block_Balanced();
-          $this->peg_silentFails--;
-          if ($s4 === $this->peg_FAILED) {
-            $s3 = null;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
-          if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
-            $this->peg_silentFails++;
-            $s5 = $this->peg_parseWP_Block_Void();
-            $this->peg_silentFails--;
-            if ($s5 === $this->peg_FAILED) {
-              $s4 = null;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-            if ($s4 !== $this->peg_FAILED) {
-              $s5 = $this->peg_currPos;
-              $this->peg_silentFails++;
-              $s6 = $this->peg_parseWP_Tag_More();
-              $this->peg_silentFails--;
-              if ($s6 === $this->peg_FAILED) {
-                $s5 = null;
-              } else {
-                $this->peg_currPos = $s5;
-                $s5 = $this->peg_FAILED;
-              }
-              if ($s5 !== $this->peg_FAILED) {
-                $s6 = $this->peg_parseAny();
-                if ($s6 !== $this->peg_FAILED) {
-                  $this->peg_reportedPos = $s2;
-                  $s3 = $this->peg_f7($s6);
-                  $s2 = $s3;
-                } else {
-                  $this->peg_currPos = $s2;
-                  $s2 = $this->peg_FAILED;
-                }
-              } else {
-                $this->peg_currPos = $s2;
-                $s2 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        }
-      } else {
-        $s1 = $this->peg_FAILED;
+        $this->peg_reportedPos = $s1;
+        $s2 = $this->peg_f9($s2);
       }
+      $s1 = $s2;
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f8($s1);
+        $s1 = $this->peg_f10($s1);
       }
       $s0 = $s1;
 
@@ -1051,7 +1046,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f9($s4, $s6);
+                    $s1 = $this->peg_f11($s4, $s6);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -1143,7 +1138,7 @@ class Gutenberg_PEG_Parser {
                 }
                 if ($s6 !== $this->peg_FAILED) {
                   $this->peg_reportedPos = $s0;
-                  $s1 = $this->peg_f10($s4);
+                  $s1 = $this->peg_f12($s4);
                   $s0 = $s1;
                 } else {
                   $this->peg_currPos = $s0;
@@ -1506,9 +1501,992 @@ class Gutenberg_PEG_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f11($s1);
+        $s1 = $this->peg_f13($s1);
       }
       $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Token() {
+
+      $s0 = $this->peg_parseHTML_Comment();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseHTML_Tag_Void();
+        if ($s0 === $this->peg_FAILED) {
+          $s0 = $this->peg_parseHTML_Tag_Balanced();
+          if ($s0 === $this->peg_FAILED) {
+            $s0 = $this->peg_currPos;
+            $s1 = array();
+            if (Gutenberg_PEG_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
+              $s2 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s2 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c23);
+              }
+            }
+            if ($s2 !== $this->peg_FAILED) {
+              while ($s2 !== $this->peg_FAILED) {
+                $s1[] = $s2;
+                if (Gutenberg_PEG_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
+                  $s2 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s2 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c23);
+                  }
+                }
+              }
+            } else {
+              $s1 = $this->peg_FAILED;
+            }
+            if ($s1 !== $this->peg_FAILED) {
+              $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+            } else {
+              $s0 = $s1;
+            }
+          }
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Comment() {
+
+      $s0 = $this->peg_currPos;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
+        $s1 = $this->peg_c0;
+        $this->peg_currPos += 4;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c1);
+        }
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = $this->peg_currPos;
+        $s3 = array();
+        $s4 = $this->peg_currPos;
+        $s5 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
+          $s6 = $this->peg_c4;
+          $this->peg_currPos += 3;
+        } else {
+          $s6 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c5);
+          }
+        }
+        $this->peg_silentFails--;
+        if ($s6 === $this->peg_FAILED) {
+          $s5 = null;
+        } else {
+          $this->peg_currPos = $s5;
+          $s5 = $this->peg_FAILED;
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s6 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s6 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c6);
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = array($s5, $s6);
+            $s4 = $s5;
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        while ($s4 !== $this->peg_FAILED) {
+          $s3[] = $s4;
+          $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
+            $s6 = $this->peg_c4;
+            $this->peg_currPos += 3;
+          } else {
+            $s6 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c5);
+            }
+          }
+          $this->peg_silentFails--;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
+          } else {
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c6);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s4;
+            $s4 = $this->peg_FAILED;
+          }
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s2 = $this->input_substr($s2, $this->peg_currPos - $s2);
+        } else {
+          $s2 = $s3;
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
+            $s3 = $this->peg_c4;
+            $this->peg_currPos += 3;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c5);
+            }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f14($s2);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Tag_Void() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_parseHTML_Tag_Open();
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $this->peg_currPos;
+        $s2 = $this->peg_f15($s1);
+        if ($s2) {
+          $s2 = null;
+        } else {
+          $s2 = $this->peg_FAILED;
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $this->peg_reportedPos = $s0;
+          $s1 = $this->peg_f16($s1);
+          $s0 = $s1;
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Tag_Balanced() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_parseHTML_Tag_Open();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parseHTML_Token();
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseHTML_Token();
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseHTML_Tag_Close();
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $this->peg_currPos;
+            $s4 = $this->peg_f17($s1, $s2, $s3);
+            if ($s4) {
+              $s4 = null;
+            } else {
+              $s4 = $this->peg_FAILED;
+            }
+            if ($s4 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s0;
+              $s1 = $this->peg_f18($s1, $s2, $s3);
+              $s0 = $s1;
+            } else {
+              $this->peg_currPos = $s0;
+              $s0 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Tag_Open() {
+
+      $s0 = $this->peg_currPos;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c24) {
+        $s1 = $this->peg_c24;
+        $this->peg_currPos++;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c25);
+        }
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = $this->peg_parseHTML_Tag_Name();
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseHTML_Attribute_List();
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = array();
+            $s5 = $this->peg_parse_();
+            while ($s5 !== $this->peg_FAILED) {
+              $s4[] = $s5;
+              $s5 = $this->peg_parse_();
+            }
+            if ($s4 !== $this->peg_FAILED) {
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+                $s5 = $this->peg_c15;
+                $this->peg_currPos++;
+              } else {
+                $s5 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c16);
+                }
+              }
+              if ($s5 === $this->peg_FAILED) {
+                $s5 = null;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c26) {
+                  $s6 = $this->peg_c26;
+                  $this->peg_currPos++;
+                } else {
+                  $s6 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c27);
+                  }
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  $this->peg_reportedPos = $s0;
+                  $s1 = $this->peg_f19($s2, $s3, $s5);
+                  $s0 = $s1;
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s0;
+              $s0 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Tag_Close() {
+
+      $s0 = $this->peg_currPos;
+      if ($this->input_substr($this->peg_currPos, 2) === $this->peg_c28) {
+        $s1 = $this->peg_c28;
+        $this->peg_currPos += 2;
+      } else {
+        $s1 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c29);
+        }
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = $this->peg_parseHTML_Tag_Name();
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = array();
+          $s4 = $this->peg_parse_();
+          while ($s4 !== $this->peg_FAILED) {
+            $s3[] = $s4;
+            $s4 = $this->peg_parse_();
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c26) {
+              $s4 = $this->peg_c26;
+              $this->peg_currPos++;
+            } else {
+              $s4 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c27);
+              }
+            }
+            if ($s4 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s0;
+              $s1 = $this->peg_f20($s2);
+              $s0 = $s1;
+            } else {
+              $this->peg_currPos = $s0;
+              $s0 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Tag_Name() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseASCII_Letter();
+      if ($s2 !== $this->peg_FAILED) {
+        $s3 = array();
+        $s4 = $this->peg_parseASCII_AlphaNumeric();
+        while ($s4 !== $this->peg_FAILED) {
+          $s3[] = $s4;
+          $s4 = $this->peg_parseASCII_AlphaNumeric();
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s2 = array($s2, $s3);
+          $s1 = $s2;
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Attribute_List() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = array();
+      $s2 = $this->peg_currPos;
+      $s3 = array();
+      $s4 = $this->peg_parse_();
+      if ($s4 !== $this->peg_FAILED) {
+        while ($s4 !== $this->peg_FAILED) {
+          $s3[] = $s4;
+          $s4 = $this->peg_parse_();
+        }
+      } else {
+        $s3 = $this->peg_FAILED;
+      }
+      if ($s3 !== $this->peg_FAILED) {
+        $s4 = $this->peg_parseHTML_Attribute_Item();
+        if ($s4 !== $this->peg_FAILED) {
+          $this->peg_reportedPos = $s2;
+          $s3 = $this->peg_f21($s4);
+          $s2 = $s3;
+        } else {
+          $this->peg_currPos = $s2;
+          $s2 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s2;
+        $s2 = $this->peg_FAILED;
+      }
+      while ($s2 !== $this->peg_FAILED) {
+        $s1[] = $s2;
+        $s2 = $this->peg_currPos;
+        $s3 = array();
+        $s4 = $this->peg_parse_();
+        if ($s4 !== $this->peg_FAILED) {
+          while ($s4 !== $this->peg_FAILED) {
+            $s3[] = $s4;
+            $s4 = $this->peg_parse_();
+          }
+        } else {
+          $s3 = $this->peg_FAILED;
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s4 = $this->peg_parseHTML_Attribute_Item();
+          if ($s4 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s2;
+            $s3 = $this->peg_f21($s4);
+            $s2 = $s3;
+          } else {
+            $this->peg_currPos = $s2;
+            $s2 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s2;
+          $s2 = $this->peg_FAILED;
+        }
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f22($s1);
+      }
+      $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Attribute_Item() {
+
+      $s0 = $this->peg_parseHTML_Attribute_Quoted();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseHTML_Attribute_Unquoted();
+        if ($s0 === $this->peg_FAILED) {
+          $s0 = $this->peg_parseHTML_Attribute_Empty();
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Attribute_Empty() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_parseHTML_Attribute_Name();
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f23($s1);
+      }
+      $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Attribute_Unquoted() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_parseHTML_Attribute_Name();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parse_();
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parse_();
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c30) {
+            $s3 = $this->peg_c30;
+            $this->peg_currPos++;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c31);
+            }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = array();
+            $s5 = $this->peg_parse_();
+            while ($s5 !== $this->peg_FAILED) {
+              $s4[] = $s5;
+              $s5 = $this->peg_parse_();
+            }
+            if ($s4 !== $this->peg_FAILED) {
+              $s5 = $this->peg_currPos;
+              $s6 = array();
+              if (Gutenberg_PEG_peg_char_class_test($this->peg_c32, $this->input_substr($this->peg_currPos, 1))) {
+                $s7 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s7 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c33);
+                }
+              }
+              if ($s7 !== $this->peg_FAILED) {
+                while ($s7 !== $this->peg_FAILED) {
+                  $s6[] = $s7;
+                  if (Gutenberg_PEG_peg_char_class_test($this->peg_c32, $this->input_substr($this->peg_currPos, 1))) {
+                    $s7 = $this->input_substr($this->peg_currPos, 1);
+                    $this->peg_currPos++;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c33);
+                    }
+                  }
+                }
+              } else {
+                $s6 = $this->peg_FAILED;
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+              } else {
+                $s5 = $s6;
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                $this->peg_reportedPos = $s0;
+                $s1 = $this->peg_f24($s1, $s5);
+                $s0 = $s1;
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s0;
+              $s0 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Attribute_Quoted() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_parseHTML_Attribute_Name();
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_parse_();
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parse_();
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c30) {
+            $s3 = $this->peg_c30;
+            $this->peg_currPos++;
+          } else {
+            $s3 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c31);
+            }
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $s4 = array();
+            $s5 = $this->peg_parse_();
+            while ($s5 !== $this->peg_FAILED) {
+              $s4[] = $s5;
+              $s5 = $this->peg_parse_();
+            }
+            if ($s4 !== $this->peg_FAILED) {
+              if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c34) {
+                $s5 = $this->peg_c34;
+                $this->peg_currPos++;
+              } else {
+                $s5 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c35);
+                }
+              }
+              if ($s5 !== $this->peg_FAILED) {
+                $s6 = $this->peg_currPos;
+                $s7 = array();
+                $s8 = $this->peg_currPos;
+                $s9 = $this->peg_currPos;
+                $this->peg_silentFails++;
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c34) {
+                  $s10 = $this->peg_c34;
+                  $this->peg_currPos++;
+                } else {
+                  $s10 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c35);
+                  }
+                }
+                $this->peg_silentFails--;
+                if ($s10 === $this->peg_FAILED) {
+                  $s9 = null;
+                } else {
+                  $this->peg_currPos = $s9;
+                  $s9 = $this->peg_FAILED;
+                }
+                if ($s9 !== $this->peg_FAILED) {
+                  if ($this->input_length > $this->peg_currPos) {
+                    $s10 = $this->input_substr($this->peg_currPos, 1);
+                    $this->peg_currPos++;
+                  } else {
+                    $s10 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c6);
+                    }
+                  }
+                  if ($s10 !== $this->peg_FAILED) {
+                    $s9 = array($s9, $s10);
+                    $s8 = $s9;
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s8;
+                  $s8 = $this->peg_FAILED;
+                }
+                while ($s8 !== $this->peg_FAILED) {
+                  $s7[] = $s8;
+                  $s8 = $this->peg_currPos;
+                  $s9 = $this->peg_currPos;
+                  $this->peg_silentFails++;
+                  if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c34) {
+                    $s10 = $this->peg_c34;
+                    $this->peg_currPos++;
+                  } else {
+                    $s10 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c35);
+                    }
+                  }
+                  $this->peg_silentFails--;
+                  if ($s10 === $this->peg_FAILED) {
+                    $s9 = null;
+                  } else {
+                    $this->peg_currPos = $s9;
+                    $s9 = $this->peg_FAILED;
+                  }
+                  if ($s9 !== $this->peg_FAILED) {
+                    if ($this->input_length > $this->peg_currPos) {
+                      $s10 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
+                    }
+                    if ($s10 !== $this->peg_FAILED) {
+                      $s9 = array($s9, $s10);
+                      $s8 = $s9;
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                }
+                if ($s7 !== $this->peg_FAILED) {
+                  $s6 = $this->input_substr($s6, $this->peg_currPos - $s6);
+                } else {
+                  $s6 = $s7;
+                }
+                if ($s6 !== $this->peg_FAILED) {
+                  if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c34) {
+                    $s7 = $this->peg_c34;
+                    $this->peg_currPos++;
+                  } else {
+                    $s7 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c35);
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $this->peg_reportedPos = $s0;
+                    $s1 = $this->peg_f24($s1, $s6);
+                    $s0 = $s1;
+                  } else {
+                    $this->peg_currPos = $s0;
+                    $s0 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s0;
+              $s0 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
+      }
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_currPos;
+        $s1 = $this->peg_parseHTML_Attribute_Name();
+        if ($s1 !== $this->peg_FAILED) {
+          $s2 = array();
+          $s3 = $this->peg_parse_();
+          while ($s3 !== $this->peg_FAILED) {
+            $s2[] = $s3;
+            $s3 = $this->peg_parse_();
+          }
+          if ($s2 !== $this->peg_FAILED) {
+            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c30) {
+              $s3 = $this->peg_c30;
+              $this->peg_currPos++;
+            } else {
+              $s3 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c31);
+              }
+            }
+            if ($s3 !== $this->peg_FAILED) {
+              $s4 = array();
+              $s5 = $this->peg_parse_();
+              while ($s5 !== $this->peg_FAILED) {
+                $s4[] = $s5;
+                $s5 = $this->peg_parse_();
+              }
+              if ($s4 !== $this->peg_FAILED) {
+                if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c36) {
+                  $s5 = $this->peg_c36;
+                  $this->peg_currPos++;
+                } else {
+                  $s5 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c37);
+                  }
+                }
+                if ($s5 !== $this->peg_FAILED) {
+                  $s6 = $this->peg_currPos;
+                  $s7 = array();
+                  $s8 = $this->peg_currPos;
+                  $s9 = $this->peg_currPos;
+                  $this->peg_silentFails++;
+                  if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c36) {
+                    $s10 = $this->peg_c36;
+                    $this->peg_currPos++;
+                  } else {
+                    $s10 = $this->peg_FAILED;
+                    if ($this->peg_silentFails === 0) {
+                        $this->peg_fail($this->peg_c37);
+                    }
+                  }
+                  $this->peg_silentFails--;
+                  if ($s10 === $this->peg_FAILED) {
+                    $s9 = null;
+                  } else {
+                    $this->peg_currPos = $s9;
+                    $s9 = $this->peg_FAILED;
+                  }
+                  if ($s9 !== $this->peg_FAILED) {
+                    if ($this->input_length > $this->peg_currPos) {
+                      $s10 = $this->input_substr($this->peg_currPos, 1);
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c6);
+                      }
+                    }
+                    if ($s10 !== $this->peg_FAILED) {
+                      $s9 = array($s9, $s10);
+                      $s8 = $s9;
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s8;
+                    $s8 = $this->peg_FAILED;
+                  }
+                  while ($s8 !== $this->peg_FAILED) {
+                    $s7[] = $s8;
+                    $s8 = $this->peg_currPos;
+                    $s9 = $this->peg_currPos;
+                    $this->peg_silentFails++;
+                    if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c36) {
+                      $s10 = $this->peg_c36;
+                      $this->peg_currPos++;
+                    } else {
+                      $s10 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c37);
+                      }
+                    }
+                    $this->peg_silentFails--;
+                    if ($s10 === $this->peg_FAILED) {
+                      $s9 = null;
+                    } else {
+                      $this->peg_currPos = $s9;
+                      $s9 = $this->peg_FAILED;
+                    }
+                    if ($s9 !== $this->peg_FAILED) {
+                      if ($this->input_length > $this->peg_currPos) {
+                        $s10 = $this->input_substr($this->peg_currPos, 1);
+                        $this->peg_currPos++;
+                      } else {
+                        $s10 = $this->peg_FAILED;
+                        if ($this->peg_silentFails === 0) {
+                            $this->peg_fail($this->peg_c6);
+                        }
+                      }
+                      if ($s10 !== $this->peg_FAILED) {
+                        $s9 = array($s9, $s10);
+                        $s8 = $s9;
+                      } else {
+                        $this->peg_currPos = $s8;
+                        $s8 = $this->peg_FAILED;
+                      }
+                    } else {
+                      $this->peg_currPos = $s8;
+                      $s8 = $this->peg_FAILED;
+                    }
+                  }
+                  if ($s7 !== $this->peg_FAILED) {
+                    $s6 = $this->input_substr($s6, $this->peg_currPos - $s6);
+                  } else {
+                    $s6 = $s7;
+                  }
+                  if ($s6 !== $this->peg_FAILED) {
+                    if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c36) {
+                      $s7 = $this->peg_c36;
+                      $this->peg_currPos++;
+                    } else {
+                      $s7 = $this->peg_FAILED;
+                      if ($this->peg_silentFails === 0) {
+                          $this->peg_fail($this->peg_c37);
+                      }
+                    }
+                    if ($s7 !== $this->peg_FAILED) {
+                      $this->peg_reportedPos = $s0;
+                      $s1 = $this->peg_f24($s1, $s6);
+                      $s0 = $s1;
+                    } else {
+                      $this->peg_currPos = $s0;
+                      $s0 = $this->peg_FAILED;
+                    }
+                  } else {
+                    $this->peg_currPos = $s0;
+                    $s0 = $this->peg_FAILED;
+                  }
+                } else {
+                  $this->peg_currPos = $s0;
+                  $s0 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s0;
+                $s0 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s0;
+              $s0 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseHTML_Attribute_Name() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = array();
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c38, $this->input_substr($this->peg_currPos, 1))) {
+        $s2 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s2 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c39);
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        while ($s2 !== $this->peg_FAILED) {
+          $s1[] = $s2;
+          if (Gutenberg_PEG_peg_char_class_test($this->peg_c38, $this->input_substr($this->peg_currPos, 1))) {
+            $s2 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s2 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c39);
+            }
+          }
+        }
+      } else {
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
 
       return $s0;
     }
@@ -1528,13 +2506,13 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseASCII_Letter() {
 
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c40, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c23);
+            $this->peg_fail($this->peg_c41);
         }
       }
 
@@ -1543,13 +2521,13 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseASCII_Digit() {
 
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c42, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
+            $this->peg_fail($this->peg_c43);
         }
       }
 
@@ -1558,13 +2536,13 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseSpecial_Chars() {
 
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c44, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c27);
+            $this->peg_fail($this->peg_c45);
         }
       }
 
@@ -1573,13 +2551,13 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseWS() {
 
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c28, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c46, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c29);
+            $this->peg_fail($this->peg_c47);
         }
       }
 
@@ -1588,13 +2566,13 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseNewline() {
 
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c48, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c31);
+            $this->peg_fail($this->peg_c49);
         }
       }
 
@@ -1603,13 +2581,13 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parse_() {
 
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c32, $this->input_substr($this->peg_currPos, 1))) {
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c50, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
         $this->peg_currPos++;
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c33);
+            $this->peg_fail($this->peg_c51);
         }
       }
 
@@ -1683,18 +2661,36 @@ class Gutenberg_PEG_Parser {
     $this->peg_c19 = "}";
     $this->peg_c20 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
     $this->peg_c21 = "";
-    $this->peg_c22 = array(array(97,122), array(65,90));
-    $this->peg_c23 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
-    $this->peg_c24 = array(array(48,57));
-    $this->peg_c25 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c26 = array(array(45,45), array(95,95));
-    $this->peg_c27 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c28 = array(array(32,32), array(9,9), array(13,13), array(10,10));
-    $this->peg_c29 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c30 = array(array(13,13), array(10,10));
-    $this->peg_c31 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c32 = array(array(32,32), array(9,9));
-    $this->peg_c33 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
+    $this->peg_c22 = array(array(60,60));
+    $this->peg_c23 = array( "type" => "class", "value" => "[<]", "description" => "[<]" );
+    $this->peg_c24 = "<";
+    $this->peg_c25 = array( "type" => "literal", "value" => "<", "description" => "\"<\"" );
+    $this->peg_c26 = ">";
+    $this->peg_c27 = array( "type" => "literal", "value" => ">", "description" => "\">\"" );
+    $this->peg_c28 = "</";
+    $this->peg_c29 = array( "type" => "literal", "value" => "</", "description" => "\"</\"" );
+    $this->peg_c30 = "=";
+    $this->peg_c31 = array( "type" => "literal", "value" => "=", "description" => "\"=\"" );
+    $this->peg_c32 = array(array(97,122), array(65,90), array(48,57));
+    $this->peg_c33 = array( "type" => "class", "value" => "[a-zA-Z0-9]", "description" => "[a-zA-Z0-9]" );
+    $this->peg_c34 = "\"";
+    $this->peg_c35 = array( "type" => "literal", "value" => "\"", "description" => "\"\\\"\"" );
+    $this->peg_c36 = "'";
+    $this->peg_c37 = array( "type" => "literal", "value" => "'", "description" => "\"'\"" );
+    $this->peg_c38 = array(array(97,122), array(65,90), array(48,57), array(58,58), array(46,46));
+    $this->peg_c39 = array( "type" => "class", "value" => "[a-zA-Z0-9:.]", "description" => "[a-zA-Z0-9:.]" );
+    $this->peg_c40 = array(array(97,122), array(65,90));
+    $this->peg_c41 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
+    $this->peg_c42 = array(array(48,57));
+    $this->peg_c43 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
+    $this->peg_c44 = array(array(45,45), array(95,95));
+    $this->peg_c45 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
+    $this->peg_c46 = array(array(32,32), array(9,9), array(13,13), array(10,10));
+    $this->peg_c47 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c48 = array(array(13,13), array(10,10));
+    $this->peg_c49 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
+    $this->peg_c50 = array(array(32,32), array(9,9));
+    $this->peg_c51 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
     $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
     $peg_startRuleFunction  = array($this, "peg_parseDocument");


### PR DESCRIPTION
related: @see #2210 

This change adds a behavior which was present in the original parser but
removed for some reason when it was pulled directly into Gutenberg. That
behavior is producing a tree of tokenized HTML inside the blocks so that
we can work with the simpler data structure than having to repeatedly
parse and validate HTML strings from within the components and
throughout the different paths in the editor.

This change adds a new field to the parse output: `children`, which
contains the tree as a list of objects, each child being able to reflect
the structure of its parent with the same tree data structure. HTML tags
appear as `type: HTML_Tag` with `name` equal to the tag name. Otherwise
the HTML tags mimick the structure of blocks at the outermost level.

Future work will replicate this pattern to add in nested blocks (also in
the original parser but removed when it was brought into Gutenberg).
Nested blocks would appear in the `children` array and contain full
block structure, nested intuitively and without having an exceptional
structure or indication.

It's my hope that components, queries, and validation can take place in the
easier/faster tree data structure instead of via the parsed HTML strings.
This could mean that attribute access is achieved with expressions as
basic as `block.children[ 0 ].attrs.href` instead of writing the equivalent
query. Further, I hope that one day we can add children not by rendering
HTML strings, but by working with the data structure itself and serializing
back to the HTML string only when we need to. This would be a very good
step if we wanted to open up the ability to store on non-stringy backends
(store elsewhere than `post_content` via a plugin: Simperium, JSON-in-`post_meta`,
a database table directly, some custom external service…). Should also pave
the way for other editors conforming to the Gutenberg spec which may not
have as easy of a time parsing HTML as the browser does.

cc: @jleandroperez

**Testing**

Since so many of our tests are testing for identical equality of output against hand-written fixtures (instead of testing for the relevant properties of some behavior under test) then this PR is breaking _a lot of tests_. At the moment I don't really have the will or the time to fix them 🙃. Can review next week.

You can open the editor and work as usual. Since we're just adding a new `children` property to the parser output there should be no breakage once the data structure is in Gutenberg.