### PR TITLE
Block API: Adding the anchor support (id)

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -19,18 +19,18 @@ import { getBlockType } from './registration';
 /**
  * Returns a block object given its type and attributes.
  *
- * @param  {String} name        Block name
- * @param  {Object} attributes  Block attributes
- * @return {Object}             Block object
+ * @param  {String} name             Block name
+ * @param  {Object} blockAttributes  Block attributes
+ * @return {Object}                  Block object
  */
-export function createBlock( name, attributes = {} ) {
+export function createBlock( name, blockAttributes = {} ) {
 	// Get the type definition associated with a registered block.
 	const blockType = getBlockType( name );
 
 	// Ensure attributes contains only values defined by block type, and merge
 	// default values for missing attributes.
-	attributes = reduce( blockType.attributes, ( result, source, key ) => {
-		const value = attributes[ key ];
+	const attributes = reduce( blockType.attributes, ( result, source, key ) => {
+		const value = blockAttributes[ key ];
 		if ( undefined !== value ) {
 			result[ key ] = value;
 		} else if ( source.default ) {
@@ -39,6 +39,9 @@ export function createBlock( name, attributes = {} ) {
 
 		return result;
 	}, {} );
+	if ( blockType.supportAnchor && blockAttributes.anchor ) {
+		attributes.anchor = blockAttributes.anchor;
+	}
 
 	// Blocks are stored with a unique ID, the assigned type name,
 	// and the block attributes.

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { parse as hpqParse } from 'hpq';
+import { parse as hpqParse, attr } from 'hpq';
 import { mapValues, reduce, pickBy } from 'lodash';
 
 /**
@@ -101,7 +101,7 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
 		blockType.attributes
 	);
 
-	return reduce( blockType.attributes, ( result, source, key ) => {
+	const blockAttributes = reduce( blockType.attributes, ( result, source, key ) => {
 		let value;
 		if ( sourcedAttributes.hasOwnProperty( key ) ) {
 			value = sourcedAttributes[ key ];
@@ -146,6 +146,13 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
 		result[ key ] = coercedValue;
 		return result;
 	}, {} );
+
+	// If the block supports anchor, parse the id
+	if ( blockType.supportAnchor ) {
+		blockAttributes.anchor = hpqParse( rawContent, attr( '*', 'id' ) );
+	}
+
+	return blockAttributes;
 }
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -50,20 +50,28 @@ export function getSaveContent( blockType, attributes ) {
 	}
 
 	// Adding a generic classname
-	const addClassnameToElement = ( element ) => {
-		if ( ! element || ! isObject( element ) || ! className ) {
+	const addGenericAttributes = ( element ) => {
+		if ( ! element || ! isObject( element ) ) {
 			return element;
 		}
 
-		const updatedClassName = classnames(
-			className,
-			element.props.className,
-			attributes.className
-		);
+		const extraProps = {};
+		if ( !! className ) {
+			const updatedClassName = classnames(
+				className,
+				element.props.className,
+				attributes.className
+			);
+			extraProps.className = updatedClassName;
+		}
 
-		return cloneElement( element, { className: updatedClassName } );
+		if ( blockType.supportAnchor && attributes.anchor ) {
+			extraProps.id = attributes.anchor;
+		}
+
+		return cloneElement( element, extraProps );
 	};
-	const contentWithClassname = Children.map( rawContent, addClassnameToElement );
+	const contentWithClassname = Children.map( rawContent, addGenericAttributes );
 
 	// Otherwise, infer as element
 	return renderToString( contentWithClassname );

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -50,7 +50,7 @@ export function getSaveContent( blockType, attributes ) {
 	}
 
 	// Adding a generic classname
-	const addGenericAttributes = ( element ) => {
+	const addAdvancedAttributes = ( element ) => {
 		if ( ! element || ! isObject( element ) ) {
 			return element;
 		}
@@ -71,7 +71,7 @@ export function getSaveContent( blockType, attributes ) {
 
 		return cloneElement( element, extraProps );
 	};
-	const contentWithClassname = Children.map( rawContent, addGenericAttributes );
+	const contentWithClassname = Children.map( rawContent, addAdvancedAttributes );
 
 	// Otherwise, infer as element
 	return renderToString( contentWithClassname );

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -54,6 +54,29 @@ describe( 'block factory', () => {
 			expect( block.isValid ).toBe( true );
 			expect( typeof block.uid ).toBe( 'string' );
 		} );
+
+		it( 'should keep the anchor if the block supports it', () => {
+			registerBlockType( 'core/test-block', {
+				attributes: {
+					align: {
+						type: 'string',
+					},
+				},
+				save: noop,
+				category: 'common',
+				supportAnchor: true,
+			} );
+			const block = createBlock( 'core/test-block', {
+				align: 'left',
+				anchor: 'chicken',
+			} );
+
+			expect( block.attributes ).toEqual( {
+				anchor: 'chicken',
+				align: 'left',
+			} );
+			expect( block.isValid ).toBe( true );
+		} );
 	} );
 
 	describe( 'switchToBlockType()', () => {

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -155,6 +155,26 @@ describe( 'block parser', () => {
 				topic: 'none',
 			} );
 		} );
+
+		it( 'should parse the anchor if the block supports it', () => {
+			const blockType = {
+				attributes: {
+					content: {
+						type: 'string',
+						source: text( 'div' ),
+					},
+				},
+				supportAnchor: true,
+			};
+
+			const rawContent = '<div id="chicken">Ribs</div>';
+			const attrs = {};
+
+			expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {
+				content: 'Ribs',
+				anchor: 'chicken',
+			} );
+		} );
 	} );
 
 	describe( 'createBlockWithFallback', () => {

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -112,6 +112,20 @@ describe( 'block serializer', () => {
 
 				expect( saved ).toBe( '<div>Bananas</div>' );
 			} );
+
+			it( 'should add an id if the block supports anchors', () => {
+				const saved = getSaveContent(
+					{
+						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
+						supportAnchor: true,
+						name: 'myplugin/fruit',
+						className: false,
+					},
+					{ fruit: 'Bananas', anchor: 'my-fruit' }
+				);
+
+				expect( saved ).toBe( '<div id="my-fruit">Bananas</div>' );
+			} );
 		} );
 
 		describe( 'component save', () => {

--- a/blocks/inspector-controls/base-control/index.js
+++ b/blocks/inspector-controls/base-control/index.js
@@ -8,11 +8,12 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-function BaseControl( { id, label, className, children } ) {
+function BaseControl( { id, label, help, className, children } ) {
 	return (
 		<div className={ classnames( 'blocks-base-control', className ) }>
 			{ label && <label className="blocks-base-control__label" htmlFor={ id }>{ label }</label> }
 			{ children }
+			{ !! help && <p className="blocks-base-control__help">{ help }</p> }
 		</div>
 	);
 }

--- a/blocks/inspector-controls/base-control/index.js
+++ b/blocks/inspector-controls/base-control/index.js
@@ -13,7 +13,7 @@ function BaseControl( { id, label, help, className, children } ) {
 		<div className={ classnames( 'blocks-base-control', className ) }>
 			{ label && <label className="blocks-base-control__label" htmlFor={ id }>{ label }</label> }
 			{ children }
-			{ !! help && <p className="blocks-base-control__help">{ help }</p> }
+			{ !! help && <p id={ id + '__help' } className="blocks-base-control__help">{ help }</p> }
 		</div>
 	);
 }

--- a/blocks/inspector-controls/base-control/style.scss
+++ b/blocks/inspector-controls/base-control/style.scss
@@ -6,3 +6,7 @@
 	display: block;
 	margin-bottom: 5px;
 }
+
+.blocks-base-control__help {
+	font-style: italic;
+}

--- a/blocks/inspector-controls/checkbox-control/index.js
+++ b/blocks/inspector-controls/checkbox-control/index.js
@@ -9,12 +9,12 @@ import { withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function CheckboxControl( { label, heading, checked, instanceId, onChange, ...props } ) {
+function CheckboxControl( { label, heading, checked, help, instanceId, onChange, ...props } ) {
 	const id = 'inspector-checkbox-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ heading } id={ id }>
+		<BaseControl label={ heading } id={ id } help={ help }>
 			<input
 				id={ id }
 				className="blocks-checkbox-control__input"
@@ -22,6 +22,7 @@ function CheckboxControl( { label, heading, checked, instanceId, onChange, ...pr
 				value="1"
 				onChange={ onChangeValue }
 				checked={ checked }
+				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props }
 			/>
 			<label className="blocks-checkbox-control__label" htmlFor={ id }>

--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -14,12 +14,12 @@ import { withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function RadioControl( { label, selected, instanceId, onChange, options = [] } ) {
+function RadioControl( { label, selected, help, instanceId, onChange, options = [] } ) {
 	const id = 'inspector-radio-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return ! isEmpty( options ) && (
-		<BaseControl label={ label } id={ id } className="blocks-radio-control">
+		<BaseControl label={ label } id={ id } help={ help } className="blocks-radio-control">
 			{ options.map( ( option, index ) =>
 				<div
 					key={ ( id + '-' + index ) }
@@ -33,6 +33,7 @@ function RadioControl( { label, selected, instanceId, onChange, options = [] } )
 						value={ option.value }
 						onChange={ onChangeValue }
 						selected={ option.value === selected }
+						aria-describedby={ !! help ? id + '__help' : undefined }
 					/>
 					<label key={ option.value } htmlFor={ ( id + '-' + index ) }>
 						{ option.label }

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -9,12 +9,12 @@ import { Dashicon, withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIcon, ...props } ) {
+function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIcon, help, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 
 	return (
-		<BaseControl label={ label } id={ id } className="blocks-range-control">
+		<BaseControl label={ label } id={ id } help={ help } className="blocks-range-control">
 			{ beforeIcon && <Dashicon icon={ beforeIcon } size={ 20 } /> }
 			<input
 				className="blocks-range-control__slider"
@@ -22,6 +22,7 @@ function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIc
 				type="range"
 				value={ value }
 				onChange={ onChangeValue }
+				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props } />
 			{ afterIcon && <Dashicon icon={ afterIcon } /> }
 			<input

--- a/blocks/inspector-controls/select-control/index.js
+++ b/blocks/inspector-controls/select-control/index.js
@@ -14,16 +14,17 @@ import { withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function SelectControl( { label, selected, instanceId, onBlur, options = [], ...props } ) {
+function SelectControl( { label, selected, help, instanceId, onBlur, options = [], ...props } ) {
 	const id = 'inspector-select-control-' + instanceId;
 	const onBlurValue = ( event ) => onBlur( event.target.value );
 
 	return ! isEmpty( options ) && (
-		<BaseControl label={ label } id={ id }>
+		<BaseControl label={ label } id={ id } help={ help }>
 			<select
 				id={ id }
 				className="blocks-select-control__input"
 				onBlur={ onBlurValue }
+				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props }
 			>
 				{ options.map( ( option ) =>

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -9,12 +9,12 @@ import { withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function TextControl( { label, value, instanceId, onChange, type = 'text', ...props } ) {
+function TextControl( { label, value, help, instanceId, onChange, type = 'text', ...props } ) {
 	const id = 'inspector-text-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ label } id={ id }>
+		<BaseControl label={ label } id={ id } help={ help }>
 			<input className="blocks-text-control__input" type={ type } id={ id } value={ value } onChange={ onChangeValue } { ...props } />
 		</BaseControl>
 	);

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -15,7 +15,14 @@ function TextControl( { label, value, help, instanceId, onChange, type = 'text',
 
 	return (
 		<BaseControl label={ label } id={ id } help={ help }>
-			<input className="blocks-text-control__input" type={ type } id={ id } value={ value } onChange={ onChangeValue } { ...props } />
+			<input className="blocks-text-control__input"
+				type={ type }
+				id={ id }
+				value={ value }
+				onChange={ onChangeValue }
+				aria-describedby={ !! help ? id + '__help' : undefined }
+				{ ...props }
+			/>
 		</BaseControl>
 	);
 }

--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -9,13 +9,20 @@ import { withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function TextareaControl( { label, value, instanceId, onChange, rows = 4, ...props } ) {
+function TextareaControl( { label, value, help, instanceId, onChange, rows = 4, ...props } ) {
 	const id = 'inspector-textarea-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ label } id={ id }>
-			<textarea className="blocks-textarea-control__input" id={ id } rows={ rows } onChange={ onChangeValue } { ...props }>
+		<BaseControl label={ label } id={ id } help={ help }>
+			<textarea
+				className="blocks-textarea-control__input"
+				id={ id }
+				rows={ rows }
+				onChange={ onChangeValue }
+				aria-describedby={ !! help ? id + '__help' : undefined }
+				{ ...props }
+			>
 				{ value }
 			</textarea>
 		</BaseControl>

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -9,12 +9,17 @@ import { withInstanceId, FormToggle } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function ToggleControl( { label, checked, instanceId, onChange } ) {
+function ToggleControl( { label, checked, help, instanceId, onChange } ) {
 	const id = 'inspector-toggle-control-' + instanceId;
 
 	return (
-		<BaseControl label={ label } id={ id } className="blocks-toggle-control">
-			<FormToggle id={ id } checked={ checked } onChange={ onChange } />
+		<BaseControl label={ label } id={ id } help={ help } className="blocks-toggle-control">
+			<FormToggle
+				id={ id }
+				checked={ checked }
+				onChange={ onChange }
+				aria-describedby={ !! help ? id + '__help' : undefined }
+			/>
 		</BaseControl>
 	);
 }

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -29,6 +29,8 @@ registerBlockType( 'core/heading', {
 
 	className: false,
 
+	supportAnchor: true,
+
 	attributes: {
 		content: {
 			type: 'array',

--- a/components/form-toggle/index.js
+++ b/components/form-toggle/index.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import './style.scss';
 
-function FormToggle( { className, checked, id, onChange = noop, showHint = true } ) {
+function FormToggle( { className, checked, id, onChange = noop, showHint = true, ...props } ) {
 	const wrapperClasses = classnames(
 		'components-form-toggle',
 		className,
@@ -29,6 +29,7 @@ function FormToggle( { className, checked, id, onChange = noop, showHint = true 
 				type="checkbox"
 				checked={ checked }
 				onChange={ onChange }
+				{ ...props }
 			/>
 			<span className="components-form-toggle__track"></span>
 			<span className="components-form-toggle__thumb"></span>

--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -16,6 +16,7 @@ import { ClipboardButton } from '@wordpress/components';
  */
 import { updateBlockAttributes } from '../../actions';
 import { getSelectedBlock, getCurrentPost } from '../../selectors';
+import { filterURLForDisplay } from '../../utils/url';
 
 /**
  * Internal constants
@@ -85,7 +86,9 @@ class BlockInspectorAdvancedControls extends Component {
 							onChange={ this.setAnchor } />
 						{ !! post.link && !! selectedBlock.attributes.anchor &&
 							<div className="editor-advanced-controls__anchor">
-								<span className="editor-advanced-controls__anchor-link">{ post.link }#{ selectedBlock.attributes.anchor }</span>
+								<span className="editor-advanced-controls__anchor-link">
+									{ filterURLForDisplay( `${ post.link }#${ selectedBlock.attributes.anchor }` ) }
+								</span>
 								<ClipboardButton className="button" text={ `${ post.link }#${ selectedBlock.attributes.anchor }` } onCopy={ this.onCopy }>
 									{ this.state.showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy' ) }
 								</ClipboardButton>

--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { Component } from '@wordpress/element';
 import { getBlockType, InspectorControls } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { ClipboardButton } from '@wordpress/components';
+import { ClipboardButton, Tooltip } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -86,11 +86,10 @@ class BlockInspectorAdvancedControls extends Component {
 							onChange={ this.setAnchor } />
 						{ !! post.link && !! selectedBlock.attributes.anchor &&
 							<div className="editor-advanced-controls__anchor">
-								<span className="editor-advanced-controls__anchor-link">
-									{ filterURLForDisplay( `${ post.link }#${ selectedBlock.attributes.anchor }` ) }
-								</span>
 								<ClipboardButton className="button" text={ `${ post.link }#${ selectedBlock.attributes.anchor }` } onCopy={ this.onCopy }>
-									{ this.state.showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy' ) }
+									<Tooltip text={ filterURLForDisplay( `${ post.link }#${ selectedBlock.attributes.anchor }` ) }>
+										<div>{ this.state.showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy Link' ) }</div>
+									</Tooltip>
 								</ClipboardButton>
 							</div>
 						}

--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -70,7 +70,7 @@ class BlockInspectorAdvancedControls extends Component {
 		return (
 			<div>
 				<h3>{ __( 'Block Settings' ) }</h3>
-				{ blockType.className &&
+				{ false !== blockType.className &&
 					<InspectorControls.TextControl
 						label={ __( 'Additional CSS Class' ) }
 						value={ selectedBlock.attributes.className || '' }

--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -21,7 +21,7 @@ import { getSelectedBlock } from '../../selectors';
  */
 const ANCHOR_REGEX = /[\s#]/g;
 
-class BlockInspectorGenericControls extends Component {
+class BlockInspectorAdvancedControls extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -76,4 +76,4 @@ export default connect(
 	{
 		setAttributes: updateBlockAttributes,
 	}
-)( BlockInspectorGenericControls );
+)( BlockInspectorAdvancedControls );

--- a/editor/sidebar/block-inspector/generic-controls.js
+++ b/editor/sidebar/block-inspector/generic-controls.js
@@ -16,11 +16,17 @@ import { __ } from '@wordpress/i18n';
 import { updateBlockAttributes } from '../../actions';
 import { getSelectedBlock } from '../../selectors';
 
-class BlockInspectorClassName extends Component {
+/**
+ * Internal constants
+ */
+const ANCHOR_REGEX = /[^\w:.-]/g;
+
+class BlockInspectorGenericControls extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.setClassName = this.setClassName.bind( this );
+		this.setAnchor = this.setAnchor.bind( this );
 	}
 
 	setClassName( className ) {
@@ -28,20 +34,33 @@ class BlockInspectorClassName extends Component {
 		setAttributes( selectedBlock.uid, { className } );
 	}
 
+	setAnchor( anchor ) {
+		const { selectedBlock, setAttributes } = this.props;
+		setAttributes( selectedBlock.uid, { anchor: anchor.replace( ANCHOR_REGEX, '-' ) } );
+	}
+
 	render() {
 		const { selectedBlock } = this.props;
 		const blockType = getBlockType( selectedBlock.name );
-		if ( false === blockType.className ) {
+		if ( false === blockType.className && ! blockType.supportAnchor ) {
 			return null;
 		}
 
 		return (
 			<div>
 				<h3>{ __( 'Block Settings' ) }</h3>
-				<InspectorControls.TextControl
-					label={ __( 'Additional CSS Class' ) }
-					value={ selectedBlock.attributes.className }
-					onChange={ this.setClassName } />
+				{ blockType.className &&
+					<InspectorControls.TextControl
+						label={ __( 'Additional CSS Class' ) }
+						value={ selectedBlock.attributes.className || '' }
+						onChange={ this.setClassName } />
+				}
+				{ blockType.supportAnchor &&
+					<InspectorControls.TextControl
+						label={ __( 'Anchor' ) }
+						value={ selectedBlock.attributes.anchor || '' }
+						onChange={ this.setAnchor } />
+				}
 			</div>
 		);
 	}
@@ -56,4 +75,4 @@ export default connect(
 	{
 		setAttributes: updateBlockAttributes,
 	}
-)( BlockInspectorClassName );
+)( BlockInspectorGenericControls );

--- a/editor/sidebar/block-inspector/generic-controls.js
+++ b/editor/sidebar/block-inspector/generic-controls.js
@@ -57,7 +57,8 @@ class BlockInspectorGenericControls extends Component {
 				}
 				{ blockType.supportAnchor &&
 					<InspectorControls.TextControl
-						label={ __( 'Anchor' ) }
+						label={ __( 'HTML Anchor' ) }
+						help={ __( 'Anchors lets you link directly to a section on a page.' ) }
 						value={ selectedBlock.attributes.anchor || '' }
 						onChange={ this.setAnchor } />
 				}

--- a/editor/sidebar/block-inspector/generic-controls.js
+++ b/editor/sidebar/block-inspector/generic-controls.js
@@ -19,7 +19,7 @@ import { getSelectedBlock } from '../../selectors';
 /**
  * Internal constants
  */
-const ANCHOR_REGEX = /[^\w:.-]/g;
+const ANCHOR_REGEX = /[\s#]/g;
 
 class BlockInspectorGenericControls extends Component {
 	constructor() {

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -14,7 +14,7 @@ import { Panel, PanelBody } from '@wordpress/components';
  * Internal Dependencies
  */
 import './style.scss';
-import BlockInspectorClassName from './class-name';
+import BlockInspectorGenericControls from './generic-controls';
 import { getSelectedBlock } from '../../selectors';
 
 const BlockInspector = ( { selectedBlock } ) => {
@@ -26,7 +26,7 @@ const BlockInspector = ( { selectedBlock } ) => {
 		<Panel>
 			<PanelBody>
 				<Slot name="Inspector.Controls" />
-				<BlockInspectorClassName />
+				<BlockInspectorGenericControls />
 			</PanelBody>
 		</Panel>
 	);

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -14,7 +14,7 @@ import { Panel, PanelBody } from '@wordpress/components';
  * Internal Dependencies
  */
 import './style.scss';
-import BlockInspectorGenericControls from './generic-controls';
+import BlockInspectorAdvancedControls from './advanced-controls';
 import { getSelectedBlock } from '../../selectors';
 
 const BlockInspector = ( { selectedBlock } ) => {
@@ -26,7 +26,7 @@ const BlockInspector = ( { selectedBlock } ) => {
 		<Panel>
 			<PanelBody>
 				<Slot name="Inspector.Controls" />
-				<BlockInspectorGenericControls />
+				<BlockInspectorAdvancedControls />
 			</PanelBody>
 		</Panel>
 	);

--- a/editor/sidebar/block-inspector/style.scss
+++ b/editor/sidebar/block-inspector/style.scss
@@ -16,3 +16,20 @@
 	border-bottom: 1px solid $light-gray-500;
 	text-align: center;
 }
+
+.editor-advanced-controls__anchor {
+	display: inline-flex;
+	max-width: 100%;
+	align-items: center;
+}
+
+.editor-advanced-controls__anchor-link {
+	flex-grow: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	position: relative;
+
+	&:after {
+		@include long-content-fade( $size: 20% );
+	}
+}


### PR DESCRIPTION
This PR starts the work on #1734 

The approach here is to add a new block API property `supportAnchor` (yeah, another property :(). A block can opt-int to the anchor support by setting `supportAnchor: true`. This will add an Anchor Text Input to the sidebar (similar to the className behaviour).
The serializer will automatically sets the `id` attribute to the wrapper node of the block.

**Notes**

I've used an opt-in approach (enabled on heading only for now), because the serializer can't automatically add an attribute to any random block. Blocks with no wrapper or with a `save` function returning a string can't declare support for the anchor.

**Not done yet:**

 - Automatically generate an id
 - Check unicity

Thoughs on the approach here?