### PR TITLE
Title: Insert new default block from title enter press

### DIFF
--- a/editor/post-title/index.js
+++ b/editor/post-title/index.js
@@ -12,13 +12,14 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import { getEditedPostTitle } from '../selectors';
-import { editPost, clearSelectedBlock } from '../actions';
+import { insertBlock, editPost, clearSelectedBlock } from '../actions';
 import PostPermalink from '../post-permalink';
 
 /**
@@ -30,11 +31,14 @@ const { ENTER } = keycodes;
 class PostTitle extends Component {
 	constructor() {
 		super( ...arguments );
+
 		this.bindTextarea = this.bindTextarea.bind( this );
 		this.onChange = this.onChange.bind( this );
 		this.onSelect = this.onSelect.bind( this );
 		this.onUnselect = this.onUnselect.bind( this );
 		this.onSelectionChange = this.onSelectionChange.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
+
 		this.state = {
 			isSelected: false,
 		};
@@ -83,6 +87,7 @@ class PostTitle extends Component {
 	onKeyDown( event ) {
 		if ( event.keyCode === ENTER ) {
 			event.preventDefault();
+			this.props.onEnterPress();
 		}
 	}
 
@@ -116,14 +121,13 @@ export default connect(
 	( state ) => ( {
 		title: getEditedPostTitle( state ),
 	} ),
-	( dispatch ) => {
-		return {
-			onUpdate( title ) {
-				dispatch( editPost( { title } ) );
-			},
-			clearSelectedBlock() {
-				dispatch( clearSelectedBlock() );
-			},
-		};
+	{
+		onEnterPress() {
+			return insertBlock( createBlock( getDefaultBlockName() ), 0 );
+		},
+		onUpdate( title ) {
+			return editPost( { title } );
+		},
+		clearSelectedBlock,
 	}
 )( clickOutside( PostTitle ) );


### PR DESCRIPTION
Closes #1650
Related: #2949 (supersedes / alternative)

This pull request seeks to handle an Enter keypress from the title field to insert a new default (paragraph) block in the first position of the post. This enables an easier flow of post authoring from entering a title to starting to create new content.

__Testing instructions:__

Verify for a new and demo content post that pressing enter from anywhere in the title field creates a new paragraph block at the beginning of post content.

__Open questions:__

See previous discussion at https://github.com/WordPress/gutenberg/pull/2949#issuecomment-335565755 . An alternative behavior to the enter press is to handle it as equivalent to the "arrow down" keypress, which for a new post has the same effect in creating a new block at the first position.