### PR TITLE
Testing: Add first test using snapshots testing

### DIFF
--- a/components/notice/test/__snapshots__/index.js.snap
+++ b/components/notice/test/__snapshots__/index.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Notice should match snapshot 1`] = `
+<div
+  className="notice notice-alt notice-example is-dismissible"
+>
+  <button
+    className="notice-dismiss"
+    onClick={[Function]}
+    type="button"
+  >
+    <span
+      className="screen-reader-text"
+    >
+      Dismiss this notice
+    </span>
+  </button>
+</div>
+`;

--- a/components/notice/test/index.js
+++ b/components/notice/test/index.js
@@ -9,13 +9,12 @@ import { shallow } from 'enzyme';
 import Notice from '../index';
 
 describe( 'Notice', () => {
-	it( 'should have valid class names', () => {
+	it( 'should match snapshot', () => {
 		const wrapper = shallow( <Notice status="example" /> );
-		expect( wrapper.hasClass( 'notice' ) ).toBe( true );
-		expect( wrapper.hasClass( 'notice-alt' ) ).toBe( true );
-		expect( wrapper.hasClass( 'notice-example' ) ).toBe( true );
-		expect( wrapper.hasClass( 'is-dismissible' ) ).toBe( true );
+
+		expect( wrapper ).toMatchSnapshot();
 	} );
+
 	it( 'should not have is-dismissible class when isDismissible prop is false', () => {
 		const wrapper = shallow( <Notice isDismissible={ false } /> );
 		expect( wrapper.hasClass( 'is-dismissible' ) ).toBe( false );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2821,9 +2821,9 @@
       }
     },
     "enzyme-to-json": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.1.4.tgz",
-      "integrity": "sha512-bGXQxsbVdRqn3ebWej90ADH+RmlKXwy4SgMWc1gG4oDKlVHEsu2eP6hMA4zFGMlQqTxgyd1XPcsryo6Ti4YG+Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.2.2.tgz",
+      "integrity": "sha512-Paym79t9PFsTxvazN5+k9aZfoZO+lul/qDLspL1UlNwhbg+RUczVuuP4SO/RZ/sFRxal3dPCl+5VmqtCE1bxBw==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -5893,7 +5893,7 @@
       "dev": true,
       "requires": {
         "enzyme-matchers": "4.0.1",
-        "enzyme-to-json": "3.1.4"
+        "enzyme-to-json": "3.2.2"
       }
     },
     "jest-get-type": {


### PR DESCRIPTION
## Description

This PR refactors one of the existing component tests to use snapshot testing to simplify the code. It also exposes the internal structure of the component in the snapshot file making it easier to reason when building additional tests. 

This PR also introduces performance optimization borrowed from Calypso project. My previous explorations have proved that by lazy-loading `enzyme` it is possible to speed up tests execution time by 30-40% on the large codebase. I didn't notice any big improvement for the number of tests we maintain at the moment, but I thought it might have it in place in case we need it someday.

## How Has This Been Tested?

Executed `npm run test-unit` and confirmed by Travis build.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.