### PR TITLE
Blocks: Preserve unknown block, remove freeform block comment delimiters

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -11,6 +11,7 @@ import { parse as grammarParse } from './post.pegjs';
 import { getBlockType, getUnknownTypeHandlerName } from './registration';
 import { createBlock } from './factory';
 import { isValidBlock } from './validation';
+import { getCommentDelimitedContent } from './serializer';
 
 /**
  * Returns true if the provided function is a valid attribute source, or false
@@ -177,6 +178,12 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
 	let blockType = getBlockType( name );
 	const fallbackBlock = getUnknownTypeHandlerName();
 	if ( ! blockType ) {
+		// If detected as a block which is not registered, preserve comment
+		// delimiters in content of unknown type handler.
+		if ( name ) {
+			rawContent = getCommentDelimitedContent( name, attributes, rawContent );
+		}
+
 		name = fallbackBlock;
 		blockType = getBlockType( name );
 	}

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -139,6 +139,30 @@ export function getBeautifulContent( content ) {
 	} );
 }
 
+/**
+ * Returns the content of a block, including comment delimiters.
+ *
+ * @param  {String} blockName  Block name
+ * @param  {Object} attributes Block attributes
+ * @param  {String} content    Block save content
+ * @return {String}            Comment-delimited block content
+ */
+export function getCommentDelimitedContent( blockName, attributes, content ) {
+	const serializedAttributes = ! isEmpty( attributes )
+		? serializeAttributes( attributes ) + ' '
+		: '';
+
+	if ( ! content ) {
+		return `<!-- wp:${ blockName } ${ serializedAttributes }/-->`;
+	}
+
+	return (
+		`<!-- wp:${ blockName } ${ serializedAttributes }-->\n` +
+		getBeautifulContent( content ) +
+		`\n<!-- /wp:${ blockName } -->`
+	);
+}
+
 export function serializeBlock( block ) {
 	const blockName = block.name;
 	const blockType = getBlockType( blockName );
@@ -158,19 +182,7 @@ export function serializeBlock( block ) {
 		return `<!--more${ saveAttributes.text ? ` ${ saveAttributes.text }` : '' }-->${ saveAttributes.noTeaser ? '\n<!--noteaser-->' : '' }`;
 	}
 
-	const serializedAttributes = ! isEmpty( saveAttributes )
-		? serializeAttributes( saveAttributes ) + ' '
-		: '';
-
-	if ( ! saveContent ) {
-		return `<!-- wp:${ blockName } ${ serializedAttributes }/-->`;
-	}
-
-	return (
-		`<!-- wp:${ blockName } ${ serializedAttributes }-->\n` +
-		getBeautifulContent( saveContent ) +
-		`\n<!-- /wp:${ blockName } -->`
-	);
+	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
 }
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -13,7 +13,7 @@ import { Component, createElement, renderToString, cloneElement, Children } from
 /**
  * Internal dependencies
  */
-import { getBlockType } from './registration';
+import { getBlockType, getUnknownTypeHandlerName } from './registration';
 
 /**
  * Returns the block's default classname from its name
@@ -163,6 +163,13 @@ export function getCommentDelimitedContent( blockName, attributes, content ) {
 	);
 }
 
+/**
+ * Returns the content of a block, including comment delimiters, determining
+ * serialized attributes and content form from the current state of the block.
+ *
+ * @param  {Object} block Block instance
+ * @return {String}       Serialized block
+ */
 export function serializeBlock( block ) {
 	const blockName = block.name;
 	const blockType = getBlockType( blockName );
@@ -178,11 +185,17 @@ export function serializeBlock( block ) {
 
 	const saveAttributes = getCommentAttributes( block.attributes, blockType.attributes );
 
-	if ( 'core/more' === blockName ) {
-		return `<!--more${ saveAttributes.text ? ` ${ saveAttributes.text }` : '' }-->${ saveAttributes.noTeaser ? '\n<!--noteaser-->' : '' }`;
-	}
+	switch ( blockName ) {
+		case 'core/more':
+			const { text, noTeaser } = saveAttributes;
+			return `<!--more${ text ? ` ${ text }` : '' }-->${ noTeaser ? '\n<!--noteaser-->' : '' }`;
 
-	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
+		case getUnknownTypeHandlerName():
+			return saveContent;
+
+		default:
+			return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
+	}
 }
 
 /**

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -199,7 +199,19 @@ describe( 'block parser', () => {
 		} );
 
 		it( 'should fall back to the unknown type handler for unknown blocks if present', () => {
-			registerBlockType( 'core/unknown-block', defaultBlockSettings );
+			registerBlockType( 'core/unknown-block', {
+				category: 'common',
+				attributes: {
+					content: {
+						type: 'string',
+						source: html(),
+					},
+					fruit: {
+						type: 'string',
+					},
+				},
+				save: ( { attributes } ) => attributes.content,
+			} );
 			setUnknownTypeHandlerName( 'core/unknown-block' );
 
 			const block = createBlockWithFallback(
@@ -207,8 +219,9 @@ describe( 'block parser', () => {
 				'content',
 				{ fruit: 'Bananas' }
 			);
-			expect( block.name ).toEqual( 'core/unknown-block' );
-			expect( block.attributes ).toEqual( { fruit: 'Bananas' } );
+			expect( block.name ).toBe( 'core/unknown-block' );
+			expect( block.attributes.fruit ).toBe( 'Bananas' );
+			expect( block.attributes.content ).toContain( 'core/test-block' );
 		} );
 
 		it( 'should fall back to the unknown type handler if block type not specified', () => {

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -12,6 +12,7 @@ import serialize, {
 	getBeautifulContent,
 	getSaveContent,
 	serializeAttributes,
+	getCommentDelimitedContent,
 } from '../serializer';
 import { getBlockTypes, registerBlockType, unregisterBlockType } from '../registration';
 import { createBlock } from '../';
@@ -207,6 +208,52 @@ describe( 'block serializer', () => {
 		} );
 		it( 'should not break standard-non-compliant tools for "&"', () => {
 			expect( serializeAttributes( { a: '& and &' } ) ).toBe( '{"a":"\\u0026 and \\u0026"}' );
+		} );
+	} );
+
+	describe( 'getCommentDelimitedContent()', () => {
+		it( 'should generate empty attributes void', () => {
+			const content = getCommentDelimitedContent(
+				'core/test-block',
+				{},
+				''
+			);
+
+			expect( content ).toBe( '<!-- wp:core/test-block /-->' );
+		} );
+
+		it( 'should generate empty attributes non-void', () => {
+			const content = getCommentDelimitedContent(
+				'core/test-block',
+				{},
+				'Delicious'
+			);
+
+			expect( content ).toBe( '<!-- wp:core/test-block -->\nDelicious\n<!-- /wp:core/test-block -->' );
+		} );
+
+		it( 'should generate non-empty attributes void', () => {
+			const content = getCommentDelimitedContent(
+				'core/test-block',
+				{ fruit: 'Banana' },
+				''
+			);
+
+			expect( content ).toBe(
+				'<!-- wp:core/test-block {"fruit":"Banana"} /-->'
+			);
+		} );
+
+		it( 'should generate non-empty attributes non-void', () => {
+			const content = getCommentDelimitedContent(
+				'core/test-block',
+				{ fruit: 'Banana' },
+				'Delicious'
+			);
+
+			expect( content ).toBe(
+				'<!-- wp:core/test-block {"fruit":"Banana"} -->\nDelicious\n<!-- /wp:core/test-block -->'
+			);
 		} );
 	} );
 

--- a/blocks/test/fixtures/core__audio.parsed.json
+++ b/blocks/test/fixtures/core__audio.parsed.json
@@ -2,7 +2,7 @@
     {
         "blockName": "core/audio",
         "attrs": {
-        	"align": "right"
+            "align": "right"
         },
         "rawContent": "\n<div class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</div>\n"
     },

--- a/blocks/test/fixtures/core__freeform.serialized.html
+++ b/blocks/test/fixtures/core__freeform.serialized.html
@@ -1,6 +1,4 @@
-<!-- wp:core/freeform -->
 Testing freeform block with some
 <div class="wp-some-class">
-    HTML <span style="color: red;">content</span>
+	HTML <span style="color: red;">content</span>
 </div>
-<!-- /wp:core/freeform -->


### PR DESCRIPTION
Closes #2126
Closes #1735

This pull request seeks to resolve issues where content parsed as block, but of an unrecognized type, is not preserved (specifically, its comment delimiters and serialized comment attributes). In the course of doing so, this pull request also removes the freeform comment delimiters from saved content, under the assumption that it would parse again into a freeform block at the next parse anyways.

__Testing instructions:__

Verify that posts with unknown types parse with the content respected. Try inserting the following in either the Gutenberg or current editor's Text mode:

```html
<!-- wp:core/paragraph -->
<p>ajsdf</p>
<!-- /wp:core/paragraph -->

<!-- wp:core/unknown /-->

Freeform

<!-- wp:core/unknown {"foo":"bar"} -->
a
<!-- /wp:core/unknown -->
```

Previously this would destroy the void unknown block, and convert the last unknown block to freeform block without comment delimiters.

When switching to Text mode or saving the post with the above content, note that subsequent reserializations respect the markup exactly as it is shown above.

__Open questions:__

Because Freeform renders a TinyMCE, it is very easy to mistakenly edit the content of an unknown block type. I'm wondering if we ought to either create a separate block representation for un-blocked content vs. block content of an unknown type (e.g. since-disabled plugins blocks).

Alternatively, or in either case, we may want to convey messaging to the user about the unknown block instead of providing them the option to edit.