### PR TITLE
FIX: Only add inserters in between blocks (not at end)

### DIFF
--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -218,7 +218,7 @@ class VisualEditorBlockList extends Component {
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
 					/>,
-					<VisualEditorSiblingInserter
+					index < blocks.length - 1 && <VisualEditorSiblingInserter
 						key={ 'sibling-inserter-' + uid }
 						insertIndex={ index + 1 }
 					/>,


### PR DESCRIPTION
Fixes #3433 

## Description
<!-- Please describe your changes -->
Stopped rendering a sibling inserter after the last block

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Condition on rendering a SiblingInserter (not in last position in array of blocks).
