### PR TITLE
Update Video Block

### DIFF
--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Placeholder } from '@wordpress/components';
+import { Placeholder, Toolbar, Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,6 +14,8 @@ import { Placeholder } from '@wordpress/components';
 import { registerBlockType, source } from '../../api';
 import MediaUploadButton from '../../media-upload-button';
 import Editable from '../../editable';
+import BlockControls from '../../block-controls';
+import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
 const { attr, children } = source;
 
@@ -25,6 +27,12 @@ registerBlockType( 'core/video', {
 	category: 'common',
 
 	attributes: {
+		align: {
+			type: 'string',
+		},
+		id: {
+			type: 'number',
+		},
 		src: {
 			type: 'string',
 			source: attr( 'video', 'src' ),
@@ -36,18 +44,50 @@ registerBlockType( 'core/video', {
 	},
 
 	edit( { attributes, setAttributes, className, focus, setFocus } ) {
-		const { src, caption } = attributes;
+		const { src, caption, align, id } = attributes;
 		const onSelectVideo = ( media ) => {
 			if ( media && media.url ) {
 				setAttributes( {
 					src: media.url,
+					id: media.id,
 				} );
 			}
 		};
 		const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );
+		const updateAlignment = ( nextAlign ) => {
+			setAttributes( { align: nextAlign } );
+		};
+
+		const controls = (
+			focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar
+						value={ align }
+						onChange={ updateAlignment }
+					/>
+
+					<Toolbar>
+						<li>
+							<MediaUploadButton
+								buttonProps={ {
+									className: 'components-icon-button components-toolbar__control',
+									'aria-label': __( 'Edit video' ),
+								} }
+								onSelect={ onSelectVideo }
+								type="video"
+								value={ id }
+							>
+								<Dashicon icon="edit" />
+							</MediaUploadButton>
+						</li>
+					</Toolbar>
+				</BlockControls>
+			)
+		);
 
 		if ( ! src ) {
 			return [
+				controls,
 				<Placeholder
 					key="placeholder"
 					icon="media-video"
@@ -67,8 +107,9 @@ registerBlockType( 'core/video', {
 
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return [
+			controls,
 			<figure key="video" className={ className }>
-				<video controls src={ src } onClick={ setFocus } />
+				<video controls src={ src } onClick={ setFocus } className={ align ? `align${ align }` : null } />
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"
@@ -86,10 +127,10 @@ registerBlockType( 'core/video', {
 	},
 
 	save( { attributes } ) {
-		const { src, caption } = attributes;
+		const { src, caption, align } = attributes;
 		return (
 
-			<figure>
+			<figure className={ align ? `align${ align }` : null }>
 				{ src && <video controls src={ src } /> }
 				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 			</figure>

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -109,7 +109,7 @@ registerBlockType( 'core/video', {
 		return [
 			controls,
 			<figure key="video" className={ className }>
-				<video controls src={ src } onClick={ setFocus } className={ align ? `align${ align }` : null } />
+				<video controls src={ src } onClick={ setFocus } />
 				{ ( caption && caption.length > 0 ) || !! focus ? (
 					<Editable
 						tagName="figcaption"

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -43,6 +43,13 @@ registerBlockType( 'core/video', {
 		},
 	},
 
+	getEditWrapperProps( attributes ) {
+		const { align } = attributes;
+		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
+			return { 'data-align': align };
+		}
+	},
+
 	edit( { attributes, setAttributes, className, focus, setFocus } ) {
 		const { src, caption, align, id } = attributes;
 		const onSelectVideo = ( media ) => {


### PR DESCRIPTION
This branch closes #2456 by adding in both the ability to set the alignment of a video block, and an edit button that allows changing the video used in the block after one has been set:

<img width="736" alt="videos___gutenberg_ _wordpress_develop_ _wordpress" src="https://user-images.githubusercontent.com/22080/29473815-0db39f60-840e-11e7-9d6f-d5974ea86095.png">

__To Test__
Interact with the new block controls on a new Video widget, and a video widget that already has a video assigned to it.  Validate that the controls work as expected.