### PR TITLE
Fix plugin build for metabox resizing.

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -93,6 +93,7 @@ mv gutenberg.tmp.php gutenberg.php
 status "Creating archive..."
 zip -r gutenberg.zip \
 	gutenberg.php \
+	assets/js/*.js \
 	lib/*.php \
 	blocks/library/*/*.php \
 	post-content.js \


### PR DESCRIPTION
#3098

The JS for metabox resizing was not being carried into the built plugin. This will bring over the necessary files. Now when the build-plugin-zip.sh is run the assets folder will be properly copied.
