### PR TITLE
Serializer: Capture and recover from save errors

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -201,11 +201,12 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
 
 		// Validate that the parsed block is valid, meaning that if we were to
 		// reserialize it given the assumed attributes, the markup matches the
-		// original value. Otherwise, preserve original to avoid destruction.
+		// original value.
 		block.isValid = isValidBlock( rawContent, blockType, block.attributes );
-		if ( ! block.isValid ) {
-			block.originalContent = rawContent;
-		}
+
+		// Preserve original content for future use in case the block is parsed
+		// as invalid, or future serialization attempt results in an error
+		block.originalContent = rawContent;
 
 		return block;
 	}

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -174,13 +174,13 @@ export function serializeBlock( block ) {
 	const blockName = block.name;
 	const blockType = getBlockType( blockName );
 
-	let saveContent;
+	// If block was parsed as invalid or encounters an error while generating
+	// save content, use original content instead to avoid content loss.
+	let saveContent = block.originalContent;
 	if ( block.isValid ) {
-		saveContent = getSaveContent( blockType, block.attributes );
-	} else {
-		// If block was parsed as invalid, skip serialization behavior and opt
-		// to use original content instead so we don't destroy user content.
-		saveContent = block.originalContent;
+		try {
+			saveContent = getSaveContent( blockType, block.attributes );
+		} catch ( error ) {}
 	}
 
 	const saveAttributes = getCommentAttributes( block.attributes, blockType.attributes );

--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -401,6 +401,21 @@ describe( 'validation', () => {
 			) ).toBe( false );
 		} );
 
+		it( 'returns false is error occurs while generating block save', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				save() {
+					throw new Error();
+				},
+			} );
+
+			expect( isValidBlock(
+				'Bananas',
+				getBlockType( 'core/test-block' ),
+				{ fruit: 'Bananas' }
+			) ).toBe( false );
+		} );
+
 		it( 'returns true is block is valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -380,8 +380,12 @@ export function isEquivalentHTML( a, b ) {
  * @return {Boolean}            Whether block is valid
  */
 export function isValidBlock( rawContent, blockType, attributes ) {
-	return isEquivalentHTML(
-		rawContent,
-		getSaveContent( blockType, attributes )
-	);
+	let saveContent;
+	try {
+		saveContent = getSaveContent( blockType, attributes );
+	} catch ( error ) {
+		return false;
+	}
+
+	return isEquivalentHTML( rawContent, saveContent );
 }

--- a/blocks/test/fixtures/core-embed__animoto.json
+++ b/blocks/test/fixtures/core-embed__animoto.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from animoto"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-animoto\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__cloudup.json
+++ b/blocks/test/fixtures/core-embed__cloudup.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from cloudup"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-cloudup\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__collegehumor.json
+++ b/blocks/test/fixtures/core-embed__collegehumor.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from collegehumor"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-collegehumor\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__dailymotion.json
+++ b/blocks/test/fixtures/core-embed__dailymotion.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from dailymotion"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-dailymotion\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__facebook.json
+++ b/blocks/test/fixtures/core-embed__facebook.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from facebook"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-facebook\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__flickr.json
+++ b/blocks/test/fixtures/core-embed__flickr.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from flickr"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-flickr\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__funnyordie.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from funnyordie"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-funnyordie\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__hulu.json
+++ b/blocks/test/fixtures/core-embed__hulu.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from hulu"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-hulu\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__imgur.json
+++ b/blocks/test/fixtures/core-embed__imgur.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from imgur"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-imgur\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__instagram.json
+++ b/blocks/test/fixtures/core-embed__instagram.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from instagram"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-instagram\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__issuu.json
+++ b/blocks/test/fixtures/core-embed__issuu.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from issuu"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-issuu\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__kickstarter.json
+++ b/blocks/test/fixtures/core-embed__kickstarter.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from kickstarter"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-kickstarter\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__meetup-com.json
+++ b/blocks/test/fixtures/core-embed__meetup-com.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from meetup-com"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-meetup-com\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__mixcloud.json
+++ b/blocks/test/fixtures/core-embed__mixcloud.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from mixcloud"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-mixcloud\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__photobucket.json
+++ b/blocks/test/fixtures/core-embed__photobucket.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from photobucket"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-photobucket\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__polldaddy.json
+++ b/blocks/test/fixtures/core-embed__polldaddy.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from polldaddy"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-polldaddy\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__reddit.json
+++ b/blocks/test/fixtures/core-embed__reddit.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from reddit"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-reddit\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__reverbnation.json
+++ b/blocks/test/fixtures/core-embed__reverbnation.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from reverbnation"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-reverbnation\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__screencast.json
+++ b/blocks/test/fixtures/core-embed__screencast.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from screencast"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-screencast\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__scribd.json
+++ b/blocks/test/fixtures/core-embed__scribd.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from scribd"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-scribd\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__slideshare.json
+++ b/blocks/test/fixtures/core-embed__slideshare.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from slideshare"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-slideshare\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__smugmug.json
+++ b/blocks/test/fixtures/core-embed__smugmug.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from smugmug"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-smugmug\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__soundcloud.json
+++ b/blocks/test/fixtures/core-embed__soundcloud.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from soundcloud"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-soundcloud\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__speaker.json
+++ b/blocks/test/fixtures/core-embed__speaker.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from speaker"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-speaker\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__spotify.json
+++ b/blocks/test/fixtures/core-embed__spotify.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from spotify"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-spotify\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__ted.json
+++ b/blocks/test/fixtures/core-embed__ted.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from ted"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-ted\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__tumblr.json
+++ b/blocks/test/fixtures/core-embed__tumblr.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from tumblr"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-tumblr\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__twitter.json
+++ b/blocks/test/fixtures/core-embed__twitter.json
@@ -8,6 +8,7 @@
             "caption": [
                 "We are Automattic"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-twitter\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__videopress.json
+++ b/blocks/test/fixtures/core-embed__videopress.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from videopress"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-videopress\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__vimeo.json
+++ b/blocks/test/fixtures/core-embed__vimeo.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from vimeo"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-vimeo\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__vine.json
+++ b/blocks/test/fixtures/core-embed__vine.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from vine"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-vine\">\n    https://vine.com/\n    <figcaption>Embedded content from vine</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress-tv.json
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from wordpress-tv"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-wordpress-tv\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress.json
+++ b/blocks/test/fixtures/core-embed__wordpress.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from WordPress"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-wordpress\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__youtube.json
+++ b/blocks/test/fixtures/core-embed__youtube.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from youtube"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed-youtube\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core__audio.json
+++ b/blocks/test/fixtures/core__audio.json
@@ -6,6 +6,7 @@
         "attributes": {
             "src": "https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3",
             "align": "right"
-        }
+        },
+        "originalContent": "<div class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</div>"
     }
 ]

--- a/blocks/test/fixtures/core__button__center.json
+++ b/blocks/test/fixtures/core__button__center.json
@@ -9,6 +9,7 @@
                 "Help build Gutenberg"
             ],
             "align": "center"
-        }
+        },
+        "originalContent": "<div class=\"wp-block-button aligncenter\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>"
     }
 ]

--- a/blocks/test/fixtures/core__categories.json
+++ b/blocks/test/fixtures/core__categories.json
@@ -7,6 +7,7 @@
             "showPostCounts": false,
             "displayAsDropdown": false,
             "showHierarchy": false
-        }
+        },
+        "originalContent": ""
     }
 ]

--- a/blocks/test/fixtures/core__code.json
+++ b/blocks/test/fixtures/core__code.json
@@ -5,6 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": "export default function MyButton() {\n\treturn <Button>Click Me!</Button>;\n}"
-        }
+        },
+        "originalContent": "<pre class=\"wp-block-code\"><code>export default function MyButton() {\n\treturn &lt;Button&gt;Click Me!&lt;/Button&gt;;\n}</code></pre>"
     }
 ]

--- a/blocks/test/fixtures/core__cover-image.json
+++ b/blocks/test/fixtures/core__cover-image.json
@@ -10,6 +10,7 @@
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "hasParallax": false,
             "hasBackgroundDim": true
-        }
+        },
+        "originalContent": "<section class=\"wp-block-cover-image has-background-dim\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg);\">\n    <h2>Guten Berg!</h2>\n</section>"
     }
 ]

--- a/blocks/test/fixtures/core__embed.json
+++ b/blocks/test/fixtures/core__embed.json
@@ -8,6 +8,7 @@
             "caption": [
                 "Embedded content from an example URL"
             ]
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core__freeform.json
+++ b/blocks/test/fixtures/core__freeform.json
@@ -5,6 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": "Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
-        }
+        },
+        "originalContent": "Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2-em.json
+++ b/blocks/test/fixtures/core__heading__h2-em.json
@@ -13,6 +13,7 @@
                 " Tool"
             ],
             "nodeName": "H2"
-        }
+        },
+        "originalContent": "<h2>The <em>Inserter</em> Tool</h2>"
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2.json
+++ b/blocks/test/fixtures/core__heading__h2.json
@@ -8,6 +8,7 @@
                 "A picture is worth a thousand words, or so the saying goes"
             ],
             "nodeName": "H2"
-        }
+        },
+        "originalContent": "<h2>A picture is worth a thousand words, or so the saying goes</h2>"
     }
 ]

--- a/blocks/test/fixtures/core__html.json
+++ b/blocks/test/fixtures/core__html.json
@@ -5,6 +5,7 @@
         "isValid": true,
         "attributes": {
             "content": "<h1>Some HTML code</h1>\n<marquee>This text will scroll from right to left</marquee>"
-        }
+        },
+        "originalContent": "<h1>Some HTML code</h1>\n<marquee>This text will scroll from right to left</marquee>"
     }
 ]

--- a/blocks/test/fixtures/core__image.json
+++ b/blocks/test/fixtures/core__image.json
@@ -6,6 +6,7 @@
         "attributes": {
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "caption": []
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" /></figure>"
     }
 ]

--- a/blocks/test/fixtures/core__latest-posts.json
+++ b/blocks/test/fixtures/core__latest-posts.json
@@ -9,6 +9,7 @@
             "layout": "list",
             "columns": 3,
             "align": "center"
-        }
+        },
+        "originalContent": ""
     }
 ]

--- a/blocks/test/fixtures/core__latest-posts__displayPostDate.json
+++ b/blocks/test/fixtures/core__latest-posts__displayPostDate.json
@@ -9,6 +9,7 @@
             "layout": "list",
             "columns": 3,
             "align": "center"
-        }
+        },
+        "originalContent": ""
     }
 ]

--- a/blocks/test/fixtures/core__list__ul.json
+++ b/blocks/test/fixtures/core__list__ul.json
@@ -38,6 +38,7 @@
                     ]
                 }
             ]
-        }
+        },
+        "originalContent": "<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>"
     }
 ]

--- a/blocks/test/fixtures/core__more.json
+++ b/blocks/test/fixtures/core__more.json
@@ -5,6 +5,7 @@
         "isValid": true,
         "attributes": {
             "noTeaser": false
-        }
+        },
+        "originalContent": ""
     }
 ]

--- a/blocks/test/fixtures/core__more__custom-text-teaser.json
+++ b/blocks/test/fixtures/core__more__custom-text-teaser.json
@@ -5,6 +5,7 @@
         "isValid": true,
         "attributes": {
             "noTeaser": true
-        }
+        },
+        "originalContent": ""
     }
 ]

--- a/blocks/test/fixtures/core__paragraph__align-right.json
+++ b/blocks/test/fixtures/core__paragraph__align-right.json
@@ -9,6 +9,7 @@
             ],
             "align": "right",
             "dropCap": false
-        }
+        },
+        "originalContent": "<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>"
     }
 ]

--- a/blocks/test/fixtures/core__preformatted.json
+++ b/blocks/test/fixtures/core__preformatted.json
@@ -16,6 +16,7 @@
                 },
                 "And more!"
             ]
-        }
+        },
+        "originalContent": "<pre class=\"wp-block-preformatted\">Some <em>preformatted</em> text...<br>And more!</pre>"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -24,6 +24,7 @@
                 "by whomever"
             ],
             "align": "none"
-        }
+        },
+        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>by whomever</footer>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -14,6 +14,7 @@
                 "Matt Mullenweg, 2017"
             ],
             "style": 1
-        }
+        },
+        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -14,6 +14,7 @@
                 "Maya Angelou"
             ],
             "style": 2
-        }
+        },
+        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__separator.json
+++ b/blocks/test/fixtures/core__separator.json
@@ -3,6 +3,7 @@
         "uid": "_uid_0",
         "name": "core/separator",
         "isValid": true,
-        "attributes": {}
+        "attributes": {},
+        "originalContent": "<hr class=\"wp-block-separator\" />"
     }
 ]

--- a/blocks/test/fixtures/core__shortcode.json
+++ b/blocks/test/fixtures/core__shortcode.json
@@ -5,6 +5,7 @@
         "isValid": true,
         "attributes": {
             "text": "[gallery ids=\"238,338\"]"
-        }
+        },
+        "originalContent": "[gallery ids=\"238,338\"]"
     }
 ]

--- a/blocks/test/fixtures/core__text-columns.json
+++ b/blocks/test/fixtures/core__text-columns.json
@@ -14,6 +14,7 @@
             ],
             "columns": 2,
             "width": "center"
-        }
+        },
+        "originalContent": "<section class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-column\">\n        <p>Two</p>\n    </div>\n</section>"
     }
 ]

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.json
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.json
@@ -13,6 +13,7 @@
                 " in #2135."
             ],
             "dropCap": false
-        }
+        },
+        "originalContent": "<p>This is an old-style text block.  Changed to <code>core/paragraph</code> in #2135.</p>"
     }
 ]

--- a/blocks/test/fixtures/core__verse.json
+++ b/blocks/test/fixtures/core__verse.json
@@ -16,6 +16,7 @@
                 },
                 "And more!"
             ]
-        }
+        },
+        "originalContent": "<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"
     }
 ]

--- a/blocks/test/fixtures/core__video.json
+++ b/blocks/test/fixtures/core__video.json
@@ -6,6 +6,7 @@
         "attributes": {
             "src": "https://awesome-fake.video/file.mp4",
             "caption": []
-        }
+        },
+        "originalContent": "<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"\"></video></figure>"
     }
 ]

--- a/editor/modes/visual-editor/block-crash-boundary.js
+++ b/editor/modes/visual-editor/block-crash-boundary.js
@@ -4,11 +4,27 @@
 import { Component } from '@wordpress/element';
 
 class BlockCrashBoundary extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			hasError: false,
+		};
+	}
+
 	componentDidCatch( error ) {
 		this.props.onError( error );
+
+		this.setState( {
+			hasError: true,
+		} );
 	}
 
 	render() {
+		if ( this.state.hasError ) {
+			return null;
+		}
+
 		return this.props.children;
 	}
 }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -10,7 +10,7 @@ import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 /**
  * WordPress dependencies
  */
-import { Children, Component } from '@wordpress/element';
+import { Children, Component, createElement } from '@wordpress/element';
 import { IconButton, Toolbar } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
 import { getBlockType, getBlockDefaultClassname, createBlock } from '@wordpress/blocks';
@@ -378,30 +378,36 @@ class VisualEditorBlock extends Component {
 					onTouchStart={ this.onPointerDown }
 					className="editor-visual-editor__block-edit"
 				>
-					{ isValid && ! error && (
-						<BlockCrashBoundary onError={ this.onBlockError }>
-							<BlockEdit
-								focus={ focus }
-								attributes={ block.attributes }
-								setAttributes={ this.setAttributes }
-								insertBlocksAfter={ this.insertBlocksAfter }
-								onReplace={ onReplace }
-								setFocus={ partial( onFocus, block.uid ) }
-								mergeBlocks={ this.mergeBlocks }
-								className={ className }
-								id={ block.uid }
-							/>
-						</BlockCrashBoundary>
-					) }
-					{ ! isValid && (
-						blockType.save( {
-							attributes: block.attributes,
-							className,
-						} )
-					) }
+					<BlockCrashBoundary onError={ this.onBlockError }>
+						{ isValid
+							? (
+								<BlockEdit
+									focus={ focus }
+									attributes={ block.attributes }
+									setAttributes={ this.setAttributes }
+									insertBlocksAfter={ this.insertBlocksAfter }
+									onReplace={ onReplace }
+									setFocus={ partial( onFocus, block.uid ) }
+									mergeBlocks={ this.mergeBlocks }
+									className={ className }
+									id={ block.uid }
+								/>
+							)
+							: [
+								createElement( blockType.save, {
+									key: 'invalid-preview',
+									attributes: block.attributes,
+									className,
+								} ),
+								<InvalidBlockWarning
+									key="invalid-warning"
+									block={ block }
+								/>,
+							]
+						}
+					</BlockCrashBoundary>
 				</div>
 				{ !! error && <BlockCrashWarning /> }
-				{ ! isValid && <InvalidBlockWarning block={ block } /> }
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */


### PR DESCRIPTION
Related: #2267

This pull request seeks to appropriately recover from unhandled errors occurring during a block's `save` implementation. Not only does this help prevent a BSOD (blank screen of death), it also preserves the original content of the block in which the error had occurred (same treatment as in an invalid block).

__Implementation notes:__

The majority of changes are regenerated fixtures, because we now _always_ assign `originalContent` into the parsed block object, not just when the post is invalid, since we fall back on this content if an error occurs during the save step.

__Testing instructions:__

You'll need to manually add the Mr. Crashy block registration prior to editor initialization. I recommend at the bottom of `editor/index.js`:

```js
wp.blocks.registerBlockType( 'myplugin/mr-crashy', { title: 'Mr. Crashy', category: 'common', icon: 'warning', edit() { return ''; }, save() { throw new Error(); } } );
```

1. Navigate to Gutenberg > New Post
2. Add a paragraph block with some text
3. Add a Mr. Crashy block
4. Save the post
5. Refresh the page
6. Note that the text block saved correctly, and the Mr. Crashy block displays with an error message
7. More interestingly, if you manually add content between the Mr. Crashy block delimiters (in Text mode) and save the post, note that content is preserved on refreshing and later saving the post again