### PR TITLE
Close sidebar when resizing from non mobile to mobile

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -335,11 +335,13 @@ export function stopTyping() {
 /**
  * Returns an action object used in signalling that the user toggled the sidebar
  *
- * @return {Object}         Action object
+ * @param  {Boolean} isMobile  Flag indicating if we are in mobile context
+ * @return {Object}            Action object
  */
-export function toggleSidebar() {
+export function toggleSidebar( isMobile ) {
 	return {
 		type: 'TOGGLE_SIDEBAR',
+		isMobile,
 	};
 }
 

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -483,9 +483,10 @@ export function blockInsertionPoint( state = {}, action ) {
 export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_SIDEBAR':
+			const isSidebarOpenedKey = action.isMobile ? 'isSidebarOpenedMobile' : 'isSidebarOpened';
 			return {
 				...state,
-				isSidebarOpened: ! state.isSidebarOpened,
+				[ isSidebarOpenedKey ]: ! state[ isSidebarOpenedKey ],
 			};
 		case 'TOGGLE_SIDEBAR_PANEL':
 			return {
@@ -676,7 +677,7 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 	}
 }
 
-// Create responsive reducer with lib default breakpoints excluding small where we are currently using 782.
+// Create responsive reducer with the breakpoints imported from the scss variables file.
 const responsive = createResponsiveStateReducer( {
 	mobile: BREAK_MOBILE,
 	small: BREAK_SMALL,
@@ -685,6 +686,7 @@ const responsive = createResponsiveStateReducer( {
 	wide: BREAK_WIDE,
 	huge: BREAK_HUGE,
 } );
+
 export const reusableBlocks = combineReducers( {
 	data( state = {}, action ) {
 		switch ( action.type ) {

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -3,6 +3,7 @@
  */
 import optimist from 'redux-optimist';
 import { combineReducers } from 'redux';
+import { createResponsiveStateReducer } from 'redux-responsive';
 import {
 	flow,
 	partialRight,
@@ -31,6 +32,14 @@ import { getBlockTypes, getBlockType } from '@wordpress/blocks';
 import withHistory from './utils/with-history';
 import withChangeDetection from './utils/with-change-detection';
 import { PREFERENCES_DEFAULTS } from './store-defaults';
+import {
+	BREAK_HUGE,
+	BREAK_WIDE,
+	BREAK_LARGE,
+	BREAK_MEDIUM,
+	BREAK_SMALL,
+	BREAK_MOBILE,
+} from './constants';
 
 /***
  * Module constants
@@ -667,6 +676,15 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 	}
 }
 
+// Create responsive reducer with lib default breakpoints excluding small where we are currently using 782.
+const responsive = createResponsiveStateReducer( {
+	mobile: BREAK_MOBILE,
+	small: BREAK_SMALL,
+	medium: BREAK_MEDIUM,
+	large: BREAK_LARGE,
+	wide: BREAK_WIDE,
+	huge: BREAK_HUGE,
+} );
 export const reusableBlocks = combineReducers( {
 	data( state = {}, action ) {
 		switch ( action.type ) {
@@ -730,5 +748,6 @@ export default optimist( combineReducers( {
 	saving,
 	notices,
 	metaBoxes,
+	responsive,
 	reusableBlocks,
 } ) );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -131,7 +131,9 @@ export function getPreference( state, preferenceKey, defaultValue ) {
  * @return {Boolean}       Whether sidebar is open
  */
 export function isEditorSidebarOpened( state ) {
-	return getPreference( state, 'isSidebarOpened' );
+	return isMobile( state ) ?
+		getPreference( state, 'isSidebarOpenedMobile' ) :
+		getPreference( state, 'isSidebarOpened' );
 }
 
 /**
@@ -198,6 +200,16 @@ export function isEditedPostDirty( state ) {
  */
 export function isCleanNewPost( state ) {
 	return ! isEditedPostDirty( state ) && isEditedPostNew( state );
+}
+
+/**
+ * Returns true if the current window size corresponds to mobile resolutions (<= medium breakpoint)
+ *
+ * @param  {Object}  state Global application state
+ * @return {Boolean}       Whether current window size corresponds to mobile resolutions
+ */
+export function isMobile( state ) {
+	return ! state.responsive.greaterThan.medium;
 }
 
 /**

--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -1,11 +1,7 @@
-/**
- * WordPress dependencies
- */
-import { viewPort } from '@wordpress/utils';
-
 export const PREFERENCES_DEFAULTS = {
 	mode: 'visual',
-	isSidebarOpened: ! viewPort.isExtraSmall(),
+	isSidebarOpened: true,
+	isSidebarOpenedMobile: false,
 	panels: { 'post-status': true },
 	recentlyUsedBlocks: [],
 	blockUsage: {},

--- a/editor/store.js
+++ b/editor/store.js
@@ -5,6 +5,7 @@ import { applyMiddleware, createStore } from 'redux';
 import refx from 'refx';
 import multi from 'redux-multi';
 import { flowRight } from 'lodash';
+import { responsiveStoreEnhancer } from 'redux-responsive';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ const GUTENBERG_PREFERENCES_KEY = `GUTENBERG_PREFERENCES_${ window.userSettings.
 function createReduxStore( preloadedState ) {
 	const enhancers = [
 		applyMiddleware( multi, refx( effects ) ),
+		responsiveStoreEnhancer,
 		storePersist( {
 			reducerKey: 'preferences',
 			storageKey: GUTENBERG_PREFERENCES_KEY,

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -908,6 +908,15 @@ describe( 'state', () => {
 			expect( state ).toEqual( { isSidebarOpened: true } );
 		} );
 
+		it( 'should toggle the mobile sidebar open flag', () => {
+			const state = preferences( deepFreeze( { isSidebarOpenedMobile: false } ), {
+				type: 'TOGGLE_SIDEBAR',
+				isMobile: true,
+			} );
+
+			expect( state ).toEqual( { isSidebarOpenedMobile: true } );
+		} );
+
 		it( 'should set the sidebar panel open flag to true if unset', () => {
 			const state = preferences( deepFreeze( { isSidebarOpened: false } ), {
 				type: 'TOGGLE_SIDEBAR_PANEL',

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -894,6 +894,7 @@ describe( 'state', () => {
 				recentlyUsedBlocks: [],
 				mode: 'visual',
 				isSidebarOpened: true,
+				isSidebarOpenedMobile: false,
 				panels: { 'post-status': true },
 				features: { fixedToolbar: false },
 			} );

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -36,6 +36,7 @@ import {
 	isEditedPostPublishable,
 	isEditedPostSaveable,
 	isEditedPostBeingScheduled,
+	isMobile,
 	getEditedPostPreviewLink,
 	getBlock,
 	getBlocks,
@@ -320,17 +321,64 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditorSidebarOpened', () => {
-		it( 'should return true when the sidebar is opened', () => {
+		it( 'should return true when is not mobile and the normal sidebar is opened', () => {
 			const state = {
-				preferences: { isSidebarOpened: true },
+				responsive: {
+					greaterThan: {
+						medium: true,
+					},
+				},
+				preferences: {
+					isSidebarOpened: true,
+					isSidebarOpenedMobile: false,
+				},
 			};
 
 			expect( isEditorSidebarOpened( state ) ).toBe( true );
 		} );
 
-		it( 'should return false when the sidebar is opened', () => {
+		it( 'should return false when is not mobile and the normal sidebar is closed', () => {
 			const state = {
-				preferences: { isSidebarOpened: false },
+				responsive: {
+					greaterThan: {
+						medium: true,
+					},
+				},
+				preferences: {
+					isSidebarOpened: false,
+				},
+			};
+
+			expect( isEditorSidebarOpened( state ) ).toBe( false );
+		} );
+
+		it( 'should return true when is mobile and the mobile sidebar is opened', () => {
+			const state = {
+				responsive: {
+					greaterThan: {
+						medium: false,
+					},
+				},
+				preferences: {
+					isSidebarOpened: false,
+					isSidebarOpenedMobile: true,
+				},
+			};
+
+			expect( isEditorSidebarOpened( state ) ).toBe( true );
+		} );
+
+		it( 'should return false when is mobile and the mobile sidebar is closed', () => {
+			const state = {
+				responsive: {
+					greaterThan: {
+						medium: false,
+					},
+				},
+				preferences: {
+					isSidebarOpened: true,
+					isSidebarOpenedMobile: false,
+				},
 			};
 
 			expect( isEditorSidebarOpened( state ) ).toBe( false );
@@ -550,6 +598,32 @@ describe( 'selectors', () => {
 			};
 
 			expect( isCleanNewPost( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isMobile', () => {
+		it( 'should return true if resolution is equal or less than medium breakpoint', () => {
+			const state = {
+				responsive: {
+					greaterThan: {
+						medium: false,
+					},
+				},
+			};
+
+			expect( isMobile( state ) ).toBe( true );
+		} );
+
+		it( 'should return true if resolution is greater than medium breakpoint', () => {
+			const state = {
+				responsive: {
+					greaterThan: {
+						medium: true,
+					},
+				},
+			};
+
+			expect( isMobile( state ) ).toBe( false );
 		} );
 	} );
 

--- a/editor/utils/mobile/index.js
+++ b/editor/utils/mobile/index.js
@@ -1,16 +1,4 @@
 /**
- * Internal dependencies
- */
-import { BREAK_MEDIUM } from '../../constants';
-
-/**
- * Checks if we are in a mobile resolution using window.innerWidth if available
- *
- * @return {Boolean}  Returns true if on mobile resolution and false if on non mobile or impossible to check.
- */
-const isMobileChecker = () => 'object' === typeof window && window.innerWidth < BREAK_MEDIUM;
-
-/**
  * Disables isSidebarOpened on rehydrate payload if the user is on a mobile screen size.
  *
  * @param  {Object}  payload   rehydrate payload
@@ -18,8 +6,8 @@ const isMobileChecker = () => 'object' === typeof window && window.innerWidth < 
  *
  * @return {Object}            rehydrate payload with isSidebarOpened disabled if on mobile
  */
-export const disableIsSidebarOpenedOnMobile = ( payload, isMobile = isMobileChecker() ) => (
-	isMobile ? { ...payload, isSidebarOpened: false } : payload
+export const disableIsSidebarOpenedOnMobile = ( payload ) => (
+	payload.isSidebarOpenedMobile ? { ...payload, isSidebarOpenedMobile: false } : payload
 );
 
 /**

--- a/editor/utils/mobile/index.js
+++ b/editor/utils/mobile/index.js
@@ -1,4 +1,10 @@
 /**
+ * Internal dependencies
+ */
+import { isMobile } from '../../selectors';
+import { toggleSidebar } from '../../actions';
+
+/**
  * Disables isSidebarOpened on rehydrate payload if the user is on a mobile screen size.
  *
  * @param  {Object}  payload   rehydrate payload
@@ -14,12 +20,15 @@ export const disableIsSidebarOpenedOnMobile = ( payload ) => (
  * Middleware
  */
 
-export const mobileMiddleware = () => next => action => {
+export const mobileMiddleware = ( { getState } ) => next => action => {
 	if ( action.type === 'REDUX_REHYDRATE' ) {
 		return next( {
 			type: 'REDUX_REHYDRATE',
 			payload: disableIsSidebarOpenedOnMobile( action.payload ),
 		} );
+	}
+	if ( action.type === 'TOGGLE_SIDEBAR' && action.isMobile === undefined ) {
+		return next( toggleSidebar( isMobile( getState() ) ) );
 	}
 	return next( action );
 };

--- a/editor/utils/mobile/test/mobile.js
+++ b/editor/utils/mobile/test/mobile.js
@@ -4,21 +4,32 @@
 import { disableIsSidebarOpenedOnMobile } from '../';
 
 describe( 'disableIsSidebarOpenOnMobile()', () => {
-	it( 'should disable isSidebarOpen on mobile and keep other properties as before', () => {
+	it( 'should disable isSidebarOpenedMobile and keep other properties as before', () => {
 		const input = {
-				isSidebarOpened: true,
+				isSidebarOpenedMobile: true,
 				dummyPref: 'dummy',
 			},
 			output = {
-				isSidebarOpened: false,
+				isSidebarOpenedMobile: false,
 				dummyPref: 'dummy',
-			},
-			isMobile = true;
+			};
 
-		expect( disableIsSidebarOpenedOnMobile( input, isMobile ) ).toEqual( output );
+		expect( disableIsSidebarOpenedOnMobile( input ) ).toEqual( output );
 	} );
 
-	it( 'should keep isSidebarOpen on non-mobile and keep other properties as before', () => {
+	it( 'should keep isSidebarOpenedMobile as false if it was false', () => {
+		const input = {
+				isSidebarOpenedMobile: false,
+				dummy: 'non-dummy',
+			},
+			output = {
+				isSidebarOpenedMobile: false,
+				dummy: 'non-dummy',
+			};
+		expect( disableIsSidebarOpenedOnMobile( input ) ).toEqual( output );
+	} );
+
+	it( 'should not make any change if the payload does not contain isSidebarOpenedMobile flag', () => {
 		const input = {
 				isSidebarOpened: true,
 				dummy: 'non-dummy',
@@ -26,8 +37,7 @@ describe( 'disableIsSidebarOpenOnMobile()', () => {
 			output = {
 				isSidebarOpened: true,
 				dummy: 'non-dummy',
-			},
-			isMobile = false;
-		expect( disableIsSidebarOpenedOnMobile( input, isMobile ) ).toEqual( output );
+			};
+		expect( disableIsSidebarOpenedOnMobile( input ) ).toEqual( output );
 	} );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7167,6 +7167,11 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
     },
+    "mediaquery": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mediaquery/-/mediaquery-0.0.3.tgz",
+      "integrity": "sha1-OH1hwQqpX/TWkH9qq90i16iY4D4="
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -8660,6 +8665,14 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/redux-optimist/-/redux-optimist-0.0.2.tgz",
       "integrity": "sha1-cNoX6GPFOoYE1YHKIKJpCL2haX4="
+    },
+    "redux-responsive": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/redux-responsive/-/redux-responsive-4.3.4.tgz",
+      "integrity": "sha1-/PbcMCUKyIKrXoYCK6XGp8hJkYs=",
+      "requires": {
+        "mediaquery": "0.0.3"
+      }
     },
     "refx": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "redux": "3.7.2",
     "redux-multi": "0.1.12",
     "redux-optimist": "0.0.2",
+    "redux-responsive": "4.3.4",
     "refx": "2.1.0",
     "rememo": "2.3.3",
     "showdown": "1.7.4",


### PR DESCRIPTION
## Description
This PR aims to close https://github.com/WordPress/gutenberg/issues/1535. It adds a new feature that automatically closes the sidebar when resizing from non-mobile to mobile sizes.

Thanks to a suggestion by @youknowriad this PR now adds redux-responsive. It simplified the implementation of the feature.

## How Has This Been Tested?
With sidebar open resize your window to a small size < 782. Verify that the sidebar automatically closes.
Open the sidebar see that you can open and close it in mobile sizes. Resize your window in small sizes with sidebar open and verify it does not close automatically. It only should close when going from big sizes > 782 to small sizes < 782.

## Notes
The layout component was refactored to be class. I was asking my self if this logic should be on layout component or sidebar component. I decided on layout component to be more general and later we may want to add more resize actions that do not affect just the sidebar.