### PR TITLE
Docs: some design and presentation tweaks.

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -4,9 +4,13 @@ Blocks are the fundamental element of the Gutenberg editor. They are the primary
 
 ## Register Block Type
 
+* **Type:** `Function`
+
 Every block starts by registering a new block type definition. The function `registerBlockType` takes two arguments, a block `name` and a block configuration object.
 
 ### Block Name
+
+* **Type:** `String`
 
 The name for a block is a unique string that identifies a block. Names have to be structured as `namespace/block-name`, where namespace is the name of your plugin or theme.
 
@@ -17,9 +21,13 @@ registerBlockType( 'my-plugin/book', {} );
 
 ### Block Configuration
 
+* **Type:** `{ key: value }`
+
 A block requires a few properties to be specified before it can be registered successfully. These are defined through a configuration object, which includes the following:
 
 #### Title
+
+* **Type:** `String`
 
 This is the display title for your block, which can be translated with our translation functions. The block inserter will show this name.
 
@@ -29,6 +37,8 @@ title: 'Book'
 ```
 
 #### Category
+
+* **Type:** `String [ formatting | layout | widgets | embeds ]`
 
 Blocks are grouped into categories to help users browse and discover them. The core provided categories are `common`, `formatting`, `layout`, `widgets`, and `embeds`.
 
@@ -57,6 +67,8 @@ keywords: [ __( 'read' ) ],
 
 #### Attributes
 
+* **Type:** `{ attr: {} }`
+
 Attributes provide the structured data needs of a block. They can exist in different forms when they are serialized, but they are declared together under a common interface.
 
 ```js
@@ -76,13 +88,15 @@ attributes: {
 },
 ```
 
-Attributes can be quite powerful, if you want to learn more about what's possible, read the specific document.
+* **See: [Attribute Sources](/reference/attribute-sources/).**
 
 ### Transforms (optional)
 
 Work in progress...
 
 ### className (optional)
+
+* **Type:** `Bool`
 
 By default, Gutenberg adds a class with the form `.wp-blocks-your-block-name` to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
 

--- a/docutron/src/components/header.js
+++ b/docutron/src/components/header.js
@@ -11,32 +11,15 @@ const header = (
 					Gutenberg Docs
 				</a>
 			</p>
+			<nav className="gutenberg-links">
+				<a href="https://wordpress.org/plugins/gutenberg/">
+					Download Plugin
+				</a>
+				<a href="https://github.com/WordPress/gutenberg/">
+					View on GitHub
+				</a>
+			</nav>
 		</div>
-		<nav id="site-navigation" className="navigation-main clear">
-			<div className="menu-navigation-container">
-				<ul id="menu-navigation" className="menu">
-					<li className="menu-item">
-						<a title="View on GitHub" href="https://github.com/WordPress/gutenberg/">
-							<span className="screen-reader-text">View on GitHub</span>
-							<svg
-								viewBox="0 0 16 16"
-								xmlns="http://www.w3.org/2000/svg"
-								fillRule="evenodd"
-								clipRule="evenodd"
-								strokeLinejoin="round"
-								strokeMiterlimit="1.414"
-								width="20"
-								height="20"
-								fill="#fff"
-								style={ { verticalAlign: 'middle' } }
-							>
-								<path d="M8 0C3.58 0 0 3.582 0 8c0 3.535 2.292 6.533 5.47 7.59.4.075.547-.172.547-.385 0-.19-.007-.693-.01-1.36-2.226.483-2.695-1.073-2.695-1.073-.364-.924-.89-1.17-.89-1.17-.725-.496.056-.486.056-.486.803.056 1.225.824 1.225.824.714 1.223 1.873.87 2.33.665.072-.517.278-.87.507-1.07-1.777-.2-3.644-.888-3.644-3.953 0-.873.31-1.587.823-2.147-.09-.202-.36-1.015.07-2.117 0 0 .67-.215 2.2.82.64-.178 1.32-.266 2-.27.68.004 1.36.092 2 .27 1.52-1.035 2.19-.82 2.19-.82.43 1.102.16 1.915.08 2.117.51.56.82 1.274.82 2.147 0 3.073-1.87 3.75-3.65 3.947.28.24.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.14.46.55.38C13.71 14.53 16 11.53 16 8c0-4.418-3.582-8-8-8" />
-							</svg>
-						</a>
-					</li>
-				</ul>
-			</div>
-		</nav>
 	</header>
 );
 

--- a/docutron/src/styles/main.css
+++ b/docutron/src/styles/main.css
@@ -144,7 +144,6 @@ code, pre {
 .content-area h4,
 .content-area h5 {
 	position: relative;
-	border-bottom: 1px solid #EDF3F1;
 	margin: 40px 0 20px;
 }
 .markdownIt-Anchor {

--- a/docutron/src/styles/main.css
+++ b/docutron/src/styles/main.css
@@ -12,12 +12,12 @@ a, a:visited, a:active, .entry-meta .entry-actions:hover a, .entry-meta .entry-a
 	color: #00B975;
 }
 
-#secondary {
-	padding: 6rem 0 0;
+.content-area a:hover {
+	color: #3498db;
 }
 
-.content-area h1, .content-area h2 {
-	margin: 40px 0 20px;
+#secondary {
+	padding: 6rem 0 0;
 }
 
 .single-handbook #primary {
@@ -72,7 +72,7 @@ code, pre {
 	background: #fff;
 	padding: 140px 0;
 	text-align: center;
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid #EDF3F1;
 }
 
 .site-header .site-title a {
@@ -85,6 +85,20 @@ code, pre {
 .site-header .site-title a:hover {
 	color: #111;
 	border-color: #00B975;
+}
+
+.gutenberg-links {
+	display: block;
+	margin: 30px 0 30px;
+}
+.gutenberg-links a {
+	color: #999;
+	font-size: 15px;
+	margin: 0 20px;
+}
+
+.gutenberg-links a:hover {
+	color: #444;
 }
 
 .single-handbook #secondary {
@@ -124,8 +138,34 @@ code, pre {
 	color: #00B975;
 }
 
+.content-area h1,
+.content-area h2,
+.content-area h3,
+.content-area h4,
+.content-area h5 {
+	position: relative;
+	border-bottom: 1px solid #EDF3F1;
+	margin: 40px 0 20px;
+}
 .markdownIt-Anchor {
-	opacity: 0.2;
+	position: absolute;
+	left: -20px;
+	display: none;
+	width: 20px;
+	font-weight: 300;
+}
+
+.content-area h1:hover .markdownIt-Anchor,
+.content-area h2:hover .markdownIt-Anchor,
+.content-area h3:hover .markdownIt-Anchor,
+.content-area h4:hover .markdownIt-Anchor,
+.content-area h5:hover .markdownIt-Anchor,
+.content-area h1:focus .markdownIt-Anchor,
+.content-area h2:focus .markdownIt-Anchor,
+.content-area h3:focus .markdownIt-Anchor,
+.content-area h4:focus .markdownIt-Anchor,
+.content-area h5:focus .markdownIt-Anchor {
+	display: block;
 }
 
 .widget-title {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/548849/30024016-300593b8-9172-11e7-9144-076a8516705b.png)

* Add links to download plugin and the github repository.
* Show permalinks on hover and remove opacity.
* Explore showing `Type` when describing API properties.