### PR TITLE
Chrome: Hide Sidebar Panels if the user don't have the right capabilities

### DIFF
--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -44,12 +44,12 @@ export class PostAuthor extends Component {
 	}
 
 	render() {
+		const { postAuthor, instanceId, user } = this.props;
 		const authors = this.getAuthors();
-		if ( authors.length < 2 ) {
+		if ( ! user.data || ! user.data.capabilities.publish_posts || authors.length < 2 ) {
 			return null;
 		}
 
-		const { postAuthor, instanceId } = this.props;
 		const selectId = 'post-author-selector-' + instanceId;
 
 		// Disable reason: A select with an onchange throws a warning
@@ -90,6 +90,7 @@ const applyConnect = connect(
 const applyWithAPIData = withAPIData( () => {
 	return {
 		users: '/wp/v2/users?context=edit&per_page=100',
+		user: '/wp/v2/users/me?context=edit',
 	};
 } );
 

--- a/editor/sidebar/post-author/test/index.js
+++ b/editor/sidebar/post-author/test/index.js
@@ -35,9 +35,17 @@ describe( 'PostAuthor', () => {
 		],
 	};
 
+	const user = {
+		data: {
+			capabilities: {
+				publish_posts: true,
+			},
+		},
+	};
+
 	describe( '#getAuthors()', () => {
 		it( 'returns empty array on unknown users', () => {
-			const wrapper = shallow( <PostAuthor users={ {} } /> );
+			const wrapper = shallow( <PostAuthor users={ {} } user={ user } /> );
 
 			const authors = wrapper.instance().getAuthors();
 
@@ -45,7 +53,7 @@ describe( 'PostAuthor', () => {
 		} );
 
 		it( 'filters users to authors', () => {
-			const wrapper = shallow( <PostAuthor users={ users } /> );
+			const wrapper = shallow( <PostAuthor users={ users } user={ user } /> );
 
 			const authors = wrapper.instance().getAuthors();
 
@@ -54,15 +62,24 @@ describe( 'PostAuthor', () => {
 	} );
 
 	describe( '#render()', () => {
+		it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
+			let wrapper = shallow( <PostAuthor users={ users } user={ {} } /> );
+			expect( wrapper.type() ).toBe( null );
+			wrapper = shallow( <PostAuthor users={ users } user={
+				{ data: { capabilities: { publish_posts: false } } }
+			} /> );
+			expect( wrapper.type() ).toBe( null );
+		} );
+
 		it( 'should not render anything if users unknown', () => {
-			const wrapper = shallow( <PostAuthor users={ {} } /> );
+			const wrapper = shallow( <PostAuthor users={ {} } user={ user } /> );
 
 			expect( wrapper.type() ).toBe( null );
 		} );
 
 		it( 'should not render anything if single user', () => {
 			const wrapper = shallow(
-				<PostAuthor users={ { data: users.data.slice( 0, 1 ) } } />
+				<PostAuthor users={ { data: users.data.slice( 0, 1 ) } } user={ user } />
 			);
 
 			expect( wrapper.type() ).toBe( null );
@@ -70,14 +87,14 @@ describe( 'PostAuthor', () => {
 
 		it( 'should not render anything if single filtered user', () => {
 			const wrapper = shallow(
-				<PostAuthor users={ { data: users.data.slice( 0, 2 ) } } />
+				<PostAuthor users={ { data: users.data.slice( 0, 2 ) } } user={ user } />
 			);
 
 			expect( wrapper.type() ).toBe( null );
 		} );
 
 		it( 'should render select control', () => {
-			const wrapper = shallow( <PostAuthor users={ users } /> );
+			const wrapper = shallow( <PostAuthor users={ users } user={ user } /> );
 
 			expect( wrapper.find( 'select' ).length ).not.toBe( 0 );
 		} );
@@ -87,6 +104,7 @@ describe( 'PostAuthor', () => {
 			const wrapper = shallow(
 				<PostAuthor
 					users={ users }
+					user={ user }
 					onUpdateAuthor={ onUpdateAuthor } />
 			);
 

--- a/editor/sidebar/post-pending-status/index.js
+++ b/editor/sidebar/post-pending-status/index.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelRow, FormToggle, withInstanceId, withAPIData } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getEditedPostAttribute,
+	isCurrentPostPublished,
+} from '../../selectors';
+import { editPost } from '../../actions';
+
+export function PostPendingStatus( { isPublished, instanceId, status, onUpdateStatus, user } ) {
+	if ( isPublished || ! user.data || ! user.data.capabilities.publish_posts ) {
+		return null;
+	}
+	const pendingId = 'pending-toggle-' + instanceId;
+	const togglePendingStatus = () => {
+		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
+		onUpdateStatus( updatedStatus );
+	};
+
+	return (
+		<PanelRow>
+			<label htmlFor={ pendingId }>{ __( 'Pending review' ) }</label>
+			<FormToggle
+				id={ pendingId }
+				checked={ status === 'pending' }
+				onChange={ togglePendingStatus }
+				showHint={ false }
+			/>
+		</PanelRow>
+	);
+}
+
+const applyConnect = connect(
+	( state ) => ( {
+		status: getEditedPostAttribute( state, 'status' ),
+		isPublished: isCurrentPostPublished( state ),
+	} ),
+	{
+		onUpdateStatus( status ) {
+			return editPost( { status } );
+		},
+	}
+);
+
+const applyWithAPIData = withAPIData( () => {
+	return {
+		user: '/wp/v2/users/me?context=edit',
+	};
+} );
+
+export default flowRight(
+	applyConnect,
+	applyWithAPIData,
+	withInstanceId
+)( PostPendingStatus );

--- a/editor/sidebar/post-pending-status/test/index.js
+++ b/editor/sidebar/post-pending-status/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostPendingStatus } from '../';
+
+describe( 'PostPendingStatus', () => {
+	const user = {
+		data: {
+			capabilities: {
+				publish_posts: true,
+			},
+		},
+	};
+
+	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
+		let wrapper = shallow( <PostPendingStatus user={ {} } /> );
+		expect( wrapper.type() ).toBe( null );
+		wrapper = shallow( <PostPendingStatus user={
+			{ data: { capabilities: { publish_posts: false } } }
+		} /> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should render if the user has the correct capability', () => {
+		const wrapper = shallow( <PostPendingStatus user={ user } /> );
+		expect( wrapper.type() ).not.toBe( null );
+	} );
+} );

--- a/editor/sidebar/post-schedule/test/index.js
+++ b/editor/sidebar/post-schedule/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostSchedule } from '../';
+
+describe( 'PostSchedule', () => {
+	const user = {
+		data: {
+			capabilities: {
+				publish_posts: true,
+			},
+		},
+	};
+
+	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
+		let wrapper = shallow( <PostSchedule user={ {} } /> );
+		expect( wrapper.type() ).toBe( null );
+		wrapper = shallow( <PostSchedule user={
+			{ data: { capabilities: { publish_posts: false } } }
+		} /> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should render if the user has the correct capability', () => {
+		const wrapper = shallow( <PostSchedule user={ user } /> );
+		expect( wrapper.type() ).not.toBe( null );
+	} );
+} );

--- a/editor/sidebar/post-status/index.js
+++ b/editor/sidebar/post-status/index.js
@@ -7,8 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
-import { PanelBody, PanelRow, FormToggle, withInstanceId } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -19,71 +18,39 @@ import PostSchedule from '../post-schedule';
 import PostSticky from '../post-sticky';
 import PostAuthor from '../post-author';
 import PostFormat from '../post-format';
+import PostPendingStatus from '../post-pending-status';
 import {
-	getEditedPostAttribute,
-	isCurrentPostPublished,
 	isEditorSidebarPanelOpened,
 } from '../../selectors';
-import { editPost, toggleSidebarPanel } from '../../actions';
+import { toggleSidebarPanel } from '../../actions';
 
 /**
  * Module Constants
  */
 const PANEL_NAME = 'post-status';
 
-class PostStatus extends Component {
-	constructor() {
-		super( ...arguments );
-		this.togglePendingStatus = this.togglePendingStatus.bind( this );
-	}
-
-	togglePendingStatus() {
-		const { status, onUpdateStatus } = this.props;
-		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
-		onUpdateStatus( updatedStatus );
-	}
-
-	render() {
-		const { status, isPublished, isOpened, instanceId, onTogglePanel } = this.props;
-		const pendingId = 'pending-toggle-' + instanceId;
-
-		return (
-			<PanelBody title={ __( 'Status & Visibility' ) } opened={ isOpened } onToggle={ onTogglePanel }>
-				<PostVisibility />
-				<PostSchedule />
-				<PostFormat />
-				<PostSticky />
-				{ ! isPublished &&
-					<PanelRow>
-						<label htmlFor={ pendingId }>{ __( 'Pending review' ) }</label>
-						<FormToggle
-							id={ pendingId }
-							checked={ status === 'pending' }
-							onChange={ this.togglePendingStatus }
-							showHint={ false }
-						/>
-					</PanelRow>
-				}
-				<PostAuthor />
-				<PostTrash />
-			</PanelBody>
-		);
-	}
+function PostStatus( { isOpened, onTogglePanel } ) {
+	return (
+		<PanelBody title={ __( 'Status & Visibility' ) } opened={ isOpened } onToggle={ onTogglePanel }>
+			<PostVisibility />
+			<PostSchedule />
+			<PostFormat />
+			<PostSticky />
+			<PostPendingStatus />
+			<PostAuthor />
+			<PostTrash />
+		</PanelBody>
+	);
 }
 
 export default connect(
 	( state ) => ( {
-		status: getEditedPostAttribute( state, 'status' ),
-		isPublished: isCurrentPostPublished( state ),
 		isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 	} ),
 	{
-		onUpdateStatus( status ) {
-			return editPost( { status } );
-		},
 		onTogglePanel() {
 			return toggleSidebarPanel( PANEL_NAME );
 		},
 	}
-)( withInstanceId( PostStatus ) );
+)( PostStatus );
 

--- a/editor/sidebar/post-visibility/test/index.js
+++ b/editor/sidebar/post-visibility/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostVisibility } from '../';
+
+describe( 'PostVisibility', () => {
+	const user = {
+		data: {
+			capabilities: {
+				publish_posts: true,
+			},
+		},
+	};
+
+	it( 'should not render the edit link if the user doesn\'t have the right capability', () => {
+		let wrapper = shallow( <PostVisibility visibility="public" user={ {} } /> );
+		expect( wrapper.find( 'a' ) ).toHaveLength( 0 );
+		wrapper = shallow( <PostVisibility visibility="public" postType="post" user={
+			{ data: { capabilities: { publish_posts: false } } }
+		} /> );
+		expect( wrapper.find( 'button' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'should render if the user has the correct capability', () => {
+		const wrapper = shallow( <PostVisibility visibility="public" user={ user } /> );
+		expect( wrapper.find( 'button' ) ).not.toHaveLength( 0 );
+	} );
+} );


### PR DESCRIPTION
If the user doesn't have the "publish_posts" capability (a contributor), several panel sidebars should be hidden.

In this PR I'm hiding the "pending" toggle, the "schedule" panel and the post visibility is not editable. (similar to the current editor)