### PR TITLE
Compat: Disable wpautop in Classic Editor when post contains block

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -122,3 +122,19 @@ function gutenberg_ensure_wp_api_request() {
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_ensure_wp_api_request', 20 );
 add_action( 'admin_enqueue_scripts', 'gutenberg_ensure_wp_api_request', 20 );
+
+/**
+ * Disables wpautop behavior in classic editor when post contains blocks, to
+ * prevent removep from invalidating paragraph blocks.
+ *
+ * @param  array $settings Original editor settings
+ * @return array           Filtered settings
+ */
+function gutenberg_disable_editor_settings_wpautop( $settings ) {
+	if ( ! isset( $settings['wpautop'] ) ) {
+		$settings['wpautop'] = ! gutenberg_post_has_blocks( get_post()->ID );
+	}
+
+	return $settings;
+}
+add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -127,8 +127,8 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_ensure_wp_api_request', 20 );
  * Disables wpautop behavior in classic editor when post contains blocks, to
  * prevent removep from invalidating paragraph blocks.
  *
- * @param  array $settings Original editor settings
- * @return array           Filtered settings
+ * @param  array $settings Original editor settings.
+ * @return array           Filtered settings.
  */
 function gutenberg_disable_editor_settings_wpautop( $settings ) {
 	if ( ! isset( $settings['wpautop'] ) ) {


### PR DESCRIPTION
This pull request seeks to resolve an issue where saving a post which contains paragraph blocks in the current editor ("Classic Editor") will cause those blocks to become invalid when returning to the Gutenberg editor.

__Implementation notes:__

The reason that blocks become invalid is because by default, the current post editor will strip paragraph tags (the `removep` behavior). Since the Gutenberg editor expects these paragraph tags to exist, it will then flag these blocks as invalid (modified externally). The implementation here detects whether the post contains blocks (using the new `gutenberg_post_has_blocks` introduced in #1797) and, if so, disables the `wpautop` behavior for the Classic Editor.

__Testing instructions:__

1. (Prerequisite) Create and save a post in Gutenberg with at least on paragraph block
2. Navigate to Posts
3. Hover the post created in Step 1 and click Classic Editor
4. If not already, switch to Visual mode
5. Press Save
6. (Depending on whether #2707 is resolve), note that when returning (or redirected to) the post in Gutenberg, the paragraphs are still valid