### PR TITLE
Use absolute positioning to correctly position the subscript.

### DIFF
--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -101,9 +101,9 @@ ul.components-toolbar {
 		font-family: $default-font;
 		font-size: $default-font-size;
 		font-weight: bold;
-		position: relative;
-		top: -5px;
-		left: -11px;
+		position: absolute;
+		right: 6px;
+		bottom: 8px;
 	}
 }
 


### PR DESCRIPTION
Fixes #2698 

In Safari, the heading numbers (subscript) were incorrectly positioned. Instead of relative positioning, absolute positioning is now used.

Safari screenshot:
![image](https://user-images.githubusercontent.com/31818/30243172-33912fa0-95b5-11e7-947b-d647fe63d9d3.png)
