### PR TITLE
Reusable Blocks: Rename the post type

### DIFF
--- a/lib/class-wp-rest-reusable-blocks-controller.php
+++ b/lib/class-wp-rest-reusable-blocks-controller.php
@@ -91,7 +91,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 		$reusable_blocks = get_posts( array(
-			'post_type' => 'gb_reusable_block',
+			'post_type' => 'wp_block',
 		) );
 
 		$collection = array();
@@ -219,7 +219,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 			$prepared_reusable_block->ID = $existing_reusable_block->ID;
 		}
 
-		$prepared_reusable_block->post_type   = 'gb_reusable_block';
+		$prepared_reusable_block->post_type   = 'wp_block';
 		$prepared_reusable_block->post_status = 'publish';
 
 		// ID. We already validated this in self::update_item().
@@ -327,7 +327,7 @@ class WP_REST_Reusable_Blocks_Controller extends WP_REST_Controller {
 	 */
 	private function get_reusable_block( $uuid ) {
 		$reusable_blocks = get_posts( array(
-			'post_type' => 'gb_reusable_block',
+			'post_type' => 'wp_block',
 			'name'      => $uuid,
 		) );
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -363,7 +363,7 @@ add_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state', 10, 2 )
  * @since 0.10.0
  */
 function gutenberg_register_post_types() {
-	register_post_type( 'gb_reusable_block', array(
+	register_post_type( 'wp_block', array(
 		'public' => false,
 	) );
 }

--- a/phpunit/class-rest-reusable-blocks-controller-test.php
+++ b/phpunit/class-rest-reusable-blocks-controller-test.php
@@ -38,7 +38,7 @@ class REST_Reusable_Blocks_Controller_Test extends WP_Test_REST_Controller_Testc
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$reusable_block_post_id = wp_insert_post( array(
-			'post_type'    => 'gb_reusable_block',
+			'post_type'    => 'wp_block',
 			'post_status'  => 'publish',
 			'post_name'    => '2d66a5c5-776c-43b1-98c7-49521cef8ea6',
 			'post_title'   => 'My cool block',


### PR DESCRIPTION
Just a Tiny PR renaming the Custom Post Type used to store the reusable blocks. `wp_block` seemed like the most popular name.
  
Not a breaking change since we do not have any UI to use this yet.

**Testing instructions**

Repeating the testing instructions here https://github.com/WordPress/gutenberg/pull/2503
