### PR TITLE
Remove multi-selection header

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -108,6 +108,18 @@ export function selectBlock( uid ) {
 	};
 }
 
+export function startMultiSelect() {
+	return {
+		type: 'START_MULTI_SELECT',
+	};
+}
+
+export function stopMultiSelect() {
+	return {
+		type: 'STOP_MULTI_SELECT',
+	};
+}
+
 export function multiSelect( start, end ) {
 	return {
 		type: 'MULTI_SELECT',

--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -17,6 +17,7 @@ import { getBlockType } from '@wordpress/blocks';
 import './style.scss';
 import { isFirstBlock, isLastBlock, getBlockIndex, getBlock } from '../selectors';
 import { getBlockMoverLabel } from './mover-label';
+import { selectBlock } from '../actions';
 
 function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex } ) {
 	// We emulate a disabled state because forcefully applying the `disabled`
@@ -68,12 +69,20 @@ export default connect(
 	} ),
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {
+			if ( ownProps.uids.length === 1 ) {
+				dispatch( selectBlock( first( ownProps.uids ) ) );
+			}
+
 			dispatch( {
 				type: 'MOVE_BLOCKS_DOWN',
 				uids: ownProps.uids,
 			} );
 		},
 		onMoveUp() {
+			if ( ownProps.uids.length === 1 ) {
+				dispatch( selectBlock( first( ownProps.uids ) ) );
+			}
+
 			dispatch( {
 				type: 'MOVE_BLOCKS_UP',
 				uids: ownProps.uids,

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -38,12 +38,12 @@ function BlockSettingsMenuContent( { onDelete, isSidebarOpened, onToggleSidebar,
 				icon="trash"
 				label={ sprintf( _n( 'Delete the block', 'Delete the %d blocks', count ), count ) }
 			/>
-			<IconButton
+			{ count === 1 && <IconButton
 				className="editor-block-settings-menu__control"
 				onClick={ onToggleMode }
 				icon="html"
 				label={ __( 'Switch between the visual/text mode' ) }
-			/>
+			/> }
 		</div>
 	);
 }
@@ -63,7 +63,7 @@ export default connect(
 			dispatch( toggleSidebar() );
 		},
 		onToggleMode() {
-			dispatch( toggleBlockMode( ownProps.uid ) );
+			dispatch( toggleBlockMode( ownProps.uids[ 0 ] ) );
 		},
 	} )
 )( BlockSettingsMenuContent );

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -6,18 +6,18 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf, _n } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { isEditorSidebarOpened } from '../selectors';
-import { selectBlock, removeBlock, toggleSidebar, setActivePanel, toggleBlockMode } from '../actions';
+import { removeBlocks, toggleSidebar, setActivePanel, toggleBlockMode } from '../actions';
 
-function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, onToggleSidebar, onShowInspector, onToggleMode } ) {
+function BlockSettingsMenuContent( { onDelete, isSidebarOpened, onToggleSidebar, onShowInspector, onToggleMode, uids } ) {
+	const count = uids.length;
 	const toggleInspector = () => {
-		onSelect();
 		onShowInspector();
 		if ( ! isSidebarOpened ) {
 			onToggleSidebar();
@@ -36,7 +36,7 @@ function BlockSettingsMenuContent( { onDelete, onSelect, isSidebarOpened, onTogg
 				className="editor-block-settings-menu__control"
 				onClick={ onDelete }
 				icon="trash"
-				label={ __( 'Delete the block' ) }
+				label={ sprintf( _n( 'Delete the block', 'Delete the %d blocks', count ), count ) }
 			/>
 			<IconButton
 				className="editor-block-settings-menu__control"
@@ -54,10 +54,7 @@ export default connect(
 	} ),
 	( dispatch, ownProps ) => ( {
 		onDelete() {
-			dispatch( removeBlock( ownProps.uid ) );
-		},
-		onSelect() {
-			dispatch( selectBlock( ownProps.uid ) );
+			dispatch( removeBlocks( ownProps.uids ) );
 		},
 		onShowInspector() {
 			dispatch( setActivePanel( 'block' ) );

--- a/editor/block-settings-menu/index.js
+++ b/editor/block-settings-menu/index.js
@@ -28,7 +28,11 @@ class BlockSettingsMenu extends Component {
 	}
 
 	toggleMenu() {
-		this.props.onSelect();
+		// Block could be hovered, not selected.
+		if ( this.props.uids.length === 1 ) {
+			this.props.onSelect( this.props.uids[ 0 ] );
+		}
+
 		this.setState( ( state ) => ( {
 			opened: ! state.opened,
 		} ) );
@@ -36,7 +40,7 @@ class BlockSettingsMenu extends Component {
 
 	render() {
 		const { opened } = this.state;
-		const { uid } = this.props;
+		const { uids } = this.props;
 		const toggleClassname = classnames( 'editor-block-settings-menu__toggle', 'editor-block-settings-menu__control', {
 			'is-opened': opened,
 		} );
@@ -50,7 +54,7 @@ class BlockSettingsMenu extends Component {
 					label={ opened ? __( 'Close Settings Menu' ) : __( 'Open Settings Menu' ) }
 				/>
 
-				{ opened && <BlockSettingsMenuContent uid={ uid } /> }
+				{ opened && <BlockSettingsMenuContent uids={ uids } /> }
 			</div>
 		);
 	}
@@ -58,9 +62,9 @@ class BlockSettingsMenu extends Component {
 
 export default connect(
 	undefined,
-	( dispatch, ownProps ) => ( {
-		onSelect() {
-			dispatch( selectBlock( ownProps.uid ) );
+	( dispatch ) => ( {
+		onSelect( uid ) {
+			dispatch( selectBlock( uid ) );
 		},
 	} )
 )( BlockSettingsMenu );

--- a/editor/block-settings-menu/index.js
+++ b/editor/block-settings-menu/index.js
@@ -40,7 +40,7 @@ class BlockSettingsMenu extends Component {
 
 	render() {
 		const { opened } = this.state;
-		const { uids } = this.props;
+		const { uids, focus } = this.props;
 		const toggleClassname = classnames( 'editor-block-settings-menu__toggle', 'editor-block-settings-menu__control', {
 			'is-opened': opened,
 		} );
@@ -52,6 +52,7 @@ class BlockSettingsMenu extends Component {
 					onClick={ this.toggleMenu }
 					icon="ellipsis"
 					label={ opened ? __( 'Close Settings Menu' ) : __( 'Open Settings Menu' ) }
+					focus={ focus }
 				/>
 
 				{ opened && <BlockSettingsMenuContent uids={ uids } /> }

--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { sprintf, _n, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 
 /**
@@ -18,13 +18,10 @@ import PublishButton from './publish-button';
 import PreviewButton from './preview-button';
 import ModeSwitcher from './mode-switcher';
 import Inserter from '../inserter';
-import { getMultiSelectedBlockUids, hasEditorUndo, hasEditorRedo, isEditorSidebarOpened } from '../selectors';
-import { clearSelectedBlock, toggleSidebar, removeBlocks } from '../actions';
+import { hasEditorUndo, hasEditorRedo, isEditorSidebarOpened } from '../selectors';
+import { toggleSidebar } from '../actions';
 
 function Header( {
-	multiSelectedBlockUids,
-	onRemove,
-	onDeselect,
 	undo,
 	redo,
 	hasRedo,
@@ -32,39 +29,6 @@ function Header( {
 	onToggleSidebar,
 	isSidebarOpened,
 } ) {
-	const count = multiSelectedBlockUids.length;
-
-	if ( count ) {
-		return (
-			<div
-				role="region"
-				aria-label={ __( 'Editor toolbar' ) }
-				className="editor-header editor-header-multi-select"
-			>
-				<div className="editor-selected-count">
-					{ sprintf( _n( '%d block selected', '%d blocks selected', count ), count ) }
-				</div>
-				<div className="editor-selected-delete">
-					<IconButton
-						icon="trash"
-						label={ __( 'Delete selected blocks' ) }
-						onClick={ () => onRemove( multiSelectedBlockUids ) }
-						focus={ true }
-					>
-						{ __( 'Delete' ) }
-					</IconButton>
-				</div>
-				<div className="editor-selected-clear">
-					<IconButton
-						icon="no"
-						label={ __( 'Clear selected blocks' ) }
-						onClick={ () => onDeselect() }
-					/>
-				</div>
-			</div>
-		);
-	}
-
 	return (
 		<div
 			role="region"
@@ -102,14 +66,11 @@ function Header( {
 
 export default connect(
 	( state ) => ( {
-		multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
 		hasUndo: hasEditorUndo( state ),
 		hasRedo: hasEditorRedo( state ),
 		isSidebarOpened: isEditorSidebarOpened( state ),
 	} ),
 	( dispatch ) => ( {
-		onDeselect: () => dispatch( clearSelectedBlock() ),
-		onRemove: ( uids ) => dispatch( removeBlocks( uids ) ),
 		undo: () => dispatch( { type: 'UNDO' } ),
 		redo: () => dispatch( { type: 'REDO' } ),
 		onToggleSidebar: () => dispatch( toggleSidebar() ),

--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -73,21 +73,6 @@
 	right: $admin-sidebar-width-big;
 }
 
-.editor-header-multi-select {
-	background: $blue-medium-100;
-	border-bottom: 1px solid $blue-medium-200;
-}
-
-.editor-selected-count {
-	padding-right: $item-spacing;
-	color: $dark-gray-500;
-	border-right: 1px solid $light-gray-500;
-}
-
-.editor-selected-clear {
-	margin: 0 0 0 auto;
-}
-
 // hide all action buttons except the inserter on mobile
 .editor-header__content-tools > .components-button {
 	display: none;

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -25,7 +25,7 @@ import {
 	getMultiSelectedBlocks,
 	getMultiSelectedBlockUids,
 } from '../../selectors';
-import { insertBlock, multiSelect } from '../../actions';
+import { insertBlock, startMultiSelect, stopMultiSelect, multiSelect } from '../../actions';
 
 const INSERTION_POINT_PLACEHOLDER = '[[insertion-point]]';
 
@@ -138,6 +138,8 @@ class VisualEditorBlockList extends Component {
 		// Capture scroll on all elements.
 		window.addEventListener( 'scroll', this.onScroll, true );
 		window.addEventListener( 'mouseup', this.onSelectionEnd );
+
+		this.props.onStartMultiSelect();
 	}
 
 	onSelectionChange( uid ) {
@@ -169,6 +171,8 @@ class VisualEditorBlockList extends Component {
 		window.removeEventListener( 'mousemove', this.onPointerMove );
 		window.removeEventListener( 'scroll', this.onScroll, true );
 		window.removeEventListener( 'mouseup', this.onSelectionEnd );
+
+		this.props.onStopMultiSelect();
 	}
 
 	appendDefaultBlock() {
@@ -243,6 +247,12 @@ export default connect(
 	( dispatch ) => ( {
 		onInsertBlock( block ) {
 			dispatch( insertBlock( block ) );
+		},
+		onStartMultiSelect() {
+			dispatch( startMultiSelect() );
+		},
+		onStopMultiSelect() {
+			dispatch( stopMultiSelect() );
 		},
 		onMultiSelect( start, end ) {
 			dispatch( multiSelect( start, end ) );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -136,7 +136,6 @@ class VisualEditorBlock extends Component {
 
 	bindBlockNode( node ) {
 		this.node = node;
-		this.props.blockRef( node );
 	}
 
 	setAttributes( attributes ) {
@@ -250,10 +249,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	onFocus( event ) {
-		// Firefox retargets to parent with tabIndex.
-		const target = event.nativeEvent.explicitOriginalTarget || event.target;
-
-		if ( target === this.node ) {
+		if ( event.target === this.node ) {
 			this.props.onSelect();
 		}
 	}
@@ -334,16 +330,12 @@ class VisualEditorBlock extends Component {
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<div
-				ref={ this.bindBlockNode }
-				onKeyDown={ this.onKeyDown }
-				onFocus={ this.onFocus }
+				ref={ this.props.blockRef }
 				onMouseMove={ this.maybeHover }
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
 				className={ wrapperClassname }
 				data-type={ block.name }
-				tabIndex="0"
-				aria-label={ blockLabel }
 				{ ...wrapperProps }
 			>
 				<BlockDropZone index={ order } />
@@ -353,10 +345,15 @@ class VisualEditorBlock extends Component {
 				{ isFirstMultiSelected && <BlockMover uids={ multiSelectedBlockUids } /> }
 				{ isFirstMultiSelected && <BlockRightMenu uids={ multiSelectedBlockUids } /> }
 				<div
+					ref={ this.bindBlockNode }
 					onKeyPress={ this.maybeStartTyping }
 					onDragStart={ ( event ) => event.preventDefault() }
 					onMouseDown={ this.onPointerDown }
+					onKeyDown={ this.onKeyDown }
+					onFocus={ this.onFocus }
 					className="editor-visual-editor__block-edit"
+					tabIndex="0"
+					aria-label={ blockLabel }
 				>
 					<BlockCrashBoundary onError={ this.onBlockError }>
 						{ isValid && mode === 'visual' && (

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -259,8 +259,9 @@ class VisualEditorBlock extends Component {
 	}
 
 	onPointerDown( event ) {
-		// Not the main button (usually the left button on pointer device).
-		if ( event.buttons !== 1 ) {
+		// Not the main button.
+		// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+		if ( event.button !== 0 ) {
 			return;
 		}
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -40,6 +40,7 @@ import {
 import {
 	getBlock,
 	getBlockFocus,
+	isMultiSelecting,
 	getBlockIndex,
 	getEditedPostAttribute,
 	getMultiSelectedBlockUids,
@@ -306,12 +307,13 @@ class VisualEditorBlock extends Component {
 		// Generate the wrapper class names handling the different states of the block.
 		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, focus } = this.props;
 		const showUI = isSelected && ( ! this.props.isTyping || focus.collapsed === false );
+		const isProperlyHovered = isHovered && ! this.props.isSelecting;
 		const { error } = this.state;
 		const wrapperClassname = classnames( 'editor-visual-editor__block', {
 			'has-warning': ! isValid || !! error,
 			'is-selected': showUI,
 			'is-multi-selected': isMultiSelected,
-			'is-hovered': isHovered,
+			'is-hovered': isProperlyHovered,
 		} );
 
 		const { onMouseLeave, onFocus, onReplace } = this.props;
@@ -339,11 +341,18 @@ class VisualEditorBlock extends Component {
 				{ ...wrapperProps }
 			>
 				<BlockDropZone index={ order } />
-				{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }
-				{ ( showUI || isHovered ) && <BlockRightMenu uids={ [ block.uid ] } /> }
+				{ ( showUI || isProperlyHovered ) && <BlockMover uids={ [ block.uid ] } /> }
+				{ ( showUI || isProperlyHovered ) && <BlockRightMenu uids={ [ block.uid ] } /> }
 				{ showUI && isValid && mode === 'visual' && <BlockToolbar uid={ block.uid } /> }
-				{ isFirstMultiSelected && <BlockMover uids={ multiSelectedBlockUids } /> }
-				{ isFirstMultiSelected && <BlockRightMenu uids={ multiSelectedBlockUids } /> }
+				{ isFirstMultiSelected && ! this.props.isSelecting &&
+					<BlockMover uids={ multiSelectedBlockUids } />
+				}
+				{ isFirstMultiSelected && ! this.props.isSelecting &&
+					<BlockRightMenu
+						uids={ multiSelectedBlockUids }
+						focus={ true }
+					/>
+				}
 				<div
 					ref={ this.bindBlockNode }
 					onKeyPress={ this.maybeStartTyping }
@@ -403,6 +412,7 @@ export default connect(
 			isFirstMultiSelected: isFirstMultiSelectedBlock( state, ownProps.uid ),
 			isHovered: isBlockHovered( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
+			isSelecting: isMultiSelecting( state ),
 			isTyping: isTyping( state ),
 			order: getBlockIndex( state, ownProps.uid ),
 			multiSelectedBlockUids: getMultiSelectedBlockUids( state ),

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -250,7 +250,10 @@ class VisualEditorBlock extends Component {
 	}
 
 	onFocus( event ) {
-		if ( event.target === this.node ) {
+		// Firefox retargets to parent with tabIndex.
+		const target = event.nativeEvent.explicitOriginalTarget || event.target;
+
+		if ( target === this.node ) {
 			this.props.onSelect();
 		}
 	}

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -344,12 +344,10 @@ class VisualEditorBlock extends Component {
 			>
 				<BlockDropZone index={ order } />
 				{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }
-				{ ( showUI || isHovered ) && <BlockRightMenu uid={ block.uid } /> }
+				{ ( showUI || isHovered ) && <BlockRightMenu uids={ [ block.uid ] } /> }
 				{ showUI && isValid && mode === 'visual' && <BlockToolbar uid={ block.uid } /> }
-
-				{ isFirstMultiSelected && (
-					<BlockMover uids={ multiSelectedBlockUids } />
-				) }
+				{ isFirstMultiSelected && <BlockMover uids={ multiSelectedBlockUids } /> }
+				{ isFirstMultiSelected && <BlockRightMenu uids={ multiSelectedBlockUids } /> }
 				<div
 					onKeyPress={ this.maybeStartTyping }
 					onDragStart={ ( event ) => event.preventDefault() }

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -314,6 +314,13 @@ export function blockSelection( state = { start: null, end: null, focus: null },
 				end: null,
 				focus: null,
 			};
+		case 'START_MULTI_SELECT':
+			return {
+				...state,
+				isMultiSelecting: true,
+			};
+		case 'STOP_MULTI_SELECT':
+			return omit( state, 'isMultiSelecting' );
 		case 'MULTI_SELECT':
 			return {
 				start: action.start,

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -350,17 +350,6 @@ export function blockSelection( state = { start: null, end: null, focus: null },
 				end: action.blocks[ 0 ].uid,
 				focus: {},
 			};
-		case 'MOVE_BLOCKS_UP':
-		case 'MOVE_BLOCKS_DOWN': {
-			const firstUid = first( action.uids );
-			return firstUid === state.start
-				? state
-				: {
-					start: firstUid,
-					end: firstUid,
-					focus: {},
-				};
-		}
 	}
 
 	return state;

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -318,7 +318,7 @@ export function blockSelection( state = { start: null, end: null, focus: null },
 			return {
 				start: action.start,
 				end: action.end,
-				focus: null,
+				focus: state.focus,
 			};
 		case 'SELECT_BLOCK':
 			if ( action.uid === state.start && action.uid === state.end ) {

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -721,7 +721,8 @@ export function isBlockHovered( state, uid ) {
  * @return {Object}       Block focus state
  */
 export function getBlockFocus( state, uid ) {
-	if ( ! isBlockSelected( state, uid ) ) {
+	// If there is multi-selection, keep returning the focus object for the start block.
+	if ( ! isBlockSelected( state, uid ) && state.blockSelection.start !== uid ) {
 		return null;
 	}
 

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -451,10 +451,26 @@ export const getBlocks = createSelector(
  * Returns the number of blocks currently present in the post.
  *
  * @param  {Object} state Global application state
- * @return {Object}       Number of blocks in the post
+ * @return {Number}       Number of blocks in the post
  */
 export function getBlockCount( state ) {
 	return getBlockUids( state ).length;
+}
+
+/**
+ * Returns the number of blocks currently selected in the post.
+ *
+ * @param  {Object} state Global application state
+ * @return {Number}       Number of blocks selected in the post
+ */
+export function getSelectedBlockCount( state ) {
+	const multiSelectedBlockCount = getMultiSelectedBlockUids( state ).length;
+
+	if ( multiSelectedBlockCount ) {
+		return multiSelectedBlockCount;
+	}
+
+	return state.blockSelection.start ? 1 : 0;
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -728,6 +728,17 @@ export function getBlockFocus( state, uid ) {
 
 	return state.blockSelection.focus;
 }
+
+/**
+ * Whether in the process of multi-selecting or not.
+ *
+ * @param  {Object} state Global application state
+ * @return {Boolean}      True if multi-selecting, false if not.
+ */
+export function isMultiSelecting( state ) {
+	return !! state.blockSelection.isMultiSelecting;
+}
+
 /**
  * Returns thee block's editing mode
  *

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -15,9 +15,13 @@ import { Panel, PanelBody } from '@wordpress/components';
  */
 import './style.scss';
 import BlockInspectorAdvancedControls from './advanced-controls';
-import { getSelectedBlock } from '../../selectors';
+import { getSelectedBlock, getSelectedBlockCount } from '../../selectors';
 
-const BlockInspector = ( { selectedBlock } ) => {
+const BlockInspector = ( { selectedBlock, count } ) => {
+	if ( count > 1 ) {
+		return <span className="editor-block-inspector__multi-blocks">{ __( 'Coming Soon' ) }</span>;
+	}
+
 	if ( ! selectedBlock ) {
 		return <span className="editor-block-inspector__no-blocks">{ __( 'No block selected.' ) }</span>;
 	}
@@ -36,6 +40,7 @@ export default connect(
 	( state ) => {
 		return {
 			selectedBlock: getSelectedBlock( state ),
+			count: getSelectedBlockCount( state ),
 		};
 	}
 )( BlockInspector );

--- a/editor/sidebar/block-inspector/style.scss
+++ b/editor/sidebar/block-inspector/style.scss
@@ -8,7 +8,8 @@
 	}
 }
 
-.editor-block-inspector__no-blocks {
+.editor-block-inspector__no-blocks,
+.editor-block-inspector__multi-blocks {
 	display: block;
 	font-size: $default-font-size;
 	background: $white;

--- a/editor/sidebar/header.js
+++ b/editor/sidebar/header.js
@@ -6,16 +6,19 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 
 /**
  * Internal Dependencies
  */
-import { getActivePanel } from '../selectors';
+import { getActivePanel, getSelectedBlockCount } from '../selectors';
 import { toggleSidebar, setActivePanel } from '../actions';
 
-const SidebarHeader = ( { panel, onSetPanel, onToggleSidebar } ) => {
+const SidebarHeader = ( { panel, onSetPanel, onToggleSidebar, count } ) => {
+	// Do not display "0 Blocks".
+	count = count === 0 ? 1 : count;
+
 	return (
 		<div className="components-panel__header editor-sidebar__panel-tabs">
 			<button
@@ -30,7 +33,7 @@ const SidebarHeader = ( { panel, onSetPanel, onToggleSidebar } ) => {
 				className={ `editor-sidebar__panel-tab ${ panel === 'block' ? 'is-active' : '' }` }
 				aria-label={ __( 'Block settings' ) }
 			>
-				{ __( 'Block' ) }
+				{ sprintf( _n( 'Block', '%d Blocks', count ), count ) }
 			</button>
 			<IconButton
 				onClick={ onToggleSidebar }
@@ -44,6 +47,7 @@ const SidebarHeader = ( { panel, onSetPanel, onToggleSidebar } ) => {
 export default connect(
 	( state ) => ( {
 		panel: getActivePanel( state ),
+		count: getSelectedBlockCount( state ),
 	} ),
 	( dispatch ) => ( {
 		onSetPanel: ( panel ) => dispatch( setActivePanel( panel ) ),

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -734,24 +734,6 @@ describe( 'state', () => {
 			expect( state3 ).toEqual( { start: 'ribs', end: 'ribs', focus: {} } );
 		} );
 
-		it( 'should return with block moved up', () => {
-			const state = blockSelection( undefined, {
-				type: 'MOVE_BLOCKS_UP',
-				uids: [ 'ribs' ],
-			} );
-
-			expect( state ).toEqual( { start: 'ribs', end: 'ribs', focus: {} } );
-		} );
-
-		it( 'should return with block moved down', () => {
-			const state = blockSelection( undefined, {
-				type: 'MOVE_BLOCKS_DOWN',
-				uids: [ 'chicken' ],
-			} );
-
-			expect( state ).toEqual( { start: 'chicken', end: 'chicken', focus: {} } );
-		} );
-
 		it( 'should not update the state if the block moved is already selected', () => {
 			const original = deepFreeze( { start: 'ribs', end: 'ribs', focus: {} } );
 			const state = blockSelection( original, {

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -693,13 +693,14 @@ describe( 'state', () => {
 		} );
 
 		it( 'should set multi selection', () => {
-			const state = blockSelection( undefined, {
+			const original = deepFreeze( { focus: { editable: 'citation' } } );
+			const state = blockSelection( original, {
 				type: 'MULTI_SELECT',
 				start: 'ribs',
 				end: 'chicken',
 			} );
 
-			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: null } );
+			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: { editable: 'citation' } } );
 		} );
 
 		it( 'should not update the state if the block is already selected', () => {

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -1493,6 +1493,30 @@ describe( 'selectors', () => {
 			expect( getBlockFocus( state, 123 ) ).toEqual( { editable: 'cite' } );
 		} );
 
+		it( 'should return the block focus for the start if the block is multi-selected', () => {
+			const state = {
+				blockSelection: {
+					start: 123,
+					end: 124,
+					focus: { editable: 'cite' },
+				},
+			};
+
+			expect( getBlockFocus( state, 123 ) ).toEqual( { editable: 'cite' } );
+		} );
+
+		it( 'should return null for the end if the block is multi-selected', () => {
+			const state = {
+				blockSelection: {
+					start: 123,
+					end: 124,
+					focus: { editable: 'cite' },
+				},
+			};
+
+			expect( getBlockFocus( state, 124 ) ).toEqual( null );
+		} );
+
 		it( 'should return null if the block is not selected', () => {
 			const state = {
 				blockSelection: {

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -36,7 +36,7 @@ class WritingFlow extends Component {
 				node.nodeName === 'INPUT' ||
 				node.nodeName === 'TEXTAREA' ||
 				node.contentEditable === 'true' ||
-				node.classList.contains( 'editor-visual-editor__block' )
+				node.classList.contains( 'editor-visual-editor__block-edit' )
 			) );
 	}
 


### PR DESCRIPTION
## Description
Split off from #1811. This PR remove this multi selection header in favour of inline actions, just like single-selected blocks. Adding inspector tools can be done in a separate PR. See #1811. 

## How Has This Been Tested?
* The multi-select header should be gone.
* There should be a right side menu. Opening the inspector should work. Deleting the blocks should work.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.