### PR TITLE
Editor: Hitting enter when a block is selected creates a default block after the selected block

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -278,7 +278,7 @@ class VisualEditorBlock extends Component {
 
 			this.props.onInsertBlocks( [
 				createBlock( 'core/paragraph' ),
-			], this.props.order );
+			], this.props.order + 1 );
 		}
 		this.removeOrDeselect( event );
 	}


### PR DESCRIPTION
fix #2842 

## Testing instructions

 - Insert an image
 - Select the image block (click on the image)
 - Hit "Enter"
 - A new paragraph block should be created after the selected block