### PR TITLE
Chrome: Fix the header left value on large screens

### DIFF
--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -21,6 +21,10 @@
 	@include break-medium() {
 		top: $admin-bar-height;
 	}
+
+	@include break-large() {
+		left: $admin-sidebar-width;
+	}
 }
 
 .sticky-menu .editor-header {	/* Sticky is when on smaller breakpoints, nav menu is manually opened */


### PR DESCRIPTION
closes #1672

Fix a small bug where the header "left" value was not set correctly on large screen causing the Editor's mode switcher and saved state to be hidden.

**Testing instructions**

 - Open the editor on a wide screen
 - Make sure your browser is not opened in Full Screen
 - Check that the header shows up properly
