### PR TITLE
Adding a feedback link to the Gutenberg menu

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -37,6 +37,8 @@ function the_gutenberg_project() {
  * @since 0.1.0
  */
 function gutenberg_menu() {
+	global $submenu;
+
 	add_menu_page(
 		'Gutenberg',
 		'Gutenberg',
@@ -62,6 +64,12 @@ function gutenberg_menu() {
 		'edit_posts',
 		'gutenberg-demo',
 		'the_gutenberg_project'
+	);
+
+	$submenu['gutenberg'][] = array(
+		__( 'Feedback', 'gutenberg' ),
+		'edit_posts',
+		'http://wordpressdotorg.polldaddy.com/s/gutenberg-support',
 	);
 }
 add_action( 'admin_menu', 'gutenberg_menu' );


### PR DESCRIPTION
fix #2802 

AFAIK, There's no easy way to add an external link with a target `_blank` to a WordPress admin menu, We'd need to add all sorts of "hacks" to do this. This PR adds a simple link instead.

