### PR TITLE
Add a z-index to the editor selector

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -481,6 +481,7 @@ function gutenberg_replace_default_add_new_button() {
 			display: block;
 			position: absolute;
 			margin-top: 3px;
+			z-index: 1;
 		}
 
 		.split-page-title-action .dropdown.visible a {


### PR DESCRIPTION
As described in #3134, the editor selector dropdown hides behind notice boxes. Adding a z-index fixes this.