### PR TITLE
Add landmark regions

### DIFF
--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -24,7 +24,11 @@ function Header( { multiSelectedBlockUids, onRemove, onDeselect } ) {
 
 	if ( count ) {
 		return (
-			<header className="editor-header editor-header-multi-select">
+			<div
+				role="region"
+				aria-label={ __( 'Editor toolbar' ) }
+				className="editor-header editor-header-multi-select"
+			>
 				<div className="editor-selected-count">
 					{ sprintf( _n( '%d block selected', '%d blocks selected', count ), count ) }
 				</div>
@@ -45,16 +49,20 @@ function Header( { multiSelectedBlockUids, onRemove, onDeselect } ) {
 						onClick={ () => onDeselect() }
 					/>
 				</div>
-			</header>
+			</div>
 		);
 	}
 
 	return (
-		<header className="editor-header">
+		<div
+			role="region"
+			aria-label={ __( 'Editor toolbar' ) }
+			className="editor-header"
+		>
 			<ModeSwitcher />
 			<SavedState />
 			<Tools />
-		</header>
+		</div>
 	);
 }
 

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -52,7 +52,7 @@ class TextEditor extends Component {
 		return (
 			<div
 				role="region"
-				aria-label={ __( 'Editor text mode' ) }
+				aria-label={ __( 'Editor content' ) }
 				className="editor-text-editor"
 			>
 				<div className="editor-text-editor__formatting">

--- a/editor/modes/text-editor/index.js
+++ b/editor/modes/text-editor/index.js
@@ -7,6 +7,7 @@ import Textarea from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 
@@ -49,8 +50,12 @@ class TextEditor extends Component {
 		const { value } = this.props;
 
 		return (
-			<div className="editor-text-editor">
-				<header className="editor-text-editor__formatting">
+			<div
+				role="region"
+				aria-label={ __( 'Editor text mode' ) }
+				className="editor-text-editor"
+			>
+				<div className="editor-text-editor__formatting">
 					<div className="editor-text-editor__formatting-group">
 						<button className="editor-text-editor__bold">b</button>
 						<button className="editor-text-editor__italic">i</button>
@@ -66,7 +71,7 @@ class TextEditor extends Component {
 						<button>more</button>
 						<button>close tags</button>
 					</div>
-				</header>
+				</div>
 				<div className="editor-text-editor__body">
 					<PostTitle />
 					<Textarea

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -84,7 +84,7 @@ class VisualEditor extends Component {
 		return (
 			<div
 				role="region"
-				aria-label={ __( 'Editor visual mode' ) }
+				aria-label={ __( 'Editor content' ) }
 				className="editor-visual-editor"
 				onMouseDown={ this.onClick }
 				onTouchStart={ this.onClick }

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -84,7 +84,7 @@ class VisualEditor extends Component {
 		return (
 			<div
 				role="region"
-				aria-label={ __( 'Visual Editor' ) }
+				aria-label={ __( 'Editor visual mode' ) }
 				className="editor-visual-editor"
 				onMouseDown={ this.onClick }
 				onTouchStart={ this.onClick }

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -20,7 +20,7 @@ import { getActivePanel } from '../selectors';
 
 const Sidebar = ( { panel } ) => {
 	return (
-		<div className="editor-sidebar" role="region" aria-label={ __( 'Editor settings sidebar' ) }>
+		<div className="editor-sidebar" role="region" aria-label={ __( 'Editor settings' ) }>
 			<Header />
 			{ panel === 'document' && <PostSettings /> }
 			{ panel === 'block' && <BlockInspector /> }

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress Dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { withFocusReturn } from '@wordpress/components';
 
 /**
@@ -19,7 +20,7 @@ import { getActivePanel } from '../selectors';
 
 const Sidebar = ( { panel } ) => {
 	return (
-		<div className="editor-sidebar">
+		<div className="editor-sidebar" role="region" aria-label={ __( 'Editor settings sidebar' ) }>
 			<Header />
 			{ panel === 'document' && <PostSettings /> }
 			{ panel === 'block' && <BlockInspector /> }

--- a/lib/register.php
+++ b/lib/register.php
@@ -15,10 +15,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * The main entry point for the Gutenberg editor. Renders the editor on the
  * wp-admin page for the plugin.
  *
+ * @todo Remove the temporary fix for the NVDA screen reader and use meaningful
+ *       content instead. See pull #2380 and issues #467 and #503.
+ *
  * @since 0.1.0
  */
 function the_gutenberg_project() {
 	?>
+	<div class="nvda-temp-fix screen-reader-text">&nbsp;</div>
 	<div class="gutenberg">
 		<div id="editor" class="gutenberg__editor"></div>
 	</div>

--- a/lib/register.php
+++ b/lib/register.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function the_gutenberg_project() {
 	?>
 	<div class="gutenberg">
-		<section id="editor" class="gutenberg__editor"></section>
+		<div id="editor" class="gutenberg__editor"></div>
 	</div>
 	<?php
 }


### PR DESCRIPTION
Partially addresses #467 

This PR tries to introduce an easy way for screen reader users to jump through the main editor sections via ARIA landmark regions.

All the major screen readers support landmarks: they're just HTML elements with special semantic meaning (nav, main, aside, etc.) or div elements with special ARIA roles (main, complementary, region, etc.).

We've discussed this in a recent accessibility team meeting (see #467) and initially decided to use `aside`. However, I'd propose to use the generic role `region` because:
https://www.w3.org/TR/wai-aria-practices/#aria_lh_complementary
> A complementary landmark is a supporting section of the document, designed to be complementary to the main content at a similar level in the DOM hierarchy, but remains meaningful when separated from the main content.

> ... complementary landmarks should be top level landmarks (e.g. not contained within any other landmarks).

Instead, the editor is nested within the main content.

> If the complementary content is not related to the main content, a more general role should be assigned (e.g. region).

So, `region` seemed more appropriate to me. Reference and examples:
https://www.w3.org/TR/wai-aria-practices/#aria_lh_region
https://www.w3.org/TR/wai-aria-practices/examples/landmarks/region.html

I'd appreciate some feedback about the aria-label values, especially thinking at how they would be translated in other languages. /cc @joedolson @rianrietveld and everyone.

Screenshots with Safari + VoiceOver:

![landmarks visual](https://user-images.githubusercontent.com/1682452/29226070-f3711020-7ed0-11e7-96b3-a5dec11f8f17.png)

![landmarks text](https://user-images.githubusercontent.com/1682452/29226071-f3727028-7ed0-11e7-8808-843a06180596.png)

I had to change some elements to clean-up some semantics. For example the `header` used for the text mode quicktags was reported as a "banner" landmark:

![landmarks text with banner](https://user-images.githubusercontent.com/1682452/29226154-39a9c140-7ed1-11e7-8bb6-7a4bec258a7e.png)
