### PR TITLE
Components: Pass empty object for unknown API path (withAPIData)

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -161,15 +161,17 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 					return result;
 				}
 
+				result[ propName ] = {};
+
 				const route = getRoute( this.schema, path );
 				if ( ! route ) {
 					return result;
 				}
 
-				result[ propName ] = route.methods.reduce( ( stateValue, method ) => {
+				route.methods.forEach( ( method ) => {
 					// Add request initiater into data props
 					const requestKey = this.getRequestKey( method );
-					stateValue[ requestKey ] = this.request.bind(
+					result[ propName ][ requestKey ] = this.request.bind(
 						this,
 						propName,
 						method,
@@ -178,13 +180,11 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 
 					// Initialize pending flags as explicitly false
 					const pendingKey = this.getPendingKey( method );
-					stateValue[ pendingKey ] = false;
+					result[ propName ][ pendingKey ] = false;
 
 					// Track path for future map skipping
-					stateValue.path = path;
-
-					return stateValue;
-				}, {} );
+					result[ propName ].path = path;
+				} );
 
 				return result;
 			}, {} );

--- a/components/higher-order/with-api-data/test/index.js
+++ b/components/higher-order/with-api-data/test/index.js
@@ -70,12 +70,15 @@ describe( 'withAPIData()', () => {
 		} );
 	} );
 
-	it( 'should ignore unmatched resources', () => {
+	it( 'should assign an empty prop object for unmatched resources', () => {
 		const wrapper = getWrapper( () => ( {
-			revision: '/wp/v2/pages/5/revisions/10',
+			unknown: '/wp/v2/unknown/route',
 		} ) );
 
-		expect( wrapper.state( 'dataProps' ) ).toEqual( {} );
+		const dataProps = wrapper.state( 'dataProps' );
+		expect( Object.keys( dataProps ) ).toEqual( [ 'unknown' ] );
+		expect( Object.keys( dataProps.unknown ) ).toEqual( [] );
+		expect( wrapper.prop( 'unknown' ) ).toEqual( {} );
 	} );
 
 	it( 'should include full gamut of method available properties', () => {


### PR DESCRIPTION
Fixes #2910 

This pull request seeks to change the behavior of the `withAPIData` component to pass an empty object when the mapping function returns a route which is not known. Specifically, this resolves a case where post types without revisions support would cause the editor not to load. The hope with the mapping function is that a developer should always be able to call on the prop as an object without first checking its existence. With these changes, a developer could still determine if the route is usable by presence of method-specific flags (i.e. `isLoading`). These will not be assigned if there are no supported methods for the given route.

__Testing instructions:__

Repeat testing instructions from https://github.com/WordPress/gutenberg/issues/2910#issuecomment-334868411, verifying that the editor loads correctly.

Here is a demo custom post type demonstrating the behavior if you do not already have one available: https://gist.github.com/aduth/6ff7c20c2500b249edf481a838af0f9e