### PR TITLE
Blocks: Clear selected block when clicking in editor whitespace

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -1,5 +1,6 @@
 .editor-visual-editor {
 	position: relative;
+	height: 100%;
 	margin: 0 auto;
 	padding: 50px 0;	// Floating up/down arrows invisible
 


### PR DESCRIPTION
This pull request seeks to improve block deselection when clicking on the blank canvas of the editor, particularly for new posts. The images below demonstrate the difference in area for which a block selection would be cleared when clicking.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/31555275-669fcb5e-b00e-11e7-807b-a076039502ac.png)|![After](https://user-images.githubusercontent.com/1779930/31555297-847903f2-b00e-11e7-818a-065a43ca52ec.png)

__Testing instructions:__

1. Navigate to Gutenberg > New Post
2. Insert a paragraph block
3. Click in the white space below the block list
4. Note that the block is deselected

__Next steps:__

We need the block to remain selected in some cases when clicking outside the editor, particularly for block settings. However, we should probably make sure that these clicks occur within the editor itself, not in e.g. the admin sidebar.