### PR TITLE
Don't enqueue Gutenberg styles if Gutenberg isn't running

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -151,7 +151,7 @@ function gutenberg_init( $return, $post ) {
 		return false;
 	}
 
-	gutenberg_is_running( true );
+	add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );
 
 	require_once( ABSPATH . 'wp-admin/admin-header.php' );
 	the_gutenberg_project();
@@ -378,21 +378,4 @@ function gutenberg_add_edit_link( $actions, $post ) {
 	);
 
 	return $actions;
-}
-
-/**
- * Returns whether Gutenberg is running, as determined during gutenberg_init().
- *
- * @since 1.5.0
- *
- * @param bool $running Optional. If passed, sets whether Gutenberg is flagged as running or not.
- *
- * @return bool True if Gutenberg is running, false if it isn't, or it hasn't been decided yet.
- */
-function gutenberg_is_running( $running = null ) {
-	static $is_running;
-	if ( null !== $running ) {
-		$is_running = (bool) $running;
-	}
-	return $is_running;
 }

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -151,6 +151,8 @@ function gutenberg_init( $return, $post ) {
 		return false;
 	}
 
+	gutenberg_is_running( true );
+
 	require_once( ABSPATH . 'wp-admin/admin-header.php' );
 	the_gutenberg_project();
 
@@ -376,4 +378,21 @@ function gutenberg_add_edit_link( $actions, $post ) {
 	);
 
 	return $actions;
+}
+
+/**
+ * Returns whether Gutenberg is running, as determined during gutenberg_init().
+ *
+ * @since 1.5.0
+ *
+ * @param bool $running Optional. If passed, sets whether Gutenberg is flagged as running or not.
+ *
+ * @return bool True if Gutenberg is running, false if it isn't, or it hasn't been decided yet.
+ */
+function gutenberg_is_running( $running = null ) {
+	static $is_running;
+	if ( null !== $running ) {
+		$is_running = (bool) $running;
+	}
+	return $is_running;
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -599,10 +599,6 @@ function gutenberg_color_palette() {
 function gutenberg_editor_scripts_and_styles( $hook ) {
 	$is_demo = isset( $_GET['gutenberg-demo'] );
 
-	if ( ! gutenberg_is_running() ) {
-		return;
-	}
-
 	wp_add_inline_script(
 		'editor', 'window.wp.oldEditor = window.wp.editor;', 'after'
 	);
@@ -810,4 +806,3 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	 */
 	do_action( 'enqueue_block_editor_assets' );
 }
-add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -599,6 +599,10 @@ function gutenberg_color_palette() {
 function gutenberg_editor_scripts_and_styles( $hook ) {
 	$is_demo = isset( $_GET['gutenberg-demo'] );
 
+	if ( ! gutenberg_is_running() ) {
+		return;
+	}
+
 	wp_add_inline_script(
 		'editor', 'window.wp.oldEditor = window.wp.editor;', 'after'
 	);


### PR DESCRIPTION
#2951 introduced a bug where Gutenberg scripts and styles were being enqueued on every page, instead of just the editor page.