### PR TITLE
Registration: Rename default block handlers as reflecting name

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -14,8 +14,8 @@ export {
 	unregisterBlockType,
 	setUnknownTypeHandlerName,
 	getUnknownTypeHandlerName,
-	setDefaultBlock,
-	getDefaultBlock,
+	setDefaultBlockName,
+	getDefaultBlockName,
 	getBlockType,
 	getBlockTypes,
 } from './registration';

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -140,7 +140,7 @@ export function getUnknownTypeHandlerName() {
  *
  * @param {string} name Block name
  */
-export function setDefaultBlock( name ) {
+export function setDefaultBlockName( name ) {
 	defaultBlockName = name;
 }
 
@@ -149,7 +149,7 @@ export function setDefaultBlock( name ) {
  *
  * @return {?string} Blog name
  */
-export function getDefaultBlock() {
+export function getDefaultBlockName() {
 	return defaultBlockName;
 }
 

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -13,8 +13,8 @@ import {
 	unregisterBlockType,
 	setUnknownTypeHandlerName,
 	getUnknownTypeHandlerName,
-	setDefaultBlock,
-	getDefaultBlock,
+	setDefaultBlockName,
+	getDefaultBlockName,
 	getBlockType,
 	getBlockTypes,
 } from '../registration';
@@ -33,7 +33,7 @@ describe( 'blocks', () => {
 			unregisterBlockType( block.name );
 		} );
 		setUnknownTypeHandlerName( undefined );
-		setDefaultBlock( undefined );
+		setDefaultBlockName( undefined );
 		console.error = error;
 	} );
 
@@ -155,17 +155,17 @@ describe( 'blocks', () => {
 		} );
 	} );
 
-	describe( 'setDefaultBlock()', () => {
+	describe( 'setDefaultBlockName()', () => {
 		it( 'assigns default block name', () => {
-			setDefaultBlock( 'core/test-block' );
+			setDefaultBlockName( 'core/test-block' );
 
-			expect( getDefaultBlock() ).toBe( 'core/test-block' );
+			expect( getDefaultBlockName() ).toBe( 'core/test-block' );
 		} );
 	} );
 
-	describe( 'getDefaultBlock()', () => {
+	describe( 'getDefaultBlockName()', () => {
 		it( 'defaults to undefined', () => {
-			expect( getDefaultBlock() ).toBeUndefined();
+			expect( getDefaultBlockName() ).toBeUndefined();
 		} );
 	} );
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlockType, createBlock, source, setDefaultBlock } from '../../api';
+import { registerBlockType, createBlock, source, setDefaultBlockName } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import BlockControls from '../../block-controls';
@@ -195,4 +195,4 @@ registerBlockType( 'core/paragraph', {
 	},
 } );
 
-setDefaultBlock( 'core/paragraph' );
+setDefaultBlockName( 'core/paragraph' );

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -10,7 +10,7 @@ import { throttle, reduce, noop } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { serialize, getDefaultBlock, createBlock } from '@wordpress/blocks';
+import { serialize, getDefaultBlockName, createBlock } from '@wordpress/blocks';
 import { IconButton } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
 
@@ -195,7 +195,7 @@ class VisualEditorBlockList extends Component {
 	}
 
 	appendDefaultBlock() {
-		const newBlock = createBlock( getDefaultBlock() );
+		const newBlock = createBlock( getDefaultBlockName() );
 		this.props.onInsertBlock( newBlock );
 	}
 


### PR DESCRIPTION
This pull request seeks to rename default block handler functions to better reflect that they operate on a block name, not a block instance, type, or otherwise. This brings default block API handlers in line with unknown type handlers, which were similarly renamed in bc4d6cdbd932f3bac4b2d68efb51a9c0543679b0. I originally planned to include these changes in a related set of changes, but since it touched a handful of files, I felt it better to create a smaller, separate pull request.

__Testing instructions:__

Verify there is no regressions in the behavior of the default block (paragraph).