### PR TITLE
Add aria-label to code and HTML block textarea elements. #2027

### DIFF
--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -69,6 +69,7 @@ registerBlockType( 'core/code', {
 				className={ className }
 				value={ attributes.content }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
+				aria-label={ __( 'Code block' ) }
 				placeholder={ __( 'Write code…' ) }
 			/>,
 		];

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -69,8 +69,7 @@ registerBlockType( 'core/code', {
 				className={ className }
 				value={ attributes.content }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
-				aria-label={ __( 'Code block' ) }
-				placeholder={ __( 'Write code…' ) }
+				aria-label={ __( 'Code' ) }
 			/>,
 		];
 	},

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -69,6 +69,7 @@ registerBlockType( 'core/code', {
 				className={ className }
 				value={ attributes.content }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
+				placeholder={ __( 'Write code…' ) }
 				aria-label={ __( 'Code' ) }
 			/>,
 		];

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -67,6 +67,7 @@ registerBlockType( 'core/html', {
 				key="editor"
 				value={ attributes.content }
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
+				aria-label={ __( 'HTML' ) }
 			/>,
 		focus && (
 			<InspectorControls key="inspector">


### PR DESCRIPTION
## Description
Implemented the suggestion in #2027: add missing textarea labels as `aria-label` attributes.

## How Has This Been Tested?
Only visually. I don't have a screen reader, nor am I familiar with software in that regard.

## Types of changes
* Add `aria-label` attribute to code and HTML block textarea elements.
* Add `placeholder` attribute to HTML block.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.