### PR TITLE
Update Heartbeat nonce refreshing for WordPress 4.9

### DIFF
--- a/editor/index.js
+++ b/editor/index.js
@@ -39,7 +39,7 @@ if ( dateSettings.timezone.string ) {
 window.jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
 	if ( response[ 'rest-nonce' ] ) {
 		window.wpApiSettings.nonce = response[ 'rest-nonce' ];
-		if ( ! _.isUndefined( wp.api.endpoints.at(0) ) {
+		if ( ! _.isUndefined( wp.api.endpoints.at(0) ) ) {
 			wp.api.endpoints.at(0).set( 'nonce', response['rest-nonce'] );
 		}
 	}

--- a/editor/index.js
+++ b/editor/index.js
@@ -39,8 +39,8 @@ if ( dateSettings.timezone.string ) {
 window.jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
 	if ( response[ 'rest-nonce' ] ) {
 		window.wpApiSettings.nonce = response[ 'rest-nonce' ];
-		if ( ! _.isUndefined( wp.api.endpoints.at(0) ) ) {
-			wp.api.endpoints.at(0).set( 'nonce', response['rest-nonce'] );
+		if ( 'undefined' !== typeof wp.api.endpoints.at( 0 ) ) {
+			wp.api.endpoints.at( 0 ).set( 'nonce', response[ 'rest-nonce' ] );
 		}
 	}
 } );

--- a/editor/index.js
+++ b/editor/index.js
@@ -39,6 +39,9 @@ if ( dateSettings.timezone.string ) {
 window.jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
 	if ( response[ 'rest-nonce' ] ) {
 		window.wpApiSettings.nonce = response[ 'rest-nonce' ];
+		if ( ! _.isUndefined( wp.api.endpoints.at(0) ) {
+			wp.api.endpoints.at(0).set( 'nonce', response['rest-nonce'] );
+		}
 	}
 } );
 


### PR DESCRIPTION
## Description
Follow up to https://github.com/WordPress/gutenberg/pull/2790 - this adds support for nonce refreshing in WordPress 4.9 (and trunk).

## How Has This Been Tested?
Tested against trunk, verifying new nonce is set on endpoint model, which is where the sync function now looks for it. Also tested in 4.8, verifying things continue to work as expected there.

## Types of changes

Since https://core.trac.wordpress.org/changeset/41553 (coming in 4.9), wp-api.js no longer uses a global nonce, instead it tracks a nonce for each api/endpoint you connect it to - enabling connecting to multiple servers, endpoints or namespaces and for each to have its own nonce.

For core, we always connect first, so we can depend on the endpoint at index 0 being to core connection. We could also store a reference to this endpoint, it is returned when the wp-api.init() promise resolves.

I noticed we are still using wpApiSettings.nonce in blocks/library/embed/index.js which we might also want to consider switching to using the nonce stored on the settings global.
