### PR TITLE
Add alt text enhancements

### DIFF
--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -9,12 +9,12 @@ import { withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function TextControl( { label, value, help, instanceId, onChange, type = 'text', ...props } ) {
+function TextControl( { label, value, help, helpText, instanceId, onChange, type = 'text', ...props } ) {
 	const id = 'inspector-text-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ label } id={ id } help={ help }>
+		<BaseControl label={ label } id={ id } help={ help } helpText={ helpText }>
 			<input className="blocks-text-control__input"
 				type={ type }
 				id={ id }
@@ -23,6 +23,9 @@ function TextControl( { label, value, help, instanceId, onChange, type = 'text',
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props }
 			/>
+			{ helpText ? (
+				<p><em>{ helpText }</em></p>
+			) : '' }
 		</BaseControl>
 	);
 }

--- a/blocks/inspector-controls/text-control/index.js
+++ b/blocks/inspector-controls/text-control/index.js
@@ -9,12 +9,12 @@ import { withInstanceId } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function TextControl( { label, value, help, helpText, instanceId, onChange, type = 'text', ...props } ) {
+function TextControl( { label, value, help, instanceId, onChange, type = 'text', ...props } ) {
 	const id = 'inspector-text-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ label } id={ id } help={ help } helpText={ helpText }>
+		<BaseControl label={ label } id={ id } help={ help }>
 			<input className="blocks-text-control__input"
 				type={ type }
 				id={ id }
@@ -23,9 +23,6 @@ function TextControl( { label, value, help, helpText, instanceId, onChange, type
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props }
 			/>
-			{ helpText ? (
-				<p><em>{ helpText }</em></p>
-			) : '' }
 		</BaseControl>
 	);
 }

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -189,7 +189,8 @@ class ImageBlock extends Component {
 						<p>{ __( 'Worth a thousand words.' ) }</p>
 					</BlockDescription>
 					<h3>{ __( 'Image Settings' ) }</h3>
-					<TextControl label={ __( 'Alternate Text' ) } value={ alt } onChange={ this.updateAlt } />
+					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } />
+					<p><em>{ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) }</em></p>
 					{ ! isEmpty( availableSizes ) && (
 						<SelectControl
 							label={ __( 'Size' ) }

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -189,8 +189,7 @@ class ImageBlock extends Component {
 						<p>{ __( 'Worth a thousand words.' ) }</p>
 					</BlockDescription>
 					<h3>{ __( 'Image Settings' ) }</h3>
-					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } />
-					<p><em>{ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) }</em></p>
+					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } helpText={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) } />
 					{ ! isEmpty( availableSizes ) && (
 						<SelectControl
 							label={ __( 'Size' ) }

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -189,7 +189,7 @@ class ImageBlock extends Component {
 						<p>{ __( 'Worth a thousand words.' ) }</p>
 					</BlockDescription>
 					<h3>{ __( 'Image Settings' ) }</h3>
-					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } helpText={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) } />
+					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) } />
 					{ ! isEmpty( availableSizes ) && (
 						<SelectControl
 							label={ __( 'Size' ) }


### PR DESCRIPTION
## Description

Fixes #1509.

This adds help text to the Alt attribute text control in the inspector for images. In doing so it also adds `helpText` as an option to the `TextControl` component. When filled out, an italicized verbose description will be output below the textfield. 

## How Has This Been Tested?

Tested in Chrome, Mac.

## Screenshot

![screen shot 2017-11-21 at 13 30 35](https://user-images.githubusercontent.com/1204802/33072612-8609aa48-cec0-11e7-850f-a2aca2a9949d.png)

## To test

- Insert an image
- Open the block inspector sidebar
- Verify that help text is present

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.