### PR TITLE
Parser: Round float attributes to check validity

### DIFF
--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -218,6 +218,32 @@ describe( 'validation', () => {
 
 			expect( isEqual ).toBe( true );
 		} );
+
+		it( 'returns true if equal float values', () => {
+			const isEqual = isEqualTagAttributePairs(
+				[
+					[ 'height', '1.012345678910' ],
+				],
+				[
+					[ 'height', '1.01234567891011' ],
+				]
+			);
+
+			expect( isEqual ).toBe( true );
+		} );
+
+		it( 'returns false for different float values', () => {
+			const isEqual = isEqualTagAttributePairs(
+				[
+					[ 'height', '1.0123' ],
+				],
+				[
+					[ 'height', '1.0124' ],
+				]
+			);
+
+			expect( isEqual ).toBe( false );
+		} );
 	} );
 
 	describe( 'isEqualTokensOfType', () => {

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -267,15 +267,25 @@ export function isEqualTagAttributePairs( a, b ) {
 
 		const aValue = aAttributes[ name ];
 		const bValue = bAttributes[ name ];
+		let attributesAreEqual = true;
 
 		const isEqualAttributes = isEqualAttributesOfName[ name ];
 		if ( isEqualAttributes ) {
 			// Defer custom attribute equality handling
-			if ( ! isEqualAttributes( aValue, bValue ) ) {
-				return false;
-			}
-		} else if ( aValue !== bValue ) {
+			attributesAreEqual = isEqualAttributes( aValue, bValue );
+		} else if (
+			! isNaN( parseFloat( aValue ) ) &&
+			! isNaN( parseFloat( bValue ) )
+		) {
+			// Float values should be compared using the rounded values,
+			// PHP and JavaScript serializing  have different precisions
+			attributesAreEqual = Number( aValue ).toFixed( 10 ) === Number( bValue ).toFixed( 10 );
+		} else {
 			// Otherwise strict inequality should bail
+			attributesAreEqual = aValue === bValue;
+		}
+
+		if ( ! attributesAreEqual ) {
 			return false;
 		}
 	}


### PR DESCRIPTION
When resizing images, they receive a float "height/width" values and these values might defer a bit when the post is saved server side because of the PHP default precision which would cause the image block to appear invalid if you refresh

This PR updates the attributes comparison mechanism to round float attributes before comparing them.

**Testing instructions**

 - Create an image block
 - Resize the image
 - Save and refresh
 - The block shouldn't show up as invalid
 - Repeat several times :)