### PR TITLE
Set textarea value as props

### DIFF
--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -21,10 +21,9 @@ function TextareaControl( { label, value, help, instanceId, onChange, rows = 4, 
 				rows={ rows }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
+				value={ value }
 				{ ...props }
-			>
-				{ value }
-			</textarea>
+			></textarea>
 		</BaseControl>
 	);
 }

--- a/blocks/inspector-controls/textarea-control/index.js
+++ b/blocks/inspector-controls/textarea-control/index.js
@@ -23,7 +23,7 @@ function TextareaControl( { label, value, help, instanceId, onChange, rows = 4, 
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				value={ value }
 				{ ...props }
-			></textarea>
+			/>
 		</BaseControl>
 	);
 }


### PR DESCRIPTION
## Description
I got the following waring by using the TextareaControl: 
`Warning: Use the defaultValue or value props instead of setting children on <textarea>.` 
This PR sets the value via the `value` props.