### PR TITLE
Blocks: Tweak the block sibling width to allow clicking the block's menu

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -446,11 +446,15 @@
 .editor-visual-editor__sibling-inserter {
 	z-index: z-index( '.editor-visual-editor__sibling-inserter' );
 	position: relative;
-	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
+	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible ) - ( 2 * $block-padding );
 	margin: 0 auto;
 	opacity: 0;
 	transition: opacity 0.25s ease-in-out;
 	transition-delay: 0.3s;
+
+	@include break-small {
+		max-width: $visual-editor-max-width - ( 2 * $block-padding );
+	}
 
 	&:not( [data-insert-index="0"] ) {
 		top: #{ -1 * ( $block-spacing / 2 ) };


### PR DESCRIPTION
closes #3088

This fixes a small regression where we're not able to click the block's ellipsis menu, because the block's sibling div (responsible of showing the inline inserter) was covering the menu.