### PR TITLE
Keyboard Shortcuts: Bind Cmd/Ctrl+S as save

### DIFF
--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -7,20 +7,28 @@ import { first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, compose } from '@wordpress/element';
+import { Component, Fragment, compose } from '@wordpress/element';
 import { KeyboardShortcuts, withContext } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { getBlockOrder, getMultiSelectedBlockUids } from '../../store/selectors';
-import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks } from '../../store/actions';
+import {
+	clearSelectedBlock,
+	multiSelect,
+	redo,
+	undo,
+	autosave,
+	removeBlocks,
+} from '../../store/actions';
 
 class EditorGlobalKeyboardShortcuts extends Component {
 	constructor() {
 		super( ...arguments );
 		this.selectAll = this.selectAll.bind( this );
 		this.undoOrRedo = this.undoOrRedo.bind( this );
+		this.save = this.save.bind( this );
 		this.deleteSelectedBlocks = this.deleteSelectedBlocks.bind( this );
 	}
 
@@ -41,6 +49,11 @@ class EditorGlobalKeyboardShortcuts extends Component {
 		event.preventDefault();
 	}
 
+	save( event ) {
+		event.preventDefault();
+		this.props.onSave();
+	}
+
 	deleteSelectedBlocks( event ) {
 		const { multiSelectedBlockUids, onRemove, isLocked } = this.props;
 		if ( multiSelectedBlockUids.length ) {
@@ -53,14 +66,24 @@ class EditorGlobalKeyboardShortcuts extends Component {
 
 	render() {
 		return (
-			<KeyboardShortcuts shortcuts={ {
-				'mod+a': this.selectAll,
-				'mod+z': this.undoOrRedo,
-				'mod+shift+z': this.undoOrRedo,
-				backspace: this.deleteSelectedBlocks,
-				del: this.deleteSelectedBlocks,
-				escape: this.props.clearSelectedBlock,
-			} } />
+			<Fragment>
+				<KeyboardShortcuts
+					shortcuts={ {
+						'mod+a': this.selectAll,
+						'mod+z': this.undoOrRedo,
+						'mod+shift+z': this.undoOrRedo,
+						backspace: this.deleteSelectedBlocks,
+						del: this.deleteSelectedBlocks,
+						escape: this.props.clearSelectedBlock,
+					} }
+				/>
+				<KeyboardShortcuts
+					bindGlobal
+					shortcuts={ {
+						'mod+s': this.save,
+					} }
+				/>
+			</Fragment>
 		);
 	}
 }
@@ -79,6 +102,7 @@ export default compose(
 			onRedo: redo,
 			onUndo: undo,
 			onRemove: removeBlocks,
+			onSave: autosave,
 		}
 	),
 	withContext( 'editor' )( ( settings ) => {


### PR DESCRIPTION
Related: #2179 
Related: #71 

~_In Progress: While this works, it could lead to unexpected results when adding a new paragraph with text and using the keyboard shortcut, since until #2758 is implemented the value of an Editable field is not synced with the post state until the field is blurred._~

This pull request seeks to add support for saving the post via Ctrl/Cmd+S .

__Open questions:__

Currently, this uses the same behavior as autosave, which is to save a draft if the post is a draft. There is no autosave behavior yet for published posts (#1295, #1773), so Ctrl/Cmd+S will do nothing in these cases. We could bind Cmd+S to update the published post, but the implementation here follows that of the current post editor.

__Testing instructions:__

Verify that Ctrl/Cmd+S saves the current post if editing the current editor.

1. Navigate to Gutenberg > New Post
2. Insert a new paragraph
3. Enter some text
4. Press Ctrl/Cmd+S
5. Note that the post is saved