### PR TITLE
Documentation: Fix invalid props references in ESNext examples

### DIFF
--- a/docs/blocks-controls.md
+++ b/docs/blocks-controls.md
@@ -107,7 +107,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 		},
 	},
 
-	edit( { attributes, setAttributes, focus } ) {
+	edit( { attributes, className, focus, setAttributes, setFocus } ) {
 		const { content, alignment } = attributes;
 
 		function onChangeContent( newContent ) {
@@ -130,12 +130,12 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 			<Editable
 				key="editable"
 				tagName="p"
-				className={ props.className }
+				className={ className }
 				style={ { textAlign: alignment } }
 				onChange={ onChangeContent }
 				value={ content }
 				focus={ focus }
-				onFocus={ props.setFocus }
+				onFocus={ setFocus }
 			/>
 		];
 	},

--- a/docs/blocks-editable.md
+++ b/docs/blocks-editable.md
@@ -77,7 +77,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 		},
 	},
 
-	edit( { attributes, setAttributes, focus, className } ) {
+	edit( { attributes, className, focus, setAttributes, setFocus } ) {
 		const { content } = attributes;
 
 		function onChangeContent( newContent ) {
@@ -91,7 +91,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 				onChange={ onChangeContent }
 				value={ content }
 				focus={ focus }
-				onFocus={ props.setFocus }
+				onFocus={ setFocus }
 			/>
 		);
 	},


### PR DESCRIPTION
This PR fixes invalid props references in code examples written using ESNext style. At the moment this code would throw error :)