### PR TITLE
Revisions: Link to the latest revision

### DIFF
--- a/editor/sidebar/last-revision/index.js
+++ b/editor/sidebar/last-revision/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight, last } from 'lodash';
+import { flowRight, first } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -23,7 +23,7 @@ import {
 import { getWPAdminURL } from '../../utils/url';
 
 function LastRevision( { revisions } ) {
-	const lastRevision = last( revisions.data );
+	const lastRevision = first( revisions.data );
 	if ( ! lastRevision ) {
 		return null;
 	}


### PR DESCRIPTION
## Description
The `X Revisions` entry in the sidebar should link to the lastest revision. So we have to select the first item of the revisions array. Before it linked to the first revision of the post.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.