### PR TITLE
Add ability to select an individual heading block from the ToC

### DIFF
--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -16,6 +16,7 @@ import { PanelBody } from '@wordpress/components';
 import './style.scss';
 import TableOfContentsItem from './item';
 import { getBlocks } from '../../selectors';
+import { selectBlock } from '../../actions';
 
 /**
  * Module constants
@@ -51,7 +52,7 @@ const getHeadingLevel = heading => {
 
 const isEmptyHeading = heading => ! heading.attributes.content || heading.attributes.content.length === 0;
 
-const TableOfContents = ( { blocks } ) => {
+const TableOfContents = ( { blocks, onSelect } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
 
 	if ( headings.length <= 1 ) {
@@ -59,6 +60,12 @@ const TableOfContents = ( { blocks } ) => {
 	}
 
 	let prevHeadingLevel = 1;
+
+	// Select the corresponding block in the main editor
+	// when clicking on a heading item from the list.
+	const onSelectHeading = ( uid ) => {
+		onSelect( uid );
+	};
 
 	const tocItems = headings.map( ( heading, index ) => {
 		const headingLevel = getHeadingLevel( heading );
@@ -81,6 +88,7 @@ const TableOfContents = ( { blocks } ) => {
 				key={ index }
 				level={ headingLevel }
 				isValid={ isValid }
+				onClick={ () => onSelectHeading( heading.uid ) }
 			>
 				{ isEmpty ? emptyHeadingContent : heading.attributes.content }
 				{ isIncorrectLevel && incorrectLevelContent }
@@ -103,5 +111,10 @@ export default connect(
 		return {
 			blocks: getBlocks( state ),
 		};
-	}
+	},
+	( dispatch ) => ( {
+		onSelect( uid ) {
+			dispatch( selectBlock( uid ) );
+		},
+	} )
 )( TableOfContents );

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -63,9 +63,7 @@ const TableOfContents = ( { blocks, onSelect } ) => {
 
 	// Select the corresponding block in the main editor
 	// when clicking on a heading item from the list.
-	const onSelectHeading = ( uid ) => {
-		onSelect( uid );
-	};
+	const onSelectHeading = ( uid ) => onSelect( uid );
 
 	const tocItems = headings.map( ( heading, index ) => {
 		const headingLevel = getHeadingLevel( heading );

--- a/editor/sidebar/table-of-contents/item.js
+++ b/editor/sidebar/table-of-contents/item.js
@@ -7,6 +7,7 @@ const TableOfContentsItem = ( {
 	children,
 	isValid,
 	level,
+	onClick,
 } ) => (
 	<li
 		className={ classnames(
@@ -16,6 +17,7 @@ const TableOfContentsItem = ( {
 				'is-invalid': ! isValid,
 			}
 		) }
+		onClick={ onClick }
 	>
 		<span className="table-of-contents-item__emdash" aria-hidden="true"></span>
 		<strong className="table-of-contents-item__level">

--- a/editor/sidebar/table-of-contents/item.js
+++ b/editor/sidebar/table-of-contents/item.js
@@ -3,6 +3,11 @@
  */
 import classnames from 'classnames';
 
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 const TableOfContentsItem = ( {
 	children,
 	isValid,
@@ -17,15 +22,20 @@ const TableOfContentsItem = ( {
 				'is-invalid': ! isValid,
 			}
 		) }
-		onClick={ onClick }
 	>
-		<span className="table-of-contents-item__emdash" aria-hidden="true"></span>
-		<strong className="table-of-contents-item__level">
-			H{ level }
-		</strong>
-		<span className="table-of-contents-item__content">
-			{ children }
-		</span>
+		<button
+			className="table-of-contents__button"
+			onClick={ onClick }
+			aria-label={ __( 'Focus heading block' ) }
+		>
+			<span className="table-of-contents-item__emdash" aria-hidden="true"></span>
+			<strong className="table-of-contents-item__level">
+				H{ level }
+			</strong>
+			<span className="table-of-contents-item__content">
+				{ children }
+			</span>
+		</button>
 	</li>
 );
 

--- a/editor/sidebar/table-of-contents/style.scss
+++ b/editor/sidebar/table-of-contents/style.scss
@@ -4,7 +4,6 @@
 
 .table-of-contents-item {
 	display: flex;
-	align-items: flex-start;
 	margin: 4px 0;
 
 	.table-of-contents-item__emdash::before {
@@ -31,6 +30,16 @@
 	&.is-h6 .table-of-contents-item__emdash::before {
 		content: '—————';
 	}
+}
+
+.table-of-contents__button {
+	cursor: pointer;
+	background: none;
+	border: none;
+	display: flex;
+	align-items: flex-start;
+	color: $dark-gray-800;
+	text-align: left;
 }
 
 .table-of-contents-item__level {


### PR DESCRIPTION
This allows selecting a heading in the table of contents panel and having the corresponding block selected in the body, so it works as a way to navigate through a post using these landmarks.