### PR TITLE
Remove multi select fade

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -93,7 +93,7 @@
 	&.is-multi-selected:before {
 		background: $blue-medium-100;
 		outline: 2px solid $blue-medium-200;
-		transition: 0.2s outline;
+		transition: 0s outline;
 	}
 
 	.iframe-overlay {


### PR DESCRIPTION
This is a tiny one line code change to remove the fade on boundaries when invoking multi select. It makes the whole process seem just _slightly_ more performant, even if it's just a feeling. The pattern to emulate is text selection, which also doesn't have a fade.

Note, I tried removing the transition line entirely, but this did not work as it still inherits the `transition` property from its parent, hence the need to unset it instead. 