### PR TITLE
Inserter: Fix the insertion point when using the inserter

### DIFF
--- a/editor/inserter/index.js
+++ b/editor/inserter/index.js
@@ -106,11 +106,11 @@ export default connect(
 		};
 	},
 	( dispatch ) => ( {
-		onInsertBlock( name, after ) {
+		onInsertBlock( name, position ) {
 			dispatch( hideInsertionPoint() );
 			dispatch( insertBlock(
 				createBlock( name ),
-				after
+				position
 			) );
 		},
 	} )

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -215,12 +215,11 @@ class VisualEditorBlockList extends Component {
 			insertionPoint,
 		} = this.props;
 
-		const insertionPointIndex = blocks.indexOf( insertionPoint );
 		const blocksWithInsertionPoint = showInsertionPoint
 			? [
-				...blocks.slice( 0, insertionPointIndex + 1 ),
+				...blocks.slice( 0, insertionPoint ),
 				INSERTION_POINT_PLACEHOLDER,
-				...blocks.slice( insertionPointIndex + 1 ),
+				...blocks.slice( insertionPoint ),
 			]
 			: blocks;
 		const continueWritingClassname = classnames( 'editor-visual-editor__continue-writing', {

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -666,29 +666,28 @@ export function isTyping( state ) {
 }
 
 /**
- * Returns the unique ID of the block after which a new block insertion would
- * be placed, or null if the insertion point is not shown. Defaults to the
- * unique ID of the last block occurring in the post if not otherwise assigned.
+ * Returns the insertion point, the index at which the new inserted block would
+ * be placed. Defaults to the last position
  *
  * @param  {Object}  state Global application state
  * @return {?String}       Unique ID after which insertion will occur
  */
 export function getBlockInsertionPoint( state ) {
 	if ( getEditorMode( state ) !== 'visual' ) {
-		return last( state.editor.blockOrder );
+		return state.editor.blockOrder.length;
 	}
 
 	const lastMultiSelectedBlock = getLastMultiSelectedBlockUid( state );
 	if ( lastMultiSelectedBlock ) {
-		return lastMultiSelectedBlock;
+		return getBlockIndex( state, lastMultiSelectedBlock ) + 1;
 	}
 
 	const selectedBlock = getSelectedBlock( state );
 	if ( selectedBlock ) {
-		return selectedBlock.uid;
+		return getBlockIndex( state, selectedBlock.uid ) + 1;
 	}
 
-	return last( state.editor.blockOrder );
+	return state.editor.blockOrder.length;
 }
 
 /**


### PR DESCRIPTION
This fixes a regression introduced by #2447 

In #2447 I updated the `INSERT_BLOCK` action to accept a position instead of a `uid` but forgot to update the inserter menu.

In the current PR, I also update the `getInsertionPoint` selector an `index` instead of returning the `uid` of the block preceding the insertion point. This simplifies the logic while keeping the flexibility of having a `position` property in the `INSERT_BLOCK` action.

**Testing instructions**

 - Try inserting a block using the inserter
 - The new block should be inserter after the selected block.