### PR TITLE
Image Block: Resizing an image was causing the external modifications message

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -58,6 +58,12 @@ registerBlockType( 'core/image', {
 		align: {
 			type: 'string',
 		},
+		width: {
+			type: 'number',
+		},
+		height: {
+			type: 'number',
+		},
 	},
 
 	transforms: {


### PR DESCRIPTION
After merging the "attributes" refactoring, all the attributes must be declared to avoid the "external modifications" message.
