### PR TITLE
Editor: Fix the scroll position when reordering blocks

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -87,6 +87,9 @@ class VisualEditorBlock extends Component {
 		if ( this.props.isTyping ) {
 			document.addEventListener( 'mousemove', this.stopTypingOnMouseMove );
 		}
+
+		// Not Ideal, but it's the easiest way to get the scrollable container
+		this.editorLayout = document.querySelector( '.editor-layout__editor' );
 	}
 
 	componentWillReceiveProps( newProps ) {
@@ -102,10 +105,9 @@ class VisualEditorBlock extends Component {
 	componentDidUpdate( prevProps ) {
 		// Preserve scroll prosition when block rearranged
 		if ( this.previousOffset ) {
-			window.scrollTo(
-				window.scrollX,
-				window.scrollY + this.node.getBoundingClientRect().top - this.previousOffset
-			);
+			this.editorLayout.scrollTop = this.editorLayout.scrollTop
+				+ this.node.getBoundingClientRect().top
+				- this.previousOffset;
 			this.previousOffset = null;
 		}
 


### PR DESCRIPTION
closes #2936

This regressed when we changed the scrollable area (from the global window to the editor's layout).
The fix here scroll's the editor's layout instead.

**Caveats**

 - A selector to the editor's layout node is hard-coded in the `Block.js` file. This is not ideal, should we provide this node as prop? Should this be something in the editor's settings?

**Teseting instructions**

 - Try moving a block
 - The scroll position should be adjusted to keep the block at the same position