### PR TITLE
Button: Fix position of the link input field

### DIFF
--- a/blocks/library/button/editor.scss
+++ b/blocks/library/button/editor.scss
@@ -14,8 +14,6 @@ $blocks-button__height: 46px;
 	.blocks-format-toolbar__link-modal {
 		z-index: 2;
 		top: $blocks-button__height + 2px;
-		left: 50%;
-		transform: translateX( -50% );
 	}
 
 	.blocks-link-url__suggestions {


### PR DESCRIPTION
This PR fixes #2635 so the position of the URL input field is in the window