### PR TITLE
Components: Add Tooltip component, display button aria-label tooltips

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -1,13 +1,18 @@
 /**
  * External dependencies
  */
-import './style.scss';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { Component, createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Tooltip from '../tooltip';
+import './style.scss';
 
 class Button extends Component {
 	constructor( props ) {
@@ -36,6 +41,7 @@ class Button extends Component {
 			isToggled,
 			className,
 			disabled,
+			'aria-label': label,
 			...additionalProps
 		} = this.props;
 		const classes = classnames( 'components-button', className, {
@@ -52,12 +58,18 @@ class Button extends Component {
 
 		delete additionalProps.focus;
 
-		return createElement( tag, {
+		let element = createElement( tag, {
 			...tagProps,
 			...additionalProps,
 			className: classes,
 			ref: this.setRef,
 		} );
+
+		if ( label ) {
+			element = <Tooltip text={ label }>{ element }</Tooltip>;
+		}
+
+		return element;
 	}
 }
 

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -11,7 +11,6 @@ import { Component, createElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Tooltip from '../tooltip';
 import './style.scss';
 
 class Button extends Component {
@@ -41,7 +40,6 @@ class Button extends Component {
 			isToggled,
 			className,
 			disabled,
-			'aria-label': label,
 			...additionalProps
 		} = this.props;
 		const classes = classnames( 'components-button', className, {
@@ -58,18 +56,12 @@ class Button extends Component {
 
 		delete additionalProps.focus;
 
-		let element = createElement( tag, {
+		return createElement( tag, {
 			...tagProps,
 			...additionalProps,
 			className: classes,
 			ref: this.setRef,
 		} );
-
-		if ( label ) {
-			element = <Tooltip text={ label }>{ element }</Tooltip>;
-		}
-
-		return element;
 	}
 }
 

--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -7,4 +7,17 @@
 	&:disabled {
 		opacity: 0.6;
 	}
+
+	&:not( :disabled ) {
+		cursor: pointer;
+	}
+
+	&:focus {
+		box-shadow: $button-focus-style;
+		outline: none;
+	}
+
+	&:active:focus {
+		box-shadow: none;
+	}
 }

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -12,6 +12,7 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
+import Tooltip from '../tooltip';
 import Button from '../button';
 import Dashicon from '../dashicon';
 
@@ -22,12 +23,18 @@ class IconButton extends Component {
 		const { icon, children, label, className, focus, ...additionalProps } = this.props;
 		const classes = classnames( 'components-icon-button', className );
 
-		return (
+		let element = (
 			<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
 				<Dashicon icon={ icon } />
 				{ children }
 			</Button>
 		);
+
+		if ( label && ! children ) {
+			element = <Tooltip text={ label }>{ element }</Tooltip>;
+		}
+
+		return element;
 	}
 }
 

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -18,20 +18,7 @@
 		width: auto;
 	}
 
-	&:not( :disabled ) {
-		cursor: pointer;
-
-		&:hover {
-			color: $blue-medium-500;
-		}
-	}
-
-	&:focus {
-		box-shadow: $button-focus-style;
-		outline: none;
-	}
-
-	&:active:focus {
-		box-shadow: none;
+	&:not( :disabled ):hover {
+		color: $blue-medium-500;
 	}
 }

--- a/components/icon-button/test/index.js
+++ b/components/icon-button/test/index.js
@@ -27,8 +27,16 @@ describe( 'IconButton', () => {
 		} );
 
 		it( 'should add an aria-label when the label property is used', () => {
-			const iconButton = shallow( <IconButton label="WordPress" /> );
+			const iconButton = shallow( <IconButton label="WordPress">WordPress</IconButton> );
+			expect( iconButton.name() ).toBe( 'Button' );
 			expect( iconButton.prop( 'aria-label' ) ).toBe( 'WordPress' );
+		} );
+
+		it( 'should add an aria-label when the label property is used, with Tooltip wrapper', () => {
+			const iconButton = shallow( <IconButton label="WordPress" /> );
+			expect( iconButton.name() ).toBe( 'Tooltip' );
+			expect( iconButton.prop( 'text' ) ).toBe( 'WordPress' );
+			expect( iconButton.find( 'Button' ).prop( 'aria-label' ) ).toBe( 'WordPress' );
 		} );
 
 		it( 'should add an additional className', () => {

--- a/components/index.js
+++ b/components/index.js
@@ -22,6 +22,7 @@ export { default as ResponsiveWrapper } from './responsive-wrapper';
 export { default as SandBox } from './sandbox';
 export { default as Spinner } from './spinner';
 export { default as Toolbar } from './toolbar';
+export { default as Tooltip } from './tooltip';
 
 // Higher-Order Components
 export { default as withFocusReturn } from './higher-order/with-focus-return';

--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -7,7 +7,8 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import IconButton from '../icon-button';
+import Button from '../button';
+import Dashicon from '../dashicon';
 
 class PanelBody extends Component {
 	constructor( props ) {
@@ -27,19 +28,22 @@ class PanelBody extends Component {
 
 	render() {
 		const { title, children } = this.props;
+		const { opened } = this.state;
+		const icon = `arrow-${ opened ? 'down' : 'right' }`;
+
 		return (
 			<div className="components-panel__body">
 				{ !! title && (
 					<h3 className="components-panel__body-title">
-						<IconButton
+						<Button
 							className="components-panel__body-toggle"
 							onClick={ this.toggle }
-							icon={ this.state.opened ? 'arrow-down' : 'arrow-right' }
-							aria-expanded={ this.state.opened }
+							aria-expanded={ opened }
 							label={ sprintf( __( 'Open section: %s' ), title ) }
 						>
+							<Dashicon icon={ icon } />
 							{ title }
-						</IconButton>
+						</Button>
 					</h3>
 				) }
 				{ this.state.opened && children }

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -58,12 +58,13 @@
 	font-size: inherit;
 }
 
-.components-panel__body-toggle.components-icon-button {
+.components-panel__body-toggle.components-button {
 	position: relative;
 	padding: 15px;
 	outline: none;
 	width: 100%;
 	font-weight: 600;
+	text-align: left;
 
 	.dashicon {
 		position: absolute;

--- a/components/panel/test/body.js
+++ b/components/panel/test/body.js
@@ -16,21 +16,23 @@ describe( 'PanelBody', () => {
 			expect( panelBody.type() ).toBe( 'div' );
 		} );
 
-		it( 'should render an IconButton matching the following props and state', () => {
+		it( 'should render an Button matching the following props and state', () => {
 			const panelBody = shallow( <PanelBody title="Some Text" /> );
-			const iconButton = panelBody.find( 'IconButton' );
-			expect( iconButton.shallow().hasClass( 'components-panel__body-toggle' ) ).toBe( true );
+			const button = panelBody.find( 'Button' );
+			const icon = panelBody.find( 'Dashicon' );
+			expect( button.shallow().hasClass( 'components-panel__body-toggle' ) ).toBe( true );
 			expect( panelBody.state( 'opened' ) ).toBe( true );
-			expect( iconButton.prop( 'onClick' ) ).toBe( panelBody.instance().toggle );
-			expect( iconButton.prop( 'icon' ) ).toBe( 'arrow-down' );
-			expect( iconButton.prop( 'children' ) ).toBe( 'Some Text' );
+			expect( button.prop( 'onClick' ) ).toBe( panelBody.instance().toggle );
+			expect( icon.prop( 'icon' ) ).toBe( 'arrow-down' );
+			expect( button.childAt( 0 ).name() ).toBe( 'Dashicon' );
+			expect( button.childAt( 1 ).text() ).toBe( 'Some Text' );
 		} );
 
 		it( 'should change state and props when sidebar is closed', () => {
 			const panelBody = shallow( <PanelBody title="Some Text" initialOpen={ false } /> );
 			expect( panelBody.state( 'opened' ) ).toBe( false );
-			const iconButton = panelBody.find( 'IconButton' );
-			expect( iconButton.prop( 'icon' ) ).toBe( 'arrow-right' );
+			const icon = panelBody.find( 'Dashicon' );
+			expect( icon.prop( 'icon' ) ).toBe( 'arrow-right' );
 		} );
 
 		it( 'should render child elements within PanelBody element', () => {

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEqual, pickBy } from 'lodash';
+import { isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,13 +14,6 @@ import { createPortal, Component } from '@wordpress/element';
  */
 import './style.scss';
 import PopoverDetectOutside from './detect-outside';
-
-/**
- * Matches an event handler prop key
- *
- * @type {RegExp}
- */
-const REGEXP_EVENT_PROP = /^on[A-Z]/;
 
 export class Popover extends Component {
 	constructor() {
@@ -142,16 +135,16 @@ export class Popover extends Component {
 	}
 
 	render() {
-		const { isOpen, onClose, children, className } = this.props;
+		// Disable reason: We generate the `...contentProps` rest as remainder
+		// of props which aren't explicitly handled by this component.
+		//
+		// eslint-disable-next-line no-unused-vars
+		const { isOpen, onClose, position, children, className, ...contentProps } = this.props;
 		const [ yAxis, xAxis ] = this.getPositions();
 
 		if ( ! isOpen ) {
 			return null;
 		}
-
-		const eventHandlers = pickBy( this.props, ( value, key ) => (
-			'onClose' !== key && REGEXP_EVENT_PROP.test( key )
-		) );
 
 		const classes = classnames(
 			'components-popover',
@@ -168,7 +161,7 @@ export class Popover extends Component {
 							ref={ this.bindNode( 'popover' ) }
 							className={ classes }
 							tabIndex="0"
-							{ ...eventHandlers }
+							{ ...contentProps }
 						>
 							<div
 								ref={ this.bindNode( 'content' ) }

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -232,5 +232,11 @@ describe( 'Popover', () => {
 
 			expect( wrapper.type() ).not.toBeNull();
 		} );
+
+		it( 'should pass additional to portaled element', () => {
+			const wrapper = shallow( <Popover isOpen role="tooltip">Hello</Popover> );
+
+			expect( wrapper.find( '.components-popover' ).prop( 'role' ) ).toBe( 'tooltip' );
+		} );
 	} );
 } );

--- a/components/tooltip/README.md
+++ b/components/tooltip/README.md
@@ -1,0 +1,50 @@
+Tooltip
+=======
+
+Tooltip is a React component to render floating help text relative to a node when it receives focus or when the user places the mouse cursor atop it. If the tooltip exceeds the bounds of the page in the direction it opens, its position will be flipped automatically.
+
+## Usage
+
+Render a Tooltip, passing as a child the element to which it should anchor:
+
+```jsx
+import { Tooltip } from '@wordpress/components';
+
+function HelpfulButton() {
+	return (
+		<Tooltip text="More information">
+			<button>
+				Hover for more information
+			</button>
+		</Tooltip>
+	);
+}
+```
+
+## Props
+
+The component accepts the following props:
+
+### position
+
+The direction in which the tooltip should open relative to its parent node. Specify y- and x-axis as a space-separated string. Supports `"top"`, `"bottom"` y axis, and `"left"`, `"center"`, `"right"` x axis.
+
+- Type: `String`
+- Required: No
+- Default: `"top center"`
+
+### children
+
+The element to which the tooltip should anchor.
+
+__NOTE:__ You must pass only a single child. Tooltip renders itself as a clone of `children` with a [`Popover`](../popover) added as an additional child.
+
+- Type: `Element`
+- Required: Yes
+
+### text
+
+The tooltip text to show on focus or hover.
+
+- Type: `String`
+- Required: No

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -71,6 +71,7 @@ class Tooltip extends Component {
 					isOpen={ isOver }
 					position={ position }
 					className="components-tooltip"
+					role="tooltip"
 				>
 					{ text }
 				</Popover>,

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, Children, cloneElement, concatChildren } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import Popover from '../popover';
+
+class Tooltip extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			isOver: false,
+		};
+	}
+
+	emitToChild( eventName, event ) {
+		const { children } = this.props;
+		if ( Children.count( children ) !== 1 ) {
+			return;
+		}
+
+		const child = Children.only( children );
+		if ( typeof child.props[ eventName ] === 'function' ) {
+			child.props[ eventName ]( event );
+		}
+	}
+
+	createToggleIsOver( eventName ) {
+		return ( event ) => {
+			const isOver = includes( [ 'focus', 'mouseover' ], event.type );
+			if ( isOver === this.state.isOver ) {
+				return;
+			}
+
+			this.setState( { isOver } );
+			this.emitToChild( eventName, event );
+		};
+	}
+
+	render() {
+		const { children, position, text } = this.props;
+		if ( Children.count( children ) !== 1 ) {
+			if ( 'development' === process.env.NODE_ENV ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Tooltip should be called with only a single child element.' );
+			}
+
+			return children;
+		}
+
+		const child = Children.only( children );
+		const { isOver } = this.state;
+		return cloneElement( child, {
+			onMouseOver: this.createToggleIsOver( 'onMouseOver' ),
+			onMouseOut: this.createToggleIsOver( 'onMouseOut' ),
+			onFocus: this.createToggleIsOver( 'onFocus' ),
+			onBlur: this.createToggleIsOver( 'onBlur' ),
+			children: concatChildren(
+				child.props.children,
+				<Popover
+					isOpen={ isOver }
+					position={ position }
+					className="components-tooltip"
+				>
+					{ text }
+				</Popover>,
+			),
+		} );
+	}
+}
+
+export default Tooltip;

--- a/components/tooltip/style.scss
+++ b/components/tooltip/style.scss
@@ -1,0 +1,22 @@
+.components-tooltip.components-popover {
+	&:before {
+		border-color: transparent;
+	}
+
+	&.is-top:after {
+		border-top-color: $dark-gray-400;
+	}
+
+	&.is-bottom:after {
+		border-bottom-color: $dark-gray-400;
+	}
+}
+
+.components-tooltip .components-popover__content {
+	width: auto;
+	padding: 4px 12px;
+	background: $dark-gray-400;
+	border-width: 0;
+	color: white;
+	white-space: nowrap;
+}

--- a/components/tooltip/test/index.js
+++ b/components/tooltip/test/index.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Tooltip from '../';
+
+describe( 'Tooltip', () => {
+	describe( '#render()', () => {
+		// Disable reason: The Tooltip component leverages array return values
+		// from render, which is not available until React 16.x
+		//
+		// TODO: When on React 16.x, unskip test
+		//
+		// eslint-disable-next-line jest/no-disabled-tests
+		it.skip( 'should render children (abort) if multiple children passed', () => {
+			const wrapper = shallow(
+				<Tooltip><div /><div /></Tooltip>
+			);
+
+			expect( wrapper.children() ).toHaveLength( 2 );
+		} );
+
+		it( 'should render children with additional popover', () => {
+			const wrapper = shallow(
+				<Tooltip position="bottom right" text="Help Text">
+					<button>Hover Me!</button>
+				</Tooltip>
+			);
+
+			const button = wrapper.find( 'button' );
+			const popover = wrapper.find( 'Popover' );
+			expect( wrapper.type() ).toBe( 'button' );
+			expect( button.children() ).toHaveLength( 2 );
+			expect( button.childAt( 0 ).text() ).toBe( 'Hover Me!' );
+			expect( button.childAt( 1 ).name() ).toBe( 'Popover' );
+			expect( popover.prop( 'isOpen' ) ).toBe( false );
+			expect( popover.prop( 'position' ) ).toBe( 'bottom right' );
+			expect( popover.children().text() ).toBe( 'Help Text' );
+		} );
+
+		it( 'should show popover on mouse over', () => {
+			const originalMouseOver = jest.fn();
+			const event = { type: 'mouseover' };
+			const wrapper = shallow(
+				<Tooltip text="Help Text">
+					<button
+						onMouseOver={ originalMouseOver }
+						onFocus={ originalMouseOver }
+					>
+						Hover Me!
+					</button>
+				</Tooltip>
+			);
+
+			const button = wrapper.find( 'button' );
+			button.simulate( 'mouseover', event );
+
+			const popover = wrapper.find( 'Popover' );
+			expect( originalMouseOver ).toHaveBeenCalledWith( event );
+			expect( wrapper.state( 'isOver' ) ).toBe( true );
+			expect( popover.prop( 'isOpen' ) ).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
Supersedes: #839

This pull request seeks to...

- Add a new `Tooltip` component
- Use the new `Tooltip` component to render `IconButton` tooltips by `aria-label` if no other children are specified (i.e. no explanatory text)

![Tooltips](https://user-images.githubusercontent.com/1779930/29084306-9531fd10-7c39-11e7-9333-e675d3dcec9f.png)

__Open questions:__

- ~Do we want all `aria-label` to show as tooltips?~ Previous iteration of this pull request applied labels to all `Button`. Now we only apply to `IconButton` with no `children` (explanatory text)

__Testing instructions:__

Verify that tooltips show, particularly:

- Both by mouseover and focus events
- Both for disabled and enabled buttons