### PR TITLE
Components: Extract a reusable PostTrash component

### DIFF
--- a/editor/post-trash/index.js
+++ b/editor/post-trash/index.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Dashicon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import {
+	isEditedPostNew,
+	getCurrentPostId,
+	getCurrentPostType,
+} from '../selectors';
+import { trashPost } from '../actions';
+
+function PostTrash( { isNew, postId, postType, ...props } ) {
+	if ( isNew || ! postId ) {
+		return null;
+	}
+
+	const onClick = () => props.trashPost( postId, postType );
+
+	return (
+		<Button className="editor-post-trash button-link button-link-delete" onClick={ onClick }>
+			{ __( 'Move to trash' ) }
+			<Dashicon icon="trash" />
+		</Button>
+	);
+}
+
+export default connect(
+	( state ) => {
+		return {
+			isNew: isEditedPostNew( state ),
+			postId: getCurrentPostId( state ),
+			postType: getCurrentPostType( state ),
+		};
+	},
+	{ trashPost }
+)( PostTrash );

--- a/editor/post-trash/style.scss
+++ b/editor/post-trash/style.scss
@@ -1,0 +1,10 @@
+.editor-post-trash {
+	margin-left: auto !important;
+	text-decoration: underline;
+
+	.dashicon {
+		display: inline-block;
+		vertical-align: middle;
+		margin: -3px -4px 0 10px;
+	}
+}

--- a/editor/sidebar/post-trash/index.js
+++ b/editor/sidebar/post-trash/index.js
@@ -6,33 +6,23 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { PanelRow, Button, Dashicon } from '@wordpress/components';
+import { PanelRow } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import {
-	isEditedPostNew,
-	getCurrentPostId,
-	getCurrentPostType,
-} from '../../selectors';
-import { trashPost } from '../../actions';
+import PostTrashLink from '../../post-trash';
+import { isEditedPostNew, getCurrentPostId } from '../../selectors';
 
-function PostTrash( { isNew, postId, postType, ...props } ) {
+function PostTrash( { isNew, postId } ) {
 	if ( isNew || ! postId ) {
 		return null;
 	}
 
-	const onClick = () => props.trashPost( postId, postType );
-
 	return (
 		<PanelRow>
-			<Button className="editor-post-trash button-link button-link-delete" onClick={ onClick }>
-				{ __( 'Move to trash' ) }
-				<Dashicon icon="trash" />
-			</Button>
+			<PostTrashLink />
 		</PanelRow>
 	);
 }
@@ -42,8 +32,6 @@ export default connect(
 		return {
 			isNew: isEditedPostNew( state ),
 			postId: getCurrentPostId( state ),
-			postType: getCurrentPostType( state ),
 		};
 	},
-	{ trashPost }
 )( PostTrash );


### PR DESCRIPTION
Related to #2761 (comment)

> All these (the sidebar panels) must be refactored slightly to drop all the "layout" pieces and keep only the "forms". For example, the sidebar panels like PostTaxonomies, we should extract only the PostTaxonomyForms into a reusable component without the expandable panel behavior that is specific to our current UI. (This step could be done in a separate PR preceding the directory structure change)

This PR addresses the comment above for the PostTrash component.

**Testing instructions**

- Test that the post trash link is working 