### PR TITLE
Testing: Add fixture for undelimited freeform block

### DIFF
--- a/blocks/test/fixtures/core__freeform__undelimited.html
+++ b/blocks/test/fixtures/core__freeform__undelimited.html
@@ -1,0 +1,4 @@
+Testing freeform block with some
+<div class="wp-some-class">
+	HTML <span style="color: red;">content</span>
+</div>

--- a/blocks/test/fixtures/core__freeform__undelimited.json
+++ b/blocks/test/fixtures/core__freeform__undelimited.json
@@ -1,0 +1,11 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/freeform",
+        "isValid": true,
+        "attributes": {
+            "content": "Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
+        },
+        "originalContent": "Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
+    }
+]

--- a/blocks/test/fixtures/core__freeform__undelimited.parsed.json
+++ b/blocks/test/fixtures/core__freeform__undelimited.parsed.json
@@ -1,0 +1,6 @@
+[
+    {
+        "attrs": {},
+        "innerHTML": "Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
+    }
+]

--- a/blocks/test/fixtures/core__freeform__undelimited.serialized.html
+++ b/blocks/test/fixtures/core__freeform__undelimited.serialized.html
@@ -1,0 +1,4 @@
+Testing freeform block with some
+<div class="wp-some-class">
+	HTML <span style="color: red;">content</span>
+</div>


### PR DESCRIPTION
This pull request seeks to add a new test fixture verifying that markup with no block delimiters are parsed and reserialized as a freeform block.

__Testing instructions:__

Ensure tests pass:

```
npm test
```