### PR TITLE
Changed advanced controls to be closed by default.

### DIFF
--- a/editor/sidebar/block-inspector/advanced-controls.js
+++ b/editor/sidebar/block-inspector/advanced-controls.js
@@ -69,7 +69,11 @@ class BlockInspectorAdvancedControls extends Component {
 		}
 
 		return (
-			<PanelBody className="editor-advanced-controls" title={ __( 'Advanced' ) }>
+			<PanelBody
+				className="editor-advanced-controls"
+				initialOpen={ false }
+				title={ __( 'Advanced' ) }
+			>
 				{ false !== blockType.className &&
 					<InspectorControls.TextControl
 						label={ __( 'Additional CSS Class' ) }

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -29,7 +29,7 @@ const BlockInspector = ( { selectedBlock, count } ) => {
 		<Panel>
 			<PanelBody className="editor-block-inspector__content">
 				<Slot name="Inspector.Controls" />
-				<BlockInspectorAdvancedControls />
+				<BlockInspectorAdvancedControls key={ `advanced-controls-${ selectedBlock.uid }` } />
 			</PanelBody>
 		</Panel>
 	);


### PR DESCRIPTION
## Description
This is a simple change to close https://github.com/WordPress/gutenberg/issues/3204. It makes advanced controls closed by default. A key had to be added because of the known problem with slot-fill key reusing in this case keys work well because the key is added to panel body which is already a child of BlockInspectorAdvancedControls.

## How Has This Been Tested?
Add an image or button and verify the advanced panel is closed by default.
