### PR TITLE
Fix error with Jetpack Markdown being enabled

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -24,6 +24,7 @@ if ( gutenberg_can_init() ) {
 	require_once dirname( __FILE__ ) . '/lib/i18n.php';
 	require_once dirname( __FILE__ ) . '/lib/parser.php';
 	require_once dirname( __FILE__ ) . '/lib/register.php';
+	require_once dirname( __FILE__ ) . '/lib/plugin-compat.php';
 
 	// Register server-side code for individual blocks.
 	foreach ( glob( dirname( __FILE__ ) . '/blocks/library/*/index.php' ) as $block_logic ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -141,23 +141,13 @@ function gutenberg_disable_editor_settings_wpautop( $settings ) {
 add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
 
 /**
- * Determine whether a content string contains blocks.
- *
- * @since 1.3
- * @param string $content Content to test.
- * @return bool Whether the content contains blocks.
- */
-function content_has_blocks( $content ) {
-	return false !== strpos( $content, '<!-- wp:' );
-}
-
-/**
  * WPCOM markdown support causes issues when saving a Gutenberg post by
  * stripping out the <p> tags. This adds a filter prior to saving the post via
  * REST API to disable markdown support. Markdown support most typically
  * provided by Jetpack.
  *
- * @since 1.3
+ * @since 1.3.0
+ *
  * @param  array $post      Post object which contains content to check for block.
  * @return array $post      Post object.
  */

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -139,3 +139,15 @@ function gutenberg_disable_editor_settings_wpautop( $settings ) {
 	return $settings;
 }
 add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
+
+/**
+ * Jetpack Markdown support causes issues when saving a Gutenberg post
+ * by stripping out the <p> tags - this is a bit heavy handed approach
+ * but disabling does fix the issue
+ */
+function gutenberg_remove_jetpack_markdown_support() {
+	if ( defined( 'JETPACK__VERSION' ) ) {
+		remove_post_type_support( 'post', 'wpcom-markdown' );
+	}
+}
+add_action( 'init', 'gutenberg_remove_jetpack_markdown_support', 99 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -139,22 +139,3 @@ function gutenberg_disable_editor_settings_wpautop( $settings ) {
 	return $settings;
 }
 add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
-
-/**
- * WPCOM markdown support causes issues when saving a Gutenberg post by
- * stripping out the <p> tags. This adds a filter prior to saving the post via
- * REST API to disable markdown support. Markdown support most typically
- * provided by Jetpack.
- *
- * @since 1.3.0
- *
- * @param  array $post      Post object which contains content to check for block.
- * @return array $post      Post object.
- */
-function gutenberg_remove_wpcom_markdown_support( $post ) {
-	if ( content_has_blocks( $post->post_content ) ) {
-		remove_post_type_support( 'post', 'wpcom-markdown' );
-	}
-	return $post;
-}
-add_filter( 'rest_pre_insert_post', 'gutenberg_remove_wpcom_markdown_support' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -140,14 +140,20 @@ function gutenberg_disable_editor_settings_wpautop( $settings ) {
 }
 add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
 
+/* temporary function, waiting on PR #2806 */
+function content_has_blocks( $content ) {
+	return false !== strpos( $content, '<!-- wp:' );
+}
+
 /**
- * Jetpack Markdown support causes issues when saving a Gutenberg post
- * by stripping out the <p> tags - this is a bit heavy handed approach
- * but disabling does fix the issue
+ * wpcom markdown support (probably added by jetpack) causes issues when 
+ * saving a Gutenberg post by stripping out the <p> tags. This adds a filter 
+ * to the rest endpoint that inserts the post and disables markdown support
  */
-function gutenberg_remove_jetpack_markdown_support() {
-	if ( defined( 'JETPACK__VERSION' ) ) {
+function gutenberg_remove_wpcom_markdown_support( $post ) {
+	if ( content_has_blocks( $post->post_content ) ) {
 		remove_post_type_support( 'post', 'wpcom-markdown' );
 	}
+	return $post;
 }
-add_action( 'init', 'gutenberg_remove_jetpack_markdown_support', 99 );
+add_filter( 'rest_pre_insert_post', 'gutenberg_remove_wpcom_markdown_support' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -140,15 +140,26 @@ function gutenberg_disable_editor_settings_wpautop( $settings ) {
 }
 add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
 
-/* temporary function, waiting on PR #2806 */
+/**
+ * Determine whether a content string contains blocks.
+ *
+ * @since 1.3
+ * @param string $content Content to test.
+ * @return bool Whether the content contains blocks.
+ */
 function content_has_blocks( $content ) {
 	return false !== strpos( $content, '<!-- wp:' );
 }
 
 /**
- * wpcom markdown support (probably added by jetpack) causes issues when 
- * saving a Gutenberg post by stripping out the <p> tags. This adds a filter 
- * to the rest endpoint that inserts the post and disables markdown support
+ * WPCOM markdown support causes issues when saving a Gutenberg post by
+ * stripping out the <p> tags. This adds a filter prior to saving the post via
+ * REST API to disable markdown support. Markdown support most typically
+ * provided by Jetpack.
+ *
+ * @since 1.3
+ * @param  array $post      Post object which contains content to check for block.
+ * @return array $post      Post object.
  */
 function gutenberg_remove_wpcom_markdown_support( $post ) {
 	if ( content_has_blocks( $post->post_content ) ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -132,8 +132,8 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_ensure_wp_api_request', 20 );
  */
 function gutenberg_disable_editor_settings_wpautop( $settings ) {
 	$post = get_post();
-	if ( ! isset( $settings['wpautop'] ) ) {
-		$settings['wpautop'] = ! ( is_object( $post ) && gutenberg_post_has_blocks( $post->ID ) );
+	if ( is_object( $post ) && gutenberg_post_has_blocks( $post->ID ) ) {
+		$settings['wpautop'] = false;
 	}
 
 	return $settings;

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file includes a set of temporary fixes for known compatibility
+ * issues with third-party plugins. These fixes likely should not to be
+ * included with core merge.
+ *
+ * @package gutenberg
+ * @since 1.3.0
+ *
+ * The goal is to provide a fix so
+ * 1. users of the plugin can continue to use and test Gutenberg,
+ * 2. provide a reference for developers of the plugin to work with, and
+ * 3. provide reference for other plugin developers on how they might work
+ *    with Gutenberg.
+ */
+
+/**
+ * WPCOM markdown support causes issues when saving a Gutenberg post by
+ * stripping out the <p> tags. This adds a filter prior to saving the post via
+ * REST API to disable markdown support. Fixes markdown support provided by
+ * plugins Jetpack, JP-Markdown, and WP Editor.MD
+ *
+ * @since 1.3.0
+ *
+ * @param  array $post      Post object which contains content to check for block.
+ * @return array $post      Post object.
+ */
+function gutenberg_remove_wpcom_markdown_support( $post ) {
+	if ( content_has_blocks( $post->post_content ) ) {
+		remove_post_type_support( 'post', 'wpcom-markdown' );
+	}
+	return $post;
+}
+add_filter( 'rest_pre_insert_post', 'gutenberg_remove_wpcom_markdown_support' );

--- a/lib/register.php
+++ b/lib/register.php
@@ -286,6 +286,18 @@ function gutenberg_post_has_blocks( $post_id ) {
 }
 
 /**
+ * Determine whether a content string contains blocks.
+ *
+ * @since 1.3.0
+ *
+ * @param string $content Content to test.
+ * @return bool Whether the content contains blocks.
+ */
+function content_has_blocks( $content ) {
+	return false !== strpos( $content, '<!-- wp:' );
+}
+
+/**
  * Adds a "Gutenberg" post state for post tables, if the post contains blocks.
  *
  * @param  array   $post_states An array of post display states.

--- a/lib/register.php
+++ b/lib/register.php
@@ -282,7 +282,7 @@ function gutenberg_can_edit_post( $post_id ) {
  */
 function gutenberg_post_has_blocks( $post_id ) {
 	$post = get_post( $post_id );
-	return $post && strpos( $post->post_content, '<!-- wp:' ) !== false;
+	return $post && content_has_blocks( $post->post_content );
 }
 
 /**


### PR DESCRIPTION
## Description

When saving text blocks while Jetpack Markdown is enabled, the `<p>` tags are stripped on save. When loaded again in Gutenberg the blocks are not recognized since the tags are needed to properly parse paragraph blocks.

## How to Test

1. Install Jetpack plugin in Settings, under Compose enable Markdown syntax
2. Create a new post with at least one text block and save
3. Click over to view the post and then click "Edit in Gutenberg"
4. The text block will have paragraph tags deleted and be asked to convert to classic block.

## Change

* This change disables markdown on content that is detected as Gutenberg by adding a filter using the `rest_pre_insert_post` hook.

