### PR TITLE
Toolbar Arrow Navigation (just adding ESC behaviour)

### DIFF
--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -1,6 +1,3 @@
-import { connect } from 'react-redux';
-
-
 /**
  * External dependencies
  */
@@ -174,4 +171,4 @@ class BlockToolbar extends Component {
 	}
 }
 
-export default BlockToolbar
+export default BlockToolbar;

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -1,3 +1,6 @@
+import { connect } from 'react-redux';
+
+
 /**
  * External dependencies
  */
@@ -20,6 +23,9 @@ import './style.scss';
 import BlockSwitcher from '../block-switcher';
 import BlockMover from '../block-mover';
 import BlockRightMenu from '../block-settings-menu';
+import {
+	focusBlock,
+} from '../actions';
 
 /**
  * Module Constants
@@ -107,11 +113,13 @@ class BlockToolbar extends Component {
 
 		switch ( event.keyCode ) {
 			case ESCAPE: {
-				// Is there a better way to focus the selected block
-				const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected' );
-				if ( indexOfTabbable !== -1 && selectedBlock ) {
-					selectedBlock.focus();
-				}
+			 // fire an action
+				this.props.onRefocusBlock();
+				// // Is there a better way to focus the selected block
+				// const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected' );
+				// if ( indexOfTabbable !== -1 && selectedBlock ) {
+				// 	selectedBlock.focus();
+				// }
 				break;
 			}
 			case LEFT:
@@ -175,4 +183,13 @@ class BlockToolbar extends Component {
 	}
 }
 
-export default BlockToolbar;
+export default connect(
+	( ) => {
+		return { };
+	},
+	( dispatch, ownProps ) => ( {
+		onRefocusBlock() {
+			dispatch( focusBlock( ownProps.uid ) );
+		},
+	} )
+)( BlockToolbar );

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -107,7 +107,7 @@ class BlockToolbar extends Component {
 
 		switch ( event.keyCode ) {
 			case ESCAPE: {
-			 	this.props.refocusBlock( this.props.uid );
+				this.props.refocusBlock( this.props.uid );
 				break;
 			}
 			case LEFT:

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -113,13 +113,7 @@ class BlockToolbar extends Component {
 
 		switch ( event.keyCode ) {
 			case ESCAPE: {
-			 // fire an action
-				this.props.onRefocusBlock();
-				// // Is there a better way to focus the selected block
-				// const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected' );
-				// if ( indexOfTabbable !== -1 && selectedBlock ) {
-				// 	selectedBlock.focus();
-				// }
+			 	this.props.refocusBlock( this.props.uid );
 				break;
 			}
 			case LEFT:
@@ -183,13 +177,4 @@ class BlockToolbar extends Component {
 	}
 }
 
-export default connect(
-	( ) => {
-		return { };
-	},
-	( dispatch, ownProps ) => ( {
-		onRefocusBlock() {
-			dispatch( focusBlock( ownProps.uid ) );
-		},
-	} )
-)( BlockToolbar );
+export default BlockToolbar

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -23,9 +23,6 @@ import './style.scss';
 import BlockSwitcher from '../block-switcher';
 import BlockMover from '../block-mover';
 import BlockRightMenu from '../block-settings-menu';
-import {
-	focusBlock,
-} from '../actions';
 
 /**
  * Module Constants

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -345,7 +345,7 @@ class VisualEditorBlock extends Component {
 				<BlockDropZone index={ order } />
 				{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }
 				{ ( showUI || isHovered ) && <BlockRightMenu uid={ block.uid } /> }
-				{ showUI && isValid && mode === 'visual' && <BlockToolbar uid={ block.uid } /> }
+				{ showUI && isValid && mode === 'visual' && <BlockToolbar uid={ block.uid } refocusBlock={ this.props.onFocus } /> }
 
 				{ isFirstMultiSelected && (
 					<BlockMover uids={ multiSelectedBlockUids } />


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
*NOTE: Only merging to an existing branch, not master*

Building on #2960, just adding the ability for pressing ESC to refocus the block (in whatever way the particular block receives focus)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Just manually.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix for ESC to focus editable areas

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation. (no documentation was there)