### PR TITLE
Accessibility: Fix Focus Style of the inserter buttons

### DIFF
--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -106,18 +106,21 @@ input[type="search"].editor-inserter__search {
 		cursor: default;
 	}
 
-	&:hover:not(:disabled),
-	&:focus:not(:disabled) {
-		color: $blue-medium-500;
-		outline: none;
-		position: relative;
-	}
+	&:not(:disabled) {
+		&:hover {
+			color: $blue-medium-500;
+		}
 
-	&:active,
-	&.is-active {
-		background: $dark-gray-500;
-		position: relative;
-		color: $white;
+		&:focus {
+			outline: 1px solid $dark-gray-500;
+		}
+
+		&:active,
+		&.is-active {
+			background: $dark-gray-500;
+			position: relative;
+			color: $white;
+		}
 	}
 
 	.dashicon {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -485,6 +485,7 @@ $sticky-bottom-offset: 20px;
 
 		&:active {
 			background: none;
+			color: $blue-medium-500;
 		}
 	}
 


### PR DESCRIPTION
closes #1355

Brings back the focus style with a gray border for the inserter buttons. The hover style is kept unchanged. Also, I fixed the text color on active links.
