### PR TITLE
Refresh nonce with heartbeat

### DIFF
--- a/editor/index.js
+++ b/editor/index.js
@@ -58,6 +58,15 @@ if ( dateSettings.timezone.string ) {
 }
 
 /**
+ * Configure heartbeat to refresh the wp-api nonce, keeping the editor authorization intact.
+ */
+jQuery( document ).on( 'heartbeat-tick',  function( e, response ) {
+	if ( response['rest-nonce'] && response['rest-nonce'] !== wp.api.endpoints.at(0).get( 'nonce' ) ) {
+		wp.api.endpoints.at(0).set( 'nonce', response['rest-nonce'] );
+	}
+});
+
+/**
  * Initializes and returns an instance of Editor.
  *
  * @param {String}  id       Unique identifier for editor instance

--- a/editor/index.js
+++ b/editor/index.js
@@ -60,11 +60,11 @@ if ( dateSettings.timezone.string ) {
 /**
  * Configure heartbeat to refresh the wp-api nonce, keeping the editor authorization intact.
  */
-jQuery( document ).on( 'heartbeat-tick',  function( e, response ) {
-	if ( response['rest-nonce'] && response['rest-nonce'] !== wp.api.endpoints.at(0).get( 'nonce' ) ) {
-		wp.api.endpoints.at(0).set( 'nonce', response['rest-nonce'] );
+window.jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
+	if ( response[ 'rest-nonce' ] ) {
+		window.wpApiSettings.nonce = response[ 'rest-nonce' ];
 	}
-});
+} );
 
 /**
  * Initializes and returns an instance of Editor.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -612,7 +612,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	wp_enqueue_script(
 		'wp-editor',
 		gutenberg_url( 'editor/build/index.js' ),
-		array( 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor' ),
+		array( 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
 		filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
 		true // enqueue in the footer.
 	);

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -139,6 +139,7 @@ function gutenberg_disable_editor_settings_wpautop( $settings ) {
 	return $settings;
 }
 add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
+
 /**
  * Add rest nonce to the heartbeat response.
  *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -150,4 +150,4 @@ function gutenberg_add_rest_nonce_to_heartbeat_response_headers( $response ) {
 	return $response;
 }
 
-add_filter( 'heartbeat_send', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
+add_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -143,7 +143,7 @@ add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
 /**
  * Add rest nonce to the heartbeat response.
  *
- * @param array  $response  The Heartbeat response.
+ * @param array $response The Heartbeat response.
  */
 function gutenberg_add_rest_nonce_to_heartbeat_response_headers( $response ) {
 	$response['rest-nonce'] = wp_create_nonce( 'wp_rest' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -139,3 +139,14 @@ function gutenberg_disable_editor_settings_wpautop( $settings ) {
 	return $settings;
 }
 add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
+/**
+ * Add rest nonce to the heartbeat response.
+ *
+ * @param array  $response  The Heartbeat response.
+ */
+function gutenberg_add_rest_nonce_to_heartbeat_response_headers( $response ) {
+	$response['rest-nonce'] = wp_create_nonce( 'wp_rest' );
+	return $response;
+}
+
+add_filter( 'heartbeat_send', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -143,7 +143,8 @@ add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
 /**
  * Add rest nonce to the heartbeat response.
  *
- * @param array $response The Heartbeat response.
+ * @param  array $response Original heartbeat response.
+ * @return array           New heartbeat response.
  */
 function gutenberg_add_rest_nonce_to_heartbeat_response_headers( $response ) {
 	$response['rest-nonce'] = wp_create_nonce( 'wp_rest' );


### PR DESCRIPTION
## Summary
Refresh the wp-api nonce when a new nonce is available, keeping the nonce fresh and the client authorized. Fixes https://github.com/WordPress/gutenberg/issues/2088.

## Description
Add a wp_rest nonce to the heartbeat response when in Gutenberg.
Add a JavaScript callback on jQuery( document ) 'heartbeat-tick' which heartbeat triggers. Update the wp-api nonce if it has changed.

## How Has This Been Tested?
Verified heartbeat returns nonce.
Verified if nonce is different, logic sets it on root endpoint.

## Notes
Wasn't sure about the best place to put the JS callback, feedback appreciated!
