### PR TITLE
Components: Extract the WritingFlow component as a reusable Editor component

### DIFF
--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -40,6 +40,7 @@ export { default as BlockToolbar } from './block-toolbar';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as Inserter } from './inserter';
 export { default as Warning } from './warning';
+export { default as WritingFlow } from './writing-flow';
 
 // State Related Components
 export { default as EditorProvider } from './provider';

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -19,16 +19,15 @@ import {
 	isVerticalEdge,
 	placeCaretAtHorizontalEdge,
 	placeCaretAtVerticalEdge,
-} from '../utils/dom';
+} from '../../utils/dom';
 import {
 	getBlockUids,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
 	getMultiSelectedBlocks,
 	getSelectedBlock,
-} from '../selectors';
-
-import { multiSelect } from '../actions';
+} from '../../selectors';
+import { multiSelect } from '../../actions';
 
 /**
  * Module Constants

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -16,8 +16,7 @@ import { KeyboardShortcuts } from '@wordpress/components';
 import './style.scss';
 import VisualEditorBlockList from './block-list';
 import VisualEditorInserter from './inserter';
-import WritingFlow from '../../writing-flow';
-import { PostTitle } from '../../components';
+import { PostTitle, WritingFlow } from '../../components';
 import { getBlockUids, getMultiSelectedBlockUids } from '../../selectors';
 import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks } from '../../actions';
 


### PR DESCRIPTION
Related to #2761 (comment)

This PR extracts WritingFlow component to the reusable components folder.

**Testing instructions**

- Test that arrow navigation between blocks works