### PR TITLE
Try/deleting multi blocks

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -285,6 +285,22 @@ export function removeBlocks( uids ) {
 }
 
 /**
+ * Returns an action object used in signalling that the blocks
+ * corresponding to the specified UID set are to be removed, and then
+ * another block given focus. It differs from removeBlocks in that it
+ * calls focus on a block afterwards
+ *
+ * @param  {String[]} uids Block UIDs
+ * @return {Object}        Action object
+ */
+export function deleteBlocks( uids ) {
+	return {
+		type: 'DELETE_BLOCKS',
+		uids,
+	};
+}
+
+/**
  * Returns an action object used in signalling that the block with the
  * specified UID is to be removed.
  *

--- a/editor/block-settings-menu/block-delete-button.js
+++ b/editor/block-settings-menu/block-delete-button.js
@@ -13,7 +13,7 @@ import { IconButton } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { removeBlocks } from '../actions';
+import { deleteBlocks } from '../actions';
 
 export function BlockDeleteButton( { onDelete, onClick = noop, small = false } ) {
 	const label = __( 'Delete' );
@@ -34,7 +34,7 @@ export default connect(
 	undefined,
 	( dispatch, ownProps ) => ( {
 		onDelete() {
-			dispatch( removeBlocks( ownProps.uids ) );
+			dispatch( deleteBlocks( ownProps.uids ) );
 		},
 	} )
 )( BlockDeleteButton );

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -189,9 +189,13 @@ export default {
 	},
 	DELETE_BLOCKS( action, store ) {
 		const { dispatch } = store;
-		const state = store.getState();
-
 		const blockUids = action.uids;
+
+		if ( blockUids.length === 0 ) {
+			return;
+		}
+
+		const state = store.getState();
 		const firstBlock = first( blockUids );
 		const lastBlock = last( blockUids );
 		const priorBlock = getPreviousBlock( state, firstBlock );

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, uniqueId } from 'lodash';
+import { get, uniqueId, first, last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +22,7 @@ import {
 	replaceBlocks,
 	createSuccessNotice,
 	createErrorNotice,
+	removeBlocks,
 	removeNotice,
 	savePost,
 	editPost,
@@ -33,6 +34,8 @@ import {
 	getDirtyMetaBoxes,
 	getEditedPostContent,
 	getPostEdits,
+	getPreviousBlock,
+	getNextBlock,
 	isCurrentPostPublished,
 	isEditedPostDirty,
 	isEditedPostNew,
@@ -183,6 +186,23 @@ export default {
 	TRASH_POST_FAILURE( action, store ) {
 		const message = action.error.message && action.error.code !== 'unknown_error' ? action.error.message : __( 'Trashing failed' );
 		store.dispatch( createErrorNotice( message, { id: TRASH_POST_NOTICE_ID } ) );
+	},
+	DELETE_BLOCKS( action, store ) {
+		const { dispatch } = store;
+		const state = store.getState();
+
+		const blockUids = action.uids;
+		const firstBlock = first( blockUids );
+		const lastBlock = last( blockUids );
+		const priorBlock = getPreviousBlock( state, firstBlock );
+		const nextBlock = getNextBlock( state, lastBlock );
+
+		dispatch( removeBlocks( blockUids ) );
+
+		const nextFocus = nextBlock || priorBlock;
+		if ( nextFocus ) {
+			dispatch( focusBlock( nextFocus.uid ) );
+		}
 	},
 	MERGE_BLOCKS( action, store ) {
 		const { dispatch } = store;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -290,7 +290,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	render() {
-		const { block, multiSelectedBlockUids, order, mode } = this.props;
+		const { block, multiSelectedBlockUids, order, mode, hasMultiSelection } = this.props;
 		const { name: blockName, isValid } = block;
 		const blockType = getBlockType( blockName );
 		// translators: %s: Type of block (i.e. Text, Image etc)
@@ -374,7 +374,7 @@ class VisualEditorBlock extends Component {
 					<BlockCrashBoundary onError={ this.onBlockError }>
 						{ isValid && mode === 'visual' && (
 							<BlockEdit
-								focus={ focus }
+								focus={ ! hasMultiSelection ? focus : null }
 								attributes={ block.attributes }
 								setAttributes={ this.setAttributes }
 								insertBlocksAfter={ this.insertBlocksAfter }
@@ -417,6 +417,7 @@ export default connect(
 			isSelected: isBlockSelected( state, ownProps.uid ),
 			isMultiSelected: isBlockMultiSelected( state, ownProps.uid ),
 			isFirstMultiSelected: isFirstMultiSelectedBlock( state, ownProps.uid ),
+			hasMultiSelection: getMultiSelectedBlockUids( state ).length > 1,
 			isHovered: isBlockHovered( state, ownProps.uid ),
 			focus: getBlockFocus( state, ownProps.uid ),
 			isSelecting: isMultiSelecting( state ),

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -21,7 +21,7 @@ import PostTitle from '../../post-title';
 import WritingFlow from '../../writing-flow';
 import TableOfContents from '../../table-of-contents';
 import { getBlockUids, getMultiSelectedBlockUids } from '../../selectors';
-import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks } from '../../actions';
+import { clearSelectedBlock, multiSelect, redo, undo, deleteBlocks } from '../../actions';
 
 class VisualEditor extends Component {
 	constructor() {
@@ -66,10 +66,10 @@ class VisualEditor extends Component {
 	}
 
 	deleteSelectedBlocks( event ) {
-		const { multiSelectedBlockUids, onRemove } = this.props;
+		const { multiSelectedBlockUids, onDelete } = this.props;
 		if ( multiSelectedBlockUids.length ) {
 			event.preventDefault();
-			onRemove( multiSelectedBlockUids );
+			onDelete( multiSelectedBlockUids );
 		}
 	}
 
@@ -116,6 +116,6 @@ export default connect(
 		onMultiSelect: multiSelect,
 		onRedo: redo,
 		onUndo: undo,
-		onRemove: removeBlocks,
+		onDelete: deleteBlocks,
 	}
 )( VisualEditor );

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -15,7 +15,9 @@ import {
 	resetPost,
 	setupNewPost,
 	mergeBlocks,
+	deleteBlocks,
 	focusBlock,
+	removeBlocks,
 	replaceBlocks,
 	editPost,
 	savePost,
@@ -30,6 +32,77 @@ describe( 'effects', () => {
 	const defaultBlockSettings = { save: () => 'Saved', category: 'common', title: 'block title' };
 
 	beforeEach( () => jest.resetAllMocks() );
+
+	describe( '.DELETE_BLOCKS', () => {
+		const handler = effects.DELETE_BLOCKS;
+
+		it( 'No blocks to be deleted', () => {
+			selectors.getNextBlock.mockReturnValue( null );
+			selectors.getPreviousBlock.mockReturnValue( null );
+
+			const dispatch = jest.fn();
+			handler( deleteBlocks( [ ] ), { dispatch, getState: () => 'state' } );
+
+			expect( selectors.getPreviousBlock ).toHaveBeenCalledTimes( 0 );
+			expect( selectors.getNextBlock ).toHaveBeenCalledTimes( 0 );
+			expect( dispatch ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		it( 'All blocks to be deleted', () => {
+			selectors.getNextBlock.mockReturnValue( null );
+			selectors.getPreviousBlock.mockReturnValue( null );
+
+			const dispatch = jest.fn();
+			handler( deleteBlocks( [ 'one', 'two', 'three' ] ), { dispatch, getState: () => 'state' } );
+
+			expect( selectors.getPreviousBlock ).toHaveBeenCalledWith( 'state', 'one' );
+			expect( selectors.getNextBlock ).toHaveBeenCalledWith( 'state', 'three' );
+			expect( dispatch ).toHaveBeenCalledTimes( 1 );
+			expect( dispatch ).toHaveBeenCalledWith( removeBlocks( [ 'one', 'two', 'three' ] ) );
+		} );
+
+		it( 'All blocks to be deleted but first', () => {
+			selectors.getNextBlock.mockReturnValue( { uid: 'first' } );
+			selectors.getPreviousBlock.mockReturnValue( null );
+
+			const dispatch = jest.fn();
+			handler( deleteBlocks( [ 'one', 'two', 'three' ] ), { dispatch, getState: () => 'state' } );
+
+			expect( selectors.getPreviousBlock ).toHaveBeenCalledWith( 'state', 'one' );
+			expect( selectors.getNextBlock ).toHaveBeenCalledWith( 'state', 'three' );
+			expect( dispatch ).toHaveBeenCalledTimes( 2 );
+			expect( dispatch ).toHaveBeenCalledWith( removeBlocks( [ 'one', 'two', 'three' ] ) );
+			expect( dispatch ).toHaveBeenCalledWith( focusBlock( 'first' ) );
+		} );
+
+		it( 'All blocks to be deleted but last', () => {
+			selectors.getNextBlock.mockReturnValue( null );
+			selectors.getPreviousBlock.mockReturnValue( { uid: 'last' } );
+
+			const dispatch = jest.fn();
+			handler( deleteBlocks( [ 'one', 'two', 'three' ] ), { dispatch, getState: () => 'state' } );
+
+			expect( dispatch ).toHaveBeenCalledTimes( 2 );
+			expect( selectors.getPreviousBlock ).toHaveBeenCalledWith( 'state', 'one' );
+			expect( selectors.getNextBlock ).toHaveBeenCalledWith( 'state', 'three' );
+			expect( dispatch ).toHaveBeenCalledWith( removeBlocks( [ 'one', 'two', 'three' ] ) );
+			expect( dispatch ).toHaveBeenCalledWith( focusBlock( 'last' ) );
+		} );
+
+		it( 'All blocks in the middle to be deleted', () => {
+			selectors.getNextBlock.mockReturnValue( { uid: 'first' } );
+			selectors.getPreviousBlock.mockReturnValue( { uid: 'last' } );
+
+			const dispatch = jest.fn();
+			handler( deleteBlocks( [ 'one', 'two', 'three' ] ), { dispatch, getState: () => 'state' } );
+
+			expect( dispatch ).toHaveBeenCalledTimes( 2 );
+			expect( selectors.getPreviousBlock ).toHaveBeenCalledWith( 'state', 'one' );
+			expect( selectors.getNextBlock ).toHaveBeenCalledWith( 'state', 'three' );
+			expect( dispatch ).toHaveBeenCalledWith( removeBlocks( [ 'one', 'two', 'three' ] ) );
+			expect( dispatch ).toHaveBeenCalledWith( focusBlock( 'first' ) );
+		} );
+	} );
 
 	describe( '.MERGE_BLOCKS', () => {
 		const handler = effects.MERGE_BLOCKS;


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fix for #3191 
Stopped focusing inside editors when multi-select was enabled, and focused an appropriate block when the current block was deleted.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Wrote a test for the `effects.js` addition `DELETE_BLOCKS`

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Introduced another effect
Stopped passing focus through to blockType.edit when we have a multi-selection
Focused a block after deleting

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.