### PR TITLE
Editable: Discard ARIA props if nil

### DIFF
--- a/blocks/editable/aria.js
+++ b/blocks/editable/aria.js
@@ -5,6 +5,8 @@
 import {
 	difference,
 	isEqual,
+	isNil,
+	keys,
 	pickBy,
 	startsWith,
 } from 'lodash';
@@ -12,15 +14,12 @@ import {
 const isAriaPropName = ( name ) =>
 	startsWith( name, 'aria-' );
 
-const getAriaKeys = ( props ) =>
-	Object.keys( props ).filter( isAriaPropName );
-
 export const pickAriaProps = ( props ) =>
-	pickBy( props, ( value, key ) => isAriaPropName( key ) );
+	pickBy( props, ( value, key ) => isAriaPropName( key ) && ! isNil( value ) );
 
 export const diffAriaProps = ( props, nextProps ) => {
-	const prevAriaKeys = getAriaKeys( props );
-	const nextAriaKeys = getAriaKeys( nextProps );
+	const prevAriaKeys = keys( pickAriaProps( props ) );
+	const nextAriaKeys = keys( pickAriaProps( nextProps ) );
 	const removedKeys = difference( prevAriaKeys, nextAriaKeys );
 	const updatedKeys = nextAriaKeys.filter( ( key ) =>
 		! isEqual( props[ key ], nextProps[ key ] ) );


### PR DESCRIPTION


## Description
This change is to make the aria-prop copying done by Editable behave
like normal react props which are not applied to dom elements if they
are null or undefined.

## How Has This Been Tested?
Manual testing and with existing automated tests.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Bug fix (where by bug I mean a behavior that was not intended). I don't think it breaks any existing code since the aria-prop copying is very new.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.