### PR TITLE
Pasting: Convert unknown shortcodes to Shortcode block

### DIFF
--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -33,7 +33,10 @@ export default function( HTML ) {
 
 			const attributes = mapValues(
 				pickBy( transform.attributes, ( schema ) => schema.shortcode ),
-				( schema ) => schema.shortcode( match.shortcode.attrs ),
+				// Passing all of `match` as second argument is intentionally
+				// broad but shouldn't be too relied upon. See
+				// https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
+				( schema ) => schema.shortcode( match.shortcode.attrs, match ),
 			);
 
 			const block = createBlock(

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -1,3 +1,4 @@
+import './shortcode';
 import './image';
 import './gallery';
 import './heading';
@@ -16,7 +17,6 @@ import './freeform';
 import './latest-posts';
 import './categories';
 import './cover-image';
-import './shortcode';
 import './text-columns';
 import './verse';
 import './video';

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -31,6 +31,27 @@ registerBlockType( 'core/shortcode', {
 		},
 	},
 
+	transforms: {
+		from: [
+			{
+				type: 'shortcode',
+				// Per "Shortcode names should be all lowercase and use all
+				// letters, but numbers and underscores should work fine too.
+				// Be wary of using hyphens (dashes), you'll be better off not
+				// using them." in https://codex.wordpress.org/Shortcode_API
+				tag: '[a-z0-9_-]+',
+				attributes: {
+					text: {
+						type: 'string',
+						shortcode: ( attrs, { content } ) => {
+							return content;
+						},
+					},
+				},
+			},
+		],
+	},
+
 	supportHTML: false,
 
 	supports: {


### PR DESCRIPTION
Fixes #3062. Builds on top of #3609 (`fix/shortcode-pasting-plain-text`).

## Description
Blocks can specify shortcodes from which blocks should be automatically created when pasting. For any other shortcode, the core Shortcode block will now act as a fallback.

The main benefit of this is that, within the Shortcode block, the code will be properly handled and never mishandled. Notably, this fixes the case where a shortcode sitting in a Paragraph block will be picked up with its double quotes rendered as `&quot;`, thus breaking parsing of a shortcode's attributes.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):
![gutenberg-shortcode-paste-fallback](https://user-images.githubusercontent.com/150562/33127033-b9799208-cf7e-11e7-9c05-8fd093ed2d9e.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.