### PR TITLE
i18n: Fix the color's aria-label in the ColorPalette component

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -9,7 +9,7 @@ import { ChromePicker } from 'react-color';
  */
 import { Component } from '@wordpress/element';
 import { Popover } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -50,7 +50,7 @@ class ColorPalette extends Component {
 								className={ className }
 								style={ style }
 								onClick={ () => onChange( value === color ? undefined : color ) }
-								aria-label={ __( 'Color: ' ) + color }
+								aria-label={ sprintf( __( 'Color: %s' ), color ) }
 								aria-current={ value === color && __( 'Selected color' ) }
 							/>
 						</div>


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/2406#discussion_r134769598