### PR TITLE
Fix issues with sticky quick toolbar positioning

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -92,7 +92,7 @@
 	position: sticky;
 
 	@include break-medium() {
-		top: $header-height + $admin-bar-height + $item-spacing;
+		top: $item-spacing;
 	}
 }
 

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -146,6 +146,10 @@
 	display: block;
 }
 
+.freeform-toolbar.has-advanced-toolbar {
+	margin-top: -85px;	/* Pull upwards the classic text toolbar when enabled */
+}
+
 .freeform-toolbar div.mce-btn-group {
 	padding: 0;
 	margin: 0;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -340,7 +340,7 @@
 	}
 
 	@include break-medium() {
-		top: $header-height + $admin-bar-height + $item-spacing;
+		top: $item-spacing;
 	}
 
 	&.is-appearing-active {


### PR DESCRIPTION
This PR improves the positioning of the sticky toolbar in normal blocks and the Classic Text blocks, which regressed when the general layout was refactored to have multiple scrollable areas.

Additionally, this PR fixes #1983 by pushing the Classic Text toolbar upwards when the kitchen sink is enabled:

![classic text block toolbar](https://user-images.githubusercontent.com/1204802/31007171-e63ac1ee-a4ff-11e7-9cae-7b0a6e445ac8.gif)
