### PR TITLE
Notices: Fix `Array.reverse` call

### DIFF
--- a/components/notice/list.js
+++ b/components/notice/list.js
@@ -13,7 +13,7 @@ function NoticeList( { notices, onRemove = noop } ) {
 
 	return (
 		<div className="components-notice-list">
-			{ notices.reverse().map( ( notice ) => (
+			{ [ ...notices ].reverse().map( ( notice ) => (
 				<Notice { ...notice } key={ notice.id } onRemove={ removeNotice( notice.id ) } />
 			) ) }
 		</div>


### PR DESCRIPTION
We have to clone the input array to avoid mutating the original parameter.

cc  https://github.com/WordPress/gutenberg/pull/1437#issuecomment-311310754