### PR TITLE
Framework: Capture and recover from application error

### DIFF
--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -57,7 +57,12 @@ class ClipboardButton extends Component {
 	}
 
 	getText() {
-		return this.props.text;
+		let text = this.props.text;
+		if ( 'function' === typeof text ) {
+			text = text();
+		}
+
+		return text;
 	}
 
 	render() {

--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -66,12 +66,14 @@ class ClipboardButton extends Component {
 	}
 
 	render() {
-		const { className, children } = this.props;
+		// Disable reason: Exclude from spread props passed to Button
+		// eslint-disable-next-line no-unused-vars
+		const { className, children, onCopy, text, ...buttonProps } = this.props;
 		const classes = classnames( 'components-clipboard-button', className );
 
 		return (
 			<div ref={ this.bindContainer }>
-				<Button className={ classes }>
+				<Button { ...buttonProps } className={ classes }>
 					{ children }
 				</Button>
 			</div>

--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -72,11 +72,11 @@ class ClipboardButton extends Component {
 		const classes = classnames( 'components-clipboard-button', className );
 
 		return (
-			<div ref={ this.bindContainer }>
+			<span ref={ this.bindContainer }>
 				<Button { ...buttonProps } className={ classes }>
 					{ children }
 				</Button>
-			</div>
+			</span>
 		);
 	}
 }

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -8,7 +8,7 @@ $z-layers: (
 	'.editor-visual-editor__block .wp-block-more:before': -1,
 	'.editor-visual-editor__block {core/image aligned left or right}': 20,
 	'.freeform-toolbar': 10,
-	'.editor-visual-editor__block-warning': 1,
+	'.editor-warning': 1,
 	'.editor-visual-editor__sibling-inserter': 1,
 	'.components-form-toggle__input': 1,
 	'.editor-format-list__menu': 1,

--- a/editor/components/error-boundary/index.js
+++ b/editor/components/error-boundary/index.js
@@ -14,34 +14,37 @@ import { Button, ClipboardButton } from '@wordpress/components';
  * Internal dependencies
  */
 import { Warning } from '../';
+import { getEditedPostContent } from '../../selectors';
 
 class ErrorBoundary extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.reboot = this.reboot.bind( this );
-		this.getStateText = this.getStateText.bind( this );
+		this.getContent = this.getContent.bind( this );
 
 		this.state = {
-			hasEncounteredError: false,
+			error: null,
 		};
 	}
 
-	componentDidCatch() {
-		this.setState( { hasEncounteredError: true } );
+	componentDidCatch( error ) {
+		this.setState( { error } );
 	}
 
 	reboot() {
 		this.props.onError( this.context.store.getState() );
 	}
 
-	getStateText() {
-		return JSON.stringify( this.context.store.getState() );
+	getContent() {
+		try {
+			return getEditedPostContent( this.context.store.getState() );
+		} catch ( error ) {}
 	}
 
 	render() {
-		const { hasEncounteredError } = this.state;
-		if ( ! hasEncounteredError ) {
+		const { error } = this.state;
+		if ( ! error ) {
 			return this.props.children;
 		}
 
@@ -54,8 +57,11 @@ class ErrorBoundary extends Component {
 					<Button onClick={ this.reboot } isLarge>
 						{ __( 'Attempt Recovery' ) }
 					</Button>
-					<ClipboardButton text={ this.getStateText } isLarge>
-						{ __( 'Copy State to Clipboard' ) }
+					<ClipboardButton text={ this.getContent } isLarge>
+						{ __( 'Copy Post Text' ) }
+					</ClipboardButton>
+					<ClipboardButton text={ error.stack } isLarge>
+						{ __( 'Copy Error' ) }
 					</ClipboardButton>
 				</p>
 			</Warning>

--- a/editor/components/error-boundary/index.js
+++ b/editor/components/error-boundary/index.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, ClipboardButton } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Warning } from '../';
+
+class ErrorBoundary extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.reboot = this.reboot.bind( this );
+		this.getStateText = this.getStateText.bind( this );
+
+		this.state = {
+			hasEncounteredError: false,
+		};
+	}
+
+	componentDidCatch() {
+		this.setState( { hasEncounteredError: true } );
+	}
+
+	reboot() {
+		this.props.onError( this.context.store.getState() );
+	}
+
+	getStateText() {
+		return JSON.stringify( this.context.store.getState() );
+	}
+
+	render() {
+		const { hasEncounteredError } = this.state;
+		if ( ! hasEncounteredError ) {
+			return this.props.children;
+		}
+
+		return (
+			<Warning>
+				<p>{ __(
+					'The editor has encountered an unexpected error.'
+				) }</p>
+				<p>
+					<Button onClick={ this.reboot } isLarge>
+						{ __( 'Attempt Recovery' ) }
+					</Button>
+					<ClipboardButton text={ this.getStateText } isLarge>
+						{ __( 'Copy State to Clipboard' ) }
+					</ClipboardButton>
+				</p>
+			</Warning>
+		);
+	}
+}
+
+ErrorBoundary.contextTypes = {
+	store: noop,
+};
+
+export default ErrorBoundary;

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -35,7 +35,9 @@ export { default as WordCount } from './word-count';
 
 // Content Related Components
 export { default as BlockInspector } from './block-inspector';
+export { default as ErrorBoundary } from './error-boundary';
 export { default as Inserter } from './inserter';
+export { default as Warning } from './warning';
 
 // State Related Components
 export { default as EditorProvider } from './provider';

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -42,8 +42,13 @@ class EditorProvider extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
-		const store = createReduxStore();
-		store.dispatch( setupEditor( props.post ) );
+		const store = createReduxStore( props.initialState );
+
+		// If initial state is passed, assume that we don't need to initialize,
+		// as in the case of an error recovery.
+		if ( ! props.initialState ) {
+			store.dispatch( setupEditor( props.post ) );
+		}
 
 		this.store = store;
 		this.settings = {

--- a/editor/components/warning/index.js
+++ b/editor/components/warning/index.js
@@ -3,13 +3,18 @@
  */
 import { Dashicon } from '@wordpress/components';
 
-function BlockWarning( { children } ) {
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function Warning( { children } ) {
 	return (
-		<div className="editor-visual-editor__block-warning">
+		<div className="editor-warning">
 			<Dashicon icon="warning" />
 			{ children }
 		</div>
 	);
 }
 
-export default BlockWarning;
+export default Warning;

--- a/editor/components/warning/style.scss
+++ b/editor/components/warning/style.scss
@@ -1,0 +1,29 @@
+.editor-warning {
+	z-index: z-index( '.editor-warning' );
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+	display: flex;
+	flex-direction: column;
+	justify-content: space-around;
+	align-items: center;
+	width: 96%;
+	max-width: 780px;
+	padding: 20px 20px 10px 20px;
+	background-color: $white;
+	border: 1px solid $light-gray-500;
+	text-align: center;
+	line-height: $default-line-height;
+	box-shadow: $shadow-popover;
+
+	.editor-visual-editor & p {
+		width: 100%;
+		font-family: $default-font;
+		font-size: $default-font-size;
+	}
+
+	.components-button {
+		margin: 0 #{ $item-spacing / 2 } 5px;
+	}
+}

--- a/editor/index.js
+++ b/editor/index.js
@@ -7,7 +7,7 @@ import 'moment-timezone/moment-timezone-utils';
 /**
  * WordPress dependencies
  */
-import { render } from '@wordpress/element';
+import { render, unmountComponentAtNode } from '@wordpress/element';
 import { settings as dateSettings } from '@wordpress/date';
 
 /**
@@ -15,7 +15,7 @@ import { settings as dateSettings } from '@wordpress/date';
  */
 import './assets/stylesheets/main.scss';
 import Layout from './layout';
-import { EditorProvider } from './components';
+import { EditorProvider, ErrorBoundary } from './components';
 import { initializeMetaBoxState } from './actions';
 
 export * from './components';
@@ -46,22 +46,48 @@ window.jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
 } );
 
 /**
+ * Reinitializes the editor after the user chooses to reboot the editor after
+ * an unhandled error occurs, replacing previously mounted editor element using
+ * an initial state from prior to the crash.
+ *
+ * @param {Element} target       DOM node in which editor is rendered
+ * @param {*}       initialState Initial editor state to hydrate
+ */
+export function recreateEditorInstance( target, initialState ) {
+	unmountComponentAtNode( target );
+
+	const reboot = recreateEditorInstance.bind( null, target );
+
+	render(
+		<EditorProvider initialState={ initialState }>
+			<ErrorBoundary onError={ reboot }>
+				<Layout />
+			</ErrorBoundary>
+		</EditorProvider>,
+		target
+	);
+}
+
+/**
  * Initializes and returns an instance of Editor.
  *
  * The return value of this function is not necessary if we change where we
  * call createEditorInstance(). This is due to metaBox timing.
  *
- * @param {String}  id       Unique identifier for editor instance
- * @param {Object}  post     API entity for post to edit
- * @param {?Object} settings Editor settings object
- * @return {Object} Editor interface. Currently supports metabox initialization.
+ * @param  {String}  id       Unique identifier for editor instance
+ * @param  {Object}  post     API entity for post to edit
+ * @param  {?Object} settings Editor settings object
+ * @return {Object}           Editor interface
  */
 export function createEditorInstance( id, post, settings ) {
 	const target = document.getElementById( id );
+	const reboot = recreateEditorInstance.bind( null, target );
 
 	const provider = render(
 		<EditorProvider settings={ settings } post={ post }>
-			<Layout />
+			<ErrorBoundary onError={ reboot }>
+				<Layout />
+			</ErrorBoundary>
 		</EditorProvider>,
 		target
 	);

--- a/editor/modes/visual-editor/block-crash-warning.js
+++ b/editor/modes/visual-editor/block-crash-warning.js
@@ -6,14 +6,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import BlockWarning from './block-warning';
+import { Warning } from '../../components';
 
 const warning = (
-	<BlockWarning>
+	<Warning>
 		<p>{ __(
 			'This block has suffered from an unhandled error and cannot be previewed.'
 		) }</p>
-	</BlockWarning>
+	</Warning>
 );
 
 export default () => warning;

--- a/editor/modes/visual-editor/block-crash-warning.js
+++ b/editor/modes/visual-editor/block-crash-warning.js
@@ -11,7 +11,7 @@ import { Warning } from '../../components';
 const warning = (
 	<Warning>
 		<p>{ __(
-			'This block has suffered from an unhandled error and cannot be previewed.'
+			'This block has encountered an error and cannot be previewed.'
 		) }</p>
 	</Warning>
 );

--- a/editor/modes/visual-editor/invalid-block-warning.js
+++ b/editor/modes/visual-editor/invalid-block-warning.js
@@ -12,7 +12,7 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import BlockWarning from './block-warning';
+import { Warning } from '../../components';
 import {
 	getBlockType,
 	getUnknownTypeHandlerName,
@@ -31,7 +31,7 @@ function InvalidBlockWarning( { ignoreInvalid, switchToBlockType } ) {
 	const switchTo = ( blockType ) => () => switchToBlockType( blockType );
 
 	return (
-		<BlockWarning>
+		<Warning>
 			<p>{ defaultBlockType && htmlBlockType && sprintf( __(
 				'This block appears to have been modified externally. ' +
 				'Overwrite the external changes or Convert to %s or %s to keep ' +
@@ -67,7 +67,7 @@ function InvalidBlockWarning( { ignoreInvalid, switchToBlockType } ) {
 					</Button>
 				) }
 			</p>
-		</BlockWarning>
+		</Warning>
 	);
 }
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -51,7 +51,7 @@
 		position: relative;
 		min-height: 250px;
 
-		> :not( .editor-visual-editor__block-warning ) {
+		> :not( .editor-warning ) {
 			pointer-events: none;
 			user-select: none;
 		}
@@ -419,40 +419,6 @@
 	display: inline-block;
 	margin-right: 8px;
 	height: 20px;
-}
-
-.editor-visual-editor__block-warning {
-	z-index: z-index( '.editor-visual-editor__block-warning' );
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate( -50%, -50% );
-	display: flex;
-	flex-direction: column;
-	justify-content: space-around;
-	align-items: center;
-	width: 96%;
-	max-width: 780px;
-	padding: 20px 20px 10px 20px;
-	background-color: $white;
-	border: 1px solid $light-gray-500;
-	text-align: center;
-	line-height: $default-line-height;
-	box-shadow: $shadow-popover;
-
-	p {
-		width: 100%;
-		font-family: $default-font;
-		font-size: $default-font-size;
-	}
-
-	.button + .button {
-		margin-left: $item-spacing;
-	}
-}
-
-.visual-editor__invalid-block-warning-buttons .components-button {
-	margin-bottom: 5px;
 }
 
 .editor-visual-editor__block .blocks-visual-editor__block-html-textarea {

--- a/editor/store.js
+++ b/editor/store.js
@@ -21,9 +21,10 @@ const GUTENBERG_PREFERENCES_KEY = `GUTENBERG_PREFERENCES_${ window.userSettings.
 /**
  * Creates a new instance of a Redux store.
  *
- * @return {Redux.Store} Redux store
+ * @param  {?*}          preloadedState Optional initial state
+ * @return {Redux.Store}                Redux store
  */
-function createReduxStore() {
+function createReduxStore( preloadedState ) {
 	const enhancers = [
 		applyMiddleware( multi, refx( effects ) ),
 		storePersist( 'preferences', GUTENBERG_PREFERENCES_KEY ),
@@ -33,7 +34,7 @@ function createReduxStore() {
 		enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
 	}
 
-	const store = createStore( reducer, flowRight( enhancers ) );
+	const store = createStore( reducer, preloadedState, flowRight( enhancers ) );
 
 	return store;
 }

--- a/element/index.js
+++ b/element/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createElement, Component, cloneElement, Children } from 'react';
-import { render, findDOMNode, createPortal } from 'react-dom';
+import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { isString } from 'lodash';
 
@@ -26,6 +26,13 @@ export { createElement };
  * @param {Element}   target  DOM node into which element should be rendered
  */
 export { render };
+
+/**
+ * Removes any mounted element from the target DOM node.
+ *
+ * @param {Element} target DOM node in which element is to be removed
+ */
+export { unmountComponentAtNode };
 
 /**
  * A base class to create WordPress Components (Refs, state and lifecycle hooks)


### PR DESCRIPTION
Related: #2410

This pull request seeks to add application-wide error handling to try to prevent content loss in the case that an unhandled error occurs in editor rendering. This is intended as a last-resort recovery to avoid a "blank screen" case, and favors state integrity over presentation, in order to avoid any risk that an error occurs during the recovery itself. There could be improvements made here to try to alleviate any stress to a user who finds themselves in this scenario.

As implemented, the user is provided options to attempt a recovery or copy the raw state data to their clipboard. In the former case, the behavior is to attempt a re-render, providing as initial state to the Redux store the state which had existed at the time of the crash. It is possible that this recovery may not be possible, if it is the state itself which is the cause of the error. Therefore, in order to provide some means of recovery, the user is also presented the option to retrieve the underlying state data from which they may be able to extract remnants of their post state.

![Error](https://user-images.githubusercontent.com/1779930/32113823-7a0a75c0-bb0f-11e7-95d2-5f827d43a2b1.png)

[Video Demonstration](https://cldup.com/eRDWEXbq2y.mov)

__Testing instructions:__

Ideally there is no way to trigger an application error. You may introduce one though, ideally which doesn't occur at initial render. I have been using the following to trigger an error when a dropdown is opened (e.g. inserter menu):

```diff
diff --git a/components/dropdown/index.js b/components/dropdown/index.js
index 1989f101..1c79f148 100644
--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -61,6 +61,7 @@ class Dropdown extends Component {
 
        render() {
                const { isOpen } = this.state;
+               if ( isOpen ) throw new Error();
                const { renderContent, renderToggle, position = 'bottom', className, contentClassName } = this.props;
                const args = { isOpen, onToggle: this.toggle, onClose: this.close };
                return (
```

When an application error occurs, note that you are presented with a dialog with options to either attempt recovery or copy to state. Attempt recovery should restore the editor to its state prior to the error occurring. Copying state should copy a (very large) serialized state object to your clipboard.