### PR TITLE
Update embed, audio and video caption colour for better accessibility.

### DIFF
--- a/blocks/library/audio/style.scss
+++ b/blocks/library/audio/style.scss
@@ -12,7 +12,7 @@
 
 .wp-block-audio figcaption {
 	margin-top: 0.5em;
-	color: $dark-gray-100;
+	color: $dark-gray-300;
 	text-align: center;
 	font-size: $default-font-size;
 }

--- a/blocks/library/embed/style.scss
+++ b/blocks/library/embed/style.scss
@@ -1,6 +1,6 @@
 .wp-block-embed figcaption {
 	margin-top: 0.5em;
-	color: $dark-gray-100;
+	color: $dark-gray-300;
 	text-align: center;
 	font-size: $default-font-size;
 }

--- a/blocks/library/video/style.scss
+++ b/blocks/library/video/style.scss
@@ -1,6 +1,6 @@
 .wp-block-video figcaption {
 	margin-top: 0.5em;
-	color: $dark-gray-100;
+	color: $dark-gray-300;
 	text-align: center;
 	font-size: $default-font-size;
 }


### PR DESCRIPTION
## Description
Use colour #6c7781 for embed, audio and video captions so that it meets colour contrast 4.5:1 guideline. See PR #3439.