### PR TITLE
Fix scroll on moving blocks

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -79,7 +79,7 @@ class VisualEditorBlockList extends Component {
 		if ( nextProps.multiSelectedBlockUids && nextProps.multiSelectedBlockUids.length > 0 ) {
 			const extent = this.nodes[ nextProps.selectionEnd ];
 			if ( extent ) {
-				scrollIntoView( extent, extent.closest( '.editor-layout__editor' ), {
+				scrollIntoView( extent, extent.closest( '.editor-layout__content' ), {
 					onlyScrollIfNeeded: true,
 				} );
 			}

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -89,7 +89,7 @@ class VisualEditorBlock extends Component {
 		}
 
 		// Not Ideal, but it's the easiest way to get the scrollable container
-		this.editorLayout = document.querySelector( '.editor-layout__editor' );
+		this.editorLayout = document.querySelector( '.editor-layout__content' );
 	}
 
 	componentWillReceiveProps( newProps ) {


### PR DESCRIPTION
Quick fix to a regression introduced by #3147 because it changed the scrollable container

also related to https://github.com/WordPress/gutenberg/issues/2959

**Testing instructions**

 - Test that moving the blocks keep the block at the same position (same for multiselection)
