### PR TITLE
Revert changes to CSS specificity from #2951.

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -1,30 +1,30 @@
-body {
+body.gutenberg-editor-page {
 	background: $white;
-}
 
-#update-nag, .update-nag {
-	display: none;
-}
-
-#wpcontent {
-	padding-left: 0;
-}
-
-#wpbody-content {
-	padding-bottom: 0;
-}
-
-#wpfooter {
-	display: none;
-}
-
-.a11y-speak-region {
-	left: -1px;
-	top: -1px;
-}
-
-svg {
-	fill: currentColor;
+	#update-nag, .update-nag {
+		display: none;
+	}
+	
+	#wpcontent {
+		padding-left: 0;
+	}
+	
+	#wpbody-content {
+		padding-bottom: 0;
+	}
+	
+	#wpfooter {
+		display: none;
+	}
+	
+	.a11y-speak-region {
+		left: -1px;
+		top: -1px;
+	}
+	
+	svg {
+		fill: currentColor;
+	}
 }
 
 .gutenberg {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -153,6 +153,7 @@ function gutenberg_init( $return, $post ) {
 
 	add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );
 	add_filter( 'screen_options_show_screen', '__return_false' );
+	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
 
 	require_once( ABSPATH . 'wp-admin/admin-header.php' );
 	the_gutenberg_project();
@@ -527,3 +528,15 @@ function gutenberg_replace_default_add_new_button() {
 	<?php
 }
 add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_button' );
+
+/**
+ * Adds the gutenberg-editor-page class to the body tag on the Gutenberg page.
+ *
+ * @since 1.5.0
+ *
+ * @param string $classes Space seperated string of classes being added to the body tag.
+ * @return string The $classes string, with gutenberg-editor-page appended.
+ */
+function gutenberg_add_admin_body_class( $classes ) {
+	return "$classes gutenberg-editor-page";
+}


### PR DESCRIPTION
Per [these](https://github.com/WordPress/gutenberg/pull/2951#issuecomment-338222113) [comments](https://github.com/WordPress/gutenberg/pull/2951/files#r145977907), the specificity changes in #2951 caused different styles to be applied on small screens.

To avoid any other issues we've missed, this PR adds a class to `<body>` on the Gutenberg editor page, and uses that class to give the same specificity that existed before #2951.