### PR TITLE
Components: Use a div wrapper for the toolbar

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -94,18 +94,16 @@ registerBlockType( 'core/audio', {
 						onChange={ updateAlignment }
 					/>
 					<Toolbar>
-						<li>
-							<Button
-								buttonProps={ {
-									className: 'components-icon-button components-toolbar__control',
-									'aria-label': __( 'Edit audio' ),
-								} }
-								type="audio"
-								onClick={ switchToEditing }
-							>
-								<Dashicon icon="edit" />
-							</Button>
-						</li>
+						<Button
+							buttonProps={ {
+								className: 'components-icon-button components-toolbar__control',
+								'aria-label': __( 'Edit audio' ),
+							} }
+							type="audio"
+							onClick={ switchToEditing }
+						>
+							<Dashicon icon="edit" />
+						</Button>
 					</Toolbar>
 				</BlockControls>
 			);

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -88,19 +88,17 @@ registerBlockType( 'core/cover-image', {
 				/>
 
 				<Toolbar>
-					<li>
-						<MediaUploadButton
-							buttonProps={ {
-								className: 'components-icon-button components-toolbar__control',
-								'aria-label': __( 'Edit image' ),
-							} }
-							onSelect={ onSelectImage }
-							type="image"
-							value={ id }
-						>
-							<Dashicon icon="edit" />
-						</MediaUploadButton>
-					</li>
+					<MediaUploadButton
+						buttonProps={ {
+							className: 'components-icon-button components-toolbar__control',
+							'aria-label': __( 'Edit image' ),
+						} }
+						onSelect={ onSelectImage }
+						type="image"
+						value={ id }
+					>
+						<Dashicon icon="edit" />
+					</MediaUploadButton>
 				</Toolbar>
 			</BlockControls>,
 			<InspectorControls key="inspector">

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -123,21 +123,19 @@ class GalleryBlock extends Component {
 					/>
 					{ !! images.length && (
 						<Toolbar>
-							<li>
-								<MediaUploadButton
-									buttonProps={ {
-										className: 'components-icon-button components-toolbar__control',
-										'aria-label': __( 'Edit Gallery' ),
-									} }
-									onSelect={ this.onSelectImages }
-									type="image"
-									multiple
-									gallery
-									value={ images.map( ( img ) => img.id ) }
-								>
-									<Dashicon icon="edit" />
-								</MediaUploadButton>
-							</li>
+							<MediaUploadButton
+								buttonProps={ {
+									className: 'components-icon-button components-toolbar__control',
+									'aria-label': __( 'Edit Gallery' ),
+								} }
+								onSelect={ this.onSelectImages }
+								type="image"
+								multiple
+								gallery
+								value={ images.map( ( img ) => img.id ) }
+							>
+								<Dashicon icon="edit" />
+							</MediaUploadButton>
 						</Toolbar>
 					) }
 				</BlockControls>

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -98,19 +98,17 @@ class ImageBlock extends Component {
 					/>
 
 					<Toolbar>
-						<li>
-							<MediaUploadButton
-								buttonProps={ {
-									className: 'components-icon-button components-toolbar__control',
-									'aria-label': __( 'Edit image' ),
-								} }
-								onSelect={ this.onSelectImage }
-								type="image"
-								value={ id }
-							>
-								<Dashicon icon="edit" />
-							</MediaUploadButton>
-						</li>
+						<MediaUploadButton
+							buttonProps={ {
+								className: 'components-icon-button components-toolbar__control',
+								'aria-label': __( 'Edit image' ),
+							} }
+							onSelect={ this.onSelectImage }
+							type="image"
+							value={ id }
+						>
+							<Dashicon icon="edit" />
+						</MediaUploadButton>
 						<UrlInputButton onChange={ this.onSetHref } url={ href } />
 					</Toolbar>
 				</BlockControls>

--- a/blocks/library/table/editor.scss
+++ b/blocks/library/table/editor.scss
@@ -1,6 +1,6 @@
 .editor-visual-editor__block[data-type="core/table"] {
 
-	.editor-block-toolbar__group > div {
+	.editor-block-toolbar__group > div:not(.editor-block-toolbar__mobile-tools) {
 		display: flex;
 	}
 

--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -113,17 +113,15 @@ export default class TableBlock extends Component {
 			focus && (
 				<BlockControls key="menu">
 					<Toolbar>
-						<li>
-							<DropdownMenu
-								icon="editor-table"
-								label={ __( 'Edit Table' ) }
-								controls={
-									TABLE_CONTROLS.map( ( control ) => ( {
-										...control,
-										onClick: () => control.onClick( this.state.editor ),
-									} ) ) }
-							/>
-						</li>
+						<DropdownMenu
+							icon="editor-table"
+							label={ __( 'Edit Table' ) }
+							controls={
+								TABLE_CONTROLS.map( ( control ) => ( {
+									...control,
+									onClick: () => control.onClick( this.state.editor ),
+								} ) ) }
+						/>
 					</Toolbar>
 				</BlockControls>
 			),

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -76,19 +76,17 @@ registerBlockType( 'core/video', {
 				/>
 
 				<Toolbar>
-					<li>
-						<MediaUploadButton
-							buttonProps={ {
-								className: 'components-icon-button components-toolbar__control',
-								'aria-label': __( 'Edit video' ),
-							} }
-							onSelect={ onSelectVideo }
-							type="video"
-							value={ id }
-						>
-							<Dashicon icon="edit" />
-						</MediaUploadButton>
-					</li>
+					<MediaUploadButton
+						buttonProps={ {
+							className: 'components-icon-button components-toolbar__control',
+							'aria-label': __( 'Edit video' ),
+						} }
+						onSelect={ onSelectVideo }
+						type="video"
+						value={ id }
+					>
+						<Dashicon icon="edit" />
+					</MediaUploadButton>
 				</Toolbar>
 			</BlockControls>,
 

--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -40,7 +40,7 @@ class UrlInputButton extends Component {
 		const { expanded } = this.state;
 
 		return (
-			<li className="blocks-url-input__button">
+			<div className="blocks-url-input__button">
 				<IconButton
 					icon="admin-links"
 					label={ __( 'Edit Link' ) }
@@ -67,7 +67,7 @@ class UrlInputButton extends Component {
 						/>
 					</form>
 				}
-			</li>
+			</div>
 		);
 	}
 }

--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -60,7 +60,7 @@
 }
 
 // Toolbar button
-ul.components-toolbar > li.blocks-url-input__button {
+.components-toolbar > .blocks-url-input__button {
 	position: inherit;	// let the dialog position according to parent
 }
 

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -24,11 +24,11 @@ function Toolbar( { controls = [], children, className } ) {
 	}
 
 	return (
-		<ul className={ classnames( 'components-toolbar', className ) }>
+		<div className={ classnames( 'components-toolbar', className ) }>
 			{ controlSets.reduce( ( result, controlSet, setIndex ) => [
 				...result,
 				...controlSet.map( ( control, controlIndex ) => (
-					<li
+					<div
 						key={ [ setIndex, controlIndex ].join() }
 						className={ setIndex > 0 && controlIndex === 0 ? 'has-left-divider' : null }
 					>
@@ -47,11 +47,11 @@ function Toolbar( { controls = [], children, className } ) {
 							disabled={ control.isDisabled }
 						/>
 						{ control.children }
-					</li>
+					</div>
 				) ),
 			], [] ) }
 			{ children }
-		</ul>
+		</div>
 	);
 }
 

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -5,15 +5,13 @@
 	display: inline-flex;
 }
 
-ul.components-toolbar {
-	list-style-type: none;
-
-	&> li {
+div.components-toolbar {
+	&> div {
 		display: inline-flex;
 		margin: 0;
 	}
 
-	&> li + li {
+	&> div + div {
 		margin-left: -3px;
 
 		&.has-left-divider {

--- a/components/toolbar/test/index.js
+++ b/components/toolbar/test/index.js
@@ -33,7 +33,6 @@ describe( 'Toolbar', () => {
 			];
 			const toolbar = shallow( <Toolbar controls={ controls } /> );
 			const listItem = toolbar.find( 'IconButton' );
-			expect( toolbar.type() ).toBe( 'ul' );
 			expect( listItem.props() ).toMatchObject( {
 				icon: 'wordpress',
 				label: 'WordPress',

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -70,12 +70,12 @@
 		margin: 1.5em 0;
 	}
 
-	ul.components-toolbar {
+	div.components-toolbar {
 		box-shadow: none;
 		margin-bottom: 1.5em;
 	}
 
-	p + ul.components-toolbar {
+	p + div.components-toolbar {
 		margin-top: -1em;
 	}
 }


### PR DESCRIPTION
Per comment https://github.com/WordPress/gutenberg/pull/2960#issuecomment-335879492 The toolbar wrapper shouldn't be a list, it was also creating some invalid HTML in some places where we were using the Toolbar component without using `li` as children. 

## Testing instructions

 -  Check that the toolbars still show up properly (Block toolbars)