### PR TITLE
Parser: Remove `WP_Block_List`

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -16,9 +16,6 @@ function maybeJSON( s ) {
 }
 
 Document
-  = WP_Block_List
-
-WP_Block_List
   = WP_Block*
 
 WP_Block


### PR DESCRIPTION
The `WP_Block_List` wasn't actually doing anything useful as it was
transparently removed when parsing the document. It's just noise and so
I'm removing it in preparation for further parser work.