### PR TITLE
Metaboxes: Try showing the metaboxes under the editor's content

### DIFF
--- a/editor/layout/index.js
+++ b/editor/layout/index.js
@@ -46,7 +46,9 @@ function Layout( { mode, isSidebarOpened, notices, ...props } ) {
 					{ mode === 'text' && <TextEditor /> }
 					{ mode === 'visual' && <VisualEditor /> }
 				</div>
-				<MetaBoxes location="normal" />
+				<div className="editor-layout__metaboxes">
+					<MetaBoxes location="normal" />
+				</div>
 			</div>
 			{ isSidebarOpened && <Sidebar /> }
 			<Popover.Slot />

--- a/editor/layout/style.scss
+++ b/editor/layout/style.scss
@@ -5,22 +5,27 @@
 
 .editor-layout {
 	position: relative;
+
+	.components-notice-list {
+		position: fixed;
+		top: 100px;
+		right: auto;
+	}
+}
+
+.editor-layout__metaboxes:not(:empty) {
+	border-top: 1px solid $light-gray-500;
+	margin-top: 10px;
+	padding: 10px 0;
+
+	.editor-meta-boxes-iframe {
+		max-width: $visual-editor-max-width;
+		margin: auto;
+	}
 }
 
 .editor-layout__content {
 	position: relative;
-	display: flex;
-	flex-direction: column;
-}
-
-.editor-layout__editor {
-	flex-basis: 100%;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
-}
-
-.editor-layout .components-notice-list {
-	position: fixed;
-	top: 100px;
-	right: auto;
 }

--- a/editor/meta-boxes/index.js
+++ b/editor/meta-boxes/index.js
@@ -10,14 +10,20 @@ import MetaBoxesIframe from './meta-boxes-iframe';
 import MetaBoxesPanel from './meta-boxes-panel';
 import { getMetaBox } from '../selectors';
 
-function MetaBox( { location, isActive } ) {
+function MetaBox( { location, isActive, usePanel = false } ) {
 	if ( ! isActive ) {
 		return null;
 	}
 
+	const element = <MetaBoxesIframe location={ location } />;
+
+	if ( ! usePanel ) {
+		return element;
+	}
+
 	return (
 		<MetaBoxesPanel>
-			<MetaBoxesIframe location={ location } />
+			{ element }
 		</MetaBoxesPanel>
 	);
 }

--- a/editor/sidebar/post-settings/index.js
+++ b/editor/sidebar/post-settings/index.js
@@ -27,7 +27,7 @@ const panel = (
 		<DiscussionPanel />
 		<PageAttributes />
 		<DocumentOutlinePanel />
-		<MetaBoxes location="side" />
+		<MetaBoxes location="side" usePanel />
 	</Panel>
 );
 


### PR DESCRIPTION
This tries something close to this design https://github.com/WordPress/gutenberg/issues/952#issuecomment-312804592

The metaboxes are shown under the content and not hidden under a panel

<img width="758" alt="screen shot 2017-10-25 at 12 26 19" src="https://user-images.githubusercontent.com/272444/31996267-bc7fb8e8-b97f-11e7-9374-31451632418d.png">

closes #3141
