### PR TITLE
Block List: Fix blank screen error on removing block placeholder

### DIFF
--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -30,7 +30,7 @@ import {
 	focusBlock,
 	insertBlocks,
 	mergeBlocks,
-	removeBlocks,
+	removeBlock,
 	replaceBlocks,
 	selectBlock,
 	startTyping,
@@ -476,8 +476,8 @@ export default connect(
 			dispatch( focusBlock( ...args ) );
 		},
 
-		onRemove( uids ) {
-			dispatch( removeBlocks( uids ) );
+		onRemove( uid ) {
+			dispatch( removeBlock( uid ) );
 		},
 
 		onMerge( ...args ) {


### PR DESCRIPTION
Regression introduced in 118f489ecace3f780a7bcf2ea8fe14d5ff2c24f6

This pull request seeks to resolve an error where removing a block placeholder (e.g. new image block) from the block list via backspace would cause an unhandled error, crashing the editor.

__Implementation notes:__

The root cause was the change to pass a singular `uid` to `onRemove`. The `removeBlocks` action creator assumes an array argument. When this string argument reached the reducer, there was differing treatment between [`state.editor.blocksByUid`](https://github.com/WordPress/gutenberg/blob/948fde6d7190e918fa09e1eeb7cf64774d828bf9/editor/reducer.js#L182-L183) and [`state.editor.blockOrder`](https://github.com/WordPress/gutenberg/blob/948fde6d7190e918fa09e1eeb7cf64774d828bf9/editor/reducer.js#L258-L259) where omitting by string would remove the block correctly, but attempting to spread a string is effectively equivalent as `without( state, [ 'e', 'x', 'a', 'm', 'p', 'l', 'e' ] )`, thus not removing the block correctly and causing the UID to remain in `blockOrder` but not `blocksByUid`, thus remaining in the [`getBlocks` selector result](https://github.com/WordPress/gutenberg/blob/948fde6d7190e918fa09e1eeb7cf64774d828bf9/editor/selectors.js#L499) but as a `null` value. The block serializer, invoked by a subsequent `isEditablePostSaveable` (see #3236) is [unable to handle the `null` block value](https://github.com/WordPress/gutenberg/blob/948fde6d7190e918fa09e1eeb7cf64774d828bf9/blocks/api/serializer.js#L205) and thus throws an error.

While ultimately the fault of using the wrong action creator, perhaps we ought to be taking other precautions to have stymied the issue along the way?

- Consolidating `removeBlocks` and `removeBlock` into a single action creator?
- Allowing `removeBlocks` to normalize non-array types with [Lodash's `castArray`](https://lodash.com/docs/4.17.4#castArray)?
- Omitting `null` blocks from `getBlocks` selector?
- Testing block truthiness from serializer?

__Testing instructions:__

Verify that you can remove an image placeholder block by backspace:

1. Navigate to Posts > New Post
2. Insert an image block
3. While block is focused, press Backspace
4. Note that the block is removed and no errors occur