### PR TITLE
Editor: HTML Editor per block

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -5,9 +5,9 @@ import * as source from './source';
 
 export { source };
 export { createBlock, switchToBlockType } from './factory';
-export { default as parse } from './parser';
+export { default as parse, getSourcedAttributes } from './parser';
 export { default as pasteHandler } from './paste';
-export { default as serialize, getBlockDefaultClassname } from './serializer';
+export { default as serialize, getBlockDefaultClassname, getBlockContent } from './serializer';
 export { getCategories } from './categories';
 export {
 	registerBlockType,

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -8,6 +8,7 @@ export { createBlock, switchToBlockType } from './factory';
 export { default as parse, getSourcedAttributes } from './parser';
 export { default as pasteHandler } from './paste';
 export { default as serialize, getBlockDefaultClassname, getBlockContent } from './serializer';
+export { isValidBlock } from './validation';
 export { getCategories } from './categories';
 export {
 	registerBlockType,

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -139,6 +139,21 @@ export function getBeautifulContent( content ) {
 	} );
 }
 
+export function getBlockContent( block ) {
+	const blockType = getBlockType( block.name );
+
+	// If block was parsed as invalid or encounters an error while generating
+	// save content, use original content instead to avoid content loss.
+	let saveContent = block.originalContent;
+	if ( block.isValid ) {
+		try {
+			saveContent = getSaveContent( blockType, block.attributes );
+		} catch ( error ) {}
+	}
+
+	return getUnknownTypeHandlerName() === block.name ? getBeautifulContent( saveContent ) : saveContent;
+}
+
 /**
  * Returns the content of a block, including comment delimiters.
  *
@@ -158,7 +173,7 @@ export function getCommentDelimitedContent( blockName, attributes, content ) {
 
 	return (
 		`<!-- wp:${ blockName } ${ serializedAttributes }-->\n` +
-		getBeautifulContent( content ) +
+		content +
 		`\n<!-- /wp:${ blockName } -->`
 	);
 }
@@ -173,16 +188,7 @@ export function getCommentDelimitedContent( blockName, attributes, content ) {
 export function serializeBlock( block ) {
 	const blockName = block.name;
 	const blockType = getBlockType( blockName );
-
-	// If block was parsed as invalid or encounters an error while generating
-	// save content, use original content instead to avoid content loss.
-	let saveContent = block.originalContent;
-	if ( block.isValid ) {
-		try {
-			saveContent = getSaveContent( blockType, block.attributes );
-		} catch ( error ) {}
-	}
-
+	const saveContent = getBlockContent( block );
 	const saveAttributes = getCommentAttributes( block.attributes, blockType.attributes );
 
 	switch ( blockName ) {

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -139,6 +139,11 @@ export function getBeautifulContent( content ) {
 	} );
 }
 
+/**
+ * Given a block object, returns the Block's Inner HTML markup
+ * @param  {Object} block Block Object
+ * @return {String}       HTML
+ */
 export function getBlockContent( block ) {
 	const blockType = getBlockType( block.name );
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -151,7 +151,7 @@ export function getBlockContent( block ) {
 		} catch ( error ) {}
 	}
 
-	return getUnknownTypeHandlerName() === block.name ? getBeautifulContent( saveContent ) : saveContent;
+	return getUnknownTypeHandlerName() === block.name || ! saveContent ? saveContent : getBeautifulContent( saveContent );
 }
 
 /**

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -14,6 +14,7 @@ import serialize, {
 	serializeAttributes,
 	getCommentDelimitedContent,
 	serializeBlock,
+	getBlockContent,
 } from '../serializer';
 import {
 	getBlockTypes,
@@ -400,6 +401,33 @@ describe( 'block serializer', () => {
 			expect( serialize( block ) ).toEqual(
 				'<!-- wp:core/test-block {"throw":true} -->\nCorrect\n<!-- /wp:core/test-block -->'
 			);
+		} );
+	} );
+
+	describe( 'getBlockContent', () => {
+		it( 'should return the block\'s serialized inner HTML', () => {
+			const blockType = {
+				attributes: {
+					content: {
+						type: 'string',
+						source: text(),
+					},
+				},
+				save( { attributes } ) {
+					return attributes.content;
+				},
+				category: 'common',
+				title: 'block title',
+			};
+			registerBlockType( 'core/chicken', blockType );
+			const block =	{
+				name: 'core/chicken',
+				attributes: {
+					content: '<p>chicken   </p>',
+				},
+				isValid: true,
+			};
+			expect( getBlockContent( block ) ).toBe( '<p>chicken </p>' );
 		} );
 	} );
 } );

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -242,6 +242,19 @@ export function removeBlock( uid ) {
 }
 
 /**
+ * Returns an action object used to toggle the block editing mode (visual/html)
+ *
+ * @param  {String} uid Block UID
+ * @return {Object}     Action object
+ */
+export function toggleBlockMode( uid ) {
+	return {
+		type: 'TOGGLE_BLOCK_MODE',
+		uid,
+	};
+}
+
+/**
  * Returns an action object used in signalling that the user has begun to type.
  *
  * @return {Object}     Action object

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -62,7 +62,7 @@ export function resetBlocks( blocks ) {
 }
 
 /**
- * Returns an action object used in signalling that the block with the
+ * Returns an action object used in signalling that the block attributes with the
  * specified UID has been updated.
  *
  * @param  {String} uid        Block UID
@@ -74,6 +74,22 @@ export function updateBlockAttributes( uid, attributes ) {
 		type: 'UPDATE_BLOCK_ATTRIBUTES',
 		uid,
 		attributes,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the block with the
+ * specified UID has been updated.
+ *
+ * @param  {String} uid        Block UID
+ * @param  {Object} updates    Block attributes to be merged
+ * @return {Object}            Action object
+ */
+export function updateBlock( uid, updates ) {
+	return {
+		type: 'UPDATE_BLOCK',
+		uid,
+		updates,
 	};
 }
 

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -21,6 +21,10 @@ $z-layers: (
 	'.editor-header': 20,
 	'.editor-text-editor__formatting': 20,
 
+	// Show Block SettingsToggle should under its content
+	'.editor-block-settings-menu__toggle': 1,
+	'.editor-block-settings-menu__content': 2,
+
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,
 	'.components-drop-zone__content': 110,

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -42,7 +42,7 @@ function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, onTogg
 				className="editor-block-settings-menu__control"
 				onClick={ onToggleMode }
 				icon="html"
-				label={ __( 'Switch between the visual/textual mode' ) }
+				label={ __( 'Switch between the visual/text mode' ) }
 			/>
 		</div>
 	);

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -12,10 +12,10 @@ import { IconButton } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { isEditorSidebarOpened } from '../selectors';
-import { selectBlock, removeBlock, toggleSidebar, setActivePanel } from '../actions';
+import { isEditorSidebarOpened, getBlockMode } from '../selectors';
+import { selectBlock, removeBlock, toggleSidebar, setActivePanel, toggleBlockMode } from '../actions';
 
-function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, onToggleSidebar, onShowInspector } ) {
+function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, mode, onToggleSidebar, onShowInspector, onToggleMode } ) {
 	const toggleInspector = () => {
 		onSelect();
 		onShowInspector();
@@ -38,13 +38,20 @@ function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, onTogg
 				icon="trash"
 				label={ __( 'Delete the block' ) }
 			/>
+			<IconButton
+				className="editor-block-settings-menu__control"
+				onClick={ onToggleMode }
+				icon={ mode === 'html' ? 'edit' : 'html' }
+				label={ __( 'Delete the block' ) }
+			/>
 		</div>
 	);
 }
 
 export default connect(
-	( state ) => ( {
+	( state, ownProps ) => ( {
 		isSidebarOpened: isEditorSidebarOpened( state ),
+		mode: getBlockMode( state, ownProps.uid ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onDelete() {
@@ -58,6 +65,9 @@ export default connect(
 		},
 		onToggleSidebar() {
 			dispatch( toggleSidebar() );
+		},
+		onToggleMode() {
+			dispatch( toggleBlockMode( ownProps.uid ) );
 		},
 	} )
 )( BlockSettingsMenuContent );

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -12,10 +12,10 @@ import { IconButton } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { isEditorSidebarOpened, getBlockMode } from '../selectors';
+import { isEditorSidebarOpened } from '../selectors';
 import { selectBlock, removeBlock, toggleSidebar, setActivePanel, toggleBlockMode } from '../actions';
 
-function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, mode, onToggleSidebar, onShowInspector, onToggleMode } ) {
+function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, onToggleSidebar, onShowInspector, onToggleMode } ) {
 	const toggleInspector = () => {
 		onSelect();
 		onShowInspector();
@@ -41,17 +41,16 @@ function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, mode, 
 			<IconButton
 				className="editor-block-settings-menu__control"
 				onClick={ onToggleMode }
-				icon={ mode === 'html' ? 'edit' : 'html' }
-				label={ __( 'Delete the block' ) }
+				icon="html"
+				label={ __( 'Switch between the visual/textual mode' ) }
 			/>
 		</div>
 	);
 }
 
 export default connect(
-	( state, ownProps ) => ( {
+	( state ) => ( {
 		isSidebarOpened: isEditorSidebarOpened( state ),
-		mode: getBlockMode( state, ownProps.uid ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onDelete() {

--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -15,12 +15,14 @@
 
 .editor-block-settings-menu__content {
 	margin-top: 8px;
+	z-index: z-index( '.editor-block-settings-menu__content' );
 }
 
 .editor-block-settings-menu__toggle {
 	transform: rotate( 90deg );
 	transition-duration: 0.3s;
 	transition-property: transform;
+	z-index: z-index( '.editor-block-settings-menu__toggle' );
 
 	&.is-opened {
 		transform: rotate(0);

--- a/editor/modes/visual-editor/block-html.js
+++ b/editor/modes/visual-editor/block-html.js
@@ -1,0 +1,69 @@
+/**
+ * WordPress Dependencies
+ */
+import { isEqual } from 'lodash';
+import { Component } from '@wordpress/element';
+import { getBlockContent, getSourcedAttributes, getBlockType } from '@wordpress/blocks';
+
+/**
+ * External Dependencies
+ */
+import { connect } from 'react-redux';
+import TextareaAutosize from 'react-autosize-textarea';
+
+/**
+ * Internal Dependencies
+ */
+import { updateBlockAttributes } from '../../actions';
+import { getBlock } from '../../selectors';
+
+class BlockHTML extends Component {
+	constructor( props ) {
+		super( ...arguments );
+		this.onChange = this.onChange.bind( this );
+		this.onBlur = this.onBlur.bind( this );
+		this.state = {
+			html: getBlockContent( props.block ),
+			attributes: props.block.attributes,
+		};
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! isEqual( nextProps.block.attributes, this.state.attributes ) ) {
+			this.setState( {
+				html: getBlockContent( nextProps.block ),
+			} );
+		}
+	}
+
+	onBlur() {
+		const blockType = getBlockType( this.props.block.name );
+		const attributes = getSourcedAttributes( this.state.html, blockType.attributes );
+		this.setState( { attributes } );
+		this.props.onChange( this.props.uid, attributes );
+	}
+
+	onChange( event ) {
+		this.setState( { html: event.target.value } );
+	}
+
+	render() {
+		const { html } = this.state;
+		return (
+			<div className="blocks-visual-editor__block-html">
+				<TextareaAutosize value={ html } onBlur={ this.onBlur } onChange={ this.onChange } />
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		block: getBlock( state, ownProps.uid ),
+	} ),
+	{
+		onChange( uid, attributes ) {
+			return updateBlockAttributes( uid, attributes );
+		},
+	}
+)( BlockHTML );

--- a/editor/modes/visual-editor/block-html.js
+++ b/editor/modes/visual-editor/block-html.js
@@ -1,7 +1,7 @@
 /**
  * WordPress Dependencies
  */
-import { isEqual, omit, keys } from 'lodash';
+import { isEqual } from 'lodash';
 import { Component } from '@wordpress/element';
 import { getBlockContent, getSourcedAttributes, getBlockType, isValidBlock } from '@wordpress/blocks';
 
@@ -39,7 +39,7 @@ class BlockHTML extends Component {
 		const blockType = getBlockType( this.props.block.name );
 		const sourcedAttributes = getSourcedAttributes( this.state.html, blockType.attributes );
 		const attributes = {
-			...( omit( this.props.block.attributes, keys( sourcedAttributes ) ) ),
+			...this.props.block.attributes,
 			...sourcedAttributes,
 		};
 		const isValid = isValidBlock( this.state.html, blockType, attributes );

--- a/editor/modes/visual-editor/block-html.js
+++ b/editor/modes/visual-editor/block-html.js
@@ -1,7 +1,7 @@
 /**
  * WordPress Dependencies
  */
-import { isEqual } from 'lodash';
+import { isEqual, omit, keys } from 'lodash';
 import { Component } from '@wordpress/element';
 import { getBlockContent, getSourcedAttributes, getBlockType, isValidBlock } from '@wordpress/blocks';
 
@@ -32,14 +32,19 @@ class BlockHTML extends Component {
 		if ( ! isEqual( nextProps.block.attributes, this.state.attributes ) ) {
 			this.setState( {
 				html: getBlockContent( nextProps.block ),
+				attributes: nextProps.block.attributes,
 			} );
 		}
 	}
 
 	onBlur() {
 		const blockType = getBlockType( this.props.block.name );
-		const attributes = getSourcedAttributes( this.state.html, blockType.attributes );
-		const isValid = isValidBlock( this.state.html, blockType, { ...this.props.block.attributes, attributes } );
+		const sourcedAttributes = getSourcedAttributes( this.state.html, blockType.attributes );
+		const attributes = {
+			...( omit( this.props.block.attributes, keys( sourcedAttributes ) ) ),
+			...sourcedAttributes,
+		};
+		const isValid = isValidBlock( this.state.html, blockType, attributes );
 		this.setState( { attributes } );
 		this.props.onChange( this.props.uid, attributes, this.state.html, isValid );
 	}

--- a/editor/modes/visual-editor/block-html.js
+++ b/editor/modes/visual-editor/block-html.js
@@ -24,15 +24,13 @@ class BlockHTML extends Component {
 		this.onBlur = this.onBlur.bind( this );
 		this.state = {
 			html: props.block.isValid ? getBlockContent( props.block ) : props.block.originalContent,
-			attributes: props.block.attributes,
 		};
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( nextProps.block.attributes, this.state.attributes ) ) {
+		if ( ! isEqual( nextProps.block.attributes, this.props.block.attributes ) ) {
 			this.setState( {
 				html: getBlockContent( nextProps.block ),
-				attributes: nextProps.block.attributes,
 			} );
 		}
 	}
@@ -45,7 +43,6 @@ class BlockHTML extends Component {
 			...sourcedAttributes,
 		};
 		const isValid = isValidBlock( this.state.html, blockType, attributes );
-		this.setState( { attributes } );
 		this.props.onChange( this.props.uid, attributes, this.state.html, isValid );
 	}
 

--- a/editor/modes/visual-editor/block-html.js
+++ b/editor/modes/visual-editor/block-html.js
@@ -3,7 +3,7 @@
  */
 import { isEqual } from 'lodash';
 import { Component } from '@wordpress/element';
-import { getBlockContent, getSourcedAttributes, getBlockType } from '@wordpress/blocks';
+import { getBlockContent, getSourcedAttributes, getBlockType, isValidBlock } from '@wordpress/blocks';
 
 /**
  * External Dependencies
@@ -14,7 +14,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * Internal Dependencies
  */
-import { updateBlockAttributes } from '../../actions';
+import { updateBlock } from '../../actions';
 import { getBlock } from '../../selectors';
 
 class BlockHTML extends Component {
@@ -23,7 +23,7 @@ class BlockHTML extends Component {
 		this.onChange = this.onChange.bind( this );
 		this.onBlur = this.onBlur.bind( this );
 		this.state = {
-			html: getBlockContent( props.block ),
+			html: props.block.isValid ? getBlockContent( props.block ) : props.block.originalContent,
 			attributes: props.block.attributes,
 		};
 	}
@@ -39,8 +39,9 @@ class BlockHTML extends Component {
 	onBlur() {
 		const blockType = getBlockType( this.props.block.name );
 		const attributes = getSourcedAttributes( this.state.html, blockType.attributes );
+		const isValid = isValidBlock( this.state.html, blockType, { ...this.props.block.attributes, attributes } );
 		this.setState( { attributes } );
-		this.props.onChange( this.props.uid, attributes );
+		this.props.onChange( this.props.uid, attributes, this.state.html, isValid );
 	}
 
 	onChange( event ) {
@@ -62,8 +63,8 @@ export default connect(
 		block: getBlock( state, ownProps.uid ),
 	} ),
 	{
-		onChange( uid, attributes ) {
-			return updateBlockAttributes( uid, attributes );
+		onChange( uid, attributes, originalContent, isValid ) {
+			return updateBlock( uid, { attributes, originalContent, isValid } );
 		},
 	}
 )( BlockHTML );

--- a/editor/modes/visual-editor/block-html.js
+++ b/editor/modes/visual-editor/block-html.js
@@ -53,9 +53,12 @@ class BlockHTML extends Component {
 	render() {
 		const { html } = this.state;
 		return (
-			<div className="blocks-visual-editor__block-html">
-				<TextareaAutosize value={ html } onBlur={ this.onBlur } onChange={ this.onChange } />
-			</div>
+			<TextareaAutosize
+				className="blocks-visual-editor__block-html-textarea"
+				value={ html }
+				onBlur={ this.onBlur }
+				onChange={ this.onChange }
+			/>
 		);
 	}
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -421,3 +421,22 @@
 .visual-editor__invalid-block-warning-buttons .components-button {
 	margin-bottom: 5px;
 }
+
+.blocks-visual-editor__block-html textarea {
+	display: block;
+	margin: 0;
+	width: 100%;
+	border: none;
+	outline: none;
+	box-shadow: none;
+	resize: none;
+	overflow: hidden;
+	font-family: $editor-html-font;
+	font-size: $text-editor-font-size;
+	line-height: 150%;
+	transition: padding .2s linear;
+
+	&:focus {
+		box-shadow: none;
+	}
+}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -422,7 +422,7 @@
 	margin-bottom: 5px;
 }
 
-.blocks-visual-editor__block-html textarea {
+.editor-visual-editor__block .blocks-visual-editor__block-html-textarea {
 	display: block;
 	margin: 0;
 	width: 100%;

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -378,6 +378,17 @@ export function hoveredBlock( state = null, action ) {
 	return state;
 }
 
+export function blocksMode( state = {}, action ) {
+	if ( action.type === 'TOGGLE_BLOCK_MODE' ) {
+		return {
+			...state,
+			[ action.uid ]: state[ action.uid ] && state[ action.uid ] === 'html' ? 'visual' : 'html',
+		};
+	}
+
+	return state;
+}
+
 /**
  * Reducer returning the block insertion point
  *
@@ -530,6 +541,7 @@ export default optimist( combineReducers( {
 	isTyping,
 	blockSelection,
 	hoveredBlock,
+	blocksMode,
 	showInsertionPoint,
 	preferences,
 	panel,

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -136,7 +136,7 @@ export const editor = combineUndoableReducers( {
 				};
 
 			case 'UPDATE_BLOCK':
-			// Ignore updates if block isn't known
+				// Ignore updates if block isn't known
 				if ( ! state[ action.uid ] ) {
 					return state;
 				}
@@ -394,9 +394,10 @@ export function hoveredBlock( state = null, action ) {
 
 export function blocksMode( state = {}, action ) {
 	if ( action.type === 'TOGGLE_BLOCK_MODE' ) {
+		const { uid } = action;
 		return {
 			...state,
-			[ action.uid ]: state[ action.uid ] && state[ action.uid ] === 'html' ? 'visual' : 'html',
+			[ uid ]: state[ uid ] && state[ uid ] === 'html' ? 'visual' : 'html',
 		};
 	}
 

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -135,6 +135,20 @@ export const editor = combineUndoableReducers( {
 					},
 				};
 
+			case 'UPDATE_BLOCK':
+			// Ignore updates if block isn't known
+				if ( ! state[ action.uid ] ) {
+					return state;
+				}
+
+				return {
+					...state,
+					[ action.uid ]: {
+						...state[ action.uid ],
+						...action.updates,
+					},
+				};
+
 			case 'INSERT_BLOCKS':
 				return {
 					...state,

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -704,6 +704,16 @@ export function getBlockFocus( state, uid ) {
 
 	return state.blockSelection.focus;
 }
+/**
+ * Returns thee block's editing mode
+ *
+ * @param  {Object} state Global application state
+ * @param  {String} uid   Block unique ID
+ * @return {Object}       Block editing mode
+ */
+export function getBlockMode( state, uid ) {
+	return state.blocksMode[ uid ] || 'visual';
+}
 
 /**
  * Returns true if the user is typing, or false otherwise.

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -1017,58 +1017,6 @@ describe( 'state', () => {
 			} );
 		} );
 	} );
-<<<<<<< HEAD
-=======
-
-	describe( 'userData()', () => {
-		beforeAll( () => {
-			registerBlockType( 'core/test-block', {
-				save: noop,
-				edit: noop,
-				category: 'common',
-				title: 'test block',
-			} );
-		} );
-
-		afterAll( () => {
-			unregisterBlockType( 'core/test-block' );
-		} );
-
-		it( 'should record recently used blocks', () => {
-			const original = userData( undefined, {} );
-			const state = userData( original, {
-				type: 'INSERT_BLOCKS',
-				blocks: [ {
-					uid: 'bacon',
-					name: 'core-embed/twitter',
-				} ],
-			} );
-
-			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
-
-			const twoRecentBlocks = userData( state, {
-				type: 'INSERT_BLOCKS',
-				blocks: [ {
-					uid: 'eggs',
-					name: 'core-embed/youtube',
-				} ],
-			} );
-
-			expect( twoRecentBlocks.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
-			expect( twoRecentBlocks.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/twitter' );
-		} );
-
-		it( 'should populate recently used blocks with blocks from the common category', () => {
-			const initial = userData( undefined, {
-				type: 'SETUP_EDITOR',
-			} );
-
-			initial.recentlyUsedBlocks.forEach(
-				block => expect( getBlockType( block ).category ).toEqual( 'common' )
-			);
-			expect( initial.recentlyUsedBlocks ).toHaveLength( 8 );
-		} );
-	} );
 
 	describe( 'blocksMode', () => {
 		it( 'should set mode to html if not set', () => {
@@ -1091,5 +1039,4 @@ describe( 'state', () => {
 			expect( value ).toEqual( { chicken: 'visual' } );
 		} );
 	} );
->>>>>>> Block HTML Mode: Adding unit tests
 } );

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -23,6 +23,7 @@ import {
 	saving,
 	notices,
 	showInsertionPoint,
+	blocksMode,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -118,6 +119,33 @@ describe( 'state', () => {
 			expect( values( state.blocksByUid )[ 0 ].name ).toBe( 'core/freeform' );
 			expect( values( state.blocksByUid )[ 0 ].uid ).toBe( 'wings' );
 			expect( state.blockOrder ).toEqual( [ 'wings' ] );
+		} );
+
+		it( 'should update the block', () => {
+			const original = editor( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
+					uid: 'chicken',
+					name: 'core/test-block',
+					attributes: {},
+					isValid: false,
+				} ],
+			} );
+			const state = editor( deepFreeze( original ), {
+				type: 'UPDATE_BLOCK',
+				uid: 'chicken',
+				updates: {
+					attributes: { content: 'ribs' },
+					isValid: true,
+				},
+			} );
+
+			expect( state.blocksByUid.chicken ).toEqual( {
+				uid: 'chicken',
+				name: 'core/test-block',
+				attributes: { content: 'ribs' },
+				isValid: true,
+			} );
 		} );
 
 		it( 'should move the block up', () => {
@@ -989,4 +1017,79 @@ describe( 'state', () => {
 			} );
 		} );
 	} );
+<<<<<<< HEAD
+=======
+
+	describe( 'userData()', () => {
+		beforeAll( () => {
+			registerBlockType( 'core/test-block', {
+				save: noop,
+				edit: noop,
+				category: 'common',
+				title: 'test block',
+			} );
+		} );
+
+		afterAll( () => {
+			unregisterBlockType( 'core/test-block' );
+		} );
+
+		it( 'should record recently used blocks', () => {
+			const original = userData( undefined, {} );
+			const state = userData( original, {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
+					uid: 'bacon',
+					name: 'core-embed/twitter',
+				} ],
+			} );
+
+			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
+
+			const twoRecentBlocks = userData( state, {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
+					uid: 'eggs',
+					name: 'core-embed/youtube',
+				} ],
+			} );
+
+			expect( twoRecentBlocks.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
+			expect( twoRecentBlocks.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/twitter' );
+		} );
+
+		it( 'should populate recently used blocks with blocks from the common category', () => {
+			const initial = userData( undefined, {
+				type: 'SETUP_EDITOR',
+			} );
+
+			initial.recentlyUsedBlocks.forEach(
+				block => expect( getBlockType( block ).category ).toEqual( 'common' )
+			);
+			expect( initial.recentlyUsedBlocks ).toHaveLength( 8 );
+		} );
+	} );
+
+	describe( 'blocksMode', () => {
+		it( 'should set mode to html if not set', () => {
+			const action = {
+				type: 'TOGGLE_BLOCK_MODE',
+				uid: 'chicken',
+			};
+			const value = blocksMode( deepFreeze( {} ), action );
+
+			expect( value ).toEqual( { chicken: 'html' } );
+		} );
+
+		it( 'should toggle mode to visual if set as html', () => {
+			const action = {
+				type: 'TOGGLE_BLOCK_MODE',
+				uid: 'chicken',
+			};
+			const value = blocksMode( deepFreeze( { chicken: 'html' } ), action );
+
+			expect( value ).toEqual( { chicken: 'visual' } );
+		} );
+	} );
+>>>>>>> Block HTML Mode: Adding unit tests
 } );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -54,6 +54,7 @@ import {
 	isFirstMultiSelectedBlock,
 	isBlockHovered,
 	getBlockFocus,
+	getBlockMode,
 	isTyping,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
@@ -1501,6 +1502,26 @@ describe( 'selectors', () => {
 			};
 
 			expect( getBlockFocus( state, 23 ) ).toEqual( null );
+		} );
+	} );
+
+	describe( 'geteBlockMode', () => {
+		it( 'should return "visual" if unset', () => {
+			const state = {
+				blocksMode: {},
+			};
+
+			expect( getBlockMode( state, 123 ) ).toEqual( 'visual' );
+		} );
+
+		it( 'should return the block mode', () => {
+			const state = {
+				blocksMode: {
+					123: 'html',
+				},
+			};
+
+			expect( getBlockMode( state, 123 ) ).toEqual( 'html' );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
This PR explores the idea in #2794 This is largely unfinished yet but this shows how this could work. The button to switch to HTML mode is located on the menu on the right of block instead of the inspector because it's not possible to keep showing the inspector controls while in HTML mode (this is probably temporary, we need some design input here)

## Checklist:
- [x] Button to toggle the mode per block
- [x] BlockHTML form
- [x] Run the block validation when switching back to the visual mode
- [x] Make this pretty
- [x] Add unit tests

## Screenshots (jpeg or gifs if applicable):
<img width="721" alt="screen shot 2017-09-26 at 14 47 27" src="https://user-images.githubusercontent.com/272444/30863730-a5daf804-a2c9-11e7-8366-39c8c054f176.png">
