### PR TITLE
Blocks: Add shortcode block

### DIFF
--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -18,6 +18,7 @@ import './latest-posts';
 import './categories';
 import './cover-image';
 import './cover-text';
+import './shortcode';
 import './text-columns';
 import './verse';
 import './video';

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { withInstanceId, Dashicon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { registerBlockType, source } from '../../api';
+
+const { text } = source;
+
+registerBlockType( 'core/shortcode', {
+	title: __( 'Shortcode' ),
+
+	icon: 'editor-code',
+
+	category: 'widgets',
+
+	attributes: {
+		text: {
+			type: 'string',
+			source: text(),
+		},
+	},
+
+	edit: withInstanceId(
+		( { attributes, setAttributes, className, instanceId } ) => {
+			const inputId = `blocks-shortcode-input-${ instanceId }`;
+
+			return (
+				<div className={ className }>
+					<label htmlFor={ inputId }>
+						<Dashicon icon="editor-code" />
+						{ __( 'Shortcode' ) }
+					</label>
+					<input
+						id={ inputId }
+						type="text"
+						value={ attributes.text }
+						placeholder={ __( 'Write shortcode here…' ) }
+						onChange={ ( event ) => setAttributes( {
+							text: event.target.value,
+						} ) } />
+				</div>
+			);
+		}
+	),
+
+	save( { attributes } ) {
+		return attributes.text;
+	},
+} );

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -9,13 +9,15 @@ import { withInstanceId, Dashicon } from '@wordpress/components';
  */
 import './style.scss';
 import { registerBlockType, source } from '../../api';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { text } = source;
 
 registerBlockType( 'core/shortcode', {
 	title: __( 'Shortcode' ),
 
-	icon: 'editor-code',
+	icon: 'marker',
 
 	category: 'widgets',
 
@@ -26,12 +28,14 @@ registerBlockType( 'core/shortcode', {
 		},
 	},
 
+	className: false,
+
 	edit: withInstanceId(
-		( { attributes, setAttributes, className, instanceId } ) => {
+		( { attributes, setAttributes, instanceId, focus } ) => {
 			const inputId = `blocks-shortcode-input-${ instanceId }`;
 
 			return (
-				<div className={ className }>
+				<div className="wp-block-shortcode">
 					<label htmlFor={ inputId }>
 						<Dashicon icon="editor-code" />
 						{ __( 'Shortcode' ) }
@@ -44,6 +48,13 @@ registerBlockType( 'core/shortcode', {
 						onChange={ ( event ) => setAttributes( {
 							text: event.target.value,
 						} ) } />
+					{ focus &&
+						<InspectorControls>
+							<BlockDescription>
+								<p>{ __( 'A shortcode is a WordPress-specific code snippet that is written between square brackets as [shortcode]. ' ) }</p>
+							</BlockDescription>
+						</InspectorControls>
+					}
 				</div>
 			);
 		}

--- a/blocks/library/shortcode/style.scss
+++ b/blocks/library/shortcode/style.scss
@@ -1,0 +1,22 @@
+.wp-block-shortcode {
+	display: flex;
+	flex-direction: row;
+	padding: 1em;
+	background-color: $light-gray-100;
+
+	label {
+		flex-basis: 0;
+		display: flex;
+		align-items: center;
+		margin-right: $item-spacing;
+		white-space: nowrap;
+	}
+
+	input {
+		flex: 1 0 0%;
+	}
+
+	.dashicon {
+		margin-right: $item-spacing;
+	}
+}

--- a/blocks/test/fixtures/core__shortcode.html
+++ b/blocks/test/fixtures/core__shortcode.html
@@ -1,0 +1,3 @@
+<!-- wp:core/shortcode -->
+[gallery ids="238,338"]
+<!-- /wp:core/shortcode -->

--- a/blocks/test/fixtures/core__shortcode.json
+++ b/blocks/test/fixtures/core__shortcode.json
@@ -1,0 +1,10 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/shortcode",
+        "isValid": true,
+        "attributes": {
+            "text": "[gallery ids=\"238,338\"]"
+        }
+    }
+]

--- a/blocks/test/fixtures/core__shortcode.parsed.json
+++ b/blocks/test/fixtures/core__shortcode.parsed.json
@@ -1,0 +1,11 @@
+[
+    {
+        "blockName": "core/shortcode",
+        "attrs": null,
+        "rawContent": "\n[gallery ids=\"238,338\"]\n"
+    },
+    {
+        "attrs": {},
+        "rawContent": "\n"
+    }
+]

--- a/blocks/test/fixtures/core__shortcode.serialized.html
+++ b/blocks/test/fixtures/core__shortcode.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:core/shortcode -->
+[gallery ids="238,338"]
+<!-- /wp:core/shortcode -->


### PR DESCRIPTION
Closes #1709

This pull request seeks to implement a new Shortcode block:

![Demo](https://user-images.githubusercontent.com/1779930/29177287-54267326-7dbc-11e7-8e40-dee2f290af46.png)

__Testing instructions:__

Verify that you can add a shortcode block, and that it is saved into post content with no additional surrounding elements.

1. Navigate to Gutenberg > New Post
2. Insert a Shortcode block
3. Add a shortcode
4. Switch to Text view
5. Confirm the shortcode markup appears as expected (only with block delimiter comments)
6. Press Preview
7. Confirm the shortcode displays as expected