### PR TITLE
Meta Box back compat and fall backs

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -72,6 +72,12 @@
 		"parent": "reference"
 	},
 	{
+		"title": "Meta Boxes",
+		"slug": "meta-box",
+		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/meta-box.md",
+		"parent": "reference"
+	},
+	{
 		"title": "Glossary",
 		"slug": "glossary",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/glossary.md",

--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -5,6 +5,38 @@ the superior developer and user experience of blocks however, especially once,
 block templates are available, **converting PHP meta boxes to blocks is highly
 encouraged!**
 
+### Testing, Converting, and Maintaining Existing Meta Boxes
+
+Before converting meta boxes to blocks, it may be  easier to test if a meta box works with Gutenberg, and explicitly mark it as such.
+
+If a meta box *doesn't* work with in Gutenberg, and updating it to work correctly is not an option, the next step is to add the `__block_editor_compatible_meta_box` argument to the meta box declaration:
+
+```php
+add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
+    null, 'normal', 'high',
+	array(
+		'__block_editor_compatible_meta_box' => false,
+	)
+);
+```
+
+This will cause WordPress to fall back to the Classic editor, where the meta box will continue working as before.
+
+Explicitly setting `__block_editor_compatible_meta_box` to `true` will cause WordPress to stay in Gutenberg (assuming another meta box doesn't cause a fallback, of course).
+
+After a meta box is converted to a block, it can be declared as existing for backwards compatibility:
+
+```php
+add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
+    null, 'normal', 'high',
+	array(
+		'__back_compat_meta_box' => false,
+	)
+);
+```
+
+When Gutenberg is run, this meta box will no longer be displayed in the meta box area, as it now only exists for backwards compatibility purposes. It will continue to be displayed correctly in the Classic editor, should some other meta box cause a fallback.
+
 ### Meta Box Data Collection
 
 On each Gutenberg page load, the global state of post.php is mimicked, this is
@@ -22,7 +54,9 @@ namely `add_meta_boxes`, `add_meta_boxes_{$post->post_type}`, and `do_meta_boxes
 
 A copy of the global `$wp_meta_boxes` is made then filtered through
 `apply_filters( 'filter_gutenberg_meta_boxes', $_meta_boxes_copy );`, which will
-strip out any core meta boxes along with standard custom taxonomy meta boxes.
+strip out any core meta boxes, standard custom taxonomy meta boxes, and any meta
+boxes that have declared themselves as only existing for backwards compatibility
+purposes.
 
 Then each location for this particular type of meta box is checked for whether it
 is active. If it is not empty a value of true is stored, if it is empty a value
@@ -36,7 +70,7 @@ have to do, unless we want to move `createEditorInstance()` to fire in the foote
 or at some point after `admin_head`. With recent changes to editor bootstrapping
 this might now be possible. Test with ACF to make sure.
 
-### Redux and React Meta Box Management.
+### Redux and React Meta Box Management
 
 *The Redux store by default will hold all meta boxes as inactive*. When
 `INITIALIZE_META_BOX_STATE` comes in, the store will update any active meta box

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -545,10 +545,8 @@ function gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type ) {
 	}
 
 	foreach ( $meta_boxes[ $page ][ $context ] as $priority => $boxes ) {
-		foreach ( $boxes as $id => $box ) {
-			if ( ! empty( $boxes ) ) {
-				return false;
-			}
+		if ( ! empty( $boxes ) ) {
+			return false;
 		}
 	}
 

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -596,14 +596,18 @@ function gutenberg_override_meta_box_callback( $object, $box ) {
 	$callback = $box['args']['__original_callback'];
 	unset( $box['args']['__original_callback'] );
 
+	$block_compatible = true;
 	if ( isset( $box['args']['__block_editor_compatible_meta_box'] ) ) {
-		$block_compatible = $box['args']['__block_editor_compatible_meta_box'];
+		$block_compatible = !! $box['args']['__block_editor_compatible_meta_box'];
 		unset( $box['args']['__block_editor_compatible_meta_box'] );
 	}
 
 	if ( isset( $box['args']['__back_compat_meta_box'] ) ) {
+		$block_compatible |= !! $box['args']['__back_compat_meta_box'];
 		unset( $box['args']['__back_compat_meta_box'] );
-	} elseif ( ! $block_compatible ) {
+	}
+
+	if ( ! $block_compatible ) {
 		gutenberg_show_meta_box_warning( $callback );
 	}
 

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -541,8 +541,11 @@ function gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type ) {
 	}
 
 	foreach ( $meta_boxes[ $page ][ $context ] as $priority => $boxes ) {
-		if ( ! empty( $boxes ) ) {
-			return false;
+		foreach ( $boxes as $id => $box ) {
+			// The meta box is only empty if a meta box exists, and hasn't declared it self as being for back compat purposes.
+			if ( ! is_array( $box['args'] ) || ! isset( $box['args']['__back_compat_meta_box'] ) ) {
+				return false;
+			}
 		}
 	}
 
@@ -550,3 +553,96 @@ function gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type ) {
 }
 
 add_filter( 'filter_gutenberg_meta_boxes', 'gutenberg_filter_meta_boxes' );
+
+/**
+ * Go through the global metaboxes, and override the render callback, so we can trigger our warning if needed.
+ *
+ * @since 1.8.0
+ */
+function gutenberg_intercept_meta_box_render() {
+	global $wp_meta_boxes;
+
+	foreach ( $wp_meta_boxes as $post_type => $contexts ) {
+		foreach ( $contexts as $context => $priorities ) {
+			foreach ( $priorities as $priority => $boxes ) {
+				foreach ( $boxes as $id => $box ) {
+					if ( ! is_array( $wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args'] ) ) {
+						$wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args'] = array();
+					}
+					if ( ! isset( $wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args']['__original_callback'] ) ) {
+						$wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args']['__original_callback'] = $box['callback'];
+						$wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['callback'] = 'gutenberg_override_meta_box_callback';
+					}
+				}
+			}
+		}
+	}
+}
+add_action( 'submitpost_box', 'gutenberg_intercept_meta_box_render' );
+add_action( 'submitpage_box', 'gutenberg_intercept_meta_box_render' );
+add_action( 'edit_page_form', 'gutenberg_intercept_meta_box_render' );
+add_action( 'edit_form_advanced', 'gutenberg_intercept_meta_box_render' );
+
+/**
+ * Check if this metabox only exists for back compat purposes, show a warning if it doesn't.
+ *
+ * @since 1.8.0
+ */
+function gutenberg_override_meta_box_callback( $object, $box ) {
+	$callback = $box['args']['__original_callback'];
+	unset( $box['args']['__original_callback'] );
+
+	if ( isset( $box['args']['__back_compat_meta_box'] ) ) {
+		unset( $box['args']['__back_compat_meta_box'] );
+	} else {
+		gutenberg_show_meta_box_warning( $callback );
+	}
+
+	call_user_func( $callback, $object, $box );
+}
+
+/**
+ * Display a warning in the metabox that the current plugin is causing the fallback to the old editor.
+ *
+ * @since 1.8.0
+ */
+function gutenberg_show_meta_box_warning( $callback ) {
+	// Only show the warning when WP_DEBUG is enabled.
+	if ( ! WP_DEBUG ) {
+		return;
+	}
+
+	// Don't show in the Gutenberg meta box UI.
+	if ( ! isset( $_REQUEST['classic-editor' ] ) ) {
+		return;
+	}
+
+	if ( is_array( $callback ) ) {
+		$reflection = new ReflectionMethod( $callback[0], $callback[1] );
+	} else {
+		$reflection = new ReflectionFunction( $callback );
+	}
+
+	if ( $reflection->isInternal() ) {
+		return;
+	}
+
+	$filename = $reflection->getFileName();
+	if ( strpos( $filename, WP_PLUGIN_DIR ) !== 0 ) {
+		return;
+	}
+
+	$filename = str_replace( WP_PLUGIN_DIR, '', $filename );
+	$filename = preg_replace( '|^/([^/]*/).*$|', '\\1', $filename );
+
+	$plugins = get_plugins();
+	foreach ( $plugins as $name => $plugin ) {
+		if ( strpos( $name, $filename ) === 0 ) {
+			?>
+				<div class="error inline">
+					<p><?php printf( __( 'Gutenberg incompatible meta box, from the "%s" plugin.', 'gutenberg' ), $plugin['Name'] ); ?></p>
+				</div>
+			<?php
+		}
+	}
+}

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -516,7 +516,7 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
 					// Filter out meta boxes that are just registered for back compat.
-					if ( is_array( $data['args'] ) && isset( $data['args']['__back_compat_meta_box'] ) ) {
+					if ( isset( $data['args']['__back_compat_meta_box'] ) && $data['args']['__back_compat_meta_box'] ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
 				}

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -516,7 +516,7 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
 					// Filter out meta boxes that are just registered for back compat.
-					if ( is_array( $box['args'] ) && isset( $box['args']['__back_compat_meta_box'] ) ) {
+					if ( is_array( $data['args'] ) && isset( $data['args']['__back_compat_meta_box'] ) ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
 				}

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -598,12 +598,12 @@ function gutenberg_override_meta_box_callback( $object, $box ) {
 
 	$block_compatible = true;
 	if ( isset( $box['args']['__block_editor_compatible_meta_box'] ) ) {
-		$block_compatible = !! $box['args']['__block_editor_compatible_meta_box'];
+		$block_compatible = (bool) $box['args']['__block_editor_compatible_meta_box'];
 		unset( $box['args']['__block_editor_compatible_meta_box'] );
 	}
 
 	if ( isset( $box['args']['__back_compat_meta_box'] ) ) {
-		$block_compatible |= !! $box['args']['__back_compat_meta_box'];
+		$block_compatible |= (bool) $box['args']['__back_compat_meta_box'];
 		unset( $box['args']['__back_compat_meta_box'] );
 	}
 

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -597,11 +597,15 @@ add_action( 'edit_form_advanced', 'gutenberg_intercept_meta_box_render' );
 function gutenberg_override_meta_box_callback( $object, $box ) {
 	$callback = $box['args']['__original_callback'];
 	unset( $box['args']['__original_callback'] );
-	unset( $box['args']['__block_editor_compatible_meta_box'] );
+
+	if ( isset( $box['args']['__block_editor_compatible_meta_box'] ) ) {
+		$block_compatible = $box['args']['__block_editor_compatible_meta_box'];
+		unset( $box['args']['__block_editor_compatible_meta_box'] );
+	}
 
 	if ( isset( $box['args']['__back_compat_meta_box'] ) ) {
 		unset( $box['args']['__back_compat_meta_box'] );
-	} else {
+	} elseif ( ! $block_compatible ) {
 		gutenberg_show_meta_box_warning( $callback );
 	}
 

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -597,6 +597,7 @@ add_action( 'edit_form_advanced', 'gutenberg_intercept_meta_box_render' );
 function gutenberg_override_meta_box_callback( $object, $box ) {
 	$callback = $box['args']['__original_callback'];
 	unset( $box['args']['__original_callback'] );
+	unset( $box['args']['__block_editor_compatible_meta_box'] );
 
 	if ( isset( $box['args']['__back_compat_meta_box'] ) ) {
 		unset( $box['args']['__back_compat_meta_box'] );

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -571,7 +571,7 @@ function gutenberg_intercept_meta_box_render() {
 					}
 					if ( ! isset( $wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args']['__original_callback'] ) ) {
 						$wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args']['__original_callback'] = $box['callback'];
-						$wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['callback'] = 'gutenberg_override_meta_box_callback';
+						$wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['callback']                    = 'gutenberg_override_meta_box_callback';
 					}
 				}
 			}
@@ -587,6 +587,9 @@ add_action( 'edit_form_advanced', 'gutenberg_intercept_meta_box_render' );
  * Check if this metabox only exists for back compat purposes, show a warning if it doesn't.
  *
  * @since 1.8.0
+ *
+ * @param mixed $object The object being operated on, on this screen.
+ * @param array $box The current meta box definition.
  */
 function gutenberg_override_meta_box_callback( $object, $box ) {
 	$callback = $box['args']['__original_callback'];
@@ -605,6 +608,8 @@ function gutenberg_override_meta_box_callback( $object, $box ) {
  * Display a warning in the metabox that the current plugin is causing the fallback to the old editor.
  *
  * @since 1.8.0
+ *
+ * @param callable $callback The function that a plugin has defined to render a meta box.
  */
 function gutenberg_show_meta_box_warning( $callback ) {
 	// Only show the warning when WP_DEBUG is enabled.
@@ -613,7 +618,7 @@ function gutenberg_show_meta_box_warning( $callback ) {
 	}
 
 	// Don't show in the Gutenberg meta box UI.
-	if ( ! isset( $_REQUEST['classic-editor' ] ) ) {
+	if ( ! isset( $_REQUEST['classic-editor'] ) ) {
 		return;
 	}
 
@@ -640,7 +645,12 @@ function gutenberg_show_meta_box_warning( $callback ) {
 		if ( strpos( $name, $filename ) === 0 ) {
 			?>
 				<div class="error inline">
-					<p><?php printf( __( 'Gutenberg incompatible meta box, from the "%s" plugin.', 'gutenberg' ), $plugin['Name'] ); ?></p>
+					<p>
+						<?php
+							/* translators: %s is the name of the plugin that generated this meta box. */
+							printf( __( 'Gutenberg incompatible meta box, from the "%s" plugin.', 'gutenberg' ), $plugin['Name'] );
+						?>
+					</p>
 				</div>
 			<?php
 		}

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -515,6 +515,10 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 					if ( isset( $data['callback'] ) && in_array( $data['callback'], $taxonomy_callbacks_to_unset ) ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
+					// Filter out meta boxes that are just registered for back compat.
+					if ( is_array( $box['args'] ) && isset( $box['args']['__back_compat_meta_box'] ) ) {
+						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
+					}
 				}
 			}
 		}
@@ -542,8 +546,7 @@ function gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type ) {
 
 	foreach ( $meta_boxes[ $page ][ $context ] as $priority => $boxes ) {
 		foreach ( $boxes as $id => $box ) {
-			// The meta box is only empty if a meta box exists, and hasn't declared it self as being for back compat purposes.
-			if ( ! is_array( $box['args'] ) || ! isset( $box['args']['__back_compat_meta_box'] ) ) {
+			if ( ! empty( $boxes ) ) {
 				return false;
 			}
 		}

--- a/lib/register.php
+++ b/lib/register.php
@@ -219,10 +219,16 @@ function gutenberg_collect_meta_box_data() {
 
 	// If the meta box should be empty set to false.
 	foreach ( $locations as $location ) {
-		if ( isset( $_meta_boxes_copy[ $post->post_type ][ $location ] ) && gutenberg_is_meta_box_empty( $_meta_boxes_copy, $location, $post->post_type ) ) {
-			$meta_box_data[ $location ] = false;
-		} else {
-			$meta_box_data[ $location ] = true;
+		if ( isset( $_meta_boxes_copy[ $post->post_type ][ $location ] ) && ! gutenberg_is_meta_box_empty( $_meta_boxes_copy, $location, $post->post_type ) ) {
+			?>
+			<script type="text/javascript">
+				var joiner = '?';
+				if ( window.location.search ) {
+					joiner = '&';
+				}
+				window.location.href += joiner + 'classic-editor';
+			</script>
+			<?php
 		}
 	}
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -219,16 +219,40 @@ function gutenberg_collect_meta_box_data() {
 
 	// If the meta box should be empty set to false.
 	foreach ( $locations as $location ) {
-		if ( isset( $_meta_boxes_copy[ $post->post_type ][ $location ] ) && ! gutenberg_is_meta_box_empty( $_meta_boxes_copy, $location, $post->post_type ) ) {
-			?>
-			<script type="text/javascript">
-				var joiner = '?';
-				if ( window.location.search ) {
-					joiner = '&';
+		if ( isset( $_meta_boxes_copy[ $post->post_type ][ $location ] ) && gutenberg_is_meta_box_empty( $_meta_boxes_copy, $location, $post->post_type ) ) {
+			$meta_box_data[ $location ] = false;
+		} else {
+			$meta_box_data[ $location ] = true;
+			$incompatible_meta_box      = false;
+			// Check if we have a meta box that has declared itself incompatible with the block editor.
+			foreach ( $_meta_boxes_copy[ $post->post_type ][ $location ] as $boxes ) {
+				foreach ( $boxes as $box ) {
+					/*
+					 * If __block_editor_compatible_meta_box is declared as a false-y value,
+					 * the meta box is not compatible with the block editor.
+					 */
+					if ( is_array( $box['args'] )
+						&& isset( $box['args']['__block_editor_compatible_meta_box'] )
+						&& ! $box['args']['__block_editor_compatible_meta_box'] ) {
+							$incompatible_meta_box = true;
+							break 2;
+					}
 				}
-				window.location.href += joiner + 'classic-editor';
-			</script>
-			<?php
+			}
+
+			// Incompatible meta boxes require an immediate redirect to the classic editor.
+			if ( $incompatible_meta_box ) {
+				?>
+				<script type="text/javascript">
+					var joiner = '?';
+					if ( window.location.search ) {
+						joiner = '&';
+					}
+					window.location.href += joiner + 'classic-editor';
+				</script>
+				<?php
+				exit;
+			}
 		}
 	}
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -219,7 +219,7 @@ function gutenberg_collect_meta_box_data() {
 
 	// If the meta box should be empty set to false.
 	foreach ( $locations as $location ) {
-		if ( isset( $_meta_boxes_copy[ $post->post_type ][ $location ] ) && gutenberg_is_meta_box_empty( $_meta_boxes_copy, $location, $post->post_type ) ) {
+		if ( gutenberg_is_meta_box_empty( $_meta_boxes_copy, $location, $post->post_type ) ) {
 			$meta_box_data[ $location ] = false;
 		} else {
 			$meta_box_data[ $location ] = true;

--- a/phpunit/class-meta-box-test.php
+++ b/phpunit/class-meta-box-test.php
@@ -137,33 +137,6 @@ class Meta_Box_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests for meta box area that only contains back compat meta boxes.
-	 */
-	public function test_gutenberg_is_meta_box_empty_with_back_compat_meta_box() {
-		$context    = 'normal';
-		$post_type  = 'post';
-		$meta_boxes = array(
-			'post' => array(
-				'normal' => array(
-					'high' => array(
-						'some-meta-box' => array(
-							'id'       => 'some-meta-box',
-							'title'    => 'Some Meta Box',
-							'callback' => 'some_meta_box',
-							'args'     => array(
-								'__back_compat_meta_box' => true,
-							),
-						),
-					),
-				),
-			),
-		);
-
-		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
-		$this->assertTrue( $is_empty );
-	}
-
-	/**
 	 * Tests for non existant location.
 	 */
 	public function test_gutenberg_is_meta_box_empty_with_non_existant_location() {
@@ -200,6 +173,37 @@ class Meta_Box_Test extends WP_UnitTestCase {
 		$expected_meta_boxes['post']['normal']['core']                  = array();
 		$expected_meta_boxes['post']['side']['core']                    = array();
 		$expected_meta_boxes['post']['normal']['high']['some-meta-box'] = array( 'meta-box-stuff' );
+
+		$actual   = gutenberg_filter_meta_boxes( $meta_boxes );
+		$expected = $expected_meta_boxes;
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Test filtering back compat meta boxes
+	 */
+	public function test_gutenberg_filter_back_compat_meta_boxes() {
+		$meta_boxes = $this->meta_boxes;
+
+		// Add in a back compat meta box.
+		$meta_boxes['post']['normal']['high']['some-meta-box'] = array(
+			'id'       => 'some-meta-box',
+			'title'    => 'Some Meta Box',
+			'callback' => 'some_meta_box',
+			'args'     => array(
+				'__back_compat_meta_box' => true,
+			),
+		);
+
+		// Add in a normal meta box.
+		$meta_boxes['post']['normal']['high']['some-other-meta-box'] = array( 'other-meta-box-stuff' );
+
+		$expected_meta_boxes = $this->meta_boxes;
+		// We expect to remove only core meta boxes.
+		$expected_meta_boxes['post']['normal']['core']                        = array();
+		$expected_meta_boxes['post']['side']['core']                          = array();
+		$expected_meta_boxes['post']['normal']['high']['some-other-meta-box'] = array( 'other-meta-box-stuff' );
 
 		$actual   = gutenberg_filter_meta_boxes( $meta_boxes );
 		$expected = $expected_meta_boxes;

--- a/phpunit/class-meta-box-test.php
+++ b/phpunit/class-meta-box-test.php
@@ -137,6 +137,33 @@ class Meta_Box_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests for meta box area that only contains back compat meta boxes.
+	 */
+	public function test_gutenberg_is_meta_box_empty_with_back_compat_meta_box() {
+		$context    = 'normal';
+		$post_type  = 'post';
+		$meta_boxes = array(
+			'post' => array(
+				'normal' => array(
+					'high' => array(
+						'some-meta-box' => array(
+							'id'       => 'some-meta-box',
+							'title'    => 'Some Meta Box',
+							'callback' => 'some_meta_box',
+							'args'     => array(
+								'__back_compat_meta_box' => true,
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
+		$this->assertTrue( $is_empty );
+	}
+
+	/**
 	 * Tests for non existant location.
 	 */
 	public function test_gutenberg_is_meta_box_empty_with_non_existant_location() {


### PR DESCRIPTION
Even after Gutenberg is merged into Core, and a plugin has upgraded all of its meta boxes to using Gutenberg APIs, those plugin will still need to register classic meta boxes, for backwards compatibility with the classic editor.

## Changes

This PR makes a few changes along those lines.

### Back Compat Meta Boxen

When registering a meta box, adding a `'__back_compat_meta_box' => true` arg to the `$callback_args` argument of `add_meta_box()` will cause Gutenberg to ignore that meta box in the meta box UI - it's assumed that a plugin developer who defines this arg will have registered a Gutenberg-specific UI for this meta box.

For example:

```php
add_meta_box(
	'lol',
	'foo',
	function() {
		echo 'whee';
	},
	null,
	'normal',
	'high',
	array(
		'__back_compat_meta_box' => true,
		'__block_editor_compatible_meta_box' => true,
	)
);
```

### Falling Back To The Classic Editor

If an unsupported meta box is detected while loading Gutenberg, we now redirect to the classic editor. Currently, this is any meta box that explicitly declares the `__block_editor_compatible_meta_box` arg as a `false`-y value.

A future iteration could check if a meta box relies on complex scripts which are unlikely to work in Gutenberg, and fall back.

### Warning the End User

Ultimately, the end user should know when a plugin causes a fallback to the classic editor. The warning looks something like this:

![Screenshot of the meta box fallback warning](https://user-images.githubusercontent.com/352291/33003557-7f37cd32-ce0f-11e7-8a7f-0663d333d0db.png)

This currently only shows when `WP_DEBUG` is enabled, though would eventually be enabled at all times.

It doesn't show for meta boxes that set the `__back_compat_meta_box` flag, and naturally wouldn't show for other meta boxes that don't trigger a fallback.

![Screenshot of a meta box without the fallback warning](https://user-images.githubusercontent.com/352291/33003601-c5533cf2-ce0f-11e7-81e7-d613bf715413.png)

## Code Note

Obviously, some of this code is kind of weird, and a little bit hacky, to hook into the existing meta box rendering scheme. `gutenberg_intercept_meta_box_render()` and `gutenberg_override_meta_box_callback()`, for example, will be reduced to some small changes to `do_meta_boxes()`, come merge time.

#952