### PR TITLE
Docs: Add talk by Andrew Duthie

### DIFF
--- a/docs/talks.md
+++ b/docs/talks.md
@@ -4,3 +4,4 @@ Talks given about Gutenberg, including slides and videos as they are available.
 
 - http://kimb.me/talk-bigwp-london-new-core-wordpress-editor/
 - http://haiku2.com/2017/09/bend-wordpress-meetup-gutenberg-notes/
+- https://www.slideshare.net/andrewmduthie/gutenberg-and-the-future-of-content-in-wordpress


### PR DESCRIPTION
Adding a link to the slide deck for a talk I gave about Gutenberg at my [local WordPress meetup](https://www.meetup.com/Cincinnati-WordPress-Meetup/) last month. Also scheduled to be given (potentially with some revisions) at [WordCamp Cincinnati](https://2017.cincinnati.wordcamp.org/) in November.