### PR TITLE
Update dashicons

### DIFF
--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -520,6 +520,9 @@ export default class Dashicon extends wp.element.Component {
 			case 'index-card':
 				path = 'M1 3.17V18h18V4H8v-.83c0-.32-.12-.6-.35-.83S7.14 2 6.82 2H2.18c-.33 0-.6.11-.83.34-.24.23-.35.51-.35.83zM10 6v2H3V6h7zm7 0v10h-5V6h5zm-7 4v2H3v-2h7zm0 4v2H3v-2h7z';
 				break;
+			case 'info-outline':
+				path = 'M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z';
+				break;
 			case 'info':
 				path = 'M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm1 4c0-.55-.45-1-1-1s-1 .45-1 1 .45 1 1 1 1-.45 1-1zm0 9V9H9v6h2z';
 				break;


### PR DESCRIPTION
This updates the dashicons component to the latest version. It contains a new info-outline icon.

This is tested like this:

![screen shot 2017-11-14 at 15 20 38](https://user-images.githubusercontent.com/1204802/32784685-c9467d70-c94f-11e7-9fad-6afe8534d728.png)

But the above is not a change this PR makes. 