### PR TITLE
Use latest MCE version

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -135,7 +135,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-i18n', 'tinymce-nightly', 'tinymce-nightly-lists', 'tinymce-nightly-paste', 'tinymce-nightly-table', 'media-views', 'media-models' ),
+		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models' ),
 		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 	wp_add_inline_script(
@@ -204,23 +204,23 @@ function gutenberg_register_vendor_scripts() {
 		array( 'react' )
 	);
 	gutenberg_register_vendor_script(
-		'tinymce-nightly',
-		'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce' . $suffix . '.js'
+		'tinymce-latest',
+		'https://fiddle.azurewebsites.net/tinymce/4.6.5/tinymce' . $suffix . '.js'
 	);
 	gutenberg_register_vendor_script(
-		'tinymce-nightly-lists',
-		'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin' . $suffix . '.js',
-		array( 'tinymce-nightly' )
+		'tinymce-latest-lists',
+		'https://fiddle.azurewebsites.net/tinymce/4.6.5/plugins/lists/plugin' . $suffix . '.js',
+		array( 'tinymce-latest' )
 	);
 	gutenberg_register_vendor_script(
-		'tinymce-nightly-paste',
-		'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/paste/plugin' . $suffix . '.js',
-		array( 'tinymce-nightly' )
+		'tinymce-latest-paste',
+		'https://fiddle.azurewebsites.net/tinymce/4.6.5/plugins/paste/plugin' . $suffix . '.js',
+		array( 'tinymce-latest' )
 	);
 	gutenberg_register_vendor_script(
-		'tinymce-nightly-table',
-		'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/table/plugin' . $suffix . '.js',
-		array( 'tinymce-nightly' )
+		'tinymce-latest-table',
+		'https://fiddle.azurewebsites.net/tinymce/4.6.5/plugins/table/plugin' . $suffix . '.js',
+		array( 'tinymce-latest' )
 	);
 	gutenberg_register_vendor_script(
 		'fetch',


### PR DESCRIPTION
This fixes both #2493 and #2494. Something in the nightly version of TinyMCE is causing these bugs.

1. @EphoxJames @tg-ephox @spocke Any ideas? :)
2. I really think we should do this change regardless of a nightly fix. It's really hard to track these bugs down without any commit making this change. I'd rather bump the version each time a new MCE version is released, or pin it to a specific commit. Cc @nylen @aduth.

@mtias Does this fix the Sublime paste issue you were having as well?