### PR TITLE
Components: Extract the discussion panel as reusable components

### DIFF
--- a/editor/post-comments/index.js
+++ b/editor/post-comments/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { FormToggle, withInstanceId } from '@wordpress/components';
+
+/**
+ * Internal Dependencies
+ */
+import { getEditedPostAttribute } from '../selectors';
+import { editPost } from '../actions';
+
+function PostComments( { commentStatus = 'open', instanceId, ...props } ) {
+	const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
+
+	const commentsToggleId = 'allow-comments-toggle-' + instanceId;
+
+	return [
+		<label key="label" htmlFor={ commentsToggleId }>{ __( 'Allow Comments' ) }</label>,
+		<FormToggle
+			key="toggle"
+			checked={ commentStatus === 'open' }
+			onChange={ onToggleComments }
+			showHint={ false }
+			id={ commentsToggleId }
+		/>,
+	];
+}
+
+export default connect(
+	( state ) => {
+		return {
+			commentStatus: getEditedPostAttribute( state, 'comment_status' ),
+		};
+	},
+	{
+		editPost,
+	}
+)( withInstanceId( PostComments ) );
+

--- a/editor/post-pingbacks/index.js
+++ b/editor/post-pingbacks/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { FormToggle, withInstanceId } from '@wordpress/components';
+
+/**
+ * Internal Dependencies
+ */
+import { getEditedPostAttribute } from '../selectors';
+import { editPost } from '../actions';
+
+function PostPingbacks( { pingStatus = 'open', instanceId, ...props } ) {
+	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
+
+	const pingbacksToggleId = 'allow-pingbacks-toggle-' + instanceId;
+
+	return [
+		<label key="label" htmlFor={ pingbacksToggleId }>{ __( 'Allow Pingbacks & Trackbacks' ) }</label>,
+		<FormToggle
+			key="toggle"
+			checked={ pingStatus === 'open' }
+			onChange={ onTogglePingback }
+			showHint={ false }
+			id={ pingbacksToggleId }
+		/>,
+	];
+}
+
+export default connect(
+	( state ) => {
+		return {
+			pingStatus: getEditedPostAttribute( state, 'ping_status' ),
+		};
+	},
+	{
+		editPost,
+	}
+)( withInstanceId( PostPingbacks ) );
+

--- a/editor/sidebar/discussion-panel/index.js
+++ b/editor/sidebar/discussion-panel/index.js
@@ -7,45 +7,29 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, PanelRow, FormToggle, withInstanceId } from '@wordpress/components';
+import { PanelBody, PanelRow } from '@wordpress/components';
 
 /**
  * Internal Dependencies
  */
-import { getEditedPostAttribute, isEditorSidebarPanelOpened } from '../../selectors';
-import { editPost, toggleSidebarPanel } from '../../actions';
+import PostComments from '../../post-comments';
+import PostPingbacks from '../../post-pingbacks';
+import { isEditorSidebarPanelOpened } from '../../selectors';
+import { toggleSidebarPanel } from '../../actions';
 
 /**
  * Module Constants
  */
 const PANEL_NAME = 'discussion-panel';
 
-function DiscussionPanel( { pingStatus = 'open', commentStatus = 'open', instanceId, isOpened, onTogglePanel, ...props } ) {
-	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
-	const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
-
-	const commentsToggleId = 'allow-comments-toggle-' + instanceId;
-	const pingbacksToggleId = 'allow-pingbacks-toggle-' + instanceId;
-
+function DiscussionPanel( { isOpened, onTogglePanel } ) {
 	return (
 		<PanelBody title={ __( 'Discussion' ) } opened={ isOpened } onToggle={ onTogglePanel }>
 			<PanelRow>
-				<label htmlFor={ commentsToggleId }>{ __( 'Allow Comments' ) }</label>
-				<FormToggle
-					checked={ commentStatus === 'open' }
-					onChange={ onToggleComments }
-					showHint={ false }
-					id={ commentsToggleId }
-				/>
+				<PostComments />
 			</PanelRow>
 			<PanelRow>
-				<label htmlFor={ pingbacksToggleId }>{ __( 'Allow Pingbacks & Trackbacks' ) }</label>
-				<FormToggle
-					checked={ pingStatus === 'open' }
-					onChange={ onTogglePingback }
-					showHint={ false }
-					id={ pingbacksToggleId }
-				/>
+				<PostPingbacks />
 			</PanelRow>
 		</PanelBody>
 	);
@@ -54,16 +38,13 @@ function DiscussionPanel( { pingStatus = 'open', commentStatus = 'open', instanc
 export default connect(
 	( state ) => {
 		return {
-			pingStatus: getEditedPostAttribute( state, 'ping_status' ),
-			commentStatus: getEditedPostAttribute( state, 'comment_status' ),
 			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
 		};
 	},
 	{
-		editPost,
 		onTogglePanel() {
 			return toggleSidebarPanel( PANEL_NAME );
 		},
 	}
-)( withInstanceId( DiscussionPanel ) );
+)( DiscussionPanel );
 


### PR DESCRIPTION
Related to #2761 (comment)

> All these (the sidebar panels) must be refactored slightly to drop all the "layout" pieces and keep only the "forms". For example, the sidebar panels like PostTaxonomies, we should extract only the PostTaxonomyForms into a reusable component without the expandable panel behavior that is specific to our current UI. (This step could be done in a separate PR preceding the directory structure change)

This PR addresses the comment above for the Discussion Panel.

**Testing instructions**

- Test that the discussion sidebar panel works 