### PR TITLE
Fix issue with collapsing popover content

### DIFF
--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -67,6 +67,7 @@
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;
+	min-width: 240px;
 
 	.components-popover.is-top & {
 		bottom: 100%;


### PR DESCRIPTION
This fixes a regression introduced by the recent refactor of the inserter. It adds a min-width to the popover component. Previously it had a fixed width.

Screenshots:

![screen shot 2017-10-24 at 15 33 41](https://user-images.githubusercontent.com/1204802/31945936-e0a51074-b8d0-11e7-8f3a-321d02e6e59d.png)

![screen shot 2017-10-24 at 15 33 45](https://user-images.githubusercontent.com/1204802/31945937-e1e1196a-b8d0-11e7-9887-266deb424f59.png)

![screen shot 2017-10-24 at 15 33 49](https://user-images.githubusercontent.com/1204802/31945939-e3286fd0-b8d0-11e7-9bda-c6b188c3dc6e.png)
