### PR TITLE
Cover Image Block: Show inspector controls when no image is selected

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -73,34 +73,29 @@ registerBlockType( 'core/cover-image', {
 			'has-background-dim': hasBackgroundDim,
 		} );
 
-		const controls = (
-			focus && (
-				<BlockControls key="controls">
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ updateAlignment }
-					/>
+		const controls = focus && [
+			<BlockControls key="controls">
+				<BlockAlignmentToolbar
+					value={ align }
+					onChange={ updateAlignment }
+				/>
 
-					<Toolbar>
-						<li>
-							<MediaUploadButton
-								buttonProps={ {
-									className: 'components-icon-button components-toolbar__control',
-									'aria-label': __( 'Edit image' ),
-								} }
-								onSelect={ onSelectImage }
-								type="image"
-								value={ id }
-							>
-								<Dashicon icon="edit" />
-							</MediaUploadButton>
-						</li>
-					</Toolbar>
-				</BlockControls>
-			)
-		);
-
-		const inspectorControls = focus && (
+				<Toolbar>
+					<li>
+						<MediaUploadButton
+							buttonProps={ {
+								className: 'components-icon-button components-toolbar__control',
+								'aria-label': __( 'Edit image' ),
+							} }
+							onSelect={ onSelectImage }
+							type="image"
+							value={ id }
+						>
+							<Dashicon icon="edit" />
+						</MediaUploadButton>
+					</li>
+				</Toolbar>
+			</BlockControls>,
 			<InspectorControls key="inspector">
 				<BlockDescription>
 					<p>{ __( 'Cover Image is a bold image block with an optional title.' ) }</p>
@@ -116,14 +111,13 @@ registerBlockType( 'core/cover-image', {
 					checked={ !! hasBackgroundDim }
 					onChange={ toggleBackgroundDim }
 				/>
-			</InspectorControls>
-		);
+			</InspectorControls>,
+		];
 
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
 			return [
 				controls,
-				inspectorControls,
 				<Placeholder
 					key="placeholder"
 					instructions={ __( 'Drag image here or insert from media library' ) }
@@ -143,7 +137,6 @@ registerBlockType( 'core/cover-image', {
 
 		return [
 			controls,
-			inspectorControls,
 			<section
 				key="preview"
 				data-url={ url }

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -65,6 +65,13 @@ registerBlockType( 'core/cover-image', {
 		const { url, title, align, id, hasParallax, hasBackgroundDim } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const onSelectImage = ( media ) => setAttributes( { url: media.url, id: media.id } );
+		const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
+		const toggleBackgroundDim = () => setAttributes( { hasBackgroundDim: ! hasBackgroundDim } );
+		const style = { backgroundImage: `url(${ url })` };
+		const classes = classnames( className, {
+			'has-parallax': hasParallax,
+			'has-background-dim': hasBackgroundDim,
+		} );
 
 		const controls = (
 			focus && (
@@ -93,10 +100,30 @@ registerBlockType( 'core/cover-image', {
 			)
 		);
 
+		const inspectorControls = focus && (
+			<InspectorControls key="inspector">
+				<BlockDescription>
+					<p>{ __( 'Cover Image is a bold image block with an optional title.' ) }</p>
+				</BlockDescription>
+				<h3>{ __( 'Cover Image Settings' ) }</h3>
+				<ToggleControl
+					label={ __( 'Fixed Background' ) }
+					checked={ !! hasParallax }
+					onChange={ toggleParallax }
+				/>
+				<ToggleControl
+					label={ __( 'Dim Background' ) }
+					checked={ !! hasBackgroundDim }
+					onChange={ toggleBackgroundDim }
+				/>
+			</InspectorControls>
+		);
+
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
 			return [
 				controls,
+				inspectorControls,
 				<Placeholder
 					key="placeholder"
 					instructions={ __( 'Drag image here or insert from media library' ) }
@@ -114,34 +141,9 @@ registerBlockType( 'core/cover-image', {
 			];
 		}
 
-		const style = { backgroundImage: `url(${ url })` };
-		const classes = classnames( className, {
-			'has-parallax': hasParallax,
-			'has-background-dim': hasBackgroundDim,
-		} );
-		const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
-		const toggleBackgroundDim = () => setAttributes( { hasBackgroundDim: ! hasBackgroundDim } );
-
 		return [
 			controls,
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Cover Image is a bold image block with an optional title.' ) }</p>
-					</BlockDescription>
-					<h3>{ __( 'Cover Image Settings' ) }</h3>
-					<ToggleControl
-						label={ __( 'Fixed Background' ) }
-						checked={ !! hasParallax }
-						onChange={ toggleParallax }
-					/>
-					<ToggleControl
-						label={ __( 'Dim Background' ) }
-						checked={ !! hasBackgroundDim }
-						onChange={ toggleBackgroundDim }
-					/>
-				</InspectorControls>
-			),
+			inspectorControls,
 			<section
 				key="preview"
 				data-url={ url }

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -67,7 +67,9 @@ registerBlockType( 'core/cover-image', {
 		const onSelectImage = ( media ) => setAttributes( { url: media.url, id: media.id } );
 		const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
 		const toggleBackgroundDim = () => setAttributes( { hasBackgroundDim: ! hasBackgroundDim } );
-		const style = { backgroundImage: `url(${ url })` };
+		const style = url
+			? { backgroundImage: `url(${ url })` }
+			: undefined;
 		const classes = classnames( className, {
 			'has-parallax': hasParallax,
 			'has-background-dim': hasBackgroundDim,
@@ -160,9 +162,9 @@ registerBlockType( 'core/cover-image', {
 
 	save( { attributes, className } ) {
 		const { url, title, hasParallax, hasBackgroundDim } = attributes;
-		const style = {
-			backgroundImage: `url(${ url })`,
-		};
+		const style = url
+			? { backgroundImage: `url(${ url })` }
+			: undefined;
 		const classes = classnames( className, {
 			'has-parallax': hasParallax,
 			'has-background-dim': hasBackgroundDim,


### PR DESCRIPTION
closes #2485 

When you insert a Cover Image, you'll be able to tweak its inspector controls even if you didn't select an image yet.