### PR TITLE
Basic cypress tests for focusing blocks in navigation and edit modes

### DIFF
--- a/test/e2e/integration/003-focusing-blocks.js
+++ b/test/e2e/integration/003-focusing-blocks.js
@@ -1,0 +1,122 @@
+describe( 'Focusing blocks', () => {
+	before( () => {
+		cy.newPost();
+	} );
+
+	// Disable reason: This navigation is not implemented yet.
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of paragraph', () => {
+		cy.auditBlockFocus( 'Paragraph' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of image', () => {
+		cy.auditBlockFocus( 'Image' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of gallery', () => {
+		cy.auditBlockFocus( 'Gallery' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of heading', () => {
+		cy.auditBlockFocus( 'Heading' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of quote', () => {
+		cy.auditBlockFocus( 'Quote' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of list', () => {
+		cy.auditBlockFocus( 'List' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of table', () => {
+		cy.auditBlockFocus( 'Table' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of preformatted', () => {
+		cy.auditBlockFocus( 'Preformatted' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of code', () => {
+		cy.auditBlockFocus( 'Code' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of html', () => {
+		cy.auditBlockFocus( 'Custom HTML' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of classic text', () => {
+		cy.auditBlockFocus( 'Classic Text' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of verse', () => {
+		cy.auditBlockFocus( 'Verse' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of separator', () => {
+		cy.auditBlockFocus( 'Separator' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of more', () => {
+		cy.auditBlockFocus( 'More' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of button', () => {
+		cy.auditBlockFocus( 'Button' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of text columns', () => {
+		cy.auditBlockFocus( 'Text Columns' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of latest posts', () => {
+		cy.auditBlockFocus( 'Latest Posts' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of categories', () => {
+		cy.auditBlockFocus( 'Categories' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of shortcode', () => {
+		cy.auditBlockFocus( 'Shortcode' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of pullquote', () => {
+		cy.auditBlockFocus( 'Pullquote' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of cover image', () => {
+		cy.auditBlockFocus( 'Cover Image' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of video', () => {
+		cy.auditBlockFocus( 'Video' );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'Testing focus of audio', () => {
+		cy.auditBlockFocus( 'Audio' );
+	} );
+} );

--- a/test/e2e/support/focus-commands.js
+++ b/test/e2e/support/focus-commands.js
@@ -1,0 +1,34 @@
+Cypress.Commands.add( 'auditBlockFocus', ( blockType ) => {
+	// Open up the Insert Block Menu
+	cy.get( 'button.editor-inserter__toggle:first' ).click()
+	// Type into the Search field for blocks
+	cy.focused().type( blockType );
+	// Click on the first result that matches. Note, be careful with things like Image vs Cover Image
+	cy.get( '.editor-inserter__menu .editor-inserter__block:contains("' + blockType + '"):first' ).click();
+
+	// Identify the item that has focus immediately after block creation
+	cy.focused().then( ( preFocus ) => {
+		// Ensure that the immediately focused item is not the outer block
+		cy.wrap( preFocus ).closest( '.editor-visual-editor__block-edit' ).then( ( outer ) => {
+			assert.notEqual( outer.get( 0 ), preFocus.get( 0 ) );
+		} );
+
+		// Press ESC to focus the outer block
+		cy.wait(500);
+		cy.focused().type( '{esc} ');
+
+		// Ensure that the outer block is now focused
+		cy.focused().then( ( outerFocus ) => {
+			expect( outerFocus ).to.have.class(  'editor-visual-editor__block-edit' );
+		} );
+
+		cy.wait(500);
+		// Press ENTER to go inside the block again
+		cy.focused().type( '{enter}' );
+
+		// Ensure that the focused item now matches the item that received focus initially after creating
+		cy.focused().then( ( postFocus ) => {
+			assert.equal( postFocus.get( 0 ), preFocus.get( 0 ) );
+		} );
+	} );
+} );

--- a/test/e2e/support/index.js
+++ b/test/e2e/support/index.js
@@ -1,5 +1,6 @@
 import './user-commands';
 import './gutenberg-commands';
+import './focus-commands';
 
 Cypress.Cookies.defaults( {
 	whitelist: /^wordpress_/,


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Introducing cypress tests for the proposed navigation being discussed in #3195. Essentially, what they test are:

For every block that can be found in the `Blocks` tab (so perhaps not embed)
* create the block
* check that the focus has shifted **into** the block after being created
* check that the focus is **not** on the outer wrapper of the block
* remember what the focus is on ('previous-focus`)
* press `escape`
* now check that the focus **is** on the outer wrapper of the block
* press `enter`
* now check that the focus is back to what is was (`previous-focus`)

The goal is to ensure that switching between navigation and edit mode works for all blocks, and that keyboard focus is initially given to each block once created. At the moment, these tests fail due to:

* Not all blocks have the inner and outer focusable wrapper required. Many blocks focus the outer wrapper on creation.
* Navigation Mode vs Editing Mode has not been implemented in general.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
It is tests. They are all skipped though, because the navigation has not been implemented yet.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Adds to the number of tests.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.