### PR TITLE
Editor: Fix resetting the drop-zone states after dropping a file

### DIFF
--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -68,7 +68,11 @@ class DropZoneProvider extends Component {
 		} );
 
 		this.dropzones.forEach( ( { updateState } ) => {
-			updateState( { isDraggingOverDocument, isDraggingOverElement: false, position: null } );
+			updateState( {
+				isDraggingOverDocument: false,
+				isDraggingOverElement: false,
+				position: null,
+			} );
 		} );
 	}
 


### PR DESCRIPTION
closes #2597

The dropzone classes were not being cleaned on drop which causes the dropzone to appear over the controls.

**Testings instructions**

 - Follow instructions ins #2597 