### PR TITLE
Fixed color picker width

### DIFF
--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -122,7 +122,3 @@ $color-palette-circle-spacing: 14px;
 
 	background-clip: content-box, content-box, content-box, content-box, content-box, content-box, padding-box, padding-box, padding-box, padding-box, padding-box, padding-box;
 }
-
-.blocks-color-palette__picker .chrome-picker {
-	width: 100% !important;
-}


### PR DESCRIPTION
This PR fixes a color picker problem that I detect recently. To reproduce the bug just go to the paragraph and try to set a custom color.


## Description
It removes a rule that overrides the normal width of the custom color picker.

## Screenshots:
Before:
<img width="815" alt="screen shot 2017-10-24 at 13 11 04" src="https://user-images.githubusercontent.com/11271197/31942338-eb8199a4-b8bc-11e7-8c40-b744cb82cd7b.png">

After:
<img width="800" alt="screen shot 2017-10-24 at 13 10 26" src="https://user-images.githubusercontent.com/11271197/31942350-f2b0f742-b8bc-11e7-9cde-72e58dc52ec5.png">



## Notes
In my environment, this fixed the problem, but maybe the problem is something specific to my environment if yes I will try to find the reason why in my machine the color picker in the master appears wrong.

This problem is not happening on my machine on an external install with the last release.