### PR TITLE
Quote: Fix new quote, transform from list block

### DIFF
--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -45,6 +45,11 @@ const toBrDelimitedContent = ( values ) => {
 	}
 	const content = [];
 	values.forEach( function( li, liIndex, listItems ) {
+		if ( typeof li === 'string' ) {
+			content.push( li );
+			return;
+		}
+
 		Children.toArray( li.props.children ).forEach( function( element, elementIndex, liChildren ) {
 			if ( 'ul' === element.type || 'ol' === element.type ) { // lists within lists
 				// we know we've just finished processing a list item, so break the text

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -163,7 +163,7 @@ registerBlockType( 'core/list', {
 				blocks: [ 'core/quote' ],
 				transform: ( { values } ) => {
 					return createBlock( 'core/quote', {
-						value: toBrDelimitedContent( values ),
+						value: [ <p key="list">{ toBrDelimitedContent( values ) }</p> ],
 					} );
 				},
 			},

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -204,7 +204,7 @@ registerBlockType( 'core/quote', {
 				className={ `blocks-quote-style-${ style }` }
 				style={ { textAlign: align ? align : null } }
 			>
-				{ value.map( ( paragraph, i ) => <p key={ i }>{ paragraph.props.children }</p> ) }
+				{ value }
 				{ citation && citation.length > 0 && (
 					<footer>{ citation }</footer>
 				) }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -29,6 +29,7 @@ registerBlockType( 'core/quote', {
 		value: {
 			type: 'array',
 			source: query( 'blockquote > p', node() ),
+			default: [],
 		},
 		citation: {
 			type: 'array',
@@ -204,7 +205,9 @@ registerBlockType( 'core/quote', {
 				className={ `blocks-quote-style-${ style }` }
 				style={ { textAlign: align ? align : null } }
 			>
-				{ value }
+				{ value.map( ( paragraph, i ) => (
+					<p key={ i }>{ paragraph.props.children }</p>
+				) ) }
 				{ citation && citation.length > 0 && (
 					<footer>{ citation }</footer>
 				) }


### PR DESCRIPTION
Fixes #2343

This pull request seeks to resolve issues relating to quote initialization and list transforms.

The quote block does not define a default value but assumes it to be an array, iterating by `Array#map` in its `save` implementation. While we could add a default value to the attributes definition, the approach here instead drops the `Array#map` since, for all I could discern, it serves no purpose (generates identical output). Instead, the value is rendered verbatim.

Further, there were some issues with list transforms, particularly for lists which do not contain any special formatting or list nesting. In these cases, list items would be plain strings, but the block's internal `toBrDelimitedContent` utility was not prepared to handle these cases.

Lastly, the List -> Quote transform was not transforming into the expected `value` type of quote and should have been wrapped in the expected array of paragraphs.

__Testing instructions:__

Verify that you can create a new Quote block.

Verify that you can convert from List block to Quote (and Paragraph) block with:

- No content
- Single list item (with and without formatted content)
- Multiple list items (with and without formatted content)
- Nested list items (with and without formatted content)