### PR TITLE
Expose ES5 way of creating a Component class in wp.element.createClass

### DIFF
--- a/element/index.js
+++ b/element/index.js
@@ -5,6 +5,7 @@ import { createElement, Component, cloneElement, Children } from 'react';
 import { render, findDOMNode, createPortal } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { isString } from 'lodash';
+import createClass from 'create-react-class';
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -18,6 +19,13 @@ import { isString } from 'lodash';
  * @return {WPElement}                   Element
  */
 export { createElement };
+
+/**
+ * Creates and returns a component class (Refs, state and lifecycle methods).
+ *
+ * For cases when ES6 is not available yet. Using Component is preferred.
+ */
+export { createClass };
 
 /**
  * Renders a given element into the target DOM node.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@wordpress/url": "0.1.0-beta.1",
     "classnames": "2.2.5",
     "clipboard": "1.7.1",
+    "create-react-class": "15.6.2",
     "dom-react": "2.2.0",
     "dom-scroll-into-view": "1.2.1",
     "element-closest": "2.0.2",


### PR DESCRIPTION
For some projects extending Gutenberg blocks, it might be useful to have React's `createClass` way of creating a Component class available. In this PR, we are exposing `createClass` from the `create-react-class` npm library to `wp.element.createClass`

## How Has This Been Tested?

We are using `wp.element.createClass` for the [Simple Payments block in Jetpack](https://github.com/Automattic/jetpack/pull/8119).
