### PR TITLE
Editable: Rename wrapperClassname prop to wrapperClassName #3046

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -597,7 +597,7 @@ export default class Editable extends Component {
 			style,
 			value,
 			focus,
-			wrapperClassname,
+			wrapperClassName,
 			className,
 			inlineToolbar = false,
 			formattingControls,
@@ -611,7 +611,7 @@ export default class Editable extends Component {
 		// mount and initialize a new child element in its place.
 		const key = [ 'editor', Tagname ].join();
 		const isPlaceholderVisible = placeholder && ( ! focus || keepPlaceholderOnFocus ) && this.state.empty;
-		const classes = classnames( wrapperClassname, 'blocks-editable' );
+		const classes = classnames( wrapperClassName, 'blocks-editable' );
 
 		const formatToolbar = (
 			<FormatToolbar

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -328,7 +328,7 @@ registerBlockType( 'core/list', {
 					value={ values }
 					focus={ focus }
 					onFocus={ setFocus }
-					wrapperClassname="blocks-list"
+					wrapperClassName="blocks-list"
 					placeholder={ __( 'Write list…' ) }
 					onMerge={ mergeBlocks }
 					onSplit={ ( before, after, ...blocks ) => {

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -80,7 +80,7 @@ registerBlockType( 'core/preformatted', {
 				focus={ focus }
 				onFocus={ setFocus }
 				placeholder={ __( 'Write preformatted text…' ) }
-				wrapperClassname={ className }
+				wrapperClassName={ className }
 			/>,
 		];
 	},

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -79,7 +79,7 @@ registerBlockType( 'core/pullquote', {
 					placeholder={ __( 'Write quote…' ) }
 					focus={ focus && focus.editable === 'value' ? focus : null }
 					onFocus={ ( props ) => setFocus( { ...props, editable: 'value' } ) }
-					wrapperClassname="blocks-pullquote__content"
+					wrapperClassName="blocks-pullquote__content"
 				/>
 				{ ( citation || !! focus ) && (
 					<Editable

--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -98,7 +98,7 @@ export default class TableBlock extends Component {
 			<Editable
 				key="editor"
 				tagName="table"
-				wrapperClassname={ className }
+				wrapperClassName={ className }
 				getSettings={ ( settings ) => ( {
 					...settings,
 					plugins: ( settings.plugins || [] ).concat( 'table' ),

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -72,7 +72,7 @@ registerBlockType( 'core/verse', {
 				focus={ focus }
 				onFocus={ setFocus }
 				placeholder={ __( 'Write…' ) }
-				wrapperClassname={ className }
+				wrapperClassName={ className }
 				formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
 			/>,
 		];

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -307,7 +307,7 @@ class VisualEditorBlock extends Component {
 		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, focus } = this.props;
 		const showUI = isSelected && ( ! this.props.isTyping || focus.collapsed === false );
 		const { error } = this.state;
-		const wrapperClassname = classnames( 'editor-visual-editor__block', {
+		const wrapperClassName = classnames( 'editor-visual-editor__block', {
 			'has-warning': ! isValid || !! error,
 			'is-selected': showUI,
 			'is-multi-selected': isMultiSelected,
@@ -336,7 +336,7 @@ class VisualEditorBlock extends Component {
 				onMouseMove={ this.maybeHover }
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }
-				className={ wrapperClassname }
+				className={ wrapperClassName }
 				data-type={ block.name }
 				tabIndex="0"
 				aria-label={ blockLabel }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR is related to https://github.com/WordPress/gutenberg/issues/3046

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Gutenberg Version: 1.4.0

All current JS tests are passing.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

The wrapperClassname prop of the <Editable> component renamed to wrapperClassName in order to adhere to lower camel case naming, and to be more consistent with React's className prop.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.