### PR TITLE
Components: Extract TableOfContents as reusable component

### DIFF
--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -31,6 +31,7 @@ export { default as PostTitle } from './post-title';
 export { default as PostTrash } from './post-trash';
 export { default as PostVisibility } from './post-visibility';
 export { default as PostVisibilityLabel } from './post-visibility/label';
+export { default as TableOfContents } from './table-of-contents';
 export { default as UnsavedChangesWarning } from './unsaved-changes-warning';
 export { default as WordCount } from './word-count';
 

--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -14,7 +14,8 @@ import { Dropdown, IconButton } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
-import { WordCount, DocumentOutline } from '../../components';
+import WordCount from '../word-count';
+import DocumentOutline from '../document-outline';
 import { getBlocks } from '../../selectors';
 import { selectBlock } from '../../actions';
 

--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -1,15 +1,3 @@
-.table-of-contents {
-	display: none;
-
-	.is-sidebar-opened & {
-		right: $sidebar-width + 16px;
-	}
-
-	@include break-small() {
-		display: block;
-	}
-}
-
 .table-of-contents__popover .components-popover__content {
 	padding: 16px;
 }

--- a/editor/edit-post/header/header-toolbar/index.js
+++ b/editor/edit-post/header/header-toolbar/index.js
@@ -13,10 +13,9 @@ import { IconButton } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
-import { Inserter, BlockToolbar } from '../../../components';
+import { Inserter, BlockToolbar, TableOfContents } from '../../../components';
 import BlockSwitcher from '../../../components/block-switcher';
 import NavigableToolbar from '../../../components/navigable-toolbar';
-import TableOfContents from '../../table-of-contents';
 import { getMultiSelectedBlockUids, hasEditorUndo, hasEditorRedo, isFeatureActive } from '../../../selectors';
 
 function HeaderToolbar( { hasUndo, hasRedo, hasFixedToolbar, undo, redo, isMultiBlockSelection, selectedBlockUids } ) {

--- a/editor/edit-post/header/header-toolbar/style.scss
+++ b/editor/edit-post/header/header-toolbar/style.scss
@@ -52,3 +52,15 @@
 		}
 	}
 }
+
+.editor-header-toolbar .table-of-contents {
+	display: none;
+
+	.is-sidebar-opened & {
+		right: $sidebar-width + 16px;
+	}
+
+	@include break-small() {
+		display: block;
+	}
+}


### PR DESCRIPTION
Extract a reusable TableOfContents to the `editor/components` folder.
Needed to be able to separate the `edit-post` and `editor` module

**Testing instructions**

 - Check that the "info" button style works (header toolbar)