### PR TITLE
Persist recently used blocks, and record block usage

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -3,12 +3,12 @@
  */
 import optimist from 'redux-optimist';
 import { combineReducers } from 'redux';
-import { difference, get, reduce, keyBy, first, last, omit, without, mapValues } from 'lodash';
+import { difference, get, reduce, keyBy, keys, first, last, omit, without, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { getBlockTypes } from '@wordpress/blocks';
+import { getBlockTypes, getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -438,15 +438,19 @@ export function preferences( state = STORE_DEFAULTS.preferences, action ) {
 				recentlyUsedBlocks,
 			};
 		case 'SETUP_EDITOR':
-			// initially populate the recently used blocks with blocks the user most frequently uses
+			const filterInvalidBlocksFromList = list => list.filter( name => getBlockType( name ) !== undefined );
+			const filterInvalidBlocksFromObject = obj => omit( obj, keys( obj ).filter( name => getBlockType( name ) === undefined ) );
 			const commonBlocks = getBlockTypes()
 				.filter( ( blockType ) => 'common' === blockType.category )
 				.map( ( blockType ) => blockType.name );
+
 			return {
 				...state,
-				recentlyUsedBlocks: [ ...state.recentlyUsedBlocks ]
+				// recently used gets filled up to `maxRecent` with blocks from the common category
+				recentlyUsedBlocks: filterInvalidBlocksFromList( [ ...state.recentlyUsedBlocks ] )
 					.concat( difference( commonBlocks, state.recentlyUsedBlocks ) )
 					.slice( 0, maxRecent ),
+				blockUsage: filterInvalidBlocksFromObject( state.blockUsage ),
 			};
 	}
 

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -3,7 +3,7 @@
  */
 import optimist from 'redux-optimist';
 import { combineReducers } from 'redux';
-import { difference, get, reduce, keyBy, keys, first, last, omit, without, mapValues } from 'lodash';
+import { difference, get, reduce, keyBy, first, last, omit, without, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -442,11 +442,10 @@ export function preferences( state = STORE_DEFAULTS.preferences, action ) {
 			const commonBlocks = getBlockTypes()
 				.filter( ( blockType ) => 'common' === blockType.category )
 				.map( ( blockType ) => blockType.name );
-			const frequentlyUsedBlocks = keys( state.blockUsage ).sort( ( a, b ) => state.blockUsage[ b ] - state.blockUsage[ a ] );
 			return {
 				...state,
-				recentlyUsedBlocks: frequentlyUsedBlocks
-					.concat( difference( commonBlocks, frequentlyUsedBlocks ) )
+				recentlyUsedBlocks: [ ...state.recentlyUsedBlocks ]
+					.concat( difference( commonBlocks, state.recentlyUsedBlocks ) )
 					.slice( 0, maxRecent ),
 			};
 	}

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -3,7 +3,7 @@
  */
 import optimist from 'redux-optimist';
 import { combineReducers } from 'redux';
-import { difference, get, reduce, keyBy, keys, first, last, omit, without, mapValues } from 'lodash';
+import { difference, get, reduce, keyBy, keys, first, last, omit, pick, without, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -444,7 +444,7 @@ export function preferences( state = STORE_DEFAULTS.preferences, action ) {
 		case 'SETUP_EDITOR':
 			const isBlockDefined = name => getBlockType( name ) !== undefined;
 			const filterInvalidBlocksFromList = list => list.filter( isBlockDefined );
-			const filterInvalidBlocksFromObject = obj => omit( obj, keys( obj ).filter( name => ! isBlockDefined( name ) ) );
+			const filterInvalidBlocksFromObject = obj => pick( obj, keys( obj ).filter( isBlockDefined ) );
 			const commonBlocks = getBlockTypes()
 				.filter( ( blockType ) => 'common' === blockType.category )
 				.map( ( blockType ) => blockType.name );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -852,5 +852,5 @@ export function getNotices( state ) {
  */
 export function getRecentlyUsedBlocks( state ) {
 	// resolves the block names in the state to the block type settings
-	return state.userData.recentlyUsedBlocks.map( blockType => getBlockType( blockType ) );
+	return state.preferences.recentlyUsedBlocks.map( blockType => getBlockType( blockType ) );
 }

--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -3,5 +3,7 @@ export const STORE_DEFAULTS = {
 		mode: 'visual',
 		isSidebarOpened: window.innerWidth >= 782,
 		panels: { 'post-status': true },
+		recentlyUsedBlocks: [],
+		blockUsage: {},
 	},
 };

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -882,6 +882,20 @@ describe( 'state', () => {
 			);
 			expect( state.recentlyUsedBlocks ).toHaveLength( 8 );
 		} );
+
+		it( 'should remove unregistered blocks from persisted recent usage', () => {
+			const state = preferences( deepFreeze( { recentlyUsedBlocks: [ 'core-embed/i-do-not-exist', 'core-embed/youtube' ] } ), {
+				type: 'SETUP_EDITOR',
+			} );
+			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
+		} );
+
+		it( 'should remove unregistered blocks from persisted block usage stats', () => {
+			const state = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: { 'core/i-do-not-exist': 42, 'core-embed/youtube': 88 } } ), {
+				type: 'SETUP_EDITOR',
+			} );
+			expect( state.blockUsage ).toEqual( { 'core-embed/youtube': 88 } );
+		} );
 	} );
 
 	describe( 'saving()', () => {

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -23,7 +23,6 @@ import {
 	saving,
 	notices,
 	showInsertionPoint,
-	userData,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -785,10 +784,10 @@ describe( 'state', () => {
 	} );
 
 	describe( 'preferences()', () => {
-		it( 'should be opened by default and show the post-status panel', () => {
+		it( 'should apply all defaults', () => {
 			const state = preferences( undefined, {} );
 
-			expect( state ).toEqual( { mode: 'visual', isSidebarOpened: true, panels: { 'post-status': true } } );
+			expect( state ).toEqual( { blockUsage: {}, recentlyUsedBlocks: [], mode: 'visual', isSidebarOpened: true, panels: { 'post-status': true } } );
 		} );
 
 		it( 'should toggle the sidebar open flag', () => {
@@ -824,6 +823,64 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( { isSidebarOpened: false, mode: 'text' } );
+		} );
+
+		it( 'should record recently used blocks', () => {
+			const state = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: {} } ), {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
+					uid: 'bacon',
+					name: 'core-embed/twitter',
+				} ],
+			} );
+
+			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
+
+			const twoRecentBlocks = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: {} } ), {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
+					uid: 'eggs',
+					name: 'core-embed/twitter',
+				}, {
+					uid: 'bacon',
+					name: 'core-embed/youtube',
+				} ],
+			} );
+
+			expect( twoRecentBlocks.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
+			expect( twoRecentBlocks.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/twitter' );
+		} );
+
+		it( 'should record block usage', () => {
+			const state = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: {} } ), {
+				type: 'INSERT_BLOCKS',
+				blocks: [ {
+					uid: 'eggs',
+					name: 'core-embed/twitter',
+				}, {
+					uid: 'bacon',
+					name: 'core-embed/youtube',
+				}, {
+					uid: 'milk',
+					name: 'core-embed/youtube',
+				} ],
+			} );
+
+			expect( state.blockUsage ).toEqual( { 'core-embed/youtube': 2, 'core-embed/twitter': 1 } );
+		} );
+
+		it( 'should populate recentlyUsedBlocks with the most frequently used blocks, filling up with common blocks, on editor setup', () => {
+			const state = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: { 'core-embed/youtube': 2, 'core-embed/twitter': 3 } } ), {
+				type: 'SETUP_EDITOR',
+			} );
+
+			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
+			expect( state.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/youtube' );
+
+			state.recentlyUsedBlocks.slice( 2 ).forEach(
+				block => expect( getBlockType( block ).category ).toEqual( 'common' )
+			);
+			expect( state.recentlyUsedBlocks ).toHaveLength( 8 );
 		} );
 	} );
 
@@ -916,56 +973,6 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				b: originalState.b,
 			} );
-		} );
-	} );
-
-	describe( 'userData()', () => {
-		beforeAll( () => {
-			registerBlockType( 'core/test-block', {
-				save: noop,
-				edit: noop,
-				category: 'common',
-				title: 'test block',
-			} );
-		} );
-
-		afterAll( () => {
-			unregisterBlockType( 'core/test-block' );
-		} );
-
-		it( 'should record recently used blocks', () => {
-			const original = userData( undefined, {} );
-			const state = userData( original, {
-				type: 'INSERT_BLOCKS',
-				blocks: [ {
-					uid: 'bacon',
-					name: 'core-embed/twitter',
-				} ],
-			} );
-
-			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
-
-			const twoRecentBlocks = userData( state, {
-				type: 'INSERT_BLOCKS',
-				blocks: [ {
-					uid: 'eggs',
-					name: 'core-embed/youtube',
-				} ],
-			} );
-
-			expect( twoRecentBlocks.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
-			expect( twoRecentBlocks.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/twitter' );
-		} );
-
-		it( 'should populate recently used blocks with blocks from the common category', () => {
-			const initial = userData( undefined, {
-				type: 'SETUP_EDITOR',
-			} );
-
-			initial.recentlyUsedBlocks.forEach(
-				block => expect( getBlockType( block ).category ).toEqual( 'common' )
-			);
-			expect( initial.recentlyUsedBlocks ).toHaveLength( 8 );
 		} );
 	} );
 } );

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -869,8 +869,8 @@ describe( 'state', () => {
 			expect( state.blockUsage ).toEqual( { 'core-embed/youtube': 2, 'core-embed/twitter': 1 } );
 		} );
 
-		it( 'should populate recentlyUsedBlocks with the most frequently used blocks, filling up with common blocks, on editor setup', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: { 'core-embed/youtube': 2, 'core-embed/twitter': 3 } } ), {
+		it( 'should populate recentlyUsedBlocks, filling up with common blocks, on editor setup', () => {
+			const state = preferences( deepFreeze( { recentlyUsedBlocks: [ 'core-embed/twitter', 'core-embed/youtube' ] } ), {
 				type: 'SETUP_EDITOR',
 			} );
 


### PR DESCRIPTION
## Description

Loading up a new post populated the recently used blocks with
blocks from the common category. This change persists the
recently used blocks, so they are there next time.

This also keeps a "highscore table" of block usage, so in
a future PR, we can use this data to display the user's
most frequently used blocks next to the inserter, where we
currently hardcode paragraph and image. The work to do
that will be in a future PR so that when it's released, we
have a better chance of the user having usage data that
is meaningful to base it on.

## How Has This Been Tested?

Add some blocks to a post, they should appear at the
top of the recently used blocks.

Start a new post, or load an existing post, and the blocks in
the recent tab should show the blocks you used most
recently.

## Types of changes
New feature (non-breaking change which adds functionality)
