### PR TITLE
Fix multi-select inside new scroll container

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -138,7 +138,8 @@ class VisualEditorBlockList extends Component {
 		this.selectionAtStart = uid;
 
 		window.addEventListener( 'mousemove', this.onPointerMove );
-		window.addEventListener( 'scroll', this.onScroll );
+		// Capture scroll on all elements.
+		window.addEventListener( 'scroll', this.onScroll, true );
 		window.addEventListener( 'mouseup', this.onSelectionEnd );
 	}
 
@@ -169,7 +170,7 @@ class VisualEditorBlockList extends Component {
 		delete this.selectionAtStart;
 
 		window.removeEventListener( 'mousemove', this.onPointerMove );
-		window.removeEventListener( 'scroll', this.onScroll );
+		window.removeEventListener( 'scroll', this.onScroll, true );
 		window.removeEventListener( 'mouseup', this.onSelectionEnd );
 	}
 

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { throttle, reduce, noop } from 'lodash';
+import { throttle, mapValues, noop, invert } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -83,14 +83,15 @@ class VisualEditorBlockList extends Component {
 	onPointerMove( { clientY } ) {
 		const BUFFER = 20;
 		const { multiSelectedBlocks } = this.props;
-		const y = clientY + window.pageYOffset;
+		const boundaries = this.refs[ this.selectionAtStart ].getBoundingClientRect();
+		const y = clientY - boundaries.top;
 
 		// If there is no selection yet, make the use move at least BUFFER px
 		// away from the block with the pointer.
 		if (
 			! multiSelectedBlocks.length &&
-			y - this.startLowerBoundary < BUFFER &&
-			this.startUpperBoundary - y < BUFFER
+			y + BUFFER > 0 &&
+			y - BUFFER < boundaries.height
 		) {
 			return;
 		}
@@ -123,20 +124,18 @@ class VisualEditorBlockList extends Component {
 	}
 
 	onSelectionStart( uid ) {
-		const { pageYOffset } = window;
 		const boundaries = this.refs[ uid ].getBoundingClientRect();
 
-		// Create a Y coödinate map to unique block IDs.
-		this.coordMap = reduce( this.refs, ( acc, node, blockUid ) => ( {
-			...acc,
-			[ pageYOffset + node.getBoundingClientRect().top ]: blockUid,
-		} ), {} );
-		// Cache an array of the Y coödrinates for use in `onPointerMove`.
-		this.coordMapKeys = Object.keys( this.coordMap );
-		this.selectionAtStart = uid;
+		// Create a uid to Y coödinate map.
+		const uidToCoordMap = mapValues( this.refs, ( node ) => {
+			return node.getBoundingClientRect().top - boundaries.top;
+		} );
 
-		this.startUpperBoundary = pageYOffset + boundaries.top;
-		this.startLowerBoundary = pageYOffset + boundaries.bottom;
+		// Cache a Y coödinate to uid map for use in `onPointerMove`.
+		this.coordMap = invert( uidToCoordMap );
+		// Cache an array of the Y coödrinates for use in `onPointerMove`.
+		this.coordMapKeys = Object.values( uidToCoordMap );
+		this.selectionAtStart = uid;
 
 		window.addEventListener( 'mousemove', this.onPointerMove );
 		window.addEventListener( 'scroll', this.onScroll );
@@ -168,8 +167,6 @@ class VisualEditorBlockList extends Component {
 		delete this.coordMap;
 		delete this.coordMapKeys;
 		delete this.selectionAtStart;
-		delete this.startUpperBoundary;
-		delete this.startLowerBoundary;
 
 		window.removeEventListener( 'mousemove', this.onPointerMove );
 		window.removeEventListener( 'scroll', this.onScroll );


### PR DESCRIPTION
## Description
This PR fixes multi-select after 43b84a59aa0a3514804c33e6f602874204fe40ae. There is a new scroll container, and the block list component was relying on the `window` scroll position. Instead of trying to figure about which node is the scroll box etc., I've changed to logic so that it's independent of the scroll position. This would also avoid future issues if more than one container becomes scrollable (intentionally or not).

## How Has This Been Tested?
1. Open the demo content (so the content exceeds screen height).
2. Verify that multi-selection works.
3. Verify that the buffer works (no selection => selection). There should be a bit of space (20px) around the start block that doesn't trigger the multi-selection.
4. Ensure that the selection updates if you move down enough to trigger a scroll by the browser.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.