### PR TITLE
Update quote footer colour and remove box-shadow from quote

### DIFF
--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -1,9 +1,8 @@
 .wp-block-quote {
 	margin: 0 0 16px;
-	box-shadow: inset 0px 0px 0px 0px $light-gray-500;
 
 	cite {
-		color: $dark-gray-100;
+		color: $dark-gray-300;
 		margin-top: 1em;
 		position: relative;
 		font-size: $default-font-size;
@@ -12,6 +11,7 @@
 
 	&.is-large {
 		padding: 0 1em;
+
 		p {
 			font-size: 24px;
 			font-style: italic;


### PR DESCRIPTION
## Description
Style fixes for blockquote block. Related issue can be found in #2901.

## How Has This Been Tested?
- Checked front-end styles for Twenty17 and couple of other themes.
- run `npm test` without errors.

## Screenshots (jpeg or gifs if applicable):

I do get this error when I save the post, visit the post and come back to edit the post. I don't know why.

<img width="658" alt="quote-error" src="https://user-images.githubusercontent.com/1820415/32690196-4b871418-c6fb-11e7-9bac-a280df3a7a70.png">

## Types of changes
-  Remove box-shadow from quote
- Update quote footer colour to meet colour contrast guidelines.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.