### PR TITLE
Unify caption styling for images and video

### DIFF
--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -11,6 +11,7 @@ import { Placeholder, Toolbar, Dashicon } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import { registerBlockType, source } from '../../api';
 import MediaUploadButton from '../../media-upload-button';
 import Editable from '../../editable';

--- a/blocks/library/video/style.scss
+++ b/blocks/library/video/style.scss
@@ -1,0 +1,6 @@
+.wp-block-video figcaption {
+	margin-top: 0.5em;
+	color: $dark-gray-100;
+	text-align: center;
+	font-size: $default-font-size;
+}


### PR DESCRIPTION
This makes the captions the same, they were different.
Fixes #2579 