### PR TITLE
Replace hard-coded API version with global config

### DIFF
--- a/editor/header/publish-button/index.js
+++ b/editor/header/publish-button/index.js
@@ -88,7 +88,7 @@ const applyConnect = connect(
 
 const applyWithAPIData = withAPIData( () => {
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: '/${ wpApiSettings.versionString }users/me?context=edit',
 	};
 } );
 

--- a/editor/header/publish-button/label.js
+++ b/editor/header/publish-button/label.js
@@ -46,7 +46,7 @@ const applyConnect = connect(
 
 const applyWithAPIData = withAPIData( () => {
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: '/${ wpApiSettings.versionString }users/me?context=edit',
 	};
 } );
 

--- a/editor/sidebar/featured-image/index.js
+++ b/editor/sidebar/featured-image/index.js
@@ -94,7 +94,7 @@ const applyWithAPIData = withAPIData( ( { featuredImageId } ) => {
 	}
 
 	return {
-		media: `/wp/v2/media/${ featuredImageId }`,
+		media: `/${ wpApiSettings.versionString }media/${ featuredImageId }`,
 	};
 } );
 

--- a/editor/sidebar/last-revision/index.js
+++ b/editor/sidebar/last-revision/index.js
@@ -60,7 +60,7 @@ export default flowRight(
 	withAPIData( ( props, { type } ) => {
 		const { postType, postId } = props;
 		return {
-			revisions: `/wp/v2/${ type( postType ) }/${ postId }/revisions`,
+			revisions: `/${ wpApiSettings.versionString }${ type( postType ) }/${ postId }/revisions`,
 		};
 	} )
 )( LastRevision );

--- a/editor/sidebar/page-attributes/index.js
+++ b/editor/sidebar/page-attributes/index.js
@@ -101,7 +101,7 @@ const applyWithAPIData = withAPIData( ( props ) => {
 	const { postTypeSlug } = props;
 
 	return {
-		postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+		postType: `/${ wpApiSettings.versionString }types/${ postTypeSlug }?context=edit`,
 	};
 } );
 

--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -89,8 +89,8 @@ const applyConnect = connect(
 
 const applyWithAPIData = withAPIData( () => {
 	return {
-		users: '/wp/v2/users?context=edit&per_page=100',
-		user: '/wp/v2/users/me?context=edit',
+		users: `/${ wpApiSettings.versionString }users?context=edit&per_page=100`,
+		user: `/${ wpApiSettings.versionString }users/me?context=edit`,
 	};
 } );
 

--- a/editor/sidebar/post-format/index.js
+++ b/editor/sidebar/post-format/index.js
@@ -92,7 +92,7 @@ export default flowRight( [
 		const { postTypeSlug } = props;
 
 		return {
-			postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+			postType: `/${ wpApiSettings.versionString }types/${ postTypeSlug }?context=edit`,
 		};
 	} ),
 	withInstanceId,

--- a/editor/sidebar/post-pending-status/index.js
+++ b/editor/sidebar/post-pending-status/index.js
@@ -56,7 +56,7 @@ const applyConnect = connect(
 
 const applyWithAPIData = withAPIData( () => {
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/${ wpApiSettings.versionString }users/me?context=edit`,
 	};
 } );
 

--- a/editor/sidebar/post-schedule/index.js
+++ b/editor/sidebar/post-schedule/index.js
@@ -96,7 +96,7 @@ const applyConnect = connect(
 
 const applyWithAPIData = withAPIData( () => {
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/${ wpApiSettings.versionString }users/me?context=edit`,
 	};
 } );
 

--- a/editor/sidebar/post-sticky/index.js
+++ b/editor/sidebar/post-sticky/index.js
@@ -59,7 +59,7 @@ const applyConnect = connect(
 
 const applyWithAPIData = withAPIData( () => {
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/${ wpApiSettings.versionString }users/me?context=edit`,
 	};
 } );
 

--- a/editor/sidebar/post-taxonomies/index.js
+++ b/editor/sidebar/post-taxonomies/index.js
@@ -63,7 +63,7 @@ const applyConnect = connect(
 );
 
 const applyWithAPIData = withAPIData( () => ( {
-	taxonomies: '/wp/v2/taxonomies?context=edit',
+	taxonomies: `/${ wpApiSettings.versionString }taxonomies?context=edit`,
 } ) );
 
 export default flowRight( [

--- a/editor/sidebar/post-visibility/index.js
+++ b/editor/sidebar/post-visibility/index.js
@@ -181,7 +181,7 @@ const applyConnect = connect(
 
 const applyWithAPIData = withAPIData( () => {
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/${ wpApiSettings.versionString }users/me?context=edit`,
 	};
 } );
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This changes editor components to use the global `wpApiSettings.versionString` instead of hardcoding "wp/v2/". This is the same approach used in [lib/client-assets.php](https://github.com/WordPress/gutenberg/blob/21533d24eaa933b45deaee9e8b99b229e83018fa/lib/client-assets.php#L457-L481)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Tested by creating a post and confirming it published correctly.
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.