### PR TITLE
Try sliding toolbar for overflow on mobile

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -322,6 +322,7 @@
 	background: $white;
 	border-top: 1px solid $light-gray-500;
 	border-bottom: 1px solid $light-gray-500;
+	overflow: auto;	// allow horizontal scrolling on mobile
 
 	> div,
 	> ul {
@@ -331,6 +332,7 @@
 
 	@include break-small() {
 		width: auto;
+		overflow: hidden;
 	}
 }
 


### PR DESCRIPTION
This PR may fix #2287, at least partially, or in a transitional way. It's a two-line code change, and all it does is ensure that on mobile, overflow can be scrolled.

This is not a good solution for desktop, of course, where the scrollbar when visible (as it is on nearly all computers) would not only cover content and be ugly, but scrolling horizontally is generally not a good experience. However on mobile, the scrollbar fades in briefly when you load the page, and you can just drag with your finger.

Let's discuss whether this is a good solution.

Demo:

![slidingtoolbar](https://user-images.githubusercontent.com/1204802/29401637-4d425946-8332-11e7-9980-85b18801ccbd.gif)
