### PR TITLE
Don't load isSidebarOpened preference from localStorage on mobile.

### DIFF
--- a/editor/constants.js
+++ b/editor/constants.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import scssVariables from '!!sass-variables-loader!./assets/stylesheets/_variables.scss';
+
+export const BREAK_HUGE = parseInt( scssVariables.breakHuge );
+export const BREAK_WIDE = parseInt( scssVariables.breakWide );
+export const BREAK_LARGE = parseInt( scssVariables.breakLarge );
+export const BREAK_MEDIUM = parseInt( scssVariables.breakMedium );
+export const BREAK_SMALL = parseInt( scssVariables.breakSmall );
+export const BREAK_MOBILE = parseInt( scssVariables.breakMobile );
+

--- a/editor/store.js
+++ b/editor/store.js
@@ -10,6 +10,7 @@ import { flowRight } from 'lodash';
  * Internal dependencies
  */
 import effects from './effects';
+import { mobileMiddleware } from './utils/mobile';
 import reducer from './reducer';
 import storePersist from './store-persist';
 import { PREFERENCES_DEFAULTS } from './store-defaults';
@@ -33,6 +34,7 @@ function createReduxStore( preloadedState ) {
 			storageKey: GUTENBERG_PREFERENCES_KEY,
 			defaults: PREFERENCES_DEFAULTS,
 		} ),
+		applyMiddleware( mobileMiddleware ),
 	];
 
 	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {

--- a/editor/utils/mobile/README.md
+++ b/editor/utils/mobile/README.md
@@ -1,0 +1,15 @@
+mobileMiddleware
+===========
+
+`mobileMiddleware` is a very simple [redux middleware](https://redux.js.org/docs/advanced/Middleware.html) that sets the isSidebarOpened flag to false on REDUX_REHYDRATE payloads. 
+This useful to make isSidebarOpened false on mobile even if the value that was saved to local storage was true.
+The middleware just needs to be added to the enhancers list:
+
+```js
+	const enhancers = [
+		...
+		applyMiddleware( mobileMiddleware ),
+	];
+	...
+	const store = createStore( reducer, flowRight( enhancers ) );
+```

--- a/editor/utils/mobile/index.js
+++ b/editor/utils/mobile/index.js
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import { BREAK_MEDIUM } from '../../constants';
+
+/**
+ * Checks if we are in a mobile resolution using window.innerWidth if available
+ *
+ * @return {Boolean}  Returns true if on mobile resolution and false if on non mobile or impossible to check.
+ */
+const isMobileChecker = () => 'object' === typeof window && window.innerWidth < BREAK_MEDIUM;
+
+/**
+ * Disables isSidebarOpened on rehydrate payload if the user is on a mobile screen size.
+ *
+ * @param  {Object}  payload   rehydrate payload
+ * @param  {Boolean} isMobile  flag indicating if executing on mobile screen sizes or not
+ *
+ * @return {Object}            rehydrate payload with isSidebarOpened disabled if on mobile
+ */
+export const disableIsSidebarOpenedOnMobile = ( payload, isMobile = isMobileChecker() ) => (
+	isMobile ? { ...payload, isSidebarOpened: false } : payload
+);
+
+/**
+ * Middleware
+ */
+
+export const mobileMiddleware = () => next => action => {
+	if ( action.type === 'REDUX_REHYDRATE' ) {
+		return next( {
+			type: 'REDUX_REHYDRATE',
+			payload: disableIsSidebarOpenedOnMobile( action.payload ),
+		} );
+	}
+	return next( action );
+};

--- a/editor/utils/mobile/test/mobile.js
+++ b/editor/utils/mobile/test/mobile.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import { disableIsSidebarOpenedOnMobile } from '../';
+
+describe( 'disableIsSidebarOpenOnMobile()', () => {
+	it( 'should disable isSidebarOpen on mobile and keep other properties as before', () => {
+		const input = {
+				isSidebarOpened: true,
+				dummyPref: 'dummy',
+			},
+			output = {
+				isSidebarOpened: false,
+				dummyPref: 'dummy',
+			},
+			isMobile = true;
+
+		expect( disableIsSidebarOpenedOnMobile( input, isMobile ) ).toEqual( output );
+	} );
+
+	it( 'should keep isSidebarOpen on non-mobile and keep other properties as before', () => {
+		const input = {
+				isSidebarOpened: true,
+				dummy: 'non-dummy',
+			},
+			output = {
+				isSidebarOpened: true,
+				dummy: 'non-dummy',
+			},
+			isMobile = false;
+		expect( disableIsSidebarOpenedOnMobile( input, isMobile ) ).toEqual( output );
+	} );
+} );

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-markdown": "2.5.0",
     "react-test-renderer": "16.0.0",
     "sass-loader": "6.0.6",
+    "sass-variables-loader": "0.1.3",
     "style-loader": "0.18.2",
     "tinymce": "4.7.2",
     "webpack": "3.8.1"


### PR DESCRIPTION
## Description
This PR aims to close https://github.com/WordPress/gutenberg/issues/2816. When loading preferences from the localStorage if we are on mobile it sets isSidebarOpened to false instead of using what is stored. The technique used to define if we are on mobile is the same that is already used to set the default value for the isSidebarOpened when not loading from localStorage.

## Testing
Resize your window on to mobile sizes (or test on mobile). Open sidebar if it is not already open. Refresh the page and see sidebar is now closed.
Verify that other preferences are still persisted e.g visual/text mode.