### PR TITLE
Editable: Hide the placeholder on Focus only for paragraph blocks

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -575,13 +575,14 @@ export default class Editable extends Component {
 			formattingControls,
 			placeholder,
 			multiline: MultilineTag,
+			keepPlaceholderOnFocus = false,
 		} = this.props;
 
 		// Generating a key that includes `tagName` ensures that if the tag
 		// changes, we unmount and destroy the previous TinyMCE element, then
 		// mount and initialize a new child element in its place.
 		const key = [ 'editor', Tagname ].join();
-		const isPlaceholderVisible = placeholder && ! focus && this.state.empty;
+		const isPlaceholderVisible = placeholder && ( ! focus || keepPlaceholderOnFocus ) && this.state.empty;
 		const classes = classnames( wrapperClassname, 'blocks-editable' );
 
 		const formatToolbar = (

--- a/blocks/library/button/editor.scss
+++ b/blocks/library/button/editor.scss
@@ -21,4 +21,8 @@ $blocks-button__height: 46px;
 	.blocks-link-url__suggestions {
 		right: -35px;
 	}
+
+	.blocks-editable__tinymce {
+		cursor: text;
+	}
 }

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -74,6 +74,7 @@ registerBlockType( 'core/button', {
 					onFocus={ setFocus }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+					keepPlaceholderOnFocus
 				/>
 				{ focus &&
 					<form


### PR DESCRIPTION
#2161 introduced hiding the placeholder on Focus, but this broke the button block where we need the placeholder to be shown even if we're focusing the input.

IMO, Focus an editable should hide the placeholder only for the text block.

fixes #2578

**Testing instructions**

 - Add a button block
 - Trying typing a text
 - The caret should be visible on an empty button
 - The placeholder should disappear on type.