### PR TITLE
Blocks: Filterable allowed inserter block types

### DIFF
--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -2,12 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Toolbar } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import withEditorSettings from '../with-editor-settings';
+import { Toolbar, withContext } from '@wordpress/components';
 
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	left: {
@@ -59,7 +54,7 @@ function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CONTROLS, 
 	);
 }
 
-export default withEditorSettings(
+export default withContext( 'editor' )(
 	( settings ) => ( {
 		wideControlsEnabled: settings.wideImages,
 	} )

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -7,14 +7,13 @@ import { ChromePicker } from 'react-color';
 /**
  * WordPress dependencies
  */
-import { Dropdown } from '@wordpress/components';
+import { Dropdown, withContext } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import withEditorSettings from '../with-editor-settings';
 
 function ColorPalette( { colors, value, onChange } ) {
 	return (
@@ -72,7 +71,7 @@ function ColorPalette( { colors, value, onChange } ) {
 	);
 }
 
-export default withEditorSettings(
+export default withContext( 'editor' )(
 	( settings ) => ( {
 		colors: settings.colors,
 	} )

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -24,12 +24,12 @@ import {
 	DropZone,
 	FormFileUpload,
 	withAPIData,
+	withContext,
 } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import withEditorSettings from '../../with-editor-settings';
 import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
@@ -282,7 +282,7 @@ class ImageBlock extends Component {
 }
 
 export default flowRight( [
-	withEditorSettings(),
+	withContext( 'editor' ),
 	withAPIData( ( props ) => {
 		const { id } = props.attributes;
 		if ( ! id ) {

--- a/components/higher-order/with-context/index.js
+++ b/components/higher-order/with-context/index.js
@@ -8,12 +8,17 @@ import { noop } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 
-const withEditorSettings = ( mapSettingsToProps ) => ( OriginalComponent ) => {
+const withContext = ( contextName ) => ( mapSettingsToProps ) => ( OriginalComponent ) => {
+	// Allow call without explicit `mapSettingsToProps`
+	if ( mapSettingsToProps instanceof Component ) {
+		return withContext( contextName )()( mapSettingsToProps );
+	}
+
 	class WrappedComponent extends Component {
 		render() {
 			const extraProps = mapSettingsToProps ?
-				mapSettingsToProps( this.context.editor, this.props ) :
-				{ settings: this.context.editor };
+				mapSettingsToProps( this.context[ contextName ], this.props ) :
+				this.context[ contextName ];
 
 			return (
 				<OriginalComponent
@@ -25,10 +30,10 @@ const withEditorSettings = ( mapSettingsToProps ) => ( OriginalComponent ) => {
 	}
 
 	WrappedComponent.contextTypes = {
-		editor: noop,
+		[ contextName ]: noop,
 	};
 
 	return WrappedComponent;
 };
 
-export default withEditorSettings;
+export default withContext;

--- a/components/index.js
+++ b/components/index.js
@@ -37,6 +37,7 @@ export { Slot, Fill, Provider as SlotFillProvider } from './slot-fill';
 // Higher-Order Components
 export { default as navigateRegions } from './higher-order/navigate-regions';
 export { default as withAPIData } from './higher-order/with-api-data';
+export { default as withContext } from './higher-order/with-context';
 export { default as withFocusOutside } from './higher-order/with-focus-outside';
 export { default as withFocusReturn } from './higher-order/with-focus-return';
 export { default as withInstanceId } from './higher-order/with-instance-id';

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -3,12 +3,13 @@
  */
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { flowRight, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton } from '@wordpress/components';
+import { Dropdown, IconButton, withContext } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 
@@ -61,7 +62,12 @@ class Inserter extends Component {
 			children,
 			onInsertBlock,
 			insertionPoint,
+			hasSupportedBlocks,
 		} = this.props;
+
+		if ( ! hasSupportedBlocks ) {
+			return null;
+		}
 
 		return (
 			<Dropdown
@@ -97,24 +103,33 @@ class Inserter extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
-		return {
-			insertionPoint: getBlockInsertionPoint( state ),
-			mode: getEditorMode( state ),
-		};
-	},
-	( dispatch ) => ( {
-		onInsertBlock( name, position ) {
-			dispatch( hideInsertionPoint() );
-			dispatch( insertBlock(
-				createBlock( name ),
-				position
-			) );
+export default flowRight( [
+	connect(
+		( state ) => {
+			return {
+				insertionPoint: getBlockInsertionPoint( state ),
+				mode: getEditorMode( state ),
+			};
 		},
-		...bindActionCreators( {
-			setInsertionPoint: setBlockInsertionPoint,
-			clearInsertionPoint: clearBlockInsertionPoint,
-		}, dispatch ),
-	} )
-)( Inserter );
+		( dispatch ) => ( {
+			onInsertBlock( name, position ) {
+				dispatch( hideInsertionPoint() );
+				dispatch( insertBlock(
+					createBlock( name ),
+					position
+				) );
+			},
+			...bindActionCreators( {
+				setInsertionPoint: setBlockInsertionPoint,
+				clearInsertionPoint: clearBlockInsertionPoint,
+			}, dispatch ),
+		} )
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { blockTypes } = settings;
+
+		return {
+			hasSupportedBlocks: true === blockTypes || ! isEmpty( blockTypes ),
+		};
+	} ),
+] )( Inserter );

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -24,6 +24,7 @@ import {
 	TabbableContainer,
 	withInstanceId,
 	withSpokenMessages,
+	withContext,
 } from '@wordpress/components';
 import { getCategories, getBlockTypes } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
@@ -112,8 +113,27 @@ export class InserterMenu extends Component {
 	}
 
 	getBlockTypes() {
+		const { blockTypes } = this.props;
+
+		// If all block types disabled, return empty set
+		if ( ! blockTypes ) {
+			return [];
+		}
+
 		// Block types that are marked as private should not appear in the inserter
-		return getBlockTypes().filter( ( block ) => ! block.isPrivate );
+		return getBlockTypes().filter( ( block ) => {
+			if ( block.isPrivate ) {
+				return false;
+			}
+
+			// Block types defined as either `true` or array:
+			//  - True: Allow
+			//  - Array: Check block name within whitelist
+			return (
+				! Array.isArray( blockTypes ) ||
+				includes( blockTypes, block.name )
+			);
+		} );
 	}
 
 	searchBlocks( blockTypes ) {
@@ -121,18 +141,28 @@ export class InserterMenu extends Component {
 	}
 
 	getBlocksForTab( tab ) {
+		const blockTypes = this.getBlockTypes();
 		// if we're searching, use everything, otherwise just get the blocks visible in this tab
 		if ( this.state.filterValue ) {
-			return this.getBlockTypes();
+			return blockTypes;
 		}
+
+		let predicate;
 		switch ( tab ) {
 			case 'recent':
-				return this.props.recentlyUsedBlocks;
+				predicate = ( block ) => find( this.props.recentlyUsedBlocks, { name: block.name } );
+				break;
+
 			case 'blocks':
-				return filter( this.getBlockTypes(), ( block ) => block.category !== 'embed' );
+				predicate = ( block ) => block.category !== 'embed';
+				break;
+
 			case 'embeds':
-				return filter( this.getBlockTypes(), ( block ) => block.category === 'embed' );
+				predicate = ( block ) => block.category === 'embed';
+				break;
 		}
+
+		return filter( blockTypes, predicate );
 	}
 
 	sortBlocks( blockTypes ) {
@@ -201,17 +231,18 @@ export class InserterMenu extends Component {
 		this.setState( { tab } );
 	}
 
-	renderTabView( tab, visibleBlocks ) {
-		switch ( tab ) {
-			case 'recent':
-				return this.renderBlocks( this.props.recentlyUsedBlocks, undefined );
-
-			case 'embed':
-				return this.renderBlocks( visibleBlocks.embed, undefined );
-
-			default:
-				return this.renderCategories( visibleBlocks, undefined );
+	renderTabView( tab ) {
+		const blocksForTab = this.getBlocksForTab( tab );
+		if ( 'recent' === tab ) {
+			return this.renderBlocks( blocksForTab );
 		}
+
+		const visibleBlocks = this.getVisibleBlocksByCategory( blocksForTab );
+		if ( 'embed' === tab ) {
+			return this.renderBlocks( visibleBlocks.embed );
+		}
+
+		return this.renderCategories( visibleBlocks );
 	}
 
 	interceptArrows( event ) {
@@ -266,19 +297,12 @@ export class InserterMenu extends Component {
 							},
 						] }
 					>
-						{
-							( tabKey ) => {
-								const blocksForTab = this.getBlocksForTab( tabKey );
-								const visibleBlocks = this.getVisibleBlocksByCategory( blocksForTab );
-
-								return (
-									<div ref={ ( ref ) => this.tabContainer = ref }
-										className="editor-inserter__content">
-										{ this.renderTabView( tabKey, visibleBlocks ) }
-									</div>
-								);
-							}
-						}
+						{ ( tabKey ) => (
+							<div ref={ ( ref ) => this.tabContainer = ref }
+								className="editor-inserter__content">
+								{ this.renderTabView( tabKey ) }
+							</div>
+						) }
 					</TabPanel>
 				}
 				{ isSearching &&
@@ -304,5 +328,6 @@ const connectComponent = connect(
 export default flow(
 	withInstanceId,
 	withSpokenMessages,
+	withContext( 'editor' )( ( settings ) => pick( settings, 'blockTypes' ) ),
 	connectComponent
 )( InserterMenu );

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -97,6 +97,7 @@ describe( 'InserterMenu', () => {
 				blocks={ [] }
 				recentlyUsedBlocks={ [] }
 				debouncedSpeak={ noop }
+				blockTypes
 			/>
 		);
 
@@ -107,6 +108,39 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.length ).toBe( 0 );
 	} );
 
+	it( 'should show no blocks if all block types disabled', () => {
+		const wrapper = mount(
+			<InserterMenu
+				position={ 'top center' }
+				instanceId={ 1 }
+				blocks={ [] }
+				recentlyUsedBlocks={ [ advancedTextBlock ] }
+				debouncedSpeak={ noop }
+				blockTypes={ false }
+			/>
+		);
+
+		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
+		expect( visibleBlocks.length ).toBe( 0 );
+	} );
+
+	it( 'should show filtered block types', () => {
+		const wrapper = mount(
+			<InserterMenu
+				position={ 'top center' }
+				instanceId={ 1 }
+				blocks={ [] }
+				recentlyUsedBlocks={ [ textBlock, advancedTextBlock ] }
+				debouncedSpeak={ noop }
+				blockTypes={ [ textBlock.name ] }
+			/>
+		);
+
+		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
+		expect( visibleBlocks.length ).toBe( 1 );
+		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
+	} );
+
 	it( 'should show the recently used blocks in the recent tab', () => {
 		const wrapper = mount(
 			<InserterMenu
@@ -115,6 +149,7 @@ describe( 'InserterMenu', () => {
 				blocks={ [] }
 				recentlyUsedBlocks={ [ advancedTextBlock ] }
 				debouncedSpeak={ noop }
+				blockTypes
 			/>
 		);
 
@@ -132,6 +167,7 @@ describe( 'InserterMenu', () => {
 				blocks={ [] }
 				recentlyUsedBlocks={ [] }
 				debouncedSpeak={ noop }
+				blockTypes
 			/>
 		);
 		const embedTab = wrapper.find( '.editor-inserter__tab' )
@@ -155,6 +191,7 @@ describe( 'InserterMenu', () => {
 				blocks={ [] }
 				recentlyUsedBlocks={ [] }
 				debouncedSpeak={ noop }
+				blockTypes
 			/>
 		);
 		const blocksTab = wrapper.find( '.editor-inserter__tab' )
@@ -180,6 +217,7 @@ describe( 'InserterMenu', () => {
 				blocks={ [ { name: moreBlock.name } ] }
 				recentlyUsedBlocks={ [] }
 				debouncedSpeak={ noop }
+				blockTypes
 			/>
 		);
 		const blocksTab = wrapper.find( '.editor-inserter__tab' )
@@ -200,6 +238,7 @@ describe( 'InserterMenu', () => {
 				blocks={ [] }
 				recentlyUsedBlocks={ [] }
 				debouncedSpeak={ noop }
+				blockTypes
 			/>
 		);
 		wrapper.setState( { filterValue: 'text' } );
@@ -222,6 +261,7 @@ describe( 'InserterMenu', () => {
 				blocks={ [] }
 				recentlyUsedBlocks={ [] }
 				debouncedSpeak={ noop }
+				blockTypes
 			/>
 		);
 		wrapper.setState( { filterValue: ' text' } );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -767,9 +767,19 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		$color_palette = $gutenberg_theme_support[0]['colors'];
 	}
 
+	/**
+	 * Filters the allowed block types for the editor, defaulting to true (all
+	 * block types supported).
+	 *
+	 * @param bool|array $allowed_block_types Array of block type slugs, or
+	 *                                        boolean to enable/disable all.
+	 */
+	$allowed_block_types = apply_filters( 'allowed_block_types', true );
+
 	$editor_settings = array(
 		'wideImages' => ! empty( $gutenberg_theme_support[0]['wide-images'] ),
 		'colors'     => $color_palette,
+		'blockTypes' => $allowed_block_types,
 	);
 
 	wp_add_inline_script( 'wp-editor', 'wp.api.init().done( function() {'


### PR DESCRIPTION
This pull request seeks to enable filtering of block types offered through the Inserter component. It does so both in the client and in the server.

On the server, a plugin author can filter `allowed_block_types` to return either `true` (all block types supported), `false` (no block types supported), or an array of block type names to allow. This may enable custom post types to limit the types of blocks allowed.

In the client, since the block types are passed through as a setting in `EditorProvider`, creating a new provider context with settings specifying block types is sufficient to limit permitted block types. This will become relevant for block nesting to allow a block to define allowed children types.

__Implementation notes:__

The behavior here required that an editor component gain access to `editor` context. The existing `withEditorSettings` higher-order component would have worked, but was implemented expecting to be used only in the context of the `blocks` module. With the changes here, I have moved `withEditorSettings` to a more generic `withContext` higher-order component in the components module, allowing a component to opt-in to receiving context of any name.

__Testing instructions:__

Ensure unit tests pass:

```
npm test
```

Verify that you can filter block types, e.g. adding filters to one of Gutenberg's PHP files:

__Disable all block types (no inserter is shown):__

```php
add_filter( 'allowed_block_types', '__return_false' );
```

__Restrict block types:__

```php
add_filter( 'allowed_block_types', function() {
	return [ 'core/paragraph' ];
} );
```