### PR TITLE
Add content values when updating text-columns column-count

### DIFF
--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -78,13 +78,15 @@ registerBlockType( 'core/text-columns', {
 						label={ __( 'Columns' ) }
 						value={ columns }
 						onChange={ ( value ) => {
+							const nextAttributes = { columns: value };
 							// Add additional content values when adding columns
 							if ( value > content.length ) {
-								while ( value > content.length ) {
-									content.push( '' );
-								}
+								nextAttributes.content = [
+									...content,
+									...times( value - content.length, () => [] ),
+								];
 							}
-							setAttributes( { columns: value, content } );
+							setAttributes( nextAttributes );
 						} }
 						min={ 2 }
 						max={ 4 }

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -77,7 +77,15 @@ registerBlockType( 'core/text-columns', {
 					<RangeControl
 						label={ __( 'Columns' ) }
 						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
+						onChange={ ( value ) => {
+							// Add additional content values when adding columns
+							if ( value > content.length ) {
+								while ( value > content.length ) {
+									content.push( '' );
+								}
+							}
+							setAttributes( { columns: value, content } );
+						} }
 						min={ 2 }
 						max={ 4 }
 					/>


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes bug #3630. When the `setAttributes` action is called when updating the column count is incremented, additional content elements are pushed to the array.

I've decided not to delete text in columns that are removed. Is this desirable? Maybe only remove data in removed columns when saving the post?

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
It has been tested by updating the column count of the Text Columns block, saving it and reloading the editor. If you know a way to unit test this, please advice.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.