### PR TITLE
Framework: Download api-request shim directly from GitHub

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -274,7 +274,7 @@ function gutenberg_register_vendor_scripts() {
 	// See: gutenberg_ensure_wp_api_request (compat.php).
 	gutenberg_register_vendor_script(
 		'wp-api-request-shim',
-		'https://rawgit.com/WordPress/wordpress-develop/master/src/wp-includes/js/api-request.js'
+		'https://raw.githubusercontent.com/WordPress/wordpress-develop/master/src/wp-includes/js/api-request.js'
 	);
 }
 


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/pull/1974#discussion_r137384007

This pull request seeks to download the `api-request.js` shim directly from GitHub, instead of through [rawgit.com](https://rawgit.com). The latter is necessary in cases where we would reference the URL by script tag directly, but given the behavior of vendor scripts to download the copy server-side to the plugin directory, this is not relevant for our usage.

__Testing instructions:__

Verify that the `api-request.js` shim continues to load as expected.

1. (Prerequisite) Your site must be running WordPress < 4.9-alpha
2. Delete your local copy if it exists: `rm vendor/api-request.*`
3. Navigate to Gutenberg > New Post
4. Note that the page loads without any errors