### PR TITLE
Accessibility: Remove the "command" shortcut

### DIFF
--- a/components/keyboard-shortcuts/README.md
+++ b/components/keyboard-shortcuts/README.md
@@ -15,7 +15,6 @@ class SelectAllDetection extends Component {
 		super( ...arguments );
 
 		this.setAllSelected = this.setAllSelected.bind( this );
-		this.save = this.save.bind( this );
 
 		this.state = { isAllSelected: false };
 	}
@@ -24,16 +23,11 @@ class SelectAllDetection extends Component {
 		this.setState( { isAllSelected: true } );
 	}
 
-	save() {
-		this.props.onSave();
-	}
-
 	render() {
 		return (
 			<div>
 				<KeyboardShorcuts shortcuts={ {
 					'mod+a': this.setAllSelected,
-					'mod+s': [ this.save, true ],
 				} } />
 				Combination pressed? { isAllSelected ? 'Yes' : 'No' }
 			</div>
@@ -44,17 +38,31 @@ class SelectAllDetection extends Component {
 
 __Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
 
-__Note:__ The callback will not be invoked if the key combination occurs in an editable field, unless you pass the callback as an array with the callback and `true` as entries of the array respectively. Refer to the example above, and see the `shortcuts` prop documentation for more information.
-
 ## Props
 
 The component accepts the following props:
 
 ### shortcuts
 
-An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed. To capture a key event globally (including within input fields), assign as the value an array with the function callback as the first argument and `true` as the second argument.
+An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed.
 
 - Type: `Object`
+- Required: No
+
+## bindGlobal
+
+By default, a callback will not be invoked if the key combination occurs in an editable field. Pass `bindGlobal` as `true` if the key events should be observed globally, including within editable fields.
+
+- Type: `Boolean`
+- Required: No
+
+_Tip:_ If you need some but not all keyboard events to be observed globally, simply render two distinct `KeyboardShortcuts` elements, one with and one without the `bindGlobal` prop.
+
+## event
+
+By default, a callback is invoked in response to the `keydown` event. To override this, pass `event` with the name of a specific keyboard event.
+
+- Type: `String`
 - Required: No
 
 ## References

--- a/components/keyboard-shortcuts/README.md
+++ b/components/keyboard-shortcuts/README.md
@@ -36,8 +36,6 @@ class SelectAllDetection extends Component {
 }
 ```
 
-__Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
-
 ## Props
 
 The component accepts the following props:
@@ -48,6 +46,10 @@ An object of shortcut bindings, where each key is a keyboard combination, the va
 
 - Type: `Object`
 - Required: No
+
+__Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
+
+__Note:__ The `KeyboardShortcuts` component will not update to reflect a changed `shortcuts` prop. If you need to change shortcuts, mount a separate `KeyboardShortcuts` element, which can be achieved by assigning a unique `key` prop.
 
 ## bindGlobal
 

--- a/components/keyboard-shortcuts/README.md
+++ b/components/keyboard-shortcuts/README.md
@@ -15,6 +15,7 @@ class SelectAllDetection extends Component {
 		super( ...arguments );
 
 		this.setAllSelected = this.setAllSelected.bind( this );
+		this.save = this.save.bind( this );
 
 		this.state = { isAllSelected: false };
 	}
@@ -23,11 +24,16 @@ class SelectAllDetection extends Component {
 		this.setState( { isAllSelected: true } );
 	}
 
+	save() {
+		this.props.onSave();
+	}
+
 	render() {
 		return (
 			<div>
 				<KeyboardShorcuts shortcuts={ {
 					'mod+a': this.setAllSelected,
+					'mod+s': [ this.save, true ],
 				} } />
 				Combination pressed? { isAllSelected ? 'Yes' : 'No' }
 			</div>
@@ -38,7 +44,7 @@ class SelectAllDetection extends Component {
 
 __Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
 
-__Note:__ The callback will not be invoked if the key combination occurs in an editable field.
+__Note:__ The callback will not be invoked if the key combination occurs in an editable field, unless you pass the callback as an array with the callback and `true` as entries of the array respectively. Refer to the example above, and see the `shortcuts` prop documentation for more information.
 
 ## Props
 
@@ -46,7 +52,7 @@ The component accepts the following props:
 
 ### shortcuts
 
-An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed.
+An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed. To capture a key event globally (including within input fields), assign as the value an array with the function callback as the first argument and `true` as the second argument.
 
 - Type: `Object`
 - Required: No

--- a/components/keyboard-shortcuts/index.js
+++ b/components/keyboard-shortcuts/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import Mousetrap from 'mousetrap';
+import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
 import { forEach } from 'lodash';
 
 /**
@@ -13,7 +14,19 @@ class KeyboardShortcuts extends Component {
 	componentWillMount() {
 		this.mousetrap = new Mousetrap;
 		forEach( this.props.shortcuts, ( callback, key ) => {
-			this.mousetrap.bind( key, callback );
+			// Normalize callback, which can be passed as either a function or
+			// an array of [ callback, isGlobal ]
+			let isGlobal = false;
+			if ( Array.isArray( callback ) ) {
+				isGlobal = callback[ 1 ];
+				callback = callback[ 0 ];
+			}
+
+			if ( isGlobal ) {
+				this.mousetrap.bindGlobal( key, callback );
+			} else {
+				this.mousetrap.bind( key, callback );
+			}
 		} );
 	}
 

--- a/components/keyboard-shortcuts/index.js
+++ b/components/keyboard-shortcuts/index.js
@@ -14,19 +14,9 @@ class KeyboardShortcuts extends Component {
 	componentWillMount() {
 		this.mousetrap = new Mousetrap;
 		forEach( this.props.shortcuts, ( callback, key ) => {
-			// Normalize callback, which can be passed as either a function or
-			// an array of [ callback, isGlobal ]
-			let isGlobal = false;
-			if ( Array.isArray( callback ) ) {
-				isGlobal = callback[ 1 ];
-				callback = callback[ 0 ];
-			}
-
-			if ( isGlobal ) {
-				this.mousetrap.bindGlobal( key, callback );
-			} else {
-				this.mousetrap.bind( key, callback );
-			}
+			const { bindGlobal, eventName } = this.props;
+			const bindFn = bindGlobal ? 'bindGlobal' : 'bind';
+			this.mousetrap[ bindFn ]( key, callback, eventName );
 		} );
 	}
 

--- a/components/keyboard-shortcuts/test/index.js
+++ b/components/keyboard-shortcuts/test/index.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import KeyboardShortcuts from '../';
+
+describe( 'KeyboardShortcuts', () => {
+	afterEach( () => {
+		while ( document.body.firstChild ) {
+			document.body.removeChild( document.body.firstChild );
+		}
+	} );
+
+	function keyPress( which, target ) {
+		[ 'keydown', 'keypress', 'keyup' ].forEach( ( eventName ) => {
+			const event = new window.Event( eventName, { bubbles: true } );
+			event.keyCode = which;
+			event.which = which;
+			target.dispatchEvent( event );
+		} );
+	}
+
+	it( 'should capture key events', () => {
+		const spy = jest.fn();
+		mount(
+			<KeyboardShortcuts
+				shortcuts={ {
+					d: spy,
+				} } />
+		);
+
+		keyPress( 68, document );
+
+		expect( spy ).toHaveBeenCalled();
+	} );
+
+	it( 'should capture key events globally', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<div>
+				<KeyboardShortcuts
+					shortcuts={ {
+						d: [ spy, true ],
+					} } />
+				<textarea></textarea>
+			</div>,
+			{ attachTo: attachNode }
+		);
+
+		keyPress( 68, wrapper.find( 'textarea' ).getDOMNode() );
+
+		expect( spy ).toHaveBeenCalled();
+	} );
+} );

--- a/components/keyboard-shortcuts/test/index.js
+++ b/components/keyboard-shortcuts/test/index.js
@@ -46,8 +46,9 @@ describe( 'KeyboardShortcuts', () => {
 		const wrapper = mount(
 			<div>
 				<KeyboardShortcuts
+					bindGlobal
 					shortcuts={ {
-						d: [ spy, true ],
+						d: spy,
 					} } />
 				<textarea></textarea>
 			</div>,
@@ -57,5 +58,28 @@ describe( 'KeyboardShortcuts', () => {
 		keyPress( 68, wrapper.find( 'textarea' ).getDOMNode() );
 
 		expect( spy ).toHaveBeenCalled();
+	} );
+
+	it( 'should capture key events on specific event', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<div>
+				<KeyboardShortcuts
+					eventName="keyup"
+					shortcuts={ {
+						d: spy,
+					} } />
+				<textarea></textarea>
+			</div>,
+			{ attachTo: attachNode }
+		);
+
+		keyPress( 68, wrapper.find( 'textarea' ).getDOMNode() );
+
+		expect( spy ).toHaveBeenCalled();
+		expect( spy.mock.calls[ 0 ][ 0 ].type ).toBe( 'keyup' );
 	} );
 } );

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, NavigableMenu } from '@wordpress/components';
+import { IconButton, NavigableMenu, KeyboardShortcuts } from '@wordpress/components';
 import { Component, findDOMNode } from '@wordpress/element';
 import { focus, keycodes } from '@wordpress/utils';
 
@@ -18,38 +18,18 @@ import './style.scss';
 import Inserter from '../../inserter';
 import BlockToolbar from '../../block-toolbar';
 import { hasEditorUndo, hasEditorRedo } from '../../selectors';
-import { isMac } from '../../utils/dom';
 
 /**
  * Module Constants
  */
-const { ESCAPE, F10 } = keycodes;
-
-function metaKeyPressed( event ) {
-	return isMac() ? event.metaKey : event.ctrlKey;
-}
+const { ESCAPE } = keycodes;
 
 class HeaderToolbar extends Component {
 	constructor() {
 		super( ...arguments );
 		this.bindNode = this.bindNode.bind( this );
-		this.onKeyUp = this.onKeyUp.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
+		this.focusToolbar = this.focusToolbar.bind( this );
 		this.onToolbarKeyDown = this.onToolbarKeyDown.bind( this );
-
-		// it's not easy to know if the user only clicked on a "meta" key without simultaneously clicking on another key
-		// We keep track of the key counts to ensure it's reliable
-		this.metaCount = 0;
-	}
-
-	componentDidMount() {
-		document.addEventListener( 'keyup', this.onKeyUp, true );
-		document.addEventListener( 'keydown', this.onKeyDown, true );
-	}
-
-	componentWillUnmount() {
-		document.removeEventListener( 'keyup', this.onKeyUp );
-		document.removeEventListener( 'keydown', this.onKeyDown );
 	}
 
 	bindNode( ref ) {
@@ -59,25 +39,10 @@ class HeaderToolbar extends Component {
 		this.toolbar = findDOMNode( ref );
 	}
 
-	onKeyDown( event ) {
-		if ( metaKeyPressed( event ) ) {
-			this.metaCount++;
-		}
-	}
-
-	onKeyUp( event ) {
-		const shouldFocusToolbar = this.metaCount === 1 || ( event.keyCode === F10 && event.altKey );
-
-		// Reset the count if it's the final released key
-		if ( ! event.shiftKey && ! event.altKey && ( ! event.ctrlKey || ! isMac() ) ) {
-			this.metaCount = 0;
-		}
-
-		if ( shouldFocusToolbar ) {
-			const tabbables = focus.tabbable.find( this.toolbar );
-			if ( tabbables.length ) {
-				tabbables[ 0 ].focus();
-			}
+	focusToolbar() {
+		const tabbables = focus.tabbable.find( this.toolbar );
+		if ( tabbables.length ) {
+			tabbables[ 0 ].focus();
 		}
 	}
 
@@ -107,6 +72,13 @@ class HeaderToolbar extends Component {
 				ref={ this.bindNode }
 				onKeyDown={ this.onToolbarKeyDown }
 			>
+				<KeyboardShortcuts
+					bindGlobal
+					eventName="keyup"
+					shortcuts={ {
+						'alt+f10': this.focusToolbar,
+					} }
+				/>
 				<Inserter position="bottom right" />
 				<IconButton
 					icon="undo"

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -303,12 +303,3 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 	selection.removeAllRanges();
 	selection.addRange( range );
 }
-
-/**
- * Checks whether the user is on MacOS or not
- *
- * @return {Boolean}           Is Mac or Not
- */
-export function isMac() {
-	return window.navigator.platform.toLowerCase().indexOf( 'mac' ) !== -1;
-}


### PR DESCRIPTION
The "command" shortcut to navigate to the editor's toolbar has proven to be technically difficult to implement properly without edge-cases and also have side effects. This PR removes it in favor of the `alt+f10` alternative. See https://github.com/WordPress/gutenberg/pull/2960#issuecomment-340892661 and #3183 

If you can think of another simple shortcut, I'd be happy to add.
This also refactors the navigation to use the KeyboardShortcuts component.

**Testing instructions**

 - Check that alt+f10 moves the focus to the header's toolbar

closes #3183 