### PR TITLE
Fix for Text Mode toolbar

### DIFF
--- a/editor/modes/text-editor/style.scss
+++ b/editor/modes/text-editor/style.scss
@@ -132,3 +132,13 @@
 	max-width: $text-editor-max-width;
 	margin: 0 auto;
 }
+
+@media (max-width: 599px) {
+	.editor-layout__editor {
+		margin-top: 56px;
+		@include break-small {
+			margin-top: 0;
+		}
+	}
+}
+


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
The Text Mode toolbar is entirely visible in every screen resolution
## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
With the help of Chrome Inspector
https://github.com/WordPress/gutenberg/issues/3041

## Screenshots (jpeg or gifs if applicable):

## Types of changes
## Checklist: