### PR TITLE
Bump version to v1.1.0.

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core. <strong>Meant for development, do not run on real sites.</strong>
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A new WordPress editor experience",
   "main": "build/app.js",
   "repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
* Add blocks "slash" autocomplete—shortcut to continue adding new block without leaving the keyboard.
* Add ability to remove an image from a gallery from within the block (selecting image).
* Support and bootstrap server-registered block attribute schemas.
* Improve accessibility of add-new-category form.
* Documentation gets an updated design and content improvements.
* Adjust column width calculation in gallery block to properly respect column count.
* Move pending review control together with sticky toggle at the bottom.
* Add caption styling for video block.
* Allow removing a "classic text" block with backspaces.
* Allow Button block to show placeholder text.
* Drop the deprecated button-secondary class name.
* Fix link dialog not showing in Safari when caret is in the middle of the word.
* Fix adding new categories and position newly added term at the top.
* Fix the resetting of drop-zone states after dropping a file.
* Fix embed saving "undefined" text when URL is not set.
* Fix placeholder styling on Text when background color is set.
* Update Composer + PHPCS.
* Rename default block handlers.
* Update code syntax tabs in docutron.
* Link to plugin download and github repo from docutron.
* Added block API document.
* Add "Edit and Save" document.