### PR TITLE
Reducer.js error with `null`

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -29,7 +29,7 @@ const MAX_RECENT_BLOCKS = 8;
  * @return {*}       Raw value
  */
 export function getPostRawValue( value ) {
-	if ( 'object' === typeof value && 'raw' in value ) {
+	if ( value && 'object' === typeof value && 'raw' in value ) {
 		return value.raw;
 	}
 

--- a/editor/sidebar/featured-image/index.js
+++ b/editor/sidebar/featured-image/index.js
@@ -80,7 +80,7 @@ const applyConnect = connect(
 			return editPost( { featured_media: image.id } );
 		},
 		onRemoveImage() {
-			return editPost( { featured_media: null } );
+			return editPost( { featured_media: 0 } );
 		},
 		onTogglePanel() {
 			return toggleSidebarPanel( PANEL_NAME );


### PR DESCRIPTION
## Description
Adds an additional check to `getPostRawValue()` in reducer.js, because `typeof null` is `'object'`.

The `featured image` param should be an integer. If you want delete it, set it to 0.
See: https://github.com/WordPress/WordPress/blob/master/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1139

Resolves #3115 

