### PR TITLE
Fix: Content overflowing outside the container in the verse block

### DIFF
--- a/blocks/library/verse/editor.scss
+++ b/blocks/library/verse/editor.scss
@@ -5,4 +5,5 @@ pre.wp-block-verse,
 	font-family: inherit;
 	font-size: inherit;
 	padding: 1em;
+	overflow: auto;
 }


### PR DESCRIPTION
## Description
This adds `overflow: auto` CSS property to the verse block so that the content does not overflow the block container.

## How Has This Been Tested?
Tested on Chrome (61.0.3163.100) on MacOS High Sierra.

## Screenshots (jpeg or gifs if applicable):

![image](https://user-images.githubusercontent.com/2931091/31009628-c7998cd6-a525-11e7-8ccc-60a0f4146473.png)


## Types of changes
- This introduces a CSS change
- Fixes: #2821 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.