### PR TITLE
Testing: Optimize e2e testing path navigation

### DIFF
--- a/test/e2e/integration/001-hello-gutenberg.js
+++ b/test/e2e/integration/001-hello-gutenberg.js
@@ -1,13 +1,9 @@
 describe( 'Hello Gutenberg', () => {
 	before( () => {
-		cy.login();
+		cy.newPost();
 	} );
 
 	it( 'Should show the New Post Page in Gutenberg', () => {
-		// Navigate to New Post
-		cy.get( '.wp-menu-name' ).contains( 'Posts' ).click();
-		cy.get( '.wp-submenu a' ).contains( 'Add New' ).click();
-
 		// Assertions
 		cy.url().should( 'include', 'post-new.php' );
 		cy.get( '[placeholder="Add title"]' ).should( 'exist' );

--- a/test/e2e/integration/002-adding-blocks.js
+++ b/test/e2e/integration/002-adding-blocks.js
@@ -1,6 +1,5 @@
 describe( 'Adding blocks', () => {
 	before( () => {
-		cy.login();
 		cy.newPost();
 	} );
 

--- a/test/e2e/support/gutenberg-commands.js
+++ b/test/e2e/support/gutenberg-commands.js
@@ -1,3 +1,11 @@
 Cypress.Commands.add( 'newPost', () => {
-	cy.visit( '/wp-admin/post-new.php' );
+	cy.visitAdmin( '/post-new.php' );
+} );
+
+Cypress.Commands.add( 'visitAdmin', ( adminPath ) => {
+	cy.visit( '/wp-admin/' + adminPath ).location( 'pathname' ).then( ( path ) => {
+		if ( path === '/wp-login.php' ) {
+			cy.login();
+		}
+	} );
 } );

--- a/test/e2e/support/index.js
+++ b/test/e2e/support/index.js
@@ -1,2 +1,6 @@
 import './user-commands';
 import './gutenberg-commands';
+
+Cypress.Cookies.defaults( {
+	whitelist: /^wordpress_/,
+} );

--- a/test/e2e/support/user-commands.js
+++ b/test/e2e/support/user-commands.js
@@ -3,7 +3,11 @@ Cypress.Commands.add( 'login', ( username = Cypress.env( 'username' ), password 
 	// and fake it by calling an API and setting a cookie
 	// (not sure this is possible in WP)
 
-	cy.visit( '/wp-admin' );
+	cy.location( 'pathname' ).then( ( path ) => {
+		if ( path !== '/wp-login.php' ) {
+			cy.visit( '/wp-login.php' );
+		}
+	} );
 	cy.get( '#user_login' ).type( username );
 	cy.get( '#user_pass' ).type( password );
 	cy.get( '#wp-submit' ).click();


### PR DESCRIPTION
Related: #3069

This pull request seeks to improve e2e testing performance in two ways:

- Creating a generic `visitAdmin` command which automatically handles login behavior, preserving `redirect_to` of the desired screen to avoid navigating from the admin dashboard root after a login.
- Preserving the WordPress session cookies between tests via a `Cypress.Cookies.defaults` whitelist, to avoid logins between tests

__Testing instructions:__

Verify that e2e tests pass:

If you don't already have the local Docker environment set-up, first ensure Docker is installed, then run `./bin/setup-local-env.sh`

Finally, run `npm run test-e2e`