### PR TITLE
Paste: remove non inline elements from inline pasted content

### DIFF
--- a/blocks/api/paste/index.js
+++ b/blocks/api/paste/index.js
@@ -19,7 +19,7 @@ import msListConverter from './ms-list-converter';
 import listMerger from './list-merger';
 import imageCorrector from './image-corrector';
 import blockquoteNormaliser from './blockquote-normaliser';
-import { deepFilter, isInvalidInline, isNotWhitelisted, isPlain } from './utils';
+import { deepFilter, isInvalidInline, isNotWhitelisted, isPlain, isInline } from './utils';
 import showdown from 'showdown';
 
 export default function( { HTML, plainText, inline } ) {
@@ -50,7 +50,7 @@ export default function( { HTML, plainText, inline } ) {
 		formattingTransformer,
 		stripAttributes,
 		commentRemover,
-		createUnwrapper( isNotWhitelisted ),
+		createUnwrapper( ( node ) => isNotWhitelisted( node ) || ( inline && ! isInline( node ) ) ),
 		blockquoteNormaliser,
 	] );
 

--- a/blocks/api/paste/test/index.js
+++ b/blocks/api/paste/test/index.js
@@ -68,6 +68,15 @@ describe( 'paste', () => {
 		equal( pastedBlock.name, 'test/unknown' );
 		equal( pastedBlock.attributes.content, '<figcaption>test</figcaption>' );
 	} );
+
+	it( 'should filter inline content', () => {
+		const filtered = paste( {
+			HTML: '<h2><em>test</em></h2>',
+			inline: true,
+		} );
+
+		equal( filtered, '<em>test</em>' );
+	} );
 } );
 
 import './integration';


### PR DESCRIPTION
## Description
This PR ensures that non inline elements are removed if the content is forced as inline (inline `Editable`). At the moment, these elements are left. E.g. paste some blocks in a caption.

## How Has This Been Tested?
1. Copy some blocks or any HTML with block-level HTML.
2. Paste it in a caption or similar.
3. Content should be free of block-level HTML, but formatting should be kept.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.