### PR TITLE
Fix: Adding an audio block doesn't update the toolbar

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -87,7 +87,7 @@ registerBlockType( 'core/audio', {
 				}
 				return false;
 			};
-			const controls = focus && (
+			const controls = focus && [
 				<BlockControls key="controls">
 					<BlockAlignmentToolbar
 						value={ align }
@@ -105,23 +105,20 @@ registerBlockType( 'core/audio', {
 							<Dashicon icon="edit" />
 						</Button>
 					</Toolbar>
-				</BlockControls>
-			);
+				</BlockControls>,
 
-			const inspectorControls = focus && (
 				<InspectorControls key="inspector">
 					<BlockDescription>
 						<p>{ __( 'The Audio block allows you to embed audio files and play them back using a simple player.' ) }</p>
 					</BlockDescription>
 				</InspectorControls>
-			);
+			];
 
 			const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );
 
 			if ( editing ) {
 				return [
 					controls,
-					inspectorControls,
 					<Placeholder
 						key="placeholder"
 						icon="media-audio"
@@ -155,7 +152,6 @@ registerBlockType( 'core/audio', {
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 			return [
 				controls,
-				inspectorControls,
 				<figure key="audio" className={ className }>
 					<audio controls="controls" src={ src } />
 					{ ( ( caption && caption.length ) || !! focus ) && (

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -120,6 +120,7 @@ registerBlockType( 'core/audio', {
 
 			if ( editing ) {
 				return [
+					controls,
 					inspectorControls,
 					<Placeholder
 						key="placeholder"

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -111,7 +111,7 @@ registerBlockType( 'core/audio', {
 					<BlockDescription>
 						<p>{ __( 'The Audio block allows you to embed audio files and play them back using a simple player.' ) }</p>
 					</BlockDescription>
-				</InspectorControls>
+				</InspectorControls>,
 			];
 
 			const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );


### PR DESCRIPTION
## Description
This PR is referencing this issue #3385 

Added controls to update the toolbar while adding an audio.

## How Has This Been Tested?
Passed all test in `npm test` run

## Screenshots (jpeg or gifs if applicable):
![selection_001](https://user-images.githubusercontent.com/6149344/32698765-c14e8192-c7d0-11e7-9106-4565643b7b9c.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.