### PR TITLE
Attributes: Add support for site options

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -102,7 +102,9 @@ export function getCommentAttributes( allAttributes, schema ) {
 		}
 
 		// Ignore values sources from content and post meta
-		if ( attributeSchema.source || attributeSchema.meta ) {
+		if ( attributeSchema.source ||
+				attributeSchema.meta ||
+				attributeSchema.option ) {
 			return result;
 		}
 

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -22,3 +22,4 @@ import './text-columns';
 import './verse';
 import './video';
 import './audio';
+import './site-description';

--- a/blocks/library/site-description/index.js
+++ b/blocks/library/site-description/index.js
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+import { Placeholder, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '../../api';
+import InspectorControls from '../../inspector-controls';
+import BlockDescription from '../../block-description';
+import BlockControls from '../../block-controls';
+
+registerBlockType( 'core/site-description', {
+	title: __( 'Site Description' ),
+
+	icon: 'list-view',
+
+	category: 'widgets',
+
+	attributes: {
+		description: {
+			type: 'string',
+			option: 'description',
+		},
+		shouldRenderDescription: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+
+	keywords: [ __( 'site tagline' ) ],
+
+	edit( { attributes, setAttributes, focus } ) {
+		const {
+			description,
+			shouldRenderDescription,
+		} = attributes;
+
+		if ( description === undefined ) {
+			return (
+				<Placeholder
+					icon="admin-post"
+					label={ __( 'Site Description' ) }
+				>
+					<Spinner />
+				</Placeholder>
+			);
+		}
+
+		return [
+			focus && <BlockControls key="controls" />,
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'Shows your site\'s description' ) }</p>
+					</BlockDescription>
+					<InspectorControls.ToggleControl
+						label={ __( 'Render description' ) }
+						checked={ shouldRenderDescription }
+						onChange={ () => setAttributes( {
+							shouldRenderDescription: ! shouldRenderDescription,
+						} ) }
+					/>
+				</InspectorControls>
+			),
+			<input key="site-title"
+				className="wp-block-site-description"
+				onChange={ ( event ) => setAttributes( {
+					description: event.target.value,
+				} ) }
+				value={ description } />,
+		];
+	},
+
+	save( { attributes } ) {
+		const { description, shouldRenderDescription } = attributes;
+		return shouldRenderDescription
+			? <div>{ description }</div>
+			: null;
+	},
+} );

--- a/blocks/library/site-description/index.php
+++ b/blocks/library/site-description/index.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Server-side rendering of the `core/site-description` block.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Renders the `core/site-description` block on server.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string Returns HTML for the site description block.
+ */
+function gutenberg_render_block_core_site_description( $attributes ) {
+	if ( ! $attributes[ 'shouldRenderDescription' ] ) {
+		return '';
+	}
+
+	$class = "wp-block-site-description";
+	$description = get_option( 'blogdescription' );
+	$block_content = sprintf(
+		'<div class="%1$s">%2$s</div>',
+		esc_attr( $class ),
+		esc_html( $description )
+	);
+
+	return $block_content;
+}
+
+register_block_type( 'core/site-description', array(
+	'attributes' => array(
+		/* option attribute
+		'description' => array(
+			'type' => 'string',
+			'option' => 'description',
+		),
+		 */
+		'shouldRenderDescription' => array(
+			'type' => 'boolean',
+			'default' => false,
+		),
+	),
+
+	'render_callback' => 'gutenberg_render_block_core_site_description',
+) );

--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -11,7 +11,7 @@ import { Component } from 'element';
 /**
  * Internal dependencies
  */
-import request from './request';
+import request, { encodeParams } from './request';
 import { getRoute } from './routes';
 
 export default ( mapPropsToData ) => ( WrappedComponent ) => {
@@ -166,6 +166,8 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 					return result;
 				}
 
+				console.log( 'route', path, route );
+
 				result[ propName ] = route.methods.reduce( ( stateValue, method ) => {
 					// Add request initiater into data props
 					const requestKey = this.getRequestKey( method );
@@ -182,6 +184,15 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 
 					// Track path for future map skipping
 					stateValue.path = path;
+
+					// TODO move this somewhere else and/or document
+					if ( method === 'PUT' ) {
+						stateValue.saveWith = ( data ) =>
+							this.request(
+									propName,
+									method,
+									path + encodeParams( data ) );
+					}
 
 					return stateValue;
 				}, {} );

--- a/components/higher-order/with-api-data/request.js
+++ b/components/higher-order/with-api-data/request.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import memoize from 'memize';
-import { mapKeys } from 'lodash';
+import { isEmpty, mapKeys, toPairs } from 'lodash';
 
 export const getStablePath = memoize( ( path ) => {
 	const [ base, query ] = path.split( '?' );
@@ -29,13 +29,20 @@ export const getStablePath = memoize( ( path ) => {
 		// 'a=5&b=1&c=2'
 } );
 
+export const encodeParams = ( data ) =>
+	isEmpty( data )
+		? ''
+		: '?' + toPairs( data )
+			.map( ( [ key, value ] ) => `${ key }=${ encodeURI( value ) }` )
+			.join( '& ' );
+
 /**
  * Response cache of path to response (object of data, headers arrays).
  * Optionally populated from window global for preloading.
  *
  * @type {Object}
  */
-export const cache = mapKeys(
+export const cache = window._wpAPICache = mapKeys(
 	window._wpAPIDataPreload,
 	( value, key ) => getStablePath( key )
 );

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -148,11 +148,23 @@ class VisualEditorBlock extends Component {
 			return result;
 		}, {} );
 
+		const optionAttributes = reduce( attributes, ( result, value, key ) => {
+			if ( type && has( type, [ 'attributes', key, 'option' ] ) ) {
+				result[ type.attributes[ key ].option ] = value;
+			}
+
+			return result;
+		}, {} );
+
 		if ( size( metaAttributes ) ) {
 			this.props.onMetaChange( {
 				...this.props.meta,
 				...metaAttributes,
 			} );
+		}
+
+		if ( size( optionAttributes ) ) {
+			this.props.onOptionsChange( optionAttributes );
 		}
 	}
 
@@ -462,6 +474,10 @@ export default connect(
 
 		onMetaChange( meta ) {
 			dispatch( editPost( { meta } ) );
+		},
+
+		onOptionsChange( siteOptions ) {
+			dispatch( { type: 'UPDATE_SITE_OPTIONS', siteOptions } );
 		},
 	} )
 )( VisualEditorBlock );

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -22,6 +22,7 @@ import WritingFlow from '../../writing-flow';
 import TableOfContents from '../../table-of-contents';
 import { getBlockUids, getMultiSelectedBlockUids } from '../../selectors';
 import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks } from '../../actions';
+import { QuerySiteOptions } from '../../site-options';
 
 class VisualEditor extends Component {
 	constructor() {
@@ -101,6 +102,7 @@ class VisualEditor extends Component {
 					backspace: this.deleteSelectedBlocks,
 					del: this.deleteSelectedBlocks,
 				} } />
+				<QuerySiteOptions />
 				<WritingFlow>
 					<PostTitle />
 					<VisualEditorBlockList ref={ this.bindBlocksContainer } />

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -524,6 +524,15 @@ export function notices( state = {}, action ) {
 	return state;
 }
 
+export function siteOptions( state = {}, action ) {
+	switch ( action.type ) {
+		case 'UPDATE_SITE_OPTIONS':
+			return { ...state, ...action.siteOptions };
+	}
+
+	return state;
+}
+
 export default optimist( combineReducers( {
 	editor,
 	currentPost,
@@ -535,4 +544,5 @@ export default optimist( combineReducers( {
 	panel,
 	saving,
 	notices,
+	siteOptions,
 } ) );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -397,13 +397,23 @@ export const getBlock = createSelector(
 			return result;
 		}, {} );
 
-		if ( ! Object.keys( metaAttributes ).length ) {
+		const optionAttributes = reduce( type.attributes, ( result, value, key ) => {
+			if ( value && ( 'option' in value ) ) {
+				result[ key ] = getSiteOption( state, value.option );
+			}
+
+			return result;
+		}, {} );
+
+		if ( ! Object.keys( metaAttributes ).length &&
+				! Object.keys( optionAttributes ).length ) {
 			return block;
 		}
 
 		return {
 			...block,
 			attributes: {
+				...optionAttributes,
 				...block.attributes,
 				...metaAttributes,
 			},
@@ -413,6 +423,7 @@ export const getBlock = createSelector(
 		get( state, [ 'editor', 'blocksByUid', uid ] ),
 		get( state, 'editor.edits.meta' ),
 		get( state, 'currentPost.meta' ),
+		get( state, 'siteOptions' ),
 	]
 );
 
@@ -420,6 +431,10 @@ function getPostMeta( state, key ) {
 	return has( state, [ 'editor', 'edits', 'meta', key ] )
 		? get( state, [ 'editor', 'edits', 'meta', key ] )
 		: get( state, [ 'currentPost', 'meta', key ] );
+}
+
+function getSiteOption( state, key ) {
+	return get( state, [ 'siteOptions', key ] );
 }
 
 /**

--- a/editor/site-options/index.js
+++ b/editor/site-options/index.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import {
+	differenceWith,
+	isEqual,
+	pick,
+	toPairs,
+} from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+const optionsModel = new wp.api.models.Settings();
+
+let callTime;
+export function fetchSiteOptions() {
+	if ( ! callTime || Date.now() - callTime > 3000 ) {
+		callTime = Date.now();
+		return Promise.resolve( optionsModel.fetch() );
+	}
+	return Promise.reject();
+}
+
+export function saveSiteOptions( options ) {
+	const newKeys = getChangedKeys( options, getSiteOptions() );
+	const newOptions = pick( options, newKeys );
+	return optionsModel.save( newOptions )
+		.then( ( result ) => pick( result, newKeys ) );
+}
+
+export function getOptionUpdatedMessage( option ) {
+	switch ( option ) {
+		case 'description':
+			return __( 'Site description updated!' );
+	}
+}
+
+function getSiteOptions() {
+	return optionsModel.attributes;
+}
+
+function getChangedKeys( newOptions, oldOptions ) {
+	return differenceWith( toPairs( newOptions ), toPairs( oldOptions ), isEqual )
+		.map( ( [ key ] ) => key );
+}
+
+export const QuerySiteOptions = connect(
+	null,
+	( dispatch ) => ( {
+		requestSiteOptions() {
+			dispatch( {
+				type: 'RESET_SITE_OPTIONS',
+			} );
+		},
+	} )
+)( class extends Component {
+	componentDidMount() {
+		this.props.requestSiteOptions();
+	}
+	render() {
+		return null;
+	}
+} );


### PR DESCRIPTION
Implements #2759 

# The essence

This pull request aims to add support for site options as an attribute source:

```js
attributes: {
  siteDescription: {
    type: 'text',
    option: 'description'
  }
},

edit( { attributes, setAttributes, focus } ) {
  return [
    focus && <InspectorControls … />,
    <input
      value={ attributes.siteDescription }
      onChange={
        ( event ) => setAttributes( {
          siteDescription: event.target.value,
        } )
      } />,
  ];
}
```

![gutenberg-site-options](https://user-images.githubusercontent.com/150562/31897025-1b2b97aa-b80d-11e7-955f-b01f8430de09.gif)

The first commit corresponds to the initial exploration, which works, though for simplicity it resorted to the pre-Gutenberg Backbone WP-API interface—`wp.api.models.Settings`—with an instance living in `editor/effects` to handle reads (populating Redux state via action dispatching) and writes (`Model#save` method).

# Next: withAPIData

Following that exploration, thought was given to putting `withAPIData` (WAD) to use, in order to interact with WP-API at `/wp/v2/settings`. Why? To see how far WAD can help Gutenberg satisfy its data needs across the board, to see if we can identify bits of it that could be improved.

## One-off, isolated use of site options

However, WAD is a higher-order component, thus designed to enhance components by injecting its data (which incidentally gets its own cache, invisibly shared across WAD-enhanced instances). It arguably has more local data needs in mind (for a specific component needing a specific external resource), potentially at odds with a new kind of attribute that is _global_ to a site.

WAD’s ideal scenario it to enhance a block directly and statically (cf. [example](https://github.com/WordPress/gutenberg/pull/1974#issuecomment-318437786)). However, we don’t want this explicit enhancement to be a burden for block authors seeking to interact with site options. Suppose, then, an enhancer—for now named `connectSiteOptions`—that builds on WAD:

```js
const connectSiteOptions = ( typeAttributes ) => flowRight(
  withAPIData( constant( { settings: '/wp/v2/settings' } ) ),
  withInterceptedAttributes( typeAttributes )
);

Block = connectSiteOptions( typeAttributes )( Block );
```

This is [straightforward to implement](https://jsfiddle.net/mcsf/s3333mz0/7/). `withInterceptedAttributes` would inject the requested site options into `attributes`, and wrap `setAttributes` so as to intercept and handle attempts to set site options. Nonetheless, it shows limitations as soon as more than one block needs site options. For instance, if a block allows the user to change a site's title, should other blocks that present the site title immediately reflect the local change? Should they only update once that change is pushed to the server?

## Stretching the mechanism too far?

It would possible to make this scale for multiple blocks the following way:
- Some top-level component like `VisualEditorBlockList` would be enhanced with a HoC that would keep its own state on site options.
- Either through React context injection or through prop passing, it would expose bound methods (e.g. `getSiteOptions`, `setSiteOptions`) to its descendants.
- BlockEdit instances would be enhanced with a HoC that would intercept attributes and their setter, just as before, but relaying this data to and from the ancestor (pseudo-code: `if attribute.name in siteOptionAttributes; then setRealAttribute(attribute); else setSiteOption(attribute)`.

I got this to work conceptually, but it doesn't seem like anything we'd want.

## As a virtual data-requesting component

Instead of working against Gutenberg's architecture, and namely its approach of centralized state, we could have something similar to Calypso's [query components](https://github.com/Automattic/wp-calypso/tree/master/client/components/data/query-posts) sitting in Layout or VisualEditor:

```js
class SiteOptionsManager extends Component {}
export default flowRight(
  withAPIData,
  connect( … ) // to detect post saves & to dispatch actions
)( SiteOptionsManager );
```

This still feels, in some way, like a suboptimal solution when compared to the existing paradigm in Gutenberg: views can dispatch actions signalling intent (to have data, to set/save it), effects react to these actions by interacting with the network and dispatching further actions, reducers commit state changes based on said actions, state is fed back into views. Suboptimal in the sense that effects (incl. XHR) are generated within a virtual component, rather than in `editor/effects`, and that the component would have to look at prop changes of `state.saving.requesting` to infer post saves.

One benefit of data "injection". as seen in §§ _One-off, isolated use of site options_ & _Stretching the mechanism too far?_, is that it means that the Gutenberg "core" doesn't need to worry about different attribute sources (aside from a pass-through in the serializer, as seen here in the first commit).

Perhaps, if we are to follow the route of § _As a virtual data-requesting component_, devising some abstraction that could accommodate these new sources—site options, post meta, and others to come—would be a prerequisite.