### PR TITLE
PostSchedule: Do not allow an invalid time

### DIFF
--- a/editor/post-schedule/clock.js
+++ b/editor/post-schedule/clock.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isInteger } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -12,6 +17,7 @@ function PostScheduleClock( { is12Hour, selected, onChange } ) {
 	const updateHours = ( event ) => {
 		const value = parseInt( event.target.value, 10 );
 		if (
+			! isInteger( value ) ||
 			( is12Hour && ( value < 1 || value > 12 ) ) ||
 			( ! is12Hour && ( value < 0 || value > 23 ) )
 		) {
@@ -26,7 +32,7 @@ function PostScheduleClock( { is12Hour, selected, onChange } ) {
 
 	const updateMinutes = ( event ) => {
 		const value = parseInt( event.target.value, 10 );
-		if ( value < 0 || value > 59 ) {
+		if ( ! isInteger( value ) || value < 0 || value > 59 ) {
 			return;
 		}
 		const newDate = selected.clone().minutes( value );


### PR DESCRIPTION
closes #3273

This PR fixes the post schedule component by forbidding any invalidate date/time including empty times. This means you can't "remove" the time but you can select and replace it instead.

An alternative would be to make the input "uncontrolled" and only call `onChange` if the value is valid.

**Testing instructions**

 - Create a post
 - Edit the publish date
 - DELETE the date value (select and delete)
 - You should not be able to delete it but you should be able to update it.