### PR TITLE
Add new category form improvements

### DIFF
--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -9,6 +9,7 @@ import { unescape as unescapeString, without, groupBy, map, repeat, find } from 
  */
 import { __ } from 'i18n';
 import { Component } from '@wordpress/element';
+import { withInstanceId } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -193,11 +194,14 @@ class HierarchicalTermSelector extends Component {
 
 	render() {
 		const { availableTermsTree, availableTerms, formName, formParent, loading, adding, showForm } = this.state;
-		const { label, slug } = this.props;
+		const { label, slug, instanceId } = this.props;
 
-		const newTermLinkLabel = slug === 'category' ? __( '+ Add New Category' ) : __( '+ Add New Term' );
-		const newTermLabel = slug === 'category' ? __( 'Add New Category' ) : __( 'Add New Term' );
-		const defaultParentLabel = slug === 'category' ? __( '-- Parent Category --' ) : __( '-- Parent Term --' );
+		const newTermButtonLabel = slug === 'category' ? __( '+ Add New Category' ) : __( '+ Add New Term' );
+		const newTermLabel = slug === 'category' ? __( 'Category Name' ) : __( 'Term Name' );
+		const parentSelectLabel = slug === 'category' ? __( 'Parent Category' ) : __( 'Parent Term' );
+		const newTermSubmitLabel = slug === 'category' ? __( 'Add Category' ) : __( 'Add Term' );
+		const inputId = `editor-post-taxonomies__hierarchical-terms-input-${ instanceId }`;
+		const selectId = `editor-post-taxonomies__hierarchical-terms-select-${ instanceId }`;
 
 		/* eslint-disable jsx-a11y/no-onchange */
 		return (
@@ -205,34 +209,39 @@ class HierarchicalTermSelector extends Component {
 				<h4 className="editor-post-taxonomies__hierarchical-terms-selector-title">{ label }</h4>
 				{ this.renderTerms( availableTermsTree ) }
 				{ ! loading &&
-					<button onClick={ this.onToggleForm } className="button-link">
-						{ newTermLinkLabel }
+					<button onClick={ this.onToggleForm } className="button-link" aria-expanded={ showForm }>
+						{ newTermButtonLabel }
 					</button>
 				}
 				{ showForm &&
 					<form onSubmit={ this.onAddTerm }>
+						<label htmlFor={ inputId }>{ newTermLabel }</label>
 						<input
+							id={ inputId }
 							className="editor-post-taxonomies__hierarchical-terms-input"
-							placeholder={ newTermLabel }
 							value={ formName }
 							onChange={ this.onChangeFormName }
 						/>
 						{ !! availableTerms.length &&
-							<select
-								className="editor-post-taxonomies__hierarchical-terms-input"
-								value={ formParent }
-								onChange={ this.onChangeFormParent }
-							>
-								<option value="">{ defaultParentLabel }</option>
-								{ this.renderParentSelectorOptions( availableTermsTree ) }
-							</select>
+							<div>
+								<label htmlFor={ selectId }>{ parentSelectLabel }</label>
+								<select
+									id={ selectId }
+									className="editor-post-taxonomies__hierarchical-terms-input"
+									value={ formParent }
+									onChange={ this.onChangeFormParent }
+								>
+									<option value="">{ __( 'None' ) }</option>
+									{ this.renderParentSelectorOptions( availableTermsTree ) }
+								</select>
+							</div>
 						}
 						<button
 							type="submit"
 							className="editor-post-taxonomies__hierarchical-terms-submit"
 							disabled={ adding }
 						>
-							{ newTermLabel }
+							{ newTermSubmitLabel }
 						</button>
 					</form>
 				}
@@ -253,5 +262,4 @@ export default connect(
 			return editPost( { [ restBase ]: terms } );
 		},
 	}
-)( HierarchicalTermSelector );
-
+)( withInstanceId( HierarchicalTermSelector ) );

--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -115,7 +115,6 @@ class HierarchicalTermSelector extends Component {
 					adding: false,
 					formName: '',
 					formParent: '',
-					showForm: true,
 					availableTerms: newAvailableTerms,
 					availableTermsTree: this.buildTermsTree( newAvailableTerms ),
 				} );

--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -115,7 +115,7 @@ class HierarchicalTermSelector extends Component {
 					adding: false,
 					formName: '',
 					formParent: '',
-					showForm: false,
+					showForm: true,
 					availableTerms: newAvailableTerms,
 					availableTermsTree: this.buildTermsTree( newAvailableTerms ),
 				} );

--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -7,7 +7,7 @@ import { unescape as unescapeString, without, groupBy, map, repeat, find } from 
 /**
  * WordPress dependencies
  */
-import { __ } from 'i18n';
+import { __, _x } from 'i18n';
 import { Component } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/components';
 
@@ -201,9 +201,10 @@ class HierarchicalTermSelector extends Component {
 		const { availableTermsTree, availableTerms, formName, formParent, loading, adding, showForm } = this.state;
 		const { label, slug, instanceId } = this.props;
 
-		const newTermButtonLabel = slug === 'category' ? __( '+ Add New Category' ) : __( '+ Add New Term' );
+		const newTermButtonLabel = slug === 'category' ? __( 'Add new category' ) : __( 'Add new term' );
 		const newTermLabel = slug === 'category' ? __( 'Category Name' ) : __( 'Term Name' );
 		const parentSelectLabel = slug === 'category' ? __( 'Parent Category' ) : __( 'Parent Term' );
+		const noParentOption = slug === 'category' ? _x( 'None', 'category' ) : _x( 'None', 'term' );
 		const newTermSubmitLabel = slug === 'category' ? __( 'Add Category' ) : __( 'Add Term' );
 		const inputId = `editor-post-taxonomies__hierarchical-terms-input-${ instanceId }`;
 		const selectId = `editor-post-taxonomies__hierarchical-terms-select-${ instanceId }`;
@@ -214,13 +215,22 @@ class HierarchicalTermSelector extends Component {
 				<h4 className="editor-post-taxonomies__hierarchical-terms-selector-title">{ label }</h4>
 				{ this.renderTerms( availableTermsTree ) }
 				{ ! loading &&
-					<button onClick={ this.onToggleForm } className="button-link" aria-expanded={ showForm }>
+					<button
+						onClick={ this.onToggleForm }
+						className="button-link editor-post-taxonomies__hierarchical-terms-add"
+						aria-expanded={ showForm }
+					>
 						{ newTermButtonLabel }
 					</button>
 				}
 				{ showForm &&
 					<form onSubmit={ this.onAddTerm }>
-						<label htmlFor={ inputId }>{ newTermLabel }</label>
+						<label
+							htmlFor={ inputId }
+							className="editor-post-taxonomies__hierarchical-terms-label"
+						>
+							{ newTermLabel }
+						</label>
 						<input
 							type="text"
 							id={ inputId }
@@ -230,14 +240,19 @@ class HierarchicalTermSelector extends Component {
 						/>
 						{ !! availableTerms.length &&
 							<div>
-								<label htmlFor={ selectId }>{ parentSelectLabel }</label>
+								<label
+									htmlFor={ selectId }
+									className="editor-post-taxonomies__hierarchical-terms-label"
+								>
+									{ parentSelectLabel }
+								</label>
 								<select
 									id={ selectId }
 									className="editor-post-taxonomies__hierarchical-terms-input"
 									value={ formParent }
 									onChange={ this.onChangeFormParent }
 								>
-									<option value="">{ __( 'None' ) }</option>
+									<option value="">{ noParentOption }</option>
 									{ this.renderParentSelectorOptions( availableTermsTree ) }
 								</select>
 							</div>

--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -222,6 +222,7 @@ class HierarchicalTermSelector extends Component {
 					<form onSubmit={ this.onAddTerm }>
 						<label htmlFor={ inputId }>{ newTermLabel }</label>
 						<input
+							type="text"
 							id={ inputId }
 							className="editor-post-taxonomies__hierarchical-terms-input"
 							value={ formName }
@@ -243,7 +244,7 @@ class HierarchicalTermSelector extends Component {
 						}
 						<button
 							type="submit"
-							className="editor-post-taxonomies__hierarchical-terms-submit"
+							className="button editor-post-taxonomies__hierarchical-terms-submit"
 							disabled={ adding }
 						>
 							{ newTermSubmitLabel }

--- a/editor/sidebar/post-taxonomies/style.scss
+++ b/editor/sidebar/post-taxonomies/style.scss
@@ -22,11 +22,17 @@
 	margin-left: $panel-padding;
 }
 
-.editor-post-taxonomies__hierarchical-terms-submit {
+.button.editor-post-taxonomies__hierarchical-terms-submit,
+.button-link.editor-post-taxonomies__hierarchical-terms-add {
+	margin-top: 10px;
+}
+
+.editor-post-taxonomies__hierarchical-terms-label {
+	display: inline-block;
 	margin-top: 10px;
 }
 
 .editor-post-taxonomies__hierarchical-terms-input {
-	margin-top: 10px;
+	margin-top: 5px;
 	width: 100%;
 }


### PR DESCRIPTION
This PR tries to improve a bit the accessibility of the mini-form used to add new categories. Further improvements should be addressed in separate issues, see #2582 and #2581.

- adds visible label elements to the input field and select
- add IDs using `withInstanceId `
- removes the input placeholder
- removes the "+" plus sign from the toggle: we don't want screen readers announce "plus" and it's inconsistent with other `button-link`s used in the sidebar, e.g. "set featured image"
- fixes the focus styles 
- adds missing `type="text"` to the input field (this also fixes the focus style)
- keeps the form open after a category has been added: otherwise, when adding multiple categories, users would be forced to re-open the form each time
- adds `aria-expanded` to the toggle
- tries to improve translations and labels

Fixes #2572