### PR TITLE
Try adding width cropping option

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -61,6 +61,10 @@ registerBlockType( 'core/gallery', {
 			type: 'boolean',
 			default: true,
 		},
+		cropToWidth: {
+			type: 'boolean',
+			default: false,
+		},
 		linkTo: {
 			type: 'string',
 			default: 'none',
@@ -75,11 +79,12 @@ registerBlockType( 'core/gallery', {
 	},
 
 	edit( { attributes, setAttributes, focus, className } ) {
-		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
+		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo, cropToWidth } = attributes;
 		const setLinkTo = ( value ) => setAttributes( { linkTo: value } );
 		const setColumnsNumber = ( value ) => setAttributes( { columns: value } );
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const toggleImageCrop = () => setAttributes( { imageCrop: ! imageCrop } );
+		const toggleCropToWidth = () => setAttributes( { cropToWidth: ! cropToWidth } );
 
 		const onSelectImages = ( imgs ) => setAttributes( { images: imgs } );
 
@@ -170,15 +175,20 @@ registerBlockType( 'core/gallery', {
 						checked={ !! imageCrop }
 						onChange={ toggleImageCrop }
 					/>
+					<ToggleControl
+						label={ __( 'Crop according to width' ) }
+						checked={ !! cropToWidth }
+						onChange={ toggleCropToWidth }
+					/>
 					<SelectControl
-						label={ __( 'Link to' ) }
+						label={ __( 'Link images to' ) }
 						selected={ linkTo }
 						onBlur={ setLinkTo }
 						options={ linkOptions }
 					/>
 				</InspectorControls>
 			),
-			<div key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
+			<div key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' } ${ cropToWidth ? 'is-cropped-width' : '' }` }>
 				{ images.map( ( img ) => (
 					<GalleryImage key={ img.url } img={ img } />
 				) ) }
@@ -187,9 +197,9 @@ registerBlockType( 'core/gallery', {
 	},
 
 	save( { attributes } ) {
-		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
+		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo, cropToWidth } = attributes;
 		return (
-			<div className={ `align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
+			<div className={ `align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' } ${ cropToWidth ? 'is-cropped-width' : '' }` } >
 				{ images.map( ( img ) => (
 					<GalleryImage key={ img.url } img={ img } linkTo={ linkTo } />
 				) ) }


### PR DESCRIPTION
This is a work in progress, not yet functional PR. It aims to let you crop images according to _width_ instead of _height_. If you have 4 images in a 2 column gallery, first is portrait, 2nd is landscape, 3rd is portrait, 4th is landscape, right now you get 4 vertical rectangles:

![crop-by-height](https://user-images.githubusercontent.com/1204802/29358133-4e788d3e-827a-11e7-95f2-0e9ffd2ea48b.png)

With this option enabled, instead you should get a vertical, then horizontal, then vertical, then horizontal rectangles:

![desired-crop-by-width](https://user-images.githubusercontent.com/1204802/29358143-5547bd88-827a-11e7-8bb5-03875c3a4f0e.png)

Exploring some of the CSS in a codepen also: https://codepen.io/joen/pen/zdPmBR?editors=1100