### PR TITLE
Blocks: Save embed with empty markup when URL not selected

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -219,6 +219,10 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 		save( { attributes } ) {
 			const { url, caption, align } = attributes;
 
+			if ( ! url ) {
+				return;
+			}
+
 			return (
 				<figure className={ align ? `align${ align }` : null }>
 					{ `\n${ url }\n` /* URL needs to be on its own line. */ }


### PR DESCRIPTION
Fixes #2612 

This pull request seeks to resolve an issue where a `figure` with text "undefined" is saved into post content for an embed block, if a URL is not yet assigned to the block.

__Open questions:__

In cases such as these where a block has a placeholder state, is it sensible to save the block at all, or would it make more sense to omit the block from the saved content? There may be technical challenges in implementing this behavior.

__Testing instructions:__

1. Navigate to Gutenberg > New Post
2. Insert an embed-type block (Vimeo, etc)
3. Preview the post
4. Note that the previewed post appears empty
5. Return to the editor
6. Refresh the page
7. Note that the embed block still exists in the post, in its placeholder state