### PR TITLE
Preview popup loader

### DIFF
--- a/editor/header/preview-button/index.js
+++ b/editor/header/preview-button/index.js
@@ -90,6 +90,7 @@ export class PreviewButton extends Component {
 				}
 				p {
 					text-align: center;
+					font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 				}
 			</style>`;
 

--- a/editor/header/preview-button/index.js
+++ b/editor/header/preview-button/index.js
@@ -75,9 +75,10 @@ export class PreviewButton extends Component {
 		);
 
 		const popupLoader = '<div><p>Please wait&hellip;</p><p>Generating preview.</p></div>';
-		const css = '<style type="text/css"> div { margin-top: 25%; } p { text-align: center; } </style>';
+		const css = '<style> div { margin-top: 25%; } p { text-align: center; } </style>';
 		this.previewWindow.document.write( css );
 		this.previewWindow.document.write( popupLoader );
+		this.previewWindow.document.close();
 	}
 
 	render() {

--- a/editor/header/preview-button/index.js
+++ b/editor/header/preview-button/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { Component, renderToString } from '@wordpress/element';
-import { IconButton, Spinner } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -76,11 +76,12 @@ export class PreviewButton extends Component {
 
 		const popupLoader = renderToString(
 			<div>
-				<Spinner />
 				<p>Please wait&hellip;</p>
 				<p>Generating preview.</p>
 			</div>
 		);
+		const css = '<style type="text/css"> div { margin-top: 25%; } p { text-align: center; } </style>';
+		this.previewWindow.document.write( css );
 		this.previewWindow.document.write( popupLoader );
 	}
 

--- a/editor/header/preview-button/index.js
+++ b/editor/header/preview-button/index.js
@@ -74,12 +74,11 @@ export class PreviewButton extends Component {
 			this.getWindowTarget()
 		);
 
-		const popupLoader = `
+		const markup = `
 			<div>
 				<p>Please wait&hellip;</p>
 				<p>Generating preview.</p>
-			</div>`;
-		const css = `
+			</div>
 			<style>
 				div {
 					display: flex;
@@ -94,8 +93,7 @@ export class PreviewButton extends Component {
 				}
 			</style>`;
 
-		this.previewWindow.document.write( css );
-		this.previewWindow.document.write( popupLoader );
+		this.previewWindow.document.write( markup );
 		this.previewWindow.document.close();
 	}
 

--- a/editor/header/preview-button/index.js
+++ b/editor/header/preview-button/index.js
@@ -74,8 +74,26 @@ export class PreviewButton extends Component {
 			this.getWindowTarget()
 		);
 
-		const popupLoader = '<div><p>Please wait&hellip;</p><p>Generating preview.</p></div>';
-		const css = '<style> div { margin-top: 25%; } p { text-align: center; } </style>';
+		const popupLoader = `
+			<div>
+				<p>Please wait&hellip;</p>
+				<p>Generating preview.</p>
+			</div>`;
+		const css = `
+			<style>
+				div {
+					display: flex;
+					flex-direction: column;
+					align-items: center;
+					justify-content: center;
+					height: 100vh;
+					width: 100vw;
+				}
+				p {
+					text-align: center;
+				}
+			</style>`;
+
 		this.previewWindow.document.write( css );
 		this.previewWindow.document.write( popupLoader );
 		this.previewWindow.document.close();

--- a/editor/header/preview-button/index.js
+++ b/editor/header/preview-button/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component, renderToString } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 
@@ -74,12 +74,7 @@ export class PreviewButton extends Component {
 			this.getWindowTarget()
 		);
 
-		const popupLoader = renderToString(
-			<div>
-				<p>Please wait&hellip;</p>
-				<p>Generating preview.</p>
-			</div>
-		);
+		const popupLoader = '<div><p>Please wait&hellip;</p><p>Generating preview.</p></div>';
 		const css = '<style type="text/css"> div { margin-top: 25%; } p { text-align: center; } </style>';
 		this.previewWindow.document.write( css );
 		this.previewWindow.document.write( popupLoader );

--- a/editor/header/preview-button/index.js
+++ b/editor/header/preview-button/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { IconButton } from '@wordpress/components';
+import { Component, renderToString } from '@wordpress/element';
+import { IconButton, Spinner } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -73,6 +73,15 @@ export class PreviewButton extends Component {
 			'about:blank',
 			this.getWindowTarget()
 		);
+
+		const popupLoader = renderToString(
+			<div>
+				<Spinner />
+				<p>Please wait&hellip;</p>
+				<p>Generating preview.</p>
+			</div>
+		);
+		this.previewWindow.document.write( popupLoader );
 	}
 
 	render() {

--- a/editor/header/preview-button/test/index.js
+++ b/editor/header/preview-button/test/index.js
@@ -57,6 +57,7 @@ describe( 'PreviewButton', () => {
 				return {
 					document: {
 						write: jest.fn(),
+						close: jest.fn(),
 					},
 				};
 			} );

--- a/editor/header/preview-button/test/index.js
+++ b/editor/header/preview-button/test/index.js
@@ -53,7 +53,13 @@ describe( 'PreviewButton', () => {
 			const autosave = jest.fn();
 			const preventDefault = jest.fn();
 			const windowOpen = window.open;
-			window.open = jest.fn();
+			window.open = jest.fn( () => {
+				return {
+					document: {
+						write: jest.fn(),
+					},
+				};
+			} );
 
 			const wrapper = shallow(
 				<PreviewButton { ...props } autosave={ autosave } />
@@ -66,6 +72,7 @@ describe( 'PreviewButton', () => {
 				expect( preventDefault ).toHaveBeenCalled();
 				expect( wrapper.state( 'isAwaitingSave' ) ).toBe( true );
 				expect( window.open ).toHaveBeenCalled();
+				expect( wrapper.instance().previewWindow.document.write ).toHaveBeenCalled();
 			} else {
 				expect( autosave ).not.toHaveBeenCalled();
 				expect( preventDefault ).not.toHaveBeenCalled();


### PR DESCRIPTION
## Description

See #3087. Added a loading message for the preview popup.

Decided against adding a spinner/loading icon because we'd have to re-load the styles - thought this would be an over-kill for the sake of a second or two. Thoughts welcome on this & the message text...

## How Has This Been Tested?

As per 533da25 - check that `document.write` is called when the preview popup is opened.

## Screenshots (jpeg or gifs if applicable):

![gutenberg-popup-preview](https://user-images.githubusercontent.com/14926880/32022013-0b21a00e-b9cd-11e7-9e91-4ddc5b4ef6a9.jpg)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.