### PR TITLE
update shortcodes to use textarea

### DIFF
--- a/blocks/library/shortcode/editor.scss
+++ b/blocks/library/shortcode/editor.scss
@@ -12,7 +12,7 @@
 		white-space: nowrap;
 	}
 
-	input {
+	textarea {
 		flex: 1 0 0%;
 	}
 

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -42,7 +42,6 @@ registerBlockType( 'core/shortcode', {
 					</label>
 					<textarea
 						id={ inputId }
-						type="text"
 						value={ attributes.text }
 						placeholder={ __( 'Write shortcode here…' ) }
 						onChange={ ( event ) => setAttributes( {

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import TextareaAutosize from 'react-autosize-textarea';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -40,13 +45,15 @@ registerBlockType( 'core/shortcode', {
 						<Dashicon icon="editor-code" />
 						{ __( 'Shortcode' ) }
 					</label>
-					<textarea
+					<TextareaAutosize
 						id={ inputId }
+						autoComplete="off"
 						value={ attributes.text }
 						placeholder={ __( 'Write shortcode here…' ) }
 						onChange={ ( event ) => setAttributes( {
 							text: event.target.value,
-						} ) } />
+						} ) }
+					/>
 					{ focus &&
 						<InspectorControls>
 							<BlockDescription>

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -40,7 +40,7 @@ registerBlockType( 'core/shortcode', {
 						<Dashicon icon="editor-code" />
 						{ __( 'Shortcode' ) }
 					</label>
-					<input
+					<textarea
 						id={ inputId }
 						type="text"
 						value={ attributes.text }


### PR DESCRIPTION
## Description
Update shortcode block to use textarea instead of input. #3154 

## How Has This Been Tested?
Ran tests locally and all is good.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Straightforward change of input -> textarea

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.