### PR TITLE
Metaboxes: Do not hold the ready event if no metaboxes are shown

### DIFF
--- a/editor/effects.js
+++ b/editor/effects.js
@@ -279,7 +279,8 @@ export default {
 	},
 	INITIALIZE_META_BOX_STATE( action ) {
 		// Hold jquery.ready until the metaboxes load
-		if ( some( action.metaBoxes ) ) {
+		const locations = [ 'normal', 'side' ];
+		if ( some( locations, ( location ) => !! action.metaBoxes[ location ] ) ) {
 			jQuery.holdReady( true );
 		}
 	},


### PR DESCRIPTION
We need to check only the metaboxes we show (ignore the "advanced" metaboxes)

**Testing instructions**

 - Open Gutenberg
 - Hover the "Gutenberg" menu on the WP sidebar
 - You should see the submenu