### PR TITLE
Parser: Apply raw transforms to fallback content

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -18,7 +18,6 @@ import {
  */
 import { getBlockType, getBlockTypes, getUnknownTypeHandlerName } from './registration';
 import { getBlockAttributes } from './parser';
-import normalize from './paste/normalise-blocks';
 
 /**
  * Returns a block object given its type and attributes.
@@ -74,7 +73,7 @@ const getBlockTypeTransforms = createSelector( ( blockTypes, type ) => {
 export function createBlocksFromMarkup( html ) {
 	// Assign markup as body of sandboxed document
 	const doc = document.implementation.createHTMLDocument( '' );
-	doc.body.innerHTML = normalize( html );
+	doc.body.innerHTML = html;
 
 	const rawTransforms = getBlockTypeTransforms( getBlockTypes(), 'raw' );
 

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import createSelector from 'rememo';
 import uuid from 'uuid/v4';
 import {
 	get,
@@ -9,12 +10,15 @@ import {
 	findIndex,
 	isObjectLike,
 	find,
+	filter,
 } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getBlockType } from './registration';
+import { getBlockType, getBlockTypes, getUnknownTypeHandlerName } from './registration';
+import { getBlockAttributes } from './parser';
+import normalize from './paste/normalise-blocks';
 
 /**
  * Returns a block object given its type and attributes.
@@ -51,6 +55,53 @@ export function createBlock( name, blockAttributes = {} ) {
 		isValid: true,
 		attributes,
 	};
+}
+
+const getBlockTypeTransforms = createSelector( ( blockTypes, type ) => {
+	return blockTypes.reduce( ( result, blockType ) => {
+		if ( blockType.transforms ) {
+			result = [
+				...result,
+				...filter( blockType.transforms.from, { type } )
+					.map( ( transform ) => [ blockType, transform ] ),
+			];
+		}
+
+		return result;
+	}, [] );
+} );
+
+export function createBlocksFromMarkup( html ) {
+	// Assign markup as body of sandboxed document
+	const doc = document.implementation.createHTMLDocument( '' );
+	doc.body.innerHTML = normalize( html );
+
+	const rawTransforms = getBlockTypeTransforms( getBlockTypes(), 'raw' );
+
+	// For each node in the document, check whether a block type with a raw
+	// transform matches the node
+	return [ ...doc.body.children ].map( ( node ) => {
+		for ( let i = 0; i < rawTransforms.length; i++ ) {
+			const [ blockType, transform ] = rawTransforms[ i ];
+			if ( ! transform.isMatch( node ) ) {
+				continue;
+			}
+
+			// Return with matched block, extracting attributes from the node
+			// as defined by the block attributes schema
+			return createBlock(
+				blockType.name,
+				transform.getAttributes
+					? transform.getAttributes( node )
+					: getBlockAttributes( blockType, node.outerHTML )
+			);
+		}
+
+		// Assuming no match, use fallback block handler
+		return createBlock( getUnknownTypeHandlerName(), {
+			content: node.outerHTML,
+		} );
+	} );
 }
 
 /**

--- a/blocks/api/paste/index.js
+++ b/blocks/api/paste/index.js
@@ -1,14 +1,8 @@
 /**
- * External dependencies
- */
-import { find, get } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import { createBlock } from '../factory';
-import { getBlockTypes, getUnknownTypeHandlerName } from '../registration';
-import { getBlockAttributes, parseWithGrammar } from '../parser';
+import { createBlocksFromMarkup } from '../factory';
+import { parseWithGrammar } from '../parser';
 import normaliseBlocks from './normalise-blocks';
 import stripAttributes from './strip-attributes';
 import commentRemover from './comment-remover';
@@ -62,38 +56,5 @@ export default function( { content: HTML, inline } ) {
 	// Allows us to ask for this information when we get a report.
 	window.console.log( 'Processed HTML piece:\n\n', HTML );
 
-	const doc = document.implementation.createHTMLDocument( '' );
-
-	doc.body.innerHTML = HTML;
-
-	return Array.from( doc.body.children ).map( ( node ) => {
-		const block = getBlockTypes().reduce( ( acc, blockType ) => {
-			if ( acc ) {
-				return acc;
-			}
-
-			const transformsFrom = get( blockType, 'transforms.from', [] );
-			const transform = find( transformsFrom, ( { type } ) => type === 'raw' );
-
-			if ( ! transform || ! transform.isMatch( node ) ) {
-				return acc;
-			}
-
-			return createBlock(
-				blockType.name,
-				getBlockAttributes(
-					blockType,
-					node.outerHTML
-				)
-			);
-		}, null );
-
-		if ( block ) {
-			return block;
-		}
-
-		return createBlock( getUnknownTypeHandlerName(), {
-			content: node.outerHTML,
-		} );
-	} );
+	return createBlocksFromMarkup( HTML );
 }

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { isFunction, some } from 'lodash';
+import { isFunction, some, omit } from 'lodash';
+import createSelector from 'rememo';
 
 /**
  * WordPress dependencies
@@ -15,7 +16,7 @@ import { getCategories } from './categories';
  *
  * @type {Object}
  */
-const blocks = {};
+let blocks = {};
 
 const categories = getCategories();
 
@@ -93,7 +94,7 @@ export function registerBlockType( name, settings ) {
 		return;
 	}
 	const block = Object.assign( { name }, settings );
-	blocks[ name ] = block;
+	blocks = { ...blocks, [ name ]: block };
 	return block;
 }
 
@@ -112,7 +113,7 @@ export function unregisterBlockType( name ) {
 		return;
 	}
 	const oldBlock = blocks[ name ];
-	delete blocks[ name ];
+	blocks = omit( blocks, name );
 	return oldBlock;
 }
 
@@ -163,11 +164,13 @@ export function getBlockType( name ) {
 	return blocks[ name ];
 }
 
+const _memoizedGetBlockTypes = createSelector( Object.values );
+
 /**
  * Returns all registered blocks.
  *
  * @return {Array} Block settings
  */
 export function getBlockTypes() {
-	return Object.values( blocks );
+	return _memoizedGetBlockTypes( blocks );
 }

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -30,6 +30,13 @@ const linkOptions = [
 	{ value: 'none', label: __( 'None' ) },
 ];
 
+/**
+ * Regular expression matching a gallery shortcode.
+ *
+ * @type {RegExp}
+ */
+const SHORTCODE_REGEXP = window.wp.shortcode.regexp( 'gallery' );
+
 function defaultColumnsNumber( attributes ) {
 	return Math.min( 3, attributes.images.length );
 }
@@ -65,6 +72,26 @@ registerBlockType( 'core/gallery', {
 			type: 'string',
 			default: 'none',
 		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				isMatch: ( node ) => SHORTCODE_REGEXP.test( node.textContent ),
+				getAttributes( node ) {
+					const { shortcode } = window.wp.shortcode.next( 'gallery', node.textContent );
+					let { ids } = shortcode.attrs.named;
+					if ( ! ids || ! ( ids = ids.trim() ) ) {
+						return {};
+					}
+
+					return {
+						images: ids.split( ',' ).map( ( id ) => ( { id } ) ),
+					};
+				},
+			},
+		],
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -63,16 +63,16 @@ registerBlockType( 'core/paragraph', {
 	},
 
 	transforms: {
-		from: [
-			{
-				type: 'raw',
-				isMatch: ( node ) => (
-					node.nodeName === 'P' &&
-					// Do not allow embedded content.
-					! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
-				),
-			},
-		],
+		// from: [
+		// 	{
+		// 		type: 'raw',
+		// 		isMatch: ( node ) => (
+		// 			node.nodeName === 'P' &&
+		// 			// Do not allow embedded content.
+		// 			! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
+		// 		),
+		// 	},
+		// ],
 	},
 
 	merge( attributes, attributesToMerge ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -135,7 +135,19 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models' ),
+		array(
+			'wp-element',
+			'wp-components',
+			'wp-utils',
+			'wp-i18n',
+			'tinymce-latest',
+			'tinymce-latest-lists',
+			'tinymce-latest-paste',
+			'tinymce-latest-table',
+			'media-views',
+			'media-models',
+			'shortcode',
+		),
 		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 	wp_add_inline_script(


### PR DESCRIPTION
Closes #2454
Closes #1728

This pull request seeks to extend raw transforms used in paste handling to fallback post content (freeform). This could be used to upgrade legacy content to compatible blocks, including images, paragraphs, and even shortcodes (providing a transition path for plugin authors and their existing shortcodes).

__Implementation notes:__

This pull request is a work-in-progress, and has encountered a number of hurdles:

- The raw transform tests expect to receive a DOM node, but in the case of legacy post content, we need to generate blocks from a string of `removep`-delimited content (`removep` replaces paragraphs with two subsequent line breaks). The implementation here applies `autop` to freeform content, assuming it to be from legacy posts (an open question as to whether this is a fair assumption).
- There may be need for transform prioritization. For example, given the above note about reapplying `autop`, the paragraph block will now match a `<p>[gallery]</p>` node, despite this being better suited as a gallery block. In the meantime, I have had to temporarily disable the paragraph block transform.
- We may want to consider just how much we automatically upgrade. While paragraph transforms were still active with these changes, it was pretty nice to see freeform paragraphs automatically upgraded to a paragraph block. But do we risk these transforms being destructive?
- To the previous point, we must determine how to handle cases where freeform content is a "match" but also has additional attributes that would be lost in the block reserialization, per the conversation between @youknowriad and @iseulde at https://github.com/WordPress/gutenberg/pull/1331#discussion_r125249135
- The gallery block expects more attributes to be sourced than can be satisfied by the gallery shortcode. This may simply be a matter of refactoring the gallery block to be able to initialize from the data available in a shortcode (only image IDs)

As an alternative implementation, we could consider limiting these upgrades to either (a) specific string patterns and/or (b) shortcode detection.

__Testing instructions:__

Noting that this is still a work in progress, you can test the behavior by saving a post in the current post editor's HTML mode as such:

```
this is a post

[gallery ids="12,34,56"]

with a gallery
```

When reopening this post in Gutenberg, you should note that the gallery shortcode is replaced with a gallery block (currently best observed in Text mode, noting issues above about gallery block initializing only from IDs).