### PR TITLE
Fix horizontal scrollbar when float element present

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -388,6 +388,12 @@
 	position: relative;
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible ) - ( 2 * $block-padding );
 	margin: 0 auto;
+	clear: left;
+	
+	[data-align="left"] + &,
+	[data-align="right"] + & {
+		clear: none;
+	}
 
 	@include break-small {
 		max-width: $visual-editor-max-width - ( 2 * $block-padding );
@@ -400,6 +406,7 @@
 	&:before {
 		content: '';
 		position: absolute;
+		left: 0;
 		width: 100%;
 		height: 44px;
 		transition: 0.1s height;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -388,12 +388,6 @@
 	position: relative;
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible ) - ( 2 * $block-padding );
 	margin: 0 auto;
-	clear: left; // fixes horizontal scrollbar when there is left aligned element
-	
-	[data-align="left"] + &,
-	[data-align="right"] + & {
-		clear: none; // above scrollbar fix applies only for inserters next to aligned elements
-	}
 
 	@include break-small {
 		max-width: $visual-editor-max-width - ( 2 * $block-padding );

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -388,11 +388,11 @@
 	position: relative;
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible ) - ( 2 * $block-padding );
 	margin: 0 auto;
-	clear: left;
+	clear: left; // fixes horizontal scrollbar when there is left aligned element
 	
 	[data-align="left"] + &,
 	[data-align="right"] + & {
-		clear: none;
+		clear: none; // above scrollbar fix applies only for inserters next to aligned elements
 	}
 
 	@include break-small {


### PR DESCRIPTION
## Description
`clear: left` was only working for non aligned elements.

## How Has This Been Tested?
Tested on PC Chrome 62 & Firefox 58 (beta5)

## Checklist:
- [x] My code is tested. (partially i guess?)
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.