### PR TITLE
Add function which checks if content of post is empty

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -12,6 +12,9 @@ import { serialize, getBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
+const REGEXP_EMPTY_CONTENT = /^<!--(.)*>(\s)*<p[^>]*>(&nbsp|\s|<br[^>]*>)*<\/p>(\s)(.)*-->$/mg;
+const CONTENT_LENGTH_ASSUME_SET = 63;
+
 /**
  * Returns the current editing mode.
  *
@@ -243,10 +246,21 @@ export function isEditedPostPublishable( state ) {
  */
 export function isEditedPostSaveable( state ) {
 	return (
-		!! getEditedPostContent( state ) ||
+		( ( !! getEditedPostContent( state ) ) && ( ! isEmptyContent( state ) ) ) ||
 		!! getEditedPostTitle( state ) ||
 		!! getEditedPostExcerpt( state )
 	);
+}
+
+/**
+ * Check if the content is empty (ignoring empty tags)
+ *
+ * @param  {Object}  state Global application state
+ * @return {Boolean}         Whether it's considered empty
+ */
+export function isEmptyContent( state ) {
+	const content = getEditedPostContent( state );
+	return ( ! content || ( content.length < CONTENT_LENGTH_ASSUME_SET && REGEXP_EMPTY_CONTENT.test( content ) ) );
 }
 
 /**


### PR DESCRIPTION
Fixes #1501.

I added a function which checks whether the content of a post is considered empty. 
Another bug occurred. But that is probably related with #1240.

Steps to reproduce:
1. go to the Gutenberg
2. click on 'Write your story' -> doesn't save after 10 sec, which I currently fixed
3. start typing something

I expect content to mark as dirty immediately and 'Save' button should be shown. But it happens after clicking next to the block.

All local tests ran OK.