### PR TITLE
Don't re-encode already encoded post titles

### DIFF
--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -203,7 +203,7 @@ registerBlockType( 'core/latest-posts', {
 				>
 					{ latestPosts.map( ( post, i ) =>
 						<li key={ i }>
-							<a href={ post.link } target="_blank">{ post.title.rendered.trim() || __( '(Untitled)' ) }</a>
+							<a href={ post.link } target="_blank" dangerouslySetInnerHTML={ { __html: post.title.rendered.trim() || __( '(Untitled)' ) } } />
 							{ displayPostDate && post.date_gmt &&
 								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
 									{ moment( post.date_gmt ).local().format( 'MMMM DD, Y' ) }

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -81,6 +81,28 @@ registerBlockType( 'core/latest-posts', {
 				.then( latestPosts => this.setState( { latestPosts } ) );
 
 			this.toggleDisplayPostDate = this.toggleDisplayPostDate.bind( this );
+
+			this.decodeEntities = this.decodeEntities.bind( this );
+		}
+
+		decodeEntities( html ) {
+			// not a string, or no entities to decode
+			if ( 'string' !== typeof html || -1 === html.indexOf( '&' ) ) {
+				return html;
+			}
+			// create a textarea for decoding entities, and that we can reuse
+			if ( undefined === this._decodeTextArea ) {
+				if ( document.implementation && document.implementation.createHTMLDocument ) {
+					this._decodeTextArea = document.implementation.createHTMLDocument( '' ).createElement( 'textarea' );
+				} else {
+					this._decodeTextArea = document.createElement( 'textarea' );
+				}
+			}
+
+			this._decodeTextArea.innerHTML = html;
+			const decoded = this._decodeTextArea.textContent;
+			this._decodeTextArea.innerHTML = '';
+			return decoded;
 		}
 
 		toggleDisplayPostDate() {
@@ -203,7 +225,7 @@ registerBlockType( 'core/latest-posts', {
 				>
 					{ latestPosts.map( ( post, i ) =>
 						<li key={ i }>
-							<a href={ post.link } target="_blank" dangerouslySetInnerHTML={ { __html: post.title.rendered.trim() || __( '(Untitled)' ) } } />
+							<a href={ post.link } target="_blank">{ this.decodeEntities( post.title.rendered.trim() ) || __( '(Untitled)' ) }</a>
 							{ displayPostDate && post.date_gmt &&
 								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
 									{ moment( post.date_gmt ).local().format( 'MMMM DD, Y' ) }

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -4,6 +4,7 @@
 import { Component } from '@wordpress/element';
 import { Placeholder, Toolbar, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/utils';
 import moment from 'moment';
 import classnames from 'classnames';
 
@@ -81,28 +82,6 @@ registerBlockType( 'core/latest-posts', {
 				.then( latestPosts => this.setState( { latestPosts } ) );
 
 			this.toggleDisplayPostDate = this.toggleDisplayPostDate.bind( this );
-
-			this.decodeEntities = this.decodeEntities.bind( this );
-		}
-
-		decodeEntities( html ) {
-			// not a string, or no entities to decode
-			if ( 'string' !== typeof html || -1 === html.indexOf( '&' ) ) {
-				return html;
-			}
-			// create a textarea for decoding entities, and that we can reuse
-			if ( undefined === this._decodeTextArea ) {
-				if ( document.implementation && document.implementation.createHTMLDocument ) {
-					this._decodeTextArea = document.implementation.createHTMLDocument( '' ).createElement( 'textarea' );
-				} else {
-					this._decodeTextArea = document.createElement( 'textarea' );
-				}
-			}
-
-			this._decodeTextArea.innerHTML = html;
-			const decoded = this._decodeTextArea.textContent;
-			this._decodeTextArea.innerHTML = '';
-			return decoded;
 		}
 
 		toggleDisplayPostDate() {
@@ -225,7 +204,7 @@ registerBlockType( 'core/latest-posts', {
 				>
 					{ latestPosts.map( ( post, i ) =>
 						<li key={ i }>
-							<a href={ post.link } target="_blank">{ this.decodeEntities( post.title.rendered.trim() ) || __( '(Untitled)' ) }</a>
+							<a href={ post.link } target="_blank">{ decodeEntities( post.title.rendered.trim() ) || __( '(Untitled)' ) }</a>
 							{ displayPostDate && post.date_gmt &&
 								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
 									{ moment( post.date_gmt ).local().format( 'MMMM DD, Y' ) }

--- a/utils/entities.js
+++ b/utils/entities.js
@@ -1,0 +1,22 @@
+let _decodeTextArea;
+
+export function decodeEntities( html ) {
+	// not a string, or no entities to decode
+	if ( 'string' !== typeof html || -1 === html.indexOf( '&' ) ) {
+		return html;
+	}
+
+	// create a textarea for decoding entities, that we can reuse
+	if ( undefined === _decodeTextArea ) {
+		if ( document.implementation && document.implementation.createHTMLDocument ) {
+			_decodeTextArea = document.implementation.createHTMLDocument( '' ).createElement( 'textarea' );
+		} else {
+			_decodeTextArea = document.createElement( 'textarea' );
+		}
+	}
+
+	_decodeTextArea.innerHTML = html;
+	const decoded = _decodeTextArea.textContent;
+	_decodeTextArea.innerHTML = '';
+	return decoded;
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,7 +1,9 @@
 import * as keycodes from './keycodes';
 import * as nodetypes from './nodetypes';
+import { decodeEntities } from './entities';
 
 export { keycodes };
 export { nodetypes };
+export { decodeEntities };
 
 export * from './mediaupload';

--- a/utils/test/entities.js
+++ b/utils/test/entities.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { decodeEntities } from '../entities';
+
+describe( 'decodeEntities', () => {
+	it( 'should not change html with no entities', () => {
+		const html = '<h1>A noble tag embiggens the smallest text.</h1>';
+		const expected = '<h1>A noble tag embiggens the smallest text.</h1>';
+		expect( decodeEntities( html ) ).toEqual( expected );
+	} );
+	it( 'should decode entities', () => {
+		const html = '&lt;h1&gt;This post&#8217;s title.&lt;/h1&gt;';
+		const expected = '<h1>This post’s title.</h1>';
+		expect( decodeEntities( html ) ).toEqual( expected );
+	} );
+	it( 'should not double decode entities', () => {
+		const html = 'This post&amp;rsquo;s title.';
+		const expected = 'This post&rsquo;s title.';
+		expect( decodeEntities( html ) ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
Data that comes from the Posts collection is already encoded, ready to output safely, so we set the inner html to avoid encoding twice.

Fixes https://github.com/WordPress/gutenberg/issues/2389