### PR TITLE
Adding cross-env when setting env var in fixtures:generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "test": "npm run lint && npm run test-unit",
     "ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
     "fixtures:clean": "rimraf \"blocks/test/fixtures/*.+(json|serialized.html)\"",
-    "fixtures:generate": "GENERATE_MISSING_FIXTURES=y npm run test-unit",
+    "fixtures:generate": "cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
     "fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
     "package-plugin": "./bin/build-plugin-zip.sh",
     "docs-start": "./docutron/bin/cli.js start",


### PR DESCRIPTION
Adding cross-env to the fixtures generate script so these scripts can be
run cross platform. When setting environment vars let's always use cross-env.