### PR TITLE
Validation: Ignore difference of empty non-meaningful attribute value

### DIFF
--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -84,6 +84,14 @@ describe( 'validation', () => {
 
 			expect( pairs ).toEqual( [ [ 'contenteditable', '' ] ] );
 		} );
+
+		it( 'returns with empty data- attributes', () => {
+			const pairs = getMeaningfulAttributePairs( {
+				attributes: [ [ 'data-foo', '' ] ],
+			} );
+
+			expect( pairs ).toEqual( [ [ 'data-foo', '' ] ] );
+		} );
 	} );
 
 	describe( 'isEqualTextTokensWithCollapsedWhitespace()', () => {
@@ -366,6 +374,15 @@ describe( 'validation', () => {
 		it( 'should return false when difference of empty enumerated attribute', () => {
 			const isEquivalent = isEquivalentHTML(
 				'<div contenteditable>',
+				'<div>'
+			);
+
+			expect( isEquivalent ).toBe( false );
+		} );
+
+		it( 'should return false when difference of data- attribute', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div data-foo>',
 				'<div>'
 			);
 

--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -4,6 +4,7 @@
 import {
 	getTextPiecesSplitOnWhitespace,
 	getTextWithCollapsedWhitespace,
+	getMeaningfulAttributePairs,
 	isEqualTextTokensWithCollapsedWhitespace,
 	getNormalizedStyleValue,
 	getStyleProperties,
@@ -48,6 +49,40 @@ describe( 'validation', () => {
 			const pieces = getTextWithCollapsedWhitespace( '  a \t  b \n c' );
 
 			expect( pieces ).toBe( 'a b c' );
+		} );
+	} );
+
+	describe( 'getMeaningfulAttributePairs()', () => {
+		it( 'returns with non-empty attributes', () => {
+			const pairs = getMeaningfulAttributePairs( {
+				attributes: [ [ 'class', 'a' ] ],
+			} );
+
+			expect( pairs ).toEqual( [ [ 'class', 'a' ] ] );
+		} );
+
+		it( 'returns without empty non-boolean, non-enumerated attributes', () => {
+			const pairs = getMeaningfulAttributePairs( {
+				attributes: [ [ 'class', '' ] ],
+			} );
+
+			expect( pairs ).toEqual( [] );
+		} );
+
+		it( 'returns with empty boolean attributes', () => {
+			const pairs = getMeaningfulAttributePairs( {
+				attributes: [ [ 'disabled', '' ] ],
+			} );
+
+			expect( pairs ).toEqual( [ [ 'disabled', '' ] ] );
+		} );
+
+		it( 'returns with empty enumerated attributes', () => {
+			const pairs = getMeaningfulAttributePairs( {
+				attributes: [ [ 'contenteditable', '' ] ],
+			} );
+
+			expect( pairs ).toEqual( [ [ 'contenteditable', '' ] ] );
 		} );
 	} );
 
@@ -308,6 +343,33 @@ describe( 'validation', () => {
 			);
 
 			expect( isEquivalent ).toBe( true );
+		} );
+
+		it( 'should return true when difference of empty non-boolean, non-enumerated attribute', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div class="">Hello</div>',
+				'<div>Hello</div>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+		} );
+
+		it( 'should return false when difference of empty boolean attribute', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<input disabled>',
+				'<input>'
+			);
+
+			expect( isEquivalent ).toBe( false );
+		} );
+
+		it( 'should return false when difference of empty enumerated attribute', () => {
+			const isEquivalent = isEquivalentHTML(
+				'<div contenteditable>',
+				'<div>'
+			);
+
+			expect( isEquivalent ).toBe( false );
 		} );
 	} );
 

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -149,7 +149,8 @@ export function getTextWithCollapsedWhitespace( text ) {
 
 /**
  * Returns attribute pairs of the given StartTag token, including only pairs
- * where the value is non-empty or the attribute is a boolean attribute.
+ * where the value is non-empty or the attribute is a boolean attribute, an
+ * enumerated attribute, or a custom data- attribute.
  *
  * @see MEANINGFUL_ATTRIBUTES
  *
@@ -159,7 +160,11 @@ export function getTextWithCollapsedWhitespace( text ) {
 export function getMeaningfulAttributePairs( token ) {
 	return token.attributes.filter( ( pair ) => {
 		const [ key, value ] = pair;
-		return value || includes( MEANINGFUL_ATTRIBUTES, key );
+		return (
+			value ||
+			key.indexOf( 'data-' ) === 0 ||
+			includes( MEANINGFUL_ATTRIBUTES, key )
+		);
 	} );
 }
 

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { tokenize } from 'simple-html-tokenizer';
-import { xor, fromPairs, isEqual } from 'lodash';
+import { xor, fromPairs, isEqual, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +31,101 @@ const REGEXP_ONLY_WHITESPACE = /^[\t\n\r\v\f ]*$/;
 const REGEXP_STYLE_URL_TYPE = /^url\s*\(['"\s]*(.*?)['"\s]*\)$/;
 
 /**
+ * Boolean attributes are attributes whose presence as being assigned is
+ * meaningful, even if only empty.
+ *
+ * See: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
+ * Extracted from: https://html.spec.whatwg.org/multipage/indices.html#attributes-3
+ *
+ * [ ...document.querySelectorAll( '#attributes-1 > tbody > tr' ) ]
+ *     .filter( ( tr ) => tr.lastChild.textContent.indexOf( 'Boolean attribute' ) !== -1 )
+ *     .map( ( tr ) => tr.firstChild.textContent.trim() )
+ *
+ * @type {Array}
+ */
+const BOOLEAN_ATTRIBUTES = [
+	'allowfullscreen',
+	'allowpaymentrequest',
+	'allowusermedia',
+	'async',
+	'autofocus',
+	'autoplay',
+	'checked',
+	'controls',
+	'default',
+	'defer',
+	'disabled',
+	'formnovalidate',
+	'hidden',
+	'ismap',
+	'itemscope',
+	'loop',
+	'multiple',
+	'muted',
+	'nomodule',
+	'novalidate',
+	'open',
+	'open',
+	'playsinline',
+	'readonly',
+	'required',
+	'reversed',
+	'selected',
+	'typemustmatch',
+];
+
+/**
+ * Enumerated attributes are attributes which must be of a specific value form.
+ * Like boolean attributes, these are meaningful if specified, even if not of a
+ * valid enumerated value.
+ *
+ * See: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute
+ * Extracted from: https://html.spec.whatwg.org/multipage/indices.html#attributes-3
+ *
+ * [ ...document.querySelectorAll( '#attributes-1 > tbody > tr' ) ]
+ *     filter( ( tr ) => /("(.+?)";?\s*)+/.test( tr.lastChild.textContent ) )
+ *     .map( ( tr ) => tr.firstChild.textContent.trim() )
+ *
+ * @type {Array}
+ */
+const ENUMERATED_ATTRIBUTES = [
+	'autocomplete',
+	'contenteditable',
+	'crossorigin',
+	'dir',
+	'dir',
+	'draggable',
+	'enctype',
+	'formenctype',
+	'formmethod',
+	'inputmode',
+	'kind',
+	'method',
+	'preload',
+	'sandbox',
+	'scope',
+	'shape',
+	'spellcheck',
+	'step',
+	'translate',
+	'type',
+	'type',
+	'workertype',
+	'wrap',
+];
+
+/**
+ * Meaningful attributes are those who cannot be safely ignored when omitted in
+ * one HTML markup string and not another.
+ *
+ * @type {Array}
+ */
+const MEANINGFUL_ATTRIBUTES = [
+	...BOOLEAN_ATTRIBUTES,
+	...ENUMERATED_ATTRIBUTES,
+];
+
+/**
  * Given a specified string, returns an array of strings split by consecutive
  * whitespace, ignoring leading or trailing whitespace.
  *
@@ -50,6 +145,22 @@ export function getTextPiecesSplitOnWhitespace( text ) {
  */
 export function getTextWithCollapsedWhitespace( text ) {
 	return getTextPiecesSplitOnWhitespace( text ).join( ' ' );
+}
+
+/**
+ * Returns attribute pairs of the given StartTag token, including only pairs
+ * where the value is non-empty or the attribute is a boolean attribute.
+ *
+ * @see MEANINGFUL_ATTRIBUTES
+ *
+ * @param  {Object}  token StartTag token
+ * @return {Array[]}       Attribute pairs
+ */
+export function getMeaningfulAttributePairs( token ) {
+	return token.attributes.filter( ( pair ) => {
+		const [ key, value ] = pair;
+		return value || includes( MEANINGFUL_ATTRIBUTES, key );
+	} );
 }
 
 /**
@@ -179,8 +290,7 @@ export const isEqualTokensOfType = {
 		}
 
 		return isEqualTagAttributePairs(
-			a.attributes,
-			b.attributes,
+			...[ a, b ].map( getMeaningfulAttributePairs )
 		);
 	},
 	Chars: isEqualTextTokensWithCollapsedWhitespace,


### PR DESCRIPTION
This pull request seeks to enhance validation leniency, to allow for equivalence of differences such as:

```js
isEquivalentHTML( '<div class></div>', '<div></div>' ); // true
```

But not:

```js
isEquivalentHTML( '<input disabled>', '<input>' ); // false
isEquivalentHTML( '<div contenteditable></div>', '<div></div>' ); // false
isEquivalentHTML( '<div data-foo></div>', '<div></div>' ); // false
```

See also specification fun:

- https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute
- https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute

__Testing instructions:__

Ensure unit tests pass:

```
npm test
```

Verify that adding an empty standard attribute to a block's element in `post-content` does not cause the block to become flagged as invalid.