### PR TITLE
update/2495: Allow updating the tinymce version in one place

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -203,23 +203,24 @@ function gutenberg_register_vendor_scripts() {
 		'https://unpkg.com/moment@2.18.1/' . $moment_script,
 		array( 'react' )
 	);
+	$tinymce_version = '4.6.5';
 	gutenberg_register_vendor_script(
 		'tinymce-latest',
-		'https://fiddle.azurewebsites.net/tinymce/4.6.5/tinymce' . $suffix . '.js'
+		'https://fiddle.azurewebsites.net/tinymce/' . $tinymce_version . '/tinymce' . $suffix . '.js'
 	);
 	gutenberg_register_vendor_script(
 		'tinymce-latest-lists',
-		'https://fiddle.azurewebsites.net/tinymce/4.6.5/plugins/lists/plugin' . $suffix . '.js',
+		'https://fiddle.azurewebsites.net/tinymce/' . $tinymce_version . '/plugins/lists/plugin' . $suffix . '.js',
 		array( 'tinymce-latest' )
 	);
 	gutenberg_register_vendor_script(
 		'tinymce-latest-paste',
-		'https://fiddle.azurewebsites.net/tinymce/4.6.5/plugins/paste/plugin' . $suffix . '.js',
+		'https://fiddle.azurewebsites.net/tinymce/' . $tinymce_version . '/plugins/paste/plugin' . $suffix . '.js',
 		array( 'tinymce-latest' )
 	);
 	gutenberg_register_vendor_script(
 		'tinymce-latest-table',
-		'https://fiddle.azurewebsites.net/tinymce/4.6.5/plugins/table/plugin' . $suffix . '.js',
+		'https://fiddle.azurewebsites.net/tinymce/' . $tinymce_version . '/plugins/table/plugin' . $suffix . '.js',
 		array( 'tinymce-latest' )
 	);
 	gutenberg_register_vendor_script(


### PR DESCRIPTION
Gutenberg recently switched to using a versioned copy of TinyMCE rather than nightly.
It makes sense to put the version number in one place so mistakes are not made updating the version.