### PR TITLE
Fixed bad grammar in featured image upload.

### DIFF
--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -59,14 +59,14 @@ const slimImageObject = ( img ) => {
 };
 
 class MediaUploadButton extends Component {
-	constructor( { multiple = false, type, gallery = false } ) {
+	constructor( { multiple = false, type, gallery = false, title = __( 'Select or Upload Media' ) } ) {
 		super( ...arguments );
 		this.openModal = this.openModal.bind( this );
 		this.onSelect = this.onSelect.bind( this );
 		this.onUpdate = this.onUpdate.bind( this );
 		this.onOpen = this.onOpen.bind( this );
 		const frameConfig = {
-			title: __( 'Select or Upload a media' ),
+			title,
 			button: {
 				text: __( 'Select' ),
 			},

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -18,11 +18,14 @@ import './style.scss';
 import { getEditedPostAttribute } from '../../selectors';
 import { editPost } from '../../actions';
 
+const FEATURED_IMAGE_SELECT_TITLE = __( 'Select a Featured Image' );
+
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media } ) {
 	return (
 		<div className="editor-post-featured-image">
 			{ !! featuredImageId &&
 				<MediaUploadButton
+					title={ FEATURED_IMAGE_SELECT_TITLE }
 					buttonProps={ { className: 'button-link editor-post-featured-image__preview' } }
 					onSelect={ onUpdateImage }
 					type="image"
@@ -45,6 +48,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 			}
 			{ ! featuredImageId &&
 				<MediaUploadButton
+					title={ FEATURED_IMAGE_SELECT_TITLE }
 					buttonProps={ { className: 'editor-post-featured-image__toggle button-link' } }
 					onSelect={ onUpdateImage }
 					type="image"


### PR DESCRIPTION
This PR aims to fix https://github.com/WordPress/gutenberg/issues/3394. An optional title parameter was added to the media upload button so we can easily change the title of the modal area in similar situations.

## Testing

1. Add a featured image.
2. Verify that the title of the image selection area is "Select a Featured Image"
3. Add the featured image.
4. Add an image or gallery block verify their titles stay the same as before.

## Screenshots (jpeg or gifs if applicable):
<img width="673" alt="screen shot 2017-11-08 at 21 22 46" src="https://user-images.githubusercontent.com/11271197/32575129-163d7f7c-c4cb-11e7-8429-eaeea2d66aa6.png">