### PR TITLE
Fixed quote<->list transformations

### DIFF
--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, compact, get, first } from 'lodash';
+import { find, compact, get, initial, last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -159,7 +159,9 @@ registerBlockType( 'core/list', {
 				blocks: [ 'core/quote' ],
 				transform: ( { values } ) => {
 					return createBlock( 'core/quote', {
-						value: [ <p key="list">{ toBrDelimitedContent( values ) }</p> ],
+						value: ( values.length === 1 ? values : initial( values ) )
+							.map( ( value ) => ( { children: <p> { get( value, 'props.children' ) } </p> } ) ),
+						citation: ( values.length === 1 ? undefined : get( last( values ), 'props.children' ) ),
 					} );
 				},
 			},

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { find, compact, get } from 'lodash';
+import { find, compact, get, first } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Component, createElement, Children, concatChildren } from '@wordpress/element';
+import { Component, createElement, Children } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -114,13 +114,10 @@ registerBlockType( 'core/list', {
 				type: 'block',
 				blocks: [ 'core/quote' ],
 				transform: ( { value, citation } ) => {
-					const listItems = fromBrDelimitedContent( value );
-					const values = citation ?
-						concatChildren( listItems, <li>{ citation }</li> ) :
-						listItems;
 					return createBlock( 'core/list', {
 						nodeName: 'UL',
-						values,
+						values: value.map( ( item, index ) => <li key={ index } >{ get( item, 'children.props.children', '' ) } </li> )
+							.concat( citation ? <li key="citation">{ citation }</li> : [] ),
 					} );
 				},
 			},


### PR DESCRIPTION
## Description
This PR aims to fix a bug that I just discovered. Transforming from a quote into a list throws an error, and transforming a list into a quote creates a quote with empty content.
This PR solves both problems and simplifies the logic in a similar way of what was done in paragraph<->list transformations.
Now, transforming from quote to list, creates a list of the quote paragraphs and the last item being the citation. Transforming a list into a quote creates a paragraph for each list item excluding the last one that is used as a citation. This makes the transformations (quote->list->quote, list->quote->list) 
 totally idempotent.

## How Has This Been Tested?
Transform a quote (empty and non-empty) into a list. Verify the first two values of the list are quote, citation. 
Transform a list (empty and non-empty) into a quote. Verify the first two values of the list are now quote and citation of the quote block. If the list contains more than two values just the first two should be used.

## Screenshots (jpeg or gifs if applicable):
### Before:
**List to quote**
![nov-16-2017 19-48-38](https://user-images.githubusercontent.com/11271197/32912517-31bbc8b6-cb07-11e7-86b4-3086da828f4f.gif)

**Quote to list**
![nov-16-2017 19-50-43](https://user-images.githubusercontent.com/11271197/32912598-771860c2-cb07-11e7-8ede-73092ebd1e13.gif)

### After:
![nov-17-2017 11-54-52](https://user-images.githubusercontent.com/11271197/32946149-40936bf0-cb8e-11e7-8f18-7d633f29b981.gif)


