### PR TITLE
Components: Remove unused focus prop from Button

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -6,61 +6,40 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, createElement } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-class Button extends Component {
-	constructor( props ) {
-		super( props );
-		this.setRef = this.setRef.bind( this );
-	}
+function Button( {
+	href,
+	target,
+	isPrimary,
+	isLarge,
+	isSmall,
+	isToggled,
+	className,
+	disabled,
+	...additionalProps
+} ) {
+	const classes = classnames( 'components-button', className, {
+		button: ( isPrimary || isLarge ),
+		'button-primary': isPrimary,
+		'button-large': isLarge,
+		'button-small': isSmall,
+		'is-toggled': isToggled,
+	} );
 
-	componentDidMount() {
-		if ( this.props.focus ) {
-			this.ref.focus();
-		}
-	}
+	const tag = href !== undefined && ! disabled ? 'a' : 'button';
+	const tagProps = tag === 'a' ? { href, target } : { type: 'button', disabled };
 
-	setRef( ref ) {
-		this.ref = ref;
-	}
-
-	render() {
-		const {
-			href,
-			target,
-			isPrimary,
-			isLarge,
-			isSmall,
-			isToggled,
-			className,
-			disabled,
-			...additionalProps
-		} = this.props;
-		const classes = classnames( 'components-button', className, {
-			button: ( isPrimary || isLarge ),
-			'button-primary': isPrimary,
-			'button-large': isLarge,
-			'button-small': isSmall,
-			'is-toggled': isToggled,
-		} );
-
-		const tag = href !== undefined && ! disabled ? 'a' : 'button';
-		const tagProps = tag === 'a' ? { href, target } : { type: 'button', disabled };
-
-		delete additionalProps.focus;
-
-		return createElement( tag, {
-			...tagProps,
-			...additionalProps,
-			className: classes,
-			ref: this.setRef,
-		} );
-	}
+	return createElement( tag, {
+		...tagProps,
+		...additionalProps,
+		className: classes,
+	} );
 }
 
 export default Button;

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -20,11 +20,11 @@ import Dashicon from '../dashicon';
 // is common to apply a ref to the button element (only supported in class)
 class IconButton extends Component {
 	render() {
-		const { icon, children, label, className, tooltip, focus, ...additionalProps } = this.props;
+		const { icon, children, label, className, tooltip, ...additionalProps } = this.props;
 		const classes = classnames( 'components-icon-button', className );
 
 		let element = (
-			<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
+			<Button { ...additionalProps } aria-label={ label } className={ classes }>
 				<Dashicon icon={ icon } />
 				{ children }
 			</Button>


### PR DESCRIPTION
Related: #896, #1459

This pull request seeks to remove the `focus` prop from the `Button` component, originally introduced in #896 and later its only usage removed in #1459. This helps simplify the component, which no longer requires lifecycle or a bound `ref`.

__Testing instructions:__

Verify there are no regressions in button behavior.