### PR TITLE
Components: Fix broken upload button for gallery and image blocks

### DIFF
--- a/components/form-file-upload/style.scss
+++ b/components/form-file-upload/style.scss
@@ -3,9 +3,12 @@
 		font-size: 0;
 		padding: 6px 0 3px;
 
+		@include break-medium() {
+			padding: 0 12px 2px;
+		}
+
 		@include break-large() {
 			font-size: inherit;
-			padding: 0 12px 2px;
 		}
 	}
 }

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -11,7 +11,7 @@
 	overflow: hidden;
 
 	.dashicon {
-		display: block;
+		display: inline-block;
 		flex: 0 0 auto;
 	}
 


### PR DESCRIPTION
## Description

I think this is a regression introduced with this change https://github.com/WordPress/gutenberg/pull/3008/files#diff-243f502da1db094f794fec5ae99b7981R14.

![screen shot 2017-10-18 at 11 59 56](https://user-images.githubusercontent.com/699132/31712610-e628ecac-b3fb-11e7-9bae-0dcc80548737.png)

## How Has This Been Tested?

Manually tested:
- Open Gutenberg editor.
- Inserted Image block.
- Inserted Gallery block,
- Checked all different resolution to make sure it looks good.
- Made sure that inserter button between blocks works as before.

## Screenshots (jpeg or gifs if applicable):

##### Small devices

![screen shot 2017-10-18 at 11 42 11](https://user-images.githubusercontent.com/699132/31712637-fd90b1ea-b3fb-11e7-8742-64b2381d3dd1.png)

##### Medium devices

![screen shot 2017-10-18 at 11 42 25](https://user-images.githubusercontent.com/699132/31712647-029664be-b3fc-11e7-8877-abb8422a8bd4.png)


##### Large devices

![screen shot 2017-10-18 at 11 42 37](https://user-images.githubusercontent.com/699132/31712673-090cfbfa-b3fc-11e7-827f-3e77eb3f799f.png)

##### Inserter button between blocks

![screen shot 2017-10-18 at 11 42 55](https://user-images.githubusercontent.com/699132/31712740-380e63bc-b3fc-11e7-881b-a2594043fe42.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.