### PR TITLE
BlockList: Extract the fixedToolbar flag as a prop

### DIFF
--- a/editor/components/block-list/block-contextual-toolbar.js
+++ b/editor/components/block-list/block-contextual-toolbar.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -13,13 +8,8 @@ import { __ } from '@wordpress/i18n';
  */
 import NavigableToolbar from '../../navigable-toolbar';
 import { BlockToolbar } from '../';
-import { isFeatureActive } from '../../selectors';
 
-function BlockContextualToolbar( { hasFixedToolbar } ) {
-	if ( hasFixedToolbar ) {
-		return null;
-	}
-
+function BlockContextualToolbar() {
 	return (
 		<NavigableToolbar
 			className="editor-block-contextual-toolbar"
@@ -30,8 +20,4 @@ function BlockContextualToolbar( { hasFixedToolbar } ) {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
-	} ),
-)( BlockContextualToolbar );
+export default BlockContextualToolbar;

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -337,7 +337,7 @@ class BlockListBlock extends Component {
 	}
 
 	render() {
-		const { block, order, mode } = this.props;
+		const { block, order, mode, showContextualToolbar } = this.props;
 		const { name: blockName, isValid } = block;
 		const blockType = getBlockType( blockName );
 		// translators: %s: Type of block (i.e. Text, Image etc)
@@ -387,7 +387,7 @@ class BlockListBlock extends Component {
 				<BlockDropZone index={ order } />
 				{ ( showUI || isHovered ) && <BlockMover uids={ [ block.uid ] } /> }
 				{ ( showUI || isHovered ) && <BlockSettingsMenu uids={ [ block.uid ] } /> }
-				{ showUI && isValid && <BlockContextualToolbar /> }
+				{ showUI && isValid && showContextualToolbar && <BlockContextualToolbar /> }
 				{ isFirstMultiSelected && <BlockMultiControls /> }
 				<div
 					ref={ this.bindBlockNode }

--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -206,7 +206,7 @@ class BlockList extends Component {
 	}
 
 	render() {
-		const { blocks } = this.props;
+		const { blocks, showContextualToolbar } = this.props;
 
 		return (
 			<div>
@@ -218,6 +218,7 @@ class BlockList extends Component {
 						blockRef={ this.setBlockRef }
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
+						showContextualToolbar={ showContextualToolbar }
 					/>,
 					<BlockListSiblingInserter
 						key={ 'sibling-inserter-' + uid }

--- a/editor/modes/visual-editor/index.js
+++ b/editor/modes/visual-editor/index.js
@@ -16,7 +16,7 @@ import { KeyboardShortcuts } from '@wordpress/components';
 import './style.scss';
 import VisualEditorInserter from './inserter';
 import { BlockList, PostTitle, WritingFlow } from '../../components';
-import { getBlockUids, getMultiSelectedBlockUids } from '../../selectors';
+import { getBlockUids, getMultiSelectedBlockUids, isFeatureActive } from '../../selectors';
 import { clearSelectedBlock, multiSelect, redo, undo, removeBlocks } from '../../actions';
 
 class VisualEditor extends Component {
@@ -93,7 +93,10 @@ class VisualEditor extends Component {
 				} } />
 				<WritingFlow>
 					<PostTitle />
-					<BlockList ref={ this.bindBlocksContainer } />
+					<BlockList
+						ref={ this.bindBlocksContainer }
+						showContextualToolbar={ ! this.props.hasFixedToolbar }
+					/>
 				</WritingFlow>
 				<VisualEditorInserter />
 			</div>
@@ -107,6 +110,7 @@ export default connect(
 		return {
 			uids: getBlockUids( state ),
 			multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
+			hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
 		};
 	},
 	{


### PR DESCRIPTION
This PR refactors the `BlockList` component slightly to extract the "Fixed Toolbar Feature Flag" as a prop. It's a layout specific config and shouldn't be accessed from state. Making it a prop allows this state to live separately in a potential future post-editor module.

This also fixes a small bug in the Ellipsis menu where the "Fix to block" checkmark was inverted.

**Testing instructions**

 - Toggle the "Fixed/Context Toolbar" 
 - Check that it works as expected