### PR TITLE
fix button link modal not closing

### DIFF
--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -147,6 +147,14 @@ class UrlInput extends Component {
 		}
 	}
 
+	onClickInputSuggestion( index, link ) {
+		this.props.onChange( link );
+		this.setState( {
+			selectedSuggestion: index,
+			showSuggestions: false,
+		} );
+	}
+
 	componentWillUnmount() {
 		if ( this.suggestionsRequest ) {
 			this.suggestionsRequest.abort();
@@ -212,7 +220,7 @@ class UrlInput extends Component {
 								className={ classnames( 'blocks-url-input__suggestion', {
 									'is-selected': index === selectedSuggestion,
 								} ) }
-								onClick={ () => this.props.onChange( post.link ) }
+								onClick={ () => this.onClickInputSuggestion( index, post.link ) }
 								aria-selected={ index === selectedSuggestion }
 							>
 								{ post.title.rendered }

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -138,19 +138,16 @@ class UrlInput extends Component {
 				if ( this.state.selectedSuggestion ) {
 					event.stopPropagation();
 					const post = this.state.posts[ this.state.selectedSuggestion ];
-					this.props.onChange( post.link );
-					this.setState( {
-						showSuggestions: false,
-					} );
+					this.selectLink( post.link );
 				}
 			}
 		}
 	}
 
-	onClickInputSuggestion( index, link ) {
+	selectLink( link ) {
 		this.props.onChange( link );
 		this.setState( {
-			selectedSuggestion: index,
+			selectedSuggestion: null,
 			showSuggestions: false,
 		} );
 	}
@@ -220,7 +217,7 @@ class UrlInput extends Component {
 								className={ classnames( 'blocks-url-input__suggestion', {
 									'is-selected': index === selectedSuggestion,
 								} ) }
-								onClick={ () => this.onClickInputSuggestion( index, post.link ) }
+								onClick={ () => this.selectLink( post.link ) }
 								aria-selected={ index === selectedSuggestion }
 							>
 								{ post.title.rendered }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes https://github.com/WordPress/gutenberg/issues/3501

Button link suggestion modal could only be closed buy first using arrow keys and pressing ENTER afterwards. When clicked, the link changed but the modal was stuck.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
JS unit test passing


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

I added a new method to handle this.
