### PR TITLE
Components: Show tooltip only after mouseover delay

### DIFF
--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -53,11 +53,21 @@ class Tooltip extends Component {
 
 	createToggleIsOver( eventName, isDelayed ) {
 		return ( event ) => {
+			// Mouse events behave unreliably in React for disabled elements,
+			// firing on mouseenter but not mouseleave.  Further, the default
+			// behavior for disabled elements in some browsers is to ignore
+			// mouse events. Don't bother trying to to handle them.
+			//
+			// See: https://github.com/facebook/react/issues/4251
+			if ( event.target.disabled ) {
+				return;
+			}
+
 			// Needed in case unsetting is over while delayed set pending, i.e.
-			// quickly blur/mouseout before delayedSetIsOver is called
+			// quickly blur/mouseleave before delayedSetIsOver is called
 			this.delayedSetIsOver.cancel();
 
-			const isOver = includes( [ 'focus', 'mouseover' ], event.type );
+			const isOver = includes( [ 'focus', 'mouseenter' ], event.type );
 			if ( isOver === this.state.isOver ) {
 				return;
 			}
@@ -86,8 +96,8 @@ class Tooltip extends Component {
 		const child = Children.only( children );
 		const { isOver } = this.state;
 		return cloneElement( child, {
-			onMouseOver: this.createToggleIsOver( 'onMouseOver', true ),
-			onMouseOut: this.createToggleIsOver( 'onMouseOut' ),
+			onMouseEnter: this.createToggleIsOver( 'onMouseEnter', true ),
+			onMouseLeave: this.createToggleIsOver( 'onMouseLeave' ),
 			onFocus: this.createToggleIsOver( 'onFocus' ),
 			onBlur: this.createToggleIsOver( 'onBlur' ),
 			children: concatChildren(

--- a/components/tooltip/test/index.js
+++ b/components/tooltip/test/index.js
@@ -44,11 +44,11 @@ describe( 'Tooltip', () => {
 
 		it( 'should show popover on focus', () => {
 			const originalFocus = jest.fn();
-			const event = { type: 'focus' };
+			const event = { type: 'focus', target: {} };
 			const wrapper = shallow(
 				<Tooltip text="Help Text">
 					<button
-						onMouseOver={ originalFocus }
+						onMouseEnter={ originalFocus }
 						onFocus={ originalFocus }
 					>
 						Hover Me!
@@ -65,15 +65,15 @@ describe( 'Tooltip', () => {
 			expect( popover.prop( 'isOpen' ) ).toBe( true );
 		} );
 
-		it( 'should show popover on delayed mouseover', () => {
+		it( 'should show popover on delayed mouseenter', () => {
 			// Mount: Issues with using `setState` asynchronously with shallow-
 			// rendered components: https://github.com/airbnb/enzyme/issues/450
-			const originalMouseOver = jest.fn();
+			const originalMouseEnter = jest.fn();
 			const wrapper = mount(
 				<Tooltip text="Help Text">
 					<button
-						onMouseOver={ originalMouseOver }
-						onFocus={ originalMouseOver }
+						onMouseEnter={ originalMouseEnter }
+						onFocus={ originalMouseEnter }
 					>
 						Hover Me!
 					</button>
@@ -81,9 +81,9 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = wrapper.find( 'button' );
-			button.simulate( 'mouseover' );
+			button.simulate( 'mouseenter' );
 
-			expect( originalMouseOver ).toHaveBeenCalled();
+			expect( originalMouseEnter ).toHaveBeenCalled();
 
 			const popover = wrapper.find( 'Popover' );
 			expect( wrapper.state( 'isOver' ) ).toBe( false );
@@ -95,15 +95,16 @@ describe( 'Tooltip', () => {
 			expect( popover.prop( 'isOpen' ) ).toBe( true );
 		} );
 
-		it( 'should cancel pending setIsOver on mouseout', () => {
+		it( 'should ignore mouseenter on disabled elements', () => {
 			// Mount: Issues with using `setState` asynchronously with shallow-
 			// rendered components: https://github.com/airbnb/enzyme/issues/450
-			const originalMouseOver = jest.fn();
+			const originalMouseEnter = jest.fn();
 			const wrapper = mount(
 				<Tooltip text="Help Text">
 					<button
-						onMouseOver={ originalMouseOver }
-						onFocus={ originalMouseOver }
+						onMouseEnter={ originalMouseEnter }
+						onFocus={ originalMouseEnter }
+						disabled
 					>
 						Hover Me!
 					</button>
@@ -111,8 +112,32 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = wrapper.find( 'button' );
-			button.simulate( 'mouseover' );
-			button.simulate( 'mouseout' );
+			button.simulate( 'mouseenter' );
+
+			const popover = wrapper.find( 'Popover' );
+			wrapper.instance().delayedSetIsOver.flush();
+			expect( wrapper.state( 'isOver' ) ).toBe( false );
+			expect( popover.prop( 'isOpen' ) ).toBe( false );
+		} );
+
+		it( 'should cancel pending setIsOver on mouseleave', () => {
+			// Mount: Issues with using `setState` asynchronously with shallow-
+			// rendered components: https://github.com/airbnb/enzyme/issues/450
+			const originalMouseEnter = jest.fn();
+			const wrapper = mount(
+				<Tooltip text="Help Text">
+					<button
+						onMouseEnter={ originalMouseEnter }
+						onFocus={ originalMouseEnter }
+					>
+						Hover Me!
+					</button>
+				</Tooltip>
+			);
+
+			const button = wrapper.find( 'button' );
+			button.simulate( 'mouseenter' );
+			button.simulate( 'mouseleave' );
 
 			wrapper.instance().delayedSetIsOver.flush();
 


### PR DESCRIPTION
Related: #2366

This pull request seeks to introduce a short delay when mousing over a Tooltip'd component before showing the tooltip text. Currently it is configured as a one second delay. The delay does not occur when the Tooltip'd component is focused by keyboard navigation.

__Testing instructions:__

Verify that tooltips show after a brief delay when moused over, and that they show immediately when tabbed to receive focus.

Examples: Content inserter button, block trash and cog, Undo/Redo, Close post settings sidebar