### PR TITLE
Components: Test presence of menu node before checking contains

### DIFF
--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -62,7 +62,7 @@ class Autocomplete extends Component {
 	onBlur( event ) {
 		// Check if related target is not within, in the case that the user is
 		// selecting an option by button click
-		if ( ! this.menuNode.contains( event.relatedTarget ) ) {
+		if ( this.menuNode && ! this.menuNode.contains( event.relatedTarget ) ) {
 			this.reset();
 		}
 	}


### PR DESCRIPTION
Regression introduced in #3174

This pull request seeks to resolve an error which occurs when blurring a paragraph block. Specifically, since we now check the menu node to determine where blur is moving to, we should first determine that the menu node is in-fact rendered. Previously we checked the wrapper autocomplete node which was always rendered, but the popover contents depend on a combination of there being a search with filtered options shown.

__Testing instructions:__

1. Navigate to Gutenberg > Demo
2. Select within a paragraph block
3. Select another block
4. Note that no errors are logged