### PR TITLE
Testing: Tidy the existing Jest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,20 +88,9 @@
   },
   "jest": {
     "collectCoverageFrom": [
-      "blocks/**/*.js",
-      "components/**/*.js",
-      "date/**/*.js",
-      "editor/**/*.js",
-      "element/**/*.js",
-      "i18n/**/*.js",
-      "utils/**/*.js"
+      "(blocks|components|date|editor|element|i18n|utils)/**/*.js"
     ],
     "coveragePathIgnorePatterns": [
-      "<rootDir>/components/clipboard-button/index.js",
-      "<rootDir>/components/notice/index.js",
-      "<rootDir>/components/notice/list.js",
-      "<rootDir>/components/form-toggle/index.js",
-      "<rootDir>/components/form-token-field/token.js",
       "<rootDir>/[^/]+/build/index.js",
       ".*/story/[^/]+.js"
     ],
@@ -114,6 +103,7 @@
       "<rootDir>"
     ],
     "setupFiles": [
+      "<rootDir>/test/setup-console.js",
       "<rootDir>/test/setup-globals.js",
       "<rootDir>/test/setup-wp-aliases.js"
     ],

--- a/test/setup-console.js
+++ b/test/setup-console.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-console */
+// Turn various warnings into errors
+console._errorOriginal = console.error;
+console.error = ( ...args ) => {
+	const util = require( 'util' );
+	throw new Error(
+		'Warning caught via console.error: ' +
+		util.format.apply( util, args )
+	);
+};

--- a/test/setup-globals.js
+++ b/test/setup-globals.js
@@ -1,15 +1,3 @@
-// Turn various warnings into errors
-/* eslint-disable no-console */
-console._errorOriginal = console.error;
-console.error = ( ...args ) => {
-	const util = require( 'util' );
-	throw new Error(
-		'Warning caught via console.error: ' +
-		util.format.apply( util, args )
-	);
-};
-/* eslint-enable no-console */
-
 // These are necessary to load TinyMCE successfully
 global.URL = window.URL;
 global.window.tinyMCEPreInit = {
@@ -17,9 +5,9 @@ global.window.tinyMCEPreInit = {
 	// <script> tag where it was loaded from, which of course fails here.
 	baseURL: 'about:blank',
 };
-window.requestAnimationFrame = setTimeout;
-window.cancelAnimationFrame = clearTimeout;
-window.matchMedia = () => ( {
+global.window.requestAnimationFrame = setTimeout;
+global.window.cancelAnimationFrame = clearTimeout;
+global.window.matchMedia = () => ( {
 	matches: false,
 	addListener: () => {},
 	removeListener: () => {},
@@ -52,11 +40,6 @@ global.window._wpDateSettings = {
 		offset: '-5',
 		string: 'America/New_York',
 	},
-};
-
-global.wp = global.wp || {};
-global.wp.a11y = {
-	speak: () => {},
 };
 
 // Setup fake localStorage

--- a/test/setup-wp-aliases.js
+++ b/test/setup-wp-aliases.js
@@ -1,4 +1,5 @@
 // Set up `wp.*` aliases.  Handled by Webpack outside of the test build.
+global.wp = {};
 [
 	'element',
 	'i18n',


### PR DESCRIPTION
## Description

This PR adds a few small tweaks to the existing Jest configuration:
* Removes from the blacklist the files that were throwing errors when executing code coverage with the previous version of Jest.
* Moves `console.error` override to its own file.
* Removed `global.wp.a11y` mock, since we already moved the code to the external package.
* Consolidated `collectCoverageFrom` into one line.

## How Has This Been Tested?
Executed:
`npm run test-unit:coverage`

Travis needs also to be happy about the changes applied :)

## Types of changes
Tweaks (non-breaking change).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.