### PR TITLE
Components: Fix autocomplete menu click behavior

### DIFF
--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -31,7 +31,7 @@ class Autocomplete extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.bindNode = this.bindNode.bind( this );
+		this.bindMenuNode = this.bindMenuNode.bind( this );
 		this.select = this.select.bind( this );
 		this.reset = this.reset.bind( this );
 		this.onBlur = this.onBlur.bind( this );
@@ -41,8 +41,8 @@ class Autocomplete extends Component {
 		this.state = this.constructor.getInitialState();
 	}
 
-	bindNode( node ) {
-		this.node = node;
+	bindMenuNode( node ) {
+		this.menuNode = node;
 	}
 
 	select( option ) {
@@ -62,7 +62,7 @@ class Autocomplete extends Component {
 	onBlur( event ) {
 		// Check if related target is not within, in the case that the user is
 		// selecting an option by button click
-		if ( ! this.node.contains( event.relatedTarget ) ) {
+		if ( ! this.menuNode.contains( event.relatedTarget ) ) {
 			this.reset();
 		}
 	}
@@ -189,7 +189,6 @@ class Autocomplete extends Component {
 		// the event will not have `relatedTarget` assigned.
 		return (
 			<div
-				ref={ this.bindNode }
 				onBlur={ this.onBlur }
 				className="components-autocomplete"
 			>
@@ -206,6 +205,7 @@ class Autocomplete extends Component {
 					<ul
 						role="menu"
 						className="components-autocomplete__results"
+						ref={ this.bindMenuNode }
 					>
 						{ filteredOptions.map( ( option, index ) => (
 							<li

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -290,6 +290,30 @@ describe( 'Autocomplete', () => {
 			expect( onSelect ).toHaveBeenCalledWith( options[ 0 ] );
 		} );
 
+		it( 'selects by click', () => {
+			const onSelect = jest.fn();
+			const wrapper = shallow(
+				<Autocomplete
+					options={ options }
+					triggerPrefix="/"
+					onSelect={ onSelect }
+				>
+					<div contentEditable />
+				</Autocomplete>
+			);
+
+			wrapper.find( '[contentEditable]' ).simulate( 'input', {
+				target: {
+					textContent: '/',
+				},
+			} );
+
+			wrapper.find( 'li' ).at( 0 ).find( 'Button' ).simulate( 'click' );
+
+			expect( wrapper.state() ).toEqual( Autocomplete.getInitialState() );
+			expect( onSelect ).toHaveBeenCalledWith( options[ 0 ] );
+		} );
+
 		it( 'doesn\'t otherwise interfere with keydown behavior', () => {
 			const preventDefault = jest.fn();
 			const stopImmediatePropagation = jest.fn();


### PR DESCRIPTION
This pull request seeks to resolve an issue where clicking an item in the slash autocomplete menu will dismiss the menu without inserting the selected block. The issue stems from the fact that the blur logic of the autocomplete component tests whether the focus is shifting to a node outside autocomplete. Since Popover renders via Slots to a different area of the DOM, this check would pass and thereby dismiss the menu before allowing the selection to occur. The changes here update this check to determine if the focus shifts outside the _menu_ options specifically (the content of the popover itself) to decide if the menu should be closed.

__Testing instructions:__

1. Navigate to Posts > New Post
2. Click the writing prompt to create a new paragraph block
3. Enter "/" to activate the autocomplete menu.
4. Click on an option in the autocomplete menu
5. Note that the selected block is inserted