### PR TITLE
Use an expandable panel for the post visibility

### DIFF
--- a/editor/header/publish-dropdown/index.js
+++ b/editor/header/publish-dropdown/index.js
@@ -2,20 +2,37 @@
  * WordPress Dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { withAPIData, PanelBody } from '@wordpress/components';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
-import PostVisibility from '../../sidebar/post-visibility';
+import PostVisibilityLabel from '../../post-visibility/label';
+import PostVisibilityForm from '../../post-visibility';
 import PostSchedule from '../../sidebar/post-schedule';
 import PublishButton from '../publish-button';
 
-function PublishDropdown( { onSubmit } ) {
+function PublishDropdown( { user, onSubmit } ) {
+	const canPublish = user.data && user.data.capabilities.publish_posts;
+
 	return (
 		<div className="editor-publish-dropdown">
 			<div><strong>{ __( 'All ready to go!' ) }</strong></div>
-			<PostVisibility />
+			{ ! canPublish &&
+				<div>
+					<span>{ __( 'Visibility' ) }</span>
+					<span><PostVisibilityLabel /></span>
+				</div>
+			}
+			{ canPublish &&
+				<PanelBody initialOpen={ false } title={ [
+					__( 'Visibility: ' ),
+					<PostVisibilityLabel key="label" />,
+				] }>
+					<PostVisibilityForm />
+				</PanelBody>
+			}
 			<PostSchedule />
 			<div className="editor-publish-dropdown__publish-button-container">
 				<PublishButton onSubmit={ onSubmit } />
@@ -24,4 +41,8 @@ function PublishDropdown( { onSubmit } ) {
 	);
 }
 
-export default PublishDropdown;
+export default withAPIData( () => {
+	return {
+		user: '/wp/v2/users/me?context=edit',
+	};
+} )( PublishDropdown );

--- a/editor/header/publish-dropdown/style.scss
+++ b/editor/header/publish-dropdown/style.scss
@@ -1,5 +1,21 @@
 .editor-publish-dropdown {
 	padding: 15px;
+
+	.components-panel__body {
+		margin-left: -16px;
+		margin-right: -16px;
+		margin-bottom: -16px;
+		margin-top: 10px;
+		border: none;
+
+		.components-panel__body-toggle {
+			font-weight: normal;
+		}
+	}
+
+	.editor-post-visibility__dialog-legend {
+		display: none;
+	}
 }
 
 .editor-publish-dropdown__publish-button-container {

--- a/editor/post-visibility/index.js
+++ b/editor/post-visibility/index.js
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { withInstanceId } from '@wordpress/components';
+
+/**
+ * Internal Dependencies
+ */
+import { visibilityOptions } from './utils';
+import {
+	getEditedPostAttribute,
+	getEditedPostVisibility,
+} from '../selectors';
+import { editPost, savePost } from '../actions';
+
+export class PostVisibility extends Component {
+	constructor( props ) {
+		super( ...arguments );
+
+		this.setPublic = this.setPublic.bind( this );
+		this.setPrivate = this.setPrivate.bind( this );
+		this.setPasswordProtected = this.setPasswordProtected.bind( this );
+		this.updatePassword = this.updatePassword.bind( this );
+
+		this.state = {
+			hasPassword: !! props.password,
+		};
+	}
+
+	setPublic() {
+		const { visibility, onUpdateVisibility, status } = this.props;
+
+		onUpdateVisibility( visibility === 'private' ? 'draft' : status );
+		this.setState( { hasPassword: false } );
+	}
+
+	setPrivate() {
+		if ( ! window.confirm( __( 'Would you like to privately publish this post now?' ) ) ) { // eslint-disable-line no-alert
+			return;
+		}
+
+		const { onUpdateVisibility, onSave } = this.props;
+
+		onUpdateVisibility( 'private' );
+		this.setState( { hasPassword: false } );
+		onSave();
+	}
+
+	setPasswordProtected() {
+		const { visibility, onUpdateVisibility, status, password } = this.props;
+
+		onUpdateVisibility( visibility === 'private' ? 'draft' : status, password || '' );
+		this.setState( { hasPassword: true } );
+	}
+
+	updatePassword( event ) {
+		const { status, onUpdateVisibility } = this.props;
+		onUpdateVisibility( status, event.target.value );
+	}
+
+	render() {
+		const { visibility, password, instanceId } = this.props;
+
+		const visibilityHandlers = {
+			public: {
+				onSelect: this.setPublic,
+				checked: visibility === 'public' && ! this.state.hasPassword,
+			},
+			private: {
+				onSelect: this.setPrivate,
+				checked: visibility === 'private',
+			},
+			password: {
+				onSelect: this.setPasswordProtected,
+				checked: this.state.hasPassword,
+			},
+		};
+
+		return [
+			<fieldset key="visibility-selector">
+				<legend className="editor-post-visibility__dialog-legend">
+					{ __( 'Post Visibility' ) }
+				</legend>
+				{ visibilityOptions.map( ( { value, label, info } ) => (
+					<div key={ value } className="editor-post-visibility__choice">
+						<input
+							type="radio"
+							name={ `editor-post-visibility__setting-${ instanceId }` }
+							value={ value }
+							onChange={ visibilityHandlers[ value ].onSelect }
+							checked={ visibilityHandlers[ value ].checked }
+							id={ `editor-post-${ value }-${ instanceId }` }
+							aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
+							className="editor-post-visibility__dialog-radio"
+						/>
+						<label
+							htmlFor={ `editor-post-${ value }-${ instanceId }` }
+							className="editor-post-visibility__dialog-label"
+						>
+							{ label }
+						</label>
+						{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
+					</div>
+				) ) }
+			</fieldset>,
+			this.state.hasPassword && (
+				<div className="editor-post-visibility__dialog-password" key="password-selector">
+					<label
+						htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+						className="screen-reader-text"
+					>
+						{ __( 'Create password' ) }
+					</label>
+					<input
+						className="editor-post-visibility__dialog-password-input"
+						id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+						type="text"
+						onChange={ this.updatePassword }
+						value={ password }
+						placeholder={ __( 'Use a secure password' ) }
+					/>
+				</div>
+			),
+		];
+	}
+}
+
+const applyConnect = connect(
+	( state ) => ( {
+		status: getEditedPostAttribute( state, 'status' ),
+		visibility: getEditedPostVisibility( state ),
+		password: getEditedPostAttribute( state, 'password' ),
+	} ),
+	{
+		onSave: savePost,
+		onUpdateVisibility( status, password = null ) {
+			return editPost( { status, password } );
+		},
+	}
+);
+
+export default flowRight(
+	applyConnect,
+	withInstanceId
+)( PostVisibility );

--- a/editor/post-visibility/label.js
+++ b/editor/post-visibility/label.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { find } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { getEditedPostVisibility } from '../selectors';
+import { visibilityOptions } from './utils';
+
+function PostVisibilityLabel( { visibility } ) {
+	const getVisibilityLabel = () => find( visibilityOptions, { value: visibility } ).label;
+
+	return getVisibilityLabel( visibility );
+}
+
+export default connect(
+	( state ) => ( {
+		visibility: getEditedPostVisibility( state ),
+	} )
+)( PostVisibilityLabel );

--- a/editor/post-visibility/utils.js
+++ b/editor/post-visibility/utils.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress Dependencies
+ */
+import { __ } from 'i18n';
+
+export const visibilityOptions = [
+	{
+		value: 'public',
+		label: __( 'Public' ),
+		info: __( 'Visible to everyone.' ),
+	},
+	{
+		value: 'private',
+		label: __( 'Private' ),
+		info: __( 'Only visible to site admins and editors.' ),
+	},
+	{
+		value: 'password',
+		label: __( 'Password Protected' ),
+		info: __( 'Protected with a password you choose. Only those with the password can view this post.' ),
+	},
+];

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -1,192 +1,46 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import { find, flowRight } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
-import { PanelRow, Dropdown, withInstanceId, withAPIData } from '@wordpress/components';
+import { PanelRow, Dropdown, withAPIData } from '@wordpress/components';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
-import {
-	getEditedPostAttribute,
-	getEditedPostVisibility,
-} from '../../selectors';
-import { editPost, savePost } from '../../actions';
+import PostVisibilityLabel from '../../post-visibility/label';
+import PostVisibilityForm from '../../post-visibility';
 
-export class PostVisibility extends Component {
-	constructor( props ) {
-		super( ...arguments );
+export function PostVisibility( { user } ) {
+	const canEdit = user.data && user.data.capabilities.publish_posts;
 
-		this.setPublic = this.setPublic.bind( this );
-		this.setPrivate = this.setPrivate.bind( this );
-		this.setPasswordProtected = this.setPasswordProtected.bind( this );
-
-		this.state = {
-			hasPassword: !! props.password,
-		};
-	}
-
-	setPublic() {
-		const { visibility, onUpdateVisibility, status } = this.props;
-
-		onUpdateVisibility( visibility === 'private' ? 'draft' : status );
-		this.setState( { hasPassword: false } );
-	}
-
-	setPrivate() {
-		if ( ! window.confirm( __( 'Would you like to privately publish this post now?' ) ) ) { // eslint-disable-line no-alert
-			return;
-		}
-
-		const { onUpdateVisibility, onSave } = this.props;
-
-		onUpdateVisibility( 'private' );
-		this.setState( { hasPassword: false } );
-		onSave();
-	}
-
-	setPasswordProtected() {
-		const { visibility, onUpdateVisibility, status, password } = this.props;
-
-		onUpdateVisibility( visibility === 'private' ? 'draft' : status, password || '' );
-		this.setState( { hasPassword: true } );
-	}
-
-	render() {
-		const { status, visibility, password, onUpdateVisibility, instanceId, user } = this.props;
-		const canEdit = user.data && user.data.capabilities.publish_posts;
-
-		const updatePassword = ( event ) => onUpdateVisibility( status, event.target.value );
-
-		const visibilityOptions = [
-			{
-				value: 'public',
-				label: __( 'Public' ),
-				info: __( 'Visible to everyone.' ),
-				onSelect: this.setPublic,
-				checked: visibility === 'public' && ! this.state.hasPassword,
-			},
-			{
-				value: 'private',
-				label: __( 'Private' ),
-				info: __( 'Only visible to site admins and editors.' ),
-				onSelect: this.setPrivate,
-				checked: visibility === 'private',
-			},
-			{
-				value: 'password',
-				label: __( 'Password Protected' ),
-				info: __( 'Protected with a password you choose. Only those with the password can view this post.' ),
-				onSelect: this.setPasswordProtected,
-				checked: this.state.hasPassword,
-			},
-		];
-		const getVisibilityLabel = () => find( visibilityOptions, { value: visibility } ).label;
-
-		// Disable Reason: The input is inside the label, we shouldn't need the htmlFor
-		/* eslint-disable jsx-a11y/label-has-for */
-		return (
-			<PanelRow className="editor-post-visibility">
-				<span>{ __( 'Visibility' ) }</span>
-				{ ! canEdit && <span>{ getVisibilityLabel( visibility ) }</span> }
-				{ canEdit && (
-					<Dropdown
-						position="bottom left"
-						contentClassName="editor-post-visibility__dialog"
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<button
-								type="button"
-								aria-expanded={ isOpen }
-								className="editor-post-visibility__toggle button-link"
-								onClick={ onToggle }
-							>
-								{ getVisibilityLabel( visibility ) }
-							</button>
-						) }
-						renderContent={ () => ( [
-							<fieldset key="visibility-selector">
-								<legend className="editor-post-visibility__dialog-legend">
-									{ __( 'Post Visibility' ) }
-								</legend>
-								{ visibilityOptions.map( ( { value, label, info, onSelect, checked } ) => (
-									<div key={ value } className="editor-post-visibility__choice">
-										<input
-											type="radio"
-											name={ `editor-post-visibility__setting-${ instanceId }` }
-											value={ value }
-											onChange={ onSelect }
-											checked={ checked }
-											id={ `editor-post-${ value }-${ instanceId }` }
-											aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
-											className="editor-post-visibility__dialog-radio"
-										/>
-										<label
-											htmlFor={ `editor-post-${ value }-${ instanceId }` }
-											className="editor-post-visibility__dialog-label"
-										>
-											{ label }
-										</label>
-										{ <p id={ `editor-post-${ value }-${ instanceId }-description` } className="editor-post-visibility__dialog-info">{ info }</p> }
-									</div>
-								) ) }
-							</fieldset>,
-							this.state.hasPassword && (
-								<div className="editor-post-visibility__dialog-password" key="password-selector">
-									<label
-										htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
-										className="screen-reader-text"
-									>
-										{ __( 'Create password' ) }
-									</label>
-									<input
-										className="editor-post-visibility__dialog-password-input"
-										id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
-										type="text"
-										onChange={ updatePassword }
-										value={ password }
-										placeholder={ __( 'Use a secure password' ) }
-									/>
-								</div>
-							),
-						] ) }
-					/>
-				) }
-			</PanelRow>
-		);
-		/* eslint-enable jsx-a11y/label-has-for */
-	}
+	return (
+		<PanelRow className="editor-post-visibility">
+			<span>{ __( 'Visibility' ) }</span>
+			{ ! canEdit && <span><PostVisibilityLabel /></span> }
+			{ canEdit && (
+				<Dropdown
+					position="bottom left"
+					contentClassName="editor-post-visibility__dialog"
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<button
+							type="button"
+							aria-expanded={ isOpen }
+							className="editor-post-visibility__toggle button-link"
+							onClick={ onToggle }
+						>
+							<PostVisibilityLabel />
+						</button>
+					) }
+					renderContent={ () => <PostVisibilityForm /> }
+				/>
+			) }
+		</PanelRow>
+	);
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		status: getEditedPostAttribute( state, 'status' ),
-		visibility: getEditedPostVisibility( state ),
-		password: getEditedPostAttribute( state, 'password' ),
-	} ),
-	{
-		onSave: savePost,
-		onUpdateVisibility( status, password = null ) {
-			return editPost( { status, password } );
-		},
-	}
-);
-
-const applyWithAPIData = withAPIData( () => {
+export default withAPIData( () => {
 	return {
 		user: '/wp/v2/users/me?context=edit',
 	};
-} );
-
-export default flowRight(
-	applyConnect,
-	applyWithAPIData,
-	withInstanceId
-)( PostVisibility );
+} )( PostVisibility );

--- a/editor/sidebar/post-visibility/test/index.js
+++ b/editor/sidebar/post-visibility/test/index.js
@@ -18,16 +18,16 @@ describe( 'PostVisibility', () => {
 	};
 
 	it( 'should not render the edit link if the user doesn\'t have the right capability', () => {
-		let wrapper = shallow( <PostVisibility visibility="public" user={ {} } /> );
+		let wrapper = shallow( <PostVisibility user={ {} } /> );
 		expect( wrapper.find( 'a' ) ).toHaveLength( 0 );
-		wrapper = shallow( <PostVisibility visibility="public" postType="post" user={
+		wrapper = shallow( <PostVisibility postType="post" user={
 			{ data: { capabilities: { publish_posts: false } } }
 		} /> );
 		expect( wrapper.find( 'Dropdown' ) ).toHaveLength( 0 );
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow( <PostVisibility visibility="public" user={ user } /> );
+		const wrapper = shallow( <PostVisibility user={ user } /> );
 		expect( wrapper.find( 'Dropdown' ) ).not.toHaveLength( 0 );
 	} );
 } );


### PR DESCRIPTION
related https://github.com/WordPress/gutenberg/pull/3036#issuecomment-337178253

This updates the design of the publish dropdown and also fixes the double popover issue.

<img width="314" alt="screen shot 2017-10-17 at 12 12 46" src="https://user-images.githubusercontent.com/272444/31661959-85ac4bfc-b334-11e7-9df9-a5441e48ed1e.png">

**Notes**

The next step would be to do the same for the PostSchedule component