### PR TITLE
New Block: Editor Promo Footer

### DIFF
--- a/blocks/library/gutenvert/index.js
+++ b/blocks/library/gutenvert/index.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '../../api';
+
+registerBlockType( 'promo/gutenberg-footer', {
+	title: __( 'Editor Promo' ),
+
+	icon: 'megaphone',
+
+	category: 'common',
+
+	save() {
+		return (
+			<div>
+				<hr className="wp-block-separator" />
+				<p style={ { color: '#9e9da4', fontSize: '14px', textAlign: 'center' } }>
+					This post brought to you by the new
+					{ ' ' }<a href="https://wordpress.org/plugins/gutenberg/">Gutenberg editor</a> for
+					{ ' ' }<a href="https://wordpress.org">WordPress</a>!
+				</p>
+			</div>
+		);
+	},
+} );

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -1,6 +1,7 @@
 import './paragraph';
 import './image';
 import './gallery';
+import './gutenvert';
 import './heading';
 import './quote';
 import './embed';


### PR DESCRIPTION
Because I'm tired of manually writing this at the end of all my posts
and I would love for other people to be spreading news about the editor
I created a block to append a basic advert intended as a post footer.

![editorpromoblock](https://user-images.githubusercontent.com/5431237/31248175-f6024134-a9e0-11e7-85a5-4e63b4c45102.gif)
