### PR TITLE
Adds Metabox Support.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ build
 coverage
 vendor
 node_modules
+/assets/js

--- a/assets/js/meta-box-resize.js
+++ b/assets/js/meta-box-resize.js
@@ -1,0 +1,46 @@
+( function() {
+	var observer;
+
+	if ( ! window.MutationObserver || ! document.getElementById( 'post' ) || ! window.parent ) {
+		return;
+	}
+
+	var previousWidth, previousHeight;
+
+	function sendResize() {
+		var form = document.getElementById( 'post' );
+		var location = form.dataset.location;
+		var newWidth = form.scrollWidth;
+		var newHeight = form.scrollHeight;
+
+		// Exit early if height has not been impacted.
+		if ( newWidth === previousWidth && newHeight === previousHeight ) {
+			return;
+		}
+
+		window.parent.postMessage( {
+			action: 'resize',
+			source: 'meta-box',
+			location: location,
+			width: newWidth,
+			height: newHeight
+		}, '*' );
+
+		previousWidth = newWidth;
+		previousHeight = newHeight;
+	}
+
+	observer = new MutationObserver( sendResize );
+	observer.observe( document.getElementById( 'post' ), {
+		attributes: true,
+		attributeOldValue: true,
+		characterData: true,
+		characterDataOldValue: true,
+		childList: true,
+		subtree: true
+	} );
+
+	window.addEventListener( 'load', sendResize, true );
+
+	sendResize();
+} )();

--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -1,0 +1,134 @@
+# Meta Boxes
+
+This is a brief document detailing how meta box support works in Gutenberg. With
+the superior developer and user experience of blocks however, especially once,
+block templates are available, **converting PHP meta boxes to blocks is highly
+encouraged!**
+
+## Breakdown
+
+Each meta box area is rendered by a React component containing an iframe.
+Each iframe will render a partial page containing only meta boxes for that area.
+Meta box data is collected and used for conditional rendering. The meta box areas
+will appear as toggle-able panels labeled "Extended Settings". More on this in
+the MetaBoxIframe component section.
+
+### Meta Box Data Collection
+
+On each Gutenberg page load, the global state of post.php is mimicked, this is
+hooked in as far back as `plugins_loaded`.
+
+See `lib/register.php gutenberg_trick_plugins_into_registering_meta_boxes()`
+
+This will register an action that collects the meta box data to determine if an
+area is empty. The original global state is reset upon collection of meta box
+data.
+
+`gutenberg_collect_meta_box_data()` is hooked in later on `admin_head`. It will
+run through the functions and hooks that `post.php` runs to register meta boxes;
+namely `add_meta_boxes`, `add_meta_boxes_{$post->post_type}`, and `do_meta_boxes`.
+
+A copy of the global `$wp_meta_boxes` is made then filtered through
+`apply_filters( 'filter_gutenberg_meta_boxes', $_meta_boxes_copy );`, which will
+strip out any core meta boxes along with standard custom taxonomy meta boxes.
+
+Then each location for this particular type of meta box is checked for whether it
+is active. If it is not empty a value of true is stored, if it is empty a value
+of false is stored. This meta box location data is then dispatched by the editor
+Redux store in `INITIALIZE_META_BOX_STATE`.
+
+Ideally, this could be done at instantiation of the editor and help simplify
+this flow. However, it is not possible to know the meta box state before
+`admin_enqueue_scripts`, where we are calling `createEditorInstance()`. This will
+have to do, unless we want to move `createEditorInstance()` to fire in the footer
+or at some point after `admin_head`. With recent changes to editor bootstrapping
+this might now be possible. Test with ACF to make sure.
+
+### Redux and React Meta Box Management.
+
+*The Redux store by default will hold all meta boxes as inactive*. When
+`INITIALIZE_META_BOX_STATE` comes in, the store will update any active meta box
+areas by setting the `isActive` flag to `true`. Once this happens React will
+check for the new props sent in by Redux on the `MetaBox` component. If that
+`MetaBox` is now active, instead of rendering null, a `MetaBoxIframe` component will
+be rendered. The `MetaBox` component is the container component that mediates
+between the `MetaBoxIframe` and the Redux Store. *If no meta boxes are active,
+nothing happens. This will be the default behavior, as all core meta boxes have
+been stripped.*
+
+#### MetaBoxIframe Component
+
+When the component renders it will store a ref to the iframe, the component will
+set up a listener for post messages to handle resizing. `assets/js/meta-box-resize.js` is
+loaded inside the iframe and will send up postMessages for resizing, which the
+`MetaBoxIframe` Component will use to manage its state. A mutation observer will
+also be created when the iframe loads. The observer will detect whether, any
+DOM changes have happened in the iframe, input and change event listeners will
+also be attached to check for changes.
+
+The change detection will store the current form's `FormData`, then whenever a
+change is detected the current form data will be checked vs, the original form
+data. This serves as a way to see if the meta box state is dirty. When the
+meta box state has been detected to have changed, a Redux action
+`META_BOX_STATE_CHANGED` is dispatched, updating the store setting the isDirty
+flag to `true`. If the state ever returns back to the original form data,
+`META_BOX_STATE_CHANGED` is dispatched again to set the isDirty flag to `false`.
+A selector `isMetaBoxStateDirty()` is used to help check whether the post can be
+updated. It checks each meta box for whether it is dirty, and if there is at
+least one dirty meta box, it will return true. This dirty detection does not
+impact creating new posts, as the content will have to change before meta boxes
+can trigger the overall dirty state.
+
+When the post is updated, only meta boxes that are active and dirty, will be
+submitted. This removes any unnecessary requests being made. No extra revisions,
+are created either by the meta box submissions. A Redux action will trigger on
+`REQUEST_POST_UPDATE` for any dirty meta box. See `editor/effects.js`. The
+`REQUEST_META_BOX_UPDATES` action will set that meta boxes' state to `isUpdating`,
+the `isUpdating` prop will be sent into the `MetaBoxIframe` and cause a form
+submission. The iframe will clone itself and perform a double buffer right
+before the main iframe submits its data. After loading, the original change
+detection process is fired again to handle the new state.
+
+Since the meta box updating is being triggered on post save success, we check to
+see if the post is saving and display an updating overlay, to prevent users from
+changing the form values while the meta box is submitting. The saving overlay
+could be made transparent, to give a more seamless effect.
+
+### Iframe serving a partial page.
+
+Each iframe will point to an individual source. These are partial pages being
+served by post.php. Why this approach? By using post.php directly, we don't have
+to worry as much about getting the global state 100% correct for each and every
+use case of a meta box, especially when it comes to saving. Essentially, when
+post.php loads it will set up all of its state correctly, and when it hits the
+three `do_action( 'do_meta_boxes' )` hooks it will trigger our partial page.
+
+When the new block editor was made into the default editor it is now required to
+provide the classic-editor flag to access the metabox partial page.
+
+`gutenberg_meta_box_partial_page()` is used to render the meta boxes for a context
+then exit the execution thread early. A `meta_box` request parameter is used to
+trigger this early exit. The `meta_box` request parameter should match one of
+`'advanced'`, `'normal'`, or `'side'`. This value will determine which meta box
+area is served. So an example url would look like:
+
+`mysite.com/wp-admin/post.php?post=1&action=edit&meta_box=$location&classic-editor`
+
+This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
+The partial page is very similar to post.php and pretty much imitates it and
+after rendering the meta boxes via `do_meta_boxes()` it imitates `admin_footer`,
+exits early, and does some hook clean up. There are two extra files that are
+enqueued. One is the js file from `assets/js/meta-box-resize.js`, which resizes the iframe.
+The other is a stylesheet that is generated by webpack from `editor/meta-boxes/meta-box-iframe.scss`
+and built into `editor/build/meta-box-iframe.css`
+
+These styles make use of some of the SASS variables, so that as the Gutenberg
+UI updates so will the meta boxes.
+
+The partial page mimics the `post.php` post form, so when it is submitted it will
+normally fire all of the necessary hooks and actions, and have the proper global
+state to correctly fire any PHP meta box mumbo jumbo without needing to modify
+any existing code. On successful submission the page will be reloaded back to
+the same partial page with updated data. React will signal a `handleMetaBoxReload`
+to set up the new form state for dirty checking, remove the updating overlay,
+and set the store to no longer be updating the meta box area.

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -408,6 +408,71 @@ export function removeNotice( id ) {
 	};
 }
 
+/**
+ * Returns an action object used to check the state of meta boxes at a location.
+ *
+ * This should only be fired once to initialize meta box state. If a meta box
+ * area is empty, this will set the store state to indicate that React should
+ * not render the meta box area.
+ *
+ * Example: metaBoxes = { side: true, normal: false }
+ * This indicates that the sidebar has a meta box but the normal area does not.
+ *
+ * @param {Object} metaBoxes Whether meta box locations are active.
+ *
+ * @return {Object} Action object
+ */
+export function initializeMetaBoxState( metaBoxes ) {
+	return {
+		type: 'INITIALIZE_META_BOX_STATE',
+		metaBoxes,
+	};
+}
+
+/**
+ * Returns an action object used to signify that a meta box finished reloading.
+ *
+ * @param {String} location Location of meta box: 'normal', 'side'.
+ *
+ * @return {Object} Action object
+ */
+export function handleMetaBoxReload( location ) {
+	return {
+		type: 'HANDLE_META_BOX_RELOAD',
+		location,
+	};
+}
+
+/**
+ * Returns an action object used to request meta box update.
+ *
+ * @param {Array} locations Locations of meta boxes: ['normal', 'side' ].
+ *
+ * @return {Object}     Action object
+ */
+export function requestMetaBoxUpdates( locations ) {
+	return {
+		type: 'REQUEST_META_BOX_UPDATES',
+		locations,
+	};
+}
+
+/**
+ * Returns an action object used to set meta box state changed.
+ *
+ * @param {String}  location   Location of meta box: 'normal', 'side'.
+ * @param {Boolean} hasChanged Whether the meta box has changed.
+ *
+ * @return {Object} Action object
+ */
+export function metaBoxStateChanged( location, hasChanged ) {
+	return {
+		type: 'META_BOX_STATE_CHANGED',
+		location,
+		hasChanged,
+	};
+}
+
 export const createSuccessNotice = partial( createNotice, 'success' );
 export const createInfoNotice = partial( createNotice, 'info' );
 export const createErrorNotice = partial( createNotice, 'error' );

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -25,10 +25,12 @@ import {
 	removeNotice,
 	savePost,
 	editPost,
+	requestMetaBoxUpdates,
 } from './actions';
 import {
 	getCurrentPost,
 	getCurrentPostType,
+	getDirtyMetaBoxes,
 	getEditedPostContent,
 	getPostEdits,
 	isCurrentPostPublished,
@@ -86,7 +88,7 @@ export default {
 	},
 	REQUEST_POST_UPDATE_SUCCESS( action, store ) {
 		const { previousPost, post } = action;
-		const { dispatch } = store;
+		const { dispatch, getState } = store;
 
 		const publishStatus = [ 'publish', 'private', 'future' ];
 		const isPublished = publishStatus.indexOf( previousPost.status ) !== -1;
@@ -112,6 +114,9 @@ export default {
 				{ id: SAVE_POST_NOTICE_ID }
 			) );
 		}
+
+		// Update dirty meta boxes.
+		dispatch( requestMetaBoxUpdates( getDirtyMetaBoxes( getState() ) ) );
 
 		if ( get( window.history.state, 'id' ) !== post.id ) {
 			window.history.replaceState(

--- a/editor/index.js
+++ b/editor/index.js
@@ -16,6 +16,7 @@ import { settings as dateSettings } from '@wordpress/date';
 import './assets/stylesheets/main.scss';
 import Layout from './layout';
 import EditorProvider from './provider';
+import { initializeMetaBoxState } from './actions';
 
 // Configure moment globally
 moment.locale( dateSettings.l10n.locale );
@@ -45,17 +46,27 @@ window.jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
 /**
  * Initializes and returns an instance of Editor.
  *
+ * The return value of this function is not necessary if we change where we
+ * call createEditorInstance(). This is due to metaBox timing.
+ *
  * @param {String}  id       Unique identifier for editor instance
  * @param {Object}  post     API entity for post to edit
  * @param {?Object} settings Editor settings object
+ * @return {Object} Editor interface. Currently supports metabox initialization.
  */
 export function createEditorInstance( id, post, settings ) {
 	const target = document.getElementById( id );
 
-	render(
+	const provider = render(
 		<EditorProvider settings={ settings } post={ post }>
 			<Layout />
 		</EditorProvider>,
 		target
 	);
+
+	return {
+		initializeMetaBoxes( metaBoxes ) {
+			provider.store.dispatch( initializeMetaBoxState( metaBoxes ) );
+		},
+	};
 }

--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -17,11 +17,11 @@ import Header from '../header';
 import Sidebar from '../sidebar';
 import TextEditor from '../modes/text-editor';
 import VisualEditor from '../modes/visual-editor';
-import MetaBoxes from '../meta-boxes';
 import UnsavedChangesWarning from '../unsaved-changes-warning';
 import DocumentTitle from '../document-title';
 import AutosaveMonitor from '../autosave-monitor';
 import { removeNotice } from '../actions';
+import MetaBoxes from '../meta-boxes';
 import {
 	getEditorMode,
 	isEditorSidebarOpened,
@@ -34,7 +34,7 @@ function Layout( { mode, isSidebarOpened, notices, ...props } ) {
 	} );
 
 	return (
-		<div className={ className }>
+		<div key="editor" className={ className }>
 			<DocumentTitle />
 			<NoticeList onRemove={ props.removeNotice } notices={ notices } />
 			<UnsavedChangesWarning />
@@ -45,7 +45,7 @@ function Layout( { mode, isSidebarOpened, notices, ...props } ) {
 					{ mode === 'text' && <TextEditor /> }
 					{ mode === 'visual' && <VisualEditor /> }
 				</div>
-				<MetaBoxes />
+				<MetaBoxes location="normal" />
 			</div>
 			{ isSidebarOpened && <Sidebar /> }
 			<Popover.Slot />

--- a/editor/meta-boxes/iframe.js
+++ b/editor/meta-boxes/iframe.js
@@ -1,0 +1,256 @@
+/**
+ * External dependencies
+ */
+import { isEqual } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import MetaBoxPanel from './panel.js';
+
+class MetaBoxIframe extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			width: 0,
+			height: 0,
+			isOpen: false,
+		};
+
+		this.originalFormData = [];
+		this.hasLoaded = false;
+		this.formData = [];
+		this.form = null;
+
+		this.checkMessageForResize = this.checkMessageForResize.bind( this );
+		this.handleDoubleBuffering = this.handleDoubleBuffering.bind( this );
+		this.handleMetaBoxReload = this.handleMetaBoxReload.bind( this );
+		this.checkMetaBoxState = this.checkMetaBoxState.bind( this );
+		this.observeChanges = this.observeChanges.bind( this );
+		this.bindNode = this.bindNode.bind( this );
+		this.isSaving = this.isSaving.bind( this );
+		this.toggle = this.toggle.bind( this );
+	}
+
+	toggle() {
+		this.setState( {
+			isOpen: ! this.state.isOpen,
+		} );
+	}
+
+	bindNode( node ) {
+		this.node = node;
+	}
+
+	componentDidMount() {
+		/**
+		 * Sets up an event listener for resizing. The resizing occurs inside
+		 * the iframe, see gutenberg/assets/js/meta-box-resize.js
+		 */
+		window.addEventListener( 'message', this.checkMessageForResize, false );
+
+		// Initially set node to not display anything so that when it loads, we can see it.
+		this.node.style.display = 'none';
+
+		this.node.addEventListener( 'load', this.observeChanges );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		// Exit early if updating, or not while the post is saving.
+		if ( ! nextProps.isUpdating || nextProps.isPostSaving ) {
+			return;
+		}
+
+		const iframe = this.node;
+
+		this.clonedNode = iframe.cloneNode( true );
+		this.clonedNode.classList.add( 'is-updating' );
+		this.hideNode( this.clonedNode );
+		const parent = iframe.parentNode;
+
+		parent.appendChild( this.clonedNode );
+
+		/**
+		 * When the dom content has loaded for the cloned iframe handle the
+		 * double buffering.
+		 */
+		this.clonedNode.addEventListener( 'load', this.handleDoubleBuffering );
+	}
+
+	handleDoubleBuffering() {
+		const { node, clonedNode, form } = this;
+
+		form.submit();
+
+		const cloneForm = clonedNode.contentWindow.document.getElementById( 'post' );
+		// Make the cloned state match the current state visually.
+		cloneForm.parentNode.replaceChild( form, cloneForm );
+
+		this.showNode( clonedNode );
+		this.hideNode( node );
+
+		node.addEventListener( 'load', this.handleMetaBoxReload );
+	}
+
+	hideNode( node ) {
+		node.classList.add( 'is-hidden' );
+	}
+
+	showNode( node ) {
+		node.classList.remove( 'is-hidden' );
+	}
+
+	componentWillUnmount() {
+		const iframe = this.node;
+		iframe.removeEventListener( 'message', this.checkMessageForResize );
+
+		if ( this.form ) {
+			this.form.removeEventListener( 'input', this.checkMetaBoxState );
+			this.form.removeEventListener( 'change', this.checkMetaBoxState );
+		}
+
+		this.node.removeEventListener( 'load', this.observeChanges );
+	}
+
+	observeChanges() {
+		const node = this.node;
+
+		// The standard post.php form ID post should probably be mimicked.
+		this.form = this.node.contentWindow.document.getElementById( 'post' );
+
+		// If the iframe has not already loaded before.
+		if ( ! this.hasLoaded ) {
+			node.style.display = 'block';
+			this.originalFormData = this.getFormData();
+			this.hasLoaded = true;
+		}
+
+		this.form.addEventListener( 'change', this.checkMetaBoxState );
+		this.form.addEventListener( 'input', this.checkMetaBoxState );
+	}
+
+	getFormData() {
+		const form = this.form;
+
+		const data = new window.FormData( form );
+		const entries = Array.from( data.entries() );
+		return entries;
+	}
+
+	checkMetaBoxState() {
+		const { isUpdating, isDirty, changedMetaBoxState, location } = this.props;
+
+		const isStateEqual = isEqual( this.originalFormData, this.getFormData() );
+
+		/**
+		 * If we are not updating, then if dirty and equal to original, then set not dirty.
+		 * If we are not updating, then if not dirty and not equal to original, set as dirty.
+		 */
+		if ( ! isUpdating && ( isDirty === isStateEqual ) ) {
+			changedMetaBoxState( location, ! isDirty );
+		}
+	}
+
+	handleMetaBoxReload( event ) {
+		// Remove the reloading event listener once the meta box has loaded.
+		event.target.removeEventListener( 'load', this.handleMetaBoxReload );
+
+		if ( this.clonedNode ) {
+			this.showNode( this.node );
+			this.hideNode( this.clonedNode );
+			this.clonedNode.removeEventListener( 'load', this.handleDoubleBuffering );
+			this.clonedNode.parentNode.removeChild( this.clonedNode );
+			delete this.clonedNode;
+		}
+
+		this.originalFormData = this.getFormData();
+		this.props.metaBoxReloaded( this.props.location );
+	}
+
+	checkMessageForResize( event ) {
+		const iframe = this.node;
+
+		// Attempt to parse the message data as JSON if passed as string
+		let data = event.data || {};
+		if ( 'string' === typeof data ) {
+			try {
+				data = JSON.parse( data );
+			} catch ( e ) {} // eslint-disable-line no-empty
+		}
+
+		// Check to make sure the meta box matches this location.
+		if ( data.source !== 'meta-box' || data.location !== this.props.location ) {
+			return;
+		}
+
+		// Verify that the mounted element is the source of the message
+		if ( ! iframe || iframe.contentWindow !== event.source ) {
+			return;
+		}
+
+		// Update the state only if the message is formatted as we expect, i.e.
+		// as an object with a 'resize' action, width, and height
+		const { action, width, height } = data;
+		const { width: oldWidth, height: oldHeight } = this.state;
+
+		if ( 'resize' === action && ( oldWidth !== width || oldHeight !== height ) ) {
+			this.setState( { width, height } );
+		}
+	}
+
+	isSaving() {
+		const { isUpdating, isDirty, isPostSaving } = this.props;
+		return isUpdating || ( isDirty && isPostSaving );
+	}
+
+	render() {
+		const { location } = this.props;
+		const { isOpen, width, height } = this.state;
+		const isSaving = this.isSaving();
+
+		const classes = classnames(
+			'editor-meta-boxes__iframe',
+			`is-${ location }`,
+			{ 'is-closed': ! isOpen }
+		);
+
+		const overlayClasses = classnames(
+			'editor-meta-boxes__loading-overlay',
+			{ 'is-visible': isSaving }
+		);
+
+		const iframeClasses = classnames( { 'is-updating': isSaving } );
+
+		return (
+			<MetaBoxPanel
+				title={ __( 'Extended Settings' ) }
+				opened={ isOpen }
+				onToggle={ this.toggle }>
+				<div className={ classes }>
+					<div className={ overlayClasses }>
+						<p className="loading-overlay__text">{ __( 'Updating Settings' ) }</p>
+					</div>
+					<iframe
+						className={ iframeClasses }
+						ref={ this.bindNode }
+						title={ __( 'Extended Settings' ) }
+						sandbox="allow-forms allow-same-origin allow-scripts"
+						src={ addQueryArgs( window._wpMetaBoxUrl, { meta_box: location } ) }
+						width={ Math.ceil( width ) }
+						height={ Math.ceil( height ) } />
+				</div>
+			</MetaBoxPanel>
+		);
+	}
+}
+
+export default MetaBoxIframe;

--- a/editor/meta-boxes/meta-box-iframe.scss
+++ b/editor/meta-boxes/meta-box-iframe.scss
@@ -1,0 +1,82 @@
+/**
+ * These styles are included within the iframe.
+ */
+
+/* Hides scrollbar to make iframe content seem as though it is part of the page. */
+.gutenberg-meta-box-html {
+	overflow: hidden;
+	width: 100%;
+}
+
+body {
+	background-color: $white;
+}
+
+/* Match width and positioning of the meta boxes. Override default styles. */
+#poststuff {
+	margin: 0 auto;
+	padding-top: 0;
+}
+
+#post {
+	margin: 0;
+}
+
+/* Override Default meta box stylings */
+
+#poststuff h3.hndle,
+#poststuff .stuffbox > h3,
+#poststuff h2.hndle { /* WordPress selectors yolo */
+	border-bottom: 1px solid $light-gray-500;
+	box-sizing: border-box;
+	color: $dark-gray-500;
+	font-weight: 600;
+	outline: none;
+	padding: 15px;
+	position: relative;
+	width: 100%;
+}
+
+.postbox {
+	border: 0;
+	color: $dark-gray-500;
+	margin-bottom: 0;
+}
+
+.postbox > .inside {
+	border-bottom: 1px solid $light-gray-500;
+	color: $dark-gray-500;
+	padding: 15px;
+	margin: 0;
+}
+
+input {
+	max-width: 300px;
+}
+
+input,
+select,
+textarea {
+	background: inherit;
+	border: 1px solid $light-gray-500;
+	border-radius: 4px;
+	box-shadow: none;
+	color: $dark-gray-800;
+	display: inline-block;
+	font-family: inherit;
+	font-size: 13px;
+	line-height: 24px;
+	outline: none;
+	padding: 4px;
+}
+
+input:hover,
+select:hover,
+textarea:hover {
+	border: 1px solid $light-gray-700;
+}
+
+.postbox .handlediv {
+	height: 44px;
+	width: 44px;
+}

--- a/editor/meta-boxes/panel.js
+++ b/editor/meta-boxes/panel.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { Button, Dashicon, Panel } from '@wordpress/components';
+
+class MetaBoxPanel extends Component {
+	constructor( props ) {
+		super( ...arguments );
+		this.state = {
+			opened: props.initialOpen === undefined ? true : props.initialOpen,
+		};
+		this.toggle = this.toggle.bind( this );
+	}
+
+	toggle( event ) {
+		event.preventDefault();
+		if ( this.props.opened === undefined ) {
+			this.setState( ( state ) => ( {
+				opened: ! state.opened,
+			} ) );
+		}
+
+		if ( this.props.onToggle ) {
+			this.props.onToggle();
+		}
+	}
+
+	render() {
+		const { title, children, opened } = this.props;
+		const isOpened = opened === undefined ? this.state.opened : opened;
+		const icon = `arrow-${ isOpened ? 'down' : 'right' }`;
+		const className = classnames( 'components-panel__body', { 'is-opened': isOpened } );
+
+		return (
+			<Panel className="editor-meta-boxes">
+				<div className={ className }>
+					{ !! title && (
+						<h3 className="components-panel__body-title">
+							<Button
+								className="components-panel__body-toggle"
+								onClick={ this.toggle }
+								aria-expanded={ isOpened }
+							>
+								<Dashicon icon={ icon } />
+								{ title }
+							</Button>
+						</h3>
+					) }
+					{ children }
+				</div>
+			</Panel>
+		);
+	}
+}
+
+export default MetaBoxPanel;

--- a/editor/meta-boxes/style.scss
+++ b/editor/meta-boxes/style.scss
@@ -1,3 +1,7 @@
+/**
+ * These are the styles that are not loaded from within the iframe.
+ */
+
 .editor-meta-boxes {
 	border-right-width: 0;
 	border-left-width: 0;
@@ -6,27 +10,61 @@
 		background-color: $light-gray-300;
 	}
 
+	.components-panel__body {
+		padding: 0;
+
+		.components-panel__body-title {
+			margin: 0;
+
+			.components-panel__body-toggle {
+				z-index: 1;
+			}
+		}
+	}
+
 	.components-panel__body.is-opened .components-panel__body-toggle {
 		border-bottom: 1px solid $light-gray-500;
 	}
 }
 
-.editor-meta-boxes__coming-soon {
-	width: 300px;
-	padding: #{ $panel-padding * 2 } 0 $panel-padding;
-	margin: 0 auto;
-	text-align: center;
+.editor-meta-boxes__iframe {
+	width: 100%;
+	position: relative;
 
-	&,
-	h3 {
-		color: $dark-gray-200;
+	&.is-closed {
+		display: none;
 	}
 
-	h3 {
-		margin: 0.6em 0;
+	.editor-meta-boxes__loading-overlay {
+		background-color: rgba( 0, 0, 0, 0.6 );
+		display: none;
+		position: absolute;
+		height: 100%;
+		top: 0;
+		left: 0;
+		width: 100%;
+		z-index: 1;
+
+		&.is-visible {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+		}
+
+		.loading-overlay__text {
+			color: $white;
+			font-weight: 700;
+		}
 	}
 
-	p {
-		margin-bottom: 0;
+	.is-updating {
+		filter: blur( 5px );
+	}
+
+	.is-hidden {
+		visibility: hidden;
+		position: absolute;
+		top: 0;
+		left: 0;
 	}
 }

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -562,6 +562,63 @@ export function notices( state = {}, action ) {
 	return state;
 }
 
+const locations = [
+	'advanced',
+	'normal',
+	'side',
+];
+
+const defaultMetaBoxState = locations.reduce( ( result, key ) => {
+	result[ key ] = {
+		isActive: false,
+		isDirty: false,
+		isUpdating: false,
+	};
+
+	return result;
+}, {} );
+
+export function metaBoxes( state = defaultMetaBoxState, action ) {
+	switch ( action.type ) {
+		case 'INITIALIZE_META_BOX_STATE':
+			return locations.reduce( ( newState, location ) => {
+				newState[ location ] = {
+					...state[ location ],
+					isActive: action.metaBoxes[ location ],
+				};
+				return newState;
+			}, { ...state } );
+		case 'HANDLE_META_BOX_RELOAD':
+			return {
+				...state,
+				[ action.location ]: {
+					...state[ action.location ],
+					isUpdating: false,
+					isDirty: false,
+				},
+			};
+		case 'REQUEST_META_BOX_UPDATES':
+			return action.locations.reduce( ( newState, location ) => {
+				newState[ location ] = {
+					...state[ location ],
+					isUpdating: true,
+					isDirty: false,
+				};
+				return newState;
+			}, { ...state } );
+		case 'META_BOX_STATE_CHANGED':
+			return {
+				...state,
+				[ action.location ]: {
+					...state[ action.location ],
+					isDirty: action.hasChanged,
+				},
+			};
+		default:
+			return state;
+	}
+}
+
 export default optimist( combineReducers( {
 	editor,
 	currentPost,
@@ -574,4 +631,5 @@ export default optimist( combineReducers( {
 	panel,
 	saving,
 	notices,
+	metaBoxes,
 } ) );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -40,6 +40,55 @@ export function getEditorMode( state ) {
 }
 
 /**
+ * Returns the state of legacy meta boxes.
+ *
+ * @param  {Object}  state Global application state
+ * @return {Object}        State of meta boxes
+ */
+export function getMetaBoxes( state ) {
+	return state.metaBoxes;
+}
+
+/**
+ * Returns the state of legacy meta boxes.
+ *
+ * @param  {Object} state    Global application state
+ * @param  {String} location Location of the meta box.
+ * @return {Object}          State of meta box at specified location.
+ */
+export function getMetaBox( state, location ) {
+	return getMetaBoxes( state )[ location ];
+}
+
+/**
+ * Returns a list of dirty meta box locations.
+ *
+ * @param  {Object} state Global application state
+ * @return {Array}        Array of locations for dirty meta boxes.
+ */
+export const getDirtyMetaBoxes = createSelector(
+	( state ) => {
+		return reduce( getMetaBoxes( state ), ( result, metaBox, location ) => {
+			return metaBox.isDirty && metaBox.isActive
+				? [ ...result, location ]
+				: result;
+		}, [] );
+	},
+	( state ) => state.metaBoxes,
+);
+
+/**
+ * Returns the dirty state of legacy meta boxes.
+ *
+ * Checks whether the entire meta box state is dirty. So if a sidebar is dirty,
+ * but a normal area is not dirty, this will overall return dirty.
+ *
+ * @param  {Object}  state Global application state
+ * @return {Boolean}       Whether state is dirty. True if dirty, false if not.
+ */
+export const isMetaBoxStateDirty = ( state ) => getDirtyMetaBoxes( state ).length > 0;
+
+/**
  * Returns the current active panel for the sidebar.
  *
  * @param  {Object}  state Global application state
@@ -145,6 +194,10 @@ export const isEditedPostDirty = createSelector(
 			return true;
 		}
 
+		if ( isMetaBoxStateDirty( state ) ) {
+			return true;
+		}
+
 		// This is a cheaper operation that still must occur after checking
 		// attributes, because a post initialized with attributes different
 		// from its saved copy should be considered dirty.
@@ -169,6 +222,7 @@ export const isEditedPostDirty = createSelector(
 	( state ) => [
 		state.editor,
 		state.currentPost,
+		state.metaBoxes,
 	]
 );
 

--- a/editor/sidebar/index.js
+++ b/editor/sidebar/index.js
@@ -16,13 +16,14 @@ import './style.scss';
 import PostSettings from './post-settings';
 import BlockInspector from './block-inspector';
 import Header from './header';
+
 import { getActivePanel } from '../selectors';
 
 const Sidebar = ( { panel } ) => {
 	return (
 		<div className="editor-sidebar" role="region" aria-label={ __( 'Editor settings' ) }>
 			<Header />
-			{ panel === 'document' && <PostSettings /> }
+			{ panel === 'document' && <PostSettings key="settings" /> }
 			{ panel === 'block' && <BlockInspector /> }
 		</div>
 	);

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -15,6 +15,7 @@ import DiscussionPanel from '../discussion-panel';
 import LastRevision from '../last-revision';
 import PageAttributes from '../page-attributes';
 import DocumentOutlinePanel from '../document-outline-panel';
+import MetaBoxes from '../../meta-boxes';
 
 const panel = (
 	<Panel>
@@ -26,6 +27,7 @@ const panel = (
 		<DiscussionPanel />
 		<PageAttributes />
 		<DocumentOutlinePanel />
+		<MetaBoxes location="side" />
 	</Panel>
 );
 

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -6,6 +6,10 @@ import {
 	replaceBlocks,
 	startTyping,
 	stopTyping,
+	requestMetaBoxUpdates,
+	handleMetaBoxReload,
+	metaBoxStateChanged,
+	initializeMetaBoxState,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -49,6 +53,49 @@ describe( 'actions', () => {
 		it( 'should return the STOP_TYPING action', () => {
 			expect( stopTyping() ).toEqual( {
 				type: 'STOP_TYPING',
+			} );
+		} );
+	} );
+
+	describe( 'requestMetaBoxUpdates', () => {
+		it( 'should return the REQUEST_META_BOX_UPDATES action', () => {
+			expect( requestMetaBoxUpdates( [ 'normal' ] ) ).toEqual( {
+				type: 'REQUEST_META_BOX_UPDATES',
+				locations: [ 'normal' ],
+			} );
+		} );
+	} );
+
+	describe( 'handleMetaBoxReload', () => {
+		it( 'should return the HANDLE_META_BOX_RELOAD action with a location and node', () => {
+			expect( handleMetaBoxReload( 'normal' ) ).toEqual( {
+				type: 'HANDLE_META_BOX_RELOAD',
+				location: 'normal',
+			} );
+		} );
+	} );
+
+	describe( 'metaBoxStateChanged', () => {
+		it( 'should return the META_BOX_STATE_CHANGED action with a hasChanged flag', () => {
+			expect( metaBoxStateChanged( 'normal', true ) ).toEqual( {
+				type: 'META_BOX_STATE_CHANGED',
+				location: 'normal',
+				hasChanged: true,
+			} );
+		} );
+	} );
+
+	describe( 'initializeMetaBoxState', () => {
+		it( 'should return the META_BOX_STATE_CHANGED action with a hasChanged flag', () => {
+			const metaBoxes = {
+				side: true,
+				normal: true,
+				advanced: false,
+			};
+
+			expect( initializeMetaBoxState( metaBoxes ) ).toEqual( {
+				type: 'INITIALIZE_META_BOX_STATE',
+				metaBoxes,
 			} );
 		} );
 	} );

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -19,6 +19,7 @@ import {
 	replaceBlocks,
 	editPost,
 	savePost,
+	requestMetaBoxUpdates,
 } from '../actions';
 import effects from '../effects';
 import * as selectors from '../selectors';
@@ -246,6 +247,32 @@ describe( 'effects', () => {
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
 			expect( dispatch ).toHaveBeenCalledWith( savePost() );
+		} );
+	} );
+
+	describe( '.REQUEST_POST_UPDATE_SUCCESS', () => {
+		const handler = effects.REQUEST_POST_UPDATE_SUCCESS;
+		const dispatch = jest.fn();
+		const store = { getState: () => {}, dispatch };
+
+		it( 'should dispatch meta box updates on success for dirty meta boxes.', () => {
+			selectors.getDirtyMetaBoxes.mockReturnValue( [ 'normal', 'side' ] );
+
+			const post = {
+				id: 1,
+				title: {
+					raw: 'A History of Pork',
+				},
+				content: {
+					raw: '',
+				},
+				status: 'draft',
+			};
+
+			handler( { post: post, previousPost: post }, store );
+
+			expect( dispatch ).toHaveBeenCalledTimes( 1 );
+			expect( dispatch ).toHaveBeenCalledWith( requestMetaBoxUpdates( [ 'normal', 'side' ] ) );
 		} );
 	} );
 

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -24,6 +24,7 @@ import {
 	notices,
 	blocksMode,
 	blockInsertionPoint,
+	metaBoxes,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -1086,6 +1087,112 @@ describe( 'state', () => {
 			const value = blocksMode( deepFreeze( { chicken: 'html' } ), action );
 
 			expect( value ).toEqual( { chicken: 'visual' } );
+		} );
+	} );
+
+	describe( 'metaBoxes()', () => {
+		it( 'should return default state', () => {
+			const actual = metaBoxes( undefined, {} );
+			const expected = {
+				advanced: {
+					isActive: false,
+					isDirty: false,
+					isUpdating: false,
+				},
+				normal: {
+					isActive: false,
+					isDirty: false,
+					isUpdating: false,
+				},
+				side: {
+					isActive: false,
+					isDirty: false,
+					isUpdating: false,
+				},
+			};
+
+			expect( actual ).toEqual( expected );
+		} );
+		it( 'should set the sidebar to active', () => {
+			const theMetaBoxes = {
+				normal: false,
+				advanced: false,
+				side: true,
+			};
+
+			const action = {
+				type: 'INITIALIZE_META_BOX_STATE',
+				metaBoxes: theMetaBoxes,
+			};
+
+			const actual = metaBoxes( undefined, action );
+			const expected = {
+				advanced: {
+					isActive: false,
+					isDirty: false,
+					isUpdating: false,
+				},
+				normal: {
+					isActive: false,
+					isDirty: false,
+					isUpdating: false,
+				},
+				side: {
+					isActive: true,
+					isDirty: false,
+					isUpdating: false,
+				},
+			};
+
+			expect( actual ).toEqual( expected );
+		} );
+		it( 'should switch updating to off', () => {
+			const action = {
+				type: 'HANDLE_META_BOX_RELOAD',
+				location: 'normal',
+			};
+
+			const theMetaBoxes = metaBoxes( { normal: { isUpdating: true, isActive: false, isDirty: true } }, action );
+			const actual = theMetaBoxes.normal;
+			const expected = {
+				isActive: false,
+				isUpdating: false,
+				isDirty: false,
+			};
+
+			expect( actual ).toEqual( expected );
+		} );
+		it( 'should switch updating to on', () => {
+			const action = {
+				type: 'REQUEST_META_BOX_UPDATES',
+				locations: [ 'normal' ],
+			};
+
+			const theMetaBoxes = metaBoxes( undefined, action );
+			const actual = theMetaBoxes.normal;
+			const expected = {
+				isActive: false,
+				isUpdating: true,
+				isDirty: false,
+			};
+
+			expect( actual ).toEqual( expected );
+		} );
+		it( 'should return with the isDirty flag as true', () => {
+			const action = {
+				type: 'META_BOX_STATE_CHANGED',
+				location: 'normal',
+				hasChanged: true,
+			};
+			const theMetaBoxes = metaBoxes( undefined, action );
+			const actual = theMetaBoxes.normal;
+			const expected = {
+				isActive: false,
+				isDirty: true,
+				isUpdating: false,
+			};
+
+			expect( actual ).toEqual( expected );
 		} );
 	} );
 } );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -66,6 +66,10 @@ import {
 	getNotices,
 	getMostFrequentlyUsedBlocks,
 	getRecentlyUsedBlocks,
+	getMetaBoxes,
+	getDirtyMetaBoxes,
+	getMetaBox,
+	isMetaBoxStateDirty,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -88,6 +92,7 @@ describe( 'selectors', () => {
 	} );
 
 	beforeEach( () => {
+		getDirtyMetaBoxes.clear();
 		isEditedPostDirty.clear();
 		getBlock.clear();
 		getBlocks.clear();
@@ -113,6 +118,177 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditorMode( state ) ).toEqual( 'visual' );
+		} );
+	} );
+
+	describe( 'getDirtyMetaBoxes', () => {
+		it( 'should return array of just the side location', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: false,
+						isDirty: false,
+						isUpdating: false,
+					},
+					side: {
+						isActive: true,
+						isDirty: true,
+						isUpdating: false,
+					},
+				},
+			};
+
+			expect( getDirtyMetaBoxes( state ) ).toEqual( [ 'side' ] );
+		} );
+	} );
+
+	describe( 'getMetaBoxes', () => {
+		it( 'should return the state of all meta boxes', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isDirty: false,
+						isUpdating: false,
+					},
+					side: {
+						isDirty: false,
+						isUpdating: false,
+					},
+				},
+			};
+
+			expect( getMetaBoxes( state ) ).toEqual( {
+				normal: {
+					isDirty: false,
+					isUpdating: false,
+				},
+				side: {
+					isDirty: false,
+					isUpdating: false,
+				},
+			} );
+		} );
+	} );
+
+	describe( 'getMetaBox', () => {
+		it( 'should return the state of selected meta box', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: false,
+						isDirty: false,
+						isUpdating: false,
+					},
+					side: {
+						isActive: true,
+						isDirty: false,
+						isUpdating: false,
+					},
+				},
+			};
+
+			expect( getMetaBox( state, 'side' ) ).toEqual( {
+				isActive: true,
+				isDirty: false,
+				isUpdating: false,
+			} );
+		} );
+	} );
+
+	describe( 'isMetaBoxStateDirty', () => {
+		it( 'should return false', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: false,
+						isDirty: false,
+						isUpdating: false,
+					},
+					side: {
+						isActive: false,
+						isDirty: false,
+						isUpdating: false,
+					},
+				},
+			};
+
+			expect( isMetaBoxStateDirty( state ) ).toEqual( false );
+		} );
+
+		it( 'should return false when a dirty meta box is not active.', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: false,
+						isDirty: true,
+						isUpdating: false,
+					},
+					side: {
+						isActive: false,
+						isDirty: false,
+						isUpdating: false,
+					},
+				},
+			};
+
+			expect( isMetaBoxStateDirty( state ) ).toEqual( false );
+		} );
+
+		it( 'should return false when both meta boxes are dirty but inactive.', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: false,
+						isDirty: true,
+						isUpdating: false,
+					},
+					side: {
+						isActive: false,
+						isDirty: true,
+						isUpdating: false,
+					},
+				},
+			};
+
+			expect( isMetaBoxStateDirty( state ) ).toEqual( false );
+		} );
+
+		it( 'should return false when a dirty meta box is active.', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: true,
+						isDirty: true,
+						isUpdating: false,
+					},
+					side: {
+						isActive: false,
+						isDirty: false,
+						isUpdating: false,
+					},
+				},
+			};
+
+			expect( isMetaBoxStateDirty( state ) ).toEqual( true );
+		} );
+
+		it( 'should return false when both meta boxes are dirty and active.', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: true,
+						isDirty: true,
+						isUpdating: false,
+					},
+					side: {
+						isActive: true,
+						isDirty: true,
+						isUpdating: false,
+					},
+				},
+			};
+
+			expect( isMetaBoxStateDirty( state ) ).toEqual( true );
 		} );
 	} );
 
@@ -271,6 +447,32 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditedPostDirty', () => {
+		const metaBoxes = {
+			normal: {
+				isActive: false,
+				isDirty: false,
+				isUpdating: false,
+			},
+			side: {
+				isActive: false,
+				isDirty: false,
+				isUpdating: false,
+			},
+		};
+		// Those dirty dang meta boxes.
+		const dirtyMetaBoxes = {
+			normal: {
+				isActive: true,
+				isDirty: true,
+				isUpdating: false,
+			},
+			side: {
+				isActive: false,
+				isDirty: false,
+				isUpdating: false,
+			},
+		};
+
 		it( 'should return true when the post has edited attributes', () => {
 			const state = {
 				currentPost: {
@@ -285,6 +487,7 @@ describe( 'selectors', () => {
 						blockOrder: [],
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( true );
@@ -304,6 +507,7 @@ describe( 'selectors', () => {
 						blockOrder: [],
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( false );
@@ -344,6 +548,7 @@ describe( 'selectors', () => {
 						blockOrder: [],
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( false );
@@ -382,6 +587,7 @@ describe( 'selectors', () => {
 						],
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( true );
@@ -426,6 +632,7 @@ describe( 'selectors', () => {
 						],
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( true );
@@ -474,6 +681,7 @@ describe( 'selectors', () => {
 						],
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( true );
@@ -522,13 +730,65 @@ describe( 'selectors', () => {
 						],
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( false );
 		} );
+
+		it( 'should return true when no edits, no changed block attributes, no changed order, but meta box state has changed.', () => {
+			const state = {
+				currentPost: {
+					title: 'The Meat Eater\'s Guide to Delicious Meats',
+				},
+				editor: getEditorState( [
+					{
+						edits: {},
+						blocksByUid: {
+							123: {
+								name: 'core/food',
+								attributes: { name: 'Chicken', delicious: true },
+							},
+							456: {
+								name: 'core/food',
+								attributes: { name: 'Ribs', delicious: true },
+							},
+						},
+						blockOrder: [
+							456,
+							123,
+						],
+					},
+					{
+						edits: {
+							title: 'The Meat Eater\'s Guide to Delicious Meats',
+						},
+						blocksByUid: {
+							123: {
+								name: 'core/food',
+								attributes: { name: 'Chicken', delicious: true },
+							},
+							456: {
+								name: 'core/food',
+								attributes: { name: 'Ribs', delicious: true },
+							},
+						},
+						blockOrder: [
+							456,
+							123,
+						],
+					},
+				] ),
+				metaBoxes: dirtyMetaBoxes,
+			};
+
+			expect( isEditedPostDirty( state ) ).toBe( true );
+		} );
 	} );
 
 	describe( 'isCleanNewPost', () => {
+		const metaBoxes = { isDirty: false, isUpdating: false };
+
 		it( 'should return true when the post is not dirty and has not been saved before', () => {
 			const state = {
 				editor: getEditorState( [
@@ -540,6 +800,7 @@ describe( 'selectors', () => {
 					id: 1,
 					status: 'auto-draft',
 				},
+				metaBoxes,
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( true );
@@ -556,6 +817,7 @@ describe( 'selectors', () => {
 					id: 1,
 					status: 'draft',
 				},
+				metaBoxes,
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( false );
@@ -575,6 +837,7 @@ describe( 'selectors', () => {
 					id: 1,
 					status: 'auto-draft',
 				},
+				metaBoxes,
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( false );
@@ -662,6 +925,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getDocumentTitle', () => {
+		const metaBoxes = { isDirty: false, isUpdating: false };
 		it( 'should return current title unedited existing post', () => {
 			const state = {
 				currentPost: {
@@ -673,6 +937,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( 'The Title' );
@@ -692,6 +957,7 @@ describe( 'selectors', () => {
 						edits: { title: 'Modified Title' },
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( 'Modified Title' );
@@ -709,6 +975,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( __( 'New post' ) );
@@ -726,6 +993,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( getDocumentTitle( state ) ).toBe( __( '(Untitled)' ) );
@@ -863,6 +1131,8 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditedPostPublishable', () => {
+		const metaBoxes = { isDirty: false, isUpdating: false };
+
 		it( 'should return true for pending posts', () => {
 			const state = {
 				currentPost: {
@@ -873,6 +1143,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( true );
@@ -888,6 +1159,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( true );
@@ -903,6 +1175,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( false );
@@ -918,6 +1191,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( false );
@@ -933,6 +1207,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( false );
@@ -951,6 +1226,7 @@ describe( 'selectors', () => {
 						edits: { title: 'Dirty' },
 					},
 				] ),
+				metaBoxes,
 			};
 
 			expect( isEditedPostPublishable( state ) ).toBe( true );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -753,6 +753,15 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	wp_localize_script( 'wp-blocks', '_wpBlocksAttributes', $schemas );
 
+	// Get admin url for handling meta boxes.
+	$meta_box_url = admin_url( 'post.php' );
+	$meta_box_url = add_query_arg( array(
+		'post'           => $post_to_edit['id'],
+		'action'         => 'edit',
+		'classic-editor' => true,
+	), $meta_box_url );
+	wp_localize_script( 'wp-editor', '_wpMetaBoxUrl', $meta_box_url );
+
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
 	$color_palette           = gutenberg_color_palette();
@@ -767,7 +776,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	);
 
 	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() {'
-		. 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
+		. 'window._wpGutenbergEditor = wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
 		. '} );'
 	);
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+require dirname( __FILE__ ) . '/meta-box-partial-page.php';
 require dirname( __FILE__ ) . '/class-wp-block-type.php';
 require dirname( __FILE__ ) . '/class-wp-block-type-registry.php';
 require dirname( __FILE__ ) . '/class-wp-rest-reusable-blocks-controller.php';

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Renders a partial page of meta boxes.
- * 
+ *
  * @since 1.5.0
  *
  * @param string $post_type Current post type.
@@ -136,7 +136,7 @@ add_action( 'do_meta_boxes', 'gutenberg_meta_box_partial_page', 1000, 2 );
  * The partial page needs to imitate aspects of admin-header.php.
  *
  * See wp-admin/admin-header.php at around line 70.
- * 
+ *
  * @since 1.5.0
  *
  * @param string    $hook_suffix    Page hook suffix.
@@ -332,7 +332,7 @@ function gutenberg_meta_box_partial_page_admin_header( $hook_suffix, $current_sc
  * This matches the portion of creating a form found in edit-form-advanced.php.
  *
  * Code starts roughly around line 500.
- * 
+ *
  * @since 1.5.0
  *
  * @param WP_Post $post     Current post object.
@@ -424,7 +424,7 @@ function gutenberg_meta_box_partial_page_post_form( $post, $location ) {
 
 /**
  * This matches the portion of creating a form found in edit-form-advanced.php.
- * 
+ *
  * @since 1.5.0
  *
  * @param string $hook_suffix The hook suffix of the current page.
@@ -495,7 +495,7 @@ function gutenberg_meta_box_partial_page_admin_footer( $hook_suffix ) {
 /**
  * Allows the meta box endpoint to correctly redirect to the meta box endpoint
  * when a post is saved.
- * 
+ *
  * @since 1.5.0
  *
  * @param string $location The location of the meta box, 'side', 'normal'.
@@ -526,7 +526,7 @@ add_filter( 'redirect_post_location', 'gutenberg_meta_box_save_redirect', 10, 2 
 
 /**
  * Filter out core meta boxes as well as the post thumbnail.
- * 
+ *
  * @since 1.5.0
  *
  * @param array $meta_boxes Meta box data.
@@ -580,7 +580,7 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 
 /**
  * Check whether a meta box is empty.
- * 
+ *
  * @since 1.5.0
  *
  * @param array  $meta_boxes Meta box data.

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Renders a partial page of meta boxes.
+ * 
+ * @since 1.5.0
  *
  * @param string $post_type Current post type.
  * @param string $meta_box_context  The context location of the meta box. Referred to as context in core.
@@ -134,6 +136,8 @@ add_action( 'do_meta_boxes', 'gutenberg_meta_box_partial_page', 1000, 2 );
  * The partial page needs to imitate aspects of admin-header.php.
  *
  * See wp-admin/admin-header.php at around line 70.
+ * 
+ * @since 1.5.0
  *
  * @param string    $hook_suffix    Page hook suffix.
  * @param WP_Screen $current_screen Current screen object.
@@ -328,6 +332,8 @@ function gutenberg_meta_box_partial_page_admin_header( $hook_suffix, $current_sc
  * This matches the portion of creating a form found in edit-form-advanced.php.
  *
  * Code starts roughly around line 500.
+ * 
+ * @since 1.5.0
  *
  * @param WP_Post $post     Current post object.
  * @param string  $location Metabox location: one of 'normal', 'advanced', 'side'.
@@ -418,6 +424,8 @@ function gutenberg_meta_box_partial_page_post_form( $post, $location ) {
 
 /**
  * This matches the portion of creating a form found in edit-form-advanced.php.
+ * 
+ * @since 1.5.0
  *
  * @param string $hook_suffix The hook suffix of the current page.
  */
@@ -487,6 +495,8 @@ function gutenberg_meta_box_partial_page_admin_footer( $hook_suffix ) {
 /**
  * Allows the meta box endpoint to correctly redirect to the meta box endpoint
  * when a post is saved.
+ * 
+ * @since 1.5.0
  *
  * @param string $location The location of the meta box, 'side', 'normal'.
  * @param int    $post_id  Post ID.
@@ -516,6 +526,8 @@ add_filter( 'redirect_post_location', 'gutenberg_meta_box_save_redirect', 10, 2 
 
 /**
  * Filter out core meta boxes as well as the post thumbnail.
+ * 
+ * @since 1.5.0
  *
  * @param array $meta_boxes Meta box data.
  */
@@ -568,6 +580,8 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 
 /**
  * Check whether a meta box is empty.
+ * 
+ * @since 1.5.0
  *
  * @param array  $meta_boxes Meta box data.
  * @param string $context    Location of meta box, one of side, advanced, normal.

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -1,0 +1,593 @@
+<?php
+/**
+ * Initialization and wp-admin integration for the Gutenberg editor plugin.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Renders a partial page of meta boxes.
+ *
+ * @param string $post_type Current post type.
+ * @param string $meta_box_context  The context location of the meta box. Referred to as context in core.
+ */
+function gutenberg_meta_box_partial_page( $post_type, $meta_box_context ) {
+	/**
+	 * Needs classic editor to be active.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/commit/bdf94e65ac0c10b3ce5d8e214f0c9e1081997d9b
+	 */
+	if ( ! isset( $_REQUEST['classic-editor'] ) ) {
+		return;
+	}
+
+	/**
+	 * The meta_box param as long as it is set on the wp-admin/post.php request
+	 * will trigger this partial page.
+	 *
+	 * Essentially all that happens is we try to load in the scripts from admin_head
+	 * and admin_footer to mimic the assets for a typical post.php.
+	 *
+	 * @in_the_future Hopefully the meta box param can be changed to a location,
+	 * or contenxt, so that we can use this API to render meta boxes that appear,
+	 * in the sidebar vs. regular content, or core meta boxes vs others. For now
+	 * a request like http://local.wordpress.dev/wp-admin/post.php?post=40007&action=edit&meta_box=taco
+	 * works just fine!
+	 */
+	if ( ! isset( $_REQUEST['meta_box'] ) || 'post.php' !== $GLOBALS['pagenow'] ) {
+		return;
+	}
+
+	/**
+	 * Prevent over firing of the meta box rendering.
+	 *
+	 * The hook do_action( 'do_meta_boxes', ... ) fires three times in
+	 * edit-form-advanced.php
+	 *
+	 * To make sure we properly fire on all three meta box locations, except
+	 * advanced, as advanced is tied in with normal for ease of use reasons, we
+	 * need to verify that the action location/context matches our requests
+	 * meta box location/context. We then exit early if they do not match.
+	 * This will prevent execution thread from dieing, so the subsequent calls
+	 * to do_meta_boxes can fire.
+	 */
+	if ( $_REQUEST['meta_box'] !== $meta_box_context ) {
+		return;
+	}
+
+	$location = $_REQUEST['meta_box'];
+
+	if ( ! in_array( $_REQUEST['meta_box'], array( 'side', 'normal', 'advanced' ) ) ) {
+		wp_die( __( 'The `meta_box` parameter should be one of "side", "normal", or "advanced".', 'gutenberg' ) );
+	}
+
+	global $post, $wp_meta_boxes, $hook_suffix, $current_screen, $wp_locale;
+
+	gutenberg_meta_box_partial_page_admin_header( $hook_suffix, $current_screen, $wp_locale );
+
+	gutenberg_meta_box_partial_page_post_form( $post, $location );
+
+	// Handle meta box state.
+	$_original_meta_boxes = $wp_meta_boxes;
+
+	/**
+	 * Fires right before the meta boxes are rendered.
+	 *
+	 * This allows for the filtering of meta box data, that should already be
+	 * present by this point. Do not use as a means of adding meta box data.
+	 *
+	 * By default gutenberg_filter_meta_boxes() is hooked in and can be
+	 * unhooked to restore core meta boxes.
+	 *
+	 * @param array $wp_meta_boxes Global meta box state.
+	 */
+	$wp_meta_boxes = apply_filters( 'filter_gutenberg_meta_boxes', $wp_meta_boxes );
+
+	// Exit early if the meta box is empty. Send out a post message to tell React to not render meta boxes.
+	if ( gutenberg_is_meta_box_empty( $wp_meta_boxes, $_REQUEST['meta_box'], $post->post_type ) ) {
+		exit();
+	}
+
+	$locations = array();
+
+	// Lump normal and advanced in together for now. Advanced usually appears after title.
+	if ( 'normal' === $_REQUEST['meta_box'] || 'advanced' === $_REQUEST['meta_box'] ) {
+		$locations = array( 'advanced', 'normal' );
+	}
+
+	if ( 'side' === $_REQUEST['meta_box'] ) {
+		$locations = array( 'side' );
+	}
+
+	// Render meta boxes.
+	if ( ! empty( $locations ) ) {
+		foreach ( $locations as $location ) {
+			do_meta_boxes(
+				$current_screen,
+				$location,
+				$post
+			);
+		}
+	}
+
+	// Reset meta box data.
+	$wp_meta_boxes = $_original_meta_boxes;
+
+	gutenberg_meta_box_partial_page_admin_footer( $hook_suffix );
+
+	/**
+	 * Shutdown hooks potentially firing.
+	 *
+	 * Try Query Monitor plugin to make sure the output isn't janky.
+	 */
+	remove_all_actions( 'shutdown' );
+	exit();
+}
+
+add_action( 'do_meta_boxes', 'gutenberg_meta_box_partial_page', 1000, 2 );
+
+/**
+ * The partial page needs to imitate aspects of admin-header.php.
+ *
+ * See wp-admin/admin-header.php at around line 70.
+ *
+ * @param string    $hook_suffix    Page hook suffix.
+ * @param WP_Screen $current_screen Current screen object.
+ * @param WP_Locale $wp_locale      Locale object.
+ */
+function gutenberg_meta_box_partial_page_admin_header( $hook_suffix, $current_screen, $wp_locale ) {
+	/* Scripts and styles that meta boxes can potentially be using */
+	wp_enqueue_style( 'common' );
+	wp_enqueue_style( 'buttons' );
+	wp_enqueue_style( 'colors' );
+	wp_enqueue_style( 'ie' );
+
+	wp_enqueue_script( 'utils' );
+	wp_enqueue_script( 'common' );
+	wp_enqueue_script( 'svg-painter' );
+
+	// These assets are Gutenberg specific.
+	wp_enqueue_style(
+		'meta-box-gutenberg',
+		gutenberg_url( 'editor/build/meta-box-iframe.css' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'editor/build/meta-box-iframe.css' )
+	);
+
+	wp_enqueue_script(
+		'meta-box-resize',
+		gutenberg_url( 'assets/js/meta-box-resize.js' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'assets/js/meta-box-resize.js' ),
+		true
+	);
+
+	// Grab the admin body class.
+	$admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );
+
+	?>
+	<!-- Add an html class so that scroll bars can be removed in css and make it appear as though the iframe is one with Gutenberg. -->
+	<html class="gutenberg-meta-box-html">
+	<head>
+	<!-- Add in JavaScript variables that some meta box plugins make use of. -->
+	<script type="text/javascript">
+	addLoadEvent = function( func ){ if( typeof jQuery!="undefined" )jQuery( document ).ready( func );else if(typeof wpOnload!='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
+	var ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>',
+		pagenow = '<?php echo $current_screen->id; ?>',
+		typenow = '<?php echo $current_screen->post_type; ?>',
+		adminpage = '<?php echo $admin_body_class; ?>',
+		thousandsSeparator = '<?php echo addslashes( $wp_locale->number_format['thousands_sep'] ); ?>',
+		decimalPoint = '<?php echo addslashes( $wp_locale->number_format['decimal_point'] ); ?>',
+		isRtl = <?php echo (int) is_rtl(); ?>;
+	</script>
+	<meta name="viewport" content="width=device-width,initial-scale=1.0">
+	<?php
+
+	/**
+	 * Enqueue scripts for all admin pages.
+	 *
+	 * @since wp-core 2.8.0
+	 *
+	 * @param string $hook_suffix The current admin page.
+	 */
+	do_action( 'admin_enqueue_scripts', $hook_suffix );
+
+	/**
+	 * Fires when styles are printed for a specific admin page based on $hook_suffix.
+	 *
+	 * @since wp-core 2.6.0
+	 */
+	// @codingStandardsIgnoreStart
+	do_action( "admin_print_styles-{$hook_suffix}" );
+	// @codingStandardsIgnoreEnd
+
+	/**
+	 * Fires when styles are printed for all admin pages.
+	 *
+	 * @since wp-core 2.6.0
+	 */
+	do_action( 'admin_print_styles' );
+
+	/**
+	 * Fires when scripts are printed for a specific admin page based on $hook_suffix.
+	 *
+	 * @since wp-core 2.1.0
+	 */
+	// @codingStandardsIgnoreStart
+	do_action( "admin_print_scripts-{$hook_suffix}" );
+	// @codingStandardsIgnoreEnd
+
+	/**
+	 * Fires when scripts are printed for all admin pages.
+	 *
+	 * @since wp-core 2.1.0
+	 */
+	do_action( 'admin_print_scripts' );
+
+	/**
+	 * Fires in head section for a specific admin page.
+	 *
+	 * The dynamic portion of the hook, `$hook_suffix`, refers to the hook suffix
+	 * for the admin page.
+	 *
+	 * @since wp-core 2.1.0
+	 */
+	// @codingStandardsIgnoreStart
+	do_action( "admin_head-{$hook_suffix}" );
+	// @codingStandardsIgnoreEnd
+
+	/**
+	 * Fires in head section for all admin pages.
+	 *
+	 * @since wp-core 2.1.0
+	 */
+	do_action( 'admin_head' );
+
+	/**
+	 * The main way post.php sets body class.
+	 */
+	if ( get_user_setting( 'mfold' ) == 'f' ) {
+		$admin_body_class .= ' folded';
+	}
+
+	if ( ! get_user_setting( 'unfold' ) ) {
+		$admin_body_class .= ' auto-fold';
+	}
+
+	if ( is_admin_bar_showing() ) {
+		$admin_body_class .= ' admin-bar';
+	}
+
+	if ( is_rtl() ) {
+		$admin_body_class .= ' rtl';
+	}
+
+	if ( $current_screen->post_type ) {
+		$admin_body_class .= ' post-type-' . $current_screen->post_type;
+	}
+
+	if ( $current_screen->taxonomy ) {
+		$admin_body_class .= ' taxonomy-' . $current_screen->taxonomy;
+	}
+
+	$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', floatval( get_bloginfo( 'version' ) ) );
+	$admin_body_class .= ' version-' . str_replace( '.', '-', preg_replace( '/^([.0-9]+).*/', '$1', get_bloginfo( 'version' ) ) );
+	$admin_body_class .= ' admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'fresh' );
+	$admin_body_class .= ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );
+
+	if ( wp_is_mobile() ) {
+		$admin_body_class .= ' mobile';
+	}
+
+	if ( is_multisite() ) {
+		$admin_body_class .= ' multisite';
+	}
+
+	if ( is_network_admin() ) {
+		$admin_body_class .= ' network-admin';
+	}
+
+	$admin_body_class .= ' no-customize-support no-svg';
+
+	?>
+	</head>
+	<?php
+
+	/**
+	 * Filters the CSS classes for the body tag in the admin.
+	 *
+	 * This filter differs from the {@see 'post_class'} and {@see 'body_class'} filters
+	 * in two important ways:
+	 *
+	 * 1. `$classes` is a space-separated string of class names instead of an array.
+	 * 2. Not all core admin classes are filterable, notably: wp-admin, wp-core-ui,
+	 *    and no-js cannot be removed.
+	 *
+	 * @since wp-core 2.3.0
+	 *
+	 * @param string $classes Space-separated list of CSS classes.
+	 */
+	$admin_body_classes = apply_filters( 'admin_body_class', '' );
+
+	// This page should always match up with the edit action.
+	$action = 'edit';
+
+	?>
+	<body class="wp-admin wp-core-ui no-js <?php echo $admin_body_classes . ' ' . $admin_body_class; ?>">
+	<script type="text/javascript">
+		document.body.className = document.body.className.replace('no-js','js');
+	</script>
+	<?php
+}
+
+/**
+ * This matches the portion of creating a form found in edit-form-advanced.php.
+ *
+ * Code starts roughly around line 500.
+ *
+ * @param WP_Post $post     Current post object.
+ * @param string  $location Metabox location: one of 'normal', 'advanced', 'side'.
+ */
+function gutenberg_meta_box_partial_page_post_form( $post, $location ) {
+	$notice     = false;
+	$form_extra = '';
+	if ( 'auto-draft' === $post->post_status ) {
+		if ( 'edit' === $action ) {
+			$post->post_title = '';
+		}
+		$autosave    = false;
+		$form_extra .= "<input type='hidden' id='auto_draft' name='auto_draft' value='1' />";
+	} else {
+		$autosave = wp_get_post_autosave( $post->id );
+	}
+
+	$form_action  = 'editpost';
+	$nonce_action = 'update-post_' . $post->ID;
+	$form_extra  .= "<input type='hidden' id='post_ID' name='post_ID' value='" . esc_attr( $post->ID ) . "' />";
+	?>
+	<form name="post" action="post.php" method="post" id="post" data-location="<?php echo esc_attr( $location ); ?>"
+	<?php
+	/**
+	 * Fires inside the post editor form tag.
+	 *
+	 * @since wp-core 3.0.0
+	 *
+	 * @param WP_Post $post Post object.
+	 */
+	do_action( 'post_edit_form_tag', $post );
+
+	$referer = wp_get_referer();
+	?>
+	><!-- End of Post Form Tag. -->
+	<?php wp_nonce_field( $nonce_action ); ?>
+	<?php
+		$current_user = wp_get_current_user();
+		$user_id      = $current_user->ID;
+	?>
+	<input type="hidden" id="user-id" name="user_ID" value="<?php echo (int) $user_id; ?>" />
+	<input type="hidden" id="hiddenaction" name="action" value="<?php echo esc_attr( $form_action ); ?>" />
+	<input type="hidden" id="originalaction" name="originalaction" value="<?php echo esc_attr( $form_action ); ?>" />
+	<input type="hidden" id="post_author" name="post_author" value="<?php echo esc_attr( $post->post_author ); ?>" />
+	<input type="hidden" id="post_type" name="post_type" value="<?php echo esc_attr( $post->post_type ); ?>" />
+	<input type="hidden" id="original_post_status" name="original_post_status" value="<?php echo esc_attr( $post->post_status ); ?>" />
+	<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>" />
+	<!-- These fields are not part of the standard post form. Used to redirect back to this page on save. -->
+	<input type="hidden" name="gutenberg_meta_boxes" value="gutenberg_meta_boxes" />
+	<input type="hidden" name="gutenberg_meta_box_location" value="<?php echo esc_attr( $location ); ?>" />
+	<?php if ( ! empty( $active_post_lock ) ) : ?>
+	<input type="hidden" id="active_post_lock" value="<?php echo esc_attr( implode( ':', $active_post_lock ) ); ?>" />
+	<?php endif; ?>
+
+	<?php
+	if ( 'draft' !== get_post_status( $post ) ) {
+		wp_original_referer_field( true, 'previous' );
+	}
+
+	echo $form_extra;
+
+	wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce', false );
+	wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false );
+
+	// Permalink title nonce.
+	wp_nonce_field( 'samplepermalink', 'samplepermalinknonce', false );
+
+	/**
+	 * Fires at the beginning of the edit form.
+	 *
+	 * At this point, the required hidden fields and nonces have already been output.
+	 *
+	 * @since wp-core 3.7.0
+	 *
+	 * @param WP_Post $post Post object.
+	 */
+	do_action( 'edit_form_top', $post );
+
+	/**
+	 * The #poststuff id selector is import for styles and scripts.
+	 */
+	?>
+	<div id="poststuff" class="sidebar-open">
+		<div><!-- THIS IS SOMEHOW REALLY IMPORTANT FOR IFRAMES TO RESIZE CORRECTLY -->
+			<div id="postbox-container-2" class="postbox-container">
+	<?php
+}
+
+/**
+ * This matches the portion of creating a form found in edit-form-advanced.php.
+ *
+ * @param string $hook_suffix The hook suffix of the current page.
+ */
+function gutenberg_meta_box_partial_page_admin_footer( $hook_suffix ) {
+	?>
+	</div><!-- END of important resize div. -->
+	<?php
+
+	/**
+	 * Prints scripts or data before the default footer scripts.
+	 *
+	 * @since wp-core 1.2.0
+	 *
+	 * @param string $data The data to print.
+	 */
+	do_action( 'admin_footer', '' );
+
+	/**
+	 * Prints scripts and data queued for the footer.
+	 *
+	 * The dynamic portion of the hook name, `$hook_suffix`,
+	 * refers to the global hook suffix of the current page.
+	 *
+	 * @since wp-core 4.6.0
+	 */
+	// @codingStandardsIgnoreStart
+	do_action( "admin_print_footer_scripts-{$hook_suffix}" );
+	// @codingStandardsIgnoreEnd
+
+	/**
+	 * Prints any scripts and data queued for the footer.
+	 *
+	 * @since wp-core 2.8.0
+	 *
+	 * @note This seems to be where most styles etc are hooked into.
+	 */
+	do_action( 'admin_print_footer_scripts' );
+
+	/**
+	 * Prints scripts or data after the default footer scripts.
+	 *
+	 * The dynamic portion of the hook name, `$hook_suffix`,
+	 * refers to the global hook suffix of the current page.
+	 *
+	 * @since wp-core 2.8.0
+	 */
+	// @codingStandardsIgnoreStart
+	do_action( "admin_footer-{$hook_suffix}" );
+	// @codingStandardsIgnoreEnd
+
+	// get_site_option() won't exist when auto upgrading from <= 2.7.
+	if ( function_exists( 'get_site_option' ) ) {
+		if ( false === get_site_option( 'can_compress_scripts' ) ) {
+			compression_test();
+		}
+	}
+
+	?>
+		<div class="clear"></div></div><!-- wpwrap -->
+		<script type="text/javascript">if(typeof wpOnload=='function')wpOnload();</script>
+	</body>
+	</html>
+
+	<?php
+}
+
+/**
+ * Allows the meta box endpoint to correctly redirect to the meta box endpoint
+ * when a post is saved.
+ *
+ * @param string $location The location of the meta box, 'side', 'normal'.
+ * @param int    $post_id  Post ID.
+ *
+ * @hooked redirect_post_location priority 10
+ */
+function gutenberg_meta_box_save_redirect( $location, $post_id ) {
+	if ( isset( $_REQUEST['gutenberg_meta_boxes'] )
+			&& isset( $_REQUEST['gutenberg_meta_box_location'] )
+			&& 'gutenberg_meta_boxes' === $_REQUEST['gutenberg_meta_boxes'] ) {
+		$meta_box_location = $_REQUEST['gutenberg_meta_box_location'];
+		$location          = add_query_arg(
+			array(
+				'meta_box'       => $meta_box_location,
+				'action'         => 'edit',
+				'classic-editor' => true,
+				'post'           => $post_id,
+			),
+			admin_url( 'post.php' )
+		);
+	}
+
+	return $location;
+}
+
+add_filter( 'redirect_post_location', 'gutenberg_meta_box_save_redirect', 10, 2 );
+
+/**
+ * Filter out core meta boxes as well as the post thumbnail.
+ *
+ * @param array $meta_boxes Meta box data.
+ */
+function gutenberg_filter_meta_boxes( $meta_boxes ) {
+	$core_side_meta_boxes = array(
+		'submitdiv',
+		'formatdiv',
+		'categorydiv',
+		'tagsdiv-post_tag',
+		'postimagediv',
+	);
+
+	$core_normal_meta_boxes = array(
+		'revisionsdiv',
+		'postexcerpt',
+		'trackbacksdiv',
+		'postcustom',
+		'commentstatusdiv',
+		'commentsdiv',
+		'slugdiv',
+		'authordiv',
+	);
+
+	$taxonomy_callbacks_to_unset = array(
+		'post_tags_meta_box',
+		'post_categories_meta_box',
+	);
+
+	foreach ( $meta_boxes as $page => $contexts ) {
+		foreach ( $contexts as $context => $priorities ) {
+			foreach ( $priorities as $priority => $boxes ) {
+				foreach ( $boxes as $name => $data ) {
+					if ( 'normal' === $context && in_array( $name, $core_normal_meta_boxes ) ) {
+						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
+					}
+					if ( 'side' === $context && in_array( $name, $core_side_meta_boxes ) ) {
+						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
+					}
+					// Filter out any taxonomies as Gutenberg already provides JS alternative.
+					if ( isset( $data['callback'] ) && in_array( $data['callback'], $taxonomy_callbacks_to_unset ) ) {
+						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
+					}
+				}
+			}
+		}
+	}
+
+	return $meta_boxes;
+}
+
+/**
+ * Check whether a meta box is empty.
+ *
+ * @param array  $meta_boxes Meta box data.
+ * @param string $context    Location of meta box, one of side, advanced, normal.
+ * @param string $post_type  Post type to investigate.
+ * @return boolean Whether the meta box is empty.
+ */
+function gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type ) {
+	$page = $post_type;
+
+	if ( ! isset( $meta_boxes[ $page ][ $context ] ) ) {
+		return true;
+	}
+
+	foreach ( $meta_boxes[ $page ][ $context ] as $priority => $boxes ) {
+		if ( ! empty( $boxes ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+add_filter( 'filter_gutenberg_meta_boxes', 'gutenberg_filter_meta_boxes' );

--- a/lib/register.php
+++ b/lib/register.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Set up global variables so that plugins will add meta boxes as if we were
  * using the main editor.
- * 
+ *
  * @since 1.5.0
  */
 function gutenberg_trick_plugins_into_registering_meta_boxes() {
@@ -34,7 +34,7 @@ add_action(
  *
  * This is used to tell React and Redux whether the meta box location has
  * meta boxes.
- * 
+ *
  * @since 1.5.0
  */
 function gutenberg_collect_meta_box_data() {

--- a/lib/register.php
+++ b/lib/register.php
@@ -28,31 +28,6 @@ add_action(
 );
 
 /**
- * Imitates the global state of a post.
- */
-function gutenberg_set_post_state() {
-	exit();
-	global $current_screen, $wp_meta_boxes, $post, $typenow;
-
-	// Depending on whether we are creating a post or editing one this may need to be different.
-	$potential_hookname = 'post';
-
-	// Set original screen to return to.
-	$GLOBALS['_gutenberg_restore_globals_after_meta_boxes']['current_screen'] = $current_screen;
-
-	// Override screen as though we are on post.php.
-	WP_Screen::get( $potential_hookname )->set_current_screen();
-
-	// If we are working with an already predetermined post.
-	if ( isset( $_REQUEST['post'] ) ) {
-		$post    = get_post( absint( $_REQUEST['post'] ) );
-		$typenow = $post->post_type;
-	} else {
-		// Eventually add handling for creating new posts of different types in Gutenberg.
-	}
-}
-
-/**
  * Collect information about meta_boxes registered for the current post.
  *
  * This is used to tell React and Redux whether the meta box location has

--- a/lib/register.php
+++ b/lib/register.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Set up global variables so that plugins will add meta boxes as if we were
  * using the main editor.
+ * 
+ * @since 1.5.0
  */
 function gutenberg_trick_plugins_into_registering_meta_boxes() {
 	global $pagenow;
@@ -32,6 +34,8 @@ add_action(
  *
  * This is used to tell React and Redux whether the meta box location has
  * meta boxes.
+ * 
+ * @since 1.5.0
  */
 function gutenberg_collect_meta_box_data() {
 	global $_gutenberg_restore_globals_after_meta_boxes, $current_screen, $wp_meta_boxes, $post, $typenow;

--- a/lib/register.php
+++ b/lib/register.php
@@ -16,17 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function gutenberg_trick_plugins_into_registering_meta_boxes() {
 	global $pagenow;
 
-	if ( 'post.php' === $pagenow && ! isset( $_REQUEST['classic-editor'] ) ) {
-		global $hook_suffix;
-
-		$GLOBALS['_gutenberg_restore_globals_after_meta_boxes'] = array(
-			'pagenow'     => $pagenow,
-			'hook_suffix' => $hook_suffix,
-		);
-
-		$pagenow     = 'post.php';
-		$hook_suffix = 'post.php';
-
+	if ( in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) && ! isset( $_REQUEST['classic-editor'] ) ) {
 		// As early as possible, but after any plugins ( ACF ) that adds meta boxes.
 		add_action( 'admin_head', 'gutenberg_collect_meta_box_data', 99 );
 	}

--- a/lib/register.php
+++ b/lib/register.php
@@ -10,6 +10,273 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Set up global variables so that plugins will add meta boxes as if we were
+ * using the main editor.
+ */
+function gutenberg_trick_plugins_into_registering_meta_boxes() {
+	global $pagenow;
+
+	if ( 'post.php' === $pagenow && ! isset( $_REQUEST['classic-editor'] ) ) {
+		global $hook_suffix;
+
+		$GLOBALS['_gutenberg_restore_globals_after_meta_boxes'] = array(
+			'pagenow'     => $pagenow,
+			'hook_suffix' => $hook_suffix,
+		);
+
+		$pagenow     = 'post.php';
+		$hook_suffix = 'post.php';
+
+		// As early as possible, but after any plugins ( ACF ) that adds meta boxes.
+		add_action( 'admin_head', 'gutenberg_collect_meta_box_data', 99 );
+	}
+}
+// As late as possible, but before any logic that adds meta boxes.
+add_action(
+	'plugins_loaded',
+	'gutenberg_trick_plugins_into_registering_meta_boxes'
+);
+
+/**
+ * Imitates the global state of a post.
+ */
+function gutenberg_set_post_state() {
+	exit();
+	global $current_screen, $wp_meta_boxes, $post, $typenow;
+
+	// Depending on whether we are creating a post or editing one this may need to be different.
+	$potential_hookname = 'post';
+
+	// Set original screen to return to.
+	$GLOBALS['_gutenberg_restore_globals_after_meta_boxes']['current_screen'] = $current_screen;
+
+	// Override screen as though we are on post.php.
+	WP_Screen::get( $potential_hookname )->set_current_screen();
+
+	// If we are working with an already predetermined post.
+	if ( isset( $_REQUEST['post'] ) ) {
+		$post    = get_post( absint( $_REQUEST['post'] ) );
+		$typenow = $post->post_type;
+	} else {
+		// Eventually add handling for creating new posts of different types in Gutenberg.
+	}
+}
+
+/**
+ * Collect information about meta_boxes registered for the current post.
+ *
+ * This is used to tell React and Redux whether the meta box location has
+ * meta boxes.
+ */
+function gutenberg_collect_meta_box_data() {
+	global $_gutenberg_restore_globals_after_meta_boxes, $current_screen, $wp_meta_boxes, $post, $typenow;
+
+	// Depending on whether we are creating a post or editing one this may need to be different.
+	$potential_hookname = 'post';
+
+	// Set original screen to return to.
+	$GLOBALS['_gutenberg_restore_globals_after_meta_boxes']['current_screen'] = $current_screen;
+
+	// Override screen as though we are on post.php We have access to WP_Screen etc. by this point.
+	WP_Screen::get( $potential_hookname )->set_current_screen();
+
+	$screen = $current_screen;
+
+	// If we are working with an already predetermined post.
+	if ( isset( $_REQUEST['post'] ) ) {
+		$post    = get_post( absint( $_REQUEST['post'] ) );
+		$typenow = $post->post_type;
+	} else {
+		// Eventually add handling for creating new posts of different types in Gutenberg.
+	}
+	$post_type        = $post->post_type;
+	$post_type_object = get_post_type_object( $post_type );
+
+	$thumbnail_support = current_theme_supports( 'post-thumbnails', $post_type ) && post_type_supports( $post_type, 'thumbnail' );
+	if ( ! $thumbnail_support && 'attachment' === $post_type && $post->post_mime_type ) {
+		if ( wp_attachment_is( 'audio', $post ) ) {
+			$thumbnail_support = post_type_supports( 'attachment:audio', 'thumbnail' ) || current_theme_supports( 'post-thumbnails', 'attachment:audio' );
+		} elseif ( wp_attachment_is( 'video', $post ) ) {
+			$thumbnail_support = post_type_supports( 'attachment:video', 'thumbnail' ) || current_theme_supports( 'post-thumbnails', 'attachment:video' );
+		}
+	}
+
+	/*
+	 * WIP: Collect and send information needed to render meta boxes.
+	 * From wp-admin/edit-form-advanced.php
+	 * Relevant code there:
+	 * do_action( 'do_meta_boxes', $post_type, {'normal','advanced','side'}, $post );
+	 * do_meta_boxes( $post_type, 'side', $post );
+	 * do_meta_boxes( null, 'normal', $post );
+	 * do_meta_boxes( null, 'advanced', $post );
+	 */
+	$meta_boxes_output = array();
+
+	$publish_callback_args = null;
+	if ( post_type_supports( $post_type, 'revisions' ) && 'auto-draft' !== $post->post_status ) {
+		$revisions = wp_get_post_revisions( $post->ID );
+
+		// We should aim to show the revisions meta box only when there are revisions.
+		if ( count( $revisions ) > 1 ) {
+			reset( $revisions ); // Reset pointer for key().
+			$publish_callback_args = array(
+				'revisions_count' => count( $revisions ),
+				'revision_id'     => key( $revisions ),
+			);
+			add_meta_box( 'revisionsdiv', __( 'Revisions', 'gutenberg' ), 'post_revisions_meta_box', $screen, 'normal', 'core' );
+		}
+	}
+
+	if ( 'attachment' == $post_type ) {
+		wp_enqueue_script( 'image-edit' );
+		wp_enqueue_style( 'imgareaselect' );
+		add_meta_box( 'submitdiv', __( 'Save', 'gutenberg' ), 'attachment_submit_meta_box', $screen, 'side', 'core' );
+		add_action( 'edit_form_after_title', 'edit_form_image_editor' );
+
+		if ( wp_attachment_is( 'audio', $post ) ) {
+			add_meta_box( 'attachment-id3', __( 'Metadata', 'gutenberg' ), 'attachment_id3_data_meta_box', $screen, 'normal', 'core' );
+		}
+	} else {
+		add_meta_box( 'submitdiv', __( 'Publish', 'gutenberg' ), 'post_submit_meta_box', $screen, 'side', 'core', $publish_callback_args );
+	}
+
+	if ( current_theme_supports( 'post-formats' ) && post_type_supports( $post_type, 'post-formats' ) ) {
+		add_meta_box( 'formatdiv', _x( 'Format', 'post format', 'gutenberg' ), 'post_format_meta_box', $screen, 'side', 'core' );
+	}
+
+	// All taxonomies.
+	foreach ( get_object_taxonomies( $post ) as $tax_name ) {
+		$taxonomy = get_taxonomy( $tax_name );
+		if ( ! $taxonomy->show_ui || false === $taxonomy->meta_box_cb ) {
+			continue;
+		}
+
+		$label = $taxonomy->labels->name;
+
+		if ( ! is_taxonomy_hierarchical( $tax_name ) ) {
+			$tax_meta_box_id = 'tagsdiv-' . $tax_name;
+		} else {
+			$tax_meta_box_id = $tax_name . 'div';
+		}
+
+		add_meta_box( $tax_meta_box_id, $label, $taxonomy->meta_box_cb, $screen, 'side', 'core', array( 'taxonomy' => $tax_name ) );
+	}
+
+	if ( post_type_supports( $post_type, 'page-attributes' ) || count( get_page_templates( $post ) ) > 0 ) {
+		add_meta_box( 'pageparentdiv', $post_type_object->labels->attributes, 'page_attributes_meta_box', $screen, 'side', 'core' );
+	}
+
+	if ( $thumbnail_support && current_user_can( 'upload_files' ) ) {
+		add_meta_box( 'postimagediv', esc_html( $post_type_object->labels->featured_image ), 'post_thumbnail_meta_box', $screen, 'side', 'low' );
+	}
+
+	if ( post_type_supports( $post_type, 'excerpt' ) ) {
+		add_meta_box( 'postexcerpt', __( 'Excerpt', 'gutenberg' ), 'post_excerpt_meta_box', $screen, 'normal', 'core' );
+	}
+
+	if ( post_type_supports( $post_type, 'trackbacks' ) ) {
+		add_meta_box( 'trackbacksdiv', __( 'Send Trackbacks', 'gutenberg' ), 'post_trackback_meta_box', $screen, 'normal', 'core' );
+	}
+
+	if ( post_type_supports( $post_type, 'custom-fields' ) ) {
+		add_meta_box( 'postcustom', __( 'Custom Fields', 'gutenberg' ), 'post_custom_meta_box', $screen, 'normal', 'core' );
+	}
+
+	/**
+	 * Fires in the middle of built-in meta box registration.
+	 *
+	 * @since 2.1.0
+	 * @deprecated 3.7.0 Use 'add_meta_boxes' instead.
+	 *
+	 * @param WP_Post $post Post object.
+	 */
+	do_action( 'dbx_post_advanced', $post );
+
+	// Allow the Discussion meta box to show up if the post type supports comments,
+	// or if comments or pings are open.
+	if ( comments_open( $post ) || pings_open( $post ) || post_type_supports( $post_type, 'comments' ) ) {
+		add_meta_box( 'commentstatusdiv', __( 'Discussion', 'gutenberg' ), 'post_comment_status_meta_box', $screen, 'normal', 'core' );
+	}
+
+	$stati = get_post_stati( array( 'public' => true ) );
+	if ( empty( $stati ) ) {
+		$stati = array( 'publish' );
+	}
+	$stati[] = 'private';
+
+	if ( in_array( get_post_status( $post ), $stati ) ) {
+		// If the post type support comments, or the post has comments, allow the
+		// Comments meta box.
+		if ( comments_open( $post ) || pings_open( $post ) || $post->comment_count > 0 || post_type_supports( $post_type, 'comments' ) ) {
+			add_meta_box( 'commentsdiv', __( 'Comments', 'gutenberg' ), 'post_comment_meta_box', $screen, 'normal', 'core' );
+		}
+	}
+
+	if ( ! ( 'pending' == get_post_status( $post ) && ! current_user_can( $post_type_object->cap->publish_posts ) ) ) {
+		add_meta_box( 'slugdiv', __( 'Slug', 'gutenberg' ), 'post_slug_meta_box', $screen, 'normal', 'core' );
+	}
+
+	if ( post_type_supports( $post_type, 'author' ) && current_user_can( $post_type_object->cap->edit_others_posts ) ) {
+		add_meta_box( 'authordiv', __( 'Author', 'gutenberg' ), 'post_author_meta_box', $screen, 'normal', 'core' );
+	}
+
+	// Set up meta box locations.
+	$locations = array( 'normal', 'advanced', 'side' );
+
+	// Foreach location run the hooks meta boxes are potentially registered on.
+	foreach ( $locations as $location ) {
+		do_action( 'add_meta_boxes', $post->post_type, $post );
+		do_action( "add_meta_boxes_{$post->post_type}", $post );
+		do_action(
+			'do_meta_boxes',
+			$screen,
+			$location,
+			$post
+		);
+	}
+	do_action( 'edit_form_advanced', $post );
+
+	// Copy meta box state.
+	$_meta_boxes_copy = $wp_meta_boxes;
+
+	/**
+	 * Documented in lib/meta-box-partial-page.php
+	 *
+	 * @param array $wp_meta_boxes Global meta box state.
+	 */
+	$_meta_boxes_copy = apply_filters( 'filter_gutenberg_meta_boxes', $_meta_boxes_copy );
+
+	$meta_box_data = array();
+
+	// If the meta box should be empty set to false.
+	foreach ( $locations as $location ) {
+		if ( isset( $_meta_boxes_copy[ $post->post_type ][ $location ] ) && gutenberg_is_meta_box_empty( $_meta_boxes_copy, $location, $post->post_type ) ) {
+			$meta_box_data[ $location ] = false;
+		} else {
+			$meta_box_data[ $location ] = true;
+		}
+	}
+
+	/**
+	 * Sadly we probably can not add this data directly into editor settings.
+	 *
+	 * ACF and other meta boxes need admin_head to fire for meta box registry.
+	 * admin_head fires after admin_enqueue_scripts which is where we create our
+	 * editor instance. If a cleaner solution can be imagined, please change
+	 * this, and try to get this data to load directly into the editor settings.
+	 */
+	wp_add_inline_script(
+		'wp-editor',
+		'window._wpGutenbergEditor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' )'
+	);
+
+	// Restore any global variables that we temporarily modified above.
+	foreach ( $_gutenberg_restore_globals_after_meta_boxes as $name => $value ) {
+		$GLOBALS[ $name ] = $value;
+	}
+}
+
+/**
  * Return whether the post can be edited in Gutenberg and by the current user.
  *
  * Gutenberg depends on the REST API, and if the post type is not shown in the
@@ -83,4 +350,3 @@ function gutenberg_register_rest_routes() {
 	$controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
-

--- a/phpunit/class-meta-box-test.php
+++ b/phpunit/class-meta-box-test.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Test for meta box integration.
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Tests meta box integration.
+ *
+ * Most of the PHP portion of the meta box integration is not testeable due to
+ * WordPress's architecture. These tests cover the portions that are testable.
+ */
+class Meta_Box_Test extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->meta_boxes = array(
+			'post' => array(
+				'normal' => array(
+					'core' => array(
+						'revisionsdiv'     => array(
+							'id'       => 'revisionsdiv',
+							'title'    => 'Revisions',
+							'callback' => 'post_revisions_meta_box',
+							'args'     => null,
+						),
+						'postexcerpt'      => array(
+							'id'       => 'postexcerpt',
+							'title'    => 'Excerpt',
+							'callback' => 'post_excerpt_meta_box',
+							'args'     => null,
+						),
+						'trackbacksdiv'    => array(
+							'id'       => 'trackbacksdiv',
+							'title'    => 'Send Trackbacks',
+							'callback' => 'post_trackback_meta_box',
+							'args'     => null,
+						),
+						'postcustom'       => array(
+							'id'       => 'postcustom',
+							'title'    => 'Custom Fields',
+							'callback' => 'post_custom_meta_box',
+							'args'     => null,
+						),
+						'commentstatusdiv' => array(
+							'id'       => 'commentstatusdiv',
+							'title'    => 'Discussion',
+							'callback' => 'post_comment_status_meta_box',
+							'args'     => null,
+						),
+						'commentsdiv'      => array(
+							'id'       => 'commentsdiv',
+							'title'    => 'Comments',
+							'callback' => 'post_comment_meta_box',
+							'args'     => null,
+						),
+						'slugdiv'          => array(
+							'id'       => 'slugdiv',
+							'title'    => 'Slug',
+							'callback' => 'post_slug_meta_box',
+							'args'     => null,
+						),
+						'authordiv'        => array(
+							'id'       => 'authordiv',
+							'title'    => 'Author',
+							'callback' => 'post_author_meta_box',
+							'args'     => null,
+						),
+					),
+					'low'  => array(),
+					'high' => array(),
+				),
+				'side'   => array(
+					'core' => array(
+						'submitdiv'        => array(
+							'id'       => 'submitdiv',
+							'title'    => 'Submit',
+							'callback' => 'post_submit_meta_box',
+							'args'     => null,
+						),
+						'formatdiv'        => array(
+							'id'       => 'formatdiv',
+							'title'    => 'Format',
+							'callback' => 'post_format_meta_box',
+							'args'     => null,
+						),
+						'categorydiv'      => array(
+							'id'       => 'categorydiv',
+							'title'    => 'Categories',
+							'callback' => 'post_categories_meta_box',
+							'args'     => null,
+						),
+						'tagsdiv-post_tag' => array(
+							'id'       => 'tagsdiv-post_tag',
+							'title'    => 'Tags',
+							'callback' => 'post_tags_meta_box',
+							'args'     => null,
+						),
+						'postimagediv'     => array(
+							'id'       => 'postimagediv',
+							'title'    => 'Featured Image',
+							'callback' => 'post_image_meta_box',
+							'args'     => null,
+						),
+					),
+					'low'  => array(),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests for empty meta box.
+	 */
+	public function test_gutenberg_is_meta_box_empty_with_empty_meta_box() {
+		$context                              = 'side';
+		$post_type                            = 'post';
+		$meta_boxes                           = $this->meta_boxes;
+		$meta_boxes[ $post_type ][ $context ] = array();
+
+		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
+		$this->assertTrue( $is_empty );
+	}
+
+	/**
+	 * Tests for non empty meta box area.
+	 */
+	public function test_gutenberg_is_meta_box_empty_with_non_empty_meta_box() {
+		$context    = 'normal';
+		$post_type  = 'post';
+		$meta_boxes = $this->meta_boxes;
+
+		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
+		$this->assertFalse( $is_empty );
+	}
+
+	/**
+	 * Tests for non existant location.
+	 */
+	public function test_gutenberg_is_meta_box_empty_with_non_existant_location() {
+		$context    = 'test';
+		$post_type  = 'post';
+		$meta_boxes = $this->meta_boxes;
+
+		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
+		$this->assertTrue( $is_empty );
+	}
+
+	/**
+	 * Tests for non existant page.
+	 */
+	public function test_gutenberg_is_meta_box_empty_with_non_existant_page() {
+		$context    = 'normal';
+		$post_type  = 'test';
+		$meta_boxes = $this->meta_boxes;
+
+		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
+		$this->assertTrue( $is_empty );
+	}
+
+	/**
+	 * Test filtering of meta box data.
+	 */
+	public function test_gutenberg_filter_meta_boxes() {
+		$meta_boxes = $this->meta_boxes;
+		// Add in a meta box.
+		$meta_boxes['post']['normal']['high']['some-meta-box'] = array( 'meta-box-stuff' );
+
+		$expected_meta_boxes = $this->meta_boxes;
+		// We expect to remove only core meta boxes.
+		$expected_meta_boxes['post']['normal']['core']                  = array();
+		$expected_meta_boxes['post']['side']['core']                    = array();
+		$expected_meta_boxes['post']['normal']['high']['some-meta-box'] = array( 'meta-box-stuff' );
+
+		$actual   = gutenberg_filter_meta_boxes( $meta_boxes );
+		$expected = $expected_meta_boxes;
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Test filtering of meta box data with taxonomy meta boxes.
+	 *
+	 * By default Gutenberg will provide a much enhanced JavaScript alternative
+	 * to the meta boxes using the standard category and tags meta box callbacks.
+	 */
+	public function test_gutenberg_filter_meta_boxes_for_taxonomies() {
+		$meta_boxes = $this->meta_boxes;
+		// Add in a meta box.
+		$meta_boxes['post']['normal']['high']['my-cool-tax']              = array( 'callback' => 'post_tags_meta_box' );
+		$meta_boxes['post']['normal']['high']['my-cool-hierarchical-tax'] = array( 'callback' => 'post_categories_meta_box' );
+
+		$expected_meta_boxes = $this->meta_boxes;
+		// We expect to remove only core meta boxes.
+		$expected_meta_boxes['post']['normal']['core'] = array();
+		$expected_meta_boxes['post']['side']['core']   = array();
+		// We expect the high location to be empty even though we have registered meta boxes.
+		$expected_meta_boxes['post']['normal']['high'] = array();
+
+		$actual   = gutenberg_filter_meta_boxes( $meta_boxes );
+		$expected = $expected_meta_boxes;
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,11 @@ const blocksCSSPlugin = new ExtractTextPlugin( {
 	filename: './blocks/build/style.css',
 } );
 
+// CSS loader for styles specific to loading inside meta box iframes.
+const metaBoxIframeCSSPlugin = new ExtractTextPlugin( {
+	filename: './editor/build/meta-box-iframe.css',
+} );
+
 // Configuration for the ExtractTextPlugin.
 const extractConfig = {
 	use: [
@@ -111,9 +116,17 @@ const config = {
 				use: editBlocksCSSPlugin.extract( extractConfig ),
 			},
 			{
+				test: /meta-box-iframe\.scss$/,
+				include: [
+					/editor/,
+				],
+				use: metaBoxIframeCSSPlugin.extract( extractConfig ),
+			},
+			{
 				test: /\.s?css$/,
 				exclude: [
 					/blocks/,
+					/meta-box-iframe/,
 				],
 				use: mainCSSExtractTextPlugin.extract( extractConfig ),
 			},
@@ -125,6 +138,7 @@ const config = {
 		} ),
 		blocksCSSPlugin,
 		editBlocksCSSPlugin,
+		metaBoxIframeCSSPlugin,
 		mainCSSExtractTextPlugin,
 		new webpack.LoaderOptionsPlugin( {
 			minimize: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## Description
This adds metabox support with the UI @aduth came up with. See the accompanying markdown file in the docs.

## How Has This Been Tested?
Tested pretty extensively. Lots more polish work to do, but I believe this is merge-able-ish.
## Screenshots (jpeg or gifs if applicable):

## Types of changes
Adds PHP metabox support, through incredible hacks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

## Testing Instructions:

- Verify that by default, on an install with no custom metaboxes, that no changes occur to the current Gutenberg experience.
- Verify that all core metaboxes do not appear, and no Extended Settings areas appear.
- Install ACF, Metabox.io, CMB2, or some other metabox creation framework, add their metaboxes to your theme, or generate some metaboxes of your own.
- Verify that metaboxes render in the Extended Settings area of your choice. There are normal, advanced, and side areas. advanced is currently merged into normal.
- Verify that normal metaboxes appear at the bottom of the editor area in an Editor Settings toggle panel.
- If you register sidebar metaboxes, verify that an 'Extended Settings' area appears in the sidebar.
- Verify that changing the form values in the metaboxes will allow you to update the post.
- Verify that returning the state of the form values to their original value will mark the metabox state as not dirty.
- When saving a post without changing metabox values, verify that they do not update.
- When saving a post with metabox changes, verify that the metaboxes indeed save the settings.
- If the sidebar only has changes and the normal area does not, verify that only the side bar saves, and vice versa.
- After successfully updating and verify the values saved correctly, try continual updates. The form data to dirty check against should now be the updated data.