### PR TITLE
Writing Flow: Create default block on enter press

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -387,6 +387,8 @@ export default class Editable extends Component {
 					this.splitContent();
 				}
 			}
+
+			event.stopImmediatePropagation();
 		}
 	}
 

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -10,7 +10,7 @@ import { has, partial, reduce, size } from 'lodash';
  */
 import { Component, createElement } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
-import { getBlockType, getBlockDefaultClassname, createBlock } from '@wordpress/blocks';
+import { getBlockType, getBlockDefaultClassname } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -51,7 +51,7 @@ import {
 	isTyping,
 } from '../../selectors';
 
-const { BACKSPACE, ESCAPE, DELETE, ENTER } = keycodes;
+const { BACKSPACE, ESCAPE, DELETE } = keycodes;
 
 class VisualEditorBlock extends Component {
 	constructor() {
@@ -66,7 +66,6 @@ class VisualEditorBlock extends Component {
 		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.onFocus = this.onFocus.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onBlockError = this.onBlockError.bind( this );
 		this.insertBlocksAfter = this.insertBlocksAfter.bind( this );
 
@@ -261,18 +260,6 @@ class VisualEditorBlock extends Component {
 		this.props.onSelect();
 	}
 
-	onKeyDown( event ) {
-		const { keyCode, target } = event;
-		if ( ENTER === keyCode && target === this.node ) {
-			event.preventDefault();
-
-			this.props.onInsertBlocks( [
-				createBlock( 'core/paragraph' ),
-			], this.props.order + 1 );
-		}
-		this.removeOrDeselect( event );
-	}
-
 	onBlockError( error ) {
 		this.setState( { error } );
 	}
@@ -327,7 +314,7 @@ class VisualEditorBlock extends Component {
 		return (
 			<div
 				ref={ this.bindBlockNode }
-				onKeyDown={ this.onKeyDown }
+				onKeyDown={ this.removeOrDeselect }
 				onFocus={ this.onFocus }
 				onMouseMove={ this.maybeHover }
 				onMouseEnter={ this.maybeHover }

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -719,10 +719,12 @@ export function isTyping( state ) {
  * Returns the insertion point, the index at which the new inserted block would
  * be placed. Defaults to the last position
  *
- * @param  {Object}  state Global application state
- * @return {?String}       Unique ID after which insertion will occur
+ * @param  {Object}   state        Global application state
+ * @param  {?Boolean} defaultAtEnd Whether block should be inserted at end if
+ *                                 no block is selected (default true)
+ * @return {?String}               Unique ID after which insertion will occur
  */
-export function getBlockInsertionPoint( state ) {
+export function getBlockInsertionPoint( state, defaultAtEnd = true ) {
 	if ( getEditorMode( state ) !== 'visual' ) {
 		return state.editor.blockOrder.length;
 	}
@@ -737,7 +739,11 @@ export function getBlockInsertionPoint( state ) {
 		return getBlockIndex( state, selectedBlock.uid ) + 1;
 	}
 
-	return state.editor.blockOrder.length;
+	if ( defaultAtEnd ) {
+		return state.editor.blockOrder.length;
+	}
+
+	return 0;
 }
 
 /**

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -1570,6 +1570,18 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toBe( 3 );
 		} );
 
+		it( 'should return 0 if no selection and default at end false', () => {
+			const state = {
+				preferences: { mode: 'visual' },
+				blockSelection: { start: null, end: null },
+				editor: {
+					blockOrder: [ 1, 2, 3 ],
+				},
+			};
+
+			expect( getBlockInsertionPoint( state, false ) ).toBe( 0 );
+		} );
+
 		it( 'should return the last block for the text mode', () => {
 			const state = {
 				preferences: { mode: 'text' },

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 import { keycodes, focus } from '@wordpress/utils';
 
 /**

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -1,18 +1,26 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { keycodes, focus } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import { isEdge, placeCaretAtEdge } from '../utils/dom';
+import { getBlockInsertionPoint } from '../selectors';
+import { insertBlock } from '../actions';
 
 /**
  * Module Constants
  */
-const { UP, DOWN, LEFT, RIGHT } = keycodes;
+const { UP, DOWN, LEFT, RIGHT, ENTER } = keycodes;
 
 class WritingFlow extends Component {
 	constructor() {
@@ -66,6 +74,12 @@ class WritingFlow extends Component {
 			event.preventDefault();
 			this.shouldMove = true;
 		}
+
+		if ( keyCode === ENTER ) {
+			const { onInsertDefaultBlock, insertionPoint } = this.props;
+			event.preventDefault();
+			onInsertDefaultBlock( insertionPoint );
+		}
 	}
 
 	onKeyUp( event ) {
@@ -94,4 +108,18 @@ class WritingFlow extends Component {
 	}
 }
 
-export default WritingFlow;
+export default connect(
+	( state ) => {
+		return {
+			insertionPoint: getBlockInsertionPoint( state, false ),
+		};
+	},
+	{
+		onInsertDefaultBlock( position ) {
+			return insertBlock(
+				createBlock( getDefaultBlockName() ),
+				position
+			);
+		},
+	},
+)( WritingFlow );


### PR DESCRIPTION
Closes #1650

This pull request seeks to implement the behavior for creating default block on enter press from VisualEditorBlock to WritingFlow, thereby enabling new blocks to be created from the title field. 

__Implementation notes:__

We may want to consider whether this is the appropriate location for handling this logic, or if it is more sensible for the title component to specifically handle the Enter press. In particular, the additional argument to `getBlockInsertionPoint` (`defaultAtEnd`) is quite specific to the title use-case. Alternatively, we may consider a different behavior for how to handle the unknown insertion point (i.e. return `null` and allow the component / `mapStateToProps` to handle).

The behavior of testing `event.target === this.node` from VisualEditorBlock is meant to avoid bubbled events from creating a paragraph. This is accounted for here by stopping propagation from the Editable component, though me may want to consider whether this fully encompasses the intention of the original condition.

__Testing instructions:__

Verify that pressing Enter from the title field creates a new adjacent paragraph block.
Verify that pressing Enter from a paragraph block creates a new (single) adjacent paragraph block.
Verify that pressing Enter while an image block placeholder is selected creates a new adjacent paragraph block.