### PR TITLE
Bump version to 1.3.

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core. <strong>Meant for development, do not run on real sites.</strong>
- * Version: 1.2.1
+ * Version: 1.3.0
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A new WordPress editor experience",
   "main": "build/app.js",
   "repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
## Changelog
* Cover image block supports an opacity range slider.
* Offer the option to convert a single block to an HTML block when conflicting content is detected.
* Persist recently used blocks through sessions.
* Added support for pasting plain text markdown content and converting to blocks.
* The block inspector groups features and settings in expandable panels.
* Accessibility improvements to the color palette component.
* Added a "feedback" link in the Gutenberg side menu.
* Use expandable panels for advanced block features (class name and anchor).
* Removed touch listeners from multi select.
* Added block descriptions to blocks that didn't have them.
* Allow stored values to be updated with new defaults.
* Refactor image block to use withApiData and fix issues with .tiff images.
* Clean up non inline elements when pasting inline content.
* Remove unused code in BlockList component.
* Added "transform into" text to block switcher.
* Fixed sidebar overflow causing extra scrollbars.
* Fixed multi-select inside new scroll container.
* Fixed image block error with .tiff image.
* Fixed the content overflowing outside the verse block container.
* Fixed issues with sticky quick toolbar position.
* Fixed hitting enter when a block is selected creating a default block after selected block.
* Fixed teaser markup in demo content.
* Clean working directory before packaging plugin.
* Updated Webpack dependencies.
* Updated Jest and React.