### PR TITLE
Fix an issue where the editor specific styles are not applied when the metaboxes are loaded.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -73,12 +73,6 @@ function gutenberg_get_script_polyfill( $tests ) {
  * @since 0.1.0
  */
 function gutenberg_register_scripts_and_styles() {
-	// We need to return early when this GET variable is set. This happens when the editor loads the metaboxes and for
-	// this case we don't need to register scripts and styles.
-	if ( isset( $_GET['classic-editor'] ) ) {
-		return false;
-	}
-
 	gutenberg_register_vendor_scripts();
 
 	// Editor Scripts.
@@ -537,6 +531,13 @@ function gutenberg_get_post_to_edit( $post_id ) {
  * @since 0.4.0
  */
 function gutenberg_common_scripts_and_styles() {
+	// We need to return early when this GET variable is set. This happens when
+	// the editor loads the metaboxes and for this case we don't need to enqueue
+	// scripts and styles.
+	if ( isset( $_GET['classic-editor'] ) ) {
+		return false;
+	}
+
 	// Enqueue basic styles built out of Gutenberg through `npm build`.
 	wp_enqueue_style( 'wp-blocks' );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -73,6 +73,12 @@ function gutenberg_get_script_polyfill( $tests ) {
  * @since 0.1.0
  */
 function gutenberg_register_scripts_and_styles() {
+	// We need to return early when this GET variable is set. This happens when the editor loads the metaboxes and for
+	// this case we don't need to register scripts and styles.
+	if ( isset( $_GET['classic-editor'] ) ) {
+		return false;
+	}
+
 	gutenberg_register_vendor_scripts();
 
 	// Editor Scripts.


### PR DESCRIPTION
## Description
When loading the metaboxes the GET variable `classic-editor` is set to true to the `_wpMetaBoxUrl`. So when `admin_enqueue_scripts` is called then and Gutenberg initializes, the initialization ends soon as this GET variable is set. At that time while `gutenberg_register_scripts_and_styles` is executed, `gutenberg_editor_scripts_and_styles` is not, so this is why the editor specific styles are not applied.

## How Has This Been Tested?
Visual testing.

## Types of changes
Fixes a bug.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.