### PR TITLE
Polish spacing in block ellipsis menu

### DIFF
--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -51,7 +51,11 @@
 		display: block;
 	}
 
-	.editor-block-settings-menu__content &:first-child {
+	.editor-block-settings-menu__content & {
 		margin-bottom: 8px;
+	}
+
+	.editor-block-settings-menu__content &:last-child {
+		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
This fixes an issue where the last child of the menu did not have top spacing.

## Screenshots (jpeg or gifs if applicable):

![screen shot 2017-10-10 at 14 28 27](https://user-images.githubusercontent.com/1204802/31386560-721ca680-adc7-11e7-8781-d331eee1fde2.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.