### PR TITLE
Fix visual issue with switcher

### DIFF
--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -1,12 +1,15 @@
 .editor-block-switcher {
 	position: relative;
-	border: 1px solid $light-gray-500;
 	background-color: $white;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 	margin-right: -1px;
 	margin-bottom: -1px;
+
+	.components-toolbar {
+		height: 38px;
+	}
 }
 
 .editor-block-switcher__toggle {


### PR DESCRIPTION
It had a double border. @iseulde's eyes caught it. This PR normalizes it.

Before:

![before](https://user-images.githubusercontent.com/1204802/31820296-fdca5b06-b5a0-11e7-87d0-9a548b661487.png)

After:

![after](https://user-images.githubusercontent.com/1204802/31820302-0028ea0c-b5a1-11e7-8c4e-b892d0b6f62a.png)
