### PR TITLE
Components: Extract a reusable Post Format Selector

### DIFF
--- a/editor/post-format/check.js
+++ b/editor/post-format/check.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { get, flowRight } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withAPIData } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentPostType } from '../selectors';
+
+function PostFormatCheck( { postType, children } ) {
+	if ( ! get( postType.data, [ 'supports', 'post-formats' ] ) ) {
+		return null;
+	}
+
+	return children;
+}
+
+export default flowRight( [
+	connect(
+		( state ) => {
+			return {
+				postTypeSlug: getCurrentPostType( state ),
+			};
+		},
+	),
+	withAPIData( ( props ) => {
+		const { postTypeSlug } = props;
+
+		return {
+			postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+		};
+	} ),
+] )( PostFormatCheck );

--- a/editor/post-format/index.js
+++ b/editor/post-format/index.js
@@ -38,7 +38,7 @@ function PostFormat( { postType, onUpdatePostFormat, postFormat = 'standard', su
 	const postFormatSelectorId = 'post-format-selector-' + instanceId;
 	const suggestion = find( POST_FORMATS, ( format ) => format.id === suggestedFormat );
 
-	// Disable reason: A select with an onchange throws a warning
+	// Disable reason: We need to change the value immiediately to show/hide the suggestion if needed
 
 	/* eslint-disable jsx-a11y/no-onchange */
 	return (

--- a/editor/post-format/index.js
+++ b/editor/post-format/index.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { find, flowRight } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { withInstanceId } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { getEditedPostAttribute, getSuggestedPostFormat } from '../selectors';
+import { editPost } from '../actions';
+
+const POST_FORMATS = [
+	{ id: 'aside', caption: __( 'Aside' ) },
+	{ id: 'gallery', caption: __( 'Gallery' ) },
+	{ id: 'link', caption: __( 'Link' ) },
+	{ id: 'image', caption: __( 'Image' ) },
+	{ id: 'quote', caption: __( 'Quote' ) },
+	{ id: 'standard', caption: __( 'Standard' ) },
+	{ id: 'status', caption: __( 'Status' ) },
+	{ id: 'video', caption: __( 'Video' ) },
+	{ id: 'audio', caption: __( 'Audio' ) },
+	{ id: 'chat', caption: __( 'Chat' ) },
+];
+
+function PostFormat( { onUpdatePostFormat, postFormat = 'standard', suggestedFormat, instanceId } ) {
+	const postFormatSelectorId = 'post-format-selector-' + instanceId;
+	const suggestion = find( POST_FORMATS, ( format ) => format.id === suggestedFormat );
+
+	// Disable reason: A select with an onchange throws a warning
+
+	/* eslint-disable jsx-a11y/no-onchange */
+	return (
+		<div className="editor-post-format">
+			<div className="editor-post-format__content">
+				<label htmlFor={ postFormatSelectorId }>{ __( 'Post Format' ) }</label>
+				<select
+					value={ postFormat }
+					onChange={ ( event ) => onUpdatePostFormat( event.target.value ) }
+					id={ postFormatSelectorId }
+				>
+					{ POST_FORMATS.map( format => (
+						<option key={ format.id } value={ format.id }>{ format.caption }</option>
+					) ) }
+				</select>
+			</div>
+
+			{ suggestion && suggestion.id !== postFormat && (
+				<div className="editor-post-format__suggestion">
+					{ __( 'Suggestion:' ) }{ ' ' }
+					<button className="button-link" onClick={ () => onUpdatePostFormat( suggestion.id ) }>
+						{ suggestion.caption }
+					</button>
+				</div>
+			) }
+		</div>
+	);
+	/* eslint-enable jsx-a11y/no-onchange */
+}
+
+export default flowRight( [
+	connect(
+		( state ) => {
+			return {
+				postFormat: getEditedPostAttribute( state, 'format' ),
+				suggestedFormat: getSuggestedPostFormat( state ),
+			};
+		},
+		{
+			onUpdatePostFormat( postFormat ) {
+				return editPost( { format: postFormat } );
+			},
+		},
+	),
+	withInstanceId,
+] )( PostFormat );

--- a/editor/post-format/style.scss
+++ b/editor/post-format/style.scss
@@ -1,12 +1,14 @@
 .editor-post-format {
 	flex-direction: column;
 	align-items: stretch;
+	width: 100%;
 }
 
 .editor-post-format__content {
 	display: inline-flex;
 	justify-content: space-between;
 	align-items: center;
+	width: 100%;
 }
 
 .editor-post-format__suggestion {

--- a/editor/sidebar/post-format/index.js
+++ b/editor/sidebar/post-format/index.js
@@ -2,90 +2,37 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get, find, flowRight } from 'lodash';
+import { get, flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { PanelRow, withAPIData, withInstanceId } from '@wordpress/components';
+import { PanelRow, withAPIData } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import './style.scss';
-import {
-	getEditedPostAttribute,
-	getSuggestedPostFormat,
-	getCurrentPostType,
-} from '../../selectors';
-import { editPost } from '../../actions';
+import PostFormatSelector from '../../post-format';
+import { getCurrentPostType } from '../../selectors';
 
-const POST_FORMATS = [
-	{ id: 'aside', caption: __( 'Aside' ) },
-	{ id: 'gallery', caption: __( 'Gallery' ) },
-	{ id: 'link', caption: __( 'Link' ) },
-	{ id: 'image', caption: __( 'Image' ) },
-	{ id: 'quote', caption: __( 'Quote' ) },
-	{ id: 'standard', caption: __( 'Standard' ) },
-	{ id: 'status', caption: __( 'Status' ) },
-	{ id: 'video', caption: __( 'Video' ) },
-	{ id: 'audio', caption: __( 'Audio' ) },
-	{ id: 'chat', caption: __( 'Chat' ) },
-];
-
-function PostFormat( { postType, onUpdatePostFormat, postFormat = 'standard', suggestedFormat, instanceId } ) {
+function PostFormat( { postType } ) {
 	if ( ! get( postType.data, [ 'supports', 'post-formats' ] ) ) {
 		return null;
 	}
 
-	const postFormatSelectorId = 'post-format-selector-' + instanceId;
-	const suggestion = find( POST_FORMATS, ( format ) => format.id === suggestedFormat );
-
-	// Disable reason: A select with an onchange throws a warning
-
-	/* eslint-disable jsx-a11y/no-onchange */
 	return (
-		<PanelRow className="editor-post-format">
-			<div className="editor-post-format__content">
-				<label htmlFor={ postFormatSelectorId }>{ __( 'Post Format' ) }</label>
-				<select
-					value={ postFormat }
-					onChange={ ( event ) => onUpdatePostFormat( event.target.value ) }
-					id={ postFormatSelectorId }
-				>
-					{ POST_FORMATS.map( format => (
-						<option key={ format.id } value={ format.id }>{ format.caption }</option>
-					) ) }
-				</select>
-			</div>
-
-			{ suggestion && suggestion.id !== postFormat && (
-				<div className="editor-post-format__suggestion">
-					{ __( 'Suggestion:' ) }{ ' ' }
-					<button className="button-link" onClick={ () => onUpdatePostFormat( suggestion.id ) }>
-						{ suggestion.caption }
-					</button>
-				</div>
-			) }
+		<PanelRow>
+			<PostFormatSelector />
 		</PanelRow>
 	);
-	/* eslint-enable jsx-a11y/no-onchange */
 }
 
 export default flowRight( [
 	connect(
 		( state ) => {
 			return {
-				postFormat: getEditedPostAttribute( state, 'format' ),
-				suggestedFormat: getSuggestedPostFormat( state ),
 				postTypeSlug: getCurrentPostType( state ),
 			};
-		},
-		{
-			onUpdatePostFormat( postFormat ) {
-				return editPost( { format: postFormat } );
-			},
 		},
 	),
 	withAPIData( ( props ) => {
@@ -95,5 +42,4 @@ export default flowRight( [
 			postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
 		};
 	} ),
-	withInstanceId,
 ] )( PostFormat );

--- a/editor/sidebar/post-format/index.js
+++ b/editor/sidebar/post-format/index.js
@@ -1,45 +1,22 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import { get, flowRight } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { PanelRow, withAPIData } from '@wordpress/components';
+import { PanelRow } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import PostFormatSelector from '../../post-format';
-import { getCurrentPostType } from '../../selectors';
+import PostFormatCheck from '../../post-format/check';
+import PostFormatForm from '../../post-format';
 
-function PostFormat( { postType } ) {
-	if ( ! get( postType.data, [ 'supports', 'post-formats' ] ) ) {
-		return null;
-	}
-
+export function PostFormat() {
 	return (
-		<PanelRow>
-			<PostFormatSelector />
-		</PanelRow>
+		<PostFormatCheck>
+			<PanelRow>
+				<PostFormatForm />
+			</PanelRow>
+		</PostFormatCheck>
 	);
 }
 
-export default flowRight( [
-	connect(
-		( state ) => {
-			return {
-				postTypeSlug: getCurrentPostType( state ),
-			};
-		},
-	),
-	withAPIData( ( props ) => {
-		const { postTypeSlug } = props;
-
-		return {
-			postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
-		};
-	} ),
-] )( PostFormat );
+export default PostFormat;


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/2761#issuecomment-338168524

> All these (the sidebar panels) must be refactored slightly to drop all the "layout" pieces and keep only the "forms". For example, the sidebar panels like PostTaxonomies, we should extract only the PostTaxonomyForms into a reusable component without the expandable panel behavior that is specific to our current UI. (This step could be done in a separate PR preceding the directory structure change)

This is the first one of multiple PRs addressing the comment above and extracting reusable pieces from our current sidebar panels. This PR does so for the PostFormat component.

**Testing instructions**

 - Test that the post format selector still works and shows as expected.