### PR TITLE
Fix issue with manually folded sidebar

### DIFF
--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -46,7 +46,11 @@
 
 /* Sidebar manually collapsed */
 .folded .editor-header {
-	left: $admin-sidebar-width-collapsed;
+	left: 0;
+
+	@include break-medium() {
+		left: $admin-sidebar-width-collapsed;
+	}
 }
 
 /* Mobile menu opened */


### PR DESCRIPTION
This PR is tiny, and fixes a responsive issue where if you manually close the navigation sidebar, at the medium breakpoint you'd see a stray left margin.

Screenshot, before:

<img width="695" alt="screen shot 2017-10-23 at 11 06 50" src="https://user-images.githubusercontent.com/1204802/31881091-b7f49f76-b7e2-11e7-8320-9a0293168103.png">

Screenshot, after: 

<img width="696" alt="screen shot 2017-10-23 at 11 07 45" src="https://user-images.githubusercontent.com/1204802/31881097-bdaa177a-b7e2-11e7-822f-f01fb5bfb2a2.png">
