### PR TITLE
Fix focus issue when toggling link setting, add aria label

### DIFF
--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -106,7 +106,10 @@ class FormatToolbar extends Component {
 	setLinkTarget( event ) {
 		const opensInNewWindow = event.target.checked;
 		this.setState( { opensInNewWindow } );
-		this.props.onChange( { link: { value: this.props.formats.link.value, target: opensInNewWindow ? '_blank' : '' } } );
+		this.props.onChange(
+			{ link: { value: this.props.formats.link.value, target: opensInNewWindow ? '_blank' : '' } },
+			true
+		);
 	}
 
 	addLink() {
@@ -176,7 +179,7 @@ class FormatToolbar extends Component {
 						<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
 						<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 						<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
-						<IconButton icon="admin-generic" onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
+						<IconButton icon="admin-generic" label={ __( 'Link settings' ) } onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
 						{ linkSettings }
 					</form>
 				}
@@ -192,7 +195,7 @@ class FormatToolbar extends Component {
 						</a>
 						<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
 						<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
-						<IconButton icon="admin-generic" onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
+						<IconButton icon="admin-generic" label={ __( 'Link settings' ) } onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
 						{ linkSettings }
 					</div>
 				}

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -547,12 +547,14 @@ export default class Editable extends Component {
 		this.editor.focus();
 		this.editor.formatter.remove( format );
 	}
-	applyFormat( format, args, node ) {
-		this.editor.focus();
+	applyFormat( format, args, node, controlKeepsFocus ) {
+		if ( ! controlKeepsFocus ) {
+			this.editor.focus();
+		}
 		this.editor.formatter.apply( format, args, node );
 	}
 
-	changeFormats( formats ) {
+	changeFormats( formats, controlKeepsFocus ) {
 		forEach( formats, ( formatValue, format ) => {
 			if ( format === 'link' ) {
 				if ( formatValue !== undefined ) {
@@ -560,7 +562,7 @@ export default class Editable extends Component {
 					if ( ! anchor ) {
 						this.removeFormat( 'link' );
 					}
-					this.applyFormat( 'link', { href: formatValue.value, target: formatValue.target }, anchor );
+					this.applyFormat( 'link', { href: formatValue.value, target: formatValue.target }, anchor, controlKeepsFocus );
 				} else {
 					this.editor.execCommand( 'Unlink' );
 				}


### PR DESCRIPTION
Adds a label to the link settings button, and fixes the issue where toggling the "new window" setting in the link settings would revert edits to the url and close the settings.