### PR TITLE
Chrome: Persist the "opened/closed" state of the sidebar panels in localStorage

### DIFF
--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -26,16 +26,22 @@ class PanelBody extends Component {
 
 	toggle( event ) {
 		event.preventDefault();
-		this.setState( ( state ) => ( {
-			opened: ! state.opened,
-		} ) );
+		if ( this.props.opened === undefined ) {
+			this.setState( ( state ) => ( {
+				opened: ! state.opened,
+			} ) );
+		}
+
+		if ( this.props.onToggle ) {
+			this.props.onToggle();
+		}
 	}
 
 	render() {
-		const { title, children } = this.props;
-		const { opened } = this.state;
-		const icon = `arrow-${ opened ? 'down' : 'right' }`;
-		const className = classnames( 'components-panel__body', { 'is-opened': opened } );
+		const { title, children, opened } = this.props;
+		const isOpened = opened === undefined ? this.state.opened : opened;
+		const icon = `arrow-${ isOpened ? 'down' : 'right' }`;
+		const className = classnames( 'components-panel__body', { 'is-opened': isOpened } );
 
 		return (
 			<div className={ className }>
@@ -44,7 +50,7 @@ class PanelBody extends Component {
 						<Button
 							className="components-panel__body-toggle"
 							onClick={ this.toggle }
-							aria-expanded={ opened }
+							aria-expanded={ isOpened }
 							label={ sprintf( __( 'Open section: %s' ), title ) }
 						>
 							<Dashicon icon={ icon } />
@@ -52,7 +58,7 @@ class PanelBody extends Component {
 						</Button>
 					</h3>
 				) }
-				{ this.state.opened && children }
+				{ isOpened && children }
 			</div>
 		);
 	}

--- a/components/panel/test/body.js
+++ b/components/panel/test/body.js
@@ -35,6 +35,13 @@ describe( 'PanelBody', () => {
 			expect( icon.prop( 'icon' ) ).toBe( 'arrow-right' );
 		} );
 
+		it( 'should use the "opened" prop instead of state if provided', () => {
+			const panelBody = shallow( <PanelBody title="Some Text" opened={ true } initialOpen={ false } /> );
+			expect( panelBody.state( 'opened' ) ).toBe( false );
+			const icon = panelBody.find( 'Dashicon' );
+			expect( icon.prop( 'icon' ) ).toBe( 'arrow-down' );
+		} );
+
 		it( 'should render child elements within PanelBody element', () => {
 			const panelBody = shallow( <PanelBody children="Some Text" /> );
 			expect( panelBody.instance().props.children ).toBe( 'Some Text' );

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -256,6 +256,19 @@ export function stopTyping() {
 }
 
 /**
+ * Returns an action object used in signalling that the user toggled a sidebar panel
+ *
+ * @param  {String} panel   The panel name
+ * @return {Object}         Action object
+ */
+export function toggleSidebarPanel( panel ) {
+	return {
+		type: 'TOGGLE_SIDEBAR_PANEL',
+		panel,
+	};
+}
+
+/**
  * Returns an action object used to create a notice
  *
  * @param {String}     status   The notice status

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -3,7 +3,7 @@
  */
 import optimist from 'redux-optimist';
 import { combineReducers } from 'redux';
-import { reduce, keyBy, first, last, omit, without, mapValues } from 'lodash';
+import { get, reduce, keyBy, first, last, omit, without, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -441,12 +441,20 @@ export function mode( state = 'visual', action ) {
 	return state;
 }
 
-export function preferences( state = { isSidebarOpened: ! isMobile }, action ) {
+export function preferences( state = { isSidebarOpened: ! isMobile, panels: { 'post-status': true } }, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_SIDEBAR':
 			return {
-				... state,
+				...state,
 				isSidebarOpened: ! state.isSidebarOpened,
+			};
+		case 'TOGGLE_SIDEBAR_PANEL':
+			return {
+				...state,
+				panels: {
+					...state.panels,
+					[ action.panel ]: ! get( state, [ 'panels', action.panel ], false ),
+				},
 			};
 	}
 

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -54,13 +54,25 @@ export function getPreference( state, preferenceKey ) {
 }
 
 /**
- * Returns true if the editor sidebar panel is open, or false otherwise.
+ * Returns true if the editor sidebar is open, or false otherwise.
  *
  * @param  {Object}  state Global application state
  * @return {Boolean}       Whether sidebar is open
  */
 export function isEditorSidebarOpened( state ) {
 	return getPreference( state, 'isSidebarOpened' );
+}
+
+/**
+ * Returns true if the editor sidebar panel is open, or false otherwise.
+ *
+ * @param  {Object}  state Global application state
+ * @param  {STring}  panel Sidebar panel name
+ * @return {Boolean}       Whether sidebar is open
+ */
+export function isEditorSidebarPanelOpened( state, panel ) {
+	const panels = getPreference( state, 'panels' );
+	return panels ? !! panels[ panel ] : false;
 }
 
 /**

--- a/editor/sidebar/discussion-panel/index.js
+++ b/editor/sidebar/discussion-panel/index.js
@@ -12,18 +12,24 @@ import { PanelBody, PanelRow, FormToggle, withInstanceId } from '@wordpress/comp
 /**
  * Internal Dependencies
  */
-import { getEditedPostAttribute } from '../../selectors';
-import { editPost } from '../../actions';
+import { getEditedPostAttribute, isEditorSidebarPanelOpened } from '../../selectors';
+import { editPost, toggleSidebarPanel } from '../../actions';
 
-function DiscussionPanel( { pingStatus = 'open', commentStatus = 'open', instanceId, ...props } ) {
+/**
+ * Module Constants
+ */
+const PANEL_NAME = 'discussion-panel';
+
+function DiscussionPanel( { pingStatus = 'open', commentStatus = 'open', instanceId, isOpened, ...props } ) {
 	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
 	const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
+	const onTogglePanel = () => props.toggleSidebarPanel( PANEL_NAME );
 
 	const commentsToggleId = 'allow-comments-toggle-' + instanceId;
 	const pingbacksToggleId = 'allow-pingbacks-toggle-' + instanceId;
 
 	return (
-		<PanelBody title={ __( 'Discussion' ) } initialOpen={ false }>
+		<PanelBody title={ __( 'Discussion' ) } opened={ isOpened } onToggle={ onTogglePanel }>
 			<PanelRow>
 				<label htmlFor={ commentsToggleId }>{ __( 'Allow Comments' ) }</label>
 				<FormToggle
@@ -51,8 +57,9 @@ export default connect(
 		return {
 			pingStatus: getEditedPostAttribute( state, 'ping_status' ),
 			commentStatus: getEditedPostAttribute( state, 'comment_status' ),
+			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 		};
 	},
-	{ editPost }
+	{ editPost, toggleSidebarPanel }
 )( withInstanceId( DiscussionPanel ) );
 

--- a/editor/sidebar/featured-image/index.js
+++ b/editor/sidebar/featured-image/index.js
@@ -15,12 +15,19 @@ import { MediaUploadButton } from '@wordpress/blocks';
  * Internal dependencies
  */
 import './style.scss';
-import { getEditedPostAttribute } from '../../selectors';
-import { editPost } from '../../actions';
+import { getEditedPostAttribute, isEditorSidebarPanelOpened } from '../../selectors';
+import { editPost, toggleSidebarPanel } from '../../actions';
 
-function FeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media } ) {
+/**
+ * Module Constants
+ */
+const PANEL_NAME = 'featured-image';
+
+function FeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, isOpened, ...props } ) {
+	const onToggle = () => props.toggleSidebarPanel( PANEL_NAME );
+
 	return (
-		<PanelBody title={ __( 'Featured image' ) } initialOpen={ false }>
+		<PanelBody title={ __( 'Featured image' ) } opened={ isOpened } onToggle={ onToggle }>
 			<div className="editor-featured-image__content">
 				{ !! featuredImageId &&
 					<MediaUploadButton
@@ -67,17 +74,17 @@ const applyConnect = connect(
 	( state ) => {
 		return {
 			featuredImageId: getEditedPostAttribute( state, 'featured_media' ),
+			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 		};
 	},
-	( dispatch ) => {
-		return {
-			onUpdateImage( image ) {
-				dispatch( editPost( { featured_media: image.id } ) );
-			},
-			onRemoveImage() {
-				dispatch( editPost( { featured_media: null } ) );
-			},
-		};
+	{
+		onUpdateImage( image ) {
+			return editPost( { featured_media: image.id } );
+		},
+		onRemoveImage() {
+			return editPost( { featured_media: null } );
+		},
+		toggleSidebarPanel,
 	}
 );
 

--- a/editor/sidebar/page-attributes/index.js
+++ b/editor/sidebar/page-attributes/index.js
@@ -14,14 +14,20 @@ import { PanelBody, PanelRow, withAPIData, withInstanceId } from '@wordpress/com
 /**
  * Internal dependencies
  */
-import { editPost } from '../../actions';
-import { getCurrentPostType, getEditedPostAttribute } from '../../selectors';
+import { editPost, toggleSidebarPanel } from '../../actions';
+import { getCurrentPostType, getEditedPostAttribute, isEditorSidebarPanelOpened } from '../../selectors';
+
+/**
+ * Module Constants
+ */
+const PANEL_NAME = 'page-attributes';
 
 export class PageAttributes extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.setUpdatedOrder = this.setUpdatedOrder.bind( this );
+		this.onToggle = this.onToggle.bind( this );
 
 		this.state = {
 			supportsPageAttributes: false,
@@ -35,8 +41,12 @@ export class PageAttributes extends Component {
 		}
 	}
 
+	onToggle() {
+		this.props.toggleSidebarPanel( PANEL_NAME );
+	}
+
 	render() {
-		const { instanceId, order, postType } = this.props;
+		const { instanceId, order, postType, isOpened } = this.props;
 		const supportsPageAttributes = get( postType.data, [
 			'supports',
 			'page-attributes',
@@ -53,7 +63,8 @@ export class PageAttributes extends Component {
 		return (
 			<PanelBody
 				title={ __( 'Page Attributes' ) }
-				initialOpen={ false }
+				opened={ isOpened }
+				onToggle={ this.onToggle }
 			>
 				<PanelRow>
 					<label htmlFor={ inputId }>
@@ -76,16 +87,16 @@ const applyConnect = connect(
 		return {
 			postTypeSlug: getCurrentPostType( state ),
 			order: getEditedPostAttribute( state, 'menu_order' ),
+			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 		};
 	},
-	( dispatch ) => {
-		return {
-			onUpdateOrder( order ) {
-				dispatch( editPost( {
-					menu_order: order,
-				} ) );
-			},
-		};
+	{
+		onUpdateOrder( order ) {
+			return editPost( {
+				menu_order: order,
+			} );
+		},
+		toggleSidebarPanel,
 	}
 );
 

--- a/editor/sidebar/post-excerpt/index.js
+++ b/editor/sidebar/post-excerpt/index.js
@@ -13,14 +13,20 @@ import { ExternalLink, PanelBody } from '@wordpress/components';
  * Internal Dependencies
  */
 import './style.scss';
-import { getEditedPostExcerpt } from '../../selectors';
-import { editPost } from '../../actions';
+import { getEditedPostExcerpt, isEditorSidebarPanelOpened } from '../../selectors';
+import { editPost, toggleSidebarPanel } from '../../actions';
 
-function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
+/**
+ * Module Constants
+ */
+const PANEL_NAME = 'post-excerpt';
+
+function PostExcerpt( { excerpt, onUpdateExcerpt, isOpened, ...props } ) {
 	const onChange = ( event ) => onUpdateExcerpt( event.target.value );
+	const onTogglePanel = () => props.toggleSidebarPanel( PANEL_NAME );
 
 	return (
-		<PanelBody title={ __( 'Excerpt' ) } initialOpen={ false }>
+		<PanelBody title={ __( 'Excerpt' ) } opened={ isOpened } onToggle={ onTogglePanel }>
 			<textarea
 				className="editor-post-excerpt__textarea"
 				onChange={ onChange }
@@ -39,14 +45,14 @@ export default connect(
 	( state ) => {
 		return {
 			excerpt: getEditedPostExcerpt( state ),
+			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 		};
 	},
-	( dispatch ) => {
-		return {
-			onUpdateExcerpt( excerpt ) {
-				dispatch( editPost( { excerpt } ) );
-			},
-		};
+	{
+		onUpdateExcerpt( excerpt ) {
+			return editPost( { excerpt } );
+		},
+		toggleSidebarPanel,
 	}
 )( PostExcerpt );
 

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -22,13 +22,20 @@ import PostFormat from '../post-format';
 import {
 	getEditedPostAttribute,
 	isCurrentPostPublished,
+	isEditorSidebarPanelOpened,
 } from '../../selectors';
-import { editPost } from '../../actions';
+import { editPost, toggleSidebarPanel } from '../../actions';
+
+/**
+ * Module Constants
+ */
+const PANEL_NAME = 'post-status';
 
 class PostStatus extends Component {
 	constructor() {
 		super( ...arguments );
 		this.togglePendingStatus = this.togglePendingStatus.bind( this );
+		this.togglePanel = this.togglePanel.bind( this );
 	}
 
 	togglePendingStatus() {
@@ -37,12 +44,16 @@ class PostStatus extends Component {
 		onUpdateStatus( updatedStatus );
 	}
 
+	togglePanel() {
+		this.props.toggleSidebarPanel( PANEL_NAME );
+	}
+
 	render() {
-		const { status, isPublished, instanceId } = this.props;
+		const { status, isPublished, isOpened, instanceId } = this.props;
 		const pendingId = 'pending-toggle-' + instanceId;
 
 		return (
-			<PanelBody title={ __( 'Status & Visibility' ) }>
+			<PanelBody title={ __( 'Status & Visibility' ) } opened={ isOpened } onToggle={ this.togglePanel }>
 				{ ! isPublished &&
 					<PanelRow>
 						<label htmlFor={ pendingId }>{ __( 'Pending review' ) }</label>
@@ -69,13 +80,13 @@ export default connect(
 	( state ) => ( {
 		status: getEditedPostAttribute( state, 'status' ),
 		isPublished: isCurrentPostPublished( state ),
+		isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 	} ),
-	( dispatch ) => {
-		return {
-			onUpdateStatus( status ) {
-				dispatch( editPost( { status } ) );
-			},
-		};
+	{
+		onUpdateStatus( status ) {
+			return editPost( { status } );
+		},
+		toggleSidebarPanel,
 	}
 )( withInstanceId( PostStatus ) );
 

--- a/editor/sidebar/post-taxonomies/index.js
+++ b/editor/sidebar/post-taxonomies/index.js
@@ -16,11 +16,20 @@ import { Component } from '@wordpress/element';
 import './style.scss';
 import HierarchicalTermSelector from './hierarchical-term-selector';
 import FlatTermSelector from './flat-term-selector';
-import { getCurrentPostType } from '../../selectors';
+import { getCurrentPostType, isEditorSidebarPanelOpened } from '../../selectors';
+import { toggleSidebarPanel } from '../../actions';
+
+/**
+ * Module Constants
+ */
+const PANEL_NAME = 'post-taxonomies';
 
 class PostTaxonomies extends Component {
 	constructor() {
 		super( ...arguments );
+
+		this.onToggle = this.onToggle.bind( this );
+
 		this.state = {
 			taxonomies: [],
 		};
@@ -38,6 +47,10 @@ class PostTaxonomies extends Component {
 		this.fetchTaxonomies.abort();
 	}
 
+	onToggle() {
+		this.props.toggleSidebarPanel( PANEL_NAME );
+	}
+
 	render() {
 		const availableTaxonomies = this.state.taxonomies
 			.filter( ( taxonomy ) => taxonomy.types.indexOf( this.props.postType ) !== -1 );
@@ -47,7 +60,7 @@ class PostTaxonomies extends Component {
 		}
 
 		return (
-			<PanelBody title={ __( 'Categories & Tags' ) } initialOpen={ false }>
+			<PanelBody title={ __( 'Categories & Tags' ) } opened={ this.props.isOpened } onToggle={ this.onToggle }>
 				{ availableTaxonomies.map( ( taxonomy ) => {
 					const TaxonomyComponent = taxonomy.hierarchical ? HierarchicalTermSelector : FlatTermSelector;
 					return (
@@ -68,7 +81,9 @@ export default connect(
 	( state ) => {
 		return {
 			postType: getCurrentPostType( state ),
+			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 		};
-	}
+	},
+	{ toggleSidebarPanel }
 )( PostTaxonomies );
 

--- a/editor/sidebar/table-of-contents/index.js
+++ b/editor/sidebar/table-of-contents/index.js
@@ -15,12 +15,13 @@ import { PanelBody } from '@wordpress/components';
  */
 import './style.scss';
 import TableOfContentsItem from './item';
-import { getBlocks } from '../../selectors';
-import { selectBlock } from '../../actions';
+import { getBlocks, isEditorSidebarPanelOpened } from '../../selectors';
+import { selectBlock, toggleSidebarPanel } from '../../actions';
 
 /**
  * Module constants
  */
+const PANEL_NAME = 'table-of-contents';
 const emptyHeadingContent = <em>{ __( '(Empty heading)' ) }</em>;
 const incorrectLevelContent = [
 	<br key="incorrect-break" />,
@@ -52,8 +53,9 @@ const getHeadingLevel = heading => {
 
 const isEmptyHeading = heading => ! heading.attributes.content || heading.attributes.content.length === 0;
 
-const TableOfContents = ( { blocks, onSelect } ) => {
+const TableOfContents = ( { blocks, onSelect, isOpened, ...props } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
+	const onTogglePanel = () => props.toggleSidebarPanel( PANEL_NAME );
 
 	if ( headings.length <= 1 ) {
 		return null;
@@ -95,7 +97,7 @@ const TableOfContents = ( { blocks, onSelect } ) => {
 	} );
 
 	return (
-		<PanelBody title={ __( 'Table of Contents' ) } initialOpen={ false }>
+		<PanelBody title={ __( 'Table of Contents' ) } opened={ isOpened } onToggle={ onTogglePanel }>
 			<div className="table-of-contents__items">
 				<p><strong>{ sprintf( '%d Headings', headings.length ) }</strong></p>
 				<ul>{ tocItems }</ul>
@@ -108,11 +110,13 @@ export default connect(
 	( state ) => {
 		return {
 			blocks: getBlocks( state ),
+			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 		};
 	},
-	( dispatch ) => ( {
+	{
 		onSelect( uid ) {
-			dispatch( selectBlock( uid ) );
+			return selectBlock( uid );
 		},
-	} )
+		toggleSidebarPanel,
+	}
 )( TableOfContents );

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -802,10 +802,10 @@ describe( 'state', () => {
 	} );
 
 	describe( 'preferences()', () => {
-		it( 'should be opened by default', () => {
+		it( 'should be opened by default and show the post-status panel', () => {
 			const state = preferences( undefined, {} );
 
-			expect( state ).toEqual( { isSidebarOpened: true } );
+			expect( state ).toEqual( { isSidebarOpened: true, panels: { 'post-status': true } } );
 		} );
 
 		it( 'should toggle the sidebar open flag', () => {
@@ -814,6 +814,24 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( { isSidebarOpened: true } );
+		} );
+
+		it( 'should set the sidebar panel open flag to true if unset', () => {
+			const state = preferences( deepFreeze( { isSidebarOpened: false } ), {
+				type: 'TOGGLE_SIDEBAR_PANEL',
+				panel: 'post-taxonomies',
+			} );
+
+			expect( state ).toEqual( { isSidebarOpened: false, panels: { 'post-taxonomies': true } } );
+		} );
+
+		it( 'should toggle the sidebar panel open flag', () => {
+			const state = preferences( deepFreeze( { isSidebarOpened: false, panels: { 'post-taxonomies': true } } ), {
+				type: 'TOGGLE_SIDEBAR_PANEL',
+				panel: 'post-taxonomies',
+			} );
+
+			expect( state ).toEqual( { isSidebarOpened: false, panels: { 'post-taxonomies': false } } );
 		} );
 	} );
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -16,6 +16,7 @@ import {
 	getEditorMode,
 	getPreference,
 	isEditorSidebarOpened,
+	isEditorSidebarPanelOpened,
 	hasEditorUndo,
 	hasEditorRedo,
 	isEditedPostNew,
@@ -131,6 +132,32 @@ describe( 'selectors', () => {
 			};
 
 			expect( isEditorSidebarOpened( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isEditorSidebarPanelOpened', () => {
+		it( 'should return false if no panels preference', () => {
+			const state = {
+				preferences: { isSidebarOpened: true },
+			};
+
+			expect( isEditorSidebarPanelOpened( state, 'post-taxonomies' ) ).toBe( false );
+		} );
+
+		it( 'should return false if the panel value is not set', () => {
+			const state = {
+				preferences: { panels: {} },
+			};
+
+			expect( isEditorSidebarPanelOpened( state, 'post-taxonomies' ) ).toBe( false );
+		} );
+
+		it( 'should return the panel value', () => {
+			const state = {
+				preferences: { panels: { 'post-taxonomies': true } },
+			};
+
+			expect( isEditorSidebarPanelOpened( state, 'post-taxonomies' ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
This PR uses the preferences persisted reducer to persist the state of the sidebar panels.
I needed to add the possibility to make the PanelBody opened flag "controlled".

solves #450 partially