### PR TITLE
Improve text columns focus style.

### DIFF
--- a/blocks/library/text-columns/editor.scss
+++ b/blocks/library/text-columns/editor.scss
@@ -1,5 +1,5 @@
 .wp-block-text-columns {
 	.blocks-editable__tinymce:focus {
-		@include button-style__focus-active;
+		outline: 1px solid $light-gray-500;
 	}
 }


### PR DESCRIPTION
In the previous focus style commit, the focus style for these columns was a bit heavy handed.

This PR changes the focus style to mimic that of a selected text block. In the not too distant future, this block itself will likely be revisited with the recent nesting feature in mind, so this improves it until that time.
