### PR TITLE
Block API: consolidate the API to declare className and anchor support

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -40,7 +40,7 @@ export function createBlock( name, blockAttributes = {} ) {
 		return result;
 	}, {} );
 
-	if ( blockType.support && !! blockType.support.anchor && blockAttributes.anchor ) {
+	if ( blockType.supports && !! blockType.supports.anchor && blockAttributes.anchor ) {
 		attributes.anchor = blockAttributes.anchor;
 	}
 

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -39,7 +39,8 @@ export function createBlock( name, blockAttributes = {} ) {
 
 		return result;
 	}, {} );
-	if ( blockType.supportAnchor && blockAttributes.anchor ) {
+
+	if ( blockType.support && !! blockType.support.anchor && blockAttributes.anchor ) {
 		attributes.anchor = blockAttributes.anchor;
 	}
 

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -148,7 +148,7 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
 	}, {} );
 
 	// If the block supports anchor, parse the id
-	if ( blockType.supportAnchor ) {
+	if ( blockType.support && !! blockType.support.anchor ) {
 		blockAttributes.anchor = hpqParse( rawContent, attr( '*', 'id' ) );
 	}
 

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -148,7 +148,7 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
 	}, {} );
 
 	// If the block supports anchor, parse the id
-	if ( blockType.support && !! blockType.support.anchor ) {
+	if ( blockType.supports && !! blockType.supports.anchor ) {
 		blockAttributes.anchor = hpqParse( rawContent, attr( '*', 'id' ) );
 	}
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, isObject, castArray } from 'lodash';
+import { isEmpty, reduce, isObject, castArray, isUndefined, get } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 import classnames from 'classnames';
 
@@ -35,7 +35,7 @@ export function getBlockDefaultClassname( blockName ) {
  * @return {string}                          Save content
  */
 export function getSaveContent( blockType, attributes ) {
-	const { save, className = getBlockDefaultClassname( blockType.name ) } = blockType;
+	const { save, support } = blockType;
 	let rawContent;
 
 	if ( save.prototype instanceof Component ) {
@@ -56,16 +56,19 @@ export function getSaveContent( blockType, attributes ) {
 		}
 
 		const extraProps = {};
-		if ( !! className ) {
+		const supportGeneratedClassname = isUndefined( get( support, 'generatedClassname' ) ) || support.generatedClassname;
+		const supportCustomClassname = ( isUndefined( get( support, 'className' ) ) || support.className ) && attributes.className;
+		if ( supportGeneratedClassname || supportCustomClassname ) {
+			const generatedClassname = supportGeneratedClassname ? getBlockDefaultClassname( blockType.name ) : undefined;
 			const updatedClassName = classnames(
-				className,
+				generatedClassname,
 				element.props.className,
 				attributes.className
 			);
 			extraProps.className = updatedClassName;
 		}
 
-		if ( blockType.supportAnchor && attributes.anchor ) {
+		if ( support && !! support.anchor ) {
 			extraProps.id = attributes.anchor;
 		}
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -35,7 +35,7 @@ export function getBlockDefaultClassname( blockName ) {
  * @return {string}                          Save content
  */
 export function getSaveContent( blockType, attributes ) {
-	const { save, support } = blockType;
+	const { save, supports } = blockType;
 	let rawContent;
 
 	if ( save.prototype instanceof Component ) {
@@ -56,19 +56,19 @@ export function getSaveContent( blockType, attributes ) {
 		}
 
 		const extraProps = {};
-		const supportGeneratedClassname = isUndefined( get( support, 'generatedClassname' ) ) || support.generatedClassname;
-		const supportCustomClassname = ( isUndefined( get( support, 'className' ) ) || support.className ) && attributes.className;
+		const supportGeneratedClassname = isUndefined( get( supports, 'generatedClassName' ) ) || supports.generatedClassName;
+		const supportCustomClassname = ( isUndefined( get( supports, 'className' ) ) || supports.className ) && attributes.className;
 		if ( supportGeneratedClassname || supportCustomClassname ) {
-			const generatedClassname = supportGeneratedClassname ? getBlockDefaultClassname( blockType.name ) : undefined;
+			const generatedClassName = supportGeneratedClassname ? getBlockDefaultClassname( blockType.name ) : undefined;
 			const updatedClassName = classnames(
-				generatedClassname,
+				generatedClassName,
 				element.props.className,
 				attributes.className
 			);
 			extraProps.className = updatedClassName;
 		}
 
-		if ( support && !! support.anchor ) {
+		if ( supports && !! supports.anchor ) {
 			extraProps.id = attributes.anchor;
 		}
 

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -64,7 +64,9 @@ describe( 'block factory', () => {
 				},
 				save: noop,
 				category: 'common',
-				supportAnchor: true,
+				support: {
+					anchor: true,
+				},
 			} );
 			const block = createBlock( 'core/test-block', {
 				align: 'left',

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -64,7 +64,7 @@ describe( 'block factory', () => {
 				},
 				save: noop,
 				category: 'common',
-				support: {
+				supports: {
 					anchor: true,
 				},
 			} );

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -164,7 +164,9 @@ describe( 'block parser', () => {
 						source: text( 'div' ),
 					},
 				},
-				supportAnchor: true,
+				support: {
+					anchor: true,
+				},
 			};
 
 			const rawContent = '<div id="chicken">Ribs</div>';

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -164,7 +164,7 @@ describe( 'block parser', () => {
 						source: text( 'div' ),
 					},
 				},
-				support: {
+				supports: {
 					anchor: true,
 				},
 			};

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -69,27 +69,13 @@ describe( 'block serializer', () => {
 				expect( saved ).toBe( '<div class="wp-block-myplugin-fruit">Bananas</div>' );
 			} );
 
-			it( 'should allow overriding the className', () => {
-				const saved = getSaveContent(
-					{
-						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
-						name: 'myplugin/fruit',
-						className: 'apples',
-					},
-					{ fruit: 'Bananas' }
-				);
-
-				expect( saved ).toBe( '<div class="apples">Bananas</div>' );
-			} );
-
-			it( 'should include additional classes in block attributes', () => {
+			it( 'should include generated class in block attributes', () => {
 				const saved = getSaveContent(
 					{
 						save: ( { attributes } ) => createElement( 'div', {
 							className: 'fruit',
 						}, attributes.fruit ),
 						name: 'myplugin/fruit',
-						className: 'apples',
 					},
 					{
 						fruit: 'Bananas',
@@ -97,7 +83,7 @@ describe( 'block serializer', () => {
 					}
 				);
 
-				expect( saved ).toBe( '<div class="apples fruit fresh">Bananas</div>' );
+				expect( saved ).toBe( '<div class="wp-block-myplugin-fruit fruit fresh">Bananas</div>' );
 			} );
 
 			it( 'should not add a className if falsy', () => {
@@ -105,7 +91,9 @@ describe( 'block serializer', () => {
 					{
 						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 						name: 'myplugin/fruit',
-						className: false,
+						support: {
+							generatedClassname: false,
+						},
 					},
 					{ fruit: 'Bananas' }
 				);
@@ -117,9 +105,11 @@ describe( 'block serializer', () => {
 				const saved = getSaveContent(
 					{
 						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
-						supportAnchor: true,
 						name: 'myplugin/fruit',
-						className: false,
+						support: {
+							generatedClassname: false,
+							anchor: true,
+						},
 					},
 					{ fruit: 'Bananas', anchor: 'my-fruit' }
 				);

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -91,8 +91,8 @@ describe( 'block serializer', () => {
 					{
 						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 						name: 'myplugin/fruit',
-						support: {
-							generatedClassname: false,
+						supports: {
+							generatedClassName: false,
 						},
 					},
 					{ fruit: 'Bananas' }
@@ -106,8 +106,8 @@ describe( 'block serializer', () => {
 					{
 						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 						name: 'myplugin/fruit',
-						support: {
-							generatedClassname: false,
+						supports: {
+							generatedClassName: false,
 							anchor: true,
 						},
 					},

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -27,9 +27,10 @@ registerBlockType( 'core/heading', {
 
 	keywords: [ __( 'title' ), __( 'subtitle' ) ],
 
-	className: false,
-
-	supportAnchor: true,
+	support: {
+		generatedClassname: false,
+		anchor: true,
+	},
 
 	attributes: {
 		content: {

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -27,8 +27,8 @@ registerBlockType( 'core/heading', {
 
 	keywords: [ __( 'title' ), __( 'subtitle' ) ],
 
-	support: {
-		generatedClassname: false,
+	supports: {
+		generatedClassName: false,
 		anchor: true,
 	},
 

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -25,8 +25,8 @@ registerBlockType( 'core/html', {
 
 	category: 'formatting',
 
-	support: {
-		generatedClassname: false,
+	supports: {
+		generatedClassName: false,
 		className: false,
 	},
 

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -25,7 +25,10 @@ registerBlockType( 'core/html', {
 
 	category: 'formatting',
 
-	className: false,
+	support: {
+		generatedClassname: false,
+		className: false,
+	},
 
 	attributes: {
 		content: {

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -92,7 +92,9 @@ registerBlockType( 'core/list', {
 		},
 	},
 
-	className: false,
+	support: {
+		generatedClassname: false,
+	},
 
 	transforms: {
 		from: [

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -92,8 +92,8 @@ registerBlockType( 'core/list', {
 		},
 	},
 
-	support: {
-		generatedClassname: false,
+	supports: {
+		generatedClassName: false,
 	},
 
 	transforms: {

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -21,7 +21,10 @@ registerBlockType( 'core/more', {
 
 	useOnce: true,
 
-	className: false,
+	support: {
+		generatedClassname: false,
+		className: false,
+	},
 
 	attributes: {
 		text: {

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -21,8 +21,8 @@ registerBlockType( 'core/more', {
 
 	useOnce: true,
 
-	support: {
-		generatedClassname: false,
+	supports: {
+		generatedClassName: false,
 		className: false,
 	},
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -31,7 +31,9 @@ registerBlockType( 'core/paragraph', {
 
 	keywords: [ __( 'text' ) ],
 
-	className: false,
+	support: {
+		generatedClassname: false,
+	},
 
 	attributes: {
 		content: {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -31,8 +31,8 @@ registerBlockType( 'core/paragraph', {
 
 	keywords: [ __( 'text' ) ],
 
-	support: {
-		generatedClassname: false,
+	supports: {
+		generatedClassName: false,
 	},
 
 	attributes: {

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -28,7 +28,10 @@ registerBlockType( 'core/shortcode', {
 		},
 	},
 
-	className: false,
+	support: {
+		generatedClassname: false,
+		className: false,
+	},
 
 	edit: withInstanceId(
 		( { attributes, setAttributes, instanceId, focus } ) => {

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -28,8 +28,8 @@ registerBlockType( 'core/shortcode', {
 		},
 	},
 
-	support: {
-		generatedClassname: false,
+	supports: {
+		generatedClassName: false,
 		className: false,
 	},
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { Slot } from 'react-slot-fill';
-import { partial } from 'lodash';
+import { partial, isUndefined, get } from 'lodash';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
@@ -317,8 +317,16 @@ class VisualEditorBlock extends Component {
 		}
 
 		// Generate a class name for the block's editable form
-		let { className = getBlockDefaultClassname( block.name ) } = blockType;
-		className = classnames( className, block.attributes.className );
+		let className;
+		const supportGeneratedClassname = isUndefined( get( blockType.support, 'generatedClassname' ) ) || blockType.support.generatedClassname;
+		const supportCustomClassname = ( isUndefined( get( blockType.support, 'className' ) ) || blockType.support.className ) && block.attributes.className;
+		if ( supportGeneratedClassname || supportCustomClassname ) {
+			const generatedClassname = supportGeneratedClassname ? getBlockDefaultClassname( blockType.name ) : undefined;
+			className = classnames(
+				generatedClassname,
+				block.attributes.className
+			);
+		}
 
 		// Disable reason: Each block can be selected by clicking on it
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -318,12 +318,12 @@ class VisualEditorBlock extends Component {
 
 		// Generate a class name for the block's editable form
 		let className;
-		const supportGeneratedClassname = isUndefined( get( blockType.support, 'generatedClassname' ) ) || blockType.support.generatedClassname;
-		const supportCustomClassname = ( isUndefined( get( blockType.support, 'className' ) ) || blockType.support.className ) && block.attributes.className;
+		const supportGeneratedClassname = isUndefined( get( blockType.supports, 'generatedClassName' ) ) || blockType.supports.generatedClassName;
+		const supportCustomClassname = ( isUndefined( get( blockType.supports, 'className' ) ) || blockType.supports.className ) && block.attributes.className;
 		if ( supportGeneratedClassname || supportCustomClassname ) {
-			const generatedClassname = supportGeneratedClassname ? getBlockDefaultClassname( blockType.name ) : undefined;
+			const generatedClassName = supportGeneratedClassname ? getBlockDefaultClassname( blockType.name ) : undefined;
 			className = classnames(
-				generatedClassname,
+				generatedClassName,
 				block.attributes.className
 			);
 		}

--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { isUndefined, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -64,20 +65,22 @@ class BlockInspectorAdvancedControls extends Component {
 	render() {
 		const { selectedBlock, post } = this.props;
 		const blockType = getBlockType( selectedBlock.name );
-		if ( false === blockType.className && ! blockType.supportAnchor ) {
+		const supportAnchor = blockType.support && !! blockType.support.anchor;
+		const supportCustomClassname = isUndefined( get( blockType, 'support.className' ) ) || blockType.support.className;
+		if ( ! supportAnchor && ! supportCustomClassname ) {
 			return null;
 		}
 
 		return (
 			<div>
 				<h3>{ __( 'Block Settings' ) }</h3>
-				{ false !== blockType.className &&
+				{ supportCustomClassname &&
 					<InspectorControls.TextControl
 						label={ __( 'Additional CSS Class' ) }
 						value={ selectedBlock.attributes.className || '' }
 						onChange={ this.setClassName } />
 				}
-				{ blockType.supportAnchor &&
+				{ supportAnchor &&
 					<div>
 						<InspectorControls.TextControl
 							label={ __( 'HTML Anchor' ) }

--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -65,8 +65,8 @@ class BlockInspectorAdvancedControls extends Component {
 	render() {
 		const { selectedBlock, post } = this.props;
 		const blockType = getBlockType( selectedBlock.name );
-		const supportAnchor = blockType.support && !! blockType.support.anchor;
-		const supportCustomClassname = isUndefined( get( blockType, 'support.className' ) ) || blockType.support.className;
+		const supportAnchor = blockType.support && !! blockType.supports.anchor;
+		const supportCustomClassname = isUndefined( get( blockType, 'supports.className' ) ) || blockType.supports.className;
 		if ( ! supportAnchor && ! supportCustomClassname ) {
 			return null;
 		}


### PR DESCRIPTION
related to #2035

This exposes the current property in the blockAPI:

```js
const block = {
   // ...
   support: {
      generatedClassname: false // automatically generate a wrapper's classname (default: true)
      className: false // allow adding a custom className using the inspector (default: true)
      anchor: true, // allow adding an anchor (default: false)
   }
};
```

Instead of the current `className` and `supportAnchor`.

This also splits `className` attribute into two `generatedClassname` and `className`. I did this because it makes sense to allow a custom classname for some blocks without generating an automattic one. For example: paragraphs, heading, lists