### PR TITLE
Try fix for Cover Image parallax in Chrome

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -150,9 +150,9 @@ registerBlockType( 'core/cover-image', {
 			<section
 				key="preview"
 				data-url={ url }
-				style={ style }
 				className={ classes }
 			>
+				<div className="wp-block-cover-image__image" style={ style }></div>
 				{ title || !! focus ? (
 					<Editable
 						tagName="h2"

--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -1,12 +1,16 @@
 .wp-block-cover-image {
-	position: relative;
-	background-size: cover;
 	height: 430px;
 	width: 100%;
 	margin: 0;
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	overflow: hidden;
+
+	position: relative;
+
+	clip-path: inset( 1px 1px );
+	margin: -1px -1px;
 
 	h2 {
 		color: white;
@@ -19,7 +23,7 @@
 	}
 
 	&.has-parallax {
-		background-attachment: fixed;
+		//background-attachment: fixed;
 	}
 
 	&.has-background-dim:before {
@@ -42,4 +46,13 @@
 		height: inherit;
 	}
 
+	.wp-block-cover-image__image {
+		position: fixed;
+	    top: 0;
+	    right: 0;
+	    bottom: 0;
+	    left: 0;
+		z-index: -1;
+		background-size: cover;
+	}
 }


### PR DESCRIPTION
## Description

When anything but the body is the scrolling container, Chrome doesn't know how to handle `background-attachment: fixed;`, as such the recent change to this regressed the Cover Image block in Chrome.

This branch is an experiment to use a different approach to fix the block. It puts the image itself on a separate layer, and uses `clip-path` to "crop it". This makes it work in Chrome, Safari, etc. But it is kind of a hack, so we need to test this thoroughly.

One benefit, however, if we can get this to work, is that performance should be much better as the image layer is now rendered on the GPU.

## How Has This Been Tested?

Chrome, Safari, still lots of testing to do, and tweaks to do.

## Screenshots (jpeg or gifs if applicable):

![cover image](https://user-images.githubusercontent.com/1204802/31173984-1116204e-a90a-11e7-8205-13587417b018.gif)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.