### PR TITLE
Use serif system font stack for the editor content

### DIFF
--- a/docutron/src/styles/main.css
+++ b/docutron/src/styles/main.css
@@ -78,7 +78,7 @@ code, pre {
 .site-header .site-title a {
 	font-size: 40px;
 	color: #444;
-	font-family: 'Noto Serif';
+	font-family: Georgia, "Times New Roman", "Bitstream Charter", Times, serif;
 	border-bottom: 2px solid transparent;
 }
 

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -40,7 +40,7 @@ $alert-green: #4ab866;
 $default-font: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 $default-font-size: 13px;
 $default-line-height: 1.4;
-$editor-font: "Noto Serif", serif;
+$editor-font: Georgia, "Times New Roman", "Bitstream Charter", Times, serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;
 $editor-font-size: 16px;
 $text-editor-font-size: 14px;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -807,11 +807,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	/**
 	 * Styles
 	 */
-
-	wp_enqueue_style(
-		'wp-editor-font',
-		'https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i'
-	);
 	wp_enqueue_style(
 		'wp-editor',
 		gutenberg_url( 'editor/build/style.css' ),


### PR DESCRIPTION
## Description

See #2782. This PR sets the default font to local serif fonts (just like the current WP editor).
In addition it removes Noto from the docs, as Noto is not even loaded there.
