### PR TITLE
Fix regression with inline toolbar shadow

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -90,4 +90,8 @@
 	left: 0;
 	right: 0;
 	z-index: 1;
+
+	ul.components-toolbar {
+		box-shadow: $shadow-toolbar;
+	}
 }

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -35,6 +35,10 @@ ul.components-toolbar {
 			height: $icon-button-size - 16px;
 		}
 	}
+
+	.block-editable__inline-toolbar & {
+		box-shadow: $shadow-toolbar;
+	}
 }
 
 .components-toolbar__control.components-button {

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -35,10 +35,6 @@ ul.components-toolbar {
 			height: $icon-button-size - 16px;
 		}
 	}
-
-	.block-editable__inline-toolbar & {
-		box-shadow: $shadow-toolbar;
-	}
 }
 
 .components-toolbar__control.components-button {


### PR DESCRIPTION
0.8 included a new unified toolbar design for the quick toolbar. I missed here, a regression with the inline toolbar (shown on Cover Image and Image captions). The regression was that the shadow was gone. This PR fixes that.

Screenshot:

![screen shot 2017-08-14 at 12 01 51](https://user-images.githubusercontent.com/1204802/29267306-67abee2e-80e8-11e7-9edc-fabe05173b14.png)
