### PR TITLE
Validation: Present option to overwrite invalid block

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, isObject } from 'lodash';
+import { isEmpty, reduce, isObject, castArray } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 import classnames from 'classnames';
 
@@ -166,11 +166,11 @@ export function serializeBlock( block ) {
 }
 
 /**
- * Takes a block list and returns the serialized post content.
+ * Takes a block or set of blocks and returns the serialized post content.
  *
- * @param  {Array}  blocks Block list
+ * @param  {Array}  blocks Block(s) to serialize
  * @return {String}        The post content
  */
 export default function serialize( blocks ) {
-	return blocks.map( serializeBlock ).join( '\n\n' );
+	return castArray( blocks ).map( serializeBlock ).join( '\n\n' );
 }

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -231,6 +231,7 @@ describe( 'block serializer', () => {
 			const expectedPostContent = '<!-- wp:core/test-block {"foo":false,"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
 
 			expect( serialize( [ block ] ) ).toEqual( expectedPostContent );
+			expect( serialize( block ) ).toEqual( expectedPostContent );
 		} );
 	} );
 } );

--- a/editor/modes/visual-editor/block-crash-warning.js
+++ b/editor/modes/visual-editor/block-crash-warning.js
@@ -10,9 +10,9 @@ import BlockWarning from './block-warning';
 
 const warning = (
 	<BlockWarning>
-		{ __(
+		<p>{ __(
 			'This block has suffered from an unhandled error and cannot be previewed.'
-		) }
+		) }</p>
 	</BlockWarning>
 );
 

--- a/editor/modes/visual-editor/block-warning.js
+++ b/editor/modes/visual-editor/block-warning.js
@@ -7,7 +7,7 @@ function BlockWarning( { children } ) {
 	return (
 		<div className="editor-visual-editor__block-warning">
 			<Dashicon icon="warning" />
-			<p>{ children }</p>
+			{ children }
 		</div>
 	);
 }

--- a/editor/modes/visual-editor/invalid-block-warning.js
+++ b/editor/modes/visual-editor/invalid-block-warning.js
@@ -17,6 +17,8 @@ import {
 	getBlockType,
 	getUnknownTypeHandlerName,
 	createBlock,
+	serialize,
+	parse,
 } from '@wordpress/blocks';
 
 /**
@@ -24,17 +26,24 @@ import {
  */
 import { replaceBlock } from '../../actions';
 
-function InvalidBlockWarning( { switchToDefaultType } ) {
+function InvalidBlockWarning( { ignoreInvalid, switchToDefaultType } ) {
 	const defaultBlockType = getBlockType( getUnknownTypeHandlerName() );
 
 	return (
 		<BlockWarning>
-			<p>{ __(
-				'This block has been modified externally and has been locked to ' +
-				'protect against content loss.'
-			) }</p>
-			{ defaultBlockType && (
-				<p>
+			<p>{ sprintf( __(
+				'This block appears to have been modified externally. ' +
+				'Overwrite the external changes or Convert to %s to keep ' +
+				'your changes.'
+			), defaultBlockType.title ) }</p>
+			<p>
+				<Button
+					onClick={ ignoreInvalid }
+					isLarge
+				>
+					{ sprintf( __( 'Overwrite' ) ) }
+				</Button>
+				{ defaultBlockType && (
 					<Button
 						onClick={ switchToDefaultType }
 						isLarge
@@ -44,8 +53,8 @@ function InvalidBlockWarning( { switchToDefaultType } ) {
 							sprintf( __( 'Convert to %s' ), defaultBlockType.title )
 						}
 					</Button>
-				</p>
-			) }
+				) }
+			</p>
 		</BlockWarning>
 	);
 }
@@ -54,6 +63,12 @@ export default connect(
 	null,
 	( dispatch, ownProps ) => {
 		return {
+			ignoreInvalid() {
+				const { block } = ownProps;
+				const serializedBlock = serialize( { ...block, isValid: true } );
+				const parsedBlocks = parse( serializedBlock );
+				dispatch( replaceBlock( block.uid, parsedBlocks ) );
+			},
 			switchToDefaultType() {
 				const defaultBlockName = getUnknownTypeHandlerName();
 				const { block } = ownProps;

--- a/editor/modes/visual-editor/invalid-block-warning.js
+++ b/editor/modes/visual-editor/invalid-block-warning.js
@@ -17,8 +17,6 @@ import {
 	getBlockType,
 	getUnknownTypeHandlerName,
 	createBlock,
-	serialize,
-	parse,
 } from '@wordpress/blocks';
 
 /**
@@ -65,9 +63,9 @@ export default connect(
 		return {
 			ignoreInvalid() {
 				const { block } = ownProps;
-				const serializedBlock = serialize( { ...block, isValid: true } );
-				const parsedBlocks = parse( serializedBlock );
-				dispatch( replaceBlock( block.uid, parsedBlocks ) );
+				const { name, attributes } = block;
+				const nextBlock = createBlock( name, attributes );
+				dispatch( replaceBlock( block.uid, nextBlock ) );
 			},
 			switchToDefaultType() {
 				const defaultBlockName = getUnknownTypeHandlerName();

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -464,7 +464,7 @@ $sticky-bottom-offset: 20px;
 	justify-content: space-around;
 	align-items: center;
 	width: 96%;
-	max-width: 360px;
+	max-width: 380px;
 	padding: 20px 20px 10px 20px;
 	background-color: $white;
 	border: 1px solid $light-gray-500;
@@ -476,5 +476,9 @@ $sticky-bottom-offset: 20px;
 		width: 100%;
 		font-family: $default-font;
 		font-size: $default-font-size;
+	}
+
+	.button + .button {
+		margin-left: $item-spacing;
 	}
 }


### PR DESCRIPTION
Related: #2196, #2132

This pull request seeks to present the user an option to "Overwrite" an invalid block. This is the equivalent of behavior prior to #2132, meaning: The editor will treat the block as it was parsed verbatim, ignoring validation issues.

![Overwrite](https://user-images.githubusercontent.com/1779930/29123263-2ba260ba-7ce3-11e7-810d-07fc57cff219.png)

__Open questions:__

- How can we clarify what "Overwrite" means?

__Testing instructions:__

1. You'll need an invalid block. Try removing a class name from the markup of the first block in `post-content.js`
2. Navigate to Gutenberg > Demo
3. Note the block modified in step 1 is flagged as invalid and you are presented with an "Overwrite" button
4. Press "Overwrite"
5. Note that the warning is dismissed, and the block is revealed as previewed
6. You may also observe that markup has been modified from revisions made in step 1 to the editor's own understanding of the block
   - In my example, I removed the `has-parallax` class from the first Cover Image block, and upon clicking Overwrite, the editor restores the class name because the assigning attribute is parsed from comment attributes