### PR TITLE
Components: Use Lodash's find in place of Array#find

### DIFF
--- a/components/tab-panel/index.js
+++ b/components/tab-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { partial, noop } from 'lodash';
+import { partial, noop, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -60,7 +60,7 @@ class TabPanel extends Component {
 			tabs,
 		} = this.props;
 
-		const selectedTab = tabs.find( ( { name } ) => name === selected );
+		const selectedTab = find( tabs, { name: selected } );
 		const selectedId = instanceId + '-' + selectedTab.name;
 
 		return (

--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual } from 'lodash';
+import { isEqual, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -30,7 +30,7 @@ export default class InserterGroup extends Component {
 		if ( ! isEqual( this.props.blockTypes, nextProps.blockTypes ) ) {
 			this.activeBlocks = deriveActiveBlocks( nextProps.blockTypes );
 			// Try and preserve any still valid selected state.
-			const current = this.activeBlocks.find( block => block.name === this.state.current );
+			const current = find( this.activeBlocks, { name: this.state.current } );
 			if ( ! current ) {
 				this.setState( {
 					current: this.activeBlocks.length > 0 ? this.activeBlocks[ 0 ].name : null,


### PR DESCRIPTION
Regression introduced in: #3281
Related: #746

This pull request seeks to resolve errors which occur in IE11 when attempting to use the inserter. The root cause is using array prototype methods which are neither supported nor polyfilled in IE11 (specifically, [`Array#find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find)). The changes here propose to use the [Lodash `_.find`](lodash.com/docs/4.17.4#find) equivalent, also leveraging object shorthand predicates.

__Testing instructions:__

Repeat testing instructions from #3281