### PR TITLE
Components: Track scroll position of all parent scrollable nodes

### DIFF
--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -93,7 +93,7 @@ export class Popover extends Component {
 
 		window.cancelAnimationFrame( this.rafHandle );
 		window[ handler ]( 'resize', this.throttledSetOffset );
-		window[ handler ]( 'scroll', this.throttledSetOffset );
+		window[ handler ]( 'scroll', this.throttledSetOffset, true );
 	}
 
 	focus() {
@@ -123,19 +123,18 @@ export class Popover extends Component {
 
 	setOffset() {
 		const { anchor, popover } = this.nodes;
-		const { parentNode } = anchor;
-		if ( ! parentNode ) {
+		if ( ! anchor || ! anchor.parentNode ) {
 			return;
 		}
 
-		const rect = parentNode.getBoundingClientRect();
+		const rect = anchor.parentNode.getBoundingClientRect();
 		const [ yAxis, xAxis ] = this.getPositions();
 		const isTop = 'top' === yAxis;
 		const isLeft = 'left' === xAxis;
 		const isRight = 'right' === xAxis;
 
 		// Offset top positioning by padding
-		const { paddingTop, paddingBottom } = window.getComputedStyle( parentNode );
+		const { paddingTop, paddingBottom } = window.getComputedStyle( anchor.parentNode );
 		let topOffset = parseInt( isTop ? paddingTop : paddingBottom, 10 );
 		if ( ! isTop ) {
 			topOffset *= -1;


### PR DESCRIPTION
Try to fix #2999 

Not sure if there are performance concerns about this, or if it's a good solution but this tries to fix popovers position if we scroll one of their parents.

**Testing instructions**

 - Hover a button with a tooltip,
 - Scroll slightly
 - The tooltip should adapt its position