### PR TITLE
Changes the editor font-setting in the paragraph block from px to em

### DIFF
--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -41,7 +41,7 @@ $default-font-size: 13px;
 $default-line-height: 1.4;
 $editor-font: "Noto Serif", serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;
-$editor-font-size: 16px;
+$editor-font-size: 1em;
 $text-editor-font-size: 14px;
 $editor-line-height: 1.8;
 $big-font-size: 18px;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -6,7 +6,7 @@
 	&,
 	& p {
 		font-family: $editor-font;
-		font-size: $editor-font-size;
+		font-size: 1em;
 		line-height: $editor-line-height;
 	}
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -6,7 +6,7 @@
 	&,
 	& p {
 		font-family: $editor-font;
-		font-size: 1em;
+		font-size: $editor-font-size;
 		line-height: $editor-line-height;
 	}
 


### PR DESCRIPTION
Fixes #2610  , but still looking for feedback if that's the best approach.

Changes the font-setting in the paragraph block from a specific pixel size (16px) to a relative size (1em). 