### PR TITLE
fix/3450: Events passed to onChange erroneously triggered shouldForce

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -287,16 +287,18 @@ export default class Editable extends Component {
 		}
 	}
 
-	onChange( shouldForce ) {
-		// Note that due to efficiency, speed and low cost requirements isDirty may
-		// not reflect reality for a brief period immediately after a change.
-		if ( ! shouldForce && ! this.editor.isDirty() ) {
-			return;
-		}
-
+	fireChange() {
 		this.savedContent = this.getContent();
 		this.editor.save();
 		this.props.onChange( this.savedContent );
+	}
+
+	onChange() {
+		// Note that due to efficiency, speed and low cost requirements isDirty may
+		// not reflect reality for a brief period immediately after a change.
+		if ( this.editor.isDirty() ) {
+			this.fireChange();
+		}
 	}
 
 	getEditorSelectionRect() {
@@ -393,7 +395,7 @@ export default class Editable extends Component {
 			)
 		) {
 			const forward = event.keyCode === DELETE;
-			this.onChange( true );
+			this.fireChange();
 			this.props.onMerge( forward );
 			event.preventDefault();
 			event.stopImmediatePropagation();


### PR DESCRIPTION
## Description
This is a fix for #3450 which caused too many undo events to be created.

## How Has This Been Tested?
Manual testing on Firefox and Chrome shows that the undo buttons work again with this fix.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.