### PR TITLE
Add block descriptions to blocks that miss them. 

### DIFF
--- a/blocks/block-description/style.scss
+++ b/blocks/block-description/style.scss
@@ -1,5 +1,5 @@
 .components-block-description {
-	&:not(:last-child):after {
+	&:after {
 		content: '';
 		display: block;
 		border-bottom: 1px solid $light-gray-500;

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -17,6 +17,8 @@ import { registerBlockType, source } from '../../api';
 import MediaUploadButton from '../../media-upload-button';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { attr } = source;
 
@@ -80,33 +82,40 @@ registerBlockType( 'core/audio', {
 				}
 				return false;
 			};
-			const controls = (
-				focus && (
-					<BlockControls key="controls">
-						<BlockAlignmentToolbar
-							value={ align }
-							onChange={ updateAlignment }
-						/>
-						<Toolbar>
-							<li>
-								<Button
-									buttonProps={ {
-										className: 'components-icon-button components-toolbar__control',
-										'aria-label': __( 'Edit audio' ),
-									} }
-									type="audio"
-									onClick={ switchToEditing }
-								>
-									<Dashicon icon="edit" />
-								</Button>
-							</li>
-						</Toolbar>
-					</BlockControls>
-				)
+			const controls = focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar
+						value={ align }
+						onChange={ updateAlignment }
+					/>
+					<Toolbar>
+						<li>
+							<Button
+								buttonProps={ {
+									className: 'components-icon-button components-toolbar__control',
+									'aria-label': __( 'Edit audio' ),
+								} }
+								type="audio"
+								onClick={ switchToEditing }
+							>
+								<Dashicon icon="edit" />
+							</Button>
+						</li>
+					</Toolbar>
+				</BlockControls>
+			);
+
+			const inspectorControls = focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Audio, locally hosted, locally sourced.' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
 			);
 
 			if ( editing ) {
 				return [
+					inspectorControls,
 					<Placeholder
 						key="placeholder"
 						icon="media-audio"
@@ -140,6 +149,7 @@ registerBlockType( 'core/audio', {
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 			return [
 				controls,
+				inspectorControls,
 				<div key="audio">
 					<audio controls="controls" src={ src } />
 				</div>,

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -108,7 +108,7 @@ registerBlockType( 'core/audio', {
 			const inspectorControls = focus && (
 				<InspectorControls key="inspector">
 					<BlockDescription>
-						<p>{ __( 'Audio, locally hosted, locally sourced.' ) }</p>
+						<p>{ __( 'The Audio block allows you to embed audio files and play them back using a simple player.' ) }</p>
 					</BlockDescription>
 				</InspectorControls>
 			);

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -16,6 +16,7 @@ import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import ColorPalette from '../../color-palette';
 import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { attr, children } = source;
 
@@ -89,6 +90,9 @@ registerBlockType( 'core/button', {
 				}
 				{ focus &&
 					<InspectorControls key="inspector">
+						<BlockDescription>
+							<p>{ __( 'A nice little button. Call something out with it.' ) }</p>
+						</BlockDescription>
 						<ColorPalette
 							value={ color }
 							onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -61,6 +61,7 @@ registerBlockType( 'core/code', {
 				</InspectorControls>
 			),
 			<TextareaAutosize
+				key="block"
 				className={ className }
 				value={ attributes.content }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -13,6 +13,8 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 import { registerBlockType, source, createBlock } from '../../api';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { prop } = source;
 
@@ -49,15 +51,22 @@ registerBlockType( 'core/code', {
 		],
 	},
 
-	edit( { attributes, setAttributes, className } ) {
-		return (
+	edit( { attributes, setAttributes, focus, className } ) {
+		return [
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'The code block maintains spaces and tabs, great for showing code snippets.' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
+			),
 			<TextareaAutosize
 				className={ className }
 				value={ attributes.content }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
 				placeholder={ __( 'Write code…' ) }
-			/>
-		);
+			/>,
+		];
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -16,6 +16,8 @@ import './editor.scss';
 import { registerBlockType, source, createBlock } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { children, prop } = source;
 
@@ -307,6 +309,14 @@ registerBlockType( 'core/list', {
 							},
 						] }
 					/>
+				),
+				focus && (
+					<InspectorControls key="inspector">
+						<BlockDescription>
+							<p>{ __( 'List. Numbered or bulleted.' ) }</p>
+						</BlockDescription>
+						<p>{ __( 'No advanced options.' ) }</p>
+					</InspectorControls>
 				),
 				<Editable
 					multiline="li"

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -9,6 +9,8 @@ import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import { registerBlockType, createBlock, source } from '../../api';
 import Editable from '../../editable';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { children } = source;
 
@@ -58,8 +60,16 @@ registerBlockType( 'core/preformatted', {
 	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { content } = attributes;
 
-		return (
+		return [
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Preformatted text keeps your spaces, tabs and linebreaks as they are.' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
+			),
 			<Editable
+				key="block"
 				tagName="pre"
 				value={ content }
 				onChange={ ( nextContent ) => {
@@ -71,8 +81,8 @@ registerBlockType( 'core/preformatted', {
 				onFocus={ setFocus }
 				placeholder={ __( 'Write preformatted text…' ) }
 				wrapperClassname={ className }
-			/>
-		);
+			/>,
+		];
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -12,6 +12,8 @@ import { registerBlockType, source } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { children, query, node } = source;
 
@@ -50,6 +52,13 @@ registerBlockType( 'core/pullquote', {
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
 		return [
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'A pullquote is a brief, attention-catching quotation taken from the main text of an article and used as a subheading or graphic feature.' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
+			),
 			focus && (
 				<BlockControls key="controls">
 					<BlockAlignmentToolbar

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -17,6 +17,8 @@ import { registerBlockType, createBlock, source } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import Editable from '../../editable';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { children, node: element, query } = source;
 
@@ -164,6 +166,13 @@ registerBlockType( 'core/quote', {
 						} }
 					/>
 				</BlockControls>
+			),
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Quote. In quoting others, we cite ourselves. (Julio Cortázar)' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
 			),
 			<blockquote
 				key="quote"

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -35,12 +35,12 @@ registerBlockType( 'core/separator', {
 		],
 	},
 
-	edit( { className, focus } ) {
+	edit( { focus, className } ) {
 		return [
 			focus && (
 				<InspectorControls key="inspector">
 					<BlockDescription>
-						<p>{ __( 'The separator represents a paragraph-level thematic break, e.g. a scene change in a story, or a transition to another topic within an article.' ) }</p>
+						<p>{ __( 'Use the separator to indicate a thematic change in the content.' ) }</p>
 					</BlockDescription>
 				</InspectorControls>
 			),

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -53,6 +53,7 @@ registerBlockType( 'core/shortcode', {
 							<BlockDescription>
 								<p>{ __( 'A shortcode is a WordPress-specific code snippet that is written between square brackets as [shortcode]. ' ) }</p>
 							</BlockDescription>
+							<p>{ __( 'No advanced options.' ) }</p>
 						</InspectorControls>
 					}
 				</div>

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -59,19 +59,19 @@ registerBlockType( 'core/table', {
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		return [
 			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Tables. Best used for tabular data.' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
+			),
+			focus && (
 				<BlockControls key="toolbar">
 					<BlockAlignmentToolbar
 						value={ attributes.align }
 						onChange={ updateAlignment }
 					/>
 				</BlockControls>
-			),
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Tables. Best used for tabular data.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
 			),
 			<TableBlock
 				key="editor"

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -12,6 +12,8 @@ import { registerBlockType, source } from '../../api';
 import TableBlock from './table-block';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { children } = source;
 
@@ -63,6 +65,13 @@ registerBlockType( 'core/table', {
 						onChange={ updateAlignment }
 					/>
 				</BlockControls>
+			),
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Tables. Best used for tabular data.' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
 			),
 			<TableBlock
 				key="editor"

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -68,7 +68,7 @@ registerBlockType( 'core/text-columns', {
 			focus && (
 				<InspectorControls key="inspector">
 					<BlockDescription>
-						<p>{ __( 'Text. Great things start here.' ) }</p>
+						<p>{ __( 'Add text across columns.' ) }</p>
 					</BlockDescription>
 					<RangeControl
 						label={ __( 'Columns' ) }

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -17,6 +17,8 @@ import MediaUploadButton from '../../media-upload-button';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
 
 const { attr, children } = source;
 
@@ -66,32 +68,36 @@ registerBlockType( 'core/video', {
 			setAttributes( { align: nextAlign } );
 		};
 
-		const controls = (
-			focus && (
-				<BlockControls key="controls">
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ updateAlignment }
-					/>
+		const controls = focus && [
+			<BlockControls key="controls">
+				<BlockAlignmentToolbar
+					value={ align }
+					onChange={ updateAlignment }
+				/>
 
-					<Toolbar>
-						<li>
-							<MediaUploadButton
-								buttonProps={ {
-									className: 'components-icon-button components-toolbar__control',
-									'aria-label': __( 'Edit video' ),
-								} }
-								onSelect={ onSelectVideo }
-								type="video"
-								value={ id }
-							>
-								<Dashicon icon="edit" />
-							</MediaUploadButton>
-						</li>
-					</Toolbar>
-				</BlockControls>
-			)
-		);
+				<Toolbar>
+					<li>
+						<MediaUploadButton
+							buttonProps={ {
+								className: 'components-icon-button components-toolbar__control',
+								'aria-label': __( 'Edit video' ),
+							} }
+							onSelect={ onSelectVideo }
+							type="video"
+							value={ id }
+						>
+							<Dashicon icon="edit" />
+						</MediaUploadButton>
+					</li>
+				</Toolbar>
+			</BlockControls>,
+
+			<InspectorControls key="inspector">
+				<BlockDescription>
+					<p>{ __( 'Video, locally hosted, locally sourced.' ) }</p>
+				</BlockDescription>
+			</InspectorControls>,
+		];
 
 		if ( ! src ) {
 			return [


### PR DESCRIPTION
This PR, though it looks big, just adds descriptions to every block that misses it, bringing our stash of blocks up to snuff with [the design doc](https://github.com/WordPress/gutenberg/blob/master/docs/design.md#block-design-checklist-dos-and-donts-and-examples). 

That also means it adds inspector controls to blocks that don't have any yet. Incidentally, I failed to do this for the "Custom HTML" block, and the "Classic Text" block. I got errors that my skills fell short of fixing. Would appreciate help in addressing those.

Finally, I got a few JS with the Code block and the Gallery block. I'm pretty sure they are errors I introduced, but I can't quite wrap my head around what I did wrong, would really appreciate insights here, thank you. (Feel free to push directly to this branch if need be)

![screen shot 2017-08-15 at 19 06 11](https://user-images.githubusercontent.com/1204802/29326942-c5b42094-81ed-11e7-80da-3a37c067344d.png)
