### PR TITLE
Gallery Block: fix the zindex value of the gallery image inline menu

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -17,6 +17,7 @@ $z-layers: (
 	'.blocks-format-toolbar__link-modal': 1,
 	'.editor-block-switcher__menu': 2,
 	'.editor-block-mover': 10,
+	'.blocks-gallery-image__inline-menu': 10,
 	'.editor-header': 20,
 	'.editor-text-editor__formatting': 20,
 	'.editor-post-schedule__dialog': 30,
@@ -36,7 +37,6 @@ $z-layers: (
 	// Show popovers above wp-admin menus and submenus and sidebar:
 	// #adminmenuwrap { z-index: 9990 }
 	'.components-popover': 1000000,
-	'.blocks-gallery-image__inline-menu': 1000000,
 	'.components-autocomplete__results': 1000000,
 	'.blocks-url-input__suggestions': 9999,
 );


### PR DESCRIPTION
fixes #2677

**testing instructions**

 - In a long post with a gallery
 - select an image in the gallery block
 - scroll down
 - The inline "delete" button should not overlap with the header.