### PR TITLE
Block Switcher: Add 'Transform into:' to top of the list

### DIFF
--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -90,7 +90,7 @@ class BlockSwitcher extends Component {
 						tabIndex="0"
 						aria-label={ __( 'Block types' ) }
 					>
-						<span>{ __( 'Transforms into:' ) }</span>
+						<span>{ __( 'Transform into:' ) }</span>
 						{ allowedBlocks.map( ( { name, title, icon } ) => (
 							<IconButton
 								key={ name }

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -90,6 +90,7 @@ class BlockSwitcher extends Component {
 						tabIndex="0"
 						aria-label={ __( 'Block types' ) }
 					>
+						<span>{ __( 'Transforms into:' ) }</span>
 						{ allowedBlocks.map( ( { name, title, icon } ) => (
 							<IconButton
 								key={ name }

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -90,7 +90,11 @@ class BlockSwitcher extends Component {
 						tabIndex="0"
 						aria-label={ __( 'Block types' ) }
 					>
-						<span>{ __( 'Transform into:' ) }</span>
+						<span
+							className="editor-block-switcher__menu-title"
+						>
+							{ __( 'Transform into:' ) }
+						</span>
 						{ allowedBlocks.map( ( { name, title, icon } ) => (
 							<IconButton
 								key={ name }

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -30,16 +30,12 @@
 	background: $white;
 	padding: 3px 3px 0 3px;
 	z-index: z-index( '.editor-block-switcher__menu' );
+}
 
-	input {
-		font-size: $default-font-size;
-	}
-
-	span {
-		display: block;
-		padding: 6px;
-		color: $light-gray-900;
-	}
+.editor-block-switcher__menu-title {
+	display: block;
+	padding: 6px;
+	color: $dark-gray-300;
 }
 
 .editor-block-switcher__menu-item {

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -34,6 +34,12 @@
 	input {
 		font-size: $default-font-size;
 	}
+
+	span {
+		display: block;
+		padding: 6px;
+		color: $light-gray-900;
+	}
 }
 
 .editor-block-switcher__menu-item {


### PR DESCRIPTION
## Description
Adds the text "Transform into" wrapped in span tags to the top of the list in the Block Switcher.
Related issue: #493 

## How Has This Been Tested?
Visually on my local machine.

## Screenshots (jpeg or gifs if applicable):
Before: https://cloudup.com/cPWwpVWU7b5
After: https://cloudup.com/cOKNmDJeu_8

## Types of changes
It's labelled as an enhancement.

## Checklist:
- [ x] My code is tested.
- [ x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.