### PR TITLE
Add URL handling to raw handler

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -124,6 +124,10 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO' } ) {
 					return acc;
 				}
 
+				if ( transform.transform ) {
+					return transform.transform( node );
+				}
+
 				return createBlock(
 					blockType.name,
 					getBlockAttributes(

--- a/blocks/api/raw-handling/test/index.js
+++ b/blocks/api/raw-handling/test/index.js
@@ -12,7 +12,7 @@ import { createBlock } from '../../factory';
 import { children, prop } from '../../source';
 
 describe( 'rawHandler', () => {
-	beforeAll( () => {
+	it( 'should convert recognised raw content', () => {
 		registerBlockType( 'test/figure', {
 			category: 'common',
 			title: 'test figure',
@@ -33,6 +33,16 @@ describe( 'rawHandler', () => {
 			save: () => {},
 		} );
 
+		const block = rawHandler( { HTML: '<figure>test</figure>' } )[ 0 ];
+		const { name, attributes } = createBlock( 'test/figure', { content: [ 'test' ] } );
+
+		equal( block.name, name );
+		deepEqual( block.attributes, attributes );
+
+		unregisterBlockType( 'test/figure' );
+	} );
+
+	it( 'should handle unknown raw content', () => {
 		registerBlockType( 'test/unknown', {
 			category: 'common',
 			title: 'test unknown',
@@ -44,29 +54,44 @@ describe( 'rawHandler', () => {
 			},
 			save: () => {},
 		} );
-
 		setUnknownTypeHandlerName( 'test/unknown' );
-	} );
 
-	afterAll( () => {
-		unregisterBlockType( 'test/figure' );
-		unregisterBlockType( 'test/unknown' );
-		setUnknownTypeHandlerName( undefined );
-	} );
-
-	it( 'should convert recognised raw content', () => {
-		const block = rawHandler( { HTML: '<figure>test</figure>' } )[ 0 ];
-		const { name, attributes } = createBlock( 'test/figure', { content: [ 'test' ] } );
-
-		equal( block.name, name );
-		deepEqual( block.attributes, attributes );
-	} );
-
-	it( 'should handle unknown raw content', () => {
 		const block = rawHandler( { HTML: '<figcaption>test</figcaption>' } )[ 0 ];
 
 		equal( block.name, 'test/unknown' );
 		equal( block.attributes.content, '<figcaption>test</figcaption>' );
+
+		unregisterBlockType( 'test/unknown' );
+		setUnknownTypeHandlerName( undefined );
+	} );
+
+	it( 'should handle raw content with transform', () => {
+		registerBlockType( 'test/transform', {
+			category: 'common',
+			title: 'test figure',
+			attributes: {
+				content: {
+					type: 'array',
+				},
+			},
+			transforms: {
+				from: [
+					{
+						type: 'raw',
+						isMatch: ( node ) => node.nodeName === 'FIGURE',
+						transform: ( node ) => createBlock( 'test/transform', { content: node.nodeName } ),
+					},
+				],
+			},
+			save: () => {},
+		} );
+
+		const block = rawHandler( { HTML: '<figure>test</figure>' } )[ 0 ];
+
+		equal( block.name, 'test/transform' );
+		equal( block.attributes.content, 'FIGURE' );
+
+		unregisterBlockType( 'test/transform' );
 	} );
 
 	it( 'should filter inline content', () => {

--- a/blocks/editable/patterns.js
+++ b/blocks/editable/patterns.js
@@ -29,7 +29,6 @@ export default function( editor ) {
 	const settings = editor.settings.wptextpattern || {};
 
 	const {
-		paste: pastePatterns,
 		enter: enterPatterns,
 		undefined: spacePatterns,
 	} = groupBy( getBlockTypes().reduce( ( acc, blockType ) => {
@@ -46,10 +45,6 @@ export default function( editor ) {
 
 	editor.on( 'selectionchange', function() {
 		canUndo = null;
-	} );
-
-	editor.on( 'pastepostprocess', () => {
-		setTimeout( () => searchFirstText( pastePatterns ) );
 	} );
 
 	editor.on( 'keydown', function( event ) {

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -250,12 +250,11 @@ registerBlockType(
 		transforms: {
 			from: [
 				{
-					type: 'pattern',
-					trigger: 'paste',
-					regExp: /^\s*(https?:\/\/\S+)\s*/i,
-					transform: ( { match } ) => {
+					type: 'raw',
+					isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*/i.test( node.textContent ),
+					transform: ( node ) => {
 						return createBlock( 'core/embed', {
-							url: match[ 1 ],
+							url: node.textContent.trim(),
 						} );
 					},
 				},

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -1,4 +1,3 @@
-import './paragraph';
 import './image';
 import './gallery';
 import './heading';
@@ -23,3 +22,4 @@ import './verse';
 import './video';
 import './audio';
 import './reusable-block';
+import './paragraph';


### PR DESCRIPTION
## Description
This PR changes several things regarding the pasting of URLs.

1. Instead of using TinyMCE's link-over-word paste, add it to Gutenberg, and add the behaviour of core which ignores whitespace and empty/wrapping HTML tags.

   https://github.com/WordPress/WordPress/blob/06fa4161aa74619239cf27017d124081c825684a/wp-includes/js/tinymce/plugins/wplink/plugin.js#L320-L336

2. Remove the 'paste' transformation type from the patterns plugin, and instead use the raw handler. This will allow URLs to be embedded from paste and raw handling in general, not just pasting a URL on an empty line. The paste transform was kind of an odd hack in the patterns plugin.

One thing that is a bit awkward is that the order of registration matters. This is similar to the `<pre>` and `<pre><code>` tags. I'm not sure what the best solution is other than ensuring the right order (also register plugins first), or adding a condition to the paragraph block to ignore ones with a URL (bad imo).

## How Has This Been Tested?
* Paste a (e.g. YouTube) URL on an empty line. Should embed.
* Create an old post (or similar) with a URL on its own line. Paste in Gutenberg. Should embed.
* Paste a URL in the classic editor block. Convert to blocks. Should keep embed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.