### PR TITLE
Sidebar: Fix sidebar scroll overflow (Edge, Safari)

### DIFF
--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -9,7 +9,7 @@
 
 	> .components-panel__header:last-child,
 	> .components-panel__body:last-child {
-		margin-bottom: -1px;
+		border-bottom-width: 0;
 	}
 }
 


### PR DESCRIPTION
Fixes #1899 

This pull request seeks to resolve a scroll overflow which occurs in some browsers in the sidebar due to panel styling. The panel uses negative margins to prevent doubling up on borders between panels. This works well for `margin-top` but in the case of `margin-bottom: -1px`, it can result in container overflow (scroll). The changes here refactor to eliminate the double border by assigning a `border-bottom-width` on the last child of the panel, in place of the negative margin.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/31132301-7647dec0-a82a-11e7-841a-70cede66583b.png)|![After](https://user-images.githubusercontent.com/1779930/31132288-6cafcb84-a82a-11e7-9296-a9d515b09eb9.png)

__Testing instructions:__

Verify that a border is still shown at the bottom of the sidebar Discussion panel (collapsed and expanded), that the border is not doubled up, and that no scroll overflow exists in your preferred browser, Safari, or Edge (Windows).

In macOS, scrollbars are not visible by default unless scrolling. You can [change this setting](https://cloudup.com/cqF641QROEe) to always show scrollbars in System Preferences > General (and I might recommend keeping the setting this way if you work with CSS frequently).