### PR TITLE
Image Block: Always use integer values for the image size

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -249,8 +249,8 @@ class ImageBlock extends Component {
 								enable={ { top: false, right: true, bottom: false, left: false, topRight: true, bottomRight: true, bottomLeft: true, topLeft: true } }
 								onResizeStop={ ( event, direction, elt, delta ) => {
 									setAttributes( {
-										width: currentWidth + delta.width,
-										height: currentHeight + delta.height,
+										width: parseInt( currentWidth + delta.width, 10 ),
+										height: parseInt( currentHeight + delta.height, 10 ),
 									} );
 								} }
 							>


### PR DESCRIPTION
Width and Height should always be integers

**Testing instructions**

 - Create a post
 - Add an image block
 - Resize
 - Check the text mode
 - Widths and Heights should be integers