### PR TITLE
Block Toolbar: Refactor using KeyboardShorcuts component

### DIFF
--- a/components/keyboard-shortcuts/README.md
+++ b/components/keyboard-shortcuts/README.md
@@ -15,7 +15,6 @@ class SelectAllDetection extends Component {
 		super( ...arguments );
 
 		this.setAllSelected = this.setAllSelected.bind( this );
-		this.save = this.save.bind( this );
 
 		this.state = { isAllSelected: false };
 	}
@@ -24,16 +23,11 @@ class SelectAllDetection extends Component {
 		this.setState( { isAllSelected: true } );
 	}
 
-	save() {
-		this.props.onSave();
-	}
-
 	render() {
 		return (
 			<div>
 				<KeyboardShorcuts shortcuts={ {
 					'mod+a': this.setAllSelected,
-					'mod+s': [ this.save, true ],
 				} } />
 				Combination pressed? { isAllSelected ? 'Yes' : 'No' }
 			</div>
@@ -44,17 +38,31 @@ class SelectAllDetection extends Component {
 
 __Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
 
-__Note:__ The callback will not be invoked if the key combination occurs in an editable field, unless you pass the callback as an array with the callback and `true` as entries of the array respectively. Refer to the example above, and see the `shortcuts` prop documentation for more information.
-
 ## Props
 
 The component accepts the following props:
 
 ### shortcuts
 
-An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed. To capture a key event globally (including within input fields), assign as the value an array with the function callback as the first argument and `true` as the second argument.
+An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed.
 
 - Type: `Object`
+- Required: No
+
+## bindGlobal
+
+By default, a callback will not be invoked if the key combination occurs in an editable field. Pass `bindGlobal` as `true` if the key events should be observed globally, including within editable fields.
+
+- Type: `Boolean`
+- Required: No
+
+_Tip:_ If you need some but not all keyboard events to be observed globally, simply render two distinct `KeyboardShortcuts` elements, one with and one without the `bindGlobal` prop.
+
+## event
+
+By default, a callback is invoked in response to the `keydown` event. To override this, pass `event` with the name of a specific keyboard event.
+
+- Type: `String`
 - Required: No
 
 ## References

--- a/components/keyboard-shortcuts/README.md
+++ b/components/keyboard-shortcuts/README.md
@@ -36,8 +36,6 @@ class SelectAllDetection extends Component {
 }
 ```
 
-__Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
-
 ## Props
 
 The component accepts the following props:
@@ -48,6 +46,10 @@ An object of shortcut bindings, where each key is a keyboard combination, the va
 
 - Type: `Object`
 - Required: No
+
+__Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
+
+__Note:__ The `KeyboardShortcuts` component will not update to reflect a changed `shortcuts` prop. If you need to change shortcuts, mount a separate `KeyboardShortcuts` element, which can be achieved by assigning a unique `key` prop.
 
 ## bindGlobal
 

--- a/components/keyboard-shortcuts/README.md
+++ b/components/keyboard-shortcuts/README.md
@@ -15,6 +15,7 @@ class SelectAllDetection extends Component {
 		super( ...arguments );
 
 		this.setAllSelected = this.setAllSelected.bind( this );
+		this.save = this.save.bind( this );
 
 		this.state = { isAllSelected: false };
 	}
@@ -23,11 +24,16 @@ class SelectAllDetection extends Component {
 		this.setState( { isAllSelected: true } );
 	}
 
+	save() {
+		this.props.onSave();
+	}
+
 	render() {
 		return (
 			<div>
 				<KeyboardShorcuts shortcuts={ {
 					'mod+a': this.setAllSelected,
+					'mod+s': [ this.save, true ],
 				} } />
 				Combination pressed? { isAllSelected ? 'Yes' : 'No' }
 			</div>
@@ -38,7 +44,7 @@ class SelectAllDetection extends Component {
 
 __Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
 
-__Note:__ The callback will not be invoked if the key combination occurs in an editable field.
+__Note:__ The callback will not be invoked if the key combination occurs in an editable field, unless you pass the callback as an array with the callback and `true` as entries of the array respectively. Refer to the example above, and see the `shortcuts` prop documentation for more information.
 
 ## Props
 
@@ -46,7 +52,7 @@ The component accepts the following props:
 
 ### shortcuts
 
-An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed.
+An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed. To capture a key event globally (including within input fields), assign as the value an array with the function callback as the first argument and `true` as the second argument.
 
 - Type: `Object`
 - Required: No

--- a/components/keyboard-shortcuts/index.js
+++ b/components/keyboard-shortcuts/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import Mousetrap from 'mousetrap';
+import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
 import { forEach } from 'lodash';
 
 /**
@@ -13,7 +14,19 @@ class KeyboardShortcuts extends Component {
 	componentWillMount() {
 		this.mousetrap = new Mousetrap;
 		forEach( this.props.shortcuts, ( callback, key ) => {
-			this.mousetrap.bind( key, callback );
+			// Normalize callback, which can be passed as either a function or
+			// an array of [ callback, isGlobal ]
+			let isGlobal = false;
+			if ( Array.isArray( callback ) ) {
+				isGlobal = callback[ 1 ];
+				callback = callback[ 0 ];
+			}
+
+			if ( isGlobal ) {
+				this.mousetrap.bindGlobal( key, callback );
+			} else {
+				this.mousetrap.bind( key, callback );
+			}
 		} );
 	}
 

--- a/components/keyboard-shortcuts/index.js
+++ b/components/keyboard-shortcuts/index.js
@@ -14,19 +14,9 @@ class KeyboardShortcuts extends Component {
 	componentWillMount() {
 		this.mousetrap = new Mousetrap;
 		forEach( this.props.shortcuts, ( callback, key ) => {
-			// Normalize callback, which can be passed as either a function or
-			// an array of [ callback, isGlobal ]
-			let isGlobal = false;
-			if ( Array.isArray( callback ) ) {
-				isGlobal = callback[ 1 ];
-				callback = callback[ 0 ];
-			}
-
-			if ( isGlobal ) {
-				this.mousetrap.bindGlobal( key, callback );
-			} else {
-				this.mousetrap.bind( key, callback );
-			}
+			const { bindGlobal, eventName } = this.props;
+			const bindFn = bindGlobal ? 'bindGlobal' : 'bind';
+			this.mousetrap[ bindFn ]( key, callback, eventName );
 		} );
 	}
 

--- a/components/keyboard-shortcuts/test/index.js
+++ b/components/keyboard-shortcuts/test/index.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import KeyboardShortcuts from '../';
+
+describe( 'KeyboardShortcuts', () => {
+	afterEach( () => {
+		while ( document.body.firstChild ) {
+			document.body.removeChild( document.body.firstChild );
+		}
+	} );
+
+	function keyPress( which, target ) {
+		[ 'keydown', 'keypress', 'keyup' ].forEach( ( eventName ) => {
+			const event = new window.Event( eventName, { bubbles: true } );
+			event.keyCode = which;
+			event.which = which;
+			target.dispatchEvent( event );
+		} );
+	}
+
+	it( 'should capture key events', () => {
+		const spy = jest.fn();
+		mount(
+			<KeyboardShortcuts
+				shortcuts={ {
+					d: spy,
+				} } />
+		);
+
+		keyPress( 68, document );
+
+		expect( spy ).toHaveBeenCalled();
+	} );
+
+	it( 'should capture key events globally', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<div>
+				<KeyboardShortcuts
+					shortcuts={ {
+						d: [ spy, true ],
+					} } />
+				<textarea></textarea>
+			</div>,
+			{ attachTo: attachNode }
+		);
+
+		keyPress( 68, wrapper.find( 'textarea' ).getDOMNode() );
+
+		expect( spy ).toHaveBeenCalled();
+	} );
+} );

--- a/components/keyboard-shortcuts/test/index.js
+++ b/components/keyboard-shortcuts/test/index.js
@@ -46,8 +46,9 @@ describe( 'KeyboardShortcuts', () => {
 		const wrapper = mount(
 			<div>
 				<KeyboardShortcuts
+					bindGlobal
 					shortcuts={ {
-						d: [ spy, true ],
+						d: spy,
 					} } />
 				<textarea></textarea>
 			</div>,
@@ -57,5 +58,28 @@ describe( 'KeyboardShortcuts', () => {
 		keyPress( 68, wrapper.find( 'textarea' ).getDOMNode() );
 
 		expect( spy ).toHaveBeenCalled();
+	} );
+
+	it( 'should capture key events on specific event', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<div>
+				<KeyboardShortcuts
+					eventName="keyup"
+					shortcuts={ {
+						d: spy,
+					} } />
+				<textarea></textarea>
+			</div>,
+			{ attachTo: attachNode }
+		);
+
+		keyPress( 68, wrapper.find( 'textarea' ).getDOMNode() );
+
+		expect( spy ).toHaveBeenCalled();
+		expect( spy.mock.calls[ 0 ][ 0 ].type ).toBe( 'keyup' );
 	} );
 } );

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress Dependencies
  */
-import { IconButton, Toolbar, NavigableMenu, Slot } from '@wordpress/components';
+import { IconButton, Toolbar, NavigableMenu, Slot, KeyboardShortcuts } from '@wordpress/components';
 import { Component, Children, findDOMNode } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { focus, keycodes } from '@wordpress/utils';
@@ -19,47 +19,29 @@ import './style.scss';
 import BlockSwitcher from '../block-switcher';
 import BlockMover from '../block-mover';
 import BlockRightMenu from '../block-settings-menu';
-import { isMac } from '../utils/dom';
 
 /**
  * Module Constants
  */
-const { ESCAPE, F10 } = keycodes;
+const { ESCAPE } = keycodes;
 
 function FirstChild( { children } ) {
 	const childrenArray = Children.toArray( children );
 	return childrenArray[ 0 ] || null;
 }
 
-function metaKeyPressed( event ) {
-	return isMac() ? event.metaKey : ( event.ctrlKey && ! event.altKey );
-}
-
 class BlockToolbar extends Component {
 	constructor() {
 		super( ...arguments );
+
 		this.toggleMobileControls = this.toggleMobileControls.bind( this );
 		this.bindNode = this.bindNode.bind( this );
-		this.onKeyUp = this.onKeyUp.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
+		this.focusToolbar = this.focusToolbar.bind( this );
 		this.onToolbarKeyDown = this.onToolbarKeyDown.bind( this );
+
 		this.state = {
 			showMobileControls: false,
 		};
-
-		// it's not easy to know if the user only clicked on a "meta" key without simultaneously clicking on another key
-		// We keep track of the key counts to ensure it's reliable
-		this.metaCount = 0;
-	}
-
-	componentDidMount() {
-		document.addEventListener( 'keyup', this.onKeyUp );
-		document.addEventListener( 'keydown', this.onKeyDown );
-	}
-
-	componentWillUnmount() {
-		document.removeEventListener( 'keyup', this.onKeyUp );
-		document.removeEventListener( 'keydown', this.onKeyDown );
 	}
 
 	bindNode( ref ) {
@@ -72,21 +54,10 @@ class BlockToolbar extends Component {
 		} ) );
 	}
 
-	onKeyDown( event ) {
-		if ( metaKeyPressed( event ) ) {
-			this.metaCount++;
-		}
-	}
-
-	onKeyUp( event ) {
-		const shouldFocusToolbar = this.metaCount === 1 || ( event.keyCode === F10 && event.altKey );
-		this.metaCount = 0;
-
-		if ( shouldFocusToolbar ) {
-			const tabbables = focus.tabbable.find( this.toolbar );
-			if ( tabbables.length ) {
-				tabbables[ 0 ].focus();
-			}
+	focusToolbar() {
+		const tabbables = focus.tabbable.find( this.toolbar );
+		if ( tabbables.length ) {
+			tabbables[ 0 ].focus();
 		}
 	}
 
@@ -128,6 +99,10 @@ class BlockToolbar extends Component {
 					role="toolbar"
 					deep
 				>
+					<KeyboardShortcuts shortcuts={ {
+						mod: [ this.focusToolbar, true ],
+						'alt+f10': [ this.focusToolbar, true ],
+					} } />
 					<div className="editor-block-toolbar__group" onKeyDown={ this.onToolbarKeyDown }>
 						{ ! showMobileControls && [
 							<BlockSwitcher key="switcher" uid={ uid } />,

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -99,10 +99,14 @@ class BlockToolbar extends Component {
 					role="toolbar"
 					deep
 				>
-					<KeyboardShortcuts shortcuts={ {
-						mod: [ this.focusToolbar, true ],
-						'alt+f10': [ this.focusToolbar, true ],
-					} } />
+					<KeyboardShortcuts
+						bindGlobal
+						eventName="keyup"
+						shortcuts={ {
+							mod: this.focusToolbar,
+							'alt+f10': this.focusToolbar,
+						} }
+					/>
 					<div className="editor-block-toolbar__group" onKeyDown={ this.onToolbarKeyDown }>
 						{ ! showMobileControls && [
 							<BlockSwitcher key="switcher" uid={ uid } />,

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -86,12 +86,3 @@ export function placeCaretAtEdge( container, start = false ) {
 	sel.addRange( range );
 	container.focus();
 }
-
-/**
- * Checks whether the user is on MacOS or not
- *
- * @return {Boolean}           Is Mac or Not
- */
-export function isMac() {
-	return window.navigator.platform.toLowerCase().indexOf( 'mac' ) !== -1;
-}


### PR DESCRIPTION
Related: #2960 (specifically https://github.com/WordPress/gutenberg/pull/2960#discussion_r144940137)
Cherry-picks 334351cfd4213483cc69924d21a58c8b373a51d0 from #2863

This pull request seeks to refactor keyboard event handling introduced in #2960 to use the KeyboardShortcuts component, which abstracts many of the complexities of keyboard combinations and OS-varying modifiers.

The main challenge with this implementation is that [Mousetrap](https://craig.is/killing/mice) (the underlying library behind KeyboardShortcuts) does not trigger callbacks if the keyboard combination is fired while within an input, except via its [global binding extension](https://craig.is/killing/mice#extensions). Since this was already implemented for #2863 (work-in-progress), it was merely cherry-picked for this pull request.

This pull request does not seek to implement any of the follow-up tasks from #2960. It is purely a refactor of existing behaviors.

__Testing instructions:__

Repeat testing instructions from #2960, verifying no regressions. From what I can tell from the discussion of #2960, this means: Pressing Ctrl (Windows) or Cmd (Mac) or a combination of Alt+F10 while a block is focused should move focus to the toolbar.