### PR TITLE
Tests: Clarify the travis tests using build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,11 @@ jobs:
       php: 5.6
       script: composer install && ./vendor/bin/phpcs
 
+    - stage: lint
+      script:
+        - npm install || exit 1
+        - npm run lint || exit 1
+
     - stage: unit
       script:
         - npm install || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,9 @@ before_install:
 
 jobs:
   include:
-    - stage: lint
+    - stage: unit
       php: 5.6
       script: composer install && ./vendor/bin/phpcs
-
-    - stage: lint
-      script:
-        - npm install || exit 1
-        - npm run lint || exit 1
 
     - stage: unit
       script:
@@ -59,7 +54,6 @@ jobs:
         - ./bin/run-wp-unit-tests.sh
 
 stages:
-  - lint
   - unit
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,44 +18,6 @@ before_install:
   - nvm install 6.11.1 && nvm use 6.11.1
   - npm install --global npm@5
 
-matrix:
-  include:
-    - php: 7.1
-      env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=latest
-    - php: 7.1
-      env: WP_VERSION=latest SWITCH_TO_PHP=5.3
-    - php: 7.1
-      env: WP_VERSION=latest SWITCH_TO_PHP=5.2
-
-script:
-  - |
-    export PATH="$HOME/.composer/vendor/bin:$PATH"
-    bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-    source bin/install-php-phpunit.sh
-    # Run the build because otherwise there will be a bunch of warnings about
-    # failed `stat` calls from `filemtime()`.
-    npm install || exit 1
-    npm run build || exit 1
-    # Make sure phpegjs parser is up to date
-    node bin/create-php-parser.js || exit 1
-    if ! git diff --quiet --exit-code lib/parser.php; then
-      echo 'ERROR: The PEG parser has been updated, but the generated PHP version'
-      echo '       (lib/parser.php) has not.  Run `bin/create-php-parser.js` and'
-      echo '       commit the resulting changes to resolve this.'
-      sleep .2 # Otherwise Travis doesn't want to print the whole message
-      exit 1
-    fi
-    echo Running with the following versions:
-    php -v
-    phpunit --version
-    # Check parser syntax
-    php lib/parser.php || exit 1
-    # Run PHPUnit tests
-    phpunit || exit 1
-    WP_MULTISITE=1 phpunit || exit 1
-
 jobs:
   include:
     - stage: lint
@@ -72,10 +34,33 @@ jobs:
         - npm install || exit 1
         - npm run ci || exit 1
 
+    - stage: unit
+      php: 7.1
+      env: WP_VERSION=latest
+      script:
+        - ./bin/run-wp-unit-tests.sh
+
+    - stage: unit
+      php: 5.6
+      env: WP_VERSION=latest
+      script:
+        - ./bin/run-wp-unit-tests.sh
+
+    - stage: unit
+      php: 7.1
+      env: WP_VERSION=latest SWITCH_TO_PHP=5.3
+      script:
+        - ./bin/run-wp-unit-tests.sh
+
+    - stage: unit
+      php: 7.1
+      env: WP_VERSION=latest SWITCH_TO_PHP=5.2
+      script:
+        - ./bin/run-wp-unit-tests.sh
+
 stages:
   - lint
   - unit
-  - test
 
 before_deploy:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,59 +28,49 @@ matrix:
       env: WP_VERSION=latest SWITCH_TO_PHP=5.3
     - php: 7.1
       env: WP_VERSION=latest SWITCH_TO_PHP=5.2
-    - php: 5.6
-      env: TRAVISCI=phpcs
-    - php: 7.1
-      env: TRAVISCI=js
-
-before_script:
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - |
-    if [[ ! -z "$WP_VERSION" ]] ; then
-      set -e
-      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-      source bin/install-php-phpunit.sh
-      set +e
-    fi
-  - |
-    if [[ "$TRAVISCI" == "phpcs" ]] ; then
-      composer install
-    fi
 
 script:
   - |
-    if [[ ! -z "$WP_VERSION" ]] ; then
-      # Run the build because otherwise there will be a bunch of warnings about
-      # failed `stat` calls from `filemtime()`.
-      npm install || exit 1
-      npm run build || exit 1
-      # Make sure phpegjs parser is up to date
-      node bin/create-php-parser.js || exit 1
-      if ! git diff --quiet --exit-code lib/parser.php; then
-        echo 'ERROR: The PEG parser has been updated, but the generated PHP version'
-        echo '       (lib/parser.php) has not.  Run `bin/create-php-parser.js` and'
-        echo '       commit the resulting changes to resolve this.'
-        sleep .2 # Otherwise Travis doesn't want to print the whole message
-        exit 1
-      fi
-      echo Running with the following versions:
-      php -v
-      phpunit --version
-      # Check parser syntax
-      php lib/parser.php || exit 1
-      # Run PHPUnit tests
-      phpunit || exit 1
-      WP_MULTISITE=1 phpunit || exit 1
+    export PATH="$HOME/.composer/vendor/bin:$PATH"
+    bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+    source bin/install-php-phpunit.sh
+    # Run the build because otherwise there will be a bunch of warnings about
+    # failed `stat` calls from `filemtime()`.
+    npm install || exit 1
+    npm run build || exit 1
+    # Make sure phpegjs parser is up to date
+    node bin/create-php-parser.js || exit 1
+    if ! git diff --quiet --exit-code lib/parser.php; then
+      echo 'ERROR: The PEG parser has been updated, but the generated PHP version'
+      echo '       (lib/parser.php) has not.  Run `bin/create-php-parser.js` and'
+      echo '       commit the resulting changes to resolve this.'
+      sleep .2 # Otherwise Travis doesn't want to print the whole message
+      exit 1
     fi
-  - |
-    if [[ "$TRAVISCI" == "phpcs" ]] ; then
-      ./vendor/bin/phpcs
-    fi
-  - |
-    if [[ "$TRAVISCI" == "js" ]] ; then
-      npm install || exit 1
-      npm run ci || exit 1
-    fi
+    echo Running with the following versions:
+    php -v
+    phpunit --version
+    # Check parser syntax
+    php lib/parser.php || exit 1
+    # Run PHPUnit tests
+    phpunit || exit 1
+    WP_MULTISITE=1 phpunit || exit 1
+
+jobs:
+  include:
+    - stage: lint
+      php: 5.6
+      script: composer install && ./vendor/bin/phpcs
+
+    - stage: unit
+      script:
+        - npm install || exit 1
+        - npm run ci || exit 1
+
+stages:
+  - lint
+  - unit
+  - test
 
 before_deploy:
   - npm install

--- a/bin/run-wp-unit-tests.sh
+++ b/bin/run-wp-unit-tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")/../"
+
+export PATH="$HOME/.composer/vendor/bin:$PATH"
+bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+source bin/install-php-phpunit.sh
+# Run the build because otherwise there will be a bunch of warnings about
+# failed `stat` calls from `filemtime()`.
+npm install || exit 1
+npm run build || exit 1
+# Make sure phpegjs parser is up to date
+node bin/create-php-parser.js || exit 1
+if ! git diff --quiet --exit-code lib/parser.php; then
+	echo 'ERROR: The PEG parser has been updated, but the generated PHP version'
+	echo '       (lib/parser.php) has not.  Run `bin/create-php-parser.js` and'
+	echo '       commit the resulting changes to resolve this.'
+	sleep .2 # Otherwise Travis doesn't want to print the whole message
+	exit 1
+fi
+echo Running with the following versions:
+php -v
+phpunit --version
+# Check parser syntax
+php lib/parser.php || exit 1
+# Run PHPUnit tests
+phpunit || exit 1
+WP_MULTISITE=1 phpunit || exit 1

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "lint": "eslint .",
     "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "npm run lint && npm run test-unit",
-    "ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
+    "ci": "concurrently \"npm run build\" \"npm run test-unit:coverage-ci\"",
     "fixtures:clean": "rimraf \"blocks/test/fixtures/*.+(json|serialized.html)\"",
     "fixtures:server-attributes": "./bin/get-server-block-attributes.php > blocks/test/server-attributes.json",
     "fixtures:generate": "npm run fixtures:server-attributes && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "lint": "eslint .",
     "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "npm run lint && npm run test-unit",
-    "ci": "concurrently \"npm run build\" \"npm run test-unit:coverage-ci\"",
+    "ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
     "fixtures:clean": "rimraf \"blocks/test/fixtures/*.+(json|serialized.html)\"",
     "fixtures:server-attributes": "./bin/get-server-block-attributes.php > blocks/test/server-attributes.json",
     "fixtures:generate": "npm run fixtures:server-attributes && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",


### PR DESCRIPTION
This PR rewrites the `.travis.yml` config file to make use of the new Build Stages feature. This feature has the following pros:

 - Dropping the matrix allows us to drop the useless env variables we're using to know which script to run
 - Each job has its own entry with its own config, makes it easy to add new jobs with custom configs (I'll add one soon for e2e tests)
 - Organize the jobs in "stages": stages run sequentially but jobs in the same stage run in parallel. (see https://travis-ci.org/WordPress/gutenberg/builds/292669637)