### PR TITLE
ensure extended settings is hidden when user hides settings sidebar

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -316,6 +316,17 @@ export function toggleSidebar() {
 }
 
 /**
+ * Returns an action object used in signalling that the user toggled the extended settings
+ *
+ * @return {Object}         Action object
+ */
+export function toggleExtendedSettings() {
+    return {
+        type: 'TOGGLE_EXTENDED_SETTINGS',
+    };
+}
+
+/**
  * Returns an action object used in signalling that the user switched the active sidebar tab panel
  *
  * @param  {String} panel   The panel name

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -321,9 +321,9 @@ export function toggleSidebar() {
  * @return {Object}         Action object
  */
 export function toggleExtendedSettings() {
-    return {
-        type: 'TOGGLE_EXTENDED_SETTINGS',
-    };
+	return {
+		type: 'TOGGLE_EXTENDED_SETTINGS',
+	};
 }
 
 /**

--- a/editor/meta-boxes/index.js
+++ b/editor/meta-boxes/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -9,33 +14,35 @@ import { Panel, PanelBody, Dashicon } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
+import { isExtendedSettingsOpened, isEditorSidebarOpened } from '../selectors';
+import { toggleExtendedSettings } from '../actions';
 
 class MetaBoxes extends Component {
 	constructor() {
 		super( ...arguments );
-
-		this.toggle = this.toggle.bind( this );
-
-		this.state = {
-			isOpen: false,
-		};
 	}
 
-	toggle() {
-		this.setState( {
-			isOpen: ! this.state.isOpen,
-		} );
-	}
+    componentWillReceiveProps( nextProps ) {
+        const { toggle } = this.props
 
-	render() {
-		const { isOpen } = this.state;
+        // if sidebar state changes
+        if( nextProps.isEditorSidebarOpened !== this.props.isEditorSidebarOpened ) {
+            // and sidebar state is set to closed and extended settings is open ensure extended settings is closed too
+            if( ! nextProps.isEditorSidebarOpened && this.props.isExtendedSettingsOpened ) {
+                toggle();
+            }
+        }
+    }
+
+    render() {
+        const { isExtendedSettingsOpened, toggle } = this.props;
 
 		return (
 			<Panel className="editor-meta-boxes">
 				<PanelBody
 					title={ __( 'Extended Settings' ) }
-					opened={ isOpen }
-					onToggle={ this.toggle }>
+					opened={ isExtendedSettingsOpened }
+					onToggle={ () => toggle() }>
 					<div className="editor-meta-boxes__coming-soon">
 						<Dashicon icon="flag" />
 						<h3>{ __( 'Coming Soon' ) }</h3>
@@ -47,4 +54,14 @@ class MetaBoxes extends Component {
 	}
 }
 
-export default MetaBoxes;
+export default connect(
+    ( state ) => ( {
+        isExtendedSettingsOpened: isExtendedSettingsOpened( state ),
+        isEditorSidebarOpened: isEditorSidebarOpened( state ),
+    } ),
+    ( dispatch ) => ( {
+        toggle: () => {
+            dispatch( toggleExtendedSettings() )
+        },
+    } )
+)( MetaBoxes );

--- a/editor/meta-boxes/index.js
+++ b/editor/meta-boxes/index.js
@@ -14,28 +14,25 @@ import { Panel, PanelBody, Dashicon } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
-import { isExtendedSettingsOpened, isEditorSidebarOpened } from '../selectors';
+import { isEditorExtendedSettingsOpened, isEditorSidebarOpened } from '../selectors';
 import { toggleExtendedSettings } from '../actions';
 
 class MetaBoxes extends Component {
-	constructor() {
-		super( ...arguments );
+
+	componentWillReceiveProps( nextProps ) {
+		const { toggle } = this.props;
+
+		// if sidebar state changes
+		if ( nextProps.isEditorSidebarOpened !== this.props.isEditorSidebarOpened ) {
+			// and sidebar state is set to closed and extended settings is open ensure extended settings is closed too
+			if ( ! nextProps.isEditorSidebarOpened && this.props.isExtendedSettingsOpened ) {
+				toggle();
+			}
+		}
 	}
 
-    componentWillReceiveProps( nextProps ) {
-        const { toggle } = this.props
-
-        // if sidebar state changes
-        if( nextProps.isEditorSidebarOpened !== this.props.isEditorSidebarOpened ) {
-            // and sidebar state is set to closed and extended settings is open ensure extended settings is closed too
-            if( ! nextProps.isEditorSidebarOpened && this.props.isExtendedSettingsOpened ) {
-                toggle();
-            }
-        }
-    }
-
-    render() {
-        const { isExtendedSettingsOpened, toggle } = this.props;
+	render() {
+		const { isExtendedSettingsOpened, toggle } = this.props;
 
 		return (
 			<Panel className="editor-meta-boxes">
@@ -55,13 +52,11 @@ class MetaBoxes extends Component {
 }
 
 export default connect(
-    ( state ) => ( {
-        isExtendedSettingsOpened: isExtendedSettingsOpened( state ),
-        isEditorSidebarOpened: isEditorSidebarOpened( state ),
-    } ),
-    ( dispatch ) => ( {
-        toggle: () => {
-            dispatch( toggleExtendedSettings() )
-        },
-    } )
+	( state ) => ( {
+		isExtendedSettingsOpened: isEditorExtendedSettingsOpened( state ),
+		isEditorSidebarOpened: isEditorSidebarOpened( state ),
+	} ),
+	( dispatch ) => ( {
+		toggle: () => dispatch( toggleExtendedSettings() ),
+	} )
 )( MetaBoxes );

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -448,6 +448,14 @@ export function preferences( state = STORE_DEFAULTS.preferences, action ) {
 				...state,
 				isExtendedSettingsOpened: ! state.isExtendedSettingsOpened,
 			};
+		case 'TOGGLE_EXTENDED_SETTINGS_PANEL':
+			return {
+				...state,
+				panels: {
+					...state.panels,
+					[ action.panel ]: ! get( state, [ 'panels', action.panel ], false ),
+				},
+			};
 		case 'SWITCH_MODE':
 			return {
 				...state,

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -443,11 +443,11 @@ export function preferences( state = STORE_DEFAULTS.preferences, action ) {
 					[ action.panel ]: ! get( state, [ 'panels', action.panel ], false ),
 				},
 			};
-        case 'TOGGLE_EXTENDED_SETTINGS':
-            return {
-                ...state,
-                isExtendedSettingsOpened: ! state.isExtendedSettingsOpened,
-            };
+		case 'TOGGLE_EXTENDED_SETTINGS':
+			return {
+				...state,
+				isExtendedSettingsOpened: ! state.isExtendedSettingsOpened,
+			};
 		case 'SWITCH_MODE':
 			return {
 				...state,

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -443,6 +443,11 @@ export function preferences( state = STORE_DEFAULTS.preferences, action ) {
 					[ action.panel ]: ! get( state, [ 'panels', action.panel ], false ),
 				},
 			};
+        case 'TOGGLE_EXTENDED_SETTINGS':
+            return {
+                ...state,
+                isExtendedSettingsOpened: ! state.isExtendedSettingsOpened,
+            };
 		case 'SWITCH_MODE':
 			return {
 				...state,

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -87,8 +87,8 @@ export function isEditorSidebarOpened( state ) {
  * @param  {Object}  state Global application state
  * @return {Boolean}       Whether this panel is open
  */
-export function isExtendedSettingsOpened(state ) {
-    return getPreference( state, 'isExtendedSettingsOpened' );
+export function isEditorExtendedSettingsOpened( state ) {
+	return getPreference( state, 'isExtendedSettingsOpened' );
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -82,6 +82,16 @@ export function isEditorSidebarOpened( state ) {
 }
 
 /**
+ * Returns true if the editor extended settings panel is open, or false otherwise.
+ *
+ * @param  {Object}  state Global application state
+ * @return {Boolean}       Whether this panel is open
+ */
+export function isExtendedSettingsOpened(state ) {
+    return getPreference( state, 'isExtendedSettingsOpened' );
+}
+
+/**
  * Returns true if the editor sidebar panel is open, or false otherwise.
  *
  * @param  {Object}  state Global application state

--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -2,6 +2,7 @@ export const STORE_DEFAULTS = {
 	preferences: {
 		mode: 'visual',
 		isSidebarOpened: window.innerWidth >= 782,
+		isExtendedSettingsOpened: window.innerWidth >= 782,
 		panels: { 'post-status': true },
 		recentlyUsedBlocks: [],
 		blockUsage: {},

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -798,7 +798,7 @@ describe( 'state', () => {
 		it( 'should apply all defaults', () => {
 			const state = preferences( undefined, {} );
 
-			expect( state ).toEqual( { blockUsage: {}, recentlyUsedBlocks: [], mode: 'visual', isSidebarOpened: true, panels: { 'post-status': true } } );
+			expect( state ).toEqual( { blockUsage: {}, recentlyUsedBlocks: [], mode: 'visual', isSidebarOpened: true, isExtendedSettingsOpened: true, panels: { 'post-status': true } } );
 		} );
 
 		it( 'should toggle the sidebar open flag', () => {

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -809,6 +809,14 @@ describe( 'state', () => {
 			expect( state ).toEqual( { isSidebarOpened: true } );
 		} );
 
+		it( 'should toggle the extended settings open flag', () => {
+			const state = preferences( deepFreeze( { isExtendedSettingsOpened: false } ), {
+				type: 'TOGGLE_EXTENDED_SETTINGS',
+			} );
+
+			expect( state ).toEqual( { isExtendedSettingsOpened: true } );
+		} );
+
 		it( 'should set the sidebar panel open flag to true if unset', () => {
 			const state = preferences( deepFreeze( { isSidebarOpened: false } ), {
 				type: 'TOGGLE_SIDEBAR_PANEL',

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -835,6 +835,24 @@ describe( 'state', () => {
 			expect( state ).toEqual( { isSidebarOpened: false, panels: { 'post-taxonomies': false } } );
 		} );
 
+		it( 'should set the extended settings panel open flag to true if unset', () => {
+			const state = preferences( deepFreeze( { isExtendedSettingsOpened: false } ), {
+				type: 'TOGGLE_EXTENDED_SETTINGS_PANEL',
+				panel: 'post-taxonomies',
+			} );
+
+			expect( state ).toEqual( { isExtendedSettingsOpened: false, panels: { 'post-taxonomies': true } } );
+		} );
+
+		it( 'should toggle the extended settings panel open flag', () => {
+			const state = preferences( deepFreeze( { isExtendedSettingsOpened: false, panels: { 'post-taxonomies': true } } ), {
+				type: 'TOGGLE_EXTENDED_SETTINGS_PANEL',
+				panel: 'post-taxonomies',
+			} );
+
+			expect( state ).toEqual( { isExtendedSettingsOpened: false, panels: { 'post-taxonomies': false } } );
+		} );
+
 		it( 'should return switched mode', () => {
 			const state = preferences( deepFreeze( { isSidebarOpened: false } ), {
 				type: 'SWITCH_MODE',


### PR DESCRIPTION
## Description
Hides the extended settings if the user hides the settings sidebar. Attempts to fix #2849  

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.