### PR TITLE
fix text mode broken on autosave

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -46,9 +46,13 @@ export default {
 		const state = getState();
 		const post = getCurrentPost( state );
 		const edits = getPostEdits( state );
+		const editedPostContent = getEditedPostContent( state );
+
+		dispatch( resetBlocks( parse( editedPostContent ) ) );
+
 		const toSend = {
 			...edits,
-			content: getEditedPostContent( state ),
+			content: editedPostContent,
 			id: post.id,
 		};
 		const transactionId = uniqueId();


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR is referencing this issue https://github.com/WordPress/gutenberg/issues/2978
Editor text mode was not working properly when autosave interrupts the content editing of a new post.
Text mode has 2 event listeners onChange and onPersist (which is triggered on blur). If blur happens before autosave everything is good otherwise the editor content goes back to its previous state.
onPersist dispatches resetBlocks action which works properly. I updated REQUEST_POST_UPDATE to dispatch resetBlocks action and the issue is fixed with that.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
No new tests are written. All current js test are passing.


## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.