### PR TITLE
Remove touch listeners from multi select

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -63,14 +63,12 @@ class VisualEditorBlockList extends Component {
 		document.addEventListener( 'copy', this.onCopy );
 		document.addEventListener( 'cut', this.onCut );
 		window.addEventListener( 'mousemove', this.setLastClientY );
-		window.addEventListener( 'touchmove', this.setLastClientY );
 	}
 
 	componentWillUnmount() {
 		document.removeEventListener( 'copy', this.onCopy );
 		document.removeEventListener( 'cut', this.onCut );
 		window.removeEventListener( 'mousemove', this.setLastClientY );
-		window.removeEventListener( 'touchmove', this.setLastClientY );
 	}
 
 	setLastClientY( { clientY } ) {
@@ -147,10 +145,8 @@ class VisualEditorBlockList extends Component {
 		this.startLowerBoundary = pageYOffset + boundaries.bottom;
 
 		window.addEventListener( 'mousemove', this.onPointerMove );
-		window.addEventListener( 'touchmove', this.onPointerMove );
 		window.addEventListener( 'scroll', this.onScroll );
 		window.addEventListener( 'mouseup', this.onSelectionEnd );
-		window.addEventListener( 'touchend', this.onSelectionEnd );
 	}
 
 	onSelectionChange( uid ) {
@@ -182,10 +178,8 @@ class VisualEditorBlockList extends Component {
 		delete this.startLowerBoundary;
 
 		window.removeEventListener( 'mousemove', this.onPointerMove );
-		window.removeEventListener( 'touchmove', this.onPointerMove );
 		window.removeEventListener( 'scroll', this.onScroll );
 		window.removeEventListener( 'mouseup', this.onSelectionEnd );
-		window.removeEventListener( 'touchend', this.onSelectionEnd );
 	}
 
 	onPlaceholderKeyDown( event ) {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -375,7 +375,6 @@ class VisualEditorBlock extends Component {
 					onKeyPress={ this.maybeStartTyping }
 					onDragStart={ ( event ) => event.preventDefault() }
 					onMouseDown={ this.onPointerDown }
-					onTouchStart={ this.onPointerDown }
 					className="editor-visual-editor__block-edit"
 				>
 					<BlockCrashBoundary onError={ this.onBlockError }>


### PR DESCRIPTION
## Description
This PR removes touch listeners to handle multi select. They will not do anything as `touchmove` scrolls, where `mousemove` does not. We'll have to find another way to do multi select on touch devices.