### PR TITLE
Components: Remove focus return handling from Popover

### DIFF
--- a/components/popover/detect-outside.js
+++ b/components/popover/detect-outside.js
@@ -2,17 +2,11 @@
  * External dependencies
  */
 import clickOutside from 'react-click-outside';
-import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import withFocusReturn from '../higher-order/with-focus-return';
 
 class PopoverDetectOutside extends Component {
 	handleClickOutside( event ) {
@@ -27,7 +21,4 @@ class PopoverDetectOutside extends Component {
 	}
 }
 
-export default flowRight( [
-	withFocusReturn,
-	clickOutside,
-] )( PopoverDetectOutside );
+export default clickOutside( PopoverDetectOutside );

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -14,8 +14,11 @@ import { focus, keycodes } from '@wordpress/utils';
  * Internal dependencies
  */
 import './style.scss';
+import withFocusReturn from '../higher-order/with-focus-return';
 import PopoverDetectOutside from './detect-outside';
 import { Slot, Fill } from '../slot-fill';
+
+const FocusManaged = withFocusReturn( ( { children } ) => children );
 
 const { ESCAPE } = keycodes;
 
@@ -260,6 +263,12 @@ class Popover extends Component {
 			</PopoverDetectOutside>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions */
+
+		// Apply focus return behavior except when default focus on open
+		// behavior is disabled.
+		if ( false !== focusOnOpen ) {
+			content = <FocusManaged>{ content }</FocusManaged>;
+		}
 
 		// In case there is no slot context in which to render, default to an
 		// in-place rendering.


### PR DESCRIPTION
Related: #2911, #2888

This pull request seeks to resolve an issue where it requires two subsequent tabs to move between buttons in the block toolbar. This is caused by the `withFocusReturn` applied to Popover forcefully moving focus back to a button after the tooltip is to be dismissed. With #2888 and #2911 the intended behavior of focus returns on toggle button popovers is now managed within the Dropdown component. If Popover were to need to manage this, it should at the very least be excluded on the basis of the `focusOnOpen` prop (which Tooltip explicitly sets as `false`).

__Testing instructions:__

Verify that tabbing through block toolbar options requires a single tab to move through buttons.
Verify there is no regressions in the behavior of focus return for Dropdown components (e.g. pressing escape while inserter is open should return focus to the inserter button).