### PR TITLE
Components: Extract a reusable PostPendingStatus component

### DIFF
--- a/editor/post-pending-status/check.js
+++ b/editor/post-pending-status/check.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withAPIData } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { isCurrentPostPublished } from '../selectors';
+
+export function PostPendingStatusCheck( { isPublished, children, user } ) {
+	if ( isPublished || ! user.data || ! user.data.capabilities.publish_posts ) {
+		return null;
+	}
+
+	return children;
+}
+
+const applyConnect = connect(
+	( state ) => ( {
+		isPublished: isCurrentPostPublished( state ),
+	} ),
+);
+
+const applyWithAPIData = withAPIData( () => {
+	return {
+		user: '/wp/v2/users/me?context=edit',
+	};
+} );
+
+export default flowRight(
+	applyConnect,
+	applyWithAPIData
+)( PostPendingStatusCheck );

--- a/editor/post-pending-status/index.js
+++ b/editor/post-pending-status/index.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { flowRight } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { FormToggle, withInstanceId } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PostPendingStatusCheck from './check';
+import { getEditedPostAttribute } from '../selectors';
+import { editPost } from '../actions';
+
+export function PostPendingStatus( { instanceId, status, onUpdateStatus } ) {
+	const pendingId = 'pending-toggle-' + instanceId;
+	const togglePendingStatus = () => {
+		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
+		onUpdateStatus( updatedStatus );
+	};
+
+	return (
+		<PostPendingStatusCheck>
+			<label htmlFor={ pendingId }>{ __( 'Pending Review' ) }</label>
+			<FormToggle
+				id={ pendingId }
+				checked={ status === 'pending' }
+				onChange={ togglePendingStatus }
+				showHint={ false }
+			/>
+		</PostPendingStatusCheck>
+	);
+}
+
+const applyConnect = connect(
+	( state ) => ( {
+		status: getEditedPostAttribute( state, 'status' ),
+	} ),
+	{
+		onUpdateStatus( status ) {
+			return editPost( { status } );
+		},
+	}
+);
+
+export default flowRight(
+	applyConnect,
+	withInstanceId
+)( PostPendingStatus );

--- a/editor/post-pending-status/test/check.js
+++ b/editor/post-pending-status/test/check.js
@@ -6,9 +6,9 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { PostPendingStatus } from '../';
+import { PostPendingStatusCheck } from '../check';
 
-describe( 'PostPendingStatus', () => {
+describe( 'PostPendingStatusCheck', () => {
 	const user = {
 		data: {
 			capabilities: {
@@ -18,16 +18,20 @@ describe( 'PostPendingStatus', () => {
 	};
 
 	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
-		let wrapper = shallow( <PostPendingStatus user={ {} } /> );
+		let wrapper = shallow( <PostPendingStatusCheck user={ {} }>status</PostPendingStatusCheck> );
 		expect( wrapper.type() ).toBe( null );
-		wrapper = shallow( <PostPendingStatus user={
-			{ data: { capabilities: { publish_posts: false } } }
-		} /> );
+		wrapper = shallow(
+			<PostPendingStatusCheck user={
+				{ data: { capabilities: { publish_posts: false } } }
+			}>
+				status
+			</PostPendingStatusCheck>
+		);
 		expect( wrapper.type() ).toBe( null );
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow( <PostPendingStatus user={ user } /> );
+		const wrapper = shallow( <PostPendingStatusCheck user={ user }>status</PostPendingStatusCheck> );
 		expect( wrapper.type() ).not.toBe( null );
 	} );
 } );

--- a/editor/sidebar/post-pending-status/index.js
+++ b/editor/sidebar/post-pending-status/index.js
@@ -1,67 +1,22 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { PanelRow, FormToggle, withInstanceId, withAPIData } from '@wordpress/components';
+import { PanelRow } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import {
-	getEditedPostAttribute,
-	isCurrentPostPublished,
-} from '../../selectors';
-import { editPost } from '../../actions';
+import PostPendingStatusCheck from '../../post-pending-status/check';
+import PostPendingStatusForm from '../../post-pending-status';
 
-export function PostPendingStatus( { isPublished, instanceId, status, onUpdateStatus, user } ) {
-	if ( isPublished || ! user.data || ! user.data.capabilities.publish_posts ) {
-		return null;
-	}
-	const pendingId = 'pending-toggle-' + instanceId;
-	const togglePendingStatus = () => {
-		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
-		onUpdateStatus( updatedStatus );
-	};
-
+export function PostPendingStatus() {
 	return (
-		<PanelRow>
-			<label htmlFor={ pendingId }>{ __( 'Pending Review' ) }</label>
-			<FormToggle
-				id={ pendingId }
-				checked={ status === 'pending' }
-				onChange={ togglePendingStatus }
-				showHint={ false }
-			/>
-		</PanelRow>
+		<PostPendingStatusCheck>
+			<PanelRow>
+				<PostPendingStatusForm />
+			</PanelRow>
+		</PostPendingStatusCheck>
 	);
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		status: getEditedPostAttribute( state, 'status' ),
-		isPublished: isCurrentPostPublished( state ),
-	} ),
-	{
-		onUpdateStatus( status ) {
-			return editPost( { status } );
-		},
-	}
-);
-
-const applyWithAPIData = withAPIData( () => {
-	return {
-		user: '/wp/v2/users/me?context=edit',
-	};
-} );
-
-export default flowRight(
-	applyConnect,
-	applyWithAPIData,
-	withInstanceId
-)( PostPendingStatus );
+export default PostPendingStatus;


### PR DESCRIPTION
Related to #2761 (comment)

> All these (the sidebar panels) must be refactored slightly to drop all the "layout" pieces and keep only the "forms". For example, the sidebar panels like PostTaxonomies, we should extract only the PostTaxonomyForms into a reusable component without the expandable panel behavior that is specific to our current UI. (This step could be done in a separate PR preceding the directory structure change)

This PR addresses the comment above for the PostPendingStatus component.

**Testing instructions**

- Test that the post pending toggle is working properly