### PR TITLE
Add "Block API" initial doc to the documentation app.

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -1,0 +1,99 @@
+# Block API
+
+Blocks are the fundamntal element of the Gutenberg editor. They are the primary way in which plugins and themes can register their own functionality and extend the capabilities of the editor. This document covers the main properties of block registration.
+
+## Register Block Type
+
+Every block starts by registering a new block type definition. The function `registerBlockType` takes two arguments, a block `name` and a block configuration object.
+
+### Block Name
+
+The name for a block is a unique string that identifies a block. Names have to be structured as `namespace/block-name`, where namespace is the name of your plugin or theme.
+
+```js
+// Registering my block with a unique name
+registerBlockType( 'my-plugin/book', {} );
+```
+
+### Block Configuration
+
+A block requires a few properties to be specified before it can be registered successfully. These are defined through a configuration object, which includes the following:
+
+#### Title
+
+This is the display title for your block, which can be translated with our translation functions. The block inserter will show this name.
+
+```js
+// Our data object
+title: 'Book'
+```
+
+#### Category
+
+Blocks are grouped into categories to help users browse and discover them. The core provided categories are `common`, `formatting`, `layout`, `widgets`, and `embeds`.
+
+```js
+// Assigning to the 'layout' category
+category: 'widgets',
+```
+
+#### Icon
+
+An icon property should be specififed to make it easier to identify a block. These can be any of [WordPress' Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
+
+```js
+// Specifying a dashicon for the block
+icon: 'book-alt',
+```
+
+#### Keywords (optional)
+
+Sometimes a block could have aliases that help users discover it while searching. For example, an `image` block could also want to be discovered by `photo`. You can do so by providing an array of terms (which can be translated). It is only allowed to add as much as three terms per block.
+
+```js
+// Make it easier to discover a block with keyword aliases
+keywords: [ __( 'read' ) ],
+```
+
+#### Attributes
+
+Attributes provide the structured data needs of a block. They can exist in different forms when they are serialized, but they are declared together under a common interface.
+
+```js
+// Specifying my block attributes
+attributes: {
+	// Cover image for the book, corresponds to the image src.
+	cover: {
+		type: 'string',
+		source: attr( 'img', 'src' ),
+	},
+	author: {
+		type: 'string',
+		source: children( '.book-author' ),
+	},
+	// This is encoded in the HTML comments of the block and is nto present
+	pages: {
+		type: 'number',
+	},
+},
+```
+
+Attributes can be quite powerful, if you want to learn more about what's possible, read the specific document.
+
+### Transforms (optional)
+
+Work in progress...
+
+### className (optional)
+
+By default, Gutenberg adds a class with the form `.wp-blocks-your-block-name` to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
+
+```js
+// Do not generate classes for this block
+className: false,
+```
+
+## Edit and Save
+
+The `edit` and `save` functions define the editor interface with wich a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so we'll cover them separately.
+

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -1,6 +1,6 @@
 # Block API
 
-Blocks are the fundamntal element of the Gutenberg editor. They are the primary way in which plugins and themes can register their own functionality and extend the capabilities of the editor. This document covers the main properties of block registration.
+Blocks are the fundamental element of the Gutenberg editor. They are the primary way in which plugins and themes can register their own functionality and extend the capabilities of the editor. This document covers the main properties of block registration.
 
 ## Register Block Type
 
@@ -39,7 +39,7 @@ category: 'widgets',
 
 #### Icon
 
-An icon property should be specififed to make it easier to identify a block. These can be any of [WordPress' Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
+An icon property should be specified to make it easier to identify a block. These can be any of [WordPress' Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
 
 ```js
 // Specifying a dashicon for the block
@@ -62,7 +62,6 @@ Attributes provide the structured data needs of a block. They can exist in diffe
 ```js
 // Specifying my block attributes
 attributes: {
-	// Cover image for the book, corresponds to the image src.
 	cover: {
 		type: 'string',
 		source: attr( 'img', 'src' ),
@@ -71,7 +70,6 @@ attributes: {
 		type: 'string',
 		source: children( '.book-author' ),
 	},
-	// This is encoded in the HTML comments of the block and is nto present
 	pages: {
 		type: 'number',
 	},
@@ -95,5 +93,5 @@ className: false,
 
 ## Edit and Save
 
-The `edit` and `save` functions define the editor interface with wich a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so we'll cover them separately.
+The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so we'll cover them separately.
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -11,6 +11,12 @@ addStory( {
 } );
 
 addStory( {
+	name: 'block-api',
+	title: 'Block API',
+	markdown: require( './block-api.md' ),
+} );
+
+addStory( {
 	name: 'blocks',
 	title: 'Creating Block Types',
 	markdown: require( './blocks.md' ),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/548849/29978920-95f6b73c-8f43-11e7-9e4c-ca2e2c2e9878.png)

This covers the main properties of block registration and is meant to be a resource highlighting what is available and how it works.

This is not mean to be a tutorial, for which we have a specific section already.