### PR TITLE
Reusable Blocks: Add reusable blocks effects

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -781,7 +781,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'wp-editor',
 		(
 			'jQuery.when( wp.api.init(), wp.api.init( { versionString: \'gutenberg/v1/\' } ) ).done( function() {'
-			. 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
 			. 'window._wpGutenbergEditor = wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
 			. '} );'
 		)

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -759,6 +759,11 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	), $meta_box_url );
 	wp_localize_script( 'wp-editor', '_wpMetaBoxUrl', $meta_box_url );
 
+	// Ensure that we've got jQuery.
+	if ( ! wp_script_is( 'jquery', 'done' ) ) {
+		wp_enqueue_script( 'jquery' );
+	}
+
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
 	$color_palette           = gutenberg_color_palette();
@@ -772,9 +777,14 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'colors'     => $color_palette,
 	);
 
-	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() {'
-		. 'window._wpGutenbergEditor = wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
-		. '} );'
+	wp_add_inline_script(
+		'wp-editor',
+		(
+			'jQuery.when( wp.api.init(), wp.api.init( { versionString: \'gutenberg/v1/\' } ) ).done( function() {'
+			. 'wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
+			. 'window._wpGutenbergEditor = wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
+			. '} );'
+		)
 	);
 
 	/**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -777,14 +777,17 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'colors'     => $color_palette,
 	);
 
-	wp_add_inline_script(
-		'wp-editor',
-		(
-			'jQuery.when( wp.api.init(), wp.api.init( { versionString: \'gutenberg/v1/\' } ) ).done( function() {'
-			. 'window._wpGutenbergEditor = wp.editor.createEditorInstance( \'editor\', window._wpGutenbergPost, ' . json_encode( $editor_settings ) . ' ); '
-			. '} );'
-		)
-	);
+	$script  = '( function() {';
+	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
+	$script .= <<<JS
+		window._wpGutenbergEditor = jQuery.Deferred();
+		jQuery.when( wp.api.init(), wp.api.init( { versionString: 'gutenberg/v1' } ) ).done( function() {
+			var editor = wp.editor.createEditorInstance( 'editor', window._wpGutenbergPost, editorSettings );
+			window._wpGutenbergEditor.resolve( editor );
+		} );
+JS;
+	$script .= '} )();';
+	wp_add_inline_script( 'wp-editor', $script );
 
 	/**
 	 * Scripts

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -759,11 +759,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	), $meta_box_url );
 	wp_localize_script( 'wp-editor', '_wpMetaBoxUrl', $meta_box_url );
 
-	// Ensure that we've got jQuery.
-	if ( ! wp_script_is( 'jquery', 'done' ) ) {
-		wp_enqueue_script( 'jquery' );
-	}
-
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
 	$color_palette           = gutenberg_color_palette();
@@ -780,10 +775,8 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$script  = '( function() {';
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
 	$script .= <<<JS
-		window._wpGutenbergEditor = jQuery.Deferred();
-		jQuery.when( wp.api.init(), wp.api.init( { versionString: 'gutenberg/v1' } ) ).done( function() {
-			var editor = wp.editor.createEditorInstance( 'editor', window._wpGutenbergPost, editorSettings );
-			window._wpGutenbergEditor.resolve( editor );
+		window._wpGutenbergEditor = Promise.all( [ wp.api.init(), wp.api.init( { versionString: 'gutenberg/v1' } ) ] ).then( function() {
+			return wp.editor.createEditorInstance( 'editor', window._wpGutenbergPost, editorSettings );
 		} );
 JS;
 	$script .= '} )();';

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -775,7 +775,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$script  = '( function() {';
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
 	$script .= <<<JS
-		window._wpGutenbergEditor = Promise.all( [ wp.api.init(), wp.api.init( { versionString: 'gutenberg/v1' } ) ] ).then( function() {
+		window._wpLoadGutenbergEditor = Promise.all( [ wp.api.init(), wp.api.init( { versionString: 'gutenberg/v1' } ) ] ).then( function() {
 			return wp.editor.createEditorInstance( 'editor', window._wpGutenbergPost, editorSettings );
 		} );
 JS;

--- a/lib/register.php
+++ b/lib/register.php
@@ -236,7 +236,7 @@ function gutenberg_collect_meta_box_data() {
 	 */
 	wp_add_inline_script(
 		'wp-editor',
-		'window._wpGutenbergEditor.done( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
+		'window._wpGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
 	);
 
 	// Restore any global variables that we temporarily modified above.

--- a/lib/register.php
+++ b/lib/register.php
@@ -236,7 +236,7 @@ function gutenberg_collect_meta_box_data() {
 	 */
 	wp_add_inline_script(
 		'wp-editor',
-		'window._wpGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
+		'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
 	);
 
 	// Restore any global variables that we temporarily modified above.

--- a/lib/register.php
+++ b/lib/register.php
@@ -236,7 +236,7 @@ function gutenberg_collect_meta_box_data() {
 	 */
 	wp_add_inline_script(
 		'wp-editor',
-		'window._wpGutenbergEditor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' )'
+		'window._wpGutenbergEditor.done( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
 	);
 
 	// Restore any global variables that we temporarily modified above.


### PR DESCRIPTION
Adds the effects necessary for supporting reusable blocks. There are 4:

- FETCH_REUSABLE_BLOCKS: Loads reusable blocks from the API and inserts
  them into the store.
- SAVE_REUSABLE_BLOCK: Persists a reusable block that's in the store to
  the API.
- MAKE_BLOCK_STATIC: Transforms a reusable block on the page into a
  regular block.
- MAKE_BLOCK_REUSABLE: Transforms a regular block on the page into a
  reusable block.