### PR TITLE
Metaboxes: Fix resizing iFrame in Firefox

### DIFF
--- a/assets/js/meta-box-resize.js
+++ b/assets/js/meta-box-resize.js
@@ -41,6 +41,7 @@
 	} );
 
 	window.addEventListener( 'load', sendResize, true );
+	window.addEventListener( 'resize', sendResize, true );
 
 	sendResize();
 } )();


### PR DESCRIPTION
It looks like Chrome was receiving the right size (widht/height) even when the iframe was closed but Firefox returns the correct dimensions only when the iframe is displayed. So I added a "resize" event handler (triggered when showing/hiding the iframe) to recompute the dimensions at that moment.