### PR TITLE
Improve and simplify the sidebar panel toggles accessibility.

### DIFF
--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -51,7 +50,6 @@ class PanelBody extends Component {
 							className="components-panel__body-toggle"
 							onClick={ this.toggle }
 							aria-expanded={ isOpened }
-							label={ sprintf( __( 'Open section: %s' ), title ) }
 						>
 							<Dashicon icon={ icon } />
 							{ title }

--- a/editor/sidebar/header.js
+++ b/editor/sidebar/header.js
@@ -20,19 +20,21 @@ const SidebarHeader = ( { panel, onSetPanel, toggleSidebar } ) => {
 			<button
 				onClick={ () => onSetPanel( 'document' ) }
 				className={ `editor-sidebar__panel-tab ${ panel === 'document' ? 'is-active' : '' }` }
+				aria-label={ __( 'Document settings' ) }
 			>
 				{ __( 'Document' ) }
 			</button>
 			<button
 				onClick={ () => onSetPanel( 'block' ) }
 				className={ `editor-sidebar__panel-tab ${ panel === 'block' ? 'is-active' : '' }` }
+				aria-label={ __( 'Block settings' ) }
 			>
 				{ __( 'Block' ) }
 			</button>
 			<IconButton
 				onClick={ toggleSidebar }
 				icon="no-alt"
-				label={ __( 'Close post settings sidebar' ) }
+				label={ __( 'Close settings' ) }
 			/>
 		</div>
 	);


### PR DESCRIPTION
This PR tries to simplify the way assistive technologies announce the sidebar panel toggles. The current text prepends "Open section:" to any panel name. From a user perspective, that could be redundant and confusing. Not sure "section" makes any sense for users.
Also, the toggles already use an aria-expanded attribute that makes screen readers announce "collapsed/expanded" depending on the panel state.

Simplifying all the things can help users to better understand what's going on.

- removes the aria-label attributes on the panel toggles (note: the `label` prop was also wrong)
- expands the "Document" and "Block" buttons text with two aria-label attributes
- simplifies the "Close" aria-label

Fixes #2376 