### PR TITLE
Drop undefined blocks from recent blocks selectors

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -13,6 +13,7 @@ import {
 	values,
 	keys,
 	without,
+	compact,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -897,7 +898,7 @@ export function getNotices( state ) {
  */
 export function getRecentlyUsedBlocks( state ) {
 	// resolves the block names in the state to the block type settings
-	return state.preferences.recentlyUsedBlocks.map( blockType => getBlockType( blockType ) );
+	return compact( state.preferences.recentlyUsedBlocks.map( blockType => getBlockType( blockType ) ) );
 }
 
 /**
@@ -913,9 +914,10 @@ export const getMostFrequentlyUsedBlocks = createSelector(
 		const { blockUsage } = state.preferences;
 		const orderedByUsage = keys( blockUsage ).sort( ( a, b ) => blockUsage[ b ] - blockUsage[ a ] );
 		// add in paragraph and image blocks if they're not already in the usage data
-		return [ ...orderedByUsage, ...without( [ 'core/paragraph', 'core/image' ], ...orderedByUsage ) ]
-			.slice( 0, MAX_FREQUENT_BLOCKS )
-			.map( blockType => getBlockType( blockType ) );
+		return compact(
+				[ ...orderedByUsage, ...without( [ 'core/paragraph', 'core/image' ], ...orderedByUsage ) ]
+					.map( blockType => getBlockType( blockType ) )
+			).slice( 0, MAX_FREQUENT_BLOCKS );
 	},
 	( state ) => state.preferences.blockUsage
 );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -64,6 +64,7 @@ import {
 	getSuggestedPostFormat,
 	getNotices,
 	getMostFrequentlyUsedBlocks,
+	getRecentlyUsedBlocks,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -1800,6 +1801,19 @@ describe( 'selectors', () => {
 
 			expect( getMostFrequentlyUsedBlocks( state ).map( ( block ) => block.name ) )
 				.toEqual( [ 'core/image', 'core/paragraph', 'core/quote' ] );
+		} );
+	} );
+
+	describe( 'getRecentlyUsedBlocks', () => {
+		it( 'should return the most recently used blocks', () => {
+			const state = {
+				preferences: {
+					recentlyUsedBlocks: [ 'core/deleted-block', 'core/paragraph', 'core/image' ],
+				},
+			};
+
+			expect( getRecentlyUsedBlocks( state ).map( ( block ) => block.name ) )
+				.toEqual( [ 'core/paragraph', 'core/image' ] );
 		} );
 	} );
 } );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -1789,6 +1789,7 @@ describe( 'selectors', () => {
 			const state = {
 				preferences: {
 					blockUsage: {
+						'core/deleted-block': 20,
 						'core/paragraph': 4,
 						'core/image': 11,
 						'core/quote': 2,


### PR DESCRIPTION
Sometimes when a plugin's script is loaded after the initial rendering of the Editor, we end up with "undefined" blocks. Not sure this is common use-cases but this is an easy fix.

## Testing instructions:
- Load the editor
- Open the console and unregister a recently used block `wp.blocks.unregisterBlockType`
- Open the inserter
- The inserter should show up with JS errors