### PR TITLE
Vertical arrow key navigation

### DIFF
--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -1,17 +1,28 @@
 /**
- * Check whether the selection touches an edge of the container
- *
- * @param  {Element} container DOM Element
- * @param  {Boolean} start     Reverse means check if it touches the start of the container
- * @return {Boolean}           Is Edge or not
+ * External dependencies
  */
-export function isEdge( container, start = false ) {
-	if ( [ 'INPUT', 'TEXTAREA' ].indexOf( container.tagName ) !== -1 ) {
+import { includes } from 'lodash';
+
+/**
+ * Browser dependencies
+ */
+const { getComputedStyle } = window;
+const { TEXT_NODE } = window.Node;
+
+/**
+ * Check whether the caret is horizontally at the edge of the container.
+ *
+ * @param  {Element} container Focusable element.
+ * @param  {Boolean} isReverse Set to true to check left, false for right.
+ * @return {Boolean}           True if at the edge, false if not.
+ */
+export function isHorizontalEdge( container, isReverse ) {
+	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		if ( container.selectionStart !== container.selectionEnd ) {
 			return false;
 		}
 
-		if ( start ) {
+		if ( isReverse ) {
 			return container.selectionStart === 0;
 		}
 
@@ -24,21 +35,22 @@ export function isEdge( container, start = false ) {
 
 	const selection = window.getSelection();
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
-	const position = start ? 'start' : 'end';
-	const order = start ? 'first' : 'last';
-	const offset = range[ `${ position }Offset` ];
-
-	let node = range.startContainer;
 
 	if ( ! range || ! range.collapsed ) {
 		return false;
 	}
 
-	if ( start && offset !== 0 ) {
+	const position = isReverse ? 'start' : 'end';
+	const order = isReverse ? 'first' : 'last';
+	const offset = range[ `${ position }Offset` ];
+
+	let node = range.startContainer;
+
+	if ( isReverse && offset !== 0 ) {
 		return false;
 	}
 
-	if ( ! start && offset !== node.textContent.length ) {
+	if ( ! isReverse && offset !== node.textContent.length ) {
 		return false;
 	}
 
@@ -56,18 +68,77 @@ export function isEdge( container, start = false ) {
 }
 
 /**
- * Places the caret at start or end of a given element
+ * Gets vertical edge information:
+ *   * isEdge: Whether the caret is at the vertical edge of the container.
+ *   * rect: Dimensions of the caret when available.
  *
- * @param  {Element} container DOM Element
- * @param  {Boolean} start     Position: Start or end of the element
+ * @param  {Element} container Focusable element.
+ * @param  {Boolean} isReverse Set to true to check top, false for bottom.
+ * @return {Object}            Vertical edge information.
  */
-export function placeCaretAtEdge( container, start = false ) {
-	const isInputOrTextarea = [ 'INPUT', 'TEXTAREA' ].indexOf( container.tagName ) !== -1;
+export function getVerticalEdge( container, isReverse ) {
+	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
+		return {
+			isEdge: isHorizontalEdge( container, isReverse ),
+		};
+	}
 
-	// Inputs and Textareas
-	if ( isInputOrTextarea ) {
+	if ( ! container.isContentEditable ) {
+		return { isEdge: true };
+	}
+
+	const selection = window.getSelection();
+	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+
+	if ( ! range || ! range.collapsed ) {
+		return { isEdge: false };
+	}
+
+	// Adjust for empty containers.
+	const rangeRect =
+		range.startContainer.nodeType === window.Node.ELEMENT_NODE
+		? range.startContainer.getBoundingClientRect()
+		: range.getClientRects()[ 0 ];
+
+	if ( ! rangeRect ) {
+		return { isEdge: false };
+	}
+
+	const buffer = rangeRect.height / 2;
+	const editableRect = container.getBoundingClientRect();
+
+	// Too low.
+	if ( isReverse && rangeRect.top - buffer > editableRect.top ) {
+		return {
+			rect: rangeRect,
+			isEdge: false,
+		};
+	}
+
+	// Too high.
+	if ( ! isReverse && rangeRect.bottom + buffer < editableRect.bottom ) {
+		return {
+			rect: rangeRect,
+			isEdge: false,
+		};
+	}
+
+	return {
+		rect: rangeRect,
+		isEdge: true,
+	};
+}
+
+/**
+ * Places the caret at start or end of a given element.
+ *
+ * @param {Element} container Focusable element.
+ * @param {Boolean} isReverse True for end, false for start.
+ */
+export function placeCaretAtHorizontalEdge( container, isReverse ) {
+	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		container.focus();
-		if ( start ) {
+		if ( isReverse ) {
 			container.selectionStart = 0;
 			container.selectionEnd = 0;
 		} else {
@@ -77,14 +148,129 @@ export function placeCaretAtEdge( container, start = false ) {
 		return;
 	}
 
-	// Content editables
+	if ( ! container.isContentEditable ) {
+		container.focus();
+		return;
+	}
+
+	const selection = window.getSelection();
 	const range = document.createRange();
+
 	range.selectNodeContents( container );
-	range.collapse( start );
-	const sel = window.getSelection();
-	sel.removeAllRanges();
-	sel.addRange( range );
+	range.collapse( ! isReverse );
+
+	selection.removeAllRanges();
+	selection.addRange( range );
+
 	container.focus();
+}
+
+/**
+ * Polyfill.
+ * Get a collapsed range for a given point.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/caretRangeFromPoint
+ *
+ * @param  {Document} doc The document of the range.
+ * @param  {Float}    x   Horizontal position within the current viewport.
+ * @param  {Float}    y   Vertical position within the current viewport.
+ * @return {?Range}       The best range for the given point.
+ */
+function caretRangeFromPoint( doc, x, y ) {
+	if ( doc.caretRangeFromPoint ) {
+		return doc.caretRangeFromPoint( x, y );
+	}
+
+	if ( ! doc.caretPositionFromPoint ) {
+		return null;
+	}
+
+	const point = doc.caretPositionFromPoint( x, y );
+	const range = doc.createRange();
+
+	range.setStart( point.offsetNode, point.offset );
+	range.collapse( true );
+
+	return range;
+}
+
+/**
+ * Get a collapsed range for a given point.
+ * Gives the container a temporary high z-index (above any UI).
+ * This is preferred over getting the UI nodes and set styles there.
+ *
+ * @param  {Document} doc       The document of the range.
+ * @param  {Float}    x         Horizontal position within the current viewport.
+ * @param  {Float}    y         Vertical position within the current viewport.
+ * @param  {Element}  container Container in which the range is expected to be found.
+ * @return {?Range}             The best range for the given point.
+ */
+function hiddenCaretRangeFromPoint( doc, x, y, container ) {
+	container.style.zIndex = '10000';
+
+	const range = caretRangeFromPoint( doc, x, y );
+
+	container.style.zIndex = null;
+
+	return range;
+}
+
+/**
+ * Places the caret at the top or bottom of a given element.
+ *
+ * @param {Element} container           Focusable element.
+ * @param {Boolean} isReverse           True for bottom, false for top.
+ * @param {DOMRect} [rect]              The rectangle to position the caret with.
+ * @param {Boolean} [mayUseScroll=true] True to allow scrolling, false to disallow.
+ */
+export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScroll = true ) {
+	if ( ! rect || ! container.isContentEditable ) {
+		placeCaretAtHorizontalEdge( container, isReverse );
+		return;
+	}
+
+	const buffer = rect.height / 2;
+	const editableRect = container.getBoundingClientRect();
+	const x = rect.left + ( rect.width / 2 );
+	const y = isReverse ? ( editableRect.bottom - buffer ) : ( editableRect.top + buffer );
+	const selection = window.getSelection();
+
+	let range = hiddenCaretRangeFromPoint( document, x, y, container );
+
+	if ( ! range || ! container.contains( range.startContainer ) ) {
+		if ( mayUseScroll && ! range.startContainer.contains( container ) ) {
+			// Might be out of view.
+			// Easier than attempting to calculate manually.
+			container.scrollIntoView( isReverse );
+			placeCaretAtVerticalEdge( container, isReverse, rect, false );
+			return;
+		}
+
+		placeCaretAtHorizontalEdge( container, isReverse );
+		return;
+	}
+
+	// Check if the closest text node is actually further away.
+	// If so, attempt to get the range again with the y position adjusted to get the right offset.
+	if ( range.startContainer.nodeType === TEXT_NODE ) {
+		const parentNode = range.startContainer.parentNode;
+		const parentRect = parentNode.getBoundingClientRect();
+		const side = isReverse ? 'bottom' : 'top';
+		const padding = parseInt( getComputedStyle( parentNode ).getPropertyValue( `padding-${ side }` ), 10 ) || 0;
+		const actualY = isReverse ? ( parentRect.bottom - padding - buffer ) : ( parentRect.top + padding + buffer );
+
+		if ( y !== actualY ) {
+			range = hiddenCaretRangeFromPoint( document, x, actualY, container );
+		}
+	}
+
+	selection.removeAllRanges();
+	selection.addRange( range );
+	container.focus();
+	// Editable was already focussed, it goes back to old range...
+	// This fixes it.
+	selection.removeAllRanges();
+	selection.addRange( range );
 }
 
 /**

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -254,7 +254,9 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 	let range = hiddenCaretRangeFromPoint( document, x, y, container );
 
 	if ( ! range || ! container.contains( range.startContainer ) ) {
-		if ( mayUseScroll && ! range.startContainer.contains( container ) ) {
+		if ( mayUseScroll && (
+				( ! range || ! range.startContainer ) ||
+				! range.startContainer.contains( container ) ) ) {
 			// Might be out of view.
 			// Easier than attempting to calculate manually.
 			container.scrollIntoView( isReverse );

--- a/editor/utils/test/dom.js
+++ b/editor/utils/test/dom.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isEdge, placeCaretAtEdge } from '../dom';
+import { isHorizontalEdge, placeCaretAtHorizontalEdge } from '../dom';
 
 describe( 'DOM', () => {
 	let parent;
@@ -15,13 +15,13 @@ describe( 'DOM', () => {
 		parent.remove();
 	} );
 
-	describe( 'isEdge', () => {
+	describe( 'isHorizontalEdge', () => {
 		it( 'Should return true for empty input', () => {
 			const input = document.createElement( 'input' );
 			parent.appendChild( input );
 			input.focus();
-			expect( isEdge( input, true ) ).toBe( true );
-			expect( isEdge( input, false ) ).toBe( true );
+			expect( isHorizontalEdge( input, true ) ).toBe( true );
+			expect( isHorizontalEdge( input, false ) ).toBe( true );
 		} );
 
 		it( 'Should return the right values if we focus the end of the input', () => {
@@ -31,8 +31,8 @@ describe( 'DOM', () => {
 			input.focus();
 			input.selectionStart = 5;
 			input.selectionEnd = 5;
-			expect( isEdge( input, true ) ).toBe( false );
-			expect( isEdge( input, false ) ).toBe( true );
+			expect( isHorizontalEdge( input, true ) ).toBe( false );
+			expect( isHorizontalEdge( input, false ) ).toBe( true );
 		} );
 
 		it( 'Should return the right values if we focus the start of the input', () => {
@@ -42,8 +42,8 @@ describe( 'DOM', () => {
 			input.focus();
 			input.selectionStart = 0;
 			input.selectionEnd = 0;
-			expect( isEdge( input, true ) ).toBe( true );
-			expect( isEdge( input, false ) ).toBe( false );
+			expect( isHorizontalEdge( input, true ) ).toBe( true );
+			expect( isHorizontalEdge( input, false ) ).toBe( false );
 		} );
 
 		it( 'Should return false if we\'re not at the edge', () => {
@@ -53,8 +53,8 @@ describe( 'DOM', () => {
 			input.focus();
 			input.selectionStart = 3;
 			input.selectionEnd = 3;
-			expect( isEdge( input, true ) ).toBe( false );
-			expect( isEdge( input, false ) ).toBe( false );
+			expect( isHorizontalEdge( input, true ) ).toBe( false );
+			expect( isHorizontalEdge( input, false ) ).toBe( false );
 		} );
 
 		it( 'Should return false if the selection is not collapseds', () => {
@@ -64,31 +64,31 @@ describe( 'DOM', () => {
 			input.focus();
 			input.selectionStart = 0;
 			input.selectionEnd = 5;
-			expect( isEdge( input, true ) ).toBe( false );
-			expect( isEdge( input, false ) ).toBe( false );
+			expect( isHorizontalEdge( input, true ) ).toBe( false );
+			expect( isHorizontalEdge( input, false ) ).toBe( false );
 		} );
 
 		it( 'Should always return true for non content editabless', () => {
 			const div = document.createElement( 'div' );
 			parent.appendChild( div );
-			expect( isEdge( div, true ) ).toBe( true );
-			expect( isEdge( div, false ) ).toBe( true );
+			expect( isHorizontalEdge( div, true ) ).toBe( true );
+			expect( isHorizontalEdge( div, false ) ).toBe( true );
 		} );
 	} );
 
-	describe( 'placeCaretAtEdge', () => {
+	describe( 'placeCaretAtHorizontalEdge', () => {
 		it( 'should place caret at the start of the input', () => {
 			const input = document.createElement( 'input' );
 			input.value = 'value';
-			placeCaretAtEdge( input, true );
-			expect( isEdge( input, true ) ).toBe( true );
+			placeCaretAtHorizontalEdge( input, true );
+			expect( isHorizontalEdge( input, true ) ).toBe( true );
 		} );
 
 		it( 'should place caret at the end of the input', () => {
 			const input = document.createElement( 'input' );
 			input.value = 'value';
-			placeCaretAtEdge( input, false );
-			expect( isEdge( input, false ) ).toBe( true );
+			placeCaretAtHorizontalEdge( input, false );
+			expect( isHorizontalEdge( input, false ) ).toBe( true );
 		} );
 	} );
 } );

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -3,11 +3,16 @@
  */
 import { Component } from 'element';
 import { keycodes, focus } from '@wordpress/utils';
-
+import { find, reverse } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEdge, placeCaretAtEdge } from '../utils/dom';
+import {
+	isHorizontalEdge,
+	getVerticalEdge,
+	placeCaretAtHorizontalEdge,
+	placeCaretAtVerticalEdge,
+} from '../utils/dom';
 
 /**
  * Module Constants
@@ -20,6 +25,8 @@ class WritingFlow extends Component {
 
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
+
+		this.verticalRect = null;
 	}
 
 	bindContainer( ref ) {
@@ -37,31 +44,75 @@ class WritingFlow extends Component {
 			) );
 	}
 
-	moveFocusInContainer( target, direction = 'UP' ) {
-		const focusableNodes = this.getVisibleTabbables();
-		if ( direction === 'UP' ) {
-			focusableNodes.reverse();
+	getClosestTabbable( target, isReverse ) {
+		let focusableNodes = this.getVisibleTabbables();
+
+		if ( isReverse ) {
+			focusableNodes = reverse( focusableNodes );
 		}
 
-		const targetNode = focusableNodes
-			.slice( focusableNodes.indexOf( target ) )
-			.reduce( ( result, node ) => {
-				return result || ( node.contains( target ) ? null : node );
-			}, null );
+		focusableNodes = focusableNodes.slice( focusableNodes.indexOf( target ) );
 
-		if ( targetNode ) {
-			placeCaretAtEdge( targetNode, direction === 'DOWN' );
-		}
+		return find( focusableNodes, ( node, i, array ) => {
+			if ( node.contains( target ) ) {
+				return false;
+			}
+
+			const nextNode = array[ i + 1 ];
+
+			// Skip node if it contains a focusable node.
+			if ( nextNode && node.contains( nextNode ) ) {
+				return false;
+			}
+
+			return true;
+		} );
 	}
 
 	onKeyDown( event ) {
 		const { keyCode, target } = event;
-		const moveUp = ( keyCode === UP || keyCode === LEFT );
-		const moveDown = ( keyCode === DOWN || keyCode === RIGHT );
+		const isUp = keyCode === UP;
+		const isDown = keyCode === DOWN;
+		const isLeft = keyCode === LEFT;
+		const isRight = keyCode === RIGHT;
+		const isReverse = isUp || isLeft;
+		const isHorizontal = isLeft || isRight;
+		const isVertical = isUp || isDown;
 
-		if ( ( moveUp || moveDown ) && isEdge( target, moveUp ) ) {
+		if ( isVertical ) {
+			const { rect, isEdge } = getVerticalEdge( target, isReverse );
+
+			if ( rect && ! this.verticalRect ) {
+				this.verticalRect = rect;
+			}
+
+			if ( ! isEdge ) {
+				return;
+			}
+
+			const closestTabbable = this.getClosestTabbable( target, isReverse );
+
+			if ( ! closestTabbable ) {
+				return;
+			}
+
+			placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
 			event.preventDefault();
-			this.moveFocusInContainer( target, moveUp ? 'UP' : 'DOWN' );
+		} else {
+			this.verticalRect = null;
+
+			if ( ! isHorizontal || ! isHorizontalEdge( target, isReverse ) ) {
+				return;
+			}
+
+			const closestTabbable = this.getClosestTabbable( target, isReverse );
+
+			if ( ! closestTabbable ) {
+				return;
+			}
+
+			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
+			event.preventDefault();
 		}
 	}
 
@@ -71,7 +122,9 @@ class WritingFlow extends Component {
 		return (
 			<div
 				ref={ this.bindContainer }
-				onKeyDown={ this.onKeyDown }>
+				onKeyDown={ this.onKeyDown }
+				onMouseDown={ () => this.verticalRect = null }
+			>
 				{ children }
 			</div>
 		);

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -9,7 +9,8 @@ import { find, reverse } from 'lodash';
  */
 import {
 	isHorizontalEdge,
-	getVerticalEdge,
+	isVerticalEdge,
+	computeCaretRect,
 	placeCaretAtHorizontalEdge,
 	placeCaretAtVerticalEdge,
 } from '../utils/dom';
@@ -79,38 +80,18 @@ class WritingFlow extends Component {
 		const isHorizontal = isLeft || isRight;
 		const isVertical = isUp || isDown;
 
-		if ( isVertical ) {
-			const { rect, isEdge } = getVerticalEdge( target, isReverse );
+		if ( ! isVertical ) {
+			this.verticalRect = null;
+		} else if ( ! this.verticalRect ) {
+			this.verticalRect = computeCaretRect( target );
+		}
 
-			if ( rect && ! this.verticalRect ) {
-				this.verticalRect = rect;
-			}
-
-			if ( ! isEdge ) {
-				return;
-			}
-
+		if ( isVertical && isVerticalEdge( target, isReverse ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
-
-			if ( ! closestTabbable ) {
-				return;
-			}
-
 			placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
 			event.preventDefault();
-		} else {
-			this.verticalRect = null;
-
-			if ( ! isHorizontal || ! isHorizontalEdge( target, isReverse ) ) {
-				return;
-			}
-
+		} else if ( isHorizontal && isHorizontalEdge( target, isReverse ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
-
-			if ( ! closestTabbable ) {
-				return;
-			}
-
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();
 		}


### PR DESCRIPTION
## Description
This is a rebase of #2296.

It allows the caret in a block to be vertically repositioned across focusable elements.

## How Has This Been Tested?
In e.g. the demo content, place the caret in an editable container. Use the UP and DOWN arrow keys to navigate across editable areas and blocks.

## Checklist:
- [x] My code is tested. (No unit test because it uses layout.)
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.