### PR TITLE
Components: Fix regression introduced in #3050 for the between-inserter

### DIFF
--- a/editor/modes/visual-editor/inserter.js
+++ b/editor/modes/visual-editor/inserter.js
@@ -25,7 +25,6 @@ export class VisualEditorInserter extends Component {
 
 		this.showControls = this.toggleControls.bind( this, true );
 		this.hideControls = this.toggleControls.bind( this, false );
-		this.insertFrequentBlock = this.insertBlock.bind( this );
 
 		this.state = {
 			isShowingControls: false,

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -480,7 +480,6 @@
 	}
 
 	.editor-inserter__toggle.components-button {
-		display: block;
 		margin: 0;
 		padding: 4px;
 		background-color: white;


### PR DESCRIPTION
## Description

It was introduced in #3050. See comment from @aduth (https://github.com/WordPress/gutenberg/pull/3050#issuecomment-337607435):

> 
> This caused a regression on the dimensions occupied by the icon button for the between-inserter, obvious when focus styles are visible:
> 
> ![image](https://user-images.githubusercontent.com/1779930/31723812-debc417a-b3ed-11e7-898b-968c082ef362.png)
> 
> (Notice the focus area is not a perfect circle, rather oblong oval)
> 
> 1. Hover after a block
> 2. Click the inserter
> 3. Press escape


## How Has This Been Tested?

Manually:
1. Hover after a block.
2. Click the inserter.
3. Press escape or click again.

## Screenshots (jpeg or gifs if applicable):

##### Before

![image](https://user-images.githubusercontent.com/1779930/31723812-debc417a-b3ed-11e7-898b-968c082ef362.png)

##### After

![screen shot 2017-10-19 at 11 59 33](https://user-images.githubusercontent.com/699132/31765606-3e752866-b4c5-11e7-83b6-9887046b82ec.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.