### PR TITLE
Changing instances of Classic Editor to Classic and renaming of url s…

### DIFF
--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -87,7 +87,7 @@ post.php loads it will set up all of its state correctly, and when it hits the
 three `do_action( 'do_meta_boxes' )` hooks it will trigger our partial page.
 
 When the new block editor was made into the default editor it is now required to
-provide the classic-editor flag to access the metabox partial page.
+provide the classic flag to access the metabox partial page.
 
 `gutenberg_meta_box_partial_page()` is used to render the meta boxes for a context
 then exit the execution thread early. A `meta_box` request parameter is used to
@@ -95,7 +95,7 @@ trigger this early exit. The `meta_box` request parameter should match one of
 `'advanced'`, `'normal'`, or `'side'`. This value will determine which meta box
 area is served. So an example url would look like:
 
-`mysite.com/wp-admin/post.php?post=1&action=edit&meta_box=$location&classic-editor`
+`mysite.com/wp-admin/post.php?post=1&action=edit&meta_box=$location&classic`
 
 This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
 The partial page is very similar to post.php and pretty much imitates it and

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -132,7 +132,7 @@ function gutenberg_init( $return, $post ) {
 		return $return;
 	}
 
-	if ( isset( $_GET['classic-editor'] ) ) {
+	if ( isset( $_GET['classic'] ) ) {
 		return false;
 	}
 
@@ -343,7 +343,7 @@ function gutenberg_add_edit_link( $actions, $post ) {
 	}
 
 	$edit_url = get_edit_post_link( $post->ID, 'raw' );
-	$edit_url = add_query_arg( 'classic-editor', '', $edit_url );
+	$edit_url = add_query_arg( 'classic', '', $edit_url );
 
 	// Build the classic edit action. See also: WP_Posts_List_Table::handle_row_actions().
 	$title       = _draft_or_post_title( $post->ID );
@@ -356,7 +356,7 @@ function gutenberg_add_edit_link( $actions, $post ) {
 				__( 'Edit &#8220;%s&#8221; in the classic editor', 'gutenberg' ),
 				$title
 			) ),
-			__( 'Classic Editor', 'gutenberg' )
+			__( 'Classic', 'gutenberg' )
 		),
 	);
 
@@ -380,7 +380,7 @@ function gutenberg_add_edit_link( $actions, $post ) {
  * @param string $url  The URL to modify.
  * @param string $path The path part of $url.
  *
- * @return string The URL with the classic-editor parameter added.
+ * @return string The URL with the classic parameter added.
  */
 function gutenberg_modify_add_new_button_url( $url, $path ) {
 	global $pagenow;
@@ -399,7 +399,7 @@ function gutenberg_modify_add_new_button_url( $url, $path ) {
 		return $url;
 	}
 
-	return add_query_arg( 'classic-editor', '', $url );
+	return add_query_arg( 'classic', '', $url );
 }
 add_filter( 'admin_url', 'gutenberg_modify_add_new_button_url', 10, 2 );
 
@@ -495,13 +495,13 @@ function gutenberg_replace_default_add_new_button() {
 			}
 
 			var url = button.href;
-			var newUrl = url.replace( /&?classic-editor/, '' );
+			var newUrl = url.replace( /&?classic/, '' );
 
 			var newbutton = '<span id="split-page-title-action" class="split-page-title-action">';
 			newbutton += '<a href="' + newUrl + '">' + button.innerText + '</a>';
 			newbutton += '<span class="expander" tabindex="0" role="button" aria-haspopup="true" aria-label="<?php echo esc_js( __( 'Toggle editor selection menu', 'gutenberg' ) ); ?>"></span>';
 			newbutton += '<span class="dropdown"><a href="' + newUrl + '">Gutenberg</a>';
-			newbutton += '<a href="' + url + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span>';
+			newbutton += '<a href="' + url + '"><?php echo esc_js( __( 'Classic', 'gutenberg' ) ); ?></a></span></span>';
 
 			button.insertAdjacentHTML( 'afterend', newbutton );
 			button.remove();

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -755,7 +755,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$meta_box_url = add_query_arg( array(
 		'post'           => $post_to_edit['id'],
 		'action'         => 'edit',
-		'classic-editor' => true,
+		'classic' => true,
 	), $meta_box_url );
 	wp_localize_script( 'wp-editor', '_wpMetaBoxUrl', $meta_box_url );
 

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -23,7 +23,7 @@ function gutenberg_meta_box_partial_page( $post_type, $meta_box_context ) {
 	 *
 	 * @see https://github.com/WordPress/gutenberg/commit/bdf94e65ac0c10b3ce5d8e214f0c9e1081997d9b
 	 */
-	if ( ! isset( $_REQUEST['classic-editor'] ) ) {
+	if ( ! isset( $_REQUEST['classic'] ) ) {
 		return;
 	}
 
@@ -457,7 +457,7 @@ function gutenberg_meta_box_save_redirect( $location, $post_id ) {
 			array(
 				'meta_box'       => $meta_box_location,
 				'action'         => 'edit',
-				'classic-editor' => true,
+				'classic' => true,
 				'post'           => $post_id,
 			),
 			admin_url( 'post.php' )

--- a/lib/register.php
+++ b/lib/register.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function gutenberg_trick_plugins_into_registering_meta_boxes() {
 	global $pagenow;
 
-	if ( in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) && ! isset( $_REQUEST['classic-editor'] ) ) {
+	if ( in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) && ! isset( $_REQUEST['classic'] ) ) {
 		// As early as possible, but after any plugins ( ACF ) that adds meta boxes.
 		add_action( 'admin_head', 'gutenberg_collect_meta_box_data', 99 );
 	}
@@ -428,7 +428,7 @@ add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_revisions' );
  */
 function gutenberg_remember_classic_editor_when_saving_posts() {
 	?>
-	<input type="hidden" name="classic-editor" />
+	<input type="hidden" name="classic" />
 	<?php
 }
 add_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
@@ -442,8 +442,8 @@ add_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_post
  * @return string Redirect url.
  */
 function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
-	if ( isset( $_REQUEST['classic-editor'] ) ) {
-		$url = add_query_arg( 'classic-editor', '', $url );
+	if ( isset( $_REQUEST['classic'] ) ) {
+		$url = add_query_arg( 'classic', '', $url );
 	}
 	return $url;
 }
@@ -460,7 +460,7 @@ add_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when
 function gutenberg_link_revisions_to_classic_editor( $url ) {
 	global $pagenow;
 	if ( 'revision.php' === $pagenow ) {
-		$url = add_query_arg( 'classic-editor', '', $url );
+		$url = add_query_arg( 'classic', '', $url );
 	}
 	return $url;
 }


### PR DESCRIPTION
Pull request to resolve issue #2956 

## Description
Changes instances of Classic Editor to Classic and renamed all slugs from classic-editor to classic.

This is my first contribution, hoping all is ok :)

## How Has This Been Tested?
Checked for instances of Classic Editor and replaced with Classic, same for the url slug pages moving from class-editor to classic.

## Screenshots (jpeg or gifs if applicable):
![screen shot 2017-11-20 at 09 18 21](https://user-images.githubusercontent.com/325424/33010859-ec9e1ed0-cdd3-11e7-9ee9-929c72cc986c.jpg)
![screen shot 2017-11-20 at 09 18 31](https://user-images.githubusercontent.com/325424/33010864-efa299a8-cdd3-11e7-97f8-0d4dd43ebe58.jpg)


## Types of changes
Basic text changes and a few variable and parameter changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.