### PR TITLE
Stop mousedown events propagating to the block level when they aren't relevant

### DIFF
--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -61,6 +61,7 @@ class FormatToolbar extends Component {
 		this.onChangeLinkValue = this.onChangeLinkValue.bind( this );
 		this.toggleLinkSettingsVisibility = this.toggleLinkSettingsVisibility.bind( this );
 		this.setLinkTarget = this.setLinkTarget.bind( this );
+		this.stopMousePropagation = this.stopMousePropagation.bind( this );
 	}
 
 	componentDidMount() {
@@ -140,6 +141,10 @@ class FormatToolbar extends Component {
 		return this.props.formats[ format ] && this.props.formats[ format ].isActive;
 	}
 
+	stopMousePropagation( event ) {
+		event.stopPropagation();
+	}
+
 	render() {
 		const { formats, focusPosition, enabledControls = DEFAULT_CONTROLS, customControls = [] } = this.props;
 		const { isAddingLink, isEditingLink, newLinkValue, settingsVisible, opensInNewWindow } = this.state;
@@ -168,12 +173,14 @@ class FormatToolbar extends Component {
 		);
 
 		return (
-			<div className="blocks-format-toolbar">
+			<div className="blocks-format-toolbar" >
 				<Toolbar controls={ toolbarControls } />
 
 				{ ( isAddingLink || isEditingLink ) &&
+					/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 					<Fill name="Editable.Siblings">
 						<form
+							onMouseDown={ this.stopMousePropagation }
 							className="blocks-format-toolbar__link-modal"
 							style={ linkStyle }
 							onSubmit={ this.submitLink }>
@@ -191,8 +198,11 @@ class FormatToolbar extends Component {
 				}
 
 				{ !! formats.link && ! isAddingLink && ! isEditingLink &&
+					/* eslint-disable jsx-a11y/no-static-element-interactions */
 					<Fill name="Editable.Siblings">
-						<div className="blocks-format-toolbar__link-modal" style={ linkStyle }>
+						<div className="blocks-format-toolbar__link-modal" style={ linkStyle }
+							onMouseDown={ this.stopMousePropagation }
+						>
 							<a
 								className="blocks-format-toolbar__link-value"
 								href={ formats.link.value }

--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -61,7 +61,6 @@ class FormatToolbar extends Component {
 		this.onChangeLinkValue = this.onChangeLinkValue.bind( this );
 		this.toggleLinkSettingsVisibility = this.toggleLinkSettingsVisibility.bind( this );
 		this.setLinkTarget = this.setLinkTarget.bind( this );
-		this.stopMousePropagation = this.stopMousePropagation.bind( this );
 	}
 
 	componentDidMount() {

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -253,6 +253,10 @@ class ImageBlock extends Component {
 										height: currentHeight + delta.height,
 									} );
 								} }
+								onResizeStart={ ( event ) => {
+									// Stop image resizing fire multi-select
+									event.stopPropagation();
+								} }
 							>
 								{ img }
 							</ResizableBox>

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -254,7 +254,7 @@ class ImageBlock extends Component {
 									} );
 								} }
 								onResizeStart={ ( event ) => {
-									// Stop image resizing fire multi-select
+									// Stop image resizing firing multi-select
 									event.stopPropagation();
 								} }
 							>


### PR DESCRIPTION
Fixes #3348 
Fixes #3454 
Fixes #3362 

## Description
<!-- Please describe your changes -->
Stops mousedown from propagating out of formatting toolbars and image blocks.

Note, this isn't a complete block solution. Each block needs to be considered separately at this stage.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix