### PR TITLE
Performance: Memoize multi selection selectors

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -553,22 +553,25 @@ export function getSelectedBlock( state ) {
  * @param  {Object} state Global application state
  * @return {Array}        Multi-selected block unique UDs
  */
-export function getMultiSelectedBlockUids( state ) {
-	const { blockOrder } = state.editor;
-	const { start, end } = state.blockSelection;
-	if ( start === end ) {
-		return [];
-	}
+export const getMultiSelectedBlockUids = createSelector(
+	( state ) => {
+		const { blockOrder } = state.editor;
+		const { start, end } = state.blockSelection;
+		if ( start === end ) {
+			return [];
+		}
 
-	const startIndex = blockOrder.indexOf( start );
-	const endIndex = blockOrder.indexOf( end );
+		const startIndex = blockOrder.indexOf( start );
+		const endIndex = blockOrder.indexOf( end );
 
-	if ( startIndex > endIndex ) {
-		return blockOrder.slice( endIndex, startIndex + 1 );
-	}
+		if ( startIndex > endIndex ) {
+			return blockOrder.slice( endIndex, startIndex + 1 );
+		}
 
-	return blockOrder.slice( startIndex, endIndex + 1 );
-}
+		return blockOrder.slice( startIndex, endIndex + 1 );
+	},
+	( state ) => [ state.editor.blockOrder, state.blockSelection ],
+);
 
 /**
  * Returns the current multi-selection set of blocks, or an empty array if
@@ -577,9 +580,16 @@ export function getMultiSelectedBlockUids( state ) {
  * @param  {Object} state Global application state
  * @return {Array}        Multi-selected block objects
  */
-export function getMultiSelectedBlocks( state ) {
-	return getMultiSelectedBlockUids( state ).map( ( uid ) => getBlock( state, uid ) );
-}
+export const getMultiSelectedBlocks = createSelector(
+	( state ) => getMultiSelectedBlockUids( state ).map( ( uid ) => getBlock( state, uid ) ),
+	( state ) => [
+		state.editor.blockOrder,
+		state.blockSelection,
+		state.editor.blocksByUid,
+		state.editor.edits.meta,
+		state.currentPost.meta,
+	]
+);
 
 /**
  * Returns the unique ID of the first block in the multi-selection set, or null

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -41,6 +41,7 @@ import {
 	getSelectedBlock,
 	getEditedPostContent,
 	getMultiSelectedBlockUids,
+	getMultiSelectedBlocks,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
 	getBlockUids,
@@ -97,6 +98,8 @@ describe( 'selectors', () => {
 		getBlock.clear();
 		getBlocks.clear();
 		getEditedPostContent.clear();
+		getMultiSelectedBlockUids.clear();
+		getMultiSelectedBlocks.clear();
 	} );
 
 	afterAll( () => {


### PR DESCRIPTION
This pull request is a first pass at render performance for posts containing many blocks. I had noted that simple changes to editor state were causing the entire list of blocks to rerender, which could degrade performance particularly when many blocks exist. With the default behavior of [react-redux's `connect`](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) applying ["pure" behavior](https://reactjs.org/docs/react-api.html#reactpurecomponent), it was unexpected that other components should be rerendering aside from the one being hovered.

- [Before](https://user-images.githubusercontent.com/1779930/32052872-852cc32e-ba27-11e7-8d3f-280f38a0a0fb.gif) (2mb GIF)
- [After](https://user-images.githubusercontent.com/1779930/32052869-835f0b74-ba27-11e7-9d32-f742ffcbe9ad.gif) (2mb GIF)

__Implementation notes:__

In this case, the VisualBlockList component would rerender because the [multi-selection selectors it depends on](https://github.com/WordPress/gutenberg/blob/f87476b6a32845f97f33694d2838045b725a7c70/editor/modes/visual-editor/block-list.js#L236-L237) would always map to return a new instance of an array. This would cascade down to each individual block because we assign a [new dynamic `ref` function reference](https://github.com/WordPress/gutenberg/blob/f87476b6a32845f97f33694d2838045b725a7c70/editor/modes/visual-editor/block-list.js#L204) in the VisualBlockList component. This latter behavior is similarly non-ideal, but not as simple to resolve, so will be addressed separately.

__Testing instructions:__

Verify there are no regressions in the behavior of block multi-selection.

Ensure unit tests pass:

```
npm run test-unit
```

If you have [React Developer Tools extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) installed, toggle "Highlight Updates" and verify hovering only impacts relevant block (also layout, which will be debugged separately).