### PR TITLE
Components: Extract a reusable PostAuthors Component

### DIFF
--- a/editor/post-author/check.js
+++ b/editor/post-author/check.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { flowRight, filter } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withAPIData, withInstanceId } from '@wordpress/components';
+
+export function PostAuthorCheck( { user, users, children } ) {
+	const authors = filter( users.data, ( { capabilities } ) => capabilities.level_1 );
+	if ( ! user.data || ! user.data.capabilities.publish_posts || authors.length < 2 ) {
+		return null;
+	}
+
+	return children;
+}
+
+const applyWithAPIData = withAPIData( () => {
+	return {
+		users: '/wp/v2/users?context=edit&per_page=100',
+		user: '/wp/v2/users/me?context=edit',
+	};
+} );
+
+export default flowRight( [
+	applyWithAPIData,
+	withInstanceId,
+] )( PostAuthorCheck );

--- a/editor/post-author/index.js
+++ b/editor/post-author/index.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { filter, flowRight } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { withAPIData, withInstanceId } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import PostAuthorCheck from './check';
+import { getEditedPostAttribute } from '../selectors';
+import { editPost } from '../actions';
+
+export class PostAuthor extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.setAuthorId = this.setAuthorId.bind( this );
+	}
+
+	setAuthorId( event ) {
+		const { onUpdateAuthor } = this.props;
+		const { value } = event.target;
+		onUpdateAuthor( Number( value ) );
+	}
+
+	getAuthors() {
+		// While User Levels are officially deprecated, the behavior of the
+		// existing users dropdown on `who=authors` tests `user_level != 0`
+		//
+		// See: https://github.com/WordPress/WordPress/blob/a193916/wp-includes/class-wp-user-query.php#L322-L327
+		// See: https://codex.wordpress.org/Roles_and_Capabilities#User_Levels
+		const { users } = this.props;
+		return filter( users.data, ( user ) => {
+			return user.capabilities.level_1;
+		} );
+	}
+
+	render() {
+		const { postAuthor, instanceId } = this.props;
+		const authors = this.getAuthors();
+		const selectId = 'post-author-selector-' + instanceId;
+
+		// Disable reason: A select with an onchange throws a warning
+
+		/* eslint-disable jsx-a11y/no-onchange */
+		return (
+			<PostAuthorCheck>
+				<label htmlFor={ selectId }>{ __( 'Author' ) }</label>
+				<select
+					id={ selectId }
+					value={ postAuthor }
+					onChange={ this.setAuthorId }
+					className="editor-post-author__select"
+				>
+					{ authors.map( ( author ) => (
+						<option key={ author.id } value={ author.id }>{ author.name }</option>
+					) ) }
+				</select>
+			</PostAuthorCheck>
+		);
+		/* eslint-enable jsx-a11y/no-onchange */
+	}
+}
+
+const applyConnect = connect(
+	( state ) => {
+		return {
+			postAuthor: getEditedPostAttribute( state, 'author' ),
+		};
+	},
+	{
+		onUpdateAuthor( author ) {
+			return editPost( { author } );
+		},
+	},
+);
+
+const applyWithAPIData = withAPIData( () => {
+	return {
+		users: '/wp/v2/users?context=edit&per_page=100',
+	};
+} );
+
+export default flowRight( [
+	applyConnect,
+	applyWithAPIData,
+	withInstanceId,
+] )( PostAuthor );

--- a/editor/post-author/test/check.js
+++ b/editor/post-author/test/check.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostAuthorCheck } from '../check';
+
+describe( 'PostAuthorCheck', () => {
+	const users = {
+		data: [
+			{
+				id: 1,
+				name: 'admin',
+				capabilities: {
+					level_1: true,
+				},
+			},
+			{
+				id: 2,
+				name: 'subscriber',
+				capabilities: {
+					level_0: true,
+				},
+			},
+			{
+				id: 3,
+				name: 'andrew',
+				capabilities: {
+					level_1: true,
+				},
+			},
+		],
+	};
+
+	const user = {
+		data: {
+			capabilities: {
+				publish_posts: true,
+			},
+		},
+	};
+
+	it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
+		let wrapper = shallow( <PostAuthorCheck users={ users } user={ {} }>authors</PostAuthorCheck> );
+		expect( wrapper.type() ).toBe( null );
+		wrapper = shallow(
+			<PostAuthorCheck users={ users } user={
+				{ data: { capabilities: { publish_posts: false } } }
+			}>
+				authors
+			</PostAuthorCheck>
+		);
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should not render anything if users unknown', () => {
+		const wrapper = shallow( <PostAuthorCheck users={ {} } user={ user }>authors</PostAuthorCheck> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should not render anything if single user', () => {
+		const wrapper = shallow(
+			<PostAuthorCheck users={ { data: users.data.slice( 0, 1 ) } } user={ user }>
+				authors
+			</PostAuthorCheck>
+		);
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should not render anything if single filtered user', () => {
+		const wrapper = shallow(
+			<PostAuthorCheck users={ { data: users.data.slice( 0, 2 ) } } user={ user }>
+				authors
+			</PostAuthorCheck>
+		);
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'should render  control', () => {
+		const wrapper = shallow(
+			<PostAuthorCheck users={ users } user={ user }>
+				authors
+			</PostAuthorCheck>
+		);
+
+		expect( wrapper.type() ).not.toBe( null );
+	} );
+} );

--- a/editor/post-author/test/index.js
+++ b/editor/post-author/test/index.js
@@ -62,43 +62,6 @@ describe( 'PostAuthor', () => {
 	} );
 
 	describe( '#render()', () => {
-		it( 'should not render anything if the user doesn\'t have the right capabilities', () => {
-			let wrapper = shallow( <PostAuthor users={ users } user={ {} } /> );
-			expect( wrapper.type() ).toBe( null );
-			wrapper = shallow( <PostAuthor users={ users } user={
-				{ data: { capabilities: { publish_posts: false } } }
-			} /> );
-			expect( wrapper.type() ).toBe( null );
-		} );
-
-		it( 'should not render anything if users unknown', () => {
-			const wrapper = shallow( <PostAuthor users={ {} } user={ user } /> );
-
-			expect( wrapper.type() ).toBe( null );
-		} );
-
-		it( 'should not render anything if single user', () => {
-			const wrapper = shallow(
-				<PostAuthor users={ { data: users.data.slice( 0, 1 ) } } user={ user } />
-			);
-
-			expect( wrapper.type() ).toBe( null );
-		} );
-
-		it( 'should not render anything if single filtered user', () => {
-			const wrapper = shallow(
-				<PostAuthor users={ { data: users.data.slice( 0, 2 ) } } user={ user } />
-			);
-
-			expect( wrapper.type() ).toBe( null );
-		} );
-
-		it( 'should render select control', () => {
-			const wrapper = shallow( <PostAuthor users={ users } user={ user } /> );
-
-			expect( wrapper.find( 'select' ).length ).not.toBe( 0 );
-		} );
-
 		it( 'should update author', () => {
 			const onUpdateAuthor = jest.fn();
 			const wrapper = shallow(

--- a/editor/sidebar/post-author/index.js
+++ b/editor/sidebar/post-author/index.js
@@ -1,101 +1,23 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import { filter, flowRight } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { PanelRow, withAPIData, withInstanceId } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { PanelRow } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { getEditedPostAttribute } from '../../selectors';
-import { editPost } from '../../actions';
+import PostAuthorCheck from '../../post-author/check';
+import PostAuthorForm from '../../post-author';
 
-export class PostAuthor extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.setAuthorId = this.setAuthorId.bind( this );
-	}
-
-	setAuthorId( event ) {
-		const { onUpdateAuthor } = this.props;
-		const { value } = event.target;
-		onUpdateAuthor( Number( value ) );
-	}
-
-	getAuthors() {
-		// While User Levels are officially deprecated, the behavior of the
-		// existing users dropdown on `who=authors` tests `user_level != 0`
-		//
-		// See: https://github.com/WordPress/WordPress/blob/a193916/wp-includes/class-wp-user-query.php#L322-L327
-		// See: https://codex.wordpress.org/Roles_and_Capabilities#User_Levels
-		const { users } = this.props;
-		return filter( users.data, ( user ) => {
-			return user.capabilities.level_1;
-		} );
-	}
-
-	render() {
-		const { postAuthor, instanceId, user } = this.props;
-		const authors = this.getAuthors();
-		if ( ! user.data || ! user.data.capabilities.publish_posts || authors.length < 2 ) {
-			return null;
-		}
-
-		const selectId = 'post-author-selector-' + instanceId;
-
-		// Disable reason: A select with an onchange throws a warning
-
-		/* eslint-disable jsx-a11y/no-onchange */
-		return (
+export function PostAuthor() {
+	return (
+		<PostAuthorCheck>
 			<PanelRow>
-				<label htmlFor={ selectId }>{ __( 'Author' ) }</label>
-				<select
-					id={ selectId }
-					value={ postAuthor }
-					onChange={ this.setAuthorId }
-					className="editor-post-author__select"
-				>
-					{ authors.map( ( author ) => (
-						<option key={ author.id } value={ author.id }>{ author.name }</option>
-					) ) }
-				</select>
+				<PostAuthorForm />
 			</PanelRow>
-		);
-		/* eslint-enable jsx-a11y/no-onchange */
-	}
+		</PostAuthorCheck>
+	);
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postAuthor: getEditedPostAttribute( state, 'author' ),
-		};
-	},
-	{
-		onUpdateAuthor( author ) {
-			return editPost( { author } );
-		},
-	},
-);
-
-const applyWithAPIData = withAPIData( () => {
-	return {
-		users: '/wp/v2/users?context=edit&per_page=100',
-		user: '/wp/v2/users/me?context=edit',
-	};
-} );
-
-export default flowRight( [
-	applyConnect,
-	applyWithAPIData,
-	withInstanceId,
-] )( PostAuthor );
+export default PostAuthor;


### PR DESCRIPTION
Related to #2761 (comment)

> All these (the sidebar panels) must be refactored slightly to drop all the "layout" pieces and keep only the "forms". For example, the sidebar panels like PostTaxonomies, we should extract only the PostTaxonomyForms into a reusable component without the expandable panel behavior that is specific to our current UI. (This step could be done in a separate PR preceding the directory structure change)

This PR addresses the comment above for the PostAuthors component.

**Testing instructions**

- Test that the post authors selector is working properly (it shows only when you have two author s at least)