### PR TITLE
Release 1.5.2

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core. <strong>Meant for development, do not run on real sites.</strong>
- * Version: 1.5.1
+ * Version: 1.5.2
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A new WordPress editor experience",
   "main": "build/app.js",
   "repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
1.5.2 has been built and released from #3163. The commits in that branch were cherry picked from master, so the only thing that needs to change in master is the version number.