### PR TITLE
Components: Show popovers fullscreen on mobile

### DIFF
--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -75,3 +75,11 @@ A callback invoked to render the content of the dropdown menu. Its first argumen
 
 - Type: `Function`
 - Required: Yes
+
+## expandOnMobile
+
+Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to avoid this behavior.
+
+ - Type: `Boolean`
+ - Required: No
+ - Default: `false`

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -61,7 +61,14 @@ class Dropdown extends Component {
 
 	render() {
 		const { isOpen } = this.state;
-		const { renderContent, renderToggle, position = 'bottom', className, contentClassName } = this.props;
+		const {
+			renderContent,
+			renderToggle,
+			position = 'bottom',
+			className,
+			contentClassName,
+			expandOnMobile,
+		} = this.props;
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
 		return (
 			<div className={ className } ref={ this.bindContainer }>
@@ -72,6 +79,7 @@ class Dropdown extends Component {
 					position={ position }
 					onClose={ this.close }
 					onClickOutside={ this.clickOutside }
+					expandOnMobile={ expandOnMobile }
 				>
 					<FocusManaged>
 						{ renderContent( args ) }

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -100,11 +100,10 @@ A callback invoked when the user clicks outside the opened popover, passing the 
 - Type: `Function`
 - Required: No
 
-
 ## expandOnMobile
 
-Popovers automatically shows up fullscreen on mobile, pass `false` in this prop to avoid this behavior.
+Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to avoid this behavior.
 
  - Type: `Boolean`
  - Required: No
- - Default: `true`
+ - Default: `false`

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -99,3 +99,12 @@ A callback invoked when the user clicks outside the opened popover, passing the 
 
 - Type: `Function`
 - Required: No
+
+
+## expandOnMobile
+
+Popovers automatically shows up fullscreen on mobile, pass `false` in this prop to avoid this behavior.
+
+ - Type: `Boolean`
+ - Required: No
+ - Default: `true`

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -16,6 +16,7 @@ import { focus, keycodes } from '@wordpress/utils';
 import './style.scss';
 import withFocusReturn from '../higher-order/with-focus-return';
 import PopoverDetectOutside from './detect-outside';
+import IconButton from '../icon-button';
 import { Slot, Fill } from '../slot-fill';
 
 const FocusManaged = withFocusReturn( ( { children } ) => children );
@@ -300,6 +301,9 @@ class Popover extends Component {
 						className="components-popover__content"
 						tabIndex="-1"
 					>
+						{ this.state.isMobile &&
+							<IconButton className="components-popover__close" icon="no-alt" onClick={ onClose } />
+						}
 						{ children }
 					</div>
 				</div>

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -35,6 +35,7 @@ const ARROW_OFFSET = 20;
  * @type {String}
  */
 const SLOT_NAME = 'Popover';
+const isMobile = () => window.innerWidth < 782;
 
 class Popover extends Component {
 	constructor() {
@@ -52,6 +53,7 @@ class Popover extends Component {
 		this.state = {
 			forcedYAxis: null,
 			forcedXAxis: null,
+			isMobile: false,
 		};
 	}
 
@@ -159,6 +161,20 @@ class Popover extends Component {
 		const { getAnchorRect = this.getAnchorRect } = this.props;
 		const { popover } = this.nodes;
 
+		if ( isMobile() ) {
+			popover.style.left = 0;
+			popover.style.top = 0;
+			popover.style.right = 0;
+			popover.style.bottom = 0;
+			this.setState( {
+				isMobile: true,
+			} );
+			return;
+		}
+		this.setState( {
+			isMobile: false,
+		} );
+
 		const [ yAxis, xAxis ] = this.getPositions();
 		const isTop = 'top' === yAxis;
 		const isLeft = 'left' === xAxis;
@@ -168,6 +184,9 @@ class Popover extends Component {
 		if ( ! rect ) {
 			return;
 		}
+
+		//popover.style.bottom = 'auto';
+		//popover.style.right = 'auto';
 
 		if ( isRight ) {
 			popover.style.left = rect.left + ARROW_OFFSET + 'px';
@@ -258,6 +277,9 @@ class Popover extends Component {
 			className,
 			'is-' + yAxis,
 			'is-' + xAxis,
+			{
+				'is-mobile': this.state.isMobile,
+			}
 		);
 
 		// Disable reason: We care to capture the _bubbled_ events from inputs

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -158,7 +158,7 @@ class Popover extends Component {
 	}
 
 	setOffset() {
-		const { getAnchorRect = this.getAnchorRect, expandOnMobile = true } = this.props;
+		const { getAnchorRect = this.getAnchorRect, expandOnMobile = false } = this.props;
 		const { popover } = this.nodes;
 
 		if ( isMobile() && expandOnMobile ) {

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -301,14 +301,16 @@ class Popover extends Component {
 					{ ...contentProps }
 					onKeyDown={ this.maybeClose }
 				>
+					{ this.state.isMobile && (
+						<div className="components-popover__header">
+							<IconButton className="components-popover__close" icon="no-alt" onClick={ onClose } />
+						</div>
+					) }
 					<div
 						ref={ this.bindNode( 'content' ) }
 						className="components-popover__content"
 						tabIndex="-1"
 					>
-						{ this.state.isMobile &&
-							<IconButton className="components-popover__close" icon="no-alt" onClick={ onClose } />
-						}
 						{ children }
 					</div>
 				</div>

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -158,10 +158,10 @@ class Popover extends Component {
 	}
 
 	setOffset() {
-		const { getAnchorRect = this.getAnchorRect } = this.props;
+		const { getAnchorRect = this.getAnchorRect, expandOnMobile = true } = this.props;
 		const { popover } = this.nodes;
 
-		if ( isMobile() ) {
+		if ( isMobile() && expandOnMobile ) {
 			popover.style.left = 0;
 			popover.style.top = 0;
 			popover.style.right = 0;

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -263,6 +263,7 @@ class Popover extends Component {
 			range,
 			focusOnOpen,
 			getAnchorRect,
+			expandOnMobile,
 			/* eslint-enable no-unused-vars */
 			...contentProps
 		} = this.props;

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -167,14 +167,19 @@ class Popover extends Component {
 			popover.style.top = 0;
 			popover.style.right = 0;
 			popover.style.bottom = 0;
-			this.setState( {
-				isMobile: true,
-			} );
+			if ( ! this.state.isMobile ) {
+				this.setState( {
+					isMobile: true,
+				} );
+			}
 			return;
 		}
-		this.setState( {
-			isMobile: false,
-		} );
+
+		if ( this.state.isMobile ) {
+			this.setState( {
+				isMobile: false,
+			} );
+		}
 
 		const [ yAxis, xAxis ] = this.getPositions();
 		const isTop = 'top' === yAxis;
@@ -186,8 +191,8 @@ class Popover extends Component {
 			return;
 		}
 
-		//popover.style.bottom = 'auto';
-		//popover.style.right = 'auto';
+		popover.style.bottom = 'auto';
+		popover.style.right = 'auto';
 
 		if ( isRight ) {
 			popover.style.left = rect.left + ARROW_OFFSET + 'px';

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -102,8 +102,14 @@
 	}
 }
 
-
 // The withFocusReturn div
 .components-popover__content > div {
 	height: 100%;
+}
+
+.components-popover__close.components-icon-button {
+	position: absolute;
+	top: 0;
+	right: 0;
+	z-index: z-index( '.components-popover__close' );
 }

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -3,90 +3,107 @@
 	z-index: z-index( ".components-popover" );
 	left: 50%;
 
-	&:before {
-		border: 8px solid $light-gray-500;
-	}
-
-	&:after {
-		border: 8px solid $white;
-	}
-
-	&:before,
-	&:after {
-		content: "";
-		position: absolute;
-		margin-left: -10px;
-		height: 0;
-		width: 0;
-		border-left-color: transparent;
-		border-right-color: transparent;
-		line-height: 0;
-	}
-
-	&.is-top {
-		bottom: 100%;
-		margin-top: -8px;
-
+	&:not(.is-mobile) {
 		&:before {
-			bottom: -8px;
+			border: 8px solid $light-gray-500;
 		}
 
 		&:after {
-			bottom: -6px;
+			border: 8px solid $white;
 		}
 
 		&:before,
 		&:after {
-			border-top-style: solid;
-			border-bottom: none;
-		}
-	}
-
-	&.is-bottom {
-		top: 100%;
-		margin-top: 8px;
-
-		&:before {
-			top: -8px;
+			content: "";
+			position: absolute;
+			margin-left: -10px;
+			height: 0;
+			width: 0;
+			border-left-color: transparent;
+			border-right-color: transparent;
+			line-height: 0;
 		}
 
-		&:after {
-			top: -6px;
+		&.is-top {
+			bottom: 100%;
+			margin-top: -8px;
+
+			&:before {
+				bottom: -8px;
+			}
+
+			&:after {
+				bottom: -6px;
+			}
+
+			&:before,
+			&:after {
+				border-top-style: solid;
+				border-bottom: none;
+			}
 		}
 
-		&:before,
-		&:after {
-			border-bottom-style: solid;
-			border-top: none;
+		&.is-bottom {
+			top: 100%;
+			margin-top: 8px;
+
+			&:before {
+				top: -8px;
+			}
+
+			&:after {
+				top: -6px;
+			}
+
+			&:before,
+			&:after {
+				border-bottom-style: solid;
+				border-top: none;
+			}
 		}
 	}
 }
 
 .components-popover__content {
-	position: absolute;
 	box-shadow: $shadow-popover;
 	border: 1px solid $light-gray-500;
 	background: $white;
-	min-width: 240px;
+	height: 100%;
 
-	.components-popover.is-top & {
+	&:focus {
+		box-shadow: $button-focus-style;
+	}
+
+	.components-popover:not(.is-mobile) & {
+		position: absolute;
+		min-width: 240px;
+		height: auto;
+	}
+
+	.components-popover:not(.is-mobile).is-top & {
 		bottom: 100%;
 	}
 
-	.components-popover.is-center & {
+	.components-popover:not(.is-mobile).is-center & {
 		left: 50%;
 		transform: translateX( -50% );
 	}
 
-	.components-popover.is-right & {
+	.components-popover:not(.is-mobile).is-right & {
 		position: absolute;
 		left: 100%;
 		margin-left: -24px;
 	}
 
-	.components-popover.is-left & {
+	.components-popover:not(.is-mobile).is-left & {
 		position: absolute;
 		right: 100%;
 		margin-right: -24px;
 	}
+}
+
+
+// The withFocusReturn div
+.components-popover__content > div {
+	height: 100%;
 }

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -70,8 +70,9 @@
 	background: $white;
 	height: 100%;
 
-	&:focus {
-		box-shadow: $button-focus-style;
+	.components-popover.is-mobile & {
+		height: calc( 100% - #{ $panel-header-height } );
+		border-top: 0;
 	}
 
 	.components-popover:not(.is-mobile) & {
@@ -107,9 +108,17 @@
 	height: 100%;
 }
 
+.components-popover__header {
+	height: $panel-header-height;
+	background: $light-gray-300;
+	padding: 0 $panel-padding;
+	border: 1px solid $light-gray-500;
+	position: relative;
+}
+
 .components-popover__close.components-icon-button {
 	position: absolute;
-	top: 0;
-	right: 0;
+	top: 6px;
+	right: 6px;
 	z-index: z-index( '.components-popover__close' );
 }

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -227,8 +227,6 @@ describe( 'Popover', () => {
 				style: {},
 			};
 
-			instance.setState = () => {};
-
 			return instance;
 		}
 
@@ -240,6 +238,8 @@ describe( 'Popover', () => {
 			expect( instance.nodes.popover.style ).toEqual( {
 				left: '225px',
 				top: '210px',
+				right: 'auto',
+				bottom: 'auto',
 			} );
 		} );
 
@@ -252,6 +252,8 @@ describe( 'Popover', () => {
 			expect( instance.nodes.popover.style ).toEqual( {
 				left: '225px',
 				top: '395px',
+				right: 'auto',
+				bottom: 'auto',
 			} );
 		} );
 	} );

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -13,7 +13,7 @@ describe( 'Popover', () => {
 		let wrapper, mocks;
 		beforeEach( () => {
 			wrapper = shallow(
-				<Popover expandOnMobile={ false } />,
+				<Popover />,
 				{ lifecycleExperimental: true }
 			);
 
@@ -206,7 +206,7 @@ describe( 'Popover', () => {
 		} );
 
 		function getInstanceWithParentNode() {
-			const instance = new Popover( { expandOnMobile: false } );
+			const instance = new Popover( {} );
 
 			instance.nodes.anchor = {
 				parentNode: {

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -13,7 +13,7 @@ describe( 'Popover', () => {
 		let wrapper, mocks;
 		beforeEach( () => {
 			wrapper = shallow(
-				<Popover />,
+				<Popover expandOnMobile={ false } />,
 				{ lifecycleExperimental: true }
 			);
 
@@ -206,7 +206,7 @@ describe( 'Popover', () => {
 		} );
 
 		function getInstanceWithParentNode() {
-			const instance = new Popover( {} );
+			const instance = new Popover( { expandOnMobile: false } );
 
 			instance.nodes.anchor = {
 				parentNode: {
@@ -226,6 +226,8 @@ describe( 'Popover', () => {
 			instance.nodes.popover = {
 				style: {},
 			};
+
+			instance.setState = () => {};
 
 			return instance;
 		}

--- a/components/tab-panel/index.js
+++ b/components/tab-panel/index.js
@@ -64,12 +64,12 @@ class TabPanel extends Component {
 		const selectedId = instanceId + '-' + selectedTab.name;
 
 		return (
-			<div>
+			<div className={ className }>
 				<NavigableMenu
 					role="tablist"
 					orientation={ orientation }
 					onNavigate={ this.onNavigate }
-					className={ className }
+					className="components-tab-panel__tabs"
 				>
 					{ tabs.map( ( tab ) => (
 						<TabButton className={ `${ tab.className } ${ tab.name === selected ? activeClass : '' }` }
@@ -87,6 +87,7 @@ class TabPanel extends Component {
 					<div aria-labelledby={ selectedId }
 						role="tabpanel"
 						id={ selectedId + '-view' }
+						className="components-tab-panel__tab-content"
 					>
 						{ this.props.children( selectedTab.name ) }
 					</div>

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -177,6 +177,7 @@ class Tooltip extends Component {
 					position={ position }
 					className="components-tooltip"
 					aria-hidden="true"
+					expandOnMobile={ false }
 				>
 					{ text }
 				</Popover>,

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -177,7 +177,6 @@ class Tooltip extends Component {
 					position={ position }
 					className="components-tooltip"
 					aria-hidden="true"
-					expandOnMobile={ false }
 				>
 					{ text }
 				</Popover>,

--- a/components/tooltip/style.scss
+++ b/components/tooltip/style.scss
@@ -15,10 +15,13 @@
 }
 
 .components-tooltip .components-popover__content {
-	min-width: 0;
 	padding: 4px 12px;
 	background: $dark-gray-400;
 	border-width: 0;
 	color: white;
 	white-space: nowrap;
+}
+
+.components-tooltip:not(.is-mobile) .components-popover__content {
+	min-width: 0;
 }

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -53,7 +53,7 @@ $header-height: 56px;
 $inserter-tabs-height: 36px;
 $block-toolbar-height: 37px;
 $sidebar-width: 280px;
-$sidebar-panel-header-height: 50px;
+$panel-header-height: 50px;
 $admin-bar-height: 32px;
 $admin-bar-height-big: 46px;
 $admin-sidebar-width: 160px;

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -20,6 +20,7 @@ $z-layers: (
 	'.blocks-format-toolbar__link-modal': 2,
 	'.editor-block-contextual-toolbar': 2,
 	'.editor-block-switcher__menu': 2,
+	'.components-popover__close': 2,
 	'.editor-block-mover': 1,
 	'.blocks-gallery-image__inline-menu': 20,
 	'.editor-block-settings-menu__popover': 20, // Below the header

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -74,6 +74,7 @@ class Inserter extends Component {
 				className="editor-inserter"
 				position={ position }
 				onToggle={ this.onToggle }
+				expandOnMobile
 				renderToggle={ ( { onToggle, isOpen } ) => (
 					<IconButton
 						icon="insert"

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -298,15 +298,14 @@ export class InserterMenu extends Component {
 						] }
 					>
 						{ ( tabKey ) => (
-							<div ref={ ( ref ) => this.tabContainer = ref }
-								className="editor-inserter__content">
+							<div ref={ ( ref ) => this.tabContainer = ref }>
 								{ this.renderTabView( tabKey ) }
 							</div>
 						) }
 					</TabPanel>
 				}
 				{ isSearching &&
-					<div role="menu" className="editor-inserter__content">
+					<div role="menu" className="editor-inserter__search-results">
 						{ this.renderCategories( this.getVisibleBlocksByCategory( getBlockTypes() ) ) }
 					</div>
 				}

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -27,13 +27,6 @@
 	}
 }
 
-.editor-inserter__content {
-	flex-grow: 1;
-
-	overflow: auto;
-	box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
-}
-
 input[type="search"].editor-inserter__search {
 	display: block;
 	width: 100%;
@@ -117,14 +110,32 @@ input[type="search"].editor-inserter__search {
 	margin-top: -1px;	// hide the first top border
 }
 
+.editor-inserter__search-results {
+	flex-grow: 1;
+	overflow: auto;
+}
+
 .editor-inserter__tabs {
-	width: 100%;
 	display: flex;
-	justify-content: space-between;
-	position: relative;
-	background: $light-gray-300;
-	border-bottom: 1px solid $light-gray-500;
-	flex-shrink: 0;
+	flex-direction: column;
+	height: 100%;
+	flex-grow: 1;
+	box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
+	overflow: hidden;
+
+	.components-tab-panel__tab-content {
+		overflow: auto;
+	}
+
+	.components-tab-panel__tabs {
+		width: 100%;
+		display: flex;
+		justify-content: space-between;
+		position: relative;
+		background: $light-gray-300;
+		border-bottom: 1px solid $light-gray-500;
+		flex-shrink: 0;
+	}
 }
 
 .editor-inserter__tab {

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -49,6 +49,10 @@ input[type="search"].editor-inserter__search {
 	&:focus {
 		@include input-style__focus-active;
 	}
+
+	.components-popover.is-mobile & {
+		padding-right: 30px;
+	}
 }
 
 .editor-inserter__category-blocks {
@@ -65,18 +69,6 @@ input[type="search"].editor-inserter__search {
 	@include break-medium {
 		width: 300px;
 		height: 320px;
-	}
-}
-
-.editor-inserter__menu.components-popover.is-center .components-popover__content {
-	@media ( max-width: #{ $break-medium - 1 } ) {
-		border-width: 0;
-		position: fixed;
-		left: 0;
-		right: 0;
-		top: $admin-bar-height-big + $header-height;
-		transform: none;
-		width: 100vw;
 	}
 }
 

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -49,10 +49,6 @@ input[type="search"].editor-inserter__search {
 	&:focus {
 		@include input-style__focus-active;
 	}
-
-	.components-popover.is-mobile & {
-		padding-right: 30px;
-	}
 }
 
 .editor-inserter__category-blocks {

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -28,11 +28,7 @@
 }
 
 .editor-inserter__content {
-	height: calc( 100vh - #{ $admin-bar-height-big + $header-height + 34 + $inserter-tabs-height } ); // 34 = search input height
-
-	@include break-medium {
-		height: 260px;
-	}
+	flex-grow: 1;
 
 	overflow: auto;
 	box-shadow: inset 0 -5px 5px -4px rgba( $dark-gray-900, .1 );
@@ -62,10 +58,13 @@ input[type="search"].editor-inserter__search {
 }
 
 .editor-inserter__menu {
-	width: calc( 100vw - 20px );
-
+	width: auto;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 	@include break-medium {
 		width: 300px;
+		height: 320px;
 	}
 }
 
@@ -137,6 +136,7 @@ input[type="search"].editor-inserter__search {
 	position: relative;
 	background: $light-gray-300;
 	border-bottom: 1px solid $light-gray-500;
+	flex-shrink: 0;
 }
 
 .editor-inserter__tab {

--- a/editor/sidebar/style.scss
+++ b/editor/sidebar/style.scss
@@ -29,7 +29,7 @@
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;
 		height: 100%;
-		padding-top: $sidebar-panel-header-height;
+		padding-top: $panel-header-height;
 		margin-top: -1px;
 		margin-bottom: -1px;
 
@@ -46,7 +46,7 @@
 		top: 0;
 		left: 0;
 		right: 0;
-		height: $sidebar-panel-header-height;
+		height: $panel-header-height;
 
 		@include break-small() {
 			position: inherit;


### PR DESCRIPTION
refs #2691 

This PR updates the Popover Component to show all popovers fullscreen on mobile.
This makes the inserter more usable on mobile. This also adds an `expandOnMobile` prop to enable this behavior for specific popovers. It's only applied to the inserter right now.

**Testing instructions**

- Try the inserter on mobile
- Try the inserter on desktop to ensure nothing is broken
- Try several popovers.