### PR TITLE
Don't lint cypress files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 build
 coverage
-vendor
+cypress
 node_modules
+vendor


### PR DESCRIPTION
Every so often I get linter errors because of changes that cypress has made. This ought to put an end to that.