### PR TITLE
Components: Extract PostTrashCheck reusable component

### DIFF
--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -33,6 +33,7 @@ export { default as PostTextEditor } from './post-text-editor';
 export { default as PostTextEditorToolbar } from './post-text-editor/toolbar';
 export { default as PostTitle } from './post-title';
 export { default as PostTrash } from './post-trash';
+export { default as PostTrashCheck } from './post-trash/check';
 export { default as PostVisibility } from './post-visibility';
 export { default as PostVisibilityLabel } from './post-visibility/label';
 export { default as TableOfContents } from './table-of-contents';

--- a/editor/components/post-trash/check.js
+++ b/editor/components/post-trash/check.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isEditedPostNew, getCurrentPostId } from '../../selectors';
+
+function PostTrashCheck( { isNew, postId, children } ) {
+	if ( isNew || ! postId ) {
+		return null;
+	}
+
+	return children;
+}
+
+export default connect(
+	( state ) => {
+		return {
+			isNew: isEditedPostNew( state ),
+			postId: getCurrentPostId( state ),
+		};
+	},
+)( PostTrashCheck );

--- a/editor/edit-post/sidebar/post-trash/index.js
+++ b/editor/edit-post/sidebar/post-trash/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { PanelRow } from '@wordpress/components';
@@ -12,26 +7,14 @@ import { PanelRow } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
-import { PostTrash as PostTrashLink } from '../../../components';
-import { isEditedPostNew, getCurrentPostId } from '../../../selectors';
+import { PostTrash as PostTrashLink, PostTrashCheck } from '../../../components';
 
-function PostTrash( { isNew, postId } ) {
-	if ( isNew || ! postId ) {
-		return null;
-	}
-
+export default function PostTrash() {
 	return (
-		<PanelRow>
-			<PostTrashLink />
-		</PanelRow>
+		<PostTrashCheck>
+			<PanelRow>
+				<PostTrashLink />
+			</PanelRow>
+		</PostTrashCheck>
 	);
 }
-
-export default connect(
-	( state ) => {
-		return {
-			isNew: isEditedPostNew( state ),
-			postId: getCurrentPostId( state ),
-		};
-	},
-)( PostTrash );


### PR DESCRIPTION
Extract a reusable PostTrashCheck component to the `editor/components` folder.
Needed to be able to separate the edit-post and editor module

Expect some similar PRs today, I'm going to merge them as soon as the tests pass, they consist of moving some files around.

**Testing instructions**

  -  Click the post trash link shows up when the post is not "new"
