### PR TITLE
Fixed bug: insertion point is missing

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -195,10 +195,15 @@ export class InserterMenu extends Component {
 		const blockTypesInfo = blockTypes.map( ( blockType ) => (
 			{ ...blockType, disabled: this.isDisabledBlock( blockType ) }
 		) );
+
 		return (
-			<InserterGroup blockTypes={ blockTypesInfo } labelledBy={ labelledBy }
+			<InserterGroup
+				blockTypes={ blockTypesInfo }
+				labelledBy={ labelledBy }
 				bindReferenceNode={ this.bindReferenceNode }
 				selectBlock={ this.selectBlock }
+				showInsertionPoint={ this.props.showInsertionPoint }
+				hideInsertionPoint={ this.props.hideInsertionPoint }
 			/>
 		);
 	}

--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -49,7 +49,7 @@
 	}
 }
 
-.editor-visual-editor .editor-visual-editor__insertion-point {
+.editor-visual-editor .editor-block-list__insertion-point {
 	position: relative;
 	width: $visual-editor-max-width - $block-padding - $block-padding;
 	margin-left: auto;


### PR DESCRIPTION
## Description
This PR fixes the problem reported in issue https://github.com/WordPress/gutenberg/issues/3599.
Where our blue line indicating where a block would be inserted was not appearing. Two bugs existed simultaneously, one wrong scss class name and missing props that would allow the correct dispatching of the actions to show the insert position.

## How Has This Been Tested?

1. Go to the inserter.
2. Pass mouse over a block and see a blue line appears in the block inserting position.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/11271197/33128808-b05f546c-cf85-11e7-842f-ee0df2b36f2c.png)