### PR TITLE
isMultiSelecting should persist across selection changes

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -306,13 +306,14 @@ export function isTyping( state = false, action ) {
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function blockSelection( state = { start: null, end: null, focus: null }, action ) {
+export function blockSelection( state = { start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK':
 			return {
 				start: null,
 				end: null,
 				focus: null,
+				isMultiSelecting: false,
 			};
 		case 'START_MULTI_SELECT':
 			return {
@@ -320,24 +321,29 @@ export function blockSelection( state = { start: null, end: null, focus: null },
 				isMultiSelecting: true,
 			};
 		case 'STOP_MULTI_SELECT':
-			return omit( state, 'isMultiSelecting' );
+			return {
+				...state,
+				isMultiSelecting: false,
+			};
 		case 'MULTI_SELECT':
 			return {
+				...state,
 				start: action.start,
 				end: action.end,
-				focus: state.focus,
 			};
 		case 'SELECT_BLOCK':
 			if ( action.uid === state.start && action.uid === state.end ) {
 				return state;
 			}
 			return {
+				...state,
 				start: action.uid,
 				end: action.uid,
 				focus: action.focus || {},
 			};
 		case 'UPDATE_FOCUS':
 			return {
+				...state,
 				start: action.uid,
 				end: action.uid,
 				focus: action.config || {},
@@ -347,6 +353,7 @@ export function blockSelection( state = { start: null, end: null, focus: null },
 				start: action.blocks[ 0 ].uid,
 				end: action.blocks[ 0 ].uid,
 				focus: {},
+				isMultiSelecting: false,
 			};
 		case 'REPLACE_BLOCKS':
 			if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.start ) === -1 ) {
@@ -356,6 +363,7 @@ export function blockSelection( state = { start: null, end: null, focus: null },
 				start: action.blocks[ 0 ].uid,
 				end: action.blocks[ 0 ].uid,
 				focus: {},
+				isMultiSelecting: false,
 			};
 	}
 

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -737,7 +737,7 @@ export function getBlockFocus( state, uid ) {
  * @return {Boolean}      True if multi-selecting, false if not.
  */
 export function isMultiSelecting( state ) {
-	return !! state.blockSelection.isMultiSelecting;
+	return state.blockSelection.isMultiSelecting;
 }
 
 /**

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -737,18 +737,36 @@ describe( 'state', () => {
 				uid: 'kumquat',
 			} );
 
-			expect( state ).toEqual( { start: 'kumquat', end: 'kumquat', focus: {} } );
+			expect( state ).toEqual( { start: 'kumquat', end: 'kumquat', focus: {}, isMultiSelecting: false } );
 		} );
 
 		it( 'should set multi selection', () => {
-			const original = deepFreeze( { focus: { editable: 'citation' } } );
+			const original = deepFreeze( { focus: { editable: 'citation' }, isMultiSelecting: true } );
 			const state = blockSelection( original, {
 				type: 'MULTI_SELECT',
 				start: 'ribs',
 				end: 'chicken',
 			} );
 
-			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: { editable: 'citation' } } );
+			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: { editable: 'citation' }, isMultiSelecting: true } );
+		} );
+
+		it( 'should start multi selection', () => {
+			const original = deepFreeze( { start: 'ribs', end: 'ribs', focus: { editable: 'citation' }, isMultiSelecting: false } );
+			const state = blockSelection( original, {
+				type: 'START_MULTI_SELECT',
+			} );
+
+			expect( state ).toEqual( { start: 'ribs', end: 'ribs', focus: { editable: 'citation' }, isMultiSelecting: true } );
+		} );
+
+		it( 'should end multi selection', () => {
+			const original = deepFreeze( { start: 'ribs', end: 'chicken', focus: { editable: 'citation' }, isMultiSelecting: true } );
+			const state = blockSelection( original, {
+				type: 'STOP_MULTI_SELECT',
+			} );
+
+			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: { editable: 'citation' }, isMultiSelecting: false } );
 		} );
 
 		it( 'should not update the state if the block is already selected', () => {
@@ -769,7 +787,7 @@ describe( 'state', () => {
 				type: 'CLEAR_SELECTED_BLOCK',
 			} );
 
-			expect( state1 ).toEqual( { start: null, end: null, focus: null } );
+			expect( state1 ).toEqual( { start: null, end: null, focus: null, isMultiSelecting: false } );
 
 			const state3 = blockSelection( original, {
 				type: 'INSERT_BLOCKS',
@@ -779,7 +797,7 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( state3 ).toEqual( { start: 'ribs', end: 'ribs', focus: {} } );
+			expect( state3 ).toEqual( { start: 'ribs', end: 'ribs', focus: {}, isMultiSelecting: false } );
 		} );
 
 		it( 'should not update the state if the block moved is already selected', () => {
@@ -799,18 +817,18 @@ describe( 'state', () => {
 				config: { editable: 'citation' },
 			} );
 
-			expect( state ).toEqual( { start: 'chicken', end: 'chicken', focus: { editable: 'citation' } } );
+			expect( state ).toEqual( { start: 'chicken', end: 'chicken', focus: { editable: 'citation' }, isMultiSelecting: false } );
 		} );
 
 		it( 'should update the focus and merge the existing state', () => {
-			const original = deepFreeze( { start: 'ribs', end: 'ribs', focus: {} } );
+			const original = deepFreeze( { start: 'ribs', end: 'ribs', focus: {}, isMultiSelecting: true } );
 			const state = blockSelection( original, {
 				type: 'UPDATE_FOCUS',
 				uid: 'ribs',
 				config: { editable: 'citation' },
 			} );
 
-			expect( state ).toEqual( { start: 'ribs', end: 'ribs', focus: { editable: 'citation' } } );
+			expect( state ).toEqual( { start: 'ribs', end: 'ribs', focus: { editable: 'citation' }, isMultiSelecting: true } );
 		} );
 
 		it( 'should replace the selected block', () => {
@@ -824,7 +842,7 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( state ).toEqual( { start: 'wings', end: 'wings', focus: {} } );
+			expect( state ).toEqual( { start: 'wings', end: 'wings', focus: {}, isMultiSelecting: false } );
 		} );
 
 		it( 'should keep the selected block', () => {


### PR DESCRIPTION
I made a mistake in #2934, fdea571. 🙁 After updating the commit to use Redux state, I did not add `isMultiSelecting` everywhere, so it would just disappear whenever the selection changes.

To test: trigger multi-selection and make sure there is no hover UI during selection. Multi-selection UI should only be displayed once selection is complete. In Safari, multi-selection will appear really buggy. With this fix, it should be smooth.