### PR TITLE
FIX: Link dialog doesn't show in Safari when caret within word

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -219,7 +219,14 @@ export default class Editable extends Component {
 	}
 
 	getFocusPosition() {
-		const range = this.editor.selection.getRng();
+		let range = this.editor.selection.getRng();
+
+		if ( range.collapsed ) {
+			const { startContainer } = range;
+			range = document.createRange();
+			range.selectNode( startContainer );
+		}
+
 		const position = range.getBoundingClientRect();
 
 		// Find the parent "relative" positioned container
@@ -420,7 +427,12 @@ export default class Editable extends Component {
 		);
 	}
 
-	onNodeChange( { parents } ) {
+	canAddLink( parents, element ) {
+		const range = this.editor.selection.getRng();
+		console.log(range.startContainer.nodeValue);
+	}
+
+	onNodeChange( { parents, element } ) {
 		const formats = {};
 		const link = find( parents, ( node ) => node.nodeName.toLowerCase() === 'a' );
 		if ( link ) {
@@ -428,7 +440,7 @@ export default class Editable extends Component {
 		}
 		const activeFormats = this.editor.formatter.matchAll( [	'bold', 'italic', 'strikethrough' ] );
 		activeFormats.forEach( ( activeFormat ) => formats[ activeFormat ] = true );
-
+		// this.canAddLink( parents, element );
 		const focusPosition = this.getFocusPosition();
 		this.setState( { formats, focusPosition, selectedNodeId: this.state.selectedNodeId + 1 } );
 	}

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -221,6 +221,7 @@ export default class Editable extends Component {
 	getFocusPosition() {
 		let range = this.editor.selection.getRng();
 
+		// use range of startContainer when collapsed as Safari returns invalid bounding rect
 		if ( range.collapsed ) {
 			const { startContainer } = range;
 			range = document.createRange();
@@ -427,12 +428,7 @@ export default class Editable extends Component {
 		);
 	}
 
-	canAddLink( parents, element ) {
-		const range = this.editor.selection.getRng();
-		console.log(range.startContainer.nodeValue);
-	}
-
-	onNodeChange( { parents, element } ) {
+	onNodeChange( { parents } ) {
 		const formats = {};
 		const link = find( parents, ( node ) => node.nodeName.toLowerCase() === 'a' );
 		if ( link ) {
@@ -440,7 +436,7 @@ export default class Editable extends Component {
 		}
 		const activeFormats = this.editor.formatter.matchAll( [	'bold', 'italic', 'strikethrough' ] );
 		activeFormats.forEach( ( activeFormat ) => formats[ activeFormat ] = true );
-		// this.canAddLink( parents, element );
+
 		const focusPosition = this.getFocusPosition();
 		this.setState( { formats, focusPosition, selectedNodeId: this.state.selectedNodeId + 1 } );
 	}


### PR DESCRIPTION
fixes https://github.com/WordPress/gutenberg/issues/2562

In Safari when the `Range` is collapsed `getBoundingRect` returns all zeros so use range of the `startContainer` in this instance

If a paragraph block is empty and the link toolbar is clicked the link dialog shows in the centre of the block which seems acceptable.  Another issue exists to stop creation of a link if no text is selected.