### PR TITLE
Drop currentColor from button background

### DIFF
--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -10,7 +10,7 @@ $blocks-button__height: 46px;
 	cursor: default;
 	border-radius: $blocks-button__height / 2;
 	white-space: nowrap;
-	background: currentColor;
+	background: $dark-gray-700;
 	vertical-align: top;
 	position: relative;
 

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -10,7 +10,7 @@ $blocks-button__height: 46px;
 	cursor: default;
 	border-radius: $blocks-button__height / 2;
 	white-space: nowrap;
-	background: $dark-gray-700;
+	background-color: $dark-gray-700;
 	vertical-align: top;
 	position: relative;
 


### PR DESCRIPTION
This fixes #3460

Alas, if the theme uses a dark background, then the text will likely be light. That means a light button with white text.

I tried using CSS color inversion. This worked for making the text color be the inverse of the button color:

```
color: currentColor;
filter: invert( 100% );
mix-blend-mode: color-dodge;
```

<img width="303" alt="screen shot 2017-11-20 at 10 04 12" src="https://user-images.githubusercontent.com/1204802/33010406-a9df1b88-cdda-11e7-8a76-98b47ac71341.png">

Clever right? It not only inverses the text color, but it also increases the contrast with the blend mode. 

Alas, the blend mode isn't very widely supported. So I just changed to a dark gray background:

<img width="262" alt="screen shot 2017-11-20 at 10 04 55" src="https://user-images.githubusercontent.com/1204802/33010417-b7fb8fe4-cdda-11e7-9c11-7b802f3bb869.png">
