### PR TITLE
Featured Image: Refactor Featured Image to use `withApiData` HoC

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -57,7 +57,10 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 			// Trigger first fetch on initial entries into state. Assumes GET
 			// request by presence of isLoading flag.
 			forEach( dataProps, ( dataProp, propName ) => {
-				if ( prevDataProps.hasOwnProperty( propName ) ) {
+				if (
+					prevDataProps.hasOwnProperty( propName ) &&
+					prevDataProps[ propName ].path === dataProp.path
+				) {
 					return;
 				}
 

--- a/components/higher-order/with-api-data/test/index.js
+++ b/components/higher-order/with-api-data/test/index.js
@@ -143,4 +143,21 @@ describe( 'withAPIData()', () => {
 			done();
 		} );
 	} );
+
+	it( 'should refetch on changed path', ( done ) => {
+		const wrapper = getWrapper(
+			( { pageId } ) => ( {
+				page: `/wp/v2/pages/${ pageId }`,
+			} ),
+			{ pageId: 5 }
+		);
+
+		process.nextTick( () => {
+			expect( wrapper.state( 'dataProps' ).page.isLoading ).toBe( false );
+			wrapper.setProps( { pageId: 7 } );
+			expect( wrapper.state( 'dataProps' ).page.isLoading ).toBe( true );
+
+			done();
+		} );
+	} );
 } );

--- a/editor/sidebar/featured-image/index.js
+++ b/editor/sidebar/featured-image/index.js
@@ -63,7 +63,7 @@ function FeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media }
 	);
 }
 
-const connectComponent = connect(
+const applyConnect = connect(
 	( state ) => {
 		return {
 			featuredImageId: getEditedPostAttribute( state, 'featured_media' ),
@@ -81,7 +81,7 @@ const connectComponent = connect(
 	}
 );
 
-const fetchAPIData = withAPIData( ( { featuredImageId } ) => {
+const applyWithAPIData = withAPIData( ( { featuredImageId } ) => {
 	if ( ! featuredImageId ) {
 		return {};
 	}
@@ -92,6 +92,6 @@ const fetchAPIData = withAPIData( ( { featuredImageId } ) => {
 } );
 
 export default flowRight(
-	connectComponent,
-	fetchAPIData,
+	applyConnect,
+	applyWithAPIData,
 )( FeaturedImage );


### PR DESCRIPTION
In this PR, I'm trying to use `withAPIData` in the featured image component and this is a huge improvement over repeating the same lifecycle calls over and over again :)

I've noticed a bug and I suspect that the HoC doesn't trigger the requests properly when the URL changes. I may be wrong though. (Try changing the featured image, the new one is not fetched) Any idea @aduth 