### PR TITLE
Rotate header ellipsis to match block ellipsis

### DIFF
--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -25,7 +25,7 @@
 	z-index: z-index( '.editor-block-settings-menu__toggle' );
 
 	&.is-opened {
-		transform: rotate(0);
+		transform: rotate( 0 );
 	}
 }
 

--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -105,6 +105,10 @@
 
 .editor-mode-switcher {
 	margin-left: $item-spacing;
+
+	.components-button svg {
+		transform: rotate( 90deg );
+	}
 }
 
 .editor-header__left .components-button {


### PR DESCRIPTION
Background: We recently put block level actions (delete, configure) buttons under an ellipsis menu on the block. Due to the position and look of this ellipsis, we went with the vertical look for it, which is commonly seen in Material Design properties.

However we should only have one style of ellipsis, ideally. So the overflow ellipsis in the editor bar should match. This PR addresses that.

Before:

<img width="374" alt="screen shot 2017-10-11 at 10 56 29" src="https://user-images.githubusercontent.com/1204802/31431305-92101a92-ae73-11e7-97c5-0447e8d202b4.png">

After:

<img width="342" alt="screen shot 2017-10-11 at 10 58 19" src="https://user-images.githubusercontent.com/1204802/31431316-96316c84-ae73-11e7-9724-802dd2ecf649.png">
