### PR TITLE
Fix the name for the matchers hook default function

### DIFF
--- a/blocks/hooks/matchers.js
+++ b/blocks/hooks/matchers.js
@@ -91,6 +91,6 @@ export function resolveAttributes( settings ) {
 	return settings;
 }
 
-export default function anchor( { addFilter } ) {
+export default function matchers( { addFilter } ) {
 	addFilter( 'registerBlockType', 'core\matchers', resolveAttributes );
 }


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/3519#discussion_r151986557