### PR TITLE
Bump plugin to version 1.2.0

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core. <strong>Meant for development, do not run on real sites.</strong>
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A new WordPress editor experience",
   "main": "build/app.js",
   "repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
## Changelog

- [Resolve block conflicts](https://github.com/WordPress/gutenberg/pull/2708) when editing a block post in the classic editor. Gutenberg's strict content validation has helped identify formatting incompatibilities, and continued improvements are planned for future releases.
- Add [word and block count](https://github.com/WordPress/gutenberg/pull/2684) to table of contents.
- Add support for [meta attributes](https://github.com/WordPress/gutenberg/pull/2740) (custom fields) in block attributes. This allows block authors to specify attributes to live outside of `post_content` entirely.
- Allow Gutenberg to be the [default editor for posts with blocks](https://github.com/WordPress/gutenberg/pull/1797) and add links to classic editor.
- Accessibility: [add landmark regions](https://github.com/WordPress/gutenberg/pull/2380).
- Add [metabox placeholder shell](https://github.com/WordPress/gutenberg/pull/2800).
- Add [crash recovery](https://github.com/WordPress/gutenberg/pull/2618) for blocks which error while saving.
- Hide Sidebar panels if the user doesn't have the [right capabilities](https://github.com/WordPress/gutenberg/pull/2585).
- [Refactor PostTaxonomies](https://github.com/WordPress/gutenberg/pull/2537) to use 'withApiData'.
- Create 'withApiData' [higher order component](https://github.com/WordPress/gutenberg/pull/1974) for managing API data.
- [Make casing](https://github.com/WordPress/gutenberg/pull/2694) consistent.
- Allow [toolbar wrapper to be clicked](https://github.com/WordPress/gutenberg/pull/2784) through.
- [Support and bootstrap](https://github.com/WordPress/gutenberg/pull/2529) server-registered block attribute schemas.
- [Shift focus](https://github.com/WordPress/gutenberg/pull/2323) into popover when opened.
- [Reuse the tabbable utility](https://github.com/WordPress/gutenberg/pull/2696) to retrieve the tabbables elements in WritingFlow.
- [Change placeholder text](https://github.com/WordPress/gutenberg/pull/2778) on button.
- [Persist the sate of the sidebar](https://github.com/WordPress/gutenberg/pull/2462) across refresh.
- Use a [small multiselec](https://github.com/WordPress/gutenberg/pull/2695)t buffer zone, improving multiple block selection.
- [Close popover](https://github.com/WordPress/gutenberg/pull/2697) by escape keypress.
- [Improve dropzone](https://github.com/WordPress/gutenberg/pull/2767) contrast ratio.
- [Improve search message](https://github.com/WordPress/gutenberg/pull/2692) to add context.
- [Improve string extraction](https://github.com/WordPress/gutenberg/pull/2655) for localized strings.
- Fixed [z-index issue](https://github.com/WordPress/gutenberg/pull/2681) of gallery image inline menu.
- Fixed [image block resizing](https://github.com/WordPress/gutenberg/pull/2682) to set the figure wrapper.
- Fixed [column widths](https://github.com/WordPress/gutenberg/pull/2629) in gallery block.
- Fixed [parsing in do_blocks()](https://github.com/WordPress/gutenberg/pull/1244) and rendering of blocks on frontend in the_content.
- Fixed [position of upload svg](https://github.com/WordPress/gutenberg/pull/2693) on mobile.