### PR TITLE
Implemented query panel in latest posts block.

### DIFF
--- a/blocks/library/latest-posts/data.js
+++ b/blocks/library/latest-posts/data.js
@@ -2,15 +2,21 @@
  * Returns a Promise with the latest posts or an error on failure.
  *
  * @param   {Number} postsToShow       Number of posts to display.
+ * @param   {String} order             Whether to sort in ascending or descending order: 'asc'|'desc'.
+ * @param   {String} orderBy           Post parameter by which to sort posts.
+ * @param   {String} categories        The terms assigned to the post in the category taxonomy.
  *
  * @returns {wp.api.collections.Posts} Returns a Promise with the latest posts.
  */
-export function getLatestPosts( postsToShow = 5 ) {
+export function getLatestPosts( postsToShow, order, orderBy, categories ) {
 	const postsCollection = new wp.api.collections.Posts();
 
 	const posts = postsCollection.fetch( {
 		data: {
 			per_page: postsToShow,
+			order,
+			orderby: orderBy,
+			categories,
 		},
 	} );
 

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -16,6 +16,9 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => $attributes['postsToShow'],
 		'post_status' => 'publish',
+		'order'       => $attributes['order'],
+		'orderby'     => $attributes['orderBy'],
+		'category'    => $attributes['categories'],
 	) );
 
 	$list_items_markup = '';
@@ -64,6 +67,9 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 
 register_block_type( 'core/latest-posts', array(
 	'attributes'      => array(
+		'categories'      => array(
+			'type' => 'string',
+		),
 		'postsToShow'     => array(
 			'type'    => 'number',
 			'default' => 5,
@@ -83,6 +89,14 @@ register_block_type( 'core/latest-posts', array(
 		'align'           => array(
 			'type'    => 'string',
 			'default' => 'center',
+		),
+		'order'           => array(
+			'type'    => 'string',
+			'default' => 'desc',
+		),
+		'orderBy'         => array(
+			'type'    => 'string',
+			'default' => 'date',
 		),
 	),
 	'render_callback' => 'gutenberg_render_block_core_latest_posts',

--- a/blocks/query-panel/category-select.js
+++ b/blocks/query-panel/category-select.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { buildTermsTree } from '@wordpress/utils';
+import { withAPIData } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import TermTreeSelect from '../term-tree-select';
+
+function CategorySelect( { label, noOptionLabel, categories, selectedCategory, onChange } ) {
+	const termsTree = buildTermsTree( get( categories, 'data', {} ) );
+	return (
+		<TermTreeSelect
+			{ ...{ label, noOptionLabel, onChange, termsTree } }
+			selectedTerm={ selectedCategory }
+		/>
+	);
+}
+
+const applyWithAPIData = withAPIData( () => ( {
+	categories: '/wp/v2/categories',
+} ) );
+
+export default applyWithAPIData( CategorySelect );

--- a/blocks/query-panel/index.js
+++ b/blocks/query-panel/index.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import CategorySelect from './category-select';
+import RangeControl from '../inspector-controls/range-control';
+import SelectControl from '../inspector-controls/select-control';
+
+const DEFAULT_MIN_ITEMS = 1;
+const DEFAULT_MAX_ITEMS = 100;
+
+export default function QueryPanel( {
+	category,
+	numberOfItems,
+	order,
+	orderBy,
+	maxItems = DEFAULT_MAX_ITEMS,
+	minItems = DEFAULT_MIN_ITEMS,
+	onCategoryChange,
+	onNumberOfItemsChange,
+	onOrderChange = noop,
+	onOrderByChange = noop,
+} ) {
+	return [
+		( onOrderChange || onOrderByChange ) && (
+			<SelectControl
+				key="query-panel-select"
+				label={ __( 'Order by' ) }
+				value={ `${ orderBy }/${ order }` }
+				options={ [
+					{
+						label: __( 'Newest to Oldest' ),
+						value: 'date/desc',
+					},
+					{
+						label: __( 'Oldest to Newest' ),
+						value: 'date/asc',
+					},
+					{
+						/* translators: label for ordering posts by title in ascending order */
+						label: __( 'A → Z' ),
+						value: 'title/asc',
+					},
+					{
+						/* translators: label for ordering posts by title in descending order */
+						label: __( 'Z → A' ),
+						value: 'title/desc',
+					},
+				] }
+				onChange={ ( value ) => {
+					const [ newOrderBy, newOrder ] = value.split( '/' );
+					if ( newOrder !== order ) {
+						onOrderChange( newOrder );
+					}
+					if ( newOrderBy !== orderBy ) {
+						onOrderByChange( newOrderBy );
+					}
+				} }
+			/>
+		),
+		onCategoryChange && (
+			<CategorySelect
+				key="query-panel-category-select"
+				label={ __( 'Category' ) }
+				noOptionLabel={ __( 'All' ) }
+				selectedCategory={ category }
+				onChange={ onCategoryChange }
+			/> ),
+		onNumberOfItemsChange && (
+			<RangeControl
+				key="query-panel-range-control"
+				label={ __( 'Number of items' ) }
+				value={ numberOfItems }
+				onChange={ onNumberOfItemsChange }
+				min={ minItems }
+				max={ maxItems }
+			/>
+		),
+	];
+}

--- a/blocks/term-tree-select/index.js
+++ b/blocks/term-tree-select/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { unescape as unescapeString, repeat, flatMap, compact } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import SelectControl from '../inspector-controls/select-control';
+
+function getSelectOptions( terms, level = 0 ) {
+	return flatMap( terms, ( term ) => [
+		{
+			value: term.id,
+			label: repeat( '\u00A0', level * 3 ) + unescapeString( term.name ),
+		},
+		...getSelectOptions( term.children, level + 1 ),
+	] );
+}
+
+export default function TermTreeSelect( { termsTree, label, noOptionLabel, selectedTerm, onChange } ) {
+	const options = compact( [
+		noOptionLabel && { value: '', label: noOptionLabel },
+		...getSelectOptions( termsTree ),
+	] );
+	return (
+		<SelectControl
+			{ ...{ label, options, onChange } }
+			value={ selectedTerm }
+		/>
+	);
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -9,5 +9,6 @@ export { decodeEntities };
 
 export * from './blob-cache';
 export * from './mediaupload';
+export * from './terms';
 
 export { viewPort };

--- a/utils/terms.js
+++ b/utils/terms.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { groupBy } from 'lodash';
+
+/**
+ * Returns terms in a tree form
+ ª
+ * @param  {Array} flatTerms  Array of terms in flat format.
+ * @return {Array}            Array of terms in tree format.
+ */
+export function buildTermsTree( flatTerms ) {
+	const termsByParent = groupBy( flatTerms, 'parent' );
+	const fillWithChildren = ( terms ) => {
+		return terms.map( ( term ) => {
+			const children = termsByParent[ term.id ];
+			return {
+				...term,
+				children: children && children.length ?
+					fillWithChildren( children ) :
+					[],
+			};
+		} );
+	};
+
+	return fillWithChildren( termsByParent[ '0' ] || [] );
+}

--- a/utils/test/terms.js
+++ b/utils/test/terms.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import { buildTermsTree } from '../terms';
+
+describe( 'buildTermsTree()', () => {
+	it( 'Should return empty array if parent is never specified.', () => {
+		const input = Object.freeze( [ { term: 2232 }, { term: 2245 } ] );
+		const termsTreem = buildTermsTree( input );
+		expect( termsTreem ).toEqual( [] );
+	} );
+	it( 'Should return same array as input with empty children added if all the elements are top level', () => {
+		const input = Object.freeze( [
+			{ id: 2232, parent: 0, dummy: true },
+			{ id: 2245, parent: 0, dummy: false },
+		] );
+		const output = [
+			{ id: 2232, parent: 0, children: [], dummy: true },
+			{ id: 2245, parent: 0, children: [], dummy: false },
+		];
+		const termsTreem = buildTermsTree( input );
+		expect( termsTreem ).toEqual( output );
+	} );
+	it( 'Should return element with its child if a child exists', () => {
+		const input = Object.freeze( [
+			{ id: 2232, parent: 0 },
+			{ id: 2245, parent: 2232 },
+		] );
+		const output = [
+			{ id: 2232, parent: 0, children: [
+				{ id: 2245, parent: 2232, children: [] },
+			] },
+		];
+		const termsTreem = buildTermsTree( input );
+		expect( termsTreem ).toEqual( output );
+	} );
+	it( 'Should return elements with multiple children and elements with no children', () => {
+		const input = Object.freeze( [
+			{ id: 2232, parent: 0 },
+			{ id: 2245, parent: 2232 },
+			{ id: 2249, parent: 0 },
+			{ id: 2246, parent: 2232 },
+		] );
+		const output = [
+			{ id: 2232, parent: 0, children: [
+				{ id: 2245, parent: 2232, children: [] },
+				{ id: 2246, parent: 2232, children: [] },
+			] },
+			{ id: 2249, parent: 0, children: [] },
+		];
+		const termsTreem = buildTermsTree( input );
+		expect( termsTreem ).toEqual( output );
+	} );
+} );


### PR DESCRIPTION
## Description
Ths PR aims to implement the query panel specified in issue https://github.com/WordPress/gutenberg/issues/2662.

The panel is added to latest posts block. But this leaves a discussion point, it allows, for example, to show 8 oldest posts by setting sorting from oldest to newest.
To solve this we need to make a decision : 
We rename this block to "Posts" allowing to show the most recent ones or oldest or other option the user chooses.
Or we maintain the most recent posts concept, we always retrieve from the database the N most recent posts and then we sort this recent posts in accordance with the sorting criteria the user selected.
Feel free to share your options.

## How Has This Been Tested?
Try to change the values of the 3 different options in the query panel. Verify that the posts in the editor update in accordance with the option selected. Save the post on each option change, and open the post, verify the server side render also shows the selected option correctly.

## Screenshots (jpeg or gifs if applicable):
<img width="915" alt="screen shot 2017-10-27 at 12 16 01" src="https://user-images.githubusercontent.com/11271197/32102170-18507902-bb13-11e7-96b3-033296bc5962.png">
<img width="904" alt="screen shot 2017-10-27 at 12 16 35" src="https://user-images.githubusercontent.com/11271197/32102130-ef8be2d6-bb12-11e7-9907-9dc270ba4935.png">
<img width="913" alt="screen shot 2017-10-27 at 12 16 23" src="https://user-images.githubusercontent.com/11271197/32102155-060b8214-bb13-11e7-89f8-61f7b9264c9b.png">


## Notes
There is a bug where component looks like loading forever if there are no posts that become more visible with this changes (because we can more easily select options without posts). A fix is being issued in https://github.com/WordPress/gutenberg/pull/3180.

The function buildTermsTree in utils was extracted from HierarchicalTermSelector component. As a future PR, this component will be refactored to make use of the utils function (removing the duplicate version) and will also be simplified/refactored to make use of the new component TermTreeSelect created in this PR.

