### PR TITLE
Fix Exception in Embed Block

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -221,7 +221,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			return (
 				<figure className={ align && `align${ align }` }>
 					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
-					{ caption.length > 0 && <figcaption>{ caption }</figcaption> }
+					{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 				</figure>
 			);
 		},

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -44,6 +44,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			caption: {
 				type: 'array',
 				source: children( 'figcaption' ),
+				default: [],
 			},
 			align: {
 				type: 'string',


### PR DESCRIPTION
Fixes #2355 

When attempting to add an embed block I was getting the following error:

<img width="1132" alt="gutenberg_ _wordpress_develop_ _wordpress" src="https://user-images.githubusercontent.com/22080/29194460-8fbd7de0-7dde-11e7-9a9e-8b1c1f6e3b14.png">

**To Test**
- Add a new embed block
- Verify no exception is thrown