### PR TITLE
fix/2563: move removeOrDeselect to key down handler

### DIFF
--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -30,7 +30,6 @@ export class DropdownMenu extends Component {
 		this.focusPrevious = this.focusPrevious.bind( this );
 		this.focusNext = this.focusNext.bind( this );
 		this.handleKeyDown = this.handleKeyDown.bind( this );
-		this.handleKeyUp = this.handleKeyUp.bind( this );
 		this.calculateMenuPosition = this.calculateMenuPosition.bind( this );
 
 		this.nodes = {};
@@ -116,23 +115,6 @@ export class DropdownMenu extends Component {
 		this.focusIndex( nextIndex );
 	}
 
-	handleKeyUp( event ) {
-		// TODO: find a better way to isolate events on nested components see GH issue #1973.
-		/*
-		 * VisualEditorBlock uses a keyup event to deselect the block. When the
-		 * menu is open we need to stop propagation after Escape has been pressed
-		 * so we use a keyup event instead of keydown, otherwise the whole block
-		 * toolbar will disappear.
-		 */
-		if ( event.keyCode === ESCAPE && this.state.open ) {
-			event.preventDefault();
-			event.stopPropagation();
-			// eslint-disable-next-line react/no-find-dom-node
-			findDOMNode( this.nodes.toggle ).focus();
-			this.closeMenu();
-		}
-	}
-
 	handleKeyDown( keydown ) {
 		if ( this.state.open ) {
 			switch ( keydown.keyCode ) {
@@ -154,7 +136,13 @@ export class DropdownMenu extends Component {
 					keydown.stopPropagation();
 					this.focusNext();
 					break;
-
+				case ESCAPE:
+					keydown.preventDefault();
+					keydown.stopPropagation();
+					// eslint-disable-next-line react/no-find-dom-node
+					findDOMNode( this.nodes.toggle ).focus();
+					this.closeMenu();
+					break;
 				default:
 					break;
 			}
@@ -218,7 +206,6 @@ export class DropdownMenu extends Component {
 			<div
 				className="components-dropdown-menu"
 				onKeyDown={ this.handleKeyDown }
-				onKeyUp={ this.handleKeyUp }
 			>
 				<IconButton
 					className={

--- a/components/dropdown-menu/test/index.js
+++ b/components/dropdown-menu/test/index.js
@@ -146,7 +146,7 @@ describe( 'DropdownMenu', () => {
 			wrapper.find( '> IconButton' ).simulate( 'click' );
 
 			// Close menu by escape
-			wrapper.simulate( 'keyup', {
+			wrapper.simulate( 'keydown', {
 				stopPropagation: () => {},
 				preventDefault: () => {},
 				keyCode: ESCAPE,

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -73,7 +73,6 @@ class VisualEditorBlock extends Component {
 		this.onFocus = this.onFocus.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
-		this.onKeyUp = this.onKeyUp.bind( this );
 		this.toggleMobileControls = this.toggleMobileControls.bind( this );
 		this.onBlockError = this.onBlockError.bind( this );
 		this.insertBlocksAfter = this.insertBlocksAfter.bind( this );
@@ -263,9 +262,6 @@ class VisualEditorBlock extends Component {
 				createBlock( 'core/paragraph' ),
 			], this.props.order );
 		}
-	}
-
-	onKeyUp( event ) {
 		this.removeOrDeselect( event );
 	}
 
@@ -331,7 +327,6 @@ class VisualEditorBlock extends Component {
 			<div
 				ref={ this.bindBlockNode }
 				onKeyDown={ this.onKeyDown }
-				onKeyUp={ this.onKeyUp }
 				onFocus={ this.onFocus }
 				onMouseMove={ this.maybeHover }
 				onMouseEnter={ this.maybeHover }


### PR DESCRIPTION
This aims to fix https://github.com/WordPress/gutenberg/issues/2563 by moving the code responsible for deleting the block to the key down event.

Some other code that was dependent on the escape key being handled on key up has been changed to match.