### PR TITLE
Fix inline paste

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -30,7 +30,7 @@ import shortcodeConverter from './shortcode-converter';
  *
  * @param  {String}       options.HTML        The HTML to convert.
  * @param  {String}       [options.plainText] Plain text version.
- * @param  {Boolean}      [options.inline]    Whether to content should be inline or not. Null to auto-detect, false to force blocks, true to force a string.
+ * @param  {?Boolean}     [options.inline]    Whether to content should be inline or not. Null to auto-detect, false to force blocks, true to force a string.
  * @return {Array|String}                     A list of blocks or a string, depending on the `inline` option.
  */
 export default function rawHandler( { HTML, plainText = '', inline = null } ) {

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -251,7 +251,8 @@ export default class Editable extends Component {
 		const content = rawHandler( {
 			HTML: event.content,
 			plainText: this.pastedPlainText,
-			inline: ! this.props.onSplit,
+			// Force inline paste if there's no `onSplit` prop.
+			inline: this.props.onSplit ? null : true,
 		} );
 
 		if ( typeof content === 'string' ) {


### PR DESCRIPTION
## Description
Fixes #3305. Broken since fecc4b3fd4a0527e5c86d173110e4e37de3f8870.

## How Has This Been Tested?
Paste some pure text in a paragraph. Text should be inline. It's not, a new block is created.
Or, paste a link on a work. Word should be linked. Instead a new block with the link is created.