### PR TITLE
Gallery: Fix column widths in gallery block.

### DIFF
--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -34,10 +34,10 @@
 	}
 
 	&.columns-1 figure {
-		width: calc(100% / 1 - 2 * 8px);
+		width: calc(100% / 1 - 16px);
 	}
 	&.columns-2 figure {
-		width: calc(100% / 2 - 3 * 8px);
+		width: calc(100% / 2 - 16px);
 	}
 
 	// Responsive fallback value, 2 columns
@@ -47,27 +47,27 @@
 	&.columns-6 figure,
 	&.columns-7 figure,
 	&.columns-8 figure {
-		width: calc(100% / 2 - 3 * 8px);
+		width: calc(100% / 2 - 16px);
 	}
 
 	@include break-small {
 		&.columns-3 figure {
-			width: calc(100% / 3 - 4 * 8px);
+			width: calc(100% / 3 - 16px);
 		}
 		&.columns-4 figure {
-			width: calc(100% / 4 - 5 * 8px);
+			width: calc(100% / 4 - 16px);
 		}
 		&.columns-5 figure {
-			width: calc(100% / 5 - 6 * 8px);
+			width: calc(100% / 5 - 16px);
 		}
 		&.columns-6 figure {
-			width: calc(100% / 6 - 7 * 8px);
+			width: calc(100% / 6 - 16px);
 		}
 		&.columns-7 figure {
-			width: calc(100% / 7 - 8 * 8px);
+			width: calc(100% / 7 - 16px);
 		}
 		&.columns-8 figure {
-			width: calc(100% / 8 - 9 * 8px);
+			width: calc(100% / 8 - 16px);
 		}
 	}
 }


### PR DESCRIPTION
The widths of columns have wrong calc() expressions, which causes more images to fit in a row than set in the "Columns" setting of the block. 

This should fix #2465