### PR TITLE
Parsing: Enforce block naming requirements consistently

### DIFF
--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -283,10 +283,10 @@ Block_Name
   / Core_Block_Name
 
 Namespaced_Block_Name
-  = $(ASCII_Letter ASCII_AlphaNumeric* "/" ASCII_Letter ASCII_AlphaNumeric*)
+  = $(ASCII_LowercaseLetter ASCII_LowercaseAlphaNumeric* "/" ASCII_LowercaseLetter ASCII_LowercaseAlphaNumeric*)
 
 Core_Block_Name
-  = type:$(ASCII_Letter ASCII_AlphaNumeric*)
+  = type:$(ASCII_LowercaseLetter ASCII_LowercaseAlphaNumeric*)
   {
     /** <?php return "core/$type"; ?> **/
     return 'core/' + type;
@@ -299,13 +299,13 @@ Block_Attributes
     return maybeJSON( attrs );
   }
 
-ASCII_AlphaNumeric
-  = ASCII_Letter
+ASCII_LowercaseAlphaNumeric
+  = ASCII_LowercaseLetter
   / ASCII_Digit
   / Special_Chars
 
-ASCII_Letter
-  = [a-zA-Z]
+ASCII_LowercaseLetter
+  = [a-z]
 
 ASCII_Digit
   = [0-9]

--- a/blocks/api/post.pegjs
+++ b/blocks/api/post.pegjs
@@ -283,14 +283,17 @@ Block_Name
   / Core_Block_Name
 
 Namespaced_Block_Name
-  = $(ASCII_LowercaseLetter ASCII_LowercaseAlphaNumeric* "/" ASCII_LowercaseLetter ASCII_LowercaseAlphaNumeric*)
+  = $( Block_Name_Part "/" Block_Name_Part )
 
 Core_Block_Name
-  = type:$(ASCII_LowercaseLetter ASCII_LowercaseAlphaNumeric*)
+  = type:$( Block_Name_Part )
   {
     /** <?php return "core/$type"; ?> **/
     return 'core/' + type;
   }
+
+Block_Name_Part
+  = $( [a-z][a-z0-9_-]* )
 
 Block_Attributes
   = attrs:$("{" (!("}" WS+ """/"? "-->") .)* "}")
@@ -298,20 +301,6 @@ Block_Attributes
     /** <?php return json_decode( $attrs, true ); ?> **/
     return maybeJSON( attrs );
   }
-
-ASCII_LowercaseAlphaNumeric
-  = ASCII_LowercaseLetter
-  / ASCII_Digit
-  / Special_Chars
-
-ASCII_LowercaseLetter
-  = [a-z]
-
-ASCII_Digit
-  = [0-9]
-
-Special_Chars
-  = [\-\_]
 
 WS
   = [ \t\r\n]

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -55,15 +55,9 @@ export function registerBlockType( name, settings ) {
 		);
 		return;
 	}
-	if ( /[A-Z]+/.test( name ) ) {
+	if ( ! /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/.test( name ) ) {
 		console.error(
-			'Block names must not contain uppercase characters.'
-		);
-		return;
-	}
-	if ( ! /^[a-z0-9-]+\/[a-z0-9-]+$/.test( name ) ) {
-		console.error(
-			'Block names must contain a namespace prefix. Example: my-plugin/my-custom-block'
+			'Block names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-block'
 		);
 		return;
 	}

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -48,25 +48,31 @@ describe( 'blocks', () => {
 
 		it( 'should reject blocks without a namespace', () => {
 			const block = registerBlockType( 'doing-it-wrong' );
-			expect( console.error ).toHaveBeenCalledWith( 'Block names must contain a namespace prefix. Example: my-plugin/my-custom-block' );
+			expect( console.error ).toHaveBeenCalledWith( 'Block names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-block' );
 			expect( block ).toBeUndefined();
 		} );
 
 		it( 'should reject blocks with too many namespaces', () => {
 			const block = registerBlockType( 'doing/it/wrong' );
-			expect( console.error ).toHaveBeenCalledWith( 'Block names must contain a namespace prefix. Example: my-plugin/my-custom-block' );
+			expect( console.error ).toHaveBeenCalledWith( 'Block names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-block' );
 			expect( block ).toBeUndefined();
 		} );
 
 		it( 'should reject blocks with invalid characters', () => {
 			const block = registerBlockType( 'still/_doing_it_wrong' );
-			expect( console.error ).toHaveBeenCalledWith( 'Block names must contain a namespace prefix. Example: my-plugin/my-custom-block' );
+			expect( console.error ).toHaveBeenCalledWith( 'Block names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-block' );
 			expect( block ).toBeUndefined();
 		} );
 
 		it( 'should reject blocks with uppercase characters', () => {
 			const block = registerBlockType( 'Core/Paragraph' );
-			expect( console.error ).toHaveBeenCalledWith( 'Block names must not contain uppercase characters.' );
+			expect( console.error ).toHaveBeenCalledWith( 'Block names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-block' );
+			expect( block ).toBeUndefined();
+		} );
+
+		it( 'should reject blocks not starting with a letter', () => {
+			const block = registerBlockType( 'my-plugin/4-fancy-block', defaultBlockSettings );
+			expect( console.error ).toHaveBeenCalledWith( 'Block names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-block' );
 			expect( block ).toBeUndefined();
 		} );
 

--- a/blocks/test/fixtures/core__4-invalid-starting-letter.html
+++ b/blocks/test/fixtures/core__4-invalid-starting-letter.html
@@ -1,0 +1,1 @@
+<!-- wp:core/4-invalid /-->

--- a/blocks/test/fixtures/core__4-invalid-starting-letter.json
+++ b/blocks/test/fixtures/core__4-invalid-starting-letter.json
@@ -1,0 +1,11 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/freeform",
+        "isValid": true,
+        "attributes": {
+            "content": "<!-- wp:core/4-invalid /-->"
+        },
+        "originalContent": "<!-- wp:core/4-invalid /-->"
+    }
+]

--- a/blocks/test/fixtures/core__4-invalid-starting-letter.parsed.json
+++ b/blocks/test/fixtures/core__4-invalid-starting-letter.parsed.json
@@ -1,0 +1,6 @@
+[
+    {
+        "attrs": {},
+        "innerHTML": "<!-- wp:core/4-invalid /-->\n"
+    }
+]

--- a/blocks/test/fixtures/core__4-invalid-starting-letter.serialized.html
+++ b/blocks/test/fixtures/core__4-invalid-starting-letter.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:core/4-invalid /-->

--- a/blocks/test/fixtures/core__invalid-Capitals.html
+++ b/blocks/test/fixtures/core__invalid-Capitals.html
@@ -1,0 +1,1 @@
+<!-- wp:core/invalid-Capitals /-->

--- a/blocks/test/fixtures/core__invalid-Capitals.json
+++ b/blocks/test/fixtures/core__invalid-Capitals.json
@@ -1,0 +1,11 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/freeform",
+        "isValid": true,
+        "attributes": {
+            "content": "<!-- wp:core/invalid-Capitals /-->"
+        },
+        "originalContent": "<!-- wp:core/invalid-Capitals /-->"
+    }
+]

--- a/blocks/test/fixtures/core__invalid-Capitals.parsed.json
+++ b/blocks/test/fixtures/core__invalid-Capitals.parsed.json
@@ -1,0 +1,6 @@
+[
+    {
+        "attrs": {},
+        "innerHTML": "<!-- wp:core/invalid-Capitals /-->\n"
+    }
+]

--- a/blocks/test/fixtures/core__invalid-Capitals.serialized.html
+++ b/blocks/test/fixtures/core__invalid-Capitals.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:core/invalid-Capitals /-->

--- a/blocks/test/fixtures/core__invalid-special.html
+++ b/blocks/test/fixtures/core__invalid-special.html
@@ -1,0 +1,1 @@
+<!-- wp:core/invalid-$special /-->

--- a/blocks/test/fixtures/core__invalid-special.json
+++ b/blocks/test/fixtures/core__invalid-special.json
@@ -1,0 +1,11 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/freeform",
+        "isValid": true,
+        "attributes": {
+            "content": "<!-- wp:core/invalid-$special /-->"
+        },
+        "originalContent": "<!-- wp:core/invalid-$special /-->"
+    }
+]

--- a/blocks/test/fixtures/core__invalid-special.parsed.json
+++ b/blocks/test/fixtures/core__invalid-special.parsed.json
@@ -1,0 +1,6 @@
+[
+    {
+        "attrs": {},
+        "innerHTML": "<!-- wp:core/invalid-$special /-->\n"
+    }
+]

--- a/blocks/test/fixtures/core__invalid-special.serialized.html
+++ b/blocks/test/fixtures/core__invalid-special.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:core/invalid-$special /-->

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -19,7 +19,9 @@ The name for a block is a unique string that identifies a block. Names have to b
 registerBlockType( 'my-plugin/book', {} );
 ```
 
-*Note:* this name is used on the comment delimiters as `<!-- wp:my-plugin/book -->`. Those blocks provided by core don't include a namespace when serialized.
+*Note:* A block name can only contain lowercase alphanumeric characters and dashes, and must begin with a letter.
+
+*Note:* This name is used on the comment delimiters as `<!-- wp:my-plugin/book -->`. Those blocks provided by core don't include a namespace when serialized.
 
 ### Block Configuration
 

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -260,8 +260,6 @@ class Gutenberg_PEG_Parser {
     private $peg_c29;
     private $peg_c30;
     private $peg_c31;
-    private $peg_c32;
-    private $peg_c33;
 
     private function peg_f0($pre, $t, $html) { return array( $t, $html ); }
     private function peg_f1($pre, $ts, $post) { return peg_join_blocks( $pre, $ts, $post ); }
@@ -1363,44 +1361,22 @@ class Gutenberg_PEG_Parser {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_LowercaseLetter();
+      $s2 = $this->peg_parseBlock_Name_Part();
       if ($s2 !== $this->peg_FAILED) {
-        $s3 = array();
-        $s4 = $this->peg_parseASCII_LowercaseAlphaNumeric();
-        while ($s4 !== $this->peg_FAILED) {
-          $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_LowercaseAlphaNumeric();
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
+          $s3 = $this->peg_c15;
+          $this->peg_currPos++;
+        } else {
+          $s3 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c16);
+          }
         }
         if ($s3 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
-            $s4 = $this->peg_c15;
-            $this->peg_currPos++;
-          } else {
-            $s4 = $this->peg_FAILED;
-            if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c16);
-            }
-          }
+          $s4 = $this->peg_parseBlock_Name_Part();
           if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseASCII_LowercaseLetter();
-            if ($s5 !== $this->peg_FAILED) {
-              $s6 = array();
-              $s7 = $this->peg_parseASCII_LowercaseAlphaNumeric();
-              while ($s7 !== $this->peg_FAILED) {
-                $s6[] = $s7;
-                $s7 = $this->peg_parseASCII_LowercaseAlphaNumeric();
-              }
-              if ($s6 !== $this->peg_FAILED) {
-                $s2 = array($s2, $s3, $s4, $s5, $s6);
-                $s1 = $s2;
-              } else {
-                $this->peg_currPos = $s1;
-                $s1 = $this->peg_FAILED;
-              }
-            } else {
-              $this->peg_currPos = $s1;
-              $s1 = $this->peg_FAILED;
-            }
+            $s2 = array($s2, $s3, $s4);
+            $s1 = $s2;
           } else {
             $this->peg_currPos = $s1;
             $s1 = $this->peg_FAILED;
@@ -1426,26 +1402,7 @@ class Gutenberg_PEG_Parser {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_currPos;
-      $s3 = $this->peg_parseASCII_LowercaseLetter();
-      if ($s3 !== $this->peg_FAILED) {
-        $s4 = array();
-        $s5 = $this->peg_parseASCII_LowercaseAlphaNumeric();
-        while ($s5 !== $this->peg_FAILED) {
-          $s4[] = $s5;
-          $s5 = $this->peg_parseASCII_LowercaseAlphaNumeric();
-        }
-        if ($s4 !== $this->peg_FAILED) {
-          $s3 = array($s3, $s4);
-          $s2 = $s3;
-        } else {
-          $this->peg_currPos = $s2;
-          $s2 = $this->peg_FAILED;
-        }
-      } else {
-        $this->peg_currPos = $s2;
-        $s2 = $this->peg_FAILED;
-      }
+      $s2 = $this->peg_parseBlock_Name_Part();
       if ($s2 !== $this->peg_FAILED) {
         $s1 = $this->input_substr($s1, $this->peg_currPos - $s1);
       } else {
@@ -1460,18 +1417,74 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
+    private function peg_parseBlock_Name_Part() {
+
+      $s0 = $this->peg_currPos;
+      $s1 = $this->peg_currPos;
+      if (Gutenberg_PEG_peg_char_class_test($this->peg_c17, $this->input_substr($this->peg_currPos, 1))) {
+        $s2 = $this->input_substr($this->peg_currPos, 1);
+        $this->peg_currPos++;
+      } else {
+        $s2 = $this->peg_FAILED;
+        if ($this->peg_silentFails === 0) {
+            $this->peg_fail($this->peg_c18);
+        }
+      }
+      if ($s2 !== $this->peg_FAILED) {
+        $s3 = array();
+        if (Gutenberg_PEG_peg_char_class_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+          $s4 = $this->input_substr($this->peg_currPos, 1);
+          $this->peg_currPos++;
+        } else {
+          $s4 = $this->peg_FAILED;
+          if ($this->peg_silentFails === 0) {
+              $this->peg_fail($this->peg_c20);
+          }
+        }
+        while ($s4 !== $this->peg_FAILED) {
+          $s3[] = $s4;
+          if (Gutenberg_PEG_peg_char_class_test($this->peg_c19, $this->input_substr($this->peg_currPos, 1))) {
+            $s4 = $this->input_substr($this->peg_currPos, 1);
+            $this->peg_currPos++;
+          } else {
+            $s4 = $this->peg_FAILED;
+            if ($this->peg_silentFails === 0) {
+                $this->peg_fail($this->peg_c20);
+            }
+          }
+        }
+        if ($s3 !== $this->peg_FAILED) {
+          $s2 = array($s2, $s3);
+          $s1 = $s2;
+        } else {
+          $this->peg_currPos = $s1;
+          $s1 = $this->peg_FAILED;
+        }
+      } else {
+        $this->peg_currPos = $s1;
+        $s1 = $this->peg_FAILED;
+      }
+      if ($s1 !== $this->peg_FAILED) {
+        $s0 = $this->input_substr($s0, $this->peg_currPos - $s0);
+      } else {
+        $s0 = $s1;
+      }
+
+      return $s0;
+    }
+
     private function peg_parseBlock_Attributes() {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c17) {
-        $s3 = $this->peg_c17;
+      if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c21) {
+        $s3 = $this->peg_c21;
         $this->peg_currPos++;
       } else {
         $s3 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c18);
+            $this->peg_fail($this->peg_c22);
         }
       }
       if ($s3 !== $this->peg_FAILED) {
@@ -1480,13 +1493,13 @@ class Gutenberg_PEG_Parser {
         $s6 = $this->peg_currPos;
         $this->peg_silentFails++;
         $s7 = $this->peg_currPos;
-        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c19) {
-          $s8 = $this->peg_c19;
+        if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+          $s8 = $this->peg_c23;
           $this->peg_currPos++;
         } else {
           $s8 = $this->peg_FAILED;
           if ($this->peg_silentFails === 0) {
-              $this->peg_fail($this->peg_c20);
+              $this->peg_fail($this->peg_c24);
           }
         }
         if ($s8 !== $this->peg_FAILED) {
@@ -1501,7 +1514,7 @@ class Gutenberg_PEG_Parser {
             $s9 = $this->peg_FAILED;
           }
           if ($s9 !== $this->peg_FAILED) {
-            $s10 = $this->peg_c21;
+            $s10 = $this->peg_c25;
             if ($s10 !== $this->peg_FAILED) {
               if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
                 $s11 = $this->peg_c15;
@@ -1582,13 +1595,13 @@ class Gutenberg_PEG_Parser {
           $s6 = $this->peg_currPos;
           $this->peg_silentFails++;
           $s7 = $this->peg_currPos;
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c19) {
-            $s8 = $this->peg_c19;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s8 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s8 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c20);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s8 !== $this->peg_FAILED) {
@@ -1603,7 +1616,7 @@ class Gutenberg_PEG_Parser {
               $s9 = $this->peg_FAILED;
             }
             if ($s9 !== $this->peg_FAILED) {
-              $s10 = $this->peg_c21;
+              $s10 = $this->peg_c25;
               if ($s10 !== $this->peg_FAILED) {
                 if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
                   $s11 = $this->peg_c15;
@@ -1680,13 +1693,13 @@ class Gutenberg_PEG_Parser {
           }
         }
         if ($s4 !== $this->peg_FAILED) {
-          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c19) {
-            $s5 = $this->peg_c19;
+          if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c23) {
+            $s5 = $this->peg_c23;
             $this->peg_currPos++;
           } else {
             $s5 = $this->peg_FAILED;
             if ($this->peg_silentFails === 0) {
-                $this->peg_fail($this->peg_c20);
+                $this->peg_fail($this->peg_c24);
             }
           }
           if ($s5 !== $this->peg_FAILED) {
@@ -1718,50 +1731,7 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseASCII_LowercaseAlphaNumeric() {
-
-      $s0 = $this->peg_parseASCII_LowercaseLetter();
-      if ($s0 === $this->peg_FAILED) {
-        $s0 = $this->peg_parseASCII_Digit();
-        if ($s0 === $this->peg_FAILED) {
-          $s0 = $this->peg_parseSpecial_Chars();
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_LowercaseLetter() {
-
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c23);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseASCII_Digit() {
-
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c24, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c25);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parseSpecial_Chars() {
+    private function peg_parseWS() {
 
       if (Gutenberg_PEG_peg_char_class_test($this->peg_c26, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1776,7 +1746,7 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseWS() {
+    private function peg_parseNewline() {
 
       if (Gutenberg_PEG_peg_char_class_test($this->peg_c28, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1791,7 +1761,7 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseNewline() {
+    private function peg_parse_() {
 
       if (Gutenberg_PEG_peg_char_class_test($this->peg_c30, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1800,21 +1770,6 @@ class Gutenberg_PEG_Parser {
         $s0 = $this->peg_FAILED;
         if ($this->peg_silentFails === 0) {
             $this->peg_fail($this->peg_c31);
-        }
-      }
-
-      return $s0;
-    }
-
-    private function peg_parse_() {
-
-      if (Gutenberg_PEG_peg_char_class_test($this->peg_c32, $this->input_substr($this->peg_currPos, 1))) {
-        $s0 = $this->input_substr($this->peg_currPos, 1);
-        $this->peg_currPos++;
-      } else {
-        $s0 = $this->peg_FAILED;
-        if ($this->peg_silentFails === 0) {
-            $this->peg_fail($this->peg_c33);
         }
       }
 
@@ -1883,23 +1838,21 @@ class Gutenberg_PEG_Parser {
     $this->peg_c14 = array( "type" => "literal", "value" => "/wp:", "description" => "\"/wp:\"" );
     $this->peg_c15 = "/";
     $this->peg_c16 = array( "type" => "literal", "value" => "/", "description" => "\"/\"" );
-    $this->peg_c17 = "{";
-    $this->peg_c18 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
-    $this->peg_c19 = "}";
-    $this->peg_c20 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
-    $this->peg_c21 = "";
-    $this->peg_c22 = array(array(97,122));
-    $this->peg_c23 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
-    $this->peg_c24 = array(array(48,57));
-    $this->peg_c25 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
-    $this->peg_c26 = array(array(45,45), array(95,95));
-    $this->peg_c27 = array( "type" => "class", "value" => "[-_]", "description" => "[-_]" );
-    $this->peg_c28 = array(array(32,32), array(9,9), array(13,13), array(10,10));
-    $this->peg_c29 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
-    $this->peg_c30 = array(array(13,13), array(10,10));
-    $this->peg_c31 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
-    $this->peg_c32 = array(array(32,32), array(9,9));
-    $this->peg_c33 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
+    $this->peg_c17 = array(array(97,122));
+    $this->peg_c18 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
+    $this->peg_c19 = array(array(97,122), array(48,57), array(95,95), array(45,45));
+    $this->peg_c20 = array( "type" => "class", "value" => "[a-z0-9_-]", "description" => "[a-z0-9_-]" );
+    $this->peg_c21 = "{";
+    $this->peg_c22 = array( "type" => "literal", "value" => "{", "description" => "\"{\"" );
+    $this->peg_c23 = "}";
+    $this->peg_c24 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
+    $this->peg_c25 = "";
+    $this->peg_c26 = array(array(32,32), array(9,9), array(13,13), array(10,10));
+    $this->peg_c27 = array( "type" => "class", "value" => "[ \t\r\n]", "description" => "[ \t\r\n]" );
+    $this->peg_c28 = array(array(13,13), array(10,10));
+    $this->peg_c29 = array( "type" => "class", "value" => "[\r\n]", "description" => "[\r\n]" );
+    $this->peg_c30 = array(array(32,32), array(9,9));
+    $this->peg_c31 = array( "type" => "class", "value" => "[ \t]", "description" => "[ \t]" );
 
     $peg_startRuleFunctions = array( 'Block_List' => array($this, "peg_parseBlock_List") );
     $peg_startRuleFunction  = array($this, "peg_parseBlock_List");

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -1363,13 +1363,13 @@ class Gutenberg_PEG_Parser {
 
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
-      $s2 = $this->peg_parseASCII_Letter();
+      $s2 = $this->peg_parseASCII_LowercaseLetter();
       if ($s2 !== $this->peg_FAILED) {
         $s3 = array();
-        $s4 = $this->peg_parseASCII_AlphaNumeric();
+        $s4 = $this->peg_parseASCII_LowercaseAlphaNumeric();
         while ($s4 !== $this->peg_FAILED) {
           $s3[] = $s4;
-          $s4 = $this->peg_parseASCII_AlphaNumeric();
+          $s4 = $this->peg_parseASCII_LowercaseAlphaNumeric();
         }
         if ($s3 !== $this->peg_FAILED) {
           if ($this->input_substr($this->peg_currPos, 1) === $this->peg_c15) {
@@ -1382,13 +1382,13 @@ class Gutenberg_PEG_Parser {
             }
           }
           if ($s4 !== $this->peg_FAILED) {
-            $s5 = $this->peg_parseASCII_Letter();
+            $s5 = $this->peg_parseASCII_LowercaseLetter();
             if ($s5 !== $this->peg_FAILED) {
               $s6 = array();
-              $s7 = $this->peg_parseASCII_AlphaNumeric();
+              $s7 = $this->peg_parseASCII_LowercaseAlphaNumeric();
               while ($s7 !== $this->peg_FAILED) {
                 $s6[] = $s7;
-                $s7 = $this->peg_parseASCII_AlphaNumeric();
+                $s7 = $this->peg_parseASCII_LowercaseAlphaNumeric();
               }
               if ($s6 !== $this->peg_FAILED) {
                 $s2 = array($s2, $s3, $s4, $s5, $s6);
@@ -1427,13 +1427,13 @@ class Gutenberg_PEG_Parser {
       $s0 = $this->peg_currPos;
       $s1 = $this->peg_currPos;
       $s2 = $this->peg_currPos;
-      $s3 = $this->peg_parseASCII_Letter();
+      $s3 = $this->peg_parseASCII_LowercaseLetter();
       if ($s3 !== $this->peg_FAILED) {
         $s4 = array();
-        $s5 = $this->peg_parseASCII_AlphaNumeric();
+        $s5 = $this->peg_parseASCII_LowercaseAlphaNumeric();
         while ($s5 !== $this->peg_FAILED) {
           $s4[] = $s5;
-          $s5 = $this->peg_parseASCII_AlphaNumeric();
+          $s5 = $this->peg_parseASCII_LowercaseAlphaNumeric();
         }
         if ($s4 !== $this->peg_FAILED) {
           $s3 = array($s3, $s4);
@@ -1718,9 +1718,9 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseASCII_AlphaNumeric() {
+    private function peg_parseASCII_LowercaseAlphaNumeric() {
 
-      $s0 = $this->peg_parseASCII_Letter();
+      $s0 = $this->peg_parseASCII_LowercaseLetter();
       if ($s0 === $this->peg_FAILED) {
         $s0 = $this->peg_parseASCII_Digit();
         if ($s0 === $this->peg_FAILED) {
@@ -1731,7 +1731,7 @@ class Gutenberg_PEG_Parser {
       return $s0;
     }
 
-    private function peg_parseASCII_Letter() {
+    private function peg_parseASCII_LowercaseLetter() {
 
       if (Gutenberg_PEG_peg_char_class_test($this->peg_c22, $this->input_substr($this->peg_currPos, 1))) {
         $s0 = $this->input_substr($this->peg_currPos, 1);
@@ -1888,8 +1888,8 @@ class Gutenberg_PEG_Parser {
     $this->peg_c19 = "}";
     $this->peg_c20 = array( "type" => "literal", "value" => "}", "description" => "\"}\"" );
     $this->peg_c21 = "";
-    $this->peg_c22 = array(array(97,122), array(65,90));
-    $this->peg_c23 = array( "type" => "class", "value" => "[a-zA-Z]", "description" => "[a-zA-Z]" );
+    $this->peg_c22 = array(array(97,122));
+    $this->peg_c23 = array( "type" => "class", "value" => "[a-z]", "description" => "[a-z]" );
     $this->peg_c24 = array(array(48,57));
     $this->peg_c25 = array( "type" => "class", "value" => "[0-9]", "description" => "[0-9]" );
     $this->peg_c26 = array(array(45,45), array(95,95));


### PR DESCRIPTION
This pull request seeks to resolve inconsistencies between block registration validation and name parsing expectations. Specifically:

- Registration requires that a block name be lowercase, but this was not enforced by the block parser
- The block parser enforces that a block name start with a letter, but this was not validated by registration

Further, these requirements were not documented in block registration documentation.

The proposed changes remedies each of the above issues.

__Testing instructions:__

Ensure tests pass:

```
npm test
```

__Follow-up Tasks:__

Gutenberg examples have names beginning with numbers and must be updated:

https://github.com/WordPress/gutenberg-examples