### PR TITLE
Try: Support block `edit` defined as tag name for web components interoperability

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -62,9 +62,9 @@ export function registerBlockType( name, settings ) {
 		);
 		return;
 	}
-	if ( 'edit' in settings && ! isFunction( settings.edit ) ) {
+	if ( 'edit' in settings && ! isFunction( settings.edit ) && 'string' !== typeof settings.edit ) {
 		console.error(
-			'The "edit" property must be a valid function.'
+			'The "edit" property must be a valid component or tag name.'
 		);
 		return;
 	}

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -82,10 +82,10 @@ describe( 'blocks', () => {
 			expect( block ).toBeUndefined();
 		} );
 
-		it( 'should reject blocks with an invalid edit function', () => {
-			const blockType = { save: noop, edit: 'not-a-function', category: 'common', title: 'block title' },
+		it( 'should reject blocks with an invalid edit value, must be web component tag name or function', () => {
+			const blockType = { save: noop, edit: { not: 'valid' }, category: 'common', title: 'block title' },
 				block = registerBlockType( 'my-plugin/fancy-block-6', blockType );
-			expect( console.error ).toHaveBeenCalledWith( 'The "edit" property must be a valid function.' );
+			expect( console.error ).toHaveBeenCalledWith( 'The "edit" property must be a valid component or tag name.' );
 			expect( block ).toBeUndefined();
 		} );
 

--- a/editor/component-interop/index.js
+++ b/editor/component-interop/index.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { isString, includes, forOwn } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+function isWebComponent( tagName ) {
+	return isString( tagName ) && includes( tagName, '-' );
+}
+
+class ComponentInterop extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.bindNode = this.bindNode.bind( this );
+	}
+
+	componentDidMount() {
+		this.setWebComponentProps( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.setWebComponentProps( nextProps );
+	}
+
+	setWebComponentProps( props ) {
+		const { tagName, attributes, ...properties } = props;
+		if ( ! isWebComponent( tagName ) ) {
+			return;
+		}
+
+		let child = this.node.firstChild;
+		if ( ! child ) {
+			child = document.createElement( tagName );
+			this.node.appendChild( child );
+		}
+
+		forOwn( properties, ( value, key ) => {
+			child[ key ] = value;
+		} );
+
+		forOwn( attributes, ( value, key ) => {
+			child.setAttribute( key, value );
+		} );
+	}
+
+	shouldComponentUpdate() {
+		const { tagName } = this.props;
+		if ( isWebComponent( tagName ) ) {
+			return false;
+		}
+
+		if ( 'function' === typeof tagName &&
+				'function' === typeof tagName.prototype.shouldComponentUpdate ) {
+			return tagName.prototype.shouldComponentUpdate.apply( this, arguments );
+		}
+
+		return true;
+	}
+
+	bindNode( node ) {
+		this.node = node;
+	}
+
+	render() {
+		const { tagName: TagName, ...componentProps } = this.props;
+		if ( isWebComponent( TagName ) ) {
+			return <div ref={ this.bindNode } />;
+		}
+
+		return <TagName { ...componentProps } />;
+	}
+}
+
+export default ComponentInterop;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -26,6 +26,7 @@ import BlockDropZone from './block-drop-zone';
 import BlockMover from '../../block-mover';
 import BlockRightMenu from '../../block-settings-menu';
 import BlockSwitcher from '../../block-switcher';
+import ComponentInterop from '../../component-interop';
 import {
 	updateBlockAttributes,
 	focusBlock,
@@ -381,7 +382,8 @@ class VisualEditorBlock extends Component {
 					<BlockCrashBoundary onError={ this.onBlockError }>
 						{ isValid
 							? (
-								<BlockEdit
+								<ComponentInterop
+									tagName={ BlockEdit }
 									focus={ focus }
 									attributes={ block.attributes }
 									setAttributes={ this.setAttributes }


### PR DESCRIPTION
Related: #2463

This pull request seeks to add support for defining a block's `edit` property as a tag name, in an effort to explore support for block editable UIs defined as [custom elements](https://developers.google.com/web/fundamentals/architecture/building-components/customelements). The idea being that custom elements may serve as a baseline interface by which the editor creates a block element to be shown in the Gutenberg application. While granting that custom elements are in many ways not an ideal pattern for authoring blocks, they may work well enough as the low-level platform primitive for WordPress to target, and framework wrappers may serve to fill the gap of developer usability.

As an example, consider the following plugin which implements a Gutenberg "Stars" block using Vue, with [VueCustomElement](https://github.com/karol-f/vue-custom-element) providing the necessary wrapper to expose the Vue component as a custom element:

https://gist.github.com/aduth/369767f8153eaad1d955a8022f14ec34

Similar wrappers exist for other frameworks, and in fact some frameworks like [Polymer](https://www.polymer-project.org/) implement their components as custom elements, and yet others like [Stencil](https://stenciljs.com/) compile at build time to custom elements.

- https://github.com/karol-f/vue-custom-element
- https://github.com/bspaulding/react-custom-element
- https://github.com/bspaulding/preact-custom-element
- https://www.polymer-project.org/
- https://stenciljs.com/

__Implementation notes:__

When assigning props to a custom element in DOM reconciliation, React currently [does not do well to distinguish between attributes and properties](https://github.com/facebook/react/issues/7249). This was originally slated for improvements in React 16, and while [treatment of unknown attributes was improved](https://facebook.github.io/react/blog/2017/09/08/dom-attributes-in-react-16.html), this particular failed distinction still exists and was [noted as "Future Work" now slated for React 17](https://facebook.github.io/react/blog/2017/09/08/dom-attributes-in-react-16.html#future-work). 

To work around this, a new [`ComponentInterop` component](https://github.com/WordPress/gutenberg/blob/88ba073b6c903d8002b4af0cf400c1db35b19d36/editor/component-interop/index.js) is included to bypass default React reconciliation for custom elements. Currently, it assigns block attributes as DOM attributes via `node.setAttribute`, and all other block props as properties of the node. This implementation is open for discussion, and may need to be improved and/or alternative terminology may need to be used to clarify between block attributes and DOM attributes, should the distinction need to be made.

- https://github.com/facebook/react/issues/7249
- https://custom-elements-everywhere.com/

__Testing instructions:__

Download and install the [reference Vue custom element block](https://gist.github.com/aduth/369767f8153eaad1d955a8022f14ec34) as a plugin to a WordPress installation:

1. Click "Download ZIP" in the top-right of the Gist page
2. On a WordPress site running Gutenberg, navigate to Plugins > Add New in the dashboard
3. Click "Upload Plugin" 
4. Upload, install, and activate the ZIP file downloaded in Step 1
5. Navigate to Gutenberg > New Post
6. Using the Inserter, insert a new Stars block
7. Note that the editable preview is shown and can be interacted by clicking a star to change