### PR TITLE
Focusable Utility: Use tabindex attribute for tabbable test

### DIFF
--- a/utils/focus/tabbable.js
+++ b/utils/focus/tabbable.js
@@ -4,18 +4,19 @@
 import { find as findFocusable } from './focusable';
 
 /**
- * Returns the tab index of the specified element. Returns null if a tabindex
- * is not explicitly assigned as an attribute. Unlike the tabIndex property,
- * this doesn't assume any defaults which helps avoid browser inconsistencies.
+ * Returns the tab index of the given element. In contrast with the tabIndex
+ * property, this normalizes the default (0) to avoid browser inconsistencies,
+ * operating under the assumption that this function is only ever called with a
+ * focusable node.
  *
  * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1190261
  *
  * @param  {Element} element Element from which to retrieve
- * @return {?Number}         Tab index of element, or null if not assigned
+ * @return {?Number}         Tab index of element (default 0)
  */
 function getTabIndex( element ) {
 	const tabIndex = element.getAttribute( 'tabindex' );
-	return tabIndex === null ? null : parseInt( tabIndex, 10 );
+	return tabIndex === null ? 0 : parseInt( tabIndex, 10 );
 }
 
 /**
@@ -63,8 +64,8 @@ function mapObjectTabbableToElement( object ) {
  * @return {Number}   Comparator result
  */
 function compareObjectTabbables( a, b ) {
-	const aTabIndex = getTabIndex( a.element ) || 0;
-	const bTabIndex = getTabIndex( b.element ) || 0;
+	const aTabIndex = getTabIndex( a.element );
+	const bTabIndex = getTabIndex( b.element );
 
 	if ( aTabIndex === bTabIndex ) {
 		return a.index - b.index;

--- a/utils/focus/tabbable.js
+++ b/utils/focus/tabbable.js
@@ -4,13 +4,28 @@
 import { find as findFocusable } from './focusable';
 
 /**
+ * Returns the tab index of the specified element. Returns null if a tabindex
+ * is not explicitly assigned as an attribute. Unlike the tabIndex property,
+ * this doesn't assume any defaults which helps avoid browser inconsistencies.
+ *
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1190261
+ *
+ * @param  {Element} element Element from which to retrieve
+ * @return {?Number}         Tab index of element, or null if not assigned
+ */
+function getTabIndex( element ) {
+	const tabIndex = element.getAttribute( 'tabindex' );
+	return tabIndex === null ? null : parseInt( tabIndex, 10 );
+}
+
+/**
  * Returns true if the specified element is tabbable, or false otherwise.
  *
  * @param  {Element} element Element to test
  * @return {Boolean}         Whether element is tabbable
  */
 function isTabbableIndex( element ) {
-	return element.tabIndex !== -1;
+	return getTabIndex( element ) !== -1;
 }
 
 /**
@@ -48,11 +63,14 @@ function mapObjectTabbableToElement( object ) {
  * @return {Number}   Comparator result
  */
 function compareObjectTabbables( a, b ) {
-	if ( a.element.tabIndex === b.element.tabIndex ) {
+	const aTabIndex = getTabIndex( a.element ) || 0;
+	const bTabIndex = getTabIndex( b.element ) || 0;
+
+	if ( aTabIndex === bTabIndex ) {
 		return a.index - b.index;
 	}
 
-	return a.element.tabIndex - b.element.tabIndex;
+	return aTabIndex - bTabIndex;
 }
 
 export function find( context ) {


### PR DESCRIPTION
This pull request seeks to resolve an issue where the tabbable utility does not correctly count contenteditable as tabbable in Firefox, therefore arrow navigation in Gutenberg can often have unpredictable results.

The issue is due to the fact that Firefox returns `-1` as the `tabIndex` property value for any `contenteditable`, regardless of whether the tabindex is specified. This is [tracked on Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1190261) and you can demonstrate this on any contenteditable: 

https://html5demos.com/contenteditable/

![firefox contenteditable tabindex](https://user-images.githubusercontent.com/1779930/31441112-3534fe18-ae60-11e7-8504-fc278b54d602.png)

The changes here update the `isTabbableIndex` check to test against the attribute value specifically.

__Testing instructions:__

Verify that arrow navigation transitions through editable fields as expected in Firefox and in your preferred browser:

1. Navigate to Gutenberg > New Post
2. Add two paragraph blocks
3. Add an image block
4. Focus the first paragraph block
5. Press the down arrow
6. Note that the cursor should be moved to the second paragraph block, not the image block