### PR TITLE
Polish rearranged header, improve mobile

### DIFF
--- a/editor/header/saved-state/style.scss
+++ b/editor/header/saved-state/style.scss
@@ -12,6 +12,7 @@
 	&.button-link {
 		text-decoration: underline;
 		color: $blue-wordpress;
+		margin-right: $item-spacing;	// needs specificity to override core CSS bleed
 
 		&:focus {
 			outline: none;

--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -88,6 +88,14 @@
 	margin: 0 0 0 auto;
 }
 
+// hide all action buttons except the inserter on mobile
+.editor-header__content-tools > .components-button {
+	display: none;
+
+	@include break-small() {
+		display: inline-flex;
+	}
+}
 
 .editor-header__content-tools,
 .editor-header__settings {
@@ -123,8 +131,10 @@
 		left: 1px;
 	}
 
-	&.editor-publish-button {
-		height: 33px;
-		line-height: 32px;
+	@include break-medium() {
+		&.editor-publish-button {
+			height: 33px;
+			line-height: 32px;
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR does two small things

1. It adds a margin to the Save Draft link which was missing
2. It fixes mobile responsiveness, by hidng all actionbuttons on the left, except the inserter, on mobile.

## How Has This Been Tested?

Tested in the browser.

## Screenshots (jpeg or gifs if applicable):

![screen shot 2017-10-06 at 09 07 01](https://user-images.githubusercontent.com/1204802/31266853-0feff060-aa76-11e7-8af5-0c329b3b36da.png)

![screen shot 2017-10-06 at 09 07 09](https://user-images.githubusercontent.com/1204802/31266856-116bf5ce-aa76-11e7-9974-f8e2ed3987d3.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.