### PR TITLE
Chrome: Avoid creating empty terms

### DIFF
--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -69,7 +69,8 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	onChangeFormName( event ) {
-		this.setState( { formName: event.target.value } );
+		const newValue = event.target.value.trim() === '' ? '' : event.target.value;
+		this.setState( { formName: newValue } );
 	}
 
 	onChangeFormParent( event ) {

--- a/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/sidebar/post-taxonomies/hierarchical-term-selector.js
@@ -85,6 +85,9 @@ class HierarchicalTermSelector extends Component {
 	onAddTerm( event ) {
 		event.preventDefault();
 		const { formName, formParent } = this.state;
+		if ( formName === '' ) {
+			return;
+		}
 		const findOrCreatePromise = new Promise( ( resolve, reject ) => {
 			this.setState( {
 				adding: true,
@@ -221,6 +224,7 @@ class HierarchicalTermSelector extends Component {
 							placeholder={ newTermLabel }
 							value={ formName }
 							onChange={ this.onChangeFormName }
+							required
 						/>
 						{ !! availableTerms.length &&
 							<select


### PR DESCRIPTION
fixes #2581

This avoids triggering a network request to create an empty term.
I don't know if it's necessary but I also added a "required" attribute to the input field.

**Testing instructions**
 - Trying creating an empty category
 - No request should be triggered when submitting.