### PR TITLE
Remove top link from embedded content block fix #3497

### DIFF
--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -140,6 +140,9 @@ export default class Sandbox extends Component {
 				margin-top: 0 !important;	/* has to have !important to override inline styles */
 				margin-bottom: 0 !important;
 			}
+			body > div > blockquote {
+				display: none;
+			}
 		`;
 
 		// put the html snippet into a html document, and then write it to the iframe's document


### PR DESCRIPTION
## Description
This PR aims to close #3497  by hidding `blockquote` from the  embedded iframe.

## How Has This Been Tested?
Add some embedded blocks, verify the top link does not appear.

## Screenshots (jpeg or gifs if applicable):
![selection_002](https://user-images.githubusercontent.com/6149344/32977917-f9f94f32-cc5c-11e7-8ad3-3991f0d04f6d.png)
