### PR TITLE
Fix Block Hover Style on medium breakpoint

### DIFF
--- a/editor/block-settings-menu/style.scss
+++ b/editor/block-settings-menu/style.scss
@@ -36,6 +36,7 @@
 	transform: rotate( 90deg );
 	transition-duration: 0.3s;
 	transition-property: transform;
+	width: auto;
 
 	&.is-opened {
 		transform: rotate( 0 );


### PR DESCRIPTION
The Block hover style is not aligned properly on medium breakpoints

before:

<img width="713" alt="screen shot 2017-10-31 at 17 00 00" src="https://user-images.githubusercontent.com/272444/32235485-e5b46878-be5f-11e7-95f6-550e296df7a9.png">

After:

<img width="680" alt="screen shot 2017-10-31 at 17 21 30" src="https://user-images.githubusercontent.com/272444/32235514-f68befea-be5f-11e7-9742-d1690bfdee08.png">
