### PR TITLE
FIX: Cursor inserted at the beginning of a paragraph instead of where the click happened

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -117,7 +117,7 @@ class VisualEditorBlock extends Component {
 		}
 
 		// Focus node when focus state is programmatically transferred.
-		if ( this.props.focus && ! prevProps.focus ) {
+		if ( this.props.focus && ! prevProps.focus && ! this.node.contains( document.activeElement ) ) {
 			this.node.focus();
 		}
 


### PR DESCRIPTION
fixes https://github.com/WordPress/gutenberg/issues/2472

Was only occurring after page load, when the block was first clicked into. 

Setting focus on the containing div was causing selection to be lost in Safari.  NB `contains` is inclusive.