### PR TITLE
Add multi-block transform functionality.

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -85,8 +85,14 @@ export function switchToBlockType( blocks, name ) {
 	const transformationsFrom = get( destinationType, 'transforms.from', [] );
 	const transformationsTo = get( sourceType, 'transforms.to', [] );
 	const transformation =
-		find( transformationsTo, t => t.type === 'block' && t.blocks.indexOf( name ) !== -1 && ( ! isMultiBlock || t.isMultiBlock ) ) ||
-		find( transformationsFrom, t => t.type === 'block' && t.blocks.indexOf( sourceName ) !== -1 && ( ! isMultiBlock || t.isMultiBlock ) );
+		find(
+			transformationsTo,
+			t => t.type === 'block' && t.blocks.indexOf( name ) !== -1 && ( ! isMultiBlock || t.isMultiBlock )
+		) ||
+		find(
+			transformationsFrom,
+			t => t.type === 'block' && t.blocks.indexOf( sourceName ) !== -1 && ( ! isMultiBlock || t.isMultiBlock )
+		);
 
 	// Stop if there is no valid transformation. (How did we get here?)
 	if ( ! transformation ) {

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -3,6 +3,7 @@
  */
 import uuid from 'uuid/v4';
 import {
+	every,
 	get,
 	reduce,
 	castArray,
@@ -61,29 +62,42 @@ export function createBlock( name, blockAttributes = {} ) {
 }
 
 /**
- * Switch a block into one or more blocks of the new block type.
+ * Switch one or more blocks into one or more blocks of the new block type.
  *
- * @param  {Object} block      Block object
+ * @param  {Array}  blocks     Blocks array
  * @param  {string} name       Block name
  * @return {Array}             Block object
  */
-export function switchToBlockType( block, name ) {
+export function switchToBlockType( blocks, name ) {
+	const isMultiBlock = blocks.length > 1;
+	const fistBlock = blocks[ 0 ];
+	const sourceName = fistBlock.name;
+
+	if ( isMultiBlock && ! every( blocks, ( block ) => ( block.name === sourceName ) ) ) {
+		return null;
+	}
+
 	// Find the right transformation by giving priority to the "to"
 	// transformation.
 	const destinationType = getBlockType( name );
-	const sourceType = getBlockType( block.name );
+	const sourceType = getBlockType( sourceName );
 	const transformationsFrom = get( destinationType, 'transforms.from', [] );
 	const transformationsTo = get( sourceType, 'transforms.to', [] );
 	const transformation =
-		find( transformationsTo, t => t.type === 'block' && t.blocks.indexOf( name ) !== -1 ) ||
-		find( transformationsFrom, t => t.type === 'block' && t.blocks.indexOf( block.name ) !== -1 );
+		find( transformationsTo, t => t.type === 'block' && t.blocks.indexOf( name ) !== -1 && ( ! isMultiBlock || t.isMultiBlock ) ) ||
+		find( transformationsFrom, t => t.type === 'block' && t.blocks.indexOf( sourceName ) !== -1 && ( ! isMultiBlock || t.isMultiBlock ) );
 
 	// Stop if there is no valid transformation. (How did we get here?)
 	if ( ! transformation ) {
 		return null;
 	}
 
-	let transformationResults = transformation.transform( block.attributes );
+	let transformationResults;
+	if ( transformation.isMultiBlock ) {
+		transformationResults = transformation.transform( blocks.map( ( currentBlock ) => currentBlock.attributes ) );
+	} else {
+		transformationResults = transformation.transform( fistBlock.attributes );
+	}
 
 	// Ensure that the transformation function returned an object or an array
 	// of objects.
@@ -112,7 +126,7 @@ export function switchToBlockType( block, name ) {
 	return transformationResults.map( ( result, index ) => ( {
 		...result,
 		// The first transformed block whose type matches the "destination"
-		// type gets to keep the existing block's UID.
-		uid: index === firstSwitchedBlock ? block.uid : result.uid,
+		// type gets to keep the existing UID of the first block.
+		uid: index === firstSwitchedBlock ? fistBlock.uid : result.uid,
 	} ) );
 }

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -64,16 +64,17 @@ export function createBlock( name, blockAttributes = {} ) {
 /**
  * Switch one or more blocks into one or more blocks of the new block type.
  *
- * @param  {Array}  blocks     Blocks array
- * @param  {string} name       Block name
- * @return {Array}             Block object
+ * @param  {Array|Object}  blocks     Blocks array or block object
+ * @param  {string}        name       Block name
+ * @return {Array}                    Array of blocks
  */
 export function switchToBlockType( blocks, name ) {
-	const isMultiBlock = blocks.length > 1;
-	const fistBlock = blocks[ 0 ];
+	const blocksArray = castArray( blocks );
+	const isMultiBlock = blocksArray.length > 1;
+	const fistBlock = blocksArray[ 0 ];
 	const sourceName = fistBlock.name;
 
-	if ( isMultiBlock && ! every( blocks, ( block ) => ( block.name === sourceName ) ) ) {
+	if ( isMultiBlock && ! every( blocksArray, ( block ) => ( block.name === sourceName ) ) ) {
 		return null;
 	}
 
@@ -94,7 +95,7 @@ export function switchToBlockType( blocks, name ) {
 
 	let transformationResults;
 	if ( transformation.isMultiBlock ) {
-		transformationResults = transformation.transform( blocks.map( ( currentBlock ) => currentBlock.attributes ) );
+		transformationResults = transformation.transform( blocksArray.map( ( currentBlock ) => currentBlock.attributes ) );
 	} else {
 		transformationResults = transformation.transform( fistBlock.attributes );
 	}

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType, source } from '../../api';
+import { registerBlockType, source, createBlock } from '../../api';
 import { default as GalleryBlock, defaultColumnsNumber } from './block';
 
 const { query, attr } = source;
@@ -48,6 +48,16 @@ registerBlockType( 'core/gallery', {
 
 	transforms: {
 		from: [
+			{
+				type: 'block',
+				isMultiBlock: true,
+				blocks: [ 'core/image' ],
+				transform: ( blockAttributes ) => {
+					return createBlock( 'core/gallery', {
+						images: blockAttributes.map( ( { id, url, alt } ) => ( { id, url, alt } ) ),
+					} );
+				},
+			},
 			{
 				type: 'shortcode',
 				tag: 'gallery',

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -89,6 +89,15 @@ registerBlockType( 'core/gallery', {
 				},
 			},
 		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/image' ],
+				transform: ( { images } ) => (
+					images.map( ( { id, url, alt } ) => createBlock( 'core/image', { id, url, alt } ) )
+				),
+			},
+		],
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, flatMap } from 'lodash';
+import { find, compact, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -105,7 +105,7 @@ registerBlockType( 'core/list', {
 				transform: ( blockAttributes ) => {
 					return createBlock( 'core/list', {
 						nodeName: 'UL',
-						values: flatMap( blockAttributes, ( { content } ) => fromBrDelimitedContent( content ) ),
+						values: blockAttributes.map( ( { content }, index ) => ( <li key={ index }>{ content }</li> ) ),
 					} );
 				},
 			},
@@ -152,11 +152,9 @@ registerBlockType( 'core/list', {
 			{
 				type: 'block',
 				blocks: [ 'core/paragraph' ],
-				transform: ( { values } ) => {
-					return createBlock( 'core/paragraph', {
-						content: toBrDelimitedContent( values ),
-					} );
-				},
+				transform: ( { values } ) =>
+					compact( values.map( ( value ) => get( value, 'props.children', null ) ) )
+						.map( ( content ) => createBlock( 'core/paragraph', { content } ) ),
 			},
 			{
 				type: 'block',

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { find, flatMap } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -100,11 +100,12 @@ registerBlockType( 'core/list', {
 		from: [
 			{
 				type: 'block',
+				isMultiBlock: true,
 				blocks: [ 'core/paragraph' ],
-				transform: ( { content } ) => {
+				transform: ( blockAttributes ) => {
 					return createBlock( 'core/list', {
 						nodeName: 'UL',
-						values: fromBrDelimitedContent( content ),
+						values: flatMap( blockAttributes, ( { content } ) => fromBrDelimitedContent( content ) ),
 					} );
 				},
 			},

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -17,17 +17,18 @@ import { keycodes } from '@wordpress/utils';
  */
 import './style.scss';
 import { replaceBlocks } from '../actions';
-import { getBlock, getSelectedBlock, getSelectedBlockCount, getMultiSelectedBlocks } from '../selectors';
+import { getBlock } from '../selectors';
 
 /**
  * Module Constants
  */
 const { DOWN } = keycodes;
 
-function BlockSwitcher( { blocks, isMultiBlock, onTransform } ) {
+function BlockSwitcher( { blocks, onTransform } ) {
 	if ( ! blocks || ! blocks[ 0 ] ) {
 		return null;
 	}
+	const isMultiBlock = blocks.length > 1;
 	const sourceBlockName = blocks[ 0 ].name;
 
 	if ( isMultiBlock && ! every( blocks, ( block ) => ( block.name === sourceBlockName ) ) ) {
@@ -119,18 +120,14 @@ function BlockSwitcher( { blocks, isMultiBlock, onTransform } ) {
 
 export default connect(
 	( state, ownProps ) => {
-		const isMultiBlock = ! ownProps.uid && getSelectedBlockCount( state ) > 1;
-		const blocks = isMultiBlock ? getMultiSelectedBlocks( state ) :
-			[ getBlock( state, ownProps.uid ) || getSelectedBlock( state ) ];
 		return {
-			isMultiBlock,
-			blocks,
+			blocks: ownProps.uids.map( ( uid ) => getBlock( state, uid ) ),
 		};
 	},
-	( dispatch ) => ( {
+	( dispatch, ownProps ) => ( {
 		onTransform( blocks, name ) {
 			dispatch( replaceBlocks(
-				blocks.map( ( block ) => block.uid ),
+				ownProps.uids,
 				switchToBlockType( blocks, name )
 			) );
 		},

--- a/editor/block-switcher/index.js
+++ b/editor/block-switcher/index.js
@@ -38,11 +38,19 @@ function BlockSwitcher( { blocks, onTransform } ) {
 	const blockType = getBlockType( sourceBlockName );
 	const blocksToBeTransformedFrom = reduce( getBlockTypes(), ( memo, type ) => {
 		const transformFrom = get( type, 'transforms.from', [] );
-		const transformation = find( transformFrom, t => t.type === 'block' && t.blocks.indexOf( sourceBlockName ) !== -1 && ( ! isMultiBlock || t.isMultiBlock ) );
+		const transformation = find(
+			transformFrom,
+			t => t.type === 'block' && t.blocks.indexOf( sourceBlockName ) !== -1 &&
+				( ! isMultiBlock || t.isMultiBlock )
+		);
 		return transformation ? memo.concat( [ type.name ] ) : memo;
 	}, [] );
 	const blocksToBeTransformedTo = get( blockType, 'transforms.to', [] )
-		.reduce( ( memo, transformation ) => memo.concat( ! isMultiBlock || transformation.isMultiBlock ? transformation.blocks : [] ), [] );
+		.reduce(
+			( memo, transformation ) =>
+				memo.concat( ! isMultiBlock || transformation.isMultiBlock ? transformation.blocks : [] ),
+			[]
+		);
 	const allowedBlocks = uniq( blocksToBeTransformedFrom.concat( blocksToBeTransformedTo ) )
 		.reduce( ( memo, name ) => {
 			const type = getBlockType( name );

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -57,7 +57,7 @@ class BlockToolbar extends Component {
 		return (
 			<div className={ toolbarClassname }>
 				{ ! showMobileControls && mode === 'visual' && [
-					<BlockSwitcher key="switcher" uid={ block.uid } />,
+					<BlockSwitcher key="switcher" uids={ [ block.uid ] } />,
 					<Slot key="slot" name="Formatting.Toolbar" />,
 				] }
 				<Toolbar className="editor-block-toolbar__mobile-tools">

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -199,7 +199,7 @@ export default {
 		// thus, we transform the block to merge first
 		const blocksWithTheSameType = blockA.name === blockB.name ?
 			[ blockB ] :
-			switchToBlockType( [ blockB ], blockA.name );
+			switchToBlockType( blockB, blockA.name );
 
 		// If the block types can not match, do nothing
 		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -199,7 +199,7 @@ export default {
 		// thus, we transform the block to merge first
 		const blocksWithTheSameType = blockA.name === blockB.name ?
 			[ blockB ] :
-			switchToBlockType( blockB, blockA.name );
+			switchToBlockType( [ blockB ], blockA.name );
 
 		// If the block types can not match, do nothing
 		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -14,11 +14,12 @@ import { IconButton } from '@wordpress/components';
  */
 import './style.scss';
 import Inserter from '../../inserter';
+import BlockSwitcher from '../../block-switcher';
 import BlockToolbar from '../../block-toolbar';
 import NavigableToolbar from '../../navigable-toolbar';
-import { hasEditorUndo, hasEditorRedo, isFeatureActive } from '../../selectors';
+import { getSelectedBlockCount, hasEditorUndo, hasEditorRedo, isFeatureActive } from '../../selectors';
 
-function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo } ) {
+function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo, isMultiBlockSelection } ) {
 	return (
 		<NavigableToolbar
 			className="editor-header-toolbar"
@@ -35,6 +36,7 @@ function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo } ) {
 				label={ __( 'Redo' ) }
 				disabled={ ! hasRedo }
 				onClick={ redo } />
+			{ isMultiBlockSelection && <BlockSwitcher key="switcher" /> }
 			{ hasFixedToolbar && (
 				<div className="editor-header-toolbar__block-toolbar">
 					<BlockToolbar />
@@ -49,6 +51,7 @@ export default connect(
 		hasUndo: hasEditorUndo( state ),
 		hasRedo: hasEditorRedo( state ),
 		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
+		isMultiBlockSelection: getSelectedBlockCount( state ) > 1,
 	} ),
 	( dispatch ) => ( {
 		undo: () => dispatch( { type: 'UNDO' } ),

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -17,9 +17,9 @@ import Inserter from '../../inserter';
 import BlockSwitcher from '../../block-switcher';
 import BlockToolbar from '../../block-toolbar';
 import NavigableToolbar from '../../navigable-toolbar';
-import { getSelectedBlockCount, hasEditorUndo, hasEditorRedo, isFeatureActive } from '../../selectors';
+import { getMultiSelectedBlockUids, hasEditorUndo, hasEditorRedo, isFeatureActive } from '../../selectors';
 
-function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo, isMultiBlockSelection } ) {
+function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo, isMultiBlockSelection, selectedBlockUids } ) {
 	return (
 		<NavigableToolbar
 			className="editor-header-toolbar"
@@ -36,7 +36,7 @@ function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo, isMulti
 				label={ __( 'Redo' ) }
 				disabled={ ! hasRedo }
 				onClick={ redo } />
-			{ isMultiBlockSelection && <BlockSwitcher key="switcher" /> }
+			{ isMultiBlockSelection && <BlockSwitcher key="switcher" uids={ selectedBlockUids } /> }
 			{ hasFixedToolbar && (
 				<div className="editor-header-toolbar__block-toolbar">
 					<BlockToolbar />
@@ -47,12 +47,16 @@ function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo, isMulti
 }
 
 export default connect(
-	( state ) => ( {
-		hasUndo: hasEditorUndo( state ),
-		hasRedo: hasEditorRedo( state ),
-		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
-		isMultiBlockSelection: getSelectedBlockCount( state ) > 1,
-	} ),
+	( state ) => {
+		const selectedBlockUids = getMultiSelectedBlockUids( state );
+		return {
+			hasUndo: hasEditorUndo( state ),
+			hasRedo: hasEditorRedo( state ),
+			hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
+			isMultiBlockSelection: selectedBlockUids.length > 1,
+			selectedBlockUids,
+		};
+	},
 	( dispatch ) => ( {
 		undo: () => dispatch( { type: 'UNDO' } ),
 		redo: () => dispatch( { type: 'REDO' } ),

--- a/editor/header/header-toolbar/index.js
+++ b/editor/header/header-toolbar/index.js
@@ -36,7 +36,10 @@ function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo, isMulti
 				label={ __( 'Redo' ) }
 				disabled={ ! hasRedo }
 				onClick={ redo } />
-			{ isMultiBlockSelection && <BlockSwitcher key="switcher" uids={ selectedBlockUids } /> }
+			{ isMultiBlockSelection && (
+				<div className="editor-header-toolbar__block-toolbar">
+					<BlockSwitcher key="switcher" uids={ selectedBlockUids } />
+				</div> ) }
 			{ hasFixedToolbar && (
 				<div className="editor-header-toolbar__block-toolbar">
 					<BlockToolbar />

--- a/editor/header/header-toolbar/style.scss
+++ b/editor/header/header-toolbar/style.scss
@@ -10,6 +10,10 @@
 .editor-header-toolbar {
 	display: inline-flex;
 	align-items: center;
+
+	.editor-block-switcher .components-toolbar {
+		border: none;
+	}
 }
 
 .editor-header-toolbar__block-toolbar {


### PR DESCRIPTION
## Description
This PR's implements multi-block transform functionality. Allowing the user to transform a selection of multiple blocks into other block types. It changes blocks api. When specifying the transform the developer can set isMultiBlock to true to set that the transform is able to handle more than one block.
Multiblock transforms were already added to transform from multiple paragraphs into a list and multiple images into a gallery.

## Testing
Create multiple paragraphs, select them, go to the transform area and transform them into a list.
Add multiple images select them and transform them into a gallery.

## Screenshots:
![nov-06-2017 22-55-50](https://user-images.githubusercontent.com/11271197/32468570-b6f178a0-c346-11e7-83bc-bb490df887e0.gif)
![nov-06-2017 22-59-24](https://user-images.githubusercontent.com/11271197/32468578-be8fd354-c346-11e7-8750-0deb09e3c19d.gif)
