### PR TITLE
Fix author select width

### DIFF
--- a/editor/edit-post/sidebar/post-author/style.scss
+++ b/editor/edit-post/sidebar/post-author/style.scss
@@ -1,3 +1,4 @@
 .editor-post-author__select {
 	margin: -5px 0;
+	width: 100%;
 }


### PR DESCRIPTION
## Description
If the name of author is too large so author select element make sidebar horizontally scrollable. #3432 

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.