### PR TITLE
Make sure link modal appears above sibling inserter

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -14,7 +14,7 @@ $z-layers: (
 	'.editor-inserter__tabs': 1,
 	'.editor-inserter__tab.is-active': 1,
 	'.components-panel__header': 1,
-	'.blocks-format-toolbar__link-modal': 1,
+	'.blocks-format-toolbar__link-modal': 2,
 	'.editor-block-switcher__menu': 2,
 	'.editor-block-mover': 20,
 	'.blocks-gallery-image__inline-menu': 20,


### PR DESCRIPTION
Fixes: #3255

## Description

z-index fix to make sure link modal appears above sibling inserter

## How Has This Been Tested?
Visual test in browser

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.