### PR TITLE
Removes text saying you can paste below

### DIFF
--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -52,7 +52,7 @@ registerBlockType( 'core/video', {
 					key="placeholder"
 					icon="media-video"
 					label={ __( 'Video' ) }
-					instructions={ __( 'Select a video file from your library, or paste a URL below:' ) }
+					instructions={ __( 'Select a video file from your library:' ) }
 					className={ className }>
 					<MediaUploadButton
 						buttonProps={ { isLarge: true } }


### PR DESCRIPTION
Pasting doesn't work below so the text shouldn't say this until it does.

Partial fix for #2419 - full fix would be having pasting work.