### PR TITLE
Framework: Upgrade re-resizable dependency to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8375,9 +8375,9 @@
       "dev": true
     },
     "re-resizable": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.0.2.tgz",
-      "integrity": "sha512-J1nZlVQr9EXZuXDKqEifdIwtF6HtiJC7X623c8JeCf11CqyqmzYLXeS48+ubmtW09rP+l/U4DN1ERqXbd6O/fw=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.0.3.tgz",
+      "integrity": "sha512-6YpsC4JFT7zVG8/8gIXxdnrlHdz64/H7dpjHgXNCy5kwy2DIG1dVbdgASNUTwy4AaHgI8rvjJJzr2BxZAVu/3Q=="
     },
     "react": {
       "version": "16.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "moment-timezone": "0.5.13",
     "mousetrap": "1.6.1",
     "prop-types": "15.5.10",
-    "re-resizable": "4.0.2",
+    "re-resizable": "4.0.3",
     "react": "16.0.0",
     "react-autosize-textarea": "0.4.8",
     "react-click-outside": "2.3.1",


### PR DESCRIPTION
Fixes #3585 
Related: https://github.com/bokuweb/re-resizable/pull/160

This pull request seeks to upgrade the `re-resizable` dependency from 4.0.2 to 4.0.3, resolving an error which occurs in IE11 when previewing an image block.

__Testing instructions:__

Repeat steps to reproduce from #3585, verifying in IE11 and your preferred browser that no errors occur in the display or editing of an image block.