### PR TITLE
Add back disabling of wpcom-markdown if blocks detected

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -16,6 +16,7 @@ require dirname( __FILE__ ) . '/class-wp-rest-reusable-blocks-controller.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/compat.php';
+require dirname( __FILE__ ) . '/plugin-compat.php';
 require dirname( __FILE__ ) . '/i18n.php';
 require dirname( __FILE__ ) . '/parser.php';
 require dirname( __FILE__ ) . '/register.php';

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -26,7 +26,7 @@
  * @return array $post      Post object.
  */
 function gutenberg_remove_wpcom_markdown_support( $post ) {
-	if ( content_has_gutenberg_blocks( $post->post_content ) ) {
+	if ( content_has_blocks( $post->post_content ) ) {
 		remove_post_type_support( 'post', 'wpcom-markdown' );
 	}
 	return $post;

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -26,7 +26,7 @@
  * @return array $post      Post object.
  */
 function gutenberg_remove_wpcom_markdown_support( $post ) {
-	if ( content_has_blocks( $post->post_content ) ) {
+	if ( content_has_gutenberg_blocks( $post->post_content ) ) {
 		remove_post_type_support( 'post', 'wpcom-markdown' );
 	}
 	return $post;

--- a/lib/register.php
+++ b/lib/register.php
@@ -317,7 +317,7 @@ function gutenberg_can_edit_post_type( $post_type ) {
  */
 function gutenberg_post_has_blocks( $post ) {
 	$post = get_post( $post );
-	return $post && content_has_gutenberg_blocks( $post->post_content );
+	return $post && content_has_blocks( $post->post_content );
 }
 
 /**
@@ -328,7 +328,7 @@ function gutenberg_post_has_blocks( $post ) {
  * @param string $content Content to test.
  * @return bool Whether the content contains blocks.
  */
-function content_has_gutenberg_blocks( $content ) {
+function content_has_blocks( $content ) {
 	return false !== strpos( $content, '<!-- wp:' );
 }
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -317,7 +317,19 @@ function gutenberg_can_edit_post_type( $post_type ) {
  */
 function gutenberg_post_has_blocks( $post ) {
 	$post = get_post( $post );
-	return $post && strpos( $post->post_content, '<!-- wp:' ) !== false;
+	return $post && content_has_gutenberg_blocks( $post->post_content );
+}
+
+/**
+ * Determine whether a content string contains gutenberg blocks.
+ *
+ * @since 1.6.0
+ *
+ * @param string $content Content to test.
+ * @return bool Whether the content contains blocks.
+ */
+function content_has_gutenberg_blocks( $content ) {
+	return false !== strpos( $content, '<!-- wp:' );
 }
 
 /**


### PR DESCRIPTION

It appears that parts of #2817 were reverted or missed in a rebase.
This change adds back the filtering of wpcom-markdown if blocks detected.

Fixes #3207 