### PR TITLE
Editor: Enable global drag and drop of files

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -2,13 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createMediaFromFile } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import './editor.scss';
-import { registerBlockType, source } from '../../api';
+import { registerBlockType, source, createBlock } from '../../api';
 import ImageBlock from './block';
 
 const { attr, children } = source;
@@ -61,6 +62,19 @@ registerBlockType( 'core/image', {
 					node.nodeName === 'IMG' ||
 					( ! node.textContent && node.querySelector( 'img' ) )
 				),
+			},
+			{
+				type: 'files',
+				isMatch( files ) {
+					return files.length === 1 && files[ 0 ].type.indexOf( 'image/' ) === 0;
+				},
+				transform( files ) {
+					return createMediaFromFile( files[ 0 ] )
+						.then( ( media ) => createBlock( 'core/image', {
+							id: media.id,
+							url: media.source_url,
+						} ) );
+				},
 			},
 		],
 	},

--- a/components/drop-zone/index.js
+++ b/components/drop-zone/index.js
@@ -25,6 +25,7 @@ class DropZone extends Component {
 		this.disconnectMutationObserver = this.disconnectMutationObserver.bind( this );
 		this.detectNodeRemoval = this.detectNodeRemoval.bind( this );
 		this.toggleDraggingOverDocument = this.toggleDraggingOverDocument.bind( this );
+		this.onDragOver = this.onDragOver.bind( this );
 		this.isWithinZoneBounds = this.isWithinZoneBounds.bind( this );
 		this.setZoneNode = this.setZoneNode.bind( this );
 		this.onDrop = this.onDrop.bind( this );
@@ -40,7 +41,7 @@ class DropZone extends Component {
 	componentDidMount() {
 		this.dragEnterNodes = [];
 
-		window.addEventListener( 'dragover', this.toggleDraggingOverDocument );
+		window.addEventListener( 'dragover', this.onDragOver );
 		window.addEventListener( 'drop', this.onDrop );
 		window.addEventListener( 'dragenter', this.toggleDraggingOverDocument );
 		window.addEventListener( 'dragleave', this.toggleDraggingOverDocument );
@@ -54,7 +55,7 @@ class DropZone extends Component {
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'dragover', this.toggleDraggingOverDocument );
+		window.removeEventListener( 'dragover', this.onDragOver );
 		window.removeEventListener( 'drop', this.onDrop );
 		window.removeEventListener( 'dragenter', this.toggleDraggingOverDocument );
 		window.removeEventListener( 'dragleave', this.toggleDraggingOverDocument );
@@ -107,9 +108,11 @@ class DropZone extends Component {
 		} );
 	}
 
-	toggleDraggingOverDocument( event ) {
+	onDragOver( event ) {
 		event.preventDefault();
+	}
 
+	toggleDraggingOverDocument( event ) {
 		// Track nodes that have received a drag event. So long as nodes exist
 		// in the set, we can assume that an item is being dragged on the page.
 		if ( 'dragenter' === event.type && ! includes( this.dragEnterNodes, event.target ) ) {
@@ -139,16 +142,22 @@ class DropZone extends Component {
 			};
 		}
 
-		this.setState( {
-			isDraggingOverDocument,
-			isDraggingOverElement,
-			position,
-		} );
-
 		if ( window.CustomEvent && event instanceof window.CustomEvent ) {
 			// For redirected CustomEvent instances, immediately remove window
 			// from tracked nodes since another "real" event will be triggered.
 			this.dragEnterNodes = without( this.dragEnterNodes, window );
+		}
+
+		if (
+			position !== this.state.position ||
+			isDraggingOverDocument !== this.state.isDraggingOverDocument ||
+			isDraggingOverElement !== this.state.isDraggingOverElement
+		) {
+			this.setState( {
+				isDraggingOverDocument,
+				isDraggingOverElement,
+				position,
+			} );
 		}
 	}
 

--- a/components/drop-zone/index.js
+++ b/components/drop-zone/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { includes, without, some } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,16 +20,9 @@ class DropZone extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.resetDragState = this.resetDragState.bind( this );
-		this.toggleMutationObserver = this.toggleMutationObserver.bind( this );
-		this.disconnectMutationObserver = this.disconnectMutationObserver.bind( this );
-		this.detectNodeRemoval = this.detectNodeRemoval.bind( this );
-		this.toggleDraggingOverDocument = this.toggleDraggingOverDocument.bind( this );
-		this.onDragOver = this.onDragOver.bind( this );
-		this.isWithinZoneBounds = this.isWithinZoneBounds.bind( this );
 		this.setZoneNode = this.setZoneNode.bind( this );
 		this.onDrop = this.onDrop.bind( this );
-		this.resetDragState = this.resetDragState.bind( this );
+		this.onFilesDrop = this.onFilesDrop.bind( this );
 
 		this.state = {
 			isDraggingOverDocument: false,
@@ -39,185 +32,36 @@ class DropZone extends Component {
 	}
 
 	componentDidMount() {
-		this.dragEnterNodes = [];
-
-		window.addEventListener( 'dragover', this.onDragOver );
-		window.addEventListener( 'drop', this.onDrop );
-		window.addEventListener( 'dragenter', this.toggleDraggingOverDocument );
-		window.addEventListener( 'dragleave', this.toggleDraggingOverDocument );
-		window.addEventListener( 'mouseup', this.resetDragState );
-	}
-
-	componentDidUpdate( prevProps, prevState ) {
-		if ( prevState.isDraggingOverDocument !== this.state.isDraggingOverDocument ) {
-			this.toggleMutationObserver();
-		}
+		this.context.dropzones.add( {
+			element: this.zone,
+			updateState: this.setState.bind( this ),
+			onDrop: this.onDrop,
+			onFilesDrop: this.onFilesDrop,
+		} );
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'dragover', this.onDragOver );
-		window.removeEventListener( 'drop', this.onDrop );
-		window.removeEventListener( 'dragenter', this.toggleDraggingOverDocument );
-		window.removeEventListener( 'dragleave', this.toggleDraggingOverDocument );
-		window.removeEventListener( 'mouseup', this.resetDragState );
-
-		this.disconnectMutationObserver();
+		this.context.dropzones.remove( this.zone );
 	}
 
-	resetDragState() {
-		const { isDraggingOverDocument, isDraggingOverElement } = this.state;
-		if ( ! ( isDraggingOverDocument || isDraggingOverElement ) ) {
-			return;
-		}
-
-		this.setState( {
-			isDraggingOverDocument: false,
-			isDraggingOverElement: false,
-			position: null,
-		} );
-	}
-
-	toggleMutationObserver() {
-		this.disconnectMutationObserver();
-
-		if ( this.state.isDraggingOverDocument ) {
-			this.observer = new window.MutationObserver( this.detectNodeRemoval );
-			this.observer.observe( document.body, {
-				childList: true,
-				subtree: true,
-			} );
+	onDrop() {
+		if ( this.props.onDrop ) {
+			this.props.onDrop( ...arguments );
 		}
 	}
 
-	disconnectMutationObserver() {
-		if ( ! this.observer ) {
-			return;
+	onFilesDrop() {
+		if ( this.props.onFilesDrop ) {
+			this.props.onFilesDrop( ...arguments );
 		}
-
-		this.observer.disconnect();
-		delete this.observer;
-	}
-
-	detectNodeRemoval( mutations ) {
-		mutations.forEach( ( mutation ) => {
-			if ( ! mutation.removedNodes.length ) {
-				return;
-			}
-
-			this.dragEnterNodes = without( this.dragEnterNodes, Array.from( mutation.removedNodes ) );
-		} );
-	}
-
-	onDragOver( event ) {
-		event.preventDefault();
-	}
-
-	toggleDraggingOverDocument( event ) {
-		// Track nodes that have received a drag event. So long as nodes exist
-		// in the set, we can assume that an item is being dragged on the page.
-		if ( 'dragenter' === event.type && ! includes( this.dragEnterNodes, event.target ) ) {
-			this.dragEnterNodes.push( event.target );
-		} else if ( 'dragleave' === event.type ) {
-			this.dragEnterNodes = without( this.dragEnterNodes, event.target );
-		}
-
-		// In some contexts, it may be necessary to capture and redirect the
-		// drag event (e.g. atop an `iframe`). To accommodate this, you can
-		// create an instance of CustomEvent with the original event specified
-		// as the `detail` property.
-		//
-		// See: https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
-		const detail = window.CustomEvent && event instanceof window.CustomEvent ? event.detail : event;
-
-		const { onVerifyValidTransfer } = this.props;
-		const isValidDrag = ! onVerifyValidTransfer || onVerifyValidTransfer( detail.dataTransfer );
-		const isDraggingOverDocument = isValidDrag && this.dragEnterNodes.length;
-		const isDraggingOverElement = isDraggingOverDocument && this.isWithinZoneBounds( detail.clientX, detail.clientY );
-		let position = null;
-		if ( isDraggingOverElement ) {
-			const rect = this.zone.getBoundingClientRect();
-			position = {
-				x: detail.clientX - rect.left < rect.right - detail.clientX ? 'left' : 'right',
-				y: detail.clientY - rect.top < rect.bottom - detail.clientY ? 'top' : 'bottom',
-			};
-		}
-
-		if ( window.CustomEvent && event instanceof window.CustomEvent ) {
-			// For redirected CustomEvent instances, immediately remove window
-			// from tracked nodes since another "real" event will be triggered.
-			this.dragEnterNodes = without( this.dragEnterNodes, window );
-		}
-
-		if (
-			position !== this.state.position ||
-			isDraggingOverDocument !== this.state.isDraggingOverDocument ||
-			isDraggingOverElement !== this.state.isDraggingOverElement
-		) {
-			this.setState( {
-				isDraggingOverDocument,
-				isDraggingOverElement,
-				position,
-			} );
-		}
-	}
-
-	isWithinZoneBounds( x, y ) {
-		if ( ! this.zone ) {
-			return false;
-		}
-
-		const isWithinElement = ( element ) => {
-			const rect = element.getBoundingClientRect();
-			/// make sure the rect is a valid rect
-			if ( rect.bottom === rect.top || rect.left === rect.right ) {
-				return false;
-			}
-
-			return (
-				x >= rect.left && x <= rect.right &&
-				y >= rect.top && y <= rect.bottom
-			);
-		};
-
-		const childZones = without( this.zone.parentElement.querySelectorAll( '.components-drop-zone' ), this.zone );
-		return ! some( childZones, isWithinElement ) && isWithinElement( this.zone );
 	}
 
 	setZoneNode( node ) {
 		this.zone = node;
 	}
 
-	onDrop( event ) {
-		// This seemingly useless line has been shown to resolve a Safari issue
-		// where files dragged directly from the dock are not recognized
-		event.dataTransfer && event.dataTransfer.files.length; // eslint-disable-line no-unused-expressions
-		const { position, isDraggingOverElement } = this.state;
-
-		this.resetDragState();
-
-		if ( ! this.zone.contains( event.target ) || ! isDraggingOverElement ) {
-			return;
-		}
-
-		if ( this.props.onDrop ) {
-			this.props.onDrop( event, position );
-		}
-
-		const { onVerifyValidTransfer } = this.props;
-		if ( onVerifyValidTransfer && ! onVerifyValidTransfer( event.dataTransfer ) ) {
-			return;
-		}
-
-		if ( event.dataTransfer ) {
-			this.props.onFilesDrop( Array.prototype.slice.call( event.dataTransfer.files ), position );
-		}
-
-		event.stopPropagation();
-		event.preventDefault();
-	}
-
 	render() {
-		const { className, children, label } = this.props;
+		const { className, label } = this.props;
 		const { isDraggingOverDocument, isDraggingOverElement, position } = this.state;
 		const classes = classnames( 'components-drop-zone', className, {
 			'is-active': isDraggingOverDocument || isDraggingOverElement,
@@ -232,7 +76,7 @@ class DropZone extends Component {
 		return (
 			<div ref={ this.setZoneNode } className={ classes }>
 				<div className="components-drop-zone__content">
-					{ children ? children : [
+					{ [
 						<Dashicon
 							key="icon"
 							icon="upload"
@@ -252,4 +96,9 @@ class DropZone extends Component {
 	}
 }
 
+DropZone.contextTypes = {
+	dropzones: noop,
+};
+
 export default DropZone;
+

--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -1,0 +1,191 @@
+/**
+ * External dependencies
+ */
+import { isEqual, without, some, filter, findIndex, noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+class DropZoneProvider extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.resetDragState = this.resetDragState.bind( this );
+		this.toggleDraggingOverDocument = this.toggleDraggingOverDocument.bind( this );
+		this.onDragOver = this.onDragOver.bind( this );
+		this.isWithinZoneBounds = this.isWithinZoneBounds.bind( this );
+		this.onDrop = this.onDrop.bind( this );
+
+		this.state = {
+			isDraggingOverDocument: false,
+			hoveredDropZone: -1,
+			position: null,
+		};
+		this.dropzones = [];
+	}
+
+	getChildContext() {
+		return {
+			dropzones: {
+				add: ( { element, updateState, onDrop, onFilesDrop } ) => {
+					this.dropzones.push( { element, updateState, onDrop, onFilesDrop } );
+				},
+				remove: ( element ) => {
+					this.dropzones = filter( this.dropzones, ( dropzone ) => dropzone.element !== element );
+				},
+			},
+		};
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'dragover', this.onDragOver );
+		window.addEventListener( 'drop', this.onDrop );
+		window.addEventListener( 'dragenter', this.toggleDraggingOverDocument );
+		window.addEventListener( 'dragleave', this.toggleDraggingOverDocument );
+		window.addEventListener( 'mouseup', this.resetDragState );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'dragover', this.onDragOver );
+		window.removeEventListener( 'drop', this.onDrop );
+		window.removeEventListener( 'dragenter', this.toggleDraggingOverDocument );
+		window.removeEventListener( 'dragleave', this.toggleDraggingOverDocument );
+		window.removeEventListener( 'mouseup', this.resetDragState );
+	}
+
+	resetDragState() {
+		const { isDraggingOverDocument, hoveredDropZone } = this.state;
+		if ( ! isDraggingOverDocument && hoveredDropZone === -1 ) {
+			return;
+		}
+
+		this.setState( {
+			isDraggingOverDocument: false,
+			hoveredDropZone: -1,
+			position: null,
+		} );
+
+		this.dropzones.forEach( ( { updateState } ) => {
+			updateState( { isDraggingOverDocument, isDraggingOverElement: false, position: null } );
+		} );
+	}
+
+	onDragOver( event ) {
+		event.preventDefault();
+	}
+
+	toggleDraggingOverDocument( event ) {
+		// In some contexts, it may be necessary to capture and redirect the
+		// drag event (e.g. atop an `iframe`). To accommodate this, you can
+		// create an instance of CustomEvent with the original event specified
+		// as the `detail` property.
+		//
+		// See: https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
+		const detail = window.CustomEvent && event instanceof window.CustomEvent ? event.detail : event;
+
+		// Computing state
+		const { onVerifyValidTransfer } = this.props;
+		const isValidDrag = ! onVerifyValidTransfer || onVerifyValidTransfer( detail.dataTransfer );
+		const isDraggingOverDocument = isValidDrag; // && this.dragEnterNodes.length;
+		const hoveredDropZone = isDraggingOverDocument && findIndex( this.dropzones, ( { element } ) =>
+			this.isWithinZoneBounds( element, detail.clientX, detail.clientY
+		) );
+		let position = null;
+		if ( hoveredDropZone !== -1 ) {
+			const rect = this.dropzones[ hoveredDropZone ].element.getBoundingClientRect();
+			position = hoveredDropZone === -1 ? null : {
+				x: detail.clientX - rect.left < rect.right - detail.clientX ? 'left' : 'right',
+				y: detail.clientY - rect.top < rect.bottom - detail.clientY ? 'top' : 'bottom',
+			};
+		}
+
+		// Optimisation: Only update the changed dropzones
+		let dropzonesToUpdate = [];
+		if ( this.state.isDraggingOverDocument !== isDraggingOverDocument ) {
+			dropzonesToUpdate = this.dropzones;
+		} else if ( hoveredDropZone !== this.state.hoveredDropZone ) {
+			if ( this.state.hoveredDropZone !== -1 ) {
+				dropzonesToUpdate.push( this.dropzones[ this.state.hoveredDropZone ] );
+			}
+			if ( hoveredDropZone !== -1 ) {
+				dropzonesToUpdate.push( this.dropzones[ hoveredDropZone ] );
+			}
+		} else if (
+			hoveredDropZone !== -1 &&
+			hoveredDropZone === this.state.hoveredDropZone &&
+			! isEqual( position, this.state.position )
+		) {
+			dropzonesToUpdate.push( this.dropzones[ hoveredDropZone ] );
+		}
+
+		// Notifying the dropzones
+		dropzonesToUpdate.map( ( dropzone ) => {
+			const index = this.dropzones.indexOf( dropzone );
+			dropzone.updateState( {
+				isDraggingOverElement: index === hoveredDropZone,
+				position: index === hoveredDropZone ? position : null,
+				isDraggingOverDocument,
+			} );
+		} );
+		this.setState( {
+			isDraggingOverDocument,
+			hoveredDropZone,
+			position,
+		} );
+	}
+
+	isWithinZoneBounds( dropzone, x, y ) {
+		const isWithinElement = ( element ) => {
+			const rect = element.getBoundingClientRect();
+			/// make sure the rect is a valid rect
+			if ( rect.bottom === rect.top || rect.left === rect.right ) {
+				return false;
+			}
+
+			return (
+				x >= rect.left && x <= rect.right &&
+				y >= rect.top && y <= rect.bottom
+			);
+		};
+
+		const childZones = without( dropzone.parentElement.querySelectorAll( '.components-drop-zone' ), dropzone );
+		return ! some( childZones, isWithinElement ) && isWithinElement( dropzone );
+	}
+
+	onDrop( event ) {
+		// This seemingly useless line has been shown to resolve a Safari issue
+		// where files dragged directly from the dock are not recognized
+		event.dataTransfer && event.dataTransfer.files.length; // eslint-disable-line no-unused-expressions
+		const { position, hoveredDropZone } = this.state;
+		const dropzone = hoveredDropZone !== -1 ? this.dropzones[ hoveredDropZone ] : null;
+		this.resetDragState();
+		if ( !! dropzone && !! dropzone.onDrop ) {
+			dropzone.onDrop( event, position );
+		}
+
+		const { onVerifyValidTransfer } = this.props;
+		if ( onVerifyValidTransfer && ! onVerifyValidTransfer( event.dataTransfer ) ) {
+			return;
+		}
+
+		if ( event.dataTransfer && !! dropzone && !! dropzone.onFilesDrop ) {
+			dropzone.onFilesDrop( Array.prototype.slice.call( event.dataTransfer.files ), position );
+		}
+
+		event.stopPropagation();
+		event.preventDefault();
+	}
+
+	render() {
+		const { children } = this.props;
+		return children;
+	}
+}
+
+DropZoneProvider.childContextTypes = {
+	dropzones: noop,
+};
+
+export default DropZoneProvider;

--- a/components/drop-zone/style.scss
+++ b/components/drop-zone/style.scss
@@ -8,7 +8,7 @@
 	visibility: hidden;
 	opacity: 0;
 	transition: 0.3s opacity, 0.3s background-color, 0s visibility 0.3s;
-	border: 2px solid $blue-wordpress;
+	border: 2px solid $blue-medium-500;
 	border-radius: 2px;
 
 	&.is-active {

--- a/components/drop-zone/style.scss
+++ b/components/drop-zone/style.scss
@@ -4,14 +4,12 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	margin: 15px;
 	z-index: z-index( '.components-drop-zone' );
 	visibility: hidden;
 	opacity: 0;
 	transition: 0.3s opacity, 0.3s background-color, 0s visibility 0.3s;
 	border: 2px solid $blue-wordpress;
 	border-radius: 2px;
-	background-color: rgba( $blue-medium-500, 0.8 );
 
 	&.is-active {
 		opacity: 1;
@@ -21,6 +19,10 @@
 
 	&.is-dragging-over-element {
 		background-color: rgba( $blue-medium-300, 0.8 );
+
+		.components-drop-zone__content {
+			display: block;
+		}
 	}
 }
 
@@ -35,6 +37,7 @@
 	text-align: center;
 	color: $white;
 	transition: transform 0.2s ease-in-out;
+	display: none;
 }
 
 .components-drop-zone.is-dragging-over-element .components-drop-zone__content {

--- a/components/index.js
+++ b/components/index.js
@@ -4,6 +4,7 @@ export { default as Button } from './button';
 export { default as ClipboardButton } from './clipboard-button';
 export { default as Dashicon } from './dashicon';
 export { default as DropZone } from './drop-zone';
+export { default as DropZoneProvider } from './drop-zone/provider';
 export { default as DropdownMenu } from './dropdown-menu';
 export { default as ExternalLink } from './external-link';
 export { default as FormFileUpload } from './form-file-upload';

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -133,7 +133,7 @@ export function insertBlock( block, after ) {
 export function insertBlocks( blocks, after ) {
 	return {
 		type: 'INSERT_BLOCKS',
-		blocks,
+		blocks: castArray( blocks ),
 		after,
 	};
 }

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -126,15 +126,15 @@ export function replaceBlock( uid, block ) {
 	return replaceBlocks( [ uid ], castArray( block ) );
 }
 
-export function insertBlock( block, after ) {
-	return insertBlocks( [ block ], after );
+export function insertBlock( block, position ) {
+	return insertBlocks( [ block ], position );
 }
 
-export function insertBlocks( blocks, after ) {
+export function insertBlocks( blocks, position ) {
 	return {
 		type: 'INSERT_BLOCKS',
 		blocks: castArray( blocks ),
-		after,
+		position,
 	};
 }
 

--- a/editor/index.js
+++ b/editor/index.js
@@ -139,7 +139,6 @@ export function createEditorInstance( id, post, settings ) {
 		// DropZone provider:
 		[
 			DropZoneProvider,
-			{},
 		],
 	];
 

--- a/editor/index.js
+++ b/editor/index.js
@@ -13,7 +13,7 @@ import 'moment-timezone/moment-timezone-utils';
  */
 import { EditableProvider } from '@wordpress/blocks';
 import { createElement, render } from '@wordpress/element';
-import { APIProvider, PopoverProvider } from '@wordpress/components';
+import { APIProvider, PopoverProvider, DropZoneProvider } from '@wordpress/components';
 import { settings as dateSettings } from '@wordpress/date';
 
 /**
@@ -134,6 +134,12 @@ export function createEditorInstance( id, post, settings ) {
 					'taxonomyRestBaseMapping',
 				] ),
 			},
+		],
+
+		// DropZone provider:
+		[
+			DropZoneProvider,
+			{},
 		],
 	];
 

--- a/editor/modes/visual-editor/block-drop-zone.js
+++ b/editor/modes/visual-editor/block-drop-zone.js
@@ -1,0 +1,51 @@
+/**
+ * External Dependencies
+ */
+import { connect } from 'react-redux';
+import { reduce, get, find } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { DropZone } from '@wordpress/components';
+import { getBlockTypes } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { insertBlocks } from '../../actions';
+
+function BlockDropZone( { index, ...props } ) {
+	const dropFiles = ( files, position ) => {
+		const transformation = reduce( getBlockTypes(), ( ret, blockType ) => {
+			if ( ret ) {
+				return ret;
+			}
+
+			return find( get( blockType, 'transforms.from', [] ), ( transform ) => (
+				transform.type === 'files' && transform.isMatch( files )
+			) );
+		}, false );
+
+		if ( transformation ) {
+			let insertPosition;
+			if ( index !== undefined ) {
+				insertPosition = position.y === 'top' ? index : index + 1;
+			}
+			transformation.transform( files ).then( ( blocks ) => {
+				props.insertBlocks( blocks, insertPosition );
+			} );
+		}
+	};
+
+	return (
+		<DropZone
+			onFilesDrop={ dropFiles }
+		/>
+	);
+}
+
+export default connect(
+	undefined,
+	{ insertBlocks }
+)( BlockDropZone );

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -18,6 +18,7 @@ import { keycodes } from '@wordpress/utils';
  * Internal dependencies
  */
 import VisualEditorBlock from './block';
+import BlockDropZone from './block-drop-zone';
 import Inserter from '../../inserter';
 import {
 	getBlockUids,
@@ -249,6 +250,7 @@ class VisualEditorBlockList extends Component {
 				} ) }
 				{ ! blocks.length &&
 					<div className="editor-visual-editor__placeholder">
+						<BlockDropZone />
 						<input
 							type="text"
 							readOnly

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -4,16 +4,16 @@
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { Slot } from 'react-slot-fill';
-import { partial } from 'lodash';
+import { partial, reduce, get, find } from 'lodash';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
  * WordPress dependencies
  */
 import { Children, Component } from '@wordpress/element';
-import { IconButton, Toolbar } from '@wordpress/components';
+import { IconButton, Toolbar, DropZone } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
-import { getBlockType, getBlockDefaultClassname, createBlock } from '@wordpress/blocks';
+import { getBlockType, getBlockDefaultClassname, createBlock, getBlockTypes } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -75,6 +75,7 @@ class VisualEditorBlock extends Component {
 		this.onKeyUp = this.onKeyUp.bind( this );
 		this.toggleMobileControls = this.toggleMobileControls.bind( this );
 		this.onBlockError = this.onBlockError.bind( this );
+		this.dropFiles = this.dropFiles.bind( this );
 
 		this.previousOffset = null;
 
@@ -254,9 +255,9 @@ class VisualEditorBlock extends Component {
 		if ( ENTER === keyCode && target === this.node ) {
 			event.preventDefault();
 
-			this.props.onInsertBlocksAfter( [
+			this.props.onInsertBlocks( [
 				createBlock( 'core/paragraph' ),
-			] );
+			], this.props.order );
 		}
 	}
 
@@ -274,8 +275,27 @@ class VisualEditorBlock extends Component {
 		this.setState( { error } );
 	}
 
+	dropFiles( files, position ) {
+		const { order } = this.props;
+		const transformation = reduce( getBlockTypes(), ( ret, blockType ) => {
+			if ( ret ) {
+				return ret;
+			}
+
+			return find( get( blockType, 'transforms.from', [] ), ( transform ) => (
+				transform.type === 'files' && transform.isMatch( files )
+			) );
+		}, false );
+
+		if ( transformation ) {
+			transformation.transform( files ).then( ( blocks ) => {
+				this.props.onInsertBlocks( blocks, position.y === 'top' ? order : order + 1 );
+			} );
+		}
+	}
+
 	render() {
-		const { block, multiSelectedBlockUids } = this.props;
+		const { block, multiSelectedBlockUids, order } = this.props;
 		const { name: blockName, isValid } = block;
 		const blockType = getBlockType( blockName );
 		// translators: %s: Type of block (i.e. Text, Image etc)
@@ -308,7 +328,7 @@ class VisualEditorBlock extends Component {
 			'is-showing-mobile-controls': showMobileControls,
 		} );
 
-		const { onMouseLeave, onFocus, onInsertBlocksAfter, onReplace } = this.props;
+		const { onMouseLeave, onFocus, onInsertBlocks, onReplace } = this.props;
 
 		// Determine whether the block has props to apply to the wrapper.
 		let wrapperProps;
@@ -337,6 +357,9 @@ class VisualEditorBlock extends Component {
 				aria-label={ blockLabel }
 				{ ...wrapperProps }
 			>
+				<DropZone
+					onFilesDrop={ this.dropFiles }
+				/>
 				{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }
 				{ ( showUI || isHovered ) && <BlockRightMenu uid={ block.uid } /> }
 				{ showUI && isValid &&
@@ -383,7 +406,7 @@ class VisualEditorBlock extends Component {
 								focus={ focus }
 								attributes={ block.attributes }
 								setAttributes={ this.setAttributes }
-								insertBlocksAfter={ onInsertBlocksAfter }
+								insertBlocksAfter={ ( blocks ) => onInsertBlocks( blocks, order + 1 ) }
 								onReplace={ onReplace }
 								setFocus={ partial( onFocus, block.uid ) }
 								mergeBlocks={ this.mergeBlocks }
@@ -458,8 +481,8 @@ export default connect(
 			} );
 		},
 
-		onInsertBlocksAfter( blocks ) {
-			dispatch( insertBlocks( blocks, ownProps.uid ) );
+		onInsertBlocks( blocks, position ) {
+			dispatch( insertBlocks( blocks, position ) );
 		},
 
 		onFocus( ...args ) {

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -2,14 +2,15 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { first, last } from 'lodash';
+import { first, last, reduce, get, find } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Component, findDOMNode } from '@wordpress/element';
-import { KeyboardShortcuts } from '@wordpress/components';
+import { KeyboardShortcuts, DropZone } from '@wordpress/components';
+import { getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ import './style.scss';
 import VisualEditorBlockList from './block-list';
 import PostTitle from '../../post-title';
 import { getBlockUids, getMultiSelectedBlockUids } from '../../selectors';
-import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks } from '../../actions';
+import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks, insertBlocks } from '../../actions';
 
 class VisualEditor extends Component {
 	constructor() {
@@ -29,6 +30,7 @@ class VisualEditor extends Component {
 		this.selectAll = this.selectAll.bind( this );
 		this.undoOrRedo = this.undoOrRedo.bind( this );
 		this.deleteSelectedBlocks = this.deleteSelectedBlocks.bind( this );
+		this.dropFiles = this.dropFiles.bind( this );
 	}
 
 	componentDidMount() {
@@ -78,6 +80,24 @@ class VisualEditor extends Component {
 		}
 	}
 
+	dropFiles( files ) {
+		const transformation = reduce( getBlockTypes(), ( ret, blockType ) => {
+			if ( ret ) {
+				return ret;
+			}
+
+			return find( get( blockType, 'transforms.from', [] ), ( transform ) => (
+				transform.type === 'files' && transform.isMatch( files )
+			) );
+		}, false );
+
+		if ( transformation ) {
+			transformation.transform( files ).then( ( blocks ) => {
+				this.props.insertBlocks( blocks );
+			} );
+		}
+	}
+
 	render() {
 		// Disable reason: Clicking the canvas should clear the selection
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
@@ -91,6 +111,9 @@ class VisualEditor extends Component {
 				onKeyDown={ this.onKeyDown }
 				ref={ this.bindContainer }
 			>
+				<DropZone
+					onFilesDrop={ this.dropFiles }
+				/>
 				<KeyboardShortcuts shortcuts={ {
 					'mod+a': this.selectAll,
 					'mod+z': this.undoOrRedo,
@@ -119,5 +142,6 @@ export default connect(
 		onRedo: redo,
 		onUndo: undo,
 		onRemove: removeBlocks,
+		insertBlocks,
 	}
 )( VisualEditor );

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -18,7 +18,7 @@ import './style.scss';
 import VisualEditorBlockList from './block-list';
 import PostTitle from '../../post-title';
 import { getBlockUids, getMultiSelectedBlockUids } from '../../selectors';
-import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks, insertBlocks } from '../../actions';
+import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks } from '../../actions';
 
 class VisualEditor extends Component {
 	constructor() {
@@ -119,6 +119,5 @@ export default connect(
 		onRedo: redo,
 		onUndo: undo,
 		onRemove: removeBlocks,
-		insertBlocks,
 	}
 )( VisualEditor );

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -2,15 +2,14 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { first, last, reduce, get, find } from 'lodash';
+import { first, last } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Component, findDOMNode } from '@wordpress/element';
-import { KeyboardShortcuts, DropZone } from '@wordpress/components';
-import { getBlockTypes } from '@wordpress/blocks';
+import { KeyboardShortcuts } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -30,7 +29,6 @@ class VisualEditor extends Component {
 		this.selectAll = this.selectAll.bind( this );
 		this.undoOrRedo = this.undoOrRedo.bind( this );
 		this.deleteSelectedBlocks = this.deleteSelectedBlocks.bind( this );
-		this.dropFiles = this.dropFiles.bind( this );
 	}
 
 	componentDidMount() {
@@ -80,24 +78,6 @@ class VisualEditor extends Component {
 		}
 	}
 
-	dropFiles( files ) {
-		const transformation = reduce( getBlockTypes(), ( ret, blockType ) => {
-			if ( ret ) {
-				return ret;
-			}
-
-			return find( get( blockType, 'transforms.from', [] ), ( transform ) => (
-				transform.type === 'files' && transform.isMatch( files )
-			) );
-		}, false );
-
-		if ( transformation ) {
-			transformation.transform( files ).then( ( blocks ) => {
-				this.props.insertBlocks( blocks );
-			} );
-		}
-	}
-
 	render() {
 		// Disable reason: Clicking the canvas should clear the selection
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
@@ -111,9 +91,6 @@ class VisualEditor extends Component {
 				onKeyDown={ this.onKeyDown }
 				ref={ this.bindContainer }
 			>
-				<DropZone
-					onFilesDrop={ this.dropFiles }
-				/>
 				<KeyboardShortcuts shortcuts={ {
 					'mod+a': this.selectAll,
 					'mod+z': this.undoOrRedo,

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -288,7 +288,8 @@
 
 	& > .components-drop-zone {
 		border: none;
-		top: -7px;
+		top: -4px;
+		bottom: -3px;
 
 		.components-drop-zone__content {
 			display: none;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -285,6 +285,25 @@
 			margin-right: auto;
 		}
 	}
+
+	& > .components-drop-zone {
+		border: none;
+		top: -7px;
+
+		.components-drop-zone__content {
+			display: none;
+		}
+
+		&.is-close-to-top {
+			background: none;
+			border-top: 2px solid $blue-wordpress;
+		}
+
+		&.is-close-to-bottom {
+			background: none;
+			border-bottom: 2px solid $blue-wordpress;
+		}
+	}
 }
 
 .editor-visual-editor__block-controls {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -289,7 +289,9 @@
 	& > .components-drop-zone {
 		border: none;
 		top: -4px;
-		bottom: -3px;
+		bottom: -4px;
+		margin: 0 $block-mover-padding-visible;
+		border-radius: 0;
 
 		.components-drop-zone__content {
 			display: none;
@@ -297,12 +299,12 @@
 
 		&.is-close-to-top {
 			background: none;
-			border-top: 2px solid $blue-wordpress;
+			border-top: 3px solid $blue-medium-500;
 		}
 
 		&.is-close-to-bottom {
 			background: none;
-			border-bottom: 2px solid $blue-wordpress;
+			border-bottom: 3px solid $blue-medium-500;
 		}
 	}
 }

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -161,7 +161,7 @@ export const editor = combineUndoableReducers( {
 				return action.blocks.map( ( { uid } ) => uid );
 
 			case 'INSERT_BLOCKS': {
-				const position = action.after ? state.indexOf( action.after ) + 1 : state.length;
+				const position = action.position !== undefined ? action.position : state.length;
 				return [
 					...state.slice( 0, position ),
 					...action.blocks.map( block => block.uid ),

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -315,7 +315,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should insert after the specified block uid', () => {
+		it( 'should insert at the specified position', () => {
 			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',
 				blocks: [ {
@@ -331,7 +331,7 @@ describe( 'state', () => {
 
 			const state = editor( original, {
 				type: 'INSERT_BLOCKS',
-				after: 'kumquat',
+				position: 1,
 				blocks: [ {
 					uid: 'persimmon',
 					name: 'core/freeform',


### PR DESCRIPTION
tries to address #2327

If we go this road, we won't be able to have both "global drag and drop" and "drag and drop in specific blocks".

For now, I implemented this for the image block. If you drag an image, it will create an Image Block.
I can do the same for The Gallery and the video blocks but wanted to ask for review first before continuing.