### PR TITLE
Add Filter to make it possible to only add gutenberg links on a per post type basis

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -90,8 +90,9 @@ add_action( 'admin_init', 'gutenberg_add_edit_links_filters' );
 function gutenberg_add_edit_links( $actions, $post ) {
 	$can_edit_post = current_user_can( 'edit_post', $post->ID );
 	$title = _draft_or_post_title( $post->ID );
+	$post_type = get_post_type( $post );
 
-	if ( $can_edit_post && 'trash' !== $post->post_status ) {
+	if ( $can_edit_post && 'trash' !== $post->post_status && apply_filters( 'gutenberg_add_edit_link_for_post_type', true, $post_type, $post ) ) {
 		// Build the Gutenberg edit action. See also: WP_Posts_List_Table::handle_row_actions().
 		$gutenberg_url = menu_page_url( 'gutenberg', false );
 		$gutenberg_action = sprintf(


### PR DESCRIPTION
Right now, Gutenberg is not the right experience for all post types. In order to help encourage testing, we should make it possible to remove the quick action from certain post types.

This is needed in order to add gutenberg to the WordCamp family of sites.

cc/ @coreymckrill

See: https://meta.trac.wordpress.org/ticket/3065#comment:5