### PR TITLE
IE11: Only fire hide if focus is transferring outside of the div

### DIFF
--- a/editor/modes/visual-editor/sibling-inserter.js
+++ b/editor/modes/visual-editor/sibling-inserter.js
@@ -27,6 +27,7 @@ class VisualEditorSiblingInserter extends Component {
 		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
 		this.show = this.toggleVisible.bind( this, true );
 		this.hide = this.toggleVisible.bind( this, false );
+		this.onBlur = this.onBlur.bind( this );
 		this.showAndFocus = this.showAndFocus.bind( this );
 		this.suspendToggleVisible = this.suspendToggleVisible.bind( this );
 
@@ -86,6 +87,12 @@ class VisualEditorSiblingInserter extends Component {
 		this.setState( { isToggleVisibleSuspended: isOpen } );
 	}
 
+	onBlur( evt ) {
+		if ( ! document.activeElement || ( ! evt.target.contains( document.activeElement ) ) ) {
+			this.hide();
+		}
+	}
+
 	render() {
 		const { insertIndex, showInsertionPoint } = this.props;
 		const { isVisible } = this.state;
@@ -100,7 +107,7 @@ class VisualEditorSiblingInserter extends Component {
 				data-insert-index={ insertIndex }
 				className={ classes }
 				onFocus={ this.showAndFocus }
-				onBlur={ this.hide }
+				onBlur={ this.onBlur }
 				onMouseEnter={ this.show }
 				onMouseLeave={ this.hide }
 				tabIndex={ isVisible ? -1 : 0 }>


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fix: #3408 

The `onBlur` was firing on IE 11, even though the focus was shifting inside the div. That was firing `hide` which meant that the focused button disappeared, and focus reverted to the body.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually

I needed to do the changes from #3415 as well. But I'm not sure if anyone else is experiencing that problem, so I might have just missed a fix somewhere.
