### PR TITLE
Writing Flow: Avoid using state for tracking arrow key navigation

### DIFF
--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -21,9 +21,8 @@ class WritingFlow extends Component {
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onKeyUp = this.onKeyUp.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
-		this.state = {
-			shouldMove: false,
-		};
+
+		this.shouldMove = false;
 	}
 
 	bindContainer( ref ) {
@@ -65,17 +64,18 @@ class WritingFlow extends Component {
 
 		if ( ( moveUp || moveDown ) && isEdge( target, moveUp ) ) {
 			event.preventDefault();
-			this.setState( { shouldMove: true } );
+			this.shouldMove = true;
 		}
 	}
 
 	onKeyUp( event ) {
 		const { keyCode, target } = event;
 		const moveUp = ( keyCode === UP || keyCode === LEFT );
-		if ( this.state.shouldMove ) {
+
+		if ( this.shouldMove ) {
 			event.preventDefault();
 			this.moveFocusInContainer( target, moveUp ? 'UP' : 'DOWN' );
-			this.setState( { shouldMove: false } );
+			this.shouldMove = false;
 		}
 	}
 

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -17,7 +17,7 @@ const { UP, DOWN, LEFT, RIGHT } = keycodes;
 class WritingFlow extends Component {
 	constructor() {
 		super( ...arguments );
-		this.zones = [];
+
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onKeyUp = this.onKeyUp.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/2424/files#r142135955

This pull request seeks to refactor the WritingFlow component to eliminate state which could be set on arrow keypresses. Assigning state will incur a rerender, and for the intended usage, we do not need state to be reflected in the render result. Instead, for tracking the "should move" behavior, an instance property is sufficient and avoids any render.

__Open questions:__

I will need to look back through the old pull request, but at a glance I'm struggling to understand why we need to bind to both key down and key up, particularly because binding to key up causes a laggy feeling to the arrow movement.

__Testing instructions:__

Verify that there are no regressions in using arrow keys (left, right, up, down) to navigate from one input to the next / previous, e.g. between two paragraph blocks.