### PR TITLE
Improve inserter style

### DIFF
--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -67,11 +67,6 @@
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;
-	width: calc( 100vw - 20px );
-
-	@include break-medium {
-		width: 320px;
-	}
 
 	.components-popover.is-top & {
 		bottom: 100%;

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -70,7 +70,7 @@
 	width: calc( 100vw - 20px );
 
 	@include break-medium {
-		width: 300px;
+		width: 320px;
 	}
 
 	.components-popover.is-top & {

--- a/editor/header/publish-dropdown/style.scss
+++ b/editor/header/publish-dropdown/style.scss
@@ -1,5 +1,6 @@
 .editor-publish-dropdown {
-	padding: 15px;
+	padding: 16px;
+	width: 300px;
 
 	.components-panel__body {
 		margin-left: -16px;

--- a/editor/inserter/menu.js
+++ b/editor/inserter/menu.js
@@ -363,12 +363,6 @@ export class InserterMenu extends Component {
 					onClick={ this.setSearchFocus }
 					ref={ this.bindReferenceNode( 'search' ) }
 				/>
-				<div role="menu" className="editor-inserter__content"
-					ref={ ( ref ) => this.tabContainer = ref }>
-					{ isShowingRecent && this.renderBlocks( this.props.recentlyUsedBlocks ) }
-					{ isShowingEmbeds && this.renderBlocks( visibleBlocksByCategory.embed ) }
-					{ ! isShowingRecent && ! isShowingEmbeds && this.renderCategories( visibleBlocksByCategory ) }
-				</div>
 				{ ! isSearching &&
 					<div className="editor-inserter__tabs is-recent">
 						<button
@@ -391,6 +385,12 @@ export class InserterMenu extends Component {
 						</button>
 					</div>
 				}
+				<div role="menu" className="editor-inserter__content"
+					ref={ ( ref ) => this.tabContainer = ref }>
+					{ isShowingRecent && this.renderBlocks( this.props.recentlyUsedBlocks ) }
+					{ isShowingEmbeds && this.renderBlocks( visibleBlocksByCategory.embed ) }
+					{ ! isShowingRecent && ! isShowingEmbeds && this.renderCategories( visibleBlocksByCategory ) }
+				</div>
 			</div>
 		);
 	}

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -126,11 +126,20 @@ input[type="search"].editor-inserter__search {
 }
 
 .editor-inserter__separator {
+	border-top: 1px solid $light-gray-500;
+	background: rgba( $white, .8 );
+	position: sticky;
+	top: 0;
+	text-align: center;
 	display: block;
 	margin: 0;
 	padding: 12px 14px 0 14px;
 	font-size: $default-font-size;
 	font-weight: 600;
+
+	&:first-child {
+		border: none;
+	}
 }
 
 .editor-inserter__tabs {

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -128,18 +128,13 @@ input[type="search"].editor-inserter__search {
 .editor-inserter__separator {
 	border-top: 1px solid $light-gray-500;
 	background: rgba( $white, .8 );
-	position: sticky;
-	top: 0;
 	text-align: center;
 	display: block;
 	margin: 0;
 	padding: 12px 14px 0 14px;
 	font-size: $default-font-size;
 	font-weight: 600;
-
-	&:first-child {
-		border: none;
-	}
+	margin-top: -1px;	// hide the first top border
 }
 
 .editor-inserter__tabs {

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -36,7 +36,7 @@
 	height: calc( 100vh - #{ $admin-bar-height-big + $header-height + 34 + $inserter-tabs-height } ); // 34 = search input height
 
 	@include break-medium {
-		height: 240px;
+		height: 260px;
 	}
 
 	overflow: auto;
@@ -53,7 +53,6 @@ input[type="search"].editor-inserter__search {
 	margin: 0;
 	box-shadow: none;
 	border: 1px solid transparent;
-	border-bottom: 1px solid $light-gray-500;
 	padding: 8px 11px;
 	font-size: $default-font-size;
 	position: relative;
@@ -89,17 +88,19 @@ input[type="search"].editor-inserter__search {
 
 .editor-inserter__block {
 	display: flex;
-	width: 50%;
+	flex-direction: column;
+	width: calc( 50% - 16px );
+	border-radius: 4px;
 	font-size: $default-font-size;
 	color: $dark-gray-500;
-	margin: 0;
-	padding: 12px 6px;
+	margin: 8px;
+	padding: 12px 6px 6px 6px;
 	align-items: center;
 	cursor: pointer;
 	border: none;
-	background: none;
 	line-height: 20px;
-
+	background: transparent;
+	border: 1px solid transparent;
 
 	&:disabled {
 		opacity: 0.6;
@@ -111,20 +112,16 @@ input[type="search"].editor-inserter__search {
 			color: $blue-medium-500;
 		}
 
-		&:focus {
-			outline: 1px solid $dark-gray-500;
-		}
-
+		&:focus,
 		&:active,
 		&.is-active {
-			background: $dark-gray-500;
+			outline: none;
+			border: 1px solid $dark-gray-500;
+			box-shadow: inset 0 0 0 1px $white;
+			color: $dark-gray-900;
+			background: $light-gray-300;
 			position: relative;
-			color: $white;
 		}
-	}
-
-	.dashicon {
-		margin-right: 8px;
 	}
 }
 
@@ -141,15 +138,16 @@ input[type="search"].editor-inserter__search {
 	display: flex;
 	justify-content: space-between;
 	position: relative;
-	z-index: z-index( '.editor-inserter__tabs' );
+	background: $light-gray-300;
+	border-top: 1px solid $light-gray-500;
+	border-bottom: 1px solid $light-gray-500;
 }
 
 .editor-inserter__tab {
-	background: $light-gray-300;
 	border: none;
-	border-bottom: 2px solid transparent;
-	border-top: 2px solid transparent;
-	box-shadow: 0 0 0 1px $light-gray-500;
+	background: none;
+	border-bottom: 3px solid transparent;
+	border-top: 3px solid transparent;
 	font-size: $default-font;
 	padding: 8px 8px;
 	width: 100%;
@@ -158,13 +156,15 @@ input[type="search"].editor-inserter__search {
 	cursor: pointer;
 
 	&.is-active {
-		background: $white;
+		font-weight: 600;
 		border-bottom-color: $blue-medium-500;
 		position: relative;
 		z-index: z-index( '.editor-inserter__tab.is-active' );
 	}
 
+	&:active,
 	&:focus {
+		z-index: z-index( '.editor-inserter__tab.is-active' );
 		box-shadow: $button-focus-style;
 		outline: none;
 	}

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -57,6 +57,7 @@ input[type="search"].editor-inserter__search {
 	font-size: $default-font-size;
 	position: relative;
 	z-index: 1;
+	border-bottom: 1px solid $light-gray-500;
 
 	&:focus {
 		outline: none;
@@ -143,7 +144,6 @@ input[type="search"].editor-inserter__search {
 	justify-content: space-between;
 	position: relative;
 	background: $light-gray-300;
-	border-top: 1px solid $light-gray-500;
 	border-bottom: 1px solid $light-gray-500;
 }
 

--- a/editor/inserter/style.scss
+++ b/editor/inserter/style.scss
@@ -71,6 +71,14 @@ input[type="search"].editor-inserter__search {
 	padding: 8px;
 }
 
+.editor-inserter__menu {
+	width: calc( 100vw - 20px );
+
+	@include break-medium {
+		width: 300px;
+	}
+}
+
 .editor-inserter__menu.components-popover.is-center .components-popover__content {
 	@media ( max-width: #{ $break-medium - 1 } ) {
 		border-width: 0;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -370,6 +370,7 @@
 	}
 
 	> .editor-inserter__block {
+		flex-direction: row;
 		opacity: 0;
 		transition: opacity 150ms;
 		margin: 0 10px;
@@ -377,10 +378,10 @@
 		font-family: $default-font;
 		font-size: $default-font-size;
 		box-shadow: none;
+		padding: 6px;
 
-		&:active {
-			background: none;
-			color: $blue-medium-500;
+		.dashicon {
+			margin-right: 8px;
 		}
 	}
 


### PR DESCRIPTION
## Description

Aims to fix #1497.

GIF:

![inserter](https://user-images.githubusercontent.com/1204802/31817423-2a9d508c-b594-11e7-83cb-c6b7d08a37a1.gif)

This moves the tabs to the top, it changes the style of the inserter a bit, and improves the focus styles per #3039. 

Note: I can't tab into the Tabs — pun not intended. Not sure why this is, would appreciate advice.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.