### PR TITLE
Cover Image: Extract title as children array (fix "modified externally")

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -19,7 +19,7 @@ import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import BlockDescription from '../../block-description';
 
-const { text } = source;
+const { children } = source;
 
 const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
 
@@ -32,8 +32,8 @@ registerBlockType( 'core/cover-image', {
 
 	attributes: {
 		title: {
-			type: 'string',
-			source: text( 'h2' ),
+			type: 'array',
+			source: children( 'h2' ),
 		},
 		url: {
 			type: 'string',

--- a/blocks/test/fixtures/core__cover-image.json
+++ b/blocks/test/fixtures/core__cover-image.json
@@ -4,7 +4,9 @@
         "name": "core/cover-image",
         "isValid": true,
         "attributes": {
-            "title": "Guten Berg!",
+            "title": [
+                "Guten Berg!"
+            ],
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "hasParallax": false,
             "hasBackgroundDim": true


### PR DESCRIPTION
Related: #1929

This pull request seeks to resolve an issue where the Cover Image block can trigger a "modified externally" warning after adding inline formatting to the title text. This is caused by an incompatibility between how the attribute is sourced, and how it is assigned / edited. Specifically:

- [The title is extracted as plain text](https://github.com/WordPress/gutenberg/blob/a6cf4e3/blocks/library/cover-image/index.js#L36)
- [But then edited as rich text](https://github.com/WordPress/gutenberg/blob/a6cf4e3/blocks/library/cover-image/index.js#L152-L160)

The value of `Editable` should always be an attribute which is sourced as `children`. We should consider adding better logging / messaging around the expected type of its `value` (i.e. warn if passed as string).

__Testing instructions:__

Verify with the following flow you do not see a "modified externally" warning:

1. Navigate to Gutenberg > New Post
2. Insert a Cover Image
3. Assign an image to the block
4. Add some text to the cover image
5. Select and apply inline formatting to text ([Screenshot](https://user-images.githubusercontent.com/1779930/29172319-99b13ad4-7dad-11e7-9eda-bab90b61a378.png))
6. Save post
7. Refresh page