### PR TITLE
Check type when finding block transforms in switchToBlockType

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -68,8 +68,8 @@ export function switchToBlockType( block, name ) {
 	const transformationsFrom = get( destinationType, 'transforms.from', [] );
 	const transformationsTo = get( sourceType, 'transforms.to', [] );
 	const transformation =
-		find( transformationsTo, t => t.blocks.indexOf( name ) !== -1 ) ||
-		find( transformationsFrom, t => t.blocks.indexOf( block.name ) !== -1 );
+		find( transformationsTo, t => t.type === 'block' && t.blocks.indexOf( name ) !== -1 ) ||
+		find( transformationsFrom, t => t.type === 'block' && t.blocks.indexOf( block.name ) !== -1 );
 
 	// Stop if there is no valid transformation. (How did we get here?)
 	if ( ! transformation ) {

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -89,6 +89,7 @@ describe( 'block factory', () => {
 				},
 				transforms: {
 					from: [ {
+						type: 'block',
 						blocks: [ 'core/text-block' ],
 						transform: ( { value } ) => {
 							return createBlock( 'core/updated-text-block', {
@@ -127,6 +128,7 @@ describe( 'block factory', () => {
 				},
 				transforms: {
 					to: [ {
+						type: 'block',
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return createBlock( 'core/updated-text-block', {
@@ -369,6 +371,7 @@ describe( 'block factory', () => {
 				},
 				transforms: {
 					to: [ {
+						type: 'block',
 						blocks: [ 'core/updated-text-block' ],
 						transform: ( { value } ) => {
 							return [

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -138,7 +138,7 @@ describe( 'effects', () => {
 				},
 				transforms: {
 					to: [ {
-						type: 'blocks',
+						type: 'block',
 						blocks: [ 'core/test-block' ],
 						transform: ( { content2 } ) => {
 							return createBlock( 'core/test-block', {


### PR DESCRIPTION
I stumbled upon this small bug in the switchToBlockType code.

Note that block transformations can now have 3 types: 'raw', 'block' or 'pattern'. Only the 'block' transformation type has the property 'blocks'.