### PR TITLE
Remove target="_blank" from View Post message

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -107,7 +107,7 @@ export default {
 				<p>
 					<span>{ noticeMessage }</span>
 					{ ' ' }
-					<a href={ post.link } target="_blank">{ __( 'View post' ) }</a>
+					<a href={ post.link }>{ __( 'View post' ) }</a>
 				</p>,
 				{ id: SAVE_POST_NOTICE_ID }
 			) );


### PR DESCRIPTION
WordPress core removed target="_blank" from most of core: https://core.trac.wordpress.org/ticket/23432

WordPress core also has standardized around "Previews are new windows, views are not": https://core.trac.wordpress.org/browser/trunk/src/wp-admin/edit-form-advanced.php#L92

Related: #1105
cc/ @afercia 