### PR TITLE
Managing multi-block selection with the keyboard

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -77,7 +77,7 @@ class VisualEditorBlockList extends Component {
 		}
 
 		if ( nextProps.multiSelectedBlockUids && nextProps.multiSelectedBlockUids.length > 0 ) {
-			const extent = this.refs[ nextProps.selectionEnd ];
+			const extent = this.nodes[ nextProps.selectionEnd ];
 			scrollIntoView( extent, extent.closest( '.editor-layout__editor' ), {
 				onlyScrollIfNeeded: true,
 			} );

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -6,10 +6,13 @@ import {
 	findLast,
 	flatMap,
 	invert,
+	isEqual,
 	mapValues,
 	noop,
 	throttle,
 } from 'lodash';
+import scrollIntoView from 'dom-scroll-into-view';
+import 'element-closest';
 
 /**
  * WordPress dependencies
@@ -66,6 +69,19 @@ class VisualEditorBlockList extends Component {
 		document.removeEventListener( 'copy', this.onCopy );
 		document.removeEventListener( 'cut', this.onCut );
 		window.removeEventListener( 'mousemove', this.setLastClientY );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( isEqual( this.props.multiSelectedBlockUids, nextProps.multiSelectedBlockUids ) ) {
+			return;
+		}
+
+		if ( nextProps.multiSelectedBlockUids && nextProps.multiSelectedBlockUids.length > 0 ) {
+			const extent = this.refs[ nextProps.selectionEnd ];
+			scrollIntoView( extent, extent.closest( '.editor-layout__editor' ), {
+				onlyScrollIfNeeded: true,
+			} );
+		}
 	}
 
 	setLastClientY( { clientY } ) {

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -12,11 +12,12 @@ const { TEXT_NODE } = window.Node;
 /**
  * Check whether the caret is horizontally at the edge of the container.
  *
- * @param  {Element} container Focusable element.
- * @param  {Boolean} isReverse Set to true to check left, false for right.
- * @return {Boolean}           True if at the edge, false if not.
+ * @param  {Element} container       Focusable element.
+ * @param  {Boolean} isReverse       Set to true to check left, false for right.
+ * @param  {Boolean} collapseRanges  Whether or not to collapse the selection range before the check
+ * @return {Boolean}                 True if at the horizontal edge, false if not.
  */
-export function isHorizontalEdge( container, isReverse ) {
+export function isHorizontalEdge( container, isReverse, collapseRanges = false ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		if ( container.selectionStart !== container.selectionEnd ) {
 			return false;
@@ -34,7 +35,11 @@ export function isHorizontalEdge( container, isReverse ) {
 	}
 
 	const selection = window.getSelection();
-	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+	let range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+	if ( collapseRanges ) {
+		range = range.cloneRange();
+		range.collapse( isReverse );
+	}
 
 	if ( ! range || ! range.collapsed ) {
 		return false;
@@ -70,11 +75,12 @@ export function isHorizontalEdge( container, isReverse ) {
 /**
  * Check whether the caret is vertically at the edge of the container.
  *
- * @param  {Element} container Focusable element.
- * @param  {Boolean} isReverse Set to true to check top, false for bottom.
- * @return {Boolean}           True if at the edge, false if not.
+ * @param  {Element} container       Focusable element.
+ * @param  {Boolean} isReverse       Set to true to check top, false for bottom.
+ * @param  {Boolean} collapseRanges  Whether or not to collapse the selection range before the check
+ * @return {Boolean}                 True if at the edge, false if not.
  */
-export function isVerticalEdge( container, isReverse ) {
+export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		return isHorizontalEdge( container, isReverse );
 	}
@@ -84,7 +90,14 @@ export function isVerticalEdge( container, isReverse ) {
 	}
 
 	const selection = window.getSelection();
-	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+	let range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+	if ( collapseRanges && ! range.collapsed ) {
+		const newRange = document.createRange();
+		// Get the end point of the selection (see focusNode vs. anchorNode)
+		newRange.setStart( selection.focusNode, selection.focusOffset );
+		newRange.collapse( true );
+		range = newRange;
+	}
 
 	if ( ! range || ! range.collapsed ) {
 		return false;


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Added Shift + arrow keys for multi-block selection

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* some tests were written for a helper method
* has been manually tested

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Introduces a feature to allow shift + up and down to create or expand a multi-selection in WritingFlow. This makes WritingFlow a connected component (to redux), which might not be desirable.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.