### PR TITLE
Extensibility: Use the Extensibility API to implement the generated className behaviour

### DIFF
--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -3,7 +3,6 @@
  */
 import { isEmpty, reduce, isObject, castArray, compact, startsWith } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -36,7 +35,7 @@ export function getBlockDefaultClassname( blockName ) {
  * @return {string}            Save content
  */
 export function getSaveContent( blockType, attributes ) {
-	const { save, className = getBlockDefaultClassname( blockType.name ) } = blockType;
+	const { save } = blockType;
 	let saveContent;
 
 	if ( save.prototype instanceof Component ) {
@@ -57,15 +56,6 @@ export function getSaveContent( blockType, attributes ) {
 
 		// Applying the filters adding extra props
 		const props = applyFilters( 'getSaveContent.extraProps', { ...element.props }, blockType, attributes );
-
-		// Adding the generated className
-		if ( !! className ) {
-			const updatedClassName = classnames(
-				className,
-				props.className,
-			);
-			props.className = updatedClassName;
-		}
 
 		return cloneElement( element, props );
 	};
@@ -114,10 +104,6 @@ export function getCommentAttributes( allAttributes, blockType ) {
 		result[ key ] = value;
 		return result;
 	}, {} );
-
-	if ( blockType.className !== false && allAttributes.className ) {
-		attributes.className = allAttributes.className;
-	}
 
 	return attributes;
 }

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -59,10 +59,10 @@ export function getSaveContent( blockType, attributes ) {
 
 		return cloneElement( element, props );
 	};
-	const contentWithClassName = Children.map( saveContent, addExtraContainerProps );
+	const contentWithExtraProps = Children.map( saveContent, addExtraContainerProps );
 
 	// Otherwise, infer as element
-	return renderToString( contentWithClassName );
+	return renderToString( contentWithExtraProps );
 }
 
 /**

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -77,19 +77,6 @@ describe( 'block serializer', () => {
 				expect( saved ).toBe( '<div class="wp-block-myplugin-fruit">Bananas</div>' );
 			} );
 
-			it( 'should allow overriding the className', () => {
-				const saved = getSaveContent(
-					{
-						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
-						name: 'myplugin/fruit',
-						className: 'apples',
-					},
-					{ fruit: 'Bananas' }
-				);
-
-				expect( saved ).toBe( '<div class="apples">Bananas</div>' );
-			} );
-
 			it( 'should include additional classes in block attributes', () => {
 				const saved = getSaveContent(
 					{
@@ -97,7 +84,6 @@ describe( 'block serializer', () => {
 							className: 'fruit',
 						}, attributes.fruit ),
 						name: 'myplugin/fruit',
-						className: 'apples',
 					},
 					{
 						fruit: 'Bananas',
@@ -105,7 +91,7 @@ describe( 'block serializer', () => {
 					}
 				);
 
-				expect( saved ).toBe( '<div class="apples fruit fresh">Bananas</div>' );
+				expect( saved ).toBe( '<div class="wp-block-myplugin-fruit fruit fresh">Bananas</div>' );
 			} );
 
 			it( 'should not add a className if falsy', () => {
@@ -113,7 +99,9 @@ describe( 'block serializer', () => {
 					{
 						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 						name: 'myplugin/fruit',
-						className: false,
+						supports: {
+							generatedClassName: false,
+						},
 					},
 					{ fruit: 'Bananas' }
 				);
@@ -186,22 +174,6 @@ describe( 'block serializer', () => {
 			} } );
 
 			expect( attributes ).toEqual( { fruit: 'bananas' } );
-		} );
-
-		it( 'should return the className attribute if allowed', () => {
-			const attributes = getCommentAttributes( {
-				className: 'chicken',
-			}, { attributes: {} } );
-
-			expect( attributes ).toEqual( { className: 'chicken' } );
-		} );
-
-		it( 'should not return the className attribute if not supported', () => {
-			const attributes = getCommentAttributes( {
-				className: 'chicken',
-			}, { attributes: {}, className: false } );
-
-			expect( attributes ).toEqual( {} );
 		} );
 	} );
 

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -100,7 +100,7 @@ describe( 'block serializer', () => {
 						save: ( { attributes } ) => createElement( 'div', null, attributes.fruit ),
 						name: 'myplugin/fruit',
 						supports: {
-							generatedClassName: false,
+							className: false,
 						},
 					},
 					{ fruit: 'Bananas' }

--- a/blocks/hooks/generated-class-name.js
+++ b/blocks/hooks/generated-class-name.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { hasBlockSupport, getBlockDefaultClassname } from '../api';
+
+/**
+ * Override props assigned to save component to inject anchor ID, if block
+ * supports anchor. This is only applied if the block's save result is an
+ * element and not a markup string.
+ *
+ * @param  {Object} extraProps Additional props applied to save element
+ * @param  {Object} blockType  Block type
+ * @return {Object}            Filtered props applied to save element
+ */
+export function addGeneratedClassName( extraProps, blockType ) {
+	// Adding the generated className
+	if ( hasBlockSupport( blockType, 'generatedClassName', true ) ) {
+		const updatedClassName = classnames(
+			getBlockDefaultClassname( blockType.name ),
+			extraProps.className,
+		);
+		extraProps.className = updatedClassName;
+	}
+
+	return extraProps;
+}
+
+export default function generatedClassName( { addFilter } ) {
+	addFilter( 'getSaveContent.extraProps', 'core\generated-class-name-save-props', addGeneratedClassName );
+}

--- a/blocks/hooks/generated-class-name.js
+++ b/blocks/hooks/generated-class-name.js
@@ -19,7 +19,7 @@ import { hasBlockSupport, getBlockDefaultClassname } from '../api';
  */
 export function addGeneratedClassName( extraProps, blockType ) {
 	// Adding the generated className
-	if ( hasBlockSupport( blockType, 'generatedClassName', true ) ) {
+	if ( hasBlockSupport( blockType, 'className', true ) ) {
 		const updatedClassName = classnames(
 			getBlockDefaultClassname( blockType.name ),
 			extraProps.className,

--- a/blocks/hooks/generated-class-name.js
+++ b/blocks/hooks/generated-class-name.js
@@ -9,8 +9,8 @@ import classnames from 'classnames';
 import { hasBlockSupport, getBlockDefaultClassname } from '../api';
 
 /**
- * Override props assigned to save component to inject anchor ID, if block
- * supports anchor. This is only applied if the block's save result is an
+ * Override props assigned to save component to inject generated className if block
+ * supports it. This is only applied if the block's save result is an
  * element and not a markup string.
  *
  * @param  {Object} extraProps Additional props applied to save element

--- a/blocks/hooks/index.js
+++ b/blocks/hooks/index.js
@@ -8,6 +8,7 @@ import createHooks from '@wordpress/hooks';
  */
 import anchor from './anchor';
 import customClassName from './custom-class-name';
+import generatedClassName from './generated-class-name';
 import matchers from './matchers';
 
 const hooks = createHooks();
@@ -48,4 +49,5 @@ export {
 
 anchor( hooks );
 customClassName( hooks );
+generatedClassName( hooks );
 matchers( hooks );

--- a/blocks/hooks/test/custom-class-name.js
+++ b/blocks/hooks/test/custom-class-name.js
@@ -56,7 +56,7 @@ describe( 'custom className', () => {
 	describe( 'addSaveProps', () => {
 		const addSaveProps = hooks.applyFilters.bind( null, 'getSaveContent.extraProps' );
 
-		it( 'should do nothing if the block settings do not define anchor support', () => {
+		it( 'should do nothing if the block settings do not define custom className support', () => {
 			const attributes = { className: 'foo' };
 			const extraProps = addSaveProps( {}, {
 				...blockSettings,
@@ -68,7 +68,7 @@ describe( 'custom className', () => {
 			expect( extraProps ).not.toHaveProperty( 'className' );
 		} );
 
-		it( 'should inject anchor attribute ID', () => {
+		it( 'should inject the custom className', () => {
 			const attributes = { className: 'bar' };
 			const extraProps = addSaveProps( { className: 'foo' }, blockSettings, attributes );
 

--- a/blocks/hooks/test/geenerated-class-name.js
+++ b/blocks/hooks/test/geenerated-class-name.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * External dependencies
+ */
+import createHooks from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import generatedClassName from '../generated-class-name';
+
+describe( 'generated className', () => {
+	const hooks = createHooks();
+
+	let blockSettings;
+	beforeEach( () => {
+		generatedClassName( hooks );
+
+		blockSettings = {
+			name: 'chicken/ribs',
+			save: noop,
+			category: 'common',
+			title: 'block title',
+		};
+	} );
+
+	afterEach( () => {
+		hooks.removeAllFilters( 'getSaveContent.extraProps' );
+	} );
+
+	describe( 'addSaveProps', () => {
+		const addSaveProps = hooks.applyFilters.bind( null, 'getSaveContent.extraProps' );
+
+		it( 'should do nothing if the block settings do not define generated className support', () => {
+			const attributes = { className: 'foo' };
+			const extraProps = addSaveProps( {}, {
+				...blockSettings,
+				supports: {
+					generatedClassName: false,
+				},
+			}, attributes );
+
+			expect( extraProps ).not.toHaveProperty( 'className' );
+		} );
+
+		it( 'should inject the generated className', () => {
+			const attributes = { className: 'bar' };
+			const extraProps = addSaveProps( { className: 'foo' }, blockSettings, attributes );
+
+			expect( extraProps.className ).toBe( 'wp-block-chicken-ribs foo' );
+		} );
+	} );
+} );

--- a/blocks/hooks/test/geenerated-class-name.js
+++ b/blocks/hooks/test/geenerated-class-name.js
@@ -40,7 +40,7 @@ describe( 'generated className', () => {
 			const extraProps = addSaveProps( {}, {
 				...blockSettings,
 				supports: {
-					generatedClassName: false,
+					className: false,
 				},
 			}, attributes );
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -25,9 +25,8 @@ registerBlockType( 'core/heading', {
 
 	keywords: [ __( 'title' ), __( 'subtitle' ) ],
 
-	className: false,
-
 	supports: {
+		generatedClassName: false,
 		anchor: true,
 	},
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -26,7 +26,7 @@ registerBlockType( 'core/heading', {
 	keywords: [ __( 'title' ), __( 'subtitle' ) ],
 
 	supports: {
-		generatedClassName: false,
+		className: false,
 		anchor: true,
 	},
 

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -27,12 +27,11 @@ registerBlockType( 'core/html', {
 
 	keywords: [ __( 'embed' ) ],
 
-	className: false,
-
 	supportHTML: false,
 
 	supports: {
 		customClassName: false,
+		generatedClassName: false,
 	},
 
 	attributes: {

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -31,7 +31,7 @@ registerBlockType( 'core/html', {
 
 	supports: {
 		customClassName: false,
-		generatedClassName: false,
+		className: false,
 	},
 
 	attributes: {

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -95,7 +95,9 @@ registerBlockType( 'core/list', {
 		},
 	},
 
-	className: false,
+	supports: {
+		generatedClassName: false,
+	},
 
 	transforms: {
 		from: [

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -96,7 +96,7 @@ registerBlockType( 'core/list', {
 	},
 
 	supports: {
-		generatedClassName: false,
+		className: false,
 	},
 
 	transforms: {

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -21,12 +21,11 @@ registerBlockType( 'core/more', {
 
 	useOnce: true,
 
-	className: false,
-
 	supportHTML: false,
 
 	supports: {
 		customClassName: false,
+		generatedClassName: false,
 	},
 
 	attributes: {

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -25,7 +25,7 @@ registerBlockType( 'core/more', {
 
 	supports: {
 		customClassName: false,
-		generatedClassName: false,
+		className: false,
 	},
 
 	attributes: {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -35,7 +35,9 @@ registerBlockType( 'core/paragraph', {
 
 	keywords: [ __( 'text' ) ],
 
-	className: false,
+	supports: {
+		generatedClassName: false,
+	},
 
 	attributes: {
 		content: {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -36,7 +36,7 @@ registerBlockType( 'core/paragraph', {
 	keywords: [ __( 'text' ) ],
 
 	supports: {
-		generatedClassName: false,
+		className: false,
 	},
 
 	attributes: {

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -31,12 +31,11 @@ registerBlockType( 'core/shortcode', {
 		},
 	},
 
-	className: false,
-
 	supportHTML: false,
 
 	supports: {
 		customClassName: false,
+		generatedClassName: false,
 	},
 
 	edit: withInstanceId(

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -35,7 +35,7 @@ registerBlockType( 'core/shortcode', {
 
 	supports: {
 		customClassName: false,
-		generatedClassName: false,
+		className: false,
 	},
 
 	edit: withInstanceId(

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -101,17 +101,6 @@ attributes: {
 
 Work in progress...
 
-#### className (optional)
-
-* **Type:** `Bool`
-
-By default, Gutenberg adds a class with the form `.wp-blocks-your-block-name` to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
-
-```js
-// Do not generate classes for this block
-className: false,
-```
-
 #### useOnce (optional)
 
 * **Type:** `Bool`
@@ -142,6 +131,13 @@ anchor: true,
 ```js
 // Remove the support for a the custom className .
 customClassName: false,
+```
+
+- `generatedClassName` (default `true`): By default, Gutenberg adds a class with the form `.wp-blocks-your-block-name` to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
+
+```js
+// Remove the support for a the generated className .
+generatedClassName: false,
 ```
 
 #### supportHTML (optional)

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -133,11 +133,11 @@ anchor: true,
 customClassName: false,
 ```
 
-- `generatedClassName` (default `true`): By default, Gutenberg adds a class with the form `.wp-blocks-your-block-name` to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
+- `className` (default `true`): By default, Gutenberg adds a class with the form `.wp-block-your-block-name` to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
 
 ```js
 // Remove the support for a the generated className .
-generatedClassName: false,
+className: false,
 ```
 
 #### supportHTML (optional)

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -365,7 +365,7 @@ class BlockListBlock extends Component {
 		}
 
 		// Generate a class name for the block's editable form
-		const generatedClassName = hasBlockSupport( blockType, 'generatedClassName', true ) ?
+		const generatedClassName = hasBlockSupport( blockType, 'className', true ) ?
 			getBlockDefaultClassname( block.name ) :
 			null;
 		const className = classnames( generatedClassName, block.attributes.className );

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -10,7 +10,7 @@ import { get, partial, reduce, size } from 'lodash';
  */
 import { Component, createElement } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
-import { getBlockType, BlockEdit, getBlockDefaultClassname, createBlock } from '@wordpress/blocks';
+import { getBlockType, BlockEdit, getBlockDefaultClassname, createBlock, hasBlockSupport } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -365,8 +365,10 @@ class BlockListBlock extends Component {
 		}
 
 		// Generate a class name for the block's editable form
-		let { className = getBlockDefaultClassname( block.name ) } = blockType;
-		className = classnames( className, block.attributes.className );
+		const generatedClassName = hasBlockSupport( blockType, 'generatedClassName', true ) ?
+			getBlockDefaultClassname( block.name ) :
+			null;
+		const className = classnames( generatedClassName, block.attributes.className );
 
 		// Disable reason: Each block can be selected by clicking on it
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */


### PR DESCRIPTION
This PR refactors the generated className beahavior to use the extensibility API and consolidate with similar hooks (anchor and custom className).

The question of whether we should keep this or not still remains. An option would be to provide the `className` as prop to the `save` function like we do for the `edit` function. Regardless, I'm personally happy with this implementation better than what we currently have.
