### PR TITLE
Update The Header Toolbar Keyboard Navigation to include the whole toolbar

### DIFF
--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -8,10 +8,9 @@ import { connect } from 'react-redux';
 /**
  * WordPress Dependencies
  */
-import { IconButton, Toolbar, NavigableMenu } from '@wordpress/components';
-import { Component, findDOMNode } from '@wordpress/element';
+import { IconButton, Toolbar } from '@wordpress/components';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { focus, keycodes } from '@wordpress/utils';
 
 /**
  * Internal Dependencies
@@ -22,88 +21,21 @@ import BlockMover from '../block-mover';
 import BlockInspectorButton from '../block-settings-menu/block-inspector-button';
 import BlockModeToggle from '../block-settings-menu/block-mode-toggle';
 import BlockDeleteButton from '../block-settings-menu/block-delete-button';
-import { isMac } from '../utils/dom';
 import { getBlockMode } from '../selectors';
-
-/**
- * Module Constants
- */
-const { ESCAPE, F10 } = keycodes;
-
-function metaKeyPressed( event ) {
-	return isMac() ? event.metaKey : ( event.ctrlKey && ! event.altKey );
-}
 
 class BlockToolbar extends Component {
 	constructor() {
 		super( ...arguments );
 		this.toggleMobileControls = this.toggleMobileControls.bind( this );
-		this.bindNode = this.bindNode.bind( this );
-		this.onKeyUp = this.onKeyUp.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
-		this.onToolbarKeyDown = this.onToolbarKeyDown.bind( this );
 		this.state = {
 			showMobileControls: false,
 		};
-
-		// it's not easy to know if the user only clicked on a "meta" key without simultaneously clicking on another key
-		// We keep track of the key counts to ensure it's reliable
-		this.metaCount = 0;
-	}
-
-	componentDidMount() {
-		document.addEventListener( 'keyup', this.onKeyUp );
-		document.addEventListener( 'keydown', this.onKeyDown );
-	}
-
-	componentWillUnmount() {
-		document.removeEventListener( 'keyup', this.onKeyUp );
-		document.removeEventListener( 'keydown', this.onKeyDown );
-	}
-
-	bindNode( ref ) {
-		// Disable reason: Need DOM node for finding first focusable element
-		// on keyboard interaction to shift to toolbar.
-		// eslint-disable-next-line react/no-find-dom-node
-		this.toolbar = findDOMNode( ref );
 	}
 
 	toggleMobileControls() {
 		this.setState( ( state ) => ( {
 			showMobileControls: ! state.showMobileControls,
 		} ) );
-	}
-
-	onKeyDown( event ) {
-		if ( metaKeyPressed( event ) ) {
-			this.metaCount++;
-		}
-	}
-
-	onKeyUp( event ) {
-		const shouldFocusToolbar = this.metaCount === 1 || ( event.keyCode === F10 && event.altKey );
-		this.metaCount = 0;
-
-		if ( shouldFocusToolbar ) {
-			const tabbables = focus.tabbable.find( this.toolbar );
-			if ( tabbables.length ) {
-				tabbables[ 0 ].focus();
-			}
-		}
-	}
-
-	onToolbarKeyDown( event ) {
-		if ( event.keyCode !== ESCAPE ) {
-			return;
-		}
-
-		// Is there a better way to focus the selected block
-		// TODO: separate focused/selected block state and use Redux actions instead
-		const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected .editor-visual-editor__block-edit' );
-		if ( !! selectedBlock ) {
-			event.stopPropagation();
-			selectedBlock.focus();
-		}
 	}
 
 	render() {
@@ -119,14 +51,8 @@ class BlockToolbar extends Component {
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
 			<Fill name="Editor.Header">
-				<NavigableMenu
+				<div
 					className={ toolbarClassname }
-					ref={ this.bindNode }
-					orientation="horizontal"
-					role="toolbar"
-					deep
-					onKeyDown={ this.onToolbarKeyDown }
-					aria-label={ __( 'Block\'s toolbar' ) }
 				>
 					{ ! showMobileControls && mode === 'visual' && [
 						<BlockSwitcher key="switcher" uid={ uid } />,
@@ -154,7 +80,7 @@ class BlockToolbar extends Component {
 							</div>
 						}
 					</Toolbar>
-				</NavigableMenu>
+				</div>
 			</Fill>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Slot, Fill } from 'react-slot-fill';
+import { Slot } from 'react-slot-fill';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 
@@ -21,7 +21,7 @@ import BlockMover from '../block-mover';
 import BlockInspectorButton from '../block-settings-menu/block-inspector-button';
 import BlockModeToggle from '../block-settings-menu/block-mode-toggle';
 import BlockDeleteButton from '../block-settings-menu/block-delete-button';
-import { getBlockMode } from '../selectors';
+import { getBlockMode, getSelectedBlock } from '../selectors';
 
 class BlockToolbar extends Component {
 	constructor() {
@@ -40,7 +40,11 @@ class BlockToolbar extends Component {
 
 	render() {
 		const { showMobileControls } = this.state;
-		const { uid, mode } = this.props;
+		const { block, mode } = this.props;
+
+		if ( ! block || ! block.isValid ) {
+			return null;
+		}
 
 		const toolbarClassname = classnames( 'editor-block-toolbar', {
 			'is-showing-mobile-controls': showMobileControls,
@@ -50,43 +54,44 @@ class BlockToolbar extends Component {
 		// bubbling events from children to determine focus shift intents.
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
-			<Fill name="Editor.Header">
-				<div
-					className={ toolbarClassname }
-				>
-					{ ! showMobileControls && mode === 'visual' && [
-						<BlockSwitcher key="switcher" uid={ uid } />,
-						<Slot key="slot" name="Formatting.Toolbar" />,
-					] }
-					<Toolbar className="editor-block-toolbar__mobile-tools">
-						<div>
-							{ mode === 'visual' &&
-								<IconButton
-									className="editor-block-toolbar__mobile-toggle"
-									onClick={ this.toggleMobileControls }
-									aria-expanded={ showMobileControls }
-									label={ __( 'Toggle extra controls' ) }
-									icon="ellipsis"
-								/>
-							}
-						</div>
-
-						{ ( mode === 'html' || showMobileControls ) &&
-							<div className="editor-block-toolbar__mobile-tools-content">
-								<BlockMover uids={ [ uid ] } />
-								<BlockInspectorButton small />
-								<BlockModeToggle uid={ uid } small />
-								<BlockDeleteButton uids={ [ uid ] } small />
-							</div>
+			<div className={ toolbarClassname }>
+				{ ! showMobileControls && mode === 'visual' && [
+					<BlockSwitcher key="switcher" uid={ block.uid } />,
+					<Slot key="slot" name="Formatting.Toolbar" />,
+				] }
+				<Toolbar className="editor-block-toolbar__mobile-tools">
+					<div>
+						{ mode === 'visual' &&
+							<IconButton
+								className="editor-block-toolbar__mobile-toggle"
+								onClick={ this.toggleMobileControls }
+								aria-expanded={ showMobileControls }
+								label={ __( 'Toggle extra controls' ) }
+								icon="ellipsis"
+							/>
 						}
-					</Toolbar>
-				</div>
-			</Fill>
+					</div>
+
+					{ ( mode === 'html' || showMobileControls ) &&
+						<div className="editor-block-toolbar__mobile-tools-content">
+							<BlockMover uids={ [ block.uid ] } />
+							<BlockInspectorButton small />
+							<BlockModeToggle uid={ block.uid } small />
+							<BlockDeleteButton uids={ [ block.uid ] } small />
+						</div>
+					}
+				</Toolbar>
+			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
 
-export default connect( ( state, ownProps ) => ( {
-	mode: getBlockMode( state, ownProps.uid ),
-} ) )( BlockToolbar );
+export default connect( ( state ) => {
+	const block = getSelectedBlock( state );
+
+	return ( {
+		block,
+		mode: block ? getBlockMode( state, block.uid ) : null,
+	} );
+} )( BlockToolbar );

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -26,7 +26,7 @@ import { isMac } from '../../utils/dom';
 const { ESCAPE, F10 } = keycodes;
 
 function metaKeyPressed( event ) {
-	return isMac() ? event.metaKey : ( event.ctrlKey && ! event.altKey );
+	return isMac() ? event.metaKey : event.ctrlKey;
 }
 
 class HeaderToolbar extends Component {
@@ -43,8 +43,8 @@ class HeaderToolbar extends Component {
 	}
 
 	componentDidMount() {
-		document.addEventListener( 'keyup', this.onKeyUp );
-		document.addEventListener( 'keydown', this.onKeyDown );
+		document.addEventListener( 'keyup', this.onKeyUp, true );
+		document.addEventListener( 'keydown', this.onKeyDown, true );
 	}
 
 	componentWillUnmount() {
@@ -67,7 +67,11 @@ class HeaderToolbar extends Component {
 
 	onKeyUp( event ) {
 		const shouldFocusToolbar = this.metaCount === 1 || ( event.keyCode === F10 && event.altKey );
-		this.metaCount = 0;
+
+		// Reset the count if it's the final released key
+		if ( ! event.shiftKey && ! event.altKey && ( ! event.ctrlKey || ! isMac() ) ) {
+			this.metaCount = 0;
+		}
 
 		if ( shouldFocusToolbar ) {
 			const tabbables = focus.tabbable.find( this.toolbar );

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { Slot } from 'react-slot-fill';
 
 /**
  * WordPress dependencies
@@ -17,6 +16,7 @@ import { focus, keycodes } from '@wordpress/utils';
  */
 import './style.scss';
 import Inserter from '../../inserter';
+import BlockToolbar from '../../block-toolbar';
 import { hasEditorUndo, hasEditorRedo } from '../../selectors';
 import { isMac } from '../../utils/dom';
 
@@ -115,7 +115,7 @@ class HeaderToolbar extends Component {
 					disabled={ ! hasRedo }
 					onClick={ redo } />
 				<div className="editor-header-toolbar__block-toolbar">
-					<Slot name="Editor.Header" />
+					<BlockToolbar />
 				</div>
 			</NavigableMenu>
 		);

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { Slot } from 'react-slot-fill';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import Inserter from '../../inserter';
+import { hasEditorUndo, hasEditorRedo } from '../../selectors';
+
+function HeaderToolbar( { hasUndo, hasRedo, undo, redo } ) {
+	return (
+		<div className="editor-header-toolbar">
+			<Inserter position="bottom right" />
+			<IconButton
+				icon="undo"
+				label={ __( 'Undo' ) }
+				disabled={ ! hasUndo }
+				onClick={ undo } />
+			<IconButton
+				icon="redo"
+				label={ __( 'Redo' ) }
+				disabled={ ! hasRedo }
+				onClick={ redo } />
+			<div className="editor-header-toolbar__block-toolbar">
+				<Slot name="Editor.Header" />
+			</div>
+		</div>
+	);
+}
+
+export default connect(
+	( state ) => ( {
+		hasUndo: hasEditorUndo( state ),
+		hasRedo: hasEditorRedo( state ),
+	} ),
+	( dispatch ) => ( {
+		undo: () => dispatch( { type: 'UNDO' } ),
+		redo: () => dispatch( { type: 'REDO' } ),
+	} )
+)( HeaderToolbar );

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -8,7 +8,9 @@ import { Slot } from 'react-slot-fill';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { IconButton, NavigableMenu } from '@wordpress/components';
+import { Component, findDOMNode } from '@wordpress/element';
+import { focus, keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -16,26 +18,108 @@ import { IconButton } from '@wordpress/components';
 import './style.scss';
 import Inserter from '../../inserter';
 import { hasEditorUndo, hasEditorRedo } from '../../selectors';
+import { isMac } from '../../utils/dom';
 
-function HeaderToolbar( { hasUndo, hasRedo, undo, redo } ) {
-	return (
-		<div className="editor-header-toolbar">
-			<Inserter position="bottom right" />
-			<IconButton
-				icon="undo"
-				label={ __( 'Undo' ) }
-				disabled={ ! hasUndo }
-				onClick={ undo } />
-			<IconButton
-				icon="redo"
-				label={ __( 'Redo' ) }
-				disabled={ ! hasRedo }
-				onClick={ redo } />
-			<div className="editor-header-toolbar__block-toolbar">
-				<Slot name="Editor.Header" />
-			</div>
-		</div>
-	);
+/**
+ * Module Constants
+ */
+const { ESCAPE, F10 } = keycodes;
+
+function metaKeyPressed( event ) {
+	return isMac() ? event.metaKey : ( event.ctrlKey && ! event.altKey );
+}
+
+class HeaderToolbar extends Component {
+	constructor() {
+		super( ...arguments );
+		this.bindNode = this.bindNode.bind( this );
+		this.onKeyUp = this.onKeyUp.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
+		this.onToolbarKeyDown = this.onToolbarKeyDown.bind( this );
+
+		// it's not easy to know if the user only clicked on a "meta" key without simultaneously clicking on another key
+		// We keep track of the key counts to ensure it's reliable
+		this.metaCount = 0;
+	}
+
+	componentDidMount() {
+		document.addEventListener( 'keyup', this.onKeyUp );
+		document.addEventListener( 'keydown', this.onKeyDown );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'keyup', this.onKeyUp );
+		document.removeEventListener( 'keydown', this.onKeyDown );
+	}
+
+	bindNode( ref ) {
+		// Disable reason: Need DOM node for finding first focusable element
+		// on keyboard interaction to shift to toolbar.
+		// eslint-disable-next-line react/no-find-dom-node
+		this.toolbar = findDOMNode( ref );
+	}
+
+	onKeyDown( event ) {
+		if ( metaKeyPressed( event ) ) {
+			this.metaCount++;
+		}
+	}
+
+	onKeyUp( event ) {
+		const shouldFocusToolbar = this.metaCount === 1 || ( event.keyCode === F10 && event.altKey );
+		this.metaCount = 0;
+
+		if ( shouldFocusToolbar ) {
+			const tabbables = focus.tabbable.find( this.toolbar );
+			if ( tabbables.length ) {
+				tabbables[ 0 ].focus();
+			}
+		}
+	}
+
+	onToolbarKeyDown( event ) {
+		if ( event.keyCode !== ESCAPE ) {
+			return;
+		}
+
+		// Is there a better way to focus the selected block
+		// TODO: separate focused/selected block state and use Redux actions instead
+		const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected .editor-visual-editor__block-edit' );
+		if ( !! selectedBlock ) {
+			event.stopPropagation();
+			selectedBlock.focus();
+		}
+	}
+
+	render() {
+		const { hasUndo, hasRedo, undo, redo } = this.props;
+		return (
+			<NavigableMenu
+				className="editor-header-toolbar"
+				orientation="horizontal"
+				role="toolbar"
+				deep
+				aria-label={ __( 'Editor Toolbar' ) }
+				ref={ this.bindNode }
+				onKeyDown={ this.onToolbarKeyDown }
+			>
+				<Inserter position="bottom right" />
+				<IconButton
+					icon="undo"
+					label={ __( 'Undo' ) }
+					disabled={ ! hasUndo }
+					onClick={ undo } />
+				<IconButton
+					icon="redo"
+					label={ __( 'Redo' ) }
+					disabled={ ! hasRedo }
+					onClick={ redo } />
+				<div className="editor-header-toolbar__block-toolbar">
+					<Slot name="Editor.Header" />
+				</div>
+			</NavigableMenu>
+		);
+	}
 }
 
 export default connect(

--- a/editor/header/header-toolbar/style.scss
+++ b/editor/header/header-toolbar/style.scss
@@ -1,0 +1,50 @@
+// hide all action buttons except the inserter on mobile
+.editor-header-toolbar > .components-button {
+	display: none;
+
+	@include break-small() {
+		display: inline-flex;
+	}
+}
+
+.editor-header-toolbar {
+	display: inline-flex;
+	align-items: center;
+}
+
+.editor-header-toolbar__block-toolbar {
+	// stacked toolbar
+	position: absolute;
+	top: $header-height;
+	left: 0;
+	right: 0;
+	background: $white;
+	border-bottom: 1px solid $light-gray-500;
+	min-height: $stacked-toolbar-height;
+
+	.is-sidebar-opened & {
+		display: none;
+	}
+
+	@include break-medium {
+		.is-sidebar-opened & {
+			display: block;
+			right: $sidebar-width;
+		}
+	}
+
+	// merge toolbars after this breakpoint
+	@include break-large {	// we should try and lower this breakpoint through an ellipsis overflow feature
+		padding-left: $item-spacing;
+		position: static;
+		left: auto;
+		right: auto;
+		background: none;
+		border-bottom: none;
+		min-height: auto;
+
+		.is-sidebar-opened & {
+			right: auto;
+		}
+	}
+}

--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { Slot } from 'react-slot-fill';
 
 /**
  * WordPress dependencies
@@ -18,18 +17,11 @@ import SavedState from './saved-state';
 import PublishWithDropdown from './publish-with-dropdown';
 import PreviewButton from './preview-button';
 import ModeSwitcher from './mode-switcher';
-import Inserter from '../inserter';
-import { hasEditorUndo, hasEditorRedo, isEditorSidebarOpened } from '../selectors';
+import HeaderToolbar from './header-toolbar';
+import { isEditorSidebarOpened } from '../selectors';
 import { toggleSidebar } from '../actions';
 
-function Header( {
-	undo,
-	redo,
-	hasRedo,
-	hasUndo,
-	onToggleSidebar,
-	isSidebarOpened,
-} ) {
+function Header( { onToggleSidebar, isSidebarOpened } ) {
 	return (
 		<div
 			role="region"
@@ -37,22 +29,7 @@ function Header( {
 			className="editor-header"
 			tabIndex="-1"
 		>
-			<div className="editor-header__content-tools">
-				<Inserter position="bottom right" />
-				<IconButton
-					icon="undo"
-					label={ __( 'Undo' ) }
-					disabled={ ! hasUndo }
-					onClick={ undo } />
-				<IconButton
-					icon="redo"
-					label={ __( 'Redo' ) }
-					disabled={ ! hasRedo }
-					onClick={ redo } />
-				<div className="editor-header__block-toolbar">
-					<Slot name="Editor.Header" />
-				</div>
-			</div>
+			<HeaderToolbar />
 			<div className="editor-header__settings">
 				<SavedState />
 				<PreviewButton />
@@ -71,13 +48,9 @@ function Header( {
 
 export default connect(
 	( state ) => ( {
-		hasUndo: hasEditorUndo( state ),
-		hasRedo: hasEditorRedo( state ),
 		isSidebarOpened: isEditorSidebarOpened( state ),
 	} ),
 	( dispatch ) => ( {
-		undo: () => dispatch( { type: 'UNDO' } ),
-		redo: () => dispatch( { type: 'REDO' } ),
 		onToggleSidebar: () => dispatch( toggleSidebar() ),
 	} )
 )( Header );

--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -72,16 +72,6 @@
 	right: $admin-sidebar-width-big;
 }
 
-// hide all action buttons except the inserter on mobile
-.editor-header__content-tools > .components-button {
-	display: none;
-
-	@include break-small() {
-		display: inline-flex;
-	}
-}
-
-.editor-header__content-tools,
 .editor-header__settings {
 	display: inline-flex;
 	align-items: center;
@@ -119,44 +109,6 @@
 		&.editor-publish-button, &.editor-publish-with-dropdown__button {
 			height: 33px;
 			line-height: 32px;
-		}
-	}
-}
-
-
-.editor-header__block-toolbar {
-	// stacked toolbar
-	position: absolute;
-	top: $header-height;
-	left: 0;
-	right: 0;
-	background: $white;
-	border-bottom: 1px solid $light-gray-500;
-	min-height: $stacked-toolbar-height;
-
-	.is-sidebar-opened & {
-		display: none;
-	}
-
-	@include break-medium {
-		.is-sidebar-opened & {
-			display: block;
-			right: $sidebar-width;
-		}
-	}
-
-	// merge toolbars after this breakpoint
-	@include break-large {	// we should try and lower this breakpoint through an ellipsis overflow feature
-		padding-left: $item-spacing;
-		position: static;
-		left: auto;
-		right: auto;
-		background: none;
-		border-bottom: none;
-		min-height: auto;
-
-		.is-sidebar-opened & {
-			right: auto;
 		}
 	}
 }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -23,7 +23,6 @@ import BlockDropZone from './block-drop-zone';
 import BlockHtml from './block-html';
 import BlockMover from '../../block-mover';
 import BlockSettingsMenu from '../../block-settings-menu';
-import BlockToolbar from '../../block-toolbar';
 import {
 	clearSelectedBlock,
 	editPost,
@@ -359,7 +358,6 @@ class VisualEditorBlock extends Component {
 				<BlockDropZone index={ order } />
 				{ ( showUI || isProperlyHovered ) && <BlockMover uids={ [ block.uid ] } /> }
 				{ ( showUI || isProperlyHovered ) && <BlockSettingsMenu uids={ [ block.uid ] } /> }
-				{ isSelected && isValid && <BlockToolbar uid={ block.uid } /> }
 				{ isFirstMultiSelected && ! this.props.isSelecting &&
 					<BlockMover uids={ multiSelectedBlockUids } />
 				}


### PR DESCRIPTION
closes #3210 #3183

Previously keyboard navigation shortcuts (meta, escape and arrow navigation) were limited to the block toolbar and were excluding the undo/redo and the insertere, this PR creates a HeaderToolbar component and moves the keyboard shortcuts handling to this component englobing the whole toolbar.

**Testing instructions**

 - Select a block
 - Click "command" or "ctrl" depending on your OS
 - This should focus the inserter in the toolbar
 - Navigate the toolbar using arrows
 - You should be able to reach undo/redo