### PR TITLE
Fixed column count problem when removing an image from gallery

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -65,8 +65,11 @@ class GalleryBlock extends Component {
 
 	onRemoveImage( index ) {
 		return () => {
+			const images = filter( this.props.attributes.images, ( img, i ) => index !== i );
+			const { columns } = this.props.attributes;
 			this.props.setAttributes( {
-				images: filter( this.props.attributes.images, ( img, i ) => index !== i ),
+				images,
+				columns: columns ? Math.min( images.length, columns ) : columns,
 			} );
 		};
 	}


### PR DESCRIPTION
Aims to close https://github.com/WordPress/gutenberg/issues/3274.
When removing an image from the gallery if the number of images becomes less than the number of columns, the number of columns was not updating. This is inconsistent because we set the maximum number of columns allowed to the number of images.

## Before
![nov-01-2017 22-23-36](https://user-images.githubusercontent.com/11271197/32300872-6249fde6-bf53-11e7-8183-07f93e88e967.gif)

## After
![nov-01-2017 22-23-22](https://user-images.githubusercontent.com/11271197/32300894-7febc33e-bf53-11e7-8aec-84fd072682ac.gif)