### PR TITLE
Performance: Optimize editor saveable selector

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -348,9 +348,9 @@ export function isEditedPostPublishable( state ) {
  */
 export function isEditedPostSaveable( state ) {
 	return (
-		!! getEditedPostContent( state ) ||
 		!! getEditedPostTitle( state ) ||
-		!! getEditedPostExcerpt( state )
+		!! getEditedPostExcerpt( state ) ||
+		!! getEditedPostContent( state )
 	);
 }
 


### PR DESCRIPTION
This pull request seeks to optimize the performance of the `isEditablePostSaveable` selector used in determining whether a Save or Publish button should be activated. A post is saveable only if it has a non-empty title, content, or excerpt.

The changes here leverage [short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation) to reorder the logic of the test to evaluate the heaviest selector last, since [`getEditedPostContent`](https://github.com/WordPress/gutenberg/blob/948fde6d7190e918fa09e1eeb7cf64774d828bf9/editor/selectors.js#L945-L967), while memoized, may invoke the post serializer. On an assumption that most posts will have a title, we can use this cheaper test to determine saveability of a post instead.

__Testing instructions:__

Verify that there are no regressions in the behavior of post Save option being offered if and only if a title, content, or excerpt is non-empty for the post.

Ensure unit tests pass:

```
npm run test-unit
```