### PR TITLE
Author: Show only users capable of authoring posts

### DIFF
--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelRow, withInstanceId } from '@wordpress/components';
+import { PanelRow, withAPIData, withInstanceId } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 
 /**
@@ -18,38 +19,13 @@ import { getEditedPostAttribute } from '../../selectors';
 import { editPost } from '../../actions';
 
 class PostAuthor extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			authors: [],
-		};
-	}
-
-	fetchAuthors() {
-		this.fetchAuthorsRequest = new wp.api.collections.Users().fetch( { data: {
-			per_page: 100,
-		} } );
-		this.fetchAuthorsRequest.then( ( authors ) => {
-			this.setState( { authors } );
-		} );
-	}
-
-	componentDidMount() {
-		this.fetchAuthors();
-	}
-
-	componentWillUnmount() {
-		this.fetchAuthorsRequest.abort();
-	}
-
 	render() {
-		const { onUpdateAuthor, postAuthor, instanceId } = this.props;
-		const { authors } = this.state;
-		const selectId = 'post-author-selector-' + instanceId;
-
-		if ( authors.length < 2 ) {
+		const { users, onUpdateAuthor, postAuthor, instanceId } = this.props;
+		if ( ! users.data || users.data.length < 2 ) {
 			return null;
 		}
+
+		const selectId = 'post-author-selector-' + instanceId;
 
 		// Disable reason: A select with an onchange throws a warning
 
@@ -63,7 +39,7 @@ class PostAuthor extends Component {
 					onChange={ ( event ) => onUpdateAuthor( event.target.value ) }
 					className="editor-post-author__select"
 				>
-					{ authors.map( ( author ) => (
+					{ users.data.map( ( author ) => (
 						<option key={ author.id } value={ author.id }>{ author.name }</option>
 					) ) }
 				</select>
@@ -73,7 +49,7 @@ class PostAuthor extends Component {
 	}
 }
 
-export default connect(
+const applyConnect = connect(
 	( state ) => {
 		return {
 			postAuthor: getEditedPostAttribute( state, 'author' ),
@@ -84,4 +60,16 @@ export default connect(
 			return editPost( { author } );
 		},
 	},
-)( withInstanceId( PostAuthor ) );
+);
+
+const applyWithAPIData = withAPIData( () => {
+	return {
+		users: '/wp/v2/users?context=edit&per_page=100',
+	};
+} );
+
+export default flowRight( [
+	applyConnect,
+	applyWithAPIData,
+	withInstanceId,
+] )( PostAuthor );

--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -19,8 +19,20 @@ import { getEditedPostAttribute } from '../../selectors';
 import { editPost } from '../../actions';
 
 class PostAuthor extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.setAuthorId = this.setAuthorId.bind( this );
+	}
+
+	setAuthorId( event ) {
+		const { onUpdateAuthor } = this.props;
+		const { value } = event.target;
+		onUpdateAuthor( Number( value ) );
+	}
+
 	render() {
-		const { users, onUpdateAuthor, postAuthor, instanceId } = this.props;
+		const { users, postAuthor, instanceId } = this.props;
 		if ( ! users.data || users.data.length < 2 ) {
 			return null;
 		}
@@ -36,7 +48,7 @@ class PostAuthor extends Component {
 				<select
 					id={ selectId }
 					value={ postAuthor }
-					onChange={ ( event ) => onUpdateAuthor( event.target.value ) }
+					onChange={ this.setAuthorId }
 					className="editor-post-author__select"
 				>
 					{ users.data.map( ( author ) => (

--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
+import { filter, flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -31,12 +31,25 @@ class PostAuthor extends Component {
 		onUpdateAuthor( Number( value ) );
 	}
 
+	getAuthors() {
+		// While User Levels are officially deprecated, the behavior of the
+		// existing users dropdown on `who=authors` tests `user_level != 0`
+		//
+		// See: https://github.com/WordPress/WordPress/blob/a193916/wp-includes/class-wp-user-query.php#L322-L327
+		// See: https://codex.wordpress.org/Roles_and_Capabilities#User_Levels
+		const { users } = this.props;
+		return filter( users.data, ( user ) => {
+			return user.capabilities.level_1;
+		} );
+	}
+
 	render() {
-		const { users, postAuthor, instanceId } = this.props;
-		if ( ! users.data || users.data.length < 2 ) {
+		const authors = this.getAuthors();
+		if ( authors.length < 2 ) {
 			return null;
 		}
 
+		const { postAuthor, instanceId } = this.props;
 		const selectId = 'post-author-selector-' + instanceId;
 
 		// Disable reason: A select with an onchange throws a warning
@@ -51,7 +64,7 @@ class PostAuthor extends Component {
 					onChange={ this.setAuthorId }
 					className="editor-post-author__select"
 				>
-					{ users.data.map( ( author ) => (
+					{ authors.map( ( author ) => (
 						<option key={ author.id } value={ author.id }>{ author.name }</option>
 					) ) }
 				</select>

--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -18,7 +18,7 @@ import './style.scss';
 import { getEditedPostAttribute } from '../../selectors';
 import { editPost } from '../../actions';
 
-class PostAuthor extends Component {
+export class PostAuthor extends Component {
 	constructor() {
 		super( ...arguments );
 

--- a/editor/sidebar/post-author/test/index.js
+++ b/editor/sidebar/post-author/test/index.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostAuthor } from '../';
+
+describe( 'PostAuthor', () => {
+	const users = {
+		data: [
+			{
+				id: 1,
+				name: 'admin',
+				capabilities: {
+					level_1: true,
+				},
+			},
+			{
+				id: 2,
+				name: 'subscriber',
+				capabilities: {
+					level_0: true,
+				},
+			},
+			{
+				id: 3,
+				name: 'andrew',
+				capabilities: {
+					level_1: true,
+				},
+			},
+		],
+	};
+
+	describe( '#getAuthors()', () => {
+		it( 'returns empty array on unknown users', () => {
+			const wrapper = shallow( <PostAuthor users={ {} } /> );
+
+			const authors = wrapper.instance().getAuthors();
+
+			expect( authors ).toEqual( [] );
+		} );
+
+		it( 'filters users to authors', () => {
+			const wrapper = shallow( <PostAuthor users={ users } /> );
+
+			const authors = wrapper.instance().getAuthors();
+
+			expect( authors.map( ( author ) => author.id ).sort() ).toEqual( [ 1, 3 ] );
+		} );
+	} );
+
+	describe( '#render()', () => {
+		it( 'should not render anything if users unknown', () => {
+			const wrapper = shallow( <PostAuthor users={ {} } /> );
+
+			expect( wrapper.type() ).toBe( null );
+		} );
+
+		it( 'should not render anything if single user', () => {
+			const wrapper = shallow(
+				<PostAuthor users={ { data: users.data.slice( 0, 1 ) } } />
+			);
+
+			expect( wrapper.type() ).toBe( null );
+		} );
+
+		it( 'should not render anything if single filtered user', () => {
+			const wrapper = shallow(
+				<PostAuthor users={ { data: users.data.slice( 0, 2 ) } } />
+			);
+
+			expect( wrapper.type() ).toBe( null );
+		} );
+
+		it( 'should render select control', () => {
+			const wrapper = shallow( <PostAuthor users={ users } /> );
+
+			expect( wrapper.find( 'select' ).length ).not.toBe( 0 );
+		} );
+
+		it( 'should update author', () => {
+			const onUpdateAuthor = jest.fn();
+			const wrapper = shallow(
+				<PostAuthor
+					users={ users }
+					onUpdateAuthor={ onUpdateAuthor } />
+			);
+
+			wrapper.find( 'select' ).simulate( 'change', {
+				target: {
+					value: '3',
+				},
+			} );
+
+			expect( onUpdateAuthor ).toHaveBeenCalledWith( 3 );
+		} );
+	} );
+} );


### PR DESCRIPTION
Related: #2029
Closes #2491 
Closes #2157 
Fixes #2524 

This pull request seeks to account for user capabilities in deciding which options to show in the Author select dropdown. It also refactors the component to use the `withAPIData` higher-order component introduced in #1974, fixes an issue with author selection permanently causing a post to be flagged as dirty, and adds unit tests.

__Testing instructions:__

Repeat testing instructions from #2100