### PR TITLE
Title: Unselect title by blur event

### DIFF
--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -3,12 +3,11 @@
  */
 import Clipboard from 'clipboard';
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { findDOMNode, Component } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,12 +15,23 @@ import { findDOMNode, Component } from '@wordpress/element';
 import { Button } from '../';
 
 class ClipboardButton extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.bindContainer = this.bindContainer.bind( this );
+		this.onCopy = this.onCopy.bind( this );
+		this.getText = this.getText.bind( this );
+	}
+
 	componentDidMount() {
-		const { text, onCopy = noop } = this.props;
-		const button = findDOMNode( this.button );
-		this.clipboard = new Clipboard( button, {
-			text: () => text,
+		const { container, getText, onCopy } = this;
+		const button = container.firstChild;
+
+		this.clipboard = new Clipboard( button,	{
+			text: getText,
+			container,
 		} );
+
 		this.clipboard.on( 'success', onCopy );
 	}
 
@@ -30,17 +40,36 @@ class ClipboardButton extends Component {
 		delete this.clipboard;
 	}
 
+	bindContainer( container ) {
+		this.container = container;
+	}
+
+	onCopy( args ) {
+		// Clearing selection will move focus back to the triggering button,
+		// ensuring that it is not reset to the body, and further that it is
+		// kept within the rendered node.
+		args.clearSelection();
+
+		const { onCopy } = this.props;
+		if ( onCopy ) {
+			onCopy();
+		}
+	}
+
+	getText() {
+		return this.props.text;
+	}
+
 	render() {
 		const { className, children } = this.props;
 		const classes = classnames( 'components-clipboard-button', className );
 
 		return (
-			<Button
-				ref={ ref => this.button = ref }
-				className={ classes }
-			>
-				{ children }
-			</Button>
+			<div ref={ this.bindContainer }>
+				<Button className={ classes }>
+					{ children }
+				</Button>
+			</div>
 		);
 	}
 }

--- a/editor/post-permalink/index.js
+++ b/editor/post-permalink/index.js
@@ -25,7 +25,7 @@ class PostPermalink extends Component {
 		this.onCopy = this.onCopy.bind( this );
 	}
 
-	componentWillUnmout() {
+	componentWillUnmount() {
 		clearTimeout( this.dismissCopyConfirmation );
 	}
 


### PR DESCRIPTION
Fixes #1390 

This pull request seeks to resolve an issue where the post title retains selected styles when tabbing away, since the title had only become unselected when explicitly clicking outside. The changes here capture focus being lost by blur event, thereby capturing both click outside and tabbing.

__Testing instructions:__

1. Navigate to Gutenberg > New Post
2. Click the title field
3. Press tab
4. Note that title focus styles are reset (note: your cursor may still be hovering the title from step 2, so hover styles may still be visible)

__Future tasks:__

There are a few other easy wins in the title component:

- ~Move `<PostTitle />` to be handled within `<WritingFlow />` to allow arrow navigation to move downward within content~ (#2052) __Edit:__ Was already included in #2424
- Consider either handling Enter press from `<PostTitle />` _or_ `<WritingFlow />` to create a new default block after (#1650)