### PR TITLE
Block API: Adding a Block API flag to disable the block's HTML mode

### DIFF
--- a/blocks/library/categories/index.js
+++ b/blocks/library/categories/index.js
@@ -44,6 +44,8 @@ registerBlockType( 'core/categories', {
 		},
 	},
 
+	supportHTML: false,
+
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
 		if ( 'left' === align || 'right' === align || 'full' === align ) {

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -31,6 +31,8 @@ registerBlockType( 'core/html', {
 
 	className: false,
 
+	supportHTML: false,
+
 	attributes: {
 		content: {
 			type: 'string',

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -36,6 +36,8 @@ registerBlockType( 'core/latest-posts', {
 
 	keywords: [ __( 'recent posts' ) ],
 
+	supportHTML: false,
+
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
 		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -23,6 +23,8 @@ registerBlockType( 'core/more', {
 
 	className: false,
 
+	supportHTML: false,
+
 	attributes: {
 		customText: {
 			type: 'string',

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -129,6 +129,18 @@ Anchors let you link directly to a specific block on a page. This property adds 
 supportAnchor: true,
 ```
 
+#### supportHTML (optional)
+
+* **Type:** `Bool`
+* **Default:** `true`
+
+Whether a block can be edited in HTML mode.
+
+```js
+// Remove support for an HTML mode.
+supportHTML: false,
+```
+
 ## Edit and Save
 
 The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](/block-edit-save/).

--- a/editor/block-settings-menu/block-mode-toggle.js
+++ b/editor/block-settings-menu/block-mode-toggle.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/components';
+import { getBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { getBlockMode, getBlock } from '../selectors';
+import { toggleBlockMode } from '../actions';
+
+export function BlockModeToggle( { blockType, mode, onToggleMode } ) {
+	if ( ! blockType || blockType.supportHTML === false ) {
+		return null;
+	}
+
+	return (
+		<IconButton
+			className="editor-block-settings-menu__control"
+			onClick={ onToggleMode }
+			icon="html"
+		>
+			{ mode === 'visual'
+				? __( 'Edit as HTML' )
+				: __( 'Edit visually' )
+			}
+		</IconButton>
+	);
+}
+
+export default connect(
+	( state, { uid } ) => {
+		const block = getBlock( state, uid );
+
+		return {
+			mode: getBlockMode( state, uid ),
+			blockType: block ? getBlockType( block.name ) : null,
+		};
+	},
+	( dispatch, { onToggle = noop, uid } ) => ( {
+		onToggleMode() {
+			dispatch( toggleBlockMode( uid ) );
+			onToggle();
+		},
+	} )
+)( BlockModeToggle );

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -9,14 +9,15 @@ import { flow } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { isEditorSidebarOpened, getBlockMode } from '../selectors';
+import { isEditorSidebarOpened, getBlockMode, getBlock } from '../selectors';
 import { removeBlocks, toggleSidebar, setActivePanel, toggleBlockMode } from '../actions';
 
-function BlockSettingsMenuContent( { mode, uids, isSidebarOpened, onDelete, onToggleSidebar, onShowInspector, onToggleMode, onClose } ) {
+export function BlockSettingsMenuContent( { blockType, mode, uids, isSidebarOpened, onDelete, onToggleSidebar, onShowInspector, onToggleMode, onClose } ) {
 	const count = uids.length;
 	const toggleInspector = () => {
 		onShowInspector();
@@ -34,7 +35,7 @@ function BlockSettingsMenuContent( { mode, uids, isSidebarOpened, onDelete, onTo
 			>
 				{ __( 'Settings' ) }
 			</IconButton>
-			{ count === 1 &&
+			{ count === 1 && blockType && blockType.supportHTML !== false &&
 				<IconButton
 					className="editor-block-settings-menu__control"
 					onClick={ flow( onToggleMode, onClose ) }
@@ -61,6 +62,7 @@ export default connect(
 	( state, { uids } ) => ( {
 		isSidebarOpened: isEditorSidebarOpened( state ),
 		mode: uids.length === 1 ? getBlockMode( state, uids[ 0 ] ) : null,
+		blockType: uids.length === 1 ? getBlockType( getBlock( state, uids[ 0 ] ).name ) : null,
 	} ),
 	( dispatch, ownProps ) => ( {
 		onDelete() {

--- a/editor/block-settings-menu/content.js
+++ b/editor/block-settings-menu/content.js
@@ -9,15 +9,15 @@ import { flow } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
-import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { isEditorSidebarOpened, getBlockMode, getBlock } from '../selectors';
-import { removeBlocks, toggleSidebar, setActivePanel, toggleBlockMode } from '../actions';
+import BlockModeToggle from './block-mode-toggle';
+import { isEditorSidebarOpened } from '../selectors';
+import { removeBlocks, toggleSidebar, setActivePanel } from '../actions';
 
-export function BlockSettingsMenuContent( { blockType, mode, uids, isSidebarOpened, onDelete, onToggleSidebar, onShowInspector, onToggleMode, onClose } ) {
+export function BlockSettingsMenuContent( { uids, isSidebarOpened, onDelete, onToggleSidebar, onShowInspector, onClose } ) {
 	const count = uids.length;
 	const toggleInspector = () => {
 		onShowInspector();
@@ -35,18 +35,7 @@ export function BlockSettingsMenuContent( { blockType, mode, uids, isSidebarOpen
 			>
 				{ __( 'Settings' ) }
 			</IconButton>
-			{ count === 1 && blockType && blockType.supportHTML !== false &&
-				<IconButton
-					className="editor-block-settings-menu__control"
-					onClick={ flow( onToggleMode, onClose ) }
-					icon="html"
-				>
-					{ mode === 'visual'
-						? __( 'Edit as HTML' )
-						: __( 'Edit visually' )
-					}
-				</IconButton>
-			}
+			{ count === 1 && <BlockModeToggle uid={ uids[ 0 ] } onToggle={ onClose } /> }
 			<IconButton
 				className="editor-block-settings-menu__control"
 				onClick={ flow( onDelete ) }
@@ -59,10 +48,8 @@ export function BlockSettingsMenuContent( { blockType, mode, uids, isSidebarOpen
 }
 
 export default connect(
-	( state, { uids } ) => ( {
+	( state ) => ( {
 		isSidebarOpened: isEditorSidebarOpened( state ),
-		mode: uids.length === 1 ? getBlockMode( state, uids[ 0 ] ) : null,
-		blockType: uids.length === 1 ? getBlockType( getBlock( state, uids[ 0 ] ).name ) : null,
 	} ),
 	( dispatch, ownProps ) => ( {
 		onDelete() {
@@ -73,9 +60,6 @@ export default connect(
 		},
 		onToggleSidebar() {
 			dispatch( toggleSidebar() );
-		},
-		onToggleMode() {
-			dispatch( toggleBlockMode( ownProps.uids[ 0 ] ) );
 		},
 	} )
 )( BlockSettingsMenuContent );

--- a/editor/block-settings-menu/test/block-mode-toggle.js
+++ b/editor/block-settings-menu/test/block-mode-toggle.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { BlockModeToggle } from '../block-mode-toggle';
+
+describe( 'BlockModeToggle', () => {
+	it( 'should not render the HTML mode button if the block doesn\'t support it', () => {
+		const wrapper = shallow(
+			<BlockModeToggle blockType={ { supportHTML: false } } />
+		);
+
+		expect( wrapper.equals( null ) ).toBe( true );
+	} );
+
+	it( 'should render the HTML mode button', () => {
+		const wrapper = shallow(
+			<BlockModeToggle
+				blockType={ { supportHTML: true } }
+				mode="visual"
+			/>
+		);
+		const text = wrapper.find( 'IconButton' ).first().prop( 'children' );
+
+		expect( text ).toEqual( 'Edit as HTML' );
+	} );
+
+	it( 'should render the Visual mode button', () => {
+		const wrapper = shallow(
+			<BlockModeToggle
+				blockType={ { supportHTML: true } }
+				mode="html"
+			/>
+		);
+		const text = wrapper.find( 'IconButton' ).first().prop( 'children' );
+
+		expect( text ).toEqual( 'Edit visually' );
+	} );
+} );

--- a/editor/block-settings-menu/test/content.js
+++ b/editor/block-settings-menu/test/content.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { BlockSettingsMenuContent } from '../content';
+
+describe( 'BlockSettingsMenuContent', () => {
+	const handlers = {
+		onDelete: noop, onToggleSidebar: noop, onShowInspector: noop, onToggleMode: noop, onClose: noop,
+	};
+
+	it( 'should not render the HTML mode button on multiselection', () => {
+		const wrapper = shallow( <BlockSettingsMenuContent uids={ [ 1, 2 ] } { ...handlers } /> );
+		const buttons = wrapper.find( 'IconButton' ).map( ( button ) => button.prop( 'children' ) );
+
+		expect( buttons ).toEqual( [ 'Settings', 'Delete' ] );
+	} );
+
+	it( 'should not render the HTML mode button if the block doesn\'t support it', () => {
+		const wrapper = shallow(
+			<BlockSettingsMenuContent uids={ [ 1 ] } blockType={ { supportHTML: false } } { ...handlers } />
+		);
+		const buttons = wrapper.find( 'IconButton' ).map( ( button ) => button.prop( 'children' ) );
+
+		expect( buttons ).toEqual( [ 'Settings', 'Delete' ] );
+	} );
+
+	it( 'should render the HTML mode button', () => {
+		const wrapper = shallow(
+			<BlockSettingsMenuContent
+				uids={ [ 1 ] }
+				blockType={ { supportHTML: true } }
+				mode="visual"
+				{ ...handlers }
+			/>
+		);
+		const buttons = wrapper.find( 'IconButton' ).map( ( button ) => button.prop( 'children' ) );
+
+		expect( buttons ).toEqual( [ 'Settings', 'Edit as HTML', 'Delete' ] );
+	} );
+
+	it( 'should render the Visual mode button', () => {
+		const wrapper = shallow(
+			<BlockSettingsMenuContent
+				uids={ [ 1 ] }
+				blockType={ { supportHTML: true } }
+				mode="html"
+				{ ...handlers }
+			/>
+		);
+		const buttons = wrapper.find( 'IconButton' ).map( ( button ) => button.prop( 'children' ) );
+
+		expect( buttons ).toEqual( [ 'Settings', 'Edit visually', 'Delete' ] );
+	} );
+} );

--- a/editor/block-settings-menu/test/content.js
+++ b/editor/block-settings-menu/test/content.js
@@ -11,50 +11,22 @@ import { BlockSettingsMenuContent } from '../content';
 
 describe( 'BlockSettingsMenuContent', () => {
 	const handlers = {
-		onDelete: noop, onToggleSidebar: noop, onShowInspector: noop, onToggleMode: noop, onClose: noop,
+		onDelete: noop, onToggleSidebar: noop, onShowInspector: noop, onClose: noop,
 	};
 
 	it( 'should not render the HTML mode button on multiselection', () => {
 		const wrapper = shallow( <BlockSettingsMenuContent uids={ [ 1, 2 ] } { ...handlers } /> );
-		const buttons = wrapper.find( 'IconButton' ).map( ( button ) => button.prop( 'children' ) );
+		const blockModeToggle = wrapper.find( 'Connect(BlockModeToggle)' );
 
-		expect( buttons ).toEqual( [ 'Settings', 'Delete' ] );
+		expect( blockModeToggle.length ).toBe( 0 );
 	} );
 
-	it( 'should not render the HTML mode button if the block doesn\'t support it', () => {
+	it( 'should render the HTML mode if not in a multiselection', () => {
 		const wrapper = shallow(
-			<BlockSettingsMenuContent uids={ [ 1 ] } blockType={ { supportHTML: false } } { ...handlers } />
+			<BlockSettingsMenuContent uids={ [ 1 ] } { ...handlers } />
 		);
-		const buttons = wrapper.find( 'IconButton' ).map( ( button ) => button.prop( 'children' ) );
+		const blockModeToggle = wrapper.find( 'Connect(BlockModeToggle)' );
 
-		expect( buttons ).toEqual( [ 'Settings', 'Delete' ] );
-	} );
-
-	it( 'should render the HTML mode button', () => {
-		const wrapper = shallow(
-			<BlockSettingsMenuContent
-				uids={ [ 1 ] }
-				blockType={ { supportHTML: true } }
-				mode="visual"
-				{ ...handlers }
-			/>
-		);
-		const buttons = wrapper.find( 'IconButton' ).map( ( button ) => button.prop( 'children' ) );
-
-		expect( buttons ).toEqual( [ 'Settings', 'Edit as HTML', 'Delete' ] );
-	} );
-
-	it( 'should render the Visual mode button', () => {
-		const wrapper = shallow(
-			<BlockSettingsMenuContent
-				uids={ [ 1 ] }
-				blockType={ { supportHTML: true } }
-				mode="html"
-				{ ...handlers }
-			/>
-		);
-		const buttons = wrapper.find( 'IconButton' ).map( ( button ) => button.prop( 'children' ) );
-
-		expect( buttons ).toEqual( [ 'Settings', 'Edit visually', 'Delete' ] );
+		expect( blockModeToggle.length ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
closes #2985

This PR adds a `supportHTML` block type property to remove support for the HTML mode. The idea is to fix this issue before the next release.

**Notes**

 - We could consider to infer this from blocks returning `null` in the save function but this is not consistent, Some dynamic blocks can decide to provide fallback HTML and some static blocks could return `null` depending on some attributes.

 - We need to start thinking about unifying all the `support*` flags under a unique property?

**Testing instructions**

 - Check that the HTML, latest posts, categories and more blocks do not support the HTML mode (no button to toggle modes)
