### PR TITLE
Blocks: Treat RangeControl value as numeric

### DIFF
--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -11,7 +11,7 @@ import './style.scss';
 
 function RangeControl( { label, value, instanceId, onChange, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
-	const onChangeValue = ( event ) => onChange( event.target.value );
+	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 
 	return (
 		<BaseControl label={ label } id={ id } className="blocks-range-control">

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -11,10 +11,17 @@ import './style.scss';
 
 function RangeControl( { label, value, instanceId, onChange, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
+	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
 		<BaseControl label={ label } id={ id } className="blocks-range-control">
-			<input className="blocks-range-control__input" id={ id } type="range" value={ value } onChange={ onChange } { ...props } />
+			<input
+				className="blocks-range-control__input"
+				id={ id }
+				type="range"
+				value={ value }
+				onChange={ onChangeValue }
+				{ ...props } />
 			<span className="blocks-range-control__hint">{ value }</span>
 		</BaseControl>
 	);

--- a/blocks/inspector-controls/range-control/test/index.js
+++ b/blocks/inspector-controls/range-control/test/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import RangeControl from '../';
+
+describe( 'RangeControl', () => {
+	describe( '#render()', () => {
+		it( 'triggers change callback with numeric value', () => {
+			// Mount: With shallow, cannot find input child of BaseControl
+			const onChange = jest.fn();
+			const wrapper = mount( <RangeControl onChange={ onChange } /> );
+
+			wrapper.find( 'input' ).simulate( 'change', { target: { value: '5' } } );
+
+			expect( onChange ).toHaveBeenCalledWith( '5' );
+		} );
+	} );
+} );

--- a/blocks/inspector-controls/range-control/test/index.js
+++ b/blocks/inspector-controls/range-control/test/index.js
@@ -17,7 +17,7 @@ describe( 'RangeControl', () => {
 
 			wrapper.find( 'input' ).simulate( 'change', { target: { value: '5' } } );
 
-			expect( onChange ).toHaveBeenCalledWith( '5' );
+			expect( onChange ).toHaveBeenCalledWith( 5 );
 		} );
 	} );
 } );

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -158,7 +158,7 @@ registerBlockType( 'core/gallery', {
 						label={ __( 'Columns' ) }
 						value={ columns }
 						onChange={ setColumnsNumber }
-						min="1"
+						min={ 1 }
 						max={ Math.min( MAX_COLUMNS, images.length ) }
 					/>
 					<ToggleControl

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -99,7 +99,7 @@ registerBlockType( 'core/gallery', {
 	edit( { attributes, setAttributes, focus, className } ) {
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
 		const setLinkTo = ( value ) => setAttributes( { linkTo: value } );
-		const setColumnsNumber = ( event ) => setAttributes( { columns: event.target.value } );
+		const setColumnsNumber = ( value ) => setAttributes( { columns: value } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const toggleImageCrop = () => setAttributes( { imageCrop: ! imageCrop } );
 

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -178,8 +178,8 @@ registerBlockType( 'core/latest-posts', {
 							<RangeControl
 								label={ __( 'Columns' ) }
 								value={ columns }
-								min="2"
 								onChange={ ( value ) => setAttributes( { columns: value } ) }
+								min={ 2 }
 								max={ Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
 							/>
 						}

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -178,8 +178,8 @@ registerBlockType( 'core/latest-posts', {
 							<RangeControl
 								label={ __( 'Columns' ) }
 								value={ columns }
-								onChange={ ( event ) => setAttributes( { columns: event.target.value } ) }
 								min="2"
+								onChange={ ( value ) => setAttributes( { columns: value } ) }
 								max={ Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
 							/>
 						}

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -73,9 +73,9 @@ registerBlockType( 'core/text-columns', {
 					<RangeControl
 						label={ __( 'Columns' ) }
 						value={ columns }
-						min="2"
-						max="4"
 						onChange={ ( value ) => setAttributes( { columns: value } ) }
+						min={ 2 }
+						max={ 4 }
 					/>
 				</InspectorControls>
 			),

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -73,9 +73,9 @@ registerBlockType( 'core/text-columns', {
 					<RangeControl
 						label={ __( 'Columns' ) }
 						value={ columns }
-						onChange={ ( event ) => setAttributes( { columns: event.target.value } ) }
 						min="2"
 						max="4"
+						onChange={ ( value ) => setAttributes( { columns: value } ) }
 					/>
 				</InspectorControls>
 			),


### PR DESCRIPTION
This pull request seeks to update `RangeControl` in line with other block inspector controls to pass through the updated value on `onChange` instead of the original event, and in doing so treat the updated value as numeric. Since `RangeControl` is used for assigning numeric values, it was easy to overlook and assigning `event.target.value` would assign a string value, resulting in warnings:

`parser.js:140 Expected attribute "columns" of type number for block type "core/gallery" but received string.`

See: #1905

__Testing instructions:__

Verify there are no regressions or console warnings in changing...

- Gallery columns
- Latest posts columns
- Text columns columns

Ensure unit tests pass:

```
npm test
```