### PR TITLE
Framework: Preload common API data

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -134,10 +134,10 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 				[ this.getPendingKey( method ) ]: true,
 			} );
 
-			request( { path, method } ).then( ( data ) => {
+			request( { path, method } ).then( ( response ) => {
 				this.setIntoDataProp( propName, {
 					[ this.getPendingKey( method ) ]: false,
-					[ this.getResponseDataKey( method ) ]: data,
+					[ this.getResponseDataKey( method ) ]: response.body,
 				} );
 			} ).catch( ( error ) => {
 				this.setIntoDataProp( propName, {

--- a/components/higher-order/with-api-data/test/index.js
+++ b/components/higher-order/with-api-data/test/index.js
@@ -9,7 +9,9 @@ import { identity, fromPairs } from 'lodash';
  */
 import withAPIData from '../';
 
-jest.mock( '../request', () => jest.fn( () => Promise.resolve( {} ) ) );
+jest.mock( '../request', () => jest.fn( () => Promise.resolve( {
+	body: {},
+} ) ) );
 
 describe( 'withAPIData()', () => {
 	const schema = {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -729,12 +729,15 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	}
 
 	// Preload common data.
+	$preload_paths = array(
+		'/wp/v2/users/me?context=edit',
+		gutenberg_get_rest_link( $post_to_edit, 'about', 'edit' ),
+	);
+	if ( ! $is_new_post ) {
+		$preload_paths[] = gutenberg_get_rest_link( $post_to_edit, 'version-history' );
+	}
 	$preload_data = array_reduce(
-		array(
-			'/wp/v2/users/me?context=edit',
-			gutenberg_get_rest_link( $post_to_edit, 'about', 'edit' ),
-			gutenberg_get_rest_link( $post_to_edit, 'version-history' ),
-		),
+		$preload_paths,
 		'gutenberg_preload_api_request',
 		array()
 	);


### PR DESCRIPTION
Related: #1974

This pull request seeks to introduce a mechanism for bootstrapping common REST API requirements for use in with the `withAPIData` higher-order component (#1974). Specifically, this improves perceived performance by making endpoint data available immediately upon page load, avoiding components flashing in and out (e.g. LastRevision in ##1974, PostFormats in #2500) where the API data would otherwise load asynchronously.

__Implementation notes:__

While not entirely necessary for the changes here, I split the response between `body` and `headers`. This will be useful for future enhancements to the `withAPIData` higher-order component in allowing a "has more results?" type functionality.

__Testing instructions:__

Repeat testing instructions from #1974, noting that the LastRevision component appears immediately upon page load if revisions are available for a post. Ensure that there is no network request occurring to retrieve `/wp/v2/posts/%d/revisions`.