### PR TITLE
Metaboxes: Hold jQuery ready only if there are metaboxes

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, uniqueId, map, filter } from 'lodash';
+import { get, uniqueId, map, filter, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -42,9 +42,6 @@ import {
 
 const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
 const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
-
-// Hold jquery.ready until the metaboxes load
-jQuery.holdReady( true );
 
 export default {
 	REQUEST_POST_UPDATE( action, store ) {
@@ -279,6 +276,12 @@ export default {
 		}
 
 		return effects;
+	},
+	INITIALIZE_META_BOX_STATE( action ) {
+		// Hold jquery.ready until the metaboxes load
+		if ( some( action.metaBoxes ) ) {
+			jQuery.holdReady( true );
+		}
 	},
 	META_BOX_LOADED( action, store ) {
 		const { getState } = store;


### PR DESCRIPTION
closes #3465

We hold jQuery ready event when we have metaboxes still being loaded but this breaks the heartbeat script since we never trigger the "ready" event if we do not have metaboxes.

This PR fixes the issue by holding the "ready" event only if we have metaboxes.