### PR TITLE
Components: withAPIData: Don't restrict to /wp/v2, allow custom endpoints

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -478,11 +478,14 @@ JS;
 	wp_add_inline_script( 'wp-api', $script );
 
 	// Localize the wp-api settings and schema.
-	$schema_response = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2' ) );
+	$schema_response = rest_do_request( new WP_REST_Request( 'GET', '/' ) );
 	if ( ! $schema_response->is_error() ) {
 		wp_add_inline_script( 'wp-api', sprintf(
 			'wpApiSettings.cacheSchema = true; wpApiSettings.schema = %s;',
-			wp_json_encode( $schema_response->get_data() )
+			wp_json_encode( array(
+				'namespace' => '',
+				'routes' => $schema_response->get_data()[ 'routes' ],
+			) )
 		), 'before' );
 	}
 }


### PR DESCRIPTION
## Description
Fixes #3209 

## How Has This Been Tested?
1. Set up a site with the appropriate branches of Sensei and Sensei Courses according to the instructions in the parent issue. Set up a post/page in Gutenberg according to the instructions and use the Network inspector.
2. Make sure that a successful request to `/sensei/v1/courses` is found alongside the request to `/wp/v2/course-category`.
3. Make sure core blocks aren't affected by this (e.g. Latest Posts), nor other consumers of `withAPIData` within the framework (e.g. sidebar controls).

/cc @donnapep

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.