### PR TITLE
fix/keyboard-shortcut-multi-block-unselect

### DIFF
--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -92,6 +92,7 @@ class VisualEditor extends Component {
 					'mod+shift+z': this.undoOrRedo,
 					backspace: this.deleteSelectedBlocks,
 					del: this.deleteSelectedBlocks,
+					escape: this.props.clearSelectedBlock,
 				} } />
 				<WritingFlow>
 					<PostTitle />

--- a/test/e2e/integration/003-multi-block-selection.js
+++ b/test/e2e/integration/003-multi-block-selection.js
@@ -1,0 +1,61 @@
+describe( 'Multi-block selection', () => {
+	before( () => {
+		cy.newPost();
+	} );
+
+	it( 'Should select/unselect multiple blocks', () => {
+
+		const lastBlockSelector = '.editor-visual-editor__block-edit:last [contenteditable="true"]:first';
+		const firstBlockContainerSelector = '.editor-visual-editor__block:first';
+		const lastBlockContainerSelector = '.editor-visual-editor__block:last';
+		const multiSelectedCssClass = 'is-multi-selected';
+
+		// Creating test blocks
+		// Using the placeholder
+		cy.get( '[value="Write your story"]' ).click();
+		cy.get( lastBlockSelector ).type( 'First Paragraph' );
+
+		// Using the quick inserter
+		cy.get( '.editor-visual-editor__inserter [aria-label="Insert Paragraph"]' ).click();
+		cy.get( lastBlockSelector ).type( 'Second Paragraph' );
+
+
+		// Default: No selection
+		cy.get( firstBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
+		cy.get( lastBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
+
+
+		// Multiselect via Shift + click
+		cy.get( firstBlockContainerSelector ).click();
+		cy.get('body').type( '{shift}', { release: false } );
+		cy.get( lastBlockContainerSelector ).click();
+
+		// Verify selection
+		cy.get( firstBlockContainerSelector ).should('have.class', multiSelectedCssClass);
+		cy.get( lastBlockContainerSelector ).should('have.class', multiSelectedCssClass);
+
+		// Unselect
+		cy.get('body').type( '{shift}' ); // releasing shift
+		cy.get( lastBlockContainerSelector ).click();
+
+		// No selection
+		cy.get( firstBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
+		cy.get( lastBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
+
+
+		// Multiselect via keyboard
+		cy.get('body').type( '{ctrl}a' );
+
+		// Verify selection
+		cy.get( firstBlockContainerSelector ).should('have.class', multiSelectedCssClass);
+		cy.get( lastBlockContainerSelector ).should('have.class', multiSelectedCssClass);
+
+		// Unselect
+		cy.get('body').type( '{esc}' );
+
+		// No selection
+		cy.get( firstBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
+		cy.get( lastBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
+
+	} );
+} );

--- a/test/e2e/integration/003-multi-block-selection.js
+++ b/test/e2e/integration/003-multi-block-selection.js
@@ -4,7 +4,6 @@ describe( 'Multi-block selection', () => {
 	} );
 
 	it( 'Should select/unselect multiple blocks', () => {
-
 		const lastBlockSelector = '.editor-visual-editor__block-edit:last [contenteditable="true"]:first';
 		const firstBlockContainerSelector = '.editor-visual-editor__block:first';
 		const lastBlockContainerSelector = '.editor-visual-editor__block:last';
@@ -19,43 +18,41 @@ describe( 'Multi-block selection', () => {
 		cy.get( '.editor-visual-editor__inserter [aria-label="Insert Paragraph"]' ).click();
 		cy.get( lastBlockSelector ).type( 'Second Paragraph' );
 
-
 		// Default: No selection
-		cy.get( firstBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
-		cy.get( lastBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
-
+		cy.get( firstBlockContainerSelector ).should( 'not.have.class', multiSelectedCssClass );
+		cy.get( lastBlockContainerSelector ).should( 'not.have.class', multiSelectedCssClass );
 
 		// Multiselect via Shift + click
 		cy.get( firstBlockContainerSelector ).click();
-		cy.get('body').type( '{shift}', { release: false } );
+		cy.get( 'body' ).type( '{shift}', { release: false } );
 		cy.get( lastBlockContainerSelector ).click();
 
 		// Verify selection
-		cy.get( firstBlockContainerSelector ).should('have.class', multiSelectedCssClass);
-		cy.get( lastBlockContainerSelector ).should('have.class', multiSelectedCssClass);
+		cy.get( firstBlockContainerSelector ).should( 'have.class', multiSelectedCssClass );
+		cy.get( lastBlockContainerSelector ).should( 'have.class', multiSelectedCssClass );
 
 		// Unselect
-		cy.get('body').type( '{shift}' ); // releasing shift
+		cy.get( 'body' ).type( '{shift}' ); // releasing shift
 		cy.get( lastBlockContainerSelector ).click();
 
 		// No selection
-		cy.get( firstBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
-		cy.get( lastBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
-
+		cy.get( firstBlockContainerSelector ).should( 'not.have.class', multiSelectedCssClass );
+		cy.get( lastBlockContainerSelector ).should( 'not.have.class', multiSelectedCssClass );
 
 		// Multiselect via keyboard
-		cy.get('body').type( '{ctrl}a' );
+		// Mac uses meta modifier so we press both here
+		cy.get( 'body' ).type( '{ctrl}a' );
+		cy.get( 'body' ).type( '{meta}a' );
 
 		// Verify selection
-		cy.get( firstBlockContainerSelector ).should('have.class', multiSelectedCssClass);
-		cy.get( lastBlockContainerSelector ).should('have.class', multiSelectedCssClass);
+		cy.get( firstBlockContainerSelector ).should( 'have.class', multiSelectedCssClass );
+		cy.get( lastBlockContainerSelector ).should( 'have.class', multiSelectedCssClass );
 
 		// Unselect
-		cy.get('body').type( '{esc}' );
+		cy.get( 'body' ).type( '{esc}' );
 
 		// No selection
-		cy.get( firstBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
-		cy.get( lastBlockContainerSelector ).should('not.have.class', multiSelectedCssClass);
-
+		cy.get( firstBlockContainerSelector ).should( 'not.have.class', multiSelectedCssClass );
+		cy.get( lastBlockContainerSelector ).should( 'not.have.class', multiSelectedCssClass );
 	} );
 } );


### PR DESCRIPTION
## Description
This PR is referencing this issue https://github.com/WordPress/gutenberg/issues/3430

Added Escape key to keyboard shortcuts so multi-block unselect works via keyboard as well.

## How Has This Been Tested?
Current JavaScript unit tests and e2e test are passing.

## Additional info
This is probably for separate issue but since it's related I put the info here. 
I have created a Cypress test for multi-block selection (not included here) but I have a problem there.
I’m using Docker Cypress image so this can be related to my setup.

This is the problem: 
There seems to be no way to add another test.
Here tests are ordered 001-hello-gutenberg.js, 002-adding-blocks.js. I added another  003-multi-block-selection.js and in this order it is failing. If I name it so it is run first or second, it passes and the one after it fails.
The same happens with 002-adding-blocks.js, if I put it first for example, 001-hello-gutenberg.js fails. This happens even with only 2 original tests reordered (probably that’s why they are numbered to begin with). This is the error message I am getting when they are reordered:

```
CypressError: Timed out after waiting '60000ms' for your remote page to load.

Your page did not fire its 'load' event within '60000ms'.

You can try increasing the 'pageLoadTimeout' value in 'cypress.json' to wait longer.

Browsers will not fire the 'load' event until all stylesheets and scripts are done downloading.

When this 'load' event occurs, Cypress will continue running commands.

Because this error occurred during a 'before all' hook we are skipping the remaining tests in the current suite: 'Hello Gutenberg'
```

Changing 'pageLoadTimeout' does not make any difference.

I have not included 003-multi-block-selection.js so original tests pass.
I’m not sure how to proceed.
