### PR TITLE
Revert: Framework: Download api-request shim directly from GitHub

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -276,7 +276,7 @@ function gutenberg_register_vendor_scripts() {
 	// See: gutenberg_ensure_wp_api_request (compat.php).
 	gutenberg_register_vendor_script(
 		'wp-api-request-shim',
-		'https://raw.githubusercontent.com/WordPress/wordpress-develop/master/src/wp-includes/js/api-request.js'
+		'https://rawgit.com/WordPress/wordpress-develop/master/src/wp-includes/js/api-request.js'
 	);
 }
 


### PR DESCRIPTION
Reverts WordPress/gutenberg#2705
Fixes #3248

This pull request reverts the change introduced by #2705 to reference the `wp.apiRequest` shim script directly from GitHub. While the logic to download a local copy of the shim from GitHub directly works correctly, the behavior of vendor scripts is such that if the download fails, the script is enqueued from its original resource:

https://github.com/WordPress/gutenberg/blob/be8d37ab7deab7baeef4eefe9b714c29c4e5cd09/lib/client-assets.php#L409-L412

Since GitHub does not allow hotlinking script resources directly on the githubusercontent.com domain, we should revert back to using the rawgit.com URL which, while not an "official" source, is intended for supporting hotlinking.

While using the fallback script is not desirable, it seems it may occur in environments such as those where file permissions do not allow for the downloaded script to be written.

__Open questions:__

- Per [documentation](http://rawgit.com/), should we use the production URL which is not updated as frequently? It was assumed using development link would not be an issue since it should ideally only be referenced once for the initial download, but if there are permissions issues preventing the vendor download, this file may be referenced often (though not in the plugin distributable, which included a pre-downloaded copy).

__Testing instructions:__

Repeat testing instructions from #3248

Verify that vendor script downloading works as expected.

1. Change into Gutenberg plugin directory: `cd path/to/gutenberg`
2. Empty contents of the vendor directory: `rm -f vendor/*`
3. Navigate to Posts > New Post
4. Note that Gutenberg loads correctly
5. Note that vendor scripts, including `api-request-*****.js` exists in your `vendor` directory