### PR TITLE
Bump memize and rememo dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3697,14 +3697,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3713,6 +3705,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5432,9 +5432,9 @@
       "dev": true
     },
     "memize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-1.0.2.tgz",
-      "integrity": "sha512-WVGAQ5W0VJW38G61r4ilz3Jxy5FE5a2QcBRQG1qqxNSmW9CJhdr2Giv3FjJAa2qUGDAz0cUvrFlELBTajU4uTw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.0.4.tgz",
+      "integrity": "sha512-S3vLa1noiP99NeP3z3am1ElEYUnTbcDZXBW1N0+diQYVR2ONUeDXRZ1z4s+Wyac+SBHtvJCsgos+ehnVUv/bTA=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -6775,9 +6775,9 @@
       }
     },
     "rememo": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-2.3.1.tgz",
-      "integrity": "sha512-rwjzytHBeGt4d50v1dwmtb2bhbwmsIHqgXI0rO2S62E9eayR5oNthp5qI7fQZMQbbZngsvmWfRKt6QE1ninYWg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-2.3.3.tgz",
+      "integrity": "sha512-dI1p0g5OveyMEcjcPiccg6y20AhPLAjDJBCqKpjuORVDXTALg5fA8OIzWm7m/RrGi+QLUG8T8hoKZLY0OBk2IA==",
       "requires": {
         "shallow-equal": "1.0.0"
       }
@@ -7331,15 +7331,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -7365,6 +7356,15 @@
       "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
       "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8=",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jed": "1.1.1",
     "js-beautify": "1.6.14",
     "lodash": "4.17.4",
-    "memize": "1.0.2",
+    "memize": "1.0.4",
     "moment": "2.18.1",
     "moment-timezone": "0.5.13",
     "mousetrap": "1.6.1",
@@ -42,7 +42,7 @@
     "redux-multi": "0.1.12",
     "redux-optimist": "0.0.2",
     "refx": "2.1.0",
-    "rememo": "2.3.1",
+    "rememo": "2.3.3",
     "simple-html-tokenizer": "0.4.1",
     "uuid": "3.1.0"
   },


### PR DESCRIPTION
This pull request seeks to bump the `memize` and `rememo` dependencies to their latest versions, v1.0.2 -> v1.0.4 and v2.3.1 -> v2.3.3 respectively. This resolves infinite loops which can occur in cache retrieval. For details, see aduth/memize@6bc7f058ec354ea4b03a1a52b3548353c253784d .

See changelogs:

- https://github.com/aduth/memize/blob/master/CHANGELOG.md
- https://github.com/aduth/rememo/blob/master/CHANGELOG.md

_Aside:_ These are projects maintained by myself.

__Testing instructions:__

I wasn't able to create reproducible steps for the issue. Instead, verify that no regressions occur in using the application. Memoization is largely used for Redux selectors (post dirty, blocks getter) and `withAPIData` helper (stable path cache).