### PR TITLE
Show block description for gallery block for 0 images

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -97,6 +97,22 @@ class GalleryBlock extends Component {
 	render() {
 		const { attributes, focus, className } = this.props;
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
+		
+		const blockDescription = (
+			<BlockDescription>
+				<p>
+					{__("Image galleries are a great way to share groups of pictures on your site.")}
+				</p>
+			</BlockDescription>	
+		);
+
+		const inspectorControls = (
+			focus && (
+				<InspectorControls key="inspector">
+					{blockDescription}
+				</InspectorControls>
+			)
+		);
 
 		const controls = (
 			focus && (
@@ -133,6 +149,7 @@ class GalleryBlock extends Component {
 
 			return [
 				controls,
+				inspectorControls,
 				<Placeholder
 					key="placeholder"
 					instructions={ __( 'Drag images here or insert from media library' ) }
@@ -165,9 +182,7 @@ class GalleryBlock extends Component {
 			controls,
 			focus && images.length > 1 && (
 				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Image galleries are a great way to share groups of pictures on your site.' ) }</p>
-					</BlockDescription>
+					{blockDescription}
 					<h3>{ __( 'Gallery Settings' ) }</h3>
 					<RangeControl
 						label={ __( 'Columns' ) }

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -97,13 +97,13 @@ class GalleryBlock extends Component {
 	render() {
 		const { attributes, focus, className } = this.props;
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
-		
+
 		const blockDescription = (
 			<BlockDescription>
 				<p>
-					{__("Image galleries are a great way to share groups of pictures on your site.")}
+					{__( 'Image galleries are a great way to share groups of pictures on your site.' )}
 				</p>
-			</BlockDescription>	
+			</BlockDescription>
 		);
 
 		const inspectorControls = (


### PR DESCRIPTION

## Description
Gallery block is updated to show block description regardless of how many images are selected. Relates to #2023 

## How Has This Been Tested?
Manually tested, ran all test suites

## Types of changes
UX updates

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.