### PR TITLE
Components: Implement focus return for Dropdown component

### DIFF
--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -6,7 +6,10 @@ import { Component } from '@wordpress/element';
 /**
  * Internal Dependencies
  */
+import withFocusReturn from '../higher-order/with-focus-return';
 import Popover from '../popover';
+
+const FocusManaged = withFocusReturn( ( { children } ) => children );
 
 class Dropdown extends Component {
 	constructor() {
@@ -51,9 +54,12 @@ class Dropdown extends Component {
 					className={ contentClassName }
 					isOpen={ isOpen }
 					position={ position }
+					onClose={ this.close }
 					onClickOutside={ this.clickOutside }
 				>
-					{ renderContent( args ) }
+					<FocusManaged>
+						{ renderContent( args ) }
+					</FocusManaged>
 				</Popover>
 			</div>
 		);

--- a/components/dropdown/test/index.js
+++ b/components/dropdown/test/index.js
@@ -16,7 +16,7 @@ describe( 'Dropdown', () => {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<button aria-expanded={ isOpen } onClick={ onToggle }>Toggleee</button>
 			) }
-			renderContent={ () => 'content' }
+			renderContent={ () => null }
 		/> );
 
 		const button = wrapper.find( 'button' );
@@ -38,7 +38,7 @@ describe( 'Dropdown', () => {
 				<button key="open" className="open" aria-expanded={ isOpen } onClick={ onToggle }>Toggleee</button>,
 				<button key="close" className="close" onClick={ onClose } >closee</button>,
 			] }
-			renderContent={ () => 'content' }
+			renderContent={ () => null }
 		/> );
 
 		const openButton = wrapper.find( '.open' );


### PR DESCRIPTION
This pull request seeks to improve the Dropdown component introduced in #2888 to restore the focus return behavior. After #2888, it is no longer possible to escape out of an inserter using the keyboard alone. With these changes, the Dropdown component now handles the Popover's `onClose` callback and ensures focus is returned to the toggle leveraging the `withFocusReturn` higher-order component.

__Testing instructions:__

1. Navigate to Gutenberg > New Post
2. Toggle an inserter
3. Press escape
4. Note that the inserter is closed and focus returned to the toggle