### PR TITLE
Remove focus on multi-select stop

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -337,12 +337,14 @@ export function blockSelection( state = { start: null, end: null, focus: null, i
 			return {
 				...state,
 				isMultiSelecting: false,
+				focus: state.start === state.end ? state.focus : null,
 			};
 		case 'MULTI_SELECT':
 			return {
 				...state,
 				start: action.start,
 				end: action.end,
+				focus: state.isMultiSelecting ? state.focus : null,
 			};
 		case 'SELECT_BLOCK':
 			if ( action.uid === state.start && action.uid === state.end ) {

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -742,6 +742,17 @@ describe( 'state', () => {
 		} );
 
 		it( 'should set multi selection', () => {
+			const original = deepFreeze( { focus: { editable: 'citation' }, isMultiSelecting: false } );
+			const state = blockSelection( original, {
+				type: 'MULTI_SELECT',
+				start: 'ribs',
+				end: 'chicken',
+			} );
+
+			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: null, isMultiSelecting: false } );
+		} );
+
+		it( 'should set continuous multi selection', () => {
 			const original = deepFreeze( { focus: { editable: 'citation' }, isMultiSelecting: true } );
 			const state = blockSelection( original, {
 				type: 'MULTI_SELECT',
@@ -761,13 +772,22 @@ describe( 'state', () => {
 			expect( state ).toEqual( { start: 'ribs', end: 'ribs', focus: { editable: 'citation' }, isMultiSelecting: true } );
 		} );
 
-		it( 'should end multi selection', () => {
+		it( 'should end multi selection with selection', () => {
 			const original = deepFreeze( { start: 'ribs', end: 'chicken', focus: { editable: 'citation' }, isMultiSelecting: true } );
 			const state = blockSelection( original, {
 				type: 'STOP_MULTI_SELECT',
 			} );
 
-			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: { editable: 'citation' }, isMultiSelecting: false } );
+			expect( state ).toEqual( { start: 'ribs', end: 'chicken', focus: null, isMultiSelecting: false } );
+		} );
+
+		it( 'should end multi selection without selection', () => {
+			const original = deepFreeze( { start: 'ribs', end: 'ribs', focus: { editable: 'citation' }, isMultiSelecting: true } );
+			const state = blockSelection( original, {
+				type: 'STOP_MULTI_SELECT',
+			} );
+
+			expect( state ).toEqual( { start: 'ribs', end: 'ribs', focus: { editable: 'citation' }, isMultiSelecting: false } );
 		} );
 
 		it( 'should not update the state if the block is already selected', () => {

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -45,6 +45,16 @@ class WritingFlow extends Component {
 		this.verticalRect = null;
 	}
 
+	componentDidMount() {
+		document.addEventListener( 'keydown', this.onKeyDown );
+		document.addEventListener( 'mousedown', this.clearVerticalRect );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'keydown', this.onKeyDown );
+		document.addEventListener( 'mousedown', this.clearVerticalRect );
+	}
+
 	bindContainer( ref ) {
 		this.container = ref;
 	}
@@ -156,19 +166,11 @@ class WritingFlow extends Component {
 	render() {
 		const { children } = this.props;
 
-		// Disable reason: Wrapper itself is non-interactive, but must capture
-		// bubbling events from children to determine focus transition intents.
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
-			<div
-				ref={ this.bindContainer }
-				onKeyDown={ this.onKeyDown }
-				onMouseDown={ this.clearVerticalRect }
-			>
+			<div ref={ this.bindContainer }>
 				{ children }
 			</div>
 		);
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 	}
 }
 


### PR DESCRIPTION
## Description
Fixes #3191. See also #3194 and #3222.

This PR removes the focus state after a selection is finished. This results in the editable blurring, and therefore fixes deleting the blocks.

The focus implicitly ends up on the body, which is something we may not want.

Additionally this this breaks shift+arrow keys, but it already seems broken in master otherwise too. It seems to rely on a focus in an editable.

## How Has This Been Tested?
1. Make a multi-block selection.
2. Press backspace.
3. Blocks are gone.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.