### PR TITLE
Performance: Refactor notices state reducer as array

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -3,7 +3,20 @@
  */
 import optimist from 'redux-optimist';
 import { combineReducers } from 'redux';
-import { difference, get, reduce, keyBy, keys, first, last, omit, pick, without, mapValues } from 'lodash';
+import {
+	difference,
+	get,
+	reduce,
+	keyBy,
+	keys,
+	first,
+	last,
+	omit,
+	pick,
+	without,
+	mapValues,
+	findIndex,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -544,19 +557,22 @@ export function saving( state = {}, action ) {
 	return state;
 }
 
-export function notices( state = {}, action ) {
+export function notices( state = [], action ) {
 	switch ( action.type ) {
 		case 'CREATE_NOTICE':
-			return {
-				...state,
-				[ action.notice.id ]: action.notice,
-			};
+			return [ ...state, action.notice ];
+
 		case 'REMOVE_NOTICE':
-			if ( ! state.hasOwnProperty( action.noticeId ) ) {
+			const { noticeId } = action;
+			const index = findIndex( state, { id: noticeId } );
+			if ( index === -1 ) {
 				return state;
 			}
 
-			return omit( state, action.noticeId );
+			return [
+				...state.slice( 0, index ),
+				...state.slice( index + 1 ),
+			];
 	}
 
 	return state;

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -10,7 +10,6 @@ import {
 	last,
 	reduce,
 	some,
-	values,
 	keys,
 	without,
 	compact,
@@ -965,7 +964,7 @@ export const getEditedPostContent = createSelector(
  * @return {Array}       List of notices
  */
 export function getNotices( state ) {
-	return values( state.notices );
+	return state.notices;
 }
 
 /**

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -1020,14 +1020,14 @@ describe( 'state', () => {
 
 	describe( 'notices()', () => {
 		it( 'should create a notice', () => {
-			const originalState = {
-				b: {
+			const originalState = [
+				{
 					id: 'b',
 					content: 'Error saving',
 					status: 'error',
 				},
-			};
-			const state = notices( originalState, {
+			];
+			const state = notices( deepFreeze( originalState ), {
 				type: 'CREATE_NOTICE',
 				notice: {
 					id: 'a',
@@ -1035,36 +1035,36 @@ describe( 'state', () => {
 					status: 'success',
 				},
 			} );
-			expect( state ).toEqual( {
-				b: originalState.b,
-				a: {
+			expect( state ).toEqual( [
+				originalState[ 0 ],
+				{
 					id: 'a',
 					content: 'Post saved',
 					status: 'success',
 				},
-			} );
+			] );
 		} );
 
 		it( 'should remove a notice', () => {
-			const originalState = {
-				a: {
+			const originalState = [
+				{
 					id: 'a',
 					content: 'Post saved',
 					status: 'success',
 				},
-				b: {
+				{
 					id: 'b',
 					content: 'Error saving',
 					status: 'error',
 				},
-			};
-			const state = notices( originalState, {
+			];
+			const state = notices( deepFreeze( originalState ), {
 				type: 'REMOVE_NOTICE',
 				noticeId: 'a',
 			} );
-			expect( state ).toEqual( {
-				b: originalState.b,
-			} );
+			expect( state ).toEqual( [
+				originalState[ 1 ],
+			] );
 		} );
 	} );
 

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -2080,16 +2080,13 @@ describe( 'selectors', () => {
 	describe( 'getNotices', () => {
 		it( 'should return the notices array', () => {
 			const state = {
-				notices: {
-					b: { id: 'b', content: 'Post saved' },
-					a: { id: 'a', content: 'Error saving' },
-				},
+				notices: [
+					{ id: 'b', content: 'Post saved' },
+					{ id: 'a', content: 'Error saving' },
+				],
 			};
 
-			expect( getNotices( state ) ).toEqual( [
-				state.notices.b,
-				state.notices.a,
-			] );
+			expect( getNotices( state ) ).toEqual( state.notices );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request seeks to optimize performance by refactoring notices state to avoid a new array reference being returned on every call to the `getNotices` selector. This was noticeable in that it would incur a render on the Layout component any time state changes.

While we could have used memoization here, the simpler alternative is to store notices themselves as an array in state. This would only be unadvisable in case that we want easy look-up of notices by ID, since storing as an array requires iterating the array. However, we do not ever reference a single notice by ID except in the reducer itself.

__Testing instructions:__

Verify that there are no regressions in creation and removal of notices:

1. Navigate to Posts > New Post
2. Enter a title
3. Toggle publish dialog and publish the post
4. Note that a notice appears that the post published successfully
5. Press the dismiss button on the notice
6. Note that the notice is dismissed

Ensure that unit tests pass:

```
npm run test-unit
```

If you have [React Developer Tools extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) installed, toggle "Highlight Updates" and verify hovering a block does not incur a layout render (may be hard to observe given other pending performance improvements, but note that there is no flash to the right of the sidebar as there is in master).