### PR TITLE
TinyMCE: Assign dummy container during removal

### DIFF
--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -46,6 +46,10 @@ export default class TinyMCE extends Component {
 			return;
 		}
 
+		// This hack prevents TinyMCE from trying to remove the container node
+		// while cleaning for destroy, since removal is handled by React. It
+		// does so by substituting the container to be removed.
+		this.editor.container = document.createDocumentFragment();
 		this.editor.destroy();
 		delete this.editor;
 	}


### PR DESCRIPTION
Fixes #3091 
Related: #2787

This pull request seeks to resolve an issue where changing level of a Heading block results in a block error. This began after a TinyMCE upgrade from 4.6.5 to 4.7.1. It is still not clear what specific changes occurred in TinyMCE in this time to introduce the error, since the problematic behavior has existed for some time. Namely, we call to `this.editor.destroy` when the TinyMCE component unmounts for TinyMCE to clean any lingering handlers. However, TinyMCE also tries to remove the container node itself, and when React then proceeds to do the same, an error occurs because the node no longer exists. The changes here assign a dummy container property to the TinyMCE instance while unmounting to trick TinyMCE into removing a different node instead.

Ultimately it would be nice if we could perform `destroy` clean-up logic without the node being removed, or alternatively not need to explicitly call `destroy` and rely on this cleanup to occur as a result of the natural DOM removal.

__Testing instructions:__

Repeat testing instructions from #3091, verifying that no error occurs in changing Heading level.