### PR TITLE
Components: Extract a reusable MultiBlocksSwitcher component

### DIFF
--- a/editor/components/block-switcher/multi-blocks-switcher.js
+++ b/editor/components/block-switcher/multi-blocks-switcher.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import BlockSwitcher from './';
+import { getMultiSelectedBlockUids } from '../../selectors';
+
+function MultiBlocksSwitcher( { isMultiBlockSelection, selectedBlockUids } ) {
+	if ( ! isMultiBlockSelection ) {
+		return null;
+	}
+	return (
+		<BlockSwitcher key="switcher" uids={ selectedBlockUids } />
+	);
+}
+
+export default connect(
+	( state ) => {
+		const selectedBlockUids = getMultiSelectedBlockUids( state );
+		return {
+			isMultiBlockSelection: selectedBlockUids.length > 1,
+			selectedBlockUids,
+		};
+	}
+)( MultiBlocksSwitcher );

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -46,6 +46,7 @@ export { default as BlockToolbar } from './block-toolbar';
 export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as Inserter } from './inserter';
+export { default as MultiBlocksSwitcher } from './block-switcher/multi-blocks-switcher';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
 

--- a/editor/edit-post/header/header-toolbar/index.js
+++ b/editor/edit-post/header/header-toolbar/index.js
@@ -12,12 +12,18 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './style.scss';
-import { Inserter, BlockToolbar, TableOfContents, EditorHistoryRedo, EditorHistoryUndo } from '../../../components';
-import BlockSwitcher from '../../../components/block-switcher';
+import {
+	Inserter,
+	BlockToolbar,
+	TableOfContents,
+	EditorHistoryRedo,
+	EditorHistoryUndo,
+	MultiBlocksSwitcher,
+} from '../../../components';
 import NavigableToolbar from '../../../components/navigable-toolbar';
-import { getMultiSelectedBlockUids, isFeatureActive } from '../../../selectors';
+import { isFeatureActive } from '../../../selectors';
 
-function HeaderToolbar( { hasFixedToolbar, isMultiBlockSelection, selectedBlockUids } ) {
+function HeaderToolbar( { hasFixedToolbar } ) {
 	return (
 		<NavigableToolbar
 			className="editor-header-toolbar"
@@ -27,10 +33,7 @@ function HeaderToolbar( { hasFixedToolbar, isMultiBlockSelection, selectedBlockU
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents />
-			{ isMultiBlockSelection && (
-				<div className="editor-header-toolbar__block-toolbar">
-					<BlockSwitcher key="switcher" uids={ selectedBlockUids } />
-				</div> ) }
+			<MultiBlocksSwitcher />
 			{ hasFixedToolbar && (
 				<div className="editor-header-toolbar__block-toolbar">
 					<BlockToolbar />
@@ -41,12 +44,7 @@ function HeaderToolbar( { hasFixedToolbar, isMultiBlockSelection, selectedBlockU
 }
 
 export default connect(
-	( state ) => {
-		const selectedBlockUids = getMultiSelectedBlockUids( state );
-		return {
-			hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
-			isMultiBlockSelection: selectedBlockUids.length > 1,
-			selectedBlockUids,
-		};
-	}
+	( state ) => ( {
+		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
+	} )
 )( HeaderToolbar );


### PR DESCRIPTION
Extract a reusable MultiBlocksSwitcher component to the `editor/components` folder.
Needed to be able to separate the edit-post and editor module

Expect some similar PRs today, I'm going to merge them as soon as the tests pass, they consist of moving some files around.

**Testing instructions**

  -  Select several paragraphs and transform them to a list
