### PR TITLE
Hide Screen Options from Gutenberg page.

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -14,7 +14,9 @@ body {
 	padding-bottom: 0;
 }
 
-#wpfooter {
+#wpfooter,
+#screen-meta-links,
+#screen-meta {
 	display: none;
 }
 


### PR DESCRIPTION
Screen Options do not play a role in Gutenberg. We should remove the markup from the post-new.php itself, but until that time we should at least hide it so it doesn't briefly show as Gutenberg loads.

This was supposed to be a CSS bleed branch, I thought there was more. But as I looked, I couldn't find any, but hence the branch name.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.