### PR TITLE
Editable: Add prop types to warn on non-array value

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -582,6 +582,19 @@ export default class Editable extends Component {
 	}
 }
 
+Editable.propTypes = {
+	value( props ) {
+		if ( undefined !== props.value && ! Array.isArray( props.value ) ) {
+			return new Error(
+				`Invalid value of type ${ typeof props.value } passed to Editable (expected ` +
+				'array). Attribute values should be sourced using the `children` source when ' +
+				'used with Editable.\n\n' +
+				'See: http://gutenberg-devdoc.surge.sh/reference/attribute-sources/#children'
+			);
+		}
+	},
+};
+
 Editable.contextTypes = {
 	onUndo: noop,
 };

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -55,6 +55,18 @@ export default class Editable extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
+		const { value } = props;
+		if ( 'production' !== process.env.NODE_ENV && undefined !== value &&
+					! Array.isArray( value ) ) {
+			// eslint-disable-next-line no-console
+			console.error(
+				`Invalid value of type ${ typeof value } passed to Editable ` +
+				'(expected array). Attribute values should be sourced using ' +
+				'the `children` source when used with Editable.\n\n' +
+				'See: http://gutenberg-devdoc.surge.sh/reference/attribute-sources/#children'
+			);
+		}
+
 		this.onInit = this.onInit.bind( this );
 		this.getSettings = this.getSettings.bind( this );
 		this.onSetup = this.onSetup.bind( this );
@@ -72,7 +84,7 @@ export default class Editable extends Component {
 		this.state = {
 			formats: {},
 			bookmark: null,
-			empty: ! props.value || ! props.value.length,
+			empty: ! value || ! value.length,
 		};
 	}
 
@@ -581,19 +593,6 @@ export default class Editable extends Component {
 		);
 	}
 }
-
-Editable.propTypes = {
-	value( props ) {
-		if ( undefined !== props.value && ! Array.isArray( props.value ) ) {
-			return new Error(
-				`Invalid value of type ${ typeof props.value } passed to Editable (expected ` +
-				'array). Attribute values should be sourced using the `children` source when ' +
-				'used with Editable.\n\n' +
-				'See: http://gutenberg-devdoc.surge.sh/reference/attribute-sources/#children'
-			);
-		}
-	},
-};
 
 Editable.contextTypes = {
 	onUndo: noop,

--- a/blocks/editable/test/index.js
+++ b/blocks/editable/test/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Editable from '../';
+
+describe( 'Editable', () => {
+	describe( '.propTypes', () => {
+		/* eslint-disable no-console */
+		let consoleError;
+		beforeEach( () => {
+			consoleError = console.error;
+			console.error = jest.fn();
+		} );
+
+		afterEach( () => {
+			console.error = consoleError;
+		} );
+
+		it( 'should warn when rendered with string value', () => {
+			shallow( <Editable value="Uh oh!" /> );
+
+			expect( console.error ).toHaveBeenCalled();
+		} );
+
+		it( 'should not warn when rendered with undefined value', () => {
+			shallow( <Editable /> );
+
+			expect( console.error ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not warn when rendered with array value', () => {
+			shallow( <Editable value={ [ 'Oh, good' ] } /> );
+
+			expect( console.error ).not.toHaveBeenCalled();
+		} );
+		/* eslint-enable no-console */
+	} );
+} );


### PR DESCRIPTION
Related: #2341

This pull request seeks to enhance `Editable` to log a warning when passed a non-Array value. As seen in #2341, it can be tempting to pass a plain text string to Editable, but these will not be parseable on subsequent editor sessions.

__Testing instructions:__

Verify that no warnings are logged for valid Editable usage (e.g. paragraph).

[Assuming #2341 has not yet been merged, ] verify that a warning is logged when rendering saved post with (non-formatted) Cover Image:

1. Navigate to Gutenberg > New Post
2. Insert a Cover Image
3. Assign an image to the block
4. Add some text to the cover image
6. Save post
7. Refresh page