### PR TITLE
Drop the deprecated button-secondary className

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -34,7 +34,6 @@ class Button extends Component {
 			href,
 			target,
 			isPrimary,
-			isSecondary,
 			isLarge,
 			isSmall,
 			isToggled,
@@ -43,9 +42,8 @@ class Button extends Component {
 			...additionalProps
 		} = this.props;
 		const classes = classnames( 'components-button', className, {
-			button: ( isPrimary || isSecondary || isLarge ),
+			button: ( isPrimary || isLarge ),
 			'button-primary': isPrimary,
-			'button-secondary': isSecondary,
 			'button-large': isLarge,
 			'button-small': isSmall,
 			'is-toggled': isToggled,

--- a/components/button/test/index.js
+++ b/components/button/test/index.js
@@ -29,13 +29,6 @@ describe( 'Button', () => {
 			expect( button.hasClass( 'button-primary' ) ).toBe( true );
 		} );
 
-		it( 'should render a button element with button-secondary class', () => {
-			const button = shallow( <Button isSecondary /> );
-			expect( button.hasClass( 'button' ) ).toBe( true );
-			expect( button.hasClass( 'button-large' ) ).toBe( false );
-			expect( button.hasClass( 'button-secondary' ) ).toBe( true );
-		} );
-
 		it( 'should render a button element with button-large class', () => {
 			const button = shallow( <Button isLarge /> );
 			expect( button.hasClass( 'button' ) ).toBe( true );

--- a/editor/sidebar/post-schedule/clock.js
+++ b/editor/sidebar/post-schedule/clock.js
@@ -66,14 +66,14 @@ function PostScheduleClock( { is12Hour, selected, onChange } ) {
 			/>
 			{ is12Hour && <div>
 				<Button
-					className="button-secondary editor-post-schedule__clock-am-button"
+					className="button editor-post-schedule__clock-am-button"
 					isToggled={ am === 'AM' }
 					onClick={ setAM }
 				>
 					{ __( 'AM' ) }
 				</Button>
 				<Button
-					className="button-secondary editor-post-schedule__clock-pm-button"
+					className="button editor-post-schedule__clock-pm-button"
 					isToggled={ am === 'PM' }
 					onClick={ setPM }
 				>


### PR DESCRIPTION
Just a tiny PR to get rid of the useless button-secondary classname 

fixes #2587