### PR TITLE
Documentation: Remove "source" key when using meta attributes

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -108,7 +108,6 @@ Attributes may be obtained from a post's meta rather than from the block's repre
 attributes: {
 	author: {
 		type: 'string',
-		source: 'meta',
 		meta: 'author'
 	},
 },


### PR DESCRIPTION
When the source key is added, the elements don't get updated in 
their lifecycle but the data gets saved correctly. Based on @pento's
Gist, removing this key fixes the problem.

https://gist.github.com/pento/19b35d621709042fc899e394a9387a54

