### PR TITLE
Framework: Rename rawContent references as innerHTML

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -33,11 +33,11 @@ export function isValidSource( source ) {
 /**
  * Returns the block attributes parsed from raw content.
  *
- * @param  {String} rawContent Raw block content
- * @param  {Object} schema     Block attribute schema
- * @return {Object}            Block attribute values
+ * @param  {String} innerHTML Raw block content
+ * @param  {Object} schema    Block attribute schema
+ * @return {Object}           Block attribute values
  */
-export function getSourcedAttributes( rawContent, schema ) {
+export function getSourcedAttributes( innerHTML, schema ) {
 	const sources = mapValues(
 		// Parse only sources with source defined
 		pickBy( schema, ( attributeSchema ) => isValidSource( attributeSchema.source ) ),
@@ -46,7 +46,7 @@ export function getSourcedAttributes( rawContent, schema ) {
 		( attributeSchema ) => attributeSchema.source
 	);
 
-	return hpqParse( rawContent, sources );
+	return hpqParse( innerHTML, sources );
 }
 
 /**
@@ -90,15 +90,15 @@ export function asType( value, type ) {
 /**
  * Returns the block attributes of a registered block node given its type.
  *
- * @param  {?Object} blockType     Block type
- * @param  {string}  rawContent    Raw block content
- * @param  {?Object} attributes    Known block attributes (from delimiters)
- * @return {Object}                All block attributes
+ * @param  {?Object} blockType  Block type
+ * @param  {string}  innerHTML  Raw block content
+ * @param  {?Object} attributes Known block attributes (from delimiters)
+ * @return {Object}             All block attributes
  */
-export function getBlockAttributes( blockType, rawContent, attributes ) {
+export function getBlockAttributes( blockType, innerHTML, attributes ) {
 	// Retrieve additional attributes sourced from content
 	const sourcedAttributes = getSourcedAttributes(
-		rawContent,
+		innerHTML,
 		blockType.attributes
 	);
 
@@ -150,7 +150,7 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
 
 	// If the block supports anchor, parse the id
 	if ( blockType.supportAnchor ) {
-		blockAttributes.anchor = hpqParse( rawContent, attr( '*', 'id' ) );
+		blockAttributes.anchor = hpqParse( innerHTML, attr( '*', 'id' ) );
 	}
 
 	// If the block supports a custom className parse it
@@ -165,11 +165,11 @@ export function getBlockAttributes( blockType, rawContent, attributes ) {
  * Creates a block with fallback to the unknown type handler.
  *
  * @param  {?String} name       Block type name
- * @param  {String}  rawContent Raw block content
+ * @param  {String}  innerHTML  Raw block content
  * @param  {?Object} attributes Attributes obtained from block delimiters
  * @return {?Object}            An initialized block object (if possible)
  */
-export function createBlockWithFallback( name, rawContent, attributes ) {
+export function createBlockWithFallback( name, innerHTML, attributes ) {
 	// Use type from block content, otherwise find unknown handler.
 	name = name || getUnknownTypeHandlerName();
 
@@ -186,7 +186,7 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
 		// If detected as a block which is not registered, preserve comment
 		// delimiters in content of unknown type handler.
 		if ( name ) {
-			rawContent = getCommentDelimitedContent( name, attributes, rawContent );
+			innerHTML = getCommentDelimitedContent( name, attributes, innerHTML );
 		}
 
 		name = fallbackBlock;
@@ -195,23 +195,23 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
 
 	// Include in set only if type were determined.
 	// TODO do we ever expect there to not be an unknown type handler?
-	if ( blockType && ( rawContent || name !== fallbackBlock ) ) {
+	if ( blockType && ( innerHTML || name !== fallbackBlock ) ) {
 		// TODO allow blocks to opt-in to receiving a tree instead of a string.
 		// Gradually convert all blocks to this new format, then remove the
 		// string serialization.
 		const block = createBlock(
 			name,
-			getBlockAttributes( blockType, rawContent, attributes )
+			getBlockAttributes( blockType, innerHTML, attributes )
 		);
 
 		// Validate that the parsed block is valid, meaning that if we were to
 		// reserialize it given the assumed attributes, the markup matches the
 		// original value.
-		block.isValid = isValidBlock( rawContent, blockType, block.attributes );
+		block.isValid = isValidBlock( innerHTML, blockType, block.attributes );
 
 		// Preserve original content for future use in case the block is parsed
 		// as invalid, or future serialization attempt results in an error
-		block.originalContent = rawContent;
+		block.originalContent = innerHTML;
 
 		return block;
 	}
@@ -225,8 +225,8 @@ export function createBlockWithFallback( name, rawContent, attributes ) {
  */
 export function parseWithGrammar( content ) {
 	return grammarParse( content ).reduce( ( memo, blockNode ) => {
-		const { blockName, innerHTML: rawContent, attrs } = blockNode;
-		const block = createBlockWithFallback( blockName, rawContent.trim(), attrs );
+		const { blockName, innerHTML, attrs } = blockNode;
+		const block = createBlockWithFallback( blockName, innerHTML.trim(), attrs );
 		if ( block ) {
 			memo.push( block );
 		}

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -30,22 +30,22 @@ export function getBlockDefaultClassname( blockName ) {
  * Given a block type containg a save render implementation and attributes, returns the
  * static markup to be saved.
  *
- * @param  {Object}               blockType  Block type
- * @param  {Object}               attributes Block attributes
- * @return {string}                          Save content
+ * @param  {Object} blockType  Block type
+ * @param  {Object} attributes Block attributes
+ * @return {string}            Save content
  */
 export function getSaveContent( blockType, attributes ) {
 	const { save, className = getBlockDefaultClassname( blockType.name ) } = blockType;
-	let rawContent;
+	let saveContent;
 
 	if ( save.prototype instanceof Component ) {
-		rawContent = createElement( save, { attributes } );
+		saveContent = createElement( save, { attributes } );
 	} else {
-		rawContent = save( { attributes } );
+		saveContent = save( { attributes } );
 
 		// Special-case function render implementation to allow raw HTML return
-		if ( 'string' === typeof rawContent ) {
-			return rawContent;
+		if ( 'string' === typeof saveContent ) {
+			return saveContent;
 		}
 	}
 
@@ -71,7 +71,7 @@ export function getSaveContent( blockType, attributes ) {
 
 		return cloneElement( element, extraProps );
 	};
-	const contentWithClassname = Children.map( rawContent, addAdvancedAttributes );
+	const contentWithClassname = Children.map( saveContent, addAdvancedAttributes );
 
 	// Otherwise, infer as element
 	return renderToString( contentWithClassname );

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -67,18 +67,18 @@ describe( 'block parser', () => {
 				},
 			};
 
-			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
+			const innerHTML = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( getSourcedAttributes( rawContent, sources ) ).toEqual( {
+			expect( getSourcedAttributes( innerHTML, sources ) ).toEqual( {
 				emphasis: '& Chicken',
 			} );
 		} );
 
 		it( 'should return an empty object if no sources defined', () => {
 			const sources = {};
-			const rawContent = '<span>Ribs <strong>& Chicken</strong></span>';
+			const innerHTML = '<span>Ribs <strong>& Chicken</strong></span>';
 
-			expect( getSourcedAttributes( rawContent, sources ) ).toEqual( {} );
+			expect( getSourcedAttributes( innerHTML, sources ) ).toEqual( {} );
 		} );
 	} );
 
@@ -146,10 +146,10 @@ describe( 'block parser', () => {
 				},
 			};
 
-			const rawContent = '<div data-number="10">Ribs</div>';
+			const innerHTML = '<div data-number="10">Ribs</div>';
 			const attrs = { align: 'left', invalid: true };
 
-			expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {
+			expect( getBlockAttributes( blockType, innerHTML, attrs ) ).toEqual( {
 				content: 'Ribs',
 				number: 10,
 				align: 'left',
@@ -168,10 +168,10 @@ describe( 'block parser', () => {
 				supportAnchor: true,
 			};
 
-			const rawContent = '<div id="chicken">Ribs</div>';
+			const innerHTML = '<div id="chicken">Ribs</div>';
 			const attrs = {};
 
-			expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {
+			expect( getBlockAttributes( blockType, innerHTML, attrs ) ).toEqual( {
 				content: 'Ribs',
 				anchor: 'chicken',
 			} );
@@ -182,10 +182,10 @@ describe( 'block parser', () => {
 				attributes: {},
 			};
 
-			const rawContent = '<div class="chicken">Ribs</div>';
+			const innerHTML = '<div class="chicken">Ribs</div>';
 			const attrs = { className: 'chicken' };
 
-			expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {
+			expect( getBlockAttributes( blockType, innerHTML, attrs ) ).toEqual( {
 				className: 'chicken',
 			} );
 		} );
@@ -196,10 +196,10 @@ describe( 'block parser', () => {
 				className: false,
 			};
 
-			const rawContent = '<div class="chicken">Ribs</div>';
+			const innerHTML = '<div class="chicken">Ribs</div>';
 			const attrs = { className: 'chicken' };
 
-			expect( getBlockAttributes( blockType, rawContent, attrs ) ).toEqual( {} );
+			expect( getBlockAttributes( blockType, innerHTML, attrs ) ).toEqual( {} );
 		} );
 	} );
 

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -374,12 +374,12 @@ export function isEquivalentHTML( a, b ) {
  *
  * Logs to console in development environments when invalid.
  *
- * @param  {String}  rawContent Original block content
+ * @param  {String}  innerHTML  Original block content
  * @param  {String}  blockType  Block type
  * @param  {Object}  attributes Parsed block attributes
  * @return {Boolean}            Whether block is valid
  */
-export function isValidBlock( rawContent, blockType, attributes ) {
+export function isValidBlock( innerHTML, blockType, attributes ) {
 	let saveContent;
 	try {
 		saveContent = getSaveContent( blockType, attributes );
@@ -387,5 +387,5 @@ export function isValidBlock( rawContent, blockType, attributes ) {
 		return false;
 	}
 
-	return isEquivalentHTML( rawContent, saveContent );
+	return isEquivalentHTML( innerHTML, saveContent );
 }


### PR DESCRIPTION
Related: #2743 (specifically https://github.com/WordPress/gutenberg/pull/2743#discussion_r147262714)

This pull request seeks to continue work started in #2743, replacing all remaining references to a block's markup from `rawContent` to `innerHTML` for consistency between the parser output and how these properties are referenced in the block API implementation.

__Testing instructions:__

Ensure tests pass:

```
npm test
```

Verify that there are no regressions in the parsing of blocks, observed in editing a saved post in Gutenberg containing block content.

Ensure that no remaining references to `rawContent` exist.