### PR TITLE
Image Block: Fix loading an existing post with an image block

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -55,10 +55,6 @@ class ImageBlock extends Component {
 		const { attributes, setAttributes } = this.props;
 		const { id, url = '' } = attributes;
 
-		if ( id ) {
-			this.fetchMedia( id );
-		}
-
 		if ( ! id && url.indexOf( 'blob:' ) === 0 ) {
 			getBlobByURL( url )
 				.then( createMediaFromFile )


### PR DESCRIPTION
closes #3403

This Fixes loading a post with an image block. This was a left-over from a merge between the refactoring to use `withAPIData` #2840 and something else.

**Testing instructions**

- Add a new post
- Add an image block
- Save or wait for autosave
- Reload the page