### PR TITLE
Layout: Improve layout paneling for short viewports

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -53,13 +53,22 @@ body.gutenberg-editor-page {
 }
 
 .gutenberg__editor {
-	position: relative;
-	height: calc( 100vh - #{ $admin-bar-height-big} );
+	position: absolute;
+	top: $admin-bar-height-big;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	min-height: calc( 100vh - #{ $admin-bar-height-big } );
 	padding-top: $header-height + $stacked-toolbar-height;
+
+	@include break-small {
+		top: 0;
+		padding-top: $header-height;
+	}
 
 	// The WP header height changes at this breakpoint
 	@include break-medium {
-		height: calc( 100vh - #{ $admin-bar-height } );
+		min-height: calc( 100vh - #{ $admin-bar-height } );
 	}
 
 	// The block toolbar disappears at this breakpoint


### PR DESCRIPTION
Related: #2800

This pull request seeks to resolve styling issues observed related to paneling introduced in #2800 , specifically in short viewports or dashboards where many sidebar navigation items exist (I first noticed the issue when using Gutenberg on a WordCamp site). The changes here try an alternative approach for occupying the full height of the screen in more contexts. Previously, the specific height `calc` style would not account for cases where the sidebar has a scrollbar.

__Testing instructions:__

Repeat testing instructions from #2800, particularly with varying viewport widths _and_ heights and sidebars expanded and collapsed.