### PR TITLE
Add reusable blocks data layer

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -17,6 +17,7 @@ const categories = [
 	{ slug: 'layout', title: __( 'Layout Blocks' ) },
 	{ slug: 'widgets', title: __( 'Widgets' ) },
 	{ slug: 'embed', title: __( 'Embed' ) },
+	{ slug: 'reusable-blocks', title: __( 'My Reusable Blocks' ) },
 ];
 
 /**

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -12,6 +12,11 @@ import {
 } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { getBlockType } from './registration';
@@ -115,4 +120,20 @@ export function switchToBlockType( block, name ) {
 		// type gets to keep the existing block's UID.
 		uid: index === firstSwitchedBlock ? block.uid : result.uid,
 	} ) );
+}
+
+/**
+ * Creates a new reusable block.
+ *
+ * @param {String} type       The type of the block referenced by the reusable block
+ * @param {Object} attributes The attributes of the block referenced by the reusable block
+ * @return {Object}           A reusable block object
+ */
+export function createReusableBlock( type, attributes ) {
+	return {
+		id: uuid(),
+		name: __( 'Untitled block' ),
+		type,
+		attributes,
+	};
 }

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -4,7 +4,7 @@
 import * as source from './source';
 
 export { source };
-export { createBlock, switchToBlockType } from './factory';
+export { createBlock, switchToBlockType, createReusableBlock } from './factory';
 export { default as parse, getSourcedAttributes } from './parser';
 export { default as rawHandler } from './raw-handling';
 export { default as serialize, getBlockDefaultClassname, getBlockContent } from './serializer';

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createBlock, switchToBlockType } from '../factory';
+import { createBlock, switchToBlockType, createReusableBlock } from '../factory';
 import { getBlockTypes, unregisterBlockType, setUnknownTypeHandlerName, registerBlockType } from '../registration';
 
 describe( 'block factory', () => {
@@ -457,6 +457,20 @@ describe( 'block factory', () => {
 			expect( transformedBlocks[ 1 ].isValid ).toBe( true );
 			expect( transformedBlocks[ 1 ].attributes ).toEqual( {
 				value: 'smoked ribs',
+			} );
+		} );
+	} );
+
+	describe( 'createReusableBlock', () => {
+		it( 'should create a reusable block', () => {
+			const type = 'core/test-block';
+			const attributes = { name: 'Big Bird' };
+
+			expect( createReusableBlock( type, attributes ) ).toMatchObject( {
+				id: expect.stringMatching( /\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/ ),
+				name: 'Untitled block',
+				type,
+				attributes,
 			} );
 		} );
 	} );

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -22,3 +22,4 @@ import './text-columns';
 import './verse';
 import './video';
 import './audio';
+import './reusable-block';

--- a/blocks/library/reusable-block/index.js
+++ b/blocks/library/reusable-block/index.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '../../api';
+
+registerBlockType( 'core/reusable-block', {
+	title: __( 'Reusable Block' ),
+	category: 'reusable-blocks',
+	isPrivate: true,
+
+	attributes: {
+		ref: {
+			type: 'string',
+		},
+	},
+
+	edit: () => <div>{ __( 'Reusable Blocks are coming soon!' ) }</div>,
+	save: () => null,
+} );

--- a/blocks/test/fixtures/core__reusable-block.html
+++ b/blocks/test/fixtures/core__reusable-block.html
@@ -1,0 +1,1 @@
+<!-- wp:core/reusable-block {"ref":"358b59ee-bab3-4d6f-8445-e8c6971a5605"} /-->

--- a/blocks/test/fixtures/core__reusable-block.json
+++ b/blocks/test/fixtures/core__reusable-block.json
@@ -1,0 +1,11 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/reusable-block",
+        "isValid": true,
+        "attributes": {
+            "ref": "358b59ee-bab3-4d6f-8445-e8c6971a5605"
+        },
+        "originalContent": ""
+    }
+]

--- a/blocks/test/fixtures/core__reusable-block.parsed.json
+++ b/blocks/test/fixtures/core__reusable-block.parsed.json
@@ -1,0 +1,14 @@
+[
+    {
+        "blockName": "core/reusable-block",
+        "attrs": {
+            "ref": "358b59ee-bab3-4d6f-8445-e8c6971a5605"
+        },
+        "rawContent": ""
+    },
+    {
+        "attrs": {},
+        "rawContent": "\n"
+    }
+]
+

--- a/blocks/test/fixtures/core__reusable-block.serialized.html
+++ b/blocks/test/fixtures/core__reusable-block.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:reusable-block {"ref":"358b59ee-bab3-4d6f-8445-e8c6971a5605"} /-->

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -496,10 +496,10 @@ export const createWarningNotice = partial( createNotice, 'warning' );
  * Returns an action object used to fetch a single reusable block or all
  * reusable blocks from the REST API into the store.
  *
- * @param {string} id If given, only a single reusable block with this ID will be fetched
+ * @param {?string} id If given, only a single reusable block with this ID will be fetched
  * @return {Object}   Action object
  */
-export function fetchReusableBlocks( id = null ) {
+export function fetchReusableBlocks( id ) {
 	return {
 		type: 'FETCH_REUSABLE_BLOCKS',
 		id,

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -491,3 +491,74 @@ export const createSuccessNotice = partial( createNotice, 'success' );
 export const createInfoNotice = partial( createNotice, 'info' );
 export const createErrorNotice = partial( createNotice, 'error' );
 export const createWarningNotice = partial( createNotice, 'warning' );
+
+/**
+ * Returns an action object used to fetch a single reusable block or all
+ * reusable blocks from the REST API into the store.
+ *
+ * @param {string} id If given, only a single reusable block with this ID will be fetched
+ * @return {Object}   Action object
+ */
+export function fetchReusableBlocks( id = null ) {
+	return {
+		type: 'FETCH_REUSABLE_BLOCKS',
+		id,
+	};
+}
+
+/**
+ * Returns an action object used to insert or update a reusable block into the store.
+ *
+ * @param {Object} id            The ID of the reusable block to update
+ * @param {Object} reusableBlock The new reusable block object. Any omitted keys are not changed
+ * @return {Object}              Action object
+ */
+export function updateReusableBlock( id, reusableBlock ) {
+	return {
+		type: 'UPDATE_REUSABLE_BLOCK',
+		id,
+		reusableBlock,
+	};
+}
+
+/**
+ * Returns an action object used to save a reusable block that's in the store
+ * to the REST API.
+ *
+ * @param {Object} id The ID of the reusable block to save
+ * @return {Object}   Action object
+ */
+export function saveReusableBlock( id ) {
+	return {
+		type: 'SAVE_REUSABLE_BLOCK',
+		id,
+	};
+}
+
+/**
+ * Returns an action object used to convert a reusable block into a static
+ * block.
+ *
+ * @param {Object} uid The ID of the block to attach
+ * @return {Object}    Action object
+ */
+export function convertBlockToStatic( uid ) {
+	return {
+		type: 'CONVERT_BLOCK_TO_STATIC',
+		uid,
+	};
+}
+
+/**
+ * Returns an action object used to convert a static block into a reusable
+ * block.
+ *
+ * @param {Object} uid The ID of the block to detach
+ * @return {Object}    Action object
+ */
+export function convertBlockToReusable( uid ) {
+	return {
+		type: 'CONVERT_BLOCK_TO_REUSABLE',
+		uid,
+	};
+}

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -59,7 +59,7 @@ export class InserterMenu extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const searchResults = this.searchBlocks( getBlockTypes() );
+		const searchResults = this.searchBlocks( this.getBlockTypes() );
 		// Announce the blocks search results to screen readers.
 		if ( !! searchResults.length ) {
 			this.props.debouncedSpeak( sprintf( _n(
@@ -100,6 +100,11 @@ export class InserterMenu extends Component {
 		};
 	}
 
+	getBlockTypes() {
+		// Block types that are marked as private should not appear in the inserter
+		return getBlockTypes().filter( ( block ) => ! block.isPrivate );
+	}
+
 	searchBlocks( blockTypes ) {
 		return searchBlocks( blockTypes, this.state.filterValue );
 	}
@@ -107,15 +112,15 @@ export class InserterMenu extends Component {
 	getBlocksForCurrentTab() {
 		// if we're searching, use everything, otherwise just get the blocks visible in this tab
 		if ( this.state.filterValue ) {
-			return getBlockTypes();
+			return this.getBlockTypes();
 		}
 		switch ( this.state.tab ) {
 			case 'recent':
 				return this.props.recentlyUsedBlocks;
 			case 'blocks':
-				return filter( getBlockTypes(), ( block ) => block.category !== 'embed' );
+				return filter( this.getBlockTypes(), ( block ) => block.category !== 'embed' );
 			case 'embeds':
-				return filter( getBlockTypes(), ( block ) => block.category === 'embed' );
+				return filter( this.getBlockTypes(), ( block ) => block.category === 'embed' );
 		}
 	}
 

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -657,6 +657,65 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 	}
 }
 
+export function reusableBlocks( state = {}, action ) {
+	switch ( action.type ) {
+		case 'FETCH_REUSABLE_BLOCKS_SUCCESS': {
+			return reduce( action.reusableBlocks, ( newState, reusableBlock ) => ( {
+				...newState,
+				[ reusableBlock.id ]: {
+					...reusableBlock,
+					isSaving: false,
+				},
+			} ), state );
+		}
+
+		case 'UPDATE_REUSABLE_BLOCK': {
+			const { id, reusableBlock } = action;
+			const existingReusableBlock = state[ id ];
+
+			return {
+				...state,
+				[ id ]: {
+					...existingReusableBlock,
+					...reusableBlock,
+					attributes: {
+						...( existingReusableBlock && existingReusableBlock.attributes ),
+						...reusableBlock.attributes,
+					},
+					isSaving: false,
+				},
+			};
+		}
+
+		case 'SAVE_REUSABLE_BLOCK': {
+			const { id } = action;
+
+			return {
+				...state,
+				[ id ]: {
+					...state[ id ],
+					isSaving: true,
+				},
+			};
+		}
+
+		case 'SAVE_REUSABLE_BLOCK_SUCCESS':
+		case 'SAVE_REUSABLE_BLOCK_FAILURE': {
+			const { id } = action;
+
+			return {
+				...state,
+				[ id ]: {
+					...state[ id ],
+					isSaving: false,
+				},
+			};
+		}
+	}
+
+	return state;
+}
+
 export default optimist( combineReducers( {
 	editor,
 	currentPost,
@@ -670,4 +729,5 @@ export default optimist( combineReducers( {
 	saving,
 	notices,
 	metaBoxes,
+	reusableBlocks,
 } ) );

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -663,9 +663,7 @@ export const reusableBlocks = combineReducers( {
 			case 'FETCH_REUSABLE_BLOCKS_SUCCESS': {
 				return reduce( action.reusableBlocks, ( newState, reusableBlock ) => ( {
 					...newState,
-					[ reusableBlock.id ]: {
-						...reusableBlock,
-					},
+					[ reusableBlock.id ]: reusableBlock,
 				} ), state );
 			}
 
@@ -692,12 +690,11 @@ export const reusableBlocks = combineReducers( {
 
 	isSaving( state = {}, action ) {
 		switch ( action.type ) {
-			case 'SAVE_REUSABLE_BLOCK': {
+			case 'SAVE_REUSABLE_BLOCK':
 				return {
 					...state,
 					[ action.id ]: true,
 				};
-			}
 
 			case 'SAVE_REUSABLE_BLOCK_SUCCESS':
 			case 'SAVE_REUSABLE_BLOCK_FAILURE': {

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -657,64 +657,58 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 	}
 }
 
-export function reusableBlocks( state = {}, action ) {
-	switch ( action.type ) {
-		case 'FETCH_REUSABLE_BLOCKS_SUCCESS': {
-			return reduce( action.reusableBlocks, ( newState, reusableBlock ) => ( {
-				...newState,
-				[ reusableBlock.id ]: {
-					...reusableBlock,
-					isSaving: false,
-				},
-			} ), state );
-		}
-
-		case 'UPDATE_REUSABLE_BLOCK': {
-			const { id, reusableBlock } = action;
-			const existingReusableBlock = state[ id ];
-
-			return {
-				...state,
-				[ id ]: {
-					...existingReusableBlock,
-					...reusableBlock,
-					attributes: {
-						...( existingReusableBlock && existingReusableBlock.attributes ),
-						...reusableBlock.attributes,
+export const reusableBlocks = combineReducers( {
+	data( state = {}, action ) {
+		switch ( action.type ) {
+			case 'FETCH_REUSABLE_BLOCKS_SUCCESS': {
+				return reduce( action.reusableBlocks, ( newState, reusableBlock ) => ( {
+					...newState,
+					[ reusableBlock.id ]: {
+						...reusableBlock,
 					},
-					isSaving: false,
-				},
-			};
+				} ), state );
+			}
+
+			case 'UPDATE_REUSABLE_BLOCK': {
+				const { id, reusableBlock } = action;
+				const existingReusableBlock = state[ id ];
+
+				return {
+					...state,
+					[ id ]: {
+						...existingReusableBlock,
+						...reusableBlock,
+						attributes: {
+							...( existingReusableBlock && existingReusableBlock.attributes ),
+							...reusableBlock.attributes,
+						},
+					},
+				};
+			}
 		}
 
-		case 'SAVE_REUSABLE_BLOCK': {
-			const { id } = action;
+		return state;
+	},
 
-			return {
-				...state,
-				[ id ]: {
-					...state[ id ],
-					isSaving: true,
-				},
-			};
+	isSaving( state = {}, action ) {
+		switch ( action.type ) {
+			case 'SAVE_REUSABLE_BLOCK': {
+				return {
+					...state,
+					[ action.id ]: true,
+				};
+			}
+
+			case 'SAVE_REUSABLE_BLOCK_SUCCESS':
+			case 'SAVE_REUSABLE_BLOCK_FAILURE': {
+				const { id } = action;
+				return omit( state, id );
+			}
 		}
 
-		case 'SAVE_REUSABLE_BLOCK_SUCCESS':
-		case 'SAVE_REUSABLE_BLOCK_FAILURE': {
-			const { id } = action;
-
-			return {
-				...state,
-				[ id ]: {
-					...state[ id ],
-					isSaving: false,
-				},
-			};
-		}
-	}
-
-	return state;
-}
+		return state;
+	},
+} );
 
 export default optimist( combineReducers( {
 	editor,

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -1020,3 +1020,24 @@ export const getMostFrequentlyUsedBlocks = createSelector(
 export function isFeatureActive( state, feature ) {
 	return !! state.preferences.features[ feature ];
 }
+
+/**
+ * Returns the reusable block with the given ID.
+ *
+ * @param {Object} state Global application state
+ * @param {String} ref   The reusable block's ID
+ * @return {Object}      The reusable block, or null if none exists
+ */
+export function getReusableBlock( state, ref ) {
+	return state.reusableBlocks[ ref ] || null;
+}
+
+/**
+ * Returns an array of all reusable blocks.
+ *
+ * @param {Object} state Global application state
+ * @return {Array}       An array of all reusable blocks.
+ */
+export function getReusableBlocks( state ) {
+	return Object.values( state.reusableBlocks );
+}

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -1029,7 +1029,18 @@ export function isFeatureActive( state, feature ) {
  * @return {Object}      The reusable block, or null if none exists
  */
 export function getReusableBlock( state, ref ) {
-	return state.reusableBlocks[ ref ] || null;
+	return state.reusableBlocks.data[ ref ] || null;
+}
+
+/**
+ * Returns whether or not the reusable block with the given ID is being saved.
+ *
+ * @param {*} state  Global application state
+ * @param {*} ref    The reusable block's ID
+ * @return {Boolean} Whether or not the reusable block is being saved
+ */
+export function isSavingReusableBlock( state, ref ) {
+	return state.reusableBlocks.isSaving[ ref ] || false;
 }
 
 /**
@@ -1039,5 +1050,5 @@ export function getReusableBlock( state, ref ) {
  * @return {Array}       An array of all reusable blocks.
  */
 export function getReusableBlocks( state ) {
-	return Object.values( state.reusableBlocks );
+	return Object.values( state.reusableBlocks.data );
 }

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -109,7 +109,6 @@ describe( 'actions', () => {
 		it( 'should return the FETCH_REUSABLE_BLOCKS action', () => {
 			expect( fetchReusableBlocks() ).toEqual( {
 				type: 'FETCH_REUSABLE_BLOCKS',
-				id: null,
 			} );
 		} );
 

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -10,6 +10,11 @@ import {
 	handleMetaBoxReload,
 	metaBoxStateChanged,
 	initializeMetaBoxState,
+	fetchReusableBlocks,
+	updateReusableBlock,
+	saveReusableBlock,
+	convertBlockToStatic,
+	convertBlockToReusable,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -97,6 +102,66 @@ describe( 'actions', () => {
 				type: 'INITIALIZE_META_BOX_STATE',
 				metaBoxes,
 			} );
+		} );
+	} );
+
+	describe( 'fetchReusableBlocks', () => {
+		it( 'should return the FETCH_REUSABLE_BLOCKS action', () => {
+			expect( fetchReusableBlocks() ).toEqual( {
+				type: 'FETCH_REUSABLE_BLOCKS',
+				id: null,
+			} );
+		} );
+
+		it( 'should take an optional id argument', () => {
+			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			expect( fetchReusableBlocks( id ) ).toEqual( {
+				type: 'FETCH_REUSABLE_BLOCKS',
+				id,
+			} );
+		} );
+	} );
+
+	describe( 'updateReusableBlock', () => {
+		it( 'should return the UPDATE_REUSABLE_BLOCK action', () => {
+			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			const reusableBlock = {
+				id,
+				name: 'My cool block',
+				type: 'core/paragraph',
+				attributes: {
+					content: 'Hello!',
+				},
+			};
+			expect( updateReusableBlock( id, reusableBlock ) ).toEqual( {
+				type: 'UPDATE_REUSABLE_BLOCK',
+				id,
+				reusableBlock,
+			} );
+		} );
+	} );
+
+	describe( 'saveReusableBlock', () => {
+		const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+		expect( saveReusableBlock( id ) ).toEqual( {
+			type: 'SAVE_REUSABLE_BLOCK',
+			id,
+		} );
+	} );
+
+	describe( 'convertBlockToStatic', () => {
+		const uid = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+		expect( convertBlockToStatic( uid ) ).toEqual( {
+			type: 'CONVERT_BLOCK_TO_STATIC',
+			uid,
+		} );
+	} );
+
+	describe( 'convertBlockToReusable', () => {
+		const uid = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+		expect( convertBlockToReusable( uid ) ).toEqual( {
+			type: 'CONVERT_BLOCK_TO_REUSABLE',
+			uid,
 		} );
 	} );
 } );

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -25,6 +25,7 @@ import {
 	blocksMode,
 	blockInsertionPoint,
 	metaBoxes,
+	reusableBlocks,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -1231,6 +1232,166 @@ describe( 'state', () => {
 			};
 
 			expect( actual ).toEqual( expected );
+		} );
+	} );
+
+	describe( 'reusableBlocks()', () => {
+		it( 'should start out empty', () => {
+			const state = reusableBlocks( undefined, {} );
+			expect( state ).toEqual( {} );
+		} );
+
+		it( 'should add fetched reusable blocks', () => {
+			const reusableBlock = {
+				id: '358b59ee-bab3-4d6f-8445-e8c6971a5605',
+				name: 'My cool block',
+				type: 'core/paragraph',
+				attributes: {
+					content: 'Hello!',
+				},
+			};
+
+			const state = reusableBlocks( {}, {
+				type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
+				reusableBlocks: [ reusableBlock ],
+			} );
+
+			expect( state ).toEqual( {
+				[ reusableBlock.id ]: {
+					...reusableBlock,
+					isSaving: false,
+				},
+			} );
+		} );
+
+		it( 'should add a reusable block', () => {
+			const reusableBlock = {
+				id: '358b59ee-bab3-4d6f-8445-e8c6971a5605',
+				name: 'My cool block',
+				type: 'core/paragraph',
+				attributes: {
+					content: 'Hello!',
+				},
+			};
+
+			const state = reusableBlocks( {}, {
+				type: 'UPDATE_REUSABLE_BLOCK',
+				id: reusableBlock.id,
+				reusableBlock,
+			} );
+
+			expect( state ).toEqual( {
+				[ reusableBlock.id ]: {
+					...reusableBlock,
+					isSaving: false,
+				},
+			} );
+		} );
+
+		it( 'should update a reusable block', () => {
+			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			const initialState = {
+				[ id ]: {
+					id,
+					name: 'My cool block',
+					type: 'core/paragraph',
+					attributes: {
+						content: 'Hello!',
+						dropCap: true,
+					},
+					isSaving: false,
+				},
+			};
+
+			const state = reusableBlocks( initialState, {
+				type: 'UPDATE_REUSABLE_BLOCK',
+				id,
+				reusableBlock: {
+					name: 'My better block',
+					attributes: {
+						content: 'Yo!',
+					},
+				},
+			} );
+
+			expect( state ).toEqual( {
+				[ id ]: {
+					id,
+					name: 'My better block',
+					type: 'core/paragraph',
+					attributes: {
+						content: 'Yo!',
+						dropCap: true,
+					},
+					isSaving: false,
+				},
+			} );
+		} );
+
+		it( 'should indicate that a reusable block is saving', () => {
+			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			const initialState = {
+				[ id ]: {
+					id,
+					isSaving: false,
+				},
+			};
+
+			const state = reusableBlocks( initialState, {
+				type: 'SAVE_REUSABLE_BLOCK',
+				id,
+			} );
+
+			expect( state ).toEqual( {
+				[ id ]: {
+					id,
+					isSaving: true,
+				},
+			} );
+		} );
+
+		it( 'should stop indicating that a reusable block is saving', () => {
+			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			const initialState = {
+				[ id ]: {
+					id,
+					isSaving: true,
+				},
+			};
+
+			const state = reusableBlocks( initialState, {
+				type: 'SAVE_REUSABLE_BLOCK_SUCCESS',
+				id,
+			} );
+
+			expect( state ).toEqual( {
+				[ id ]: {
+					id,
+					isSaving: false,
+				},
+			} );
+		} );
+
+		it( 'should indicate that a reusable block had an error saving', () => {
+			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			const initialState = {
+				[ id ]: {
+					id,
+					isSaving: true,
+				},
+			};
+
+			const state = reusableBlocks( initialState, {
+				type: 'SAVE_REUSABLE_BLOCK_FAILURE',
+				id,
+			} );
+
+			expect( state ).toEqual( {
+				[ id ]: {
+					id,
+					isSaving: false,
+				},
+			} );
 		} );
 	} );
 } );

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -1238,7 +1238,10 @@ describe( 'state', () => {
 	describe( 'reusableBlocks()', () => {
 		it( 'should start out empty', () => {
 			const state = reusableBlocks( undefined, {} );
-			expect( state ).toEqual( {} );
+			expect( state ).toEqual( {
+				data: {},
+				isSaving: {},
+			} );
 		} );
 
 		it( 'should add fetched reusable blocks', () => {
@@ -1257,10 +1260,10 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( {
-				[ reusableBlock.id ]: {
-					...reusableBlock,
-					isSaving: false,
+				data: {
+					[ reusableBlock.id ]: reusableBlock,
 				},
+				isSaving: {},
 			} );
 		} );
 
@@ -1281,26 +1284,28 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( {
-				[ reusableBlock.id ]: {
-					...reusableBlock,
-					isSaving: false,
+				data: {
+					[ reusableBlock.id ]: reusableBlock,
 				},
+				isSaving: {},
 			} );
 		} );
 
 		it( 'should update a reusable block', () => {
 			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
 			const initialState = {
-				[ id ]: {
-					id,
-					name: 'My cool block',
-					type: 'core/paragraph',
-					attributes: {
-						content: 'Hello!',
-						dropCap: true,
+				data: {
+					[ id ]: {
+						id,
+						name: 'My cool block',
+						type: 'core/paragraph',
+						attributes: {
+							content: 'Hello!',
+							dropCap: true,
+						},
 					},
-					isSaving: false,
 				},
+				isSaving: {},
 			};
 
 			const state = reusableBlocks( initialState, {
@@ -1315,26 +1320,26 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( {
-				[ id ]: {
-					id,
-					name: 'My better block',
-					type: 'core/paragraph',
-					attributes: {
-						content: 'Yo!',
-						dropCap: true,
+				data: {
+					[ id ]: {
+						id,
+						name: 'My better block',
+						type: 'core/paragraph',
+						attributes: {
+							content: 'Yo!',
+							dropCap: true,
+						},
 					},
-					isSaving: false,
 				},
+				isSaving: {},
 			} );
 		} );
 
 		it( 'should indicate that a reusable block is saving', () => {
 			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
 			const initialState = {
-				[ id ]: {
-					id,
-					isSaving: false,
-				},
+				data: {},
+				isSaving: {},
 			};
 
 			const state = reusableBlocks( initialState, {
@@ -1343,19 +1348,19 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( {
-				[ id ]: {
-					id,
-					isSaving: true,
+				data: {},
+				isSaving: {
+					[ id ]: true,
 				},
 			} );
 		} );
 
-		it( 'should stop indicating that a reusable block is saving', () => {
+		it( 'should stop indicating that a reusable block is saving when the save succeeded', () => {
 			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
 			const initialState = {
-				[ id ]: {
-					id,
-					isSaving: true,
+				data: {},
+				isSaving: {
+					[ id ]: true,
 				},
 			};
 
@@ -1365,19 +1370,17 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( {
-				[ id ]: {
-					id,
-					isSaving: false,
-				},
+				data: {},
+				isSaving: {},
 			} );
 		} );
 
-		it( 'should indicate that a reusable block had an error saving', () => {
+		it( 'should stop indicating that a reusable block is saving when there is an error', () => {
 			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
 			const initialState = {
-				[ id ]: {
-					id,
-					isSaving: true,
+				data: {},
+				isSaving: {
+					[ id ]: true,
 				},
 			};
 
@@ -1387,10 +1390,8 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( {
-				[ id ]: {
-					id,
-					isSaving: false,
-				},
+				data: {},
+				isSaving: {},
 			} );
 		} );
 	} );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -74,6 +74,7 @@ import {
 	getMetaBox,
 	isMetaBoxStateDirty,
 	getReusableBlock,
+	isSavingReusableBlock,
 	getReusableBlocks,
 } from '../selectors';
 
@@ -2039,7 +2040,9 @@ describe( 'selectors', () => {
 			};
 			const state = {
 				reusableBlocks: {
-					[ id ]: expectedReusableBlock,
+					data: {
+						[ id ]: expectedReusableBlock,
+					},
 				},
 			};
 
@@ -2049,11 +2052,40 @@ describe( 'selectors', () => {
 
 		it( 'should return null when no reusable block exists', () => {
 			const state = {
-				reusableBlocks: {},
+				reusableBlocks: {
+					data: {},
+				},
 			};
 
 			const reusableBlock = getReusableBlock( state, '358b59ee-bab3-4d6f-8445-e8c6971a5605' );
 			expect( reusableBlock ).toBeNull();
+		} );
+	} );
+
+	describe( 'isSavingReusableBlock', () => {
+		it( 'should return false when the block is not being saved', () => {
+			const state = {
+				reusableBlocks: {
+					isSaving: {},
+				},
+			};
+
+			const isSaving = isSavingReusableBlock( state, '358b59ee-bab3-4d6f-8445-e8c6971a5605' );
+			expect( isSaving ).toBe( false );
+		} );
+
+		it( 'should return true when the block is being saved', () => {
+			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			const state = {
+				reusableBlocks: {
+					isSaving: {
+						[ id ]: true,
+					},
+				},
+			};
+
+			const isSaving = isSavingReusableBlock( state, id );
+			expect( isSaving ).toBe( true );
 		} );
 	} );
 
@@ -2077,8 +2109,10 @@ describe( 'selectors', () => {
 			};
 			const state = {
 				reusableBlocks: {
-					[ reusableBlock1.id ]: reusableBlock1,
-					[ reusableBlock2.id ]: reusableBlock2,
+					data: {
+						[ reusableBlock1.id ]: reusableBlock1,
+						[ reusableBlock2.id ]: reusableBlock2,
+					},
 				},
 			};
 
@@ -2088,7 +2122,9 @@ describe( 'selectors', () => {
 
 		it( 'should return an empty array when no reusable blocks exist', () => {
 			const state = {
-				reusableBlocks: {},
+				reusableBlocks: {
+					data: {},
+				},
 			};
 
 			const reusableBlocks = getReusableBlocks( state );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -73,6 +73,8 @@ import {
 	getDirtyMetaBoxes,
 	getMetaBox,
 	isMetaBoxStateDirty,
+	getReusableBlock,
+	getReusableBlocks,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -2021,6 +2023,76 @@ describe( 'selectors', () => {
 
 			expect( getRecentlyUsedBlocks( state ).map( ( block ) => block.name ) )
 				.toEqual( [ 'core/paragraph', 'core/image' ] );
+		} );
+	} );
+
+	describe( 'getReusableBlock', () => {
+		it( 'should return a reusable block', () => {
+			const id = '358b59ee-bab3-4d6f-8445-e8c6971a5605';
+			const expectedReusableBlock = {
+				id,
+				name: 'My cool block',
+				type: 'core/paragraph',
+				attributes: {
+					content: 'Hello!',
+				},
+			};
+			const state = {
+				reusableBlocks: {
+					[ id ]: expectedReusableBlock,
+				},
+			};
+
+			const actualReusableBlock = getReusableBlock( state, id );
+			expect( actualReusableBlock ).toEqual( expectedReusableBlock );
+		} );
+
+		it( 'should return null when no reusable block exists', () => {
+			const state = {
+				reusableBlocks: {},
+			};
+
+			const reusableBlock = getReusableBlock( state, '358b59ee-bab3-4d6f-8445-e8c6971a5605' );
+			expect( reusableBlock ).toBeNull();
+		} );
+	} );
+
+	describe( 'getReusableBlocks', () => {
+		it( 'should return an array of reusable blocks', () => {
+			const reusableBlock1 = {
+				id: '358b59ee-bab3-4d6f-8445-e8c6971a5605',
+				name: 'My cool block',
+				type: 'core/paragraph',
+				attributes: {
+					content: 'Hello!',
+				},
+			};
+			const reusableBlock2 = {
+				id: '687e1a87-cca1-41f2-a782-197ddaea9abf',
+				name: 'My neat block',
+				type: 'core/paragraph',
+				attributes: {
+					content: 'Goodbye!',
+				},
+			};
+			const state = {
+				reusableBlocks: {
+					[ reusableBlock1.id ]: reusableBlock1,
+					[ reusableBlock2.id ]: reusableBlock2,
+				},
+			};
+
+			const reusableBlocks = getReusableBlocks( state );
+			expect( reusableBlocks ).toEqual( [ reusableBlock1, reusableBlock2 ] );
+		} );
+
+		it( 'should return an empty array when no reusable blocks exist', () => {
+			const state = {
+				reusableBlocks: {},
+			};
+
+			const reusableBlocks = getReusableBlocks( state );
+			expect( reusableBlocks ).toEqual( [] );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description

Adds the actions, selectors and reducers necessary for supporting reusable blocks. There are 5 actions:

- `FETCH_REUSABLE_BLOCKS`—Loads reusable blocks from the API and inserts them into the store.
- `UPDATE_REUSABLE_BLOCK`—Inserts and updates a reusable block that is in the store.
- `SAVE_REUSABLE_BLOCK`—Persists a reusable block that's in the store to the API.
- `MAKE_BLOCK_STATIC`—Transforms a reusable block on the page into a regular block.
- `MAKE_BLOCK_REUSABLE`—Transforms a regular block on the page into a reusable block.

https://github.com/WordPress/gutenberg/issues/1516 describes the feature and https://github.com/WordPress/gutenberg/issues/2081 (https://github.com/WordPress/gutenberg/issues/2081#issuecomment-325231157, in particular) describes the technical approach I'm taking.

This PR is a subset of https://github.com/WordPress/gutenberg/pull/2659, which was too large. Check it out though if you'd like to play with the complete feature!

## How Has This Been Tested?

Unit tests are included for the new actions, selectors and reducers. 

I changed the inserter to ignore blocks that are marked with `isPrivate: true`, so it's worth testing the inserter to make sure that there are no regressions.

---
cc. @mtias @aduth @youknowriad 

❤️