### PR TITLE
Validation: Fix pointer events for invalid block warning

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -59,8 +59,11 @@
 	&.has-warning .editor-visual-editor__block-edit {
 		position: relative;
 		min-height: 250px;
-		pointer-events: none;
-		user-select: none;
+
+		> :not( .editor-visual-editor__block-warning ) {
+			pointer-events: none;
+			user-select: none;
+		}
 	}
 
 	&.has-warning .editor-visual-editor__block-edit::after {


### PR DESCRIPTION
Related: #2807
Regression introduced in #2618

This pull request seeks to resolve an issue where it is not possible to click buttons within the block validation warning. This regressed in #2618 with moving the warning into the invalid block.

https://github.com/WordPress/gutenberg/pull/2618/files#diff-5cb891cd3125ad3b221777433a61a524

The style should only apply to the preview, not the warning.

__Testing instructions:__

Verify that you can use buttons within the invalid block warning.