### PR TITLE
Chrome: Fix new posts publish button label

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -310,7 +310,10 @@ export function isEditedPostSaveable( state ) {
  */
 export function isEditedPostBeingScheduled( state ) {
 	const date = getEditedPostAttribute( state, 'date' );
-	return moment( date ).isAfter( moment() );
+	// Adding 1 minute as an error threshold between the server and the client dates.
+	const now = moment().add( 1, 'minute' );
+
+	return moment( date ).isAfter( now );
 }
 
 /**


### PR DESCRIPTION
To decide which label to show in the publish button, we compare the post’s date (sent by the server) and the current’s datetime (generated in the client). For new posts, I’m seeing that the date sent by the server is 2 seconds ahead of the date generated by the client which is odd because technically the client is rendered after the server.

- I wonder if there hasn’t been a change in how the server generates the default date (maybe adding a small delay or something)
- Not perfect but my fix for this i to add an error threshold of 5 minutes to the date generated by the client.

**Testing instructions**

 - Check that the publish button's label is "Publish" for new posts.