### PR TITLE
Gallery Block: show InspectorControls (1 image) 

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -198,13 +198,13 @@ class GalleryBlock extends Component {
 				<InspectorControls key="inspector">
 					{blockDescription}
 					<h3>{ __( 'Gallery Settings' ) }</h3>
-					<RangeControl
+					{ images.length > 1 && <RangeControl
 						label={ __( 'Columns' ) }
 						value={ columns }
 						onChange={ this.setColumnsNumber }
 						min={ 1 }
 						max={ Math.min( MAX_COLUMNS, images.length ) }
-					/>
+					/> }
 					<ToggleControl
 						label={ __( 'Crop Images' ) }
 						checked={ !! imageCrop }

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -194,7 +194,7 @@ class GalleryBlock extends Component {
 
 		return [
 			controls,
-			focus && images.length > 1 && (
+			focus && (
 				<InspectorControls key="inspector">
 					{blockDescription}
 					<h3>{ __( 'Gallery Settings' ) }</h3>


### PR DESCRIPTION
## Description
The gallery settings should also be visible if the gallery has just 1 image. There is already a check for 0 images (line 161), so we can completely remove the length-check.

## How Has This Been Tested?
1. Add a Gallery Block
2. Open the block settings
3. The gallery settings should be visible.