### PR TITLE
Editable: sync state on input, signal undo levelling

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -166,10 +166,8 @@ registerBlockType( 'core/paragraph', {
 						textAlign: align,
 					} }
 					value={ content }
-					onChange={ ( nextContent ) => {
-						setAttributes( {
-							content: nextContent,
-						} );
+					onChange={ ( nextContent, settings ) => {
+						setAttributes( { content: nextContent }, settings );
 					} }
 					focus={ focus }
 					onFocus={ setFocus }

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -67,10 +67,12 @@ export function resetBlocks( blocks ) {
  *
  * @param  {String} uid        Block UID
  * @param  {Object} attributes Block attributes to be merged
+ * @param  {Object} settings   Settings
  * @return {Object}            Action object
  */
-export function updateBlockAttributes( uid, attributes ) {
+export function updateBlockAttributes( uid, attributes, settings ) {
 	return {
+		...settings,
 		type: 'UPDATE_BLOCK_ATTRIBUTES',
 		uid,
 		attributes,
@@ -80,6 +82,7 @@ export function updateBlockAttributes( uid, attributes ) {
 export function focusBlock( uid, config ) {
 	return {
 		type: 'UPDATE_FOCUS',
+		skipEditorSnapshot: true,
 		uid,
 		config,
 	};
@@ -88,6 +91,7 @@ export function focusBlock( uid, config ) {
 export function selectBlock( uid ) {
 	return {
 		type: 'SELECT_BLOCK',
+		skipEditorSnapshot: true,
 		uid,
 	};
 }
@@ -95,6 +99,7 @@ export function selectBlock( uid ) {
 export function multiSelect( start, end ) {
 	return {
 		type: 'MULTI_SELECT',
+		skipEditorSnapshot: true,
 		start,
 		end,
 	};
@@ -103,6 +108,7 @@ export function multiSelect( start, end ) {
 export function clearSelectedBlock() {
 	return {
 		type: 'CLEAR_SELECTED_BLOCK',
+		skipEditorSnapshot: true,
 	};
 }
 

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -61,10 +61,10 @@ export default {
 		dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
 		const Model = wp.api.getPostTypeModel( getCurrentPostType( state ) );
 		new Model( toSend ).save().done( ( newPost ) => {
-			dispatch( {
-				type: 'RESET_POST',
-				post: newPost,
-			} );
+			// dispatch( {
+			// 	type: 'RESET_POST',
+			// 	post: newPost,
+			// } );
 			dispatch( {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				previousPost: post,

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -135,10 +135,10 @@ class VisualEditorBlock extends Component {
 		this.props.blockRef( node );
 	}
 
-	setAttributes( attributes ) {
+	setAttributes( attributes, settings ) {
 		const { block, onChange } = this.props;
 		const type = getBlockType( block.name );
-		onChange( block.uid, attributes );
+		onChange( block.uid, attributes, settings );
 
 		const metaAttributes = reduce( attributes, ( result, value, key ) => {
 			if ( type && has( type, [ 'attributes', key, 'meta' ] ) ) {
@@ -406,8 +406,8 @@ export default connect(
 		};
 	},
 	( dispatch, ownProps ) => ( {
-		onChange( uid, attributes ) {
-			dispatch( updateBlockAttributes( uid, attributes ) );
+		onChange( uid, attributes, settings ) {
+			dispatch( updateBlockAttributes( uid, attributes, settings ) );
 		},
 
 		onSelect() {

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -234,6 +234,66 @@ export const editor = combineUndoableReducers( {
 
 		return state;
 	},
+
+	selection( state = { start: null, end: null, focus: null }, action ) {
+		switch ( action.type ) {
+			case 'CLEAR_SELECTED_BLOCK':
+				return {
+					start: null,
+					end: null,
+					focus: null,
+				};
+			case 'MULTI_SELECT':
+				return {
+					start: action.start,
+					end: action.end,
+					focus: null,
+				};
+			case 'SELECT_BLOCK':
+				if ( action.uid === state.start && action.uid === state.end ) {
+					return state;
+				}
+				return {
+					start: action.uid,
+					end: action.uid,
+					focus: action.focus || {},
+				};
+			case 'UPDATE_FOCUS':
+				return {
+					start: action.uid,
+					end: action.uid,
+					focus: action.config || {},
+				};
+			case 'INSERT_BLOCKS':
+				return {
+					start: action.blocks[ 0 ].uid,
+					end: action.blocks[ 0 ].uid,
+					focus: {},
+				};
+			case 'REPLACE_BLOCKS':
+				if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.start ) === -1 ) {
+					return state;
+				}
+				return {
+					start: action.blocks[ 0 ].uid,
+					end: action.blocks[ 0 ].uid,
+					focus: {},
+				};
+			case 'MOVE_BLOCKS_UP':
+			case 'MOVE_BLOCKS_DOWN': {
+				const firstUid = first( action.uids );
+				return firstUid === state.start
+					? state
+					: {
+						start: firstUid,
+						end: firstUid,
+						focus: {},
+					};
+			}
+		}
+
+		return state;
+	},
 }, { resetTypes: [ 'RESET_POST' ] } );
 
 /**
@@ -280,73 +340,6 @@ export function isTyping( state = false, action ) {
 
 		case 'STOP_TYPING':
 			return false;
-	}
-
-	return state;
-}
-
-/**
- * Reducer returning the block selection's state.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Dispatched action
- * @return {Object}        Updated state
- */
-export function blockSelection( state = { start: null, end: null, focus: null }, action ) {
-	switch ( action.type ) {
-		case 'CLEAR_SELECTED_BLOCK':
-			return {
-				start: null,
-				end: null,
-				focus: null,
-			};
-		case 'MULTI_SELECT':
-			return {
-				start: action.start,
-				end: action.end,
-				focus: null,
-			};
-		case 'SELECT_BLOCK':
-			if ( action.uid === state.start && action.uid === state.end ) {
-				return state;
-			}
-			return {
-				start: action.uid,
-				end: action.uid,
-				focus: action.focus || {},
-			};
-		case 'UPDATE_FOCUS':
-			return {
-				start: action.uid,
-				end: action.uid,
-				focus: action.config || {},
-			};
-		case 'INSERT_BLOCKS':
-			return {
-				start: action.blocks[ 0 ].uid,
-				end: action.blocks[ 0 ].uid,
-				focus: {},
-			};
-		case 'REPLACE_BLOCKS':
-			if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.start ) === -1 ) {
-				return state;
-			}
-			return {
-				start: action.blocks[ 0 ].uid,
-				end: action.blocks[ 0 ].uid,
-				focus: {},
-			};
-		case 'MOVE_BLOCKS_UP':
-		case 'MOVE_BLOCKS_DOWN': {
-			const firstUid = first( action.uids );
-			return firstUid === state.start
-				? state
-				: {
-					start: firstUid,
-					end: firstUid,
-					focus: {},
-				};
-		}
 	}
 
 	return state;
@@ -528,7 +521,6 @@ export default optimist( combineReducers( {
 	editor,
 	currentPost,
 	isTyping,
-	blockSelection,
 	hoveredBlock,
 	showInsertionPoint,
 	preferences,

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -457,7 +457,7 @@ export function getBlockCount( state ) {
  * @return {?Object}       Selected block
  */
 export function getSelectedBlock( state ) {
-	const { start, end } = state.blockSelection;
+	const { start, end } = state.editor.selection;
 	if ( start !== end || ! start ) {
 		return null;
 	}
@@ -474,7 +474,7 @@ export function getSelectedBlock( state ) {
  */
 export function getMultiSelectedBlockUids( state ) {
 	const { blockOrder } = state.editor;
-	const { start, end } = state.blockSelection;
+	const { start, end } = state.editor.selection;
 	if ( start === end ) {
 		return [];
 	}
@@ -558,7 +558,7 @@ export function isBlockMultiSelected( state, uid ) {
  * @return {?String}       Unique ID of block beginning multi-selection
  */
 export function getMultiSelectedBlocksStartUid( state ) {
-	const { start, end } = state.blockSelection;
+	const { start, end } = state.editor.selection;
 	if ( start === end ) {
 		return null;
 	}
@@ -576,7 +576,7 @@ export function getMultiSelectedBlocksStartUid( state ) {
  * @return {?String}       Unique ID of block ending multi-selection
  */
 export function getMultiSelectedBlocksEndUid( state ) {
-	const { start, end } = state.blockSelection;
+	const { start, end } = state.editor.selection;
 	if ( start === end ) {
 		return null;
 	}
@@ -667,7 +667,7 @@ export function getNextBlock( state, uid ) {
  * @return {Boolean}      Whether block is selected and multi-selection exists
  */
 export function isBlockSelected( state, uid ) {
-	const { start, end } = state.blockSelection;
+	const { start, end } = state.editor.selection;
 
 	if ( start !== end ) {
 		return null;
@@ -702,7 +702,7 @@ export function getBlockFocus( state, uid ) {
 		return null;
 	}
 
-	return state.blockSelection.focus;
+	return state.editor.selection.focus;
 }
 
 /**

--- a/editor/utils/undoable-reducer.js
+++ b/editor/utils/undoable-reducer.js
@@ -63,6 +63,13 @@ export function undoable( reducer, options = {} ) {
 			return state;
 		}
 
+		if ( action.skipEditorSnapshot ) {
+			return {
+				...state,
+				present: nextPresent,
+			};
+		}
+
 		return {
 			past: [ ...past, present ],
 			present: nextPresent,


### PR DESCRIPTION
## Description
See #2758.

This PR attempts to let Editable continuously sync state on the `input` event, and signal for the creation of undo levels when it is triggered by TinyMCE. This keeps the logic for creating undo levels in TinyMCE in use, though not the data.

This is very much a work in progress, but I'm creating a PR now for further discussion.

* Ideally there need to be several improvement to the current undo reducer first as it seems to create too many undo levels and there are several bugs. See e.g. #2915, #2916, #2931 and #2932.
* This PR adds the selection reducer as an undoable reducer, not because it should trigger and undo level, but because we need the selection data to set back the selection (both the block and in editable). But do we even want to reset the selection, or do we just want to blur everything? Resetting seems smoother, but more complex I guess.

@aduth would love to hear your general thoughts on this.