### PR TITLE
Documentation: Linkify Markdown in Docs

### DIFF
--- a/docutron/src/markdown/index.js
+++ b/docutron/src/markdown/index.js
@@ -8,6 +8,7 @@ import { compact } from 'lodash';
 
 const parser = new MarkdownIt( {
 	html: true,
+	linkify: true,
 } );
 parser
 	.use( markdownItTOCAndAnchorPlugin )


### PR DESCRIPTION
#2335 introduced some links to the documentation. The current automatically converts links in markdown files to actual HTML links.