### PR TITLE
Remove inserter inside multi-selection

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -209,8 +209,8 @@ class VisualEditorBlockList extends Component {
 
 		return (
 			<div>
-				{ !! blocks.length && <VisualEditorSiblingInserter insertIndex={ 0 } /> }
-				{ flatMap( blocks, ( uid, index ) => [
+				{ !! blocks.length && <VisualEditorSiblingInserter /> }
+				{ flatMap( blocks, ( uid ) => [
 					<VisualEditorBlock
 						key={ 'block-' + uid }
 						uid={ uid }
@@ -221,7 +221,6 @@ class VisualEditorBlockList extends Component {
 					<VisualEditorSiblingInserter
 						key={ 'sibling-inserter-' + uid }
 						uid={ uid }
-						insertIndex={ index + 1 }
 					/>,
 				] ) }
 				{ ! blocks.length &&

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -11,8 +11,6 @@ import {
 	noop,
 	sortBy,
 	throttle,
-	includes,
-	dropRight,
 } from 'lodash';
 import scrollIntoView from 'dom-scroll-into-view';
 import 'element-closest';
@@ -207,8 +205,7 @@ class VisualEditorBlockList extends Component {
 	}
 
 	render() {
-		const { blocks, multiSelectedBlockUids } = this.props;
-		const selectedWithoutLastUids = dropRight( multiSelectedBlockUids );
+		const { blocks } = this.props;
 
 		return (
 			<div>
@@ -221,8 +218,9 @@ class VisualEditorBlockList extends Component {
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
 					/>,
-					! includes( selectedWithoutLastUids, uid ) && <VisualEditorSiblingInserter
+					<VisualEditorSiblingInserter
 						key={ 'sibling-inserter-' + uid }
+						uid={ uid }
 						insertIndex={ index + 1 }
 					/>,
 				] ) }

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -11,6 +11,8 @@ import {
 	noop,
 	sortBy,
 	throttle,
+	includes,
+	dropRight,
 } from 'lodash';
 import scrollIntoView from 'dom-scroll-into-view';
 import 'element-closest';
@@ -205,7 +207,8 @@ class VisualEditorBlockList extends Component {
 	}
 
 	render() {
-		const { blocks } = this.props;
+		const { blocks, multiSelectedBlockUids } = this.props;
+		const selectedWithoutLastUids = dropRight( multiSelectedBlockUids );
 
 		return (
 			<div>
@@ -218,7 +221,7 @@ class VisualEditorBlockList extends Component {
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
 					/>,
-					<VisualEditorSiblingInserter
+					! includes( selectedWithoutLastUids, uid ) && <VisualEditorSiblingInserter
 						key={ 'sibling-inserter-' + uid }
 						insertIndex={ index + 1 }
 					/>,

--- a/editor/modes/visual-editor/sibling-inserter.js
+++ b/editor/modes/visual-editor/sibling-inserter.js
@@ -17,6 +17,7 @@ import { Inserter } from '../../components';
 import {
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
+	isBlockWithinSelection,
 } from '../../selectors';
 
 class VisualEditorSiblingInserter extends Component {
@@ -87,6 +88,10 @@ class VisualEditorSiblingInserter extends Component {
 	}
 
 	render() {
+		if ( this.props.shouldDisable ) {
+			return null;
+		}
+
 		const { insertIndex, showInsertionPoint } = this.props;
 		const { isVisible } = this.state;
 
@@ -123,6 +128,7 @@ class VisualEditorSiblingInserter extends Component {
 export default connect(
 	( state, ownProps ) => {
 		return {
+			shouldDisable: isBlockWithinSelection( state, ownProps.uid ),
 			showInsertionPoint: (
 				isBlockInsertionPointVisible( state ) &&
 				getBlockInsertionPoint( state ) === ownProps.insertIndex

--- a/editor/modes/visual-editor/sibling-inserter.js
+++ b/editor/modes/visual-editor/sibling-inserter.js
@@ -15,6 +15,7 @@ import { focus } from '@wordpress/utils';
  */
 import { Inserter } from '../../components';
 import {
+	getBlockUids,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
 	isBlockWithinSelection,
@@ -126,12 +127,16 @@ class VisualEditorSiblingInserter extends Component {
 }
 
 export default connect(
-	( state, ownProps ) => {
+	( state, { uid } ) => {
+		const blockIndex = uid ? getBlockUids( state ).indexOf( uid ) : -1;
+		const insertIndex = blockIndex > -1 ? blockIndex + 1 : 0;
+
 		return {
-			shouldDisable: isBlockWithinSelection( state, ownProps.uid ),
+			shouldDisable: isBlockWithinSelection( state, uid ),
+			insertIndex,
 			showInsertionPoint: (
 				isBlockInsertionPointVisible( state ) &&
-				getBlockInsertionPoint( state ) === ownProps.insertIndex
+				getBlockInsertionPoint( state ) === insertIndex
 			),
 		};
 	}

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -749,6 +749,26 @@ export function isBlockSelected( state, uid ) {
 }
 
 /**
+ * Returns true if the block corresponding to the specified unique ID is
+ * currently selected but isn't the last of the selected blocks. Here "last"
+ * refers to the block sequence in the document, _not_ the sequence of
+ * multi-selection, which is why `state.blockSelection.end` isn't used.
+ *
+ * @param  {Object} state Global application state
+ * @param  {String} uid   Block unique ID
+ * @return {Boolean}      Whether block is selected and not the last in the selection
+ */
+export function isBlockWithinSelection( state, uid ) {
+	if ( ! uid ) {
+		return false;
+	}
+
+	const uids = getMultiSelectedBlockUids( state );
+	const index = uids.indexOf( uid );
+	return index > -1 && index < uids.length - 1;
+}
+
+/**
  * Returns true if the cursor is hovering the block corresponding to the
  * specified unique ID, or false otherwise.
  *

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -53,6 +53,7 @@ import {
 	getPreviousBlock,
 	getNextBlock,
 	isBlockSelected,
+	isBlockWithinSelection,
 	isBlockMultiSelected,
 	isFirstMultiSelectedBlock,
 	isBlockHovered,
@@ -1545,6 +1546,60 @@ describe( 'selectors', () => {
 			};
 
 			expect( isBlockSelected( state, 23 ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isBlockWithinSelection', () => {
+		it( 'should return true if the block is selected but not the last', () => {
+			const state = {
+				blockSelection: { start: 5, end: 3 },
+				editor: {
+					present: {
+						blockOrder: [ 5, 4, 3, 2, 1 ],
+					},
+				},
+			};
+
+			expect( isBlockWithinSelection( state, 4 ) ).toBe( true );
+		} );
+
+		it( 'should return false if the block is the last selected', () => {
+			const state = {
+				blockSelection: { start: 5, end: 3 },
+				editor: {
+					present: {
+						blockOrder: [ 5, 4, 3, 2, 1 ],
+					},
+				},
+			};
+
+			expect( isBlockWithinSelection( state, 3 ) ).toBe( false );
+		} );
+
+		it( 'should return false if the block is not selected', () => {
+			const state = {
+				blockSelection: { start: 5, end: 3 },
+				editor: {
+					present: {
+						blockOrder: [ 5, 4, 3, 2, 1 ],
+					},
+				},
+			};
+
+			expect( isBlockWithinSelection( state, 2 ) ).toBe( false );
+		} );
+
+		it( 'should return false if there is no selection', () => {
+			const state = {
+				blockSelection: {},
+				editor: {
+					present: {
+						blockOrder: [ 5, 4, 3, 2, 1 ],
+					},
+				},
+			};
+
+			expect( isBlockWithinSelection( state, 4 ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
Fixes #3076.

## How Has This Been Tested?
Make a multi block selection. Make sure there are inserters around the block (visible by hover), but not inside the block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.