### PR TITLE
Inserter: Fix default block slash inserter

### DIFF
--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -198,6 +198,7 @@ class Autocomplete extends Component {
 				} ) }
 				<Popover
 					isOpen={ isOpen }
+					focusOnOpen={ false }
 					position="top right"
 					className={ classes }
 				>

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -183,6 +183,7 @@ class Autocomplete extends Component {
 		const { children, className } = this.props;
 		const { isOpen, selectedIndex } = this.state;
 		const classes = classnames( 'components-autocomplete__popover', className );
+		const filteredOptions = this.getFilteredOptions();
 
 		// Blur is applied to the wrapper node, since if the child is Editable,
 		// the event will not have `relatedTarget` assigned.
@@ -197,7 +198,7 @@ class Autocomplete extends Component {
 					onKeyDown: this.setSelectedIndex,
 				} ) }
 				<Popover
-					isOpen={ isOpen }
+					isOpen={ isOpen && filteredOptions.length > 0 }
 					focusOnOpen={ false }
 					position="top right"
 					className={ classes }
@@ -206,7 +207,7 @@ class Autocomplete extends Component {
 						role="menu"
 						className="components-autocomplete__results"
 					>
-						{ this.getFilteredOptions().map( ( option, index ) => (
+						{ filteredOptions.map( ( option, index ) => (
 							<li
 								key={ option.value }
 								role="menuitem"

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -78,7 +78,27 @@ describe( 'Autocomplete', () => {
 			expect( wrapper.state( 'isOpen' ) ).toBe( true );
 			expect( wrapper.state( 'selectedIndex' ) ).toBe( 0 );
 			expect( wrapper.state( 'search' ) ).toEqual( /b/i );
+			expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( true );
 			expect( wrapper.find( '.components-autocomplete__result' ) ).toHaveLength( 1 );
+		} );
+
+		it( 'does not render popover as open if no results', () => {
+			const wrapper = shallow(
+				<Autocomplete options={ options }>
+					<div contentEditable />
+				</Autocomplete>
+			);
+			const clone = wrapper.find( '[contentEditable]' );
+
+			clone.simulate( 'input', {
+				target: {
+					textContent: 'zzz',
+				},
+			} );
+
+			expect( wrapper.state( 'isOpen' ) ).toBe( true );
+			expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( false );
+			expect( wrapper.find( '.components-autocomplete__result' ) ).toHaveLength( 0 );
 		} );
 
 		it( 'opens on trigger prefix search', () => {
@@ -215,8 +235,7 @@ describe( 'Autocomplete', () => {
 			const preventDefault = jest.fn();
 			const stopImmediatePropagation = jest.fn();
 			const wrapper = shallow(
-				<Autocomplete options={ options } triggerPrefix="/"
-				>
+				<Autocomplete options={ options } triggerPrefix="/">
 					<div contentEditable />
 				</Autocomplete>
 			);

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -55,6 +55,7 @@ describe( 'Autocomplete', () => {
 			const popover = wrapper.find( 'Popover' );
 
 			expect( wrapper.state( 'isOpen' ) ).toBe( false );
+			expect( popover.prop( 'focusOnOpen' ) ).toBe( false );
 			expect( popover.hasClass( 'my-autocomplete' ) ).toBe( true );
 			expect( popover.hasClass( 'components-autocomplete__popover' ) ).toBe( true );
 			expect( wrapper.hasClass( 'components-autocomplete' ) ).toBe( true );

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -45,7 +45,23 @@ render(
 
 ## Props
 
-The component accepts the following props:
+The component accepts the following props. Props not included in this set will be applied to the element wrapping Popover content.
+
+### isOpen
+
+As a controlled component, it is expected that you will pass `isOpen` to control whether the popover is visible. Refer to the `onClose` documentation for the complementary behavior for determining when this value should be toggled in your parent component state.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
+### focusOnOpen
+
+By default, the popover will receive focus when it transitions from closed to open. To suppress this behavior, assign `focusOnOpen` to `true`. This should only be assigned when an appropriately accessible substitute behavior exists.
+
+- Type: `Boolean`
+- Required: No
+- Default: `true`
 
 ### position
 

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -97,6 +97,11 @@ export class Popover extends Component {
 	}
 
 	focus() {
+		const { focusOnOpen = true } = this.props;
+		if ( ! focusOnOpen ) {
+			return;
+		}
+
 		const { content, popover } = this.nodes;
 		if ( ! content ) {
 			return;
@@ -200,14 +205,15 @@ export class Popover extends Component {
 		const {
 			isOpen,
 			onClose,
+			children,
+			className,
 			onClickOutside = onClose,
 			// Disable reason: We generate the `...contentProps` rest as remainder
 			// of props which aren't explicitly handled by this component.
-			//
-			// eslint-disable-next-line no-unused-vars
+			/* eslint-disable no-unused-vars */
 			position,
-			children,
-			className,
+			focusOnOpen,
+			/* eslint-enable no-unused-vars */
 			...contentProps
 		} = this.props;
 		const [ yAxis, xAxis ] = this.getPositions();

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -67,6 +67,27 @@ describe( 'Popover', () => {
 			expect( mocks.setOffset ).toHaveBeenCalled();
 			expect( mocks.setForcedPositions ).not.toHaveBeenCalled();
 		} );
+
+		it( 'should focus when opening', () => {
+			// An ideal test here would mount with an input child and focus the
+			// child, but in context of JSDOM the inputs are not visible and
+			// are therefore skipped as tabbable, defaulting to popover.
+			wrapper = mount( <Popover /> );
+			wrapper.setProps( { isOpen: true } );
+
+			const popover = wrapper.find( '.components-popover' ).getDOMNode();
+
+			expect( document.activeElement ).toBe( popover );
+		} );
+
+		it( 'should allow focus-on-open behavior to be disabled', () => {
+			const activeElement = document.activeElement;
+
+			wrapper = mount( <Popover focusOnOpen={ false } /> );
+			wrapper.setProps( { isOpen: true } );
+
+			expect( document.activeElement ).toBe( activeElement );
+		} );
 	} );
 
 	describe( '#getPositions()', () => {

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -104,6 +104,7 @@ class Tooltip extends Component {
 				child.props.children,
 				<Popover
 					isOpen={ isOver }
+					focusOnOpen={ false }
 					position={ position }
 					className="components-tooltip"
 					aria-hidden="true"

--- a/components/tooltip/test/index.js
+++ b/components/tooltip/test/index.js
@@ -38,6 +38,7 @@ describe( 'Tooltip', () => {
 			expect( button.childAt( 0 ).text() ).toBe( 'Hover Me!' );
 			expect( button.childAt( 1 ).name() ).toBe( 'Popover' );
 			expect( popover.prop( 'isOpen' ) ).toBe( false );
+			expect( popover.prop( 'focusOnOpen' ) ).toBe( false );
 			expect( popover.prop( 'position' ) ).toBe( 'bottom right' );
 			expect( popover.children().text() ).toBe( 'Help Text' );
 		} );


### PR DESCRIPTION
Regression introduced in #2323
Related: #2630

This pull request seeks to resolve an issue where the slash inserter introduced in #2630 stopped working after #2323. The issue is that because focus is now moved into a Popover when it transitions from a closed to open state, and because the Autocomplete field closes the popover when it loses focus, the popover is shown but immediately dismissed.

The changes here resolve this issue by adding a new `focusOnOpen` (default: `true`) prop to the `Popover` component to suppress the default focus behavior in cases such as Autocomplete where the focus behavior is not desirable, since it manages keyboard interactivity of the popover controls via the Editable input.

(**Note:** The following changes were extracted as a separate pull request to simplify review of the minimal set of changes necessary to resolve the regressed behavior. See #2789)

~To better represent the relation between the Editable and Popover search listing, props applied to the Editable have been improved using reference from the [`combobox` role specification](https://www.w3.org/TR/wai-aria/roles#combobox).~

~However, this highlighted an issue: Applying arbitrary props to the Editable `contenteditable` node is not currently possible. In a few cases, we have hard-coded support for a few whitelisted props (style, className, label). Instead, the changes here refactor Editable and TinyMCE to support arbitrary prop assignment, using a "mirror" node which is leverages React reconciliation in the parent Editable component. Since we disable reconciliation for the TinyMCE component, this mirror node serves to copy attributes when changed using [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver). This is made more challenging by the fact that Editable accepts many props, most of which are handled by the root Editable component and should not be assigned to the contenteditable node. While I otherwise discourage `propTypes` assignments, the usage here helps simplify picking props to assign to the mirroring node.~

__Testing instructions:__

Repeat testing instructions from #2630 

~Verify that there are no regressions in:~

- ~Attribute assignment to TinyMCE (e.g. try applying background color to Paragraph block, which assigns itself as a combination of class and style attribute)~
- ~Placeholder behavior for Editable~

~Verify that [correct ARIA expanded / ownership / active descendant attributes](https://www.w3.org/TR/wai-aria/roles#combobox) are assigned to both the mirror node (`aria-hidden`) and the contenteditable while using the default block slash inserter.~