### PR TITLE
Cover Text Block: Prevent class=false when serializing the block

### DIFF
--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -131,7 +131,7 @@ registerBlockType( 'core/cover-text', {
 
 	save( { attributes } ) {
 		const { width, align, content, dropCap, backgroundColor, textColor } = attributes;
-		const className = dropCap && 'has-drop-cap';
+		const className = dropCap ? 'has-drop-cap' : null;
 		const wrapperClassName = width && `align${ width }`;
 
 		if ( ! align ) {

--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -109,7 +114,16 @@ registerBlockType( 'core/cover-text', {
 					/>
 				</InspectorControls>
 			),
-			<div className={ `${ className } align${ width }` } style={ { backgroundColor: backgroundColor, color: textColor } } key="block">
+			<div
+				key="block"
+				className={ classnames( className, {
+					[ `align${ width }` ]: width,
+				} ) }
+				style={ {
+					backgroundColor: backgroundColor,
+					color: textColor,
+				} }
+			>
 				<Editable
 					tagName="p"
 					value={ content }
@@ -122,7 +136,7 @@ registerBlockType( 'core/cover-text', {
 					onFocus={ setFocus }
 					onMerge={ mergeBlocks }
 					style={ { textAlign: align } }
-					className={ dropCap && 'has-drop-cap' }
+					className={ dropCap ? 'has-drop-cap' : null }
 					placeholder={ placeholder || __( 'New Paragraph' ) }
 				/>
 			</div>,
@@ -132,7 +146,7 @@ registerBlockType( 'core/cover-text', {
 	save( { attributes } ) {
 		const { width, align, content, dropCap, backgroundColor, textColor } = attributes;
 		const className = dropCap ? 'has-drop-cap' : null;
-		const wrapperClassName = width && `align${ width }`;
+		const wrapperClassName = width ? `align${ width }` : null;
 
 		if ( ! align ) {
 			return (

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -219,7 +219,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			const { url, caption, align } = attributes;
 
 			return (
-				<figure className={ align && `align${ align }` }>
+				<figure className={ align ? `align${ align }` : null }>
 					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
 					{ caption.length > 0 && <figcaption>{ caption }</figcaption> }
 				</figure>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -288,7 +288,7 @@ registerBlockType( 'core/image', {
 		const image = <img src={ url } alt={ alt } { ...extraImageProps } />;
 
 		return (
-			<figure className={ align && `align${ align }` }>
+			<figure className={ align ? `align${ align }` : null }>
 				{ href ? <a href={ href }>{ image }</a> : image }
 				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 			</figure>

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -116,7 +116,7 @@ registerBlockType( 'core/paragraph', {
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }
 				style={ { textAlign: align } }
-				className={ dropCap && 'has-drop-cap' }
+				className={ dropCap ? 'has-drop-cap' : null }
 				placeholder={ placeholder || __( 'New Paragraph' ) }
 			/>,
 		];

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -71,7 +71,7 @@ registerBlockType( 'core/table', {
 	save( { attributes } ) {
 		const { content, align } = attributes;
 		return (
-			<table className={ align && `align${ align }` }>
+			<table className={ align ? `align${ align }` : null }>
 				{ content }
 			</table>
 		);


### PR DESCRIPTION
Props @aduth for catching that. The Cover Text block was serializing `class="false"` with default Attributes which was causing the "externally modified content" message.

