### PR TITLE
Chrome: Adding a Toggle to switch between fixed/contextual block toolbar

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -98,10 +98,14 @@
 
 .freeform-toolbar .mce-tinymce-inline {
 	margin: 0;
-	margin-top: -$block-controls-height - $item-spacing;
+	margin-top: -$block-controls-height - $block-padding;
 	border: 1px solid $light-gray-500;
 	background-color: $white;
-	box-shadow: $shadow-popover;
+
+	@include break-small() {
+		margin-left: - $block-padding - 1px;
+		margin-right: - $block-padding - 1px;
+	}
 }
 
 // Overwrite inline styles.

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -473,6 +473,20 @@ export function metaBoxStateChanged( location, hasChanged ) {
 	};
 }
 
+/**
+ * Returns an action object used to toggle a feature flag
+ *
+ * @param {String}  feature   Featurre name.
+ *
+ * @return {Object}           Action object
+ */
+export function toggleFeature( feature ) {
+	return {
+		type: 'TOGGLE_FEATURE',
+		feature,
+	};
+}
+
 export const createSuccessNotice = partial( createNotice, 'success' );
 export const createInfoNotice = partial( createNotice, 'info' );
 export const createErrorNotice = partial( createNotice, 'error' );

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -50,7 +50,7 @@ $item-spacing: 10px;
 $panel-padding: 16px;
 $header-height: 56px;
 $inserter-tabs-height: 36px;
-$stacked-toolbar-height: 37px;
+$block-toolbar-height: 37px;
 $sidebar-width: 280px;
 $sidebar-panel-header-height: 50px;
 $admin-bar-height: 32px;

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -16,6 +16,7 @@ $z-layers: (
 	'.editor-inserter__tab.is-active': 1,
 	'.components-panel__header': 1,
 	'.blocks-format-toolbar__link-modal': 2,
+	'.editor-block-contextual-toolbar': 2,
 	'.editor-block-switcher__menu': 2,
 	'.editor-block-mover': 20,
 	'.blocks-gallery-image__inline-menu': 20,

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -59,7 +59,7 @@ body.gutenberg-editor-page {
 	bottom: 0;
 	left: 0;
 	min-height: calc( 100vh - #{ $admin-bar-height-big } );
-	padding-top: $header-height + $stacked-toolbar-height;
+	padding-top: $header-height + $block-toolbar-height;
 
 	// The parent relative container changes
 	@include break-small {

--- a/editor/header/ellipsis-menu/index.js
+++ b/editor/header/ellipsis-menu/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { IconButton, Dropdown } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import ModeSwitcher from '../mode-switcher';
+import FixedToolbarToggle from '../fixed-toolbar-toggle';
+
+const element = (
+	<Dropdown
+		className="editor-ellipsis-menu"
+		position="bottom left"
+		renderToggle={ ( { isOpen, onToggle } ) => (
+			<IconButton
+				icon="ellipsis"
+				label={ __( 'More' ) }
+				onClick={ onToggle }
+				aria-expanded={ isOpen }
+			/>
+		) }
+		renderContent={ ( { onClose } ) => (
+			<div>
+				<ModeSwitcher onSwitch={ onClose } />
+				<FixedToolbarToggle onToggle={ onClose } />
+			</div>
+		) }
+	/>
+);
+
+function EllipsisMenu() {
+	return element;
+}
+
+export default EllipsisMenu;

--- a/editor/header/ellipsis-menu/style.scss
+++ b/editor/header/ellipsis-menu/style.scss
@@ -1,0 +1,7 @@
+.editor-ellipsis-menu {
+	margin-left: $item-spacing;
+
+	.components-button svg {
+		transform: rotate( 90deg );
+	}
+}

--- a/editor/header/fixed-toolbar-toggle/index.js
+++ b/editor/header/fixed-toolbar-toggle/index.js
@@ -1,0 +1,43 @@
+/**
+ * External Dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress Dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { IconButton, withInstanceId } from '@wordpress/components';
+
+/**
+ * Internal Dependencies
+ */
+import './style.scss';
+import { isFeatureActive } from '../../selectors';
+import { toggleFeature } from '../../actions';
+
+function FeatureToggle( { onToggle, active } ) {
+	return (
+		<IconButton
+			className="editor-fixed-toolbar-toggle"
+			icon={ active ? 'yes' : 'no' }
+			onClick={ () => {
+				onToggle();
+			} }
+		>
+			{ __( 'Fixed Block Toolbar' ) }
+		</IconButton>
+	);
+}
+
+export default connect(
+	( state ) => ( {
+		active: isFeatureActive( state, 'fixedToolbar' ),
+	} ),
+	( dispatch, ownProps ) => ( {
+		onToggle() {
+			dispatch( toggleFeature( 'fixedToolbar' ) );
+			ownProps.onToggle();
+		},
+	} )
+)( withInstanceId( FeatureToggle ) );

--- a/editor/header/fixed-toolbar-toggle/index.js
+++ b/editor/header/fixed-toolbar-toggle/index.js
@@ -20,12 +20,12 @@ function FeatureToggle( { onToggle, active } ) {
 	return (
 		<IconButton
 			className="editor-fixed-toolbar-toggle"
-			icon={ active ? 'yes' : 'no' }
+			icon="editor-kitchensink"
 			onClick={ () => {
 				onToggle();
 			} }
 		>
-			{ __( 'Fixed Block Toolbar' ) }
+			{ active ? __( 'Fix toolbar to block' ) : __( 'Fix toolbar to top' ) }
 		</IconButton>
 	);
 }

--- a/editor/header/fixed-toolbar-toggle/style.scss
+++ b/editor/header/fixed-toolbar-toggle/style.scss
@@ -1,0 +1,8 @@
+.editor-fixed-toolbar-toggle {
+	width: 100%;
+	padding: 15px;
+
+	.dashicon {
+		margin-right: 20px;
+	}
+}

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -7,9 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, NavigableMenu, KeyboardShortcuts } from '@wordpress/components';
-import { Component, findDOMNode } from '@wordpress/element';
-import { focus, keycodes } from '@wordpress/utils';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,87 +15,33 @@ import { focus, keycodes } from '@wordpress/utils';
 import './style.scss';
 import Inserter from '../../inserter';
 import BlockToolbar from '../../block-toolbar';
+import NavigableToolbar from '../../navigable-toolbar';
 import { hasEditorUndo, hasEditorRedo, isFeatureActive } from '../../selectors';
 
-/**
- * Module Constants
- */
-const { ESCAPE } = keycodes;
-
-class HeaderToolbar extends Component {
-	constructor() {
-		super( ...arguments );
-		this.bindNode = this.bindNode.bind( this );
-		this.focusToolbar = this.focusToolbar.bind( this );
-		this.onToolbarKeyDown = this.onToolbarKeyDown.bind( this );
-	}
-
-	bindNode( ref ) {
-		// Disable reason: Need DOM node for finding first focusable element
-		// on keyboard interaction to shift to toolbar.
-		// eslint-disable-next-line react/no-find-dom-node
-		this.toolbar = findDOMNode( ref );
-	}
-
-	focusToolbar() {
-		const tabbables = focus.tabbable.find( this.toolbar );
-		if ( tabbables.length ) {
-			tabbables[ 0 ].focus();
-		}
-	}
-
-	onToolbarKeyDown( event ) {
-		if ( event.keyCode !== ESCAPE ) {
-			return;
-		}
-
-		// Is there a better way to focus the selected block
-		// TODO: separate focused/selected block state and use Redux actions instead
-		const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected .editor-visual-editor__block-edit' );
-		if ( !! selectedBlock ) {
-			event.stopPropagation();
-			selectedBlock.focus();
-		}
-	}
-
-	render() {
-		const { hasUndo, hasRedo, hasFixedToolbar, undo, redo } = this.props;
-		return (
-			<NavigableMenu
-				className="editor-header-toolbar"
-				orientation="horizontal"
-				role="toolbar"
-				deep
-				aria-label={ __( 'Editor Toolbar' ) }
-				ref={ this.bindNode }
-				onKeyDown={ this.onToolbarKeyDown }
-			>
-				<KeyboardShortcuts
-					bindGlobal
-					eventName="keyup"
-					shortcuts={ {
-						'alt+f10': this.focusToolbar,
-					} }
-				/>
-				<Inserter position="bottom right" />
-				<IconButton
-					icon="undo"
-					label={ __( 'Undo' ) }
-					disabled={ ! hasUndo }
-					onClick={ undo } />
-				<IconButton
-					icon="redo"
-					label={ __( 'Redo' ) }
-					disabled={ ! hasRedo }
-					onClick={ redo } />
-				{ hasFixedToolbar && (
-					<div className="editor-header-toolbar__block-toolbar">
-						<BlockToolbar />
-					</div>
-				) }
-			</NavigableMenu>
-		);
-	}
+function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo } ) {
+	return (
+		<NavigableToolbar
+			className="editor-header-toolbar"
+			aria-label={ __( 'Editor Toolbar' ) }
+		>
+			<Inserter position="bottom right" />
+			<IconButton
+				icon="undo"
+				label={ __( 'Undo' ) }
+				disabled={ ! hasUndo }
+				onClick={ undo } />
+			<IconButton
+				icon="redo"
+				label={ __( 'Redo' ) }
+				disabled={ ! hasRedo }
+				onClick={ redo } />
+			{ hasFixedToolbar && (
+				<div className="editor-header-toolbar__block-toolbar">
+					<BlockToolbar />
+				</div>
+			) }
+		</NavigableToolbar>
+	);
 }
 
 export default connect(

--- a/editor/header/header-toolbar/style.scss
+++ b/editor/header/header-toolbar/style.scss
@@ -20,7 +20,7 @@
 	right: 0;
 	background: $white;
 	border-bottom: 1px solid $light-gray-500;
-	min-height: $stacked-toolbar-height;
+	min-height: $block-toolbar-height;
 
 	.is-sidebar-opened & {
 		display: none;

--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -16,7 +16,7 @@ import './style.scss';
 import SavedState from './saved-state';
 import PublishWithDropdown from './publish-with-dropdown';
 import PreviewButton from './preview-button';
-import ModeSwitcher from './mode-switcher';
+import EllipsisMenu from './ellipsis-menu';
 import HeaderToolbar from './header-toolbar';
 import { isEditorSidebarOpened } from '../selectors';
 import { toggleSidebar } from '../actions';
@@ -40,7 +40,7 @@ function Header( { onToggleSidebar, isSidebarOpened } ) {
 					isToggled={ isSidebarOpened }
 					label={ __( 'Settings' ) }
 				/>
-				<ModeSwitcher />
+				<EllipsisMenu />
 			</div>
 		</div>
 	);

--- a/editor/header/mode-switcher/index.js
+++ b/editor/header/mode-switcher/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, Dropdown } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -34,49 +34,33 @@ const MODES = [
 ];
 
 function ModeSwitcher( { onSwitch, mode } ) {
-	return (
-		<Dropdown
-			className="editor-mode-switcher"
-			position="bottom left"
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<IconButton
-					icon="ellipsis"
-					label={ __( 'More' ) }
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-				/>
-			) }
-			renderContent={ ( { onClose } ) => (
-				MODES
-					.filter( ( { value } ) => value !== mode )
-					.map( ( { value, label, icon } ) => (
-						<IconButton
-							className="editor-mode-switcher__button"
-							key={ value }
-							icon={ icon }
-							onClick={ () => {
-								onSwitch( value );
-								onClose();
-							} }
-						>
-							{ label }
-						</IconButton>
-					) )
-			) }
-		/>
-	);
+	return MODES
+		.filter( ( { value } ) => value !== mode )
+		.map( ( { value, label, icon } ) => (
+			<IconButton
+				className="editor-mode-switcher__button"
+				key={ value }
+				icon={ icon }
+				onClick={ () => {
+					onSwitch( value );
+				} }
+			>
+				{ label }
+			</IconButton>
+		) );
 }
 
 export default connect(
 	( state ) => ( {
 		mode: getEditorMode( state ),
 	} ),
-	( dispatch ) => ( {
+	( dispatch, ownProps ) => ( {
 		onSwitch( mode ) {
 			dispatch( {
 				type: 'SWITCH_MODE',
 				mode: mode,
 			} );
+			ownProps.onSwitch( mode );
 		},
 	} )
 )( ModeSwitcher );

--- a/editor/header/style.scss
+++ b/editor/header/style.scss
@@ -77,14 +77,6 @@
 	align-items: center;
 }
 
-.editor-mode-switcher {
-	margin-left: $item-spacing;
-
-	.components-button svg {
-		transform: rotate( 90deg );
-	}
-}
-
 .editor-header .components-button {
 	border-radius: 3px;
 

--- a/editor/modes/visual-editor/block-contextual-toolbar.js
+++ b/editor/modes/visual-editor/block-contextual-toolbar.js
@@ -7,24 +7,22 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, NavigableMenu, KeyboardShortcuts } from '@wordpress/components';
+import { NavigableMenu, KeyboardShortcuts } from '@wordpress/components';
 import { Component, findDOMNode } from '@wordpress/element';
 import { focus, keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
-import './style.scss';
-import Inserter from '../../inserter';
 import BlockToolbar from '../../block-toolbar';
-import { hasEditorUndo, hasEditorRedo, isFeatureActive } from '../../selectors';
+import { isFeatureActive } from '../../selectors';
 
 /**
  * Module Constants
  */
 const { ESCAPE } = keycodes;
 
-class HeaderToolbar extends Component {
+class BlockContextualToolbar extends Component {
 	constructor() {
 		super( ...arguments );
 		this.bindNode = this.bindNode.bind( this );
@@ -61,10 +59,15 @@ class HeaderToolbar extends Component {
 	}
 
 	render() {
-		const { hasUndo, hasRedo, hasFixedToolbar, undo, redo } = this.props;
+		const { hasFixedToolbar } = this.props;
+
+		if ( hasFixedToolbar ) {
+			return null;
+		}
+
 		return (
 			<NavigableMenu
-				className="editor-header-toolbar"
+				className="editor-block-contextual-toolbar"
 				orientation="horizontal"
 				role="toolbar"
 				deep
@@ -79,22 +82,7 @@ class HeaderToolbar extends Component {
 						'alt+f10': this.focusToolbar,
 					} }
 				/>
-				<Inserter position="bottom right" />
-				<IconButton
-					icon="undo"
-					label={ __( 'Undo' ) }
-					disabled={ ! hasUndo }
-					onClick={ undo } />
-				<IconButton
-					icon="redo"
-					label={ __( 'Redo' ) }
-					disabled={ ! hasRedo }
-					onClick={ redo } />
-				{ hasFixedToolbar && (
-					<div className="editor-header-toolbar__block-toolbar">
-						<BlockToolbar />
-					</div>
-				) }
+				<BlockToolbar />
 			</NavigableMenu>
 		);
 	}
@@ -102,12 +90,6 @@ class HeaderToolbar extends Component {
 
 export default connect(
 	( state ) => ( {
-		hasUndo: hasEditorUndo( state ),
-		hasRedo: hasEditorRedo( state ),
 		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
 	} ),
-	( dispatch ) => ( {
-		undo: () => dispatch( { type: 'UNDO' } ),
-		redo: () => dispatch( { type: 'REDO' } ),
-	} )
-)( HeaderToolbar );
+)( BlockContextualToolbar );

--- a/editor/modes/visual-editor/block-contextual-toolbar.js
+++ b/editor/modes/visual-editor/block-contextual-toolbar.js
@@ -7,85 +7,27 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { NavigableMenu, KeyboardShortcuts } from '@wordpress/components';
-import { Component, findDOMNode } from '@wordpress/element';
-import { focus, keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
+import NavigableToolbar from '../../navigable-toolbar';
 import BlockToolbar from '../../block-toolbar';
 import { isFeatureActive } from '../../selectors';
 
-/**
- * Module Constants
- */
-const { ESCAPE } = keycodes;
-
-class BlockContextualToolbar extends Component {
-	constructor() {
-		super( ...arguments );
-		this.bindNode = this.bindNode.bind( this );
-		this.focusToolbar = this.focusToolbar.bind( this );
-		this.onToolbarKeyDown = this.onToolbarKeyDown.bind( this );
+function BlockContextualToolbar( { hasFixedToolbar } ) {
+	if ( hasFixedToolbar ) {
+		return null;
 	}
 
-	bindNode( ref ) {
-		// Disable reason: Need DOM node for finding first focusable element
-		// on keyboard interaction to shift to toolbar.
-		// eslint-disable-next-line react/no-find-dom-node
-		this.toolbar = findDOMNode( ref );
-	}
-
-	focusToolbar() {
-		const tabbables = focus.tabbable.find( this.toolbar );
-		if ( tabbables.length ) {
-			tabbables[ 0 ].focus();
-		}
-	}
-
-	onToolbarKeyDown( event ) {
-		if ( event.keyCode !== ESCAPE ) {
-			return;
-		}
-
-		// Is there a better way to focus the selected block
-		// TODO: separate focused/selected block state and use Redux actions instead
-		const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected .editor-visual-editor__block-edit' );
-		if ( !! selectedBlock ) {
-			event.stopPropagation();
-			selectedBlock.focus();
-		}
-	}
-
-	render() {
-		const { hasFixedToolbar } = this.props;
-
-		if ( hasFixedToolbar ) {
-			return null;
-		}
-
-		return (
-			<NavigableMenu
-				className="editor-block-contextual-toolbar"
-				orientation="horizontal"
-				role="toolbar"
-				deep
-				aria-label={ __( 'Editor Toolbar' ) }
-				ref={ this.bindNode }
-				onKeyDown={ this.onToolbarKeyDown }
-			>
-				<KeyboardShortcuts
-					bindGlobal
-					eventName="keyup"
-					shortcuts={ {
-						'alt+f10': this.focusToolbar,
-					} }
-				/>
-				<BlockToolbar />
-			</NavigableMenu>
-		);
-	}
+	return (
+		<NavigableToolbar
+			className="editor-block-contextual-toolbar"
+			aria-label={ __( 'Block Toolbar' ) }
+		>
+			<BlockToolbar />
+		</NavigableToolbar>
+	);
 }
 
 export default connect(

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -21,6 +21,7 @@ import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
 import BlockDropZone from './block-drop-zone';
 import BlockHtml from './block-html';
+import BlockContextualToolbar from './block-contextual-toolbar';
 import BlockMover from '../../block-mover';
 import BlockSettingsMenu from '../../block-settings-menu';
 import {
@@ -358,6 +359,7 @@ class VisualEditorBlock extends Component {
 				<BlockDropZone index={ order } />
 				{ ( showUI || isProperlyHovered ) && <BlockMover uids={ [ block.uid ] } /> }
 				{ ( showUI || isProperlyHovered ) && <BlockSettingsMenu uids={ [ block.uid ] } /> }
+				{ showUI && isValid && <BlockContextualToolbar /> }
 				{ isFirstMultiSelected && ! this.props.isSelecting &&
 					<BlockMover uids={ multiSelectedBlockUids } />
 				}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -273,7 +273,7 @@
 
 	&[data-align="full"],
 	&[data-align="wide"] {
-		.editor-block-toolbar {
+		.editor-block-contextual-toolbar {
 			@include break-small() {
 				width: $visual-editor-max-width - $block-padding - $block-padding;
 			}
@@ -533,7 +533,10 @@ $sticky-bottom-offset: 20px;
 	margin-top: - $block-toolbar-height - $block-padding - 1px;
 	margin-bottom: $block-padding + $sticky-bottom-offset;
 	white-space: nowrap;
+	text-align: left;
 	pointer-events: none;
+	height: $block-toolbar-height;
+	top: $header-height - 1px;
 
 	.editor-block-toolbar {
 		border: 1px solid $light-gray-500;
@@ -556,6 +559,10 @@ $sticky-bottom-offset: 20px;
 	@include break-small() {
 		margin-left: - $block-padding - 1px;
 		margin-right: - $block-padding - 1px;
+	}
+
+	@include break-medium() {
+		top: $item-spacing;
 	}
 }
 

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -524,3 +524,43 @@
 		}
 	}
 }
+
+$sticky-bottom-offset: 20px;
+
+.editor-block-contextual-toolbar {
+	position: sticky;
+	z-index: z-index( '.editor-block-contextual-toolbar' );
+	margin-top: - $block-toolbar-height - $block-padding - 1px;
+	margin-bottom: $block-padding + $sticky-bottom-offset;
+	white-space: nowrap;
+	pointer-events: none;
+
+	.editor-block-toolbar {
+		border: 1px solid $light-gray-500;
+		width: 100%;;
+		.components-toolbar:first-child {
+			margin-left: -1px;
+		}
+
+
+		@include break-small() {
+			width: auto;
+		}
+	}
+
+	// Reset pointer-events on children.
+	& > * {
+		pointer-events: auto;
+	}
+
+	@include break-small() {
+		margin-left: - $block-padding - 1px;
+		margin-right: - $block-padding - 1px;
+	}
+}
+
+.editor-block-contextual-toolbar + div {
+	// prevent collapsing margins between block and toolbar, matches the 20px bottom offset		 +		display: flex;
+	margin-top: - $sticky-bottom-offset - 1px;
+	padding-top: 1px;
+}

--- a/editor/navigable-toolbar/index.js
+++ b/editor/navigable-toolbar/index.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies
+ */
+import { NavigableMenu, KeyboardShortcuts } from '@wordpress/components';
+import { Component, findDOMNode } from '@wordpress/element';
+import { focus, keycodes } from '@wordpress/utils';
+
+/**
+ * Module Constants
+ */
+const { ESCAPE } = keycodes;
+
+class NavigableToolbar extends Component {
+	constructor() {
+		super( ...arguments );
+		this.bindNode = this.bindNode.bind( this );
+		this.focusToolbar = this.focusToolbar.bind( this );
+		this.onToolbarKeyDown = this.onToolbarKeyDown.bind( this );
+	}
+
+	bindNode( ref ) {
+		// Disable reason: Need DOM node for finding first focusable element
+		// on keyboard interaction to shift to toolbar.
+		// eslint-disable-next-line react/no-find-dom-node
+		this.toolbar = findDOMNode( ref );
+	}
+
+	focusToolbar() {
+		const tabbables = focus.tabbable.find( this.toolbar );
+		if ( tabbables.length ) {
+			tabbables[ 0 ].focus();
+		}
+	}
+
+	onToolbarKeyDown( event ) {
+		if ( event.keyCode !== ESCAPE ) {
+			return;
+		}
+
+		// Is there a better way to focus the selected block
+		// TODO: separate focused/selected block state and use Redux actions instead
+		const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected .editor-visual-editor__block-edit' );
+		if ( !! selectedBlock ) {
+			event.stopPropagation();
+			selectedBlock.focus();
+		}
+	}
+
+	render() {
+		const { children, ...props } = this.props;
+		return (
+			<NavigableMenu
+				orientation="horizontal"
+				role="toolbar"
+				deep
+				ref={ this.bindNode }
+				onKeyDown={ this.onToolbarKeyDown }
+				{ ...props }
+			>
+				<KeyboardShortcuts
+					bindGlobal
+					eventName="keyup"
+					shortcuts={ {
+						'alt+f10': this.focusToolbar,
+					} }
+				/>
+				{ children }
+			</NavigableMenu>
+		);
+	}
+}
+
+export default NavigableToolbar;

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -33,9 +33,6 @@ import { STORE_DEFAULTS } from './store-defaults';
  * Module constants
  */
 const MAX_RECENT_BLOCKS = 8;
-const DEFAULT_FEATURES = {
-	fixedToolbar: true,
-};
 
 /**
  * Returns a post attribute value, flattening nested rendered content using its
@@ -513,6 +510,14 @@ export function preferences( state = STORE_DEFAULTS.preferences, action ) {
 					.slice( 0, MAX_RECENT_BLOCKS ),
 				blockUsage: filterInvalidBlocksFromObject( state.blockUsage ),
 			};
+		case 'TOGGLE_FEATURE':
+			return {
+				...state,
+				features: {
+					...state.features,
+					[ action.feature ]: ! state.features[ action.feature ],
+				},
+			};
 	}
 
 	return state;
@@ -640,24 +645,6 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 	}
 }
 
-/**
- * Reducer keeping track of the enabled features hidden behind a flag
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Dispatched action
- * @return {Object}        Updated state
- */
-export function features( state = DEFAULT_FEATURES, action ) {
-	if ( action.type === 'TOGGLE_FEATURE' ) {
-		return {
-			...state,
-			[ action.feature ]: ! state[ action.feature ],
-		};
-	}
-
-	return state;
-}
-
 export default optimist( combineReducers( {
 	editor,
 	currentPost,
@@ -671,5 +658,4 @@ export default optimist( combineReducers( {
 	saving,
 	notices,
 	metaBoxes,
-	features,
 } ) );

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -33,6 +33,9 @@ import { STORE_DEFAULTS } from './store-defaults';
  * Module constants
  */
 const MAX_RECENT_BLOCKS = 8;
+const DEFAULT_FEATURES = {
+	fixedToolbar: true,
+};
 
 /**
  * Returns a post attribute value, flattening nested rendered content using its
@@ -637,6 +640,24 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 	}
 }
 
+/**
+ * Reducer keeping track of the enabled features hidden behind a flag
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Dispatched action
+ * @return {Object}        Updated state
+ */
+export function features( state = DEFAULT_FEATURES, action ) {
+	if ( action.type === 'TOGGLE_FEATURE' ) {
+		return {
+			...state,
+			[ action.feature ]: ! state[ action.feature ],
+		};
+	}
+
+	return state;
+}
+
 export default optimist( combineReducers( {
 	editor,
 	currentPost,
@@ -650,4 +671,5 @@ export default optimist( combineReducers( {
 	saving,
 	notices,
 	metaBoxes,
+	features,
 } ) );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -1051,3 +1051,14 @@ export const getMostFrequentlyUsedBlocks = createSelector(
 	},
 	( state ) => state.preferences.blockUsage
 );
+
+/**
+ * Returns whether the given feature is enabled or not
+ *
+ * @param {Object}    state   Global application state
+ * @param {String}    feature Feature slug
+ * @return {Booleean}         Is active
+ */
+export function isFeatureActive( state, feature ) {
+	return !! state.features[ feature ];
+}

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -1060,5 +1060,5 @@ export const getMostFrequentlyUsedBlocks = createSelector(
  * @return {Booleean}         Is active
  */
 export function isFeatureActive( state, feature ) {
-	return !! state.features[ feature ];
+	return !! state.preferences.features[ feature ];
 }

--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -5,5 +5,8 @@ export const STORE_DEFAULTS = {
 		panels: { 'post-status': true },
 		recentlyUsedBlocks: [],
 		blockUsage: {},
+		features: {
+			fixedToolbar: true,
+		},
 	},
 };

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -885,7 +885,14 @@ describe( 'state', () => {
 		it( 'should apply all defaults', () => {
 			const state = preferences( undefined, {} );
 
-			expect( state ).toEqual( { blockUsage: {}, recentlyUsedBlocks: [], mode: 'visual', isSidebarOpened: true, panels: { 'post-status': true } } );
+			expect( state ).toEqual( {
+				blockUsage: {},
+				recentlyUsedBlocks: [],
+				mode: 'visual',
+				isSidebarOpened: true,
+				panels: { 'post-status': true },
+				features: { fixedToolbar: true },
+			} );
 		} );
 
 		it( 'should toggle the sidebar open flag', () => {
@@ -993,6 +1000,14 @@ describe( 'state', () => {
 				type: 'SETUP_EDITOR',
 			} );
 			expect( state.blockUsage ).toEqual( { 'core-embed/youtube': 88 } );
+		} );
+
+		it( 'should toggle a feature flag', () => {
+			const state = preferences( deepFreeze( { features: { chicken: true } } ), {
+				type: 'TOGGLE_FEATURE',
+				feature: 'chicken',
+			} );
+			expect( state ).toEqual( { features: { chicken: false } } );
 		} );
 	} );
 

--- a/test/e2e/integration/002-adding-blocks.js
+++ b/test/e2e/integration/002-adding-blocks.js
@@ -27,7 +27,7 @@ describe( 'Adding blocks', () => {
 		cy.get( '[placeholder="Write code…"]' ).type( 'Code block' );
 
 		// Switch to Text Mode to check HTML Output
-		cy.get( '.editor-mode-switcher [aria-label="More"]' ).click();
+		cy.get( '.editor-ellipsis-menu [aria-label="More"]' ).click();
 		cy.get( 'button' ).contains( 'Switch To Text Mode' ).click();
 
 		// Assertions


### PR DESCRIPTION
This PR adds a Toggle in the ellipsis menu to switch back to the contextual block toolbar. This could serve as a A/B test.

<img width="991" alt="screen shot 2017-11-02 at 12 34 55" src="https://user-images.githubusercontent.com/272444/32324046-50d4206a-bfca-11e7-968d-69f0b5b93b80.png">

**Todo:**

 - [x] Persist this preference