### PR TITLE
Classic Text: Only show InspectorControls on focus

### DIFF
--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -163,14 +163,16 @@ export default class OldEditor extends Component {
 	}
 
 	render() {
-		const { id } = this.props;
+		const { focus, id } = this.props;
 
 		return [
-			<InspectorControls key="inspector">
-				<BlockDescription>
-					<p>{ __( 'The classic editor, in block form.' ) }</p>
-				</BlockDescription>
-			</InspectorControls>,
+			focus && (
+				<InspectorControls key="inspector">
+					<BlockDescription>
+						<p>{ __( 'The classic editor, in block form.' ) }</p>
+					</BlockDescription>
+				</InspectorControls>
+			),
 			<div
 				key="toolbar"
 				id={ id + '-toolbar' }


### PR DESCRIPTION
## Description
Only show Classic Text InspectorControls on `focus`.