### PR TITLE
Add focusable="false" to prevent IE11 getting focus in the SVG icon.

### DIFF
--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -829,6 +829,7 @@ export default class Dashicon extends wp.element.Component {
 			<svg
 				aria-hidden
 				role="img"
+				focusable="false"
 				className={ iconClass }
 				xmlns="http://www.w3.org/2000/svg"
 				width={ size }


### PR DESCRIPTION
More details in the issues #1578.