### PR TITLE
Added contrast verification to paragraph colors

### DIFF
--- a/blocks/contrast-checker/index.js
+++ b/blocks/contrast-checker/index.js
@@ -14,12 +14,12 @@ import { Notice } from '@wordpress/components';
  */
 import './style.scss';
 
-function ContrastChecker( { backgroundColor, textColor, isLargeText } ) {
-	if ( ! backgroundColor || ! textColor ) {
+function ContrastChecker( { backgroundColor, textColor, isLargeText, fallbackBackgroundColor, fallbackTextColor } ) {
+	if ( ! ( backgroundColor || fallbackBackgroundColor ) || ! ( textColor || fallbackTextColor ) ) {
 		return null;
 	}
-	const tinyBackgroundColor = tinycolor( backgroundColor );
-	const tinyTextColor = tinycolor( textColor );
+	const tinyBackgroundColor = tinycolor( backgroundColor || fallbackBackgroundColor );
+	const tinyTextColor = tinycolor( textColor || fallbackTextColor );
 	if ( tinycolor.isReadable(
 		tinyBackgroundColor,
 		tinyTextColor,

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -23,9 +23,21 @@ import BlockDescription from '../../block-description';
 
 const { getComputedStyle } = window;
 
+const ContrastCheckerWithFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textColor, backgroundColor } = ownProps;
+	//avoid the use of querySelector if textColor color is known and verify if node is available.
+	const textNode = ! textColor && node ? node.querySelector( '[contenteditable="true"]' ) : null;
+	return {
+		fallbackBackgroundColor: backgroundColor || ! node ? undefined : getComputedStyle( node ).backgroundColor,
+		fallbackTextColor: textColor || ! textNode ? undefined : getComputedStyle( textNode ).color,
+	};
+} )( ContrastChecker );
+
 class ButtonBlock extends Component {
 	constructor() {
 		super( ...arguments );
+		this.nodeRef = null;
+		this.bindRef = this.bindRef.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
 		this.toggleClear = this.toggleClear.bind( this );
 	}
@@ -39,6 +51,13 @@ class ButtonBlock extends Component {
 		setAttributes( { clear: ! attributes.clear } );
 	}
 
+	bindRef( node ) {
+		if ( ! node ) {
+			return;
+		}
+		this.nodeRef = node;
+	}
+
 	render() {
 		const {
 			attributes,
@@ -46,8 +65,6 @@ class ButtonBlock extends Component {
 			focus,
 			setFocus,
 			className,
-			fallbackBackgroundColor,
-			fallbackTextColor,
 		} = this.props;
 
 		const {
@@ -66,7 +83,7 @@ class ButtonBlock extends Component {
 					<BlockAlignmentToolbar value={ align } onChange={ this.updateAlignment } />
 				</BlockControls>
 			),
-			<span key="button" className={ className } title={ title } style={ { backgroundColor: color } }>
+			<span key="button" className={ className } title={ title } style={ { backgroundColor: color } } ref={ this.bindRef }>
 				<Editable
 					tagName="span"
 					placeholder={ __( 'Add text…' ) }
@@ -103,11 +120,12 @@ class ButtonBlock extends Component {
 								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
 							/>
 						</PanelColor>
-						<ContrastChecker
-							textColor={ textColor || fallbackTextColor }
-							backgroundColor={ color || fallbackBackgroundColor }
+						{ this.nodeRef && <ContrastCheckerWithFallbackStyles
+							node={ this.nodeRef }
+							textColor={ textColor }
+							backgroundColor={ color }
 							isLargeText={ true }
-						/>
+						/> }
 					</InspectorControls>
 				}
 			</span>,
@@ -127,14 +145,6 @@ class ButtonBlock extends Component {
 		];
 	}
 }
-
-const ButtonBlockFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
-	const { textColor, color } = ownProps.attributes;
-	return {
-		fallbackBackgroundColor: color ? undefined : getComputedStyle( node.querySelector( `.${ ownProps.className }` ) ).backgroundColor,
-		fallbackTextColor: textColor ? undefined : getComputedStyle( node.querySelector( '[contenteditable="true"]' ) ).color,
-	};
-} )( ButtonBlock );
 
 registerBlockType( 'core/button', {
 	title: __( 'Button' ),
@@ -188,9 +198,7 @@ registerBlockType( 'core/button', {
 		return props;
 	},
 
-	edit( props ) {
-		return <ButtonBlockFallbackStyles { ...props } />;
-	},
+	edit: ButtonBlock,
 
 	save( { attributes } ) {
 		const { url, text, title, align, color, textColor } = attributes;

--- a/blocks/library/paragraph/editor.scss
+++ b/blocks/library/paragraph/editor.scss
@@ -1,0 +1,3 @@
+.editor-block-list__block:not( .is-multi-selected ) .wp-block-paragraph {
+	background: white;
+}

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -7,12 +7,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { concatChildren } from '@wordpress/element';
-import { Autocomplete, PanelBody, PanelColor } from '@wordpress/components';
+import { concatChildren, Component } from '@wordpress/element';
+import { Autocomplete, PanelBody, PanelColor, withFallbackStyles } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import './editor.scss';
 import './style.scss';
 import { registerBlockType, createBlock, setDefaultBlockName } from '../../api';
 import { blockAutocompleter, userAutocompleter } from '../../autocompleters';
@@ -25,7 +26,9 @@ import ToggleControl from '../../inspector-controls/toggle-control';
 import RangeControl from '../../inspector-controls/range-control';
 import ColorPalette from '../../color-palette';
 import BlockDescription from '../../block-description';
+import ContrastChecker from '../../contrast-checker';
 
+const { getComputedStyle } = window;
 
 class ParagraphBlock extends Component {
 	constructor() {
@@ -43,6 +46,8 @@ class ParagraphBlock extends Component {
 			attributes,
 			setAttributes,
 			insertBlocksAfter,
+			fallbackBackgroundColor,
+			fallbackTextColor,
 			focus,
 			setFocus,
 			mergeBlocks,
@@ -106,6 +111,11 @@ class ParagraphBlock extends Component {
 							onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
 						/>
 					</PanelColor>
+					<ContrastChecker
+						textColor={ textColor || fallbackTextColor }
+						backgroundColor={ backgroundColor || fallbackBackgroundColor }
+						isLargeText={ true }
+					/>
 					<PanelBody title={ __( 'Block Alignment' ) }>
 						<BlockAlignmentToolbar
 							value={ width }
@@ -159,6 +169,15 @@ class ParagraphBlock extends Component {
 		];
 	}
 }
+
+const ParagraphBlockFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textColor, backgroundColor } = ownProps.attributes;
+	const computedStyles = ( ! textColor || ! backgroundColor ) ? getComputedStyle( node.querySelector( '[contenteditable="true"]' ) ) : null;
+	return {
+		fallbackBackgroundColor: backgroundColor ? undefined : computedStyles.backgroundColor,
+		fallbackTextColor: textColor ? undefined : computedStyles.color,
+	};
+} )( ParagraphBlock );
 
 registerBlockType( 'core/paragraph', {
 	title: __( 'Paragraph' ),
@@ -231,7 +250,7 @@ registerBlockType( 'core/paragraph', {
 	},
 
 	edit( props ) {
-		return <ParagraphBlock { ...props } />;
+		return <ParagraphBlockFallbackStyles { ...props } />;
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -26,78 +26,40 @@ import RangeControl from '../../inspector-controls/range-control';
 import ColorPalette from '../../color-palette';
 import BlockDescription from '../../block-description';
 
-registerBlockType( 'core/paragraph', {
-	title: __( 'Paragraph' ),
 
-	icon: 'editor-paragraph',
+class ParagraphBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.toggleDropCap = this.toggleDropCap.bind( this );
+	}
 
-	category: 'common',
+	toggleDropCap() {
+		const { attributes, setAttributes } = this.props;
+		setAttributes( { dropCap: ! attributes.dropCap } );
+	}
 
-	keywords: [ __( 'text' ) ],
+	render() {
+		const {
+			attributes,
+			setAttributes,
+			insertBlocksAfter,
+			focus,
+			setFocus,
+			mergeBlocks,
+			onReplace,
+		} = this.props;
 
-	supports: {
-		className: false,
-	},
+		const {
+			align,
+			content,
+			dropCap,
+			placeholder,
+			fontSize,
+			backgroundColor,
+			textColor,
+			width,
+		} = attributes;
 
-	attributes: {
-		content: {
-			type: 'array',
-			source: 'children',
-			selector: 'p',
-		},
-		align: {
-			type: 'string',
-		},
-		dropCap: {
-			type: 'boolean',
-			default: false,
-		},
-		placeholder: {
-			type: 'string',
-		},
-		width: {
-			type: 'string',
-		},
-		textColor: {
-			type: 'string',
-		},
-		backgroundColor: {
-			type: 'string',
-		},
-		fontSize: {
-			type: 'number',
-		},
-	},
-
-	transforms: {
-		from: [
-			{
-				type: 'raw',
-				isMatch: ( node ) => (
-					node.nodeName === 'P' &&
-					// Do not allow embedded content.
-					! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
-				),
-			},
-		],
-	},
-
-	merge( attributes, attributesToMerge ) {
-		return {
-			content: concatChildren( attributes.content, attributesToMerge.content ),
-		};
-	},
-
-	getEditWrapperProps( attributes ) {
-		const { width } = attributes;
-		if ( [ 'wide', 'full', 'left', 'right' ].indexOf( width ) !== -1 ) {
-			return { 'data-align': width };
-		}
-	},
-
-	edit( { attributes, setAttributes, insertBlocksAfter, focus, setFocus, mergeBlocks, onReplace } ) {
-		const { align, content, dropCap, placeholder, fontSize, backgroundColor, textColor, width } = attributes;
-		const toggleDropCap = () => setAttributes( { dropCap: ! dropCap } );
 		const className = dropCap ? 'has-drop-cap' : null;
 
 		return [
@@ -120,7 +82,7 @@ registerBlockType( 'core/paragraph', {
 						<ToggleControl
 							label={ __( 'Drop Cap' ) }
 							checked={ !! dropCap }
-							onChange={ toggleDropCap }
+							onChange={ this.toggleDropCap }
 						/>
 						<RangeControl
 							label={ __( 'Font Size' ) }
@@ -195,6 +157,81 @@ registerBlockType( 'core/paragraph', {
 				) }
 			</Autocomplete>,
 		];
+	}
+}
+
+registerBlockType( 'core/paragraph', {
+	title: __( 'Paragraph' ),
+
+	icon: 'editor-paragraph',
+
+	category: 'common',
+
+	keywords: [ __( 'text' ) ],
+
+	supports: {
+		className: false,
+	},
+
+
+	attributes: {
+		content: {
+			type: 'array',
+			source: 'children',
+			selector: 'p',
+		},
+		align: {
+			type: 'string',
+		},
+		dropCap: {
+			type: 'boolean',
+			default: false,
+		},
+		placeholder: {
+			type: 'string',
+		},
+		width: {
+			type: 'string',
+		},
+		textColor: {
+			type: 'string',
+		},
+		backgroundColor: {
+			type: 'string',
+		},
+		fontSize: {
+			type: 'number',
+		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				isMatch: ( node ) => (
+					node.nodeName === 'P' &&
+					// Do not allow embedded content.
+					! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
+				),
+			},
+		],
+	},
+
+	merge( attributes, attributesToMerge ) {
+		return {
+			content: concatChildren( attributes.content, attributesToMerge.content ),
+		};
+	},
+
+	getEditWrapperProps( attributes ) {
+		const { width } = attributes;
+		if ( [ 'wide', 'full', 'left', 'right' ].indexOf( width ) !== -1 ) {
+			return { 'data-align': width };
+		}
+	},
+
+	edit( props ) {
+		return <ParagraphBlock { ...props } />;
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/paragraph/style.scss
+++ b/blocks/library/paragraph/style.scss
@@ -18,3 +18,7 @@ p.has-drop-cap:not( :focus )  {
 p.has-background {
 	padding: 20px 30px;
 }
+
+.editor-block-list__block:not( .is-multi-selected ) .wp-block-paragraph {
+	background: white;
+}

--- a/components/higher-order/with-fallback-styles/index.js
+++ b/components/higher-order/with-fallback-styles/index.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { every, isEqual } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+export default ( mapNodeToProps ) => ( WrappedComponent ) => {
+	return class extends Component {
+		constructor() {
+			super( ...arguments );
+			this.nodeRef = null;
+			this.state = {
+				fallbackStyles: undefined,
+				grabStylesCompleted: false,
+			};
+
+			this.bindRef = this.bindRef.bind( this );
+		}
+
+		bindRef( node ) {
+			if ( ! node ) {
+				return;
+			}
+			this.nodeRef = node;
+		}
+
+		componentDidMount() {
+			this.grabFallbackStyles();
+		}
+
+		componentDidUpdate() {
+			this.grabFallbackStyles();
+		}
+
+		grabFallbackStyles() {
+			const { grabStylesCompleted, fallbackStyles } = this.state;
+			if ( this.nodeRef && ! grabStylesCompleted ) {
+				const newFallbackStyles = mapNodeToProps( this.nodeRef, this.props );
+				if ( ! isEqual( newFallbackStyles, fallbackStyles ) ) {
+					this.setState( {
+						fallbackStyles: newFallbackStyles,
+						grabStylesCompleted: !! every( newFallbackStyles ),
+					} );
+				}
+			}
+		}
+
+		render() {
+			return (
+				<div ref={ this.bindRef }>
+					<WrappedComponent { ...this.props } { ...this.state.fallbackStyles } />
+				</div>
+			);
+		}
+	};
+};

--- a/components/higher-order/with-fallback-styles/index.js
+++ b/components/higher-order/with-fallback-styles/index.js
@@ -12,7 +12,7 @@ export default ( mapNodeToProps ) => ( WrappedComponent ) => {
 	return class extends Component {
 		constructor() {
 			super( ...arguments );
-			this.nodeRef = null;
+			this.nodeRef = this.props.node;
 			this.state = {
 				fallbackStyles: undefined,
 				grabStylesCompleted: false,
@@ -50,11 +50,8 @@ export default ( mapNodeToProps ) => ( WrappedComponent ) => {
 		}
 
 		render() {
-			return (
-				<div ref={ this.bindRef }>
-					<WrappedComponent { ...this.props } { ...this.state.fallbackStyles } />
-				</div>
-			);
+			const wrappedComponent = <WrappedComponent { ...this.props } { ...this.state.fallbackStyles } />;
+			return this.props.node ? wrappedComponent : <div ref={ this.bindRef }> { wrappedComponent } </div>;
 		}
 	};
 };

--- a/components/index.js
+++ b/components/index.js
@@ -38,6 +38,7 @@ export { Slot, Fill, Provider as SlotFillProvider } from './slot-fill';
 export { default as navigateRegions } from './higher-order/navigate-regions';
 export { default as withAPIData } from './higher-order/with-api-data';
 export { default as withContext } from './higher-order/with-context';
+export { default as withFallbackStyles } from './higher-order/with-fallback-styles';
 export { default as withFocusOutside } from './higher-order/with-focus-outside';
 export { default as withFocusReturn } from './higher-order/with-focus-return';
 export { default as withInstanceId } from './higher-order/with-instance-id';


### PR DESCRIPTION
## Description
This PR aims to address the remaining part of https://github.com/WordPress/gutenberg/issues/2381, by adding a contrast checking following WCAG 2.0- AA (https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) to the paragraph.

## How Has This Been Tested?
Test some colors in the paragraph and verify that when contrast is high no message, in low contrast color pairs a message appear.
Verify that when the background is darker than text, we suggest making the background darker and/or the text lighter and when text is darker we suggest making the text darker and/or background lighter.
Verify that for some color pairs e.g. background #C46161 and black text or our blue with no background the message does not appear, if the font size is equal or larger than 18 and the message appears if the font size is smaller.

## Screenshots (jpeg or gifs if applicable):

![nov-14-2017 17-07-04](https://user-images.githubusercontent.com/11271197/32794361-8b015c90-c960-11e7-8a83-09e3caafc965.gif)
![nov-14-2017 17-07-19](https://user-images.githubusercontent.com/11271197/32794362-8b28785c-c960-11e7-9d2d-f8c9d54f3a69.gif)
