### PR TITLE
Enable smooth scrolling iOS with new scroll container

### DIFF
--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -16,6 +16,7 @@
 .editor-layout__editor {
 	flex-basis: 100%;
 	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
 }
 
 .editor-layout .components-notice-list {

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -16,6 +16,7 @@
 		z-index: auto;
 		height: auto;
 		overflow: auto;
+		-webkit-overflow-scrolling: touch;
 	}
 
 	@include break-medium() {
@@ -26,6 +27,7 @@
 		border-left: none;
 		border-right: none;
 		overflow: auto;
+		-webkit-overflow-scrolling: touch;
 		height: 100%;
 		padding-top: $sidebar-panel-header-height;
 		margin-top: -1px;


### PR DESCRIPTION
## Description
This PR enables smooth scrolling on iOS with the introduction of a separate scroll container for the content. See 43b84a59aa0a3514804c33e6f602874204fe40ae. It also adds it for the sidebar. Maybe there's some places I missed.

## How Has This Been Tested?
Use iOS and scroll the main content and side bar.

## Screenshots (jpeg or gifs if applicable):

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.