### PR TITLE
Build: Clean working directory prior to packaging

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -7,6 +7,13 @@ set -e
 cd "$(dirname "$0")"
 cd ..
 
+# Enable nicer messaging for build status
+YELLOW_BOLD='\033[1;33m';
+COLOR_RESET='\033[0m';
+status () {
+	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
+}
+
 # Make sure there are no changes in the working tree.  Release builds should be
 # traceable to a particular commit and reliably reproducible.  (This is not
 # totally true at the moment because we download nightly vendor scripts).
@@ -33,9 +40,11 @@ fi
 
 # Remove ignored files to reset repository to pristine condition. Previous test
 # ensures that changed files abort the plugin build.
+status "Cleaning working directory..."
 git clean -xdf
 
 # Download all vendor scripts
+status "Downloading remote vendor scripts..."
 vendor_scripts=""
 # Using `command | while read...` is more typical, but the inside of the while
 # loop will run under a separate process this way, meaning that it cannot
@@ -66,7 +75,9 @@ while IFS='|' read -u 3 url filename; do
 done
 
 # Run the build
+status "Installing dependencies..."
 npm install
+status "Generating build..."
 npm run build
 
 # Remove any existing zip file
@@ -79,6 +90,7 @@ php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
 # Generate the plugin zip file
+status "Creating archive..."
 zip -r gutenberg.zip \
 	gutenberg.php \
 	lib/*.php \
@@ -99,3 +111,5 @@ zip -r gutenberg.zip \
 
 # Reset `gutenberg.php`
 git checkout gutenberg.php
+
+status "Done."

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -31,6 +31,10 @@ if [ "$branch" != 'master' ]; then
 	sleep 2
 fi
 
+# Remove ignored files to reset repository to pristine condition. Previous test
+# ensures that changed files abort the plugin build.
+git clean -xdf
+
 # Download all vendor scripts
 vendor_scripts=""
 # Using `command | while read...` is more typical, but the inside of the while


### PR DESCRIPTION
This pull request seeks to improve the plugin build packager script to ensure a clean working directory before creating the plugin archive. This seeks to avoid the case where ignored local files are accidentally included in the built package. It also adds improved messaging to the build script to indicate the current status of the build ("Downloading remote vendor scripts...", "Creating archive...", etc).

__Open questions:__

- The script uses `git clean -xdf` to forcefully remove ignored files from the current working directory. A previous condition in the build script will check if there are any uncommitted changes, so this should only capture ignored files (`build/`, `node_modules/`, `vendor/`, etc). If there are concerns around removing files, we could either make this more interactive or present the user with the option to run the command for themselves. However, given the prior condition and the context in which this script is run, I don't think there's very much risk in this.
- These changes reveal that `.map` files were incidentally included in the build likely as leftovers from local development, and are not generated by the production build. We should consider ignoring `.map` from being included in the archive, or update the production build to create sourcemap files. Currently a warning is logged that the `zip` command matches no `.map` files.

https://github.com/WordPress/gutenberg/blob/769fcb8c42ab0962673acb1468cfdb03d8f31c22/bin/build-plugin-zip.sh#L100-L106 

__Testing instructions:__

1. Create a dummy file in an ignored directory, e.g. `echo "foo" > editor/build/foo.js`
2. Run `npm run package-plugin`
3. Note the script displays that the file added in step 1 is removed
4. After the script has finished, check the archive and verify that `editor/build/foo.js` within the archive does not exist
5. Extra credit: Verify on a test site that the plugin can be installed and used from the generated archive