### PR TITLE
Editor: Avoids resetting the focus config when the block is already selected

### DIFF
--- a/editor/state.js
+++ b/editor/state.js
@@ -339,6 +339,9 @@ export function blockSelection( state = { start: null, end: null, focus: null },
 				focus: null,
 			};
 		case 'SELECT_BLOCK':
+			if ( action.uid === state.start && action.uid === state.end ) {
+				return state;
+			}
 			return {
 				start: action.uid,
 				end: action.uid,

--- a/editor/test/state.js
+++ b/editor/test/state.js
@@ -676,6 +676,17 @@ describe( 'state', () => {
 			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: null } );
 		} );
 
+		it( 'should not update the state if the block is already selected', () => {
+			const original = deepFreeze( { start: 'ribs', end: 'ribs' } );
+
+			const state1 = blockSelection( original, {
+				type: 'SELECT_BLOCK',
+				uid: 'ribs',
+			} );
+
+			expect( state1 ).toBe( original );
+		} );
+
 		it( 'should unset multi selection and select inserted block', () => {
 			const original = deepFreeze( { start: 'ribs', end: 'chicken' } );
 


### PR DESCRIPTION
closes #2480

The changes 8a2f170 introduced a small regression where the `focus` state was being reset by the `SELECT_BLOCK` action even if this block was already selected. This was causing the formatting toolbar to disappear because we're considering that the caption editable was not focused anymore.

**Testing instructions**

- Try formatting an image caption