### PR TITLE
Parser: Allow block nesting

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -225,7 +225,7 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
  */
 export function parseWithGrammar( content ) {
 	return grammarParse( content ).reduce( ( memo, blockNode ) => {
-		const { blockName, rawContent, attrs } = blockNode;
+		const { blockName, innerHTML: rawContent, attrs } = blockNode;
 		const block = createBlockWithFallback( blockName, rawContent.trim(), attrs );
 		if ( block ) {
 			memo.push( block );

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -1,33 +1,179 @@
 {
 
+/*
+ *
+ *    _____       _             _
+ *   / ____|     | |           | |
+ *  | |  __ _   _| |_ ___ _ __ | |__   ___ _ __ __ _
+ *  | | |_ | | | | __/ _ \ '_ \| '_ \ / _ \ '__/ _` |
+ *  | |__| | |_| | ||  __/ | | | |_) |  __/ | | (_| |
+ *   \_____|\__,_|\__\___|_| |_|_.__/ \___|_|  \__, |
+ *                                              __/ |
+ *                  GRAMMAR                    |___/
+ *
+ *
+ * Welcome to the grammar file for Gutenberg posts!
+ *
+ * Please don't be distracted by the functions at the top
+ * here - they're just helpers for the grammar below. We
+ * try to keep them as minimal and simple as possible,
+ * but the parser generator forces us to declare them at
+ * the beginning of the file.
+ *
+ * What follows is the official specification grammar for
+ * documents created or edited in Gutenberg. It starts at
+ * the top-level rule `Block_List`
+ *
+ * The grammar is defined by a series of _rules_ and ways
+ * to return matches on those rules. It's a _PEG_, a
+ * parsing expression grammar, which simply means that for
+ * each of our rules we have a set of sub-rules to match
+ * on and the generated parser will try them in order
+ * until it finds the first match.
+ *
+ * This grammar is a _specification_ (with as little actual
+ * code as we can get away with) which is used by the
+ * parser generator to generate the actual _parser_ which
+ * is used by Gutenberg. We generate two parsers: one in
+ * JavaScript for use the browser and one in PHP for
+ * WordPress itself. PEG parser generators are available
+ * in many languages, though different libraries may require
+ * some translation of this grammar into their syntax.
+ *
+ * For more information:
+ * @see https://pegjs.org
+ * @see https://en.wikipedia.org/wiki/Parsing_expression_grammar
+ *
+ */
+
 /** <?php
 // The `maybeJSON` function is not needed in PHP because its return semantics
 // are the same as `json_decode`
+
+// array arguments are backwards because of PHP
+if ( ! function_exists( 'peg_array_partition' ) ) {
+    function peg_array_partition( $array, $predicate ) {
+        $truthy = array();
+        $falsey = array();
+
+        foreach ( $array as $item ) {
+            call_user_func( $predicate, $item )
+                ? $truthy[] = $item
+                : $falsey[] = $item;
+        }
+
+        return array( $truthy, $falsey );
+    }
+}
+
+if ( ! function_exists( 'peg_join_blocks' ) ) {
+    function peg_join_blocks( $pre, $tokens, $post ) {
+        $blocks = array();
+
+        if ( ! empty( $pre ) ) {
+            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+        }
+
+        foreach ( $tokens as $token ) {
+            list( $token, $html ) = $token;
+
+            $blocks[] = $token;
+
+            if ( ! empty( $html ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+            }
+        }
+
+        if ( ! empty( $post ) ) {
+            $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+        }
+
+        return $blocks;
+    }
+}
+
 ?> **/
 
+function freeform( s ) {
+    return s.length && {
+        attrs: {},
+        innerHTML: s
+    };
+}
+
+function joinBlocks( pre, tokens, post ) {
+    var blocks = [], i, l, html, item, token;
+
+    if ( pre.length ) {
+        blocks.push( freeform( pre ) );
+    }
+
+    for ( i = 0, l = tokens.length; i < l; i++ ) {
+        item = tokens[ i ];
+        token = item[ 0 ];
+        html = item[ 1 ];
+
+        blocks.push( token );
+        if ( html.length ) {
+            blocks.push( freeform( html ) );
+        }
+    }
+
+    if ( post.length ) {
+        blocks.push( freeform( post ) );
+    }
+
+    return blocks;
+}
+
 function maybeJSON( s ) {
-	try {
-		return JSON.parse( s );
-	} catch (e) {
-		return null;
-	}
+    try {
+        return JSON.parse( s );
+    } catch (e) {
+        return null;
+    }
+}
+
+function partition( predicate, list ) {
+    var i, l, item;
+    var truthy = [];
+    var falsey = [];
+
+    // nod to performance over a simpler reduce
+    // and clone model we could have taken here
+    for ( i = 0, l = list.length; i < l; i++ ) {
+        item = list[ i ];
+
+        predicate( item )
+            ? truthy.push( item )
+            : falsey.push( item )
+    };
+
+    return [ truthy, falsey ];
 }
 
 }
 
-Document
-  = WP_Block_List
+//////////////////////////////////////////////////////
+//
+//   Here starts the grammar proper!
+//
+//////////////////////////////////////////////////////
 
-WP_Block_List
-  = WP_Block*
+Block_List
+  = pre:$(!Token .)*
+    ts:(t:Token html:$((!Token .)*) { /** <?php return array( $t, $html ); ?> **/ return [ t, html ] })*
+    post:$(.*)
+  { /** <?php return peg_join_blocks( $pre, $ts, $post ); ?> **/
+    return joinBlocks( pre, ts, post );
+  }
 
-WP_Block
-  = WP_Tag_More
-  / WP_Block_Void
-  / WP_Block_Balanced
-  / WP_Block_Html
+Token
+  = Tag_More
+  / Block_Void
+  / Block_Balanced
 
-WP_Tag_More
+Tag_More
   = "<!--" WS* "more" customText:(WS+ text:$((!(WS* "-->") .)+) { /** <?php return $text; ?> **/ return text })? WS* "-->" noTeaser:(WS* "<!--noteaser-->")?
   { /** <?php
     $attrs = array( 'noTeaser' => (bool) $noTeaser );
@@ -37,7 +183,7 @@ WP_Tag_More
     return array(
        'blockName' => 'core/more',
        'attrs' => $attrs,
-       'rawContent' => ''
+       'innerHTML' => ''
     );
     ?> **/
     return {
@@ -46,12 +192,12 @@ WP_Tag_More
         customText: customText || undefined,
         noTeaser: !! noTeaser
       },
-      rawContent: ''
+      innerHTML: ''
     }
   }
 
-WP_Block_Void
-  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ {
+Block_Void
+  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
     /** <?php return $a; ?> **/
     return a;
   })? "/-->"
@@ -60,62 +206,47 @@ WP_Block_Void
     return array(
       'blockName'  => $blockName,
       'attrs'      => $attrs,
-      'rawContent' => '',
+      'innerBlocks' => array(),
+      'innerHTML' => '',
     );
     ?> **/
 
     return {
       blockName: blockName,
       attrs: attrs,
-      rawContent: ''
+      innerBlocks: [],
+      innerHTML: ''
     };
   }
 
-WP_Block_Balanced
-  = s:WP_Block_Start ts:(!WP_Block_End c:Any {
-    /** <?php return $c; ?> **/
-    return c;
-  })* e:WP_Block_End & {
-    /** <?php return $s['blockName'] === $e['blockName']; ?> **/
-    return s.blockName === e.blockName;
-  }
+Block_Balanced
+  = s:Block_Start children:(Token / $(!Block_End .))* e:Block_End
   {
     /** <?php
+    list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
     return array(
       'blockName'  => $s['blockName'],
       'attrs'      => $s['attrs'],
-      'rawContent' => implode( '', $ts ),
+      'innerBlocks'  => $innerBlocks,
+      'innerHTML'  => implode( '', $innerHTML ),
     );
     ?> **/
+
+    var innerContent = partition( function( a ) { return 'string' === typeof a }, children );
+    var innerHTML = innerContent[ 0 ];
+    var innerBlocks = innerContent[ 1 ];
 
     return {
       blockName: s.blockName,
       attrs: s.attrs,
-      rawContent: ts.join( '' )
+      innerBlocks: innerBlocks,
+      innerHTML: innerHTML.join( '' )
     };
   }
 
-WP_Block_Html
-  = ts:(!WP_Block_Balanced !WP_Block_Void !WP_Tag_More c:Any {
-    /** <?php return $c; ?> **/
-    return c;
-  })+
-  {
-    /** <?php
-    return array(
-      'attrs'      => array(),
-      'rawContent' => implode( '', $ts ),
-    );
-    ?> **/
-
-    return {
-      attrs: {},
-      rawContent: ts.join( '' )
-    }
-  }
-
-WP_Block_Start
-  = "<!--" WS+ "wp:" blockName:WP_Block_Name WS+ attrs:(a:WP_Block_Attributes WS+ {
+Block_Start
+  = "<!--" WS+ "wp:" blockName:Block_Name WS+ attrs:(a:Block_Attributes WS+ {
     /** <?php return $a; ?> **/
     return a;
   })? "-->"
@@ -133,8 +264,8 @@ WP_Block_Start
     };
   }
 
-WP_Block_End
-  = "<!--" WS+ "/wp:" blockName:WP_Block_Name WS+ "-->"
+Block_End
+  = "<!--" WS+ "/wp:" blockName:Block_Name WS+ "-->"
   {
     /** <?php
     return array(
@@ -147,21 +278,21 @@ WP_Block_End
     };
   }
 
-WP_Block_Name
-  = WP_Namespaced_Block_Name
-  / WP_Core_Block_Name
+Block_Name
+  = Namespaced_Block_Name
+  / Core_Block_Name
 
-WP_Namespaced_Block_Name
+Namespaced_Block_Name
   = $(ASCII_Letter ASCII_AlphaNumeric* "/" ASCII_Letter ASCII_AlphaNumeric*)
 
-WP_Core_Block_Name
+Core_Block_Name
   = type:$(ASCII_Letter ASCII_AlphaNumeric*)
   {
     /** <?php return "core/$type"; ?> **/
     return 'core/' + type;
   }
 
-WP_Block_Attributes
+Block_Attributes
   = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")
   {
     /** <?php return json_decode( $attrs, true ); ?> **/

--- a/blocks/test/fixtures/core-embed__animoto.parsed.json
+++ b/blocks/test/fixtures/core-embed__animoto.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://animoto.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-animoto\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-animoto\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__cloudup.parsed.json
+++ b/blocks/test/fixtures/core-embed__cloudup.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://cloudup.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-cloudup\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-cloudup\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__collegehumor.parsed.json
+++ b/blocks/test/fixtures/core-embed__collegehumor.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://collegehumor.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-collegehumor\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-collegehumor\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__dailymotion.parsed.json
+++ b/blocks/test/fixtures/core-embed__dailymotion.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://dailymotion.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-dailymotion\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-dailymotion\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__facebook.parsed.json
+++ b/blocks/test/fixtures/core-embed__facebook.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://facebook.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-facebook\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-facebook\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__flickr.parsed.json
+++ b/blocks/test/fixtures/core-embed__flickr.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://flickr.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-flickr\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-flickr\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__funnyordie.parsed.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://funnyordie.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-funnyordie\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-funnyordie\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__hulu.parsed.json
+++ b/blocks/test/fixtures/core-embed__hulu.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://hulu.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-hulu\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-hulu\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__imgur.parsed.json
+++ b/blocks/test/fixtures/core-embed__imgur.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://imgur.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-imgur\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-imgur\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__instagram.parsed.json
+++ b/blocks/test/fixtures/core-embed__instagram.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://instagram.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-instagram\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-instagram\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__issuu.parsed.json
+++ b/blocks/test/fixtures/core-embed__issuu.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://issuu.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-issuu\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-issuu\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__kickstarter.parsed.json
+++ b/blocks/test/fixtures/core-embed__kickstarter.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://kickstarter.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-kickstarter\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-kickstarter\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__meetup-com.parsed.json
+++ b/blocks/test/fixtures/core-embed__meetup-com.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://meetup.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-meetup-com\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-meetup-com\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__mixcloud.parsed.json
+++ b/blocks/test/fixtures/core-embed__mixcloud.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://mixcloud.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-mixcloud\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-mixcloud\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__photobucket.parsed.json
+++ b/blocks/test/fixtures/core-embed__photobucket.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://photobucket.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-photobucket\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-photobucket\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__polldaddy.parsed.json
+++ b/blocks/test/fixtures/core-embed__polldaddy.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://polldaddy.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-polldaddy\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-polldaddy\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__reddit.parsed.json
+++ b/blocks/test/fixtures/core-embed__reddit.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://reddit.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-reddit\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-reddit\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__reverbnation.parsed.json
+++ b/blocks/test/fixtures/core-embed__reverbnation.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://reverbnation.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-reverbnation\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-reverbnation\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__screencast.parsed.json
+++ b/blocks/test/fixtures/core-embed__screencast.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://screencast.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-screencast\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-screencast\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__scribd.parsed.json
+++ b/blocks/test/fixtures/core-embed__scribd.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://scribd.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-scribd\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-scribd\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__slideshare.parsed.json
+++ b/blocks/test/fixtures/core-embed__slideshare.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://slideshare.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-slideshare\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-slideshare\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__smugmug.parsed.json
+++ b/blocks/test/fixtures/core-embed__smugmug.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://smugmug.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-smugmug\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-smugmug\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__soundcloud.parsed.json
+++ b/blocks/test/fixtures/core-embed__soundcloud.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://soundcloud.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-soundcloud\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-soundcloud\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__speaker.parsed.json
+++ b/blocks/test/fixtures/core-embed__speaker.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://speaker.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-speaker\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-speaker\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__spotify.parsed.json
+++ b/blocks/test/fixtures/core-embed__spotify.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://spotify.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-spotify\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-spotify\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__ted.parsed.json
+++ b/blocks/test/fixtures/core-embed__ted.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://ted.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-ted\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-ted\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__tumblr.parsed.json
+++ b/blocks/test/fixtures/core-embed__tumblr.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://tumblr.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-tumblr\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-tumblr\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__twitter.parsed.json
+++ b/blocks/test/fixtures/core-embed__twitter.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://twitter.com/automattic"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-twitter\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-twitter\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__videopress.parsed.json
+++ b/blocks/test/fixtures/core-embed__videopress.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://videopress.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-videopress\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-videopress\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__vimeo.parsed.json
+++ b/blocks/test/fixtures/core-embed__vimeo.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://vimeo.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-vimeo\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-vimeo\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__vine.parsed.json
+++ b/blocks/test/fixtures/core-embed__vine.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://vine.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-vine\">\n    https://vine.com/\n    <figcaption>Embedded content from vine</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-vine\">\n    https://vine.com/\n    <figcaption>Embedded content from vine</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress-tv.parsed.json
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://wordpress.tv/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-wordpress-tv\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-wordpress-tv\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress.parsed.json
+++ b/blocks/test/fixtures/core-embed__wordpress.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://wordpress.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-wordpress\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-wordpress\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core-embed__youtube.parsed.json
+++ b/blocks/test/fixtures/core-embed__youtube.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://youtube.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed-youtube\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed-youtube\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__audio.parsed.json
+++ b/blocks/test/fixtures/core__audio.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "align": "right"
         },
-        "rawContent": "\n<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__button__center.parsed.json
+++ b/blocks/test/fixtures/core__button__center.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "align": "center"
         },
-        "rawContent": "\n<div class=\"wp-block-button aligncenter\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<div class=\"wp-block-button aligncenter\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__categories.parsed.json
+++ b/blocks/test/fixtures/core__categories.parsed.json
@@ -6,10 +6,11 @@
             "displayAsDropdown": false,
             "showHierarchy": false
         },
-        "rawContent": ""
+        "innerBlocks": [],
+        "innerHTML": ""
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__code.parsed.json
+++ b/blocks/test/fixtures/core__code.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/code",
         "attrs": null,
-        "rawContent": "\n<pre class=\"wp-block-code\"><code>export default function MyButton() {\n\treturn &lt;Button&gt;Click Me!&lt;/Button&gt;;\n}</code></pre>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<pre class=\"wp-block-code\"><code>export default function MyButton() {\n\treturn &lt;Button&gt;Click Me!&lt;/Button&gt;;\n}</code></pre>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__cover-image.parsed.json
+++ b/blocks/test/fixtures/core__cover-image.parsed.json
@@ -5,10 +5,11 @@
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
             "dimRatio": 40
         },
-        "rawContent": "\n<section class=\"wp-block-cover-image has-background-dim-40 has-background-dim\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <h2>Guten Berg!</h2>\n</section>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<section class=\"wp-block-cover-image has-background-dim-40 has-background-dim\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <h2>Guten Berg!</h2>\n</section>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__embed.parsed.json
+++ b/blocks/test/fixtures/core__embed.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "url": "https://example.com/"
         },
-        "rawContent": "\n<figure class=\"wp-block-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__freeform.parsed.json
+++ b/blocks/test/fixtures/core__freeform.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/freeform",
         "attrs": null,
-        "rawContent": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
+        "innerBlocks": [],
+        "innerHTML": "\nTesting freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__gallery.parsed.json
+++ b/blocks/test/fixtures/core__gallery.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/gallery",
         "attrs": null,
-        "rawContent": "\n<div class=\"wp-block-gallery\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<div class=\"wp-block-gallery\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__gallery__columns.parsed.json
+++ b/blocks/test/fixtures/core__gallery__columns.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "columns": "1"
         },
-        "rawContent": "\n<div class=\"wp-block-gallery columns-1 \">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<div class=\"wp-block-gallery columns-1 \">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2-em.parsed.json
+++ b/blocks/test/fixtures/core__heading__h2-em.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/heading",
         "attrs": null,
-        "rawContent": "\n<h2>The <em>Inserter</em> Tool</h2>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<h2>The <em>Inserter</em> Tool</h2>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__heading__h2.parsed.json
+++ b/blocks/test/fixtures/core__heading__h2.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/heading",
         "attrs": null,
-        "rawContent": "\n<h2>A picture is worth a thousand words, or so the saying goes</h2>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<h2>A picture is worth a thousand words, or so the saying goes</h2>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__html.parsed.json
+++ b/blocks/test/fixtures/core__html.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/html",
         "attrs": null,
-        "rawContent": "\n<h1>Some HTML code</h1>\n<marquee>This text will scroll from right to left</marquee>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<h1>Some HTML code</h1>\n<marquee>This text will scroll from right to left</marquee>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__image.parsed.json
+++ b/blocks/test/fixtures/core__image.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/image",
         "attrs": null,
-        "rawContent": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" /></figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" /></figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__image__center-caption.parsed.json
+++ b/blocks/test/fixtures/core__image__center-caption.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "align": "center"
         },
-        "rawContent": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" class=\"aligncenter\"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" class=\"aligncenter\"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__latest-posts.parsed.json
+++ b/blocks/test/fixtures/core__latest-posts.parsed.json
@@ -5,10 +5,11 @@
             "postsToShow": 5,
             "displayPostDate": false
         },
-        "rawContent": ""
+        "innerBlocks": [],
+        "innerHTML": ""
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__latest-posts__displayPostDate.parsed.json
+++ b/blocks/test/fixtures/core__latest-posts__displayPostDate.parsed.json
@@ -5,10 +5,11 @@
             "postsToShow": 5,
             "displayPostDate": true
         },
-        "rawContent": ""
+        "innerBlocks": [],
+        "innerHTML": ""
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__list__ul.parsed.json
+++ b/blocks/test/fixtures/core__list__ul.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/list",
         "attrs": null,
-        "rawContent": "\n<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__more.parsed.json
+++ b/blocks/test/fixtures/core__more.parsed.json
@@ -4,10 +4,10 @@
         "attrs": {
             "noTeaser": false
         },
-        "rawContent": ""
+        "innerHTML": ""
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__more__custom-text-teaser.parsed.json
+++ b/blocks/test/fixtures/core__more__custom-text-teaser.parsed.json
@@ -5,10 +5,10 @@
             "customText": "Continue Reading",
             "noTeaser": true
         },
-        "rawContent": ""
+        "innerHTML": ""
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__paragraph__align-right.parsed.json
+++ b/blocks/test/fixtures/core__paragraph__align-right.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "align": "right"
         },
-        "rawContent": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<p style=\"text-align:right;\">... like this one, which is separate from the above and right aligned.</p>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__preformatted.parsed.json
+++ b/blocks/test/fixtures/core__preformatted.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/preformatted",
         "attrs": null,
-        "rawContent": "\n<pre class=\"wp-block-preformatted\">Some <em>preformatted</em> text...<br>And more!</pre>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<pre class=\"wp-block-preformatted\">Some <em>preformatted</em> text...<br>And more!</pre>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote.parsed.json
+++ b/blocks/test/fixtures/core__pullquote.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "rawContent": "\n<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><footer>...with a caption</footer>\n</blockquote>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><footer>...with a caption</footer>\n</blockquote>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "rawContent": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>by whomever</footer>\n</blockquote>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>by whomever</footer>\n</blockquote>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "style": "1"
         },
-        "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "style": "2"
         },
-        "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__reusable-block.parsed.json
+++ b/blocks/test/fixtures/core__reusable-block.parsed.json
@@ -4,11 +4,11 @@
         "attrs": {
             "ref": "358b59ee-bab3-4d6f-8445-e8c6971a5605"
         },
-        "rawContent": ""
+        "innerBlocks": [],
+        "innerHTML": ""
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]
-

--- a/blocks/test/fixtures/core__separator.parsed.json
+++ b/blocks/test/fixtures/core__separator.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/separator",
         "attrs": null,
-        "rawContent": "\n<hr class=\"wp-block-separator\" />\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<hr class=\"wp-block-separator\" />\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__shortcode.parsed.json
+++ b/blocks/test/fixtures/core__shortcode.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/shortcode",
         "attrs": null,
-        "rawContent": "\n[gallery ids=\"238,338\"]\n"
+        "innerBlocks": [],
+        "innerHTML": "\n[gallery ids=\"238,338\"]\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__table.parsed.json
+++ b/blocks/test/fixtures/core__table.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/table",
         "attrs": null,
-        "rawContent": "\n<table><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<table><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><td><a href=\"https://wordpress.org/news/2003/05/wordpress-now-available/\">.70</a></td><td>No musician chosen.</td><td>May 27, 2003</td></tr><tr><td><a href=\"https://wordpress.org/news/2004/01/wordpress-10/\">1.0</a></td><td>Miles Davis</td><td>January 3, 2004</td></tr><tr><td>Lots of versions skipped, see <a href=\"https://codex.wordpress.org/WordPress_Versions\">the full list</a></td><td>&hellip;</td><td>&hellip;</td></tr><tr><td><a href=\"https://wordpress.org/news/2015/12/clifford/\">4.4</a></td><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/04/coleman/\">4.5</a></td><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/08/pepper/\">4.6</a></td><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr><td><a href=\"https://wordpress.org/news/2016/12/vaughan/\">4.7</a></td><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n\n"
+        "innerHTML": "\n\n"
     }
 ]

--- a/blocks/test/fixtures/core__text-columns.parsed.json
+++ b/blocks/test/fixtures/core__text-columns.parsed.json
@@ -4,10 +4,11 @@
         "attrs": {
             "width": "center"
         },
-        "rawContent": "\n<section class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-column\">\n        <p>Two</p>\n    </div>\n</section>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<section class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-column\">\n        <p>Two</p>\n    </div>\n</section>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/text",
         "attrs": null,
-        "rawContent": "\n<p>This is an old-style text block.  Changed to <code>paragraph</code> in #2135.</p>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<p>This is an old-style text block.  Changed to <code>paragraph</code> in #2135.</p>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__verse.parsed.json
+++ b/blocks/test/fixtures/core__verse.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/verse",
         "attrs": null,
-        "rawContent": "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<pre class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/blocks/test/fixtures/core__video.parsed.json
+++ b/blocks/test/fixtures/core__video.parsed.json
@@ -2,10 +2,11 @@
     {
         "blockName": "core/video",
         "attrs": null,
-        "rawContent": "\n<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"\"></video></figure>\n"
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"\"></video></figure>\n"
     },
     {
         "attrs": {},
-        "rawContent": "\n"
+        "innerHTML": "\n"
     }
 ]

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -75,7 +75,7 @@ function do_blocks( $content ) {
 	foreach ( $blocks as $block ) {
 		$block_name  = isset( $block['blockName'] ) ? $block['blockName'] : null;
 		$attributes  = is_array( $block['attrs'] ) ? $block['attrs'] : array();
-		$raw_content = isset( $block['rawContent'] ) ? $block['rawContent'] : null;
+		$raw_content = isset( $block['innerHTML'] ) ? $block['innerHTML'] : null;
 
 		if ( $block_name ) {
 			$block_type = $registry->get_registered( $block_name );

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -263,8 +263,10 @@ class Gutenberg_PEG_Parser {
     private $peg_c32;
     private $peg_c33;
 
-    private function peg_f0($text) { return $text; }
-    private function peg_f1($customText, $noTeaser) {
+    private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
+    private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
+    private function peg_f2($text) { return $text; }
+    private function peg_f3($customText, $noTeaser) {
         $attrs = array( 'noTeaser' => (bool) $noTeaser );
         if ( ! empty( $customText ) ) {
           $attrs['customText'] = $customText;
@@ -272,92 +274,374 @@ class Gutenberg_PEG_Parser {
         return array(
            'blockName' => 'core/more',
            'attrs' => $attrs,
-           'rawContent' => ''
+           'innerHTML' => ''
         );
         }
-    private function peg_f2($blockName, $a) { return $a; }
-    private function peg_f3($blockName, $attrs) {
+    private function peg_f4($blockName, $a) { return $a; }
+    private function peg_f5($blockName, $attrs) {
         return array(
           'blockName'  => $blockName,
           'attrs'      => $attrs,
-          'rawContent' => '',
+          'innerBlocks' => array(),
+          'innerHTML' => '',
         );
         }
-    private function peg_f4($s, $c) { return $c; }
-    private function peg_f5($s, $ts, $e) { return $s['blockName'] === $e['blockName']; }
-    private function peg_f6($s, $ts, $e) {
+    private function peg_f6($s, $children, $e) {
+        list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+
         return array(
           'blockName'  => $s['blockName'],
           'attrs'      => $s['attrs'],
-          'rawContent' => implode( '', $ts ),
+          'innerBlocks'  => $innerBlocks,
+          'innerHTML'  => implode( '', $innerHTML ),
         );
         }
-    private function peg_f7($c) { return $c; }
-    private function peg_f8($ts) {
-        return array(
-          'attrs'      => array(),
-          'rawContent' => implode( '', $ts ),
-        );
-        }
-    private function peg_f9($blockName, $attrs) {
+    private function peg_f7($blockName, $attrs) {
         return array(
           'blockName' => $blockName,
           'attrs'     => $attrs,
         );
         }
-    private function peg_f10($blockName) {
+    private function peg_f8($blockName) {
         return array(
           'blockName' => $blockName,
         );
         }
-    private function peg_f11($type) { return "core/$type"; }
-    private function peg_f12($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f9($type) { return "core/$type"; }
+    private function peg_f10($attrs) { return json_decode( $attrs, true ); }
 
-    private function peg_parseDocument() {
+    private function peg_parseBlock_List() {
 
-      $s0 = $this->peg_parseWP_Block_List();
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_List() {
-
-      $s0 = array();
-      $s1 = $this->peg_parseWP_Block();
-      while ($s1 !== $this->peg_FAILED) {
-        $s0[] = $s1;
-        $s1 = $this->peg_parseWP_Block();
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = array();
+      $s3 = $this->peg_currPos;
+      $s4 = $this->peg_currPos;
+      $this->peg_silentFails++;
+      $s5 = $this->peg_parseToken();
+      $this->peg_silentFails--;
+      if ($s5 === $this->peg_FAILED) {
+        $s4 = null;
+      } else {
+        $this->peg_currPos = $s4;
+        $s4 = $this->peg_FAILED;
+      }
+      if ($s4 !== $this->peg_FAILED) {
+        if ($this->input_length > $this->peg_currPos) {
+          $s5 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s5 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c0);
+          }
+        }
+        if ($s5 !== $this->peg_FAILED) {
+          $s4 = array($s4, $s5);
+          $s3 = $s4;
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s3;
+        $s3 = $this->peg_FAILED;
+      }
+      while ($s3 !== $this->peg_FAILED) {
+        $s2[] = $s3;
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_currPos;
+        $this->peg_silentFails++;
+        $s5 = $this->peg_parseToken();
+        $this->peg_silentFails--;
+        if ($s5 === $this->peg_FAILED) {
+          $s4 = null;
+        } else {
+          $this->peg_currPos = $s4;
+          $s4 = $this->peg_FAILED;
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $s4 = array($s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s2 = array();
+        $s3 = $this->peg_currPos;
+        $s4 = $this->peg_parseToken();
+        if ($s4 !== $this->peg_FAILED) {
+          $s5 = $this->peg_currPos;
+          $s6 = array();
+          $s7 = $this->peg_currPos;
+          $s8 = $this->peg_currPos;
+          $this->peg_silentFails++;
+          $s9 = $this->peg_parseToken();
+          $this->peg_silentFails--;
+          if ($s9 === $this->peg_FAILED) {
+            $s8 = null;
+          } else {
+            $this->peg_currPos = $s8;
+            $s8 = $this->peg_FAILED;
+          }
+          if ($s8 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s9 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s9 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s9 !== $this->peg_FAILED) {
+              $s8 = array($s8, $s9);
+              $s7 = $s8;
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s7;
+            $s7 = $this->peg_FAILED;
+          }
+          while ($s7 !== $this->peg_FAILED) {
+            $s6[] = $s7;
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+          }
+          if ($s6 !== $this->peg_FAILED) {
+            $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+          } else {
+            $s5 = $s6;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s3;
+            $s4 = $this->peg_f0($s1, $s4, $s5);
+            $s3 = $s4;
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s3;
+          $s3 = $this->peg_FAILED;
+        }
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_currPos;
+          $s4 = $this->peg_parseToken();
+          if ($s4 !== $this->peg_FAILED) {
+            $s5 = $this->peg_currPos;
+            $s6 = array();
+            $s7 = $this->peg_currPos;
+            $s8 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s9 = $this->peg_parseToken();
+            $this->peg_silentFails--;
+            if ($s9 === $this->peg_FAILED) {
+              $s8 = null;
+            } else {
+              $this->peg_currPos = $s8;
+              $s8 = $this->peg_FAILED;
+            }
+            if ($s8 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s9 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s9 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s9 !== $this->peg_FAILED) {
+                $s8 = array($s8, $s9);
+                $s7 = $s8;
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s7;
+              $s7 = $this->peg_FAILED;
+            }
+            while ($s7 !== $this->peg_FAILED) {
+              $s6[] = $s7;
+              $s7 = $this->peg_currPos;
+              $s8 = $this->peg_currPos;
+              $this->peg_silentFails++;
+              $s9 = $this->peg_parseToken();
+              $this->peg_silentFails--;
+              if ($s9 === $this->peg_FAILED) {
+                $s8 = null;
+              } else {
+                $this->peg_currPos = $s8;
+                $s8 = $this->peg_FAILED;
+              }
+              if ($s8 !== $this->peg_FAILED) {
+                if ($this->input_length > $this->peg_currPos) {
+                  $s9 = $this->input_substr($this->peg_currPos, 1);
+                  $this->peg_currPos++;
+                } else {
+                  $s9 = $this->peg_FAILED;
+                  if ($this->peg_silentFails === 0) {
+                      $this->peg_fail($this->peg_c0);
+                  }
+                }
+                if ($s9 !== $this->peg_FAILED) {
+                  $s8 = array($s8, $s9);
+                  $s7 = $s8;
+                } else {
+                  $this->peg_currPos = $s7;
+                  $s7 = $this->peg_FAILED;
+                }
+              } else {
+                $this->peg_currPos = $s7;
+                $s7 = $this->peg_FAILED;
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = $this->input_substr($s5, $this->peg_currPos - $s5);
+            } else {
+              $s5 = $s6;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              $this->peg_reportedPos = $s3;
+              $s4 = $this->peg_f0($s1, $s4, $s5);
+              $s3 = $s4;
+            } else {
+              $this->peg_currPos = $s3;
+              $s3 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s3;
+            $s3 = $this->peg_FAILED;
+          }
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_currPos;
+          $s4 = array();
+          if ($this->input_length > $this->peg_currPos) {
+            $s5 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s5 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c0);
+            }
+          }
+          while ($s5 !== $this->peg_FAILED) {
+            $s4[] = $s5;
+            if ($this->input_length > $this->peg_currPos) {
+              $s5 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s5 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
+          } else {
+            $s3 = $s4;
+          }
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f1($s1, $s2, $s3);
+            $s0 = $s1;
+          } else {
+            $this->peg_currPos = $s0;
+            $s0 = $this->peg_FAILED;
+          }
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Block() {
+    private function peg_parseToken() {
 
-      $s0 = $this->peg_parseWP_Tag_More();
+      $s0 = $this->peg_parseTag_More();
       if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseWP_Block_Void();
+        $s0 = $this->peg_parseBlock_Void();
         if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseWP_Block_Balanced();
-          if ($s0 === $this->peg_FAILED) {
-            $s0 = $this->peg_parseWP_Block_Html();
-          }
+          $s0 = $this->peg_parseBlock_Balanced();
         }
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Tag_More() {
+    private function peg_parseTag_More() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -368,13 +652,13 @@ class Gutenberg_PEG_Parser {
           $s3 = $this->peg_parseWS();
         }
         if ($s2 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c2) {
-            $s3 = $this->peg_c2;
+          if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c3) {
+            $s3 = $this->peg_c3;
             $this->peg_currPos += 4;
           } else {
             $s3 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c3);
+                $this->peg_fail($this->peg_c4);
             }
           }
           if ($s3 !== $this->peg_FAILED) {
@@ -403,13 +687,13 @@ class Gutenberg_PEG_Parser {
                 $s12 = $this->peg_parseWS();
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
-                  $s12 = $this->peg_c4;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c5);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -437,7 +721,7 @@ class Gutenberg_PEG_Parser {
                 } else {
                   $s10 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c6);
+                      $this->peg_fail($this->peg_c0);
                   }
                 }
                 if ($s10 !== $this->peg_FAILED) {
@@ -465,13 +749,13 @@ class Gutenberg_PEG_Parser {
                     $s12 = $this->peg_parseWS();
                   }
                   if ($s11 !== $this->peg_FAILED) {
-                    if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
-                      $s12 = $this->peg_c4;
+                    if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                      $s12 = $this->peg_c5;
                       $this->peg_currPos += 3;
                     } else {
                       $s12 = $this->peg_FAILED;
                       if ($this->peg_silentFails === 0) {
-                          $this->peg_fail($this->peg_c5);
+                          $this->peg_fail($this->peg_c6);
                       }
                     }
                     if ($s12 !== $this->peg_FAILED) {
@@ -499,7 +783,7 @@ class Gutenberg_PEG_Parser {
                     } else {
                       $s10 = $this->peg_FAILED;
                       if ($this->peg_silentFails === 0) {
-                          $this->peg_fail($this->peg_c6);
+                          $this->peg_fail($this->peg_c0);
                       }
                     }
                     if ($s10 !== $this->peg_FAILED) {
@@ -524,7 +808,7 @@ class Gutenberg_PEG_Parser {
               }
               if ($s6 !== $this->peg_FAILED) {
                 $this->peg_reportedPos = $s4;
-                $s5 = $this->peg_f0($s6);
+                $s5 = $this->peg_f2($s6);
                 $s4 = $s5;
               } else {
                 $this->peg_currPos = $s4;
@@ -545,13 +829,13 @@ class Gutenberg_PEG_Parser {
                 $s6 = $this->peg_parseWS();
               }
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
-                  $s6 = $this->peg_c4;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c5);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
@@ -588,7 +872,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f1($s4, $s7);
+                    $s1 = $this->peg_f3($s4, $s7);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -622,16 +906,16 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Void() {
+    private function peg_parseBlock_Void() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -656,7 +940,7 @@ class Gutenberg_PEG_Parser {
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -670,7 +954,7 @@ class Gutenberg_PEG_Parser {
               }
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
+                $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
                   $s8 = array();
                   $s9 = $this->peg_parseWS();
@@ -684,7 +968,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f2($s4, $s7);
+                    $s7 = $this->peg_f4($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -709,7 +993,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f3($s4, $s6);
+                    $s1 = $this->peg_f5($s4, $s6);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -743,83 +1027,103 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Balanced() {
+    private function peg_parseBlock_Balanced() {
 
       $s0 = $this->peg_currPos;
-      $s1 = $this->peg_parseWP_Block_Start();
+      $s1 = $this->peg_parseBlock_Start();
       if ($s1 !== $this->peg_FAILED) {
         $s2 = array();
-        $s3 = $this->peg_currPos;
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_End();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_parseAny();
-          if ($s5 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $s3;
-            $s4 = $this->peg_f4($s1, $s5);
-            $s3 = $s4;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s3;
-          $s3 = $this->peg_FAILED;
-        }
-        while ($s3 !== $this->peg_FAILED) {
-          $s2[] = $s3;
+        $s3 = $this->peg_parseToken();
+        if ($s3 === $this->peg_FAILED) {
           $s3 = $this->peg_currPos;
           $s4 = $this->peg_currPos;
+          $s5 = $this->peg_currPos;
           $this->peg_silentFails++;
-          $s5 = $this->peg_parseWP_Block_End();
+          $s6 = $this->peg_parseBlock_End();
           $this->peg_silentFails--;
-          if ($s5 === $this->peg_FAILED) {
-            $s4 = null;
+          if ($s6 === $this->peg_FAILED) {
+            $s5 = null;
+          } else {
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
+          }
+          if ($s5 !== $this->peg_FAILED) {
+            if ($this->input_length > $this->peg_currPos) {
+              $s6 = $this->input_substr($this->peg_currPos, 1);
+              $this->peg_currPos++;
+            } else {
+              $s6 = $this->peg_FAILED;
+              if ($this->peg_silentFails === 0) {
+                  $this->peg_fail($this->peg_c0);
+              }
+            }
+            if ($s6 !== $this->peg_FAILED) {
+              $s5 = array($s5, $s6);
+              $s4 = $s5;
+            } else {
+              $this->peg_currPos = $s4;
+              $s4 = $this->peg_FAILED;
+            }
           } else {
             $this->peg_currPos = $s4;
             $s4 = $this->peg_FAILED;
           }
           if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseAny();
-            if ($s5 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s3;
-              $s4 = $this->peg_f4($s1, $s5);
-              $s3 = $s4;
-            } else {
-              $this->peg_currPos = $s3;
-              $s3 = $this->peg_FAILED;
-            }
+            $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
           } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
+            $s3 = $s4;
           }
         }
-        if ($s2 !== $this->peg_FAILED) {
-          $s3 = $this->peg_parseWP_Block_End();
-          if ($s3 !== $this->peg_FAILED) {
-            $this->peg_reportedPos = $this->peg_currPos;
-            $s4 = $this->peg_f5($s1, $s2, $s3);
-            if ($s4) {
-              $s4 = null;
+        while ($s3 !== $this->peg_FAILED) {
+          $s2[] = $s3;
+          $s3 = $this->peg_parseToken();
+          if ($s3 === $this->peg_FAILED) {
+            $s3 = $this->peg_currPos;
+            $s4 = $this->peg_currPos;
+            $s5 = $this->peg_currPos;
+            $this->peg_silentFails++;
+            $s6 = $this->peg_parseBlock_End();
+            $this->peg_silentFails--;
+            if ($s6 === $this->peg_FAILED) {
+              $s5 = null;
             } else {
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
+            }
+            if ($s5 !== $this->peg_FAILED) {
+              if ($this->input_length > $this->peg_currPos) {
+                $s6 = $this->input_substr($this->peg_currPos, 1);
+                $this->peg_currPos++;
+              } else {
+                $s6 = $this->peg_FAILED;
+                if ($this->peg_silentFails === 0) {
+                    $this->peg_fail($this->peg_c0);
+                }
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s5 = array($s5, $s6);
+                $s4 = $s5;
+              } else {
+                $this->peg_currPos = $s4;
+                $s4 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s4;
               $s4 = $this->peg_FAILED;
             }
             if ($s4 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s0;
-              $s1 = $this->peg_f6($s1, $s2, $s3);
-              $s0 = $s1;
+              $s3 = $this->input_substr($s3, $this->peg_currPos - $s3);
             } else {
-              $this->peg_currPos = $s0;
-              $s0 = $this->peg_FAILED;
+              $s3 = $s4;
             }
+          }
+        }
+        if ($s2 !== $this->peg_FAILED) {
+          $s3 = $this->peg_parseBlock_End();
+          if ($s3 !== $this->peg_FAILED) {
+            $this->peg_reportedPos = $s0;
+            $s1 = $this->peg_f6($s1, $s2, $s3);
+            $s0 = $s1;
           } else {
             $this->peg_currPos = $s0;
             $s0 = $this->peg_FAILED;
@@ -836,146 +1140,16 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Html() {
+    private function peg_parseBlock_Start() {
 
       $s0 = $this->peg_currPos;
-      $s1 = array();
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_currPos;
-      $this->peg_silentFails++;
-      $s4 = $this->peg_parseWP_Block_Balanced();
-      $this->peg_silentFails--;
-      if ($s4 === $this->peg_FAILED) {
-        $s3 = null;
-      } else {
-        $this->peg_currPos = $s3;
-        $s3 = $this->peg_FAILED;
-      }
-      if ($s3 !== $this->peg_FAILED) {
-        $s4 = $this->peg_currPos;
-        $this->peg_silentFails++;
-        $s5 = $this->peg_parseWP_Block_Void();
-        $this->peg_silentFails--;
-        if ($s5 === $this->peg_FAILED) {
-          $s4 = null;
-        } else {
-          $this->peg_currPos = $s4;
-          $s4 = $this->peg_FAILED;
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s5 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s6 = $this->peg_parseWP_Tag_More();
-          $this->peg_silentFails--;
-          if ($s6 === $this->peg_FAILED) {
-            $s5 = null;
-          } else {
-            $this->peg_currPos = $s5;
-            $s5 = $this->peg_FAILED;
-          }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseAny();
-            if ($s6 !== $this->peg_FAILED) {
-              $this->peg_reportedPos = $s2;
-              $s3 = $this->peg_f7($s6);
-              $s2 = $s3;
-            } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
-      if ($s2 !== $this->peg_FAILED) {
-        while ($s2 !== $this->peg_FAILED) {
-          $s1[] = $s2;
-          $s2 = $this->peg_currPos;
-          $s3 = $this->peg_currPos;
-          $this->peg_silentFails++;
-          $s4 = $this->peg_parseWP_Block_Balanced();
-          $this->peg_silentFails--;
-          if ($s4 === $this->peg_FAILED) {
-            $s3 = null;
-          } else {
-            $this->peg_currPos = $s3;
-            $s3 = $this->peg_FAILED;
-          }
-          if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
-            $this->peg_silentFails++;
-            $s5 = $this->peg_parseWP_Block_Void();
-            $this->peg_silentFails--;
-            if ($s5 === $this->peg_FAILED) {
-              $s4 = null;
-            } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
-            }
-            if ($s4 !== $this->peg_FAILED) {
-              $s5 = $this->peg_currPos;
-              $this->peg_silentFails++;
-              $s6 = $this->peg_parseWP_Tag_More();
-              $this->peg_silentFails--;
-              if ($s6 === $this->peg_FAILED) {
-                $s5 = null;
-              } else {
-                $this->peg_currPos = $s5;
-                $s5 = $this->peg_FAILED;
-              }
-              if ($s5 !== $this->peg_FAILED) {
-                $s6 = $this->peg_parseAny();
-                if ($s6 !== $this->peg_FAILED) {
-                  $this->peg_reportedPos = $s2;
-                  $s3 = $this->peg_f7($s6);
-                  $s2 = $s3;
-                } else {
-                  $this->peg_currPos = $s2;
-                  $s2 = $this->peg_FAILED;
-                }
-              } else {
-                $this->peg_currPos = $s2;
-                $s2 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s2;
-              $s2 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s2;
-            $s2 = $this->peg_FAILED;
-          }
-        }
-      } else {
-        $s1 = $this->peg_FAILED;
-      }
-      if ($s1 !== $this->peg_FAILED) {
-        $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f8($s1);
-      }
-      $s0 = $s1;
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_Start() {
-
-      $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -1000,7 +1174,7 @@ class Gutenberg_PEG_Parser {
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -1014,7 +1188,7 @@ class Gutenberg_PEG_Parser {
               }
               if ($s5 !== $this->peg_FAILED) {
                 $s6 = $this->peg_currPos;
-                $s7 = $this->peg_parseWP_Block_Attributes();
+                $s7 = $this->peg_parseBlock_Attributes();
                 if ($s7 !== $this->peg_FAILED) {
                   $s8 = array();
                   $s9 = $this->peg_parseWS();
@@ -1028,7 +1202,7 @@ class Gutenberg_PEG_Parser {
                   }
                   if ($s8 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s6;
-                    $s7 = $this->peg_f2($s4, $s7);
+                    $s7 = $this->peg_f4($s4, $s7);
                     $s6 = $s7;
                   } else {
                     $this->peg_currPos = $s6;
@@ -1042,18 +1216,18 @@ class Gutenberg_PEG_Parser {
                   $s6 = null;
                 }
                 if ($s6 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
-                    $s7 = $this->peg_c4;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s7 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s7 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c5);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s7 !== $this->peg_FAILED) {
                     $this->peg_reportedPos = $s0;
-                    $s1 = $this->peg_f9($s4, $s6);
+                    $s1 = $this->peg_f7($s4, $s6);
                     $s0 = $s1;
                   } else {
                     $this->peg_currPos = $s0;
@@ -1087,16 +1261,16 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_End() {
+    private function peg_parseBlock_End() {
 
       $s0 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c0) {
-        $s1 = $this->peg_c0;
+      if ($this->input_substr($this->peg_currPos, 4) === $this->peg_c1) {
+        $s1 = $this->peg_c1;
         $this->peg_currPos += 4;
       } else {
         $s1 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c1);
+            $this->peg_fail($this->peg_c2);
         }
       }
       if ($s1 !== $this->peg_FAILED) {
@@ -1121,7 +1295,7 @@ class Gutenberg_PEG_Parser {
             }
           }
           if ($s3 !== $this->peg_FAILED) {
-            $s4 = $this->peg_parseWP_Block_Name();
+            $s4 = $this->peg_parseBlock_Name();
             if ($s4 !== $this->peg_FAILED) {
               $s5 = array();
               $s6 = $this->peg_parseWS();
@@ -1134,18 +1308,18 @@ class Gutenberg_PEG_Parser {
                 $s5 = $this->peg_FAILED;
               }
               if ($s5 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
-                  $s6 = $this->peg_c4;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s6 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s6 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c5);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s6 !== $this->peg_FAILED) {
                   $this->peg_reportedPos = $s0;
-                  $s1 = $this->peg_f10($s4);
+                  $s1 = $this->peg_f8($s4);
                   $s0 = $s1;
                 } else {
                   $this->peg_currPos = $s0;
@@ -1175,17 +1349,17 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Block_Name() {
+    private function peg_parseBlock_Name() {
 
-      $s0 = $this->peg_parseWP_Namespaced_Block_Name();
+      $s0 = $this->peg_parseNamespaced_Block_Name();
       if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseWP_Core_Block_Name();
+        $s0 = $this->peg_parseCore_Block_Name();
       }
 
       return $s0;
     }
 
-    private function peg_parseWP_Namespaced_Block_Name() {
+    private function peg_parseNamespaced_Block_Name() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
@@ -1248,7 +1422,7 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseWP_Core_Block_Name() {
+    private function peg_parseCore_Block_Name() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
@@ -1279,14 +1453,14 @@ class Gutenberg_PEG_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f11($s1);
+        $s1 = $this->peg_f9($s1);
       }
       $s0 = $s1;
 
       return $s0;
     }
 
-    private function peg_parseWP_Block_Attributes() {
+    private function peg_parseBlock_Attributes() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
@@ -1342,13 +1516,13 @@ class Gutenberg_PEG_Parser {
                 $s11 = null;
               }
               if ($s11 !== $this->peg_FAILED) {
-                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
-                  $s12 = $this->peg_c4;
+                if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                  $s12 = $this->peg_c5;
                   $this->peg_currPos += 3;
                 } else {
                   $s12 = $this->peg_FAILED;
                   if ($this->peg_silentFails === 0) {
-                      $this->peg_fail($this->peg_c5);
+                      $this->peg_fail($this->peg_c6);
                   }
                 }
                 if ($s12 !== $this->peg_FAILED) {
@@ -1388,7 +1562,7 @@ class Gutenberg_PEG_Parser {
           } else {
             $s7 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c6);
+                $this->peg_fail($this->peg_c0);
             }
           }
           if ($s7 !== $this->peg_FAILED) {
@@ -1444,13 +1618,13 @@ class Gutenberg_PEG_Parser {
                   $s11 = null;
                 }
                 if ($s11 !== $this->peg_FAILED) {
-                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c4) {
-                    $s12 = $this->peg_c4;
+                  if ($this->input_substr($this->peg_currPos, 3) === $this->peg_c5) {
+                    $s12 = $this->peg_c5;
                     $this->peg_currPos += 3;
                   } else {
                     $s12 = $this->peg_FAILED;
                     if ($this->peg_silentFails === 0) {
-                        $this->peg_fail($this->peg_c5);
+                        $this->peg_fail($this->peg_c6);
                     }
                   }
                   if ($s12 !== $this->peg_FAILED) {
@@ -1490,7 +1664,7 @@ class Gutenberg_PEG_Parser {
             } else {
               $s7 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c6);
+                  $this->peg_fail($this->peg_c0);
               }
             }
             if ($s7 !== $this->peg_FAILED) {
@@ -1537,7 +1711,7 @@ class Gutenberg_PEG_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f12($s1);
+        $s1 = $this->peg_f10($s1);
       }
       $s0 = $s1;
 
@@ -1671,7 +1845,7 @@ class Gutenberg_PEG_Parser {
       } else {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c6);
+            $this->peg_fail($this->peg_c0);
         }
       }
 
@@ -1692,13 +1866,13 @@ class Gutenberg_PEG_Parser {
     $this->input_length = count($this->input);
 
     $this->peg_FAILED = new stdClass;
-    $this->peg_c0 = "<!--";
-    $this->peg_c1 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
-    $this->peg_c2 = "more";
-    $this->peg_c3 = array( "type" => "literal", "value" => "more", "description" => "\"more\"" );
-    $this->peg_c4 = "-->";
-    $this->peg_c5 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
-    $this->peg_c6 = array("type" => "any", "description" => "any character" );
+    $this->peg_c0 = array("type" => "any", "description" => "any character" );
+    $this->peg_c1 = "<!--";
+    $this->peg_c2 = array( "type" => "literal", "value" => "<!--", "description" => "\"<!--\"" );
+    $this->peg_c3 = "more";
+    $this->peg_c4 = array( "type" => "literal", "value" => "more", "description" => "\"more\"" );
+    $this->peg_c5 = "-->";
+    $this->peg_c6 = array( "type" => "literal", "value" => "-->", "description" => "\"-->\"" );
     $this->peg_c7 = "<!--noteaser-->";
     $this->peg_c8 = array( "type" => "literal", "value" => "<!--noteaser-->", "description" => "\"<!--noteaser-->\"" );
     $this->peg_c9 = "wp:";
@@ -1727,8 +1901,8 @@ class Gutenberg_PEG_Parser {
     $this->peg_c32 = array(array(32,32), array(9,9));
     $this->peg_c33 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
-    $peg_startRuleFunctions = array( 'Document' => array($this, "peg_parseDocument") );
-    $peg_startRuleFunction  = array($this, "peg_parseDocument");
+    $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
+    $peg_startRuleFunction  = array($this, "peg_parseBlock_List");
     if (isset($options["startRule"])) {
       if (!(isset($peg_startRuleFunctions[$options["startRule"]]))) {
         throw new Exception("Can't start parsing from rule \"" + $options["startRule"] + "\".");
@@ -1741,6 +1915,49 @@ class Gutenberg_PEG_Parser {
 
     // The `maybeJSON` function is not needed in PHP because its return semantics
     // are the same as `json_decode`
+
+    // array arguments are backwards because of PHP
+    if ( ! function_exists( 'peg_array_partition' ) ) {
+        function peg_array_partition( $array, $predicate ) {
+            $truthy = array();
+            $falsey = array();
+
+            foreach ( $array as $item ) {
+                call_user_func( $predicate, $item )
+                    ? $truthy[] = $item
+                    : $falsey[] = $item;
+            }
+
+            return array( $truthy, $falsey );
+        }
+    }
+
+    if ( ! function_exists( 'peg_join_blocks' ) ) {
+        function peg_join_blocks( $pre, $tokens, $post ) {
+            $blocks = array();
+
+            if ( ! empty( $pre ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $pre );
+            }
+
+            foreach ( $tokens as $token ) {
+                list( $token, $html ) = $token;
+
+                $blocks[] = $token;
+
+                if ( ! empty( $html ) ) {
+                    $blocks[] = array( 'attrs' => array(), 'innerHTML' => $html );
+                }
+            }
+
+            if ( ! empty( $post ) ) {
+                $blocks[] = array( 'attrs' => array(), 'innerHTML' => $post );
+            }
+
+            return $blocks;
+        }
+    }
+
 
     /* END initializer code */
 


### PR DESCRIPTION
In this patch we're opening up a new avenue for allowing nested blocks
in the data structure.

For each block:
 - Nested blocks appear as `innerBlocks` as a sequential list
 - The contained HTML _without_ the nested blocks appear as a string
   property `innerHtml` which replaces `rawContent` (~**update** it doesn't replace it yet~)

**Testing**

Smoke test in the browser.
Load the [grammar](https://raw.githubusercontent.com/WordPress/gutenberg/bcb4c078c227600a7a66eb80c360e8ca5f16d0fb/blocks/api/post.pegjs) into the [explorer](https://dmsnell.github.io/peg-parser-explorer/) (you can use the fetcher URL in the explorer for the grammar link) then load in some test content and play with nesting. You should be able to see how `innerBlocks` grows and when blocks do nest, that the snippet which represents them disappears from `innerHtml`.

**Input**
```html
Front

<!-- wp:core/void /-->

<!-- wp:core/nest -->
Before
<!-- wp:core/inside -->
This is working
<!-- /wp:core/inside -->
Middle
<!-- wp:core/inside -->
Another in the <!-- wp:core/mark -->jump here<!-- /wp:core/mark -->list
<!-- /wp:core/inside -->
After
<!-- /wp:core/nest -->

End
```

**Output**
```js
[
  {
    "blockName": "core/freeform",
    "rawContent": "Front\n\n"
  },
  {
    "blockName": "core/void",
    "attrs": null,
    "innerBlocks": [],
    "rawContent": ""
  },
  {
    "blockName": "core/freeform",
    "rawContent": "\n\n"
  },
  {
    "blockName": "core/nest",
    "attrs": null,
    "innerBlocks": [
      {
        "blockName": "core/inside",
        "attrs": null,
        "innerBlocks": [],
        "rawContent": "\nThis is working\n"
      },
      {
        "blockName": "core/inside",
        "attrs": null,
        "innerBlocks": [
          {
            "blockName": "core/mark",
            "attrs": null,
            "innerBlocks": [],
            "rawContent": "jump here"
          }
        ],
        "rawContent": "\nAnother in the list\n"
      }
    ],
    "rawContent": "\nBefore\n\nMiddle\n\nAfter\n"
  },
  {
    "blockName": "core/freeform",
    "rawContent": "\n\nEnd"
  }
]
```

**Notes**
 - This could end up going really slowly on account of how we are parsing a list of non-token characters and then eventually joining them.
 - I haven't tested any of this. Main purpose of the PR is to get something going to explore and see if it's good. We can update and fix all things later if we need to.