### PR TITLE
Editor: Add tests for DefaultBlockAppender

### DIFF
--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -20,7 +20,7 @@ import BlockDropZone from '../block-drop-zone';
 import { insertBlock } from '../../actions';
 import { getBlockCount } from '../../selectors';
 
-class DefaultBlockAppender extends Component {
+export class DefaultBlockAppender extends Component {
 	constructor( props ) {
 		super( props );
 		this.appendDefaultBlock = this.appendDefaultBlock.bind( this );

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefaultBlockAppender blocks present should match snapshot 1`] = `
+<div
+  className="editor-default-block-appender"
+>
+  <Connect(BlockDropZone) />
+  <button
+    className="editor-default-block-appender__content"
+    onClick={[Function]}
+  />
+</div>
+`;
+
+exports[`DefaultBlockAppender no block present should match snapshot 1`] = `
+<div
+  className="editor-default-block-appender is-visible-placeholder"
+>
+  <Connect(BlockDropZone) />
+  <input
+    className="editor-default-block-appender__content"
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    readOnly={true}
+    type="text"
+    value="Write your story"
+  />
+</div>
+`;

--- a/editor/components/default-block-appender/test/index.js
+++ b/editor/components/default-block-appender/test/index.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { DefaultBlockAppender } from '../';
+
+describe( 'DefaultBlockAppender', () => {
+	const expectInsertBlockCalled = ( insertBlock ) => {
+		expect( insertBlock ).toHaveBeenCalledTimes( 1 );
+		expect( insertBlock ).toHaveBeenCalledWith( expect.objectContaining( {
+			attributes: {},
+			isValid: true,
+			name: 'core/paragraph',
+			uid: expect.any( String ),
+		} ) );
+	};
+
+	describe( 'no block present', () => {
+		it( 'should match snapshot', () => {
+			const wrapper = shallow( <DefaultBlockAppender count={ 0 } /> );
+
+			expect( wrapper ).toMatchSnapshot();
+		} );
+
+		it( 'should append a default block when input clicked', () => {
+			const insertBlock = jest.fn();
+			const wrapper = shallow( <DefaultBlockAppender count={ 0 } onInsertBlock={ insertBlock } /> );
+
+			wrapper.find( 'input.editor-default-block-appender__content' ).simulate( 'click' );
+
+			expectInsertBlockCalled( insertBlock );
+		} );
+
+		it( 'should append a default block when input focused', () => {
+			const insertBlock = jest.fn();
+			const wrapper = shallow( <DefaultBlockAppender count={ 0 } onInsertBlock={ insertBlock } /> );
+
+			wrapper.find( 'input.editor-default-block-appender__content' ).simulate( 'focus' );
+
+			expectInsertBlockCalled( insertBlock );
+		} );
+	} );
+
+	describe( 'blocks present', () => {
+		it( 'should match snapshot', () => {
+			const wrapper = shallow( <DefaultBlockAppender count={ 5 } /> );
+
+			expect( wrapper ).toMatchSnapshot();
+		} );
+
+		it( 'should append a default block when button clicked', () => {
+			const insertBlock = jest.fn();
+			const wrapper = shallow( <DefaultBlockAppender count={ 5 } onInsertBlock={ insertBlock } /> );
+
+			wrapper.find( 'button.editor-default-block-appender__content' ).simulate( 'click' );
+
+			expectInsertBlockCalled( insertBlock );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Description
Follow-up for #3623.

As discussed in the referenced PR, I'm adding tests for newly introduced `DefaultBlockAppender` component.

## How Has This Been Tested?

`npm run test-unit`
## Types of changes

Adds tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.