### PR TITLE
Blocks: Refactor the block toolbar component and move it to its own component

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -88,7 +88,7 @@
 .freeform-toolbar {
 	width: auto;
 	top: $header-height - 1px;
-	z-index: z-index( '.editor-visual-editor__block-controls' );
+	z-index: z-index( '.editor-block-toolbar' );
 	position: sticky;
 
 	@include break-medium() {

--- a/blocks/library/table/editor.scss
+++ b/blocks/library/table/editor.scss
@@ -1,6 +1,6 @@
 .editor-visual-editor__block[data-type="core/table"] {
 
-	.editor-visual-editor__group > div {
+	.editor-block-toolbar__group > div {
 		display: flex;
 	}
 

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -7,7 +7,7 @@ $z-layers: (
 	'.editor-visual-editor__block:before': -1,
 	'.editor-visual-editor__block .wp-block-more:before': -1,
 	'.editor-visual-editor__block {core/image aligned left or right}': 10,
-	'.editor-visual-editor__block-controls': 1,
+	'.editor-block-toolbar': 1,
 	'.editor-visual-editor__block-warning': 1,
 	'.components-form-toggle__input': 1,
 	'.editor-format-list__menu': 1,

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { Slot } from 'react-slot-fill';
+import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+import classnames from 'classnames';
+
+/**
+ * WordPress Dependencies
+ */
+import { IconButton, Toolbar } from '@wordpress/components';
+import { Component, Children } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal Dependencies
+ */
+import './style.scss';
+import BlockSwitcher from '../block-switcher';
+import BlockMover from '../block-mover';
+import BlockRightMenu from '../block-settings-menu';
+
+function FirstChild( { children } ) {
+	const childrenArray = Children.toArray( children );
+	return childrenArray[ 0 ] || null;
+}
+
+class BlockToolbar extends Component {
+	constructor() {
+		super( ...arguments );
+		this.toggleMobileControls = this.toggleMobileControls.bind( this );
+		this.state = {
+			showMobileControls: false,
+		};
+	}
+
+	toggleMobileControls() {
+		this.setState( ( state ) => ( {
+			showMobileControls: ! state.showMobileControls,
+		} ) );
+	}
+
+	render() {
+		const { showMobileControls } = this.state;
+		const { uid } = this.props;
+
+		const toolbarClassname = classnames( 'editor-block-toolbar', {
+			'is-showing-mobile-controls': showMobileControls,
+		} );
+
+		return (
+			<CSSTransitionGroup
+				transitionName={ { appear: 'is-appearing', appearActive: 'is-appearing-active' } }
+				transitionAppear={ true }
+				transitionAppearTimeout={ 100 }
+				transitionEnter={ false }
+				transitionLeave={ false }
+				component={ FirstChild }
+			>
+				<div className={ toolbarClassname }>
+					<div className="editor-block-toolbar__group">
+						{ ! showMobileControls && [
+							<BlockSwitcher key="switcher" uid={ uid } />,
+							<Slot key="slot" name="Formatting.Toolbar" />,
+						] }
+						<Toolbar className="editor-block-toolbar__mobile-tools">
+							<IconButton
+								className="editor-block-toolbar__mobile-toggle"
+								onClick={ this.toggleMobileControls }
+								aria-expanded={ showMobileControls }
+								label={ __( 'Toggle extra controls' ) }
+								icon="ellipsis"
+							/>
+
+							{ showMobileControls &&
+								<div className="editor-block-toolbar__mobile-tools-content">
+									<BlockMover uids={ [ uid ] } />
+									<BlockRightMenu uid={ uid } />
+								</div>
+							}
+						</Toolbar>
+					</div>
+				</div>
+			</CSSTransitionGroup>
+		);
+	}
+}
+
+export default BlockToolbar;

--- a/editor/block-toolbar/style.scss
+++ b/editor/block-toolbar/style.scss
@@ -1,0 +1,94 @@
+
+.editor-block-toolbar {
+	display: flex;
+	position: sticky;
+	z-index: z-index( '.editor-block-toolbar' );
+	margin-top: -$block-controls-height - $item-spacing;
+	margin-bottom: $item-spacing + 20px;	// 20px is the offset from the bottom of the selected block where it stops sticking
+	white-space: nowrap;
+	height: $block-controls-height;
+
+	// Mobile viewport
+	top: $header-height - 1px;
+	margin-left: -$block-padding;
+	margin-right: -$block-padding;
+
+	// Allow this invisible layer to be clicked through.
+	pointer-events: none;
+
+	// Reset pointer-events on children.
+	& > * {
+		pointer-events: auto;
+	}
+
+	// Larger viewports
+	@include break-small() {
+		margin-left: 0;
+	}
+
+	@include break-medium() {
+		top: $item-spacing;
+	}
+
+	&.is-appearing-active {
+		@include animate_fade;
+	}
+}
+
+.editor-block-toolbar__group {
+	display: inline-flex;
+	box-shadow: $shadow-toolbar;
+	width: 100%;
+	background: $white;
+	overflow: auto;	// allow horizontal scrolling on mobile
+
+	@include break-small() {
+		width: auto;
+		overflow: hidden;
+	}
+}
+
+$sticky-bottom-offset: 20px;
+.editor-block-toolbar + div {
+	// prevent collapsing margins between block and toolbar, matches the 20px bottom offset
+ 	margin-top: -$sticky-bottom-offset - 1px;
+	padding-top: 1px;
+ }
+
+.editor-block-toolbar .components-toolbar {
+	margin-right: -1px;
+}
+
+.editor-block-toolbar .editor-block-switcher {
+	display: inline-flex;
+}
+
+.editor-block-toolbar__mobile-tools {
+	align-items: baseline;
+	display: flex;
+	justify-content: space-between;
+	flex-direction: row-reverse;
+	width: 100%;
+
+	&.components-toolbar {
+		margin-right: 0;
+	}
+
+	@include break-small {
+		display: none;
+	}
+
+	.editor-block-mover,
+	.editor-block-settings-menu {
+		display: inline-flex;
+		height: auto;
+		position: initial;
+		.components-button {
+			margin: 0 5px;
+		}
+	}
+}
+
+.editor-block-toolbar__mobile-tools-content {
+	overflow: hidden;
+}

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -3,15 +3,12 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { Slot } from 'react-slot-fill';
 import { has, partial, reduce, size } from 'lodash';
-import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
  * WordPress dependencies
  */
-import { Children, Component, createElement } from '@wordpress/element';
-import { IconButton, Toolbar } from '@wordpress/components';
+import { Component, createElement } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 import { getBlockType, getBlockDefaultClassname, createBlock } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
@@ -25,7 +22,7 @@ import BlockCrashBoundary from './block-crash-boundary';
 import BlockDropZone from './block-drop-zone';
 import BlockMover from '../../block-mover';
 import BlockRightMenu from '../../block-settings-menu';
-import BlockSwitcher from '../../block-switcher';
+import BlockToolbar from '../../block-toolbar';
 import {
 	clearSelectedBlock,
 	editPost,
@@ -56,11 +53,6 @@ import {
 
 const { BACKSPACE, ESCAPE, DELETE, ENTER } = keycodes;
 
-function FirstChild( { children } ) {
-	const childrenArray = Children.toArray( children );
-	return childrenArray[ 0 ] || null;
-}
-
 class VisualEditorBlock extends Component {
 	constructor() {
 		super( ...arguments );
@@ -75,14 +67,12 @@ class VisualEditorBlock extends Component {
 		this.onFocus = this.onFocus.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
-		this.toggleMobileControls = this.toggleMobileControls.bind( this );
 		this.onBlockError = this.onBlockError.bind( this );
 		this.insertBlocksAfter = this.insertBlocksAfter.bind( this );
 
 		this.previousOffset = null;
 
 		this.state = {
-			showMobileControls: false,
 			error: null,
 		};
 	}
@@ -283,12 +273,6 @@ class VisualEditorBlock extends Component {
 		this.removeOrDeselect( event );
 	}
 
-	toggleMobileControls() {
-		this.setState( {
-			showMobileControls: ! this.state.showMobileControls,
-		} );
-	}
-
 	onBlockError( error ) {
 		this.setState( { error } );
 	}
@@ -318,13 +302,12 @@ class VisualEditorBlock extends Component {
 		// Generate the wrapper class names handling the different states of the block.
 		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, focus } = this.props;
 		const showUI = isSelected && ( ! this.props.isTyping || focus.collapsed === false );
-		const { error, showMobileControls } = this.state;
+		const { error } = this.state;
 		const wrapperClassname = classnames( 'editor-visual-editor__block', {
 			'has-warning': ! isValid || !! error,
 			'is-selected': showUI,
 			'is-multi-selected': isMultiSelected,
 			'is-hovered': isHovered,
-			'is-showing-mobile-controls': showMobileControls,
 		} );
 
 		const { onMouseLeave, onFocus, onReplace } = this.props;
@@ -358,34 +341,8 @@ class VisualEditorBlock extends Component {
 				<BlockDropZone index={ order } />
 				{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }
 				{ ( showUI || isHovered ) && <BlockRightMenu uid={ block.uid } /> }
-				{ showUI && isValid &&
-					<CSSTransitionGroup
-						transitionName={ { appear: 'is-appearing', appearActive: 'is-appearing-active' } }
-						transitionAppear={ true }
-						transitionAppearTimeout={ 100 }
-						transitionEnter={ false }
-						transitionLeave={ false }
-						component={ FirstChild }
-					>
-						<div className="editor-visual-editor__block-controls">
-							<div className="editor-visual-editor__group">
-								<BlockSwitcher uid={ block.uid } />
-								<Slot name="Formatting.Toolbar" />
-								<Toolbar className="editor-visual-editor__mobile-tools">
-									{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }
-									{ ( showUI || isHovered ) && <BlockRightMenu uid={ block.uid } /> }
-									<IconButton
-										className="editor-visual-editor__mobile-toggle"
-										onClick={ this.toggleMobileControls }
-										aria-expanded={ showMobileControls }
-										label={ __( 'Toggle extra controls' ) }
-										icon="ellipsis"
-									/>
-								</Toolbar>
-							</div>
-						</div>
-					</CSSTransitionGroup>
-				}
+				{ showUI && isValid && <BlockToolbar uid={ block.uid } /> }
+
 				{ isFirstMultiSelected && (
 					<BlockMover uids={ multiSelectedBlockUids } />
 				) }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -86,39 +86,6 @@
 		transition: 0.2s outline;
 	}
 
-	&.is-showing-mobile-controls {
-		.editor-visual-editor__group > :not( .editor-visual-editor__mobile-tools ) {
-			display: none;
-		}
-		.editor-visual-editor__mobile-tools {
-			align-items: baseline;
-			display: flex;
-			width: 100%;
-
-			@include break-small {
-				display: none;
-			}
-
-			.editor-block-mover,
-			.editor-block-settings-menu {
-				display: block;
-				display: flex;
-				position: static;
-				.components-button {
-					margin: 0 5px;
-				}
-			}
-
-			.editor-block-settings-menu {
-				left: 80px;
-				right: auto;
-			}
-			.editor-visual-editor__mobile-toggle {
-				margin-left: auto;
-			}
-		}
-	}
-
 	&.is-multi-selected *::selection {
 		background: transparent;
 	}
@@ -312,84 +279,6 @@
 	}
 }
 
-.editor-visual-editor__block-controls {
-	display: flex;
-	position: sticky;
-	z-index: z-index( '.editor-visual-editor__block-controls' );
-	margin-top: -$block-controls-height - $item-spacing;
-	margin-bottom: $item-spacing + 20px;	// 20px is the offset from the bottom of the selected block where it stops sticking
-	white-space: nowrap;
-	height: $block-controls-height;
-
-	// Mobile viewport
-	top: $header-height - 1px;
-	margin-left: -$block-padding;
-	margin-right: -$block-padding;
-
-	// Allow this invisible layer to be clicked through.
-	pointer-events: none;
-
-	// Reset pointer-events on children.
-	& > * {
-		pointer-events: auto;
-	}
-
-	// Larger viewports
-	@include break-small() {
-		margin-left: 0;
-	}
-
-	@include break-medium() {
-		top: $item-spacing;
-	}
-
-	&.is-appearing-active {
-		@include animate_fade;
-	}
-}
-
-.editor-visual-editor__group {
-	display: inline-flex;
-	box-shadow: $shadow-toolbar;
-	width: 100%;
-	background: $white;
-	border-top: 1px solid $light-gray-500;
-	border-bottom: 1px solid $light-gray-500;
-	overflow: auto;	// allow horizontal scrolling on mobile
-
-	> div,
-	> ul {
-		margin-top: -1px;
-		margin-bottom: -1px;
-	}
-
-	@include break-small() {
-		width: auto;
-		overflow: hidden;
-	}
-}
-
-$sticky-bottom-offset: 20px;
-.editor-visual-editor__block-controls + div {
-	// prevent collapsing margins between block and toolbar, matches the 20px bottom offset
- 	margin-top: -$sticky-bottom-offset - 1px;
-	padding-top: 1px;
- }
-
-.editor-visual-editor__block-controls .components-toolbar {
-	margin-right: -1px;
-
-	&.editor-visual-editor__mobile-tools {
-		margin-left: auto;
-		margin-top: -1px;
-		margin-bottom: -1px;
-	}
-}
-
-.editor-visual-editor__block-controls .editor-block-switcher {
-	display: inline-flex;
-}
-
 .editor-visual-editor .editor-inserter {
 	margin: $item-spacing;
 
@@ -491,16 +380,6 @@ $sticky-bottom-offset: 20px;
 	&:hover > .editor-inserter__block,
 	&.is-showing-controls > .editor-inserter__block {
 		opacity: 1;
-	}
-}
-
-.editor-visual-editor__mobile-tools {
-	@include break-small {
-		display: none;
-	}
-	.editor-block-mover,
-	.editor-block-settings-menu {
-		display: none;
 	}
 }
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -247,7 +247,7 @@
 
 	&[data-align="full"],
 	&[data-align="wide"] {
-		.editor-visual-editor__block-controls {
+		.editor-block-toolbar {
 			@include break-small() {
 				width: $visual-editor-max-width - $block-padding - $block-padding;
 			}


### PR DESCRIPTION
This refactors the block toolbar to its own component. It has several goals:

 - Having a lighter `VisualEditorBlock` component (and style)
 - Better directory structure (BlockToolbar same level as BlockMover, BlockInspector...)
 - Prepare the toolbar for future enhancements (arrow navigation, fixed toolbar?)

This also fixes some styling glitches on mobile (scrollbar always appearing in the toolbar)

## Testing instructions

 - Check the docked block toolbar still works as expected in Mobile and in Desktop