### PR TITLE
Publish Button: Submit for review as pending for contributor

### DIFF
--- a/editor/header/tools/publish-button.js
+++ b/editor/header/tools/publish-button.js
@@ -3,12 +3,13 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, withAPIData } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -23,7 +24,7 @@ import {
 	isEditedPostPublishable,
 } from '../../selectors';
 
-function PublishButton( {
+export function PublishButton( {
 	isSaving,
 	isPublished,
 	onStatusChange,
@@ -32,23 +33,37 @@ function PublishButton( {
 	visibility,
 	isPublishable,
 	isSaveable,
+	user,
 } ) {
-	const buttonEnabled = ! isSaving && isPublishable && isSaveable;
+	const isButtonEnabled = user.data && ! isSaving && isPublishable && isSaveable;
+	const isContributor = user.data && ! user.data.capabilities.publish_posts;
+
 	let buttonText;
-	if ( isPublished ) {
+	if ( isContributor ) {
+		buttonText = __( 'Submit for Review' );
+	} else if ( isPublished ) {
 		buttonText = __( 'Update' );
 	} else if ( isBeingScheduled ) {
 		buttonText = __( 'Schedule' );
 	} else {
 		buttonText = __( 'Publish' );
 	}
-	let publishStatus = 'publish';
-	if ( isBeingScheduled ) {
+
+	let publishStatus;
+	if ( isContributor ) {
+		publishStatus = 'pending';
+	} else if ( isBeingScheduled ) {
 		publishStatus = 'future';
 	} else if ( visibility === 'private' ) {
 		publishStatus = 'private';
+	} else {
+		publishStatus = 'publish';
 	}
-	const className = classnames( 'editor-tools__publish-button', { 'is-saving': isSaving } );
+
+	const className = classnames( 'editor-tools__publish-button', {
+		'is-saving': isSaving,
+	} );
+
 	const onClick = () => {
 		onStatusChange( publishStatus );
 		onSave();
@@ -59,7 +74,7 @@ function PublishButton( {
 			isPrimary
 			isLarge
 			onClick={ onClick }
-			disabled={ ! buttonEnabled }
+			disabled={ ! isButtonEnabled }
 			className={ className }
 		>
 			{ buttonText }
@@ -67,7 +82,7 @@ function PublishButton( {
 	);
 }
 
-export default connect(
+const applyConnect = connect(
 	( state ) => ( {
 		isSaving: isSavingPost( state ),
 		isPublished: isCurrentPostPublished( state ),
@@ -80,4 +95,15 @@ export default connect(
 		onStatusChange: ( status ) => editPost( { status } ),
 		onSave: savePost,
 	}
-)( PublishButton );
+);
+
+const applyWithAPIData = withAPIData( () => {
+	return {
+		user: '/wp/v2/users/me?context=edit',
+	};
+} );
+
+export default flowRight( [
+	applyConnect,
+	applyWithAPIData,
+] )( PublishButton );

--- a/editor/header/tools/test/publish-button.js
+++ b/editor/header/tools/test/publish-button.js
@@ -1,0 +1,203 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import { merge } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { PublishButton } from '../publish-button';
+
+describe( 'PublishButton', () => {
+	const user = {
+		data: {
+			id: 1,
+			capabilities: {
+				publish_posts: true,
+			},
+		},
+	};
+
+	const contributor = merge( {}, user, {
+		data: {
+			capabilities: {
+				publish_posts: false,
+			},
+		},
+	} );
+
+	describe( 'disabled', () => {
+		it( 'should be disabled if current user is unknown', () => {
+			const wrapper = shallow(
+				<PublishButton user={ {} } />
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+		} );
+
+		it( 'should be disabled if post is currently saving', () => {
+			const wrapper = shallow(
+				<PublishButton user={ user } isSaving />
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+		} );
+
+		it( 'should be disabled if post is not publishable', () => {
+			const wrapper = shallow(
+				<PublishButton user={ user } isPublishable={ false } />
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+		} );
+
+		it( 'should be disabled if post is not saveable', () => {
+			const wrapper = shallow(
+				<PublishButton user={ user } isSaveable={ false } />
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+		} );
+
+		it( 'should be enabled otherwise', () => {
+			const wrapper = shallow(
+				<PublishButton user={ user } isPublishable isSaveable />
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'button text', () => {
+		it( 'should show publish if user unknown', () => {
+			const wrapper = shallow(
+				<PublishButton user={ {} } />
+			);
+
+			expect( wrapper.children().text() ).toBe( 'Publish' );
+		} );
+
+		it( 'should show submit for review for contributor', () => {
+			const wrapper = shallow(
+				<PublishButton user={ contributor } />
+			);
+
+			expect( wrapper.children().text() ).toBe( 'Submit for Review' );
+		} );
+
+		it( 'should show update for already published', () => {
+			const wrapper = shallow(
+				<PublishButton user={ user } isPublished />
+			);
+
+			expect( wrapper.children().text() ).toBe( 'Update' );
+		} );
+
+		it( 'should show schedule for scheduled', () => {
+			const wrapper = shallow(
+				<PublishButton user={ user } isBeingScheduled />
+			);
+
+			expect( wrapper.children().text() ).toBe( 'Schedule' );
+		} );
+
+		it( 'should show publish otherwise', () => {
+			const wrapper = shallow(
+				<PublishButton user={ user } />
+			);
+
+			expect( wrapper.children().text() ).toBe( 'Publish' );
+		} );
+	} );
+
+	describe( 'publish status', () => {
+		it( 'should be pending for contributor', () => {
+			const onStatusChange = jest.fn();
+			const onSave = jest.fn();
+			const wrapper = shallow(
+				<PublishButton
+					user={ contributor }
+					onStatusChange={ onStatusChange }
+					onSave={ onSave } />
+			);
+
+			wrapper.simulate( 'click' );
+
+			expect( onStatusChange ).toHaveBeenCalledWith( 'pending' );
+		} );
+
+		it( 'should be future for scheduled post', () => {
+			const onStatusChange = jest.fn();
+			const onSave = jest.fn();
+			const wrapper = shallow(
+				<PublishButton
+					user={ user }
+					onStatusChange={ onStatusChange }
+					onSave={ onSave }
+					isBeingScheduled />
+			);
+
+			wrapper.simulate( 'click' );
+
+			expect( onStatusChange ).toHaveBeenCalledWith( 'future' );
+		} );
+
+		it( 'should be private for private visibility', () => {
+			const onStatusChange = jest.fn();
+			const onSave = jest.fn();
+			const wrapper = shallow(
+				<PublishButton
+					user={ user }
+					onStatusChange={ onStatusChange }
+					onSave={ onSave }
+					visibility="private" />
+			);
+
+			wrapper.simulate( 'click' );
+
+			expect( onStatusChange ).toHaveBeenCalledWith( 'private' );
+		} );
+
+		it( 'should be publish otherwise', () => {
+			const onStatusChange = jest.fn();
+			const onSave = jest.fn();
+			const wrapper = shallow(
+				<PublishButton
+					user={ user }
+					onStatusChange={ onStatusChange }
+					onSave={ onSave } />
+			);
+
+			wrapper.simulate( 'click' );
+
+			expect( onStatusChange ).toHaveBeenCalledWith( 'publish' );
+		} );
+	} );
+
+	describe( 'click', () => {
+		it( 'should save with status', () => {
+			const onStatusChange = jest.fn();
+			const onSave = jest.fn();
+			const wrapper = shallow(
+				<PublishButton
+					user={ user }
+					onStatusChange={ onStatusChange }
+					onSave={ onSave } />
+			);
+
+			wrapper.simulate( 'click' );
+
+			expect( onStatusChange ).toHaveBeenCalledWith( 'publish' );
+			expect( onSave ).toHaveBeenCalled();
+		} );
+	} );
+
+	it( 'should have save modifier class', () => {
+		const wrapper = shallow(
+			<PublishButton user={ user } isSaving />
+		);
+
+		expect( wrapper.hasClass( 'is-saving' ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
Closes #2029
Closes #2547 

This pull request seeks to account for user capability in deciding the behavior of the Publish button. Specifically, if a user is not capable of publishing posts, they must Submit for Review instead, flagging the post as Pending.

__Testing instructions:__

1. Navigate to the post editor
2. Note that...
   - If your current user has ability to publish posts, the Publish button shows as Publish
   - Otherwise, the Publish button shows as Submit for Review

The "Submit for Review" label should take priority over all other scenarios, including updating an existing post and setting a post into the future.