### PR TITLE
fix image insert console error

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -82,16 +82,10 @@ class ImageBlock extends Component {
 	}
 
 	onSelectImage( media ) {
-		const attributes = { 
-			url: media.url, 
-			alt: media.alt, 
-			id: media.id,
-		};
-
+		const attributes = { url: media.url, alt: media.alt, id: media.id };
 		if ( media.caption ) {
 			attributes.caption = [ media.caption ];
 		}
-
 		this.props.setAttributes( attributes );
 	}
 

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -268,7 +268,7 @@ class ImageBlock extends Component {
 					<Editable
 						tagName="figcaption"
 						placeholder={ __( 'Write caption…' ) }
-						value={ caption }
+						value={ caption ? caption : undefined }
 						focus={ focus && focus.editable === 'caption' ? focus : undefined }
 						onFocus={ focusCaption }
 						onChange={ ( value ) => setAttributes( { caption: value } ) }

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -82,7 +82,17 @@ class ImageBlock extends Component {
 	}
 
 	onSelectImage( media ) {
-		this.props.setAttributes( { url: media.url, alt: media.alt, caption: media.caption, id: media.id } );
+		const attributes = { 
+			url: media.url, 
+			alt: media.alt, 
+			id: media.id,
+		};
+
+		if ( media.caption ) {
+			attributes.caption = [ media.caption ];
+		}
+
+		this.props.setAttributes( attributes );
 	}
 
 	onSetHref( value ) {
@@ -268,7 +278,7 @@ class ImageBlock extends Component {
 					<Editable
 						tagName="figcaption"
 						placeholder={ __( 'Write caption…' ) }
-						value={ caption ? caption : undefined }
+						value={ caption }
 						focus={ focus && focus.editable === 'caption' ? focus : undefined }
 						onFocus={ focusCaption }
 						onChange={ ( value ) => setAttributes( { caption: value } ) }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes https://github.com/WordPress/gutenberg/issues/3633

Editable component is complaining about the caption value type.
On new Image its an empty string and Editable expects an array (caption is registered as type array) or undefined so I set it to undefined if empty string.

I tried setting a default value when registering block type to empty array but that does not work.
```javascript
caption: {
    type: 'array',
    source: 'children',
    selector: 'figcaption',
    default: [],
},

```
I would also assume that since caption is registered as type array that default value would be empty array. But I guess it doesn't work that way.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Manually tested in the browser. 
Current js unit tests pass.

