### PR TITLE
editor: Use a small multiselect buffer zone

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -89,7 +89,7 @@ class VisualEditorBlockList extends Component {
 	}
 
 	onPointerMove( { clientY } ) {
-		const BUFFER = 60;
+		const BUFFER = 20;
 		const { multiSelectedBlocks } = this.props;
 		const y = clientY + window.pageYOffset;
 


### PR DESCRIPTION
fixes #2646 

I'm not sure why this buffer zone exists in the first place, but making it smaller makes it a better experience IMO.