### PR TITLE
Polish gallery, fix crop in Safari

### DIFF
--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -4,10 +4,11 @@
 	flex-wrap: wrap;
 
 	.blocks-gallery-image {
-		flex-grow: 1;
 		margin: 0 16px 16px 0;
 		display: flex;
-		align-items: center;
+		flex-grow: 1;
+		flex-direction: column;
+		justify-content: center;
 
 		img {
 			max-width: 100%;
@@ -18,9 +19,11 @@
 	// Cropped
 	&.is-cropped .blocks-gallery-image {
 		img {
+			flex: 1;
 			width: 100%;
 			height: 100%;
 			object-fit: cover;
+
 		}
 
 		// Alas, IE11+ doesn't support object-fit

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -24,10 +24,10 @@
 		}
 
 		// Alas, IE11+ doesn't support object-fit
-		/*_:-ms-lang(x), img {
+		_:-ms-lang(x), img {
 			height: auto;
 			width: auto;
-		}*/
+		}
 	}
 
 	&.columns-1 figure {

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -11,6 +11,7 @@
 
 		img {
 			max-width: 100%;
+			height: auto;
 		}
 	}
 
@@ -23,10 +24,10 @@
 		}
 
 		// Alas, IE11+ doesn't support object-fit
-		_:-ms-lang(x), img {
+		/*_:-ms-lang(x), img {
 			height: auto;
 			width: auto;
-		}
+		}*/
 	}
 
 	&.columns-1 figure {

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -6,6 +6,8 @@
 	.blocks-gallery-image {
 		flex-grow: 1;
 		margin: 0 16px 16px 0;
+		display: flex;
+		align-items: center;
 
 		img {
 			max-width: 100%;


### PR DESCRIPTION
This polishes the gallery block by vertically centering uncropped images, and fixing an issue where in Safari, images weren't cropped.

It also probably fixes #2337, but we need to test that. 