### PR TITLE
FIX: Remove image resizing on mobile

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -17,7 +17,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { mediaUpload, createMediaFromFile, getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
-import { mediaUpload,  } from '@wordpress/utils';
 import {
 	Placeholder,
 	Dashicon,

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -16,7 +16,8 @@ import {
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { mediaUpload, createMediaFromFile, getBlobByURL, revokeBlobURL } from '@wordpress/utils';
+import { mediaUpload, createMediaFromFile, getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
+import { mediaUpload,  } from '@wordpress/utils';
 import {
 	Placeholder,
 	Dashicon,
@@ -109,7 +110,7 @@ class ImageBlock extends Component {
 
 		const availableSizes = this.getAvailableSizes();
 		const figureStyle = width ? { width } : {};
-		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1;
+		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && ( ! viewPort.isExtraSmall() );
 		const uploadButtonProps = { isLarge: true };
 		const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setAttributes );
 		const dropFiles = ( files ) => mediaUpload( files, setAttributes );

--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -1,7 +1,9 @@
+import { viewPort } from '../utils';
+
 export const STORE_DEFAULTS = {
 	preferences: {
 		mode: 'visual',
-		isSidebarOpened: window.innerWidth >= 782,
+		isSidebarOpened: ! viewPort.isExtraSmall(),
 		panels: { 'post-status': true },
 		recentlyUsedBlocks: [],
 		blockUsage: {},

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,6 @@
 import * as focus from './focus';
 import * as keycodes from './keycodes';
+import * as viewPort from './viewport';
 import { decodeEntities } from './entities';
 
 export { focus };
@@ -8,3 +9,5 @@ export { decodeEntities };
 
 export * from './blob-cache';
 export * from './mediaupload';
+
+export { viewPort };

--- a/utils/viewport.js
+++ b/utils/viewport.js
@@ -1,3 +1,3 @@
 export function isExtraSmall() {
-	return window && window.innerWidth < 768;
+	return window && window.innerWidth < 782;
 }

--- a/utils/viewport.js
+++ b/utils/viewport.js
@@ -1,0 +1,3 @@
+export function isExtraSmall() {
+	return window && window.innerWidth < 768;
+}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
fixes https://github.com/WordPress/gutenberg/issues/2675

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manual testing on devices

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix - Image resizing disabled on extra small devices (< 768px)
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.