### PR TITLE
Layout: Add metabox placeholder shell

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -3,6 +3,11 @@
 	border: none;
 	outline: none;
 	text-decoration: none;
+	margin: 0;
+
+	&:active {
+		color: currentColor;
+	}
 
 	&:disabled {
 		opacity: 0.6;

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -54,7 +54,7 @@
 .components-panel .components-panel__body-title {
 	display: block;
 	padding: 0;
-	margin: -15px;
+	margin: -1 * $panel-padding;
 	font-size: inherit;
 }
 .components-panel__body.is-opened .components-panel__body-title {

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -10,6 +10,10 @@ body.gutenberg_page_gutenberg-demo {
 		padding-left: 0;
 	}
 
+	#wpbody-content {
+		padding-bottom: 0;
+	}
+
 	#wpfooter {
 		display: none;
 	}
@@ -51,6 +55,11 @@ body.gutenberg_page_gutenberg-demo {
 
 .gutenberg__editor {
 	position: relative;
+	height: calc( 100vh - #{ $admin-bar-height-big } );
+
+	@include break-medium {
+		height: calc( 100vh - #{ $admin-bar-height } );
+	}
 
 	img {
 		max-width: 100%;

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -14,6 +14,11 @@ body.gutenberg_page_gutenberg-demo {
 		display: none;
 	}
 
+	.a11y-speak-region {
+		left: -1px;
+		top: -1px;
+	}
+
 	svg {
 		fill: currentColor;
 	}

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -17,6 +17,7 @@ import Header from '../header';
 import Sidebar from '../sidebar';
 import TextEditor from '../modes/text-editor';
 import VisualEditor from '../modes/visual-editor';
+import MetaBoxes from '../meta-boxes';
 import UnsavedChangesWarning from '../unsaved-changes-warning';
 import DocumentTitle from '../document-title';
 import AutosaveMonitor from '../autosave-monitor';
@@ -40,8 +41,11 @@ function Layout( { mode, isSidebarOpened, notices, ...props } ) {
 			<AutosaveMonitor />
 			<Header />
 			<div className="editor-layout__content">
-				{ mode === 'text' && <TextEditor /> }
-				{ mode === 'visual' && <VisualEditor /> }
+				<div className="editor-layout__editor">
+					{ mode === 'text' && <TextEditor /> }
+					{ mode === 'visual' && <VisualEditor /> }
+				</div>
+				<MetaBoxes />
 			</div>
 			{ isSidebarOpened && <Sidebar /> }
 		</div>

--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -1,5 +1,18 @@
+.editor-layout,
+.editor-layout__content {
+	height: 100%;
+}
+
 .editor-layout {
 	position: relative;
+}
+
+.editor-layout__content {
+	margin-top: #{ -1 * $header-height };
+
+	@include break-medium {
+		margin-top: 0;
+	}
 }
 
 .editor-layout .components-notice-list {

--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -8,11 +8,18 @@
 }
 
 .editor-layout__content {
+	display: flex;
+	flex-direction: column;
 	margin-top: #{ -1 * $header-height };
 
 	@include break-medium {
 		margin-top: 0;
 	}
+}
+
+.editor-layout__editor {
+	flex-basis: 100%;
+	overflow-y: auto;
 }
 
 .editor-layout .components-notice-list {

--- a/editor/meta-boxes/index.js
+++ b/editor/meta-boxes/index.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Panel, PanelBody, Dashicon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class MetaBoxes extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.toggle = this.toggle.bind( this );
+
+		this.state = {
+			isOpen: false,
+		};
+	}
+
+	toggle() {
+		this.setState( {
+			isOpen: ! this.state.isOpen,
+		} );
+	}
+
+	render() {
+		const { isOpen } = this.state;
+
+		return (
+			<Panel className="editor-meta-boxes">
+				<PanelBody
+					title={ __( 'Extended Settings' ) }
+					opened={ isOpen }
+					onToggle={ this.toggle }>
+					<div className="editor-meta-boxes__coming-soon">
+						<Dashicon icon="flag" />
+						<h3>{ __( 'Coming Soon' ) }</h3>
+						<p>{ __( 'Meta boxes are not yet supported, but are planned for a future release.' ) }</p>
+					</div>
+				</PanelBody>
+			</Panel>
+		);
+	}
+}
+
+export default MetaBoxes;

--- a/editor/meta-boxes/style.scss
+++ b/editor/meta-boxes/style.scss
@@ -1,0 +1,32 @@
+.editor-meta-boxes {
+	border-right-width: 0;
+	border-left-width: 0;
+
+	.components-panel__body-toggle {
+		background-color: $light-gray-300;
+	}
+
+	.components-panel__body.is-opened .components-panel__body-toggle {
+		border-bottom: 1px solid $light-gray-500;
+	}
+}
+
+.editor-meta-boxes__coming-soon {
+	width: 300px;
+	padding: #{ $panel-padding * 2 } 0 $panel-padding;
+	margin: 0 auto;
+	text-align: center;
+
+	&,
+	h3 {
+		color: $dark-gray-200;
+	}
+
+	h3 {
+		margin: 0.6em 0;
+	}
+
+	p {
+		margin-bottom: 0;
+	}
+}


### PR DESCRIPTION
Closes #2760
Closes #2322
Related: #2583

Closed|Opened
---|---
![Closed](https://user-images.githubusercontent.com/1779930/30881031-68b47000-a2d2-11e7-96e2-f98771a33ee5.png)|![Opened](https://user-images.githubusercontent.com/1779930/30881037-6cafd082-a2d2-11e7-9194-36fdd0286a1e.png)

While development of metaboxes continues in #2583, this pull request seeks to add a static content shell for representing the container in which meta fields will be rendered. In doing so, it tackles styling issues with the current layout where content does not occupy the full height of the viewport, complicating panels pinned to the bottom, and disrupting "click outside" behavior for the currently selected block.

__Testing instructions:__

1. Navigate to Gutenberg > Demo or Gutenberg > New Post
2. Note that an "Extended Settings" toggle heading is shown at the bottom of the page
3. Toggle the Extended Settings panel
4. Note that the panel expands upward, and that it is still possible to reach all content of the post while the panel is expanded