### PR TITLE
Cover Image Block: Added button.

### DIFF
--- a/blocks/library/cover-image/editor.scss
+++ b/blocks/library/cover-image/editor.scss
@@ -1,3 +1,4 @@
+$blocks-cover-image__button-height: 46px;
 .editor-visual-editor__block[data-type="core/cover-image"] {
 	.blocks-editable__tinymce[data-is-empty="true"]:before {
 		position: inherit;
@@ -17,5 +18,20 @@
 
 	.blocks-editable strong {
 		font-weight: 300;
+	}
+
+	.blocks-format-toolbar__link-modal {
+		z-index: z-index('.blocks-format-toolbar__link-modal');
+		top: $blocks-cover-image__button-height + 2px;
+		left: 50%;
+		transform: translateX( -50% );
+	}
+
+	.blocks-link-url__suggestions {
+		right: -35px;
+	}
+
+	.blocks-editable__tinymce {
+		cursor: text;
 	}
 }

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -139,7 +139,7 @@ registerBlockType( 'core/cover-image', {
 					step={ 10 }
 				/>
 				<ToggleControl
-					label={ __( 'Show Button' ) }
+					label={ __( 'Call to action' ) }
 					checked={ buttonText !== undefined }
 					onChange={ toggleButton }
 				/>

--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -1,3 +1,4 @@
+$blocks-cover-image__button-height: 46px;
 .wp-block-cover-image {
 	position: relative;
 	background-size: cover;
@@ -7,6 +8,7 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	flex-direction: column;
 
 	h2 {
 		color: white;
@@ -42,4 +44,27 @@
 		height: inherit;
 	}
 
+	.wp-block-cover-image__button {
+		margin-top: 30px;
+		font-family: $default-font;
+		display: inline-block;
+		text-decoration: none;
+		font-size: $big-font-size;
+		padding: 0 24px;
+		height: $blocks-cover-image__button-height;
+		line-height: $blocks-cover-image__button-height;
+		border-radius: $blocks-cover-image__button-height / 2;
+		white-space: nowrap;
+		background: $blue-medium-400;
+		color: $white;
+		vertical-align: top;
+		position: relative;
+		cursor: pointer;
+		border: none;
+		box-shadow: none;
+
+		&:hover {
+			color: $white !important;
+		}
+	}
 }


### PR DESCRIPTION
## Description
This PR adds an optional button to the cover image. Allowing button customization options. As specified in issue https://github.com/WordPress/gutenberg/issues/2765.


## Testing

1. Add a cover image. Verify everything works as before.
2. Add a button verify things worked as before.
3. In the cover image enable show button
4. Customize the button of the cover image see things worked as expected.
5. Save the post see the result, see if the result is ok.
6. Open a post with a cover image and button created before this changes and see if they load as expected.


## Screenshots:
<img width="1496" alt="screen shot 2017-10-18 at 09 37 44" src="https://user-images.githubusercontent.com/11271197/31710739-d1def7d6-b3ed-11e7-814b-15294c1490cb.png">



## Notes:
In order to not repeat button block code, 2 components were extracted one that renders button editor and other that render button for saving. This 2 components can be used by other blocks that need a button.
The CSS was a little by trial error maybe it can be improved, but in my tries, this looked like the simplest way.
