### PR TITLE
Components: Remove findDOMNode usage from Autocomplete

### DIFF
--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -7,7 +7,7 @@ import { escapeRegExp, find, filter, map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, findDOMNode, renderToString } from '@wordpress/element';
+import { Component, renderToString } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -368,11 +368,8 @@ export class Autocomplete extends Component {
 		// native browser event has already bubbled so we can't stopPropagation
 		// and avoid Editable getting the event from TinyMCE, hence we must
 		// register a native event handler.
-		// Disable reason: Accessing the DOM node to add native event handlers.
-		// eslint-disable-next-line react/no-find-dom-node
-		const realNode = findDOMNode( this.node );
 		const handler = isListening ? 'addEventListener' : 'removeEventListener';
-		realNode[ handler ]( 'keydown', this.setSelectedIndex, true );
+		this.node[ handler ]( 'keydown', this.setSelectedIndex, true );
 	}
 
 	componentDidUpdate( prevProps, prevState ) {


### PR DESCRIPTION
This pull request seeks to refactor the Autocomplete component to drop use of `findDOMNode`, which is discouraged and flagged as error in our lint configuration. For the usage within this component, it is not necessarily and can be replaced with a direct reference to the assigned DOM `ref` callback value.

__Implementation notes:__

There's an assumption that `this.node` would not ever be assigned a `null` value (from `ref` unmounting behavior) since the `toggleKeyEvents` function is only called during the mounted lifecycle of the component. This was true before, and remains true with these changes.

__Testing instructions:__

Ensure that unit tests pass:

```
npm test
```

Verify that there is no regression in the behavior of block or user autocomplete, particularly in the opening, closing, and deletion of blocks (complete lifecycle of the components).