### PR TITLE
Chrome: Use an expandable panel for the block's advanced settings

### DIFF
--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { Component } from '@wordpress/element';
 import { getBlockType, InspectorControls } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { ClipboardButton, Tooltip } from '@wordpress/components';
+import { ClipboardButton, Tooltip, PanelBody } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -69,8 +69,7 @@ class BlockInspectorAdvancedControls extends Component {
 		}
 
 		return (
-			<div>
-				<h3>{ __( 'Block Settings' ) }</h3>
+			<PanelBody className="editor-advanced-controls" title={ __( 'Block Settings' ) }>
 				{ false !== blockType.className &&
 					<InspectorControls.TextControl
 						label={ __( 'Additional CSS Class' ) }
@@ -95,7 +94,7 @@ class BlockInspectorAdvancedControls extends Component {
 						}
 					</div>
 				}
-			</div>
+			</PanelBody>
 		);
 	}
 }

--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -69,7 +69,7 @@ class BlockInspectorAdvancedControls extends Component {
 		}
 
 		return (
-			<PanelBody className="editor-advanced-controls" title={ __( 'Block Settings' ) }>
+			<PanelBody className="editor-advanced-controls" title={ __( 'Advanced' ) }>
 				{ false !== blockType.className &&
 					<InspectorControls.TextControl
 						label={ __( 'Additional CSS Class' ) }

--- a/editor/sidebar/block-inspector/style.scss
+++ b/editor/sidebar/block-inspector/style.scss
@@ -34,6 +34,10 @@
 	}
 }
 
+.editor-block-inspector__content .editor-advanced-controls {
+	margin-bottom: -14px;
+}
+
 .editor-advanced-controls__anchor {
 	display: inline-flex;
 	max-width: 100%;


### PR DESCRIPTION
## Description
closes #2851

## Screenshots (jpeg or gifs if applicable):
<img width="277" alt="screen shot 2017-10-02 at 14 09 10" src="https://user-images.githubusercontent.com/272444/31078781-53087e9c-a77b-11e7-968a-8b3a56d7ee6e.png">
