### PR TITLE
fix/2896: Ellipse operator did not copy properties from DomRect

### DIFF
--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -143,12 +143,18 @@ class Popover extends Component {
 		const { paddingTop, paddingBottom } = window.getComputedStyle( anchor.parentNode );
 		const topPad = parseInt( paddingTop, 10 );
 		const bottomPad = parseInt( paddingBottom, 10 );
+		const top = rect.top + topPad;
+		const height = rect.height - topPad - bottomPad;
 		return {
-			...rect,
-			top: rect.top + topPad,
-			bottom: rect.bottom - bottomPad,
-			height: rect.height - topPad - bottomPad,
-		};
+			x: rect.left,
+			y: top,
+			width: rect.width,
+			height: height,
+			left: rect.left,
+			right: rect.right,
+			top: top,
+			bottom: top + height
+		}
 	}
 
 	setOffset() {

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -153,8 +153,8 @@ class Popover extends Component {
 			left: rect.left,
 			right: rect.right,
 			top: top,
-			bottom: top + height
-		}
+			bottom: top + height,
+		};
 	}
 
 	setOffset() {

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -143,17 +143,15 @@ class Popover extends Component {
 		const { paddingTop, paddingBottom } = window.getComputedStyle( anchor.parentNode );
 		const topPad = parseInt( paddingTop, 10 );
 		const bottomPad = parseInt( paddingBottom, 10 );
-		const top = rect.top + topPad;
-		const height = rect.height - topPad - bottomPad;
 		return {
 			x: rect.left,
-			y: top,
+			y: rect.top + topPad,
 			width: rect.width,
-			height: height,
+			height: rect.height - topPad - bottomPad,
 			left: rect.left,
 			right: rect.right,
-			top: top,
-			bottom: top + height,
+			top: rect.top + topPad,
+			bottom: rect.bottom - bottomPad,
 		};
 	}
 


### PR DESCRIPTION
## Description
PR #2896 caused a bug because it used the ellipse operator to copy properties from a DomRect but that apparently does not work. This meant that the popover did not have the correct x-axis position.
I have updated the code to avoid the "..." operator which resolves the problem.
<!-- Please describe your changes -->

## How Has This Been Tested?
Manually verified.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Bug fix.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.