### PR TITLE
Restore `gutenberg_add_edit_link_for_post_type` filter.

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -147,7 +147,7 @@ function gutenberg_init( $return, $post ) {
 		return false;
 	}
 
-	if ( ! post_type_supports( $post_type, 'editor' ) ) {
+	if ( ! post_type_supports( $post_type, 'editor' ) || ! apply_filters( 'gutenberg_add_edit_link_for_post_type', true, $post_type, $post ) ) {
 		return false;
 	}
 
@@ -349,7 +349,8 @@ add_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
  * @return array          Updated post actions.
  */
 function gutenberg_add_edit_link( $actions, $post ) {
-	if ( 'trash' === $post->post_status || ! post_type_supports( $post->post_type, 'editor' ) ) {
+	$post_type_supported = post_type_supports( $post->post_type, 'editor' ) && apply_filters( 'gutenberg_add_edit_link_for_post_type', true, $post->post_type, $post );
+	if ( 'trash' === $post->post_status || ! $post_type_supported ) {
 		return $actions;
 	}
 


### PR DESCRIPTION
## Description

The filter was added in 6884717, but then removed in bdf94e6. It's being added back because Gutenberg does not yet have support for advanced meta boxes, which many custom post types rely on.

Gutenberg should not be the default editor for post types which it does not fully support, because that leads to a poor user experience.

`gutenberg_add_edit_link_for_post_type` isn't a good name for this filter, since it's true purpose is to prevent Gutenberg from doing anything with CPTs that opt-out of it. For the initial draft, though, I left it as-is in order to get feedback. One advantage of keeping it is that it preserves back-compat with sites that are already using it.

It may also not be worth changing at this time, since I imagine a different solution will be desired by the time the plugin gets closer to the merge with Core. @BE-Webdesign [suggested](https://github.com/WordPress/gutenberg/pull/2528#pullrequestreview-58441418) using `post_type_supports( 'block_editor' )` instead of a filter, which seems like a good idea to me, and would be a much more semantic solution. That would not necessarily mean that support would be off by default; Gutenberg could enable it by default, similar to how the REST API did.

I'm happy to adjust the PR if y'all prefer that approach instead.

This also likely conflicts with #3146, but I'm happy to adapt this one if it's accepted after that one is merged.

Fixes #3158

## Testing

1. Setup a callback for the filter, similar to [5944-meta](https://meta.trac.wordpress.org/changeset/5944)
1. Visit `wp-admin/edit.php`; the `Classic Editor` link appears when hovering over an post in the list
1. Open one of those posts using the default link; it should open in Gutenberg.
1. Visit the posts lists for a CPT that is disabled by the filter above, e.g., `wp-admin/edit.php?post_type=wordcamp`; the `Classic Editor` links should *not* appear when hovering over a post.
1. Open one of those posts using the default link; it should open in the classic editor instead of Gutenberg.