### PR TITLE
Paste caption shortcode

### DIFF
--- a/blocks/api/paste/convert-shortcodes.js
+++ b/blocks/api/paste/convert-shortcodes.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { find, get, dropRight, last } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { createBlock } from '../factory';
+import { getBlockTypes } from '../registration';
+import { getBlockAttributes } from '../parser';
+
+const { shortcode } = window.wp;
+
+export default function( HTML ) {
+	// Get all matches. These are *not* ordered.
+	const matches = getBlockTypes().reduce( ( acc, blockType ) => {
+		const transformsFrom = get( blockType, 'transforms.from', [] );
+		const transform = find( transformsFrom, ( { type } ) => type === 'shortcode' );
+
+		if ( ! transform ) {
+			return acc;
+		}
+
+		let match;
+		let lastIndex = 0;
+
+		while ( ( match = shortcode.next( transform.tag, HTML, lastIndex ) ) ) {
+			lastIndex = match.index + match.content.length;
+
+			const block = createBlock(
+				blockType.name,
+				getBlockAttributes(
+					{
+						...blockType,
+						attributes: transform.content,
+					},
+					match.shortcode.content,
+					transform.attributes( match.shortcode.attrs ),
+				)
+			);
+
+			acc[ match.index ] = { block, lastIndex };
+		}
+
+		return acc;
+	}, {} );
+
+	let negativeI = 0;
+
+	// Sort the matches and return an array of text pieces and blocks.
+	return Object.keys( matches ).sort().reduce( ( acc, index ) => {
+		const match = matches[ index ];
+
+		acc = [
+			// Add all pieces except the last text piece.
+			...dropRight( acc ),
+			// Add the start of the last text piece.
+			last( acc ).slice( 0, index - negativeI ),
+			// Add the block.
+			match.block,
+			// Add the rest of the last text piece.
+			last( acc ).slice( match.lastIndex - negativeI ),
+		];
+
+		negativeI = match.lastIndex;
+
+		return acc;
+	}, [ HTML ] );
+}

--- a/blocks/api/paste/index.js
+++ b/blocks/api/paste/index.js
@@ -12,47 +12,60 @@ import { getBlockAttributes } from '../parser';
 import normaliseBlocks from './normalise-blocks';
 import stripAttributes from './strip-attributes';
 import stripWrappers from './strip-wrappers';
+import convertShortcodes from './convert-shortcodes';
 
-export default function( nodes ) {
-	const prepare = flow( [
-		stripWrappers,
-		normaliseBlocks,
-		stripAttributes,
-	] );
-
-	const prepared = prepare( nodes );
-
-	// Allows us to ask for this information when we get a report.
-	window.console.log( 'Processed HTML:\n\n', prepared.map( ( node ) => node.outerHTML ) );
-
-	return prepared.map( ( node ) => {
-		const block = getBlockTypes().reduce( ( acc, blockType ) => {
-			if ( acc ) {
-				return acc;
-			}
-
-			const transformsFrom = get( blockType, 'transforms.from', [] );
-			const transform = find( transformsFrom, ( { type } ) => type === 'raw' );
-
-			if ( ! transform || ! transform.isMatch( node ) ) {
-				return acc;
-			}
-
-			return createBlock(
-				blockType.name,
-				getBlockAttributes(
-					blockType,
-					node.outerHTML
-				)
-			);
-		}, null );
-
-		if ( block ) {
-			return block;
+export default function( HTML ) {
+	return convertShortcodes( HTML ).reduce( ( accu, piece ) => {
+		if ( typeof piece !== 'string' ) {
+			return [ ...accu, piece ];
 		}
 
-		return createBlock( getUnknownTypeHandlerName(), {
-			content: node.outerHTML,
+		const prepare = flow( [
+			stripWrappers,
+			normaliseBlocks,
+			stripAttributes,
+		] );
+
+		const preparedHTML = prepare( piece );
+
+		// Allows us to ask for this information when we get a report.
+		window.console.log( 'Processed HTML piece:\n\n', piece );
+
+		const doc = document.implementation.createHTMLDocument( '' );
+
+		doc.body.innerHTML = preparedHTML;
+
+		const blocks = Array.from( doc.body.children ).map( ( node ) => {
+			const block = getBlockTypes().reduce( ( acc, blockType ) => {
+				if ( acc ) {
+					return acc;
+				}
+
+				const transformsFrom = get( blockType, 'transforms.from', [] );
+				const transform = find( transformsFrom, ( { type } ) => type === 'raw' );
+
+				if ( ! transform || ! transform.isMatch( node ) ) {
+					return acc;
+				}
+
+				return createBlock(
+					blockType.name,
+					getBlockAttributes(
+						blockType,
+						node.outerHTML
+					)
+				);
+			}, null );
+
+			if ( block ) {
+				return block;
+			}
+
+			return createBlock( getUnknownTypeHandlerName(), {
+				content: node.outerHTML,
+			} );
 		} );
-	} );
+
+		return [ ...accu, ...blocks ];
+	}, [] );
 }

--- a/blocks/api/paste/normalise-blocks.js
+++ b/blocks/api/paste/normalise-blocks.js
@@ -24,18 +24,14 @@ function isInline( node ) {
 	return inlineTags.indexOf( node.nodeName.toLowerCase() ) !== -1;
 }
 
-/**
- * Normalises array nodes of any node type to an array of block level nodes.
- *
- * @param  {Array} nodes Array of Nodes.
- * @return {Array}       Array of block level HTMLElements
- */
-export default function( nodes ) {
-	const decu = document.createDocumentFragment();
-	const accu = document.createDocumentFragment();
+export default function( HTML ) {
+	const decuDoc = document.implementation.createHTMLDocument( '' );
+	const accuDoc = document.implementation.createHTMLDocument( '' );
 
-	// A fragment is easier to work with.
-	nodes.forEach( node => decu.appendChild( node.cloneNode( true ) ) );
+	const decu = decuDoc.body;
+	const accu = accuDoc.body;
+
+	decu.innerHTML = HTML;
 
 	while ( decu.firstChild ) {
 		const node = decu.firstChild;
@@ -84,5 +80,5 @@ export default function( nodes ) {
 		}
 	}
 
-	return Array.from( accu.childNodes );
+	return accu.innerHTML;
 }

--- a/blocks/api/paste/strip-attributes.js
+++ b/blocks/api/paste/strip-attributes.js
@@ -4,18 +4,18 @@ const attributes = [
 	'id',
 ];
 
-export default function( nodes ) {
-	const fragment = document.createDocumentFragment();
+export default function( HTML ) {
+	const doc = document.implementation.createHTMLDocument( '' );
 
-	nodes.forEach( node => fragment.appendChild( node.cloneNode( true ) ) );
+	doc.body.innerHTML = HTML;
 
-	deepAttributeStrip( fragment.children );
+	deepAttributeStrip( doc.body.children );
 
-	return Array.from( fragment.childNodes );
+	return doc.body.innerHTML;
 }
 
-function deepAttributeStrip( nodes ) {
-	Array.from( nodes ).forEach( ( node ) => {
+function deepAttributeStrip( nodeList ) {
+	Array.from( nodeList ).forEach( ( node ) => {
 		if ( node.hasAttributes() ) {
 			Array.from( node.attributes ).forEach( ( { name } ) => {
 				if ( attributes.indexOf( name ) !== -1 ) {

--- a/blocks/api/paste/strip-wrappers.js
+++ b/blocks/api/paste/strip-wrappers.js
@@ -21,18 +21,14 @@ function unwrap( node ) {
 	parent.removeChild( node );
 }
 
-/**
- * @param  {Array} nodes Array of nodes.
- * @return {Array}       Array of nodes without any SPANs or DIVs.
- */
-export default function( nodes ) {
-	const fragment = document.createDocumentFragment();
+export default function( HTML ) {
+	const doc = document.implementation.createHTMLDocument( '' );
 
-	nodes.forEach( node => fragment.appendChild( node.cloneNode( true ) ) );
+	doc.body.innerHTML = HTML;
 
-	const wrappers = fragment.querySelectorAll( tags );
+	const wrappers = doc.body.querySelectorAll( tags );
 
 	Array.from( wrappers ).forEach( ( wrapper ) => unwrap( wrapper ) );
 
-	return Array.from( fragment.childNodes );
+	return doc.body.innerHTML;
 }

--- a/blocks/api/paste/test/index.js
+++ b/blocks/api/paste/test/index.js
@@ -11,11 +11,6 @@ import { registerBlockType, unregisterBlockType, setUnknownTypeHandlerName } fro
 import { createBlock } from '../../factory';
 import { children, prop } from '../../source';
 
-function createNodes( HTML ) {
-	document.body.innerHTML = HTML;
-	return Array.from( document.body.childNodes );
-}
-
 describe( 'paste', () => {
 	beforeAll( () => {
 		registerBlockType( 'test/small', {
@@ -58,7 +53,7 @@ describe( 'paste', () => {
 	} );
 
 	it( 'should convert recognised pasted content', () => {
-		const pastedBlock = paste( createNodes( '<small>test</small>' ) )[ 0 ];
+		const pastedBlock = paste( '<small>test</small>' )[ 0 ];
 		const block = createBlock( 'test/small', { content: [ 'test' ] } );
 
 		equal( pastedBlock.name, block.name );
@@ -66,7 +61,7 @@ describe( 'paste', () => {
 	} );
 
 	it( 'should handle unknown pasted content', () => {
-		const pastedBlock = paste( createNodes( '<big>test</big>' ) )[ 0 ];
+		const pastedBlock = paste( '<big>test</big>' )[ 0 ];
 
 		equal( pastedBlock.name, 'test/unknown' );
 		equal( pastedBlock.attributes.content, '<big>test</big>' );

--- a/blocks/api/paste/test/normalise-blocks.js
+++ b/blocks/api/paste/test/normalise-blocks.js
@@ -8,43 +8,30 @@ import { equal } from 'assert';
  */
 import normaliseBlocks from '../normalise-blocks';
 
-function createNodes( HTML ) {
-	document.body.innerHTML = HTML;
-	return Array.from( document.body.childNodes );
-}
-
-function outerHTML( nodes ) {
-	return nodes.map( node => node.outerHTML ).join( '' );
-}
-
-function transform( HTML ) {
-	return outerHTML( normaliseBlocks( createNodes( HTML ) ) );
-}
-
 describe( 'normaliseBlocks', () => {
 	it( 'should convert double line breaks to paragraphs', () => {
-		equal( transform( 'test<br><br>test' ), '<p>test</p><p>test</p>' );
+		equal( normaliseBlocks( 'test<br><br>test' ), '<p>test</p><p>test</p>' );
 	} );
 
 	it( 'should not convert single line break to paragraphs', () => {
-		equal( transform( 'test<br>test' ), '<p>test<br>test</p>' );
+		equal( normaliseBlocks( 'test<br>test' ), '<p>test<br>test</p>' );
 	} );
 
 	it( 'should not add extra line at the start', () => {
-		equal( transform( 'test<br><br><br>test' ), '<p>test</p><p>test</p>' );
-		equal( transform( '<br>test<br><br>test' ), '<p>test</p><p>test</p>' );
+		equal( normaliseBlocks( 'test<br><br><br>test' ), '<p>test</p><p>test</p>' );
+		equal( normaliseBlocks( '<br>test<br><br>test' ), '<p>test</p><p>test</p>' );
 	} );
 
 	it( 'should preserve non-inline content', () => {
 		const HTML = '<p>test</p><div>test<br>test</div>';
-		equal( transform( HTML ), HTML );
+		equal( normaliseBlocks( HTML ), HTML );
 	} );
 
 	it( 'should remove empty paragraphs', () => {
-		equal( transform( '<p>&nbsp;</p>' ), '' );
+		equal( normaliseBlocks( '<p>&nbsp;</p>' ), '' );
 	} );
 
 	it( 'should wrap lose inline elements', () => {
-		equal( transform( '<a href="#">test</a>' ), '<p><a href="#">test</a></p>' );
+		equal( normaliseBlocks( '<a href="#">test</a>' ), '<p><a href="#">test</a></p>' );
 	} );
 } );

--- a/blocks/api/paste/test/strip-attributes.js
+++ b/blocks/api/paste/test/strip-attributes.js
@@ -8,37 +8,24 @@ import { equal } from 'assert';
  */
 import stripAttributes from '../strip-attributes';
 
-function createNodes( HTML ) {
-	document.body.innerHTML = HTML;
-	return Array.from( document.body.childNodes );
-}
-
-function outerHTML( nodes ) {
-	return nodes.map( node => node.outerHTML ).join( '' );
-}
-
-function transform( HTML ) {
-	return outerHTML( stripAttributes( createNodes( HTML ) ) );
-}
-
 describe( 'stripAttributes', () => {
 	it( 'should remove attributes', () => {
-		equal( transform( '<p class="test">test</p>' ), '<p>test</p>' );
+		equal( stripAttributes( '<p class="test">test</p>' ), '<p>test</p>' );
 	} );
 
 	it( 'should remove multiple attributes', () => {
-		equal( transform( '<p class="test" id="test">test</p>' ), '<p>test</p>' );
+		equal( stripAttributes( '<p class="test" id="test">test</p>' ), '<p>test</p>' );
 	} );
 
 	it( 'should deep remove attributes', () => {
-		equal( transform( '<p class="test">test <em id="test">test</em></p>' ), '<p>test <em>test</em></p>' );
+		equal( stripAttributes( '<p class="test">test <em id="test">test</em></p>' ), '<p>test <em>test</em></p>' );
 	} );
 
 	it( 'should remove data-* attributes', () => {
-		equal( transform( '<p data-reactid="1">test</p>' ), '<p>test</p>' );
+		equal( stripAttributes( '<p data-reactid="1">test</p>' ), '<p>test</p>' );
 	} );
 
 	it( 'should keep some attributes', () => {
-		equal( transform( '<a href="#keep">test</a>' ), '<a href="#keep">test</a>' );
+		equal( stripAttributes( '<a href="#keep">test</a>' ), '<a href="#keep">test</a>' );
 	} );
 } );

--- a/blocks/api/paste/test/strip-wrappers.js
+++ b/blocks/api/paste/test/strip-wrappers.js
@@ -4,50 +4,28 @@
 import { equal } from 'assert';
 
 /**
- * WordPress dependencies
- */
-import { ELEMENT_NODE } from 'utils/nodetypes';
-
-/**
  * Internal dependencies
  */
 import stripWrappers from '../strip-wrappers';
 
-function createNodes( HTML ) {
-	document.body.innerHTML = HTML;
-	return Array.from( document.body.childNodes );
-}
-
-function outerHTML( nodes ) {
-	return nodes.map( node =>
-		node.nodeType === ELEMENT_NODE ?
-		node.outerHTML :
-		node.nodeValue
-	).join( '' );
-}
-
-function transform( HTML ) {
-	return outerHTML( stripWrappers( createNodes( HTML ) ) );
-}
-
 describe( 'stripWrappers', () => {
 	it( 'should remove spans', () => {
-		equal( transform( '<span>test</span>' ), 'test' );
+		equal( stripWrappers( '<span>test</span>' ), 'test' );
 	} );
 
 	it( 'should remove wrapped spans', () => {
-		equal( transform( '<p><span>test</span></p>' ), '<p>test</p>' );
+		equal( stripWrappers( '<p><span>test</span></p>' ), '<p>test</p>' );
 	} );
 
 	it( 'should remove spans with attributes', () => {
-		equal( transform( '<p><span id="test">test</span></p>' ), '<p>test</p>' );
+		equal( stripWrappers( '<p><span id="test">test</span></p>' ), '<p>test</p>' );
 	} );
 
 	it( 'should remove nested spans', () => {
-		equal( transform( '<p><span><span>test</span></span></p>' ), '<p>test</p>' );
+		equal( stripWrappers( '<p><span><span>test</span></span></p>' ), '<p>test</p>' );
 	} );
 
 	it( 'should remove spans, but preserve nested structure', () => {
-		equal( transform( '<p><span><em>test</em> <em>test</em></span></p>' ), '<p><em>test</em> <em>test</em></p>' );
+		equal( stripWrappers( '<p><span><em>test</em> <em>test</em></span></p>' ), '<p><em>test</em> <em>test</em></p>' );
 	} );
 } );

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -180,9 +180,7 @@ export default class Editable extends Component {
 	}
 
 	onPastePostProcess( event ) {
-		// Allows us to ask for this information when we get a report.
-		window.console.log( 'MCE processed HTML:\n\n', event.node.innerHTML );
-
+		const HTML = event.node.innerHTML;
 		const childNodes = Array.from( event.node.childNodes );
 		const isBlockDelimiter = ( node ) =>
 			node.nodeType === 8 && /^ wp:/.test( node.nodeValue );
@@ -191,6 +189,9 @@ export default class Editable extends Component {
 		const isBlockPart = ( node ) =>
 			isDoubleBR( node ) || this.editor.dom.isBlock( node );
 
+		// Allows us to ask for this information when we get a report.
+		window.console.log( 'MCE processed HTML:\n\n', HTML );
+
 		// If there's no `onSplit` prop, content will later be converted to
 		// inline content.
 		if ( this.props.onSplit ) {
@@ -198,11 +199,11 @@ export default class Editable extends Component {
 
 			// Internal paste, so parse.
 			if ( childNodes.some( isBlockDelimiter ) ) {
-				blocks = parse( event.node.innerHTML.replace( /<meta[^>]+>/, '' ) );
+				blocks = parse( HTML.replace( /<meta[^>]+>/, '' ) );
 			// External paste with block level content, so attempt to assign
 			// blocks.
 			} else if ( childNodes.some( isBlockPart ) ) {
-				blocks = pasteHandler( childNodes );
+				blocks = pasteHandler( HTML.replace( /<meta[^>]+>/, '' ) );
 			}
 
 			if ( blocks.length ) {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -28,7 +28,7 @@ import BlockDescription from '../../block-description';
 import UrlInputButton from '../../url-input/button';
 import ImageSize from './image-size';
 
-const { attr, children } = source;
+const { attr, children, text } = source;
 
 registerBlockType( 'core/image', {
 	title: __( 'Image' ),
@@ -78,6 +78,31 @@ registerBlockType( 'core/image', {
 					node.nodeName === 'IMG' ||
 					( ! node.textContent && node.querySelector( 'img' ) )
 				),
+			},
+			{
+				type: 'shortcode',
+				tag: 'caption',
+				content: {
+					url: {
+						type: 'string',
+						source: attr( 'img', 'src' ),
+					},
+					alt: {
+						type: 'string',
+						source: attr( 'img', 'alt' ),
+					},
+					caption: {
+						type: 'array',
+						source: text(),
+					},
+					href: {
+						type: 'string',
+						source: attr( 'a', 'href' ),
+					},
+				},
+				attributes: ( { named } ) => ( {
+					id: window.parseInt( named.id.replace( 'attachment_', '' ), 10 ),
+				} ),
 			},
 		],
 	},

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -135,7 +135,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-i18n', 'tinymce-nightly', 'tinymce-nightly-lists', 'tinymce-nightly-paste', 'tinymce-nightly-table', 'media-views', 'media-models' ),
+		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-i18n', 'tinymce-nightly', 'tinymce-nightly-lists', 'tinymce-nightly-paste', 'tinymce-nightly-table', 'media-views', 'media-models', 'shortcode' ),
 		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 	wp_add_inline_script(


### PR DESCRIPTION
This is a first attempt at handling pasted shortcodes.

* Shortcode handling needs to occur before anything else, otherwise we risk losing important info or splitting the shortcode.
* I've created block transforms for this, so it will the the image block that handles the caption shortcode, gallery that handles the gallery shortcode etc.
* I'd like to regard the shortcode attributes as the "sourced" attributes we have for blocks, then parse the content of the shortcode with hpq.

While I used the core shortcodes script in this PR, I think we should bundle it so that we can write tests.