### PR TITLE
Update image caption colour for better accessibility

### DIFF
--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -1,6 +1,6 @@
 .wp-block-image figcaption {
 	margin-top: 0.5em;
-	color: $dark-gray-100;
+	color: $dark-gray-300;
 	text-align: center;
 	font-size: $default-font-size;
 }


### PR DESCRIPTION
## Description
Use colour #6c7781 for image captions so that it meets colour contrast 4.5:1 guideline.

See issue #2899.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.