### PR TITLE
Small example code fix, missing single quote.

### DIFF
--- a/blocks/README.md
+++ b/blocks/README.md
@@ -33,7 +33,7 @@ function myplugin_enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'myplugin-block',
 		plugins_url( 'block.js', __FILE__ ),
-		array( 'wp-blocks', wp-element' )
+		array( 'wp-blocks', 'wp-element' )
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'myplugin_enqueue_block_editor_assets' );


### PR DESCRIPTION
## Description

Noticed a missing single quote in the getting started document for blocks. You can see the change here: 

https://github.com/octalmage/gutenberg/tree/patch-1/blocks#getting-started
