### PR TITLE
Editable: Fix Placeholder styling

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -619,7 +619,7 @@ export default class Editable extends Component {
 				/>
 				{ isPlaceholderVisible &&
 					<Tagname
-						className="blocks-editable__tinymce"
+						className={ classnames( 'blocks-editable__tinymce', className ) }
 						style={ style }
 					>
 						{ MultilineTag ? <MultilineTag>{ placeholder }</MultilineTag> : placeholder }


### PR DESCRIPTION
On an empty paragraph block with a background color, a padding was applied using an extra className. But these extra classNames were not applied to the placeholder, which caused the placeholder to be incorrectly styled. 

**Testing instructions**

 - Create a paragraph block
 - Apply a background color
 - Unselect the block
 - The placeholder should be shown properly.