### PR TITLE
Components: Avoid passing the `deep` prop down in the NavigableMenu Component

### DIFF
--- a/components/navigable-menu/index.js
+++ b/components/navigable-menu/index.js
@@ -62,7 +62,7 @@ class NavigableMenu extends Component {
 		const { children, ...props } = this.props;
 
 		return (
-			<div ref={ this.bindContainer } { ...omit( props, [ 'orientation', 'onNavigate' ] ) } onKeyDown={ this.onKeyDown }>
+			<div ref={ this.bindContainer } { ...omit( props, [ 'orientation', 'onNavigate', 'deep' ] ) } onKeyDown={ this.onKeyDown }>
 				{ children }
 			</div>
 		);


### PR DESCRIPTION
Testing instructions:

** Check that there's no warning when selecting a block