### PR TITLE
Try a more compact save state indicator

### DIFF
--- a/editor/header/mode-switcher/style.scss
+++ b/editor/header/mode-switcher/style.scss
@@ -1,7 +1,8 @@
-#wpbody .editor-mode-switcher {	/* #wpbody for extra specificity */
+#wpbody .editor-mode-switcher {		// #wpbody for extra specificity
 	position: relative;
 	margin-right: $item-spacing;
-	padding-right: $item-spacing;
+	margin-left: -8px;	// use the full hit area of the select box, but maintain optical editor bar padding
+	padding-right: 2px;
 	color: $dark-gray-500;
 	align-items: center;
 	cursor: pointer;

--- a/editor/header/saved-state/index.js
+++ b/editor/header/saved-state/index.js
@@ -59,7 +59,8 @@ export function SavedState( { isNew, isPublished, isDirty, isSaving, isSaveable,
 
 	return (
 		<Button className={ classnames( className, 'button-link' ) } onClick={ onClick }>
-			{ __( 'Save Draft' ) }
+			<span className="editor-saved-state__mobile">{ __( 'Save' ) }</span>
+			<span className="editor-saved-state__desktop">{ __( 'Save Draft' ) }</span>
 		</Button>
 	);
 }

--- a/editor/header/saved-state/style.scss
+++ b/editor/header/saved-state/style.scss
@@ -6,6 +6,7 @@
 
 	.dashicon {
 		margin-right: 4px;
+		margin-left: -4px;
 	}
 
 	&.button-link {

--- a/editor/header/saved-state/style.scss
+++ b/editor/header/saved-state/style.scss
@@ -21,3 +21,16 @@
 		}
 	}
 }
+
+.editor-saved-state__mobile {
+	@include break-small {
+		display: none;
+	}
+}
+
+.editor-saved-state__desktop {
+	display: none;
+	@include break-small {
+		display: inline;
+	}
+}

--- a/editor/header/saved-state/test/index.js
+++ b/editor/header/saved-state/test/index.js
@@ -67,7 +67,7 @@ describe( 'SavedState', () => {
 		);
 
 		expect( wrapper.name() ).toBe( 'Button' );
-		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save Draft' );
+		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save' );
 		wrapper.simulate( 'click' );
 		expect( statusSpy ).toHaveBeenCalledWith( 'draft' );
 		expect( saveSpy ).toHaveBeenCalled();
@@ -87,7 +87,7 @@ describe( 'SavedState', () => {
 		);
 
 		expect( wrapper.name() ).toBe( 'Button' );
-		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save Draft' );
+		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save' );
 		wrapper.simulate( 'click' );
 		expect( statusSpy ).not.toHaveBeenCalled();
 		expect( saveSpy ).toHaveBeenCalled();


### PR DESCRIPTION
This PR does three things:

1. It makes the "Save Draft" label just say "Save" on mobile
2. It tightens the space around the editor mode switch, while keeping the hit area the same
3. It adds negative margin to the "Saved" dashicon so it visually aligns with the text

Screenshots:

![screen shot 2017-08-17 at 10 18 00](https://user-images.githubusercontent.com/1204802/29402573-c33a0c36-8335-11e7-8a87-85f834de2a8d.png)

![screen shot 2017-08-17 at 10 18 07](https://user-images.githubusercontent.com/1204802/29402575-c5503e14-8335-11e7-935a-45bb3aebe07c.png)

![screen shot 2017-08-17 at 10 18 39](https://user-images.githubusercontent.com/1204802/29402576-c70fad02-8335-11e7-8aaf-e5576b7fa168.png)


![saveindicator](https://user-images.githubusercontent.com/1204802/29402618-ee16bc10-8335-11e7-9d6a-2fcf8c8169b2.gif)
