### PR TITLE
Framework: Decrease build size by fixing import statements

### DIFF
--- a/blocks/library/image/image-size.js
+++ b/blocks/library/image/image-size.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 class ImageSize extends Component {
 	constructor() {

--- a/components/form-file-upload/index.js
+++ b/components/form-file-upload/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -6,7 +6,7 @@ import { mapValues, reduce, forEach, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/components/higher-order/with-api-data/provider.js
+++ b/components/higher-order/with-api-data/provider.js
@@ -6,7 +6,7 @@ import { mapValues, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 
 export default class APIProvider extends Component {
 	getChildContext() {

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -7,7 +7,7 @@ import { unescape as unescapeString, without, groupBy, map, repeat, find } from 
 /**
  * WordPress dependencies
  */
-import { __, _x } from 'i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/components';
 

--- a/editor/components/post-visibility/utils.js
+++ b/editor/components/post-visibility/utils.js
@@ -1,7 +1,7 @@
 /**
  * WordPress Dependencies
  */
-import { __ } from 'i18n';
+import { __ } from '@wordpress/i18n';
 
 export const visibilityOptions = [
 	{

--- a/editor/components/word-count/index.js
+++ b/editor/components/word-count/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { getBlocks } from '../../selectors';
-import { serialize } from 'blocks';
+import { serialize } from '@wordpress/blocks';
 
 function WordCount( { content } ) {
 	const wordCount = wp.utils.WordCounter.prototype.count( content );

--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -1,4 +1,4 @@
-import { viewPort } from '../utils';
+import { viewPort } from '@wordpress/utils';
 
 export const STORE_DEFAULTS = {
 	preferences: {

--- a/editor/writing-flow/index.js
+++ b/editor/writing-flow/index.js
@@ -3,13 +3,13 @@
  */
 import { connect } from 'react-redux';
 import 'element-closest';
-
+import { find, reverse } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from 'element';
+import { Component } from '@wordpress/element';
 import { keycodes, focus } from '@wordpress/utils';
-import { find, reverse } from 'lodash';
+
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
## Description

This PR updates import statements that were using legacy format. It turned out this caused `blocks` chunk to be also bundled together with `editor` chunk doubling the size of the chunk.

`editor` chunk has decreased size from **1.02 MB** to **551 kB** for production build. This is before compression.

It's worth mention that side-effects from `blocks` chunk were executed twice including all block registrations!

#### Before

>                              Asset     Size               Chunks                    Chunk Names
>                i18n/build/index.js  17.5 kB                    5  [emitted]         i18n
>              blocks/build/index.js   552 kB                 1, 4  [emitted]  [big]  blocks
>          components/build/index.js   262 kB                 2, 4  [emitted]  [big]  components
>               utils/build/index.js  23.4 kB                    3  [emitted]         utils
>             element/build/index.js  9.51 kB                    4  [emitted]         element
>              editor/build/index.js  1.02 MB        0, 1, 3, 4, 5  [emitted]  [big]  editor
>                date/build/index.js  3.08 kB                    6  [emitted]         date
>           ./blocks/build/style.css  42.7 kB  0, 1, 3, 4, 5, 1, 4  [emitted]         editor, blocks
>     ./blocks/build/edit-blocks.css  31.3 kB  0, 1, 3, 4, 5, 1, 4  [emitted]         editor, blocks
>       ./components/build/style.css  30.8 kB                 2, 4  [emitted]         components
>           ./editor/build/style.css  82.3 kB        0, 1, 3, 4, 5  [emitted]         editor

#### After 

>                              Asset     Size  Chunks                    Chunk Names
>                i18n/build/index.js  17.6 kB       5  [emitted]         i18n
>              blocks/build/index.js   551 kB       0  [emitted]  [big]  blocks
>          components/build/index.js   260 kB       2  [emitted]  [big]  components
>               utils/build/index.js  23.4 kB       3  [emitted]         utils
>             element/build/index.js  9.52 kB       4  [emitted]         element
>              editor/build/index.js   551 kB       1  [emitted]  [big]  editor
>                date/build/index.js  3.08 kB       6  [emitted]         date
>           ./blocks/build/style.css  42.7 kB       0  [emitted]         blocks
>     ./blocks/build/edit-blocks.css  31.3 kB       0  [emitted]         blocks
>       ./components/build/style.css  30.8 kB       2  [emitted]         components
>           ./editor/build/style.css  82.3 kB       1  [emitted]         editor
> 

## How Has This Been Tested?
Manually.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.