### PR TITLE
Parser: Hide the core namespace in serialised data

### DIFF
--- a/blocks/api/paste/test/integration/apple-out.html
+++ b/blocks/api/paste/test/integration/apple-out.html
@@ -1,16 +1,16 @@
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p><strong>This is a </strong>title</p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p><strong>This is a <em>heading</em></strong></p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>This is a <strong>paragraph</strong> with a <a href="https://w.org">link</a>.</p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ul>
     <li>A</li>
     <li>Bulleted</li>
@@ -19,17 +19,17 @@
     </ul>
     <li>List</li>
 </ul>
-<!-- /wp:core/list -->
+<!-- /wp:list -->
 
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ol>
     <li>One</li>
     <li>Two</li>
     <li>Three</li>
 </ol>
-<!-- /wp:core/list -->
+<!-- /wp:list -->
 
-<!-- wp:core/table -->
+<!-- wp:table -->
 <table class="wp-block-table">
     <tbody>
         <tr>
@@ -67,8 +67,8 @@
         </tr>
     </tbody>
 </table>
-<!-- /wp:core/table -->
+<!-- /wp:table -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>An image: </p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->

--- a/blocks/api/paste/test/integration/google-docs-out.html
+++ b/blocks/api/paste/test/integration/google-docs-out.html
@@ -1,16 +1,16 @@
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>This is a <strong>title</strong><br/></p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/heading -->
+<!-- wp:heading -->
 <h2>This is a <em>heading</em></h2>
-<!-- /wp:core/heading -->
+<!-- /wp:heading -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>This is a <strong>paragraph</strong> with a <a href="https://w.org">link</a>.<br/></p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ul>
     <li>A</li>
     <li>Bulleted</li>
@@ -19,17 +19,17 @@
     </ul>
     <li>List</li>
 </ul>
-<!-- /wp:core/list -->
+<!-- /wp:list -->
 
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ol>
     <li>One</li>
     <li>Two</li>
     <li>Three</li>
 </ol>
-<!-- /wp:core/list -->
+<!-- /wp:list -->
 
-<!-- wp:core/table -->
+<!-- wp:table -->
 <table class="wp-block-table">
     <tbody>
         <tr>
@@ -49,17 +49,17 @@
         </tr>
     </tbody>
 </table>
-<!-- /wp:core/table -->
+<!-- /wp:table -->
 
-<!-- wp:core/separator -->
+<!-- wp:separator -->
 <hr class="wp-block-separator" />
-<!-- /wp:core/separator -->
+<!-- /wp:separator -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>An image:<br/></p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/image -->
+<!-- wp:image -->
 <figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" /></figure>
-<!-- /wp:core/image -->
+<!-- /wp:image -->
 

--- a/blocks/api/paste/test/integration/ms-word-online-out.html
+++ b/blocks/api/paste/test/integration/ms-word-online-out.html
@@ -1,29 +1,29 @@
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>This is a <em>heading</em> </p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>This is a <strong>paragraph </strong>with a <a href="https://w.org/">link</a>. </p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ul>
     <li>A </li>
     <li>Bulleted </li>
     <li>Indented </li>
     <li>List </li>
 </ul>
-<!-- /wp:core/list -->
+<!-- /wp:list -->
 
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ol>
     <li>One </li>
     <li>Two </li>
     <li>Three </li>
 </ol>
-<!-- /wp:core/list -->
+<!-- /wp:list -->
 
-<!-- wp:core/table -->
+<!-- wp:table -->
 <table class="wp-block-table">
     <tbody>
         <tr>
@@ -43,12 +43,12 @@
         </tr>
     </tbody>
 </table>
-<!-- /wp:core/table -->
+<!-- /wp:table -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>An image: </p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/image -->
+<!-- wp:image -->
 <figure class="wp-block-image"><img src="data:image/jpeg;base64,###" /></figure>
-<!-- /wp:core/image -->
+<!-- /wp:image -->

--- a/blocks/api/paste/test/integration/ms-word-out.html
+++ b/blocks/api/paste/test/integration/ms-word-out.html
@@ -1,26 +1,26 @@
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>This is a title
 </p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>This is a subtitle
 </p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/heading -->
+<!-- wp:heading -->
 <h1>This is a heading level 1</h1>
-<!-- /wp:core/heading -->
+<!-- /wp:heading -->
 
-<!-- wp:core/heading -->
+<!-- wp:heading -->
 <h2>This is a heading level 2</h2>
-<!-- /wp:core/heading -->
+<!-- /wp:heading -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>This is a <strong>paragraph</strong> with a <a href="https://w.org/">link</a>.</p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ul>
     <li>A</li>
     <li>Bulleted
@@ -30,17 +30,17 @@
     </li>
     <li>List</li>
 </ul>
-<!-- /wp:core/list -->
+<!-- /wp:list -->
 
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ol>
     <li>One</li>
     <li>Two</li>
     <li>Three</li>
 </ol>
-<!-- /wp:core/list -->
+<!-- /wp:list -->
 
-<!-- wp:core/table -->
+<!-- wp:table -->
 <table class="wp-block-table">
     <tbody>
         <tr>
@@ -78,12 +78,12 @@
         </tr>
     </tbody>
 </table>
-<!-- /wp:core/table -->
+<!-- /wp:table -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>An image:</p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/image -->
+<!-- wp:image -->
 <figure class="wp-block-image"><img src="" /></figure>
-<!-- /wp:core/image -->
+<!-- /wp:image -->

--- a/blocks/api/paste/test/integration/plain-out.html
+++ b/blocks/api/paste/test/integration/plain-out.html
@@ -1,7 +1,7 @@
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>test<br/>test</p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->
 
-<!-- wp:core/paragraph -->
+<!-- wp:paragraph -->
 <p>test<br/></p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -148,20 +148,26 @@ WP_Block_End
   }
 
 WP_Block_Name
-  = blockName:$(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
+  = namespace:$(WP_Block_Namespace "/")? name:WP_Namespaced_Block_Name
   {
     /** <?php
-    if ( false === strpos( $blockName, '/' ) ) {
-      $blockName = "core/$blockName";
+    if ( ! $namespace ) {
+      $namespace = 'core/';
     }
-    return $blockName;
+    return $namespace . $name;
     ?> **/
 
-    if ( ! blockName.includes( '/' ) ) {
-      blockName = 'core/' + blockName;
+    if ( ! namespace ) {
+      namespace = 'core/';
     }
-    return blockName;
+    return namespace + name;
   }
+
+WP_Block_Namespace
+  = $(ASCII_Letter ASCII_AlphaNumeric*)
+
+WP_Namespaced_Block_Name
+  = $(ASCII_Letter ASCII_AlphaNumeric*)
 
 WP_Block_Attributes
   = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -148,26 +148,18 @@ WP_Block_End
   }
 
 WP_Block_Name
-  = namespace:$(WP_Block_Namespace "/")? name:WP_Namespaced_Block_Name
-  {
-    /** <?php
-    if ( ! $namespace ) {
-      $namespace = 'core/';
-    }
-    return $namespace . $name;
-    ?> **/
-
-    if ( ! namespace ) {
-      namespace = 'core/';
-    }
-    return namespace + name;
-  }
-
-WP_Block_Namespace
-  = $(ASCII_Letter ASCII_AlphaNumeric*)
+  = WP_Namespaced_Block_Name
+  / WP_Core_Block_Name
 
 WP_Namespaced_Block_Name
-  = $(ASCII_Letter ASCII_AlphaNumeric*)
+  = $(ASCII_Letter ASCII_AlphaNumeric* "/" ASCII_Letter ASCII_AlphaNumeric*)
+
+WP_Core_Block_Name
+  = type:$(ASCII_Letter ASCII_AlphaNumeric*)
+  {
+    /** <?php return "core/$type"; ?> **/
+    return 'core/' + type;
+  }
 
 WP_Block_Attributes
   = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -148,7 +148,20 @@ WP_Block_End
   }
 
 WP_Block_Name
-  = $(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
+  = blockName:$(ASCII_Letter (ASCII_AlphaNumeric / "/" ASCII_AlphaNumeric)*)
+  {
+    /** <?php
+    if ( false === strpos( $blockName, '/' ) ) {
+      $blockName = "core/$blockName";
+    }
+    return $blockName;
+    ?> **/
+
+    if ( ! blockName.includes( '/' ) ) {
+      blockName = 'core/' + blockName;
+    }
+    return blockName;
+  }
 
 WP_Block_Attributes
   = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -50,6 +50,12 @@ export function registerBlockType( name, settings ) {
 		);
 		return;
 	}
+	if ( /[A-Z]+/.test( name ) ) {
+		console.error(
+			'Block names must not contain uppercase characters.'
+		);
+		return;
+	}
 	if ( ! /^[a-z0-9-]+\/[a-z0-9-]+$/.test( name ) ) {
 		console.error(
 			'Block names must contain a namespace prefix. Example: my-plugin/my-custom-block'

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -168,19 +168,20 @@ export function getBlockContent( block ) {
 /**
  * Returns the content of a block, including comment delimiters.
  *
- * @param  {String} blockName  Block name
- * @param  {Object} attributes Block attributes
- * @param  {String} content    Block save content
- * @return {String}            Comment-delimited block content
+ * @param  {String} rawBlockName  Block name
+ * @param  {Object} attributes    Block attributes
+ * @param  {String} content       Block save content
+ * @return {String}               Comment-delimited block content
  */
-export function getCommentDelimitedContent( blockName, attributes, content ) {
+export function getCommentDelimitedContent( rawBlockName, attributes, content ) {
 	const serializedAttributes = ! isEmpty( attributes )
 		? serializeAttributes( attributes ) + ' '
 		: '';
 
-	if ( blockName.startsWith( 'core/' ) ) {
-		blockName = blockName.substr( 5 );
-	}
+	// strip core blocks of their namespace prefix
+	const blockName = rawBlockName.startsWith( 'core/' )
+		? rawBlockName.slice( 5 )
+		: rawBlockName;
 
 	if ( ! content ) {
 		return `<!-- wp:${ blockName } ${ serializedAttributes }/-->`;

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -178,6 +178,10 @@ export function getCommentDelimitedContent( blockName, attributes, content ) {
 		? serializeAttributes( attributes ) + ' '
 		: '';
 
+	if ( blockName.startsWith( 'core/' ) ) {
+		blockName = blockName.substr( 5 );
+	}
+
 	if ( ! content ) {
 		return `<!-- wp:${ blockName } ${ serializedAttributes }/-->`;
 	}

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -248,7 +248,7 @@ describe( 'block parser', () => {
 			);
 			expect( block.name ).toBe( 'core/unknown-block' );
 			expect( block.attributes.fruit ).toBe( 'Bananas' );
-			expect( block.attributes.content ).toContain( 'core/test-block' );
+			expect( block.attributes.content ).toContain( 'wp:test-block' );
 		} );
 
 		it( 'should fall back to the unknown type handler if block type not specified', () => {

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -333,6 +333,17 @@ describe( 'block parser', () => {
 			expect( typeof parsed[ 0 ].uid ).toBe( 'string' );
 		} );
 
+		it( 'should add the core namespace to un-namespaced blocks', () => {
+			registerBlockType( 'core/test-block', defaultBlockSettings );
+
+			const parsed = parse(
+				'<!-- wp:test-block -->\nRibs\n<!-- /wp:test-block -->'
+			);
+
+			expect( parsed ).toHaveLength( 1 );
+			expect( parsed[ 0 ].name ).toBe( 'core/test-block' );
+		} );
+
 		it( 'should ignore blocks with a bad namespace', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -333,6 +333,20 @@ describe( 'block parser', () => {
 			expect( typeof parsed[ 0 ].uid ).toBe( 'string' );
 		} );
 
+		it( 'should ignore blocks with a bad namespace', () => {
+			registerBlockType( 'core/test-block', defaultBlockSettings );
+
+			setUnknownTypeHandlerName( 'core/unknown-block' );
+
+			const parsed = parse(
+				'<!-- wp:core/test-block -->Ribs<!-- /wp:core/test-block -->' +
+				'<p>Broccoli</p>' +
+				'<!-- wp:core/unknown/block -->Ribs<!-- /wp:core/unknown/block -->'
+			);
+			expect( parsed ).toHaveLength( 1 );
+			expect( parsed[ 0 ].name ).toBe( 'core/test-block' );
+		} );
+
 		it( 'should parse the post content, using unknown block handler', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 			registerBlockType( 'core/unknown-block', defaultBlockSettings );

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -63,6 +63,12 @@ describe( 'blocks', () => {
 			expect( block ).toBeUndefined();
 		} );
 
+		it( 'should reject blocks with uppercase characters', () => {
+			const block = registerBlockType( 'Core/Paragraph' );
+			expect( console.error ).toHaveBeenCalledWith( 'Block names must not contain uppercase characters.' );
+			expect( block ).toBeUndefined();
+		} );
+
 		it( 'should accept valid block names', () => {
 			const block = registerBlockType( 'my-plugin/fancy-block-4', defaultBlockSettings );
 			expect( console.error ).not.toHaveBeenCalled();

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -246,6 +246,16 @@ describe( 'block serializer', () => {
 			expect( content ).toBe( '<!-- wp:test-block /-->' );
 		} );
 
+		it( 'should include the namespace for non-core blocks', () => {
+			const content = getCommentDelimitedContent(
+				'my-wonderful-namespace/test-block',
+				{},
+				''
+			);
+
+			expect( content ).toBe( '<!-- wp:my-wonderful-namespace/test-block /-->' );
+		} );
+
 		it( 'should generate empty attributes non-void', () => {
 			const content = getCommentDelimitedContent(
 				'core/test-block',

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -243,7 +243,7 @@ describe( 'block serializer', () => {
 				''
 			);
 
-			expect( content ).toBe( '<!-- wp:core/test-block /-->' );
+			expect( content ).toBe( '<!-- wp:test-block /-->' );
 		} );
 
 		it( 'should generate empty attributes non-void', () => {
@@ -253,7 +253,7 @@ describe( 'block serializer', () => {
 				'Delicious'
 			);
 
-			expect( content ).toBe( '<!-- wp:core/test-block -->\nDelicious\n<!-- /wp:core/test-block -->' );
+			expect( content ).toBe( '<!-- wp:test-block -->\nDelicious\n<!-- /wp:test-block -->' );
 		} );
 
 		it( 'should generate non-empty attributes void', () => {
@@ -264,7 +264,7 @@ describe( 'block serializer', () => {
 			);
 
 			expect( content ).toBe(
-				'<!-- wp:core/test-block {"fruit":"Banana"} /-->'
+				'<!-- wp:test-block {"fruit":"Banana"} /-->'
 			);
 		} );
 
@@ -276,7 +276,7 @@ describe( 'block serializer', () => {
 			);
 
 			expect( content ).toBe(
-				'<!-- wp:core/test-block {"fruit":"Banana"} -->\nDelicious\n<!-- /wp:core/test-block -->'
+				'<!-- wp:test-block {"fruit":"Banana"} -->\nDelicious\n<!-- /wp:test-block -->'
 			);
 		} );
 	} );
@@ -387,7 +387,7 @@ describe( 'block serializer', () => {
 				content: 'Ribs & Chicken',
 				stuff: 'left & right -- but <not>',
 			} );
-			const expectedPostContent = '<!-- wp:core/test-block {"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:core/test-block -->';
+			const expectedPostContent = '<!-- wp:test-block {"stuff":"left \\u0026 right \\u002d\\u002d but \\u003cnot\\u003e"} -->\n<p class="wp-block-test-block">Ribs & Chicken</p>\n<!-- /wp:test-block -->';
 
 			expect( serialize( [ block ] ) ).toEqual( expectedPostContent );
 			expect( serialize( block ) ).toEqual( expectedPostContent );
@@ -402,7 +402,7 @@ describe( 'block serializer', () => {
 			block.originalContent = 'Correct';
 
 			expect( serialize( block ) ).toEqual(
-				'<!-- wp:core/test-block -->\nCorrect\n<!-- /wp:core/test-block -->'
+				'<!-- wp:test-block -->\nCorrect\n<!-- /wp:test-block -->'
 			);
 		} );
 
@@ -415,7 +415,7 @@ describe( 'block serializer', () => {
 			block.originalContent = 'Correct';
 
 			expect( serialize( block ) ).toEqual(
-				'<!-- wp:core/test-block {"throw":true} -->\nCorrect\n<!-- /wp:core/test-block -->'
+				'<!-- wp:test-block {"throw":true} -->\nCorrect\n<!-- /wp:test-block -->'
 			);
 		} );
 	} );

--- a/blocks/test/fixtures/core__audio.serialized.html
+++ b/blocks/test/fixtures/core__audio.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/audio {"align":"right"} -->
+<!-- wp:audio {"align":"right"} -->
 <figure class="wp-block-audio alignright"><audio controls="" src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3"></audio></figure>
-<!-- /wp:core/audio -->
+<!-- /wp:audio -->

--- a/blocks/test/fixtures/core__button__center.serialized.html
+++ b/blocks/test/fixtures/core__button__center.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/button {"align":"center"} -->
+<!-- wp:button {"align":"center"} -->
 <div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
-<!-- /wp:core/button -->
+<!-- /wp:button -->

--- a/blocks/test/fixtures/core__categories.serialized.html
+++ b/blocks/test/fixtures/core__categories.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:core/categories /-->
+<!-- wp:categories /-->

--- a/blocks/test/fixtures/core__code.serialized.html
+++ b/blocks/test/fixtures/core__code.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:core/code -->
+<!-- wp:code -->
 <pre class="wp-block-code"><code>export default function MyButton() {
 	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
 }</code></pre>
-<!-- /wp:core/code -->
+<!-- /wp:code -->

--- a/blocks/test/fixtures/core__cover-image.serialized.html
+++ b/blocks/test/fixtures/core__cover-image.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
+<!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
 <section class="wp-block-cover-image has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg);">
     <h2>Guten Berg!</h2>
 </section>
-<!-- /wp:core/cover-image -->
+<!-- /wp:cover-image -->

--- a/blocks/test/fixtures/core__embed.serialized.html
+++ b/blocks/test/fixtures/core__embed.serialized.html
@@ -1,6 +1,6 @@
-<!-- wp:core/embed {"url":"https://example.com/"} -->
+<!-- wp:embed {"url":"https://example.com/"} -->
 <figure class="wp-block-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>
 </figure>
-<!-- /wp:core/embed -->
+<!-- /wp:embed -->

--- a/blocks/test/fixtures/core__gallery.serialized.html
+++ b/blocks/test/fixtures/core__gallery.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/gallery -->
+<!-- wp:gallery -->
 <div class="wp-block-gallery">
     <figure class="blocks-gallery-image">
         <img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
@@ -7,4 +7,4 @@
         <img src="http://google.com/hi.png" alt="title" />
     </figure>
 </div>
-<!-- /wp:core/gallery -->
+<!-- /wp:gallery -->

--- a/blocks/test/fixtures/core__gallery__columns.serialized.html
+++ b/blocks/test/fixtures/core__gallery__columns.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/gallery {"columns":1} -->
+<!-- wp:gallery {"columns":1} -->
 <div class="wp-block-gallery columns-1 ">
     <figure class="blocks-gallery-image">
         <img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
@@ -7,4 +7,4 @@
         <img src="http://google.com/hi.png" alt="title" />
     </figure>
 </div>
-<!-- /wp:core/gallery -->
+<!-- /wp:gallery -->

--- a/blocks/test/fixtures/core__heading__h2-em.serialized.html
+++ b/blocks/test/fixtures/core__heading__h2-em.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/heading -->
+<!-- wp:heading -->
 <h2>The <em>Inserter</em> Tool</h2>
-<!-- /wp:core/heading -->
+<!-- /wp:heading -->

--- a/blocks/test/fixtures/core__heading__h2.serialized.html
+++ b/blocks/test/fixtures/core__heading__h2.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/heading -->
+<!-- wp:heading -->
 <h2>A picture is worth a thousand words, or so the saying goes</h2>
-<!-- /wp:core/heading -->
+<!-- /wp:heading -->

--- a/blocks/test/fixtures/core__html.serialized.html
+++ b/blocks/test/fixtures/core__html.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/html -->
+<!-- wp:html -->
 <h1>Some HTML code</h1>
 <marquee>This text will scroll from right to left</marquee>
-<!-- /wp:core/html -->
+<!-- /wp:html -->

--- a/blocks/test/fixtures/core__image.serialized.html
+++ b/blocks/test/fixtures/core__image.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/image -->
+<!-- wp:image -->
 <figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
-<!-- /wp:core/image -->
+<!-- /wp:image -->

--- a/blocks/test/fixtures/core__image__center-caption.serialized.html
+++ b/blocks/test/fixtures/core__image__center-caption.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:core/image {"align":"center"} -->
+<!-- wp:image {"align":"center"} -->
 <figure class="wp-block-image"><img src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter" />
     <figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption>
 </figure>
-<!-- /wp:core/image -->
+<!-- /wp:image -->

--- a/blocks/test/fixtures/core__latest-posts.serialized.html
+++ b/blocks/test/fixtures/core__latest-posts.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latest-posts /-->
+<!-- wp:latest-posts /-->

--- a/blocks/test/fixtures/core__latest-posts__displayPostDate.serialized.html
+++ b/blocks/test/fixtures/core__latest-posts__displayPostDate.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:core/latest-posts {"displayPostDate":true} /-->
+<!-- wp:latest-posts {"displayPostDate":true} /-->

--- a/blocks/test/fixtures/core__list__ul.serialized.html
+++ b/blocks/test/fixtures/core__list__ul.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/list -->
+<!-- wp:list -->
 <ul>
     <li>Text &amp; Headings</li>
     <li>Images &amp; Videos</li>
@@ -7,4 +7,4 @@
     <li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li>
     <li>And <em>Lists</em> like this one of course :)</li>
 </ul>
-<!-- /wp:core/list -->
+<!-- /wp:list -->

--- a/blocks/test/fixtures/core__paragraph__align-right.serialized.html
+++ b/blocks/test/fixtures/core__paragraph__align-right.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/paragraph {"align":"right"} -->
+<!-- wp:paragraph {"align":"right"} -->
 <p style="text-align:right;">... like this one, which is separate from the above and right aligned.</p>
-<!-- /wp:core/paragraph -->
+<!-- /wp:paragraph -->

--- a/blocks/test/fixtures/core__preformatted.serialized.html
+++ b/blocks/test/fixtures/core__preformatted.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/preformatted -->
+<!-- wp:preformatted -->
 <pre class="wp-block-preformatted">Some <em>preformatted</em> text...<br/>And more!</pre>
-<!-- /wp:core/preformatted -->
+<!-- /wp:preformatted -->

--- a/blocks/test/fixtures/core__pullquote.serialized.html
+++ b/blocks/test/fixtures/core__pullquote.serialized.html
@@ -1,6 +1,6 @@
-<!-- wp:core/pullquote -->
+<!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote">
     <p>Testing pullquote block...</p>
     <footer>...with a caption</footer>
 </blockquote>
-<!-- /wp:core/pullquote -->
+<!-- /wp:pullquote -->

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.serialized.html
@@ -1,7 +1,7 @@
-<!-- wp:core/pullquote -->
+<!-- wp:pullquote -->
 <blockquote class="wp-block-pullquote alignnone">
     <p>Paragraph <strong>one</strong></p>
     <p>Paragraph two</p>
     <footer>by whomever</footer>
 </blockquote>
-<!-- /wp:core/pullquote -->
+<!-- /wp:pullquote -->

--- a/blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,6 +1,6 @@
-<!-- wp:core/quote -->
+<!-- wp:quote -->
 <blockquote class="wp-block-quote blocks-quote-style-1">
     <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
     <footer>Matt Mullenweg, 2017</footer>
 </blockquote>
-<!-- /wp:core/quote -->
+<!-- /wp:quote -->

--- a/blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,6 +1,6 @@
-<!-- wp:core/quote {"style":2} -->
+<!-- wp:quote {"style":2} -->
 <blockquote class="wp-block-quote blocks-quote-style-2">
     <p>There is no greater agony than bearing an untold story inside you.</p>
     <footer>Maya Angelou</footer>
 </blockquote>
-<!-- /wp:core/quote -->
+<!-- /wp:quote -->

--- a/blocks/test/fixtures/core__separator.serialized.html
+++ b/blocks/test/fixtures/core__separator.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/separator -->
+<!-- wp:separator -->
 <hr class="wp-block-separator" />
-<!-- /wp:core/separator -->
+<!-- /wp:separator -->

--- a/blocks/test/fixtures/core__shortcode.serialized.html
+++ b/blocks/test/fixtures/core__shortcode.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/shortcode -->
+<!-- wp:shortcode -->
 [gallery ids="238,338"]
-<!-- /wp:core/shortcode -->
+<!-- /wp:shortcode -->

--- a/blocks/test/fixtures/core__table.serialized.html
+++ b/blocks/test/fixtures/core__table.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/table -->
+<!-- wp:table -->
 <table>
     <thead>
         <tr>
@@ -45,4 +45,4 @@
         </tr>
     </tbody>
 </table>
-<!-- /wp:core/table -->
+<!-- /wp:table -->

--- a/blocks/test/fixtures/core__text-columns.serialized.html
+++ b/blocks/test/fixtures/core__text-columns.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:core/text-columns {"width":"center"} -->
+<!-- wp:text-columns {"width":"center"} -->
 <section class="wp-block-text-columns aligncenter columns-2">
     <div class="wp-block-column">
         <p>One</p>
@@ -7,4 +7,4 @@
         <p>Two</p>
     </div>
 </section>
-<!-- /wp:core/text-columns -->
+<!-- /wp:text-columns -->

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.html
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.html
@@ -1,3 +1,3 @@
 <!-- wp:core/text -->
-<p>This is an old-style text block.  Changed to <code>core/paragraph</code> in #2135.</p>
+<p>This is an old-style text block.  Changed to <code>paragraph</code> in #2135.</p>
 <!-- /wp:core/text -->

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.json
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.json
@@ -8,12 +8,12 @@
                 "This is an old-style text block.  Changed to ",
                 {
                     "type": "code",
-                    "children": "core/paragraph"
+                    "children": "paragraph"
                 },
                 " in #2135."
             ],
             "dropCap": false
         },
-        "originalContent": "<p>This is an old-style text block.  Changed to <code>core/paragraph</code> in #2135.</p>"
+        "originalContent": "<p>This is an old-style text block.  Changed to <code>paragraph</code> in #2135.</p>"
     }
 ]

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.parsed.json
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.parsed.json
@@ -2,7 +2,7 @@
     {
         "blockName": "core/text",
         "attrs": null,
-        "rawContent": "\n<p>This is an old-style text block.  Changed to <code>core/paragraph</code> in #2135.</p>\n"
+        "rawContent": "\n<p>This is an old-style text block.  Changed to <code>paragraph</code> in #2135.</p>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.serialized.html
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/paragraph -->
-<p>This is an old-style text block. Changed to <code>core/paragraph</code> in #2135.</p>
-<!-- /wp:core/paragraph -->
+<!-- wp:paragraph -->
+<p>This is an old-style text block. Changed to <code>paragraph</code> in #2135.</p>
+<!-- /wp:paragraph -->

--- a/blocks/test/fixtures/core__verse.serialized.html
+++ b/blocks/test/fixtures/core__verse.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/verse -->
+<!-- wp:verse -->
 <pre class="wp-block-verse">A <em>verse</em>…<br/>And more!</pre>
-<!-- /wp:core/verse -->
+<!-- /wp:verse -->

--- a/blocks/test/fixtures/core__video.serialized.html
+++ b/blocks/test/fixtures/core__video.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:core/video -->
+<!-- wp:video -->
 <figure class="wp-block-video"><video controls="" src="https://awesome-fake.video/file.mp4"></video></figure>
-<!-- /wp:core/video -->
+<!-- /wp:video -->

--- a/lib/class-wp-block-type-registry.php
+++ b/lib/class-wp-block-type-registry.php
@@ -62,6 +62,12 @@ final class WP_Block_Type_Registry {
 			return false;
 		}
 
+		if ( preg_match( '/[A-Z]+/', $name ) ) {
+			$message = __( 'Block type names must not contain uppercase characters.', 'gutenberg' );
+			_doing_it_wrong( __METHOD__, $message, '1.5.0' );
+			return false;
+		}
+
 		$name_matcher = '/^[a-z0-9-]+\/[a-z0-9-]+$/';
 		if ( ! preg_match( $name_matcher, $name ) ) {
 			$message = __( 'Block type names must contain a namespace prefix. Example: my-plugin/my-custom-block-type', 'gutenberg' );

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -310,7 +310,13 @@ class Gutenberg_PEG_Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f11($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f11($blockName) {
+        if ( false === strpos( $blockName, '/' ) ) {
+          $blockName = "core/$blockName";
+        }
+        return $blockName;
+        }
+    private function peg_f12($attrs) { return json_decode( $attrs, true ); }
 
     private function peg_parseDocument() {
 
@@ -1178,80 +1184,86 @@ class Gutenberg_PEG_Parser {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
-      if ($s2 !== $this->peg_FAILED) {
-        $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
-        if ($s4 === $this->peg_FAILED) {
-          $s4 = $this->peg_currPos;
+      $s2 = $this->peg_currPos;
+      $s3 = $this->peg_parseASCII_Letter();
+      if ($s3 !== $this->peg_FAILED) {
+        $s4 = array();
+        $s5 = $this->peg_parseASCII_AlphaNumeric();
+        if ($s5 === $this->peg_FAILED) {
+          $s5 = $this->peg_currPos;
           if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
-            $s5 = $this->peg_c15;
+            $s6 = $this->peg_c15;
             $this->peg_currPos++;
           } else {
-            $s5 = $this->peg_FAILED;
+            $s6 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
                 $this->peg_fail($this->peg_c16);
             }
           }
-          if ($s5 !== $this->peg_FAILED) {
-            $s6 = $this->peg_parseASCII_AlphaNumeric();
-            if ($s6 !== $this->peg_FAILED) {
-              $s5 = array($s5, $s6);
-              $s4 = $s5;
+          if ($s6 !== $this->peg_FAILED) {
+            $s7 = $this->peg_parseASCII_AlphaNumeric();
+            if ($s7 !== $this->peg_FAILED) {
+              $s6 = array($s6, $s7);
+              $s5 = $s6;
             } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
             }
           } else {
-            $this->peg_currPos = $s4;
-            $s4 = $this->peg_FAILED;
+            $this->peg_currPos = $s5;
+            $s5 = $this->peg_FAILED;
           }
         }
-        while ($s4 !== $this->peg_FAILED) {
-          $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
-          if ($s4 === $this->peg_FAILED) {
-            $s4 = $this->peg_currPos;
+        while ($s5 !== $this->peg_FAILED) {
+          $s4[] = $s5;
+          $s5 = $this->peg_parseASCII_AlphaNumeric();
+          if ($s5 === $this->peg_FAILED) {
+            $s5 = $this->peg_currPos;
             if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
-              $s5 = $this->peg_c15;
+              $s6 = $this->peg_c15;
               $this->peg_currPos++;
             } else {
-              $s5 = $this->peg_FAILED;
+              $s6 = $this->peg_FAILED;
               if ($this->peg_silentFails === 0) {
                   $this->peg_fail($this->peg_c16);
               }
             }
-            if ($s5 !== $this->peg_FAILED) {
-              $s6 = $this->peg_parseASCII_AlphaNumeric();
-              if ($s6 !== $this->peg_FAILED) {
-                $s5 = array($s5, $s6);
-                $s4 = $s5;
+            if ($s6 !== $this->peg_FAILED) {
+              $s7 = $this->peg_parseASCII_AlphaNumeric();
+              if ($s7 !== $this->peg_FAILED) {
+                $s6 = array($s6, $s7);
+                $s5 = $s6;
               } else {
-                $this->peg_currPos = $s4;
-                $s4 = $this->peg_FAILED;
+                $this->peg_currPos = $s5;
+                $s5 = $this->peg_FAILED;
               }
             } else {
-              $this->peg_currPos = $s4;
-              $s4 = $this->peg_FAILED;
+              $this->peg_currPos = $s5;
+              $s5 = $this->peg_FAILED;
             }
           }
         }
-        if ($s3 !== $this->peg_FAILED) {
-          $s2 = array($s2, $s3);
-          $s1 = $s2;
+        if ($s4 !== $this->peg_FAILED) {
+          $s3 = array($s3, $s4);
+          $s2 = $s3;
         } else {
-          $this->peg_currPos = $s1;
-          $s1 = $this->peg_FAILED;
+          $this->peg_currPos = $s2;
+          $s2 = $this->peg_FAILED;
         }
       } else {
-        $this->peg_currPos = $s1;
-        $s1 = $this->peg_FAILED;
+        $this->peg_currPos = $s2;
+        $s2 = $this->peg_FAILED;
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
       }
       if ($s1 !== $this->peg_FAILED) {
-        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
-      } else {
-        $s0 = $s1;
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f11($s1);
       }
+      $s0 = $s1;
 
       return $s0;
     }
@@ -1507,7 +1519,7 @@ class Gutenberg_PEG_Parser {
       }
       if ($s1 !== $this->peg_FAILED) {
         $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f11($s1);
+        $s1 = $this->peg_f12($s1);
       }
       $s0 = $s1;
 

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -310,11 +310,11 @@ class Gutenberg_PEG_Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f11($blockName) {
-        if ( false === strpos( $blockName, '/' ) ) {
-          $blockName = "core/$blockName";
+    private function peg_f11($namespace, $name) {
+        if ( ! $namespace ) {
+          $namespace = 'core/';
         }
-        return $blockName;
+        return $namespace . $name;
         }
     private function peg_f12($attrs) { return json_decode( $attrs, true ); }
 
@@ -1185,62 +1185,15 @@ class Gutenberg_PEG_Parser {
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      $s3 = $this->peg_parseASCII_Letter();
+      $s3 = $this->peg_parseWP_Block_Namespace();
       if ($s3 !== $this->peg_FAILED) {
-        $s4 = array();
-        $s5 = $this->peg_parseASCII_AlphaNumeric();
-        if ($s5 === $this->peg_FAILED) {
-          $s5 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
-            $s6 = $this->peg_c15;
-            $this->peg_currPos++;
-          } else {
-            $s6 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c16);
-            }
-          }
-          if ($s6 !== $this->peg_FAILED) {
-            $s7 = $this->peg_parseASCII_AlphaNumeric();
-            if ($s7 !== $this->peg_FAILED) {
-              $s6 = array($s6, $s7);
-              $s5 = $s6;
-            } else {
-              $this->peg_currPos = $s5;
-              $s5 = $this->peg_FAILED;
-            }
-          } else {
-            $this->peg_currPos = $s5;
-            $s5 = $this->peg_FAILED;
-          }
-        }
-        while ($s5 !== $this->peg_FAILED) {
-          $s4[] = $s5;
-          $s5 = $this->peg_parseASCII_AlphaNumeric();
-          if ($s5 === $this->peg_FAILED) {
-            $s5 = $this->peg_currPos;
-            if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
-              $s6 = $this->peg_c15;
-              $this->peg_currPos++;
-            } else {
-              $s6 = $this->peg_FAILED;
-              if ($this->peg_silentFails === 0) {
-                  $this->peg_fail($this->peg_c16);
-              }
-            }
-            if ($s6 !== $this->peg_FAILED) {
-              $s7 = $this->peg_parseASCII_AlphaNumeric();
-              if ($s7 !== $this->peg_FAILED) {
-                $s6 = array($s6, $s7);
-                $s5 = $s6;
-              } else {
-                $this->peg_currPos = $s5;
-                $s5 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s5;
-              $s5 = $this->peg_FAILED;
-            }
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+          $s4 = $this->peg_c15;
+          $this->peg_currPos++;
+        } else {
+          $s4 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c16);
           }
         }
         if ($s4 !== $this->peg_FAILED) {
@@ -1254,16 +1207,92 @@ class Gutenberg_PEG_Parser {
         $this->peg_currPos = $s2;
         $s2 = $this->peg_FAILED;
       }
+      if ($s2 === $this->peg_FAILED) {
+        $s2 = null;
+      }
       if ($s2 !== $this->peg_FAILED) {
         $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
       } else {
         $s1 = $s2;
       }
       if ($s1 !== $this->peg_FAILED) {
-        $this->peg_reportedPos = $s0;
-        $s1 = $this->peg_f11($s1);
+        $s2 = $this->peg_parseWP_Namespaced_Block_Name();
+        if ($s2 !== $this->peg_FAILED) {
+          $this->peg_reportedPos = $s0;
+          $s1 = $this->peg_f11($s1, $s2);
+          $s0 = $s1;
+        } else {
+          $this->peg_currPos = $s0;
+          $s0 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s0;
+        $s0 = $this->peg_FAILED;
       }
-      $s0 = $s1;
+
+      return $s0;
+    }
+
+    private function peg_parseWP_Block_Namespace() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseASCII_Letter();
+      if ($s2 !== $this->peg_FAILED) {
+        $s3 = array();
+        $s4 = $this->peg_parseASCII_AlphaNumeric();
+        while ($s4 !== $this->peg_FAILED) {
+          $s3[] = $s4;
+          $s4 = $this->peg_parseASCII_AlphaNumeric();
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s2 = array($s2, $s3);
+          $s1 = $s2;
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      return $s0;
+    }
+
+    private function peg_parseWP_Namespaced_Block_Name() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_parseASCII_Letter();
+      if ($s2 !== $this->peg_FAILED) {
+        $s3 = array();
+        $s4 = $this->peg_parseASCII_AlphaNumeric();
+        while ($s4 !== $this->peg_FAILED) {
+          $s3[] = $s4;
+          $s4 = $this->peg_parseASCII_AlphaNumeric();
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s2 = array($s2, $s3);
+          $s1 = $s2;
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
 
       return $s0;
     }

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -310,12 +310,7 @@ class Gutenberg_PEG_Parser {
           'blockName' => $blockName,
         );
         }
-    private function peg_f11($namespace, $name) {
-        if ( ! $namespace ) {
-          $namespace = 'core/';
-        }
-        return $namespace . $name;
-        }
+    private function peg_f11($type) { return "core/$type"; }
     private function peg_f12($attrs) { return json_decode( $attrs, true ); }
 
     private function peg_parseDocument() {
@@ -1182,84 +1177,9 @@ class Gutenberg_PEG_Parser {
 
     private function peg_parseWP_Block_Name() {
 
-      $s0 = $this->peg_currPos;
-      $s1 = $this->peg_currPos;
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_parseWP_Block_Namespace();
-      if ($s3 !== $this->peg_FAILED) {
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
-          $s4 = $this->peg_c15;
-          $this->peg_currPos++;
-        } else {
-          $s4 = $this->peg_FAILED;
-          if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c16);
-          }
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s3 = array($s3, $s4);
-          $s2 = $s3;
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
-      if ($s2 === $this->peg_FAILED) {
-        $s2 = null;
-      }
-      if ($s2 !== $this->peg_FAILED) {
-        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
-      } else {
-        $s1 = $s2;
-      }
-      if ($s1 !== $this->peg_FAILED) {
-        $s2 = $this->peg_parseWP_Namespaced_Block_Name();
-        if ($s2 !== $this->peg_FAILED) {
-          $this->peg_reportedPos = $s0;
-          $s1 = $this->peg_f11($s1, $s2);
-          $s0 = $s1;
-        } else {
-          $this->peg_currPos = $s0;
-          $s0 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s0;
-        $s0 = $this->peg_FAILED;
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseWP_Block_Namespace() {
-
-      $s0 = $this->peg_currPos;
-      $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
-      if ($s2 !== $this->peg_FAILED) {
-        $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
-        while ($s4 !== $this->peg_FAILED) {
-          $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
-        }
-        if ($s3 !== $this->peg_FAILED) {
-          $s2 = array($s2, $s3);
-          $s1 = $s2;
-        } else {
-          $this->peg_currPos = $s1;
-          $s1 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s1;
-        $s1 = $this->peg_FAILED;
-      }
-      if ($s1 !== $this->peg_FAILED) {
-        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
-      } else {
-        $s0 = $s1;
+      $s0 = $this->peg_parseWP_Namespaced_Block_Name();
+      if ($s0 === $this->peg_FAILED) {
+        $s0 = $this->peg_parseWP_Core_Block_Name();
       }
 
       return $s0;
@@ -1278,8 +1198,39 @@ class Gutenberg_PEG_Parser {
           $s4 = $this->peg_parseASCII_AlphaNumeric();
         }
         if ($s3 !== $this->peg_FAILED) {
-          $s2 = array($s2, $s3);
-          $s1 = $s2;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+            $s4 = $this->peg_c15;
+            $this->peg_currPos++;
+          } else {
+            $s4 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c16);
+            }
+          }
+          if ($s4 !== $this->peg_FAILED) {
+            $s5 = $this->peg_parseASCII_Letter();
+            if ($s5 !== $this->peg_FAILED) {
+              $s6 = array();
+              $s7 = $this->peg_parseASCII_AlphaNumeric();
+              while ($s7 !== $this->peg_FAILED) {
+                $s6[] = $s7;
+                $s7 = $this->peg_parseASCII_AlphaNumeric();
+              }
+              if ($s6 !== $this->peg_FAILED) {
+                $s2 = array($s2, $s3, $s4, $s5, $s6);
+                $s1 = $s2;
+              } else {
+                $this->peg_currPos = $s1;
+                $s1 = $this->peg_FAILED;
+              }
+            } else {
+              $this->peg_currPos = $s1;
+              $s1 = $this->peg_FAILED;
+            }
+          } else {
+            $this->peg_currPos = $s1;
+            $s1 = $this->peg_FAILED;
+          }
         } else {
           $this->peg_currPos = $s1;
           $s1 = $this->peg_FAILED;
@@ -1293,6 +1244,44 @@ class Gutenberg_PEG_Parser {
       } else {
         $s0 = $s1;
       }
+
+      return $s0;
+    }
+
+    private function peg_parseWP_Core_Block_Name() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      $s2 = $this->peg_currPos;
+      $s3 = $this->peg_parseASCII_Letter();
+      if ($s3 !== $this->peg_FAILED) {
+        $s4 = array();
+        $s5 = $this->peg_parseASCII_AlphaNumeric();
+        while ($s5 !== $this->peg_FAILED) {
+          $s4[] = $s5;
+          $s5 = $this->peg_parseASCII_AlphaNumeric();
+        }
+        if ($s4 !== $this->peg_FAILED) {
+          $s3 = array($s3, $s4);
+          $s2 = $s3;
+        } else {
+          $this->peg_currPos = $s2;
+          $s2 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s2;
+        $s2 = $this->peg_FAILED;
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
+      } else {
+        $s1 = $s2;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $this->peg_reportedPos = $s0;
+        $s1 = $this->peg_f11($s1);
+      }
+      $s0 = $s1;
 
       return $s0;
     }

--- a/phpunit/class-block-type-registry-test.php
+++ b/phpunit/class-block-type-registry-test.php
@@ -60,6 +60,16 @@ class Block_Type_Registry_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Should reject blocks with uppercase characters
+	 *
+	 * @expectedIncorrectUsage WP_Block_Type_Registry::register
+	 */
+	function test_uppercase_characters() {
+		$result = $this->registry->register( 'Core/Paragraph', array() );
+		$this->assertFalse( $result );
+	}
+
+	/**
 	 * Should accept valid block names
 	 */
 	function test_register_block_type() {


### PR DESCRIPTION
## Description

To make the serialised data format a little easier to read, this PR removes the `core/` namespace from serialised core blocks. 

## Implementation Notes

This is a sizeable PR for a relatively small change. We don't allow block registration without a namespace, so `serializer.js` can simply remove the `core/` namespace from any blocks that have it.

Similarly, to maintain backwards compatibility with blocks stored prior to this change, `post.pegjs` can simply assume that any block name without a namespace should have the `core/` namespace.

Everything else is updated tests, and the freshly generated `parser.php`.