### PR TITLE
Sidebar: Fix crash on collapsing categories

### DIFF
--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -153,8 +153,13 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	componentWillUnmount() {
-		this.fetchRequest.abort();
-		this.addRequest.abort();
+		if ( this.fetchRequest ) {
+			this.fetchRequest.abort();
+		}
+
+		if ( this.addRequest ) {
+			this.addRequest.abort();
+		}
 	}
 
 	renderTerms( renderedTerms ) {


### PR DESCRIPTION
This pull request seeks to resolve a crash which occurs when collapsing the "Categories & Tags" sidebar panel. Specifically, the affected code of `HierarchicalTermSelector` assumes that request objects have been assigned for fetching or adding terms. In the latter case, the request is only assigned after user has entered a term.

A long-term solution should probably seek to migrate this to the [`withAPIData` higher-order component](https://github.com/WordPress/gutenberg/tree/master/components/higher-order/with-api-data), but this addresses the immediate issue.

__Testing instructions:__

1. Navigate to Gutenberg > New post
2. Expand Categories & Tags in sidebar
3. Collapse Categories & Tags in sidebar
4. Note that no crash occurs