### PR TITLE
Hide Extended Settings unless Sidebar is opened

### DIFF
--- a/editor/meta-boxes/style.scss
+++ b/editor/meta-boxes/style.scss
@@ -25,6 +25,12 @@
 	.components-panel__body.is-opened .components-panel__body-toggle {
 		border-bottom: 1px solid $light-gray-500;
 	}
+
+	// don't show unless sidebar is also opened
+	display: none;
+	.is-sidebar-opened & {
+		display: block;
+	}
 }
 
 .editor-meta-boxes__iframe {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -342,6 +342,7 @@
 		line-height: $editor-line-height;
 		cursor: text;
 		left: -1px;
+		max-width: none;	// fixes a bleed issue from the admin
 
 		&:hover {
 			outline: 1px solid $light-gray-500;


### PR DESCRIPTION
This fixes #2849, props @DevinWalker for concept.

Extended settings is the panel at the bottom that holds extra metaboxes. It is present when a plugin adds such metaboxes, otherwise it's not there. Given that the purpose of being able to dismiss the sidebar is for a simpler, lighter, writing experience, it makes sense to hide this panel if the sidebar panel is hidden. This PR does that.

Additionally it fixes a CSS bleed issue for the placeholder text block.

## How Has This Been Tested?

Tested in Chrome, WP Docker, with Yoast SEO enabled.

## Screenshots (jpeg or gifs if applicable):

![screen shot 2017-10-19 at 13 26 10](https://user-images.githubusercontent.com/1204802/31768868-7485b3b0-b4d1-11e7-9034-f25d761f9f26.png)

![screen shot 2017-10-19 at 13 26 12](https://user-images.githubusercontent.com/1204802/31768872-765233bc-b4d1-11e7-8a3c-0aebe4e92fad.png)

![bleed issue](https://user-images.githubusercontent.com/1204802/31768876-794abac6-b4d1-11e7-9c23-4093024fb02d.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.