### PR TITLE
i18n: Extract concatenated strings of translate functions

### DIFF
--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -83,6 +83,29 @@ const VALID_TRANSLATION_KEYS = [ 'msgid', 'msgid_plural', 'msgctxt' ];
 const REGEXP_TRANSLATOR_COMMENT = /^\s*translators:\s*([\s\S]+)/im;
 
 /**
+ * Given an argument node (or recursed node), attempts to return a string
+ * represenation of that node's value.
+ *
+ * @param  {Object} node AST node
+ * @return {String}      String value
+ */
+function getNodeAsString( node ) {
+	switch ( node.type ) {
+		case 'BinaryExpression':
+			return (
+				getNodeAsString( node.left ) +
+				getNodeAsString( node.right )
+			);
+
+		case 'StringLiteral':
+			return node.value;
+
+		default:
+			return '';
+	}
+}
+
+/**
  * Returns translator comment for a given AST traversal path if one exists.
  *
  * @param  {Object}  path              Traversal path
@@ -185,7 +208,7 @@ module.exports = function() {
 				const translation = path.node.arguments.reduce( ( memo, arg, i ) => {
 					const key = functionKeys[ i ];
 					if ( isValidTranslationKey( key ) ) {
-						memo[ key ] = arg.value;
+						memo[ key ] = getNodeAsString( arg );
 					}
 
 					return memo;
@@ -312,6 +335,7 @@ module.exports = function() {
 	};
 };
 
+module.exports.getNodeAsString = getNodeAsString;
+module.exports.getTranslatorComment = getTranslatorComment;
 module.exports.isValidTranslationKey = isValidTranslationKey;
 module.exports.isSameTranslation = isSameTranslation;
-module.exports.getTranslatorComment = getTranslatorComment;

--- a/i18n/test/babel-plugin.js
+++ b/i18n/test/babel-plugin.js
@@ -11,9 +11,10 @@ import babelPlugin from '../babel-plugin';
 
 describe( 'babel-plugin', () => {
 	const {
+		getNodeAsString,
+		getTranslatorComment,
 		isValidTranslationKey,
 		isSameTranslation,
-		getTranslatorComment,
 	} = babelPlugin;
 
 	describe( '.isValidTranslationKey()', () => {
@@ -88,6 +89,37 @@ describe( 'babel-plugin', () => {
 			const comment = getCommentFromString( '/* translators: Long comment\nspanning multiple \nlines */\nconst string = __( \'Hello world\' );' );
 
 			expect( comment ).toBe( 'Long comment spanning multiple lines' );
+		} );
+	} );
+
+	describe( '.getNodeAsString()', () => {
+		function getNodeAsStringFromArgument( source ) {
+			let string;
+			traverse( transform( source ).ast, {
+				CallExpression( path ) {
+					string = getNodeAsString( path.node.arguments[ 0 ] );
+				},
+			} );
+
+			return string;
+		}
+
+		it( 'should returns an empty string by default', () => {
+			const string = getNodeAsStringFromArgument( '__( {} );' );
+
+			expect( string ).toBe( '' );
+		} );
+
+		it( 'should return a string value', () => {
+			const string = getNodeAsStringFromArgument( '__( "hello" );' );
+
+			expect( string ).toBe( 'hello' );
+		} );
+
+		it( 'should be a concatenated binary expression string value', () => {
+			const string = getNodeAsStringFromArgument( '__( "hello" + " world" );' );
+
+			expect( string ).toBe( 'hello world' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Closes #1927

This pull request seeks to enhance the i18n strings extraction parser to support string concatenation (BinaryExpression type).

__Testing instructions:__

Verify that concatenated strings (like [that of the InvalidBlockWarning component](https://github.com/WordPress/gutenberg/blob/78dd8b6/editor/modes/visual-editor/invalid-block-warning.js#L32-L36)) are included in the generated `languages/gutenberg.pot` file when running `npm run gettext-strings`.