### PR TITLE
Color picker improvements, first round

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -42,20 +42,19 @@ class ColorPalette extends Component {
 				{ colors.map( ( color ) => {
 					const style = { color: color };
 					const className = classnames( 'blocks-color-palette__item', { 'is-active': value === color } );
-					/* Disable reason: aria-current seems like a valid aria-prop and well-suited for this */
-					/* eslint-disable jsx-a11y/aria-props */
+
 					return (
 						<div key={ color } className="blocks-color-palette__item-wrapper">
 							<button
+								type="button"
 								className={ className }
 								style={ style }
 								onClick={ () => onChange( value === color ? undefined : color ) }
 								aria-label={ sprintf( __( 'Color: %s' ), color ) }
-								aria-current={ value === color && __( 'Selected color' ) }
+								aria-pressed={ value === color ? true : false }
 							/>
 						</div>
 					);
-					/* eslint-enable jsx-a11y/aria-props */
 				} ) }
 
 				<div className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color">
@@ -82,8 +81,12 @@ class ColorPalette extends Component {
 				</div>
 
 				<div className="blocks-color-palette__item-wrapper blocks-color-palette__clear-color">
-					<button className="blocks-color-palette__item" onClick={ () => onChange( undefined ) }>
-						<div className="blocks-color-palette__clear-color-line" />
+					<button
+						className="blocks-color-palette__item"
+						onClick={ () => onChange( undefined ) }
+						aria-label={ __( 'Remove color' ) }
+					>
+						<span className="blocks-color-palette__clear-color-line" />
 					</button>
 				</div>
 			</div>

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -91,7 +91,7 @@ class ColorPalette extends Component {
 							color={ value }
 							onChangeComplete={ ( color ) => {
 								onChange( color.hex );
-								this.closePicker();
+								this.togglePicker();
 							} }
 							style={ { width: '100%' } }
 							disableAlpha

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -78,7 +78,9 @@ class ColorPalette extends Component {
 						onClick={ this.togglePicker }
 						ref={ this.bindToggleNode }
 						aria-label={ __( 'Custom color picker' ) }
-					/>
+					>
+						<span className="blocks-color-palette__custom-color-gradient"></span>
+					</button>
 					<Popover
 						isOpen={ this.state.opened }
 						onClose={ this.closeOnClickOutside }

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -23,16 +23,29 @@ class ColorPalette extends Component {
 		this.state = {
 			opened: false,
 		};
-		this.openPicker = this.openPicker.bind( this );
-		this.closePicker = this.closePicker.bind( this );
+		this.togglePicker = this.togglePicker.bind( this );
+		this.stopPropagation = this.stopPropagation.bind( this );
+		this.closeOnClickOutside = this.closeOnClickOutside.bind( this );
+		this.bindToggleNode = this.bindToggleNode.bind( this );
 	}
 
-	openPicker() {
-		this.setState( { opened: true } );
+	togglePicker() {
+		this.setState( ( state ) => ( { opened: ! state.opened } ) );
 	}
 
-	closePicker() {
-		this.setState( { opened: false } );
+	stopPropagation( event ) {
+		event.stopPropagation();
+	}
+
+	closeOnClickOutside( event ) {
+		const { opened } = this.state;
+		if ( opened && ! this.toggleNode.contains( event.target ) ) {
+			this.togglePicker();
+		}
+	}
+
+	bindToggleNode( node ) {
+		this.toggleNode = node;
 	}
 
 	render() {
@@ -59,13 +72,17 @@ class ColorPalette extends Component {
 
 				<div className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color">
 					<button
+						type="button"
+						aria-expanded={ this.state.opened }
 						className="blocks-color-palette__item"
-						onClick={ this.openPicker }
-						aria-label={ __( 'Open custom color picker' ) }
+						onClick={ this.togglePicker }
+						ref={ this.bindToggleNode }
+						aria-label={ __( 'Custom color picker' ) }
 					/>
 					<Popover
 						isOpen={ this.state.opened }
-						onClose={ this.closePicker }
+						onClose={ this.closeOnClickOutside }
+						onClick={ this.stopPropagation }
 						className="blocks-color-palette__picker"
 					>
 						<ChromePicker

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -79,7 +79,7 @@ class ColorPalette extends Component {
 						ref={ this.bindToggleNode }
 						aria-label={ __( 'Custom color picker' ) }
 					>
-						<span className="blocks-color-palette__custom-color-gradient"/>
+						<span className="blocks-color-palette__custom-color-gradient" />
 					</button>
 					<Popover
 						isOpen={ this.state.opened }

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -64,7 +64,7 @@ class ColorPalette extends Component {
 								style={ style }
 								onClick={ () => onChange( value === color ? undefined : color ) }
 								aria-label={ sprintf( __( 'Color: %s' ), color ) }
-								aria-pressed={ value === color ? true : false }
+								aria-pressed={ value === color }
 							/>
 						</div>
 					);
@@ -79,12 +79,11 @@ class ColorPalette extends Component {
 						ref={ this.bindToggleNode }
 						aria-label={ __( 'Custom color picker' ) }
 					>
-						<span className="blocks-color-palette__custom-color-gradient"></span>
+						<span className="blocks-color-palette__custom-color-gradient"/>
 					</button>
 					<Popover
 						isOpen={ this.state.opened }
-						onClose={ this.closeOnClickOutside }
-						onClick={ this.stopPropagation }
+						onClickOutside={ this.closeOnClickOutside }
 						className="blocks-color-palette__picker"
 					>
 						<ChromePicker

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -24,17 +24,12 @@ class ColorPalette extends Component {
 			opened: false,
 		};
 		this.togglePicker = this.togglePicker.bind( this );
-		this.stopPropagation = this.stopPropagation.bind( this );
 		this.closeOnClickOutside = this.closeOnClickOutside.bind( this );
 		this.bindToggleNode = this.bindToggleNode.bind( this );
 	}
 
 	togglePicker() {
 		this.setState( ( state ) => ( { opened: ! state.opened } ) );
-	}
-
-	stopPropagation( event ) {
-		event.stopPropagation();
 	}
 
 	closeOnClickOutside( event ) {

--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -11,6 +11,7 @@ $color-palette-circle-spacing: 14px;
 	width: $color-palette-circle-size;
 	margin-right: $color-palette-circle-spacing;
 	margin-bottom: $color-palette-circle-spacing;
+	vertical-align: top;
 	transform: scale( 1 );
 	transition: 100ms transform ease;
 	&:hover {
@@ -51,7 +52,6 @@ $color-palette-circle-spacing: 14px;
 .blocks-color-palette__clear-color .blocks-color-palette__item {
 	color: $white;
 	background: $white;
-	overflow: hidden;
 }
 
 .blocks-color-palette__clear-color-line {
@@ -81,10 +81,20 @@ $color-palette-circle-spacing: 14px;
 .blocks-color-palette__custom-color .blocks-color-palette__item {
 	position: relative;
 	box-shadow: none;
+}
+
+.blocks-color-palette__custom-color .blocks-color-palette__custom-color-gradient {
+	display: block;
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+	border-radius: 50%;
 	overflow: hidden;
 }
 
-.blocks-color-palette__custom-color .blocks-color-palette__item:before {
+.blocks-color-palette__custom-color .blocks-color-palette__custom-color-gradient:before {
 	box-sizing: border-box;
 	content: '';
 	filter: blur( 6px ) saturate( 0.7 ) brightness( 1.1 );

--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -55,7 +55,7 @@ $color-palette-circle-spacing: 14px;
 }
 
 .blocks-color-palette__clear-color-line {
-	cursor: pointer;
+	display: block;
 	position: absolute;
 	border: 2px solid $alert-red;
 	border-radius: 50%;

--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -21,6 +21,7 @@ $color-palette-circle-spacing: 14px;
 
 .blocks-color-palette__item {
 	display: inline-block;
+	vertical-align: top;
 	height: 100%;
 	width: 100%;
 	border: none;


### PR DESCRIPTION
This PR tries to address a first round of improvements to the Color picker buttons.

- changes  aria-current to aria-pressed, see screenshot below to check how this the way buttons and itneraction with them get announced
- fix invalid HTML: buttons can't contain divs
- add missing aria-label on the "remove color" button
- make the Custom color picker toggle a real toggle that opens/closes the popover and uses aria-expanded
- fix the focus style on the Custom color picker: adds an inner span and applies overflow: hidden on it instead of applying it on the button (I guess this button with gradients needs to be tested a bit in IE 11 / Edge)

Fixes #2679 