### PR TITLE
Chrome: Persist the state of the sidebar across page refresh

### DIFF
--- a/editor/index.js
+++ b/editor/index.js
@@ -21,7 +21,7 @@ import { settings as dateSettings } from '@wordpress/date';
  */
 import './assets/stylesheets/main.scss';
 import Layout from './layout';
-import { createReduxStore } from './state';
+import createReduxStore from './store';
 import { setInitialPost, undo } from './actions';
 import EditorSettingsProvider from './settings/provider';
 

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -448,8 +448,6 @@ export function preferences( state = { isSidebarOpened: ! isMobile }, action ) {
 				... state,
 				isSidebarOpened: ! state.isSidebarOpened,
 			};
-		case 'UPDATE_PREFERENCES':
-			return action.preferences;
 	}
 
 	return state;

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -2,10 +2,8 @@
  * External dependencies
  */
 import optimist from 'redux-optimist';
-import { combineReducers, applyMiddleware, createStore } from 'redux';
-import refx from 'refx';
-import multi from 'redux-multi';
-import { reduce, keyBy, first, last, omit, without, flowRight, mapValues } from 'lodash';
+import { combineReducers } from 'redux';
+import { reduce, keyBy, first, last, omit, without, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,7 +14,6 @@ import { getBlockTypes } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { combineUndoableReducers } from './utils/undoable-reducer';
-import effects from './effects';
 
 const isMobile = window.innerWidth < 782;
 
@@ -444,10 +441,15 @@ export function mode( state = 'visual', action ) {
 	return state;
 }
 
-export function isSidebarOpened( state = ! isMobile, action ) {
+export function preferences( state = { isSidebarOpened: ! isMobile }, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_SIDEBAR':
-			return ! state;
+			return {
+				... state,
+				isSidebarOpened: ! state.isSidebarOpened,
+			};
+		case 'UPDATE_PREFERENCES':
+			return action.preferences;
 	}
 
 	return state;
@@ -515,33 +517,17 @@ export function notices( state = {}, action ) {
 	return state;
 }
 
-/**
- * Creates a new instance of a Redux store.
- *
- * @return {Redux.Store} Redux store
- */
-export function createReduxStore() {
-	const reducer = optimist( combineReducers( {
-		editor,
-		currentPost,
-		isTyping,
-		blockSelection,
-		hoveredBlock,
-		showInsertionPoint,
-		mode,
-		isSidebarOpened,
-		panel,
-		saving,
-		notices,
-		userData,
-	} ) );
-
-	const enhancers = [ applyMiddleware( multi, refx( effects ) ) ];
-	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
-		enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
-	}
-
-	return createStore( reducer, flowRight( enhancers ) );
-}
-
-export default createReduxStore;
+export default optimist( combineReducers( {
+	editor,
+	currentPost,
+	isTyping,
+	blockSelection,
+	hoveredBlock,
+	showInsertionPoint,
+	mode,
+	preferences,
+	panel,
+	saving,
+	notices,
+	userData,
+} ) );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -33,13 +33,23 @@ export function getActivePanel( state ) {
 }
 
 /**
+ * Returns the preferences (these preferences are persisted locally)
+ *
+ * @param  {Object}  state Global application state
+ * @return {Object}        Preferences Object
+ */
+export function getPreferences( state ) {
+	return state.preferences;
+}
+
+/**
  * Returns true if the editor sidebar panel is open, or false otherwise.
  *
  * @param  {Object}  state Global application state
  * @return {Boolean}       Whether sidebar is open
  */
 export function isEditorSidebarOpened( state ) {
-	return state.isSidebarOpened;
+	return state.preferences.isSidebarOpened;
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -43,13 +43,24 @@ export function getPreferences( state ) {
 }
 
 /**
+ *
+ * @param  {Object}  state          Global application state
+ * @param  {String}  preferenceKey  Preference Key
+ * @return {Mixed}                  Preference Value
+ */
+export function getPreference( state, preferenceKey ) {
+	const preferences = getPreferences( state );
+	return preferences[ preferenceKey ];
+}
+
+/**
  * Returns true if the editor sidebar panel is open, or false otherwise.
  *
  * @param  {Object}  state Global application state
  * @return {Boolean}       Whether sidebar is open
  */
 export function isEditorSidebarOpened( state ) {
-	return state.preferences.isSidebarOpened;
+	return getPreference( state, 'isSidebarOpened' );
 }
 
 /**

--- a/editor/store-persist.js
+++ b/editor/store-persist.js
@@ -28,10 +28,10 @@ export default function storePersist( reducerKey, storageKey = DEFAULT_STORAGE_K
 		// Load initially persisted value
 		const persistedString = window.localStorage.getItem( storageKey );
 		if ( persistedString ) {
-			const persitedState = JSON.parse( persistedString );
+			const persistedState = JSON.parse( persistedString );
 			store.dispatch( {
 				type: 'REDUX_REHYDRATE',
-				payload: persitedState,
+				payload: persistedState,
 			} );
 		}
 

--- a/editor/store-persist.js
+++ b/editor/store-persist.js
@@ -1,0 +1,50 @@
+const DEFAULT_STORAGE_KEY = 'REDUX_PERSIST';
+
+/**
+ * Store enhancer to persist a specified reducer key
+ * @param {String}     reducerKey The reducer key to persist
+ * @param {String}     storageKey The storage key to use
+ *
+ * @return {Function}             Store enhancer
+ */
+export default function storePersist( reducerKey, storageKey = DEFAULT_STORAGE_KEY ) {
+	return ( createStore ) => ( reducer, preloadedState, enhancer ) => {
+		// EnhancedReducer with auto-rehydration
+		const enhancedReducer = ( state, action ) => {
+			const nextState = reducer( state, action );
+
+			if ( action.type === 'REDUX_REHYDRATE' ) {
+				return {
+					...nextState,
+					[ reducerKey ]: action.payload,
+				};
+			}
+
+			return nextState;
+		};
+
+		const store = createStore( enhancedReducer, preloadedState, enhancer );
+
+		// Load initially persisted value
+		const persistedString = window.localStorage.getItem( storageKey );
+		if ( persistedString ) {
+			const persitedState = JSON.parse( persistedString );
+			store.dispatch( {
+				type: 'REDUX_REHYDRATE',
+				payload: persitedState,
+			} );
+		}
+
+		// Persist updated preferences
+		let currentStateValue = store.getState()[ reducerKey ];
+		store.subscribe( () => {
+			const newStateValue = store.getState()[ reducerKey ];
+			if ( newStateValue !== currentStateValue ) {
+				currentStateValue = newStateValue;
+				window.localStorage.setItem( storageKey, JSON.stringify( currentStateValue ) );
+			}
+		} );
+
+		return store;
+	};
+}

--- a/editor/store.js
+++ b/editor/store.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { applyMiddleware, createStore } from 'redux';
+import refx from 'refx';
+import multi from 'redux-multi';
+import { flowRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import effects from './effects';
+import reducer from './reducer';
+import { getPreferences } from './selectors';
+
+/**
+ * Module constants
+ */
+const GUTENBERG_PREFERENCES_KEY = 'GUTENBERG_PREFERENCES';
+
+/**
+ * Loads the initial preferences and saves them to the local storage once changed
+ * @param {Object} store Redux Store
+ */
+function setupStorePersistence( store ) {
+	// Load initial preferences
+	const userPreferencesString = window.localStorage.getItem( GUTENBERG_PREFERENCES_KEY );
+	if ( userPreferencesString ) {
+		const preferences = JSON.parse( userPreferencesString );
+		store.dispatch( {
+			type: 'UPDATE_PREFERENCES',
+			preferences,
+		} );
+	}
+
+	// Persist updated preferences
+	let currentPreferences = getPreferences( store.getState() );
+	store.subscribe( () => {
+		const newPreferences = getPreferences( store.getState() );
+		if ( newPreferences !== currentPreferences ) {
+			currentPreferences = newPreferences;
+			window.localStorage.setItem( GUTENBERG_PREFERENCES_KEY, JSON.stringify( currentPreferences ) );
+		}
+	} );
+}
+
+/**
+ * Creates a new instance of a Redux store.
+ *
+ * @return {Redux.Store} Redux store
+ */
+function createReduxStore() {
+	const enhancers = [ applyMiddleware( multi, refx( effects ) ) ];
+	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
+		enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
+	}
+
+	const store = createStore( reducer, flowRight( enhancers ) );
+	setupStorePersistence( store );
+
+	return store;
+}
+
+export default createReduxStore;

--- a/editor/store.js
+++ b/editor/store.js
@@ -11,7 +11,7 @@ import { flowRight } from 'lodash';
  */
 import effects from './effects';
 import reducer from './reducer';
-import { getPreferences } from './selectors';
+import storePersist from './store-persist';
 
 /**
  * Module constants
@@ -19,44 +19,17 @@ import { getPreferences } from './selectors';
 const GUTENBERG_PREFERENCES_KEY = 'GUTENBERG_PREFERENCES';
 
 /**
- * Loads the initial preferences and saves them to the local storage once changed
- * @param {Object} store Redux Store
- */
-function setupStorePersistence( store ) {
-	// Load initial preferences
-	const userPreferencesString = window.localStorage.getItem( GUTENBERG_PREFERENCES_KEY );
-	if ( userPreferencesString ) {
-		const preferences = JSON.parse( userPreferencesString );
-		store.dispatch( {
-			type: 'UPDATE_PREFERENCES',
-			preferences,
-		} );
-	}
-
-	// Persist updated preferences
-	let currentPreferences = getPreferences( store.getState() );
-	store.subscribe( () => {
-		const newPreferences = getPreferences( store.getState() );
-		if ( newPreferences !== currentPreferences ) {
-			currentPreferences = newPreferences;
-			window.localStorage.setItem( GUTENBERG_PREFERENCES_KEY, JSON.stringify( currentPreferences ) );
-		}
-	} );
-}
-
-/**
  * Creates a new instance of a Redux store.
  *
  * @return {Redux.Store} Redux store
  */
 function createReduxStore() {
-	const enhancers = [ applyMiddleware( multi, refx( effects ) ) ];
+	const enhancers = [ applyMiddleware( multi, refx( effects ) ), storePersist( 'preferences', GUTENBERG_PREFERENCES_KEY ) ];
 	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
 		enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
 	}
 
 	const store = createStore( reducer, flowRight( enhancers ) );
-	setupStorePersistence( store );
 
 	return store;
 }

--- a/editor/store.js
+++ b/editor/store.js
@@ -24,7 +24,11 @@ const GUTENBERG_PREFERENCES_KEY = `GUTENBERG_PREFERENCES_${ window.userSettings.
  * @return {Redux.Store} Redux store
  */
 function createReduxStore() {
-	const enhancers = [ applyMiddleware( multi, refx( effects ) ), storePersist( 'preferences', GUTENBERG_PREFERENCES_KEY ) ];
+	const enhancers = [
+		applyMiddleware( multi, refx( effects ) ),
+		storePersist( 'preferences', GUTENBERG_PREFERENCES_KEY ),
+	];
+
 	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
 		enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
 	}

--- a/editor/store.js
+++ b/editor/store.js
@@ -16,7 +16,7 @@ import storePersist from './store-persist';
 /**
  * Module constants
  */
-const GUTENBERG_PREFERENCES_KEY = 'GUTENBERG_PREFERENCES';
+const GUTENBERG_PREFERENCES_KEY = `GUTENBERG_PREFERENCES_${ window.userSettings.uid }`;
 
 /**
  * Creates a new instance of a Redux store.

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -20,13 +20,12 @@ import {
 	isTyping,
 	blockSelection,
 	mode,
-	isSidebarOpened,
+	preferences,
 	saving,
 	notices,
 	showInsertionPoint,
-	createReduxStore,
 	userData,
-} from '../state';
+} from '../reducer';
 
 describe( 'state', () => {
 	describe( 'getPostRawValue', () => {
@@ -802,19 +801,29 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'isSidebarOpened()', () => {
+	describe( 'preferences()', () => {
 		it( 'should be opened by default', () => {
-			const state = isSidebarOpened( undefined, {} );
+			const state = preferences( undefined, {} );
 
-			expect( state ).toBe( true );
+			expect( state ).toEqual( { isSidebarOpened: true } );
 		} );
 
 		it( 'should toggle the sidebar open flag', () => {
-			const state = isSidebarOpened( false, {
+			const state = preferences( { isSidebarOpened: false }, {
 				type: 'TOGGLE_SIDEBAR',
 			} );
 
-			expect( state ).toBe( true );
+			expect( state ).toEqual( { isSidebarOpened: true } );
+		} );
+
+		it( 'should update preferences', () => {
+			const prefs = { awesome: true };
+			const state = preferences( { isSidebarOpened: false }, {
+				type: 'UPDATE_PREFERENCES',
+				preferences: prefs,
+			} );
+
+			expect( state ).toBe( prefs );
 		} );
 	} );
 
@@ -907,34 +916,6 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				b: originalState.b,
 			} );
-		} );
-	} );
-
-	describe( 'createReduxStore()', () => {
-		it( 'should return a redux store', () => {
-			const store = createReduxStore();
-
-			expect( typeof store.dispatch ).toBe( 'function' );
-			expect( typeof store.getState ).toBe( 'function' );
-		} );
-
-		it( 'should have expected reducer keys', () => {
-			const store = createReduxStore();
-			const state = store.getState();
-
-			expect( Object.keys( state ) ).toEqual( expect.arrayContaining( [
-				'optimist',
-				'editor',
-				'currentPost',
-				'isTyping',
-				'blockSelection',
-				'hoveredBlock',
-				'mode',
-				'isSidebarOpened',
-				'saving',
-				'showInsertionPoint',
-				'notices',
-			] ) );
 		} );
 	} );
 

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -815,16 +815,6 @@ describe( 'state', () => {
 
 			expect( state ).toEqual( { isSidebarOpened: true } );
 		} );
-
-		it( 'should update preferences', () => {
-			const prefs = { awesome: true };
-			const state = preferences( deepFreeze( { isSidebarOpened: false } ), {
-				type: 'UPDATE_PREFERENCES',
-				preferences: prefs,
-			} );
-
-			expect( state ).toBe( prefs );
-		} );
 	} );
 
 	describe( 'saving()', () => {

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -809,7 +809,7 @@ describe( 'state', () => {
 		} );
 
 		it( 'should toggle the sidebar open flag', () => {
-			const state = preferences( { isSidebarOpened: false }, {
+			const state = preferences( deepFreeze( { isSidebarOpened: false } ), {
 				type: 'TOGGLE_SIDEBAR',
 			} );
 
@@ -818,7 +818,7 @@ describe( 'state', () => {
 
 		it( 'should update preferences', () => {
 			const prefs = { awesome: true };
-			const state = preferences( { isSidebarOpened: false }, {
+			const state = preferences( deepFreeze( { isSidebarOpened: false } ), {
 				type: 'UPDATE_PREFERENCES',
 				preferences: prefs,
 			} );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -100,7 +100,7 @@ describe( 'selectors', () => {
 	describe( 'isEditorSidebarOpened', () => {
 		it( 'should return true when the sidebar is opened', () => {
 			const state = {
-				isSidebarOpened: true,
+				preferences: { isSidebarOpened: true },
 			};
 
 			expect( isEditorSidebarOpened( state ) ).toBe( true );
@@ -108,7 +108,7 @@ describe( 'selectors', () => {
 
 		it( 'should return false when the sidebar is opened', () => {
 			const state = {
-				isSidebarOpened: false,
+				preferences: { isSidebarOpened: false },
 			};
 
 			expect( isEditorSidebarOpened( state ) ).toBe( false );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -14,6 +14,7 @@ import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
  */
 import {
 	getEditorMode,
+	getPreference,
 	isEditorSidebarOpened,
 	hasEditorUndo,
 	hasEditorRedo,
@@ -94,6 +95,24 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditorMode( state ) ).toEqual( 'visual' );
+		} );
+	} );
+
+	describe( 'getPreference', () => {
+		it( 'should return the preference value if set', () => {
+			const state = {
+				preferences: { chicken: true },
+			};
+
+			expect( getPreference( state, 'chicken' ) ).toBe( true );
+		} );
+
+		it( 'should return undefined if the preference is unset', () => {
+			const state = {
+				preferences: { chicken: true },
+			};
+
+			expect( getPreference( state, 'ribs' ) ).toBeUndefined();
 		} );
 	} );
 

--- a/editor/test/store-persist.js
+++ b/editor/test/store-persist.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { createStore } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import persistStore from '../store-persist';
+
+describe( 'persistStore', () => {
+	it( 'should load the initial value from the local storage', () => {
+		const storageKey = 'dumbStorageKey';
+		window.localStorage.setItem( storageKey, JSON.stringify( { chicken: true } ) );
+		const reducer = () => {
+			return {
+				preferences: { ribs: true },
+			};
+		};
+		const store = createStore( reducer, persistStore( 'preferences', storageKey ) );
+		expect( store.getState().preferences ).toEqual( { chicken: true } );
+	} );
+
+	it( 'should persit to local storage once the state value changes', () => {
+		const storageKey = 'dumbStorageKey2';
+		const reducer = ( state, action ) => {
+			if ( action.type === 'UPDATE' ) {
+				return {
+					preferences: { chicken: true },
+				};
+			}
+
+			return {
+				preferences: { ribs: true },
+			};
+		};
+		const store = createStore( reducer, persistStore( 'preferences', storageKey ) );
+		store.dispatch( { type: 'UPDATE' } );
+		expect( JSON.parse( window.localStorage.getItem( storageKey ) ) ).toEqual( { chicken: true } );
+	} );
+} );

--- a/editor/test/store.js
+++ b/editor/test/store.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import createReduxStore from '../store';
+
+describe( 'store', () => {
+	describe( 'createReduxStore()', () => {
+		it( 'should return a redux store', () => {
+			const store = createReduxStore();
+
+			expect( typeof store.dispatch ).toBe( 'function' );
+			expect( typeof store.getState ).toBe( 'function' );
+		} );
+
+		it( 'should have expected reducer keys', () => {
+			const store = createReduxStore();
+			const state = store.getState();
+
+			expect( Object.keys( state ) ).toEqual( expect.arrayContaining( [
+				'optimist',
+				'editor',
+				'currentPost',
+				'isTyping',
+				'blockSelection',
+				'hoveredBlock',
+				'mode',
+				'preferences',
+				'saving',
+				'showInsertionPoint',
+				'notices',
+			] ) );
+		} );
+	} );
+} );

--- a/test/setup-globals.js
+++ b/test/setup-globals.js
@@ -53,3 +53,10 @@ global.wp = global.wp || {};
 global.wp.a11y = {
 	speak: () => {},
 };
+
+// Setup fake localStorage
+const storage = {};
+global.window.localStorage = {
+	getItem: ( key ) => key in storage ? storage[ key ] : null,
+	setItem: ( key, value ) => storage[ key ] = value,
+};

--- a/test/setup-globals.js
+++ b/test/setup-globals.js
@@ -60,3 +60,6 @@ global.window.localStorage = {
 	getItem: ( key ) => key in storage ? storage[ key ] : null,
 	setItem: ( key, value ) => storage[ key ] = value,
 };
+
+// UserSettings global
+global.window.userSettings = { uid: 1 };


### PR DESCRIPTION
This PR bootstrap the work to persist some UI preferences locally. (It uses localStorage)
For now, this persists only the sidebar state (opened/closed) but could be updated later to include the state of the difference sidebar panels.

solves #450 partially
