### PR TITLE
Chrome: Use Popover component for the PostSchedule component

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -19,7 +19,6 @@ $z-layers: (
 	'.editor-block-mover': 10,
 	'.editor-header': 20,
 	'.editor-text-editor__formatting': 20,
-	'.editor-post-schedule__dialog': 30,
 
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,

--- a/editor/sidebar/post-schedule/index.js
+++ b/editor/sidebar/post-schedule/index.js
@@ -13,7 +13,7 @@ import { flowRight } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { dateI18n, settings } from '@wordpress/date';
-import { PanelRow, withAPIData } from '@wordpress/components';
+import { PanelRow, Popover, withAPIData } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ export class PostSchedule extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
-			open: false,
+			opened: false,
 		};
 		this.toggleDialog = this.toggleDialog.bind( this );
 	}
@@ -74,11 +74,11 @@ export class PostSchedule extends Component {
 					aria-expanded={ this.state.opened }
 				>
 					{ label }
-				</button>
-
-				{ this.state.opened &&
-					<div className="editor-post-schedule__dialog">
-						<div className="editor-post-schedule__dialog-arrow" />
+					<Popover
+						position="bottom left"
+						isOpen={ this.state.opened }
+						className="editor-post-schedule__dialog"
+					>
 						<DatePicker
 							inline
 							selected={ momentDate }
@@ -90,8 +90,8 @@ export class PostSchedule extends Component {
 							onChange={ handleChange }
 							is12Hour={ is12HourTime }
 						/>
-					</div>
-				}
+					</Popover>
+				</button>
 			</PanelRow>
 		);
 	}

--- a/editor/sidebar/post-schedule/style.scss
+++ b/editor/sidebar/post-schedule/style.scss
@@ -18,43 +18,11 @@
 	}
 }
 
-.editor-post-schedule__dialog {
-	position: absolute;
-	top: 30px;
-	right: 0;
-	box-shadow: $shadow-popover;
-	border: 1px solid $light-gray-500;
-	background: $white;
+.editor-post-schedule__dialog .components-popover__content {
 	padding: 10px;
-	min-width: 265px;
-	z-index: z-index( '.editor-post-schedule__dialog' );
-}
 
-.editor-post-schedule__dialog-arrow {
-	position: absolute;
-	border: 10px dashed $light-gray-500;
-	height: 0;
-	width: 0;
-	line-height: 0;
-	top: -10px;
-	right: 5px;
-	margin-left: -10px;
-	border-bottom-style: solid;
-	border-top: none;
-	border-left-color: transparent;
-	border-right-color: transparent;
-
-	&:before {
-		top: 2px;
-		border: 10px solid $white;
-		content: " ";
-		position: absolute;
-		left: 50%;
-		margin-left: -10px;
-		border-bottom-style: solid;
-		border-top: none;
-		border-left-color: transparent;
-		border-right-color: transparent;
+	@include break-medium {
+		width: 270px;
 	}
 }
 


### PR DESCRIPTION
This refactors the `PostSchedule` component to use `Popover`. This fixes a bug where the Post Schedule modal was hidden behind the content area (z-index issues).