### PR TITLE
Components: Trigger focus return by tracking focus events

### DIFF
--- a/components/higher-order/with-focus-return/index.js
+++ b/components/higher-order/with-focus-return/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component, findDOMNode } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 
 /**
  * Higher Order Component used to be used to wrap disposable elements like Sidebars, modals, dropdowns.
@@ -14,25 +14,37 @@ import { Component, findDOMNode } from '@wordpress/element';
  */
 function withFocusReturn( WrappedComponent ) {
 	return class extends Component {
+		constructor() {
+			super( ...arguments );
+
+			this.setIsFocusedTrue = () => this.isFocused = true;
+			this.setIsFocusedFalse = () => this.isFocused = false;
+		}
+
 		componentWillMount() {
-			this.activeElement = document.activeElement;
+			this.activeElementOnMount = document.activeElement;
 		}
 
 		componentWillUnmount() {
-			const wrapper = findDOMNode( this );
-			if (
-				this.activeElement && (
-					( document.activeElement && wrapper && wrapper.contains( document.activeElement ) ) ||
-					( ! document.activeElement || document.body === document.activeElement )
-				)
-			) {
-				this.activeElement.focus();
+			const { activeElementOnMount, isFocused } = this;
+			if ( ! activeElementOnMount ) {
+				return;
+			}
+
+			const { body, activeElement } = document;
+			if ( isFocused || null === activeElement || body === activeElement ) {
+				activeElementOnMount.focus();
 			}
 		}
 
 		render() {
 			return (
-				<WrappedComponent { ...this.props } />
+				<div
+					onFocus={ this.setIsFocusedTrue }
+					onBlur={ this.setIsFocusedFalse }
+				>
+					<WrappedComponent { ...this.props } />
+				</div>
 			);
 		}
 	};

--- a/components/higher-order/with-focus-return/test/index.js
+++ b/components/higher-order/with-focus-return/test/index.js
@@ -49,7 +49,7 @@ describe( 'withFocusReturn()', () => {
 
 		it( 'should not switch focus back to the bound focus element', () => {
 			const mountedComposite = mount( <Composite /> );
-			expect( mountedComposite.instance().activeElement ).toBe( activeElement );
+			expect( mountedComposite.instance().activeElementOnMount ).toBe( activeElement );
 
 			// Change activeElement.
 			switchFocusTo.focus();
@@ -62,7 +62,7 @@ describe( 'withFocusReturn()', () => {
 
 		it( 'should return focus to element associated with HOC', () => {
 			const mountedComposite = mount( <Composite /> );
-			expect( mountedComposite.instance().activeElement ).toBe( activeElement );
+			expect( mountedComposite.instance().activeElementOnMount ).toBe( activeElement );
 
 			// Change activeElement.
 			document.activeElement.blur();


### PR DESCRIPTION
Partially addresses #2306

This pull request seeks to refactor the `withFocusReturn` higher-order component to track an instance property reflecting whether the rendered element currently has focus. This proves to be more reliable when the disposable component is portaled to another location in the DOM (#2306), since the previous `element.contains` test will not match said content. Instead, the implementation here leverages event bubbling (and [event bubbling of portaled content](https://github.com/WordPress/gutenberg/pull/2160#issuecomment-320272243)) to track at all times whether the wrapped component has focus. Then, the focus return condition is simply a matter of: Is the component unmounting while it has focus?

__Testing instructions:__

Verify that focus is returned to initial active element after dismissing a `withFocusReturn` component:

1. Navigate to Gutenberg > New Post
2. Open an inserter
3. Press Escape
4. Note that focus is returned to the inserter button