### PR TITLE
Performance: Memoize by specific block selection state keys

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -569,7 +569,11 @@ export const getMultiSelectedBlockUids = createSelector(
 
 		return blockOrder.slice( startIndex, endIndex + 1 );
 	},
-	( state ) => [ state.editor.blockOrder, state.blockSelection ],
+	( state ) => [
+		state.editor.blockOrder,
+		state.blockSelection.start,
+		state.blockSelection.end,
+	],
 );
 
 /**
@@ -583,7 +587,8 @@ export const getMultiSelectedBlocks = createSelector(
 	( state ) => getMultiSelectedBlockUids( state ).map( ( uid ) => getBlock( state, uid ) ),
 	( state ) => [
 		state.editor.blockOrder,
-		state.blockSelection,
+		state.blockSelection.start,
+		state.blockSelection.end,
 		state.editor.blocksByUid,
 		state.editor.edits.meta,
 		state.currentPost.meta,


### PR DESCRIPTION
Related: #3170

This pull request seeks to further optimize multi-selection selectors based on the specific state keys that are used in the `getMultiSelectedBlockUids` selector. Since `blockSelection` is an object which also encompasses the start-and-stop selection behavior, merely clicking or highlighting into a block, whether already selected, is enough to trigger a re-render of the `VisualEditorBlockList` component. With these changes, only if multi-selection is triggered will the cached value of `getMultiSelectedBlockUids` be busted.

__Implementation notes:__

I'm not particularly happy with how `getMultiSelectedBlocks` defines its state dependencies based on the implementation of `getMultiSelectedBlockUids`, but it is the most performant option in lieu of defining its dependency as the result of `getMultiSelectedBlockUids` itself.

__Testing instructions:__

Verify that there are no regressions in block multi-selection.

Optional: Apply the following diff and verify that there are no props updates to `VisualEditorBlockList` when repeatedly clicking within a paragraph block†:

```diff
diff --git a/editor/modes/visual-editor/block-list.js b/editor/modes/visual-editor/block-list.js
index c2bd938f..4e7eb351 100644
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -72,6 +72,12 @@ class VisualEditorBlockList extends Component {
        }
 
        componentWillReceiveProps( nextProps ) {
+               for ( var i in nextProps ) {
+                       if ( nextProps[ i ] !== this.props[ i ] ) {
+                               console.log( i );
+                       }
+               }
+
                if ( isEqual( this.props.multiSelectedBlockUids, nextProps.multiSelectedBlockUids ) ) {
                        return;
                }
```

† With React Developer Tools extension, I am still seeing that frequent renders occur elsewhere in the application. This will be explored separately.