### PR TITLE
Fix for issue 2635

### DIFF
--- a/blocks/library/button/editor.scss
+++ b/blocks/library/button/editor.scss
@@ -14,8 +14,6 @@ $blocks-button__height: 46px;
 	.blocks-format-toolbar__link-modal {
 		z-index: 2;
 		top: $blocks-button__height + 2px;
-		left: 50%;
-		transform: translateX( -50% );
 	}
 
 	.blocks-link-url__suggestions {


### PR DESCRIPTION
## Description
This fixes the overlapping problem with the WordPress admin sidebar.

## How Has This Been Tested?
Tested with chrome inspector too.