### PR TITLE
Framework: Extract arrow navigation to its own component

### DIFF
--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -104,6 +104,10 @@ class UrlInput extends Component {
 
 	onKeyDown( event ) {
 		const { selectedSuggestion, posts } = this.state;
+		if ( ! this.state.showSuggestions || ! this.state.posts.length ) {
+			return false;
+		}
+
 		switch ( event.keyCode ) {
 			case UP: {
 				event.stopPropagation();

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -104,6 +104,8 @@ class UrlInput extends Component {
 
 	onKeyDown( event ) {
 		const { selectedSuggestion, posts } = this.state;
+		// If the suggestions are not shown, we shouldn't handle the arrow keys
+		// We shouldn't preventDefault to allow block arrow keys navigation
 		if ( ! this.state.showSuggestions || ! this.state.posts.length ) {
 			return false;
 		}

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -107,7 +107,7 @@ class UrlInput extends Component {
 		// If the suggestions are not shown, we shouldn't handle the arrow keys
 		// We shouldn't preventDefault to allow block arrow keys navigation
 		if ( ! this.state.showSuggestions || ! this.state.posts.length ) {
-			return false;
+			return;
 		}
 
 		switch ( event.keyCode ) {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -256,7 +256,6 @@ class VisualEditorBlock extends Component {
 
 	onKeyDown( event ) {
 		const { keyCode, target } = event;
-
 		if ( ENTER === keyCode && target === this.node ) {
 			event.preventDefault();
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -117,7 +117,7 @@ class VisualEditorBlock extends Component {
 		}
 
 		// Focus node when focus state is programmatically transferred.
-		if ( this.props.focus && ! prevProps.focus ) {
+		if ( this.props.focus && ! prevProps.focus && ! this.node.contains( document.activeElement ) ) {
 			this.node.focus();
 		}
 

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -17,6 +17,7 @@ import { KeyboardShortcuts } from '@wordpress/components';
 import './style.scss';
 import VisualEditorBlockList from './block-list';
 import PostTitle from '../../post-title';
+import WritingFlow from '../../writing-flow';
 import { getBlockUids, getMultiSelectedBlockUids } from '../../selectors';
 import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks } from '../../actions';
 
@@ -98,8 +99,10 @@ class VisualEditor extends Component {
 					backspace: this.deleteSelectedBlocks,
 					del: this.deleteSelectedBlocks,
 				} } />
-				<PostTitle />
-				<VisualEditorBlockList ref={ this.bindBlocksContainer } />
+				<WritingFlow>
+					<PostTitle />
+					<VisualEditorBlockList ref={ this.bindBlocksContainer } />
+				</WritingFlow>
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -63,29 +63,26 @@ export function isEdge( container, start = false ) {
  */
 export function placeCaretAtEdge( container, start = false ) {
 	const isInputOrTextarea = [ 'INPUT', 'TEXTAREA' ].indexOf( container.tagName ) !== -1;
+
+	// Inputs and Textareas
 	if ( isInputOrTextarea ) {
 		container.focus();
-		setTimeout( () => {
-			if ( start ) {
-				container.selectionStart = 0;
-				container.selectionEnd = 0;
-			} else {
-				container.selectionStart = container.value.length;
-				container.selectionEnd = container.value.length;
-			}
-		} );
+		if ( start ) {
+			container.selectionStart = 0;
+			container.selectionEnd = 0;
+		} else {
+			container.selectionStart = container.value.length;
+			container.selectionEnd = container.value.length;
+		}
 		return;
 	}
 
-	function placeCaretInContentEditable( element, atStart ) {
-		const range = document.createRange();
-		range.selectNodeContents( element );
-		range.collapse( atStart );
-		const sel = window.getSelection();
-		sel.removeAllRanges();
-		sel.addRange( range );
-		element.focus();
-	}
-
-	placeCaretInContentEditable( container, start );
+	// Content editables
+	const range = document.createRange();
+	range.selectNodeContents( container );
+	range.collapse( start );
+	const sel = window.getSelection();
+	sel.removeAllRanges();
+	sel.addRange( range );
+	container.focus();
 }

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -77,33 +77,15 @@ export function placeCaretAtEdge( container, start = false ) {
 		return;
 	}
 
-	function createCaretPlacer( atStart ) {
-		return ( el ) => {
-			el.focus();
-			if (
-				typeof window.getSelection !== 'undefined' &&
-				typeof document.createRange !== 'undefined'
-			) {
-				const range = document.createRange();
-				range.selectNodeContents( el );
-				range.collapse( atStart );
-				const sel = window.getSelection();
-				sel.removeAllRanges();
-				sel.addRange( range );
-			} else if ( typeof document.body.createTextRange !== 'undefined' ) {
-				const textRange = document.body.createTextRange();
-				textRange.moveToElementText( el );
-				textRange.collapse( atStart );
-				textRange.select();
-			}
-		};
+	function placeCaretInContentEditable( element, atStart ) {
+		const range = document.createRange();
+		range.selectNodeContents( element );
+		range.collapse( atStart );
+		const sel = window.getSelection();
+		sel.removeAllRanges();
+		sel.addRange( range );
+		element.focus();
 	}
-	const placeCaretAtStart = createCaretPlacer( true );
-	const placeCaretAtEnd = createCaretPlacer( false );
 
-	if ( start ) {
-		placeCaretAtStart( container );
-	} else {
-		placeCaretAtEnd( container );
-	}
+	placeCaretInContentEditable( container, start );
 }

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -2,16 +2,16 @@
  * Check whether the selection touches an edge of the container
  *
  * @param  {Element} container DOM Element
- * @param  {Boolean} reverse   Reverse means check if it touches the start of the container
+ * @param  {Boolean} start     Reverse means check if it touches the start of the container
  * @return {Boolean}           Is Edge or not
  */
-export function isEdge( container, reverse = false ) {
+export function isEdge( container, start = false ) {
 	if ( [ 'INPUT', 'TEXTAREA' ].indexOf( container.tagName ) !== -1 ) {
 		if ( container.selectionStart !== container.selectionEnd ) {
 			return false;
 		}
 
-		if ( reverse ) {
+		if ( start ) {
 			return container.selectionStart === 0;
 		}
 
@@ -24,8 +24,8 @@ export function isEdge( container, reverse = false ) {
 
 	const selection = window.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
-	const position = reverse ? 'start' : 'end';
-	const order = reverse ? 'first' : 'last';
+	const position = start ? 'start' : 'end';
+	const order = start ? 'first' : 'last';
 	const offset = range[ `${ position }Offset` ];
 
 	let node = range.startContainer;
@@ -34,11 +34,11 @@ export function isEdge( container, reverse = false ) {
 		return false;
 	}
 
-	if ( reverse && offset !== 0 ) {
+	if ( start && offset !== 0 ) {
 		return false;
 	}
 
-	if ( ! reverse && offset !== node.textContent.length ) {
+	if ( ! start && offset !== node.textContent.length ) {
 		return false;
 	}
 

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -1,0 +1,111 @@
+/**
+ * Check whether the selection touches an edge of the container
+ *
+ * @param  {Element} container DOM Element
+ * @param  {Boolean} reverse   Reverse means check if it touches the start of the container
+ * @return {Boolean}           Is Edge or not
+ */
+export function isEdge( container, reverse = false ) {
+	const isInputOrTextarea = [ 'INPUT', 'TEXTAREA' ].indexOf( container.tagName ) !== -1;
+	const selection = window.getSelection();
+	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+
+	function isStartOfContainer() {
+		if ( isInputOrTextarea ) {
+			return container.selectionStart === 0 && container.selectionStart === container.selectionEnd;
+		}
+		if ( ! container.isContentEditable ) {
+			return true;
+		}
+		if ( range.startOffset !== 0 || ! range.collapsed ) {
+			return false;
+		}
+		const start = range.startContainer;
+		let element = start;
+		while ( element !== container ) {
+			const child = element;
+			element = element.parentNode;
+			if ( element.firstChild !== child ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	function isEndOfContainer() {
+		if ( isInputOrTextarea ) {
+			return container.value.length === container.selectionStart && container.selectionStart === container.selectionEnd;
+		}
+		if ( ! container.isContentEditable ) {
+			return true;
+		}
+		if ( range.endOffset !== range.endContainer.textContent.length || ! range.collapsed ) {
+			return false;
+		}
+		const start = range.endContainer;
+		let element = start;
+		while ( element !== container ) {
+			const child = element;
+			element = element.parentNode;
+			if ( element.lastChild !== child ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	return reverse ? isStartOfContainer() : isEndOfContainer();
+}
+
+/**
+ * Places the caret at start or end of a given element
+ *
+ * @param  {Element} container DOM Element
+ * @param  {Boolean} start     Position: Start or end of the element
+ */
+export function placeCaretAtEdge( container, start = false ) {
+	const isInputOrTextarea = [ 'INPUT', 'TEXTAREA' ].indexOf( container.tagName ) !== -1;
+	if ( isInputOrTextarea ) {
+		container.focus();
+		setTimeout( () => {
+			if ( start ) {
+				container.selectionStart = 0;
+				container.selectionEnd = 0;
+			} else {
+				container.selectionStart = container.value.length;
+				container.selectionEnd = container.value.length;
+			}
+		} );
+		return;
+	}
+
+	function createCaretPlacer( atStart ) {
+		return ( el ) => {
+			el.focus();
+			if (
+				typeof window.getSelection !== 'undefined' &&
+				typeof document.createRange !== 'undefined'
+			) {
+				const range = document.createRange();
+				range.selectNodeContents( el );
+				range.collapse( atStart );
+				const sel = window.getSelection();
+				sel.removeAllRanges();
+				sel.addRange( range );
+			} else if ( typeof document.body.createTextRange !== 'undefined' ) {
+				const textRange = document.body.createTextRange();
+				textRange.moveToElementText( el );
+				textRange.collapse( atStart );
+				textRange.select();
+			}
+		};
+	}
+	const placeCaretAtStart = createCaretPlacer( true );
+	const placeCaretAtEnd = createCaretPlacer( false );
+
+	if ( start ) {
+		placeCaretAtStart( container );
+	} else {
+		placeCaretAtEnd( container );
+	}
+}

--- a/editor/utils/test/dom.js
+++ b/editor/utils/test/dom.js
@@ -1,0 +1,98 @@
+/**
+ * Internal dependencies
+ */
+import { isEdge, placeCaretAtEdge } from '../dom';
+
+jest.useFakeTimers();
+
+describe( 'DOM', () => {
+	let parent;
+
+	beforeEach( () => {
+		parent = document.createElement( 'div' );
+		document.body.appendChild( parent );
+	} );
+
+	afterEach( () => {
+		parent.remove();
+	} );
+
+	describe( 'isEdge', () => {
+		it( 'Should return true for empty input', () => {
+			const input = document.createElement( 'input' );
+			parent.appendChild( input );
+			input.focus();
+			expect( isEdge( input, true ) ).toBe( true );
+			expect( isEdge( input, false ) ).toBe( true );
+		} );
+
+		it( 'Should return the right values if we focus the end of the input', () => {
+			const input = document.createElement( 'input' );
+			parent.appendChild( input );
+			input.value = 'value';
+			input.focus();
+			input.selectionStart = 5;
+			input.selectionEnd = 5;
+			expect( isEdge( input, true ) ).toBe( false );
+			expect( isEdge( input, false ) ).toBe( true );
+		} );
+
+		it( 'Should return the right values if we focus the start of the input', () => {
+			const input = document.createElement( 'input' );
+			parent.appendChild( input );
+			input.value = 'value';
+			input.focus();
+			input.selectionStart = 0;
+			input.selectionEnd = 0;
+			expect( isEdge( input, true ) ).toBe( true );
+			expect( isEdge( input, false ) ).toBe( false );
+		} );
+
+		it( 'Should return false if we\'re not at the edge', () => {
+			const input = document.createElement( 'input' );
+			parent.appendChild( input );
+			input.value = 'value';
+			input.focus();
+			input.selectionStart = 3;
+			input.selectionEnd = 3;
+			expect( isEdge( input, true ) ).toBe( false );
+			expect( isEdge( input, false ) ).toBe( false );
+		} );
+
+		it( 'Should return false if the selection is not collapseds', () => {
+			const input = document.createElement( 'input' );
+			parent.appendChild( input );
+			input.value = 'value';
+			input.focus();
+			input.selectionStart = 0;
+			input.selectionEnd = 5;
+			expect( isEdge( input, true ) ).toBe( false );
+			expect( isEdge( input, false ) ).toBe( false );
+		} );
+
+		it( 'Should always return true for non content editabless', () => {
+			const div = document.createElement( 'div' );
+			parent.appendChild( div );
+			expect( isEdge( div, true ) ).toBe( true );
+			expect( isEdge( div, false ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'placeCaretAtEdge', () => {
+		it( 'should place caret at the start of the input', () => {
+			const input = document.createElement( 'input' );
+			input.value = 'value';
+			placeCaretAtEdge( input, true );
+			jest.runAllTimers();
+			expect( isEdge( input, true ) ).toBe( true );
+		} );
+
+		it( 'should place caret at the end of the input', () => {
+			const input = document.createElement( 'input' );
+			input.value = 'value';
+			placeCaretAtEdge( input, false );
+			jest.runAllTimers();
+			expect( isEdge( input, false ) ).toBe( true );
+		} );
+	} );
+} );

--- a/editor/utils/test/dom.js
+++ b/editor/utils/test/dom.js
@@ -3,8 +3,6 @@
  */
 import { isEdge, placeCaretAtEdge } from '../dom';
 
-jest.useFakeTimers();
-
 describe( 'DOM', () => {
 	let parent;
 
@@ -83,7 +81,6 @@ describe( 'DOM', () => {
 			const input = document.createElement( 'input' );
 			input.value = 'value';
 			placeCaretAtEdge( input, true );
-			jest.runAllTimers();
 			expect( isEdge( input, true ) ).toBe( true );
 		} );
 
@@ -91,7 +88,6 @@ describe( 'DOM', () => {
 			const input = document.createElement( 'input' );
 			input.value = 'value';
 			placeCaretAtEdge( input, false );
-			jest.runAllTimers();
 			expect( isEdge( input, false ) ).toBe( true );
 		} );
 	} );

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -1,0 +1,90 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from 'element';
+import { keycodes } from '@wordpress/utils';
+
+const { UP, DOWN, LEFT, RIGHT } = keycodes;
+
+class WritingFlow extends Component {
+	constructor() {
+		super( ...arguments );
+		this.zones = [];
+		this.onKeyDown = this.onKeyDown.bind( this );
+		this.onKeyUp = this.onKeyUp.bind( this );
+		this.bindContainer = this.bindContainer.bind( this );
+	}
+
+	bindContainer( ref ) {
+		this.container = ref;
+	}
+
+	moveFocusInContainer( target, direction = 'UP' ) {
+		const selectors = [
+			'*[contenteditable="true"]',
+			'*[tabindex]',
+			'textarea',
+			'input',
+		].join( ',' );
+
+		const focusableNodes = Array.from( this.container.querySelectorAll( selectors ) );
+		if ( direction === 'UP' ) {
+			focusableNodes.reverse();
+		}
+
+		const targetNode = focusableNodes
+			.slice( focusableNodes.indexOf( target ) )
+			.reduce( ( result, node ) => {
+				return result || ( node.contains( target ) ? null : node );
+			}, null );
+
+		if ( targetNode ) {
+			targetNode.focus();
+		}
+	}
+
+	onKeyDown( event ) {
+		const { keyCode } = event;
+		if ( [ UP, LEFT, DOWN, RIGHT ].indexOf( keyCode ) !== -1 ) {
+			const selection = window.getSelection();
+			this.lastRange = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+		}
+	}
+
+	onKeyUp( event ) {
+		const { keyCode, target } = event;
+		const moveUp = ( keyCode === UP || keyCode === LEFT );
+		const moveDown = ( keyCode === DOWN || keyCode === RIGHT );
+
+		if ( moveUp || moveDown ) {
+			const selection = window.getSelection();
+			const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+
+			// If there's no movement, so we're either at the end of start, or
+			// no text input at all.
+			if ( range !== this.lastRange ) {
+				return;
+			}
+
+			this.moveFocusInContainer( target, moveUp ? 'UP' : 'DOWN' );
+		}
+
+		delete this.lastRange;
+	}
+
+	render() {
+		const { children } = this.props;
+
+		return (
+			<div
+				ref={ this.bindContainer }
+				onKeyDown={ this.onKeyDown }
+				onKeyUp={ this.onKeyUp }
+			>
+				{ children }
+			</div>
+		);
+	}
+}
+
+export default WritingFlow;

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -19,7 +19,11 @@ class WritingFlow extends Component {
 		super( ...arguments );
 		this.zones = [];
 		this.onKeyDown = this.onKeyDown.bind( this );
+		this.onKeyUp = this.onKeyUp.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
+		this.state = {
+			shouldMove: false,
+		};
 	}
 
 	bindContainer( ref ) {
@@ -60,8 +64,18 @@ class WritingFlow extends Component {
 		const moveDown = ( keyCode === DOWN || keyCode === RIGHT );
 
 		if ( ( moveUp || moveDown ) && isEdge( target, moveUp ) ) {
-			this.moveFocusInContainer( target, moveUp ? 'UP' : 'DOWN' );
 			event.preventDefault();
+			this.setState( { shouldMove: true } );
+		}
+	}
+
+	onKeyUp( event ) {
+		const { keyCode, target } = event;
+		const moveUp = ( keyCode === UP || keyCode === LEFT );
+		if ( this.state.shouldMove ) {
+			event.preventDefault();
+			this.moveFocusInContainer( target, moveUp ? 'UP' : 'DOWN' );
+			this.setState( { shouldMove: false } );
 		}
 	}
 
@@ -72,6 +86,7 @@ class WritingFlow extends Component {
 			<div
 				ref={ this.bindContainer }
 				onKeyDown={ this.onKeyDown }
+				onKeyUp={ this.onKeyUp }
 			>
 				{ children }
 			</div>

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -31,14 +31,14 @@ class WritingFlow extends Component {
 	}
 
 	getVisibleTabbables() {
-		const tabblablesSelector = [
+		const tabbablesSelector = [
 			'*[contenteditable="true"]',
 			'*[tabindex]:not([tabindex="-1"])',
 			'textarea',
 			'input',
 		].join( ', ' );
 		const isVisible = ( elem ) => elem.offsetWidth > 0 || elem.offsetHeight > 0 || elem.getClientRects().length > 0;
-		return Array.from( this.container.querySelectorAll( tabblablesSelector ) ).filter( isVisible );
+		return Array.from( this.container.querySelectorAll( tabbablesSelector ) ).filter( isVisible );
 	}
 
 	moveFocusInContainer( target, direction = 'UP' ) {

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -38,7 +38,7 @@ class WritingFlow extends Component {
 			'input',
 		].join( ', ' );
 		const isVisible = ( elem ) => elem.offsetWidth > 0 || elem.offsetHeight > 0 || elem.getClientRects().length > 0;
-		return Array.from( this.container.querySelectorAll( tabbablesSelector ) ).filter( isVisible );
+		return [ ...this.container.querySelectorAll( tabbablesSelector ) ].filter( isVisible );
 	}
 
 	moveFocusInContainer( target, direction = 'UP' ) {

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -61,6 +61,7 @@ class WritingFlow extends Component {
 
 		if ( ( moveUp || moveDown ) && isEdge( target, moveUp ) ) {
 			this.moveFocusInContainer( target, moveUp ? 'UP' : 'DOWN' );
+			event.preventDefault();
 		}
 	}
 

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -33,7 +33,7 @@ class WritingFlow extends Component {
 	getVisibleTabbables() {
 		const tabblablesSelector = [
 			'*[contenteditable="true"]',
-			'*[tabindex]',
+			'*[tabindex]:not([tabindex="-1"])',
 			'textarea',
 			'input',
 		].join( ', ' );

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -27,7 +27,9 @@ class WritingFlow extends Component {
 			'input',
 		].join( ',' );
 
-		const focusableNodes = Array.from( this.container.querySelectorAll( selectors ) );
+		const isVisible = ( elem ) => elem.offsetWidth > 0 || elem.offsetHeight > 0 || elem.getClientRects().length > 0;
+
+		const focusableNodes = Array.from( this.container.querySelectorAll( selectors ) ).filter( isVisible );
 		if ( direction === 'UP' ) {
 			focusableNodes.reverse();
 		}
@@ -41,6 +43,17 @@ class WritingFlow extends Component {
 		if ( targetNode ) {
 			targetNode.focus();
 		}
+	}
+
+	isSameRanges( range1, range2 ) {
+		return ( ! range1 && ! range2 ) || (
+			!! range1 &&
+			!! range2 &&
+			range1.startContainer === range2.startContainer &&
+			range1.startOffset === range2.startOffset &&
+			range1.endContainer === range2.endContainer &&
+			range1.endOffset === range2.endOffset
+		);
 	}
 
 	onKeyDown( event ) {
@@ -62,7 +75,7 @@ class WritingFlow extends Component {
 
 			// If there's no movement, so we're either at the end of start, or
 			// no text input at all.
-			if ( range !== this.lastRange ) {
+			if ( ! this.isSameRanges( range, this.lastRange ) ) {
 				return;
 			}
 


### PR DESCRIPTION
related #2421 and transversal to #2296 

This doesn't change the way arrow navigation works (like #2296 does) but just extracts it to its own component.

**Pros**
 
 - The `VisualEditorBlock` component handles way more than it should
 - More composable approach, the `WritingFlow` component can wrap anything to allow arrow navigation between tabbables.
 - This fixes a bug where we were stuck in the PostTitle while still allowing the PostTitle to be used in the text mode without duplicating the navigation behaviour

**Notes**

- Like suggested in #2421 I think we should think more about how to "compose" all these behaviours. I think this component could also handle `Enter` and `Backspace` navigation the same way we do for arrow navigation. It could be done separately and probably after merging #2296 

- Not done in this PR yet, I think the `isTyping` reducer/actions should be handled by this component (WriningFlow) because the PostTitle should be able to update this property too.
