### PR TITLE
Build 1.5.2

### DIFF
--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -67,6 +67,7 @@
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;
+	min-width: 240px;
 
 	.components-popover.is-top & {
 		bottom: 100%;

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -136,18 +136,7 @@ function gutenberg_init( $return, $post ) {
 		return false;
 	}
 
-	$post_type        = $post->post_type;
-	$post_type_object = get_post_type_object( $post_type );
-
-	if ( 'attachment' === $post_type ) {
-		return false;
-	}
-
-	if ( ! $post_type_object->show_in_rest ) {
-		return false;
-	}
-
-	if ( ! post_type_supports( $post_type, 'editor' ) ) {
+	if ( ! gutenberg_can_edit_post( $post ) ) {
 		return false;
 	}
 
@@ -349,7 +338,7 @@ add_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
  * @return array          Updated post actions.
  */
 function gutenberg_add_edit_link( $actions, $post ) {
-	if ( 'trash' === $post->post_status || ! post_type_supports( $post->post_type, 'editor' ) ) {
+	if ( ! gutenberg_can_edit_post( $post ) ) {
 		return $actions;
 	}
 
@@ -420,6 +409,10 @@ add_filter( 'admin_url', 'gutenberg_modify_add_new_button_url', 10, 2 );
  * @since 1.5.0
  */
 function gutenberg_replace_default_add_new_button() {
+	global $typenow;
+	if ( ! gutenberg_can_edit_post_type( $typenow ) ) {
+		return;
+	}
 	?>
 	<style type="text/css">
 		.split-page-title-action {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core. <strong>Meant for development, do not run on real sites.</strong>
- * Version: 1.5.1
+ * Version: 1.5.2
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -474,6 +474,7 @@ function gutenberg_replace_default_add_new_button() {
 			display: block;
 			position: absolute;
 			margin-top: 3px;
+			z-index: 1;
 		}
 
 		.split-page-title-action .dropdown.visible a {

--- a/lib/register.php
+++ b/lib/register.php
@@ -292,7 +292,7 @@ function gutenberg_can_edit_post_type( $post_type ) {
 	}
 
 	$post_type_object = get_post_type_object( $post_type );
-	if ( ! $post_type_object->show_in_rest ) {
+	if ( $post_type_object && ! $post_type_object->show_in_rest ) {
 		$can_edit = false;
 	}
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -319,3 +319,49 @@ function gutenberg_register_rest_routes() {
 	$controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
+
+
+/**
+ * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
+ *
+ * @since 1.5.2
+ */
+function gutenberg_remember_classic_editor_when_saving_posts() {
+	?>
+	<input type="hidden" name="classic-editor" />
+	<?php
+}
+add_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
+
+/**
+ * Appends a query argument to the redirect url to make sure it gets redirected to the classic editor.
+ *
+ * @since 1.5.2
+ *
+ * @param string $url Redirect url.
+ * @return string Redirect url.
+ */
+function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
+	if ( isset( $_REQUEST['classic-editor'] ) ) {
+		$url = add_query_arg( 'classic-editor', '', $url );
+	}
+	return $url;
+}
+add_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts', 10, 1 );
+
+/**
+ * Appends a query argument to the edit url to make sure it gets redirected to the classic editor.
+ *
+ * @since 1.5.2
+ *
+ * @param string $url Edit url.
+ * @return string Edit url.
+ */
+function gutenberg_link_revisions_to_classic_editor( $url ) {
+	global $pagenow;
+	if ( 'revision.php' === $pagenow ) {
+		$url = add_query_arg( 'classic-editor', '', $url );
+	}
+	return $url;
+}
+add_filter( 'get_edit_post_link', 'gutenberg_link_revisions_to_classic_editor' );

--- a/lib/register.php
+++ b/lib/register.php
@@ -248,24 +248,63 @@ function gutenberg_collect_meta_box_data() {
 /**
  * Return whether the post can be edited in Gutenberg and by the current user.
  *
- * Gutenberg depends on the REST API, and if the post type is not shown in the
- * REST API, then the post cannot be edited in Gutenberg.
- *
  * @since 0.5.0
  *
- * @param int $post_id Post.
+ * @param int|WP_Post $post_id Post.
  * @return bool Whether the post can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post( $post_id ) {
 	$post = get_post( $post_id );
-	if ( ! $post || ! post_type_exists( $post->post_type ) ) {
+	if ( ! $post ) {
 		return false;
 	}
-	$post_type_object = get_post_type_object( $post->post_type );
-	if ( ! $post_type_object->show_in_rest ) {
+
+	if ( 'trash' === $post->post_status ) {
 		return false;
 	}
+
+	if ( ! gutenberg_can_edit_post_type( $post->post_type ) ) {
+		return false;
+	}
+
 	return current_user_can( 'edit_post', $post_id );
+}
+
+/**
+ * Return whether the post type can be edited in Gutenberg.
+ *
+ * Gutenberg depends on the REST API, and if the post type is not shown in the
+ * REST API, then the post cannot be edited in Gutenberg.
+ *
+ * @since 1.5.2
+ *
+ * @param string $post_type The post type.
+ * @return bool Wehther the post type can be edited with Gutenberg.
+ */
+function gutenberg_can_edit_post_type( $post_type ) {
+	$can_edit = true;
+	if ( ! post_type_exists( $post_type ) ) {
+		$can_edit = false;
+	}
+
+	if ( ! post_type_supports( $post_type, 'editor' ) ) {
+		$can_edit = false;
+	}
+
+	$post_type_object = get_post_type_object( $post_type );
+	if ( ! $post_type_object->show_in_rest ) {
+		$can_edit = false;
+	}
+
+	/**
+	 * Filter to allow plugins to enable/disable Gutenberg for particular post types.
+	 *
+	 * @since 1.5.2
+	 *
+	 * @param bool   $can_edit  Whether the post type can be edited or not.
+	 * @param string $post_type The post type being checked.
+	 */
+	return apply_filters( 'gutenberg_can_edit_post_type', $can_edit, $post_type );
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A new WordPress editor experience",
   "main": "build/app.js",
   "repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
There are a handful of bugs that have been fixed after 1.5.1, they need to be released sooner than 1.6.

This is a branch from the `v1.5.1` tag, with the relevant commits cherry picked.

## Changes

- Add the `gutenberg_can_edit_post_type` filter for plugins to add or remove support for custom post types.
- Fix Classic Editor redirecting to Gutenberg when saving a post.
- Fix Classic Editor dropdown showing on post types that don't support Gutenberg.
- Fix Classic Editor dropdown hiding behind notices.
- Fix an issue with collapsing popover content.