### PR TITLE
Fix SVG colors

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -13,15 +13,15 @@ body.gutenberg_page_gutenberg-demo {
 	#wpfooter {
 		display: none;
 	}
+
+	svg {
+		fill: currentColor;
+	}
 }
 
 .gutenberg {
 	* {
 		box-sizing: border-box;
-	}
-
-	svg {
-		fill: currentColor;
 	}
 
 	ul {


### PR DESCRIPTION
By moving places in the dom, the SVGs in the inserter no longer inherited their colors. This fixes that.