### PR TITLE
BlockMover: Safe-guard against a non existing block uid

### DIFF
--- a/editor/block-mover/index.js
+++ b/editor/block-mover/index.js
@@ -61,12 +61,16 @@ function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, f
 }
 
 export default connect(
-	( state, ownProps ) => ( {
-		isFirst: isFirstBlock( state, first( ownProps.uids ) ),
-		isLast: isLastBlock( state, last( ownProps.uids ) ),
-		firstIndex: getBlockIndex( state, first( ownProps.uids ) ),
-		blockType: getBlockType( getBlock( state, first( ownProps.uids ) ).name ),
-	} ),
+	( state, ownProps ) => {
+		const block = getBlock( state, first( ownProps.uids ) );
+
+		return ( {
+			isFirst: isFirstBlock( state, first( ownProps.uids ) ),
+			isLast: isLastBlock( state, last( ownProps.uids ) ),
+			firstIndex: getBlockIndex( state, first( ownProps.uids ) ),
+			blockType: block ? getBlockType( block.name ) : null,
+		} );
+	},
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {
 			if ( ownProps.uids.length === 1 ) {


### PR DESCRIPTION
Fixes #3221

With React Slot/Fill, the "Fill" can rerender once even if it has been removed, we need to safe-guard components against removed blocks. This fixes deleting a block in HTML mode.

**Testing instructions**

 - Add a block and switch to HTML mode
 - Remove this block using the "ellipsis" menu
 - No JS error is thrown.