### PR TITLE
Chrome: Fix adding new categories and terms

### DIFF
--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -107,8 +107,8 @@ class HierarchicalTermSelector extends Component {
 		} );
 		findOrCreatePromise
 			.then( ( term ) => {
-				const hasTerm = !! find( this.state.availableTerms, ( availableTerm ) => availableTerm.id !== term.id );
-				const newAvailableTerms = hasTerm ? this.state.availableTerms : [ ...this.state.availableTerms, term ];
+				const hasTerm = !! find( this.state.availableTerms, ( availableTerm ) => availableTerm.id === term.id );
+				const newAvailableTerms = hasTerm ? this.state.availableTerms : [ term, ...this.state.availableTerms ];
 				const { onUpdateTerms, restBase, terms } = this.props;
 				this.setState( {
 					adding: false,


### PR DESCRIPTION
closes #2582

Not sure where this regressed, but this PR fixes the form and also moves the newly inserted term to the top.

**Testing instructions**

 - Try creating a new category
 - It should be added at the top of the list and selected automatically