### PR TITLE
Adjust classic editor filter order for mce advanced plugin

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -623,7 +623,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 			'baseURL'  => includes_url( 'js/tinymce' ),
 			'suffix'   => SCRIPT_DEBUG ? '' : '.min',
 			'settings' => apply_filters( 'tiny_mce_before_init', array(
-				'external_plugins' => apply_filters( 'mce_external_plugins', array() ),
 				'plugins'          => array_unique( apply_filters( 'tiny_mce_plugins', array(
 					'charmap',
 					'colorpicker',
@@ -674,6 +673,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 				), 'editor' ) ),
 				'toolbar3'         => implode( ',', apply_filters( 'mce_buttons_3', array(), 'editor' ) ),
 				'toolbar4'         => implode( ',', apply_filters( 'mce_buttons_4', array(), 'editor' ) ),
+				'external_plugins' => apply_filters( 'mce_external_plugins', array() ),
 			), 'editor' ),
 		),
 	) );


### PR DESCRIPTION
## Description
One way to fix #2678. @azaozz may want to look into this so that the TinyMCE Advanced plugin does not rely on the order that filters are called. Maybe we need to adjust something that makes this order necessary?

## How Has This Been Tested?
Install TinyMCE Advanced. Load a Classic Text block. Verify that the table button is added to the second button bar.
