### PR TITLE
Improved store persist.

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -30,7 +30,7 @@ import { getBlockTypes, getBlockType } from '@wordpress/blocks';
  */
 import withHistory from './utils/with-history';
 import withChangeDetection from './utils/with-change-detection';
-import { STORE_DEFAULTS } from './store-defaults';
+import { PREFERENCES_DEFAULTS } from './store-defaults';
 
 /***
  * Module constants
@@ -471,7 +471,7 @@ export function blockInsertionPoint( state = {}, action ) {
  * @param  {Object}  action                Dispatched action
  * @return {string}                        Updated state
  */
-export function preferences( state = STORE_DEFAULTS.preferences, action ) {
+export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 	switch ( action.type ) {
 		case 'TOGGLE_SIDEBAR':
 			return {

--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -1,14 +1,12 @@
 import { viewPort } from '../utils';
 
-export const STORE_DEFAULTS = {
-	preferences: {
-		mode: 'visual',
-		isSidebarOpened: ! viewPort.isExtraSmall(),
-		panels: { 'post-status': true },
-		recentlyUsedBlocks: [],
-		blockUsage: {},
-		features: {
-			fixedToolbar: true,
-		},
+export const PREFERENCES_DEFAULTS = {
+	mode: 'visual',
+	isSidebarOpened: ! viewPort.isExtraSmall(),
+	panels: { 'post-status': true },
+	recentlyUsedBlocks: [],
+	blockUsage: {},
+	features: {
+		fixedToolbar: true,
 	},
 };

--- a/editor/store-persist.js
+++ b/editor/store-persist.js
@@ -1,19 +1,22 @@
 /**
  * Internal dependencies
  */
-import { STORE_DEFAULTS } from './store-defaults';
-
 const DEFAULT_STORAGE_KEY = 'REDUX_PERSIST';
 
 /**
  * Store enhancer to persist a specified reducer key
- * @param {String}     reducerKey The reducer key to persist
- * @param {String}     storageKey The storage key to use
- * @param {Object}     defaults   Default values
+ * @param {Object}     options             Options object
+ * @param {String}     options.reducerKey  The reducer key to persist
+ * @param {String}     options.storageKey  The storage key to use
+ * @param {Object}     options.defaults    Default values of the reducer key
  *
- * @return {Function}             Store enhancer
+ * @return {Function}                      Store enhancer
  */
-export default function storePersist( reducerKey, storageKey = DEFAULT_STORAGE_KEY, defaults = STORE_DEFAULTS ) {
+export default function storePersist( {
+	reducerKey,
+	storageKey = DEFAULT_STORAGE_KEY,
+	defaults = {},
+} ) {
 	return ( createStore ) => ( reducer, preloadedState, enhancer ) => {
 		// EnhancedReducer with auto-rehydration
 		const enhancedReducer = ( state, action ) => {
@@ -35,7 +38,7 @@ export default function storePersist( reducerKey, storageKey = DEFAULT_STORAGE_K
 		const persistedString = window.localStorage.getItem( storageKey );
 		if ( persistedString ) {
 			const persistedState = {
-				...defaults[ reducerKey ],
+				...defaults,
 				...JSON.parse( persistedString ),
 			};
 

--- a/editor/store.js
+++ b/editor/store.js
@@ -12,6 +12,7 @@ import { flowRight } from 'lodash';
 import effects from './effects';
 import reducer from './reducer';
 import storePersist from './store-persist';
+import { STORE_DEFAULTS } from './store-defaults';
 
 /**
  * Module constants
@@ -27,7 +28,11 @@ const GUTENBERG_PREFERENCES_KEY = `GUTENBERG_PREFERENCES_${ window.userSettings.
 function createReduxStore( preloadedState ) {
 	const enhancers = [
 		applyMiddleware( multi, refx( effects ) ),
-		storePersist( 'preferences', GUTENBERG_PREFERENCES_KEY ),
+		storePersist( {
+			reducerKey: 'preferences',
+			storageKey: GUTENBERG_PREFERENCES_KEY,
+			defaults: STORE_DEFAULTS.preferences,
+		} ),
 	];
 
 	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {

--- a/editor/store.js
+++ b/editor/store.js
@@ -12,7 +12,7 @@ import { flowRight } from 'lodash';
 import effects from './effects';
 import reducer from './reducer';
 import storePersist from './store-persist';
-import { STORE_DEFAULTS } from './store-defaults';
+import { PREFERENCES_DEFAULTS } from './store-defaults';
 
 /**
  * Module constants
@@ -31,7 +31,7 @@ function createReduxStore( preloadedState ) {
 		storePersist( {
 			reducerKey: 'preferences',
 			storageKey: GUTENBERG_PREFERENCES_KEY,
-			defaults: STORE_DEFAULTS.preferences,
+			defaults: PREFERENCES_DEFAULTS,
 		} ),
 	];
 

--- a/editor/test/store-persist.js
+++ b/editor/test/store-persist.js
@@ -46,10 +46,8 @@ describe( 'persistStore', () => {
 	} );
 
 	it( 'should apply defaults to any missing properties on previously stored objects', () => {
-		const defaults = {
-			preferences: {
-				counter: 41,
-			},
+		const defaultsPreferences = {
+			counter: 41,
 		};
 		const storageKey = 'dumbStorageKey3';
 		const reducer = ( state, action ) => {
@@ -69,7 +67,7 @@ describe( 'persistStore', () => {
 		const store = createStore( reducer, persistStore( {
 			reducerKey: 'preferences',
 			storageKey,
-			defaults: defaults.preferences,
+			defaults: defaultsPreferences,
 		} ) );
 		store.dispatch( { type: 'INCREMENT' } );
 
@@ -79,10 +77,8 @@ describe( 'persistStore', () => {
 	} );
 
 	it( 'should not override stored values with defaults', () => {
-		const defaults = {
-			preferences: {
-				counter: 41,
-			},
+		const defaultsPreferences = {
+			counter: 41,
 		};
 		const storageKey = 'dumbStorageKey4';
 		const reducer = ( state, action ) => {
@@ -101,7 +97,7 @@ describe( 'persistStore', () => {
 		const store = createStore( reducer, persistStore( {
 			reducerKey: 'preferences',
 			storageKey,
-			defaults: defaults.preferences,
+			defaults: defaultsPreferences,
 		} ) );
 		store.dispatch( { type: 'INCREMENT' } );
 

--- a/editor/test/store-persist.js
+++ b/editor/test/store-persist.js
@@ -17,7 +17,10 @@ describe( 'persistStore', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( reducer, persistStore( 'preferences', storageKey, {} ) );
+		const store = createStore( reducer, persistStore( {
+			reducerKey: 'preferences',
+			storageKey,
+		} ) );
 		expect( store.getState().preferences ).toEqual( { chicken: true } );
 	} );
 
@@ -34,7 +37,10 @@ describe( 'persistStore', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( reducer, persistStore( 'preferences', storageKey, {} ) );
+		const store = createStore( reducer, persistStore( {
+			reducerKey: 'preferences',
+			storageKey,
+		} ) );
 		store.dispatch( { type: 'UPDATE' } );
 		expect( JSON.parse( window.localStorage.getItem( storageKey ) ) ).toEqual( { chicken: true } );
 	} );
@@ -60,7 +66,11 @@ describe( 'persistStore', () => {
 		// store preferences without the `counter` default
 		window.localStorage.setItem( storageKey, JSON.stringify( {} ) );
 
-		const store = createStore( reducer, persistStore( 'preferences', storageKey, defaults ) );
+		const store = createStore( reducer, persistStore( {
+			reducerKey: 'preferences',
+			storageKey,
+			defaults: defaults.preferences,
+		} ) );
 		store.dispatch( { type: 'INCREMENT' } );
 
 		// the default should have been applied, as the `counter` was missing from the
@@ -88,7 +98,11 @@ describe( 'persistStore', () => {
 
 		window.localStorage.setItem( storageKey, JSON.stringify( { counter: 1 } ) );
 
-		const store = createStore( reducer, persistStore( 'preferences', storageKey, defaults ) );
+		const store = createStore( reducer, persistStore( {
+			reducerKey: 'preferences',
+			storageKey,
+			defaults: defaults.preferences,
+		} ) );
 		store.dispatch( { type: 'INCREMENT' } );
 
 		expect( JSON.parse( window.localStorage.getItem( storageKey ) ) ).toEqual( { counter: 2 } );


### PR DESCRIPTION
This PR comes from https://github.com/WordPress/gutenberg/pull/3331, and includes the possible improves we found to store-persist during the discussion. 

Store persist is now generic with no access to default values.
Store persist receives the default values of the specific reducer key passed to it.
Receives an options object instead of a set of parameters.