### PR TITLE
Adjust transition and delay for the between-blocks inserter.

### DIFF
--- a/editor/modes/visual-editor/sibling-inserter.js
+++ b/editor/modes/visual-editor/sibling-inserter.js
@@ -107,18 +107,14 @@ class VisualEditorSiblingInserter extends Component {
 				{ showInsertionPoint && (
 					<div className="editor-visual-editor__insertion-point" />
 				) }
-				{ isVisible && [
-					<hr
-						key="rule"
-						className="editor-visual-editor__sibling-inserter-rule"
-					/>,
+				{ isVisible &&
 					<Inserter
 						key="inserter"
 						position="bottom"
 						insertIndex={ insertIndex }
 						onToggle={ this.suspendToggleVisible }
-					/>,
-				] }
+					/>
+				}
 			</div>
 		);
 	}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -486,18 +486,9 @@
 		margin: 0;
 		padding: 4px;
 		background-color: white;
-	}
-}
 
-.editor-visual-editor__sibling-inserter-rule {
-	position: absolute;
-	left: 50%;
-	top: 50%;
-	width: 80px;
-	margin: 0;
-	margin-top: -1px;
-	margin-left: -40px;
-	border: none;
-	border-top: 2px solid $blue-medium-500;
-	display: none; /* todo: remove the whole element */
+		.dashicon {
+			vertical-align: bottom;
+		}
+	}
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -449,7 +449,8 @@
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
 	margin: 0 auto;
 	opacity: 0;
-	transition: 0.1s opacity;
+	transition: opacity 0.25s ease-in-out;
+	transition-delay: 0.3s;
 
 	&:not( [data-insert-index="0"] ) {
 		top: #{ -1 * ( $block-spacing / 2 ) };
@@ -463,7 +464,7 @@
 		content: '';
 		position: absolute;
 		width: 100%;
-		height: 10px;
+		height: 44px;
 		transition: 0.1s height;
 		transform: translateY( -50% );
 	}
@@ -498,4 +499,5 @@
 	margin-left: -40px;
 	border: none;
 	border-top: 2px solid $blue-medium-500;
+	display: none; /* todo: remove the whole element */
 }


### PR DESCRIPTION
This aims to make the between-blocks inserter appear when needed, but out of the way when not. It reduces the visual weight a bit by removing the line. When opening the inserter and hovering a block, the usual blue line still appears.