### PR TITLE
Experiment: support for non-contiguous blocks in selection

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -22,6 +22,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { getBlockType } from './registration';
 
+let counter = 0;
+
 /**
  * Returns a block object given its type and attributes.
  *
@@ -46,10 +48,13 @@ export function createBlock( name, blockAttributes = {} ) {
 		return result;
 	}, {} );
 
+	counter++;
+
 	// Blocks are stored with a unique ID, the assigned type name,
 	// and the block attributes.
 	return {
-		uid: uuid(),
+		// uid: uuid(),
+		uid: counter + '-block',
 		name,
 		isValid: true,
 		attributes,

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -128,6 +128,22 @@ export function multiSelect( start, end ) {
 	};
 }
 
+export function setSelection( start, end, selected ) {
+	return {
+		type: 'SET_SELECTION',
+		start,
+		end,
+		selected,
+	};
+}
+
+export function spawnSelection( uid ) {
+	return {
+		type: 'SPAWN_SELECTION',
+		uid,
+	};
+}
+
 export function clearSelectedBlock() {
 	return {
 		type: 'CLEAR_SELECTED_BLOCK',

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -144,6 +144,12 @@ export function toggleSelection( uid ) {
 	};
 }
 
+export function startNavigation() {
+	return {
+		type: 'START_NAVIGATION',
+	};
+}
+
 export function clearSelectedBlock() {
 	return {
 		type: 'CLEAR_SELECTED_BLOCK',

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -128,6 +128,14 @@ export function multiSelect( start, end ) {
 	};
 }
 
+export function combineRange( start, end ) {
+	return {
+		type: 'COMBINE_SELECTION_RANGE',
+		start,
+		end,
+	};
+}
+
 export function setSelection( start, end, selected, focusUid ) {
 	return {
 		type: 'SET_SELECTION',

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -128,19 +128,21 @@ export function multiSelect( start, end ) {
 	};
 }
 
-export function setSelection( start, end, selected ) {
+export function setSelection( start, end, selected, focusUid ) {
 	return {
 		type: 'SET_SELECTION',
 		start,
 		end,
 		selected,
+		focusUid,
 	};
 }
 
-export function toggleSelection( uid ) {
+export function toggleSelection( uid, focusUid = null ) {
 	return {
 		type: 'TOGGLE_SELECTION',
 		uid,
+		focusUid,
 	};
 }
 

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -122,7 +122,7 @@ export function stopMultiSelect() {
 
 export function multiSelect( start, end ) {
 	return {
-		type: 'MULTI_SELECT',
+		type: 'ADD_SELECTION_RANGE',
 		start,
 		end,
 	};
@@ -137,16 +137,9 @@ export function setSelection( start, end, selected ) {
 	};
 }
 
-export function spawnSelection( uid ) {
+export function toggleSelection( uid ) {
 	return {
-		type: 'SPAWN_SELECTION',
-		uid,
-	};
-}
-
-export function toggleOffSelection( uid ) {
-	return {
-		type: 'TOGGLE_OFF_SELECTION',
+		type: 'TOGGLE_SELECTION',
 		uid,
 	};
 }

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -144,6 +144,13 @@ export function spawnSelection( uid ) {
 	};
 }
 
+export function toggleOffSelection( uid ) {
+	return {
+		type: 'TOGGLE_OFF_SELECTION',
+		uid,
+	};
+}
+
 export function clearSelectedBlock() {
 	return {
 		type: 'CLEAR_SELECTED_BLOCK',

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -16,7 +16,7 @@ import { getBlockType } from '@wordpress/blocks';
  */
 import './style.scss';
 import { getBlockMoverLabel } from './mover-label';
-import { isFirstBlock, isLastBlock, getBlockIndex, getBlock } from '../../selectors';
+import { isFirstBlock, isLastBlock, getBlockIndex, getBlock, isNavigating } from '../../selectors';
 import { selectBlock } from '../../actions';
 
 export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex } ) {
@@ -27,6 +27,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 	return (
 		<div className="editor-block-mover">
 			<IconButton
+				onKeyDown={ ( evt ) => evt.stopPropagation() }
 				className="editor-block-mover__control"
 				onClick={ isFirst ? null : onMoveUp }
 				icon="arrow-up-alt2"
@@ -42,6 +43,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 				aria-disabled={ isFirst }
 			/>
 			<IconButton
+				onKeyDown={ ( evt ) => evt.stopPropagation() }
 				className="editor-block-mover__control"
 				onClick={ isLast ? null : onMoveDown }
 				icon="arrow-down-alt2"
@@ -69,11 +71,12 @@ export default connect(
 			isLast: isLastBlock( state, last( ownProps.uids ) ),
 			firstIndex: getBlockIndex( state, first( ownProps.uids ) ),
 			blockType: block ? getBlockType( block.name ) : null,
+			isNavigating: isNavigating( state ),
 		} );
 	},
 	( dispatch, ownProps ) => ( {
 		onMoveDown() {
-			if ( ownProps.uids.length === 1 ) {
+			if ( ownProps.uids.length === 1 && ! isNavigating ) {
 				dispatch( selectBlock( first( ownProps.uids ) ) );
 			}
 
@@ -83,7 +86,7 @@ export default connect(
 			} );
 		},
 		onMoveUp() {
-			if ( ownProps.uids.length === 1 ) {
+			if ( ownProps.uids.length === 1 && ! isNavigating ) {
 				dispatch( selectBlock( first( ownProps.uids ) ) );
 			}
 

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -35,6 +35,7 @@ function BlockSettingsMenu( { uids, onSelect, focus } ) {
 
 				return (
 					<IconButton
+						onKeyDown={ ( evt ) => evt.stopPropagation() }
 						className={ toggleClassname }
 						onClick={ () => {
 							if ( uids.length === 1 ) {
@@ -51,7 +52,9 @@ function BlockSettingsMenu( { uids, onSelect, focus } ) {
 			} }
 			renderContent={ ( { onClose } ) => (
 				// Should this just use a DropdownMenu instead of a DropDown ?
-				<NavigableMenu className="editor-block-settings-menu__content">
+				<NavigableMenu className="editor-block-settings-menu__content"
+					onKeyDown={ ( evt ) => evt.stopPropagation() }
+				>
 					<BlockInspectorButton onClick={ onClose } />
 					{ count === 1 && <BlockModeToggle uid={ uids[ 0 ] } onToggle={ onClose } /> }
 					{ count === 1 && <UnknownConverter uid={ uids[ 0 ] } /> }

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -32,8 +32,6 @@ function BlockSwitcher( { blocks, onTransform, uids } ) {
 	const isMultiBlock = blocks.length > 1;
 	const sourceBlockName = blocks[ 0 ].name;
 
-	console.log('blocks', blocks, uids);
-
 	if ( isMultiBlock && ! every( blocks, ( block ) => ( block.name === sourceBlockName ) ) ) {
 		return null;
 	}

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -24,13 +24,15 @@ import { getBlock } from '../../selectors';
  */
 const { DOWN } = keycodes;
 
-function BlockSwitcher( { blocks, onTransform } ) {
+function BlockSwitcher( { blocks, onTransform, uids } ) {
 	if ( ! blocks || ! blocks[ 0 ] ) {
 		return null;
 	}
 
 	const isMultiBlock = blocks.length > 1;
 	const sourceBlockName = blocks[ 0 ].name;
+
+	console.log('blocks', blocks, uids);
 
 	if ( isMultiBlock && ! every( blocks, ( block ) => ( block.name === sourceBlockName ) ) ) {
 		return null;

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -28,6 +28,7 @@ function BlockSwitcher( { blocks, onTransform } ) {
 	if ( ! blocks || ! blocks[ 0 ] ) {
 		return null;
 	}
+
 	const isMultiBlock = blocks.length > 1;
 	const sourceBlockName = blocks[ 0 ].name;
 

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -114,6 +114,11 @@ class WritingFlow extends Component {
 	onKeyDown( event ) {
 		const { selectedBlock, selectionStart, selectionEnd, blocks, hasMultiSelection } = this.props;
 
+		if ( selectedBlock === null && ! hasMultiSelection ) {
+			console.error('selectedBlock is null');
+			return;
+		}
+
 		const { keyCode, target } = event;
 		const isUp = keyCode === UP;
 		const isDown = keyCode === DOWN;
@@ -141,6 +146,9 @@ class WritingFlow extends Component {
 			// Shift key is down, but no existing block selection
 			event.preventDefault();
 			this.expandSelection( blocks, selectedBlock.uid, selectedBlock.uid, isReverse ? -1 : +1 );
+		} else if ( isNav && ! isShift && hasMultiSelection ) {
+			this.props.selectBlock( selectionEnd );
+
 		} else if ( isVertical && isVerticalEdge( target, isReverse, isShift ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
@@ -149,10 +157,6 @@ class WritingFlow extends Component {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();
-		}
-
-		if ( ! isShift && isNav && hasMultiSelection ) {
-			this.props.onMultiSelect( null, null );
 		}
 	}
 

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -143,17 +143,17 @@ class WritingFlow extends Component {
 
 		const wayward = focusedUid !== selectionEnd;
 
-		if ( ! focusedUid ) {
-			return;
-		}
-
 		if ( ! isVertical ) {
 			this.verticalRect = null;
 		} else if ( ! this.verticalRect ) {
 			this.verticalRect = computeCaretRect( target );
 		}
 
-		if ( isNav && isShift && isNavigating ) {
+		// NOTE: This is going to stop up moving away from blocks (e.g. post title) in navigation mode.
+
+		// Also, space and enter on the other buttons are now being intercepted.
+
+		if ( focusedUid && isNav && isShift && this.props.inNavigationMode ) {
 			// Shift key is down and existing block selection
 			event.preventDefault();
 
@@ -169,11 +169,11 @@ class WritingFlow extends Component {
 			} else {
 				this.expandSelection( blocks, selectionStart, selectionEnd, isReverse ? -1 : +1 );
 			}
-		} else if ( isNav && isShift && this.isEditableEdge( isReverse, target ) && isNavEdge( target, isReverse, true ) ) {
+		} else if ( focusedUid, isNav && isShift && this.isEditableEdge( isReverse, target ) && isNavEdge( target, isReverse, true ) ) {
 			// Shift key is down, but no existing block selection
 			event.preventDefault();
 			this.expandSelection( blocks, focusedUid, focusedUid, isReverse ? -1 : +1 );
-		} else if ( isNav && ! isShift && this.props.inNavigationMode ) {
+		} else if ( focusedUid && isNav && ! isShift && this.props.inNavigationMode ) {
 			console.log('FOCUS ON CURRENTLY', focusedUid );
 			this.focusBlock( blocks, focusedUid, isReverse ? -1 : 1 );
 		} else if ( isVertical && isVerticalEdge( target, isReverse, isShift ) ) {
@@ -184,7 +184,7 @@ class WritingFlow extends Component {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();
-		} else if ( this.props.inNavigationMode && keyCode === SPACE ) {
+		} else if ( focusedUid && this.props.inNavigationMode && keyCode === SPACE ) {
 			if ( event.metaKey || event.ctrlKey ) {
 				this.props.toggleSelection( focusedUid, focusedUid );
 			} else if ( includes( this.props.multiSelectedUids, focusedUid ) ) {
@@ -194,11 +194,11 @@ class WritingFlow extends Component {
 				this.props.setSelection( focusedUid, focusedUid, [ ], focusedUid );
 			}
 
-			event.preventDefault();
+			// event.preventDefault();
 			event.stopPropagation();
-		} else if ( this.props.inNavigationMode && keyCode === ENTER ) {
+		} else if ( focusedUid && this.props.inNavigationMode && keyCode === ENTER ) {
 			this.props.selectBlock( focusedUid );
-			event.preventDefault();
+			// event.preventDefault();
 			event.stopPropagation();
 		}
 	}

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -28,7 +28,7 @@ import {
 	getSelectedBlock,
 	isNavigating,
 } from '../../selectors';
-import { multiSelect, focusBlock, selectBlock, toggleSelection } from '../../actions';
+import { multiSelect, focusBlock, selectBlock, setSelection, toggleSelection } from '../../actions';
 
 /**
  * Module Constants
@@ -170,7 +170,12 @@ class WritingFlow extends Component {
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();
 		} else if ( hasMultiSelection && keyCode === SPACE ) {
-			this.props.toggleSelection( focusedUid, focusedUid );
+			if ( event.metaKey || event.ctrlKey ) {
+				this.props.toggleSelection( focusedUid, focusedUid );
+			} else {
+				this.props.setSelection( focusedUid, focusedUid, [ ], focusedUid );
+			}
+
 			event.preventDefault();
 			event.stopPropagation();
 		} else if ( hasMultiSelection && keyCode === ENTER ) {
@@ -227,6 +232,10 @@ export default connect(
 
 		toggleSelection( uid, focusUid ) {
 			dispatch( toggleSelection( uid, focusUid ) );
+		},
+
+		setSelection( start, end, selected, focusUid ) {
+			dispatch( setSelection( start, end, selected, focusUid ) );
 		},
 	} )
 )( WritingFlow );

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -161,7 +161,7 @@ class WritingFlow extends Component {
 			if ( wayward ) {
 				const lastIndex = blocks.indexOf( focusedUid );
 				const nextIndex = Math.max( 0, Math.min( blocks.length - 1, lastIndex + ( isReverse ? -1 : +1 ) ) );
-				if ( event.ctrlKey ) {
+				if ( event.ctrlKey || event.metaKey ) {
 					this.props.combineRange( focusedUid, blocks[ nextIndex ] || focusedUid );
 				} else {
 					this.props.setSelection( focusedUid, blocks[ nextIndex ] || focusedUid, [ ], null );
@@ -176,6 +176,7 @@ class WritingFlow extends Component {
 		} else if ( focusedUid && isNav && ! isShift && this.props.inNavigationMode ) {
 			console.log('FOCUS ON CURRENTLY', focusedUid );
 			this.focusBlock( blocks, focusedUid, isReverse ? -1 : 1 );
+			event.preventDefault();
 		} else if ( isVertical && isVerticalEdge( target, isReverse, isShift ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
@@ -189,6 +190,9 @@ class WritingFlow extends Component {
 				this.props.toggleSelection( focusedUid, focusedUid );
 			} else if ( includes( this.props.multiSelectedUids, focusedUid ) ) {
 				this.props.setSelection( focusedUid, null, [ ], focusedUid )
+
+				// Can't just always prevent default, because need to fire space on buttons.
+				event.preventDefault();
 			} else {
 				// HERE LIES BAD CODE.
 				this.props.setSelection( focusedUid, focusedUid, [ ], focusedUid );

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -113,11 +113,7 @@ class WritingFlow extends Component {
 
 	onKeyDown( event ) {
 		const { selectedBlock, selectionStart, selectionEnd, blocks, hasMultiSelection } = this.props;
-
-		if ( selectedBlock === null && ! hasMultiSelection ) {
-			console.error('selectedBlock is null');
-			return;
-		}
+		console.log( 'selectedBlock', selectedBlock, this.props.stateDump );
 
 		const { keyCode, target } = event;
 		const isUp = keyCode === UP;
@@ -186,6 +182,7 @@ export default connect(
 		selectionEnd: getMultiSelectedBlocksEndUid( state ),
 		hasMultiSelection: getMultiSelectedBlocks( state ).length > 0,
 		selectedBlock: getSelectedBlock( state ),
+		stateDump: state,
 	} ),
 	( dispatch ) => ( {
 		onMultiSelect( start, end ) {

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -27,7 +27,7 @@ import {
 	getMultiSelectedBlocks,
 	getSelectedBlock,
 } from '../../selectors';
-import { multiSelect } from '../../actions';
+import { multiSelect, selectBlock } from '../../actions';
 
 /**
  * Module Constants
@@ -150,6 +150,10 @@ class WritingFlow extends Component {
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();
 		}
+
+		if ( ! isShift && isNav && hasMultiSelection ) {
+			this.props.onMultiSelect( null, null );
+		}
 	}
 
 	render() {
@@ -176,12 +180,15 @@ export default connect(
 		blocks: getBlockUids( state ),
 		selectionStart: getMultiSelectedBlocksStartUid( state ),
 		selectionEnd: getMultiSelectedBlocksEndUid( state ),
-		hasMultiSelection: getMultiSelectedBlocks( state ).length > 1,
+		hasMultiSelection: getMultiSelectedBlocks( state ).length > 0,
 		selectedBlock: getSelectedBlock( state ),
 	} ),
 	( dispatch ) => ( {
 		onMultiSelect( start, end ) {
 			dispatch( multiSelect( start, end ) );
+		},
+		selectBlock( uid ) {
+			dispatch( selectBlock( uid ) );
 		},
 	} )
 )( WritingFlow );

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -113,7 +113,6 @@ class WritingFlow extends Component {
 
 	onKeyDown( event ) {
 		const { selectedBlock, selectionStart, selectionEnd, blocks, hasMultiSelection } = this.props;
-		console.log( 'selectedBlock', selectedBlock, this.props.stateDump );
 
 		const { keyCode, target } = event;
 		const isUp = keyCode === UP;

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -191,7 +191,8 @@ class WritingFlow extends Component {
 			} else if ( includes( this.props.multiSelectedUids, focusedUid ) ) {
 				this.props.setSelection( focusedUid, null, [ ], focusedUid )
 
-				// Can't just always prevent default, because need to fire space on buttons.
+				// Can't just always prevent default, because need to fire space on buttons. Or is that
+				// handled now with stopPropagation in the menus?
 				event.preventDefault();
 			} else {
 				// HERE LIES BAD CODE.

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -340,9 +340,9 @@ export default {
 		const state = getState();
 		console.log('state', state);
 		const newSelection = toggle( state.blockSelection, action.uid, state.editor.present.blockOrder );
-		console.log( 'newSelection', newSelection );
+		console.log( 'newSelection', newSelection, 'action', action.focusUid );
 		dispatch(
-			setSelection( newSelection.start, newSelection.end, newSelection.selected )
+			setSelection( newSelection.start, newSelection.end, newSelection.selected, action.focusUid )
 		);
 	},
 };

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getPostEditUrl, getWPAdminURL } from './utils/url';
-import { reset, resetRange, toggle, includeRange } from './utils/block-selection';
+import { reset, resetRange, toggle, includeRange, combineRange } from './utils/block-selection';
 
 import {
 	setSelection,
@@ -329,6 +329,16 @@ export default {
 
 		const state = getState();
 		const newSelection = includeRange( state.blockSelection, action.start, action.end, state.editor.present.blockOrder );
+		dispatch(
+			setSelection( newSelection.start, newSelection.end, newSelection.selected )
+		);
+	},
+
+	COMBINE_SELECTION_RANGE( action, store ) {
+		const { getState, dispatch } = store;
+
+		const state = getState();
+		const newSelection = combineRange( state.blockSelection, action.start, action.end, state.editor.present.blockOrder );
 		dispatch(
 			setSelection( newSelection.start, newSelection.end, newSelection.selected )
 		);

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -348,7 +348,7 @@ export default {
 		const { getState, dispatch } = store;
 
 		const state = getState();
-		console.log('state', state);
+		console.log( '**** ', action );
 		const newSelection = toggle( state.blockSelection, action.uid, state.editor.present.blockOrder );
 		console.log( 'newSelection', newSelection, 'action', action.focusUid );
 		dispatch(

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -302,11 +302,34 @@ export default {
 		}
 	},
 
-	SPAWN_SELECTION( action, store ) {
+	ADD_SELECTION_RANGE( action, store ) {
 		const { getState, dispatch } = store;
-		console.log( 'spawn.state.lookup.pre', getState().blockSelection );
-		// Take everything that is currently in the start->end range, and put it in selected
+		const state = getState();
+
+		const inRange = getBlocksInRange( state.editor.present.blockOrder, action.start, action.end );
 		const selectedUids = getAllSelectedBlockUids( getState() );
+		const filteredUids = filter( selectedUids, ( uid ) => ! includes( inRange, uid ) );
+		dispatch( setSelection( action.start, action.end, filteredUids ) );
+	},
+
+	// HERE. Breaking everything again.
+	TOGGLE_SELECTION( action, store ) {
+		const { getState, dispatch } = store;
+		const state = getState();
+
+		// Find everything currently selected.
+		const selectedUids = getAllSelectedBlockUids( getState() );
+
+		// If already selected, remove it from selection.
+		if ( includes( selectedUids, action.uid ) ) {
+			const uidsWithout = filter( state.blockSelection.selected, ( s ) => s !== action.uid );
+			dispatch(
+				setSelection( state.blockSelection.start, state.blockSelection.end, uidsWithout )
+			);
+		} else {
+
+		}
+
 		console.log( 'spawn.state.lookup.post', selectedUids );
 		const filteredUids = filter( selectedUids, ( uid ) => action.uid !== uid );
 		console.log('spawning.initial', getState().blockSelection );
@@ -314,7 +337,7 @@ export default {
 		console.log('spawning.result', getState( ).blockSelection );
 	},
 
-	TOGGLE_OFF_SELECTION( action, store ) {
+	TOGGLE_SELECTION( action, store ) {
 		const { getState, dispatch } = store;
 
 
@@ -323,9 +346,7 @@ export default {
 		// If this is just in the selecteds, remove it.
 		if ( includes( state.blockSelection.selected, action.uid ) ) {
 			console.log(' should be clearing selection' );
-			dispatch(
-				setSelection( state.blockSelection.start, state.blockSelection.end, filter( state.blockSelection.selected, ( s ) => s !== action.uid ) )
-			);
+
 			return;
 		}
 

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -14,6 +14,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getPostEditUrl, getWPAdminURL } from './utils/url';
+import { reset, resetRange, toggle, includeRange } from './utils/block-selection';
+
 import {
 	setSelection,
 	resetPost,
@@ -302,81 +304,45 @@ export default {
 		}
 	},
 
+	RESET_SELECTION( action, store ) {
+		const { getState, dispatch } = store;
+
+		const state = getState();
+		const newSelection = reset( state.blockSelection, action.uid );
+		dispatch(
+			setSelection( newSelection.start, newSelection.end, newSelection.selected )
+		);
+	},
+
+	RESET_SELECTION_RANGE( action, store ) {
+		const { getState, dispatch } = store;
+
+		const state = getState();
+		const newSelection = resetRange( state.blockSelection, action.start, action.end );
+		dispatch(
+			setSelection( newSelection.start, newSelection.end, newSelection.selected )
+		);
+	},
+
 	ADD_SELECTION_RANGE( action, store ) {
 		const { getState, dispatch } = store;
+
 		const state = getState();
-
-		const inRange = getBlocksInRange( state.editor.present.blockOrder, action.start, action.end );
-		const selectedUids = getAllSelectedBlockUids( getState() );
-		const filteredUids = filter( selectedUids, ( uid ) => ! includes( inRange, uid ) );
-		dispatch( setSelection( action.start, action.end, filteredUids ) );
-	},
-
-	// HERE. Breaking everything again.
-	TOGGLE_SELECTION( action, store ) {
-		const { getState, dispatch } = store;
-		const state = getState();
-
-		// Find everything currently selected.
-		const selectedUids = getAllSelectedBlockUids( getState() );
-
-		// If already selected, remove it from selection.
-		if ( includes( selectedUids, action.uid ) ) {
-			const uidsWithout = filter( state.blockSelection.selected, ( s ) => s !== action.uid );
-			dispatch(
-				setSelection( state.blockSelection.start, state.blockSelection.end, uidsWithout )
-			);
-		} else {
-
-		}
-
-		console.log( 'spawn.state.lookup.post', selectedUids );
-		const filteredUids = filter( selectedUids, ( uid ) => action.uid !== uid );
-		console.log('spawning.initial', getState().blockSelection );
-		dispatch( setSelection( action.uid, action.uid, filteredUids ) );
-		console.log('spawning.result', getState( ).blockSelection );
+		const newSelection = includeRange( state.blockSelection, action.start, action.end, state.editor.present.blockOrder );
+		dispatch(
+			setSelection( newSelection.start, newSelection.end, newSelection.selected )
+		);
 	},
 
 	TOGGLE_SELECTION( action, store ) {
 		const { getState, dispatch } = store;
 
-
 		const state = getState();
-		console.log('toggling off', action.uid, state.blockSelection.selected );
-		// If this is just in the selecteds, remove it.
-		if ( includes( state.blockSelection.selected, action.uid ) ) {
-			console.log(' should be clearing selection' );
-
-			return;
-		}
-
-		const inRange = getBlocksInRange( state.editor.present.blockOrder, state.blockSelection.start, state.blockSelection.end );
-		if ( action.uid === state.blockSelection.start ) {
-			const selectedUids = getAllSelectedBlockUids( getState() );
-			const filteredUids = filter( selectedUids, ( uid ) => {
-				return uid !== action.uid;
-			} );
-			const startUid = last( filteredUids );
-			dispatch(
-				setSelection( startUid, startUid, filteredUids.slice( 0, filteredUids.length - 1 ) )
-			);
-		} else if ( includes( inRange, action.uid ) ) {
-			const selectedUids = getAllSelectedBlockUids( getState() );
-
-			const filteredUids = filter( selectedUids, ( uid ) => {
-				return uid !== action.uid && uid !== state.blockSelection.start;
-			} );
-
-			dispatch(
-				setSelection( state.blockSelection.start, state.blockSelection.start, filteredUids )
-			)
-
-			// Make this the last anchor point.
-		}
-
-		// If this is in the range part, push all the range to selected, except start if different.
-
-		// If this in the the range part, and is the start, push all the range to selected, and remove
-		// the last one to be the next anchor
+		console.log('state', state);
+		const newSelection = toggle( state.blockSelection, action.uid, state.editor.present.blockOrder );
+		console.log( 'newSelection', newSelection );
+		dispatch(
+			setSelection( newSelection.start, newSelection.end, newSelection.selected )
+		);
 	},
 };

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, uniqueId, map, filter, remove, some } from 'lodash';
+import { get, uniqueId, map, filter, remove, some, includes, last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -40,6 +40,7 @@ import {
 	isEditedPostNew,
 	isEditedPostSaveable,
 	getMetaBoxes,
+	getBlocksInRange,
 } from './selectors';
 
 const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
@@ -311,5 +312,50 @@ export default {
 		console.log('spawning.initial', getState().blockSelection );
 		dispatch( setSelection( action.uid, action.uid, filteredUids ) );
 		console.log('spawning.result', getState( ).blockSelection );
+	},
+
+	TOGGLE_OFF_SELECTION( action, store ) {
+		const { getState, dispatch } = store;
+
+
+		const state = getState();
+		console.log('toggling off', action.uid, state.blockSelection.selected );
+		// If this is just in the selecteds, remove it.
+		if ( includes( state.blockSelection.selected, action.uid ) ) {
+			console.log(' should be clearing selection' );
+			dispatch(
+				setSelection( state.blockSelection.start, state.blockSelection.end, filter( state.blockSelection.selected, ( s ) => s !== action.uid ) )
+			);
+			return;
+		}
+
+		const inRange = getBlocksInRange( state.editor.present.blockOrder, state.blockSelection.start, state.blockSelection.end );
+		if ( action.uid === state.blockSelection.start ) {
+			const selectedUids = getAllSelectedBlockUids( getState() );
+			const filteredUids = filter( selectedUids, ( uid ) => {
+				return uid !== action.uid;
+			} );
+			const startUid = last( filteredUids );
+			dispatch(
+				setSelection( startUid, startUid, filteredUids.slice( 0, filteredUids.length - 1 ) )
+			);
+		} else if ( includes( inRange, action.uid ) ) {
+			const selectedUids = getAllSelectedBlockUids( getState() );
+
+			const filteredUids = filter( selectedUids, ( uid ) => {
+				return uid !== action.uid && uid !== state.blockSelection.start;
+			} );
+
+			dispatch(
+				setSelection( state.blockSelection.start, state.blockSelection.start, filteredUids )
+			)
+
+			// Make this the last anchor point.
+		}
+
+		// If this is in the range part, push all the range to selected, except start if different.
+
+		// If this in the the range part, and is the start, push all the range to selected, and remove
+		// the last one to be the next anchor
 	},
 };

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, uniqueId, map, filter, some } from 'lodash';
+import { get, uniqueId, map, filter, remove, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { getPostEditUrl, getWPAdminURL } from './utils/url';
 import {
+	setSelection,
 	resetPost,
 	setupNewPost,
 	resetBlocks,
@@ -32,6 +33,7 @@ import {
 	getCurrentPostType,
 	getDirtyMetaBoxes,
 	getEditedPostContent,
+	getAllSelectedBlockUids,
 	getPostEdits,
 	isCurrentPostPublished,
 	isEditedPostDirty,
@@ -297,5 +299,17 @@ export default {
 		if ( unloadedMetaboxes.length === 1 && unloadedMetaboxes[ 0 ].key === action.location ) {
 			jQuery.holdReady( false );
 		}
+	},
+
+	SPAWN_SELECTION( action, store ) {
+		const { getState, dispatch } = store;
+		console.log( 'spawn.state.lookup.pre', getState().blockSelection );
+		// Take everything that is currently in the start->end range, and put it in selected
+		const selectedUids = getAllSelectedBlockUids( getState() );
+		console.log( 'spawn.state.lookup.post', selectedUids );
+		const filteredUids = filter( selectedUids, ( uid ) => action.uid !== uid );
+		console.log('spawning.initial', getState().blockSelection );
+		dispatch( setSelection( action.uid, action.uid, filteredUids ) );
+		console.log('spawning.result', getState( ).blockSelection );
 	},
 };

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -160,12 +160,14 @@ class VisualEditorBlockList extends Component {
 		const { selectionAtStart } = this;
 		const isAtStart = selectionAtStart === uid;
 
+		console.log('start', selectionStart, 'end', selectionEnd, ' selectionAtStart', selectionAtStart );
+
 		if ( ! selectionAtStart ) {
 			return;
 		}
 
 		if ( isAtStart && selectionStart ) {
-			onMultiSelect( null, null );
+			onMultiSelect( uid, null );
 		}
 
 		if ( ! isAtStart && selectionEnd !== uid ) {

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -36,7 +36,7 @@ import {
 	getMultiSelectedBlockUids,
 	getSelectedBlock,
 } from '../../selectors';
-import { insertBlock, startMultiSelect, toggleOffSelection, stopMultiSelect, multiSelect, spawnSelection, selectBlock } from '../../actions';
+import { insertBlock, startMultiSelect, toggleSelection, stopMultiSelect, multiSelect, selectBlock } from '../../actions';
 
 class VisualEditorBlockList extends Component {
 	constructor( props ) {
@@ -192,7 +192,6 @@ class VisualEditorBlockList extends Component {
 
 	onShiftSelection( uid ) {
 		const { selectedBlock, selectionStart, onMultiSelect, onSelect } = this.props;
-		console.log("selected", selectedBlock, 'start', selectionStart);
 		if ( selectedBlock ) {
 			onMultiSelect( selectedBlock.uid, uid );
 		} else if ( selectionStart ) {
@@ -203,12 +202,8 @@ class VisualEditorBlockList extends Component {
 	}
 
 	onMetaSelection( uid ) {
-		const { onSpawnSelection, onToggleOffSelection, multiSelectedBlockUids } = this.props;
-		if ( multiSelectedBlockUids.indexOf( uid ) > -1 ) {
-			onToggleOffSelection( uid );
-		} else {
-			onSpawnSelection( uid );
-		}
+		const { onToggleSelection } = this.props;
+		onToggleSelection( uid );
 	}
 
 	appendDefaultBlock() {
@@ -218,6 +213,8 @@ class VisualEditorBlockList extends Component {
 
 	render() {
 		const { blocks } = this.props;
+
+		console.log( '***** MULTI_SELECT', this.props.multiSelectedBlockUids, this.props.stateDump );
 
 		return (
 			<div>
@@ -262,6 +259,7 @@ export default connect(
 		multiSelectedBlocks: getMultiSelectedBlocks( state ),
 		multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
 		selectedBlock: getSelectedBlock( state ),
+		stateDump: state,
 	} ),
 	( dispatch ) => ( {
 		onInsertBlock( block ) {
@@ -282,11 +280,8 @@ export default connect(
 		onRemove( uids ) {
 			dispatch( { type: 'REMOVE_BLOCKS', uids } );
 		},
-		onSpawnSelection( uid ) {
-			dispatch( spawnSelection( uid ) );
-		},
-		onToggleOffSelection( uid ) {
-			dispatch( toggleOffSelection( uid ) );
+		onToggleSelection( uid ) {
+			dispatch( toggleSelection( uid ) );
 		},
 	} )
 )( VisualEditorBlockList );

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -226,7 +226,7 @@ class VisualEditorBlockList extends Component {
 						onShiftSelection={ this.onShiftSelection }
 						onMetaSelection={ this.onMetaSelection }
 						isMultiSelectFocus={ this.props.selectionEnd === uid ? true : false }
-						isMultiSelectAnchor={ this.props.selectionStart === uid ? true : false }
+						isMultiSelectAnchor={ this.props.selectionStart === uid && this.props.multiSelectedBlockUids.length > 0 ? true : false }
 					/>,
 					<VisualEditorSiblingInserter
 						key={ 'sibling-inserter-' + uid }

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -203,7 +203,7 @@ class VisualEditorBlockList extends Component {
 
 	onMetaSelection( uid ) {
 		const { onToggleSelection } = this.props;
-		onToggleSelection( uid );
+		onToggleSelection( uid, uid );
 	}
 
 	appendDefaultBlock() {
@@ -280,8 +280,8 @@ export default connect(
 		onRemove( uids ) {
 			dispatch( { type: 'REMOVE_BLOCKS', uids } );
 		},
-		onToggleSelection( uid ) {
-			dispatch( toggleSelection( uid ) );
+		onToggleSelection( uid, focusUid ) {
+			dispatch( toggleSelection( uid, focusUid ) );
 		},
 	} )
 )( VisualEditorBlockList );

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -225,6 +225,8 @@ class VisualEditorBlockList extends Component {
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
 						onMetaSelection={ this.onMetaSelection }
+						isMultiSelectFocus={ this.props.selectionEnd === uid ? true : false }
+						isMultiSelectAnchor={ this.props.selectionStart === uid ? true : false }
 					/>,
 					<VisualEditorSiblingInserter
 						key={ 'sibling-inserter-' + uid }

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -36,7 +36,7 @@ import {
 	getMultiSelectedBlockUids,
 	getSelectedBlock,
 } from '../../selectors';
-import { insertBlock, startMultiSelect, stopMultiSelect, multiSelect, spawnSelection, selectBlock } from '../../actions';
+import { insertBlock, startMultiSelect, toggleOffSelection, stopMultiSelect, multiSelect, spawnSelection, selectBlock } from '../../actions';
 
 class VisualEditorBlockList extends Component {
 	constructor( props ) {
@@ -201,8 +201,12 @@ class VisualEditorBlockList extends Component {
 	}
 
 	onMetaSelection( uid ) {
-		const { onSpawnSelection } = this.props;
-		onSpawnSelection( uid );
+		const { onSpawnSelection, onToggleOffSelection, multiSelectedBlockUids } = this.props;
+		if ( multiSelectedBlockUids.indexOf( uid ) > -1 ) {
+			onToggleOffSelection( uid );
+		} else {
+			onSpawnSelection( uid );
+		}
 	}
 
 	appendDefaultBlock() {
@@ -278,6 +282,9 @@ export default connect(
 		},
 		onSpawnSelection( uid ) {
 			dispatch( spawnSelection( uid ) );
+		},
+		onToggleOffSelection( uid ) {
+			dispatch( toggleOffSelection( uid ) );
 		},
 	} )
 )( VisualEditorBlockList );

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -190,7 +190,7 @@ class VisualEditorBlockList extends Component {
 
 	onShiftSelection( uid ) {
 		const { selectedBlock, selectionStart, onMultiSelect, onSelect } = this.props;
-
+		console.log("selected", selectedBlock, 'start', selectionStart);
 		if ( selectedBlock ) {
 			onMultiSelect( selectedBlock.uid, uid );
 		} else if ( selectionStart ) {

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -36,7 +36,7 @@ import {
 	getMultiSelectedBlockUids,
 	getSelectedBlock,
 } from '../../selectors';
-import { insertBlock, startMultiSelect, stopMultiSelect, multiSelect, selectBlock } from '../../actions';
+import { insertBlock, startMultiSelect, stopMultiSelect, multiSelect, spawnSelection, selectBlock } from '../../actions';
 
 class VisualEditorBlockList extends Component {
 	constructor( props ) {
@@ -45,6 +45,7 @@ class VisualEditorBlockList extends Component {
 		this.onSelectionStart = this.onSelectionStart.bind( this );
 		this.onSelectionEnd = this.onSelectionEnd.bind( this );
 		this.onShiftSelection = this.onShiftSelection.bind( this );
+		this.onMetaSelection = this.onMetaSelection.bind( this );
 		this.onCopy = this.onCopy.bind( this );
 		this.onCut = this.onCut.bind( this );
 		this.setBlockRef = this.setBlockRef.bind( this );
@@ -199,6 +200,11 @@ class VisualEditorBlockList extends Component {
 		}
 	}
 
+	onMetaSelection( uid ) {
+		const { onSpawnSelection } = this.props;
+		onSpawnSelection( uid );
+	}
+
 	appendDefaultBlock() {
 		const newBlock = createBlock( getDefaultBlockName() );
 		this.props.onInsertBlock( newBlock );
@@ -217,6 +223,7 @@ class VisualEditorBlockList extends Component {
 						blockRef={ this.setBlockRef }
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
+						onMetaSelection={ this.onMetaSelection }
 					/>,
 					<VisualEditorSiblingInserter
 						key={ 'sibling-inserter-' + uid }
@@ -268,6 +275,9 @@ export default connect(
 		},
 		onRemove( uids ) {
 			dispatch( { type: 'REMOVE_BLOCKS', uids } );
+		},
+		onSpawnSelection( uid ) {
+			dispatch( spawnSelection( uid ) );
 		},
 	} )
 )( VisualEditorBlockList );

--- a/editor/modes/visual-editor/block-list.js
+++ b/editor/modes/visual-editor/block-list.js
@@ -214,8 +214,6 @@ class VisualEditorBlockList extends Component {
 	render() {
 		const { blocks } = this.props;
 
-		console.log( '***** MULTI_SELECT', this.props.multiSelectedBlockUids, this.props.stateDump );
-
 		return (
 			<div>
 				{ !! blocks.length && <VisualEditorSiblingInserter /> }

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -83,6 +83,8 @@ class VisualEditorBlock extends Component {
 		this.previousOffset = null;
 		this.hadTouchStart = false;
 
+		this.outerNode = null;
+
 		this.state = {
 			error: null,
 		};
@@ -90,7 +92,7 @@ class VisualEditorBlock extends Component {
 
 	componentDidMount() {
 		if ( this.props.focus && this.props.navigating ) {
-			this.node.focus();
+			this.outerNode.focus();
 		}
 
 		if ( this.props.isTyping ) {
@@ -122,7 +124,7 @@ class VisualEditorBlock extends Component {
 
 		// Focus node when focus state is programmatically transferred.
 		if ( this.props.focus && ! prevProps.focus && ! this.node.contains( document.activeElement ) && this.props.navigating ) {
-			this.node.focus();
+			this.outerNode.focus();
 		}
 
 		// Bind or unbind mousemove from page when user starts or stops typing
@@ -135,7 +137,7 @@ class VisualEditorBlock extends Component {
 		}
 
 		if ( this.props.isMultiSelectFocus && ! prevProps.isMultiSelectFocus ) {
-			this.node.focus();
+			this.outerNode.focus();
 		} else if ( prevProps.isMultiSelectFocus && ! this.props.isMultiSelectFocus ) {
 			// blur ?
 		}
@@ -151,6 +153,8 @@ class VisualEditorBlock extends Component {
 
 	setBlockListRef( node ) {
 		this.props.blockRef( node, this.props.uid );
+
+		this.outerNode = node;
 	}
 
 	bindBlockNode( node ) {
@@ -381,6 +385,7 @@ class VisualEditorBlock extends Component {
 				className={ wrapperClassName }
 				data-type={ block.name }
 				onTouchStart={ this.onTouchStart }
+				tabIndex="0"
 				onClick={ this.onClick }
 				{ ...wrapperProps }
 			>

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -136,11 +136,11 @@ class VisualEditorBlock extends Component {
 			}
 		}
 
-		if ( this.props.isMultiSelectFocus && ! prevProps.isMultiSelectFocus ) {
-			this.outerNode.focus();
-		} else if ( prevProps.isMultiSelectFocus && ! this.props.isMultiSelectFocus ) {
-			// blur ?
-		}
+		// if ( this.props.isMultiSelectFocus && ! prevProps.isMultiSelectFocus ) {
+		// 	this.outerNode.focus();
+		// } else if ( prevProps.isMultiSelectFocus && ! this.props.isMultiSelectFocus ) {
+		// 	// blur ?
+		// }
 	}
 
 	componentWillUnmount() {
@@ -253,7 +253,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	onFocus( event ) {
-		if ( event.target === this.node && ! this.props.isMultiSelected ) {
+		if ( event.target === this.node ) {
 			this.props.onSelect();
 		}
 	}

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -255,6 +255,11 @@ class VisualEditorBlock extends Component {
 				this.props.onShiftSelection( this.props.uid );
 				event.preventDefault();
 			}
+		} else if ( event.ctrlKey ) {
+			// Generalise for Mac as well.
+			this.props.onMetaSelection( this.props.uid );
+			event.preventDefault();
+			console.log(' stopping Ctrl+shift');
 		} else {
 			this.props.onSelectionStart( this.props.uid );
 			this.props.onSelect();
@@ -468,7 +473,7 @@ export default connect(
 		},
 
 		onFocus( ...args ) {
-			dispatch( focusBlock( ...args ) );
+			// dispatch( focusBlock( ...args ) );
 		},
 
 		onRemove( uid ) {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -53,6 +53,7 @@ import {
 	isFirstMultiSelectedBlock,
 	isNavigating,
 	getMultiSelectedBlocksStartUid,
+	getMultiSelectedBlocksEndUid,
 	isTyping,
 	getBlockMode,
 } from '../../selectors';
@@ -131,6 +132,12 @@ class VisualEditorBlock extends Component {
 			} else {
 				this.removeStopTypingListener();
 			}
+		}
+
+		if ( this.props.isMultiSelectFocus && ! prevProps.isMultiSelectFocus ) {
+			this.node.focus();
+		} else if ( prevProps.isMultiSelectFocus && ! this.props.isMultiSelectFocus ) {
+			// blur ?
 		}
 	}
 
@@ -248,7 +255,6 @@ class VisualEditorBlock extends Component {
 	}
 
 	onPointerDown( event ) {
-		console.log( 'event', event.nativeEvent );
 		// Not the main button.
 		// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
 		if ( event.button !== 0 ) {
@@ -347,6 +353,8 @@ class VisualEditorBlock extends Component {
 			'is-selected': showUI,
 			'is-multi-selected': isMultiSelected,
 			'is-hovered': isHovered,
+			'is-multi-selected-focus': this.props.isMultiSelectFocus,
+			'is-multi-selected-anchor': this.props.isMultiSelectAnchor,
 		} );
 
 		const { onMouseLeave, onFocus, onReplace } = this.props;

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -248,6 +248,7 @@ class VisualEditorBlock extends Component {
 	}
 
 	onPointerDown( event ) {
+		console.log( 'event', event.nativeEvent );
 		// Not the main button.
 		// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
 		if ( event.button !== 0 ) {
@@ -259,7 +260,7 @@ class VisualEditorBlock extends Component {
 				this.props.onShiftSelection( this.props.uid );
 				event.preventDefault();
 			}
-		} else if ( event.ctrlKey ) {
+		} else if ( event.ctrlKey || event.metaKey ) {
 			// Generalise for Mac as well.
 			this.props.onMetaSelection( this.props.uid );
 			event.preventDefault();

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -361,7 +361,7 @@ class VisualEditorBlock extends Component {
 			'is-multi-selected-anchor': this.props.isMultiSelectAnchor,
 		} );
 
-		const { onMouseLeave, onFocus, onReplace } = this.props;
+		const { onMouseLeave, onFocus, onReplace, hasNavigationFocus } = this.props;
 
 		// Determine whether the block has props to apply to the wrapper.
 		let wrapperProps;
@@ -402,7 +402,7 @@ class VisualEditorBlock extends Component {
 					onKeyDown={ this.onKeyDown }
 					onFocus={ this.onFocus }
 					className="editor-visual-editor__block-edit"
-					tabIndex="0"
+					tabIndex={ this.props.navigating ? '-1' : '0' }
 					aria-label={ blockLabel }
 				>
 					<BlockCrashBoundary onError={ this.onBlockError }>
@@ -460,6 +460,7 @@ export default connect(
 			meta: getEditedPostAttribute( state, 'meta' ),
 			mode: getBlockMode( state, ownProps.uid ),
 			navigating: isNavigating( state ),
+			hasNavigationFocus: isNavigating( state ) && getBlockFocus( state, ownProps.uid ),
 		};
 	},
 	( dispatch, ownProps ) => ( {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -50,6 +50,7 @@ import {
 	isBlockMultiSelected,
 	isBlockSelected,
 	isFirstMultiSelectedBlock,
+	getMultiSelectedBlocksStartUid,
 	isTyping,
 	getBlockMode,
 } from '../../selectors';
@@ -238,7 +239,9 @@ class VisualEditorBlock extends Component {
 	}
 
 	onFocus( event ) {
-		if ( event.target === this.node ) {
+		// BUG: Cannot control click without a multi-selection, because this clobbers it.
+		console.log('focusing', this.props.isMultiSelected);
+		if ( event.target === this.node && ! this.props.isMultiSelected ) {
 			this.props.onSelect();
 		}
 	}
@@ -259,7 +262,6 @@ class VisualEditorBlock extends Component {
 			// Generalise for Mac as well.
 			this.props.onMetaSelection( this.props.uid );
 			event.preventDefault();
-			console.log(' stopping Ctrl+shift');
 		} else {
 			this.props.onSelectionStart( this.props.uid );
 			this.props.onSelect();
@@ -382,7 +384,7 @@ class VisualEditorBlock extends Component {
 						{ isValid && mode === 'visual' && (
 							<BlockEdit
 								name={ blockName }
-								focus={ focus }
+								focus={ isMultiSelected ? null : focus }
 								attributes={ block.attributes }
 								setAttributes={ this.setAttributes }
 								insertBlocksAfter={ this.insertBlocksAfter }
@@ -423,6 +425,7 @@ export default connect(
 			nextBlock: getNextBlock( state, ownProps.uid ),
 			block: getBlock( state, ownProps.uid ),
 			isSelected: isBlockSelected( state, ownProps.uid ),
+			multiSelectStartUid: getMultiSelectedBlocksStartUid( state ),
 			isMultiSelected: isBlockMultiSelected( state, ownProps.uid ),
 			isFirstMultiSelected: isFirstMultiSelectedBlock( state, ownProps.uid ),
 			isHovered: isBlockHovered( state, ownProps.uid ) && ! isMultiSelecting( state ),
@@ -473,7 +476,7 @@ export default connect(
 		},
 
 		onFocus( ...args ) {
-			// dispatch( focusBlock( ...args ) );
+			dispatch( focusBlock( ...args ) );
 		},
 
 		onRemove( uid ) {

--- a/editor/modes/visual-editor/block.js
+++ b/editor/modes/visual-editor/block.js
@@ -240,7 +240,6 @@ class VisualEditorBlock extends Component {
 
 	onFocus( event ) {
 		// BUG: Cannot control click without a multi-selection, because this clobbers it.
-		console.log('focusing', this.props.isMultiSelected);
 		if ( event.target === this.node && ! this.props.isMultiSelected ) {
 			this.props.onSelect();
 		}

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -90,7 +90,6 @@ class VisualEditor extends Component {
 					'mod+shift+z': this.undoOrRedo,
 					backspace: this.deleteSelectedBlocks,
 					del: this.deleteSelectedBlocks,
-					escape: this.props.clearSelectedBlock,
 				} } />
 				<WritingFlow>
 					<PostTitle />

--- a/editor/modes/visual-editor/multi-controls.js
+++ b/editor/modes/visual-editor/multi-controls.js
@@ -26,7 +26,6 @@ function VisualEditorBlockMultiControls( { multiSelectedBlockUids, isSelecting }
 		<BlockSettingsMenu
 			key="menu"
 			uids={ multiSelectedBlockUids }
-			focus
 		/>,
 	];
 }

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -108,6 +108,14 @@
 		background: $blue-medium-highlight;
 	}
 
+	&.is-multi-selected-focus:before {
+		outline: 1px solid blue;
+	}
+
+	&.is-multi-selected-anchor:before {
+		outline: 1px solid yellowgreen;
+	}
+
 	.iframe-overlay {
 		position: relative;
 	}

--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -116,6 +116,11 @@
 		outline: 1px solid yellowgreen;
 	}
 
+	&:focus {
+		outline: 4px solid magenta;
+	}
+
+
 	.iframe-overlay {
 		position: relative;
 	}

--- a/editor/navigable-toolbar/index.js
+++ b/editor/navigable-toolbar/index.js
@@ -42,7 +42,7 @@ class NavigableToolbar extends Component {
 		const selectedBlock = document.querySelector( '.editor-visual-editor__block.is-selected .editor-visual-editor__block-edit' );
 		if ( !! selectedBlock ) {
 			event.stopPropagation();
-			selectedBlock.focus();
+			// selectedBlock.focus();
 		}
 	}
 

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -331,11 +331,12 @@ export function isTyping( state = false, action ) {
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function blockSelection( state = { selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
+export function blockSelection( state = { isNavigating: false, selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
 	const ff = () => {
 		switch ( action.type ) {
 			case 'CLEAR_SELECTED_BLOCK':
 				return {
+					isNavigating: state.isNavigating,
 					selected: [ ],
 					start: null,
 					end: null,
@@ -376,6 +377,12 @@ export function blockSelection( state = { selected: [ ], start: null, end: null,
 					focus: action.config || {},
 				};
 
+			case 'START_NAVIGATION':
+				return {
+					...state,
+					isNavigating: true,
+				};
+
 			case 'SET_SELECTION':
 				return {
 					...state,
@@ -386,6 +393,7 @@ export function blockSelection( state = { selected: [ ], start: null, end: null,
 
 			case 'INSERT_BLOCKS':
 				return {
+					isNavigating: state.isNavigating,
 					start: action.blocks[ 0 ].uid,
 					end: null,
 					selected: [ ],
@@ -397,6 +405,7 @@ export function blockSelection( state = { selected: [ ], start: null, end: null,
 					return state;
 				}
 				return {
+					isNavigating: state.isNavigating,
 					start: action.blocks[ 0 ].uid,
 					end: null,
 					selected: [ ],

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -409,7 +409,6 @@ export function blockSelection( state = { selected: [ ], start: null, end: null,
 	};
 
 	const res = ff();
-	console.log( 'res', res );
 	return res;
 }
 

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -331,11 +331,11 @@ export function isTyping( state = false, action ) {
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function blockSelection( state = { current: null, selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
+export function blockSelection( state = { selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
+	console.log("switching", action.type, state);
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK':
 			return {
-				current: null,
 				selected: [ ],
 				start: null,
 				end: null,
@@ -351,33 +351,27 @@ export function blockSelection( state = { current: null, selected: [ ], start: n
 			return {
 				...state,
 				isMultiSelecting: false,
-				focus: state.start === state.end ? state.focus : null,
+				focus: state.start && ! state.end ? state.focus : null,
 			};
 		case 'MULTI_SELECT':
 			return {
 				...state,
 				start: action.start,
 				end: action.end,
-				current: null,
 				focus: state.isMultiSelecting ? state.focus : null,
 			};
 		case 'SELECT_BLOCK':
-			if ( action.uid === state.current && ! state.start && ! state.end ) {
-				return state;
-			}
 			return {
 				...state,
 				selected: [ ],
-				current: action.uid,
-				start: null,
+				start: action.uid,
 				end: null,
 				focus: action.focus || {},
 			};
 		case 'UPDATE_FOCUS':
 			return {
 				...state,
-				start: null,
-				current: action.uid,
+				start: action.uid,
 				end: null,
 				focus: action.config || {},
 			};
@@ -385,7 +379,6 @@ export function blockSelection( state = { current: null, selected: [ ], start: n
 		case 'SET_SELECTION':
 			return {
 				...state,
-				current: null,
 				selected: action.selected,
 				start: action.start,
 				end: action.end,
@@ -393,8 +386,7 @@ export function blockSelection( state = { current: null, selected: [ ], start: n
 
 		case 'INSERT_BLOCKS':
 			return {
-				current: action.blocks[ 0 ].uid,
-				start: null,
+				start: action.blocks[ 0 ].uid,
 				end: null,
 				selected: [ ],
 				focus: {},
@@ -405,8 +397,7 @@ export function blockSelection( state = { current: null, selected: [ ], start: n
 				return state;
 			}
 			return {
-				current: action.blocks[ 0 ].uid,
-				start: null,
+				start: action.blocks[ 0 ].uid,
 				end: null,
 				selected: [ ],
 				focus: {},

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -333,6 +333,7 @@ export function isTyping( state = false, action ) {
  */
 export function blockSelection( state = { isNavigating: false, selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
 	const ff = () => {
+		console.log('action', action);
 		switch ( action.type ) {
 			case 'CLEAR_SELECTED_BLOCK':
 				return {
@@ -369,6 +370,7 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 				return {
 					...state,
 					selected: [ ],
+					isNavigating: false,
 					start: action.uid,
 					end: null,
 					focus: {
@@ -403,7 +405,7 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 					end: action.end,
 					isNavigating: action.selected.length > 0 || !! action.end,
 					focus: {
-						uid: action.end,
+						uid: action.focusUid || action.end,
 						config: { },
 					},
 				};
@@ -441,6 +443,7 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 	};
 
 	const res = ff();
+	console.log('resulting state', res);
 	return res;
 }
 

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -362,7 +362,7 @@ export function blockSelection( state = { current: null, selected: [ ], start: n
 				focus: state.isMultiSelecting ? state.focus : null,
 			};
 		case 'SELECT_BLOCK':
-			if ( action.uid === state.current ) {
+			if ( action.uid === state.current && ! state.start && ! state.end ) {
 				return state;
 			}
 			return {

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -332,80 +332,85 @@ export function isTyping( state = false, action ) {
  * @return {Object}        Updated state
  */
 export function blockSelection( state = { selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
-	console.log("switching", action.type, state);
-	switch ( action.type ) {
-		case 'CLEAR_SELECTED_BLOCK':
-			return {
-				selected: [ ],
-				start: null,
-				end: null,
-				focus: null,
-				isMultiSelecting: false,
-			};
-		case 'START_MULTI_SELECT':
-			return {
-				...state,
-				isMultiSelecting: true,
-			};
-		case 'STOP_MULTI_SELECT':
-			return {
-				...state,
-				isMultiSelecting: false,
-				focus: state.start && ! state.end ? state.focus : null,
-			};
-		case 'MULTI_SELECT':
-			return {
-				...state,
-				start: action.start,
-				end: action.end,
-				focus: state.isMultiSelecting ? state.focus : null,
-			};
-		case 'SELECT_BLOCK':
-			return {
-				...state,
-				selected: [ ],
-				start: action.uid,
-				end: null,
-				focus: action.focus || {},
-			};
-		case 'UPDATE_FOCUS':
-			return {
-				...state,
-				start: action.uid,
-				end: null,
-				focus: action.config || {},
-			};
+	const ff = () => {
+		switch ( action.type ) {
+			case 'CLEAR_SELECTED_BLOCK':
+				return {
+					selected: [ ],
+					start: null,
+					end: null,
+					focus: null,
+					isMultiSelecting: false,
+				};
+			case 'START_MULTI_SELECT':
+				return {
+					...state,
+					isMultiSelecting: true,
+				};
+			case 'STOP_MULTI_SELECT':
+				return {
+					...state,
+					isMultiSelecting: false,
+					focus: state.start && ! state.end ? state.focus : null,
+				};
+			case 'MULTI_SELECT':
+				return {
+					...state,
+					start: action.start,
+					end: action.end,
+					focus: state.isMultiSelecting ? state.focus : null,
+				};
+			case 'SELECT_BLOCK':
+				return {
+					...state,
+					selected: [ ],
+					start: action.uid,
+					end: null,
+					focus: action.focus || {},
+				};
+			case 'UPDATE_FOCUS':
+				return {
+					...state,
+					start: action.uid,
+					end: null,
+					focus: action.config || {},
+				};
 
-		case 'SET_SELECTION':
-			return {
-				...state,
-				selected: action.selected,
-				start: action.start,
-				end: action.end,
-			};
+			case 'SET_SELECTION':
+				return {
+					...state,
+					selected: action.selected,
+					start: action.start,
+					end: action.end,
+				};
 
-		case 'INSERT_BLOCKS':
-			return {
-				start: action.blocks[ 0 ].uid,
-				end: null,
-				selected: [ ],
-				focus: {},
-				isMultiSelecting: false,
-			};
-		case 'REPLACE_BLOCKS':
-			if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.start ) === -1 ) {
-				return state;
-			}
-			return {
-				start: action.blocks[ 0 ].uid,
-				end: null,
-				selected: [ ],
-				focus: {},
-				isMultiSelecting: false,
-			};
-	}
+			case 'INSERT_BLOCKS':
+				return {
+					start: action.blocks[ 0 ].uid,
+					end: null,
+					selected: [ ],
+					focus: {},
+					isMultiSelecting: false,
+				};
+			case 'REPLACE_BLOCKS':
+				if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.start ) === -1 ) {
+					return state;
+				}
+				return {
+					start: action.blocks[ 0 ].uid,
+					end: null,
+					selected: [ ],
+					focus: {},
+					isMultiSelecting: false,
+				};
+		}
 
-	return state;
+		return state;
+	};
+
+	const res = ff();
+	console.log( 'res', res );
+	return res;
 }
 
 /**

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -359,7 +359,10 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 					...state,
 					start: action.start,
 					end: action.end,
-					focus: state.isMultiSelecting ? state.focus : null,
+					focus: {
+						... state.focus,
+						uid: action.uid,
+					},
 				};
 			case 'SELECT_BLOCK':
 				return {
@@ -367,20 +370,30 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 					selected: [ ],
 					start: action.uid,
 					end: null,
-					focus: action.focus || {},
+					focus: {
+						uid: action.uid,
+						config: action.config || { },
+					},
 				};
 			case 'UPDATE_FOCUS':
 				return {
 					...state,
 					start: action.uid,
 					end: null,
-					focus: action.config || {},
+					focus: {
+						uid: action.uid,
+						config: action.config,
+					},
 				};
 
 			case 'START_NAVIGATION':
 				return {
 					...state,
 					isNavigating: true,
+					focus: {
+						uid: state.end || state.start,
+						config: { },
+					},
 				};
 
 			case 'SET_SELECTION':
@@ -397,7 +410,10 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 					start: action.blocks[ 0 ].uid,
 					end: null,
 					selected: [ ],
-					focus: {},
+					focus: {
+						uid: action.blocks[ 0 ].uid,
+						config: { },
+					},
 					isMultiSelecting: false,
 				};
 			case 'REPLACE_BLOCKS':
@@ -409,7 +425,10 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 					start: action.blocks[ 0 ].uid,
 					end: null,
 					selected: [ ],
-					focus: {},
+					focus: {
+						uid: action.blocks[ 0 ].uid,
+						config: { },
+					},
 					isMultiSelecting: false,
 				};
 		}

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -331,10 +331,11 @@ export function isTyping( state = false, action ) {
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function blockSelection( state = { selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
+export function blockSelection( state = { current: null, selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK':
 			return {
+				current: null,
 				selected: [ ],
 				start: null,
 				end: null,
@@ -357,31 +358,44 @@ export function blockSelection( state = { selected: [ ], start: null, end: null,
 				...state,
 				start: action.start,
 				end: action.end,
+				current: null,
 				focus: state.isMultiSelecting ? state.focus : null,
 			};
 		case 'SELECT_BLOCK':
-			if ( action.uid === state.start && action.uid === state.end ) {
+			if ( action.uid === state.current ) {
 				return state;
 			}
 			return {
 				...state,
 				selected: [ ],
-				start: action.uid,
-				end: action.uid,
+				current: action.uid,
+				start: null,
+				end: null,
 				focus: action.focus || {},
 			};
 		case 'UPDATE_FOCUS':
 			return {
 				...state,
-				selected: [ ],
-				start: action.uid,
-				end: action.uid,
+				start: null,
+				current: action.uid,
+				end: null,
 				focus: action.config || {},
 			};
+
+		case 'SET_SELECTION':
+			return {
+				...state,
+				current: null,
+				selected: action.selected,
+				start: action.start,
+				end: action.end,
+			};
+
 		case 'INSERT_BLOCKS':
 			return {
-				start: action.blocks[ 0 ].uid,
-				end: action.blocks[ 0 ].uid,
+				current: action.blocks[ 0 ].uid,
+				start: null,
+				end: null,
 				selected: [ ],
 				focus: {},
 				isMultiSelecting: false,
@@ -391,8 +405,9 @@ export function blockSelection( state = { selected: [ ], start: null, end: null,
 				return state;
 			}
 			return {
-				start: action.blocks[ 0 ].uid,
-				end: action.blocks[ 0 ].uid,
+				current: action.blocks[ 0 ].uid,
+				start: null,
+				end: null,
 				selected: [ ],
 				focus: {},
 				isMultiSelecting: false,

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -352,16 +352,17 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 				return {
 					...state,
 					isMultiSelecting: false,
-					focus: state.start && ! state.end ? state.focus : null,
+					// focus: state.start && ! state.end ? state.focus : null,
 				};
 			case 'MULTI_SELECT':
 				return {
 					...state,
 					start: action.start,
 					end: action.end,
+					isNavigating: true,
 					focus: {
 						... state.focus,
-						uid: action.uid,
+						uid: action.end,
 					},
 				};
 			case 'SELECT_BLOCK':
@@ -378,8 +379,6 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 			case 'UPDATE_FOCUS':
 				return {
 					...state,
-					start: action.uid,
-					end: null,
 					focus: {
 						uid: action.uid,
 						config: action.config,
@@ -402,6 +401,11 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 					selected: action.selected,
 					start: action.start,
 					end: action.end,
+					isNavigating: action.selected.length > 0 || !! action.end,
+					focus: {
+						uid: action.end,
+						config: { },
+					},
 				};
 
 			case 'INSERT_BLOCKS':

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -381,6 +381,8 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 			case 'UPDATE_FOCUS':
 				return {
 					...state,
+					// Update the start if don't have a multi-selection
+					start: state.end ? state.start : action.uid,
 					focus: {
 						uid: action.uid,
 						config: action.config,
@@ -403,7 +405,7 @@ export function blockSelection( state = { isNavigating: false, selected: [ ], st
 					selected: action.selected,
 					start: action.start,
 					end: action.end,
-					isNavigating: action.selected.length > 0 || !! action.end,
+					isNavigating: true,
 					focus: {
 						uid: action.focusUid || action.end,
 						config: { },

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -331,10 +331,11 @@ export function isTyping( state = false, action ) {
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function blockSelection( state = { start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
+export function blockSelection( state = { selected: [ ], start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK':
 			return {
+				selected: [ ],
 				start: null,
 				end: null,
 				focus: null,
@@ -364,6 +365,7 @@ export function blockSelection( state = { start: null, end: null, focus: null, i
 			}
 			return {
 				...state,
+				selected: [ ],
 				start: action.uid,
 				end: action.uid,
 				focus: action.focus || {},
@@ -371,6 +373,7 @@ export function blockSelection( state = { start: null, end: null, focus: null, i
 		case 'UPDATE_FOCUS':
 			return {
 				...state,
+				selected: [ ],
 				start: action.uid,
 				end: action.uid,
 				focus: action.config || {},
@@ -379,6 +382,7 @@ export function blockSelection( state = { start: null, end: null, focus: null, i
 			return {
 				start: action.blocks[ 0 ].uid,
 				end: action.blocks[ 0 ].uid,
+				selected: [ ],
 				focus: {},
 				isMultiSelecting: false,
 			};
@@ -389,6 +393,7 @@ export function blockSelection( state = { start: null, end: null, focus: null, i
 			return {
 				start: action.blocks[ 0 ].uid,
 				end: action.blocks[ 0 ].uid,
+				selected: [ ],
 				focus: {},
 				isMultiSelecting: false,
 			};

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -837,7 +837,7 @@ export function isBlockHovered( state, uid ) {
  * @return {Object}       Block focus state
  */
 export function getBlockFocus( state, uid ) {
-	return isBlockSelected( state, uid ) ? state.blockSelection.focus : null;
+	return state.blockSelection.focus && state.blockSelection.focus.uid === uid ? state.blockSelection.focus.config : null;
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -676,11 +676,7 @@ export function isBlockMultiSelected( state, uid ) {
  */
 export function getMultiSelectedBlocksStartUid( state ) {
 	const { start, current } = state.blockSelection;
-	if ( ! start ) {
-		return current;
-	}
-
-	return start || null;
+	return start || current;
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -517,8 +517,8 @@ export function getSelectedBlockCount( state ) {
  * @return {?Object}       Selected block
  */
 export function getSelectedBlock( state ) {
-	const { current, start, end, selected } = state.blockSelection;
-	if ( start !== end || selected.length > 0 || ! current ) {
+	const { current } = state.blockSelection;
+	if ( ! current ) {
 		return null;
 	}
 

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -525,7 +525,7 @@ export function getSelectedBlock( state ) {
 	return getBlock( state, current );
 }
 
-function getBlocksInRange( blockOrder, start, end ) {
+export function getBlocksInRange( blockOrder, start, end ) {
 	if ( ! start || ! end ) return [ ];
 	const startIndex = blockOrder.indexOf( start );
 	const endIndex = blockOrder.indexOf( end );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -658,9 +658,7 @@ export function getLastMultiSelectedBlockUid( state ) {
  * @return {Boolean}       Whether block is first in mult-selection
  */
 export function isFirstMultiSelectedBlock( state, uid ) {
-	const firstUid = getFirstMultiSelectedBlockUid( state )
-	console.log( 'firstUid', firstUid );
-	return firstUid === uid;
+	return getFirstMultiSelectedBlockUid( state ) === uid;
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -9,6 +9,7 @@ import {
 	last,
 	reduce,
 	includes,
+	sortBy,
 	keys,
 	without,
 	compact,
@@ -547,7 +548,7 @@ export function getBlocksInRange( blockOrder, start, end ) {
 }
 
 function sortByOrder( blockOrder ) {
-	return ( a, b ) => blockOrder.indexOf( a ) < blockOrder.indexOf( b );
+	return ( a ) => blockOrder.indexOf( a );
 }
 
 export const hasMultiSelection = createSelector(
@@ -593,7 +594,9 @@ export const getMultiSelectedBlockUids = createSelector(
 		const { start, end, selected } = state.blockSelection;
 
 		const ranged = start && start === end ? [ start ] : getBlocksInRange( blockOrder, start, end );
-		return selected.concat( ranged ).sort( sortByOrder( blockOrder ) );
+		const all = sortBy( selected.concat( ranged ), sortByOrder( blockOrder ) );
+		console.log( 'all', all, 'blockOrder', blockOrder );
+		return all;
 	},
 	( state ) => [
 		state.editor.present.blockOrder,
@@ -655,7 +658,9 @@ export function getLastMultiSelectedBlockUid( state ) {
  * @return {Boolean}       Whether block is first in mult-selection
  */
 export function isFirstMultiSelectedBlock( state, uid ) {
-	return getFirstMultiSelectedBlockUid( state ) === uid;
+	const firstUid = getFirstMultiSelectedBlockUid( state )
+	console.log( 'firstUid', firstUid );
+	return firstUid === uid;
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -8,6 +8,7 @@ import {
 	has,
 	last,
 	reduce,
+	includes,
 	keys,
 	without,
 	compact,
@@ -516,8 +517,8 @@ export function getSelectedBlockCount( state ) {
  * @return {?Object}       Selected block
  */
 export function getSelectedBlock( state ) {
-	const { start, end } = state.blockSelection;
-	if ( start !== end || ! start ) {
+	const { start, end, selected } = state.blockSelection;
+	if ( start !== end || ! start || selected.length > 0 ) {
 		return null;
 	}
 
@@ -534,24 +535,33 @@ export function getSelectedBlock( state ) {
 export const getMultiSelectedBlockUids = createSelector(
 	( state ) => {
 		const { blockOrder } = state.editor.present;
-		const { start, end } = state.blockSelection;
+		const { start, end, selected } = state.blockSelection;
 		if ( start === end ) {
-			return [];
+			return selected;
 		}
 
-		const startIndex = blockOrder.indexOf( start );
-		const endIndex = blockOrder.indexOf( end );
+		const rangeUids = () => {
+			const startIndex = blockOrder.indexOf( start );
+			const endIndex = blockOrder.indexOf( end );
 
-		if ( startIndex > endIndex ) {
-			return blockOrder.slice( endIndex, startIndex + 1 );
-		}
+			if ( startIndex > endIndex ) {
+				return blockOrder.slice( endIndex, startIndex + 1 );
+			}
 
-		return blockOrder.slice( startIndex, endIndex + 1 );
+			return blockOrder.slice( startIndex, endIndex + 1 );
+		};
+
+		const otherUids = selected;
+		const output = otherUids.concat( rangeUids() ).sort( ( a, b ) => blockOrder.indexOf( a ) < blockOrder.indexOf( b ) );
+
+		console.log('output', output, otherUids);
+		return output;
 	},
 	( state ) => [
 		state.editor.present.blockOrder,
 		state.blockSelection.start,
 		state.blockSelection.end,
+		state.blockSelection.selected,
 	],
 );
 
@@ -568,6 +578,7 @@ export const getMultiSelectedBlocks = createSelector(
 		state.editor.present.blockOrder,
 		state.blockSelection.start,
 		state.blockSelection.end,
+		state.blockSelection.selected,
 		state.editor.present.blocksByUid,
 		state.editor.present.edits.meta,
 		state.currentPost.meta,

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -675,10 +675,11 @@ export function isBlockMultiSelected( state, uid ) {
  * @return {?String}       Unique ID of block beginning multi-selection
  */
 export function getMultiSelectedBlocksStartUid( state ) {
-	const { start, end, current } = state.blockSelection;
-	if ( start === end ) {
+	const { start, current } = state.blockSelection;
+	if ( ! start ) {
 		return current;
 	}
+
 	return start || null;
 }
 
@@ -694,10 +695,10 @@ export function getMultiSelectedBlocksStartUid( state ) {
  */
 export function getMultiSelectedBlocksEndUid( state ) {
 	const { start, end, current } = state.blockSelection;
-	if ( start === end ) {
-		return current;
+	if ( ! end ) {
+		return start || current;
 	}
-	return end || null;
+	return end;
 }
 
 /**

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -594,9 +594,7 @@ export const getMultiSelectedBlockUids = createSelector(
 		const { start, end, selected } = state.blockSelection;
 
 		const ranged = start && start === end ? [ start ] : getBlocksInRange( blockOrder, start, end );
-		const all = sortBy( selected.concat( ranged ), sortByOrder( blockOrder ) );
-		console.log( 'all', all, 'blockOrder', blockOrder );
-		return all;
+		return sortBy( selected.concat( ranged ), sortByOrder( blockOrder ) );
 	},
 	( state ) => [
 		state.editor.present.blockOrder,
@@ -623,6 +621,13 @@ export const getMultiSelectedBlocks = createSelector(
 		state.editor.present.blocksByUid,
 		state.editor.present.edits.meta,
 		state.currentPost.meta,
+	]
+);
+
+export const isNavigating = createSelector(
+	( state ) => state.blockSelection.isNavigating,
+	( state ) => [
+		state.blockSelection.isNavigating,
 	]
 );
 

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -1,4 +1,32 @@
-export function resetSelection( current, uid ) {
+import { sortBy, includes, last, difference } from 'lodash';
+
+function getRange( start, end, ordering ) {
+	if ( start && ! end ) {
+		return [ start ];
+	} else if ( ! start && ! end ) {
+		return [ ];
+	}
+
+	const startIndex = ordering.indexOf( start );
+	const endIndex = ordering.indexOf( end );
+
+	if ( startIndex > endIndex ) {
+		return ordering.slice( endIndex, startIndex + 1 );
+	}
+
+	return ordering.slice( startIndex, endIndex + 1 );
+}
+
+function sortByOrder( ordering ) {
+	return ( a ) => ordering.indexOf( a );
+}
+
+function getSelected( current, ordering ) {
+	const ranged = getRange( current.start, current.end, ordering );
+	return sortBy( current.selected.concat( ranged ), sortByOrder( ordering ) );
+}
+
+export function reset( current, uid ) {
 	return {
 		selected: [ ],
 		start: uid,
@@ -6,5 +34,31 @@ export function resetSelection( current, uid ) {
 	};
 }
 
+export function toggle( current, uid, ordering ) {
+	const everything = getSelected( current, ordering );
 
+	if ( ! includes( everything, uid ) ) {
+		// This is not in our selection, so let's make it our new anchor
+		return { selected: everything, start: uid, end: null };
+	}
+
+	const withoutUid = difference( everything, [ uid ] );
+	console.log( 'withoutUid', withoutUid );
+
+	if ( current.start === uid ) {
+		const nextStart = last( withoutUid );
+		if ( nextStart ) {
+			return { selected: withoutUid.slice( 0, withoutUid.length - 1 ), start: nextStart, end: null };
+		}
+
+		// I don't know what should happen here
+		return { selected: [ ], start: uid, end: null };
+	}
+
+	return { selected: difference( withoutUid, [ current.start ] ), start: current.start, end: null };
+}
+
+export function includeRange( current, start, end, ordering ) {
+	return current;
+}
 

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -57,7 +57,11 @@ export function toggle( current, uid, ordering ) {
 	return { selected: difference( withoutUid, [ current.start ] ), start: current.start, end: null };
 }
 
-export function includeRange( current, start, end, ordering ) {
-	return current;
+export function incorporate( current, start, end, ordering ) {
+	// get the range based on the range here.
+	const everything = getSelected( current, ordering );
+	const inRange = getRange( start, end, ordering );
+	const withoutRange = difference( everything, inRange );
+	return { selected: withoutRange, start: start, end: end };
 }
 

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -43,7 +43,6 @@ export function toggle( current, uid, ordering ) {
 	}
 
 	const withoutUid = difference( everything, [ uid ] );
-	console.log( 'withoutUid', withoutUid );
 
 	if ( current.start === uid ) {
 		const nextStart = last( withoutUid );

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -43,7 +43,6 @@ export function resetRange( current, start, end ) {
 }
 
 export function toggle( current, uid, ordering ) {
-	console.log("TOGGLING");
 	const everything = getSelected( current, ordering );
 
 	if ( ! includes( everything, uid ) ) {
@@ -54,16 +53,13 @@ export function toggle( current, uid, ordering ) {
 	const withoutUid = difference( everything, [ uid ] );
 
 	if ( current.start === uid ) {
-		console.log( "STARTING");
 		const nextStart = last( withoutUid );
 		if ( nextStart ) {
-			console.log("NEXTING");
 			return { selected: withoutUid.slice( 0, withoutUid.length - 1 ), start: nextStart, end: nextStart };
 		}
-		console.log("OTHERING");
 
 		// I don't know what should happen here
-		return { selected: [ ], start: uid, end: null };
+		return { selected: [ ], start: uid, end: uid };
 	}
 
 	return { selected: difference( withoutUid, [ current.start ] ), start: current.start, end: current.start };

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -43,11 +43,12 @@ export function resetRange( current, start, end ) {
 }
 
 export function toggle( current, uid, ordering ) {
+	console.log('args', arguments);
 	const everything = getSelected( current, ordering );
 
 	if ( ! includes( everything, uid ) ) {
 		// This is not in our selection, so let's make it our new anchor
-		return { selected: everything, start: uid, end: null };
+		return { selected: everything, start: uid, end: uid };
 	}
 
 	const withoutUid = difference( everything, [ uid ] );
@@ -55,14 +56,14 @@ export function toggle( current, uid, ordering ) {
 	if ( current.start === uid ) {
 		const nextStart = last( withoutUid );
 		if ( nextStart ) {
-			return { selected: withoutUid.slice( 0, withoutUid.length - 1 ), start: nextStart, end: null };
+			return { selected: withoutUid.slice( 0, withoutUid.length - 1 ), start: nextStart, end: nextStart };
 		}
 
 		// I don't know what should happen here
-		return { selected: [ ], start: uid, end: null };
+		return { selected: [ ], start: uid, end: uid };
 	}
 
-	return { selected: difference( withoutUid, [ current.start ] ), start: current.start, end: null };
+	return { selected: difference( withoutUid, [ current.start ] ), start: current.start, end: current.start };
 }
 
 export function includeRange( current, start, end, ordering ) {

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -34,6 +34,14 @@ export function reset( current, uid ) {
 	};
 }
 
+export function resetRange( current, start, end ) {
+	return {
+		selected: [ ],
+		start: start,
+		end: end,
+	};
+}
+
 export function toggle( current, uid, ordering ) {
 	const everything = getSelected( current, ordering );
 
@@ -57,7 +65,7 @@ export function toggle( current, uid, ordering ) {
 	return { selected: difference( withoutUid, [ current.start ] ), start: current.start, end: null };
 }
 
-export function incorporate( current, start, end, ordering ) {
+export function includeRange( current, start, end, ordering ) {
 	// get the range based on the range here.
 	const everything = getSelected( current, ordering );
 	const inRange = getRange( start, end, ordering );

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -43,6 +43,7 @@ export function resetRange( current, start, end ) {
 }
 
 export function toggle( current, uid, ordering ) {
+	console.log("TOGGLING");
 	const everything = getSelected( current, ordering );
 
 	if ( ! includes( everything, uid ) ) {
@@ -53,13 +54,16 @@ export function toggle( current, uid, ordering ) {
 	const withoutUid = difference( everything, [ uid ] );
 
 	if ( current.start === uid ) {
+		console.log( "STARTING");
 		const nextStart = last( withoutUid );
 		if ( nextStart ) {
+			console.log("NEXTING");
 			return { selected: withoutUid.slice( 0, withoutUid.length - 1 ), start: nextStart, end: nextStart };
 		}
+		console.log("OTHERING");
 
 		// I don't know what should happen here
-		return { selected: [ ], start: uid, end: uid };
+		return { selected: [ ], start: uid, end: null };
 	}
 
 	return { selected: difference( withoutUid, [ current.start ] ), start: current.start, end: current.start };

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -71,3 +71,12 @@ export function includeRange( current, start, end, ordering ) {
 	return { selected: withoutRange, start: start, end: end };
 }
 
+export function combineRange( current, start, end, ordering ) {
+	const everything = getSelected( current, ordering );
+
+	const inRange = getRange( start, end, ordering );
+
+	const withoutRange = difference( everything, inRange );
+	return { selected: withoutRange, start: start, end: end };
+}
+

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -43,7 +43,6 @@ export function resetRange( current, start, end ) {
 }
 
 export function toggle( current, uid, ordering ) {
-	console.log('args', arguments);
 	const everything = getSelected( current, ordering );
 
 	if ( ! includes( everything, uid ) ) {

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -1,4 +1,4 @@
-import { sortBy, includes, last, difference } from 'lodash';
+import { sortBy, includes, last, difference, isEqual } from 'lodash';
 
 function getRange( start, end, ordering ) {
 	if ( start && ! end ) {
@@ -66,10 +66,8 @@ export function toggle( current, uid, ordering ) {
 }
 
 export function includeRange( current, start, end, ordering ) {
-	// get the range based on the range here.
-	const everything = getSelected( current, ordering );
 	const inRange = getRange( start, end, ordering );
-	const withoutRange = difference( everything, inRange );
+	const withoutRange = difference( current.selected, inRange );
 	return { selected: withoutRange, start: start, end: end };
 }
 

--- a/editor/utils/block-selection.js
+++ b/editor/utils/block-selection.js
@@ -1,0 +1,10 @@
+export function resetSelection( current, uid ) {
+	return {
+		selected: [ ],
+		start: uid,
+		end: null,
+	};
+}
+
+
+

--- a/editor/utils/test/block-selection.js
+++ b/editor/utils/test/block-selection.js
@@ -121,13 +121,13 @@ describe( 'block-selection', () => {
 		it( 'Add a ranged selection that does not overlap with the current selection', () => {
 			const current = { selected: [ ], start: 'alpha', end: 'gamma' };
 			const actual = includeRange( current, 'delta', 'rho', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma' ], start: 'delta', end: 'rho' } );
+			expect( actual ).toEqual( { selected: [ ], start: 'delta', end: 'rho' } );
 		} );
 
 		it( 'Add a ranged selection that overlaps with some of the selected', () => {
 			const current = { selected: [ 'epsilon' ], start: 'alpha', end: 'gamma' };
 			const actual = includeRange( current, 'delta', 'rho', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma' ], start: 'delta', end: 'rho' } );
+			expect( actual ).toEqual( { selected: [ ], start: 'delta', end: 'rho' } );
 		} );
 
 		it( 'Add a ranged selection that overlaps with all of the range', () => {
@@ -139,13 +139,19 @@ describe( 'block-selection', () => {
 		it( 'Add a ranged selection that overlaps with some of the range', () => {
 			const current = { selected: [ 'epsilon' ], start: 'alpha', end: 'gamma' };
 			const actual = includeRange( current, 'beta', 'delta', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha', 'epsilon' ], start: 'beta', end: 'delta' } );
+			expect( actual ).toEqual( { selected: [ 'epsilon' ], start: 'beta', end: 'delta' } );
 		} );
 
 		it( 'Add a ranged selection that overlaps with all of the range (plus more)', () => {
 			const current = { selected: [ ], start: 'alpha', end: 'gamma' };
 			const actual = includeRange( current, 'alpha', 'delta', ordering );
 			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'delta' } );
+		} );
+
+		it( 'Add a decreased range should deselect the previous range', () => {
+			const current = { selected: [ ], start: 'alpha', end: 'delta' };
+			const actual = includeRange( current, 'alpha', 'gamma', ordering );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'gamma' } );
 		} );
 	} );
 } );

--- a/editor/utils/test/block-selection.js
+++ b/editor/utils/test/block-selection.js
@@ -65,14 +65,14 @@ describe( 'block-selection', () => {
 			expect( actual ).toEqual( { selected: [ 'alpha' ], start: 'beta', end: 'beta' } );
 		} );
 
-		it( 'Exclude a selection when only a start value (cannot do)', () => {
+		it( 'Toggle a selection when only a start value  (should select it)', () => {
 			const current = {
 				selected: [ ],
 				start: 'alpha',
 				end: null,
 			};
 			const actual = toggle( current, 'alpha', ordering );
-			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'alpha' } );
 		} );
 
 		it( 'Add to selection when no start value, but a selected array', () => {

--- a/editor/utils/test/block-selection.js
+++ b/editor/utils/test/block-selection.js
@@ -76,5 +76,17 @@ describe( 'block-selection', () => {
 			const actual = toggle( current, 'gamma', ordering );
 			expect( actual ).toEqual( { selected: [ 'alpha', 'delta' ], start: 'beta', end: null } );
 		} );
+
+		it( 'Toggle off selection something that is in selected', () => {
+			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
+			const actual = toggle( current, 'alpha', ordering );
+			expect( actual ).toEqual( { selected: [ 'gamma', 'delta' ], start: 'beta', end: null } );
+		} );
+
+		it( 'Toggle off selection something that is the start', () => {
+			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
+			const actual = toggle( current, 'beta', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'gamma' ], start: 'delta', end: null } );
+		} );
 	} );
 } );

--- a/editor/utils/test/block-selection.js
+++ b/editor/utils/test/block-selection.js
@@ -1,0 +1,25 @@
+import { resetSelection } from '../block-selection';
+
+describe( 'block-selection', () => {
+	describe( 'reset', () => {
+		it( 'resetSelection sets alpha', () => {
+			const actual = resetSelection( { selected: [ ], start: null, end: null }, 'alpha' );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+		} );
+
+		it( 'resetSelection changes beta to alpha', () => {
+			const actual = resetSelection( { selected: [ ], start: 'beta', end: null }, 'alpha' );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+		} );
+
+		it( 'resetSelection changes beta to alpha and clears end', () => {
+			const actual = resetSelection( { selected: [ ], start: 'beta', end: 'gamma' }, 'alpha' );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+		} );
+
+		it( 'resetSelection changes beta to alpha and clears selected, end', () => {
+			const actual = resetSelection( { selected: [ 'delta' ], start: 'beta', end: 'gamma' }, 'alpha' );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+		} );
+	} );
+} );

--- a/editor/utils/test/block-selection.js
+++ b/editor/utils/test/block-selection.js
@@ -1,8 +1,8 @@
-import { reset, toggle, incorporate } from '../block-selection';
+import { reset, toggle, includeRange, resetRange } from '../block-selection';
 
 const nothing = { selected: [ ], start: null, end: null };
 
-const ordering = [ 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'rho' ];
+const ordering = [ 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'rho', 'gnu' ];
 
 describe( 'block-selection', () => {
 	describe( 'reset', () => {
@@ -24,6 +24,28 @@ describe( 'block-selection', () => {
 		it( '([ delta ], Beta -> Gamma) >>> alpha', () => {
 			const actual = reset( { selected: [ 'delta' ], start: 'beta', end: 'gamma' }, 'alpha' );
 			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+		} );
+	} );
+
+	describe( 'resetRange', () => {
+		it( 'Nothing >>> (alpha -> gamma)', () => {
+			const actual = resetRange( nothing, 'alpha', 'gamma' );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'gamma' } );
+		} );
+
+		it( '(Beta -> ..) >>> (alpha -> gamma)', () => {
+			const actual = resetRange( { selected: [ ], start: 'beta', end: null }, 'alpha', 'gamma' );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'gamma' } );
+		} );
+
+		it( '(Beta -> Gamma) >>> alpha', () => {
+			const actual = resetRange( { selected: [ ], start: 'beta', end: 'gamma' }, 'alpha', 'gamma' );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'gamma' } );
+		} );
+
+		it( '([ delta ], Beta -> Gamma) >>> alpha', () => {
+			const actual = resetRange( { selected: [ 'delta' ], start: 'beta', end: 'gamma' }, 'alpha', 'gamma' );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'gamma' } );
 		} );
 	} );
 
@@ -90,10 +112,40 @@ describe( 'block-selection', () => {
 		} );
 	} );
 
-	describe( 'incorporate', () => {
+	describe( 'includeRange', () => {
 		it( 'Nothing >>> (alpha, alpha)', () => {
-			const actual = incorporate( nothing, 'alpha', 'alpha', ordering );
+			const actual = includeRange( nothing, 'alpha', 'alpha', ordering );
 			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'alpha' } );
+		} );
+
+		it( 'Add a ranged selection that does not overlap with the current selection', () => {
+			const current = { selected: [ ], start: 'alpha', end: 'gamma' };
+			const actual = includeRange( current, 'delta', 'rho', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma' ], start: 'delta', end: 'rho' } );
+		} );
+
+		it( 'Add a ranged selection that overlaps with some of the selected', () => {
+			const current = { selected: [ 'epsilon' ], start: 'alpha', end: 'gamma' };
+			const actual = includeRange( current, 'delta', 'rho', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma' ], start: 'delta', end: 'rho' } );
+		} );
+
+		it( 'Add a ranged selection that overlaps with all of the range', () => {
+			const current = { selected: [ 'epsilon' ], start: 'alpha', end: 'gamma' };
+			const actual = includeRange( current, 'alpha', 'gamma', ordering );
+			expect( actual ).toEqual( { selected: [ 'epsilon' ], start: 'alpha', end: 'gamma' } );
+		} );
+
+		it( 'Add a ranged selection that overlaps with some of the range', () => {
+			const current = { selected: [ 'epsilon' ], start: 'alpha', end: 'gamma' };
+			const actual = includeRange( current, 'beta', 'delta', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'epsilon' ], start: 'beta', end: 'delta' } );
+		} );
+
+		it( 'Add a ranged selection that overlaps with all of the range (plus more)', () => {
+			const current = { selected: [ ], start: 'alpha', end: 'gamma' };
+			const actual = includeRange( current, 'alpha', 'delta', ordering );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'delta' } );
 		} );
 	} );
 } );

--- a/editor/utils/test/block-selection.js
+++ b/editor/utils/test/block-selection.js
@@ -1,25 +1,80 @@
-import { resetSelection } from '../block-selection';
+import { reset, toggle } from '../block-selection';
+
+const nothing = { selected: [ ], start: null, end: null };
+
+const ordering = [ 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'rho' ];
 
 describe( 'block-selection', () => {
 	describe( 'reset', () => {
-		it( 'resetSelection sets alpha', () => {
-			const actual = resetSelection( { selected: [ ], start: null, end: null }, 'alpha' );
+		it( 'Nothing >>> alpha', () => {
+			const actual = reset( nothing, 'alpha' );
 			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
 		} );
 
-		it( 'resetSelection changes beta to alpha', () => {
-			const actual = resetSelection( { selected: [ ], start: 'beta', end: null }, 'alpha' );
+		it( '(Beta -> ..) >>> alpha', () => {
+			const actual = reset( { selected: [ ], start: 'beta', end: null }, 'alpha' );
 			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
 		} );
 
-		it( 'resetSelection changes beta to alpha and clears end', () => {
-			const actual = resetSelection( { selected: [ ], start: 'beta', end: 'gamma' }, 'alpha' );
+		it( '(Beta -> Gamma) >>> alpha', () => {
+			const actual = reset( { selected: [ ], start: 'beta', end: 'gamma' }, 'alpha' );
 			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
 		} );
 
-		it( 'resetSelection changes beta to alpha and clears selected, end', () => {
-			const actual = resetSelection( { selected: [ 'delta' ], start: 'beta', end: 'gamma' }, 'alpha' );
+		it( '([ delta ], Beta -> Gamma) >>> alpha', () => {
+			const actual = reset( { selected: [ 'delta' ], start: 'beta', end: 'gamma' }, 'alpha' );
 			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+		} );
+	} );
+
+	describe( 'toggle', () => {
+		it( 'Nothing >>> alpha', () => {
+			const actual = toggle( nothing, 'alpha', ordering );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+		} );
+
+		it( 'Include a selection when only a start value', () => {
+			const current = {
+				selected: [ ],
+				start: 'alpha',
+				end: null,
+			};
+			const actual = toggle( current, 'beta', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha' ], start: 'beta', end: null } );
+		} );
+
+		it( 'Exclude a selection when only a start value (cannot do)', () => {
+			const current = {
+				selected: [ ],
+				start: 'alpha',
+				end: null,
+			};
+			const actual = toggle( current, 'alpha', ordering );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+		} );
+
+		it( 'Add to selection when no start value, but a selected array', () => {
+			const current = { selected: [ 'alpha' ], start: null, end: null };
+			const actual = toggle( current, 'beta', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha' ], start: 'beta', end: null } );
+		} );
+
+		it( 'Add to selection when no selected, but a start->end range', () => {
+			const current = { selected: [ ], start: 'alpha', end: 'gamma' };
+			const actual = toggle( current, 'epsilon', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma' ], start: 'epsilon', end: null } );
+		} );
+
+		it( 'Add to selection selected AND a start->end range', () => {
+			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
+			const actual = toggle( current, 'epsilon', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma', 'delta' ], start: 'epsilon', end: null } );
+		} );
+
+		it( 'Toggle off selection something that is already within the range', () => {
+			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
+			const actual = toggle( current, 'gamma', ordering );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'delta' ], start: 'beta', end: null } );
 		} );
 	} );
 } );

--- a/editor/utils/test/block-selection.js
+++ b/editor/utils/test/block-selection.js
@@ -1,4 +1,4 @@
-import { reset, toggle } from '../block-selection';
+import { reset, toggle, incorporate } from '../block-selection';
 
 const nothing = { selected: [ ], start: null, end: null };
 
@@ -87,6 +87,13 @@ describe( 'block-selection', () => {
 			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
 			const actual = toggle( current, 'beta', ordering );
 			expect( actual ).toEqual( { selected: [ 'alpha', 'gamma' ], start: 'delta', end: null } );
+		} );
+	} );
+
+	describe( 'incorporate', () => {
+		it( 'Nothing >>> (alpha, alpha)', () => {
+			const actual = incorporate( nothing, 'alpha', 'alpha', ordering );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'alpha' } );
 		} );
 	} );
 } );

--- a/editor/utils/test/block-selection.js
+++ b/editor/utils/test/block-selection.js
@@ -52,7 +52,7 @@ describe( 'block-selection', () => {
 	describe( 'toggle', () => {
 		it( 'Nothing >>> alpha', () => {
 			const actual = toggle( nothing, 'alpha', ordering );
-			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: null } );
+			expect( actual ).toEqual( { selected: [ ], start: 'alpha', end: 'alpha' } );
 		} );
 
 		it( 'Include a selection when only a start value', () => {
@@ -62,7 +62,7 @@ describe( 'block-selection', () => {
 				end: null,
 			};
 			const actual = toggle( current, 'beta', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha' ], start: 'beta', end: null } );
+			expect( actual ).toEqual( { selected: [ 'alpha' ], start: 'beta', end: 'beta' } );
 		} );
 
 		it( 'Exclude a selection when only a start value (cannot do)', () => {
@@ -78,37 +78,37 @@ describe( 'block-selection', () => {
 		it( 'Add to selection when no start value, but a selected array', () => {
 			const current = { selected: [ 'alpha' ], start: null, end: null };
 			const actual = toggle( current, 'beta', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha' ], start: 'beta', end: null } );
+			expect( actual ).toEqual( { selected: [ 'alpha' ], start: 'beta', end: 'beta' } );
 		} );
 
 		it( 'Add to selection when no selected, but a start->end range', () => {
 			const current = { selected: [ ], start: 'alpha', end: 'gamma' };
 			const actual = toggle( current, 'epsilon', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma' ], start: 'epsilon', end: null } );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma' ], start: 'epsilon', end: 'epsilon' } );
 		} );
 
 		it( 'Add to selection selected AND a start->end range', () => {
 			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
 			const actual = toggle( current, 'epsilon', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma', 'delta' ], start: 'epsilon', end: null } );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'beta', 'gamma', 'delta' ], start: 'epsilon', end: 'epsilon' } );
 		} );
 
 		it( 'Toggle off selection something that is already within the range', () => {
 			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
 			const actual = toggle( current, 'gamma', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha', 'delta' ], start: 'beta', end: null } );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'delta' ], start: 'beta', end: 'beta' } );
 		} );
 
 		it( 'Toggle off selection something that is in selected', () => {
 			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
 			const actual = toggle( current, 'alpha', ordering );
-			expect( actual ).toEqual( { selected: [ 'gamma', 'delta' ], start: 'beta', end: null } );
+			expect( actual ).toEqual( { selected: [ 'gamma', 'delta' ], start: 'beta', end: 'beta' } );
 		} );
 
 		it( 'Toggle off selection something that is the start', () => {
 			const current = { selected: [ 'alpha' ], start: 'beta', end: 'delta' };
 			const actual = toggle( current, 'beta', ordering );
-			expect( actual ).toEqual( { selected: [ 'alpha', 'gamma' ], start: 'delta', end: null } );
+			expect( actual ).toEqual( { selected: [ 'alpha', 'gamma' ], start: 'delta', end: 'delta' } );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This is an experiment to explore how to support non-contiguous selected blocks.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
It's a rough, hacky POC ... so it hasn't :)

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Ctrl+Click will toggle the selection of a block (and set a new last active block)
Shift+Click will select from the last active block to the current block
Click will focus a block

Arrow keys will move the focus to a block
Shift arrow keys will grow a selection
There is no current way to select a block with the keyboard (except for the existing growing selection with shift arrow keys. We are anticipating selecting a block with the space bar when in navigation mode)

Note, this will also differentiate between a multi-select with one block, and focus in the block. When you have a multi-select with one block, pressing any arrow key will just focus that block normally (as long as you aren't holding shift). This means that we are no longer losing focus when collapsing the selection back to one block.

Issues identified:

* block transformations will often need to be disallowed (or changed) when the selection is not contiguous. For example, converting separate paragraphs into a list should make them all separate lists where they are, rather than do what it does at the moment which is jam non-contiguous blocks in the same block.
* the selection code is still quite hacky and the redux state is potentially overly complex

The main purpose of this PR is to get this tested (not code reviewed yet) and see if we like the behaviour. The code will all (probably) change once we're sure of what we want.

@jasmussen @afercia , do you like how this feels? It is mostly modelled on how Safari's Finder works.
