### PR TITLE
Compat: Disable wpautop for block-based posts

### DIFF
--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -82,9 +82,10 @@ export default class OldEditor extends Component {
 	onSetup( editor ) {
 		const { attributes: { content }, setAttributes } = this.props;
 		const { ref } = this;
-		const initialContent = window.switchEditors.wpautop( content || '' );
 
-		editor.on( 'loadContent', () => editor.setContent( initialContent ) );
+		if ( content ) {
+			editor.on( 'loadContent', () => editor.setContent( content ) );
+		}
 
 		editor.on( 'blur', () => {
 			setAttributes( {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -58,6 +58,80 @@ function gutenberg_parse_blocks( $content ) {
 }
 
 /**
+ * Given an array of parsed blocks, returns content string.
+ *
+ * @since 1.7.0
+ *
+ * @param array $blocks Parsed blocks.
+ *
+ * @return string Content string.
+ */
+function gutenberg_serialize_blocks( $blocks ) {
+	return implode( '', array_map( 'gutenberg_serialize_block', $blocks ) );
+}
+
+/**
+ * Given a parsed block, returns content string.
+ *
+ * @since 1.7.0
+ *
+ * @param array $block Parsed block.
+ *
+ * @return string Content string.
+ */
+function gutenberg_serialize_block( $block ) {
+	// Return content of unknown block verbatim.
+	if ( ! isset( $block['blockName'] ) ) {
+		return $block['innerHTML'];
+	}
+
+	// Custom formatting for specific block types.
+	if ( 'core/more' === $block['blockName'] ) {
+		$content = '<!--more';
+		if ( ! empty( $block['attrs']['customText'] ) ) {
+			$content .= ' ' . $block['attrs']['customText'];
+		}
+
+		$content .= '-->';
+		if ( ! empty( $block['attrs']['noTeaser'] ) ) {
+			$content .= "\n" . '<!--noteaser-->';
+		}
+
+		return $content;
+	}
+
+	// For standard blocks, return with comment-delimited wrapper.
+	$content = '<!-- wp:' . $block['blockName'] . ' ';
+
+	if ( ! empty( $block['attrs'] ) ) {
+		$attrs_json = json_encode( $block['attrs'] );
+
+		// In PHP 5.4+, we would pass the `JSON_UNESCAPED_SLASHES` option to
+		// `json_encode`. To support older versions, we must apply manually.
+		$attrs_json = str_replace( '\\/', '/', $attrs_json );
+
+		// Don't break HTML comments.
+		$attrs_json = str_replace( '--', '\\u002d\\u002d', $attrs_json );
+
+		// Don't break standard-non-compliant tools.
+		$attrs_json = str_replace( '<', '\\u003c', $attrs_json );
+		$attrs_json = str_replace( '>', '\\u003e', $attrs_json );
+		$attrs_json = str_replace( '&', '\\u0026', $attrs_json );
+
+		$content .= $attrs_json . ' ';
+	}
+
+	if ( empty( $block['innerHTML'] ) ) {
+		return $content . '/-->';
+	}
+
+	$content .= '-->';
+	$content .= $block['innerHTML'];
+	$content .= '<!-- /wp:' . $block['blockName'] . ' -->';
+	return $content;
+}
+
+/**
  * Parses dynamic blocks out of `post_content` and re-renders them.
  *
  * @since 0.1.0
@@ -93,3 +167,44 @@ function do_blocks( $content ) {
 	return $content_after_blocks;
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode() and wpautop().
+
+/**
+ * Given a string, returns content normalized with automatic paragraphs applied
+ * to text not identified as a block. Since this executes the block parser, it
+ * should not be used in a performance-critical flow such as content display.
+ * Block content will not have automatic paragraphs applied.
+ *
+ * @since 1.7.0
+ *
+ * @param  string $content Original content.
+ * @return string          Content formatted with automatic paragraphs applied
+ *                         to unknown blocks.
+ */
+function gutenberg_wpautop_block_content( $content ) {
+	$blocks = gutenberg_parse_blocks( $content );
+	foreach ( $blocks as $i => $block ) {
+		if ( isset( $block['blockName'] ) ) {
+			continue;
+		}
+
+		$content = $block['innerHTML'];
+
+		// wpautop will trim leading whitespace and return whitespace-only text
+		// as an empty string. Preserve to apply leading whitespace as prefix.
+		preg_match( '/^(\s+)/', $content, $prefix_match );
+		$prefix = empty( $prefix_match ) ? '' : $prefix_match[0];
+
+		$content = $prefix . wpautop( $content, false );
+
+		// To normalize as text where wpautop would not be applied, restore
+		// double newline to wpautop'd text if not at the end of content.
+		$is_last_block = ( count( $blocks ) === $i + 1 );
+		if ( ! $is_last_block ) {
+			$content = str_replace( "</p>\n", "</p>\n\n", $content );
+		}
+
+		$blocks[ $i ]['innerHTML'] = $content;
+	}
+
+	return gutenberg_serialize_blocks( $blocks );
+}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -208,3 +208,21 @@ function gutenberg_wpautop_block_content( $content ) {
 
 	return gutenberg_serialize_blocks( $blocks );
 }
+
+/**
+ * Filters saved post data to apply wpautop to freeform block content.
+ *
+ * @since 1.7.0
+ *
+ * @param  array $data An array of slashed post data.
+ * @return array       An array of post data with wpautop applied to freeform
+ *                     block content.
+ */
+function gutenberg_wpautop_insert_post_data( $data ) {
+	if ( ! empty( $data['post_content'] ) && gutenberg_content_has_blocks( $data['post_content'] ) ) {
+		$data['post_content'] = gutenberg_wpautop_block_content( $data['post_content'] );
+	}
+
+	return $data;
+}
+add_filter( 'wp_insert_post_data', 'gutenberg_wpautop_insert_post_data' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -682,12 +682,19 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	}
 
 	// Set initial title to empty string for auto draft for duration of edit.
+	// Otherwise, title defaults to and displays as "Auto Draft".
 	$is_new_post = 'auto-draft' === $post_to_edit['status'];
 	if ( $is_new_post ) {
 		$post_to_edit['title'] = array(
 			'raw'      => '',
 			'rendered' => apply_filters( 'the_title', '', $post->ID ),
 		);
+	}
+
+	// Set initial content to apply autop on unknown blocks, preserving this
+	// behavior for classic content while otherwise disabling for blocks.
+	if ( ! $is_new_post && is_array( $post_to_edit['content'] ) ) {
+		$post_to_edit['content']['raw'] = gutenberg_wpautop_block_content( $post_to_edit['content']['raw'] );
 	}
 
 	// Preload common data.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -152,3 +152,20 @@ function gutenberg_add_rest_nonce_to_heartbeat_response_headers( $response ) {
 }
 
 add_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
+
+/**
+ * As a substitute for the default content `wpautop` filter, applies autop
+ * behavior only for posts where content does not contain blocks.
+ *
+ * @param  string $content Post content.
+ * @return string          Paragraph-converted text if non-block content.
+ */
+function gutenberg_wpautop( $content ) {
+	if ( gutenberg_content_has_blocks( $content ) ) {
+		return $content;
+	}
+
+	return wpautop( $content );
+}
+remove_filter( 'the_content', 'wpautop' );
+add_filter( 'the_content', 'gutenberg_wpautop' );

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -26,7 +26,7 @@
  * @return array $post      Post object.
  */
 function gutenberg_remove_wpcom_markdown_support( $post ) {
-	if ( content_has_blocks( $post->post_content ) ) {
+	if ( gutenberg_content_has_blocks( $post->post_content ) ) {
 		remove_post_type_support( 'post', 'wpcom-markdown' );
 	}
 	return $post;

--- a/lib/register.php
+++ b/lib/register.php
@@ -308,7 +308,12 @@ function gutenberg_can_edit_post_type( $post_type ) {
 }
 
 /**
- * Determine whether a post has blocks.
+ * Determine whether a post has blocks. This test optimizes for performance
+ * rather than strict accuracy, detecting the pattern of a block but not
+ * validating its structure. For strict accuracy, you should use the block
+ * parser on post content.
+ *
+ * @see gutenberg_parse_blocks()
  *
  * @since 0.5.0
  *
@@ -317,18 +322,22 @@ function gutenberg_can_edit_post_type( $post_type ) {
  */
 function gutenberg_post_has_blocks( $post ) {
 	$post = get_post( $post );
-	return $post && content_has_blocks( $post->post_content );
+	return $post && gutenberg_content_has_blocks( $post->post_content );
 }
 
 /**
- * Determine whether a content string contains gutenberg blocks.
+ * Determine whether a content string contains blocks. This test optimizes for
+ * performance rather than strict accuracy, detecting the pattern of a block
+ * but not validating its structure. For strict accuracy, you should use the
+ * block parser on post content.
  *
  * @since 1.6.0
+ * @see gutenberg_parse_blocks()
  *
  * @param string $content Content to test.
  * @return bool Whether the content contains blocks.
  */
-function content_has_blocks( $content ) {
+function gutenberg_content_has_blocks( $content ) {
 	return false !== strpos( $content, '<!-- wp:' );
 }
 

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -90,6 +90,19 @@ class Admin_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests gutenberg_content_has_blocks().
+	 *
+	 * @covers gutenberg_content_has_blocks
+	 */
+	function test_gutenberg_content_has_blocks() {
+		$content_with_blocks    = get_post_field( 'post_content', self::$post_with_blocks );
+		$content_without_blocks = get_post_field( 'post_content', self::$post_without_blocks );
+
+		$this->assertTrue( gutenberg_content_has_blocks( $content_with_blocks ) );
+		$this->assertFalse( gutenberg_content_has_blocks( $content_without_blocks ) );
+	}
+
+	/**
 	 * Tests gutenberg_add_gutenberg_post_state().
 	 *
 	 * @covers gutenberg_add_gutenberg_post_state

--- a/phpunit/class-serializing-test.php
+++ b/phpunit/class-serializing-test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Block serializer (PHP code target) tests
+ *
+ * @package Gutenberg
+ */
+
+class Serializing_Test extends WP_UnitTestCase {
+	protected static $fixtures_dir;
+
+	function serializing_test_filenames() {
+		self::$fixtures_dir = dirname( dirname( __FILE__ ) ) . '/blocks/test/fixtures';
+
+		require_once dirname( dirname( __FILE__ ) ) . '/lib/parser.php';
+
+		$fixture_filenames = glob( self::$fixtures_dir . '/*.{json,html}', GLOB_BRACE );
+		$fixture_filenames = array_values( array_unique( array_map(
+			array( $this, 'clean_fixture_filename' ),
+			$fixture_filenames
+		) ) );
+
+		return array_map(
+			array( $this, 'pass_serializer_fixture_filenames' ),
+			$fixture_filenames
+		);
+	}
+
+	function clean_fixture_filename( $filename ) {
+		$filename = basename( $filename );
+		$filename = preg_replace( '/\..+$/', '', $filename );
+		return $filename;
+	}
+
+	function pass_serializer_fixture_filenames( $filename ) {
+		return array(
+			"$filename.html",
+			"$filename.parsed.json",
+		);
+	}
+
+	/**
+	 * @dataProvider serializing_test_filenames
+	 */
+	function test_serializer_output( $html_filename, $parsed_json_filename ) {
+		$html_path        = self::$fixtures_dir . '/' . $html_filename;
+		$parsed_json_path = self::$fixtures_dir . '/' . $parsed_json_filename;
+
+		foreach ( array( $html_path, $parsed_json_path ) as $filename ) {
+			if ( ! file_exists( $filename ) ) {
+				throw new Exception( "Missing fixture file: '$filename'" );
+			}
+		}
+
+		$parsed        = json_decode( file_get_contents( $parsed_json_path ), true );
+		$expected_html = file_get_contents( $html_path );
+
+		$result = gutenberg_serialize_blocks( $parsed );
+
+		$this->assertEquals(
+			$expected_html,
+			$result,
+			"File '$html_filename' does not match expected value"
+		);
+	}
+
+	function test_serializer_escape() {
+		$original_html = '<!-- wp:core/test-block {"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
+		$parsed_block  = gutenberg_parse_blocks( $original_html );
+
+		$serialized = gutenberg_serialize_blocks( $parsed_block );
+
+		$this->assertEquals( 'left & right -- but <not>', $parsed_block[0]['attrs']['stuff'] );
+		$this->assertEquals( $original_html, $serialized );
+	}
+}

--- a/phpunit/class-wpautop-test.php
+++ b/phpunit/class-wpautop-test.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Automatic paragraph applicatino tests
+ *
+ * @package Gutenberg
+ */
+
+class WPAutoP_Test extends WP_UnitTestCase {
+	function test_gutenberg_wpautop_block_content() {
+		$original_html = file_get_contents( dirname( __FILE__ ) . '/fixtures/wpautop-original.html' );
+		$expected_html = file_get_contents( dirname( __FILE__ ) . '/fixtures/wpautop-expected.html' );
+
+		$actual_html = gutenberg_wpautop_block_content( $original_html );
+
+		$this->assertEquals( $expected_html, $actual_html );
+	}
+}

--- a/phpunit/class-wpautop-test.php
+++ b/phpunit/class-wpautop-test.php
@@ -14,4 +14,18 @@ class WPAutoP_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_html, $actual_html );
 	}
+
+	function test_gutenberg_wpautop_insert_post_data() {
+		$original_html = file_get_contents( dirname( __FILE__ ) . '/fixtures/wpautop-original.html' );
+		$expected_html = file_get_contents( dirname( __FILE__ ) . '/fixtures/wpautop-expected.html' );
+
+		$post_id = self::factory()->post->create( array(
+			'post_title'   => 'Example',
+			'post_content' => $original_html,
+		) );
+
+		$post = get_post( $post_id );
+
+		$this->assertEquals( $expected_html, $post->post_content );
+	}
 }

--- a/phpunit/fixtures/wpautop-expected.html
+++ b/phpunit/fixtures/wpautop-expected.html
@@ -1,0 +1,25 @@
+<p>First Auto Paragraph</p>
+
+<!--more-->
+
+<!-- wp:core/paragraph -->
+<p>First Gutenberg Paragraph</p>
+<!-- /wp:core/paragraph -->
+
+<p>Second Auto Paragraph</p>
+
+<!-- wp:core/test-self-closing /-->
+
+<!-- wp:core/test-ignore-autop -->
+Can't
+
+Touch
+
+This
+<!-- /wp:core/test-ignore-autop -->
+
+<!-- wp:core/paragraph -->
+<p>Third Gutenberg Paragraph</p>
+<!-- /wp:core/paragraph -->
+
+<p>Third Auto Paragraph</p>

--- a/phpunit/fixtures/wpautop-original.html
+++ b/phpunit/fixtures/wpautop-original.html
@@ -1,0 +1,25 @@
+First Auto Paragraph
+
+<!--more-->
+
+<!-- wp:core/paragraph -->
+<p>First Gutenberg Paragraph</p>
+<!-- /wp:core/paragraph -->
+
+Second Auto Paragraph
+
+<!-- wp:core/test-self-closing /-->
+
+<!-- wp:core/test-ignore-autop -->
+Can't
+
+Touch
+
+This
+<!-- /wp:core/test-ignore-autop -->
+
+<!-- wp:core/paragraph -->
+<p>Third Gutenberg Paragraph</p>
+<!-- /wp:core/paragraph -->
+
+Third Auto Paragraph


### PR DESCRIPTION
Closes #2736

This pull request seeks to disable wpautop for Gutenberg posts. The markup structure of a block is defined as the result of the block implementation's `save` function, and does not need (and should not have) formatting of automatic paragraph application from `wpautop`. The changes here disable `the_content`'s filter of `wpautop` for posts containing blocks.

The challenge here is in managing posts which were originally authored in the Classic editor, then later in Gutenberg to add new content blocks (which will be a common occurrence after Gutenberg is merged). 

(See revised behavior: https://github.com/WordPress/gutenberg/pull/2806#issuecomment-332962480)

~To preserve paragraphs which had previously relied on the behavior of `autop`, the Gutenberg editor will apply `autop` during the parse step. This has the result of setting `<p>` into saved content, instead of relying on this to be applied later during `the_content`.~

~This is unlike some of the considerations proposed at #2708, where autop would be applied on a per-block basis in `the_content`. I am very wary of the performance impact of detecting and individually formatting blocks in content during a front-end filter. In the suggested use-case of an external editor, autop behavior would continue to apply for posts which do not contain blocks. It should never be the case that a post contains both blocks and legacy freeform content without explicit `<p>` tags if edited in Gutenberg, but it would be true that such an external client would need to pass new saved content in a block post with explicit tags as well. This is not complete compatibility, and it may be worth exploring whether `wpautop` should _also_ be applied server-side when saving a post containing both blocks and freeform content to capture these instances.~

__Testing instructions:__

1. Create a new post in the classic editor with a single paragraph of text
2. Save the post as a draft
3. Return to the posts list
4. Edit the post saved in Step 2 in the Gutenberg editor (hover in list, then click Gutenberg)
5. Add a new paragraph block with some text
6. Press Preview
7. Inspect content of preview
8. Note that both paragraphs are wrapped in `<p>` tags