### PR TITLE
Paragraph Block: Fix Applying and clearing colors

### DIFF
--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -32,6 +32,7 @@ export default class TinyMCE extends Component {
 		}
 
 		if ( ! isEqual( this.props.style, nextProps.style ) ) {
+			this.editorNode.style = {};
 			Object.assign( this.editorNode.style, nextProps.style );
 		}
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -127,13 +127,13 @@ registerBlockType( 'core/paragraph', {
 					<h3>{ __( 'Background Color' ) }</h3>
 					<ColorPalette
 						value={ backgroundColor }
-						onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue.hex } ) }
+						onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
 						withTransparentOption
 					/>
 					<h3>{ __( 'Text Color' ) }</h3>
 					<ColorPalette
 						value={ textColor }
-						onChange={ ( colorValue ) => setAttributes( { textColor: colorValue.hex } ) }
+						onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
 					/>
 					<h3>{ __( 'Block Alignment' ) }</h3>
 					<BlockAlignmentToolbar


### PR DESCRIPTION
This PR fixes two things:

 - Applying colors was broken because of a merge
 - Fixes updating the TinyMCE component style