### PR TITLE
Performance: Simplify return value of multi-selection selected selector

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -739,9 +739,7 @@ export function getNextBlock( state, uid ) {
 
 /**
  * Returns true if the block corresponding to the specified unique ID is
- * currently selected and a multi-selection exists, null if there is no
- * multi-selection active, or false if multi-selection exists, but the
- * specified unique ID is not the selected block.
+ * currently selected and no multi-selection exists, or false otherwise.
  *
  * @param  {Object} state Global application state
  * @param  {String} uid   Block unique ID
@@ -751,7 +749,7 @@ export function isBlockSelected( state, uid ) {
 	const { start, end } = state.blockSelection;
 
 	if ( start !== end ) {
-		return null;
+		return false;
 	}
 
 	return start === uid;

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -1697,6 +1697,14 @@ describe( 'selectors', () => {
 			expect( isBlockSelected( state, 123 ) ).toBe( true );
 		} );
 
+		it( 'should return false if a multi-selection range exists', () => {
+			const state = {
+				blockSelection: { start: 123, end: 124 },
+			};
+
+			expect( isBlockSelected( state, 123 ) ).toBe( false );
+		} );
+
 		it( 'should return false if the block is not selected', () => {
 			const state = {
 				blockSelection: { start: null, end: null },


### PR DESCRIPTION
Related: #3171, #3170, #3172

This pull request seeks to optimize the rendering of individual blocks when selection occurs. Currently, any time a selection is made, including for a single block, the `isSelected` prop changes for every block such that it incurs a render on all blocks. Since this change is often from two equivalent states for most blocks (`null` to `false`, and vice-versa), the changes here seek to simplify the return value of the selector for determining whether a single block is selected to simply return `false` when a multi-selection exists (instead of `null`). This prevents renders except in the blocks included in the multi-selection.

__Implementation notes:__

The documented behavior of the `isBlockSelected` was opposite that of its implementation. Both documentation and tests have been updated to reflect what appears to be the intended behavior, but verification would be appreciated.

__Testing instructions:__

Verify there are no regressions in the behavior of block multi-selection.