### PR TITLE
Components: Drop withContext optional mapSettingsToProps

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -282,7 +282,9 @@ class ImageBlock extends Component {
 }
 
 export default flowRight( [
-	withContext( 'editor' ),
+	withContext( 'editor' )( ( settings ) => {
+		return { settings };
+	} ),
 	withAPIData( ( props ) => {
 		const { id } = props.attributes;
 		if ( ! id ) {

--- a/components/higher-order/with-context/README.md
+++ b/components/higher-order/with-context/README.md
@@ -1,0 +1,25 @@
+# withContext
+
+`withContext` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) to opt in to receiving [React context](https://reactjs.org/docs/context.html) into a component as props.
+
+## Usage
+
+Wrap your original component with `withContext`, defining a key of context to receive and an optional mapping function.
+
+```jsx
+function OriginalComponent( { favoriteColor } ) {
+	return <div>Your favorite color is: { favoriteColor }</div>;
+}
+
+const EnhancedComponent = withContext( 'settings' )( ( settings ) => {
+	return {
+		favoriteColor: settings.favoriteColor
+	};
+} )( OriginalComponent );
+```
+
+The above example assumes that an ancestor component provides a `settings` context containing a key `favoriteColor`. When the enhanced component is rendered, the favorite color setting will be injected as a prop.
+
+If the mapping function is not provided, a prop with the context key will be passed, assigned the value of the context.
+
+Note that you [should not rely on context updates](https://reactjs.org/docs/context.html#updating-context), so use of `withContext` should be very limited to cases where values do not change over time.

--- a/components/higher-order/with-context/index.js
+++ b/components/higher-order/with-context/index.js
@@ -9,16 +9,11 @@ import { noop } from 'lodash';
 import { Component } from '@wordpress/element';
 
 const withContext = ( contextName ) => ( mapSettingsToProps ) => ( OriginalComponent ) => {
-	// Allow call without explicit `mapSettingsToProps`
-	if ( mapSettingsToProps instanceof Component ) {
-		return withContext( contextName )()( mapSettingsToProps );
-	}
-
 	class WrappedComponent extends Component {
 		render() {
 			const extraProps = mapSettingsToProps ?
 				mapSettingsToProps( this.context[ contextName ], this.props ) :
-				this.context[ contextName ];
+				{ [ contextName ]: this.context[ contextName ] };
 
 			return (
 				<OriginalComponent

--- a/components/higher-order/with-context/test/index.js
+++ b/components/higher-order/with-context/test/index.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import withContext from '../';
+
+describe( 'withContext', () => {
+	it( 'should return a new component which has context', () => {
+		const Component = withContext( 'value' )()( ( { value } ) => <div>{ value }</div> );
+		const wrapper = mount(
+			<Component />,
+			{ context: { value: 'ok' } }
+		);
+
+		expect( wrapper.text() ).toBe( 'ok' );
+	} );
+
+	it( 'should allow specifying a context getter mapping', () => {
+		const Component = withContext( 'settings' )(
+			( settings ) => ( { remap: settings.value } )
+		)(
+			( { ignore, remap } ) => <div>{ ignore }{ remap }</div>
+		);
+
+		const wrapper = mount(
+			<Component />,
+			{ context: { settings: { ignore: 'ignore', value: 'ok' } } }
+		);
+
+		expect( wrapper.text() ).toBe( 'ok' );
+	} );
+} );


### PR DESCRIPTION
Regression introduced in #3577 

This pull request seeks to resolve an error which occurs when inserting a new image block. Notably, it was planned to support omitting the `mapSettingsToProps` function altogether, but the logic to detect component by `instanceof Component` is flawed, since it does not account for function components. Support for this usage has been dropped in favor of consistently providing `mapSettingsToProps`, even if explicitly `undefined`.

To atone for my trespasses, I have included shiny new documentation and unit tests for the expected use of `withContext`.

__Testing instructions:__

Verify that you can insert and edit a block in the editor.

1. Navigate to Posts > New Post
2. Insert an image block
3. Note that no errors occur