### PR TITLE
Disable ToC button when there are no blocks.

### DIFF
--- a/editor/table-of-contents/index.js
+++ b/editor/table-of-contents/index.js
@@ -32,6 +32,7 @@ function TableOfContents( { blocks } ) {
 					icon="admin-page"
 					aria-expanded={ isOpen }
 					label={ __( 'Information' ) }
+					disabled={ blocks.length === 0 }
 				/>
 			) }
 			renderContent={ () => ( [


### PR DESCRIPTION
Small QoL improvement:

![image](https://user-images.githubusercontent.com/548849/32781090-fed08564-c943-11e7-922d-4ad5e3b85c38.png)
