### PR TITLE
Add reusable blocks REST API

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -18,6 +18,7 @@ if ( gutenberg_can_init() ) {
 	// Load API functions, register scripts and actions, etc.
 	require_once dirname( __FILE__ ) . '/lib/class-wp-block-type.php';
 	require_once dirname( __FILE__ ) . '/lib/class-wp-block-type-registry.php';
+	require_once dirname( __FILE__ ) . '/lib/class-wp-rest-reusable-blocks-controller.php';
 	require_once dirname( __FILE__ ) . '/lib/blocks.php';
 	require_once dirname( __FILE__ ) . '/lib/client-assets.php';
 	require_once dirname( __FILE__ ) . '/lib/compat.php';

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -230,25 +230,13 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 			) );
 		}
 
-		// Type.
-		if ( isset( $request['type'] ) && is_string( $request['type'] ) ) {
-			$prepared_reusable_block->meta_input['_gutenberg_type'] = $request['type'];
-		} else {
-			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid block type.', 'gutenberg' ), array(
-				'status' => 400,
-			) );
-		}
-
-		// Atttributes.
-		if ( isset( $request['attributes'] ) && is_array( $request['attributes'] ) ) {
-			$prepared_reusable_block->meta_input['_gutenberg_attributes'] = $request['attributes'];
-		} else {
-			$prepared_reusable_block->meta_input['_gutenberg_attributes'] = array();
-		}
-
 		// Content.
 		if ( isset( $request['content'] ) && is_string( $request['content'] ) ) {
 			$prepared_reusable_block->post_content = $request['content'];
+		} else {
+			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid reusable block content.', 'gutenberg' ), array(
+				'status' => 400,
+			) );
 		}
 
 		return $prepared_reusable_block;
@@ -268,8 +256,6 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 		$data = array(
 			'id' => $reusable_block->post_name,
 			'name' => $reusable_block->post_title,
-			'type' => get_post_meta( $reusable_block->ID, '_gutenberg_type', true ),
-			'attributes' => get_post_meta( $reusable_block->ID, '_gutenberg_attributes', true ),
 			'content' => $reusable_block->post_content,
 		);
 
@@ -315,21 +301,11 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 					'context'      => array( 'view', 'edit' ),
 					'required'     => true,
 				),
-				'type'             => array(
-					'description'  => __( 'The block\'s type, e.g. core/text', 'gutenberg' ),
-					'type'         => 'string',
-					'context'      => array( 'view', 'edit' ),
-					'required'     => true,
-				),
-				'attributes'       => array(
-					'description'  => __( 'The block\'s attributes, e.g. { "dropCap": true }', 'gutenberg' ),
-					'type'         => 'object',
-					'context'      => array( 'view', 'edit' ),
-				),
 				'content'          => array(
 					'description'  => __( 'The block\'s HTML content.', 'gutenberg' ),
 					'type'         => 'object',
 					'context'      => array( 'view', 'edit' ),
+					'required'     => true,
 				),
 			),
 		);

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -221,6 +221,15 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 		// ID. We already validated this in self::update_item().
 		$prepared_reusable_block->post_name = $request['id'];
 
+		// Name.
+		if ( isset( $request['name'] ) && is_string( $request['name'] ) ) {
+			$prepared_reusable_block->post_title = $request['name'];
+		} else {
+			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid reusable block name.', 'gutenberg' ), array(
+				'status' => 400,
+			) );
+		}
+
 		// Type.
 		if ( isset( $request['type'] ) && is_string( $request['type'] ) ) {
 			$prepared_reusable_block->meta_input['_gutenberg_type'] = $request['type'];
@@ -258,6 +267,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	public function prepare_item_for_response( $reusable_block, $request ) {
 		$data = array(
 			'id' => $reusable_block->post_name,
+			'name' => $reusable_block->post_title,
 			'type' => get_post_meta( $reusable_block->ID, '_gutenberg_type', true ),
 			'attributes' => get_post_meta( $reusable_block->ID, '_gutenberg_attributes', true ),
 			'content' => $reusable_block->post_content,
@@ -299,6 +309,12 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 					'context'      => array( 'view', 'edit' ),
 					'readonly'     => true,
 				),
+				'name'             => array(
+					'description'  => __( 'Name that identifies this reusable block', 'gutenberg' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'required'     => true,
+				),
 				'type'             => array(
 					'description'  => __( 'The block\'s type, e.g. core/text', 'gutenberg' ),
 					'type'         => 'string',
@@ -309,13 +325,11 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 					'description'  => __( 'The block\'s attributes, e.g. { "dropCap": true }', 'gutenberg' ),
 					'type'         => 'object',
 					'context'      => array( 'view', 'edit' ),
-					'required'     => true,
 				),
 				'content'          => array(
 					'description'  => __( 'The block\'s HTML content.', 'gutenberg' ),
 					'type'         => 'object',
 					'context'      => array( 'view', 'edit' ),
-					'required'     => true,
 				),
 			),
 		);

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -79,7 +79,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	public function get_item( $request ) {
 		$uuid = $request['id'];
 		if ( ! $this->is_valid_uuid4( $uuid ) ) {
-			return new WP_Error( 'gutenberg_reusable_block_invalid_id', __( 'Invalid ID.', 'gutenberg' ), array(
+			return new WP_Error( 'gutenberg_reusable_block_invalid_id', __( 'ID is not a valid UUID v4.', 'gutenberg' ), array(
 				'status' => 404,
 			) );
 		}
@@ -125,7 +125,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	public function update_item( $request ) {
 		$uuid = $request['id'];
 		if ( ! $this->is_valid_uuid4( $uuid ) ) {
-			return new WP_Error( 'gutenberg_reusable_block_invalid_id', __( 'Invalid ID.', 'gutenberg' ), array(
+			return new WP_Error( 'gutenberg_reusable_block_invalid_id', __( 'ID is not a valid UUID v4.', 'gutenberg' ), array(
 				'status' => 404,
 			) );
 		}
@@ -168,18 +168,18 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 
 		// Type. TODO: Validate this somehow.
 		if ( isset( $request['type'] ) && is_string( $request['type'] ) ) {
-			$prepared_reusable_block->meta_input['_gb_type'] = $request['type'];
+			$prepared_reusable_block->meta_input['_gutenberg_type'] = $request['type'];
 		} else {
-			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid type.', 'gutenberg' ), array(
+			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid block type.', 'gutenberg' ), array(
 				'status' => 400,
 			) );
 		}
 
 		// Atttributes. TODO: Validate these further, and maybe against any PHP block definitions we have.
 		if ( isset( $request['attributes'] ) && is_array( $request['attributes'] ) ) {
-			$prepared_reusable_block->meta_input['_gb_attributes'] = $request['attributes'];
+			$prepared_reusable_block->meta_input['_gutenberg_attributes'] = $request['attributes'];
 		} else {
-			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid attributes.', 'gutenberg' ), array(
+			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid block attributes.', 'gutenberg' ), array(
 				'status' => 400,
 			) );
 		}
@@ -188,7 +188,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 		if ( isset( $request['content'] ) && is_string( $request['content'] ) ) {
 			$prepared_reusable_block->post_content = $request['content'];
 		} else {
-			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid content.', 'gutenberg' ), array(
+			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid block content.', 'gutenberg' ), array(
 				'status' => 400,
 			) );
 		}
@@ -209,8 +209,8 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	public function prepare_item_for_response( $reusable_block, $request ) {
 		$data = array(
 			'id' => $reusable_block->post_name,
-			'type' => get_post_meta( $reusable_block->ID, '_gb_type', true ),
-			'attributes' => get_post_meta( $reusable_block->ID, '_gb_attributes', true ),
+			'type' => get_post_meta( $reusable_block->ID, '_gutenberg_type', true ),
+			'attributes' => get_post_meta( $reusable_block->ID, '_gutenberg_attributes', true ),
 			'content' => $reusable_block->post_content,
 		);
 

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -51,7 +51,6 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_item' ),
 				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -22,6 +22,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	 * @access public
 	 */
 	public function __construct() {
+		// @codingStandardsIgnoreLine - PHPCS mistakes $this->namespace for the namespace keyword
 		$this->namespace = 'gutenberg/v1';
 		$this->rest_base = 'reusable-blocks';
 	}
@@ -33,7 +34,10 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	 * @access public
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		// @codingStandardsIgnoreLine - PHPCS mistakes $this->namespace for the namespace keyword
+		$namespace = $this->namespace;
+
+		register_rest_route( $namespace, '/' . $this->rest_base, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
@@ -42,7 +46,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\w-]+)', array(
+		register_rest_route( $namespace, '/' . $this->rest_base . '/(?P<id>[\w-]+)', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -7,7 +7,8 @@
  */
 
 /**
- * Controller which allows Gutenberg reusable blocks to be read, created and edited via a REST API.
+ * Controller which provides a REST endpoint for Gutenberg to read, create and edit reusable blocks. Reusable blocks are
+ * stored as posts with a custom post type.
  *
  * @since 0.10.0
  *

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -131,6 +131,9 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 		}
 
 		$reusable_block = $this->prepare_item_for_database( $request );
+		if ( is_wp_error( $reusable_block ) ) {
+			return $reusable_block;
+		}
 
 		// wp_insert_post will unslash its input, so we have to slash it first.
 		$post_id = wp_insert_post( wp_slash( (array) $reusable_block ), true );
@@ -166,7 +169,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 		// ID. We already validated this in self::update_item().
 		$prepared_reusable_block->post_name = $request['id'];
 
-		// Type. TODO: Validate this somehow.
+		// Type.
 		if ( isset( $request['type'] ) && is_string( $request['type'] ) ) {
 			$prepared_reusable_block->meta_input['_gutenberg_type'] = $request['type'];
 		} else {
@@ -175,22 +178,16 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 			) );
 		}
 
-		// Atttributes. TODO: Validate these further, and maybe against any PHP block definitions we have.
+		// Atttributes.
 		if ( isset( $request['attributes'] ) && is_array( $request['attributes'] ) ) {
 			$prepared_reusable_block->meta_input['_gutenberg_attributes'] = $request['attributes'];
 		} else {
-			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid block attributes.', 'gutenberg' ), array(
-				'status' => 400,
-			) );
+			$prepared_reusable_block->meta_input['_gutenberg_attributes'] = array();
 		}
 
 		// Content.
 		if ( isset( $request['content'] ) && is_string( $request['content'] ) ) {
 			$prepared_reusable_block->post_content = $request['content'];
-		} else {
-			return new WP_Error( 'gutenberg_reusable_block_invalid_field', __( 'Invalid block content.', 'gutenberg' ), array(
-				'status' => 400,
-			) );
 		}
 
 		return $prepared_reusable_block;

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Reusable Blocks REST API: WP_REST_Reusable_Blocks_Controller class
+ *
+ * @package gutenberg
+ * @since 0.10.0
+ */
+
+/**
+ * Controller which allows Gutenberg reusable blocks to be read, created and edited via a REST API.
+ *
+ * @since 0.10.0
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
+	/**
+	 * Constructs the controller.
+	 *
+	 * @since 0.10.0
+	 * @access public
+	 */
+	public function __construct() {
+		$this->namespace = 'gutenberg/v1';
+		$this->rest_base = 'reusable-blocks';
+	}
+
+	/**
+	 * Registers the necessary REST API routes.
+	 *
+	 * @since 0.10.0
+	 * @access public
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\w-]+)', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_item' ),
+				'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Checks if a given request has access to read a reusable block.
+	 *
+	 * @since 0.10.0
+	 * @access public
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		// TODO: Implement this.
+		return true;
+	}
+
+	/**
+	 * Retrieves a single reusable block.
+	 *
+	 * @since 0.10.0
+	 * @access public
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+		return rest_ensure_response( array(
+			'id' => $request['id'],
+		) );
+	}
+
+	/**
+	 * Checks if a given request has access to update a reusable block.
+	 *
+	 * @since 0.10.0
+	 * @access public
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access to update the item, WP_Error object otherwise.
+	 */
+	public function update_item_permissions_check( $request ) {
+		// TODO: Implement this.
+		return true;
+	}
+
+	/**
+	 * Updates a single reusable block.
+	 *
+	 * @since 0.10.0
+	 * @access public
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function update_item( $request ) {
+		return rest_ensure_response( array(
+			'id' => $request['id'],
+			'type' => $request['type'],
+			'attributes' => $request['attributes'],
+			'content' => $request['content'],
+		) );
+	}
+
+	/**
+	 * Retrieves a reusable block's schema, conforming to JSON Schema.
+	 *
+	 * @since 0.10.0
+	 * @access public
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		return array(
+			'$schema'              => 'http://json-schema.org/schema#',
+			'title'                => 'reusable-block',
+			'type'                 => 'object',
+			'properties'           => array(
+				'id'               => array(
+					'description'  => __( 'UUID that identifies this reusable block.', 'gutenberg' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'readonly'     => true,
+				),
+				'type'             => array(
+					'description'  => __( 'The block\'s type, e.g. core/text', 'gutenberg' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'required'     => true,
+				),
+				'attributes'       => array(
+					'description'  => __( 'The block\'s attributes, e.g. { "dropCap": true }', 'gutenberg' ),
+					'type'         => 'object',
+					'context'      => array( 'view', 'edit' ),
+					'required'     => true,
+				),
+				'content'          => array(
+					'description'  => __( 'The block\'s HTML content.', 'gutenberg' ),
+					'type'         => 'object',
+					'context'      => array( 'view', 'edit' ),
+					'required'     => true,
+				),
+			),
+		);
+	}
+}

--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -58,7 +58,12 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
-		// TODO: Implement this.
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error( 'gutenberg_reusable_block_cannot_read', __( 'Sorry, you are not allowed to read reusable blocks as this user.', 'gutenberg' ), array(
+				'status' => rest_authorization_required_code(),
+			) );
+		}
+
 		return true;
 	}
 
@@ -99,7 +104,12 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	 * @return true|WP_Error True if the request has access to update the item, WP_Error object otherwise.
 	 */
 	public function update_item_permissions_check( $request ) {
-		// TODO: Implement this.
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error( 'gutenberg_reusable_block_cannot_edit', __( 'Sorry, you are not allowed to edit reusable blocks as this user.', 'gutenberg' ), array(
+				'status' => rest_authorization_required_code(),
+			) );
+		}
+
 		return true;
 	}
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -302,6 +302,18 @@ function gutenberg_add_gutenberg_post_state( $post_states, $post ) {
 add_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state', 10, 2 );
 
 /**
+ * Registers custom post types required by the Gutenberg editor.
+ *
+ * @since 0.10.0
+ */
+function gutenberg_register_post_types() {
+	register_post_type( 'gb_reusable_block', array(
+		'public' => false,
+	) );
+}
+add_action( 'init', 'gutenberg_register_post_types' );
+
+/**
  * Registers the REST API routes needed by the Gutenberg editor.
  *
  * @since 0.10.0
@@ -311,3 +323,4 @@ function gutenberg_register_rest_routes() {
 	$controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
+

--- a/lib/register.php
+++ b/lib/register.php
@@ -300,3 +300,14 @@ function gutenberg_add_gutenberg_post_state( $post_states, $post ) {
 	return $post_states;
 }
 add_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state', 10, 2 );
+
+/**
+ * Registers the REST API routes needed by the Gutenberg editor.
+ *
+ * @since 0.10.0
+ */
+function gutenberg_register_rest_routes() {
+	$controller = new WP_REST_Reusable_Blocks_Controller();
+	$controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );

--- a/phpunit/class-rest-reusable-blocks-controller-test.php
+++ b/phpunit/class-rest-reusable-blocks-controller-test.php
@@ -42,12 +42,6 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 			'post_status' => 'publish',
 			'post_name' => '2d66a5c5-776c-43b1-98c7-49521cef8ea6',
 			'post_title' => 'My cool block',
-			'meta_input' => array(
-				'_gutenberg_type' => 'core/paragraph',
-				'_gutenberg_attributes' => array(
-					'dropCap' => true,
-				),
-			),
 			'post_content' => '<p class="has-drop-cap">Hello!</p>',
 		) );
 
@@ -95,10 +89,6 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 			array(
 				'id' => '2d66a5c5-776c-43b1-98c7-49521cef8ea6',
 				'name' => 'My cool block',
-				'type' => 'core/paragraph',
-				'attributes' => array(
-					'dropCap' => true,
-				),
 				'content' => '<p class="has-drop-cap">Hello!</p>',
 			),
 		), $response->get_data() );
@@ -131,10 +121,6 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 		$this->assertEquals( array(
 			'id' => '2d66a5c5-776c-43b1-98c7-49521cef8ea6',
 			'name' => 'My cool block',
-			'type' => 'core/paragraph',
-			'attributes' => array(
-				'dropCap' => true,
-			),
 			'content' => '<p class="has-drop-cap">Hello!</p>',
 		), $response->get_data() );
 	}
@@ -190,10 +176,6 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 		$request = new WP_REST_Request( 'PUT', '/gutenberg/v1/reusable-blocks/75236553-f4ba-4f12-aa25-4ba402044bd5' );
 		$request->set_body_params( array(
 			'name' => 'Another cool block',
-			'type' => 'core/image',
-			'attributes' => array(
-				'id' => 42,
-			),
 			'content' => '<figure class="wp-block-image"><img src="/image.jpg" alt="An image" /></figure>',
 		) );
 
@@ -203,10 +185,6 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 		$this->assertEquals( array(
 			'id' => '75236553-f4ba-4f12-aa25-4ba402044bd5',
 			'name' => 'Another cool block',
-			'type' => 'core/image',
-			'attributes' => array(
-				'id' => 42,
-			),
 			'content' => '<figure class="wp-block-image"><img src="/image.jpg" alt="An image" /></figure>',
 		), $response->get_data() );
 	}
@@ -223,30 +201,6 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 
 		$this->assertEquals( 403, $response->get_status() );
 		$this->assertEquals( 'gutenberg_reusable_block_cannot_edit', $data['code'] );
-	}
-
-	/**
-	 * Check that we can PUT a single reusable block without specifying optional attributes.
-	 */
-	public function test_update_item_with_optional_attributes_not_specified() {
-		wp_set_current_user( self::$editor_id );
-
-		$request = new WP_REST_Request( 'PUT', '/gutenberg/v1/reusable-blocks/75236553-f4ba-4f12-aa25-4ba402044bd5' );
-		$request->set_body_params( array(
-			'name' => 'Another cool block',
-			'type' => 'core/image',
-		) );
-
-		$response = $this->server->dispatch( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id' => '75236553-f4ba-4f12-aa25-4ba402044bd5',
-			'name' => 'Another cool block',
-			'type' => 'core/image',
-			'attributes' => array(),
-			'content' => '',
-		), $response->get_data() );
 	}
 
 	/**
@@ -268,16 +222,16 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 			),
 			array(
 				array(
-					'name' => 'Another cool block',
+					'name' => 'My cool block',
 				),
-				'Invalid block type.',
+				'Invalid reusable block content.',
 			),
 			array(
 				array(
-					'name' => 'Another cool block',
-					'type' => 42,
+					'name' => 'My cool block',
+					'content' => 42,
 				),
-				'Invalid block type.',
+				'Invalid reusable block content.',
 			),
 		);
 	}
@@ -310,11 +264,9 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 5, count( $properties ) );
+		$this->assertEquals( 3, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
-		$this->assertArrayHasKey( 'type', $properties );
-		$this->assertArrayHasKey( 'attributes', $properties );
 		$this->assertArrayHasKey( 'content', $properties );
 	}
 

--- a/phpunit/class-rest-reusable-blocks-controller-test.php
+++ b/phpunit/class-rest-reusable-blocks-controller-test.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * WP_REST_Reusable_Blocks_Controller tests
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Tests for WP_REST_Reusable_Blocks_Controller.
+ */
+class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * Our fake reusable block's post ID.
+	 *
+	 * @var int
+	 */
+	protected static $reusable_block_post_id;
+
+	/**
+	 * Our fake editor's user ID.
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
+	 * Our fake subscriber's user ID.
+	 *
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$reusable_block_post_id = wp_insert_post( array(
+			'post_type' => 'gb_reusable_block',
+			'post_status' => 'publish',
+			'post_name' => '2d66a5c5-776c-43b1-98c7-49521cef8ea6',
+			'post_title' => 'My cool block',
+			'meta_input' => array(
+				'_gutenberg_type' => 'core/paragraph',
+				'_gutenberg_attributes' => array(
+					'dropCap' => true,
+				),
+			),
+			'post_content' => '<p class="has-drop-cap">Hello!</p>',
+		) );
+
+		self::$editor_id = $factory->user->create( array(
+			'role' => 'editor',
+		) );
+		self::$subscriber_id = $factory->user->create( array(
+			'role' => 'subscriber',
+		) );
+	}
+
+	/**
+	 * Delete our fake data after our tests run.
+	 */
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$reusable_block_post_id );
+
+		self::delete_user( self::$editor_id );
+		self::delete_user( self::$subscriber_id );
+	}
+
+	/**
+	 * Check that our routes get set up properly.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/gutenberg/v1/reusable-blocks', $routes );
+		$this->assertCount( 1, $routes['/gutenberg/v1/reusable-blocks'] );
+		$this->assertArrayHasKey( '/gutenberg/v1/reusable-blocks/(?P<id>[\w-]+)', $routes );
+		$this->assertCount( 2, $routes['/gutenberg/v1/reusable-blocks/(?P<id>[\w-]+)'] );
+	}
+
+	/**
+	 * Check that we can GET a collection of reusable blocks.
+	 */
+	public function test_get_items() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/reusable-blocks' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array(
+			array(
+				'id' => '2d66a5c5-776c-43b1-98c7-49521cef8ea6',
+				'name' => 'My cool block',
+				'type' => 'core/paragraph',
+				'attributes' => array(
+					'dropCap' => true,
+				),
+				'content' => '<p class="has-drop-cap">Hello!</p>',
+			),
+		), $response->get_data() );
+	}
+
+	/**
+	 * Check that users without permission can't GET a collection of reusable blocks.
+	 */
+	public function test_get_items_when_not_allowed() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/reusable-blocks' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'gutenberg_reusable_block_cannot_read', $data['code'] );
+	}
+
+	/**
+	 * Check that we can GET a single reusable block.
+	 */
+	public function test_get_item() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/reusable-blocks/2d66a5c5-776c-43b1-98c7-49521cef8ea6' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array(
+			'id' => '2d66a5c5-776c-43b1-98c7-49521cef8ea6',
+			'name' => 'My cool block',
+			'type' => 'core/paragraph',
+			'attributes' => array(
+				'dropCap' => true,
+			),
+			'content' => '<p class="has-drop-cap">Hello!</p>',
+		), $response->get_data() );
+	}
+
+	/**
+	 * Check that users without permission can't GET a single reusable block.
+	 */
+	public function test_get_item_when_not_allowed() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/reusable-blocks/2d66a5c5-776c-43b1-98c7-49521cef8ea6' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'gutenberg_reusable_block_cannot_read', $data['code'] );
+	}
+
+	/**
+	 * Check that invalid UUIDs 404.
+	 */
+	public function test_get_item_invalid_id() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/reusable-blocks/invalid-uuid' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 'gutenberg_reusable_block_invalid_id', $data['code'] );
+	}
+
+	/**
+	 * Check that we get a 404 when we GET a non-existent reusable block.
+	 */
+	public function test_get_item_not_found() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'GET', '/gutenberg/v1/reusable-blocks/6e614ced-e80d-4e10-bd04-1e890b5f7f83' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 'gutenberg_reusable_block_not_found', $data['code'] );
+	}
+
+	/**
+	 * Check that we can PUT a single reusable block.
+	 */
+	public function test_update_item() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'PUT', '/gutenberg/v1/reusable-blocks/75236553-f4ba-4f12-aa25-4ba402044bd5' );
+		$request->set_body_params( array(
+			'name' => 'Another cool block',
+			'type' => 'core/image',
+			'attributes' => array(
+				'id' => 42,
+			),
+			'content' => '<figure class="wp-block-image"><img src="/image.jpg" alt="An image" /></figure>',
+		) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array(
+			'id' => '75236553-f4ba-4f12-aa25-4ba402044bd5',
+			'name' => 'Another cool block',
+			'type' => 'core/image',
+			'attributes' => array(
+				'id' => 42,
+			),
+			'content' => '<figure class="wp-block-image"><img src="/image.jpg" alt="An image" /></figure>',
+		), $response->get_data() );
+	}
+
+	/**
+	 * Check that users without permission can't PUT a single reusable block.
+	 */
+	public function test_update_item_when_not_allowed() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request = new WP_REST_Request( 'PUT', '/gutenberg/v1/reusable-blocks/2d66a5c5-776c-43b1-98c7-49521cef8ea6' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'gutenberg_reusable_block_cannot_edit', $data['code'] );
+	}
+
+	/**
+	 * Check that we can PUT a single reusable block without specifying optional attributes.
+	 */
+	public function test_update_item_with_optional_attributes_not_specified() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'PUT', '/gutenberg/v1/reusable-blocks/75236553-f4ba-4f12-aa25-4ba402044bd5' );
+		$request->set_body_params( array(
+			'name' => 'Another cool block',
+			'type' => 'core/image',
+		) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array(
+			'id' => '75236553-f4ba-4f12-aa25-4ba402044bd5',
+			'name' => 'Another cool block',
+			'type' => 'core/image',
+			'attributes' => array(),
+			'content' => '',
+		), $response->get_data() );
+	}
+
+	/**
+	 * Test cases for test_update_item_with_invalid_fields().
+	 *
+	 * @return array
+	 */
+	public function data_update_item_with_invalid_fields() {
+		return array(
+			array(
+				array(),
+				'Invalid reusable block name.',
+			),
+			array(
+				array(
+					'name' => 42,
+				),
+				'Invalid reusable block name.',
+			),
+			array(
+				array(
+					'name' => 'Another cool block',
+				),
+				'Invalid block type.',
+			),
+			array(
+				array(
+					'name' => 'Another cool block',
+					'type' => 42,
+				),
+				'Invalid block type.',
+			),
+		);
+	}
+
+	/**
+	 * Check that attributes are validated correctly when we PUT a single reusable block.
+	 *
+	 * @dataProvider data_update_item_with_invalid_fields
+	 */
+	public function test_update_item_with_invalid_fields( $body_params, $expected_message ) {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'PUT', '/gutenberg/v1/reusable-blocks/75236553-f4ba-4f12-aa25-4ba402044bd5' );
+		$request->set_body_params( $body_params );
+
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'gutenberg_reusable_block_invalid_field', $data['code'] );
+		$this->assertEquals( $expected_message, $data['message'] );
+	}
+
+	/**
+	 * Check that we have defined a JSON schema.
+	 */
+	public function test_get_item_schema() {
+		$request = new WP_REST_Request( 'OPTIONS', '/gutenberg/v1/reusable-blocks' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 5, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'type', $properties );
+		$this->assertArrayHasKey( 'attributes', $properties );
+		$this->assertArrayHasKey( 'content', $properties );
+	}
+
+	public function test_context_param() {
+		$this->markTestSkipped( 'Controller doesn\'t implement get_context_param().' );
+	}
+	public function test_create_item() {
+		$this->markTestSkipped( 'Controller doesn\'t implement create_item().' );
+	}
+	public function test_delete_item() {
+		$this->markTestSkipped( 'Controller doesn\'t implement delete_item().' );
+	}
+	public function test_prepare_item() {
+		$this->markTestSkipped( 'Controller doesn\'t implement prepare_item().' );
+	}
+}


### PR DESCRIPTION
Baby's first PR! 👶

This adds the REST API for creating, viewing and editing reusable blocks that @westonruter described in https://github.com/WordPress/gutenberg/issues/2081. This API will let us add the ability to turn a static block into a dynamic reusable block (see https://github.com/WordPress/gutenberg/issues/1516).

## What I did

The TL;DR of it all is:

- I'm adding a new post type named `gb_reusable_block`
- I'm adding three REST API endpoints:
    - `GET /wp-json/gutenberg/v1/reusable-blocks` - lists all reusable blocks
    - `GET /wp-json/gutenberg/v1/reusable-blocks/:uuid` - fetches a single reusable block
    - `PUT /wp-json/gutenberg/v1/reusable-blocks/:uuid` - creates or edits a reusable block
- A reusable block looks like this:  
  ```json
  {
    "id": "358b59ee-bab3-4d6f-8445-e8c6971a5605",
    "name": "My cool block",
    "content": "<!-- wp:core/paragraph -->\n<p>Hello <strong>World</strong>! How are you?</p>\n<!-- /wp:core/paragraph -->"
  }
  ```
  They're stored as posts with `post_type` set to `gb_reusable_block`.
  - `id` is stored in `post_name`
  - `name` is stored in `post_title`
  - `content` is stored in `post_content`

## How to test

OK. First, make sure you have the [JSON Basic Authentication](https://github.com/WP-API/Basic-Auth/blob/master/basic-auth.php) plugin installed, and that your test WordPress environment has pretty URLs enabled.

Now, you can create a block by hitting the `PUT` endpoint:

```
$ curl -v -X PUT --user admin:password -H 'Content-type: application/json' -d '{"content":"<!-- wp:core/paragraph -->\n<p>Hello!</p>\n<!-- /wp:core/paragraph -->","name":"My cool block"}' http://vagrant.local/wp-json/gutenberg/v1/reusable-blocks/358b59ee-bab3-4d6f-8445-e8c6971a5605
```

You'll likely want to change `admin:password` and `http://vagrant.local` to match your test WordPress environment. 

Now that our block is created, we can fetch it:

```
$ curl --user admin:password http://vagrant.local/wp-json/gutenberg/v1/reusable-blocks/358b59ee-bab3-4d6f-8445-e8c6971a5605
{"id":"358b59ee-bab3-4d6f-8445-e8c6971a5605","name":"My cool block","content":"<!-- wp:core/paragraph -->\n<p>Hello!</p>\n<!-- /wp:core/paragraph -->"}
```

We can also list all blocks:

```
$ curl --user admin:password http://vagrant.local/wp-json/gutenberg/v1/reusable-blocks
[{"id":"358b59ee-bab3-4d6f-8445-e8c6971a5605","name":"My cool block","content":"<!-- wp:core/paragraph -->\n<p>Hello!</p>\n<!-- /wp:core/paragraph -->"}]
```

Play around with creating, editing and reading a few different valid and invalid reusable blocks.

---

cc. @nb @mtias @westonruter 