### PR TITLE
Made button link editor consistent with paragraph link editor

### DIFF
--- a/blocks/library/button/editor.scss
+++ b/blocks/library/button/editor.scss
@@ -11,11 +11,13 @@ $blocks-button__height: 46px;
 }
 
 .wp-block-button {
-	.blocks-format-toolbar__link-modal {
+	.blocks-link-editor__link-modal {
 		z-index: 2;
 		top: $blocks-button__height + 2px;
 		left: 50%;
 		transform: translateX( -50% );
+		color: #444;
+		text-align: left;
 	}
 
 	.blocks-link-url__suggestions {

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, PanelBody } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import './editor.scss';
 import './style.scss';
 import { registerBlockType, source } from '../../api';
 import Editable from '../../editable';
-import UrlInput from '../../url-input';
+import LinkEditor from '../../link-editor';
 import BlockControls from '../../block-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
@@ -51,6 +51,10 @@ registerBlockType( 'core/button', {
 		textColor: {
 			type: 'string',
 		},
+		opensInNewWindow: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -69,9 +73,10 @@ registerBlockType( 'core/button', {
 	},
 
 	edit( { attributes, setAttributes, focus, setFocus, className } ) {
-		const { text, url, title, align, color, textColor, clear } = attributes;
+		const { text, url, title, align, color, textColor, clear, opensInNewWindow } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		const toggleClear = () => setAttributes( { clear: ! clear } );
+		const toggleOpensInNewWindow = () => setAttributes( { opensInNewWindow: ! opensInNewWindow } );
 
 		return [
 			focus && (
@@ -94,15 +99,12 @@ registerBlockType( 'core/button', {
 					keepPlaceholderOnFocus
 				/>
 				{ focus &&
-					<form
-						className="blocks-format-toolbar__link-modal"
-						onSubmit={ ( event ) => event.preventDefault() }>
-						<UrlInput
-							value={ url }
-							onChange={ ( value ) => setAttributes( { url: value } ) }
-						/>
-						<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-					</form>
+					<LinkEditor
+						{ ...{ opensInNewWindow, toggleOpensInNewWindow } }
+						linkValue={ url }
+						onLinkChange={ ( value ) => setAttributes( { url: value } ) }
+						onDrop={ () => setAttributes( { url: null } ) }
+					/>
 				}
 				{ focus &&
 					<InspectorControls key="inspector">
@@ -114,6 +116,11 @@ registerBlockType( 'core/button', {
 							label={ __( 'Stand on a line' ) }
 							checked={ !! clear }
 							onChange={ toggleClear }
+						/>
+						<ToggleControl
+							label={ __( 'Open in new window' ) }
+							checked={ !! opensInNewWindow }
+							onChange={ toggleOpensInNewWindow }
 						/>
 						<PanelBody title={ __( 'Button Background Color' ) }>
 							<ColorPalette
@@ -134,11 +141,11 @@ registerBlockType( 'core/button', {
 	},
 
 	save( { attributes } ) {
-		const { url, text, title, align, color, textColor } = attributes;
+		const { url, text, title, align, color, textColor, opensInNewWindow } = attributes;
 
 		return (
 			<div className={ `align${ align }` } style={ { backgroundColor: color } }>
-				<a href={ url } title={ title } style={ { color: textColor } }>
+				<a href={ url } target={ opensInNewWindow ? '_blank' : null } title={ title } style={ { color: textColor } }>
 					{ text }
 				</a>
 			</div>

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -17,13 +17,6 @@ $blocks-button__height: 46px;
 	vertical-align: top;
 	position: relative;
 
-	a {
-		box-shadow: none !important;
-		color: $white;
-		cursor: pointer;
-		text-decoration: none !important;
-	}
-
 	&:hover {
 		color: $white;
 	}
@@ -31,4 +24,11 @@ $blocks-button__height: 46px;
 	&.aligncenter {
 		display: inline-block;
 	}
+}
+
+.wp-block-button > a {
+	box-shadow: none !important;
+	color: $white;
+	cursor: pointer;
+	text-decoration: none !important;
 }

--- a/blocks/link-editor/index.js
+++ b/blocks/link-editor/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isBoolean, noop } from 'lodash';
+import { isBoolean } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -63,7 +63,9 @@ export default class LinkEditor extends Component {
 			newLinkValue: this.props.linkValue,
 			isEditing: true,
 		} );
-		( this.props.onEdit || noop )();
+		if ( this.props.onEdit ) {
+			this.props.onEdit();
+		}
 	}
 
 	dropClicked() {

--- a/blocks/link-editor/index.js
+++ b/blocks/link-editor/index.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import { isBoolean, noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { IconButton } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import UrlInput from '../url-input';
+import { filterURLForDisplay } from '../../editor/utils/url';
+import ToggleControl from '../inspector-controls/toggle-control';
+
+export default class LinkEditor extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			settingsVisible: false,
+			newLinkValue: '',
+			isEditing: null,
+		};
+
+		this.onChangeLinkValue = this.onChangeLinkValue.bind( this );
+		this.toggleLinkSettingsVisibility = this.toggleLinkSettingsVisibility.bind( this );
+		this.submitLink = this.submitLink.bind( this );
+		this.editClicked = this.editClicked.bind( this );
+		this.dropClicked = this.dropClicked.bind( this );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( isBoolean( nextProps.isEditing ) ) {
+			this.setState( { isEditing: nextProps.isEditing } );
+		} else if ( this.state.isEditing === null ) {
+			this.setState( { isEditing: ! nextProps.linkValue } );
+		}
+	}
+
+	onChangeLinkValue( value ) {
+		this.setState( { newLinkValue: value } );
+	}
+
+	toggleLinkSettingsVisibility() {
+		this.setState( ( state ) => ( { settingsVisible: ! state.settingsVisible } ) );
+	}
+
+	submitLink( event ) {
+		event.preventDefault();
+		this.setState( {
+			isEditing: false,
+		} );
+		this.props.onLinkChange( this.state.newLinkValue );
+	}
+
+	editClicked() {
+		this.setState( {
+			newLinkValue: this.props.linkValue,
+			isEditing: true,
+		} );
+		( this.props.onEdit || noop )();
+	}
+
+	dropClicked() {
+		this.setState( {
+			newLinkValue: '',
+			isEditing: true,
+		} );
+		this.props.onDrop();
+	}
+
+	render() {
+		const { linkValue, linkStyle, opensInNewWindow, toggleOpensInNewWindow } = this.props;
+		const { isEditing, settingsVisible, newLinkValue } = this.state;
+		const linkSettings = settingsVisible && (
+			<fieldset className="blocks-link-editor__link-settings">
+				<ToggleControl
+					label={ __( 'Open in new window' ) }
+					checked={ !! opensInNewWindow }
+					onChange={ toggleOpensInNewWindow }
+				/>
+			</fieldset>
+		);
+
+		if ( isEditing ) {
+			return (
+				<form className="blocks-link-editor__link-modal"
+					style={ linkStyle }
+					onSubmit={ this.submitLink }>
+					<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
+					<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
+					<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropClicked } />
+					<IconButton icon="admin-generic" onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
+					{ linkSettings }
+				</form>
+			);
+		}
+
+		return (
+			<div className="blocks-link-editor__link-modal" style={ linkStyle }>
+				<a className="blocks-link-editor__link-value"
+					href={ linkValue }
+					target="_blank">
+					{ linkValue && filterURLForDisplay( decodeURI( linkValue ) ) }
+				</a>
+				<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editClicked } />
+				<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropClicked } />
+				<IconButton icon="admin-generic" onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
+				{ linkSettings }
+			</div>
+		);
+	}
+}

--- a/blocks/link-editor/style.scss
+++ b/blocks/link-editor/style.scss
@@ -1,0 +1,39 @@
+// Link input
+.blocks-link-editor__link-modal {
+	position: absolute;
+	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
+	border: 1px solid #e0e5e9;
+	background: #fff;
+	width: 305px;
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	font-family: $default-font;
+	font-size: $default-font-size;
+	line-height: $default-line-height;
+	z-index: z-index( '.blocks-link-editor__link-modal' );
+
+	.blocks-url-input {
+		width: auto;
+	}
+}
+
+.blocks-link-editor__link-value {
+	padding: 10px;
+	flex-grow: 1;
+	overflow: hidden;
+	position: relative;
+
+	&:after {
+		@include long-content-fade( $size: 40% );
+	}
+}
+.blocks-link-editor__link-settings {
+	border-top: 1px solid $light-gray-500;
+	width: 100%;
+	padding: 10px 8px;
+
+	.blocks-base-control {
+		margin: 0;
+	}
+}

--- a/blocks/test/fixtures/core__button__center.json
+++ b/blocks/test/fixtures/core__button__center.json
@@ -8,7 +8,8 @@
             "text": [
                 "Help build Gutenberg"
             ],
-            "align": "center"
+            "align": "center",
+            "opensInNewWindow": false
         },
         "originalContent": "<div class=\"wp-block-button aligncenter\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>"
     }

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -16,6 +16,7 @@ $z-layers: (
 	'.editor-inserter__tab.is-active': 1,
 	'.components-panel__header': 1,
 	'.blocks-format-toolbar__link-modal': 2,
+	'.blocks-link-editor__link-modal': 2,
 	'.editor-block-switcher__menu': 2,
 	'.editor-block-mover': 20,
 	'.blocks-gallery-image__inline-menu': 20,


### PR DESCRIPTION
This PR aims to solve https://github.com/WordPress/gutenberg/issues/1670. It makes the button link editor equal to the paragraph link editor. The warnings that were being displayed also get fixed.
Before the changes, link edition was applied right way and the apply button did not have noticeable effects, now changes need to be applied.
A new attribute was added that allows configuring if we want to open the link in a new window or not.

## How Has This Been Tested?

1. Add a button. Write the link and apply it. See that it is possible to click the link text and open it.
2. Press edit and see it is possible to edit the link and save changes.
3. Press remove link button, see that link field becomes empty, see if you can write the link again and apply it.
4. Add another button, and press show settings field, enable open in a new window.
5. Save the post and view it, see that one button opens in a new page and the other don't.

## Screenshots:
<img width="388" alt="screen shot 2017-10-20 at 20 24 06" src="https://user-images.githubusercontent.com/11271197/31839103-92179a7c-b5d7-11e7-8ea0-2b6c21a641b9.png">
<img width="1084" alt="screen shot 2017-10-20 at 20 24 45" src="https://user-images.githubusercontent.com/11271197/31839108-94cd202a-b5d7-11e7-8709-fa980a116b9a.png">
<img width="1094" alt="screen shot 2017-10-20 at 20 44 14" src="https://user-images.githubusercontent.com/11271197/31839117-99d16004-b5d7-11e7-99ec-571b894f3f98.png">
<img width="342" alt="screen shot 2017-10-20 at 20 47 23" src="https://user-images.githubusercontent.com/11271197/31839185-f47ef016-b5d7-11e7-8157-796fe996a7cd.png">

## Some notes

The link-editor was extracted mainly from the editable used in the paragraph. It can manage its own state e.g editing or not like when used here. But there are scenarios where the state needs to be managed also in parent component, e.g in paragraph link editor. So this component also supports receiving editing state as props, the idea is to refactor editable to use this component for link edition so duplicate code gets removed.