### PR TITLE
Prevent Codecov from using "approximate" PR base commits

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  allow_coverage_offsets: false
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Per https://docs.codecov.io/v4.3.6/docs/comparing-commits#section-resolution, if Codecov does not find a coverage report for the "base commit" of a pull request (the commit the PR shares in common with `master`), then it will attempt to find a similar commit and use it as the base.

This causes incorrect coverage results, I suspect it is the reason the report in https://github.com/WordPress/gutenberg/pull/2226 is wrong and partly related to the Codecov issues in #2296 as well.

Testing at #2296 seems to indicate that adding this setting has the intended effect, and https://docs.codecov.io/v4.3.6/docs/commit-status seems to indicate that this situation won't cause a build failure due to the default setting of `if_not_found: success`.