### PR TITLE
Blocks: Put anchor inside block inspector's Advanced  section

### DIFF
--- a/blocks/hooks/anchor.js
+++ b/blocks/hooks/anchor.js
@@ -55,7 +55,7 @@ export function addInspectorControl( element, props ) {
 	if ( hasBlockSupport( props.name, 'anchor' ) && props.focus ) {
 		element = [
 			cloneElement( element, { key: 'edit' } ),
-			<InspectorControls key="inspector">
+			<InspectorControls.Advanced key="inspector">
 				<InspectorControls.TextControl
 					label={ __( 'HTML Anchor' ) }
 					help={ __( 'Anchors lets you link directly to a section on a page.' ) }
@@ -67,7 +67,7 @@ export function addInspectorControl( element, props ) {
 							anchor: nextValue,
 						} );
 					} } />
-			</InspectorControls>,
+			</InspectorControls.Advanced>,
 		];
 	}
 

--- a/blocks/inspector-controls/index.js
+++ b/blocks/inspector-controls/index.js
@@ -23,6 +23,15 @@ export default function InspectorControls( { children } ) {
 	);
 }
 
+function InspectorAdvancedControls( { children } ) {
+	return (
+		<Fill name="Inspector.AdvancedControls">
+			{ children }
+		</Fill>
+	);
+}
+
+InspectorControls.Advanced = InspectorAdvancedControls;
 InspectorControls.BaseControl = BaseControl;
 InspectorControls.CheckboxControl = CheckboxControl;
 InspectorControls.RadioControl = RadioControl;

--- a/components/slot-fill/slot.js
+++ b/components/slot-fill/slot.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, map, isString } from 'lodash';
+import { noop, map, isString, identity } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -45,7 +45,7 @@ class Slot extends Component {
 	}
 
 	render() {
-		const { name, bubblesVirtually = false } = this.props;
+		const { name, bubblesVirtually = false, renderFills = identity } = this.props;
 		const { getFills = noop } = this.context;
 
 		if ( bubblesVirtually ) {
@@ -54,7 +54,7 @@ class Slot extends Component {
 
 		return (
 			<div ref={ this.bindNode }>
-				{ map( getFills( name ), ( fill ) => {
+				{ renderFills( map( getFills( name ), ( fill ) => {
 					const fillKey = fill.props.instanceId;
 					return Children.map( fill.props.children, ( child, childIndex ) => {
 						if ( ! child || isString( child ) ) {
@@ -63,7 +63,7 @@ class Slot extends Component {
 						const childKey = `${ fillKey }---${ child.key || childIndex }`;
 						return cloneElement( child, { key: childKey } );
 					} );
-				} ) }
+				} ) ) }
 			</div>
 		);
 	}

--- a/editor/components/block-inspector/advanced-controls.js
+++ b/editor/components/block-inspector/advanced-controls.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -9,7 +10,7 @@ import { connect } from 'react-redux';
 import { Component } from '@wordpress/element';
 import { getBlockType, InspectorControls } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, Slot } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -30,25 +31,32 @@ class BlockInspectorAdvancedControls extends Component {
 	}
 
 	render() {
-		const { selectedBlock } = this.props;
-		const blockType = getBlockType( selectedBlock.name );
-		if ( false === blockType.className ) {
-			return null;
-		}
-
 		return (
-			<PanelBody
-				className="editor-advanced-controls"
-				initialOpen={ false }
-				title={ __( 'Advanced' ) }
-			>
-				{ false !== blockType.className &&
-					<InspectorControls.TextControl
-						label={ __( 'Additional CSS Class' ) }
-						value={ selectedBlock.attributes.className || '' }
-						onChange={ this.setClassName } />
-				}
-			</PanelBody>
+			<Slot
+				name="Inspector.AdvancedControls"
+				renderFills={ ( fills ) => {
+					const { selectedBlock } = this.props;
+					const blockType = getBlockType( selectedBlock.name );
+					if ( false === blockType.className && isEmpty( fills ) ) {
+						return null;
+					}
+
+					return (
+						<PanelBody
+							className="editor-advanced-controls"
+							initialOpen={ false }
+							title={ __( 'Advanced' ) }
+						>
+							{ false !== blockType.className &&
+							<InspectorControls.TextControl
+								label={ __( 'Additional CSS Class' ) }
+								value={ selectedBlock.attributes.className || '' }
+								onChange={ this.setClassName } />
+							}
+							{ fills }
+						</PanelBody>
+					);
+				} } />
 		);
 	}
 }


### PR DESCRIPTION
## Description

Related to: #3318, #3472. 

As noted [in here](https://github.com/WordPress/gutenberg/pull/3318#issuecomment-344210032), with #3318 we introduced new ways to make blocks extensible. To make it happen we moved `anchor` out of the `Advanced` section in the block's toolbar. This PR tries to bring back this section in a way which allows to work it with the extensibility layer. To make sure that `Advanced` section gets displayed only when it contains items to render I used `render prop` technique. This is the same pattern @youknowriad used when refactoring and extracting reusable `<Dropdown />` component.

## How Has This Been Tested?
1. Open Gutenberg editor.
2. Add a `Paragraph` block.
3. Open block settings.
4. Make sure there are no advanced settings.
5. Add a `Heading` block.
6. Open block settings.
7. Make sure there are advanced settings in the collapsed state.
8. Make sure they open and work properly after you click toggle icon.
9. Add an `Image` block.
10. Make sure there are advanced settings in the collapsed state.
11. Make sure they open and work properly after you click toggle icon.

## Screenshots (jpeg or gifs if applicable):

#### Before

![screen shot 2017-11-14 at 15 34 29](https://user-images.githubusercontent.com/699132/32785237-56b2b8a8-c951-11e7-8adc-12b17d7e04bd.png)


#### After

![screen shot 2017-11-14 at 15 27 29](https://user-images.githubusercontent.com/699132/32784890-6052159e-c950-11e7-9875-ac90fba0f5fa.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

## TODO:
- [ ] Update documentation.