### PR TITLE
Remove `withTransparentOption` from ColorPalette

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -135,7 +135,6 @@ registerBlockType( 'core/paragraph', {
 						<ColorPalette
 							value={ backgroundColor }
 							onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
-							withTransparentOption
 						/>
 					</PanelBody>
 					<PanelBody title={ __( 'Text Color' ) }>


### PR DESCRIPTION
## Description
The property `withTransparentOption` is not being used in ColorPalette.

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style.
- [ x ] My code follows has proper inline documentation.