### PR TITLE
Update button block CSS and add class to link

### DIFF
--- a/blocks/library/button/editor.scss
+++ b/blocks/library/button/editor.scss
@@ -9,6 +9,10 @@
 }
 
 .wp-block-button {
+	display: inline-block;
+	margin-bottom: 0;
+	position: relative;
+
 	.blocks-format-toolbar__link-modal {
 		z-index: 2;
 		top: calc( 100% + 2px );

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -143,6 +143,36 @@ class ButtonBlock extends Component {
 	}
 }
 
+const blockAttributes = {
+	url: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a',
+		attribute: 'href',
+	},
+	title: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a',
+		attribute: 'title',
+	},
+	text: {
+		type: 'array',
+		source: 'children',
+		selector: 'a',
+	},
+	align: {
+		type: 'string',
+		default: 'none',
+	},
+	color: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+};
+
 registerBlockType( 'core/button', {
 	title: __( 'Button' ),
 
@@ -152,35 +182,7 @@ registerBlockType( 'core/button', {
 
 	category: 'layout',
 
-	attributes: {
-		url: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'a',
-			attribute: 'href',
-		},
-		title: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'a',
-			attribute: 'title',
-		},
-		text: {
-			type: 'array',
-			source: 'children',
-			selector: 'a',
-		},
-		align: {
-			type: 'string',
-			default: 'none',
-		},
-		color: {
-			type: 'string',
-		},
-		textColor: {
-			type: 'string',
-		},
-	},
+	attributes: blockAttributes,
 
 	getEditWrapperProps( attributes ) {
 		const { align, clear } = attributes;
@@ -217,4 +219,18 @@ registerBlockType( 'core/button', {
 			</div>
 		);
 	},
+
+	deprecated: [ {
+		save( { attributes } ) {
+			const { url, text, title, align, color, textColor } = attributes;
+
+			return (
+				<div className={ `align${ align }` } style={ { backgroundColor: color } }>
+					<a href={ url } title={ title } style={ { color: textColor } }>
+						{ text }
+					</a>
+				</div>
+			);
+		},
+	} ],
 } );

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -221,6 +221,8 @@ registerBlockType( 'core/button', {
 	},
 
 	deprecated: [ {
+		attributes: blockAttributes,
+
 		save( { attributes } ) {
 			const { url, text, title, align, color, textColor } = attributes;
 

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -82,7 +82,7 @@ class ButtonBlock extends Component {
 					<BlockAlignmentToolbar value={ align } onChange={ this.updateAlignment } />
 				</BlockControls>
 			),
-			<span key="button" className={ className } title={ title } style={ { backgroundColor: color } } ref={ this.bindRef }>
+			<span key="button" className={ className } title={ title } ref={ this.bindRef }>
 				<Editable
 					tagName="span"
 					placeholder={ __( 'Add text…' ) }
@@ -91,7 +91,9 @@ class ButtonBlock extends Component {
 					onFocus={ setFocus }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+					className="wp-block-button-link"
 					style={ {
+						backgroundColor: color,
 						color: textColor,
 					} }
 					keepPlaceholderOnFocus
@@ -200,9 +202,16 @@ registerBlockType( 'core/button', {
 	save( { attributes } ) {
 		const { url, text, title, align, color, textColor } = attributes;
 
+		const buttonStyle = {
+			backgroundColor: color,
+			color: textColor,
+		};
+
+		const linkClass = 'wp-block-button-link';
+
 		return (
-			<div className={ `align${ align }` } style={ { backgroundColor: color } }>
-				<a href={ url } title={ title } style={ { color: textColor } }>
+			<div className={ `align${ align }` }>
+				<a className={ linkClass } href={ url } title={ title } style={ buttonStyle }>
 					{ text }
 				</a>
 			</div>

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -91,7 +91,7 @@ class ButtonBlock extends Component {
 					onFocus={ setFocus }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
-					className="wp-block-button-link"
+					className="wp-block-button__link"
 					style={ {
 						backgroundColor: color,
 						color: textColor,
@@ -207,7 +207,7 @@ registerBlockType( 'core/button', {
 			color: textColor,
 		};
 
-		const linkClass = 'wp-block-button-link';
+		const linkClass = 'wp-block-button__link';
 
 		return (
 			<div className={ `align${ align }` }>

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -3,7 +3,7 @@ $blocks-button__height: 46px;
 .wp-block-button {
 	margin-bottom: 1.5em;
 
-	& .wp-block-button-link {
+	& .wp-block-button__link {
 		background-color: $dark-gray-700;
 		border: none;
 		border-radius: $blocks-button__height / 2;

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -1,28 +1,37 @@
 $blocks-button__height: 46px;
 
 .wp-block-button {
-	display: inline-block;
-	text-decoration: none;
-	margin: 0;
-	padding: 7px 24px;
-	cursor: default;
-	border-radius: $blocks-button__height / 2;
-	background-color: $dark-gray-700;
-	vertical-align: top;
-	position: relative;
+	margin-bottom: 1.5em;
 
-	> div {
-		color: $white;
-	}
-
-	a {
+	& .wp-block-button-link {
+		background-color: $dark-gray-700;
+		border: none;
+		border-radius: $blocks-button__height / 2;
 		box-shadow: none !important;
 		color: $white;
 		cursor: pointer;
+		display: inline-block;
+		font-size: $big-font-size;
+		height: $blocks-button__height;
+		line-height: $blocks-button__height;
+		margin: 0;
+		padding: 0 24px;
 		text-decoration: none !important;
+		white-space: nowrap;
+
+		&:hover,
+		&:focus,
+		&:active {
+			background-color: $blue-medium-400;
+			color: $white;
+		}
 	}
 
 	&.aligncenter {
-		display: inline-block;
+		text-align: center;
+	}
+
+	&.alignright {
+		text-align: right;
 	}
 }

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -22,7 +22,7 @@ $blocks-button__height: 46px;
 		&:hover,
 		&:focus,
 		&:active {
-			background-color: $blue-medium-400;
+			background-color: $dark-gray-700;
 			color: $white;
 		}
 	}

--- a/blocks/test/fixtures/core__button__center.html
+++ b/blocks/test/fixtures/core__button__center.html
@@ -1,3 +1,3 @@
 <!-- wp:core/button {"align":"center"} -->
-<div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="wp-block-button aligncenter"><a class="wp-block-button-link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->

--- a/blocks/test/fixtures/core__button__center.html
+++ b/blocks/test/fixtures/core__button__center.html
@@ -1,3 +1,3 @@
 <!-- wp:core/button {"align":"center"} -->
-<div class="wp-block-button aligncenter"><a class="wp-block-button-link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:core/button -->

--- a/blocks/test/fixtures/core__button__center.json
+++ b/blocks/test/fixtures/core__button__center.json
@@ -10,6 +10,6 @@
             ],
             "align": "center"
         },
-        "originalContent": "<div class=\"wp-block-button aligncenter\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>"
+        "originalContent": "<div class=\"wp-block-button aligncenter\"><a class=\"wp-block-button-link\" href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>"
     }
 ]

--- a/blocks/test/fixtures/core__button__center.json
+++ b/blocks/test/fixtures/core__button__center.json
@@ -10,6 +10,6 @@
             ],
             "align": "center"
         },
-        "originalContent": "<div class=\"wp-block-button aligncenter\"><a class=\"wp-block-button-link\" href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>"
+        "originalContent": "<div class=\"wp-block-button aligncenter\"><a class=\"wp-block-button__link\" href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>"
     }
 ]

--- a/blocks/test/fixtures/core__button__center.parsed.json
+++ b/blocks/test/fixtures/core__button__center.parsed.json
@@ -5,7 +5,7 @@
             "align": "center"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-button aligncenter\"><a href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
+        "innerHTML": "\n<div class=\"wp-block-button aligncenter\"><a class=\"wp-block-button-link\" href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__button__center.parsed.json
+++ b/blocks/test/fixtures/core__button__center.parsed.json
@@ -5,7 +5,7 @@
             "align": "center"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-button aligncenter\"><a class=\"wp-block-button-link\" href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
+        "innerHTML": "\n<div class=\"wp-block-button aligncenter\"><a class=\"wp-block-button__link\" href=\"https://github.com/WordPress/gutenberg\">Help build Gutenberg</a></div>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__button__center.serialized.html
+++ b/blocks/test/fixtures/core__button__center.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:button {"align":"center"} -->
-<div class="wp-block-button aligncenter"><a class="wp-block-button-link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:button -->

--- a/blocks/test/fixtures/core__button__center.serialized.html
+++ b/blocks/test/fixtures/core__button__center.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:button {"align":"center"} -->
-<div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
+<div class="wp-block-button aligncenter"><a class="wp-block-button-link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:button -->

--- a/post-content.js
+++ b/post-content.js
@@ -143,7 +143,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:button { "align": "center" } -->',
-		'<div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>',
+		'<div class="wp-block-button aligncenter"><a class="wp-block-button-link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>',
 		'<!-- /wp:button -->',
 
 		'<!-- wp:separator -->',

--- a/post-content.js
+++ b/post-content.js
@@ -143,7 +143,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:button { "align": "center" } -->',
-		'<div class="wp-block-button aligncenter"><a class="wp-block-button-link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>',
+		'<div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>',
 		'<!-- /wp:button -->',
 
 		'<!-- wp:separator -->',


### PR DESCRIPTION
## Description
This PR moves all styles (also inline styles) to link itself. Also adds class to link for easier styling in the editor. See issue #2907.

Also align center and right works now.

## How Has This Been Tested?
- Tested with default themes and random .org themes.
- Run `npm test` without errors.
- Tested alignment, background-color, and text color changes.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
- Moves styles to link itself.
- Moves inline styles to link itself.
- Add class `wp-block-button-link` to link. Note that I don't is this the correct way to add class.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.