### PR TITLE
Update post date color and added breakpoint to grid in latest posts block.

### DIFF
--- a/blocks/library/latest-posts/style.scss
+++ b/blocks/library/latest-posts/style.scss
@@ -13,32 +13,22 @@
 
 		li {
 			margin: 0 16px 16px 0;
+			width: 100%;
 		}
 	}
 
-	&.columns-1 li {
-		width: calc( ( 100% / 1 ) - 16px );
-	}
-	&.columns-2 li {
-		width: calc( ( 100% / 2 ) - 16px );
-	}
-	&.columns-3 li {
-		width: calc( ( 100% / 3 ) - 16px );
-	}
-	&.columns-4 li {
-		width: calc( ( 100% / 4 ) - 16px );
-	}
-	&.columns-5 li {
-		width: calc( ( 100% / 5 ) - 16px );
-	}
-	&.columns-6 li {
-		width: calc( ( 100% / 6 ) - 16px );
+	@include break-small {
+		@for $i from 2 through 6 {
+			&.columns-#{ $i } li {
+				width: calc( ( 100% / #{ $i } ) - 16px );
+			}
+		}
 	}
 }
 
 .wp-block-latest-posts__post-date {
 	display: block;
-	color: $dark-gray-100;
+	color: $dark-gray-300;
 	font-size: $default-font-size;
 }
 


### PR DESCRIPTION
## Description
Update post date color to `$dark-gray-300` which meats accessibility guidelines on white background. Other backgrounds can be a problem.

Also added breakpoint on grid.

## How Has This Been Tested?
- Run `npm test` without errors.
- Testes front-end with default themes and random .org themes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.