### PR TITLE
Selectors: Fix getBlock error for block not in state

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -380,9 +380,12 @@ export function getEditedPostPreviewLink( state ) {
 export const getBlock = createSelector(
 	( state, uid ) => {
 		const block = state.editor.blocksByUid[ uid ];
-		const type = getBlockType( block.name );
+		if ( ! block ) {
+			return null;
+		}
 
-		if ( ! block || ! type || ! type.attributes ) {
+		const type = getBlockType( block.name );
+		if ( ! type || ! type.attributes ) {
 			return block;
 		}
 
@@ -394,8 +397,7 @@ export const getBlock = createSelector(
 			return result;
 		}, {} );
 
-		// Avoid injecting an empty `attributes: {}`
-		if ( ! block.attributes && ! metaAttributes.length ) {
+		if ( ! Object.keys( metaAttributes ).length ) {
 			return block;
 		}
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -39,6 +39,7 @@ import {
 	getBlocks,
 	getBlockCount,
 	getSelectedBlock,
+	getEditedPostContent,
 	getMultiSelectedBlockUids,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
@@ -84,6 +85,9 @@ describe( 'selectors', () => {
 
 	beforeEach( () => {
 		isEditedPostDirty.clear();
+		getBlock.clear();
+		getBlocks.clear();
+		getEditedPostContent.clear();
 	} );
 
 	afterAll( () => {

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -1075,6 +1075,54 @@ describe( 'selectors', () => {
 
 			expect( getBlock( state, 123 ) ).toEqual( { uid: 123, name: 'core/paragraph' } );
 		} );
+
+		it( 'should return null if the block is not present in state', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					blocksByUid: {},
+					edits: {},
+				},
+			};
+
+			expect( getBlock( state, 123 ) ).toBe( null );
+		} );
+
+		it( 'should merge meta attributes for the block', () => {
+			registerBlockType( 'core/meta-block', {
+				save: ( props ) => props.attributes.text,
+				category: 'common',
+				title: 'test block',
+				attributes: {
+					foo: {
+						type: 'string',
+						meta: 'foo',
+					},
+				},
+			} );
+
+			const state = {
+				currentPost: {
+					meta: {
+						foo: 'bar',
+					},
+				},
+				editor: {
+					blocksByUid: {
+						123: { uid: 123, name: 'core/meta-block' },
+					},
+					edits: {},
+				},
+			};
+
+			expect( getBlock( state, 123 ) ).toEqual( {
+				uid: 123,
+				name: 'core/meta-block',
+				attributes: {
+					foo: 'bar',
+				},
+			} );
+		} );
 	} );
 
 	describe( 'getBlocks', () => {


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/2740#issuecomment-332373318

This pull request seeks to resolve an error which occurs when trashing a selected block. It also improves the behavior of attributes mapped to meta fields, which currently does not work.

__Testing instructions:__

No blocks make use of meta fields attribute mapping. Instead, ensure tests pass:

```
npm test
```

Verify that an error does not occur when removing a selected block:

1. Navigate to Gutenberg > New Post
2. Insert a new block
3. Select the block
4. Remove the block using the trash in secondary actions