### PR TITLE
Editor: offer the option to convert to HTML on invalid blocks

### DIFF
--- a/editor/modes/visual-editor/invalid-block-warning.js
+++ b/editor/modes/visual-editor/invalid-block-warning.js
@@ -24,17 +24,20 @@ import {
  */
 import { replaceBlock } from '../../actions';
 
-function InvalidBlockWarning( { ignoreInvalid, switchToDefaultType } ) {
+function InvalidBlockWarning( { ignoreInvalid, switchToBlockType } ) {
+	const htmlBlockName = 'core/html';
 	const defaultBlockType = getBlockType( getUnknownTypeHandlerName() );
+	const htmlBlockType = getBlockType( htmlBlockName );
+	const switchTo = ( blockType ) => () => switchToBlockType( blockType );
 
 	return (
 		<BlockWarning>
-			<p>{ sprintf( __(
+			<p>{ defaultBlockType && htmlBlockType && sprintf( __(
 				'This block appears to have been modified externally. ' +
-				'Overwrite the external changes or Convert to %s to keep ' +
+				'Overwrite the external changes or Convert to %s or %s to keep ' +
 				'your changes.'
-			), defaultBlockType.title ) }</p>
-			<p>
+			), defaultBlockType.title, htmlBlockType.title ) }</p>
+			<p className="visual-editor__invalid-block-warning-buttons">
 				<Button
 					onClick={ ignoreInvalid }
 					isLarge
@@ -43,12 +46,23 @@ function InvalidBlockWarning( { ignoreInvalid, switchToDefaultType } ) {
 				</Button>
 				{ defaultBlockType && (
 					<Button
-						onClick={ switchToDefaultType }
+						onClick={ switchTo( defaultBlockType ) }
 						isLarge
 					>
 						{
-							/* translators: Revert invalid block to default */
+							/* translators: Revert invalid block to another block type */
 							sprintf( __( 'Convert to %s' ), defaultBlockType.title )
+						}
+					</Button>
+				) }
+
+				{ htmlBlockType && (
+					<Button
+						onClick={ switchTo( htmlBlockType ) }
+						isLarge
+					>
+						{
+							sprintf( __( 'Edit as HTML block' ) )
 						}
 					</Button>
 				) }
@@ -67,11 +81,10 @@ export default connect(
 				const nextBlock = createBlock( name, attributes );
 				dispatch( replaceBlock( block.uid, nextBlock ) );
 			},
-			switchToDefaultType() {
-				const defaultBlockName = getUnknownTypeHandlerName();
+			switchToBlockType( blockType ) {
 				const { block } = ownProps;
-				if ( defaultBlockName && block ) {
-					const nextBlock = createBlock( defaultBlockName, {
+				if ( blockType && block ) {
+					const nextBlock = createBlock( blockType.name, {
 						content: block.originalContent,
 					} );
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -533,3 +533,7 @@ $sticky-bottom-offset: 20px;
 		margin-left: $item-spacing;
 	}
 }
+
+.visual-editor__invalid-block-warning-buttons .components-button {
+	margin-bottom: 5px;
+}


### PR DESCRIPTION
This PR adds a way to convert to a simple HTML block on invalid blocks. 
This also fixes the invalid warning buttons (it was not possible for me to click the buttons)

This will help move forward with #2794 

## Screenshots
<img width="642" alt="screen shot 2017-09-27 at 10 10 22" src="https://user-images.githubusercontent.com/272444/30905229-1b595254-a36c-11e7-8e57-3d838bb516e4.png">


## Testing instructions

 * Edit a block in the text mode and make it invalid
 * Get back to the visual mode
 * Click the "convert to HTML"
 * The broken HTML should be kept and the block converted to an HTML block 