### PR TITLE
Inserter: Render menu as content of Popover

### DIFF
--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { IconButton } from '@wordpress/components';
+import { Popover, IconButton } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -86,13 +86,13 @@ class Inserter extends Component {
 				>
 					{ children }
 				</IconButton>
-				{ opened && (
-					<InserterMenu
-						position={ position }
-						onSelect={ this.insertBlock }
-						onClose={ this.closeOnClickOutside }
-					/>
-				) }
+				<Popover
+					isOpen={ opened }
+					position={ position }
+					onClose={ this.closeOnClickOutside }
+				>
+					<InserterMenu onSelect={ this.insertBlock } />
+				</Popover>
 			</div>
 		);
 	}

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Popover, withFocusReturn, withInstanceId, withSpokenMessages } from '@wordpress/components';
+import { withFocusReturn, withInstanceId, withSpokenMessages } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
 import { getCategories, getBlockTypes, BlockIcon } from '@wordpress/blocks';
 
@@ -314,17 +314,13 @@ export class InserterMenu extends Component {
 	}
 
 	render() {
-		const { position, onClose, instanceId } = this.props;
+		const { instanceId } = this.props;
 		const isSearching = this.state.filterValue;
 		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( this.getBlocksForCurrentTab() );
 
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
-			<Popover
-				position={ position }
-				isOpen
-				onClose={ onClose }
-				className="editor-inserter__menu">
+			<div className="editor-inserter__menu">
 				<label htmlFor={ `editor-inserter__search-${ instanceId }` } className="screen-reader-text">
 					{ __( 'Search blocks' ) }
 				</label>
@@ -435,7 +431,7 @@ export class InserterMenu extends Component {
 						</button>
 					</div>
 				}
-			</Popover>
+			</div>
 		);
 		/* eslint-enable jsx-a11y/no-autofocus */
 	}


### PR DESCRIPTION
This pull request seeks to resolve an issue where clicking the Inserter button in content causes the menu to appear overlapping the button, rather than above it. The issue is described at https://github.com/WordPress/gutenberg/pull/2323#issuecomment-321804505:

>Seems the `div` wrapper introduced in #2321 is causing some issues with Popover being able to calculate its offset position. I think eventually we'll want to move `withFocusReturn` to be part of `Popover` itself, which should hopefully provide a better long-term solution.

This pull request merely extracts most of the 26b75c8c36c993da50d52b42e562b6dc79438690 commit that was already slated for #2323 while other requested changes are in-progress there.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/29213914-4b1a1578-7e73-11e7-8247-81ea49f02e10.png)|![image](https://user-images.githubusercontent.com/1779930/29213861-12b6256e-7e73-11e7-9129-0c0c3d48509f.png)

__Testing instructions:__

This is most obvious for inserter menu which opens upwards, meaning it must be for a post which has enough content to allow vertical upward space to open. Try the Demo content or a new post with at least a couple blocks added.

Verify that the content inserter menu opens upward above button:

1. Navigate to Gutenberg > Demo
2. Scroll to bottom of content
3. Toggle Inserter
4. Note insert shows above button