### PR TITLE
Editor: Fix editor top position on the small breakpoint

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -61,9 +61,9 @@ body.gutenberg-editor-page {
 	min-height: calc( 100vh - #{ $admin-bar-height-big } );
 	padding-top: $header-height + $stacked-toolbar-height;
 
+	// The parent relative container changes
 	@include break-small {
 		top: 0;
-		padding-top: $header-height;
 	}
 
 	// The WP header height changes at this breakpoint


### PR DESCRIPTION
Small regression introduced by #2909 

On small breakpoints, the padding should still include the stacked toolbar