### PR TITLE
Fix some boxes being too big for the screen

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -360,8 +360,7 @@
 
 	input[type=text] {
 		height: $text-editor-font-size * 4; // same height as an empty paragraph
-		margin-top: 0px;
-		margin-bottom: 4px;
+		margin: 0px 0px 4px 0px;
 		outline: 1px solid transparent;
 		border: none;
 		background: none;
@@ -374,7 +373,6 @@
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
 		cursor: text;
-		left: -1px;
 		max-width: none;	// fixes a bleed issue from the admin
 
 		&:hover {


### PR DESCRIPTION
## Description

On mobile devices, it seems like there are sometimes some boxes too big for the screen. #3316 describes one issue, and 1b861a2 addresses another I've run into.

## How Has This Been Tested?

Tested manually in Chrome's mobile device simulator, and XCode's iPhone simulator.
