### PR TITLE
Fix broken multi-block selection after block movements

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -9,6 +9,7 @@ import {
 	isEqual,
 	mapValues,
 	noop,
+	sortBy,
 	throttle,
 } from 'lodash';
 import scrollIntoView from 'dom-scroll-into-view';
@@ -42,7 +43,6 @@ class VisualEditorBlockList extends Component {
 		super( props );
 
 		this.onSelectionStart = this.onSelectionStart.bind( this );
-		this.onSelectionChange = this.onSelectionChange.bind( this );
 		this.onSelectionEnd = this.onSelectionEnd.bind( this );
 		this.onShiftSelection = this.onShiftSelection.bind( this );
 		this.onCopy = this.onCopy.bind( this );
@@ -133,14 +133,15 @@ class VisualEditorBlockList extends Component {
 		const boundaries = this.nodes[ uid ].getBoundingClientRect();
 
 		// Create a uid to Y coördinate map.
-		const uidToCoordMap = mapValues( this.nodes, ( node ) => {
-			return node.getBoundingClientRect().top - boundaries.top;
-		} );
+		const uidToCoordMap = mapValues( this.nodes, ( node ) =>
+			node.getBoundingClientRect().top - boundaries.top );
 
 		// Cache a Y coördinate to uid map for use in `onPointerMove`.
 		this.coordMap = invert( uidToCoordMap );
 		// Cache an array of the Y coördinates for use in `onPointerMove`.
-		this.coordMapKeys = Object.values( uidToCoordMap );
+		// Sort the coördinates, as `this.nodes` will not necessarily reflect
+		// the current block sequence.
+		this.coordMapKeys = sortBy( Object.values( uidToCoordMap ) );
 		this.selectionAtStart = uid;
 
 		window.addEventListener( 'mousemove', this.onPointerMove );


### PR DESCRIPTION
Fixes #3226

## Description

Pointer-based block selection hinges on finding blocks in the pointer's path by looking at a map of _y_ coordinates. The finding algorithm expects the _y_ coordinates to be sorted from least to greatest. Once a block is moved, the node map `this.nodes` in `VisualEditorBlockList` is updated, but its order isn't, thus breaking the ability to find the closest block under the pointer when performing multi-block selection.

JS objects' key order isn't reliable anyway, so this fix sorts `this.coordMapKeys` directly.

## How Has This Been Tested?

Try reproducing the parent issue.