### PR TITLE
Fix the Post Edit URL when saving a post/page/CPT

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getGutenbergURL, getWPAdminURL } from './utils/url';
+import { getPostEditUrl, getWPAdminURL } from './utils/url';
 import {
 	resetPost,
 	setupNewPost,
@@ -122,9 +122,7 @@ export default {
 			window.history.replaceState(
 				{ id: post.id },
 				'Post ' + post.id,
-				getGutenbergURL( {
-					post_id: post.id,
-				} )
+				getPostEditUrl( post.id )
 			);
 		}
 	},

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -251,6 +251,13 @@ describe( 'effects', () => {
 	} );
 
 	describe( '.REQUEST_POST_UPDATE_SUCCESS', () => {
+		const historyOriginalSetState = window.history.replaceState;
+		beforeAll( () => {
+			window.history.replaceState = jest.fn();
+		} );
+		afterAll( () => {
+			window.history.replaceState = historyOriginalSetState;
+		} );
 		const handler = effects.REQUEST_POST_UPDATE_SUCCESS;
 		const dispatch = jest.fn();
 		const store = { getState: () => {}, dispatch };

--- a/editor/utils/url.js
+++ b/editor/utils/url.js
@@ -4,14 +4,14 @@
 import { addQueryArgs } from '@wordpress/url';
 
 /**
- * Returns the Gutenberg page URL with extra query strings
+ * Returns the Post's Edit URL
  *
- * @param  {Object} query  Query Args
+ * @param  {Number} postId  Post ID
  *
- * @return {String}        URL
+ * @return {String}         URL
  */
-export function getGutenbergURL( query = {} ) {
-	return addQueryArgs( window.location.href, query );
+export function getPostEditUrl( postId ) {
+	return getWPAdminURL( 'post.php', { post: postId, action: 'edit' } );
 }
 
 /**


### PR DESCRIPTION
This PR fixes the browser's URL when a new post (of any type) get saved.

**Testing instructions**

- click add new post
- write some text
- save draft or wait for autosave
- verify the URL changes to something a la `http://127.0.0.1/wp-admin/post.php?post=199&action=edit`
- reload the page, the content should still be there