### PR TITLE
Fix the formatting of the Markdown links in the Release doc

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -4,14 +4,14 @@ This document is a checklist for building and releasing a new version of Gutenbe
 
 ## Writing the Release Post and Changelog
 
-* Open the [https://github.com/WordPress/gutenberg/pulls?page=2&q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc](recently updated PRs view), and find the PR where the last version bump occurred.
+* Open the [recently updated PRs view](https://github.com/WordPress/gutenberg/pulls?page=2&q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc), and find the PR where the last version bump occurred.
 * Read through each PR since then, to determine if it needs to be included in the Release Post and/or changelog.
 * Choose a feature or two to highlight in the release post - record an animation of them in action.
-* Save the draft post on [https://make.wordpress.org/core/](make.wordpress.org/core), for publishing after the release.
+* Save the draft post on [make.wordpress.org/core](https://make.wordpress.org/core/), for publishing after the release.
 
 ## Bumping the Version
 
-* Create a PR like [https://github.com/WordPress/gutenberg/pull/3479/files](this one), bumping the version number in `gutenberg.php`, `package.json`, and `package-lock.json`.
+* Create a PR like [this one](https://github.com/WordPress/gutenberg/pull/3479/files), bumping the version number in `gutenberg.php`, `package.json`, and `package-lock.json`.
 * Check that there's no work in progress that's just about to land, and inform committers to hold off on merging any changes until after the release process is complete.
 * Merge the version bump PR.
 


### PR DESCRIPTION
I'm bad at Markdown.