### PR TITLE
add onReplace to Heading block

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -98,7 +98,7 @@ registerBlockType( 'core/heading', {
 		};
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlocksAfter } ) {
+	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlocksAfter, onReplace } ) {
 		const { align, content, nodeName, placeholder } = attributes;
 
 		return [
@@ -158,6 +158,7 @@ registerBlockType( 'core/heading', {
 						createBlock( 'core/paragraph', { content: after } ),
 					] );
 				} }
+				onReplace={ onReplace }
 				style={ { textAlign: align } }
 				placeholder={ placeholder || __( 'Write heading…' ) }
 			/>,


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes https://github.com/WordPress/gutenberg/issues/3351

When pasting copied heading from html page to Heading block two Heading blocks are created.

This is only happening when html tag is present in the pasted text (h, strong...), because browser tries to keep the formatting of copied text. (Depending on the markup Heading can be converted to Paragraph and vice versa)
Editable component is doing paste pre processing of the text and if the text is not plain string it determines if the content should be replaced or split.
Paragraph, which does not have this problem, has onReplace set and Heading does not, so it splits and creates two blocks.
I added onReplace to the Heading and it seems to behave the same as Paragraph in that regard now.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually tested in the browser.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
I added onReplace to the Heading and it seems to behave the same as Paragraph in that regard now.
