### PR TITLE
Don't show the classic editor dropdown on unsupported post types.

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -136,18 +136,7 @@ function gutenberg_init( $return, $post ) {
 		return false;
 	}
 
-	$post_type        = $post->post_type;
-	$post_type_object = get_post_type_object( $post_type );
-
-	if ( 'attachment' === $post_type ) {
-		return false;
-	}
-
-	if ( ! $post_type_object->show_in_rest ) {
-		return false;
-	}
-
-	if ( ! post_type_supports( $post_type, 'editor' ) ) {
+	if ( ! gutenberg_can_edit_post( $post ) ) {
 		return false;
 	}
 
@@ -349,7 +338,7 @@ add_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
  * @return array          Updated post actions.
  */
 function gutenberg_add_edit_link( $actions, $post ) {
-	if ( 'trash' === $post->post_status || ! post_type_supports( $post->post_type, 'editor' ) ) {
+	if ( ! gutenberg_can_edit_post( $post ) ) {
 		return $actions;
 	}
 
@@ -420,6 +409,10 @@ add_filter( 'admin_url', 'gutenberg_modify_add_new_button_url', 10, 2 );
  * @since 1.5.0
  */
 function gutenberg_replace_default_add_new_button() {
+	global $typenow;
+	if ( ! gutenberg_can_edit_post_type( $typenow ) ) {
+		return;
+	}
 	?>
 	<style type="text/css">
 		.split-page-title-action {

--- a/lib/register.php
+++ b/lib/register.php
@@ -282,20 +282,29 @@ function gutenberg_can_edit_post( $post_id ) {
  * @return bool Wehther the post type can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post_type( $post_type ) {
+	$can_edit = true;
 	if ( ! post_type_exists( $post_type ) ) {
-		return false;
+		$can_edit = false;
 	}
 
 	if ( ! post_type_supports( $post_type, 'editor' ) ) {
-		return false;
+		$can_edit = false;
 	}
 
 	$post_type_object = get_post_type_object( $post_type );
 	if ( ! $post_type_object->show_in_rest ) {
-		return false;
+		$can_edit = false;
 	}
 
-	return true;
+	/**
+	 * Filter to allow plugins to enable/disable Gutenberg for particular post types.
+	 *
+	 * @since 1.5.2
+	 *
+	 * @param bool   $can_edit  Whether the post type can be edited or not.
+	 * @param string $post_type The post type being checked.
+	 */
+	return apply_filters( 'gutenberg_can_edit_post_type', $can_edit, $post_type );
 }
 
 /**


### PR DESCRIPTION
The editor selector dropdown on the post list table shows on post types that aren't supported, which isn't ideal.

This PR addresses that, as well as tidies up some of the post and post type checks that are used to decide whether Gutenberg can edit the post or post type.