### PR TITLE
Accessibility: Keyboard shortcuts to navigate to/from/in the block's toolbar

### DIFF
--- a/components/navigable-menu/README.md
+++ b/components/navigable-menu/README.md
@@ -38,3 +38,11 @@ A callback invoked when the menu navigates to one of its children passing the in
 
 - Type: `Function`
 - Required: No
+
+## deep
+
+A boolean to look for navigable children in the direct children or any descendant.
+
+- Type: `Boolean`
+- Required: No
+- default: false

--- a/components/navigable-menu/index.js
+++ b/components/navigable-menu/index.js
@@ -26,18 +26,18 @@ class NavigableMenu extends Component {
 	}
 
 	onKeyDown( event ) {
-		const { orientation = 'vertical', onNavigate = noop } = this.props;
+		const { orientation = 'vertical', onNavigate = noop, deep = false } = this.props;
 		if (
 			( orientation === 'vertical' && [ UP, DOWN, TAB ].indexOf( event.keyCode ) === -1 ) ||
 			( orientation === 'horizontal' && [ RIGHT, LEFT, TAB ].indexOf( event.keyCode ) === -1 )
 		) {
 			return;
 		}
-
 		const tabbables = focus.tabbable
 			.find( this.container )
-			.filter( ( node ) => node.parentElement === this.container );
+			.filter( ( node ) => deep || node.parentElement === this.container );
 		const indexOfTabbable = tabbables.indexOf( document.activeElement );
+
 		if ( indexOfTabbable === -1 ) {
 			return;
 		}

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -61,7 +61,7 @@ class BlockToolbar extends Component {
 		document.addEventListener( 'keydown', this.onKeyDown );
 	}
 
-	componentWillUnmout() {
+	componentWillUnmount() {
 		document.removeEventListener( 'keyup', this.onKeyUp );
 		document.removeEventListener( 'keydown', this.onKeyDown );
 	}

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -11,6 +11,7 @@ import classnames from 'classnames';
 import { IconButton, Toolbar } from '@wordpress/components';
 import { Component, Children } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { focus, keycodes } from '@wordpress/utils';
 
 /**
  * Internal Dependencies
@@ -19,6 +20,11 @@ import './style.scss';
 import BlockSwitcher from '../block-switcher';
 import BlockMover from '../block-mover';
 import BlockRightMenu from '../block-settings-menu';
+
+/**
+ * Module Constants
+ */
+const { LEFT, RIGHT, ESCAPE, ALT } = keycodes;
 
 function FirstChild( { children } ) {
 	const childrenArray = Children.toArray( children );
@@ -29,15 +35,69 @@ class BlockToolbar extends Component {
 	constructor() {
 		super( ...arguments );
 		this.toggleMobileControls = this.toggleMobileControls.bind( this );
+		this.bindNode = this.bindNode.bind( this );
+		this.onKeyUp = this.onKeyUp.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
 		this.state = {
 			showMobileControls: false,
 		};
+	}
+
+	componentDidMount() {
+		document.addEventListener( 'keyup', this.onKeyUp );
+	}
+
+	componentWillUnmout() {
+		document.removeEventListener( 'keyup', this.onKeyUp );
+	}
+
+	bindNode( ref ) {
+		this.toolbar = ref;
 	}
 
 	toggleMobileControls() {
 		this.setState( ( state ) => ( {
 			showMobileControls: ! state.showMobileControls,
 		} ) );
+	}
+
+	onKeyDown( event ) {
+		// This is required to avoid messing up with the WritingFlow navigation
+		event.stopPropagation();
+	}
+
+	onKeyUp( event ) {
+		// Is there a better way to focus the selected block
+		const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected' );
+		const tabbables = focus.tabbable.find( this.toolbar );
+		const indexOfTabbable = tabbables.indexOf( document.activeElement );
+
+		if ( event.keyCode === ALT ) {
+			if ( tabbables.length ) {
+				tabbables[ 0 ].focus();
+			}
+			return;
+		}
+
+		switch ( event.keyCode ) {
+			case ESCAPE:
+				if ( indexOfTabbable !== -1 && selectedBlock ) {
+					selectedBlock.focus();
+				}
+				break;
+			case LEFT:
+				if ( indexOfTabbable > 0 ) {
+					tabbables[ indexOfTabbable - 1 ].focus();
+				}
+				event.stopPropagation();
+				break;
+			case RIGHT:
+				if ( indexOfTabbable !== -1 && indexOfTabbable !== tabbables.length - 1 ) {
+					tabbables[ indexOfTabbable + 1 ].focus();
+				}
+				event.stopPropagation();
+				break;
+		}
 	}
 
 	render() {
@@ -57,7 +117,7 @@ class BlockToolbar extends Component {
 				transitionLeave={ false }
 				component={ FirstChild }
 			>
-				<div className={ toolbarClassname }>
+				<div className={ toolbarClassname } ref={ this.bindNode } onKeyDown={ this.onKeyDown }>
 					<div className="editor-block-toolbar__group">
 						{ ! showMobileControls && [
 							<BlockSwitcher key="switcher" uid={ uid } />,

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -20,6 +20,7 @@ import './style.scss';
 import BlockSwitcher from '../block-switcher';
 import BlockMover from '../block-mover';
 import BlockRightMenu from '../block-settings-menu';
+import { isMac } from '../utils/dom';
 
 /**
  * Module Constants
@@ -29,10 +30,6 @@ const { ESCAPE, F10 } = keycodes;
 function FirstChild( { children } ) {
 	const childrenArray = Children.toArray( children );
 	return childrenArray[ 0 ] || null;
-}
-
-function isMac() {
-	return window.navigator.platform.toLowerCase().indexOf( 'mac' ) !== -1;
 }
 
 function metaKeyPressed( event ) {

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -88,15 +88,17 @@ class BlockToolbar extends Component {
 	}
 
 	onKeyUp( event ) {
-		const isMeta = this.metaCount === 1;
+		const shouldFocusToolbar = this.metaCount === 1 || ( event.keyCode === F10 && event.altKey );
 		this.metaCount = 0;
 
-		// Is there a better way to focus the selected block
-		const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected' );
+		if ( ! shouldFocusToolbar && [ ESCAPE, LEFT, RIGHT ].indexOf( event.keyCode ) === -1 ) {
+			return;
+		}
+
 		const tabbables = focus.tabbable.find( this.toolbar );
 		const indexOfTabbable = tabbables.indexOf( document.activeElement );
 
-		if ( isMeta || ( event.keyCode === F10 && event.altKey ) ) {
+		if ( shouldFocusToolbar ) {
 			if ( tabbables.length ) {
 				tabbables[ 0 ].focus();
 			}
@@ -104,11 +106,14 @@ class BlockToolbar extends Component {
 		}
 
 		switch ( event.keyCode ) {
-			case ESCAPE:
+			case ESCAPE: {
+				// Is there a better way to focus the selected block
+				const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected' );
 				if ( indexOfTabbable !== -1 && selectedBlock ) {
 					selectedBlock.focus();
 				}
 				break;
+			}
 			case LEFT:
 				if ( indexOfTabbable > 0 ) {
 					tabbables[ indexOfTabbable - 1 ].focus();

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -86,3 +86,12 @@ export function placeCaretAtEdge( container, start = false ) {
 	sel.addRange( range );
 	container.focus();
 }
+
+/**
+ * Checks whether the user is on MacOS or not
+ *
+ * @return {Boolean}           Is Mac or Not
+ */
+export function isMac() {
+	return window.navigator.platform.toLowerCase().indexOf( 'mac' ) !== -1;
+}

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -1,8 +1,6 @@
 export const BACKSPACE = 8;
 export const TAB = 9;
 export const ENTER = 13;
-export const CTRL = 17;
-export const ALT = 18;
 export const ESCAPE = 27;
 export const SPACE = 32;
 export const LEFT = 37;

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -1,6 +1,7 @@
 export const BACKSPACE = 8;
 export const TAB = 9;
 export const ENTER = 13;
+export const CTRL = 17;
 export const ALT = 18;
 export const ESCAPE = 27;
 export const SPACE = 32;
@@ -9,3 +10,5 @@ export const UP = 38;
 export const RIGHT = 39;
 export const DOWN = 40;
 export const DELETE = 46;
+
+export const F10 = 121;

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -1,6 +1,7 @@
 export const BACKSPACE = 8;
 export const TAB = 9;
 export const ENTER = 13;
+export const ALT = 18;
 export const ESCAPE = 27;
 export const SPACE = 32;
 export const LEFT = 37;


### PR DESCRIPTION
closes #552

This PR adds keyboard shortcuts to navigate

 - from a block to its toolbar (using `alt` key)
 - in the toolbar using arrows
 - back to the block (using `esc` key)

I've used `alt` because it's common to navigate to menus using `alt` in desktop applications. Also, avoid the hurdle of dealing with specific keys by OS (ctrl and command).

## Caveats

 - The block's selector is hard coded in the component :(
 - We need to stop propagation in the onKeyDown event to avoid messing up with the WritingFlow
