### PR TITLE
FIX: Link Dialog's position appears randomly generated

### DIFF
--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -177,7 +177,7 @@ class FormatToolbar extends Component {
 				<Toolbar controls={ toolbarControls } />
 
 				{ ( isAddingLink || isEditingLink ) &&
-					<Fill name="Formatting.LinkDialog">
+					<Fill name="Editable.Siblings">
 						<form
 							className="blocks-format-toolbar__link-modal"
 							style={ linkStyle }
@@ -192,7 +192,7 @@ class FormatToolbar extends Component {
 				}
 
 				{ !! formats.link && ! isAddingLink && ! isEditingLink &&
-					<Fill name="Formatting.LinkDialog">
+					<Fill name="Editable.Siblings">
 						<div className="blocks-format-toolbar__link-modal" style={ linkStyle }>
 							<a
 								className="blocks-format-toolbar__link-value"

--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Fill } from 'react-slot-fill';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -172,32 +177,36 @@ class FormatToolbar extends Component {
 				<Toolbar controls={ toolbarControls } />
 
 				{ ( isAddingLink || isEditingLink ) &&
-					<form
-						className="blocks-format-toolbar__link-modal"
-						style={ linkStyle }
-						onSubmit={ this.submitLink }>
-						<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
-						<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-						<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
-						<IconButton icon="admin-generic" onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
-						{ linkSettings }
-					</form>
+					<Fill name="Formatting.LinkDialog">
+						<form
+							className="blocks-format-toolbar__link-modal"
+							style={ linkStyle }
+							onSubmit={ this.submitLink }>
+							<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
+							<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
+							<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
+							<IconButton icon="admin-generic" onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
+							{ linkSettings }
+						</form>
+					</Fill>
 				}
 
 				{ !! formats.link && ! isAddingLink && ! isEditingLink &&
-					<div className="blocks-format-toolbar__link-modal" style={ linkStyle }>
-						<a
-							className="blocks-format-toolbar__link-value"
-							href={ formats.link.value }
-							target="_blank"
-						>
-							{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
-						</a>
-						<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
-						<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
-						<IconButton icon="admin-generic" onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
-						{ linkSettings }
-					</div>
+					<Fill name="Formatting.LinkDialog">
+						<div className="blocks-format-toolbar__link-modal" style={ linkStyle }>
+							<a
+								className="blocks-format-toolbar__link-value"
+								href={ formats.link.value }
+								target="_blank"
+							>
+								{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
+							</a>
+							<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
+							<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
+							<IconButton icon="admin-generic" onClick={ this.toggleLinkSettingsVisibility } aria-expanded={ settingsVisible } />
+							{ linkSettings }
+						</div>
+					</Fill>
 				}
 			</div>
 		);

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -15,7 +15,7 @@ import {
 	noop,
 } from 'lodash';
 import { nodeListToReact } from 'dom-react';
-import { Fill } from 'react-slot-fill';
+import { Fill, Slot } from 'react-slot-fill';
 import 'element-closest';
 
 /**
@@ -325,9 +325,9 @@ export default class Editable extends Component {
 		// is absolute positioned and it's not shown when we compute the position here
 		// so we compute the position about its parent relative position and adds the offset
 		const toolbarOffset = this.props.inlineToolbar ?
-			{ top: 50, left: 0 } :
-			{ top: 40, left: -( ( blockPadding * 2 ) + blockMoverMargin ) };
-		const linkModalWidth = 250;
+			{ top: 10, left: 0 } :
+			{ top: 0, left: -( ( blockPadding * 2 ) + blockMoverMargin ) };
+		const linkModalWidth = 305;
 
 		return {
 			top: position.top - containerPosition.top + ( position.height ) + toolbarOffset.top,
@@ -709,6 +709,7 @@ export default class Editable extends Component {
 						{ MultilineTag ? <MultilineTag>{ placeholder }</MultilineTag> : placeholder }
 					</Tagname>
 				}
+				{ focus && <Slot name="Formatting.LinkDialog" /> }
 			</div>
 		);
 	}

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -709,7 +709,7 @@ export default class Editable extends Component {
 						{ MultilineTag ? <MultilineTag>{ placeholder }</MultilineTag> : placeholder }
 					</Tagname>
 				}
-				{ focus && <Slot name="Formatting.LinkDialog" /> }
+				{ focus && <Slot name="Editable.Siblings" /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
fixes: https://github.com/WordPress/gutenberg/issues/3211

Moving the FormatToolbar out of the block caused the LinkDialog's offsetParent to be incorrect.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manual browser testing

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.