### PR TITLE
Framework: Refactor PostTaxonomies to use `withApiData` HoC

### DIFF
--- a/editor/sidebar/post-taxonomies/index.js
+++ b/editor/sidebar/post-taxonomies/index.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
+import { flowRight, filter } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -25,13 +25,7 @@ import { toggleSidebarPanel } from '../../actions';
 const PANEL_NAME = 'post-taxonomies';
 
 function PostTaxonomies( { postType, taxonomies, isOpened, onTogglePanel } ) {
-	const availableTaxonomies = !! taxonomies.data
-		? Object.values( taxonomies.data ).filter( ( taxonomy ) => taxonomy.types.indexOf( postType ) !== -1 )
-		: [];
-
-	if ( ! availableTaxonomies.length ) {
-		return null;
-	}
+	const availableTaxonomies = filter( taxonomies.data, ( taxonomy ) => taxonomy.types.indexOf( postType ) !== -1 );
 
 	return (
 		<PanelBody

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -731,6 +731,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Preload common data.
 	$preload_paths = array(
 		'/wp/v2/users/me?context=edit',
+		'/wp/v2/taxonomies?context=edit',
 		gutenberg_get_rest_link( $post_to_edit, 'about', 'edit' ),
 	);
 	if ( ! $is_new_post ) {


### PR DESCRIPTION
Just some more consistency in fetching API DATA