### PR TITLE
Set sensible gallery column default for responsive

### DIFF
--- a/blocks/library/gallery/block.scss
+++ b/blocks/library/gallery/block.scss
@@ -33,22 +33,35 @@
 	&.columns-2 figure {
 		width: calc(100% / 2 - 3 * 8px);
 	}
-	&.columns-3 figure {
-		width: calc(100% / 3 - 4 * 8px);
-	}
-	&.columns-4 figure {
-		width: calc(100% / 4 - 5 * 8px);
-	}
-	&.columns-5 figure {
-		width: calc(100% / 5 - 6 * 8px);
-	}
-	&.columns-6 figure {
-		width: calc(100% / 6 - 7 * 8px);
-	}
-	&.columns-7 figure {
-		width: calc(100% / 7 - 8 * 8px);
-	}
+
+	// Responsive fallback value, 2 columns
+	&.columns-3 figure,
+	&.columns-4 figure,
+	&.columns-5 figure,
+	&.columns-6 figure,
+	&.columns-7 figure,
 	&.columns-8 figure {
-		width: calc(100% / 8 - 9 * 8px);
+		width: calc(100% / 2 - 3 * 8px);
+	}
+
+	@include break-small {
+		&.columns-3 figure {
+			width: calc(100% / 3 - 4 * 8px);
+		}
+		&.columns-4 figure {
+			width: calc(100% / 4 - 5 * 8px);
+		}
+		&.columns-5 figure {
+			width: calc(100% / 5 - 6 * 8px);
+		}
+		&.columns-6 figure {
+			width: calc(100% / 6 - 7 * 8px);
+		}
+		&.columns-7 figure {
+			width: calc(100% / 7 - 8 * 8px);
+		}
+		&.columns-8 figure {
+			width: calc(100% / 8 - 9 * 8px);
+		}
 	}
 }


### PR DESCRIPTION
This fixes #1433.

If you have a gallery that uses 3 or more columns, those columns only start working once the responsive breakpoint is larger than "small" (which invokes at 600px).