### PR TITLE
Autocomplete: Assign ARIA attributes as combobox, with TinyMCE node mirroring

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -26,6 +26,26 @@
 		color: $blue-medium-500;
 	}
 
+	&[data-mirror] {
+		display: none;
+	}
+
+	&[data-placeholder] {
+		opacity: 0.5;
+		pointer-events: none;
+
+		& + .blocks-editable__tinymce {
+			position: absolute;
+			top: 0;
+			width: 100%;
+			margin-top: 0;
+
+			& > p {
+				margin-top: 0;
+			}
+		}
+	}
+
 	&:focus a[data-mce-selected] {
 		padding: 0 2px;
 		margin: 0 -2px;
@@ -45,22 +65,6 @@
 
 	&:focus code[data-mce-selected] {
 		background: $light-gray-400;
-	}
-
-	&[data-is-placeholder-visible="true"] {
-		position: absolute;
-		top: 0;
-		width: 100%;
-		margin-top: 0;
-
-		& > p {
-			margin-top: 0;
-		}
-	}
-
-	& + .blocks-editable__tinymce {
-		opacity: 0.5;
-		pointer-events: none;
 	}
 }
 

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -16,10 +16,11 @@ import { keycodes } from '@wordpress/utils';
 import './style.scss';
 import Button from '../button';
 import Popover from '../popover';
+import withInstanceId from '../higher-order/with-instance-id';
 
 const { ENTER, ESCAPE, UP, DOWN } = keycodes;
 
-class Autocomplete extends Component {
+export class Autocomplete extends Component {
 	static getInitialState() {
 		return {
 			isOpen: false,
@@ -180,10 +181,12 @@ class Autocomplete extends Component {
 	}
 
 	render() {
-		const { children, className } = this.props;
+		const { children, className, instanceId } = this.props;
 		const { isOpen, selectedIndex } = this.state;
 		const classes = classnames( 'components-autocomplete__popover', className );
 		const filteredOptions = this.getFilteredOptions();
+		const listBoxId = `components-autocomplete-listbox-${ instanceId }`;
+		const activeId = `components-autocomplete-item-${ instanceId }-${ selectedIndex }`;
 
 		// Blur is applied to the wrapper node, since if the child is Editable,
 		// the event will not have `relatedTarget` assigned.
@@ -196,6 +199,10 @@ class Autocomplete extends Component {
 				{ cloneElement( Children.only( children ), {
 					onInput: this.search,
 					onKeyDown: this.setSelectedIndex,
+					role: 'combobox',
+					'aria-expanded': isOpen,
+					'aria-activedescendant': isOpen ? activeId : null,
+					'aria-owns': isOpen ? listBoxId : null,
 				} ) }
 				<Popover
 					isOpen={ isOpen && filteredOptions.length > 0 }
@@ -204,13 +211,15 @@ class Autocomplete extends Component {
 					className={ classes }
 				>
 					<ul
-						role="menu"
+						id={ listBoxId }
+						role="listbox"
 						className="components-autocomplete__results"
 					>
 						{ filteredOptions.map( ( option, index ) => (
 							<li
 								key={ option.value }
-								role="menuitem"
+								id={ `components-autocomplete-item-${ instanceId }-${ index }` }
+								role="option"
 								className={ classnames( 'components-autocomplete__result', {
 									'is-selected': index === selectedIndex,
 								} ) }
@@ -227,4 +236,4 @@ class Autocomplete extends Component {
 	}
 }
 
-export default Autocomplete;
+export default withInstanceId( Autocomplete );

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -11,7 +11,7 @@ import { keycodes } from '@wordpress/utils';
 /**
  * Internal dependencies
  */
-import Autocomplete from '../';
+import { Autocomplete } from '../';
 
 const { ENTER, ESCAPE, UP, DOWN, SPACE } = keycodes;
 
@@ -53,13 +53,17 @@ describe( 'Autocomplete', () => {
 				</Autocomplete>
 			);
 			const popover = wrapper.find( 'Popover' );
+			const clone = wrapper.find( '[data-ok]' );
 
 			expect( wrapper.state( 'isOpen' ) ).toBe( false );
 			expect( popover.prop( 'focusOnOpen' ) ).toBe( false );
 			expect( popover.hasClass( 'my-autocomplete' ) ).toBe( true );
 			expect( popover.hasClass( 'components-autocomplete__popover' ) ).toBe( true );
 			expect( wrapper.hasClass( 'components-autocomplete' ) ).toBe( true );
-			expect( wrapper.find( '[data-ok]' ) ).toHaveLength( 1 );
+			expect( clone ).toHaveLength( 1 );
+			expect( clone.prop( 'aria-expanded' ) ).toBe( false );
+			expect( clone.prop( 'aria-activedescendant' ) ).toBe( null );
+			expect( clone.prop( 'aria-owns' ) ).toBe( null );
 		} );
 
 		it( 'opens on absent trigger prefix search', () => {
@@ -68,8 +72,9 @@ describe( 'Autocomplete', () => {
 					<div contentEditable />
 				</Autocomplete>
 			);
+			const clone = wrapper.find( '[contentEditable]' );
 
-			wrapper.find( '[contentEditable]' ).simulate( 'input', {
+			clone.simulate( 'input', {
 				target: {
 					textContent: 'b',
 				},
@@ -80,6 +85,9 @@ describe( 'Autocomplete', () => {
 			expect( wrapper.state( 'search' ) ).toEqual( /b/i );
 			expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( true );
 			expect( wrapper.find( '.components-autocomplete__result' ) ).toHaveLength( 1 );
+			expect( clone.prop( 'aria-expanded' ) ).toBe( false );
+			expect( clone.prop( 'aria-activedescendant' ) ).toBe( null );
+			expect( clone.prop( 'aria-owns' ) ).toBe( null );
 		} );
 
 		it( 'does not render popover as open if no results', () => {


### PR DESCRIPTION
Related: #2771

This pull request seeks to assign attributes of the `Autocomplete` cloned input as a combobox, bound as "owning" the `Popover` which it controls. To better represent the relation between the Editable and Popover search listing, props applied to the Editable have been improved using reference from the [`combobox` role specification](https://www.w3.org/TR/wai-aria/roles#combobox).

>However, this highlighted an issue: Applying arbitrary props to the Editable `contenteditable` node is not currently possible. In a few cases, we have hard-coded support for a few whitelisted props (style, className, label). Instead, the changes here refactor Editable and TinyMCE to support arbitrary prop assignment, using a "mirror" node which is leverages React reconciliation in the parent Editable component. Since we disable reconciliation for the TinyMCE component, this mirror node serves to copy attributes when changed using [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver). This is made more challenging by the fact that Editable accepts many props, most of which are handled by the root Editable component and should not be assigned to the contenteditable node. While I otherwise discourage `propTypes` assignments, the usage here helps simplify picking props to assign to the mirroring node.

These changes are extracted from commits originally present in #2771, in order to simplify review there to the minimal set of changes to fix the regression introduced to autocomplete behavior after #2323.

__Testing instructions:__

Verify that there are no regressions in:

- Attribute assignment to TinyMCE (e.g. try applying background color to Paragraph block, which assigns itself as a combination of class and style attribute)
- Placeholder behavior for Editable

Verify that [correct ARIA expanded / ownership / active descendant attributes](https://www.w3.org/TR/wai-aria/roles#combobox) are assigned to both the mirror node (`aria-hidden`) and the contenteditable while using the default block slash inserter.