### PR TITLE
Popover: Visually indicate focus effect on popover content

### DIFF
--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -110,7 +110,7 @@ class Popover extends Component {
 			return;
 		}
 
-		const { content, popover } = this.nodes;
+		const { content } = this.nodes;
 		if ( ! content ) {
 			return;
 		}
@@ -120,8 +120,8 @@ class Popover extends Component {
 		const firstTabbable = focus.tabbable.find( content )[ 0 ];
 		if ( firstTabbable ) {
 			firstTabbable.focus();
-		} else if ( popover ) {
-			popover.focus();
+		} else {
+			content.focus();
 		}
 	}
 
@@ -246,13 +246,13 @@ class Popover extends Component {
 				<div
 					ref={ this.bindNode( 'popover' ) }
 					className={ classes }
-					tabIndex="0"
 					{ ...contentProps }
 					onKeyDown={ this.maybeClose }
 				>
 					<div
 						ref={ this.bindNode( 'content' ) }
 						className="components-popover__content"
+						tabIndex="-1"
 					>
 						{ children }
 					</div>

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -73,6 +73,10 @@
 		width: 300px;
 	}
 
+	&:focus {
+		box-shadow: $button-focus-style;
+	}
+
 	.components-popover.is-top & {
 		bottom: 100%;
 	}

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -74,9 +74,9 @@ describe( 'Popover', () => {
 			wrapper = mount( <Popover /> );
 			wrapper.setProps( { isOpen: true } );
 
-			const popover = wrapper.find( '.components-popover' ).getDOMNode();
+			const content = wrapper.find( '.components-popover__content' ).getDOMNode();
 
-			expect( document.activeElement ).toBe( popover );
+			expect( document.activeElement ).toBe( content );
 		} );
 
 		it( 'should allow focus-on-open behavior to be disabled', () => {

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -108,7 +108,6 @@ class Tooltip extends Component {
 					position={ position }
 					className="components-tooltip"
 					aria-hidden="true"
-					tabIndex={ undefined }
 				>
 					{ text }
 				</Popover>,


### PR DESCRIPTION
This pull request seeks to add styling to indicate the popover content as focus target, used as fallback when there is no tabbable items within the opened popover.

![Focus](https://user-images.githubusercontent.com/1779930/31736413-b364e1d8-b412-11e7-81ca-ff6076b45bae.png)

In master, when tabbing to the Publish button and pressing Space, the popover opens but it is not clear where focus is. In fact, the focus is on the popover content, but this would not be known until trying to tab.

__Open questions:__

- Why is the publish button "focus on open" behavior not causing the Visibility button toggle to be focused?
- Should popover "focus on open" only take effect when triggered by keyboard events? With these changes, the focus halo styles are shown when clicking the publish button.
- Should popover have a non-negative tab index? (i.e. reachable by tabbing) Previously it did, though since the popover is rendered elsewhere in the element tree, the tab position was not consecutive with adjacent siblings elements. With "focus on open" behavior, combined with focus return on closing, it may be the expectation that keyboard focus would be managed as the relationship between the popover and the opening trigger element (should probably be reflected with ownership ARIA attributes).
   - This is related to the `tabIndex` override from Tooltip, where the assumption is that the tooltip should not be tabbable, but effectively it was not anyways because the popover is rendered out of sequence to where the tooltip is shown