### PR TITLE
Metaboxes: Prefetch Metaboxes and don't reload them on save

### DIFF
--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -1,9 +1,6 @@
 # Meta Boxes
 
-This is a brief document detailing how meta box support works in Gutenberg. With
-the superior developer and user experience of blocks however, especially once,
-block templates are available, **converting PHP meta boxes to blocks is highly
-encouraged!**
+This is a brief document detailing how meta box support works in Gutenberg. With the superior developer and user experience of blocks however, especially once, block templates are available, **converting PHP meta boxes to blocks is highly encouraged!**
 
 ### Testing, Converting, and Maintaining Existing Meta Boxes
 
@@ -39,11 +36,9 @@ When Gutenberg is run, this meta box will no longer be displayed in the meta box
 
 ### Meta Box Data Collection
 
-On each Gutenberg page load, the global state of post.php is mimicked, this is hooked in as far back as `plugins_loaded`.
+On each Gutenberg page load, we register an action that collects the meta box data to determine if an area is empty. The original global state is reset upon collection of meta box data.
 
 See `lib/register.php gutenberg_trick_plugins_into_registering_meta_boxes()`
-
-This will register an action that collects the meta box data to determine if an area is empty. The original global state is reset upon collection of meta box data.
 
 `gutenberg_collect_meta_box_data()` is hooked in later on `admin_head`. It will run through the functions and hooks that `post.php` runs to register meta boxes; namely `add_meta_boxes`, `add_meta_boxes_{$post->post_type}`, and `do_meta_boxes`.
 
@@ -55,27 +50,29 @@ Ideally, this could be done at instantiation of the editor and help simplify thi
 
 ### Redux and React Meta Box Management
 
-*The Redux store by default will hold all meta boxes as inactive*. When `INITIALIZE_META_BOX_STATE` comes in, the store will update any active meta box areas by setting the `isActive` flag to `true`. Once this happens React will check for the new props sent in by Redux on the `MetaBox` component. If that `MetaBox` is now active, instead of rendering null, a `MetaBoxArea` component will be rendered. The `MetaBox` component is the container component that mediates between the `MetaBoxArea` and the Redux Store. *If no meta boxes are active, nothing happens. This will be the default behavior, as all core meta boxes have been stripped.*
+When rendering the Gutenberg Page, the metaboxes are rendered to a hidden div `#metaboxes`.
+
+*The Redux store by default will hold all meta boxes as inactive*. When
+`INITIALIZE_META_BOX_STATE` comes in, the store will update any active meta box areas by setting the `isActive` flag to `true`. Once this happens React will check for the new props sent in by Redux on the `MetaBox` component. If that `MetaBox` is now active, instead of rendering null, a `MetaBoxArea` component will be rendered. The `MetaBox` component is the container component that mediates between the `MetaBoxArea` and the Redux Store. *If no meta boxes are active, nothing happens. This will be the default behavior, as all core meta boxes have been stripped.*
 
 #### MetaBoxArea Component
 
-When the component renders it will store a ref to the metaboxes container, calls the page rendering the metaboxes and watches input and changes.
- The change detection will store the current form's `FormData`, then whenever a change is detected the current form data will be checked vs, the original form data. This serves as a way to see if the meta box state is dirty. When the meta box state has been detected to have changed, a Redux action `META_BOX_STATE_CHANGED` is dispatched, updating the store setting the isDirty flag to `true`. If the state ever returns back to the original form data, `META_BOX_STATE_CHANGED` is dispatched again to set the isDirty flag to `false`. A selector `isMetaBoxStateDirty()` is used to help check whether the post can be updated. It checks each meta box for whether it is dirty, and if there is at least one dirty meta box, it will return true. This dirty detection does not impact creating new posts, as the content will have to change before meta boxes can trigger the overall dirty state.
+When the component renders it will store a ref to the metaboxes container, retrieve the metaboxes HTML from the prefetch location and watches input and changes.
 
-When the post is updated, only meta boxes that are active and dirty, will be submitted. This removes any unnecessary requests being made. No extra revisions, are created either by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any dirty meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta boxes' state to `isUpdating`, the `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
+The change detection will store the current form's `FormData`, then whenever a change is detected the current form data will be checked vs, the original form data. This serves as a way to see if the meta box state is dirty. When the meta box state has been detected to have changed, a Redux action `META_BOX_STATE_CHANGED` is dispatched, updating the store setting the isDirty flag to `true`. If the state ever returns back to the original form data, `META_BOX_STATE_CHANGED` is dispatched again to set the isDirty flag to `false`. A selector `isMetaBoxStateDirty()` is used to help check whether the post can be updated. It checks each meta box for whether it is dirty, and if there is at least one dirty meta box, it will return true. This dirty detection does not impact creating new posts, as the content will have to change before meta boxes can trigger the overall dirty state.
 
-Since the meta box updating is being triggered on post save success, we check to see if the post is saving and display an updating overlay, to prevent users from changing the form values while the meta box is submitting. The saving overlay could be made transparent, to give a more seamless effect.
+When the post is updated, only meta boxes areas that are active and dirty, will be submitted. This removes any unnecessary requests being made. No extra revisions, are created either by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any dirty meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta boxes' state to `isUpdating`, the `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
 
-Each `MetaBoxArea` will point to an individual source. These are partial pages being served by post.php. Why this approach? By using post.php directly, we don't have to worry as much about getting the global state 100% correct for each and every use case of a meta box, especially when it comes to saving. Essentially, when post.php loads it will set up all of its state correctly, and when it hits the three `do_action( 'do_meta_boxes' )` hooks it will trigger our partial page.
+If the metabox area is saving, we display an updating overlay, to prevent users from changing the form values while the meta box is submitting.
 
 When the new block editor was made into the default editor it is now required to provide the classic-editor flag to access the metabox partial page.
 
-`gutenberg_meta_box_partial_page()` is used to render the meta boxes for a context then exit the execution thread early. A `meta_box` request parameter is used to trigger this early exit. The `meta_box` request parameter should match one of `'advanced'`, `'normal'`, or `'side'`. This value will determine which meta box area is served. So an example url would look like:
+`gutenberg_meta_box_save()` is used to save the meta boxes changes. A `meta_box` request parameter should be present and should match one of `'advanced'`, `'normal'`, or `'side'`. This value will determine which meta box area is served.
+
+So an example url would look like:
 
 `mysite.com/wp-admin/post.php?post=1&action=edit&meta_box=$location&classic-editor`
 
-This url is automatically passed into React via a `_wpMetaBoxUrl` global variable. The partial page is very similar to post.php and pretty much imitates it and after rendering the meta boxes via `do_meta_boxes()` it imitates `admin_footer`, exits early, and does some hook clean up.
+This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
 
-These styles make use of some of the SASS variables, so that as the Gutenberg UI updates so will the meta boxes.
-
-The partial page mimics the `post.php` post form, so when it is submitted it will normally fire all of the necessary hooks and actions, and have the proper global state to correctly fire any PHP meta box mumbo jumbo without needing to modify any existing code. On successful submission the page will be reloaded back to the same partial page with updated data. React will signal a `handleMetaBoxReload` to set up the new form state for dirty checking, remove the updating overlay, and set the store to no longer be updating the meta box area.
+Thus page page mimics the `post.php` post form, so when it is submitted it will normally fire all of the necessary hooks and actions, and have the proper global state to correctly fire any PHP meta box mumbo jumbo without needing to modify any existing code. On successful submission, React will signal a `handleMetaBoxReload` to set up the new form state for dirty checking, remove the updating overlay, and set the store to no longer be updating the meta box area.

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, includes, map, filter, some, castArray } from 'lodash';
+import { get, includes, map, castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -46,7 +46,6 @@ import {
 	isEditedPostDirty,
 	isEditedPostNew,
 	isEditedPostSaveable,
-	getMetaBoxes,
 	getBlock,
 	getReusableBlock,
 } from './selectors';
@@ -310,27 +309,6 @@ export default {
 		}
 
 		return effects;
-	},
-	INITIALIZE_META_BOX_STATE( action ) {
-		// Hold jquery.ready until the metaboxes load
-		const locations = [ 'normal', 'side' ];
-		if ( some( locations, ( location ) => !! action.metaBoxes[ location ] ) ) {
-			jQuery.holdReady( true );
-		}
-	},
-	META_BOX_LOADED( action, store ) {
-		const { getState } = store;
-		const metaboxes = getMetaBoxes( getState() );
-		const unloadedMetaboxes = filter(
-			map( metaboxes, ( value, key ) => ( {
-				...value,
-				key,
-			} ) ),
-			( metabox ) => metabox.isActive && ! metabox.isLoaded
-		);
-		if ( unloadedMetaboxes.length === 1 && unloadedMetaboxes[ 0 ].key === action.location ) {
-			jQuery.holdReady( false );
-		}
 	},
 	FETCH_REUSABLE_BLOCKS( action, store ) {
 		const { id } = action;

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -31,6 +31,9 @@ function the_gutenberg_project() {
 	<div class="nvda-temp-fix screen-reader-text">&nbsp;</div>
 	<div class="gutenberg">
 		<div id="editor" class="gutenberg__editor"></div>
+		<div id="metaboxes" style="display: none;">
+			<?php the_gutenberg_metaboxes(); ?>
+		</div>
 	</div>
 	<?php
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -609,7 +609,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	wp_enqueue_script(
 		'wp-editor',
 		gutenberg_url( 'editor/build/index.js' ),
-		array( 'jquery', 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
+		array( 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
 		filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
 		true // enqueue in the footer.
 	);

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -10,14 +10,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Renders a partial page of meta boxes.
+ * Page loaded when saving the meta boxes.
+ * The HTML returned by this page is irrelevant, it's being called in AJAX ignoring its output
  *
- * @since 1.5.0
+ * @since 1.8.0
  *
  * @param string $post_type Current post type.
  * @param string $meta_box_context  The context location of the meta box. Referred to as context in core.
  */
-function gutenberg_meta_box_partial_page( $post_type, $meta_box_context ) {
+function gutenberg_meta_box_save( $post_type, $meta_box_context ) {
 	/**
 	 * Needs classic editor to be active.
 	 *
@@ -70,372 +71,10 @@ function gutenberg_meta_box_partial_page( $post_type, $meta_box_context ) {
 		wp_die( __( 'The `meta_box` parameter should be one of "side", "normal", or "advanced".', 'gutenberg' ) );
 	}
 
-	global $post, $wp_meta_boxes, $hook_suffix, $current_screen, $wp_locale;
-
-	gutenberg_meta_box_partial_page_admin_header( $hook_suffix, $current_screen, $wp_locale );
-
-	gutenberg_meta_box_partial_page_post_form( $post, $location );
-
-	// Handle meta box state.
-	$_original_meta_boxes = $wp_meta_boxes;
-
-	/**
-	 * Fires right before the meta boxes are rendered.
-	 *
-	 * This allows for the filtering of meta box data, that should already be
-	 * present by this point. Do not use as a means of adding meta box data.
-	 *
-	 * By default gutenberg_filter_meta_boxes() is hooked in and can be
-	 * unhooked to restore core meta boxes.
-	 *
-	 * @param array $wp_meta_boxes Global meta box state.
-	 */
-	$wp_meta_boxes = apply_filters( 'filter_gutenberg_meta_boxes', $wp_meta_boxes );
-
-	// Exit early if the meta box is empty. Send out a post message to tell React to not render meta boxes.
-	if ( gutenberg_is_meta_box_empty( $wp_meta_boxes, $_REQUEST['meta_box'], $post->post_type ) ) {
-		exit();
-	}
-
-	$locations = array();
-
-	// Lump normal and advanced in together for now. Advanced usually appears after title.
-	if ( 'normal' === $_REQUEST['meta_box'] || 'advanced' === $_REQUEST['meta_box'] ) {
-		$locations = array( 'advanced', 'normal' );
-	}
-
-	if ( 'side' === $_REQUEST['meta_box'] ) {
-		$locations = array( 'side' );
-	}
-
-	// Render meta boxes.
-	if ( ! empty( $locations ) ) {
-		foreach ( $locations as $location ) {
-			do_meta_boxes(
-				$current_screen,
-				$location,
-				$post
-			);
-		}
-	}
-
-	// Reset meta box data.
-	$wp_meta_boxes = $_original_meta_boxes;
-
-	gutenberg_meta_box_partial_page_admin_footer( $hook_suffix );
-
-	/**
-	 * Shutdown hooks potentially firing.
-	 *
-	 * Try Query Monitor plugin to make sure the output isn't janky.
-	 */
-	remove_all_actions( 'shutdown' );
-	exit();
+	the_gutenberg_metaboxes( array( $location ) );
 }
 
-add_action( 'do_meta_boxes', 'gutenberg_meta_box_partial_page', 1000, 2 );
-
-/**
- * The partial page needs to imitate aspects of admin-header.php.
- *
- * See wp-admin/admin-header.php at around line 70.
- *
- * @since 1.5.0
- *
- * @param string    $hook_suffix    Page hook suffix.
- * @param WP_Screen $current_screen Current screen object.
- * @param WP_Locale $wp_locale      Locale object.
- */
-function gutenberg_meta_box_partial_page_admin_header( $hook_suffix, $current_screen, $wp_locale ) {
-	/* Scripts that meta boxes can potentially be using */
-	wp_enqueue_script( 'utils' );
-	wp_enqueue_script( 'common' );
-	wp_enqueue_script( 'svg-painter' );
-	?>
-	<html>
-	<head>
-	<?php
-	// Grab the admin body class.
-	$admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );
-
-	/**
-	 * The main way post.php sets body class.
-	 */
-	if ( get_user_setting( 'mfold' ) == 'f' ) {
-		$admin_body_class .= ' folded';
-	}
-
-	if ( ! get_user_setting( 'unfold' ) ) {
-		$admin_body_class .= ' auto-fold';
-	}
-
-	if ( is_admin_bar_showing() ) {
-		$admin_body_class .= ' admin-bar';
-	}
-
-	if ( is_rtl() ) {
-		$admin_body_class .= ' rtl';
-	}
-
-	if ( $current_screen->post_type ) {
-		$admin_body_class .= ' post-type-' . $current_screen->post_type;
-	}
-
-	if ( $current_screen->taxonomy ) {
-		$admin_body_class .= ' taxonomy-' . $current_screen->taxonomy;
-	}
-
-	$admin_body_class .= ' branch-' . str_replace( array( '.', ',' ), '-', floatval( get_bloginfo( 'version' ) ) );
-	$admin_body_class .= ' version-' . str_replace( '.', '-', preg_replace( '/^([.0-9]+).*/', '$1', get_bloginfo( 'version' ) ) );
-	$admin_body_class .= ' admin-color-' . sanitize_html_class( get_user_option( 'admin_color' ), 'fresh' );
-	$admin_body_class .= ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );
-
-	if ( wp_is_mobile() ) {
-		$admin_body_class .= ' mobile';
-	}
-
-	if ( is_multisite() ) {
-		$admin_body_class .= ' multisite';
-	}
-
-	if ( is_network_admin() ) {
-		$admin_body_class .= ' network-admin';
-	}
-
-	$admin_body_class .= ' no-customize-support no-svg';
-	?>
-	</head>
-	<body>
-	<!-- Add in JavaScript variables that some meta box plugins make use of. -->
-	<script type="text/javascript">
-	addLoadEvent = function( func ){ if( typeof jQuery!="undefined" )jQuery( document ).ready( func );else if(typeof wpOnload!='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
-	var ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>',
-		pagenow = '<?php echo $current_screen->id; ?>',
-		typenow = '<?php echo $current_screen->post_type; ?>',
-		adminpage = '<?php echo $admin_body_class; ?>',
-		thousandsSeparator = '<?php echo addslashes( $wp_locale->number_format['thousands_sep'] ); ?>',
-		decimalPoint = '<?php echo addslashes( $wp_locale->number_format['decimal_point'] ); ?>',
-		isRtl = <?php echo (int) is_rtl(); ?>;
-	</script>
-	<?php
-
-	/**
-	 * Enqueue scripts for all admin pages.
-	 *
-	 * @since wp-core 2.8.0
-	 *
-	 * @param string $hook_suffix The current admin page.
-	 */
-	do_action( 'admin_enqueue_scripts', $hook_suffix );
-
-	/**
-	 * Fires when styles are printed for a specific admin page based on $hook_suffix.
-	 *
-	 * @since wp-core 2.6.0
-	 */
-	// @codingStandardsIgnoreStart
-	do_action( "admin_print_styles-{$hook_suffix}" );
-	// @codingStandardsIgnoreEnd
-
-	/**
-	 * Fires when styles are printed for all admin pages.
-	 *
-	 * @since wp-core 2.6.0
-	 */
-	do_action( 'admin_print_styles' );
-
-	/**
-	 * Fires when scripts are printed for a specific admin page based on $hook_suffix.
-	 *
-	 * @since wp-core 2.1.0
-	 */
-	// @codingStandardsIgnoreStart
-	do_action( "admin_print_scripts-{$hook_suffix}" );
-	// @codingStandardsIgnoreEnd
-
-	/**
-	 * Fires when scripts are printed for all admin pages.
-	 *
-	 * @since wp-core 2.1.0
-	 */
-	do_action( 'admin_print_scripts' );
-
-	/**
-	 * Fires in head section for a specific admin page.
-	 *
-	 * The dynamic portion of the hook, `$hook_suffix`, refers to the hook suffix
-	 * for the admin page.
-	 *
-	 * @since wp-core 2.1.0
-	 */
-	// @codingStandardsIgnoreStart
-	do_action( "admin_head-{$hook_suffix}" );
-	// @codingStandardsIgnoreEnd
-
-	/**
-	 * Fires in head section for all admin pages.
-	 *
-	 * @since wp-core 2.1.0
-	 */
-	do_action( 'admin_head' );
-}
-
-/**
- * This matches the portion of creating a form found in edit-form-advanced.php.
- *
- * Code starts roughly around line 500.
- *
- * @since 1.5.0
- *
- * @param WP_Post $post     Current post object.
- * @param string  $location Metabox location: one of 'normal', 'advanced', 'side'.
- */
-function gutenberg_meta_box_partial_page_post_form( $post, $location ) {
-	$notice     = false;
-	$form_extra = '';
-	if ( 'auto-draft' === $post->post_status ) {
-		$post->post_title = '';
-		$autosave         = false;
-		$form_extra      .= "<input type='hidden' id='auto_draft' name='auto_draft' value='1' />";
-	} else {
-		$autosave = wp_get_post_autosave( $post->id );
-	}
-
-	$form_action  = 'editpost';
-	$nonce_action = 'update-post_' . $post->ID;
-	$form_extra  .= "<input type='hidden' id='post_ID' name='post_ID' value='" . esc_attr( $post->ID ) . "' />";
-	?>
-	<form name="post" action="post.php" method="post" class="meta-box-form" data-location="<?php echo esc_attr( $location ); ?>"
-	<?php
-	/**
-	 * Fires inside the post editor form tag.
-	 *
-	 * @since wp-core 3.0.0
-	 *
-	 * @param WP_Post $post Post object.
-	 */
-	do_action( 'post_edit_form_tag', $post );
-
-	$referer = wp_get_referer();
-	?>
-	><!-- End of Post Form Tag. -->
-	<?php wp_nonce_field( $nonce_action ); ?>
-	<?php
-		$current_user = wp_get_current_user();
-		$user_id      = $current_user->ID;
-	?>
-	<input type="hidden" id="user-id" name="user_ID" value="<?php echo (int) $user_id; ?>" />
-	<input type="hidden" id="hiddenaction" name="action" value="<?php echo esc_attr( $form_action ); ?>" />
-	<input type="hidden" id="originalaction" name="originalaction" value="<?php echo esc_attr( $form_action ); ?>" />
-	<input type="hidden" id="post_author" name="post_author" value="<?php echo esc_attr( $post->post_author ); ?>" />
-	<input type="hidden" id="post_type" name="post_type" value="<?php echo esc_attr( $post->post_type ); ?>" />
-	<input type="hidden" id="original_post_status" name="original_post_status" value="<?php echo esc_attr( $post->post_status ); ?>" />
-	<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>" />
-	<!-- These fields are not part of the standard post form. Used to redirect back to this page on save. -->
-	<input type="hidden" name="gutenberg_meta_boxes" value="gutenberg_meta_boxes" />
-	<input type="hidden" name="gutenberg_meta_box_location" value="<?php echo esc_attr( $location ); ?>" />
-	<?php if ( ! empty( $active_post_lock ) ) : ?>
-	<input type="hidden" id="active_post_lock" value="<?php echo esc_attr( implode( ':', $active_post_lock ) ); ?>" />
-	<?php endif; ?>
-
-	<?php
-	if ( 'draft' !== get_post_status( $post ) ) {
-		wp_original_referer_field( true, 'previous' );
-	}
-
-	echo $form_extra;
-
-	wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce', false );
-	wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false );
-
-	// Permalink title nonce.
-	wp_nonce_field( 'samplepermalink', 'samplepermalinknonce', false );
-
-	/**
-	 * Fires at the beginning of the edit form.
-	 *
-	 * At this point, the required hidden fields and nonces have already been output.
-	 *
-	 * @since wp-core 3.7.0
-	 *
-	 * @param WP_Post $post Post object.
-	 */
-	do_action( 'edit_form_top', $post );
-
-	/**
-	 * The #poststuff id selector is import for styles and scripts.
-	 */
-	?>
-	<div id="poststuff" class="sidebar-open">
-			<div id="postbox-container-2" class="postbox-container">
-	<?php
-}
-
-/**
- * This matches the portion of creating a form found in edit-form-advanced.php.
- *
- * @since 1.5.0
- *
- * @param string $hook_suffix The hook suffix of the current page.
- */
-function gutenberg_meta_box_partial_page_admin_footer( $hook_suffix ) {
-	/**
-	 * Prints scripts or data before the default footer scripts.
-	 *
-	 * @since wp-core 1.2.0
-	 *
-	 * @param string $data The data to print.
-	 */
-	do_action( 'admin_footer', '' );
-
-	/**
-	 * Prints scripts and data queued for the footer.
-	 *
-	 * The dynamic portion of the hook name, `$hook_suffix`,
-	 * refers to the global hook suffix of the current page.
-	 *
-	 * @since wp-core 4.6.0
-	 */
-	// @codingStandardsIgnoreStart
-	do_action( "admin_print_footer_scripts-{$hook_suffix}" );
-	// @codingStandardsIgnoreEnd
-
-	/**
-	 * Prints any scripts and data queued for the footer.
-	 *
-	 * @since wp-core 2.8.0
-	 *
-	 * @note This seems to be where most styles etc are hooked into.
-	 */
-	do_action( 'admin_print_footer_scripts' );
-
-	/**
-	 * Prints scripts or data after the default footer scripts.
-	 *
-	 * The dynamic portion of the hook name, `$hook_suffix`,
-	 * refers to the global hook suffix of the current page.
-	 *
-	 * @since wp-core 2.8.0
-	 */
-	// @codingStandardsIgnoreStart
-	do_action( "admin_footer-{$hook_suffix}" );
-	// @codingStandardsIgnoreEnd
-
-	// get_site_option() won't exist when auto upgrading from <= 2.7.
-	if ( function_exists( 'get_site_option' ) ) {
-		if ( false === get_site_option( 'can_compress_scripts' ) ) {
-			compression_test();
-		}
-	}
-
-	?>
-		<div class="clear"></div></div><!-- wpwrap -->
-		<script type="text/javascript">if(typeof wpOnload=='function')wpOnload();</script>
-	</body>
-	</html>
-
-	<?php
-}
+add_action( 'do_meta_boxes', 'gutenberg_meta_box_save', 1000, 2 );
 
 /**
  * Allows the meta box endpoint to correctly redirect to the meta box endpoint
@@ -665,4 +304,102 @@ function gutenberg_show_meta_box_warning( $callback ) {
 			<?php
 		}
 	}
+}
+
+/**
+ * Renders the WP meta boxes forms.
+ *
+ * @since 1.8.0
+ *
+ * @param string $locations The metaboxes locations to render.
+ */
+function the_gutenberg_metaboxes( $locations = array( 'advanced', 'normal', 'side' ) ) {
+	global $post, $current_screen, $wp_meta_boxes;
+
+	// Handle meta box state.
+	$_original_meta_boxes = $wp_meta_boxes;
+
+	/**
+	 * Fires right before the meta boxes are rendered.
+	 *
+	 * This allows for the filtering of meta box data, that should already be
+	 * present by this point. Do not use as a means of adding meta box data.
+	 *
+	 * By default gutenberg_filter_meta_boxes() is hooked in and can be
+	 * unhooked to restore core meta boxes.
+	 *
+	 * @param array $wp_meta_boxes Global meta box state.
+	 */
+	$wp_meta_boxes = apply_filters( 'filter_gutenberg_meta_boxes', $wp_meta_boxes );
+
+	// Render meta boxes.
+	if ( ! empty( $locations ) ) {
+		foreach ( $locations as $location ) {
+			?>
+			<form class="metabox-location-<?php echo $location; ?>">
+				<div id="poststuff" class="sidebar-open">
+					<div id="postbox-container-2" class="postbox-container">
+						<?php
+						gutenberg_meta_box_post_form_hidden_fields( $post, $location );
+						do_meta_boxes(
+							$current_screen,
+							$location,
+							$post
+						);
+						?>
+					</div>
+				</div>
+			</form>
+			<?php
+		}
+	}
+
+	// Reset meta box data.
+	$wp_meta_boxes = $_original_meta_boxes;
+}
+
+/**
+ * Renders the hidden form required for the meta boxes form.
+ *
+ * @param WP_Post $post     Current post object.
+ * @param string  $location The metaboxes location to render.
+ *
+ * @since 1.8.0
+ */
+function gutenberg_meta_box_post_form_hidden_fields( $post, $location ) {
+	$form_extra = '';
+	if ( 'auto-draft' === $post->post_status ) {
+		$form_extra .= "<input type='hidden' id='auto_draft' name='auto_draft' value='1' />";
+	}
+	$form_action  = 'editpost';
+	$nonce_action = 'update-post_' . $post->ID;
+	$form_extra  .= "<input type='hidden' id='post_ID' name='post_ID' value='" . esc_attr( $post->ID ) . "' />";
+	$referer      = wp_get_referer();
+	$current_user = wp_get_current_user();
+	$user_id      = $current_user->ID;
+	wp_nonce_field( $nonce_action );
+	?>
+	<input type="hidden" id="user-id" name="user_ID" value="<?php echo (int) $user_id; ?>" />
+	<input type="hidden" id="hiddenaction" name="action" value="<?php echo esc_attr( $form_action ); ?>" />
+	<input type="hidden" id="originalaction" name="originalaction" value="<?php echo esc_attr( $form_action ); ?>" />
+	<input type="hidden" id="post_author" name="post_author" value="<?php echo esc_attr( $post->post_author ); ?>" />
+	<input type="hidden" id="post_type" name="post_type" value="<?php echo esc_attr( $post->post_type ); ?>" />
+	<input type="hidden" id="original_post_status" name="original_post_status" value="<?php echo esc_attr( $post->post_status ); ?>" />
+	<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>" />
+	<!-- These fields are not part of the standard post form. Used to redirect back to this page on save. -->
+	<input type="hidden" name="gutenberg_meta_boxes" value="gutenberg_meta_boxes" />
+	<input type="hidden" name="gutenberg_meta_box_location" value="<?php echo esc_attr( $location ); ?>" />
+	<?php if ( ! empty( $active_post_lock ) ) : ?>
+	<input type="hidden" id="active_post_lock" value="<?php echo esc_attr( implode( ':', $active_post_lock ) ); ?>" />
+	<?php endif; ?>
+
+	<?php
+	if ( 'draft' !== get_post_status( $post ) ) {
+		wp_original_referer_field( true, 'previous' );
+	}
+	echo $form_extra;
+	wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce', false );
+	wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false );
+	// Permalink title nonce.
+	wp_nonce_field( 'samplepermalink', 'samplepermalinknonce', false );
 }


### PR DESCRIPTION
The idea is that the metaboxes needs to be loaded with Gutenberg on initial load to initialize properly and their HTML don't need to be updated on Save.

So this does:

 - Prefetch the metaboxes HTML when loading Gutenberg
 - When showing "the metabox area", the dom node are moved from the "prefetch" zone to the the "metabox area" and when the "metabox area" is unmounted (for example, closing the sidebar) the "prefetched metaboxes" are moved back to the "prefetch" zone.
 - When saving a post with metaboxes, an AJAX request is triggered to save the metaboxes but the returned HTML is ignored.

closes #3523 #3277