### PR TITLE
Normalise pasted blockquote contents

### DIFF
--- a/blocks/api/paste/blockquote-normaliser.js
+++ b/blocks/api/paste/blockquote-normaliser.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import normaliseBlocks from './normalise-blocks';
+
+/**
+ * Browser dependencies
+ */
+const { ELEMENT_NODE } = window.Node;
+
+export default function( node ) {
+	if ( node.nodeType !== ELEMENT_NODE ) {
+		return;
+	}
+
+	if ( node.nodeName !== 'BLOCKQUOTE' ) {
+		return;
+	}
+
+	node.innerHTML = normaliseBlocks( node.innerHTML );
+}

--- a/blocks/api/paste/index.js
+++ b/blocks/api/paste/index.js
@@ -18,6 +18,7 @@ import formattingTransformer from './formatting-transformer';
 import msListConverter from './ms-list-converter';
 import listMerger from './list-merger';
 import imageCorrector from './image-corrector';
+import blockquoteNormaliser from './blockquote-normaliser';
 import { deepFilter, isInvalidInline, isNotWhitelisted } from './utils';
 
 export default function( { content: HTML, inline } ) {
@@ -41,6 +42,7 @@ export default function( { content: HTML, inline } ) {
 		stripAttributes,
 		commentRemover,
 		createUnwrapper( isNotWhitelisted ),
+		blockquoteNormaliser,
 	] );
 
 	// Inline paste.

--- a/blocks/api/paste/test/blockquote-normaliser.js
+++ b/blocks/api/paste/test/blockquote-normaliser.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { equal } from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import blockquoteNormaliser from '../blockquote-normaliser';
+import { deepFilter } from '../utils';
+
+describe( 'blockquoteNormaliser', () => {
+	it( 'should normalise blockquote', () => {
+		const input = '<blockquote>test</blockquote>';
+		const output = '<blockquote><p>test</p></blockquote>';
+		equal( deepFilter( input, [ blockquoteNormaliser ] ), output );
+	} );
+} );


### PR DESCRIPTION
Note: this has been broken for a while.

The quote block doesn't recognise content when it's not wrapped in paragraphs, so all the content is stripped. The content is not stripped by the paste handler, but by the block. To fix the issue, we can normalise the block quote contents much like we normalise the top level nodes.