### PR TITLE
Update gallery markup for using list

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -224,7 +224,7 @@ class GalleryBlock extends Component {
 					/>
 				</InspectorControls>
 			),
-			<div key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
+			<ul key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
 				{ dropZone }
 				{ images.map( ( img, index ) => (
 					<GalleryImage
@@ -238,7 +238,7 @@ class GalleryBlock extends Component {
 						setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
 					/>
 				) ) }
-			</div>,
+			</ul>,
 		];
 	}
 }

--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -1,4 +1,4 @@
-.blocks-gallery-image {
+.blocks-gallery-item {
 	position: relative;
 
 	&.is-selected {

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -36,26 +36,28 @@ class GalleryImage extends Component {
 
 		const img = url ? <img src={ url } alt={ alt } data-id={ id } /> : <Spinner />;
 
-		const className = classnames( 'blocks-gallery-image', {
+		const className = classnames( 'blocks-gallery-item', {
 			'is-selected': isSelected,
 		} );
 
 		// Disable reason: Each block can be selected by clicking on it and we should keep the same saved markup
 		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
-			<figure className={ className } onClick={ onClick }>
-				{ isSelected &&
-					<div className="blocks-gallery-image__inline-menu">
-						<IconButton
-							icon="no-alt"
-							onClick={ onRemove }
-							className="blocks-gallery-image__remove"
-							label={ __( 'Remove Image' ) }
-						/>
-					</div>
-				}
-				{ href ? <a href={ href }>{ img }</a> : img }
-			</figure>
+			<li className={ className } onClick={ onClick }>
+				<figure>
+					{ isSelected &&
+						<div className="blocks-gallery-image__inline-menu">
+							<IconButton
+								icon="no-alt"
+								onClick={ onRemove }
+								className="blocks-gallery-image__remove"
+								label={ __( 'Remove Image' ) }
+							/>
+						</div>
+					}
+					{ href ? <a href={ href }>{ img }</a> : img }
+				</figure>
+			</li>
 		);
 		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 	}

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -32,7 +32,6 @@ registerBlockType( 'core/gallery', {
 		images: {
 			type: 'array',
 			default: [],
-<<<<<<< HEAD
 			source: 'query',
 			selector: 'ul.wp-block-gallery .blocks-gallery-item img',
 			query: {
@@ -49,13 +48,6 @@ registerBlockType( 'core/gallery', {
 					attribute: 'data-id',
 				},
 			},
-=======
-			source: query( 'ul.wp-block-gallery .blocks-gallery-item img', {
-				url: attr( 'src' ),
-				alt: attr( 'alt' ),
-				id: attr( 'data-id' ),
-			} ),
->>>>>>> Change class to blocks-gallery-item.
 		},
 		columns: {
 			type: 'number',

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -32,6 +32,7 @@ registerBlockType( 'core/gallery', {
 		images: {
 			type: 'array',
 			default: [],
+<<<<<<< HEAD
 			source: 'query',
 			selector: 'ul.wp-block-gallery .blocks-gallery-item img',
 			query: {
@@ -48,6 +49,13 @@ registerBlockType( 'core/gallery', {
 					attribute: 'data-id',
 				},
 			},
+=======
+			source: query( 'ul.wp-block-gallery .blocks-gallery-item img', {
+				url: attr( 'src' ),
+				alt: attr( 'alt' ),
+				id: attr( 'data-id' ),
+			} ),
+>>>>>>> Change class to blocks-gallery-item.
 		},
 		columns: {
 			type: 'number',

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -17,7 +17,7 @@ import './style.scss';
 import { registerBlockType, createBlock } from '../../api';
 import { default as GalleryBlock, defaultColumnsNumber } from './block';
 
-const blockAttributes = {
+const galleryBlockAttributes = {
 	align: {
 		type: 'string',
 		default: 'none',
@@ -62,7 +62,7 @@ registerBlockType( 'core/gallery', {
 	category: 'common',
 	keywords: [ __( 'images' ), __( 'photos' ) ],
 
-	attributes: blockAttributes,
+	attributes: galleryBlockAttributes,
 
 	transforms: {
 		from: [
@@ -181,7 +181,7 @@ registerBlockType( 'core/gallery', {
 
 	deprecated: [ {
 		attributes: {
-			...blockAttributes,
+			...galleryBlockAttributes,
 			images: {
 				type: 'array',
 				default: [],

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -33,7 +33,7 @@ registerBlockType( 'core/gallery', {
 			type: 'array',
 			default: [],
 			source: 'query',
-			selector: 'div.wp-block-gallery figure.blocks-gallery-image img',
+			selector: 'ul.wp-block-gallery .blocks-gallery-item img',
 			query: {
 				url: {
 					source: 'attribute',
@@ -150,7 +150,7 @@ registerBlockType( 'core/gallery', {
 	save( { attributes } ) {
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
 		return (
-			<div className={ `align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
+			<ul className={ `align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
 				{ images.map( ( image ) => {
 					let href;
 
@@ -166,12 +166,14 @@ registerBlockType( 'core/gallery', {
 					const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } />;
 
 					return (
-						<figure key={ image.id || image.url } className="blocks-gallery-image">
-							{ href ? <a href={ href }>{ img }</a> : img }
-						</figure>
+						<li key={ image.id || image.url } className="blocks-gallery-item">
+							<figure>
+								{ href ? <a href={ href }>{ img }</a> : img }
+							</figure>
+						</li>
 					);
 				} ) }
-			</div>
+			</ul>
 		);
 	},
 

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -17,6 +17,44 @@ import './style.scss';
 import { registerBlockType, createBlock } from '../../api';
 import { default as GalleryBlock, defaultColumnsNumber } from './block';
 
+const blockAttributes = {
+	align: {
+		type: 'string',
+		default: 'none',
+	},
+	images: {
+		type: 'array',
+		default: [],
+		source: 'query',
+		selector: 'ul.wp-block-gallery .blocks-gallery-item img',
+		query: {
+			url: {
+				source: 'attribute',
+				attribute: 'src',
+			},
+			alt: {
+				source: 'attribute',
+				attribute: 'alt',
+			},
+			id: {
+				source: 'attribute',
+				attribute: 'data-id',
+			},
+		},
+	},
+	columns: {
+		type: 'number',
+	},
+	imageCrop: {
+		type: 'boolean',
+		default: true,
+	},
+	linkTo: {
+		type: 'string',
+		default: 'none',
+	},
+};
+
 registerBlockType( 'core/gallery', {
 	title: __( 'Gallery' ),
 	description: __( 'Image galleries are a great way to share groups of pictures on your site.' ),
@@ -24,43 +62,7 @@ registerBlockType( 'core/gallery', {
 	category: 'common',
 	keywords: [ __( 'images' ), __( 'photos' ) ],
 
-	attributes: {
-		align: {
-			type: 'string',
-			default: 'none',
-		},
-		images: {
-			type: 'array',
-			default: [],
-			source: 'query',
-			selector: 'ul.wp-block-gallery .blocks-gallery-item img',
-			query: {
-				url: {
-					source: 'attribute',
-					attribute: 'src',
-				},
-				alt: {
-					source: 'attribute',
-					attribute: 'alt',
-				},
-				id: {
-					source: 'attribute',
-					attribute: 'data-id',
-				},
-			},
-		},
-		columns: {
-			type: 'number',
-		},
-		imageCrop: {
-			type: 'boolean',
-			default: true,
-		},
-		linkTo: {
-			type: 'string',
-			default: 'none',
-		},
-	},
+	attributes: blockAttributes,
 
 	transforms: {
 		from: [
@@ -177,4 +179,57 @@ registerBlockType( 'core/gallery', {
 		);
 	},
 
+	deprecated: [ {
+		attributes: {
+			...blockAttributes,
+			images: {
+				type: 'array',
+				default: [],
+				source: 'query',
+				selector: 'div.wp-block-gallery figure.blocks-gallery-image img',
+				query: {
+					url: {
+						source: 'attribute',
+						attribute: 'src',
+					},
+					alt: {
+						source: 'attribute',
+						attribute: 'alt',
+					},
+					id: {
+						source: 'attribute',
+						attribute: 'data-id',
+					},
+				},
+			},
+		},
+
+		save( { attributes } ) {
+			const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
+			return (
+				<div className={ `align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
+					{ images.map( ( image ) => {
+						let href;
+
+						switch ( linkTo ) {
+							case 'media':
+								href = image.url;
+								break;
+							case 'attachment':
+								href = image.link;
+								break;
+						}
+
+						const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } />;
+
+						return (
+							<figure key={ image.id || image.url } className="blocks-gallery-image">
+								{ href ? <a href={ href }>{ img }</a> : img }
+							</figure>
+						);
+					} ) }
+				</div>
+			);
+		},
+	} ],
 } );

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -8,72 +8,56 @@
 .wp-block-gallery.aligncenter {
 	display: flex;
 	flex-wrap: wrap;
+	list-style-type: none;
+	margin-left: -16px;
+	margin-top: 0;
 
-	.blocks-gallery-image {
+	.blocks-gallery-item {
 		margin: 8px;
 		display: flex;
 		flex-grow: 1;
-		flex-direction: column;
-		justify-content: center;
+
+		figure {
+			height: 100%;
+			margin: 0;
+		}
 
 		img {
+			display: block;
 			max-width: 100%;
 			height: auto;
 		}
 	}
 
 	// Cropped
-	&.is-cropped .blocks-gallery-image {
+	&.is-cropped .blocks-gallery-item {
 		img {
-			flex: 1;
 			width: 100%;
 			height: 100%;
 			object-fit: cover;
-
 		}
 
 		// Alas, IE11+ doesn't support object-fit
-		_:-ms-lang(x), img {
+		_:-ms-lang(x), figure {
 			height: auto;
 			width: auto;
 		}
 	}
 
-	&.columns-1 figure {
-		width: calc(100% / 1 - 16px);
-	}
-	&.columns-2 figure {
+	// Responsive fallback value, 2 columns
+	& .blocks-gallery-item {
 		width: calc(100% / 2 - 16px);
 	}
 
-	// Responsive fallback value, 2 columns
-	&.columns-3 figure,
-	&.columns-4 figure,
-	&.columns-5 figure,
-	&.columns-6 figure,
-	&.columns-7 figure,
-	&.columns-8 figure {
-		width: calc(100% / 2 - 16px);
+	&.columns-1 .blocks-gallery-item {
+		width: calc(100% / 1 - 16px);
 	}
 
 	@include break-small {
-		&.columns-3 figure {
-			width: calc(100% / 3 - 16px);
-		}
-		&.columns-4 figure {
-			width: calc(100% / 4 - 16px);
-		}
-		&.columns-5 figure {
-			width: calc(100% / 5 - 16px);
-		}
-		&.columns-6 figure {
-			width: calc(100% / 6 - 16px);
-		}
-		&.columns-7 figure {
-			width: calc(100% / 7 - 16px);
-		}
-		&.columns-8 figure {
-			width: calc(100% / 8 - 16px);
+		@for $i from 3 through 8 {
+			&.columns-#{ $i } .blocks-gallery-item {
+				width: calc(100% / #{ $i } - 16px );
+			}
 		}
 	}
 }

--- a/blocks/test/fixtures/core__gallery.html
+++ b/blocks/test/fixtures/core__gallery.html
@@ -1,10 +1,14 @@
 <!-- wp:core/gallery -->
-<div class="wp-block-gallery alignnone columns-2 is-cropped">
-	<figure class="blocks-gallery-image">
-		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
-	</figure>
-	<figure class="blocks-gallery-image">
-		<img src="http://google.com/hi.png" alt="title" />
-	</figure>
-</div>
+<ul class="wp-block-gallery alignnone columns-2 is-cropped">
+	<li class="blocks-gallery-item">
+		<figure>
+			<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
+		</figure>
+	</li>
+	<li class="blocks-gallery-item">
+		<figure>
+			<img src="http://google.com/hi.png" alt="title" />
+		</figure>
+	</li>
+</ul>
 <!-- /wp:core/gallery -->

--- a/blocks/test/fixtures/core__gallery.html
+++ b/blocks/test/fixtures/core__gallery.html
@@ -1,5 +1,9 @@
 <!-- wp:core/gallery -->
+<<<<<<< HEAD
 <ul class="wp-block-gallery alignnone columns-2 is-cropped">
+=======
+<ul class="wp-block-gallery">
+>>>>>>> Change all classes to blocks-gallery-item, including json.
 	<li class="blocks-gallery-item">
 		<figure>
 			<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />

--- a/blocks/test/fixtures/core__gallery.json
+++ b/blocks/test/fixtures/core__gallery.json
@@ -18,6 +18,10 @@
             "imageCrop": true,
             "linkTo": "none"
         },
+<<<<<<< HEAD
         "originalContent": "<ul class=\"wp-block-gallery alignnone columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>"
+=======
+        "originalContent": "<ul class=\"wp-block-gallery\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>"
+>>>>>>> Change all classes to blocks-gallery-item, including json.
     }
 ]

--- a/blocks/test/fixtures/core__gallery.json
+++ b/blocks/test/fixtures/core__gallery.json
@@ -18,6 +18,6 @@
             "imageCrop": true,
             "linkTo": "none"
         },
-        "originalContent": "<div class=\"wp-block-gallery alignnone columns-2 is-cropped\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>"
+        "originalContent": "<ul class=\"wp-block-gallery alignnone columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>"
     }
 ]

--- a/blocks/test/fixtures/core__gallery.parsed.json
+++ b/blocks/test/fixtures/core__gallery.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/gallery",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-gallery alignnone columns-2 is-cropped\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>\n"
+        "innerHTML": "\n<ul class=\"wp-block-gallery alignnone columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__gallery.parsed.json
+++ b/blocks/test/fixtures/core__gallery.parsed.json
@@ -3,7 +3,11 @@
         "blockName": "core/gallery",
         "attrs": null,
         "innerBlocks": [],
+<<<<<<< HEAD
         "innerHTML": "\n<ul class=\"wp-block-gallery alignnone columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
+=======
+        "innerHTML": "\n<ul class=\"wp-block-gallery\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
+>>>>>>> Change all classes to blocks-gallery-item, including json.
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__gallery.serialized.html
+++ b/blocks/test/fixtures/core__gallery.serialized.html
@@ -1,6 +1,14 @@
 <!-- wp:gallery -->
-<div class="wp-block-gallery alignnone columns-2 is-cropped">
-    <figure class="blocks-gallery-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
-    <figure class="blocks-gallery-image"><img src="http://google.com/hi.png" alt="title" /></figure>
-</div>
+<ul class="wp-block-gallery alignnone columns-2 is-cropped">
+    <li class="blocks-gallery-item">
+        <figure>
+            <img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
+        </figure>
+    </li>
+    <li class="blocks-gallery-item">
+        <figure>
+            <img src="http://google.com/hi.png" alt="title" />
+        </figure>
+    </li>
+</ul>
 <!-- /wp:gallery -->

--- a/blocks/test/fixtures/core__gallery.serialized.html
+++ b/blocks/test/fixtures/core__gallery.serialized.html
@@ -1,5 +1,9 @@
 <!-- wp:gallery -->
+<<<<<<< HEAD
 <ul class="wp-block-gallery alignnone columns-2 is-cropped">
+=======
+<ul class="wp-block-gallery">
+>>>>>>> Change all classes to blocks-gallery-item, including json.
     <li class="blocks-gallery-item">
         <figure>
             <img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />

--- a/blocks/test/fixtures/core__gallery__columns.html
+++ b/blocks/test/fixtures/core__gallery__columns.html
@@ -1,10 +1,14 @@
 <!-- wp:core/gallery {"columns":"1"} -->
-<div class="wp-block-gallery alignnone columns-1 is-cropped">
-	<figure class="blocks-gallery-image">
-		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
-	</figure>
-	<figure class="blocks-gallery-image">
-		<img src="http://google.com/hi.png" alt="title" />
-	</figure>
-</div>
+<ul class="wp-block-gallery alignnone columns-1 is-cropped">
+	<li class="blocks-gallery-item">
+		<figure>
+			<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
+		</figure>
+	</li>
+	<li class="blocks-gallery-item">
+		<figure>
+			<img src="http://google.com/hi.png" alt="title" />
+		</figure>
+	</li>
+</ul>
 <!-- /wp:core/gallery -->

--- a/blocks/test/fixtures/core__gallery__columns.html
+++ b/blocks/test/fixtures/core__gallery__columns.html
@@ -1,5 +1,9 @@
 <!-- wp:core/gallery {"columns":"1"} -->
+<<<<<<< HEAD
 <ul class="wp-block-gallery alignnone columns-1 is-cropped">
+=======
+<ul class="wp-block-gallery columns-1 ">
+>>>>>>> Change all classes to blocks-gallery-item, including json.
 	<li class="blocks-gallery-item">
 		<figure>
 			<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />

--- a/blocks/test/fixtures/core__gallery__columns.json
+++ b/blocks/test/fixtures/core__gallery__columns.json
@@ -19,6 +19,10 @@
             "imageCrop": true,
             "linkTo": "none"
         },
+<<<<<<< HEAD
         "originalContent": "<ul class=\"wp-block-gallery alignnone columns-1 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>"
+=======
+        "originalContent": "<ul class=\"wp-block-gallery columns-1 \">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>"
+>>>>>>> Change all classes to blocks-gallery-item, including json.
     }
 ]

--- a/blocks/test/fixtures/core__gallery__columns.json
+++ b/blocks/test/fixtures/core__gallery__columns.json
@@ -19,6 +19,6 @@
             "imageCrop": true,
             "linkTo": "none"
         },
-        "originalContent": "<div class=\"wp-block-gallery alignnone columns-1 is-cropped\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>"
+        "originalContent": "<ul class=\"wp-block-gallery alignnone columns-1 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>"
     }
 ]

--- a/blocks/test/fixtures/core__gallery__columns.parsed.json
+++ b/blocks/test/fixtures/core__gallery__columns.parsed.json
@@ -5,7 +5,11 @@
             "columns": "1"
         },
         "innerBlocks": [],
+<<<<<<< HEAD
         "innerHTML": "\n<ul class=\"wp-block-gallery alignnone columns-1 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
+=======
+        "innerHTML": "\n<ul class=\"wp-block-gallery columns-1 \">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
+>>>>>>> Change all classes to blocks-gallery-item, including json.
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__gallery__columns.parsed.json
+++ b/blocks/test/fixtures/core__gallery__columns.parsed.json
@@ -5,7 +5,7 @@
             "columns": "1"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-gallery alignnone columns-1 is-cropped\">\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t</figure>\n\t<figure class=\"blocks-gallery-image\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t</figure>\n</div>\n"
+        "innerHTML": "\n<ul class=\"wp-block-gallery alignnone columns-1 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__gallery__columns.serialized.html
+++ b/blocks/test/fixtures/core__gallery__columns.serialized.html
@@ -1,6 +1,14 @@
 <!-- wp:gallery {"columns":1} -->
-<div class="wp-block-gallery alignnone columns-1 is-cropped">
-    <figure class="blocks-gallery-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure>
-    <figure class="blocks-gallery-image"><img src="http://google.com/hi.png" alt="title" /></figure>
-</div>
+<ul class="wp-block-gallery alignnone columns-1 is-cropped">
+    <li class="blocks-gallery-item">
+        <figure>
+            <img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
+        </figure>
+    </li>
+    <li class="blocks-gallery-item">
+        <figure>
+            <img src="http://google.com/hi.png" alt="title" />
+        </figure>
+    </li>
+</ul>
 <!-- /wp:gallery -->

--- a/blocks/test/fixtures/core__gallery__columns.serialized.html
+++ b/blocks/test/fixtures/core__gallery__columns.serialized.html
@@ -1,5 +1,9 @@
 <!-- wp:gallery {"columns":1} -->
+<<<<<<< HEAD
 <ul class="wp-block-gallery alignnone columns-1 is-cropped">
+=======
+<ul class="wp-block-gallery columns-1 ">
+>>>>>>> Change all classes to blocks-gallery-item, including json.
     <li class="blocks-gallery-item">
         <figure>
             <img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -43,7 +43,7 @@ body.gutenberg-editor-page {
 		box-sizing: border-box;
 	}
 
-	ul {
+	ul:not(.wp-block-gallery) {
 		list-style-type: disc;
 	}
 
@@ -51,7 +51,7 @@ body.gutenberg-editor-page {
 		list-style-type: decimal;
 	}
 
-	ul,
+	ul:not(.wp-block-gallery),
 	ol {
 		margin: 0;
 		padding: 0;

--- a/post-content.js
+++ b/post-content.js
@@ -84,11 +84,11 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:gallery {"columns":2} -->',
-		'<div class="wp-block-gallery alignnone columns-2 is-cropped">',
-		'<figure class="blocks-gallery-image"><img src="https://cldup.com/n0g6ME5VKC.jpg" alt="" /></figure>',
-		'<figure class="blocks-gallery-image"><img src="https://cldup.com/ZjESfxPI3R.jpg" alt="" /></figure>',
-		'<figure class="blocks-gallery-image"><img src="https://cldup.com/EKNF8xD2UM.jpg" alt="" /></figure>',
-		'</div>',
+		'<ul class="wp-block-gallery alignnone columns-2 is-cropped">',
+		'<li class="blocks-gallery-item"><figure><img src="https://cldup.com/n0g6ME5VKC.jpg" alt="" /></figure></li>',
+		'<li class="blocks-gallery-item"><figure><img src="https://cldup.com/ZjESfxPI3R.jpg" alt="" /></figure></li>',
+		'<li class="blocks-gallery-item"><figure><img src="https://cldup.com/EKNF8xD2UM.jpg" alt="" /></figure></li>',
+		'</ul>',
 		'<!-- /wp:gallery -->',
 
 		'<!-- wp:paragraph -->',
@@ -112,10 +112,10 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:gallery {"align":"wide","images":[{"url":"https://cldup.com/_rSwtEeDGD.jpg","alt":""},{"url":"https://cldup.com/L-cC3qX2DN.jpg","alt":""}]} -->',
-		'<div class="wp-block-gallery alignwide columns-2 is-cropped">',
-		'<figure class="blocks-gallery-image"><img src="https://cldup.com/_rSwtEeDGD.jpg" alt="" /></figure>',
-		'<figure class="blocks-gallery-image"><img src="https://cldup.com/L-cC3qX2DN.jpg" alt="" /></figure>',
-		'</div>',
+		'<ul class="wp-block-gallery alignwide columns-2 is-cropped">',
+		'<li class="blocks-gallery-item"><figure><img src="https://cldup.com/_rSwtEeDGD.jpg" alt="" /></figure></li>',
+		'<li class="blocks-gallery-item"><figure><img src="https://cldup.com/L-cC3qX2DN.jpg" alt="" /></figure></li>',
+		'</ul>',
 		'<!-- /wp:gallery -->',
 
 		'<!-- wp:paragraph -->',


### PR DESCRIPTION
## Description
Update gallery block for using list markup. See issue #2900.

There is also lot's of small CSS changes. Note that I didn't implement `alignleft` or `alignright` styles yet. It needs further investigation if we decide to go with this markup.

## How Has This Been Tested?
- Tested with several default themes and random .org themes.
- Tested with 1 - max columns.
- Run `npm test` without errors.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
- Markup changes to list format.
- CSS changes because of markup changes.
- CSS class name for list item, I suggest `blocks-gallery-item`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.