### PR TITLE
Testing: Move renderToString implementation to test setup

### DIFF
--- a/element/index.js
+++ b/element/index.js
@@ -67,27 +67,7 @@ export { unstable_createPortal as createPortal }; // eslint-disable-line camelca
  * @param  {WPElement} element Element to render
  * @return {String}            HTML
  */
-export function renderToString( element ) {
-	if ( ! element ) {
-		return '';
-	}
-
-	if ( 'string' === typeof element ) {
-		return element;
-	}
-
-	if ( Array.isArray( element ) ) {
-		// React 16 supports rendering array children of an element, but not as
-		// an argument to the render methods directly. To support this, we pass
-		// the array as children of a dummy wrapper, then remove the wrapper's
-		// opening and closing tags.
-		return renderToStaticMarkup(
-			createElement( 'div', null, ...element )
-		).slice( 5 /* <div> */, -6 /* </div> */ );
-	}
-
-	return renderToStaticMarkup( element );
-}
+export { renderToStaticMarkup as renderToString };
 
 /**
  * Concatenate two or more React children objects

--- a/test/setup-test-framework.js
+++ b/test/setup-test-framework.js
@@ -1,9 +1,34 @@
 // `babel-jest` should be doing this instead, but apparently it's not working.
 require( 'core-js/modules/es7.object.values' );
 
-// TODO: This is only necessary so long as we're running React 15.x in the Node
-// context, since createPortal is only available in 16.x
+// TODO: These exist only to stub or monkey-patch differences between React 15
+// and 16, since the test environment runs an older version (while we wait for
+// test dependencies like Enzyme to support 16)
+//
+// See: https://github.com/airbnb/enzyme/issues/928
 jest.mock( '@wordpress/element', () => ( {
 	...require.requireActual( '@wordpress/element' ),
 	createPortal: ( x ) => x,
+	renderToString: ( element ) => {
+		const { createElement } = require( 'react' );
+		const { renderToStaticMarkup } = require( 'react-dom/server' );
+
+		if ( ! element ) {
+			return '';
+		}
+
+		if ( 'string' === typeof element ) {
+			return element;
+		}
+
+		if ( Array.isArray( element ) ) {
+			// Pass the array as children of a dummy wrapper, then remove the
+			// wrapper's opening and closing tags.
+			return renderToStaticMarkup(
+				createElement( 'div', null, ...element )
+			).slice( 5 /* <div> */, -6 /* </div> */ );
+		}
+
+		return renderToStaticMarkup( element );
+	},
 } ) );


### PR DESCRIPTION
The original implementation of `@wordpress/element`'s `renderToString` was customized to support falsey, string, and array type arguments in addition to React elements. However, it turned out this was only necessary due to the test environment running React 15.x. Therefore, instead of using the custom implementation in the browser environment, we should move this to be a mock defined in the test setup. This mock is only necessary so long as we continue to run React 15.x in the test environment, and is commented is such. At this time, it does not appear to be possible to upgrade to React 16 beta due to test dependencies not yet supporting it (https://github.com/airbnb/enzyme/issues/928).

You can confirm that React 16.x supports falsey, string, and array type arguments here:

http://jsbin.com/titepebene/edit?html,js,console

__Testing instructions:__

Verify that there are no regressions in the serialization of blocks. Specifically, the freeform block serializes its saved content as a raw HTML string and may have been impacted by these changes.

Ensure unit tests pass:

```
npm run test-unit
```