### PR TITLE
Framework: Bump rememo dependency to latest

### DIFF
--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -79,7 +79,7 @@ describe( 'selectors', () => {
 	} );
 
 	beforeEach( () => {
-		isEditedPostDirty.memoizedSelector.clear();
+		isEditedPostDirty.clear();
 	} );
 
 	afterAll( () => {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "redux": "^3.6.0",
     "redux-optimist": "0.0.2",
     "refx": "^2.0.0",
-    "rememo": "^1.1.1",
+    "rememo": "^2.3.0",
     "simple-html-tokenizer": "^0.4.1",
     "uuid": "^3.0.1"
   },


### PR DESCRIPTION
This pull request seeks to bump our [rememo](https://github.com/aduth/rememo) dependency to its latest version. This is a project I maintain as a side-project. I've been obsessing over memoization performance the past couple weeks and have made a number of significant optimizations. There should be no major incompatibilities with these changes, _only speeeeeed_.

[Changelog](https://github.com/aduth/rememo/blob/master/CHANGELOG.md)

__Testing instructions:__

Verify there are no generally no regressions, particularly related to memoized selectors (visual editor blocks listing, accurate block order on change, accurate saved post content on change, "dirtiness" updating on change).

Ensure tests pass:

```
npm test
```