### PR TITLE
Disable block selection when resizing image

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -113,7 +113,7 @@ class ImageBlock extends Component {
 	}
 
 	render() {
-		const { attributes, setAttributes, focus, setFocus, className, settings } = this.props;
+		const { attributes, setAttributes, focus, setFocus, className, settings, toggleSelection } = this.props;
 		const { url, alt, caption, align, id, href, width, height } = attributes;
 
 		const availableSizes = this.getAvailableSizes();
@@ -265,11 +265,15 @@ class ImageBlock extends Component {
 									bottomLeft: 'wp-block-image__resize-handler-bottom-left',
 								} }
 								enable={ { top: false, right: true, bottom: false, left: false, topRight: true, bottomRight: true, bottomLeft: true, topLeft: true } }
+								onResizeStart={ () => {
+									toggleSelection( false );
+								} }
 								onResizeStop={ ( event, direction, elt, delta ) => {
 									setAttributes( {
 										width: parseInt( currentWidth + delta.width, 10 ),
 										height: parseInt( currentHeight + delta.height, 10 ),
 									} );
+									toggleSelection( true );
 								} }
 							>
 								{ img }

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -137,6 +137,19 @@ export function clearSelectedBlock() {
 }
 
 /**
+ * Returns an action object that enables or disables block selection
+ *
+ * @param {boolean} [isSelectionEnabled=true] Whether block selection should be enabled
+ * @return {Object}                           Action object
+ */
+export function toggleSelection( isSelectionEnabled = true ) {
+	return {
+		type: 'TOGGLE_SELECTION',
+		isSelectionEnabled,
+	};
+}
+
+/**
  * Returns an action object signalling that a blocks should be replaced with
  * one or more replacement blocks.
  *

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -38,6 +38,7 @@ import {
 	startTyping,
 	stopTyping,
 	updateBlockAttributes,
+	toggleSelection,
 } from '../../actions';
 import {
 	getBlock,
@@ -51,6 +52,7 @@ import {
 	isBlockMultiSelected,
 	isBlockSelected,
 	isFirstMultiSelectedBlock,
+	isSelectionEnabled,
 	isTyping,
 	getBlockMode,
 } from '../../selectors';
@@ -414,6 +416,8 @@ class BlockListBlock extends Component {
 								mergeBlocks={ this.mergeBlocks }
 								className={ className }
 								id={ block.uid }
+								isSelectionEnabled={ this.props.isSelectionEnabled }
+								toggleSelection={ this.props.toggleSelection }
 							/>
 						) }
 						{ isValid && mode === 'html' && (
@@ -452,6 +456,7 @@ const mapStateToProps = ( state, { uid } ) => ( {
 	order: getBlockIndex( state, uid ),
 	meta: getEditedPostAttribute( state, 'meta' ),
 	mode: getBlockMode( state, uid ),
+	isSelectionEnabled: isSelectionEnabled( state ),
 } );
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
@@ -511,6 +516,9 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 
 	onMetaChange( meta ) {
 		dispatch( editPost( { meta } ) );
+	},
+	toggleSelection( selectionEnabled ) {
+		dispatch( toggleSelection( selectionEnabled ) );
 	},
 } );
 

--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -33,6 +33,7 @@ import {
 	getMultiSelectedBlocks,
 	getMultiSelectedBlockUids,
 	getSelectedBlock,
+	isSelectionEnabled,
 } from '../../selectors';
 import { startMultiSelect, stopMultiSelect, multiSelect, selectBlock } from '../../actions';
 
@@ -129,6 +130,10 @@ class BlockList extends Component {
 	}
 
 	onSelectionStart( uid ) {
+		if ( ! this.props.isSelectionEnabled ) {
+			return;
+		}
+
 		const boundaries = this.nodes[ uid ].getBoundingClientRect();
 
 		// Create a uid to Y coördinate map.
@@ -156,7 +161,7 @@ class BlockList extends Component {
 		const { selectionAtStart } = this;
 		const isAtStart = selectionAtStart === uid;
 
-		if ( ! selectionAtStart ) {
+		if ( ! selectionAtStart || ! this.props.isSelectionEnabled ) {
 			return;
 		}
 
@@ -185,6 +190,10 @@ class BlockList extends Component {
 	}
 
 	onShiftSelection( uid ) {
+		if ( ! this.props.isSelectionEnabled ) {
+			return;
+		}
+
 		const { selectedBlock, selectionStart, onMultiSelect, onSelect } = this.props;
 
 		if ( selectedBlock ) {
@@ -229,6 +238,7 @@ export default connect(
 		multiSelectedBlocks: getMultiSelectedBlocks( state ),
 		multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
 		selectedBlock: getSelectedBlock( state ),
+		isSelectionEnabled: isSelectionEnabled( state ),
 	} ),
 	( dispatch ) => ( {
 		onStartMultiSelect() {

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -341,10 +341,17 @@ export function isTyping( state = false, action ) {
  * @param  {Object} action Dispatched action
  * @return {Object}        Updated state
  */
-export function blockSelection( state = { start: null, end: null, focus: null, isMultiSelecting: false }, action ) {
+export function blockSelection( state = {
+	start: null,
+	end: null,
+	focus: null,
+	isMultiSelecting: false,
+	isEnabled: true,
+}, action ) {
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK':
 			return {
+				...state,
 				start: null,
 				end: null,
 				focus: null,
@@ -387,6 +394,7 @@ export function blockSelection( state = { start: null, end: null, focus: null, i
 			};
 		case 'INSERT_BLOCKS':
 			return {
+				...state,
 				start: action.blocks[ 0 ].uid,
 				end: action.blocks[ 0 ].uid,
 				focus: {},
@@ -397,10 +405,16 @@ export function blockSelection( state = { start: null, end: null, focus: null, i
 				return state;
 			}
 			return {
+				...state,
 				start: action.blocks[ 0 ].uid,
 				end: action.blocks[ 0 ].uid,
 				focus: {},
 				isMultiSelecting: false,
+			};
+		case 'TOGGLE_SELECTION':
+			return {
+				...state,
+				isEnabled: action.isSelectionEnabled,
 			};
 	}
 

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -827,6 +827,16 @@ export function isMultiSelecting( state ) {
 }
 
 /**
+ * Whether is selection disable or not.
+ *
+ * @param  {Object} state Global application state
+ * @return {Boolean}      True if multi is disable, false if not.
+ */
+export function isSelectionEnabled( state ) {
+	return state.blockSelection.isEnabled;
+}
+
+/**
  * Returns thee block's editing mode
  *
  * @param  {Object} state Global application state

--- a/editor/test/actions.js
+++ b/editor/test/actions.js
@@ -15,6 +15,7 @@ import {
 	saveReusableBlock,
 	convertBlockToStatic,
 	convertBlockToReusable,
+	toggleSelection,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -161,6 +162,29 @@ describe( 'actions', () => {
 		expect( convertBlockToReusable( uid ) ).toEqual( {
 			type: 'CONVERT_BLOCK_TO_REUSABLE',
 			uid,
+		} );
+	} );
+
+	describe( 'toggleSelection', () => {
+		it( 'should return the TOGGLE_SELECTION action with default value for isSelectionEnabled = true', () => {
+			expect( toggleSelection() ).toEqual( {
+				type: 'TOGGLE_SELECTION',
+				isSelectionEnabled: true,
+			} );
+		} );
+
+		it( 'should return the TOGGLE_SELECTION action with isSelectionEnabled = true as passed in the argument', () => {
+			expect( toggleSelection( true ) ).toEqual( {
+				type: 'TOGGLE_SELECTION',
+				isSelectionEnabled: true,
+			} );
+		} );
+
+		it( 'should return the TOGGLE_SELECTION action with isSelectionEnabled = false as passed in the argument', () => {
+			expect( toggleSelection( false ) ).toEqual( {
+				type: 'TOGGLE_SELECTION',
+				isSelectionEnabled: false,
+			} );
 		} );
 	} );
 } );

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -742,7 +742,13 @@ describe( 'state', () => {
 				uid: 'kumquat',
 			} );
 
-			expect( state ).toEqual( { start: 'kumquat', end: 'kumquat', focus: {}, isMultiSelecting: false } );
+			expect( state ).toEqual( {
+				start: 'kumquat',
+				end: 'kumquat',
+				focus: {},
+				isMultiSelecting: false,
+				isEnabled: true,
+			} );
 		} );
 
 		it( 'should set multi selection', () => {
@@ -842,7 +848,13 @@ describe( 'state', () => {
 				config: { editable: 'citation' },
 			} );
 
-			expect( state ).toEqual( { start: 'chicken', end: 'chicken', focus: { editable: 'citation' }, isMultiSelecting: false } );
+			expect( state ).toEqual( {
+				start: 'chicken',
+				end: 'chicken',
+				focus: { editable: 'citation' },
+				isMultiSelecting: false,
+				isEnabled: true,
+			} );
 		} );
 
 		it( 'should update the focus and merge the existing state', () => {

--- a/editor/test/selectors.js
+++ b/editor/test/selectors.js
@@ -77,6 +77,7 @@ import {
 	isMetaBoxStateDirty,
 	getReusableBlock,
 	isSavingReusableBlock,
+	isSelectionEnabled,
 	getReusableBlocks,
 	getStateBeforeOptimisticTransaction,
 	isPublishingPost,
@@ -1822,6 +1823,28 @@ describe( 'selectors', () => {
 			};
 
 			expect( isTyping( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isSelectionEnabled', () => {
+		it( 'should return true if selection is enable', () => {
+			const state = {
+				blockSelection: {
+					isEnabled: true,
+				},
+			};
+
+			expect( isSelectionEnabled( state ) ).toBe( true );
+		} );
+
+		it( 'should return false if selection is disabled', () => {
+			const state = {
+				blockSelection: {
+					isEnabled: false,
+				},
+			};
+
+			expect( isSelectionEnabled( state ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
This PR fixes the problem reported in https://github.com/WordPress/gutenberg/issues/3362. It adds a functionality to disable block selection and then disables block selection during the image resize.

## How Has This Been Tested?

1. Add an image block (with an image) and some paragraphs below it.
2. Resize it to small size.
3. Resize it back up enthusiastically, expecting the grabber to hit the corner of the block, so you know it's as big as it can be.
4. Verify no block selection happened.
5. Try to select blocks as before and verify you are still able to select them (when not resizing an image).