### PR TITLE
Inserter: Target end-of-content styles to specific inserter

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -40,11 +40,8 @@
 }
 
 .editor-visual-editor .editor-inserter {
-	margin: $item-spacing;
-
 	.editor-inserter__toggle {
 		color: $dark-gray-300;
-		margin: 4px 0 0 -4px;	// align better with text blocks
 	}
 
 	.editor-inserter__toggle.components-icon-button:not(:disabled):hover {
@@ -76,9 +73,11 @@
 	margin: 0 auto;
 	clear: both;
 
-	padding: 0;
-	@include break-small() {
-		padding: 0 ( $block-mover-padding-visible );
+	padding: $block-padding;
+	padding-left: $block-padding - 8px; // Offset by left button's own padding
+	@include break-small {
+		padding: $block-padding ( $block-padding + $block-mover-padding-visible );
+		padding-left: $block-padding + $block-mover-padding-visible - 8px;
 	}
 
 	> .editor-inserter__block {


### PR DESCRIPTION
Regression introduced in #3546

This pull request seeks to resolve a styling issue with the between-inserter where it appears positioned lower than it should be. This was an unanticipated side effect of moving styles in #3546 where two styles of equal specificity were reordered. The proposed changes here eliminate one of these two styles, moving instead the intended styling to target the end-of-content inserter more specifically, instead of applying styles to all inserters within the visual editor.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/33085172-f0895e72-ceb1-11e7-9149-80bef92ffa3d.png)|![After](https://user-images.githubusercontent.com/1779930/33085148-d427b45e-ceb1-11e7-86e8-2255adb60f94.png)

__Testing instructions:__

Verify that the between-inserter is positioned vertically as expected (at the mid point on the top and bottom lines of a selected block).

Verify that the end-of-content inserter is positioned as expected (aligned horizontally to left of block content), in small and large viewports.