### PR TITLE
Components: Improve Tooltips positioning, avoid flicker effect

### DIFF
--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -20,7 +20,7 @@ import Dashicon from '../dashicon';
 // is common to apply a ref to the button element (only supported in class)
 class IconButton extends Component {
 	render() {
-		const { icon, children, label, className, focus, ...additionalProps } = this.props;
+		const { icon, children, label, className, tooltip, focus, ...additionalProps } = this.props;
 		const classes = classnames( 'components-icon-button', className );
 
 		let element = (
@@ -30,8 +30,8 @@ class IconButton extends Component {
 			</Button>
 		);
 
-		if ( label && ! children ) {
-			element = <Tooltip text={ label }>{ element }</Tooltip>;
+		if ( label && ! children && false !== tooltip ) {
+			element = <Tooltip text={ tooltip || label }>{ element }</Tooltip>;
 		}
 
 		return element;

--- a/components/icon-button/test/index.js
+++ b/components/icon-button/test/index.js
@@ -48,5 +48,18 @@ describe( 'IconButton', () => {
 			const iconButton = shallow( <IconButton test="test" /> );
 			expect( iconButton.props().test ).toBe( 'test' );
 		} );
+
+		it( 'should allow custom tooltip text', () => {
+			const iconButton = shallow( <IconButton label="WordPress" tooltip="Custom" /> );
+			expect( iconButton.name() ).toBe( 'Tooltip' );
+			expect( iconButton.prop( 'text' ) ).toBe( 'Custom' );
+			expect( iconButton.find( 'Button' ).prop( 'aria-label' ) ).toBe( 'WordPress' );
+		} );
+
+		it( 'should allow tooltip disable', () => {
+			const iconButton = shallow( <IconButton label="WordPress" tooltip={ false } /> );
+			expect( iconButton.name() ).toBe( 'Button' );
+			expect( iconButton.prop( 'aria-label' ) ).toBe( 'WordPress' );
+		} );
 	} );
 } );

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -92,13 +92,21 @@ export class Popover extends Component {
 		}
 
 		const rect = parentNode.getBoundingClientRect();
+		const [ yAxis ] = this.getPositions();
+		const isTop = 'top' === yAxis;
+
+		// Offset top positioning by padding
+		const { paddingTop, paddingBottom } = window.getComputedStyle( parentNode );
+		let topOffset = parseInt( isTop ? paddingTop : paddingBottom, 10 );
+		if ( ! isTop ) {
+			topOffset *= -1;
+		}
 
 		// Set popover at parent node center
 		popover.style.left = Math.round( rect.left + ( rect.width / 2 ) ) + 'px';
 
 		// Set at top or bottom of parent node based on popover position
-		const [ yAxis ] = this.getPositions();
-		popover.style.top = rect[ yAxis ] + 'px';
+		popover.style.top = ( rect[ yAxis ] + topOffset ) + 'px';
 	}
 
 	setForcedPositions() {

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -25,7 +25,7 @@
 
 	&.is-top {
 		bottom: 100%;
-		margin-bottom: 10px;
+		margin-top: -10px;
 
 		&:before {
 			bottom: -10px;

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -172,6 +172,19 @@ describe( 'Popover', () => {
 	} );
 
 	describe( '#setOffset()', () => {
+		let getComputedStyle;
+		beforeEach( () => {
+			getComputedStyle = window.getComputedStyle;
+			window.getComputedStyle = jest.fn().mockReturnValue( {
+				paddingTop: 10,
+				paddingBottom: 5,
+			} );
+		} );
+
+		afterEach( () => {
+			window.getComputedStyle = getComputedStyle;
+		} );
+
 		function getInstanceWithParentNode() {
 			const instance = new Popover( {} );
 
@@ -204,7 +217,7 @@ describe( 'Popover', () => {
 
 			expect( instance.nodes.popover.style ).toEqual( {
 				left: '225px',
-				top: '200px',
+				top: '210px',
 			} );
 		} );
 
@@ -216,7 +229,7 @@ describe( 'Popover', () => {
 
 			expect( instance.nodes.popover.style ).toEqual( {
 				left: '225px',
-				top: '400px',
+				top: '395px',
 			} );
 		} );
 	} );

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -72,6 +72,7 @@ class Tooltip extends Component {
 					position={ position }
 					className="components-tooltip"
 					aria-hidden="true"
+					tabIndex={ undefined }
 				>
 					{ text }
 				</Popover>,

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -71,7 +71,7 @@ class Tooltip extends Component {
 					isOpen={ isOver }
 					position={ position }
 					className="components-tooltip"
-					role="tooltip"
+					aria-hidden="true"
 				>
 					{ text }
 				</Popover>,

--- a/components/tooltip/style.scss
+++ b/components/tooltip/style.scss
@@ -1,4 +1,6 @@
 .components-tooltip.components-popover {
+	pointer-events: none;
+
 	&:before {
 		border-color: transparent;
 	}

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -7,6 +7,7 @@ import { first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 
@@ -28,6 +29,7 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, f
 				className="editor-block-mover__control"
 				onClick={ isFirst ? null : onMoveUp }
 				icon="arrow-up-alt2"
+				tooltip={ __( 'Move Up' ) }
 				label={ getBlockMoverLabel(
 					uids.length,
 					blockType && blockType.title,
@@ -42,6 +44,7 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, f
 				className="editor-block-mover__control"
 				onClick={ isLast ? null : onMoveDown }
 				icon="arrow-down-alt2"
+				tooltip={ __( 'Move Down' ) }
 				label={ getBlockMoverLabel(
 					uids.length,
 					blockType && blockType.title,


### PR DESCRIPTION
Related: #2293

This pull request seeks to add some small quality improvements to the Tooltip component implemented in #2293 :

- Tooltips would previously show colliding with the block trash and cog icons
- Tooltips could previously "flicker" when cursor moved within bounds of tooltip

To first point, the issue was that we did not account for padding when calculating position of a Popover, and only previously worked for most Popovers because offset of Popover "tail" matched padding in most cases. For these smaller icon buttons, there is no padding so the collision became much more obvious.

To the second point, we now disable pointer events within the Tooltip.

__Testing instructions:__

Verify that all Popovers and Tooltips display as expected. Current Popovers include Inserter Menu and Post Visibility. Tooltips occur on any IconButton which does not have any text of its own, but has an `aria-label` assigned.