### PR TITLE
Image Block: Resizing an image sets the figure wrapper

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -95,6 +95,7 @@ class ImageBlock extends Component {
 		const { attributes, setAttributes, focus, setFocus, className, settings } = this.props;
 		const { url, alt, caption, align, id, href, width, height } = attributes;
 
+		const figureStyle = width ? { width } : {};
 		const availableSizes = Object.keys( this.state.availableSizes ).sort();
 		const selectedSize = findKey( this.state.availableSizes, ( size ) => size.source_url === url );
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1;
@@ -193,7 +194,7 @@ class ImageBlock extends Component {
 					) }
 				</InspectorControls>
 			),
-			<figure key="image" className={ classes }>
+			<figure key="image" className={ classes } style={ figureStyle }>
 				<ImageSize src={ url } dirtynessTrigger={ align }>
 					{ ( sizes ) => {
 						const {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -94,10 +94,11 @@ registerBlockType( 'core/image', {
 	save( { attributes } ) {
 		const { url, alt, caption, align, href, width, height } = attributes;
 		const extraImageProps = width || height ? { width, height } : {};
+		const figureStyle = width ? { width } : {};
 		const image = <img src={ url } alt={ alt } { ...extraImageProps } />;
 
 		return (
-			<figure className={ align ? `align${ align }` : null }>
+			<figure className={ align ? `align${ align }` : null } style={ figureStyle }>
 				{ href ? <a href={ href }>{ image }</a> : image }
 				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 			</figure>


### PR DESCRIPTION
closes #2543

This PR apply the image resized width to its figure wrapper to constrain the caption in these boundaries.

**Note:** This PR makes previously resized image blocks invalid.

