### PR TITLE
Remove font size from post-visibility legend

### DIFF
--- a/editor/sidebar/post-visibility/style.scss
+++ b/editor/sidebar/post-visibility/style.scss
@@ -26,7 +26,6 @@
 
 .editor-post-visibility__dialog-legend {
 	font-weight: 600;
-	font-size: 0.9em;
 }
 
 .editor-post-visibility__choice {


### PR DESCRIPTION
This fixes #1347 incidentally, because the em unit is no longer there to reduce the font size.

The meta issue, that em units are subject to browser rounding, is a correct observation, and we should use these units carefully, ideally in whole or half numbers. We should also use as few font sizes as possible, and adhere to what sizes are in WordPress already. This is on us as developers to remember, and I'm making a note to put this in the pattern library also.
