### PR TITLE
Components: Fix stuck tooltips by testing child disabled attribute

### DIFF
--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -128,7 +128,7 @@ class Tooltip extends Component {
 			// mouse events. Don't bother trying to to handle them.
 			//
 			// See: https://github.com/facebook/react/issues/4251
-			if ( event.target.disabled ) {
+			if ( event.currentTarget.disabled ) {
 				return;
 			}
 

--- a/components/tooltip/test/index.js
+++ b/components/tooltip/test/index.js
@@ -45,7 +45,7 @@ describe( 'Tooltip', () => {
 
 		it( 'should show popover on focus', () => {
 			const originalFocus = jest.fn();
-			const event = { type: 'focus', target: {} };
+			const event = { type: 'focus', currentTarget: {} };
 			const wrapper = shallow(
 				<Tooltip text="Help Text">
 					<button
@@ -78,13 +78,17 @@ describe( 'Tooltip', () => {
 						onMouseEnter={ originalMouseEnter }
 						onFocus={ originalMouseEnter }
 					>
-						Hover Me!
+						<span>Hover Me!</span>
 					</button>
 				</Tooltip>
 			);
 
-			const button = wrapper.find( 'button' );
-			button.simulate( 'mouseenter' );
+			wrapper.find( 'button' ).simulate( 'mouseenter', {
+				// Enzyme does not accurately emulate event targets
+				// See: https://github.com/airbnb/enzyme/issues/218
+				currentTarget: wrapper.find( 'button' ).getDOMNode(),
+				target: wrapper.find( 'button > span' ).getDOMNode(),
+			} );
 
 			expect( originalMouseEnter ).toHaveBeenCalled();
 
@@ -108,13 +112,17 @@ describe( 'Tooltip', () => {
 						onFocus={ originalMouseEnter }
 						disabled
 					>
-						Hover Me!
+						<span>Hover Me!</span>
 					</button>
 				</Tooltip>
 			);
 
-			const button = wrapper.find( 'button' );
-			button.simulate( 'mouseenter' );
+			wrapper.find( 'button' ).simulate( 'mouseenter', {
+				// Enzyme does not accurately emulate event targets
+				// See: https://github.com/airbnb/enzyme/issues/218
+				currentTarget: wrapper.find( 'button' ).getDOMNode(),
+				target: wrapper.find( 'button > span' ).getDOMNode(),
+			} );
 
 			expect( originalMouseEnter ).toHaveBeenCalled();
 


### PR DESCRIPTION
Fixes #3481
Related: #3177

This pull request seeks to address an issue where tooltips may become stuck for disabled buttons. As described at https://github.com/WordPress/gutenberg/issues/3481#issuecomment-344610213, the issue is that `event.target` of a `mouseenter` event may be a non-disabled child of a disabled button (e.g. an SVG's `path` node). The changes proposed here update the condition to test the wrapped element of the tooltip receiving the bubbled event (the button itself).

__Testing instructions:__

Repeat steps to reproduce at https://github.com/WordPress/gutenberg/issues/3481#issuecomment-344503025, verifying that it is not possible to encounter a stuck tooltip.

Ensure that tooltips are shown correctly when expected (enabled `IconButton`s).

Ensure that updated unit tests pass:

```
npm run test-unit components/tooltip/test/index.js
```