### PR TITLE
Performance: Assign block list refs by constant reference

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -339,7 +339,6 @@ class VisualEditorBlock extends Component {
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<div
-				ref={ this.props.blockRef }
 				onMouseMove={ this.maybeHover }
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }


### PR DESCRIPTION
Related: #3170

This pull request seeks to optimize to eliminate a render cascade which occurs to every block when the VisualEditorBlockList component renders. Previously, we would assign a new function as the `ref` prop to every rendered VisualEditorBlock element, thereby incurring a new render to every block rendered in the post.

The changes here seek to use a single constant reference of `setBlockRef`, eliminating the custom `blockRef` component passed to `VisualEditorBlock` in favor of `findDOMNode` to access the DOM node from the component instance.

__Testing instructions:__

Verify there are no regressions in the behavior of block multi-selection.