### PR TITLE
Bring back movers for floated images.

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -149,10 +149,6 @@
 		// Without z-index, won't be clickable as "above" adjacent content
 		z-index: z-index( '.editor-visual-editor__block {core/image aligned left or right}' );
 		max-width: 370px;
-
-		.editor-block-mover {
-			display: none;
-		}
 	}
 
 	&[data-align="left"] {


### PR DESCRIPTION
I can't recall exactly why we hid these, I believe it had to do with something responsive.

However I'm going to work separately on a responsive play for the movers, which would solve any such issues.