### PR TITLE
Fix the line height in the classic text block

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -1,6 +1,6 @@
 .editor-visual-editor__block[data-type="core/freeform"] .blocks-editable__tinymce {
 	p {
-		line-height: inherit;
+		line-height: $editor-line-height;
 	}
 
 	ul, ol {


### PR DESCRIPTION
closes #2957 

<img width="677" alt="screen shot 2017-10-18 at 10 45 28" src="https://user-images.githubusercontent.com/272444/31711973-b8c641f6-b3f1-11e7-93c9-10dc61785988.png">
