### PR TITLE
Convert "pullquote" design to feel more like a real pullquote.

### DIFF
--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -74,8 +74,8 @@
 	}
 }
 
-.editor-visual-editor__block[data-align="right"],
-.editor-visual-editor__block[data-align="left"] {
+.editor-visual-editor__block[data-type="core/image"][data-align="right"],
+.editor-visual-editor__block[data-type="core/image"][data-align="left"] {
 	max-width: none !important;
 	&[data-resized="false"] {
 		max-width: 370px !important;

--- a/blocks/library/pullquote/editor.scss
+++ b/blocks/library/pullquote/editor.scss
@@ -1,7 +1,12 @@
 .editor-visual-editor__block[data-type="core/pullquote"] {
 	&[data-align="left"],
 	&[data-align="right"] {
-		max-width: 450px;
+		max-width: 400px;
+
+		& .blocks-pullquote__content .blocks-editable__tinymce[data-is-empty="true"]:before,
+		& .blocks-editable p {
+			font-size: 20px;
+		}
 	}
 }
 

--- a/blocks/library/pullquote/editor.scss
+++ b/blocks/library/pullquote/editor.scss
@@ -1,15 +1,7 @@
 .editor-visual-editor__block[data-type="core/pullquote"] {
 	&[data-align="left"],
 	&[data-align="right"] {
-		max-width: 450px !important;
-	}
-
-	&[data-align="left"] {
-		margin-left: calc( 50% - 500px) !important;
-	}
-
-	&[data-align="right"] {
-		margin-right: calc( 50% - 500px) !important;
+		max-width: 450px;
 	}
 }
 

--- a/blocks/library/pullquote/editor.scss
+++ b/blocks/library/pullquote/editor.scss
@@ -1,6 +1,21 @@
+.editor-visual-editor__block[data-type="core/pullquote"] {
+	&[data-align="left"],
+	&[data-align="right"] {
+		max-width: 450px !important;
+	}
+
+	&[data-align="left"] {
+		margin-left: calc( 50% - 500px) !important;
+	}
+
+	&[data-align="right"] {
+		margin-right: calc( 50% - 500px) !important;
+	}
+}
+
 .wp-block-pullquote {
 	footer .blocks-editable__tinymce[data-is-empty="true"]:before {
-		font-size: 16px;
+		font-size: 14px;
 		font-family: $default-font;
 	}
 
@@ -12,7 +27,8 @@
 
 	& > .blocks-pullquote__content .blocks-editable__tinymce[data-is-empty="true"]:before,
 	& > .blocks-editable p {
-		font-size: 48px;
-		font-weight: bold;
+		font-size: 24px;
+		font-weight: 900;
+		line-height: 1.6;
 	}
 }

--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -1,21 +1,26 @@
 .wp-block-pullquote {
-	color: $light-gray-900;
-	padding: 2em;
+	border-top: 4px solid $dark-gray-500;
+	border-bottom: 4px solid $dark-gray-500;
+	color: $dark-gray-600;
+	padding: 3em 0;
 	text-align: center;
 
 	> p {
 		font-family: $default-font;
-		font-size: 48px;
+		font-size: 24px;
 		font-weight: 900;
+		line-height: 1.6;
 	}
 
 	footer {
-		color: $dark-gray-900;
+		color: $dark-gray-600;
 		position: relative;
+		font-weight: 900;
+		text-transform: uppercase;
+		font-size: 13px;
 	}
 
 	footer p {
-		font-size: 16px;
 		font-family: $default-font;
 	}
 }

--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -5,6 +5,15 @@
 	padding: 3em 0;
 	text-align: center;
 
+	&.alignleft,
+	&.alignright {
+		max-width: 400px;
+
+		> p {
+			font-size: 20px;
+		}
+	}
+
 	> p {
 		font-family: $default-font;
 		font-size: 24px;


### PR DESCRIPTION
Wide:
![image](https://user-images.githubusercontent.com/548849/29273577-190c4cd8-8105-11e7-93ce-c317c3ed7660.png)

Floated:
![image](https://user-images.githubusercontent.com/548849/29273593-26df4cd4-8105-11e7-95a0-83dd843a05a4.png)

@jasmussen we need to clean up these floated styles that are starting to become awkward with overwrites.