### PR TITLE
Blocks: Tweak the classic text block toolbar design

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -91,7 +91,7 @@
 	width: auto;
 	top: $header-height;
 	margin: 0;
-	margin-top: -$block-controls-height + 1px;
+	margin-top: -$block-controls-height;
 	border: 1px solid $light-gray-500;
 	z-index: z-index( '.freeform-toolbar' );
 	background-color: $white;

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -1,4 +1,6 @@
 .editor-visual-editor__block[data-type="core/freeform"] .blocks-editable__tinymce {
+	margin-top: $item-spacing;
+
 	p {
 		line-height: $editor-line-height;
 	}
@@ -56,7 +58,6 @@
 
 	&.mce-edit-focus {
 		outline: none;
-		margin-top: $item-spacing;
 	}
 
 	a {
@@ -86,21 +87,19 @@
 }
 
 .freeform-toolbar {
-	width: auto;
-	top: $header-height - 1px;
-	z-index: z-index( '.freeform-toolbar' );
 	position: sticky;
+	width: auto;
+	top: $header-height;
+	margin: 0;
+	margin-top: -$block-controls-height + 1px;
+	border: 1px solid $light-gray-500;
+	z-index: z-index( '.freeform-toolbar' );
+	background-color: $white;
+	min-height: $block-controls-height;
 
 	@include break-medium() {
 		top: $item-spacing;
 	}
-}
-
-.freeform-toolbar .mce-tinymce-inline {
-	margin: 0;
-	margin-top: -$block-controls-height - $block-padding;
-	border: 1px solid $light-gray-500;
-	background-color: $white;
 
 	@include break-small() {
 		margin-left: - $block-padding - 1px;

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -91,6 +91,7 @@ export default class OldEditor extends Component {
 			setAttributes( {
 				content: editor.getContent(),
 			} );
+			return false;
 		} );
 
 		editor.on( 'keydown', ( event ) => {
@@ -179,6 +180,7 @@ export default class OldEditor extends Component {
 				id={ id + '-toolbar' }
 				ref={ ref => this.ref = ref }
 				className="freeform-toolbar"
+				style={ ! focus ? { display: 'none' } : {} }
 			/>,
 			<div
 				key="editor"


### PR DESCRIPTION
This applies subtle changes to the classic text block toolbar to make it show and hide properly. In `master` The toolbar lingers when you click on another text block.

This also fixes its design a bit, no more jumps when you focus a classic text block.