### PR TITLE
FIX: use lodash version of startsWith because IE does not support startsWith natively

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, isObject, castArray, compact } from 'lodash';
+import { isEmpty, reduce, isObject, castArray, compact, startsWith } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 import classnames from 'classnames';
 
@@ -179,7 +179,7 @@ export function getCommentDelimitedContent( rawBlockName, attributes, content ) 
 		'';
 
 	// strip core blocks of their namespace prefix
-	const blockName = rawBlockName.startsWith( 'core/' ) ?
+	const blockName = startsWith( rawBlockName, 'core/' ) ?
 		rawBlockName.slice( 5 ) :
 		rawBlockName;
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes #3414 

Use lodash's startsWith implementation. IE does not support startsWith

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix.