### PR TITLE
Blocks: Improve VisualEditorBlock rendering of settings menu

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -354,10 +354,7 @@ class VisualEditorBlock extends Component {
 					<BlockMover uids={ multiSelectedBlockUids } />
 				}
 				{ isFirstMultiSelected && ! this.props.isSelecting &&
-					<BlockSettingsMenu
-						uids={ multiSelectedBlockUids }
-						focus={ true }
-					/>
+					<BlockSettingsMenu uids={ multiSelectedBlockUids } />
 				}
 				<div
 					ref={ this.bindBlockNode }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -22,7 +22,7 @@ import BlockCrashBoundary from './block-crash-boundary';
 import BlockDropZone from './block-drop-zone';
 import BlockHtml from './block-html';
 import BlockMover from '../../block-mover';
-import BlockRightMenu from '../../block-settings-menu';
+import BlockSettingsMenu from '../../block-settings-menu';
 import BlockToolbar from '../../block-toolbar';
 import {
 	clearSelectedBlock,
@@ -348,13 +348,13 @@ class VisualEditorBlock extends Component {
 			>
 				<BlockDropZone index={ order } />
 				{ ( showUI || isProperlyHovered ) && <BlockMover uids={ [ block.uid ] } /> }
-				{ ( showUI || isProperlyHovered ) && <BlockRightMenu uids={ [ block.uid ] } /> }
+				{ ( showUI || isProperlyHovered ) && <BlockSettingsMenu uids={ [ block.uid ] } /> }
 				{ isSelected && isValid && <BlockToolbar uid={ block.uid } /> }
 				{ isFirstMultiSelected && ! this.props.isSelecting &&
 					<BlockMover uids={ multiSelectedBlockUids } />
 				}
 				{ isFirstMultiSelected && ! this.props.isSelecting &&
-					<BlockRightMenu
+					<BlockSettingsMenu
 						uids={ multiSelectedBlockUids }
 						focus={ true }
 					/>


### PR DESCRIPTION
Related: #2934

This pull request seeks to...

- Update the imported name of the BlockSettingsMenu component to match its exported name
- Remove an unhandled `focus` prop not managed by the BlockSettingsMenu component

__Testing instructions:__

Verify there are no regressions in the behavior of the block right menu, particularly for multi-selection.