### PR TITLE
Button Block: Added configurable text color.

### DIFF
--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { IconButton, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -48,6 +48,9 @@ registerBlockType( 'core/button', {
 		color: {
 			type: 'string',
 		},
+		textColor: {
+			type: 'string',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -66,7 +69,7 @@ registerBlockType( 'core/button', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus, className } ) {
-		const { text, url, title, align, color, clear } = attributes;
+		const { text, url, title, align, color, textColor, clear } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const toggleClear = () => setAttributes( { clear: ! clear } );
 
@@ -85,6 +88,9 @@ registerBlockType( 'core/button', {
 					onFocus={ setFocus }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+					style={ {
+						color: textColor,
+					} }
 					keepPlaceholderOnFocus
 				/>
 				{ focus &&
@@ -109,16 +115,18 @@ registerBlockType( 'core/button', {
 							checked={ !! clear }
 							onChange={ toggleClear }
 						/>
-
-						<ColorPalette
-							value={ color }
-							onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
-						/>
-						<InspectorControls.TextControl
-							label={ __( 'Hex Color' ) }
-							value={ color || '' }
-							onChange={ ( value ) => setAttributes( { color: value } ) }
-						/>
+						<PanelBody title={ __( 'Button Background Color' ) }>
+							<ColorPalette
+								value={ color }
+								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
+							/>
+						</PanelBody>
+						<PanelBody title={ __( 'Button Text Color' ) }>
+							<ColorPalette
+								value={ textColor }
+								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
+							/>
+						</PanelBody>
 					</InspectorControls>
 				}
 			</span>,
@@ -126,11 +134,11 @@ registerBlockType( 'core/button', {
 	},
 
 	save( { attributes } ) {
-		const { url, text, title, align, color } = attributes;
+		const { url, text, title, align, color, textColor } = attributes;
 
 		return (
 			<div className={ `align${ align }` } style={ { backgroundColor: color } }>
-				<a href={ url } title={ title }>
+				<a href={ url } title={ title } style={ { color: textColor } }>
 					{ text }
 				</a>
 			</div>


### PR DESCRIPTION
## Description
This PR adds the option to set the text color of a button as specified in issue https://github.com/WordPress/gutenberg/issues/2766.

## Testing instructions

1. Create a new post/edit an existing one.
2. Add a button.
3. Go to the block inspector set the background color and the text color.
4. Verify the chosen colors appear in the editor, save the post publish and verify the button appears with correct colors.

## Screenshots:
<img width="1008" alt="screen shot 2017-10-17 at 09 13 19" src="https://user-images.githubusercontent.com/11271197/31654056-b08d79c6-b31c-11e7-9018-c6ee3be8e83a.png">

## Some notes:
The background and text color configurators are very similar to the ones in the paragraph, and other components will probably have it too. I think maybe creating a new component to choose the colors for background and text may be a good idea. This component than would be able to have a contrast verification feature as being discussed in https://github.com/WordPress/gutenberg/issues/2381. If you prefer this approach let me know, and I will create a new component and use it in paragraph and button.
