### PR TITLE
Filters out private taxonomies from sidebar UI.

### DIFF
--- a/editor/components/post-taxonomies/index.js
+++ b/editor/components/post-taxonomies/index.js
@@ -20,7 +20,8 @@ import { getCurrentPostType } from '../../store/selectors';
 
 export function PostTaxonomies( { postType, taxonomies, taxonomyWrapper = identity } ) {
 	const availableTaxonomies = filter( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
-	return availableTaxonomies.map( ( taxonomy ) => {
+	const visibleTaxonomies = filter( availableTaxonomies, ( taxonomy ) => taxonomy.visibility.show_ui );
+	return visibleTaxonomies.map( ( taxonomy ) => {
 		const TaxonomyComponent = taxonomy.hierarchical ? HierarchicalTermSelector : FlatTermSelector;
 		return (
 			<Fragment key={ `taxonomy-${ taxonomy.slug }` }>

--- a/editor/components/post-taxonomies/test/index.js
+++ b/editor/components/post-taxonomies/test/index.js
@@ -68,4 +68,42 @@ describe( 'PostTaxonomies', () => {
 
 		expect( wrapperTwo.at( 0 ) ).toHaveLength( 2 );
 	} );
+
+	it( 'should not render taxonomy components that hide their ui', () => {
+		const genresTaxonomy = {
+			name: 'Genres',
+			slug: 'genre',
+			types: [ 'book' ],
+			hierarchical: true,
+			rest_base: 'genres',
+			visibility: {
+				show_ui: true,
+			},
+		};
+
+		const wrapperOne = shallow(
+			<PostTaxonomies postType="book"
+				taxonomies={ {
+					data: [ genresTaxonomy ],
+				} }
+			/>
+		);
+
+		expect( wrapperOne.at( 0 ) ).toHaveLength( 1 );
+
+		const wrapperTwo = shallow(
+			<PostTaxonomies postType="book"
+				taxonomies={ {
+					data: [
+						{
+							...genresTaxonomy,
+							visibility: { show_ui: false },
+						},
+					],
+				} }
+			/>
+		);
+
+		expect( wrapperTwo.at( 0 ) ).toHaveLength( 0 );
+	} );
 } );

--- a/editor/components/post-taxonomies/test/index.js
+++ b/editor/components/post-taxonomies/test/index.js
@@ -26,6 +26,9 @@ describe( 'PostTaxonomies', () => {
 			types: [ 'book' ],
 			hierarchical: true,
 			rest_base: 'genres',
+			visibility: {
+				show_ui: true,
+			},
 		};
 
 		const categoriesTaxonomy = {
@@ -34,6 +37,9 @@ describe( 'PostTaxonomies', () => {
 			types: [ 'post', 'page' ],
 			hierarchical: true,
 			rest_base: 'categories',
+			visibility: {
+				show_ui: true,
+			},
 		};
 
 		const wrapperOne = shallow(

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -360,3 +360,37 @@ function gutenberg_filter_oembed_result( $response, $handler, $request ) {
 	return $response;
 }
 add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10, 3 );
+
+/**
+ * Add additional 'public' rest api field to taxonomies.
+ *
+ * Used so private taxonomies are not displayed in the UI.
+ */
+function gutenberg_add_taxonomy_public_field() {
+	register_rest_field(
+		'taxonomy',
+		'public',
+		array(
+			'get_callback'    => 'get_post_meta_for_api',
+			'schema'          => array(
+				'description' => __( 'Whether taxonomy is public.', 'gutenberg' ),
+				'type'        => 'boolean',
+				'context'     => array( 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+}
+
+/**
+ * Gets taxonomy public property.
+ *
+ * @param array $object Taxonomy data from REST API.
+ * @return boolean Whether the taxonomy is public.
+ */
+function get_post_meta_for_api( $object ) {
+	$taxonomy = get_taxonomy( $object['slug'] );
+	return $taxonomy->public;
+}
+
+add_action( 'rest_api_init', 'gutenberg_add_taxonomy_public_field' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -375,33 +375,33 @@ function gutenberg_add_taxonomy_visibility_field() {
 		array(
 			'get_callback' => 'gutenberg_get_taxonomy_visibility_data',
 			'schema'       => array(
-				'description' => __( 'The visibility settings for the taxonomy.' ),
+				'description' => __( 'The visibility settings for the taxonomy.', 'gutenberg' ),
 				'type'        => 'object',
 				'context'     => array( 'edit' ),
 				'readonly'    => true,
 				'properties'  => array(
 					'public'             => array(
-						'description' => __( 'Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.' ),
+						'description' => __( 'Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.', 'gutenberg' ),
 						'type'        => 'boolean',
 					),
 					'publicly_queryable' => array(
-						'description' => __( 'Whether the taxonomy is publicly queryable.' ),
+						'description' => __( 'Whether the taxonomy is publicly queryable.', 'gutenberg' ),
 						'type'        => 'boolean',
 					),
 					'show_ui'            => array(
-						'description' => __( 'Whether to generate a default UI for managing this taxonomy.' ),
+						'description' => __( 'Whether to generate a default UI for managing this taxonomy.', 'gutenberg' ),
 						'type'        => 'boolean',
 					),
 					'show_admin_column'  => array(
-						'description' => __( 'Whether to allow automatic creation of taxonomy columns on associated post-types table.' ),
+						'description' => __( 'Whether to allow automatic creation of taxonomy columns on associated post-types table.', 'gutenberg' ),
 						'type'        => 'boolean',
 					),
 					'show_in_nav_menus'  => array(
-						'description' => __( 'Whether to make the taxonomy available for selection in navigation menus.' ),
+						'description' => __( 'Whether to make the taxonomy available for selection in navigation menus.', 'gutenberg' ),
 						'type'        => 'boolean',
 					),
 					'show_in_quick_edit' => array(
-						'description' => __( 'Whether to show the taxonomy in the quick/bulk edit panel.' ),
+						'description' => __( 'Whether to show the taxonomy in the quick/bulk edit panel.', 'gutenberg' ),
 						'type'        => 'boolean',
 					),
 				),

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -28,9 +28,9 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should return an extra public field on response when in edit context.
+	 * Should return an extra visibility field on response when in edit context.
 	 */
-	function test_public_field() {
+	function test_visibility_field() {
 		wp_set_current_user( $this->administrator );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
@@ -39,14 +39,20 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 
 		$result = $response->get_data();
 
-		$this->assertTrue( isset( $result['public'] ) );
-		$this->assertTrue( $result['public'] );
+		$this->assertTrue( isset( $result['visibility'] ) );
+		$this->assertInternalType( 'array', $result['visibility'] );
+		$this->assertArrayHasKey( 'public', $result['visibility'] );
+		$this->assertArrayHasKey( 'publicly_queryable', $result['visibility'] );
+		$this->assertArrayHasKey( 'show_ui', $result['visibility'] );
+		$this->assertArrayHasKey( 'show_admin_column', $result['visibility'] );
+		$this->assertArrayHasKey( 'show_in_nav_menus', $result['visibility'] );
+		$this->assertArrayHasKey( 'show_in_quick_edit', $result['visibility'] );
 	}
 
 	/**
-	 * Should return an extra public field on response.
+	 * Should return an extra visibility field on response.
 	 */
-	function test_public_field_for_non_admin_roles() {
+	function test_visibility_field_for_non_admin_roles() {
 		wp_set_current_user( $this->editor );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
@@ -55,8 +61,14 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 
 		$result = $response->get_data();
 
-		$this->assertTrue( isset( $result['public'] ) );
-		$this->assertTrue( $result['public'] );
+		$this->assertTrue( isset( $result['visibility'] ) );
+		$this->assertInternalType( 'array', $result['visibility'] );
+		$this->assertArrayHasKey( 'public', $result['visibility'] );
+		$this->assertArrayHasKey( 'publicly_queryable', $result['visibility'] );
+		$this->assertArrayHasKey( 'show_ui', $result['visibility'] );
+		$this->assertArrayHasKey( 'show_admin_column', $result['visibility'] );
+		$this->assertArrayHasKey( 'show_in_nav_menus', $result['visibility'] );
+		$this->assertArrayHasKey( 'show_in_quick_edit', $result['visibility'] );
 
 		/**
 		 * See https://github.com/WordPress/gutenberg/issues/2545
@@ -70,18 +82,18 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 
 		$result = $response->get_data();
 
-		$this->assertTrue( ! isset( $result['public'] ) );
+		$this->assertFalse( isset( $result['visibility'] ) );
 	}
 
 	/**
-	 * Should not return an extra public field without context set.
+	 * Should not return an extra visibility field without context set.
 	 */
-	function test_public_field_without_context() {
+	function test_visibility_field_without_context() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
 		$response = rest_do_request( $request );
 
 		$result = $response->get_data();
 
-		$this->assertTrue( ! isset( $result['public'] ) );
+		$this->assertFalse( isset( $result['visibility'] ) );
 	}
 }

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -15,10 +15,10 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 		$this->administrator = $this->factory->user->create( array(
 			'role' => 'administrator',
 		) );
-		$this->author = $this->factory->user->create( array(
+		$this->author        = $this->factory->user->create( array(
 			'role' => 'author',
 		) );
-		$this->editor = $this->factory->user->create( array(
+		$this->editor        = $this->factory->user->create( array(
 			'role' => 'editor',
 		) );
 	}
@@ -89,7 +89,7 @@ class Gutenberg_REST_API_Test extends WP_UnitTestCase {
 	 * Should not return an extra visibility field without context set.
 	 */
 	function test_visibility_field_without_context() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
 		$response = rest_do_request( $request );
 
 		$result = $response->get_data();

--- a/phpunit/class-gutenberg-rest-api-test.php
+++ b/phpunit/class-gutenberg-rest-api-test.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * WP_Block_Type_Registry Tests
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Tests for WP_Block_Type_Registry
+ */
+class Gutenberg_REST_API_Test extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+
+		$this->administrator = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+		$this->author = $this->factory->user->create( array(
+			'role' => 'author',
+		) );
+		$this->editor = $this->factory->user->create( array(
+			'role' => 'editor',
+		) );
+	}
+
+	function tearDown() {
+		parent::tearDown();
+	}
+
+	/**
+	 * Should return an extra public field on response when in edit context.
+	 */
+	function test_public_field() {
+		wp_set_current_user( $this->administrator );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+
+		$result = $response->get_data();
+
+		$this->assertTrue( isset( $result['public'] ) );
+		$this->assertTrue( $result['public'] );
+	}
+
+	/**
+	 * Should return an extra public field on response.
+	 */
+	function test_public_field_for_non_admin_roles() {
+		wp_set_current_user( $this->editor );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_do_request( $request );
+
+		$result = $response->get_data();
+
+		$this->assertTrue( isset( $result['public'] ) );
+		$this->assertTrue( $result['public'] );
+
+		/**
+		 * See https://github.com/WordPress/gutenberg/issues/2545
+		 *
+		 * Until that is resolved authors will not be able to set taxonomies.
+		 * This should definitely be resolved though.
+		 */
+		wp_set_current_user( $this->author );
+
+		$response = rest_do_request( $request );
+
+		$result = $response->get_data();
+
+		$this->assertTrue( ! isset( $result['public'] ) );
+	}
+
+	/**
+	 * Should not return an extra public field without context set.
+	 */
+	function test_public_field_without_context() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
+		$response = rest_do_request( $request );
+
+		$result = $response->get_data();
+
+		$this->assertTrue( ! isset( $result['public'] ) );
+	}
+}


### PR DESCRIPTION
Fixes #2450,

Could potentially break if the user does not have privileges to see the
edit context. Will need to test more.

**Testing Instructions**

1. Register a private taxonomy.
2. Load Gutenberg.
3. Verify that the taxonomy does not show up in the Categories & Tags portion of the sidebar.