### PR TITLE
Make actions by the block as default not fixed to toolbar.

### DIFF
--- a/editor/store-defaults.js
+++ b/editor/store-defaults.js
@@ -10,6 +10,6 @@ export const PREFERENCES_DEFAULTS = {
 	recentlyUsedBlocks: [],
 	blockUsage: {},
 	features: {
-		fixedToolbar: true,
+		fixedToolbar: false,
 	},
 };

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -895,7 +895,7 @@ describe( 'state', () => {
 				mode: 'visual',
 				isSidebarOpened: true,
 				panels: { 'post-status': true },
-				features: { fixedToolbar: true },
+				features: { fixedToolbar: false },
 			} );
 		} );
 


### PR DESCRIPTION
## Description
This PR Makes actions by the block as default not fixed to toolbar closing issue https://github.com/WordPress/gutenberg/issues/3570.  Please note the setting is persisted in the localStorage. To clear it, it is possible to execute window.localStorage.clear(); in the browser, console doing that it is possible to see the default setting for a new user.
