### PR TITLE
Post Settings: Refactor revisions handling to avoid performance issues

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -270,6 +270,27 @@ export function getCurrentPostId( state ) {
 }
 
 /**
+ * Returns the number of revisions of the post currently being edited.
+ *
+ * @param  {Object}  state Global application state
+ * @return {Number}        Number of revisions
+ */
+export function getCurrentPostRevisionsCount( state ) {
+	return get( getCurrentPost( state ), 'revisions.count', 0 );
+}
+
+/**
+ * Returns the last revision ID of the post currently being edited,
+ * or null if the post has no revisions.
+ *
+ * @param  {Object}  state Global application state
+ * @return {?Number}       ID of the last revision
+ */
+export function getCurrentPostLastRevisionId( state ) {
+	return get( getCurrentPost( state ), 'revisions.last_id', null );
+}
+
+/**
  * Returns any post values which have been changed in the editor but not yet
  * been saved.
  *

--- a/editor/sidebar/last-revision/index.js
+++ b/editor/sidebar/last-revision/index.js
@@ -2,43 +2,39 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight, first } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { sprintf, _n } from '@wordpress/i18n';
-import { IconButton, PanelBody, withAPIData } from '@wordpress/components';
+import { IconButton, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import {
-	isEditedPostNew,
-	getCurrentPostId,
-	getCurrentPostType,
-	isSavingPost,
+	getCurrentPostLastRevisionId,
+	getCurrentPostRevisionsCount,
 } from '../../selectors';
 import { getWPAdminURL } from '../../utils/url';
 
-function LastRevision( { revisions } ) {
-	const lastRevision = first( revisions.data );
-	if ( ! lastRevision ) {
+function LastRevision( { lastRevisionId, revisionsCount } ) {
+	if ( ! lastRevisionId ) {
 		return null;
 	}
 
 	return (
 		<PanelBody>
 			<IconButton
-				href={ getWPAdminURL( 'revision.php', { revision: lastRevision.id } ) }
+				href={ getWPAdminURL( 'revision.php', { revision: lastRevisionId } ) }
 				className="editor-last-revision__title"
 				icon="backup"
 			>
 				{
 					sprintf(
-						_n( '%d Revision', '%d Revisions', revisions.data.length ),
-						revisions.data.length
+						_n( '%d Revision', '%d Revisions', revisionsCount ),
+						revisionsCount
 					)
 				}
 			</IconButton>
@@ -46,21 +42,11 @@ function LastRevision( { revisions } ) {
 	);
 }
 
-export default flowRight(
-	connect(
-		( state ) => {
-			return {
-				isNew: isEditedPostNew( state ),
-				postId: getCurrentPostId( state ),
-				postType: getCurrentPostType( state ),
-				isSaving: isSavingPost( state ),
-			};
-		}
-	),
-	withAPIData( ( props, { type } ) => {
-		const { postType, postId } = props;
+export default connect(
+	( state ) => {
 		return {
-			revisions: `/wp/v2/${ type( postType ) }/${ postId }/revisions`,
+			lastRevisionId: getCurrentPostLastRevisionId( state ),
+			revisionsCount: getCurrentPostRevisionsCount( state ),
 		};
-	} )
+	}
 )( LastRevision );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -24,6 +24,8 @@ import {
 	isCleanNewPost,
 	getCurrentPost,
 	getCurrentPostId,
+	getCurrentPostLastRevisionId,
+	getCurrentPostRevisionsCount,
 	getCurrentPostType,
 	getPostEdits,
 	getEditedPostTitle,
@@ -872,6 +874,50 @@ describe( 'selectors', () => {
 			};
 
 			expect( getCurrentPostId( state ) ).toBe( 1 );
+		} );
+	} );
+
+	describe( 'getCurrentPostLastRevisionId', () => {
+		it( 'should return null if the post has not yet been saved', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( getCurrentPostLastRevisionId( state ) ).toBeNull();
+		} );
+
+		it( 'should return the last revision ID', () => {
+			const state = {
+				currentPost: {
+					revisions: {
+						last_id: 123,
+					},
+				},
+			};
+
+			expect( getCurrentPostLastRevisionId( state ) ).toBe( 123 );
+		} );
+	} );
+
+	describe( 'getCurrentPostRevisionsCount', () => {
+		it( 'should return 0 if the post has no revisions', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( getCurrentPostRevisionsCount( state ) ).toBe( 0 );
+		} );
+
+		it( 'should return the number of revisions', () => {
+			const state = {
+				currentPost: {
+					revisions: {
+						count: 5,
+					},
+				},
+			};
+
+			expect( getCurrentPostRevisionsCount( state ) ).toBe( 5 );
 		} );
 	} );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -462,12 +462,6 @@ function gutenberg_extend_wp_api_backbone_client() {
 				return model.prototype.route && route === model.prototype.route.index;
 			} );
 		};
-		wp.api.getPostTypeRevisionsCollection = function( postType ) {
-			var route = '/' + wpApiSettings.versionString + this.postTypeRestBaseMapping[ postType ] + '/(?P<parent>[\\\\d]+)/revisions';
-			return _.find( wp.api.collections, function( model ) {
-				return model.prototype.route && route === model.prototype.route.index;
-			} );
-		};
 		wp.api.getTaxonomyModel = function( taxonomy ) {
 			var route = '/' + wpApiSettings.versionString + this.taxonomyRestBaseMapping[ taxonomy ] + '/(?P<id>[\\\\d]+)';
 			return _.find( wp.api.models, function( model ) {
@@ -702,10 +696,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'/wp/v2/taxonomies?context=edit',
 		gutenberg_get_rest_link( $post_to_edit, 'about', 'edit' ),
 	);
-
-	if ( ! $is_new_post ) {
-		$preload_paths[] = gutenberg_get_rest_link( $post_to_edit, 'version-history' );
-	}
 
 	$preload_data = array_reduce(
 		$preload_paths,

--- a/lib/register.php
+++ b/lib/register.php
@@ -361,6 +361,46 @@ add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
 
 
 /**
+ * Gets revisions details for the selected post.
+ *
+ * @since 1.6.0
+ *
+ * @param array $post The post object from the response.
+ * @return array|null Revisions details or null when no revisions present.
+ */
+function gutenberg_get_post_revisions( $post ) {
+	$revisions       = wp_get_post_revisions( $post['id'] );
+	$revisions_count = count( $revisions );
+	if ( 0 === $revisions_count ) {
+		return null;
+	}
+
+	$last_revision = array_shift( $revisions );
+
+	return array(
+		'count'   => $revisions_count,
+		'last_id' => $last_revision->ID,
+	);
+}
+
+/**
+ * Adds the custom field `revisions` to the REST API response of post.
+ *
+ * TODO: This is a temporary solution. Next step would be to find a solution that is limited to the editor.
+ *
+ * @since 1.6.0
+ */
+function gutenberg_register_rest_api_post_revisions() {
+	register_rest_field( get_post_types( '', 'names' ),
+		'revisions',
+		array(
+			'get_callback' => 'gutenberg_get_post_revisions',
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_revisions' );
+
+/**
  * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
  *
  * @since 1.5.2


### PR DESCRIPTION
## Description

Fixes #3167 - Post edit script takes way much longer to generate for Gutenberg editor. With the help of @pento we were able to identify the root cause:

> Performance improves significantly when I comment out this block:
> 
> https://github.com/WordPress/gutenberg/blob/master/lib/client-assets.php#L706-L708

This code preloads API response for revisions endpoint, which fetches all existing post revisions and exposes them in the `<script />` tag. When you have let's say 50 revisions, all of them are loaded from the database and exposed in the HTML code leading to the big size of the HTML and processing time to create all objects.

I refactored the handling of revisions to extend REST API endpoint for post types to include information about the number of revisions and the last revision id.

It solves a few issues I noticed:
- performance of the post edit page
- number of revisions updates whenever new revision gets created together with the link
- the link to the revision was pointing to the wrong revision

## How Has This Been Tested?

Manually:
- Create new post or page
- Make sure they are no errors
- Save draft
- Make sure that link to the revision shows up and you can navigate to this page
- Load existing post or page
- Make sure that link to the revisions shows up and you can navigate to this page
- Save another revision
- Make sure that link to the revisions updates properly

## Screenshots (jpeg or gifs if applicable):

<img width="314" alt="screen shot 2017-10-30 at 11 47 09" src="https://user-images.githubusercontent.com/699132/32167072-1b64b6b0-bd68-11e7-84cd-32004239f5e2.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue). Code was refactored.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.