### PR TITLE
fix/1273: Delete or backspace in a empty classic text block removes it

### DIFF
--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -7,6 +7,22 @@ import { keycodes } from '@wordpress/utils';
 
 const { BACKSPACE, DELETE } = keycodes;
 
+function isTmceEmpty( editor ) {
+	// When tinyMce is empty the content seems to be:
+	// <p><br data-mce-bogus="1"></p>
+	// avoid expensive checks for large documents
+	const body = editor.getBody();
+	if ( body.childNodes > 1 ) {
+		return false;
+	} else if ( body.childNodes === 0 ) {
+		return true;
+	}
+	if ( body.childNodes[ 0 ].childNodes > 1 ) {
+		return false;
+	}
+	return /^\n?$/.test( body.innerText || body.textContent );
+}
+
 export default class OldEditor extends Component {
 	constructor( props ) {
 		super( props );
@@ -71,8 +87,7 @@ export default class OldEditor extends Component {
 		} );
 
 		editor.on( 'keydown', ( event ) => {
-			if ( ( event.keyCode === BACKSPACE || event.keyCode === DELETE ) &&
-					/^\n?$/.test( editor.getContent( { format: 'text' } ) ) ) {
+			if ( ( event.keyCode === BACKSPACE || event.keyCode === DELETE ) && isTmceEmpty( editor ) ) {
 				// delete the block
 				this.props.onReplace( [] );
 				event.preventDefault();

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -3,6 +3,9 @@
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { keycodes } from '@wordpress/utils';
+
+const { BACKSPACE, DELETE } = keycodes;
 
 export default class OldEditor extends Component {
 	constructor( props ) {
@@ -65,6 +68,16 @@ export default class OldEditor extends Component {
 			setAttributes( {
 				content: editor.getContent(),
 			} );
+		} );
+
+		editor.on( 'keydown', ( event ) => {
+			if ( ( event.keyCode === BACKSPACE || event.keyCode === DELETE ) &&
+					/^\n?$/.test( editor.getContent( { format: 'text' } ) ) ) {
+				// delete the block
+				this.props.onReplace( [] );
+				event.preventDefault();
+				event.stopImmediatePropagation();
+			}
 		} );
 
 		editor.addButton( 'kitchensink', {


### PR DESCRIPTION
This pull request fixes issue https://github.com/WordPress/gutenberg/issues/1273

Pressing delete or backspace inside an empty classic text block will now remove it.