### PR TITLE
Framework: Require '@wordpress/' import path for application entry points

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,6 +91,34 @@
 				"message": "Path access on WordPress dependencies is not allowed."
 			},
 			{
+				"selector": "ImportDeclaration[source.value=/^blocks$/]",
+				"message": "Use @wordpress/blocks as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^components$/]",
+				"message": "Use @wordpress/components as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^date$/]",
+				"message": "Use @wordpress/date as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^editor$/]",
+				"message": "Use @wordpress/editor as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^element$/]",
+				"message": "Use @wordpress/element as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^i18n$/]",
+				"message": "Use @wordpress/i18n as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^utils$/]",
+				"message": "Use @wordpress/utils as import path instead."
+			},
+			{
 				"selector": "CallExpression[callee.name=/^__|_n|_x$/]:not([arguments.0.type=/^Literal|BinaryExpression$/])",
 				"message": "Translate function arguments must be string literals."
 			},


### PR DESCRIPTION
## Description

See #3531.

## How Has This Been Tested?

Attempt to change any import from `import { Foo } from '@wordpress/element'` to `import { Foo } from 'element'`. Try the same for other Gutenberg entry points (e.g. `blocks`, `i18n`).

## Screenshots (jpeg or gifs if applicable):

<img width="631" alt="screen shot 2017-11-17 at 12 56 17" src="https://user-images.githubusercontent.com/150562/32948321-bf9698d4-cb96-11e7-9a4c-a26ec9ae34e2.png">

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.