### PR TITLE
Block: Assign block list ref from block child

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -72,17 +72,8 @@ class VisualEditorBlockList extends Component {
 		this.lastClientY = clientY;
 	}
 
-	setBlockRef( ref ) {
-		// To avoid dynamically creating function references for ref on every
-		// block element, instead reach into props of element directly.
-		const uid = ref.props.uid;
-
-		// Disable reason: We use DOM nodes of each rendered block in the list
-		// to determine multi-selection thresholds.
-		// eslint-disable-next-line react/no-find-dom-node
-		const node = findDOMNode( ref );
-
-		if ( ref === null ) {
+	setBlockRef( node, uid ) {
+		if ( node === null ) {
 			delete this.nodes[ uid ];
 		} else {
 			this.nodes = {
@@ -204,7 +195,7 @@ class VisualEditorBlockList extends Component {
 					<VisualEditorBlock
 						key={ 'block-' + uid }
 						uid={ uid }
-						ref={ this.setBlockRef }
+						blockRef={ this.setBlockRef }
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
 					/>,

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -60,6 +60,7 @@ class VisualEditorBlock extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.setBlockListRef = this.setBlockListRef.bind( this );
 		this.bindBlockNode = this.bindBlockNode.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
@@ -133,6 +134,10 @@ class VisualEditorBlock extends Component {
 
 	removeStopTypingListener() {
 		document.removeEventListener( 'mousemove', this.stopTypingOnMouseMove );
+	}
+
+	setBlockListRef( node ) {
+		this.props.blockRef( node, this.props.uid );
 	}
 
 	bindBlockNode( node ) {
@@ -339,6 +344,7 @@ class VisualEditorBlock extends Component {
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<div
+				ref={ this.setBlockListRef }
 				onMouseMove={ this.maybeHover }
 				onMouseEnter={ this.maybeHover }
 				onMouseLeave={ onMouseLeave }


### PR DESCRIPTION
Regression introduced in #3171 

This pull request is a partial revert of #3171, seeking to address an error which occurs when removing a block. The changes in #3171 depend to access props of a rendered element ref are insufficient, since the `ref` callback is invoked with `null` when the element unmounts. The changes here partially restore the original behavior prior to #3171, with an optimization to still use a constant reference to binding the block `ref` in VisualEditorBlockList by passing UID from the child Block component's own `ref` callback.

__Testing instructions:__

Verify that no errors occur when removing a block.