### PR TITLE
Components: Extract a reusable PostLastRevision component

### DIFF
--- a/editor/post-last-revision/check.js
+++ b/editor/post-last-revision/check.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentPostLastRevisionId } from '../selectors';
+
+function PostLastRevisionCheck( { lastRevisionId, children } ) {
+	if ( ! lastRevisionId ) {
+		return null;
+	}
+
+	return children;
+}
+
+export default connect(
+	( state ) => {
+		return {
+			lastRevisionId: getCurrentPostLastRevisionId( state ),
+		};
+	}
+)( PostLastRevisionCheck );

--- a/editor/post-last-revision/index.js
+++ b/editor/post-last-revision/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { sprintf, _n } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import PostLastRevisionCheck from './check';
+import {
+	getCurrentPostLastRevisionId,
+	getCurrentPostRevisionsCount,
+} from '../selectors';
+import { getWPAdminURL } from '../utils/url';
+
+function LastRevision( { lastRevisionId, revisionsCount } ) {
+	return (
+		<PostLastRevisionCheck>
+			<IconButton
+				href={ getWPAdminURL( 'revision.php', { revision: lastRevisionId } ) }
+				className="editor-post-last-revision__title"
+				icon="backup"
+			>
+				{
+					sprintf(
+						_n( '%d Revision', '%d Revisions', revisionsCount ),
+						revisionsCount
+					)
+				}
+			</IconButton>
+		</PostLastRevisionCheck>
+	);
+}
+
+export default connect(
+	( state ) => {
+		return {
+			lastRevisionId: getCurrentPostLastRevisionId( state ),
+			revisionsCount: getCurrentPostRevisionsCount( state ),
+		};
+	}
+)( LastRevision );

--- a/editor/post-last-revision/style.scss
+++ b/editor/post-last-revision/style.scss
@@ -1,4 +1,4 @@
-.editor-last-revision__title {
+.editor-post-last-revision__title {
 	padding: 0;
 	width: 100%;
 	font-weight: 600;

--- a/editor/sidebar/last-revision/index.js
+++ b/editor/sidebar/last-revision/index.js
@@ -1,52 +1,22 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
-import { sprintf, _n } from '@wordpress/i18n';
-import { IconButton, PanelBody } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import './style.scss';
-import {
-	getCurrentPostLastRevisionId,
-	getCurrentPostRevisionsCount,
-} from '../../selectors';
-import { getWPAdminURL } from '../../utils/url';
+import PostLastRevisionCheck from '../../post-last-revision/check';
+import PostLastRevision from '../../post-last-revision';
 
-function LastRevision( { lastRevisionId, revisionsCount } ) {
-	if ( ! lastRevisionId ) {
-		return null;
-	}
-
+function LastRevision() {
 	return (
-		<PanelBody>
-			<IconButton
-				href={ getWPAdminURL( 'revision.php', { revision: lastRevisionId } ) }
-				className="editor-last-revision__title"
-				icon="backup"
-			>
-				{
-					sprintf(
-						_n( '%d Revision', '%d Revisions', revisionsCount ),
-						revisionsCount
-					)
-				}
-			</IconButton>
-		</PanelBody>
+		<PostLastRevisionCheck>
+			<PanelBody>
+				<PostLastRevision />
+			</PanelBody>
+		</PostLastRevisionCheck>
 	);
 }
 
-export default connect(
-	( state ) => {
-		return {
-			lastRevisionId: getCurrentPostLastRevisionId( state ),
-			revisionsCount: getCurrentPostRevisionsCount( state ),
-		};
-	}
-)( LastRevision );
+export default LastRevision;


### PR DESCRIPTION
Related to #2761 (comment)

> All these (the sidebar panels) must be refactored slightly to drop all the "layout" pieces and keep only the "forms". For example, the sidebar panels like PostTaxonomies, we should extract only the PostTaxonomyForms into a reusable component without the expandable panel behavior that is specific to our current UI. (This step could be done in a separate PR preceding the directory structure change)

This PR addresses the comment above for the PostLastRevision component.

**Testing instructions**

- Test that the last revision link is working as expected