### PR TITLE
Disable front-end default style for quotes.

### DIFF
--- a/blocks/library/quote/editor.scss
+++ b/blocks/library/quote/editor.scss
@@ -1,4 +1,4 @@
-.wp-block-quote.blocks-quote-style-2 > .blocks-editable p {
-	font-size: 24px;
-	font-style: italic;
+.wp-block-quote.blocks-quote-style-1 {
+	border-left: 4px solid $black;
+	padding-left: 1em;
 }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -13,6 +13,7 @@ import { Toolbar } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
+import './editor.scss';
 import { registerBlockType, createBlock, source } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';

--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -10,12 +10,6 @@
 		font-style: normal;
 	}
 
-
-	&.blocks-quote-style-1 {
-		border-left: 4px solid $black;
-		padding-left: 1em;
-	}
-
 	&.blocks-quote-style-2 {
 		padding: 0 1em;
 		p {


### PR DESCRIPTION
This remove the default quote style on the front-end (still applies it in the editor) as most themes have base styles that would conflict with such a generic element.

Closes #3259.