### PR TITLE
Restore multi-select focus

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -6,40 +6,61 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createElement } from '@wordpress/element';
+import { Component, createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-function Button( {
-	href,
-	target,
-	isPrimary,
-	isLarge,
-	isSmall,
-	isToggled,
-	className,
-	disabled,
-	...additionalProps
-} ) {
-	const classes = classnames( 'components-button', className, {
-		button: ( isPrimary || isLarge ),
-		'button-primary': isPrimary,
-		'button-large': isLarge,
-		'button-small': isSmall,
-		'is-toggled': isToggled,
-	} );
+class Button extends Component {
+	constructor( props ) {
+		super( props );
+		this.setRef = this.setRef.bind( this );
+	}
 
-	const tag = href !== undefined && ! disabled ? 'a' : 'button';
-	const tagProps = tag === 'a' ? { href, target } : { type: 'button', disabled };
+	componentDidMount() {
+		if ( this.props.focus ) {
+			this.ref.focus();
+		}
+	}
 
-	return createElement( tag, {
-		...tagProps,
-		...additionalProps,
-		className: classes,
-	} );
+	setRef( ref ) {
+		this.ref = ref;
+	}
+
+	render() {
+		const {
+			href,
+			target,
+			isPrimary,
+			isLarge,
+			isSmall,
+			isToggled,
+			className,
+			disabled,
+			...additionalProps
+		} = this.props;
+		const classes = classnames( 'components-button', className, {
+			button: ( isPrimary || isLarge ),
+			'button-primary': isPrimary,
+			'button-large': isLarge,
+			'button-small': isSmall,
+			'is-toggled': isToggled,
+		} );
+
+		const tag = href !== undefined && ! disabled ? 'a' : 'button';
+		const tagProps = tag === 'a' ? { href, target } : { type: 'button', disabled };
+
+		delete additionalProps.focus;
+
+		return createElement( tag, {
+			...tagProps,
+			...additionalProps,
+			className: classes,
+			ref: this.setRef,
+		} );
+	}
 }
 
 export default Button;

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -20,11 +20,11 @@ import Dashicon from '../dashicon';
 // is common to apply a ref to the button element (only supported in class)
 class IconButton extends Component {
 	render() {
-		const { icon, children, label, className, tooltip, ...additionalProps } = this.props;
+		const { icon, children, label, className, tooltip, focus, ...additionalProps } = this.props;
 		const classes = classnames( 'components-icon-button', className );
 
 		let element = (
-			<Button { ...additionalProps } aria-label={ label } className={ classes }>
+			<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
 				<Dashicon icon={ icon } />
 				{ children }
 			</Button>

--- a/editor/block-settings-menu/index.js
+++ b/editor/block-settings-menu/index.js
@@ -19,7 +19,7 @@ import BlockModeToggle from './block-mode-toggle';
 import BlockDeleteButton from './block-delete-button';
 import { selectBlock } from '../actions';
 
-function BlockSettingsMenu( { uids, onSelect } ) {
+function BlockSettingsMenu( { uids, onSelect, focus } ) {
 	const count = uids.length;
 
 	return (
@@ -31,6 +31,7 @@ function BlockSettingsMenu( { uids, onSelect } ) {
 				const toggleClassname = classnames( 'editor-block-settings-menu__toggle', {
 					'is-opened': isOpen,
 				} );
+
 				return (
 					<IconButton
 						className={ toggleClassname }
@@ -43,6 +44,7 @@ function BlockSettingsMenu( { uids, onSelect } ) {
 						icon="ellipsis"
 						label={ isOpen ? __( 'Close Settings Menu' ) : __( 'Open Settings Menu' ) }
 						aria-expanded={ isOpen }
+						focus={ focus }
 					/>
 				);
 			} }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -364,7 +364,10 @@ class VisualEditorBlock extends Component {
 					<BlockMover uids={ multiSelectedBlockUids } />
 				}
 				{ isFirstMultiSelected && ! this.props.isSelecting &&
-					<BlockSettingsMenu uids={ multiSelectedBlockUids } />
+					<BlockSettingsMenu
+						uids={ multiSelectedBlockUids }
+						focus={ true }
+					/>
 				}
 				<div
 					ref={ this.bindBlockNode }


### PR DESCRIPTION
## Description
This PR restores setting focus on a multi-select action after multi-selecting. Somehow this was all reverted in a few commits after redoing `BlockSettingsMenu`.

~~A side effect of this is that the focus does not leave the `Editable`, which breaks deleting the multi-selection. Fixes #3191. See also #3194.~~ Done in #3253.

## How Has This Been Tested?
1. Make a multi-selection.
2. Observe the focus moving to the right block settings toggle.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.