### PR TITLE
Editable: Skip focus event prop proxying

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -131,6 +131,13 @@ export default class Editable extends Component {
 
 	proxyPropHandler( name ) {
 		return ( event ) => {
+			// TODO: Reconcile with `onFocus` instance handler which does not
+			// pass the event object. Otherwise we have double focus handling
+			// and editor instance being stored into state.
+			if ( name === 'Focus' ) {
+				return;
+			}
+
 			// Allow props an opportunity to handle the event, before default
 			// Editable behavior takes effect. Should the event be handled by a
 			// prop, it should `stopImmediatePropagation` on the event to stop


### PR DESCRIPTION
This pull request seeks to serve as a temporary resolution to an issue where an Editable's `onFocus` is called twice. Not only is this redundant, but because of [how we tend to assign `onFocus={ setFocus }` and because the [Redux `focusBlock` action creator accepts arguments](https://github.com/WordPress/gutenberg/blob/3316c3cce56f124f37ff492de88caf781e671299/editor/modes/visual-editor/block.js#L470), it is causing the entire event, including TinyMCE instance, to be stored in state when a block editable is focused. The workaround here is to bypass the `Focus` event explicitly in the broad event proxying logic. This logic was originally introduced in #2630 to allow the Autocomplete component to bind to arbitrary events on the Editable element.

__Testing instructions:__

This is easiest to test with the [Redux DevTools extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)

1. Navigate to Gutenberg > Demo
2. Open Redux DevTools in browser developer tools
3. Click a paragraph
4. Observe that only a single `UPDATE_FOCUS` event is triggered
5. Verify that `state.blockSelection.focus` is a reasonable (perhaps empty) object, not a full event object

__Future tasks:__

Ultimately I'd like to see us remove most common `setFocus` use altogether, and have this handled by WritingFlow. I have a work-in-progress branch for this, but it is not yet near ready for review and is a significant refactor.

Alternatively, we should remove the explicit `onFocus = () => this.props.onFocus()` method from Editable, and force consumers to handle the incoming event object, e.g. `onFocus={ () => setFocus() ) }`

#2896 proposes removing the event handlers from Autocomplete which prompted the `proxyPropHandler` logic, so if merged could eliminate the need altogether. Then again, it is nice to be able to allow consumers to bind to TinyMCE events via `on*` props.