### PR TITLE
Add Audio Block

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -45,7 +45,7 @@ registerBlockType( 'core/audio', {
 					key="placeholder"
 					icon="media-audio"
 					label={ __( 'Audio' ) }
-					instructions={ __( 'Select an audio file from your library, or paste a URL below:' ) }
+					instructions={ __( 'Select an audio file from your library, or upload a new one:' ) }
 					className={ className }>
 					<MediaUploadButton
 						buttonProps={ { isLarge: true } }
@@ -54,12 +54,6 @@ registerBlockType( 'core/audio', {
 					>
 						{ __( 'Insert from Media Library' ) }
 					</MediaUploadButton>
-					<input
-						type="url"
-						value={ src || '' }
-						className="components-placeholder__input"
-						placeholder={ __( 'Enter URL to audio file here…' ) }
-						onChange={ ( event ) => setAttributes( { src: event.target.value } ) } />
 				</Placeholder>,
 			];
 		}

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Placeholder } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { registerBlockType, query } from '../../api';
+import MediaUploadButton from '../../media-upload-button';
+
+const { attr } = query;
+
+registerBlockType( 'core/audio', {
+	title: __( 'Audio' ),
+
+	icon: 'media-audio',
+
+	category: 'common',
+
+	attributes: {
+		src: attr( 'audio', 'src' ),
+		loop: attr( 'audio', 'loop' ),
+		mime: attr( 'audio', 'type' ),
+	},
+
+	edit( { attributes, setAttributes, className } ) {
+		const { src } = attributes;
+		const onSelectAudio = ( media ) => {
+			if ( media && media.url ) {
+				setAttributes( {
+					src: media.url,
+					mime: media.mime,
+				} );
+			}
+		};
+
+		if ( ! src ) {
+			return [
+				<Placeholder
+					key="placeholder"
+					icon="media-audio"
+					label={ __( 'Audio' ) }
+					instructions={ __( 'Select an audio file from your library, or paste a URL below:' ) }
+					className={ className }>
+					<MediaUploadButton
+						buttonProps={ { isLarge: true } }
+						onSelect={ onSelectAudio }
+						type="audio"
+					>
+						{ __( 'Insert from Media Library' ) }
+					</MediaUploadButton>
+					<input
+						type="url"
+						value={ src || '' }
+						className="components-placeholder__input"
+						placeholder={ __( 'Enter URL to audio file here…' ) }
+						onChange={ ( event ) => setAttributes( { src: event.target.value } ) } />
+				</Placeholder>,
+			];
+		}
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		return [
+			<div key="audio">
+				<audio controls="controls" src={ src } />
+			</div>,
+		];
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+	},
+
+	save( { attributes } ) {
+		const { src, loop, mime } = attributes;
+		return (
+			<audio controls="controls" src={ src } loop={ loop } type={ mime } />
+		);
+	},
+} );

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -12,10 +12,10 @@ import { Placeholder } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlockType, query } from '../../api';
+import { registerBlockType, source } from '../../api';
 import MediaUploadButton from '../../media-upload-button';
 
-const { attr } = query;
+const { attr } = source;
 
 registerBlockType( 'core/audio', {
 	title: __( 'Audio' ),
@@ -25,19 +25,17 @@ registerBlockType( 'core/audio', {
 	category: 'common',
 
 	attributes: {
-		src: attr( 'audio', 'src' ),
-		loop: attr( 'audio', 'loop' ),
-		mime: attr( 'audio', 'type' ),
+		src: {
+			type: 'string',
+			source: attr( 'audio', 'src' ),
+		},
 	},
 
 	edit( { attributes, setAttributes, className } ) {
 		const { src } = attributes;
 		const onSelectAudio = ( media ) => {
 			if ( media && media.url ) {
-				setAttributes( {
-					src: media.url,
-					mime: media.mime,
-				} );
+				setAttributes( { src: media.url } );
 			}
 		};
 
@@ -76,9 +74,9 @@ registerBlockType( 'core/audio', {
 	},
 
 	save( { attributes } ) {
-		const { src, loop, mime } = attributes;
+		const { src } = attributes;
 		return (
-			<audio controls="controls" src={ src } loop={ loop } type={ mime } />
+			<audio controls="controls" src={ src } />
 		);
 	},
 } );

--- a/blocks/library/audio/style.scss
+++ b/blocks/library/audio/style.scss
@@ -1,0 +1,3 @@
+.wp-block-audio .components-placeholder__input {
+	margin-top: 1em;
+}

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -22,3 +22,4 @@ import './shortcode';
 import './text-columns';
 import './verse';
 import './video';
+import './audio';

--- a/blocks/test/fixtures/core__audio.html
+++ b/blocks/test/fixtures/core__audio.html
@@ -1,0 +1,3 @@
+<!-- wp:core/audio -->
+<audio controls="" src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3" class="wp-block-audio"></audio>
+<!-- /wp:core/audio -->

--- a/blocks/test/fixtures/core__audio.json
+++ b/blocks/test/fixtures/core__audio.json
@@ -1,0 +1,10 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/audio",
+        "isValid": true,
+        "attributes": {
+            "src": "https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3"
+        }
+    }
+]

--- a/blocks/test/fixtures/core__audio.parsed.json
+++ b/blocks/test/fixtures/core__audio.parsed.json
@@ -1,0 +1,11 @@
+[
+    {
+        "blockName": "core/audio",
+        "attrs": null,
+        "rawContent": "\n<audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\" class=\"wp-block-audio\"></audio>\n"
+    },
+    {
+        "attrs": {},
+        "rawContent": "\n"
+    }
+]

--- a/blocks/test/fixtures/core__audio.serialized.html
+++ b/blocks/test/fixtures/core__audio.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:core/audio -->
+<audio controls="" src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3" class="wp-block-audio"></audio>
+<!-- /wp:core/audio -->


### PR DESCRIPTION
For #804

This branch adds the basics of the audio block.  Currently you can select/upload an audio file from the Media Library, or use an external url.  As mentioned on the ticket, the audio widget supports additional parameters like adding additional playback types, and looping - which we might consider in future iterations.

Also, perhaps there could potentially be some simple validation on the url field - but taking a page from the video block and trying to simplify things for now.

**To Test**
- Create an audio block using an existing mp3 in your media library
- Create an audio block by uploading a new audio file to your media library
- Create an audio block using an externally hosted mp3 file.