### PR TITLE
Paste: strip more tags and data-attributes

### DIFF
--- a/blocks/api/paste/index.js
+++ b/blocks/api/paste/index.js
@@ -20,7 +20,12 @@ export default function( nodes ) {
 		stripAttributes,
 	] );
 
-	return prepare( nodes ).map( ( node ) => {
+	const prepared = prepare( nodes );
+
+	// Allows us to ask for this information when we get a report.
+	window.console.log( 'Processed HTML:\n\n', prepared.map( ( node ) => node.outerHTML ) );
+
+	return prepared.map( ( node ) => {
 		const block = getBlockTypes().reduce( ( acc, blockType ) => {
 			if ( acc ) {
 				return acc;

--- a/blocks/api/paste/index.js
+++ b/blocks/api/paste/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, flowRight as compose } from 'lodash';
+import { find, get, flow } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ import stripAttributes from './strip-attributes';
 import stripWrappers from './strip-wrappers';
 
 export default function( nodes ) {
-	const prepare = compose( [
+	const prepare = flow( [
 		stripWrappers,
 		normaliseBlocks,
 		stripAttributes,

--- a/blocks/api/paste/normalise-blocks.js
+++ b/blocks/api/paste/normalise-blocks.js
@@ -5,6 +5,25 @@ import { nodetypes } from '@wordpress/utils';
 
 const { ELEMENT_NODE, TEXT_NODE } = nodetypes;
 
+const inlineTags = [
+	'strong',
+	'em',
+	'b',
+	'i',
+	'del',
+	'ins',
+	'a',
+	'code',
+	'abbr',
+	'time',
+	'sub',
+	'sup',
+];
+
+function isInline( node ) {
+	return inlineTags.indexOf( node.nodeName.toLowerCase() ) !== -1;
+}
+
 /**
  * Normalises array nodes of any node type to an array of block level nodes.
  *
@@ -54,6 +73,9 @@ export default function( nodes ) {
 				} else {
 					accu.appendChild( node );
 				}
+			} else if ( isInline( node ) ) {
+				accu.appendChild( document.createElement( 'P' ) );
+				accu.lastChild.appendChild( node );
 			} else {
 				accu.appendChild( node );
 			}

--- a/blocks/api/paste/strip-attributes.js
+++ b/blocks/api/paste/strip-attributes.js
@@ -1,16 +1,33 @@
-import { ELEMENT_NODE } from 'utils/nodetypes';
+const attributes = [
+	'style',
+	'class',
+	'id',
+];
 
 export default function( nodes ) {
-	// MUTATION!
-	nodes.forEach( deepAttributeStrip );
-	return nodes;
+	const fragment = document.createDocumentFragment();
+
+	nodes.forEach( node => fragment.appendChild( node.cloneNode( true ) ) );
+
+	deepAttributeStrip( fragment.children );
+
+	return Array.from( fragment.childNodes );
 }
 
-function deepAttributeStrip( node ) {
-	if ( ELEMENT_NODE === node.nodeType ) {
-		node.removeAttribute( 'style' );
-		node.removeAttribute( 'class' );
-		node.removeAttribute( 'id' );
-		Array.from( node.children ).forEach( deepAttributeStrip );
-	}
+function deepAttributeStrip( nodes ) {
+	Array.from( nodes ).forEach( ( node ) => {
+		if ( node.hasAttributes() ) {
+			Array.from( node.attributes ).forEach( ( { name } ) => {
+				if ( attributes.indexOf( name ) !== -1 ) {
+					node.removeAttribute( name );
+				}
+
+				if ( name.indexOf( 'data-' ) === 0 ) {
+					node.removeAttribute( name );
+				}
+			} );
+		}
+
+		deepAttributeStrip( node.children );
+	} );
 }

--- a/blocks/api/paste/strip-wrappers.js
+++ b/blocks/api/paste/strip-wrappers.js
@@ -1,3 +1,15 @@
+const tags = [
+	'span',
+	'div',
+	'article',
+	'header',
+	'footer',
+	'section',
+	'nav',
+	'hgroup',
+	'main',
+].join( ',' );
+
 function unwrap( node ) {
 	const parent = node.parentNode;
 
@@ -17,7 +29,7 @@ export default function( nodes ) {
 
 	nodes.forEach( node => fragment.appendChild( node.cloneNode( true ) ) );
 
-	const wrappers = fragment.querySelectorAll( 'span,div' );
+	const wrappers = fragment.querySelectorAll( tags );
 
 	Array.from( wrappers ).forEach( ( wrapper ) => unwrap( wrapper ) );
 

--- a/blocks/api/paste/strip-wrappers.js
+++ b/blocks/api/paste/strip-wrappers.js
@@ -8,6 +8,7 @@ const tags = [
 	'nav',
 	'hgroup',
 	'main',
+	'aside',
 ].join( ',' );
 
 function unwrap( node ) {

--- a/blocks/api/paste/test/normalise-blocks.js
+++ b/blocks/api/paste/test/normalise-blocks.js
@@ -43,4 +43,8 @@ describe( 'normaliseBlocks', () => {
 	it( 'should remove empty paragraphs', () => {
 		equal( transform( '<p>&nbsp;</p>' ), '' );
 	} );
+
+	it( 'should wrap lose inline elements', () => {
+		equal( transform( '<a href="#">test</a>' ), '<p><a href="#">test</a></p>' );
+	} );
 } );

--- a/blocks/api/paste/test/strip-attributes.js
+++ b/blocks/api/paste/test/strip-attributes.js
@@ -22,7 +22,23 @@ function transform( HTML ) {
 }
 
 describe( 'stripAttributes', () => {
-	it( 'should remove id, class, and style', () => {
-		equal( transform( '<p class="test" style="display:none;">test</p><p id="test">test <a href="#keep">test</a></p>' ), '<p>test</p><p>test <a href="#keep">test</a></p>' );
+	it( 'should remove attributes', () => {
+		equal( transform( '<p class="test">test</p>' ), '<p>test</p>' );
+	} );
+
+	it( 'should remove multiple attributes', () => {
+		equal( transform( '<p class="test" id="test">test</p>' ), '<p>test</p>' );
+	} );
+
+	it( 'should deep remove attributes', () => {
+		equal( transform( '<p class="test">test <em id="test">test</em></p>' ), '<p>test <em>test</em></p>' );
+	} );
+
+	it( 'should remove data-* attributes', () => {
+		equal( transform( '<p data-reactid="1">test</p>' ), '<p>test</p>' );
+	} );
+
+	it( 'should keep some attributes', () => {
+		equal( transform( '<a href="#keep">test</a>' ), '<a href="#keep">test</a>' );
 	} );
 } );

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -79,6 +79,7 @@ export default class Editable extends Component {
 		this.changeFormats = this.changeFormats.bind( this );
 		this.onSelectionChange = this.onSelectionChange.bind( this );
 		this.maybePropagateUndo = this.maybePropagateUndo.bind( this );
+		this.onBeforePastePreProcess = this.onBeforePastePreProcess.bind( this );
 		this.onPastePostProcess = this.onPastePostProcess.bind( this );
 
 		this.state = {
@@ -106,6 +107,7 @@ export default class Editable extends Component {
 		editor.on( 'keyup', this.onKeyUp );
 		editor.on( 'selectionChange', this.onSelectionChange );
 		editor.on( 'BeforeExecCommand', this.maybePropagateUndo );
+		editor.on( 'BeforePastePreProcess', this.onBeforePastePreProcess );
 		editor.on( 'PastePostProcess', this.onPastePostProcess );
 
 		patterns.apply( this, [ editor ] );
@@ -172,7 +174,15 @@ export default class Editable extends Component {
 		}
 	}
 
+	onBeforePastePreProcess( event ) {
+		// Allows us to ask for this information when we get a report.
+		window.console.log( 'Received HTML:\n\n', event.content );
+	}
+
 	onPastePostProcess( event ) {
+		// Allows us to ask for this information when we get a report.
+		window.console.log( 'MCE processed HTML:\n\n', event.node.innerHTML );
+
 		const childNodes = Array.from( event.node.childNodes );
 		const isBlockDelimiter = ( node ) =>
 			node.nodeType === 8 && /^ wp:/.test( node.nodeValue );


### PR DESCRIPTION
This PR introduces more tag stripping such as `<article>` etc. I've been copy pasting content from several sites, and these tags are copied quite a few times. Since we don't handle them, we better strip them than dump it all in a freeform block.

It also strips all data-* attributes.