### PR TITLE
FIX: Saving in Classic Editor shouldn't redirect to Gutenberg

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -221,6 +221,13 @@ function gutenberg_get_edit_post_url( $post_id ) {
  * @return string Edit post link.
  */
 function gutenberg_filter_edit_post_link( $url, $post_id, $context ) {
+	$sendback = wp_get_referer();
+	if ( $sendback && (
+		 strpos( $sendback, 'post.php' ) !== false ||
+		 strpos( $sendback, 'post-new.php' ) !== false ) ) {
+		return $url;
+	}
+
 	$post = get_post( $post_id );
 	if ( gutenberg_can_edit_post( $post_id ) && gutenberg_post_has_blocks( $post_id ) && post_type_supports( get_post_type( $post_id ), 'editor' ) ) {
 		$gutenberg_url = gutenberg_get_edit_post_url( $post->ID );

--- a/lib/register.php
+++ b/lib/register.php
@@ -221,10 +221,11 @@ function gutenberg_get_edit_post_url( $post_id ) {
  * @return string Edit post link.
  */
 function gutenberg_filter_edit_post_link( $url, $post_id, $context ) {
+	// Avoid redirect to Gutenberg after saving a block post in Classic editor.
 	$sendback = wp_get_referer();
 	if ( $sendback && (
-		 strpos( $sendback, 'post.php' ) !== false ||
-		 strpos( $sendback, 'post-new.php' ) !== false ) ) {
+			0 === strpos( $sendback, parse_url( admin_url( 'post.php' ), PHP_URL_PATH ) ) ||
+			0 === strpos( $sendback, parse_url( admin_url( 'post-new.php' ), PHP_URL_PATH ) ) ) ) {
 		return $url;
 	}
 


### PR DESCRIPTION
`get_edit_post_link` is used in `post.php` to redirect when saving. See https://core.trac.wordpress.org/browser/trunk/src/wp-admin/post.php#L190

By checking to see if the referer is the classic editor, modification to the edit post link is preserved.

Introduced in #1797
Fixes #2707