### PR TITLE
Blocks: Restore freeform block toolbar z-index

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -88,7 +88,7 @@
 .freeform-toolbar {
 	width: auto;
 	top: $header-height - 1px;
-	z-index: z-index( '.editor-block-toolbar' );
+	z-index: z-index( '.freeform-toolbar' );
 	position: sticky;
 
 	@include break-medium() {

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -7,6 +7,7 @@ $z-layers: (
 	'.editor-visual-editor__block:before': -1,
 	'.editor-visual-editor__block .wp-block-more:before': -1,
 	'.editor-visual-editor__block {core/image aligned left or right}': 20,
+	'.freeform-toolbar': 10,
 	'.editor-visual-editor__block-warning': 1,
 	'.editor-visual-editor__sibling-inserter': 1,
 	'.components-form-toggle__input': 1,

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -42,5 +42,9 @@ $z-layers: (
 );
 
 @function z-index( $key ) {
-	@return map-get( $z-layers, $key );
+	@if map-has-key( $z-layers, $key ) {
+		@return map-get( $z-layers, $key );
+	}
+
+	@error "Error: Specified z-index `#{$key}` does not exist in the mapping";
 }


### PR DESCRIPTION
This pull request seeks to resolve an issue where the freeform block floating toolbar could not be clicked when overlapping content. The freeform block toolbar inherited `z-index` from the block toolbar which was removed as part of #2998. It is unclear whether the freeform block toolbar should be moved to the header as well, but in the interim this resolves the layering issues. Further, it introduces a change to surface `z-index` function unmatched references by failing the build when attempting to use a key which is not defined.

__Testing instructions:__

1. Create a post in the Classic Editor with enough content to cause scroll when viewed in Gutenberg
2. Edit the post created in step 1 in Gutenberg
3. Select within the freeform content block
4. Scroll the page until the freeform toolbar sticky positioning takes effect
5. Note that you can still interact with the toolbar and it is shown above content

Verify that there are no errors in Gutenberg build.