### PR TITLE
Blocks: Fix inserting a pull quote

### DIFF
--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -95,7 +95,7 @@ registerBlockType( 'core/pullquote', {
 
 		return (
 			<blockquote className={ `align${ align }` }>
-				{ value.map( ( paragraph, i ) => <p key={ i }>{ paragraph.props.children }</p> ) }
+				{ value && value.map( ( paragraph, i ) => <p key={ i }>{ paragraph.props.children }</p> ) }
 				{ citation && citation.length > 0 && (
 					<footer>{ citation }</footer>
 				) }


### PR DESCRIPTION
not sure where this regression was introduced, but we need to check if the value is defined before looping over it.

An alternative could be using a default value.

closes #2398