### PR TITLE
Shortcode: Disable HTML view

### DIFF
--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -29,7 +29,7 @@ registerBlockType( 'core/shortcode', {
 	},
 
 	className: false,
-	
+
 	supportHTML: false,
 
 	edit: withInstanceId(

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -29,6 +29,8 @@ registerBlockType( 'core/shortcode', {
 	},
 
 	className: false,
+	
+	supportHTML: false,
 
 	edit: withInstanceId(
 		( { attributes, setAttributes, instanceId, focus } ) => {


### PR DESCRIPTION
## Description
Shortcodes don't need a HTML view. This PR adds `supportHTML: false,`
