### PR TITLE
Editable: Fix updating the style prop in iOS

### DIFF
--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -32,7 +32,7 @@ export default class TinyMCE extends Component {
 		}
 
 		if ( ! isEqual( this.props.style, nextProps.style ) ) {
-			this.editorNode.style = {};
+			this.editorNode.setAttribute( 'style', '' );
 			Object.assign( this.editorNode.style, nextProps.style );
 		}
 


### PR DESCRIPTION
closes #2603 

This should fix the iOS issue but not sure how to test this in iOS (and I don't have iOS at all).
Also, I tried the solution proposed by @aduth, map over previous props and unset them but for some reason I couldn't understand all the style were not reset. (You can try choosing a background color for a text block and reset it).