### PR TITLE
Add wp-element dependency to example

### DIFF
--- a/blocks/README.md
+++ b/blocks/README.md
@@ -33,7 +33,7 @@ function myplugin_enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'myplugin-block',
 		plugins_url( 'block.js', __FILE__ ),
-		array( 'wp-blocks' )
+		array( 'wp-blocks', wp-element' )
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'myplugin_enqueue_block_editor_assets' );


### PR DESCRIPTION
Just to be consistent with the paragraph leading to the example: "...with a dependency on the
`wp-blocks` and `wp-element` script handles"