### PR TITLE
Try alternate style to indicate selected blocks

### DIFF
--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -1,6 +1,6 @@
 .editor-block-mover {
 	position: absolute;
-	top: 0;
+	top: 4px;
 	left: 4px;
 	height: $text-editor-font-size * 4; // same height as an empty paragraph
 	padding: 6px 14px 6px 0; // handles hover area

--- a/editor/block-mover/style.scss
+++ b/editor/block-mover/style.scss
@@ -1,9 +1,9 @@
 .editor-block-mover {
 	position: absolute;
-	top: 4px;
+	top: 2px;
 	left: 4px;
 	height: $text-editor-font-size * 4; // same height as an empty paragraph
-	padding: 6px 14px 6px 0; // handles hover area
+	padding: 4px 14px 6px 0; // handles hover area
 	z-index: z-index( '.editor-block-mover' );
 
 	// Mobile, to be revisited

--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -1,6 +1,6 @@
 .editor-block-settings-menu {
 	position: absolute;
-	top: 0;
+	top: 16px;
 	right: 4px;
 	padding: 6px 0 6px 14px; // handles hover area
 

--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -1,8 +1,8 @@
 .editor-block-settings-menu {
 	position: absolute;
-	top: 16px;
+	top: 4px;
 	right: 4px;
-	padding: 6px 0 6px 14px; // handles hover area
+	padding: 16px 0 6px 14px; // handles hover area
 
 	// Mobile
 	display: none;
@@ -31,6 +31,7 @@
 }
 
 .editor-block-settings-menu__toggle {
+	border-radius: 50%;
 	padding: 0;
 	transform: rotate( 90deg );
 	transition-duration: 0.3s;

--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -1,8 +1,8 @@
 .editor-block-settings-menu {
 	position: absolute;
-	top: 4px;
+	top: 2px;
 	right: 4px;
-	padding: 16px 0 6px 14px; // handles hover area
+	padding: 16px 0 20px 14px; // handles hover area
 
 	// Mobile
 	display: none;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -283,6 +283,7 @@ class VisualEditorBlock extends Component {
 			], this.props.order + 1 );
 		}
 		this.removeOrDeselect( event );
+		this.maybeStartTyping( event );
 	}
 
 	onBlockError( error ) {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -54,7 +54,7 @@ import {
 	getBlockMode,
 } from '../../selectors';
 
-const { BACKSPACE, ESCAPE, DELETE, ENTER } = keycodes;
+const { BACKSPACE, ESCAPE, DELETE, ENTER, UP, RIGHT, DOWN, LEFT } = keycodes;
 
 class VisualEditorBlock extends Component {
 	constructor() {
@@ -65,7 +65,6 @@ class VisualEditorBlock extends Component {
 		this.maybeHover = this.maybeHover.bind( this );
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
 		this.stopTypingOnMouseMove = this.stopTypingOnMouseMove.bind( this );
-		this.removeOrDeselect = this.removeOrDeselect.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.onFocus = this.onFocus.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
@@ -198,35 +197,6 @@ class VisualEditorBlock extends Component {
 		this.lastClientY = clientY;
 	}
 
-	removeOrDeselect( event ) {
-		const { keyCode, target } = event;
-		const {
-			uid,
-			previousBlock,
-			onRemove,
-			onFocus,
-			onDeselect,
-		} = this.props;
-
-		// Remove block on backspace.
-		if (
-			target === this.node &&
-			( BACKSPACE === keyCode || DELETE === keyCode )
-		) {
-			event.preventDefault();
-			onRemove( [ uid ] );
-
-			if ( previousBlock ) {
-				onFocus( previousBlock.uid, { offset: -1 } );
-			}
-		}
-
-		// Deselect on escape.
-		if ( ESCAPE === keyCode ) {
-			onDeselect();
-		}
-	}
-
 	mergeBlocks( forward = false ) {
 		const { block, previousBlock, nextBlock, onMerge } = this.props;
 
@@ -275,15 +245,48 @@ class VisualEditorBlock extends Component {
 
 	onKeyDown( event ) {
 		const { keyCode, target } = event;
-		if ( ENTER === keyCode && target === this.node ) {
-			event.preventDefault();
 
-			this.props.onInsertBlocks( [
-				createBlock( 'core/paragraph' ),
-			], this.props.order + 1 );
+		switch ( keyCode ) {
+			case ENTER:
+				// Insert default block after current block if enter and event
+				// not already handled by descendant.
+				if ( target === this.node ) {
+					event.preventDefault();
+
+					this.props.onInsertBlocks( [
+						createBlock( 'core/paragraph' ),
+					], this.props.order + 1 );
+				}
+				break;
+
+			case UP:
+			case RIGHT:
+			case DOWN:
+			case LEFT:
+				// Arrow keys do not fire keypress event, but should still
+				// trigger typing mode.
+				this.maybeStartTyping();
+				break;
+
+			case BACKSPACE:
+			case DELETE:
+				// Remove block on backspace.
+				if ( target === this.node ) {
+					event.preventDefault();
+					const { uid, onRemove, previousBlock, onFocus } = this.props;
+					onRemove( uid );
+
+					if ( previousBlock ) {
+						onFocus( previousBlock.uid, { offset: -1 } );
+					}
+				}
+				break;
+
+			case ESCAPE:
+				// Deselect on escape.
+				this.props.onDeselect();
+				break;
 		}
-		this.removeOrDeselect( event );
-		this.maybeStartTyping( event );
 	}
 
 	onBlockError( error ) {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -98,15 +98,6 @@
 		left: 4px;
 	}
 
-	&.is-selected:before,
-	&.is-hovered:before {
-		content: '';
-		position: absolute;
-		height: 36px;
-		top: 8px;
-		outline: 1px solid transparent;
-	}
-
 	&.is-selected .editor-block-mover:before,
 	&.is-hovered .editor-block-mover:before {
 		border-right: 1px solid $light-gray-500;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -47,6 +47,7 @@
 		bottom: 0;
 		left: 0;
 		right: 0;
+		outline: 1px solid transparent;
 
 		@include break-small {
 			left: $block-mover-padding-visible;
@@ -102,21 +103,28 @@
 		content: '';
 		position: absolute;
 		height: 36px;
-		top: 10px;
+		top: 0;
+		outline: 1px solid transparent;
 	}
 
 	&.is-selected .editor-block-mover:before,
 	&.is-hovered .editor-block-mover:before {
 		border-right: 1px solid $light-gray-500;
-		right: 4px;
+		right: 6px;
 	}
 
 	&.is-selected .editor-block-settings-menu:before,
 	&.is-hovered .editor-block-settings-menu:before {
 		border-left: 1px solid $light-gray-500;
-		left: 4px;
+		left: 6px;
 	}
 
+	// focused block-style
+	&.is-selected:before {
+ 		outline: 1px solid $light-gray-500;
+	}
+
+	// selection style for multiple blocks
 	&.is-multi-selected *::selection {
 		background: transparent;
 	}
@@ -315,30 +323,6 @@
 			background: none;
 			border-bottom: 3px solid $blue-medium-500;
 		}
-	}
-}
-
-// show a separate cursor/caret highlight style for when an item was selected by the mouse or keyboard (but isn't multi selected)
-// this is only for some blocks
-.editor-visual-editor__block.is-selected[data-type="core/more"],
-.editor-visual-editor__block.is-selected[data-type="core/separator"],
-.editor-visual-editor__block.is-selected[data-type="core/button"] {
-	&:after {
-		content: '';
-		position: absolute;
-		pointer-events: none;
-		top: $block-padding;
-		bottom: $block-padding;
-		left: $block-padding + $block-mover-padding-visible;
-		right: $block-padding + $block-mover-padding-visible;
-		background: $blue-medium-300;
-		background: Highlight;
-		opacity: .15;
-	}
-
-	&[data-align="full"]:after {
-		left: 0;
-		right: 0;
 	}
 }
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -102,6 +102,7 @@
 	}
 
 	&.is-multi-selected:before {
+		background: $blue-medium-200;
 		background: Highlight;	// This variable is a CSS 2.1 variable that selects the operating system select color
 	}
 
@@ -310,6 +311,7 @@
 		bottom: $block-padding;
 		left: $block-padding + $block-mover-padding-visible;
 		right: $block-padding + $block-mover-padding-visible;
+		background: $blue-medium-300;
 		background: Highlight;
 		opacity: .15;
 	}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -97,6 +97,26 @@
 		left: 4px;
 	}
 
+	&.is-selected:before,
+	&.is-hovered:before {
+		content: '';
+		position: absolute;
+		border-left: 1px solid $light-gray-500;
+		height: 36px;
+		top: $block-padding;
+		left: $block-padding + $block-mover-padding-visible - $item-spacing;
+	}
+
+	&.is-selected:before,
+	&.is-hovered:before {
+		content: '';
+		position: absolute;
+		border-right: 1px solid $light-gray-500;
+		height: 36px;
+		top: $block-padding;
+		right: $block-padding + $block-mover-padding-visible - $item-spacing;
+	}
+
 	&.is-multi-selected *::selection {
 		background: transparent;
 	}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -74,6 +74,7 @@
 		background-color: rgba( $white, 0.6 );
 	}
 
+	// simpler style for a block that has cursor focus (but hasn't been selected)
 	&.is-selected .editor-block-mover:before,
 	&.is-hovered .editor-block-mover:before,
 	&.is-selected .editor-block-settings-menu:before,
@@ -227,12 +228,13 @@
 		@include break-wide() {
 			.editor-block-mover {
 				display: block;
-			}
-
-			.editor-block-mover {
 				top: -30px;
 				left: 10px;
 				height: auto;
+
+				&:before {
+					content: none;
+				}
 			}
 
 			.editor-block-mover__control {
@@ -250,6 +252,10 @@
 			top: -30px;
 			right: 10px;
 			height: auto;
+
+			&:before {
+				content: none;
+			}
 		}
 	}
 
@@ -288,6 +294,29 @@
 			background: none;
 			border-bottom: 3px solid $blue-medium-500;
 		}
+	}
+}
+
+// show a separate cursor/caret highlight style for when an item was selected by the mouse or keyboard (but isn't multi selected)
+// this is only for some blocks
+.editor-visual-editor__block.is-selected[data-type="core/more"],
+.editor-visual-editor__block.is-selected[data-type="core/separator"],
+.editor-visual-editor__block.is-selected[data-type="core/button"] {
+	&:after {
+		content: '';
+		position: absolute;
+		pointer-events: none;
+		top: $block-padding;
+		bottom: $block-padding;
+		left: $block-padding + $block-mover-padding-visible;
+		right: $block-padding + $block-mover-padding-visible;
+		background: Highlight;
+		opacity: .15;
+	}
+
+	&[data-align="full"]:after {
+		left: 0;
+		right: 0;
 	}
 }
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -103,7 +103,7 @@
 		content: '';
 		position: absolute;
 		height: 36px;
-		top: 0;
+		top: 8px;
 		outline: 1px solid transparent;
 	}
 
@@ -507,7 +507,7 @@
 		opacity: 1;
 	}
 
-	&::before {
+	&:before {
 		content: '';
 		position: absolute;
 		width: 100%;
@@ -516,7 +516,7 @@
 		transform: translateY( -50% );
 	}
 
-	&:hover::before {
+	&:hover:before {
 		height: 44px;
 	}
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -43,8 +43,8 @@
 		z-index: z-index( '.editor-visual-editor__block:before' );
 		content: '';
 		position: absolute;
-		outline: 1px solid transparent;
-		transition: 0.2s outline;
+		/*outline: 1px solid transparent;
+		transition: 0.2s outline; */
 		top: 0;
 		bottom: 0;
 
@@ -67,7 +67,7 @@
 		}
 	}
 
-	&.has-warning .editor-visual-editor__block-edit::after {
+	&.has-warning .editor-visual-editor__block-edit:after {
 		content: '';
 		position: absolute;
 		top: 0;
@@ -77,14 +77,24 @@
 		background-color: rgba( $white, 0.6 );
 	}
 
+	&.is-selected:before,
 	&.is-hovered:before {
-		outline: 1px solid $light-gray-500;
-		transition: 0.2s outline;
+		content: '';
+		position: absolute;
+		border-left: 1px solid $light-gray-500;
+		height: 36px;
+		top: $block-padding;
+		left: $block-padding + $block-mover-padding-visible - $item-spacing;
 	}
 
-	&.is-selected:before {
-		outline: 2px solid $light-gray-500;
-		transition: 0.2s outline;
+	&.is-selected:before,
+	&.is-hovered:before {
+		content: '';
+		position: absolute;
+		border-right: 1px solid $light-gray-500;
+		height: 36px;
+		top: $block-padding;
+		right: $block-padding + $block-mover-padding-visible - $item-spacing;
 	}
 
 	&.is-multi-selected *::selection {
@@ -92,9 +102,7 @@
 	}
 
 	&.is-multi-selected:before {
-		background: $blue-medium-100;
-		outline: 2px solid $blue-medium-200;
-		transition: 0s outline;
+		background: rgba( $blue-medium-200, .6 );
 	}
 
 	.iframe-overlay {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -101,20 +101,20 @@
 	&.is-hovered:before {
 		content: '';
 		position: absolute;
-		border-left: 1px solid $light-gray-500;
 		height: 36px;
-		top: $block-padding;
-		left: $block-padding + $block-mover-padding-visible - $item-spacing;
+		top: 10px;
 	}
 
-	&.is-selected:before,
-	&.is-hovered:before {
-		content: '';
-		position: absolute;
+	&.is-selected .editor-block-mover:before,
+	&.is-hovered .editor-block-mover:before {
 		border-right: 1px solid $light-gray-500;
-		height: 36px;
-		top: $block-padding;
-		right: $block-padding + $block-mover-padding-visible - $item-spacing;
+		right: 4px;
+	}
+
+	&.is-selected .editor-block-settings-menu:before,
+	&.is-hovered .editor-block-settings-menu:before {
+		border-left: 1px solid $light-gray-500;
+		left: 4px;
 	}
 
 	&.is-multi-selected *::selection {

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -257,7 +257,7 @@
 		@include break-wide() {
 			.editor-block-mover {
 				display: block;
-				top: -30px;
+				top: -29px;
 				left: 10px;
 				height: auto;
 
@@ -278,7 +278,7 @@
 		}
 
 		.editor-block-settings-menu {
-			top: -30px;
+			top: -41px;
 			right: 10px;
 			height: auto;
 
@@ -370,7 +370,7 @@
 	input[type=text] {
 		height: $text-editor-font-size * 4; // same height as an empty paragraph
 		margin-top: 0px;
-		margin-bottom: 5px;
+		margin-bottom: 4px;
 		outline: 1px solid transparent;
 		border: none;
 		background: none;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -43,11 +43,8 @@
 		z-index: z-index( '.editor-visual-editor__block:before' );
 		content: '';
 		position: absolute;
-		/*outline: 1px solid transparent;
-		transition: 0.2s outline; */
 		top: 0;
 		bottom: 0;
-
 		left: 0;
 		right: 0;
 
@@ -77,24 +74,26 @@
 		background-color: rgba( $white, 0.6 );
 	}
 
-	&.is-selected:before,
-	&.is-hovered:before {
+	&.is-selected .editor-block-mover:before,
+	&.is-hovered .editor-block-mover:before,
+	&.is-selected .editor-block-settings-menu:before,
+	&.is-hovered .editor-block-settings-menu:before {
 		content: '';
 		position: absolute;
-		border-left: 1px solid $light-gray-500;
 		height: 36px;
-		top: $block-padding;
-		left: $block-padding + $block-mover-padding-visible - $item-spacing;
+		top: 10px;
 	}
 
-	&.is-selected:before,
-	&.is-hovered:before {
-		content: '';
-		position: absolute;
+	&.is-selected .editor-block-mover:before,
+	&.is-hovered .editor-block-mover:before {
 		border-right: 1px solid $light-gray-500;
-		height: 36px;
-		top: $block-padding;
-		right: $block-padding + $block-mover-padding-visible - $item-spacing;
+		right: 4px;
+	}
+
+	&.is-selected .editor-block-settings-menu:before,
+	&.is-hovered .editor-block-settings-menu:before {
+		border-left: 1px solid $light-gray-500;
+		left: 4px;
 	}
 
 	&.is-multi-selected *::selection {
@@ -102,7 +101,7 @@
 	}
 
 	&.is-multi-selected:before {
-		background: rgba( $blue-medium-200, .6 );
+		background: Highlight;	// This variable is a CSS 2.1 variable that selects the operating system select color
 	}
 
 	.iframe-overlay {


### PR DESCRIPTION
## Description

This PR takes a first stab at some of the changes discussed/mocked up in #2983.

Basically it removes both the hover and selected styles for blocks, in favor of little floating mover/settings blobs on the side, and some subtler selection styles for a few blocks (separator, more, button). 

Additionally, it changes the visual style of multi-selected blocks. Given incoming keyboard-multi-select features, this changes it so a multi selected block has the same color as highlighted text does. This uses a kind of magical CSS value, `Highlight`, which is documented in https://www.sitepoint.com/css-system-styles/. Video:

![behavior](https://user-images.githubusercontent.com/1204802/31773494-3ddea31e-b4e3-11e7-96f3-eb4c7f86b6a8.gif)

This property is quite magical, and actually changes along with whatever choice you make at the operating system level:

![itshappening](https://user-images.githubusercontent.com/1204802/31773759-07cc1f26-b4e4-11e7-97ab-00454ef314df.gif)

It's a CSS 2.1 property and I've tested this color and found it working all the way back to IE9 (didn't test further). 

I'm marking this as "In Progress", as I'd like both some code reviews, as well as some _experience_ reviews. How does this feel? What feels good? What feels not so good? What else needs to be done in this branch? Any experience regressions?

Keep in mind that this is only one aspect of the visual refresh, you can see a list of other complimentary tasks here: https://github.com/WordPress/gutenberg/issues/2983#issuecomment-337841535

## How Has This Been Tested?

Tested the color effect in Safari, Firefox, Chrome both on Mac and Windows, as well as Edge and IE9-11 on Windows. Not that we need 9 support, I was just impressed that the CSS property worked all the way back for that one.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.