### PR TITLE
Add font-size option to cover text.

### DIFF
--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from '@wordpress/components';
+import { Dashicon, withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -9,12 +9,13 @@ import { withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function RangeControl( { label, value, instanceId, onChange, ...props } ) {
+function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIcon, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 
 	return (
 		<BaseControl label={ label } id={ id } className="blocks-range-control">
+			{ beforeIcon && <Dashicon icon={ beforeIcon } size={ 20 } /> }
 			<input
 				className="blocks-range-control__input"
 				id={ id }
@@ -22,7 +23,13 @@ function RangeControl( { label, value, instanceId, onChange, ...props } ) {
 				value={ value }
 				onChange={ onChangeValue }
 				{ ...props } />
-			<span className="blocks-range-control__hint">{ value }</span>
+			{ afterIcon && <Dashicon icon={ afterIcon } /> }
+			<input
+				className="blocks-range-control__hint"
+				type="number"
+				onChange={ onChangeValue }
+				value={ value }
+			/>
 		</BaseControl>
 	);
 }

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -17,7 +17,7 @@ function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIc
 		<BaseControl label={ label } id={ id } className="blocks-range-control">
 			{ beforeIcon && <Dashicon icon={ beforeIcon } size={ 20 } /> }
 			<input
-				className="blocks-range-control__input"
+				className="blocks-range-control__slider"
 				id={ id }
 				type="range"
 				value={ value }
@@ -25,10 +25,11 @@ function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIc
 				{ ...props } />
 			{ afterIcon && <Dashicon icon={ afterIcon } /> }
 			<input
-				className="blocks-range-control__hint"
+				className="blocks-range-control__number"
 				type="number"
 				onChange={ onChangeValue }
 				value={ value }
+				{ ...props }
 			/>
 		</BaseControl>
 	);

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -1,6 +1,22 @@
 .blocks-range-control {
 	display: flex;
 	justify-content: center;
+	flex-wrap: wrap;
+	align-items: center;
+
+	.dashicon {
+		flex-shrink: 0;
+		margin-right: 10px;
+	}
+
+	.blocks-base-control__label {
+		width: 100%;
+	}
+
+	.blocks-range-control__input {
+		margin-left: 0;
+		flex: 1;
+	}
 }
 
 // creating mixin because we can't do multiline variables, and we can't comma-group the selectors for styling the range slider
@@ -102,4 +118,6 @@
 	display: inline-block;
 	margin-left: $item-spacing;
 	font-weight: 500;
+	width: 50px;
+	padding: 3px 5px !important;
 }

--- a/blocks/inspector-controls/range-control/style.scss
+++ b/blocks/inspector-controls/range-control/style.scss
@@ -13,7 +13,7 @@
 		width: 100%;
 	}
 
-	.blocks-range-control__input {
+	.blocks-range-control__slider {
 		margin-left: 0;
 		flex: 1;
 	}
@@ -114,7 +114,7 @@
 	}
 }
 
-.blocks-range-control__hint {
+.blocks-range-control__number {
 	display: inline-block;
 	margin-left: $item-spacing;
 	font-weight: 500;

--- a/blocks/inspector-controls/range-control/test/index.js
+++ b/blocks/inspector-controls/range-control/test/index.js
@@ -15,7 +15,7 @@ describe( 'RangeControl', () => {
 			const onChange = jest.fn();
 			const wrapper = mount( <RangeControl onChange={ onChange } /> );
 
-			wrapper.find( 'input' ).simulate( 'change', { target: { value: '5' } } );
+			wrapper.find( 'input.blocks-range-control__slider' ).simulate( 'change', { target: { value: '5' } } );
 
 			expect( onChange ).toHaveBeenCalledWith( 5 );
 		} );

--- a/blocks/inspector-controls/range-control/test/index.js
+++ b/blocks/inspector-controls/range-control/test/index.js
@@ -15,9 +15,34 @@ describe( 'RangeControl', () => {
 			const onChange = jest.fn();
 			const wrapper = mount( <RangeControl onChange={ onChange } /> );
 
-			wrapper.find( 'input.blocks-range-control__slider' ).simulate( 'change', { target: { value: '5' } } );
+			wrapper.find( 'input[type="range"]' ).simulate( 'change', { target: { value: '5' } } );
+			wrapper.find( 'input[type="number"]' ).simulate( 'change', { target: { value: '10' } } );
 
 			expect( onChange ).toHaveBeenCalledWith( 5 );
+			expect( onChange ).toHaveBeenCalledWith( 10 );
+		} );
+
+		it( 'renders with icons', () => {
+			let wrapper, icons;
+
+			wrapper = mount( <RangeControl /> );
+			icons = wrapper.find( 'Dashicon' );
+			expect( icons.length ).toBe( 0 );
+
+			wrapper = mount( <RangeControl beforeIcon="format-image" /> );
+			icons = wrapper.find( 'Dashicon' );
+			expect( icons.length ).toBe( 1 );
+			expect( icons.at( 0 ).prop( 'icon' ) ).toBe( 'format-image' );
+
+			wrapper = mount(
+				<RangeControl
+					beforeIcon="format-image"
+					afterIcon="format-video" />
+			);
+			icons = wrapper.find( 'Dashicon' );
+			expect( icons.length ).toBe( 2 );
+			expect( icons.at( 0 ).prop( 'icon' ) ).toBe( 'format-image' );
+			expect( icons.at( 1 ).prop( 'icon' ) ).toBe( 'format-video' );
 		} );
 	} );
 } );

--- a/blocks/library/cover-text/editor.scss
+++ b/blocks/library/cover-text/editor.scss
@@ -1,0 +1,3 @@
+.wp-block-cover-text p.blocks-editable__tinymce {
+	font-size: inherit;
+}

--- a/blocks/library/cover-text/index.js
+++ b/blocks/library/cover-text/index.js
@@ -13,6 +13,7 @@ import { concatChildren } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
+import './editor.scss';
 import { registerBlockType, source } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
@@ -20,6 +21,7 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import ColorPalette from '../../color-palette';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
+import RangeControl from '../../inspector-controls/range-control';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import BlockDescription from '../../block-description';
 
@@ -58,6 +60,9 @@ registerBlockType( 'core/cover-text', {
 		backgroundColor: {
 			type: 'string',
 		},
+		fontSize: {
+			type: 'number',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -74,7 +79,17 @@ registerBlockType( 'core/cover-text', {
 	},
 
 	edit( { attributes, setAttributes, className, focus, setFocus, mergeBlocks } ) {
-		const { align, width, content, dropCap, placeholder, textColor, backgroundColor } = attributes;
+		const {
+			align,
+			width,
+			content,
+			dropCap,
+			placeholder,
+			textColor,
+			backgroundColor,
+			fontSize,
+		} = attributes;
+
 		const toggleDropCap = () => setAttributes( { dropCap: ! dropCap } );
 
 		return [
@@ -102,6 +117,14 @@ registerBlockType( 'core/cover-text', {
 						checked={ !! dropCap }
 						onChange={ toggleDropCap }
 					/>
+					<RangeControl
+						label={ __( 'Font Size' ) }
+						value={ fontSize }
+						onChange={ ( value ) => setAttributes( { fontSize: value } ) }
+						min={ 10 }
+						max={ 200 }
+						beforeIcon="editor-textcolor"
+					/>
 					<h3>{ __( 'Background Color' ) }</h3>
 					<ColorPalette
 						value={ backgroundColor }
@@ -119,10 +142,12 @@ registerBlockType( 'core/cover-text', {
 				key="block"
 				className={ classnames( className, {
 					[ `align${ width }` ]: width,
+					'has-background': backgroundColor,
 				} ) }
 				style={ {
 					backgroundColor: backgroundColor,
 					color: textColor,
+					fontSize: fontSize,
 				} }
 			>
 				<Editable
@@ -145,20 +170,34 @@ registerBlockType( 'core/cover-text', {
 	},
 
 	save( { attributes } ) {
-		const { width, align, content, dropCap, backgroundColor, textColor } = attributes;
+		const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
 		const className = dropCap ? 'has-drop-cap' : null;
-		const wrapperClassName = width ? `align${ width }` : null;
+		const wrapperClassName = classnames( className, {
+			[ `align${ width }` ]: width,
+			'has-background': backgroundColor,
+		} );
+		const styles = {
+			backgroundColor: backgroundColor,
+			color: textColor,
+			fontSize: fontSize,
+		};
 
 		if ( ! align ) {
 			return (
-				<div className={ wrapperClassName } style={ { backgroundColor: backgroundColor, color: textColor } }>
+				<div
+					className={ wrapperClassName }
+					style={ styles }
+				>
 					<p className={ className }>{ content }</p>
 				</div>
 			);
 		}
 
 		return (
-			<div className={ wrapperClassName } style={ { backgroundColor: backgroundColor, color: textColor } }>
+			<div
+				className={ wrapperClassName }
+				style={ styles }
+			>
 				<p style={ { textAlign: align } } className={ className }>{ content }</p>
 			</div>
 		);

--- a/blocks/library/cover-text/style.scss
+++ b/blocks/library/cover-text/style.scss
@@ -1,7 +1,11 @@
 .wp-block-cover-text {
-	padding: 20px 30px;
+
+	&.has-background {
+		padding: 20px 30px;
+	}
 
 	p {
+		font-size: inherit !important;
 		max-width: $visual-editor-max-width - ( $block-mover-padding-visible );
 		margin: 0 auto;
 	}


### PR DESCRIPTION
This PR does two things:

* Updates `RangeControl` to have a number input, adds icon support, and moves the label to the top.
* Adds font-size support to cover text.

![font-size-control](https://user-images.githubusercontent.com/548849/29267908-fbd3f63a-80ea-11e7-8bd0-db90c26f9b29.gif)

----

cc @jasmussen @karmatosed @melchoyce @westonruter 
