### PR TITLE
Added a menu subitem for pages, updated the posts subitem

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -48,18 +48,18 @@ function gutenberg_menu() {
 
 	add_submenu_page(
 		'gutenberg',
-		__( 'Gutenberg Page', 'gutenberg' ),
-		__( 'New Page', 'gutenberg' ),
-		'edit_pages',
+		__( 'Gutenberg Post', 'gutenberg' ),
+		__( 'New Post', 'gutenberg' ),
+		'edit_posts',
 		'gutenberg',
 		'the_gutenberg_project'
 	);
 
 	add_submenu_page(
 		'gutenberg',
-		__( 'Gutenberg Post', 'gutenberg' ),
-		__( 'New Post', 'gutenberg' ),
-		'edit_posts',
+		__( 'Gutenberg Page', 'gutenberg' ),
+		__( 'New Page', 'gutenberg' ),
+		'edit_pages',
 		'gutenberg',
 		'the_gutenberg_project'
 	);

--- a/lib/register.php
+++ b/lib/register.php
@@ -48,7 +48,16 @@ function gutenberg_menu() {
 
 	add_submenu_page(
 		'gutenberg',
-		__( 'Gutenberg', 'gutenberg' ),
+		__( 'Gutenberg Page', 'gutenberg' ),
+		__( 'New Page', 'gutenberg' ),
+		'edit_pages',
+		'gutenberg',
+		'the_gutenberg_project'
+	);
+
+	add_submenu_page(
+		'gutenberg',
+		__( 'Gutenberg Post', 'gutenberg' ),
 		__( 'New Post', 'gutenberg' ),
 		'edit_posts',
 		'gutenberg',


### PR DESCRIPTION
## Description
Admin menu amendment per #2239. Adds a **New Page** item above **New Post**.

## How Has This Been Tested?
Ran on a local WordPress install (Windows 10 & XAMPP) using a fresh checkout.

Small amendment to the routine the registers menu items.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/183909/31108489-6bff4d76-a7ae-11e7-82ea-ffd5c44428ff.png)

## Types of changes

Added a **New Page** item above **New Post**.

Amended the New Post configuration to update the title attribute to distinguish posts and pages.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.