### PR TITLE
Allow stored values to be updated with new defaults

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -14,15 +14,7 @@ import { getBlockTypes } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { combineUndoableReducers } from './utils/undoable-reducer';
-
-/**
- * Module constants
- */
-const DEFAULT_PREFERENCES = {
-	mode: 'visual',
-	isSidebarOpened: window.innerWidth >= 782,
-	panels: { 'post-status': true },
-};
+import { STORE_DEFAULTS } from './store-defaults';
 
 /**
  * Returns a post attribute value, flattening nested rendered content using its
@@ -442,7 +434,7 @@ export function showInsertionPoint( state = false, action ) {
  * @param  {Object}  action                Dispatched action
  * @return {string}                        Updated state
  */
-export function preferences( state = DEFAULT_PREFERENCES, action ) {
+export function preferences( state = STORE_DEFAULTS.preferences, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_SIDEBAR':
 			return {

--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -1,0 +1,7 @@
+export const STORE_DEFAULTS = {
+	preferences: {
+		mode: 'visual',
+		isSidebarOpened: window.innerWidth >= 782,
+		panels: { 'post-status': true },
+	},
+};

--- a/editor/store-persist.js
+++ b/editor/store-persist.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapKeys } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { STORE_DEFAULTS } from './store-defaults';
@@ -39,14 +34,10 @@ export default function storePersist( reducerKey, storageKey = DEFAULT_STORAGE_K
 		// Load initially persisted value
 		const persistedString = window.localStorage.getItem( storageKey );
 		if ( persistedString ) {
-			const persistedState = JSON.parse( persistedString );
-
-			// hydrate any missing properties with defaults
-			mapKeys( defaults[ reducerKey ] || {}, function( value, key ) {
-				if ( persistedState[ key ] === undefined ) {
-					persistedState[ key ] = value;
-				}
-			} );
+			const persistedState = {
+				...defaults[ reducerKey ],
+				...JSON.parse( persistedString ),
+			};
 
 			store.dispatch( {
 				type: 'REDUX_REHYDRATE',

--- a/editor/store-persist.js
+++ b/editor/store-persist.js
@@ -1,13 +1,24 @@
+/**
+ * External dependencies
+ */
+import { mapKeys } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_DEFAULTS } from './store-defaults';
+
 const DEFAULT_STORAGE_KEY = 'REDUX_PERSIST';
 
 /**
  * Store enhancer to persist a specified reducer key
  * @param {String}     reducerKey The reducer key to persist
  * @param {String}     storageKey The storage key to use
+ * @param {Object}     defaults   Default values
  *
  * @return {Function}             Store enhancer
  */
-export default function storePersist( reducerKey, storageKey = DEFAULT_STORAGE_KEY ) {
+export default function storePersist( reducerKey, storageKey = DEFAULT_STORAGE_KEY, defaults = STORE_DEFAULTS ) {
 	return ( createStore ) => ( reducer, preloadedState, enhancer ) => {
 		// EnhancedReducer with auto-rehydration
 		const enhancedReducer = ( state, action ) => {
@@ -29,6 +40,14 @@ export default function storePersist( reducerKey, storageKey = DEFAULT_STORAGE_K
 		const persistedString = window.localStorage.getItem( storageKey );
 		if ( persistedString ) {
 			const persistedState = JSON.parse( persistedString );
+
+			// hydrate any missing properties with defaults
+			mapKeys( defaults[ reducerKey ] || {}, function( value, key ) {
+				if ( persistedState[ key ] === undefined ) {
+					persistedState[ key ] = value;
+				}
+			} );
+
 			store.dispatch( {
 				type: 'REDUX_REHYDRATE',
 				payload: persistedState,

--- a/editor/test/store-persist.js
+++ b/editor/test/store-persist.js
@@ -17,7 +17,7 @@ describe( 'persistStore', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( reducer, persistStore( 'preferences', storageKey ) );
+		const store = createStore( reducer, persistStore( 'preferences', storageKey, {} ) );
 		expect( store.getState().preferences ).toEqual( { chicken: true } );
 	} );
 
@@ -34,8 +34,63 @@ describe( 'persistStore', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( reducer, persistStore( 'preferences', storageKey ) );
+		const store = createStore( reducer, persistStore( 'preferences', storageKey, {} ) );
 		store.dispatch( { type: 'UPDATE' } );
 		expect( JSON.parse( window.localStorage.getItem( storageKey ) ) ).toEqual( { chicken: true } );
+	} );
+
+	it( 'should apply defaults to any missing properties on previously stored objects', () => {
+		const defaults = {
+			preferences: {
+				counter: 41,
+			},
+		};
+		const storageKey = 'dumbStorageKey3';
+		const reducer = ( state, action ) => {
+			if ( action.type === 'INCREMENT' ) {
+				return {
+					preferences: { counter: state.preferences.counter + 1 },
+				};
+			}
+			return {
+				preferences: { counter: 0 },
+			};
+		};
+
+		// store preferences without the `counter` default
+		window.localStorage.setItem( storageKey, JSON.stringify( {} ) );
+
+		const store = createStore( reducer, persistStore( 'preferences', storageKey, defaults ) );
+		store.dispatch( { type: 'INCREMENT' } );
+
+		// the default should have been applied, as the `counter` was missing from the
+		// saved preferences, then the INCREMENT action should have taken effect to give us 42
+		expect( JSON.parse( window.localStorage.getItem( storageKey ) ) ).toEqual( { counter: 42 } );
+	} );
+
+	it( 'should not override stored values with defaults', () => {
+		const defaults = {
+			preferences: {
+				counter: 41,
+			},
+		};
+		const storageKey = 'dumbStorageKey4';
+		const reducer = ( state, action ) => {
+			if ( action.type === 'INCREMENT' ) {
+				return {
+					preferences: { counter: state.preferences.counter + 1 },
+				};
+			}
+			return {
+				preferences: { counter: 0 },
+			};
+		};
+
+		window.localStorage.setItem( storageKey, JSON.stringify( { counter: 1 } ) );
+
+		const store = createStore( reducer, persistStore( 'preferences', storageKey, defaults ) );
+		store.dispatch( { type: 'INCREMENT' } );
+
+		expect( JSON.parse( window.localStorage.getItem( storageKey ) ) ).toEqual( { counter: 2 } );
 	} );
 } );


### PR DESCRIPTION
## Description
If we store preferences, then we want to add new preferences
with new defaults, things break because the new defaults
were not applied, so the new preferences were not in place,
and we had to have code checking for `undefined` everywhere
we wanted to use the newly added preference.

This change applies defaults to stored data where the properties
do not already exist, allowing us to apply defaults to
stored data that was produced before we added the new preferences.

## How Has This Been Tested?
Unit tests have been added.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
