### PR TITLE
Framework: Fix change detection to maintain multiple instances of state

### DIFF
--- a/editor/utils/with-change-detection/index.js
+++ b/editor/utils/with-change-detection/index.js
@@ -14,10 +14,8 @@ import { includes } from 'lodash';
  * @return {Function}                    Enhanced reducer
  */
 export default function withChangeDetection( reducer, options = {} ) {
-	let originalState;
-
 	return ( state, action ) => {
-		let nextState = reducer( state, action );
+		const nextState = reducer( state, action );
 
 		// Reset at:
 		//  - Initial state
@@ -27,22 +25,17 @@ export default function withChangeDetection( reducer, options = {} ) {
 			includes( options.resetTypes, action.type )
 		);
 
-		const nextIsDirty = ! isReset && originalState !== nextState;
-
-		// Only revise state if changing.
-		if ( nextIsDirty !== nextState.isDirty ) {
-			// In case the original reducer returned the same reference and we
-			// intend to mutate, create a shallow clone.
-			if ( state === nextState ) {
-				nextState = { ...nextState };
-			}
-
-			nextState.isDirty = nextIsDirty;
+		if ( isReset ) {
+			return {
+				...nextState,
+				isDirty: false,
+			};
 		}
 
-		// Track original state against which dirty test compares reference
-		if ( isReset ) {
-			originalState = nextState;
+		const isChanging = state !== nextState;
+
+		if ( isChanging ) {
+			nextState.isDirty = true;
 		}
 
 		return nextState;


### PR DESCRIPTION
This pull request seeks to improve the `withChangeDetection` higher-order reducer to resolve an issue where state is maintained between invocations of the original reducer, whether or not those invocations occur within the same store instance. Notably, this becomes an issue if there are multiple instances of Redux stores sharing the same reducer. The previous behavior was not pure, which has been remedied with the changes here. The only downside is that `isDirty` does not revert back to `false` if the state resets to its original reference. Since this would be a very rare occurrence anyways, it is a reasonable sacrifice. The only other option I could consider was to maintain both current and original states in an injected subtree of state.

__Testing instructions:__

Ensure unit tests pass:

```
npm test
```

Verify that there are no regressions in the behavior of saved state dirty detection.

1. New posts should not have unsaved changes
2. Changes should flag a post as needing save
3. Saving a post should reset to no unsaved changes after completion