### PR TITLE
Polish heading numbers.

### DIFF
--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -66,7 +66,7 @@ div.components-toolbar {
 		font-size: $default-font-size;
 		font-weight: bold;
 		position: absolute;
-		right: 6px;
+		right: 8px;
 		bottom: 8px;
 	}
 


### PR DESCRIPTION
This is a teensy fix for headings. It just moves the subscript numbers a bit leftwards making them look much better:

<img width="238" alt="screen shot 2017-11-15 at 09 05 57" src="https://user-images.githubusercontent.com/1204802/32825452-6570e33a-c9e5-11e7-8455-673344b74d63.png">