### PR TITLE
Framework: Merge our two initialization actions into a single onee

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -11,9 +11,9 @@ import { partial, castArray } from 'lodash';
  * @param  {Object} post Post object
  * @return {Object}      Action object
  */
-export function setInitialPost( post ) {
+export function setupEditor( post ) {
 	return {
-		type: 'SET_INITIAL_POST',
+		type: 'SETUP_EDITOR',
 		post,
 	};
 }

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -251,7 +251,7 @@ export default {
 
 		dispatch( savePost() );
 	},
-	SET_INITIAL_POST( action ) {
+	SETUP_EDITOR( action ) {
 		const { post } = action;
 		const effects = [];
 

--- a/editor/index.js
+++ b/editor/index.js
@@ -22,7 +22,7 @@ import { settings as dateSettings } from '@wordpress/date';
 import './assets/stylesheets/main.scss';
 import Layout from './layout';
 import createReduxStore from './store';
-import { setInitialPost, undo } from './actions';
+import { setupEditor, undo } from './actions';
 import EditorSettingsProvider from './settings/provider';
 
 /**
@@ -73,9 +73,7 @@ export function createEditorInstance( id, post, settings ) {
 		...settings,
 	};
 
-	store.dispatch( { type: 'SETUP_EDITOR' } );
-
-	store.dispatch( setInitialPost( post ) );
+	store.dispatch( setupEditor( post ) );
 
 	const providers = [
 		// Redux provider:

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -249,8 +249,8 @@ describe( 'effects', () => {
 		} );
 	} );
 
-	describe( '.SET_INITIAL_POST', () => {
-		const handler = effects.SET_INITIAL_POST;
+	describe( '.SETUP_EDITOR', () => {
+		const handler = effects.SETUP_EDITOR;
 
 		it( 'should return post reset action', () => {
 			const post = {


### PR DESCRIPTION
Just a small refactoring merging our two initialization actions into a single one `SETUP_EDITOR`. As a follow up we could imagine dropping the `SETUP_EDITOR` effect entirely, all its behavior is synchronous and could be moved to the reducer, but it serves as a factorization for some processing (parsing).

**Testing instructions**

 - Ensure the editor loads properly for new and saved posts.