### PR TITLE
Updated color picker clear and created a color indication in title.

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -61,15 +61,12 @@ function ColorPalette( { colors, value, onChange } ) {
 				) }
 			/>
 
-			<div className="blocks-color-palette__item-wrapper blocks-color-palette__clear-color">
-				<button
-					className="blocks-color-palette__item"
-					onClick={ () => onChange( undefined ) }
-					aria-label={ __( 'Remove color' ) }
-				>
-					<span className="blocks-color-palette__clear-color-line" />
-				</button>
-			</div>
+			<button className="button-link blocks-color-palette__clear"
+				onClick={ () => onChange( undefined ) }
+				aria-label={ __( 'Remove color' ) }
+			>
+				{ __( 'Clear' ) }
+			</button>
 		</div>
 	);
 }

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -61,9 +61,10 @@ function ColorPalette( { colors, value, onChange } ) {
 				) }
 			/>
 
-			<button className="button-link blocks-color-palette__clear"
+			<button
+				className="button-link blocks-color-palette__clear"
+				type="button"
 				onClick={ () => onChange( undefined ) }
-				aria-label={ __( 'Remove color' ) }
 			>
 				{ __( 'Clear' ) }
 			</button>

--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -3,6 +3,11 @@ $color-palette-circle-spacing: 14px;
 
 .blocks-color-palette {
 	margin-right: -14px;
+
+	.blocks-color-palette__clear {
+		float: right;
+		margin-right: 20px;
+	}
 }
 
 .blocks-color-palette__item-wrapper {

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Dashicon, IconButton, PanelBody } from '@wordpress/components';
+import { Dashicon, IconButton, PanelColor } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -135,18 +135,18 @@ class ButtonBlock extends Component {
 							checked={ !! clear }
 							onChange={ this.toggleClear }
 						/>
-						<PanelBody title={ __( 'Button Background Color' ) }>
+						<PanelColor title={ __( 'Button Background' ) } colorValue={ color }>
 							<ColorPalette
 								value={ color }
 								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
 							/>
-						</PanelBody>
-						<PanelBody title={ __( 'Button Text Color' ) }>
+						</PanelColor>
+						<PanelColor title={ __( 'Button Text' ) } colorValue={ textColor }>
 							<ColorPalette
 								value={ textColor }
 								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
 							/>
-						</PanelBody>
+						</PanelColor>
 						<ContrastChecker
 							textColor={ textColor || fallbackTextColor }
 							backgroundColor={ color || fallbackBackgroundColor }

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -135,13 +135,13 @@ class ButtonBlock extends Component {
 							checked={ !! clear }
 							onChange={ this.toggleClear }
 						/>
-						<PanelColor title={ __( 'Button Background' ) } colorValue={ color } key="panel-color-button-1">
+						<PanelColor title={ __( 'Background Color' ) } colorValue={ color } >
 							<ColorPalette
 								value={ color }
 								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
 							/>
 						</PanelColor>
-						<PanelColor title={ __( 'Button Text' ) } colorValue={ textColor } key="panel-color-button-2">
+						<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } >
 							<ColorPalette
 								value={ textColor }
 								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -135,13 +135,13 @@ class ButtonBlock extends Component {
 							checked={ !! clear }
 							onChange={ this.toggleClear }
 						/>
-						<PanelColor title={ __( 'Button Background' ) } colorValue={ color }>
+						<PanelColor title={ __( 'Button Background' ) } colorValue={ color } key="panel-color-button-1">
 							<ColorPalette
 								value={ color }
 								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
 							/>
 						</PanelColor>
-						<PanelColor title={ __( 'Button Text' ) } colorValue={ textColor }>
+						<PanelColor title={ __( 'Button Text' ) } colorValue={ textColor } key="panel-color-button-2">
 							<ColorPalette
 								value={ textColor }
 								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -131,13 +131,13 @@ registerBlockType( 'core/paragraph', {
 							allowReset
 						/>
 					</PanelBody>
-					<PanelColor title={ __( 'Background' ) } colorValue={ backgroundColor } initialOpen={ false } key="panel-color-paragraph-1">
+					<PanelColor title={ __( 'Background Color' ) } colorValue={ backgroundColor } initialOpen={ false }>
 						<ColorPalette
 							value={ backgroundColor }
 							onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
 						/>
 					</PanelColor>
-					<PanelColor title={ __( 'Text' ) } colorValue={ textColor } initialOpen={ false } key="panel-color-paragraph-2">
+					<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } initialOpen={ false }>
 						<ColorPalette
 							value={ textColor }
 							onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import { concatChildren } from '@wordpress/element';
-import { Autocomplete, PanelBody } from '@wordpress/components';
+import { Autocomplete, PanelBody, PanelColor } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ import { blockAutocompleter, userAutocompleter } from '../../autocompleters';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import BlockControls from '../../block-controls';
+import BlockAutocomplete from '../../block-autocomplete';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
@@ -131,18 +132,18 @@ registerBlockType( 'core/paragraph', {
 							allowReset
 						/>
 					</PanelBody>
-					<PanelBody title={ __( 'Background Color' ) }>
+					<PanelColor title={ __( 'Background' ) } colorValue={ backgroundColor }>
 						<ColorPalette
 							value={ backgroundColor }
 							onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
 						/>
-					</PanelBody>
-					<PanelBody title={ __( 'Text Color' ) }>
+					</PanelColor>
+					<PanelColor title={ __( 'Text' ) } colorValue={ textColor }>
 						<ColorPalette
 							value={ textColor }
 							onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
 						/>
-					</PanelBody>
+					</PanelColor>
 					<PanelBody title={ __( 'Block Alignment' ) }>
 						<BlockAlignmentToolbar
 							value={ width }

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -19,7 +19,6 @@ import { blockAutocompleter, userAutocompleter } from '../../autocompleters';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import BlockControls from '../../block-controls';
-import BlockAutocomplete from '../../block-autocomplete';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
@@ -132,13 +131,13 @@ registerBlockType( 'core/paragraph', {
 							allowReset
 						/>
 					</PanelBody>
-					<PanelColor title={ __( 'Background' ) } colorValue={ backgroundColor }>
+					<PanelColor title={ __( 'Background' ) } colorValue={ backgroundColor } initialOpen={ false } key="panel-color-paragraph-1">
 						<ColorPalette
 							value={ backgroundColor }
 							onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
 						/>
 					</PanelColor>
-					<PanelColor title={ __( 'Text' ) } colorValue={ textColor }>
+					<PanelColor title={ __( 'Text' ) } colorValue={ textColor } initialOpen={ false } key="panel-color-paragraph-2">
 						<ColorPalette
 							value={ textColor }
 							onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }

--- a/components/index.js
+++ b/components/index.js
@@ -19,6 +19,7 @@ export { default as Notice } from './notice';
 export { default as NoticeList } from './notice/list';
 export { default as Panel } from './panel';
 export { default as PanelBody } from './panel/body';
+export { default as PanelColor } from './panel/color';
 export { default as PanelHeader } from './panel/header';
 export { default as PanelRow } from './panel/row';
 export { default as Placeholder } from './placeholder';

--- a/components/panel/color.js
+++ b/components/panel/color.js
@@ -4,11 +4,10 @@
 import './style.scss';
 import PanelBody from './body';
 
-function PanelColor( { colorValue, title, initialOpen = false, ...props } ) {
+function PanelColor( { colorValue, title, ...props } ) {
 	return (
 		<PanelBody
 			{ ...props }
-			initialOpen={ initialOpen }
 			title={ [
 				<span className="components-panel__color-title" key="title">{ title }</span>,
 				colorValue && <span className="components-panel__color-area" key="color" style={ { background: colorValue } } />,

--- a/components/panel/color.js
+++ b/components/panel/color.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import PanelBody from './body';
+
+function PanelColor( { colorValue, title, initialOpen = false, ...props } ) {
+	return (
+		<PanelBody
+			{ ...props }
+			initialOpen={ initialOpen }
+			title={ [
+				<span className="components-panel__color-title" key="title">{ title }</span>,
+				colorValue && <span className="components-panel__color-area" key="color" style={ { background: colorValue } } />,
+			] }
+		/>
+	);
+}
+
+export default PanelColor;

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -85,6 +85,19 @@
 	margin-right: -5px;
 }
 
+.components-panel__color-title {
+	float: left;
+	height: 19px;
+}
+
+.components-panel__color-area {
+	width: 25px;
+	height: 16px;
+	margin-left: 15px;
+	border: 1px solid #DADADA;
+	display: inline-block;
+}
+
 .components-panel__row {
 	display: flex;
 	justify-content: space-between;


### PR DESCRIPTION
## Description
This PR tries to close issue https://github.com/WordPress/gutenberg/issues/2770. By updating color picker to have a clear button in link style. And have a color indication in the panel titles.
## Testing

1. Add a paragraph block, choose a color for text and background, verify the color appears at the side of the title.
2. Repeat for the button block.
3. Collapse the color panels and verify the color indication persists.
4. Use the clear button and verify it clears the color changes. 

## Screenshots
<img width="1070" alt="screen shot 2017-10-18 at 16 19 34" src="https://user-images.githubusercontent.com/11271197/31727011-6f85643e-b420-11e7-907d-b52c6c63ff7e.png">
<img width="1076" alt="screen shot 2017-10-18 at 16 20 07" src="https://user-images.githubusercontent.com/11271197/31727018-764e821e-b420-11e7-9f81-d5466d4d7bdb.png">


