### PR TITLE
Submenu: prevent users from having an empty submenu item if they cann…

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -66,7 +66,7 @@ function gutenberg_menu() {
 		'the_gutenberg_project'
 	);
 
-	$submenu['gutenberg'][] = array(
+	$submenu['gutenberg.php'][] = array(
 		__( 'Feedback', 'gutenberg' ),
 		'edit_posts',
 		'http://wordpressdotorg.polldaddy.com/s/gutenberg-support',

--- a/lib/register.php
+++ b/lib/register.php
@@ -66,11 +66,13 @@ function gutenberg_menu() {
 		'the_gutenberg_project'
 	);
 
-	$submenu['gutenberg.php'][] = array(
-		__( 'Feedback', 'gutenberg' ),
-		'edit_posts',
-		'http://wordpressdotorg.polldaddy.com/s/gutenberg-support',
-	);
+	if ( current_user_can( 'edit_posts' ) ) {
+		$submenu['gutenberg'][] = array(
+			__( 'Feedback', 'gutenberg' ),
+			'edit_posts',
+			'http://wordpressdotorg.polldaddy.com/s/gutenberg-support',
+		);
+	}
 }
 add_action( 'admin_menu', 'gutenberg_menu' );
 


### PR DESCRIPTION
Just a small bug that I noticed in the way that the Feedback submenu link was being added. All users, regardless of role, were able to see the Gutenberg menu link.
![screen shot 2017-10-05 at 11 43 41 am](https://user-images.githubusercontent.com/12139422/31246539-8b2ac408-a9c2-11e7-824b-b055ac4198ff.png)
