### PR TITLE
Performance: Use Lodash flatMap for accumulating blocks in block list

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { throttle, mapValues, noop, invert } from 'lodash';
+import { throttle, mapValues, noop, invert, flatMap } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -197,7 +197,7 @@ class VisualEditorBlockList extends Component {
 		return (
 			<div>
 				{ !! blocks.length && <VisualEditorSiblingInserter insertIndex={ 0 } /> }
-				{ blocks.reduce( ( result, uid, index ) => result.concat(
+				{ flatMap( blocks, ( uid, index ) => [
 					<VisualEditorBlock
 						key={ 'block-' + uid }
 						uid={ uid }
@@ -209,7 +209,7 @@ class VisualEditorBlockList extends Component {
 						key={ 'sibling-inserter-' + uid }
 						insertIndex={ index + 1 }
 					/>,
-				), [] ) }
+				] ) }
 				{ ! blocks.length &&
 					<div className="editor-visual-editor__placeholder">
 						<BlockDropZone />


### PR DESCRIPTION
This pull request seeks to optimize rendering of block list block elements by using [Lodash's `flatMap`](https://lodash.com/docs/4.17.4#flatMap) instead of accumulating an array of flattened blocks with a combination of `Array#reduce` and `Array#concat`. Benchmarks reveal that this performs approximately 4x faster when run on my machine:

https://jsperf.com/lodash-flatmap-vs-array-reduce/1

Further, the revised implementation is more concise.

h/t @ockham for pointer to this Lodash utility I've yet overlooked 😄  (see https://github.com/Automattic/wp-calypso/pull/19105)

__Testing instructions:__

Verify that there are no regressions in the rendering of block list, particularly in sibling inserters between blocks.