### PR TITLE
FIX - Cannot type in the Link Input dialog when in a paragraph

### DIFF
--- a/components/slot-fill/fill.js
+++ b/components/slot-fill/fill.js
@@ -39,6 +39,14 @@ class Fill extends Component {
 		}
 	}
 
+	componentDidUpdate() {
+		const { getSlot = noop } = this.context;
+		const slot = getSlot( this.props.name );
+		if ( slot && ! slot.props.bubblesVirtually ) {
+			slot.forceUpdate();
+		}
+	}
+
 	render() {
 		const { getSlot = noop } = this.context;
 		const { name, children } = this.props;

--- a/components/slot-fill/test/slot.js
+++ b/components/slot-fill/test/slot.js
@@ -10,6 +10,27 @@ import Slot from '../slot';
 import Fill from '../fill';
 import Provider from '../provider';
 
+/**
+ * WordPress Dependencies
+ */
+import { Component } from '@wordpress/element';
+
+class Filler extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			num: 1,
+		};
+	}
+	render() {
+		return [
+			<button key="1" type="button" onClick={ () => this.setState( { num: this.state.num + 1 } ) } />,
+			<Fill name={ this.props.name } key="2">{ this.state.num.toString() }</Fill>,
+		];
+	}
+}
+
 describe( 'Slot', () => {
 	it( 'should render empty Fills', () => {
 		const element = mount(
@@ -59,5 +80,20 @@ describe( 'Slot', () => {
 		);
 
 		expect( element.find( 'Slot > div' ).html() ).toBe( '<div><span></span><div></div>text</div>' );
+	} );
+
+	it( 'should re-render when bubbling virtually', () => {
+		const element = mount(
+			<Provider>
+				<Slot name="egg" />
+				<Filler name="egg" />
+			</Provider>
+		);
+
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div>1</div>' );
+
+		element.find( 'button' ).simulate( 'click' );
+
+		expect( element.find( 'Slot > div' ).html() ).toBe( '<div>2</div>' );
 	} );
 } );

--- a/components/slot-fill/test/slot.js
+++ b/components/slot-fill/test/slot.js
@@ -82,7 +82,7 @@ describe( 'Slot', () => {
 		expect( element.find( 'Slot > div' ).html() ).toBe( '<div><span></span><div></div>text</div>' );
 	} );
 
-	it( 'should re-render when bubbling virtually', () => {
+	it( 'should re-render Slot when not bubbling virtually', () => {
 		const element = mount(
 			<Provider>
 				<Slot name="egg" />


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
fixes https://github.com/WordPress/gutenberg/issues/3466
fixes https://github.com/WordPress/gutenberg/issues/3467

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manual, unit tests

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.