### PR TITLE
Add aria-expanded attribute to Settings button

### DIFF
--- a/editor/header/index.js
+++ b/editor/header/index.js
@@ -38,6 +38,7 @@ function Header( { onToggleSidebar, isSidebarOpened } ) {
 					onClick={ onToggleSidebar }
 					isToggled={ isSidebarOpened }
 					label={ __( 'Settings' ) }
+					aria-expanded={ isSidebarOpened }
 				/>
 				<EllipsisMenu />
 			</div>


### PR DESCRIPTION
## Description
The "Settings" button that toggles the sidebar needs an aria-expanded attribute to indicate the sidebar status. #3407 

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.