### PR TITLE
Blocks: Use a dropdown menu for the block's menu

### DIFF
--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -4,11 +4,11 @@
 	left: 50%;
 
 	&:before {
-		border: 10px solid $light-gray-500;
+		border: 8px solid $light-gray-500;
 	}
 
 	&:after {
-		border: 10px solid $white;
+		border: 8px solid $white;
 	}
 
 	&:before,
@@ -25,14 +25,14 @@
 
 	&.is-top {
 		bottom: 100%;
-		margin-top: -10px;
+		margin-top: -8px;
 
 		&:before {
-			bottom: -10px;
+			bottom: -8px;
 		}
 
 		&:after {
-			bottom: -8px;
+			bottom: -6px;
 		}
 
 		&:before,
@@ -44,14 +44,14 @@
 
 	&.is-bottom {
 		top: 100%;
-		margin-top: 10px;
+		margin-top: 8px;
 
 		&:before {
-			top: -10px;
+			top: -8px;
 		}
 
 		&:after {
-			top: -8px;
+			top: -6px;
 		}
 
 		&:before,

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -21,10 +21,6 @@ $z-layers: (
 	'.editor-header': 20,
 	'.editor-text-editor__formatting': 20,
 
-	// Show Block SettingsToggle should under its content
-	'.editor-block-settings-menu__toggle': 1,
-	'.editor-block-settings-menu__content': 2,
-
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,
 	'.components-drop-zone__content': 110,

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -18,6 +18,7 @@ $z-layers: (
 	'.editor-block-switcher__menu': 2,
 	'.editor-block-mover': 10,
 	'.blocks-gallery-image__inline-menu': 10,
+	'.editor-block-settings-menu__popover': 10, // Bellow the header
 	'.editor-header': 20,
 	'.editor-text-editor__formatting': 20,
 

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -42,7 +42,7 @@ function BlockSettingsMenuContent( { mode, uids, isSidebarOpened, onDelete, onTo
 				>
 					{ mode === 'visual'
 						? __( 'Edit as HTML' )
-						: __( 'Edit in the visual mode' )
+						: __( 'Edit visually' )
 					}
 				</IconButton>
 			}

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -2,20 +2,21 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { flow } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { __, sprintf, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { isEditorSidebarOpened } from '../selectors';
+import { isEditorSidebarOpened, getBlockMode } from '../selectors';
 import { removeBlocks, toggleSidebar, setActivePanel, toggleBlockMode } from '../actions';
 
-function BlockSettingsMenuContent( { onDelete, isSidebarOpened, onToggleSidebar, onShowInspector, onToggleMode, uids } ) {
+function BlockSettingsMenuContent( { mode, uids, isSidebarOpened, onDelete, onToggleSidebar, onShowInspector, onToggleMode, onClose } ) {
 	const count = uids.length;
 	const toggleInspector = () => {
 		onShowInspector();
@@ -28,29 +29,38 @@ function BlockSettingsMenuContent( { onDelete, isSidebarOpened, onToggleSidebar,
 		<div className="editor-block-settings-menu__content">
 			<IconButton
 				className="editor-block-settings-menu__control"
-				onClick={ toggleInspector }
+				onClick={ flow( toggleInspector, onClose ) }
 				icon="admin-generic"
-				label={ __( 'Show inspector' ) }
-			/>
+			>
+				{ __( 'Settings' ) }
+			</IconButton>
+			{ count === 1 &&
+				<IconButton
+					className="editor-block-settings-menu__control"
+					onClick={ flow( onToggleMode, onClose ) }
+					icon="html"
+				>
+					{ mode === 'visual'
+						? __( 'Edit as HTML' )
+						: __( 'Edit in the visual mode' )
+					}
+				</IconButton>
+			}
 			<IconButton
 				className="editor-block-settings-menu__control"
-				onClick={ onDelete }
+				onClick={ flow( onDelete ) }
 				icon="trash"
-				label={ sprintf( _n( 'Delete the block', 'Delete the %d blocks', count ), count ) }
-			/>
-			{ count === 1 && <IconButton
-				className="editor-block-settings-menu__control"
-				onClick={ onToggleMode }
-				icon="html"
-				label={ __( 'Switch between the visual/text mode' ) }
-			/> }
+			>
+				{ __( 'Delete' ) }
+			</IconButton>
 		</div>
 	);
 }
 
 export default connect(
-	( state ) => ( {
+	( state, { uids } ) => ( {
 		isSidebarOpened: isEditorSidebarOpened( state ),
+		mode: uids.length === 1 ? getBlockMode( state, uids[ 0 ] ) : null,
 	} ),
 	( dispatch, ownProps ) => ( {
 		onDelete() {

--- a/editor/block-settings-menu/index.js
+++ b/editor/block-settings-menu/index.js
@@ -8,8 +8,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { IconButton, Dropdown } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -18,47 +17,36 @@ import './style.scss';
 import BlockSettingsMenuContent from './content';
 import { selectBlock } from '../actions';
 
-class BlockSettingsMenu extends Component {
-	constructor() {
-		super( ...arguments );
-		this.toggleMenu = this.toggleMenu.bind( this );
-		this.state = {
-			opened: false,
-		};
-	}
-
-	toggleMenu() {
-		// Block could be hovered, not selected.
-		if ( this.props.uids.length === 1 ) {
-			this.props.onSelect( this.props.uids[ 0 ] );
-		}
-
-		this.setState( ( state ) => ( {
-			opened: ! state.opened,
-		} ) );
-	}
-
-	render() {
-		const { opened } = this.state;
-		const { uids, focus } = this.props;
-		const toggleClassname = classnames( 'editor-block-settings-menu__toggle', 'editor-block-settings-menu__control', {
-			'is-opened': opened,
-		} );
-
-		return (
-			<div className="editor-block-settings-menu">
-				<IconButton
-					className={ toggleClassname }
-					onClick={ this.toggleMenu }
-					icon="ellipsis"
-					label={ opened ? __( 'Close Settings Menu' ) : __( 'Open Settings Menu' ) }
-					focus={ focus }
-				/>
-
-				{ opened && <BlockSettingsMenuContent uids={ uids } /> }
-			</div>
-		);
-	}
+function BlockSettingsMenu( { uids, onSelect } ) {
+	return (
+		<Dropdown
+			className="editor-block-settings-menu"
+			contentClassName="editor-block-settings-menu__popover"
+			position="bottom left"
+			renderToggle={ ( { onToggle, isOpen } ) => {
+				const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
+					'is-opened': isOpen,
+				} );
+				return (
+					<IconButton
+						className={ toggleClassname }
+						onClick={ () => {
+							if ( uids.length === 1 ) {
+								onSelect( uids[ 0 ] );
+							}
+							onToggle();
+						} }
+						icon="ellipsis"
+						label={ isOpen ? __( 'Close Settings Menu' ) : __( 'Open Settings Menu' ) }
+						aria-expanded={ isOpen }
+					/>
+				);
+			} }
+			renderContent={ ( { onClose } ) => (
+				<BlockSettingsMenuContent uids={ uids } onClose={ onClose } />
+			) }
+		/>
+	);
 }
 
 export default connect(

--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -13,13 +13,19 @@
 	}
 }
 
-.editor-block-settings-menu__popover .components-popover__content {
-	width: 200px;
+.editor-block-settings-menu__popover {
+	&:before,
+	&:after {
+		margin-left: 2px;
+	}
+
+	.components-popover__content {
+		width: 182px;
+	}
 }
 
 .editor-block-settings-menu__content {
 	width: 100%;
-	padding: 5px;
 }
 
 .editor-block-settings-menu__toggle {
@@ -36,21 +42,20 @@
 .editor-block-settings-menu__control {
 	width: 100%;
 	justify-content: flex-start;
-	margin-bottom: 3px;
-	padding: 6px;
+	padding: 8px;
 	background: none;
-	border: 1px solid transparent;
 	outline: none;
 	border-radius: 0;
 	color: $dark-gray-500;
 	cursor: pointer;
+	border: 1px solid transparent;
 
 	&:hover,
 	&:focus,
 	&:not(:disabled):hover {
 		box-shadow: none;
 		color: $dark-gray-500;
-		border-color: $dark-gray-500;
+		border: 1px solid $dark-gray-500;
 	}
 
 	.dashicon {

--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -14,6 +14,8 @@
 }
 
 .editor-block-settings-menu__popover {
+	z-index: z-index( '.editor-block-settings-menu__popover' );
+
 	&:before,
 	&:after {
 		margin-left: 2px;

--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -13,16 +13,20 @@
 	}
 }
 
+.editor-block-settings-menu__popover .components-popover__content {
+	width: 200px;
+}
+
 .editor-block-settings-menu__content {
-	margin-top: 8px;
-	z-index: z-index( '.editor-block-settings-menu__content' );
+	width: 100%;
+	padding: 5px;
 }
 
 .editor-block-settings-menu__toggle {
+	padding: 0;
 	transform: rotate( 90deg );
 	transition-duration: 0.3s;
 	transition-property: transform;
-	z-index: z-index( '.editor-block-settings-menu__toggle' );
 
 	&.is-opened {
 		transform: rotate( 0 );
@@ -30,32 +34,26 @@
 }
 
 .editor-block-settings-menu__control {
-	display: block;
-	padding: 0;
-	border: none;
-	outline: none;
+	width: 100%;
+	justify-content: flex-start;
+	margin-bottom: 3px;
+	padding: 6px;
 	background: none;
-	color: $dark-gray-300;
+	border: 1px solid transparent;
+	outline: none;
+	border-radius: 0;
+	color: $dark-gray-500;
 	cursor: pointer;
-	width: 20px;
-	height: 20px;
-	border-radius: 50%;
 
-	&[aria-disabled="true"] {
-		cursor: default;
-		color: $light-gray-300;
-		pointer-events: none;
+	&:hover,
+	&:focus,
+	&:not(:disabled):hover {
+		box-shadow: none;
+		color: $dark-gray-500;
+		border-color: $dark-gray-500;
 	}
 
 	.dashicon {
-		display: block;
-	}
-
-	.editor-block-settings-menu__content & {
-		margin-bottom: 8px;
-	}
-
-	.editor-block-settings-menu__content &:last-child {
-		margin-bottom: 0;
+		margin-right: 5px;
 	}
 }


### PR DESCRIPTION
This is the first step towards #2984 transforming the block's menu to a dropdown menu.

Future steps would be to:

 - Bring extra menu items (insert After, duplicate, switcher)
 - Implement and show the keyboard shortcuts.

<img width="228" alt="screen shot 2017-10-11 at 13 51 07" src="https://user-images.githubusercontent.com/272444/31441508-49be719a-ae8b-11e7-907f-06061005cb35.png">
