### PR TITLE
In blockquotes, use cite element instead of footer. #2647

### DIFF
--- a/blocks/library/pullquote/editor.scss
+++ b/blocks/library/pullquote/editor.scss
@@ -11,7 +11,7 @@
 }
 
 .wp-block-pullquote {
-	footer .blocks-editable__tinymce[data-is-empty="true"]:before {
+	cite .blocks-editable__tinymce[data-is-empty="true"]:before {
 		font-size: 14px;
 		font-family: $default-font;
 	}

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -32,7 +32,7 @@ registerBlockType( 'core/pullquote', {
 		},
 		citation: {
 			type: 'array',
-			source: children( 'cite' ),
+			source: children( 'cite,footer' ),
 		},
 		align: {
 			type: 'string',

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -32,7 +32,7 @@ registerBlockType( 'core/pullquote', {
 		},
 		citation: {
 			type: 'array',
-			source: children( 'footer' ),
+			source: children( 'cite' ),
 		},
 		align: {
 			type: 'string',
@@ -83,7 +83,7 @@ registerBlockType( 'core/pullquote', {
 				/>
 				{ ( citation || !! focus ) && (
 					<Editable
-						tagName="footer"
+						tagName="cite"
 						value={ citation }
 						placeholder={ __( 'Write caption…' ) }
 						onChange={
@@ -106,7 +106,7 @@ registerBlockType( 'core/pullquote', {
 			<blockquote className={ `align${ align }` }>
 				{ value && value.map( ( paragraph, i ) => <p key={ i }>{ paragraph.props.children }</p> ) }
 				{ citation && citation.length > 0 && (
-					<footer>{ citation }</footer>
+					<cite>{ citation }</cite>
 				) }
 			</blockquote>
 		);

--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -21,7 +21,7 @@
 		line-height: 1.6;
 	}
 
-	footer {
+	cite {
 		color: $dark-gray-600;
 		position: relative;
 		font-weight: 900;
@@ -29,7 +29,7 @@
 		font-size: 13px;
 	}
 
-	footer p {
+	cite p {
 		font-family: $default-font;
 	}
 }

--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -21,7 +21,8 @@
 		line-height: 1.6;
 	}
 
-	cite {
+	cite,
+	footer {
 		color: $dark-gray-600;
 		position: relative;
 		font-weight: 900;

--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -28,8 +28,4 @@
 		text-transform: uppercase;
 		font-size: 13px;
 	}
-
-	cite p {
-		font-family: $default-font;
-	}
 }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -35,7 +35,7 @@ registerBlockType( 'core/quote', {
 		},
 		citation: {
 			type: 'array',
-			source: children( 'footer' ),
+			source: children( 'cite' ),
 		},
 		align: {
 			type: 'string',
@@ -194,7 +194,7 @@ registerBlockType( 'core/quote', {
 				/>
 				{ ( ( citation && citation.length > 0 ) || !! focus ) && (
 					<Editable
-						tagName="footer"
+						tagName="cite"
 						value={ citation }
 						placeholder={ __( 'Write citation…' ) }
 						onChange={
@@ -222,7 +222,7 @@ registerBlockType( 'core/quote', {
 					<p key={ i }>{ paragraph.props.children }</p>
 				) ) }
 				{ citation && citation.length > 0 && (
-					<footer>{ citation }</footer>
+					<cite>{ citation }</cite>
 				) }
 			</blockquote>
 		);

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -35,7 +35,7 @@ registerBlockType( 'core/quote', {
 		},
 		citation: {
 			type: 'array',
-			source: children( 'cite' ),
+			source: children( 'cite,footer' ),
 		},
 		align: {
 			type: 'string',

--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -2,7 +2,7 @@
 	margin: 0 0 16px;
 	box-shadow: inset 0px 0px 0px 0px $light-gray-500;
 
-	footer {
+	cite {
 		color: $dark-gray-100;
 		margin-top: 1em;
 		position: relative;
@@ -23,7 +23,7 @@
 			font-style: italic;
 			line-height: 1.6;
 		}
-		footer {
+		cite {
 			font-size: 19px;
 			text-align: right;
 		}

--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -2,14 +2,14 @@
 	margin: 0 0 16px;
 	box-shadow: inset 0px 0px 0px 0px $light-gray-500;
 
-	cite {
+	cite,
+	footer {
 		color: $dark-gray-100;
 		margin-top: 1em;
 		position: relative;
 		font-size: $default-font-size;
 		font-style: normal;
 	}
-
 
 	&.blocks-quote-style-1 {
 		border-left: 4px solid $black;
@@ -23,7 +23,9 @@
 			font-style: italic;
 			line-height: 1.6;
 		}
-		cite {
+
+		cite,
+		footer {
 			font-size: 19px;
 			text-align: right;
 		}

--- a/blocks/test/fixtures/core__pullquote.html
+++ b/blocks/test/fixtures/core__pullquote.html
@@ -1,5 +1,5 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote">
-<p>Testing pullquote block...</p><footer>...with a caption</footer>
+<p>Testing pullquote block...</p><cite>...with a caption</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote.json
+++ b/blocks/test/fixtures/core__pullquote.json
@@ -15,6 +15,6 @@
             ],
             "align": "none"
         },
-        "originalContent": "<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><footer>...with a caption</footer>\n</blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote.parsed.json
+++ b/blocks/test/fixtures/core__pullquote.parsed.json
@@ -2,7 +2,7 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "rawContent": "\n<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><footer>...with a caption</footer>\n</blockquote>\n"
+        "rawContent": "\n<blockquote class=\"wp-block-pullquote\">\n<p>Testing pullquote block...</p><cite>...with a caption</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__pullquote.serialized.html
+++ b/blocks/test/fixtures/core__pullquote.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core/pullquote -->
 <blockquote class="wp-block-pullquote">
     <p>Testing pullquote block...</p>
-    <footer>...with a caption</footer>
+    <cite>...with a caption</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.html
@@ -2,6 +2,6 @@
 <blockquote class="wp-block-pullquote alignnone">
     <p>Paragraph <strong>one</strong></p>
     <p>Paragraph two</p>
-    <footer>by whomever</footer>
+    <cite>by whomever</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -25,6 +25,6 @@
             ],
             "align": "none"
         },
-        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>by whomever</footer>\n</blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.parsed.json
@@ -2,7 +2,7 @@
     {
         "blockName": "core/pullquote",
         "attrs": null,
-        "rawContent": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <footer>by whomever</footer>\n</blockquote>\n"
+        "rawContent": "\n<blockquote class=\"wp-block-pullquote alignnone\">\n    <p>Paragraph <strong>one</strong></p>\n    <p>Paragraph two</p>\n    <cite>by whomever</cite>\n</blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -2,6 +2,6 @@
 <blockquote class="wp-block-pullquote alignnone">
     <p>Paragraph <strong>one</strong></p>
     <p>Paragraph two</p>
-    <footer>by whomever</footer>
+    <cite>by whomever</cite>
 </blockquote>
 <!-- /wp:core/pullquote -->

--- a/blocks/test/fixtures/core__quote__style-1.html
+++ b/blocks/test/fixtures/core__quote__style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"style":"1"} -->
-<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
+<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -15,6 +15,6 @@
             ],
             "style": 1
         },
-        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "style": "1"
         },
-        "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>\n"
+        "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core/quote -->
 <blockquote class="wp-block-quote blocks-quote-style-1">
     <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
-    <footer>Matt Mullenweg, 2017</footer>
+    <cite>Matt Mullenweg, 2017</cite>
 </blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-2.html
+++ b/blocks/test/fixtures/core__quote__style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"style":"2"} -->
-<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
+<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -15,6 +15,6 @@
             ],
             "style": 2
         },
-        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -4,7 +4,7 @@
         "attrs": {
             "style": "2"
         },
-        "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>\n"
+        "rawContent": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,6 +1,6 @@
 <!-- wp:core/quote {"style":2} -->
 <blockquote class="wp-block-quote blocks-quote-style-2">
     <p>There is no greater agony than bearing an untold story inside you.</p>
-    <footer>Maya Angelou</footer>
+    <cite>Maya Angelou</cite>
 </blockquote>
 <!-- /wp:core/quote -->

--- a/phpunit/fixtures/long-content.html
+++ b/phpunit/fixtures/long-content.html
@@ -56,7 +56,7 @@
 <p>A huge benefit of blocks is that you can edit them in place and manipulate your content directly. Instead of having fields for editing things like the source of a quote, or the text of a button, you can directly change the content. Try editing the following quote:</p>
 <!-- /wp:core/paragraph -->
 <!-- wp:core/quote { "style": 1 } -->
-<blockquote class="blocks-quote-style-1 wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
+<blockquote class="blocks-quote-style-1 wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:core/quote -->
 <!-- wp:core/paragraph -->
 <p>The information corresponding to the source of the quote is a separate text field, similar to captions under images, so the structure of the quote is protected even if you select, modify, or remove the source. It's always easy to add it back.</p>
@@ -65,7 +65,7 @@
 <p>Blocks can be anything you need. For instance, you may want to insert a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>
 <!-- /wp:core/paragraph -->
 <!-- wp:core/quote { "style": 2 } -->
-<blockquote class="blocks-quote-style-2 wp-block-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
+<blockquote class="blocks-quote-style-2 wp-block-quote"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:core/quote -->
 <!-- wp:core/separator -->
 <hr class="wp-block-separator" />
@@ -109,7 +109,7 @@
 <ul><li>Est quis reque cetero ad</li><li>Sea id autem nominavi deseruisse</li><li>Veniam qualisque definitionem pri id, ea autem feugiat delenit ius, mei at loem affert accumsan</li><li>Dicat eruditi cu est, te pro dicant pericula conclusionemque</li><li>Eius postea volumus mei ad</li></ul>
 <!-- /wp:core/list -->
 <!-- wp:core/pullquote -->
-<blockquote class="blocks-pullquote wp-block-pullquote"><p>Code is Poetry</p><footer>The WordPress community</footer></blockquote>
+<blockquote class="blocks-pullquote wp-block-pullquote"><p>Code is Poetry</p><cite>The WordPress community</cite></blockquote>
 <!-- /wp:core/pullquote -->
 <!-- wp:core/separator -->
 <hr class="wp-block-separator" />

--- a/post-content.js
+++ b/post-content.js
@@ -83,7 +83,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:core/paragraph -->',
 
 		'<!-- wp:core/quote {"style":1} -->',
-		'<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>',
+		'<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>',
 		'<!-- /wp:core/quote -->',
 
 		'<!-- wp:core/paragraph -->',
@@ -95,7 +95,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:core/paragraph -->',
 
 		'<!-- wp:core/quote {"style":2} -->',
-		'<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>',
+		'<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>',
 		'<!-- /wp:core/quote -->',
 
 		'<!-- wp:core/separator -->',
@@ -153,7 +153,7 @@ return &lt;Button&gt;Click Me!&lt;/Button&gt;;\n\
 		'<!-- /wp:core/list -->',
 
 		'<!-- wp:core/pullquote -->',
-		'<blockquote class="wp-block-pullquote alignnone"><p>Code is Poetry</p><footer>The WordPress community</footer></blockquote>',
+		'<blockquote class="wp-block-pullquote alignnone"><p>Code is Poetry</p><cite>The WordPress community</cite></blockquote>',
 		'<!-- /wp:core/pullquote -->',
 
 		'<!-- wp:core/separator -->',


### PR DESCRIPTION
## Description
When merged, this PR implements changes as proposed in #2647: a potential citation in a `<blockquote>` element is now wrapped in a `<cite>` tag instead of `<footer>`.

Changes:

* Update source code.
* Adapt SCSS files.
* Adapt JS fixtures.
* Adapt PHP fixtures.

## How Has This Been Tested?
`$ npm i && npm run ci`
`$ composer install && ./vendor/bin/phpcs`
`$ phpunit`

## Types of changes
Change: in `<blockquote>` elements, replace `<footer>` elements with `<cite>`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

**Happy Hacktober!** 🙂