### PR TITLE
Improve image drop zone contrast ratio

### DIFF
--- a/components/drop-zone/style.scss
+++ b/components/drop-zone/style.scss
@@ -8,7 +8,7 @@
 	visibility: hidden;
 	opacity: 0;
 	transition: 0.3s opacity, 0.3s background-color, 0s visibility 0.3s;
-	border: 2px solid $blue-medium-500;
+	border: 2px solid $blue-dark-900;
 	border-radius: 2px;
 
 	&.is-active {
@@ -18,7 +18,7 @@
 	}
 
 	&.is-dragging-over-element {
-		background-color: rgba( $blue-medium-300, 0.8 );
+		background-color: rgba( $blue-dark-900, 0.8 );
 
 		.components-drop-zone__content {
 			display: block;
@@ -35,7 +35,7 @@
 	transform: translateY( -50% );
 	width: 100%;
 	text-align: center;
-	color: $dark-gray-700;
+	color: $white;
 	transition: transform 0.2s ease-in-out;
 	display: none;
 }

--- a/components/drop-zone/style.scss
+++ b/components/drop-zone/style.scss
@@ -35,7 +35,7 @@
 	transform: translateY( -50% );
 	width: 100%;
 	text-align: center;
-	color: $white;
+	color: $dark-gray-700;
 	transition: transform 0.2s ease-in-out;
 	display: none;
 }

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -24,6 +24,7 @@ $white: #fff;
 $blue-wordpress-700: #00669b;
 $blue-wordpress: #0073aa;
 
+$blue-dark-900: #0071a1;
 $blue-medium-500: #00a0d2;
 $blue-medium-400: #33B3DB;
 $blue-medium-300: #66C6E4;


### PR DESCRIPTION
Change the color from white to dark gray ($dark-gray-700). Now the color constrast ratio is 6.16:1.

#2134 

![screen shot 2017-09-22 at 10 35 31](https://user-images.githubusercontent.com/6010232/30746961-067b29f4-9f82-11e7-8acf-6c298d1bf165.png)


 