### PR TITLE
Editor: Display an item in Table of Contents when only one heading added

### DIFF
--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -51,10 +51,10 @@ const getHeadingLevel = heading => {
 
 const isEmptyHeading = heading => ! heading.attributes.content || heading.attributes.content.length === 0;
 
-const DocumentOutline = ( { blocks, onSelect } ) => {
+export const DocumentOutline = ( { blocks = [], onSelect } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
 
-	if ( headings.length <= 1 ) {
+	if ( headings.length < 1 ) {
 		return null;
 	}
 

--- a/editor/components/document-outline/test/__snapshots__/index.js.snap
+++ b/editor/components/document-outline/test/__snapshots__/index.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DocumentOutline header blocks present should match snapshot 1`] = `
+<div
+  className="document-outline"
+>
+  <ul>
+    <TableOfContentsItem
+      isValid={2}
+      key="0"
+      level={2}
+      onClick={[Function]}
+    >
+      Heading parent
+    </TableOfContentsItem>
+    <TableOfContentsItem
+      isValid={3}
+      key="1"
+      level={3}
+      onClick={[Function]}
+    >
+      Heading child
+    </TableOfContentsItem>
+  </ul>
+</div>
+`;

--- a/editor/components/document-outline/test/index.js
+++ b/editor/components/document-outline/test/index.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { DocumentOutline } from '../';
+
+describe( 'DocumentOutline', () => {
+	const paragraph = createBlock( 'core/paragraph' );
+	const headingParent = createBlock( 'core/heading', {
+		content: 'Heading parent',
+		nodeName: 'H2',
+	} );
+	const headingChild = createBlock( 'core/heading', {
+		content: 'Heading child',
+		nodeName: 'H3',
+	} );
+
+	describe( 'no header blocks present', () => {
+		it( 'should not render when no blocks provided', () => {
+			const wrapper = shallow( <DocumentOutline /> );
+
+			expect( wrapper.html() ).toBe( null );
+		} );
+
+		it( 'should not render when no heading blocks provided', () => {
+			const blocks = [ paragraph ];
+			const wrapper = shallow( <DocumentOutline blocks={ blocks } /> );
+
+			expect( wrapper.html() ).toBe( null );
+		} );
+	} );
+
+	describe( 'header blocks present', () => {
+		it( 'should match snapshot', () => {
+			const blocks = [ headingParent, headingChild ];
+			const wrapper = shallow( <DocumentOutline blocks={ blocks } /> );
+
+			expect( wrapper ).toMatchSnapshot();
+		} );
+
+		it( 'should render an item when only one heading provided', () => {
+			const blocks = [ headingParent ];
+			const wrapper = shallow( <DocumentOutline blocks={ blocks } /> );
+
+			expect( wrapper.find( 'TableOfContentsItem' ) ).toHaveLength( 1 );
+		} );
+
+		it( 'should render two items when two headings and some paragraphs provided', () => {
+			const blocks = [ paragraph, headingParent, paragraph, headingChild, paragraph ];
+			const wrapper = shallow( <DocumentOutline blocks={ blocks } /> );
+
+			expect( wrapper.find( 'TableOfContentsItem' ) ).toHaveLength( 2 );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Description

You need to add at least 2 heading to the document to see them listed in the table of contents. This PR tries to fix that. It also adds unit tests which will prevent regression in the future.

## How Has This Been Tested?
Manually + newly created unit tests.

## Screenshots (jpeg or gifs if applicable):

### Before

![screen shot 2017-11-24 at 13 55 18](https://user-images.githubusercontent.com/699132/33212833-1218604a-d125-11e7-8fa7-d34c8cc7156d.png)


### After

![screen shot 2017-11-24 at 14 37 14](https://user-images.githubusercontent.com/699132/33212836-165b2f02-d125-11e7-8965-624009832abb.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.