### PR TITLE
Visual Editor: Hide sibling inserter by CSS

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -388,9 +388,6 @@
 	position: relative;
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible ) - ( 2 * $block-padding );
 	margin: 0 auto;
-	opacity: 0;
-	transition: opacity 0.25s ease-in-out;
-	transition-delay: 0.3s;
 
 	@include break-small {
 		max-width: $visual-editor-max-width - ( 2 * $block-padding );
@@ -398,10 +395,6 @@
 
 	&:not( [data-insert-index="0"] ) {
 		top: #{ -1 * ( $block-spacing / 2 ) };
-	}
-
-	&.is-visible {
-		opacity: 1;
 	}
 
 	&:before {
@@ -423,6 +416,18 @@
 		left: 50%;
 		transform: translate( -50%, -50% );
 		margin: 0;
+	}
+
+	.editor-inserter__toggle {
+		opacity: 0;
+		transition: opacity 0.25s ease-in-out;
+		transition-delay: 0.3s;
+	}
+
+	&.is-forced-visible .editor-inserter__toggle,
+	&:hover .editor-inserter__toggle,
+	.editor-inserter__toggle:focus {
+		opacity: 1;
 	}
 
 	.editor-inserter__toggle.components-button {

--- a/test/e2e/integration/002-adding-blocks.js
+++ b/test/e2e/integration/002-adding-blocks.js
@@ -20,7 +20,7 @@ describe( 'Adding blocks', () => {
 		cy.get( lastBlockSelector ).type( 'Quote block' );
 
 		// Using the regular inserter
-		cy.get( '.editor-visual-editor [aria-label="Insert block"]' ).click();
+		cy.get( '.editor-visual-editor__inserter [aria-label="Insert block"]' ).click();
 		cy.get( '[placeholder="Search for a block"]' ).type( 'code' );
 		cy.get( '.editor-inserter__block' ).contains( 'Code' ).click();
 		cy.get( '[placeholder="Write code…"]' ).type( 'Code block' );


### PR DESCRIPTION
Fixes #3408
Context: https://github.com/WordPress/gutenberg/issues/3408#issuecomment-343404965
Cherry-picks cefa3aad030544832bf65684405df22a669407c1 from #3502 (otherwise untestable)

This pull request seeks to simplify the rendering implementation of `VisualEditorSiblingInserter` to avoid manually handling rendering of the child `Inserter` component, instead allowing the inserter to render and visual appearance by CSS styling. This resolves issues where the Inserter was not appearing when tabbing in IE11. Some manual management of inserter visibility is still required, specifically when focus or cursor positioning moves within the inserter while active.

__Testing instructions:__

Verify that there are no regressions in the behavior of between-inserters.

Repeat steps to reproduce from #3408, verifying that the between-inserter can be activated via keyboard.