### PR TITLE
Add embed keyword to custom HTML block

### DIFF
--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -25,6 +25,8 @@ registerBlockType( 'core/html', {
 
 	category: 'formatting',
 
+	keywords: [ __( 'embed' ) ],
+
 	className: false,
 
 	attributes: {


### PR DESCRIPTION
See #2505.

The block can handle iframes too, though we might want to check if the user is an admin.