### PR TITLE
Components: withAPIData: Populate cached data for initial render

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -11,7 +11,7 @@ import { Component } from 'element';
 /**
  * Internal dependencies
  */
-import request from './request';
+import request, { getCachedResponse } from './request';
 import { getRoute } from './routes';
 
 export default ( mapPropsToData ) => ( WrappedComponent ) => {
@@ -61,6 +61,11 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 					prevDataProps.hasOwnProperty( propName ) &&
 					prevDataProps[ propName ].path === dataProp.path
 				) {
+					return;
+				}
+
+				// Skip request is already assigned via cache
+				if ( dataProp[ this.getResponseDataKey( 'GET' ) ] ) {
 					return;
 				}
 
@@ -181,6 +186,13 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 					// Initialize pending flags as explicitly false
 					const pendingKey = this.getPendingKey( method );
 					result[ propName ][ pendingKey ] = false;
+
+					// If cached data already exists, populate in result
+					const cachedResponse = getCachedResponse( { path, method } );
+					if ( cachedResponse ) {
+						const dataKey = this.getResponseDataKey( method );
+						result[ propName ][ dataKey ] = cachedResponse.body;
+					}
 
 					// Track path for future map skipping
 					result[ propName ].path = path;

--- a/components/higher-order/with-api-data/test/index.js
+++ b/components/higher-order/with-api-data/test/index.js
@@ -9,9 +9,19 @@ import { identity, fromPairs } from 'lodash';
  */
 import withAPIData from '../';
 
-jest.mock( '../request', () => jest.fn( () => Promise.resolve( {
-	body: {},
-} ) ) );
+jest.mock( '../request', () => {
+	const request = jest.fn( () => Promise.resolve( {
+		body: {},
+	} ) );
+
+	request.getCachedResponse = ( { method, path } ) => {
+		return method === 'GET' && '/wp/v2/pages/10' === path
+			? { body: { title: 'OK!' }, headers: [] }
+			: undefined;
+	};
+
+	return request;
+} );
 
 describe( 'withAPIData()', () => {
 	const schema = {
@@ -65,6 +75,29 @@ describe( 'withAPIData()', () => {
 		process.nextTick( () => {
 			expect( wrapper.state( 'dataProps' ).revisions.isLoading ).toBe( false );
 			expect( wrapper.state( 'dataProps' ).revisions.data ).toEqual( {} );
+
+			done();
+		} );
+	} );
+
+	it( 'should preassign cached data', ( done ) => {
+		const wrapper = getWrapper( () => ( {
+			page: '/wp/v2/pages/10',
+		} ) );
+
+		const dataProps = wrapper.state( 'dataProps' );
+		expect( Object.keys( dataProps ) ).toEqual( [ 'page' ] );
+		expect( Object.keys( dataProps.page ) ).toEqual( expect.arrayContaining( [
+			'get',
+			'isLoading',
+			'path',
+			'data',
+		] ) );
+		expect( dataProps.page.isLoading ).toBe( false );
+		expect( wrapper.state( 'dataProps' ).page.data ).toEqual( { title: 'OK!' } );
+
+		process.nextTick( () => {
+			expect( wrapper.state( 'dataProps' ).page.isLoading ).toBe( false );
 
 			done();
 		} );

--- a/components/higher-order/with-api-data/test/request.js
+++ b/components/higher-order/with-api-data/test/request.js
@@ -73,7 +73,7 @@ describe( 'request', () => {
 			cache[ getStablePath( '/wp?c=5&a=5&b=5' ) ] = actualResponse;
 			const cachedResponse = getCachedResponse( {
 				path: '/wp?b=5&c=5&a=5',
-				method: 'post',
+				method: 'POST',
 			} );
 
 			expect( cachedResponse ).toBe( undefined );

--- a/components/higher-order/with-api-data/test/request.js
+++ b/components/higher-order/with-api-data/test/request.js
@@ -5,7 +5,7 @@ import request, {
 	cache,
 	getStablePath,
 	getResponseHeaders,
-	getResponseFromCache,
+	getCachedResponse,
 	getResponseFromNetwork,
 	isRequestMethod,
 } from '../request';
@@ -59,14 +59,34 @@ describe( 'request', () => {
 		} );
 	} );
 
-	describe( 'getResponseFromCache()', () => {
-		it( 'returns response from cache', () => {
-			cache[ getStablePath( '/wp?c=5&a=5&b=5' ) ] = actualResponse;
-			const awaitResponse = getResponseFromCache( {
+	describe( 'getCachedResponse()', () => {
+		it( 'returns undefined for missing cache', () => {
+			const cachedResponse = getCachedResponse( {
 				path: '/wp?b=5&c=5&a=5',
+				method: 'GET',
 			} );
 
-			expect( awaitResponse ).resolves.toEqual( actualResponse );
+			expect( cachedResponse ).toBe( undefined );
+		} );
+
+		it( 'returns undefined for non-GET request', () => {
+			cache[ getStablePath( '/wp?c=5&a=5&b=5' ) ] = actualResponse;
+			const cachedResponse = getCachedResponse( {
+				path: '/wp?b=5&c=5&a=5',
+				method: 'post',
+			} );
+
+			expect( cachedResponse ).toBe( undefined );
+		} );
+
+		it( 'returns response from cache', () => {
+			cache[ getStablePath( '/wp?c=5&a=5&b=5' ) ] = actualResponse;
+			const cachedResponse = getCachedResponse( {
+				path: '/wp?b=5&c=5&a=5',
+				method: 'GET',
+			} );
+
+			expect( cachedResponse ).toEqual( actualResponse );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request seeks to improve the behavior of the `withAPIData` higher-order component to make data available during an initial render if a cached response is already available. Previously, even if the cache value was to become immediately available after mount, it would occur on an update after the initial mount. The changes here not only save a render in these cases, but it also seeks to resolve an issue where the publish dropdown menu doesn't initially focus tabbables within the dropdown menu because capabilities weren't yet known at the time.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```

Verify that there are no regressions in API data behavior, either in cases where data is fetched fresh (e.g. authors) or prepopulated (current user publish permissions).

Verify that the first tabbable panel in the publish menu becomes focused when the menu is opened. See #3057 for more context on whether we want this to occur on click behaviors.