### PR TITLE
Unslash post content before parsing during save

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -220,7 +220,15 @@ function gutenberg_wpautop_block_content( $content ) {
  */
 function gutenberg_wpautop_insert_post_data( $data ) {
 	if ( ! empty( $data['post_content'] ) && gutenberg_content_has_blocks( $data['post_content'] ) ) {
-		$data['post_content'] = gutenberg_wpautop_block_content( $data['post_content'] );
+		// WP_REST_Posts_Controller slashes post data before inserting/updating
+		// a post. This data gets unslashed by `wp_insert_post` right before
+		// saving to the DB. The PEG parser needs unslashed input in order to
+		// properly parse JSON attributes.
+		$content = wp_unslash( $data['post_content'] );
+		$content = gutenberg_wpautop_block_content( $content );
+		$content = wp_slash( $content );
+
+		$data['post_content'] = $content;
 	}
 
 	return $data;


### PR DESCRIPTION
Fixes #3426

See #2806 for context on wpautop filter.

## Description

Per the comment in the fix, _WP_REST_Posts_Controller [slashes](https://github.com/WordPress/WordPress/blob/master/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L668) post data before inserting/updating a post. This data gets [unslashed](https://github.com/WordPress/WordPress/blob/4e320fe0087e8df83e6ba7f7765dbc7100c20067/wp-includes/post.php#L3359) by `wp_insert_post` right before saving to the DB. The PEG parser expects unslashed input in order to properly parse JSON attributes._

## How Has This Been Tested?

Try reproducing the parent issue.

## Types of changes

Bug fix.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.