### PR TITLE
Added contrast verification and readability checking to button.

### DIFF
--- a/blocks/contrast-checker/index.js
+++ b/blocks/contrast-checker/index.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import tinycolor from 'tinycolor2';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function ContrastChecker( { backgroundColor, textColor, isLargeText } ) {
+	if ( ! backgroundColor || ! textColor ) {
+		return null;
+	}
+	const tinyBackgroundColor = tinycolor( backgroundColor );
+	const tinyTextColor = tinycolor( textColor );
+	if ( tinycolor.isReadable(
+			tinyBackgroundColor,
+			tinyTextColor,
+			{ level: 'AA', size: ( isLargeText ? 'large' : 'small' ) }
+		)
+	) {
+		return null;
+	}
+	const msg = tinyBackgroundColor.getBrightness() < tinyTextColor.getBrightness() ?
+		__( 'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.' ) :
+		__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.' );
+	return (
+		<div className="blocks-contrast-checker">
+			<Notice status="warning" content={ msg } isDismissible={ false } />
+		</div>
+	);
+}
+
+export default ContrastChecker;

--- a/blocks/contrast-checker/index.js
+++ b/blocks/contrast-checker/index.js
@@ -21,11 +21,10 @@ function ContrastChecker( { backgroundColor, textColor, isLargeText } ) {
 	const tinyBackgroundColor = tinycolor( backgroundColor );
 	const tinyTextColor = tinycolor( textColor );
 	if ( tinycolor.isReadable(
-			tinyBackgroundColor,
-			tinyTextColor,
-			{ level: 'AA', size: ( isLargeText ? 'large' : 'small' ) }
-		)
-	) {
+		tinyBackgroundColor,
+		tinyTextColor,
+		{ level: 'AA', size: ( isLargeText ? 'large' : 'small' ) }
+	) ) {
 		return null;
 	}
 	const msg = tinyBackgroundColor.getBrightness() < tinyTextColor.getBrightness() ?

--- a/blocks/contrast-checker/style.scss
+++ b/blocks/contrast-checker/style.scss
@@ -1,0 +1,3 @@
+.blocks-contrast-checker > .notice {
+	margin: 0;
+}

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -22,13 +22,26 @@ import InspectorControls from '../../inspector-controls';
 import BlockDescription from '../../block-description';
 
 const { attr, children } = source;
+const { getComputedStyle } = window;
 
 class ButtonBlock extends Component {
 	constructor() {
 		super( ...arguments );
+
+		this.containers = {};
 		this.fallbackColors = {};
+
 		this.updateAlignment = this.updateAlignment.bind( this );
 		this.toggleClear = this.toggleClear.bind( this );
+		this.bindRef = this.bindRef.bind( this );
+	}
+
+	componentDidMount() {
+		this.grabColors();
+	}
+
+	componentDidUpdate() {
+		this.grabColors();
 	}
 
 	updateAlignment( nextAlign ) {
@@ -38,6 +51,29 @@ class ButtonBlock extends Component {
 	toggleClear() {
 		const { attributes, setAttributes } = this.props;
 		setAttributes( { clear: ! attributes.clear } );
+	}
+
+	bindRef( node ) {
+		if ( ! node ) {
+			return;
+		}
+
+		this.containers.background = node;
+		this.containers.text = node.querySelector( '[contenteditable="true"]' );
+	}
+
+	grabColors() {
+		const { background, text } = this.containers;
+
+		if ( background ) {
+			this.fallbackColors.backgroundColor =
+				getComputedStyle( background ).backgroundColor;
+		}
+
+		if ( text ) {
+			this.fallbackColors.textColor =
+				getComputedStyle( text ).color;
+		}
 	}
 
 	render() {
@@ -65,7 +101,7 @@ class ButtonBlock extends Component {
 					<BlockAlignmentToolbar value={ align } onChange={ this.updateAlignment } />
 				</BlockControls>
 			),
-			<span key="button" className={ className } title={ title } style={ { backgroundColor: color } } >
+			<span key="button" className={ className } title={ title } style={ { backgroundColor: color } } ref={ this.bindRef }>
 				<Editable
 					tagName="span"
 					placeholder={ __( 'Add text…' ) }
@@ -96,8 +132,8 @@ class ButtonBlock extends Component {
 								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
 							/>
 							<ContrastChecker
-								{ ...{ textColor } }
-								backgroundColor={ color }
+								textColor={ textColor || this.fallbackColors.textColor }
+								backgroundColor={ color || this.fallbackColors.backgroundColor }
 								isLargeText={ true }
 							/>
 						</PanelBody>

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import { Dashicon, IconButton, PanelBody } from '@wordpress/components';
 
 /**
@@ -21,6 +22,109 @@ import InspectorControls from '../../inspector-controls';
 import BlockDescription from '../../block-description';
 
 const { attr, children } = source;
+
+class ButtonBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.fallbackColors = {};
+		this.updateAlignment = this.updateAlignment.bind( this );
+		this.toggleClear = this.toggleClear.bind( this );
+	}
+
+	updateAlignment( nextAlign ) {
+		this.props.setAttributes( { align: nextAlign } );
+	}
+
+	toggleClear() {
+		const { attributes, setAttributes } = this.props;
+		setAttributes( { clear: ! attributes.clear } );
+	}
+
+	render() {
+		const {
+			attributes,
+			setAttributes,
+			focus,
+			setFocus,
+			className,
+		} = this.props;
+
+		const {
+			text,
+			url,
+			title,
+			align,
+			color,
+			textColor,
+			clear,
+		} = attributes;
+
+		return [
+			focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar value={ align } onChange={ this.updateAlignment } />
+				</BlockControls>
+			),
+			<span key="button" className={ className } title={ title } style={ { backgroundColor: color } } >
+				<Editable
+					tagName="span"
+					placeholder={ __( 'Add text…' ) }
+					value={ text }
+					focus={ focus }
+					onFocus={ setFocus }
+					onChange={ ( value ) => setAttributes( { text: value } ) }
+					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+					style={ {
+						color: textColor,
+					} }
+					keepPlaceholderOnFocus
+				/>
+				{ focus &&
+					<InspectorControls key="inspector">
+						<BlockDescription>
+							<p>{ __( 'A nice little button. Call something out with it.' ) }</p>
+						</BlockDescription>
+
+						<ToggleControl
+							label={ __( 'Stand on a line' ) }
+							checked={ !! clear }
+							onChange={ this.toggleClear }
+						/>
+						<PanelBody title={ __( 'Button Background Color' ) }>
+							<ColorPalette
+								value={ color }
+								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
+							/>
+							<ContrastChecker
+								{ ...{ textColor } }
+								backgroundColor={ color }
+								isLargeText={ true }
+							/>
+						</PanelBody>
+						<PanelBody title={ __( 'Button Text Color' ) }>
+							<ColorPalette
+								value={ textColor }
+								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
+							/>
+						</PanelBody>
+					</InspectorControls>
+				}
+			</span>,
+			focus && (
+				<form
+					className="blocks-button__inline-link"
+					onSubmit={ ( event ) => event.preventDefault() }>
+					<Dashicon icon="admin-links" />
+					<UrlInput
+						value={ url }
+						onChange={ ( value ) => setAttributes( { url: value } ) }
+					/>
+					<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
+				</form>
+			),
+		];
+	}
+}
 
 registerBlockType( 'core/button', {
 	title: __( 'Button' ),
@@ -69,75 +173,8 @@ registerBlockType( 'core/button', {
 		return props;
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, className } ) {
-		const { text, url, title, align, color, textColor, clear } = attributes;
-		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
-		const toggleClear = () => setAttributes( { clear: ! clear } );
-
-		return [
-			focus && (
-				<BlockControls key="controls">
-					<BlockAlignmentToolbar value={ align } onChange={ updateAlignment } />
-				</BlockControls>
-			),
-			<span key="button" className={ className } title={ title } style={ { backgroundColor: color } } >
-				<Editable
-					tagName="span"
-					placeholder={ __( 'Add text…' ) }
-					value={ text }
-					focus={ focus }
-					onFocus={ setFocus }
-					onChange={ ( value ) => setAttributes( { text: value } ) }
-					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
-					style={ {
-						color: textColor,
-					} }
-					keepPlaceholderOnFocus
-				/>
-				{ focus &&
-					<InspectorControls key="inspector">
-						<BlockDescription>
-							<p>{ __( 'A nice little button. Call something out with it.' ) }</p>
-						</BlockDescription>
-
-						<ToggleControl
-							label={ __( 'Stand on a line' ) }
-							checked={ !! clear }
-							onChange={ toggleClear }
-						/>
-						<PanelBody title={ __( 'Button Background Color' ) }>
-							<ColorPalette
-								value={ color }
-								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
-							/>
-							<ContrastChecker
-								{ ...{ textColor } }
-								backgroundColor={ color }
-								isLargeText={ true }
-							/>
-						</PanelBody>
-						<PanelBody title={ __( 'Button Text Color' ) }>
-							<ColorPalette
-								value={ textColor }
-								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
-							/>
-						</PanelBody>
-					</InspectorControls>
-				}
-			</span>,
-			focus && (
-				<form
-					className="blocks-button__inline-link"
-					onSubmit={ ( event ) => event.preventDefault() }>
-					<Dashicon icon="admin-links" />
-					<UrlInput
-						value={ url }
-						onChange={ ( value ) => setAttributes( { url: value } ) }
-					/>
-					<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-				</form>
-			),
-		];
+	edit( props ) {
+		return <ButtonBlock { ...props } />;
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -16,6 +16,7 @@ import BlockControls from '../../block-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import ColorPalette from '../../color-palette';
+import ContrastChecker from '../../contrast-checker';
 import InspectorControls from '../../inspector-controls';
 import BlockDescription from '../../block-description';
 
@@ -108,6 +109,11 @@ registerBlockType( 'core/button', {
 							<ColorPalette
 								value={ color }
 								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
+							/>
+							<ContrastChecker
+								{ ...{ textColor } }
+								backgroundColor={ color }
+								isLargeText={ true }
 							/>
 						</PanelBody>
 						<PanelBody title={ __( 'Button Text Color' ) }>

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -31,6 +31,11 @@ class ButtonBlock extends Component {
 		this.containers = {};
 		this.fallbackColors = {};
 
+		this.state = {
+			fallbackBackgroundColor: undefined,
+			fallbackTextColor: undefined,
+		};
+
 		this.updateAlignment = this.updateAlignment.bind( this );
 		this.toggleClear = this.toggleClear.bind( this );
 		this.bindRef = this.bindRef.bind( this );
@@ -64,15 +69,15 @@ class ButtonBlock extends Component {
 
 	grabColors() {
 		const { background, text } = this.containers;
+		const { textColor, color } = this.props.attributes;
+		const { fallbackTextColor, fallbackBackgroundColor } = this.state;
 
-		if ( background ) {
-			this.fallbackColors.backgroundColor =
-				getComputedStyle( background ).backgroundColor;
+		if ( ! color && ! fallbackBackgroundColor && background ) {
+			this.setState( { fallbackBackgroundColor: getComputedStyle( background ).backgroundColor } );
 		}
 
-		if ( text ) {
-			this.fallbackColors.textColor =
-				getComputedStyle( text ).color;
+		if ( ! textColor && ! fallbackTextColor && text ) {
+			this.setState( { fallbackTextColor: getComputedStyle( text ).color } );
 		}
 	}
 
@@ -95,6 +100,10 @@ class ButtonBlock extends Component {
 			clear,
 		} = attributes;
 
+		const {
+			fallbackBackgroundColor,
+			fallbackTextColor,
+		} = this.state;
 		return [
 			focus && (
 				<BlockControls key="controls">
@@ -131,11 +140,6 @@ class ButtonBlock extends Component {
 								value={ color }
 								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
 							/>
-							<ContrastChecker
-								textColor={ textColor || this.fallbackColors.textColor }
-								backgroundColor={ color || this.fallbackColors.backgroundColor }
-								isLargeText={ true }
-							/>
 						</PanelBody>
 						<PanelBody title={ __( 'Button Text Color' ) }>
 							<ColorPalette
@@ -143,6 +147,11 @@ class ButtonBlock extends Component {
 								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
 							/>
 						</PanelBody>
+						<ContrastChecker
+							textColor={ textColor || fallbackTextColor }
+							backgroundColor={ color || fallbackBackgroundColor }
+							isLargeText={ true }
+						/>
 					</InspectorControls>
 				}
 			</span>,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "rememo": "2.3.3",
     "showdown": "1.7.4",
     "simple-html-tokenizer": "0.4.1",
+    "tinycolor2": "1.4.1",
     "uuid": "3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR aims to address part of https://github.com/WordPress/gutenberg/issues/2381, by adding a contrast checking following WCAG 2.0- AA (https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) to the button.

## Testing
Test some colors in button and verify that when contrast is high no message, in low contrast color pairs a message appear.
Verify that when background is darker than text, we suggest making background darker and/or text lighter and when text is darker we suggest making text darker and/or background lighter

## Screenshots (jpeg or gifs if applicable):
<img width="798" alt="screen shot 2017-11-08 at 19 50 32" src="https://user-images.githubusercontent.com/11271197/32571084-2967382a-c4be-11e7-8fbd-dd454d157834.png">

## Notes
This verification is implemented thanks to tinycolor2 lib. React-color (used in our color palette) already depends on it. This lib has no external dependencies. A new component was created that uses tinycolor2 to verify readability and then shows the correct warning message.