### PR TITLE
Try: Framework-agnostic block interoperability (Vanilla, Vue)

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, createElement, renderToString, cloneElement, Children } from '@wordpress/element';
+import { Component, createElement, buildVTree, renderToString, cloneElement, Children } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,13 +41,20 @@ export function getSaveContent( blockType, attributes ) {
 	if ( save.prototype instanceof Component ) {
 		rawContent = createElement( save, { attributes } );
 	} else {
-		rawContent = save( { attributes } );
+		const target = document.createElement( 'div' );
+		rawContent = save( { attributes, target } );
 
-		// Special-case function render implementation to allow raw HTML return
-		if ( 'string' === typeof rawContent ) {
-			return rawContent;
+		switch ( typeof rawContent ) {
+			// Special-case function render implementation for raw HTML return
+			case 'string':
+				return rawContent;
+
+			case 'undefined':
+				return target.innerHTML;
 		}
 	}
+
+	rawContent = buildVTree( rawContent );
 
 	// Adding a generic classname
 	const addClassnameToElement = ( element ) => {

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -23,3 +23,5 @@ import './text-columns';
 import './verse';
 import './video';
 import './audio';
+import './vanilla-banner';
+import './vue-banner';

--- a/blocks/library/vanilla-banner/index.js
+++ b/blocks/library/vanilla-banner/index.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlockType, source } from '../../api';
+
+const { text } = source;
+
+registerBlockType( 'core/vanilla-banner', {
+	title: __( 'Vanilla Banner' ),
+
+	icon: 'marker',
+
+	category: 'widgets',
+
+	attributes: {
+		text: {
+			type: 'string',
+			source: text( 'h1' ),
+			default: 'Hello World',
+		},
+	},
+
+	className: false,
+
+	edit( { attributes, setAttributes } ) {
+		return [ 'div',
+			[ 'input', {
+				value: attributes.text,
+				onChange( event ) {
+					setAttributes( {
+						text: event.target.value,
+					} );
+				},
+			} ],
+			[ 'h1', attributes.text ],
+		];
+	},
+
+	save( { attributes } ) {
+		return [ 'h1', attributes.text ];
+	},
+} );

--- a/blocks/library/vue-banner/index.js
+++ b/blocks/library/vue-banner/index.js
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import Vue from 'vue/dist/vue';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlockType, source } from '../../api';
+
+const { text } = source;
+
+registerBlockType( 'core/vue-banner', {
+	title: __( 'Vue Banner' ),
+
+	icon: 'marker',
+
+	category: 'widgets',
+
+	attributes: {
+		text: {
+			type: 'string',
+			source: text( 'h1' ),
+			default: 'Hello World',
+		},
+	},
+
+	className: false,
+
+	edit( { attributes, setAttributes, target } ) {
+		if ( target.firstChild ) {
+			Object.assign( target.firstChild.__vue__, attributes );
+			return;
+		}
+
+		const child = document.createElement( 'div' );
+		target.appendChild( child );
+
+		new Vue( {
+			el: target.firstChild,
+
+			data: () => ( { ...attributes } ),
+
+			template: `
+				<div>
+					<input :value="text" @input="setText( $event.target.value )">
+					<h1>{{ text }}</h1>
+				</div>
+			`,
+
+			methods: {
+				setText( nextText ) {
+					setAttributes( { text: nextText } );
+				},
+			},
+		} );
+	},
+
+	save( { attributes, target } ) {
+		const child = document.createElement( 'div' );
+		target.appendChild( child );
+
+		new Vue( {
+			el: target.firstChild,
+
+			data: () => ( { ...attributes } ),
+
+			template: `
+				<h1>{{ text }}</h1>
+			`,
+		} );
+	},
+} );

--- a/editor/modes/visual-editor/block-render-context.js
+++ b/editor/modes/visual-editor/block-render-context.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { buildVTree, renderSubtreeIntoContainer, Component } from '@wordpress/element';
+
+class BlockRenderContext extends Component {
+	componentDidMount() {
+		this.delegatedRender();
+	}
+
+	componentDidUpdate() {
+		this.delegatedRender();
+	}
+
+	delegatedRender() {
+		const { render, ...props } = this.props;
+		const result = render( { ...props, target: this.node } );
+
+		if ( result ) {
+			renderSubtreeIntoContainer(
+				this,
+				buildVTree( result ),
+				this.node
+			);
+		}
+	}
+
+	render() {
+		return <div ref={ ( node ) => this.node = node } />;
+	}
+}
+
+export default BlockRenderContext;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -22,6 +22,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import InvalidBlockWarning from './invalid-block-warning';
 import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
+import BlockRenderContext from './block-render-context';
 import BlockMover from '../../block-mover';
 import BlockRightMenu from '../../block-settings-menu';
 import BlockSwitcher from '../../block-switcher';
@@ -430,7 +431,8 @@ class VisualEditorBlock extends Component {
 				>
 					{ isValid && ! error && (
 						<BlockCrashBoundary onError={ this.onBlockError }>
-							<BlockEdit
+							<BlockRenderContext
+								render={ BlockEdit }
 								focus={ focus }
 								attributes={ block.attributes }
 								setAttributes={ this.setAttributes }
@@ -443,12 +445,12 @@ class VisualEditorBlock extends Component {
 							/>
 						</BlockCrashBoundary>
 					) }
-					{ ! isValid && (
+					{ /* TODO: Re-enable */ /* ! isValid && (
 						blockType.save( {
 							attributes: block.attributes,
 							className,
 						} )
-					) }
+					) */ }
 				</div>
 				{ !! error && <BlockCrashWarning /> }
 				{ ! isValid && <InvalidBlockWarning block={ block } /> }

--- a/element/index.js
+++ b/element/index.js
@@ -1,10 +1,138 @@
 /**
  * External dependencies
  */
-import { createElement, Component, cloneElement, Children } from 'react';
-import { render, findDOMNode, unstable_createPortal } from 'react-dom'; // eslint-disable-line camelcase
+import { createElement, Component, cloneElement, Children, isValidElement } from 'react';
+import {
+	render,
+	findDOMNode,
+	unstable_createPortal, // eslint-disable-line camelcase
+	unstable_renderSubtreeIntoContainer, // eslint-disable-line camelcase
+} from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { isString } from 'lodash';
+import { isString, castArray } from 'lodash';
+
+const interops = [
+	// {
+	// 	isHandled: ( element ) => (
+	// 		element.$$typeof === Symbol.for( 'react.element' )
+	// 	),
+	// 	render( element, target ) {
+	// 		render( element, target );
+	// 	},
+	// },
+	// {
+	// 	isHandled: ( [ tagName ] ) => (
+	// 		tagName && tagName.prototype instanceof Component
+	// 	),
+	// 	render( [ tagName, props, ...children ], target ) {
+	// 		render(
+	// 			createElement( tagName, props, children ),
+	// 			target
+	// 		);
+	// 	},
+	// },
+	// {
+	// 	isHandled: ( [ VueComponent ] ) => VueComponent.prototype instanceof Vue,
+	// 	render( [ VueComponent, props, ...children ], target ) {
+	// 		if ( ! target.firstChild ) {
+	// 			const child = document.createElement( 'div' );
+	// 			target.appendChild( child );
+	// 		}
+
+	// 		new Vue( {
+	// 			el: target.firstChild,
+
+	// 			functional: true,
+
+	// 			render( h ) {
+	// 				return h( VueComponent, { props }, children );
+	// 			},
+	// 		} );
+	// 	},
+	// },
+];
+
+class InteropRenderer extends Component {
+	componentDidMount() {
+		this.props.handler.render( this.props.element, this.node );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		nextProps.handler.render( nextProps.element, this.node );
+	}
+
+	shouldComponentUpdate() {
+		return false;
+	}
+
+	render() {
+		return createElement( 'div', { ref: ( node ) => this.node = node } );
+	}
+}
+
+export function buildVTree( element ) {
+	if ( null === element || undefined === element ) {
+		return null;
+	}
+
+	if ( isValidElement( element ) ) {
+		return element;
+	}
+
+	// Defer to interoperability handler
+	const handler = interops.find( ( interop ) => interop.isHandled( element ) );
+	if ( handler ) {
+		return createElement( InteropRenderer, {
+			handler,
+			element,
+		} );
+	}
+
+	const [ type ] = element;
+
+	// Handle React 16.x array render returns
+	const isNodeType = 'function' === typeof type || 'string' === typeof type;
+	if ( ! isNodeType ) {
+		return castArray( element ).map( buildVTree );
+	}
+
+	// Handle case where children starts at second argument
+	let [ , attributes, ...children ] = element;
+	if ( attributes && attributes.constructor !== Object ) {
+		children.unshift( attributes );
+		attributes = null;
+	}
+
+	children = castArray( children ).map( ( child ) => {
+		if ( 'boolean' === typeof child ) {
+			child = null;
+		}
+
+		if ( null === child || undefined === child ) {
+			child = '';
+		} else if ( 'number' === typeof child ) {
+			child = String( child );
+		}
+
+		if ( 'string' === typeof child ) {
+			return child;
+		}
+
+		return buildVTree( child );
+	} );
+
+	switch ( typeof type ) {
+		case 'string':
+			return createElement( type, attributes, ...children );
+
+		case 'function':
+			return buildVTree( type( { ...attributes, children } ) );
+	}
+}
+
+export function wpRender( element, target ) {
+	render( buildVTree( element ), null, target );
+}
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -60,6 +188,8 @@ export { Children };
  * @param {Element}   target    DOM node into which element should be rendered
  */
 export { unstable_createPortal as createPortal }; // eslint-disable-line camelcase
+
+export { unstable_renderSubtreeIntoContainer as renderSubtreeIntoContainer }; // eslint-disable-line camelcase
 
 /**
  * Renders a given element into a string

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "refx": "^2.0.0",
     "rememo": "^2.3.0",
     "simple-html-tokenizer": "^0.4.1",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "vue": "^2.4.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",


### PR DESCRIPTION
This pull request seeks to explore a few different options for framework-agnostic block rendering. It stemmed from some initial attempts to refactor Editable state structure (#771) to be less dependent on React element trees, because (a) it would simplify block transforms to ensure a consistent state structure and (b) it would resolve issues with block state serialization for collaborative editing (#1877).

While changing the shape of `children`s value was itself not too problematic, it surfaced that we were dependent on the React element shape to allow for `save` serialization, since React would otherwise not know how to handle the `children` value. An option here could have been to have block authors convert the `children` value to a React element with a helper method, but this would introduce additional overhead to implementing a block's save behavior.

Since we've also encountered other issues with using React for `save` serialization -- disabling HTML escaping (#421) and unnecessary applications of element `key` (https://github.com/WordPress/gutenberg/pull/2349#issuecomment-321585871) -- I took to exploring what it might take to give us full control over the render behavior for a tree of "nodes", where nodes could be a React element, or a `children` value, or even a component from another library.

### A "Vanilla" element syntax

The element signature `type, attributes, ...children` has gained widespread adoption for representing a tree of nodes: [React](https://facebook.github.io/react/docs/react-api.html#createelement), [Vue](https://vuejs.org/v2/guide/render-function.html#createElement-Arguments), [and](https://preactjs.com/guide/api-reference#-preact-h-preact-createelement-) [many](https://github.com/hyperhype/hyperscript#h-tag-attrs-text-elements) [other](https://mithril.js.org/api.html#mselector,-attrs,-children---) [libraries](https://github.com/Matt-Esch/virtual-dom/blob/master/virtual-hyperscript/README.md#hselector-properties-children) use it, but in all of these cases, you need to feed it into their own flavor of an element creator function (`createElement`). Could we not represent these arguments as a simple array instead?

```js
// React
React.createElement( 'section', 
	React.createElement( 'header',
		React.createElement( 'h1', 'Welcome' ) ),
	React.createElement( 'p', 'Hello World' )
);

// Vanilla
[ 'section', 
	[ 'header', 
		[ 'h1', 'Welcome' ] ],
	[ 'p', 'Hello World' ]
]
```

The performance characteristics of representing it this way should be measured, especially as currently implemented where we first traverse the tree to convert it to the equivalent React element hierarchy, but the interface considered alone is appealing. Would an ideal implementation require reinventing the wheel? Maybe not: Poking through internals of a library like Preact, its [diffing logic](https://github.com/developit/preact/blob/master/src/vdom/diff.js) is pretty well isolated, compact, performant, and compatible.

### Interoperability renderers

An initial approach considered for interoperability operated by traversing this vanilla element hierarchy, specifically on looking at the type of element. Where custom logic is necessary, we can provide hooks to enable an implementation to determine whether it can handle an element of a particular type. For example, if it looks like a `children` value, pass it to Children Renderer implementation (Vue component, unescaped HTML markup, etc).

The implementation proposed here works by replacing the custom element type with a component which renders a mount target (DOM element), but defers actual rendering to the specifics of the implementation. It's assumed that custom implementations will accept the element (its props, children, if applicable) and perform necessary DOM operations. React reconciliation is bypassed by implementing `shouldComponentUpdate = () => false`:

https://github.com/WordPress/gutenberg/blob/9a5326e80393d9dd411cc19c852d32b1cf2983a9/element/index.js#L55-L71

This is a pattern we've used elsewhere, specifically the [TinyMCE component](https://github.com/WordPress/gutenberg/blob/master/blocks/editable/tinymce.js) which needs to manage itself without interference from React reconciliation.

If there is no interoperability handler for the element type, the array shape is then coerced to its React equivalent.

### Block mount targets

One downside of a render interoperability pattern is that the handlers must be explicitly defined: Would it be the responsibility of WordPress to provide interoperability handlers for popular frameworks? If plugin authors implement their own, how would we avoid duplication/conflicts?

Another option is to apply only the idea of the mounting target. When rendering a block, we could provide as an additional parameter to the `edit` and `save` functions a DOM node to which the block should render, using its own appropriate implementation. This works in the same way as the interoperability renderer, as a component which excludes itself from React reconciliation (except in the case that the `edit` or `save` functions return a React element).

### Proofs of Concept: Vanilla and Vue Blocks

Included in these changes are two example blocks, one implemented with no framework, and the other with Vue. Here's how they look:

**Vanilla:**

https://github.com/WordPress/gutenberg/blob/9a5326e80393d9dd411cc19c852d32b1cf2983a9/blocks/library/vanilla-banner/index.js#L30-L46

**Vue:**

https://github.com/WordPress/gutenberg/blob/9a5326e80393d9dd411cc19c852d32b1cf2983a9/blocks/library/vue-banner/index.js#L35-L77

The Vue component is slightly more difficult to manage for a few reasons:

- By default, it transforms an assigned data object to its [observable/reactive object format](https://vuejs.org/v2/guide/reactivity.html), so we must clone `attributes` to prevent it from becoming overridden (assuming we still want attribute changes to flow through `setAttributes`).
- Rendering into a mount target requires creating a child node, since in my testing it appears Vue rendering wants to take the place of the target `el`, and assumes it to be of the same tag name of its root template node.
- To apply attributes updates, we access and assign to the `__vue__` internal property of the DOM element

### Future Considerations and Challenges

There are a few different directions we could take here, particularly around how far we take the idea of no-framework "array" elements. Potentially, this could serve as a first-class WordPress rendering pattern in lieu of a third-party library. Of course, most of what's explored here is the simplest of cases, and will need further exploration around more difficult challenges:

- [React context](https://facebook.github.io/react/docs/context.html)
   - Used by [`react-redux`](https://github.com/reactjs/react-redux) to make Redux state available throughout components of the application
   - Used by [`react-slot-fill`](https://github.com/camwest/react-slot-fill) to allow merging React subtrees. Gutenberg uses slots for rendering toolbars and inspector controls, and has been proposed as an option for plugin extensibility.
- Component interoperability
   - If we become more framework-agnostic, how do we expect other frameworks to consume or reimplement React (or no-framework) equivalent components ([Editable](https://github.com/WordPress/gutenberg/blob/master/blocks/editable/index.js), [InspectorControls](https://github.com/WordPress/gutenberg/blob/master/blocks/inspector-controls/index.js), etc)
- Component lifecycle
   - An array reimplementation of components works well for equivalent output of stateless function components, but what about components with lifecycle (`didMount`, `willReceiveProps`)? Presumably we would need some equivalent of a component class? _... or would we?_ [💭](https://github.com/acdlite/recompose) 

The work here begs the question though: Why did React et. al take the approach of a `createElement` function? Am I overlooking some critical disadvantage to plain object elements?