### PR TITLE
Fix the quick inserter for blocks with custom svg icons

### DIFF
--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { isString } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -25,7 +26,7 @@ class IconButton extends Component {
 
 		let element = (
 			<Button { ...additionalProps } aria-label={ label } className={ classes }>
-				<Dashicon icon={ icon } />
+				{ isString( icon ) ? <Dashicon icon={ icon } /> : icon }
 				{ children }
 			</Button>
 		);

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -9,7 +9,7 @@ import { uniq, get, reduce, find } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu } from '@wordpress/components';
-import { getBlockType, getBlockTypes, switchToBlockType } from '@wordpress/blocks';
+import { getBlockType, getBlockTypes, switchToBlockType, BlockIcon } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -64,7 +64,7 @@ function BlockSwitcher( { block, onTransform } ) {
 					<Toolbar>
 						<IconButton
 							className="editor-block-switcher__toggle"
-							icon={ blockType.icon }
+							icon={ <BlockIcon icon={ blockType.icon } /> }
 							onClick={ onToggle }
 							aria-haspopup="true"
 							aria-expanded={ isOpen }
@@ -95,7 +95,11 @@ function BlockSwitcher( { block, onTransform } ) {
 									onClose();
 								} }
 								className="editor-block-switcher__menu-item"
-								icon={ icon }
+								icon={ (
+									<span className="editor-block-switcher__block-icon">
+										<BlockIcon icon={ icon } />
+									</span>
+								) }
 								role="menuitem"
 							>
 								{ title }

--- a/editor/block-switcher/style.scss
+++ b/editor/block-switcher/style.scss
@@ -51,8 +51,8 @@
 		color: $dark-gray-500;
 		border-color: $dark-gray-500;
 	}
+}
 
-	.dashicon {
-		margin-right: 5px;
-	}
+.editor-block-switcher__block-icon {
+	margin-right: 5px;
 }

--- a/editor/modes/visual-editor/inserter.js
+++ b/editor/modes/visual-editor/inserter.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { createBlock, BlockIcon } from '@wordpress/blocks';
 
@@ -58,17 +58,19 @@ export class VisualEditorInserter extends Component {
 					insertIndex={ blockCount }
 					position="top right" />
 				{ mostFrequentlyUsedBlocks && mostFrequentlyUsedBlocks.map( ( block ) => (
-					<Button
+					<IconButton
 						key={ 'frequently_used_' + block.name }
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( block.name ) }
-						aria-label={ sprintf( __( 'Insert %s' ), block.title ) }
+						label={ sprintf( __( 'Insert %s' ), block.title ) }
+						icon={ (
+							<span className="editor-visual-editor__inserter-block-icon">
+								<BlockIcon icon={ block.icon } />
+							</span>
+						) }
 					>
-						<span className="editor-visual-editor__inserter-block-icon">
-							<BlockIcon icon={ block.icon } />
-						</span>
 						{ block.title }
-					</Button>
+					</IconButton>
 				) ) }
 			</div>
 		);

--- a/editor/modes/visual-editor/inserter.js
+++ b/editor/modes/visual-editor/inserter.js
@@ -8,9 +8,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, BlockIcon } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -57,18 +57,19 @@ export class VisualEditorInserter extends Component {
 				<Inserter
 					insertIndex={ blockCount }
 					position="top right" />
-				{ mostFrequentlyUsedBlocks && mostFrequentlyUsedBlocks.map(
-					( block ) =>
-						<IconButton
-							key={ 'frequently_used_' + block.name }
-							icon={ block.icon }
-							className="editor-inserter__block"
-							onClick={ () => this.insertBlock( block.name ) }
-							label={ sprintf( __( 'Insert %s' ), block.title ) }
-						>
-							{ block.title }
-						</IconButton>
-				) }
+				{ mostFrequentlyUsedBlocks && mostFrequentlyUsedBlocks.map( ( block ) => (
+					<Button
+						key={ 'frequently_used_' + block.name }
+						className="editor-inserter__block"
+						onClick={ () => this.insertBlock( block.name ) }
+						aria-label={ sprintf( __( 'Insert %s' ), block.title ) }
+					>
+						<span className="editor-visual-editor__inserter-block-icon">
+							<BlockIcon icon={ block.icon } />
+						</span>
+						{ block.title }
+					</Button>
+				) ) }
 			</div>
 		);
 	}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -404,16 +404,19 @@
 		font-size: $default-font-size;
 		box-shadow: none;
 		padding: 6px;
-
-		.dashicon {
-			margin-right: 8px;
-		}
+		align-items: center;
 	}
 
 	&:hover > .editor-inserter__block,
 	&.is-showing-controls > .editor-inserter__block {
 		opacity: 1;
 	}
+}
+
+.editor-visual-editor__inserter-block-icon {
+	display: inline-block;
+	margin-right: 8px;
+	height: 20px;
 }
 
 .editor-visual-editor__block-warning {

--- a/editor/modes/visual-editor/test/inserter.js
+++ b/editor/modes/visual-editor/test/inserter.js
@@ -45,7 +45,7 @@ describe( 'VisualEditorInserter', () => {
 		};
 
 		wrapper
-			.findWhere( ( node ) => node.prop( 'children' ) === 'Paragraph' )
+			.findWhere( ( node ) => node.prop( 'aria-label' ) === 'Insert Paragraph' )
 			.simulate( 'click' );
 
 		expect( onInsertBlock ).toHaveBeenCalled();

--- a/editor/modes/visual-editor/test/inserter.js
+++ b/editor/modes/visual-editor/test/inserter.js
@@ -45,7 +45,7 @@ describe( 'VisualEditorInserter', () => {
 		};
 
 		wrapper
-			.findWhere( ( node ) => node.prop( 'aria-label' ) === 'Insert Paragraph' )
+			.findWhere( ( node ) => node.prop( 'children' ) === 'Paragraph' )
 			.simulate( 'click' );
 
 		expect( onInsertBlock ).toHaveBeenCalled();


### PR DESCRIPTION
closes #3190

This PR uses the `BlockIcon` component to display the blocks with custom SVG icons properly on the "quick inserter" (inserter shown when hovering the bottom inserter).

**Testing instrructions**

 - Set a custom SVG icon to one of your most used blocks, example:

```
<svg width="20" height="20">
	<circle cx="10" cy="10" r="8" stroke="green" strokeWidth="2" fill="yellow" />
</svg>
```

 - The icon should show up properly in the quick inserter