### PR TITLE
Reduce width and padding of ellipsis button

### DIFF
--- a/editor/edit-post/header/ellipsis-menu/style.scss
+++ b/editor/edit-post/header/ellipsis-menu/style.scss
@@ -1,5 +1,10 @@
 .editor-ellipsis-menu {
-	margin-left: $item-spacing;
+	// the padding and margin of the ellipsis menu is intentionally non-standard
+	margin-left: 4px;
+
+	.components-icon-button {
+		padding: 8px 4px;
+	}
 
 	.components-button svg {
 		transform: rotate( 90deg );


### PR DESCRIPTION
This makes the footprint of the ellipsis menu button smaller. This acknowledges both that it is overflow, and that it has a visually smaller footprint in being a vertical icon. As such it also addresses an optical imbalance that it had before.

**Before:**

![screen shot 2017-11-22 at 08 43 28](https://user-images.githubusercontent.com/1204802/33115704-424bfc3c-cf62-11e7-8058-7933b980f065.png)

![screen shot 2017-11-22 at 08 43 38](https://user-images.githubusercontent.com/1204802/33115706-4444ee5e-cf62-11e7-81b3-cb570956dee7.png)

**After:**

![screen shot 2017-11-22 at 08 47 47](https://user-images.githubusercontent.com/1204802/33115710-4707f1b8-cf62-11e7-9b66-79796b17d8a7.png)

![screen shot 2017-11-22 at 08 47 52](https://user-images.githubusercontent.com/1204802/33115711-48923868-cf62-11e7-9902-0f98ed9478ac.png)

![screen shot 2017-11-22 at 08 48 05](https://user-images.githubusercontent.com/1204802/33115713-4a51266e-cf62-11e7-9f32-d641b1828641.png)
