### PR TITLE
Chrome: Use expandable panels for the block inspector

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -1,10 +1,14 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { concatChildren } from '@wordpress/element';
-import classnames from 'classnames';
-import { PanelBody } from 'components';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { concatChildren } from '@wordpress/element';
 import classnames from 'classnames';
+import { PanelBody } from 'components';
 
 /**
  * Internal dependencies
@@ -110,37 +111,41 @@ registerBlockType( 'core/paragraph', {
 					<BlockDescription>
 						<p>{ __( 'Text. Great things start here.' ) }</p>
 					</BlockDescription>
-					<h3>{ __( 'Text Settings' ) }</h3>
-					<ToggleControl
-						label={ __( 'Drop Cap' ) }
-						checked={ !! dropCap }
-						onChange={ toggleDropCap }
-					/>
-					<RangeControl
-						label={ __( 'Font Size' ) }
-						value={ fontSize || '' }
-						onChange={ ( value ) => setAttributes( { fontSize: value } ) }
-						min={ 10 }
-						max={ 200 }
-						beforeIcon="editor-textcolor"
-						allowReset
-					/>
-					<h3>{ __( 'Background Color' ) }</h3>
-					<ColorPalette
-						value={ backgroundColor }
-						onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
-						withTransparentOption
-					/>
-					<h3>{ __( 'Text Color' ) }</h3>
-					<ColorPalette
-						value={ textColor }
-						onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
-					/>
-					<h3>{ __( 'Block Alignment' ) }</h3>
-					<BlockAlignmentToolbar
-						value={ width }
-						onChange={ ( nextWidth ) => setAttributes( { width: nextWidth } ) }
-					/>
+					<PanelBody title={ __( 'Text Settings' ) }>
+						<ToggleControl
+							label={ __( 'Drop Cap' ) }
+							checked={ !! dropCap }
+							onChange={ toggleDropCap }
+						/>
+						<RangeControl
+							label={ __( 'Font Size' ) }
+							value={ fontSize || '' }
+							onChange={ ( value ) => setAttributes( { fontSize: value } ) }
+							min={ 10 }
+							max={ 200 }
+							beforeIcon="editor-textcolor"
+							allowReset
+						/>
+					</PanelBody>
+					<PanelBody title={ __( 'Background Color' ) }>
+						<ColorPalette
+							value={ backgroundColor }
+							onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
+							withTransparentOption
+						/>
+					</PanelBody>
+					<PanelBody title={ __( 'Text Color' ) }>
+						<ColorPalette
+							value={ textColor }
+							onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
+						/>
+					</PanelBody>
+					<PanelBody title={ __( 'Block Alignment' ) }>
+						<BlockAlignmentToolbar
+							value={ width }
+							onChange={ ( nextWidth ) => setAttributes( { width: nextWidth } ) }
+						/>
+					</PanelBody>
 				</InspectorControls>
 			),
 			<BlockAutocomplete key="editable" onReplace={ onReplace }>

--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -37,13 +37,13 @@ class PanelBody extends Component {
 	}
 
 	render() {
-		const { title, children, opened } = this.props;
+		const { title, children, opened, className } = this.props;
 		const isOpened = opened === undefined ? this.state.opened : opened;
 		const icon = `arrow-${ isOpened ? 'down' : 'right' }`;
-		const className = classnames( 'components-panel__body', { 'is-opened': isOpened } );
+		const classes = classnames( 'components-panel__body', className, { 'is-opened': isOpened } );
 
 		return (
-			<div className={ className }>
+			<div className={ classes }>
 				{ !! title && (
 					<h3 className="components-panel__body-title">
 						<Button

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -18,12 +18,15 @@
 }
 
 .components-panel__body {
-	padding: $panel-padding;
 	border-top: 1px solid $light-gray-500;
 	border-bottom: 1px solid $light-gray-500;
 
 	h3 {
 		margin: 0 0 .5em 0;
+	}
+
+	&.is-opened {
+		padding: $panel-padding;
 	}
 }
 
@@ -51,13 +54,14 @@
 	margin-top: -1px;
 }
 
-.components-panel .components-panel__body-title {
+.components-panel__body > .components-panel__body-title {
 	display: block;
 	padding: 0;
-	margin: -1 * $panel-padding;
 	font-size: inherit;
+	margin-bottom: 0;
 }
-.components-panel__body.is-opened .components-panel__body-title {
+.components-panel__body.is-opened > .components-panel__body-title {
+	margin: -1 * $panel-padding;
 	margin-bottom: 0;
 }
 

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -24,7 +24,7 @@ const BlockInspector = ( { selectedBlock } ) => {
 
 	return (
 		<Panel>
-			<PanelBody>
+			<PanelBody className="editor-block-inspector__content">
 				<Slot name="Inspector.Controls" />
 				<BlockInspectorAdvancedControls />
 			</PanelBody>

--- a/editor/sidebar/block-inspector/style.scss
+++ b/editor/sidebar/block-inspector/style.scss
@@ -25,7 +25,7 @@
 		margin: 0 0 1em 0;
 	}
 
-	&.is-opened> .components-panel__body-title {
+	&.is-opened > .components-panel__body-title {
 		margin-bottom: 5px;
 	}
 

--- a/editor/sidebar/block-inspector/style.scss
+++ b/editor/sidebar/block-inspector/style.scss
@@ -17,6 +17,23 @@
 	text-align: center;
 }
 
+.editor-block-inspector__content .components-panel__body {
+	border: none;
+	margin: 0 -16px;
+
+	.blocks-base-control {
+		margin: 0 0 1em 0;
+	}
+
+	&.is-opened> .components-panel__body-title {
+		margin-bottom: 5px;
+	}
+
+	.components-panel__body-toggle {
+		color: $dark-gray-500;
+	}
+}
+
 .editor-advanced-controls__anchor {
 	display: inline-flex;
 	max-width: 100%;


### PR DESCRIPTION
## Description
fixes #2769 This PR adds expandable panels to the block inspector for the text block. we'll have to think block by block how to group things together.

## Screenshots 

<img width="287" alt="screen shot 2017-09-28 at 11 14 37" src="https://user-images.githubusercontent.com/272444/30961493-483a7ec4-a43e-11e7-80f8-f7589a083f8f.png">

**Question:** 

 - I ended up overriding the PanelBody styling for the inspector panels, I wonder if it's worth creating a separate component or if we're ok with these overrides.

 - The open/closed state is not persisted. If we want to do so, it will create a lot of overhead because we need per block persistence and we do not want to introduce a block API just for this. ( we can change the default opened state value of each panel separately)