### PR TITLE
Fix alignment of fixed toolbar on wide and full wide

### DIFF
--- a/editor/modes/visual-editor/style.scss
+++ b/editor/modes/visual-editor/style.scss
@@ -31,7 +31,7 @@
 	&[data-align="wide"] {
 		.editor-block-contextual-toolbar {
 			@include break-small() {
-				width: $visual-editor-max-width - $block-padding - $block-padding;
+				width: $visual-editor-max-width + 2;	// 1px border left and right
 			}
 			margin-left: auto;
 			margin-right: auto;


### PR DESCRIPTION
Fixes #3596 

To test, insert an image, make sure your toolbar setting is set to show the toolbar on the block, and then make sure the block toolbar for the block sits in the same spot for images of any alignment.

Screenshots:

![screen shot 2017-11-22 at 14 09 01](https://user-images.githubusercontent.com/1204802/33128999-c6e221a2-cf8e-11e7-8b42-663ca1024c04.png)

![screen shot 2017-11-22 at 14 09 05](https://user-images.githubusercontent.com/1204802/33129001-c8530ff6-cf8e-11e7-8fed-3b8726f71668.png)
