### PR TITLE
Add paragraph count to table of contents component.

### DIFF
--- a/editor/table-of-contents/index.js
+++ b/editor/table-of-contents/index.js
@@ -20,6 +20,7 @@ import { selectBlock } from '../actions';
 
 function TableOfContents( { blocks } ) {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
+	const paragraphs = filter( blocks, ( block ) => block.name === 'core/paragraph' );
 
 	return (
 		<Dropdown
@@ -47,6 +48,10 @@ function TableOfContents( { blocks } ) {
 					<div className="table-of-contents__count">
 						<span className="table-of-contents__number">{ headings.length }</span>
 						{ __( 'Headings' ) }
+					</div>
+					<div className="table-of-contents__count">
+						<span className="table-of-contents__number">{ paragraphs.length }</span>
+						{ __( 'Paragraphs' ) }
 					</div>
 				</div>,
 				headings.length > 0 && (


### PR DESCRIPTION
Show paragraph-block count in table of contents, completing the grid:

![image](https://user-images.githubusercontent.com/548849/32781134-280881de-c944-11e7-9efe-c5f51285edbd.png)

(Note: this will miscount paragraphs within quotes, etc, until we make those nested blocks.)