### PR TITLE
[Text Editor] Prevent editor toolbar from overlapping post title

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -18,8 +18,8 @@ $z-layers: (
 	'.editor-block-switcher__menu': 2,
 	'.editor-block-mover': 10,
 	'.editor-header': 20,
-	'.editor-post-schedule__dialog': 30,
 	'.editor-text-editor__formatting': 20,
+	'.editor-post-schedule__dialog': 30,
 
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -19,6 +19,7 @@ $z-layers: (
 	'.editor-block-mover': 10,
 	'.editor-header': 20,
 	'.editor-post-schedule__dialog': 30,
+	'.editor-text-editor__formatting': 20,
 
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,

--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -43,6 +43,7 @@
 		margin-left: 0;
 		margin-right: 0;
 		position: fixed;
+		z-index: z-index( '.editor-text-editor__formatting' );
 	}
 
 	.auto-fold.sticky-menu &,


### PR DESCRIPTION
The editor toolbar overlaps the post title when we are text mode, giving it a `z-index` value should take care of this.

#### Steps to reproduce:

1. Open Demo post
2. Switch to "Text" mode
3. Scroll down until toolbar is over post title.

|Before|After|
|---|---|
| <img width="592" alt="screen shot 2017-08-20 at 7 24 16 am" src="https://user-images.githubusercontent.com/661330/29492627-53424820-857a-11e7-9123-c1a98c10f722.png"> | <img width="699" alt="screen shot 2017-08-20 at 7 28 21 am" src="https://user-images.githubusercontent.com/661330/29492629-5f68bd32-857a-11e7-9d97-c453339f1470.png"> |