### PR TITLE
Don't redirect to Gutenberg from the classic editor.

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -319,3 +319,32 @@ function gutenberg_register_rest_routes() {
 	$controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
+
+
+/**
+ * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
+ *
+ * @since 1.5.0
+ */
+function gutenberg_remember_classic_editor_when_saving_posts() {
+	?>
+	<input type="hidden" name="classic-editor" />
+	<?php
+}
+add_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
+
+/**
+ * Appends a query argument to the redirect url to make sure it gets redirected to the classic editor.
+ *
+ * @since 1.5.0
+ *
+ * @param string $url Redirect url.
+ * @return string Redirect url.
+ */
+function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
+	if ( isset( $_REQUEST['classic-editor'] ) ) {
+		$url = add_query_arg( 'classic-editor', '', $url );
+	}
+	return $url;
+}
+add_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts', 10, 1 );

--- a/lib/register.php
+++ b/lib/register.php
@@ -348,3 +348,20 @@ function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
 	return $url;
 }
 add_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts', 10, 1 );
+
+/**
+ * Appends a query argument to the edit url to make sure it gets redirected to the classic editor.
+ *
+ * @since 1.5.2
+ *
+ * @param string $url Edit url.
+ * @return string Edit url.
+ */
+function gutenberg_link_revisions_to_classic_editor( $url ) {
+	global $pagenow;
+	if ( 'revision.php' === $pagenow ) {
+		$url = add_query_arg( 'classic-editor', '', $url );
+	}
+	return $url;
+}
+add_filter( 'get_edit_post_link', 'gutenberg_link_revisions_to_classic_editor' );

--- a/lib/register.php
+++ b/lib/register.php
@@ -324,7 +324,7 @@ add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
 /**
  * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
  *
- * @since 1.5.0
+ * @since 1.5.2
  */
 function gutenberg_remember_classic_editor_when_saving_posts() {
 	?>
@@ -336,7 +336,7 @@ add_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_post
 /**
  * Appends a query argument to the redirect url to make sure it gets redirected to the classic editor.
  *
- * @since 1.5.0
+ * @since 1.5.2
  *
  * @param string $url Redirect url.
  * @return string Redirect url.


### PR DESCRIPTION
When saving a post in the classic editor, it redirects to Gutenberg. As much as I enjoy this bug, it's a somewhat surprising user experience.

Fixes #3137.
