### PR TITLE
Handle direct image data paste

### DIFF
--- a/blocks/api/raw-handling/image-corrector.js
+++ b/blocks/api/raw-handling/image-corrector.js
@@ -1,6 +1,12 @@
 /**
+ * WordPress dependencies
+ */
+import { createBlobURL } from '@wordpress/utils';
+
+/**
  * Browser dependencies
  */
+const { atob, Blob } = window;
 const { ELEMENT_NODE } = window.Node;
 
 export default function( node ) {
@@ -14,6 +20,37 @@ export default function( node ) {
 
 	if ( node.src.indexOf( 'file:' ) === 0 ) {
 		node.src = '';
+	}
+
+	// This piece cannot be tested outside a browser env.
+	if ( node.src.indexOf( 'data:' ) === 0 ) {
+		const [ properties, data ] = node.src.split( ',' );
+		const [ type ] = properties.slice( 5 ).split( ';' );
+
+		if ( ! data || ! type ) {
+			node.src = '';
+			return;
+		}
+
+		let decoded;
+
+		// Can throw DOMException!
+		try {
+			decoded = atob( data );
+		} catch ( e ) {
+			node.src = '';
+			return;
+		}
+
+		const uint8Array = new Uint8Array( decoded.length );
+
+		for ( let i = 0; i < uint8Array.length; i++ ) {
+			uint8Array[ i ] = decoded.charCodeAt( i );
+		}
+
+		const blob = new Blob( [ uint8Array ], { type } );
+
+		node.src = createBlobURL( blob );
 	}
 
 	// Remove trackers and hardly visible images.

--- a/blocks/api/raw-handling/test/integration/ms-word-online-out.html
+++ b/blocks/api/raw-handling/test/integration/ms-word-online-out.html
@@ -50,5 +50,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="data:image/jpeg;base64,###" /></figure>
+<figure class="wp-block-image"><img src="" /></figure>
 <!-- /wp:image -->

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -22,7 +22,7 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { createElement, Component, renderToString } from '@wordpress/element';
-import { keycodes } from '@wordpress/utils';
+import { keycodes, createBlobURL } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -134,7 +134,7 @@ export default class Editable extends Component {
 		editor.on( 'selectionChange', this.onSelectionChange );
 		editor.on( 'BeforeExecCommand', this.maybePropagateUndo );
 		editor.on( 'PastePreProcess', this.onPastePreProcess, true /* Add before core handlers */ );
-		editor.on( 'paste', this.onPaste );
+		editor.on( 'paste', this.onPaste, true /* Add before core handlers */ );
 
 		patterns.apply( this, [ editor ] );
 
@@ -238,18 +238,29 @@ export default class Editable extends Component {
 	}
 
 	onPaste( event ) {
-		const dataTransfer = event.clipboardData || this.editor.getDoc().dataTransfer;
+		const dataTransfer = event.clipboardData || event.dataTransfer || this.editor.getDoc().dataTransfer;
+		const { items = [], files = [] } = dataTransfer;
+		const item = find( [ ...items, ...files ], ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
+
+		if ( item ) {
+			// Allows us to ask for this information when we get a report.
+			window.console.log( 'Received item:\n\n', item );
+
+			const blob = item.getAsFile ? item.getAsFile() : item;
+
+			this.pastedContent = `<img src="${ createBlobURL( blob ) }">`;
+		}
 
 		this.pastedPlainText = dataTransfer ? dataTransfer.getData( 'text/plain' ) : '';
 	}
 
 	onPastePreProcess( event ) {
 		// Allows us to ask for this information when we get a report.
-		window.console.log( 'Received HTML:\n\n', event.content );
+		window.console.log( 'Received HTML:\n\n', this.pastedContent || event.content );
 		window.console.log( 'Received plain text:\n\n', this.pastedPlainText );
 
 		const content = rawHandler( {
-			HTML: event.content,
+			HTML: this.pastedContent || event.content,
 			plainText: this.pastedPlainText,
 			inline: ! this.props.onSplit,
 		} );

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -16,7 +16,7 @@ import {
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { mediaUpload } from '@wordpress/utils';
+import { mediaUpload, createMediaFromFile, getBlobByURL, revokeBlobURL } from '@wordpress/utils';
 import {
 	Placeholder,
 	Dashicon,
@@ -49,6 +49,35 @@ class ImageBlock extends Component {
 		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSetHref = this.onSetHref.bind( this );
 		this.updateImageURL = this.updateImageURL.bind( this );
+	}
+
+	componentDidMount() {
+		const { attributes, setAttributes } = this.props;
+		const { id, url = '' } = attributes;
+
+		if ( id ) {
+			this.fetchMedia( id );
+		}
+
+		if ( ! id && url.indexOf( 'blob:' ) === 0 ) {
+			getBlobByURL( url )
+				.then( createMediaFromFile )
+				.then( ( media ) => {
+					setAttributes( {
+						id: media.id,
+						url: media.source_url,
+					} );
+				} );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { id: prevID, url: prevUrl = '' } = prevProps.attributes;
+		const { id, url = '' } = this.props.attributes;
+
+		if ( ! prevID && prevUrl.indexOf( 'blob:' ) === 0 && id && url.indexOf( 'blob:' ) === -1 ) {
+			revokeBlobURL( url );
+		}
 	}
 
 	onSelectImage( media ) {

--- a/utils/blob-cache.js
+++ b/utils/blob-cache.js
@@ -1,0 +1,31 @@
+/**
+ * Browser dependencies
+ */
+const { fetch } = window;
+const { createObjectURL, revokeObjectURL } = window.URL;
+
+const cache = {};
+
+export function createBlobURL( blob ) {
+	const url = createObjectURL( blob );
+
+	cache[ url ] = blob;
+
+	return url;
+}
+
+export function getBlobByURL( url ) {
+	if ( cache[ url ] ) {
+		return Promise.resolve( cache[ url ] );
+	}
+
+	return fetch( url ).then( ( response ) => response.blob() );
+}
+
+export function revokeBlobURL( url ) {
+	if ( cache[ url ] ) {
+		revokeObjectURL( url );
+	}
+
+	delete cache[ url ];
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -6,4 +6,5 @@ export { focus };
 export { keycodes };
 export { decodeEntities };
 
+export * from './blob-cache';
 export * from './mediaupload';

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -69,7 +69,7 @@ export function mediaUpload( filesList, setAttributes, gallery = false ) {
 export function createMediaFromFile( file ) {
 	// Create upload payload
 	const data = new window.FormData();
-	data.append( 'file', file );
+	data.append( 'file', file, file.name || file.type.replace( '/', '.' ) );
 
 	return new wp.api.models.Media().save( null, {
 		data: data,


### PR DESCRIPTION
## Description
This PR aims to:

1. Allow pasting standalone images directly into Gutenberg and upload them.
2. Upload pasted base64 encoded images.

## How Has This Been Tested?
1. Right click any image (on the web or in a native app) and choose "Copy image". *Not* "Copy Image URL/Address". Not sure how this works on Linux and Windows. This copies the image data, no HTML. Now paste it in Gutenberg. Without this PR, nothing will happen. With this PR, it should be inserted as a block and be uploaded to the server.
2. Find a base64 encoded image. Pasted content from MS Word Online has it for example. Without this PR it will display (data in src). With this PR it will display as a linked blob (no data in src) and upload.

## Screenshots (jpeg or gifs if applicable):

<img width="538" alt="screenshot 2017-09-26 00 03 15" src="https://user-images.githubusercontent.com/4710635/30833193-310967fc-a24e-11e7-9596-42f5e84c9d79.png">
