### PR TITLE
Use same term as current editor to make translatable.

### DIFF
--- a/editor/sidebar/post-schedule/index.js
+++ b/editor/sidebar/post-schedule/index.js
@@ -60,7 +60,7 @@ class PostSchedule extends Component {
 
 		return (
 			<PanelRow className="editor-post-schedule">
-				<span>{ __( 'Publish' ) }</span>
+				<span>{ __( 'Publish on' ) }</span>
 				<button
 					type="button"
 					className="editor-post-schedule__toggle button-link"


### PR DESCRIPTION
Especially for translators, publish button and the string "Publish on <date>" should have different translation.

<img width="217" alt="_2017_08_22_4_39" src="https://user-images.githubusercontent.com/1886443/29535539-27caf134-86f5-11e7-8083-9cd84eedb7d4.png">
