### PR TITLE
#2504 Fix for aligned embed videos

### DIFF
--- a/blocks/library/embed/editor.scss
+++ b/blocks/library/embed/editor.scss
@@ -1,7 +1,20 @@
+.editor-block-list__block[data-type="core/embed"] {
+	&[data-align="left"],
+	&[data-align="right"] {
+		max-width: 100%;
+	}
+}
+
 .wp-block-embed {
 	margin: 0;
 	clear: both; // necessary because we use responsive trickery to set width/height, and therefore the video doesn't intrinsically clear floats like an img does
 
+	[data-align="left"] &,
+	[data-align="right"] & {
+		width: 300px;
+		max-width: 100%;
+	}
+		
 	&.is-loading {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
## Description
Added static width on aligned video embeds, otherwise they have no width. Also made sure it works on mobile.

## How Has This Been Tested?
Tested on PC Chrome 62 & Firefox 58 (beta5)

## Types of changes
CSS

## Checklist:
- [x] My code is tested (partially i guess?).
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.