### PR TITLE
Make URL input actually a plain text input. #732

### DIFF
--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -172,7 +172,7 @@ class UrlInput extends Component {
 			<div className="blocks-url-input">
 				<input
 					autoFocus
-					type="url"
+					type="text"
 					aria-label={ __( 'URL' ) }
 					required
 					value={ value }

--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -4,7 +4,7 @@
 	flex-grow: 1;
 	position: relative;
 
-	input[type=url] {
+	input[type=text] {
 		padding: 10px;
 		font-size: $default-font-size;
 		width: 100%;


### PR DESCRIPTION
## Description
The URL input, defined as `type="url"`, does only allow valid URLs, not (partial) URIs. In order to create links to things like anchors, the field is now defined as a plain text input (i.e., without any browser validation).

## How Has This Been Tested?
Code it, build it, use it. 🙂

## Screenshots (jpeg or gifs if applicable):
![url-input](https://user-images.githubusercontent.com/6049306/31171555-68e5a18c-a900-11e7-9f44-e892ed975be2.png)

## Types of changes
* Change the type of the URL input field.
* Adapt the according CSS rule.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.