### PR TITLE
Blocks: The custom classname should be persisted properly in the block's comment

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -39,8 +39,15 @@ export function createBlock( name, blockAttributes = {} ) {
 
 		return result;
 	}, {} );
+
+	// Keep the anchor if the block supports it
 	if ( blockType.supportAnchor && blockAttributes.anchor ) {
 		attributes.anchor = blockAttributes.anchor;
+	}
+
+	// Keep the className if the block supports it
+	if ( blockType.className !== false && blockAttributes.className ) {
+		attributes.className = blockAttributes.className;
 	}
 
 	// Blocks are stored with a unique ID, the assigned type name,

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -153,6 +153,11 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
 		blockAttributes.anchor = hpqParse( rawContent, attr( '*', 'id' ) );
 	}
 
+	// If the block supports a custom className parse it
+	if ( blockType.className !== false && attributes && attributes.className ) {
+		blockAttributes.className = attributes.className;
+	}
+
 	return blockAttributes;
 }
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -89,11 +89,11 @@ export function getSaveContent( blockType, attributes ) {
  * which cannot be matched from the block content.
  *
  * @param   {Object<String,*>} allAttributes Attributes from in-memory block data
- * @param   {Object<String,*>} schema        Block type schema
+ * @param   {Object<String,*>} blockType     Block type
  * @returns {Object<String,*>}               Subset of attributes for comment serialization
  */
-export function getCommentAttributes( allAttributes, schema ) {
-	return reduce( schema, ( result, attributeSchema, key ) => {
+export function getCommentAttributes( allAttributes, blockType ) {
+	const attributes = reduce( blockType.attributes, ( result, attributeSchema, key ) => {
 		const value = allAttributes[ key ];
 
 		// Ignore undefined values
@@ -115,6 +115,12 @@ export function getCommentAttributes( allAttributes, schema ) {
 		result[ key ] = value;
 		return result;
 	}, {} );
+
+	if ( blockType.className !== false && allAttributes.className ) {
+		attributes.className = allAttributes.className;
+	}
+
+	return attributes;
 }
 
 export function serializeAttributes( attrs ) {
@@ -194,7 +200,7 @@ export function serializeBlock( block ) {
 	const blockName = block.name;
 	const blockType = getBlockType( blockName );
 	const saveContent = getBlockContent( block );
-	const saveAttributes = getCommentAttributes( block.attributes, blockType.attributes );
+	const saveAttributes = getCommentAttributes( block.attributes, blockType );
 
 	switch ( blockName ) {
 		case 'core/more':

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -80,6 +80,39 @@ describe( 'block factory', () => {
 			} );
 			expect( block.isValid ).toBe( true );
 		} );
+
+		it( 'should keep the className if the block supports it', () => {
+			registerBlockType( 'core/test-block', {
+				attributes: {},
+				save: noop,
+				category: 'common',
+				title: 'test block',
+			} );
+			const block = createBlock( 'core/test-block', {
+				className: 'chicken',
+			} );
+
+			expect( block.attributes ).toEqual( {
+				className: 'chicken',
+			} );
+			expect( block.isValid ).toBe( true );
+		} );
+
+		it( 'should not keep the className if the block supports it', () => {
+			registerBlockType( 'core/test-block', {
+				attributes: {},
+				save: noop,
+				category: 'common',
+				title: 'test block',
+				className: false,
+			} );
+			const block = createBlock( 'core/test-block', {
+				className: 'chicken',
+			} );
+
+			expect( block.attributes ).toEqual( {} );
+			expect( block.isValid ).toBe( true );
+		} );
 	} );
 
 	describe( 'switchToBlockType()', () => {

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -176,6 +176,31 @@ describe( 'block parser', () => {
 				anchor: 'chicken',
 			} );
 		} );
+
+		it( 'should parse the className if the block supports it', () => {
+			const blockType = {
+				attributes: {},
+			};
+
+			const rawContent = '<div class="chicken">Ribs</div>';
+			const attrs = { className: 'chicken' };
+
+			expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {
+				className: 'chicken',
+			} );
+		} );
+
+		it( 'should not parse the className if the block supports it', () => {
+			const blockType = {
+				attributes: {},
+				className: false,
+			};
+
+			const rawContent = '<div class="chicken">Ribs</div>';
+			const attrs = { className: 'chicken' };
+
+			expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {} );
+		} );
 	} );
 
 	describe( 'createBlockWithFallback', () => {

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -168,7 +168,7 @@ describe( 'block serializer', () => {
 				fruit: 'bananas',
 				category: 'food',
 				ripeness: 'ripe',
-			}, {
+			}, { attributes: {
 				fruit: {
 					type: 'string',
 					source: text(),
@@ -179,7 +179,7 @@ describe( 'block serializer', () => {
 				ripeness: {
 					type: 'string',
 				},
-			} );
+			} } );
 
 			expect( attributes ).toEqual( {
 				category: 'food',
@@ -191,16 +191,32 @@ describe( 'block serializer', () => {
 			const attributes = getCommentAttributes( {
 				fruit: 'bananas',
 				ripeness: undefined,
-			}, {
+			}, { attributes: {
 				fruit: {
 					type: 'string',
 				},
 				ripeness: {
 					type: 'string',
 				},
-			} );
+			} } );
 
 			expect( attributes ).toEqual( { fruit: 'bananas' } );
+		} );
+
+		it( 'should return the className attribute if allowed', () => {
+			const attributes = getCommentAttributes( {
+				className: 'chicken',
+			}, { attributes: {} } );
+
+			expect( attributes ).toEqual( { className: 'chicken' } );
+		} );
+
+		it( 'should not return the className attribute if not supported', () => {
+			const attributes = getCommentAttributes( {
+				className: 'chicken',
+			}, { attributes: {}, className: false } );
+
+			expect( attributes ).toEqual( {} );
 		} );
 	} );
 


### PR DESCRIPTION
closes #2946

I guess this regressed once we moved to explicit comment attributes, the custom className was not being serialized and parsed from the comment anymore.

**Testing instructions**

 - Add an image block
 - Add a custom class to this block
 - Save the post and reload the page
 - Everything should be kept (classname, block still valid)