### PR TITLE
Update issue template to ask for screenshots/video

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 BEFORE POSTING YOUR ISSUE:
 - These comments won't show up when you submit the issue.
 - Try to add as much detail as possible. Be specific!
-- Please add the version of Gutenberg you are using in the description
+- Please add the version of Gutenberg you are using in the description.
 - If you're requesting a new feature, explain why you'd like it to be added.
 - Search this repository for the issue and whether it has been fixed or reported already.
 - Ensure you are using the latest code before logging bugs.
@@ -10,7 +10,7 @@ BEFORE POSTING YOUR ISSUE:
 -->
 
 ## Issue Overview
-<!-- This is a brief overview of the issue. --->
+<!-- This is a brief overview of the issue --->
 
 ## Steps to Reproduce (for bugs)
 <!-- Provide a link to a live example, or an unambiguous set of steps to -->
@@ -33,8 +33,11 @@ BEFORE POSTING YOUR ISSUE:
 <!-- Not obligatory, but suggest a fix/reason for the bug, -->
 <!-- or ideas how to implement the addition or change -->
 
+## Screenshots / Video
+<!-- Visual records are oxygen for others to understand what you are sharing -->
+
 ## Related Issues and/or PRs
-<!-- List related issues or PRs against other branches:  -->
+<!-- List related issues or PRs against other branches -->
 
 ## Todos
 - [ ] Tests


### PR DESCRIPTION
## Description

Simple text changes to the GitHub issue template.

1. Add a section for Screenshots / Video to encourage visual oxygen.
2. Minor grammatical cleanup.