### PR TITLE
Fix gallery not displaying correctly when aligning right or left.

### DIFF
--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -1,4 +1,6 @@
 .wp-block-gallery,
+.wp-block-gallery.alignleft,
+.wp-block-gallery.alignright,
 .wp-block-gallery.aligncenter {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
This two lines PR aims to address an issue raised in https://github.com/WordPress/gutenberg/issues/2690. The problem is that some themes overwrite the display property. The problem happens in right and left alignment, not in center. The technique already being used to increase selector specificity for center alignment was also applied for left and right. With this simple change, it looks like the problem got fixed.
Please that in the editor things look nice the problem only happens when seeing the post. It is possible to see the problem happening in the screen below where the gallery was set to two columns and the setting was not respected.

The container may still take all the space and we may not be able to notice the difference between the center and right/left alignments. But this is common in many other blocks e.g: image block. And for now, it looks like the expected behavior from blocks when the width is big.

## Before
<img width="557" alt="screen shot 2017-11-01 at 20 40 39" src="https://user-images.githubusercontent.com/11271197/32297000-a4df598e-bf45-11e7-8ef8-c5316b42b0ae.png">

## After
<img width="569" alt="screen shot 2017-11-01 at 20 40 11" src="https://user-images.githubusercontent.com/11271197/32297039-c05743de-bf45-11e7-8536-ea0f5c48bf64.png">
