### PR TITLE
Allow toolbar wrapper to be clicked through

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -323,6 +323,14 @@
 	margin-left: -$block-padding;
 	margin-right: -$block-padding;
 
+	// Allow this invisible layer to be clicked through.
+	pointer-events: none;
+
+	// Reset pointer-events on children.
+	& > * {
+		pointer-events: auto;
+	}
+
 	// Larger viewports
 	@include break-small() {
 		margin-left: 0;


### PR DESCRIPTION
## Description
When you click right next to a toolbar horizontally (e.g. the end of a line of a paragraph), the wrapper of the toolbar will block it, so nothing happens. This PR fixes this by allowing you to click through the wrapper. Not sure if it's a good fix, maybe it can be addressed by removing the wrapper or not let it take up full width, but I'm not sure how that might affect the rest.
