### PR TITLE
fix/3428: Update convertToBlocks rawHandler call to specify mode

### DIFF
--- a/editor/components/block-settings-menu/unknown-converter.js
+++ b/editor/components/block-settings-menu/unknown-converter.js
@@ -43,7 +43,7 @@ export default connect(
 		convertToBlocks( block ) {
 			dispatch( replaceBlocks( uid, rawHandler( {
 				HTML: serialize( block ),
-				inline: false,
+				mode: 'BLOCKS',
 			} ) ) );
 		},
 	} )


### PR DESCRIPTION
## Description
Fixes #3428 
It looks like the rawHandler was changed to use the string-enum parameter mode instead of the boolean parameter inline at some point and this broke convertToBlocks for inline input like empty string.

## How Has This Been Tested?
Manual check in Firefox and Chrome.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.