### PR TITLE
Components: Reset min width for tooltip component

### DIFF
--- a/components/tooltip/style.scss
+++ b/components/tooltip/style.scss
@@ -15,7 +15,7 @@
 }
 
 .components-tooltip .components-popover__content {
-	width: auto;
+	min-width: 0;
 	padding: 4px 12px;
 	background: $dark-gray-400;
 	border-width: 0;


### PR DESCRIPTION
Related: #3125, #3080

The changes introduced in #3080 had caused many popover contents to become collapsed (#3136). This was later fixed in #3125 but did not account for tooltip styling which originally reset to a non-predetermined width based on the `width` style. Since this was changed in #3125 to apply as `min-width`, the changes here reflect this.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/31997731-04794472-b95b-11e7-9106-8f8902616de6.png)|![After](https://user-images.githubusercontent.com/1779930/31997717-f25170b2-b95a-11e7-8bbd-e98fea6dde95.png)


__Testing instructions:__

Verify that tooltips do not show at a predefined minimum width.