### PR TITLE
Blocks: Translate embed title prior to passing to settings factory

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,6 +79,18 @@
 			{
 				"selector": "ImportDeclaration[source.value=/^@wordpress\\u002F.+\\u002F/]",
 				"message": "Path access on WordPress dependencies is not allowed."
+			},
+			{
+				"selector": "CallExpression[callee.name=/^__|_n|_x$/]:not([arguments.0.type=/^Literal|BinaryExpression$/])",
+				"message": "Translate function arguments must be string literals."
+			},
+			{
+				"selector": "CallExpression[callee.name=/^_n|_x$/]:not([arguments.1.type=/^Literal|BinaryExpression$/])",
+				"message": "Translate function arguments must be string literals."
+			},
+			{
+				"selector": "CallExpression[callee.name=_nx]:not([arguments.2.type=/^Literal|BinaryExpression$/])",
+				"message": "Translate function arguments must be string literals."
 			}
 		],
 		"no-shadow": "error",

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -29,7 +29,7 @@ const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 
 function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, keywords = [] } ) {
 	return {
-		title: __( title ),
+		title,
 
 		icon,
 
@@ -236,7 +236,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 registerBlockType(
 	'core/embed',
 	getEmbedBlockSettings( {
-		title: 'Embed',
+		title: __( 'Embed' ),
 		icon: 'video-alt3',
 		transforms: {
 			from: [


### PR DESCRIPTION
This pull request seeks to resolve invalid usage of i18n functions where string extraction by static analysis would be unable to retrieve the referenced string argument. There was one instance of this in the embed block.

Further, the behavior of the embed block was such that it would attempt to translate titles for services such as YouTube, etc. Since these are brands, they are not intended to be translatable.

Finally, in order to prevent against future issues, I've introduced new lint rules for restricted syntax which will capture these errors during CI.

__Testing instructions:__

Verify that generating gettext strings includes the "Embed" string, and not any of the other embed services.

```
npm run test-client
```

Try locally to update the invocation of `__`, `_n`, `_x`, or `_nx` to include an argument which is not either a string or concatenated string (see #2655), and confirm that linting fails:

```
npm run lint
```