### PR TITLE
Use div in text columns and create responsive grid.

### DIFF
--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -81,7 +81,7 @@ registerBlockType( 'core/text-columns', {
 					/>
 				</InspectorControls>
 			),
-			<section className={ `${ className } align${ width } columns-${ columns }` } key="block">
+			<div className={ `${ className } align${ width } columns-${ columns }` } key="block">
 				{ times( columns, ( index ) =>
 					<div className="wp-block-column" key={ `column-${ index }` }>
 						<Editable
@@ -102,20 +102,20 @@ registerBlockType( 'core/text-columns', {
 						/>
 					</div>
 				) }
-			</section>,
+			</div>,
 		];
 	},
 
 	save( { attributes } ) {
 		const { width, content, columns } = attributes;
 		return (
-			<section className={ `align${ width } columns-${ columns }` }>
+			<div className={ `align${ width } columns-${ columns }` }>
 				{ times( columns, ( index ) =>
 					<div className="wp-block-column" key={ `column-${ index }` }>
 						<p>{ content && content[ index ].children }</p>
 					</div>
 				) }
-			</section>
+			</div>
 		);
 	},
 } );

--- a/blocks/library/text-columns/style.scss
+++ b/blocks/library/text-columns/style.scss
@@ -1,31 +1,23 @@
 .wp-block-text-columns {
 	display: flex;
-
-	&.aligncenter {
-		display: flex;
-	}
+	flex-wrap: wrap;
+	margin-left: -1.5em;
 
 	.wp-block-column {
-		box-sizing: border-box;
-		margin: 0 16px;
-		padding: 0;
+		flex: 1 0 8em;
+		margin-left: 1.5em;
+	}
+}
 
-		&:first-child {
+@supports (grid-area: auto) {
+	.wp-block-text-columns {
+		display: grid;
+		grid-gap: 1.5em;
+		grid-template-columns: repeat( auto-fit,minmax( 8em, 1fr ) );
+		margin-left: 0;
+
+		.wp-block-column {
 			margin-left: 0;
 		}
-
-		&:last-child {
-			margin-right: 0;
-		}
-	}
-
-	&.columns-2 .wp-block-column {
-		width: calc( 100% / 2 );
-	}
-	&.columns-3 .wp-block-column {
-		width: calc( 100% / 3 );
-	}
-	&.columns-4 .wp-block-column {
-		width: calc( 100% / 4 );
 	}
 }

--- a/blocks/library/text-columns/style.scss
+++ b/blocks/library/text-columns/style.scss
@@ -1,23 +1,31 @@
 .wp-block-text-columns {
 	display: flex;
-	flex-wrap: wrap;
-	margin-left: -1.5em;
+
+	&.aligncenter {
+		display: flex;
+	}
 
 	.wp-block-column {
-		flex: 1 0 8em;
-		margin-left: 1.5em;
-	}
-}
+		box-sizing: border-box;
+		margin: 0 16px;
+		padding: 0;
 
-@supports (grid-area: auto) {
-	.wp-block-text-columns {
-		display: grid;
-		grid-gap: 1.5em;
-		grid-template-columns: repeat( auto-fit,minmax( 8em, 1fr ) );
-		margin-left: 0;
-
-		.wp-block-column {
+		&:first-child {
 			margin-left: 0;
 		}
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+
+	&.columns-2 .wp-block-column {
+		width: calc( 100% / 2 );
+	}
+	&.columns-3 .wp-block-column {
+		width: calc( 100% / 3 );
+	}
+	&.columns-4 .wp-block-column {
+		width: calc( 100% / 4 );
 	}
 }

--- a/blocks/test/fixtures/core__text-columns.html
+++ b/blocks/test/fixtures/core__text-columns.html
@@ -1,10 +1,10 @@
 <!-- wp:core/text-columns {"width":"center"} -->
-<section class="wp-block-text-columns aligncenter columns-2">
+<div class="wp-block-text-columns aligncenter columns-2">
     <div class="wp-block-column">
         <p>One</p>
     </div>
     <div class="wp-block-column">
         <p>Two</p>
     </div>
-</section>
+</div>
 <!-- /wp:core/text-columns -->

--- a/blocks/test/fixtures/core__text-columns.json
+++ b/blocks/test/fixtures/core__text-columns.json
@@ -19,6 +19,6 @@
             "columns": 2,
             "width": "center"
         },
-        "originalContent": "<section class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-column\">\n        <p>Two</p>\n    </div>\n</section>"
+        "originalContent": "<div class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-column\">\n        <p>Two</p>\n    </div>\n</div>"
     }
 ]

--- a/blocks/test/fixtures/core__text-columns.parsed.json
+++ b/blocks/test/fixtures/core__text-columns.parsed.json
@@ -5,7 +5,7 @@
             "width": "center"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<section class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-column\">\n        <p>Two</p>\n    </div>\n</section>\n"
+        "innerHTML": "\n<div class=\"wp-block-text-columns aligncenter columns-2\">\n    <div class=\"wp-block-column\">\n        <p>One</p>\n    </div>\n    <div class=\"wp-block-column\">\n        <p>Two</p>\n    </div>\n</div>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__text-columns.serialized.html
+++ b/blocks/test/fixtures/core__text-columns.serialized.html
@@ -1,10 +1,10 @@
 <!-- wp:text-columns {"width":"center"} -->
-<section class="wp-block-text-columns aligncenter columns-2">
+<div class="wp-block-text-columns aligncenter columns-2">
     <div class="wp-block-column">
         <p>One</p>
     </div>
     <div class="wp-block-column">
         <p>Two</p>
     </div>
-</section>
+</div>
 <!-- /wp:text-columns -->


### PR DESCRIPTION
## Description
Update text columns block markup and create responsive Grid. See issues #2908. Note that depending on content width 3-4 columns blocks **might not have** 3-4 columns. 

We can always force 4 columns using media queries but I wanted to hear opinions first using fluid responsive Grid.

Columns could get really narrow and unreadable if we force them to be in 4 columns.

## Screenshots (jpeg or gifs if applicable):

**Screenshot of Twenty Seventeen (current PR)**:
<img width="530" alt="4 columns fluid grid" src="https://user-images.githubusercontent.com/1820415/32691820-344736c8-c716-11e7-9015-a13d2432ee8e.png">

**Screenshot of Twenty Seventeen if forcing to 4 columns**:
<img width="544" alt="4 columns forced" src="https://user-images.githubusercontent.com/1820415/32691790-b6b4358a-c715-11e7-8052-5d519a0cb303.png">

## How Has This Been Tested?
- Running `npm test` was successful.
- Testing with default themes and random .org themes.

## Types of changes
- Change `<section>` to `<div>`.
- Change to fluid Grid.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.