### PR TITLE
Change z-index to fix block mover over link input

### DIFF
--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -17,10 +17,10 @@ $z-layers: (
 	'.components-panel__header': 1,
 	'.editor-meta-boxes-area.is-loading:before': 1,
 	'.editor-meta-boxes-area .spinner': 2,
-	'.blocks-format-toolbar__link-modal': 21,
+	'.blocks-format-toolbar__link-modal': 2,
 	'.editor-block-contextual-toolbar': 2,
 	'.editor-block-switcher__menu': 2,
-	'.editor-block-mover': 20,
+	'.editor-block-mover': 1,
 	'.blocks-gallery-image__inline-menu': 20,
 	'.editor-block-settings-menu__popover': 20, // Below the header
 	'.editor-header': 30,

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -17,7 +17,7 @@ $z-layers: (
 	'.components-panel__header': 1,
 	'.editor-meta-boxes-area.is-loading:before': 1,
 	'.editor-meta-boxes-area .spinner': 2,
-	'.blocks-format-toolbar__link-modal': 2,
+	'.blocks-format-toolbar__link-modal': 21,
 	'.editor-block-contextual-toolbar': 2,
 	'.editor-block-switcher__menu': 2,
 	'.editor-block-mover': 20,


### PR DESCRIPTION
## Description
Block mover handles showing over link input #3464 

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.