### PR TITLE
Fix the mobile tools ellipsis style

### DIFF
--- a/editor/block-toolbar/style.scss
+++ b/editor/block-toolbar/style.scss
@@ -2,6 +2,7 @@
 	display: inline-flex;
 	overflow: auto; // allow horizontal scrolling on mobile
 	flex-grow: 1;
+	width: 100%;
 
 	.components-toolbar {
 		border: none;
@@ -19,11 +20,11 @@
 }
 
 .editor-block-toolbar__mobile-tools {
-	align-items: baseline;
+	align-items: stretch;
 	display: flex;
 	justify-content: space-between;
 	flex-direction: row-reverse;
-	width: 100%;
+	flex-grow: 1;
 
 	&.components-toolbar {
 		margin-right: 0;
@@ -37,6 +38,8 @@
 		display: inline-flex;
 		height: auto;
 		position: initial;
+		padding: 0 5px;
+		align-items: stretch;
 	}
 }
 
@@ -47,6 +50,7 @@
 		margin: 0 5px 0 0;
 		padding: 0 5px;
 		width: auto;
+		height: auto;
 
 		.dashicon {
 			margin: 0;


### PR DESCRIPTION
Small CSS tweaks to the mobile tools toolbar:

 - Show the ellipsis at the right of the toolbar
 - Fix the height of the toolbar

<img width="473" alt="screen shot 2017-10-31 at 16 12 26" src="https://user-images.githubusercontent.com/272444/32231609-50d0e12c-be56-11e7-8545-add5d1a68636.png">
