### PR TITLE
Framework: Preserve settings when rebooting from crash

### DIFF
--- a/editor/index.js
+++ b/editor/index.js
@@ -51,15 +51,16 @@ window.jQuery( document ).on( 'heartbeat-tick', ( event, response ) => {
  * an initial state from prior to the crash.
  *
  * @param {Element} target       DOM node in which editor is rendered
+ * @param {?Object} settings     Editor settings object
  * @param {*}       initialState Initial editor state to hydrate
  */
-export function recreateEditorInstance( target, initialState ) {
+export function recreateEditorInstance( target, settings, initialState ) {
 	unmountComponentAtNode( target );
 
-	const reboot = recreateEditorInstance.bind( null, target );
+	const reboot = recreateEditorInstance.bind( null, target, settings );
 
 	render(
-		<EditorProvider initialState={ initialState }>
+		<EditorProvider settings={ settings } initialState={ initialState }>
 			<ErrorBoundary onError={ reboot }>
 				<Layout />
 			</ErrorBoundary>
@@ -81,7 +82,7 @@ export function recreateEditorInstance( target, initialState ) {
  */
 export function createEditorInstance( id, post, settings ) {
 	const target = document.getElementById( id );
-	const reboot = recreateEditorInstance.bind( null, target );
+	const reboot = recreateEditorInstance.bind( null, target, settings );
 
 	const provider = render(
 		<EditorProvider settings={ settings } post={ post }>


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/3208#discussion_r150916345

This pull request seeks to ensure that editor settings are respected when attempting to reboot from a crashed state. See https://github.com/WordPress/gutenberg/pull/3208#discussion_r150916345 for more context.

__Testing instructions:__

Ideally there is no way to create a crash in the application. You may introduce one though with the following diff:

```diff
diff --git a/components/dropdown/index.js b/components/dropdown/index.js
index 1989f101..1c79f148 100644
--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -61,6 +61,7 @@ class Dropdown extends Component {
 
        render() {
                const { isOpen } = this.state;
+               if ( isOpen ) throw new Error();
                const { renderContent, renderToggle, position = 'bottom', className, contentClassName } = this.props;
                const args = { isOpen, onToggle: this.toggle, onClose: this.close };
                return (
```

After applying these changes, add a breakpoint in the `recreateEditorInstance` function, incur the crash by opening a dropdown (e.g. inserter menu), then "Attempt Restore" and verify that `recreateEditorInstance` is called with the original settings of the editor.