### PR TITLE
Try alternate highlight color

### DIFF
--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -30,6 +30,7 @@ $blue-medium-400: #33B3DB;
 $blue-medium-300: #66C6E4;
 $blue-medium-200: #BFE7F3;
 $blue-medium-100: #E5F5FA;
+$blue-medium-highlight: #b3e7fe;
 
 // Alerts
 $alert-yellow: #f0b849;

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -107,14 +107,22 @@
  		outline: 1px solid $light-gray-500;
 	}
 
+	// selection style for textarea
+	::-moz-selection {
+		background: $blue-medium-highlight;
+	}
+
+	::selection {
+		background: $blue-medium-highlight;
+	}
+
 	// selection style for multiple blocks
 	&.is-multi-selected *::selection {
 		background: transparent;
 	}
 
 	&.is-multi-selected:before {
-		background: $blue-medium-200;
-		background: Highlight;	// This variable is a CSS 2.1 variable that selects the operating system select color
+		background: $blue-medium-highlight;
 	}
 
 	.iframe-overlay {


### PR DESCRIPTION
Since we have both mouse and keyboard interactions for selecting starting in text and expanding into selecting blocks at the block level, we tried using the CSS 2.1 `Highlight` variable so the operating system highlight color would be used. Sadly, this variable isn't uniformly implemented across platforms. It seems that on Firefox, you have to add your own translucency to the mix — the color is still probably right, but the light blue color we'e used to is actually that blue color shown at .3 opacity.

Now we can look at hacks to make that work, but it's probably a futile game. This PR takes a different approach. There's a new color, $blue-medium-highlight, which has almost the exact same saturation and lightness that the operating system light blue color has, but with a hue that's the same as the other WordPress medium blue colors. This is combined with using the `::selection` and `::-moz-selection` CSS properties to change the selection color, and the two match in that way. For browsers that don't support those properties, text selection will just be the same color of the operating system.

This issue was discovered here: https://github.com/WordPress/gutenberg/pull/3068#issuecomment-343184681

GIFs, Chrome:

![chrome](https://user-images.githubusercontent.com/1204802/32660514-7efe3836-c623-11e7-8504-fa441c999a89.gif)

Firefox:

![firefox](https://user-images.githubusercontent.com/1204802/32660517-82070fb2-c623-11e7-98e8-0e272212e438.gif)
