### PR TITLE
Components: Choosing the event bubbling strategy for our Slot & Fill implementation

### DIFF
--- a/blocks/block-controls/index.js
+++ b/blocks/block-controls/index.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import { Fill } from 'react-slot-fill';
-
-/**
  * WordPress dependencies
  */
-import { Toolbar } from '@wordpress/components';
+import { Toolbar, Fill } from '@wordpress/components';
 
 export default function BlockControls( { controls, children } ) {
 	return (

--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -1,14 +1,9 @@
 /**
- * External dependencies
- */
-import { Fill } from 'react-slot-fill';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { IconButton, Toolbar, withSpokenMessages } from '@wordpress/components';
+import { IconButton, Toolbar, withSpokenMessages, Fill } from '@wordpress/components';
 import { keycodes } from '@wordpress/utils';
 
 /**

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -15,7 +15,6 @@ import {
 	noop,
 } from 'lodash';
 import { nodeListToReact } from 'dom-react';
-import { Fill, Slot } from 'react-slot-fill';
 import 'element-closest';
 
 /**
@@ -23,6 +22,7 @@ import 'element-closest';
  */
 import { createElement, Component, renderToString } from '@wordpress/element';
 import { keycodes, createBlobURL } from '@wordpress/utils';
+import { Slot, Fill } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/blocks/inspector-controls/index.js
+++ b/blocks/inspector-controls/index.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { Fill } from 'react-slot-fill';
+import { Fill } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -305,6 +305,6 @@ Popover.contextTypes = {
 	getSlot: noop,
 };
 
-Popover.Slot = () => <Slot name={ SLOT_NAME } />;
+Popover.Slot = () => <Slot bubble name={ SLOT_NAME } />;
 
 export default Popover;

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -305,6 +305,6 @@ Popover.contextTypes = {
 	getSlot: noop,
 };
 
-Popover.Slot = () => <Slot bubble name={ SLOT_NAME } />;
+Popover.Slot = () => <Slot bubblesVirtually name={ SLOT_NAME } />;
 
 export default Popover;

--- a/components/slot-fill/README.md
+++ b/components/slot-fill/README.md
@@ -48,4 +48,7 @@ The `SlotFillProvider` component does not accept any props.
 
 Both `Slot` and `Fill` accept a `name` string prop, where a `Slot` with a given `name` will render the `children` of any associated `Fill`s.
 
-`Slot` also accepts a `bubble` event which changes the rendering behavior. If we want to bubble events to the Fills parent component, we need to pass this prop to the correspondig `Slot`.
+`Slot` also accepts a `bubblesVirtually` prop which changes the event bubbling behaviour:
+
+ - By default, events will bubble to their parents on the DOM hierarchy (native event bubbling)
+ - If `bubblesVirtually` is set to true, events will bubble to their virtual parent in the React elements hierarchy instead.

--- a/components/slot-fill/README.md
+++ b/components/slot-fill/README.md
@@ -47,3 +47,5 @@ You can either use the Fill component directly, or a wrapper component type as i
 The `SlotFillProvider` component does not accept any props.
 
 Both `Slot` and `Fill` accept a `name` string prop, where a `Slot` with a given `name` will render the `children` of any associated `Fill`s.
+
+`Slot` also accepts a `bubble` event which changes the rendering behavior. If we want to bubble events to the Fills parent component, we need to pass this prop to the correspondig `Slot`.

--- a/components/slot-fill/fill.js
+++ b/components/slot-fill/fill.js
@@ -43,7 +43,7 @@ class Fill extends Component {
 		const { getSlot = noop } = this.context;
 		const { name, children } = this.props;
 		const slot = getSlot( name );
-		if ( ! slot || ! slot.props.bubble ) {
+		if ( ! slot || ! slot.props.bubblesVirtually ) {
 			return null;
 		}
 

--- a/components/slot-fill/fill.js
+++ b/components/slot-fill/fill.js
@@ -8,6 +8,11 @@ import { noop } from 'lodash';
  */
 import { Component, createPortal } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import withInstanceId from '../higher-order/with-instance-id';
+
 class Fill extends Component {
 	componentDidMount() {
 		const { registerFill = noop } = this.context;
@@ -37,10 +42,12 @@ class Fill extends Component {
 	render() {
 		const { getSlot = noop } = this.context;
 		const { name, children } = this.props;
-
 		const slot = getSlot( name );
+		if ( ! slot || ! slot.props.bubble ) {
+			return null;
+		}
 
-		return slot ? createPortal( children, slot ) : null;
+		return createPortal( children, slot.node );
 	}
 }
 
@@ -50,4 +57,4 @@ Fill.contextTypes = {
 	unregisterFill: noop,
 };
 
-export default Fill;
+export default withInstanceId( Fill );

--- a/components/slot-fill/provider.js
+++ b/components/slot-fill/provider.js
@@ -17,6 +17,7 @@ class SlotFillProvider extends Component {
 		this.unregisterSlot = this.unregisterSlot.bind( this );
 		this.unregisterFill = this.unregisterFill.bind( this );
 		this.getSlot = this.getSlot.bind( this );
+		this.getFills = this.getFills.bind( this );
 
 		this.slots = {};
 		this.fills = {};
@@ -29,12 +30,12 @@ class SlotFillProvider extends Component {
 			'unregisterSlot',
 			'unregisterFill',
 			'getSlot',
+			'getFills',
 		] );
 	}
 
 	registerSlot( name, node ) {
 		this.slots[ name ] = node;
-
 		this.forceUpdateFills( name );
 	}
 
@@ -43,10 +44,12 @@ class SlotFillProvider extends Component {
 			...( this.fills[ name ] || [] ),
 			instance,
 		];
+		this.forceUpdateSlot( name );
 	}
 
 	unregisterSlot( name ) {
 		delete this.slots[ name ];
+		this.forceUpdateFills( name );
 	}
 
 	unregisterFill( name, instance ) {
@@ -54,10 +57,15 @@ class SlotFillProvider extends Component {
 			this.fills[ name ],
 			instance
 		);
+		this.forceUpdateSlot( name );
 	}
 
 	getSlot( name ) {
 		return this.slots[ name ];
+	}
+
+	getFills( name ) {
+		return this.fills[ name ];
 	}
 
 	forceUpdateFills( name ) {
@@ -65,6 +73,13 @@ class SlotFillProvider extends Component {
 			this.fills[ name ].forEach( ( instance ) => {
 				instance.forceUpdate();
 			} );
+		}
+	}
+
+	forceUpdateSlot( name ) {
+		const slot = this.getSlot( name );
+		if ( slot ) {
+			slot.forceUpdate();
 		}
 	}
 
@@ -79,6 +94,7 @@ SlotFillProvider.childContextTypes = {
 	registerFill: noop,
 	unregisterFill: noop,
 	getSlot: noop,
+	getFills: noop,
 };
 
 export default SlotFillProvider;

--- a/components/slot-fill/provider.js
+++ b/components/slot-fill/provider.js
@@ -34,9 +34,13 @@ class SlotFillProvider extends Component {
 		] );
 	}
 
-	registerSlot( name, node ) {
-		this.slots[ name ] = node;
+	registerSlot( name, slot ) {
+		this.slots[ name ] = slot;
 		this.forceUpdateFills( name );
+
+		// Sometimes the fills are registered after the intial render of slot
+		// But before the registerSlot call, we need to rerender the slot
+		this.forceUpdateSlot( name );
 	}
 
 	registerFill( name, instance ) {
@@ -78,6 +82,7 @@ class SlotFillProvider extends Component {
 
 	forceUpdateSlot( name ) {
 		const slot = this.getSlot( name );
+
 		if ( slot ) {
 			slot.forceUpdate();
 		}

--- a/components/slot-fill/slot.js
+++ b/components/slot-fill/slot.js
@@ -57,7 +57,7 @@ class Slot extends Component {
 				{ map( getFills( name ), ( fill ) => {
 					const fillKey = fill.props.instanceId;
 					return Children.map( fill.props.children, ( child, childIndex ) => {
-						const childKey = fillKey + '---' + ( child.props.key || childIndex );
+						const childKey = `${ fillKey }---${ child.props.key || childIndex }`;
 						return cloneElement( child, { key: childKey } );
 					} );
 				} ) }

--- a/components/slot-fill/slot.js
+++ b/components/slot-fill/slot.js
@@ -45,10 +45,10 @@ class Slot extends Component {
 	}
 
 	render() {
-		const { name, bubble = false } = this.props;
+		const { name, bubblesVirtually = false } = this.props;
 		const { getFills = noop } = this.context;
 
-		if ( bubble ) {
+		if ( bubblesVirtually ) {
 			return <div ref={ this.bindNode } />;
 		}
 
@@ -57,7 +57,7 @@ class Slot extends Component {
 				{ map( getFills( name ), ( fill ) => {
 					const fillKey = fill.props.instanceId;
 					return Children.map( fill.props.children, ( child, childIndex ) => {
-						const childKey = fillKey + '---' + child.props.key || childIndex;
+						const childKey = fillKey + '---' + ( child.props.key || childIndex );
 						return cloneElement( child, { key: childKey } );
 					} );
 				} ) }

--- a/editor/block-toolbar/index.js
+++ b/editor/block-toolbar/index.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { Slot } from 'react-slot-fill';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 
 /**
  * WordPress Dependencies
  */
-import { IconButton, Toolbar } from '@wordpress/components';
+import { IconButton, Toolbar, Slot } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 

--- a/editor/provider/index.js
+++ b/editor/provider/index.js
@@ -3,7 +3,6 @@
  */
 import { bindActionCreators } from 'redux';
 import { Provider as ReduxProvider } from 'react-redux';
-import { Provider as SlotFillProvider } from 'react-slot-fill';
 import { flow, pick, noop } from 'lodash';
 
 /**
@@ -14,7 +13,7 @@ import { EditableProvider } from '@wordpress/blocks';
 import {
 	APIProvider,
 	DropZoneProvider,
-	SlotFillProvider as WPSlotFillProvider,
+	SlotFillProvider,
 } from '@wordpress/components';
 
 /**
@@ -80,14 +79,6 @@ class EditorProvider extends Component {
 				{ store: this.store },
 			],
 
-			// Slot / Fill provider:
-			//
-			//  - context.slots
-			//  - context.fills
-			[
-				SlotFillProvider,
-			],
-
 			// Editable provider:
 			//
 			//  - context.onUndo
@@ -104,7 +95,7 @@ class EditorProvider extends Component {
 			//  - context.registerSlot
 			//  - context.unregisterSlot
 			[
-				WPSlotFillProvider,
+				SlotFillProvider,
 			],
 
 			// APIProvider

--- a/editor/sidebar/block-inspector/index.js
+++ b/editor/sidebar/block-inspector/index.js
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { Slot } from 'react-slot-fill';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Panel, PanelBody } from '@wordpress/components';
+import { Panel, PanelBody, Slot } from '@wordpress/components';
 
 /**
  * Internal Dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -7286,11 +7286,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
-    "mitt": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.2.tgz",
-      "integrity": "sha1-OA5hSA1qYVtmDwertg1R4KTkvtY="
-    },
     "mixin-object": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
@@ -8525,14 +8520,6 @@
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.0.tgz",
           "integrity": "sha1-7eFjGML/H5/joCU5a6Bv1MRGCLs="
         }
-      }
-    },
-    "react-slot-fill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-slot-fill/-/react-slot-fill-1.0.1.tgz",
-      "integrity": "sha1-Abu9tmkoZiPp0p6OOpy/3ptZQJE=",
-      "requires": {
-        "mitt": "1.1.2"
       }
     },
     "react-test-renderer": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react-datepicker": "0.46.0",
     "react-dom": "16.0.0",
     "react-redux": "5.0.6",
-    "react-slot-fill": "1.0.1",
     "react-transition-group": "1.2.0",
     "redux": "3.7.2",
     "redux-multi": "0.1.12",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,11 +89,6 @@ const config = {
 			__dirname,
 			'node_modules',
 		],
-		alias: {
-			// There are currently resolution errors on RSF's "mitt" dependency
-			// when imported as native ES module
-			'react-slot-fill': 'react-slot-fill/lib/rsf.js',
-		},
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
closes #3132 

This pull request is the second attempt to replace react-slot-fill by our own implementation entirely. It introduces two way of rendering fills:

 - By default, fills are rendered as children to the slot
 - If you pass a `bubble` prop to the `Slot`, the fills are rendered using `Portal` and enable event bubbling to their parents.

The first implementation also resolves the issue where components were reused instead of remounted between similar Fills. It does so by introducing an `instanceId` prop to the Fill and this prop is used as a `key` to ensure remounting

__Testing instructions:__

 - Verify that there are no regressions in the BlockToolbar and the Block Inspector usage, particularly
 - Verify that if you have two buttons, you open or close an inspector panel (background color for example) for one of these buttons blocks and then you focus the second button. The state of these panels is reset. 