### PR TITLE
State: Reset editor undo history only at initial setup

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -248,7 +248,7 @@ export const editor = combineUndoableReducers( {
 
 		return state;
 	},
-}, { resetTypes: [ 'RESET_POST' ] } );
+}, { resetTypes: [ 'SETUP_EDITOR' ] } );
 
 /**
  * Reducer returning the last-known state of the current post, in the format


### PR DESCRIPTION
Fixes #2916
Fixes #2915

This pull request seeks to revise the action types on which the editor undo history is reset. The current `RESET_POST` reset type is insufficient for two reasons:

- It wipes history when an autosave occurs (#2915)
- Other changes occur during initial setup that flag history on a new post (#2916)

By changing the reset type to `SETUP_EDITOR`, we resolve both of these issues by only resetting at the final setup action during editor initialization.

__Testing instructions:__

Repeat testing instructions from #2916 and #2915, verifying that you can:

- Undo after a save occurs
- No undo when starting a new post