### PR TITLE
Inserter: Fix misaligned tooltip for the trailing inserter

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -289,7 +289,6 @@
 
 	.editor-inserter__toggle {
 		color: $dark-gray-300;
-		margin: 4px 0 0 -4px;	// align better with text blocks
 	}
 
 	.editor-inserter__toggle.components-icon-button:not(:disabled):hover {


### PR DESCRIPTION
## Description

I noticed that the tooltip opened for the trailing inserter is misaligned at the moment:

![screen shot 2017-10-19 at 11 38 01](https://user-images.githubusercontent.com/699132/31817213-5f91b34c-b593-11e7-9719-0c2d5492a8f9.png)

This PR tries to fix it.

## How Has This Been Tested?

Manually:
* Open Gutenberg editor.
* Click inserter button on the very bottom of the post/page.

## Screenshots (jpeg or gifs if applicable):

##### Before

![screen shot 2017-10-19 at 11 38 01](https://user-images.githubusercontent.com/699132/31817213-5f91b34c-b593-11e7-9719-0c2d5492a8f9.png)

<img width="211" alt="screen shot 2017-10-23 at 10 59 43" src="https://user-images.githubusercontent.com/699132/31880814-ef8bb9de-b7e1-11e7-9ebe-b30bbc145085.png">

##### After

<img width="227" alt="screen shot 2017-10-23 at 11 01 00" src="https://user-images.githubusercontent.com/699132/31880828-f6fe56ea-b7e1-11e7-9423-a8929e093243.png">
<img width="239" alt="screen shot 2017-10-23 at 11 01 16" src="https://user-images.githubusercontent.com/699132/31880829-f717b7f2-b7e1-11e7-9c0c-4a73e382d1f8.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.