### PR TITLE
Components: Dismiss icon button tooltip when clicked

### DIFF
--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -99,6 +99,7 @@ class Tooltip extends Component {
 		return cloneElement( child, {
 			onMouseEnter: this.createToggleIsOver( 'onMouseEnter', true ),
 			onMouseLeave: this.createToggleIsOver( 'onMouseLeave' ),
+			onClick: this.createToggleIsOver( 'onClick' ),
 			onFocus: this.createToggleIsOver( 'onFocus' ),
 			onBlur: this.createToggleIsOver( 'onBlur' ),
 			children: concatChildren(

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -53,6 +53,9 @@ class Tooltip extends Component {
 
 	createToggleIsOver( eventName, isDelayed ) {
 		return ( event ) => {
+			// Preserve original child callback behavior
+			this.emitToChild( eventName, event );
+
 			// Mouse events behave unreliably in React for disabled elements,
 			// firing on mouseenter but not mouseleave.  Further, the default
 			// behavior for disabled elements in some browsers is to ignore
@@ -77,8 +80,6 @@ class Tooltip extends Component {
 			} else {
 				this.setState( { isOver } );
 			}
-
-			this.emitToChild( eventName, event );
 		};
 	}
 

--- a/components/tooltip/test/index.js
+++ b/components/tooltip/test/index.js
@@ -116,6 +116,8 @@ describe( 'Tooltip', () => {
 			const button = wrapper.find( 'button' );
 			button.simulate( 'mouseenter' );
 
+			expect( originalMouseEnter ).toHaveBeenCalled();
+
 			const popover = wrapper.find( 'Popover' );
 			wrapper.instance().delayedSetIsOver.flush();
 			expect( wrapper.state( 'isOver' ) ).toBe( false );


### PR DESCRIPTION
This pull request seeks to revise the behavior of the IconButton to dismiss its visible tooltip after being clicked / pressed. This is intended to eliminate visual clutter under the assumption that the tooltip provides value only prior to making the decision to click the button. The dismissal state is reset when either the cursor or focus leaves the button.

__Testing instructions:__

1. Navigate to Gutenberg > Demo
2. Select a block
3. Hover the Move Down button until the tooltip becomes visible
4. Click the Move Down button
5. Note that the tooltip is dismissed
6. Move mouse outside the button
7. Repeat step 3, noting that the tooltip becomes visible once more