### PR TITLE
Try block annotation, starting with full block annotation

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -576,3 +576,25 @@ export function convertBlockToReusable( uid ) {
 		uid,
 	};
 }
+
+/**
+ * Returns an action object used to add an annotation to the editor.
+ *
+ * @param {string} start The ID of the block to start the annotation.
+ * @param {string} end The ID of the block to end the annotation.
+ * @returns {Object} Action object.
+ */
+export function annotateBlocks( start, end ) {
+	return {
+		type: 'ADD_ANNOTATION',
+		annotation: {
+			start: {
+				block: start,
+			},
+			end: {
+				block: end,
+			},
+			blockAnnotation: true,
+		},
+	};
+}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -52,6 +52,7 @@ import {
 	isFirstMultiSelectedBlock,
 	isTyping,
 	getBlockMode,
+	getAnnotationsForBlock,
 } from '../../selectors';
 
 const { BACKSPACE, ESCAPE, DELETE, ENTER, UP, RIGHT, DOWN, LEFT } = keycodes;
@@ -346,7 +347,7 @@ class BlockListBlock extends Component {
 		// (mover, toolbar, wrapper) and the display of the block content.
 
 		// Generate the wrapper class names handling the different states of the block.
-		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, focus } = this.props;
+		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected, focus, annotations } = this.props;
 		const showUI = isSelected && ( ! this.props.isTyping || ( focus && focus.collapsed === false ) );
 		const { error } = this.state;
 		const wrapperClassName = classnames( 'editor-block-list__block', {
@@ -354,6 +355,7 @@ class BlockListBlock extends Component {
 			'is-selected': showUI,
 			'is-multi-selected': isMultiSelected,
 			'is-hovered': isHovered,
+			'is-fully-annotated': annotations.filter( annotation => annotation.blockAnnotation ).length !== 0,
 		} );
 
 		const { onMouseLeave, onFocus, onReplace } = this.props;
@@ -453,6 +455,7 @@ export default connect(
 			order: getBlockIndex( state, ownProps.uid ),
 			meta: getEditedPostAttribute( state, 'meta' ),
 			mode: getBlockMode( state, ownProps.uid ),
+			annotations: getAnnotationsForBlock( state, ownProps.uid ),
 		};
 	},
 	( dispatch, ownProps ) => ( {

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -91,6 +91,10 @@
 		background: $blue-medium-highlight;
 	}
 
+	&.is-fully-annotated {
+		outline: 1px solid red;
+	}
+
 	.iframe-overlay {
 		position: relative;
 	}

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { connect } from 'react-redux';
+import { flow, noop, head, last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,9 +19,9 @@ import BlockInspectorButton from './block-inspector-button';
 import BlockModeToggle from './block-mode-toggle';
 import BlockDeleteButton from './block-delete-button';
 import UnknownConverter from './unknown-converter';
-import { selectBlock } from '../../actions';
+import { selectBlock, annotateBlocks } from '../../actions';
 
-function BlockSettingsMenu( { uids, onSelect, focus } ) {
+function BlockSettingsMenu( { uids, onSelect, focus, onAnnotate } ) {
 	const count = uids.length;
 
 	return (
@@ -55,6 +56,13 @@ function BlockSettingsMenu( { uids, onSelect, focus } ) {
 					<BlockInspectorButton onClick={ onClose } />
 					{ count === 1 && <BlockModeToggle uid={ uids[ 0 ] } onToggle={ onClose } /> }
 					{ count === 1 && <UnknownConverter uid={ uids[ 0 ] } /> }
+					<IconButton
+						className="editor-block-settings-menu__control"
+						onClick={ () => onAnnotate( uids ) }
+						icon="admin-generic"
+					>
+						{ __( 'Annotate' ) }
+					</IconButton>
 					<BlockDeleteButton uids={ uids } />
 				</NavigableMenu>
 			) }
@@ -68,5 +76,8 @@ export default connect(
 		onSelect( uid ) {
 			dispatch( selectBlock( uid ) );
 		},
+		onAnnotate( uids ) {
+			dispatch( annotateBlocks( head( uids ), last( uids ) ) );
+		}
 	} )
 )( BlockSettingsMenu );

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -717,6 +717,19 @@ export const reusableBlocks = combineReducers( {
 	},
 } );
 
+export function annotations( state = [], action ) {
+	switch ( action.type ) {
+		case 'ADD_ANNOTATION':
+			return [
+				action.annotation,
+				...state
+			];
+			break;
+	}
+
+	return state;
+}
+
 export default optimist( combineReducers( {
 	editor,
 	currentPost,
@@ -731,4 +744,5 @@ export default optimist( combineReducers( {
 	notices,
 	metaBoxes,
 	reusableBlocks,
+	annotations,
 } ) );

--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -1072,3 +1072,30 @@ export function isSavingReusableBlock( state, ref ) {
 export function getReusableBlocks( state ) {
 	return Object.values( state.reusableBlocks.data );
 }
+
+/**
+ * Returns all the annotations for a specific block.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} uid The block UID to get annotations for.
+ * @returns {Object[]} The annotations relevant for this block.
+ */
+export const getAnnotationsForBlock = createSelector(
+	( state, uid ) => {
+		const { blockOrder } = state.editor.present;
+		const { annotations } = state;
+
+		return annotations.filter( ( annotation ) => {
+			const startIndex = blockOrder.indexOf( annotation.start.block );
+			const endIndex = blockOrder.indexOf( annotation.end.block );
+
+			const annotatedBlocks = blockOrder.slice( startIndex, endIndex + 1 );
+
+			return annotatedBlocks.includes( uid );
+		} );
+	},
+	( state, uid ) => [
+		state.annotations,
+	],
+);
+


### PR DESCRIPTION
## Description
This is a PR that explores how to do annotation on blocks. A lot of work has gone into exploration instead of actual code changes. But this is the PoC I have running locally, so I thought it would be good to share it.

### How did I get here

I first started thinking about different annotation data formats. I started with the least amount of data:

```js
{
	blockId: "",
	range: [ 0, 0 ],
	fullBlock: true|false,
	comment: "Some text comment",
}
```

After discussing this with @omarreiss we iterated on this and ended up with the following data structure:

```js
{
	start: {
		block: "",
		position: 0,
	},
	end: {
		block: "",
		position: 0,
	},
	blockAnnotation: true|false,
	comments: [
		{
			body: "This is a comment.",
			date: Date
		},
		{
			body: "A reaction to that other comment.",
			date: Date
		}
	],
	persist: true|false,
	id: ""
};
```

`start` and `end`: We figured that an annotation always has a start and an end position. Blocks can either be fully annotated or the text inside blocks can be annotated. So an annotation starts at a block and a position. And an annotation ends at a block and a position.

`blockAnnotation`: An annotation can either be a full block annotation or a default text annotation. For non-text blocks, there might not be a distinction, but I could see that you might want to comment on one image in a gallery block.

`comments`: Comments are objects on their own. They probably have more fields than `body` and `date`, but those are the bare minimum. `type` might be something we want to add.

`persist` and `id`: Some annotations should be persisted, some shouldn't. So the `id` is only relevant when an annotation needs to be persisted. Annotations that haven't been persisted to the server can be detected because they have no `id` yet.

In this data model, a comment is always bound to an annotation. This is a trade-off that forces a user to always be specific about what a comment is about.

### Challenges

There are a ton of challenges to be solved. Persisting annotations is one that comes to mind. Which I have commented on here: https://github.com/WordPress/gutenberg/issues/3026#issuecomment-345997173.

Another one is handling moving blocks. I think this can be solved by handling moving of blocks in the annotations reducer and changing the annotations to still be correct.

## How Has This Been Tested?
By running it in Chrome & Firefox

## Screenshots (jpeg or gifs if applicable):
n.a. (It doesn't look good yet)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

## TODO:

- [ ] Add unit tests.
- [ ] Implement a proper annotation style.

See https://github.com/WordPress/gutenberg/issues/2893 and https://github.com/WordPress/gutenberg/issues/3026.