### PR TITLE
Invert toolbar setting in ellipsis menu

### DIFF
--- a/components/menu-items/style.scss
+++ b/components/menu-items/style.scss
@@ -4,7 +4,6 @@
 }
 
 .components-choice-menu__label {
-	font-weight: 600;
 	margin-bottom: 10px;
 	color: $light-gray-900;
 }

--- a/editor/header/fixed-toolbar-toggle/index.js
+++ b/editor/header/fixed-toolbar-toggle/index.js
@@ -31,7 +31,7 @@ function FeatureToggle( { onToggle, active } ) {
 
 export default connect(
 	( state ) => ( {
-		active: isFeatureActive( state, 'fixedToolbar' ),
+		active: !isFeatureActive( state, 'fixedToolbar' ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onToggle() {

--- a/editor/header/fixed-toolbar-toggle/index.js
+++ b/editor/header/fixed-toolbar-toggle/index.js
@@ -31,7 +31,7 @@ function FeatureToggle( { onToggle, active } ) {
 
 export default connect(
 	( state ) => ( {
-		active: !isFeatureActive( state, 'fixedToolbar' ),
+		active: ! isFeatureActive( state, 'fixedToolbar' ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onToggle() {


### PR DESCRIPTION
Now there's a checkmark next to "Fix toolbar to block", when the toolbar is actually fixed to the block. It was the inverse before.

This also makes the group labels non-bold.

![screen shot 2017-11-22 at 13 57 25](https://user-images.githubusercontent.com/1204802/33128600-3ebcf276-cf8d-11e7-8bfb-e182151119dc.png)
