### PR TITLE
Framework: Handle and upgrade deprecated blocks

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { parse as hpqParse } from 'hpq';
-import { mapValues, find, omit } from 'lodash';
+import { mapValues, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -130,6 +130,32 @@ export function getBlockAttributes( blockType, innerHTML, attributes ) {
 }
 
 /**
+ * Attempt to parse the innerHTML using using a supplied `deprecated` definition.
+ *
+ * @param  {?Object} blockType  Block type
+ * @param  {string}  innerHTML  Raw block content
+ * @param  {?Object} attributes Known block attributes (from delimiters)
+ * @return {Object}             Block attributes
+ */
+export function getAttributesFromDeprecatedVersion( blockType, innerHTML, attributes ) {
+	if ( ! blockType.deprecated ) {
+		return;
+	}
+
+	for ( let i = 0; i < blockType.deprecated.length; i++ ) {
+		const deprecatedBlockType = {
+			...omit( blockType, [ 'attributes', 'save', 'supports' ] ), // Parsing/Serialization properties
+			...blockType.deprecated[ i ],
+		};
+		const deprecatedBlockAttributes = getBlockAttributes( deprecatedBlockType, innerHTML, attributes );
+		const isValid = isValidBlock( innerHTML, deprecatedBlockType, deprecatedBlockAttributes );
+		if ( isValid ) {
+			return deprecatedBlockAttributes;
+		}
+	}
+}
+
+/**
  * Creates a block with fallback to the unknown type handler.
  *
  * @param  {?String} name       Block type name
@@ -181,23 +207,14 @@ export function createBlockWithFallback( name, innerHTML, attributes ) {
 		// as invalid, or future serialization attempt results in an error
 		block.originalContent = innerHTML;
 
-		// When a block is invalid, attempt to validate again using a supplied `deprecated` definition.
+		// When a block is invalid, attempt to parse it using a supplied `deprecated` definition.
 		// This allows blocks to modify their attribute and markup structure without invalidating
 		// content written in previous formats.
-		if ( ! block.isValid && blockType.deprecated ) {
-			let attributesParsedWithDeprecatedVersion;
-			const hasValidOlderVersion = find( blockType.deprecated, ( oldBlockType ) => {
-				const deprecatedBlockType = {
-					...omit( blockType, [ 'attributes', 'save', 'supports' ] ), // Parsing/Serialization properties
-					...oldBlockType,
-				};
-				const deprecatedBlockAttributes = getBlockAttributes( deprecatedBlockType, innerHTML, attributes );
-				const isValid = isValidBlock( innerHTML, deprecatedBlockType, deprecatedBlockAttributes );
-				attributesParsedWithDeprecatedVersion = isValid ? deprecatedBlockAttributes : undefined;
-				return isValid;
-			} );
-
-			if ( hasValidOlderVersion ) {
+		if ( ! block.isValid ) {
+			const attributesParsedWithDeprecatedVersion = getAttributesFromDeprecatedVersion(
+				blockType, innerHTML, attributes
+			);
+			if ( attributesParsedWithDeprecatedVersion ) {
 				block.isValid = true;
 				block.attributes = attributesParsedWithDeprecatedVersion;
 			}

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -181,10 +181,12 @@ export function createBlockWithFallback( name, innerHTML, attributes ) {
 		// as invalid, or future serialization attempt results in an error
 		block.originalContent = innerHTML;
 
-		// If the block is invalid, try to find an older compatible version
-		if ( ! block.isValid && blockType.deprecatedVersions ) {
+		// When a block is invalid, attempt to validate again using a supplied `deprecated` definition.
+		// This allows blocks to modify their attribute and markup structure without invalidating
+		// content written in previous formats.
+		if ( ! block.isValid && blockType.deprecated ) {
 			let attributesParsedWithDeprecatedVersion;
-			const hasValidOlderVersion = find( blockType.deprecatedVersions, ( oldBlockType ) => {
+			const hasValidOlderVersion = find( blockType.deprecated, ( oldBlockType ) => {
 				const deprecatedBlockType = {
 					...omit( blockType, [ 'attributes', 'save', 'supports' ] ), // Parsing/Serialization properties
 					...oldBlockType,

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -211,6 +211,47 @@ describe( 'block parser', () => {
 			const block = createBlockWithFallback( 'core/test-block', '' );
 			expect( block ).toBeUndefined();
 		} );
+
+		it( 'should fallback to an older version of the block if the current one is invalid', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					fruit: {
+						type: 'string',
+						source: 'text',
+						selector: 'div',
+					},
+				},
+				save: ( { attributes } ) => <div>{attributes.fruit}</div>,
+				deprecatedVersions: [
+					{
+						attributes: {
+							fruit: {
+								type: 'string',
+								source: 'text',
+								selector: 'span',
+							},
+						},
+						save: ( { attributes } ) => <span>{attributes.fruit}</span>,
+					},
+				],
+			} );
+
+			const block = createBlockWithFallback(
+				'core/test-block',
+				'<span class="wp-block-test-block">Bananas</span>',
+				{ fruit: 'Bananas' }
+			);
+			expect( block.name ).toEqual( 'core/test-block' );
+			expect( block.attributes ).toEqual( { fruit: 'Bananas' } );
+			expect( block.isValid ).toBe( true );
+			/* eslint-disable no-console */
+			expect( console.error ).toHaveBeenCalled();
+			expect( console.warn ).toHaveBeenCalled();
+			console.warn.mockClear();
+			console.error.mockClear();
+			/* eslint-enable no-console */
+		} );
 	} );
 
 	describe( 'parse()', () => {

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -223,7 +223,7 @@ describe( 'block parser', () => {
 					},
 				},
 				save: ( { attributes } ) => <div>{attributes.fruit}</div>,
-				deprecatedVersions: [
+				deprecated: [
 					{
 						attributes: {
 							fruit: {

--- a/blocks/library/quote/editor.scss
+++ b/blocks/library/quote/editor.scss
@@ -1,4 +1,4 @@
-.wp-block-quote.blocks-quote-style-1 {
+.wp-block-quote:not(.is-large) {
 	border-left: 4px solid $black;
 	padding-left: 1em;
 }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { isString, get } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -154,6 +155,7 @@ registerBlockType( 'core/quote', {
 	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, className } ) {
 		const { align, value, citation, style } = attributes;
 		const focusedEditable = focus ? focus.editable || 'value' : null;
+		const containerClassname = classnames( className, style === 2 ? 'is-large' : '' );
 
 		return [
 			focus && (
@@ -183,7 +185,7 @@ registerBlockType( 'core/quote', {
 			),
 			<blockquote
 				key="quote"
-				className={ `${ className } blocks-quote-style-${ style }` }
+				className={ containerClassname }
 			>
 				<Editable
 					multiline="p"
@@ -222,7 +224,7 @@ registerBlockType( 'core/quote', {
 
 		return (
 			<blockquote
-				className={ `blocks-quote-style-${ style }` }
+				className={ style === 2 ? 'is-large' : '' }
 				style={ { textAlign: align ? align : null } }
 			>
 				{ value.map( ( paragraph, i ) => (

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -235,7 +235,7 @@ registerBlockType( 'core/quote', {
 		);
 	},
 
-	deprecatedVersions: [
+	deprecated: [
 		{
 			attributes: {
 				...blockAttributes,

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -26,36 +26,38 @@ const fromEditableValue = value => value.map( ( subValue ) => ( {
 	children: subValue,
 } ) );
 
+const blockAttributes = {
+	value: {
+		type: 'array',
+		source: 'query',
+		selector: 'blockquote > p',
+		query: {
+			children: {
+				source: 'node',
+			},
+		},
+		default: [],
+	},
+	citation: {
+		type: 'array',
+		source: 'children',
+		selector: 'cite',
+	},
+	align: {
+		type: 'string',
+	},
+	style: {
+		type: 'number',
+		default: 1,
+	},
+};
+
 registerBlockType( 'core/quote', {
 	title: __( 'Quote' ),
 	icon: 'format-quote',
 	category: 'common',
 
-	attributes: {
-		value: {
-			type: 'array',
-			source: 'query',
-			selector: 'blockquote > p',
-			query: {
-				children: {
-					source: 'node',
-				},
-			},
-			default: [],
-		},
-		citation: {
-			type: 'array',
-			source: 'children',
-			selector: 'footer',
-		},
-		align: {
-			type: 'string',
-		},
-		style: {
-			type: 'number',
-			default: 1,
-		},
-	},
+	attributes: blockAttributes,
 
 	transforms: {
 		from: [
@@ -227,9 +229,40 @@ registerBlockType( 'core/quote', {
 					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
 				) ) }
 				{ citation && citation.length > 0 && (
-					<footer>{ citation }</footer>
+					<cite>{ citation }</cite>
 				) }
 			</blockquote>
 		);
 	},
+
+	deprecatedVersions: [
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					type: 'array',
+					source: 'children',
+					selector: 'footer',
+				},
+			},
+
+			save( { attributes } ) {
+				const { align, value, citation, style } = attributes;
+
+				return (
+					<blockquote
+						className={ `blocks-quote-style-${ style }` }
+						style={ { textAlign: align ? align : null } }
+					>
+						{ value.map( ( paragraph, i ) => (
+							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
+						) ) }
+						{ citation && citation.length > 0 && (
+							<footer>{ citation }</footer>
+						) }
+					</blockquote>
+				);
+			},
+		},
+	],
 } );

--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -10,7 +10,7 @@
 		font-style: normal;
 	}
 
-	&.blocks-quote-style-2 {
+	&.is-large {
 		padding: 0 1em;
 		p {
 			font-size: 24px;

--- a/blocks/test/fixtures/core__quote__style-1.html
+++ b/blocks/test/fixtures/core__quote__style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"style":"1"} -->
-<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
+<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-1.html
+++ b/blocks/test/fixtures/core__quote__style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"style":"1"} -->
-<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -23,6 +23,6 @@
             ],
             "style": 1
         },
-        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -23,6 +23,6 @@
             ],
             "style": 1
         },
-        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -5,7 +5,7 @@
             "style": "1"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-1.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-1.parsed.json
@@ -5,7 +5,7 @@
             "style": "1"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote blocks-quote-style-1\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,6 +1,4 @@
 <!-- wp:quote -->
 <blockquote class="wp-block-quote blocks-quote-style-1">
-    <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
-    <footer>Matt Mullenweg, 2017</footer>
-</blockquote>
+    <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:quote -->

--- a/blocks/test/fixtures/core__quote__style-1.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-1.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:quote -->
-<blockquote class="wp-block-quote blocks-quote-style-1">
+<blockquote class="wp-block-quote">
     <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
 <!-- /wp:quote -->

--- a/blocks/test/fixtures/core__quote__style-2.html
+++ b/blocks/test/fixtures/core__quote__style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"style":"2"} -->
-<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-2.html
+++ b/blocks/test/fixtures/core__quote__style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"style":"2"} -->
-<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
+<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:core/quote -->

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -23,6 +23,6 @@
             ],
             "style": 2
         },
-        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote is-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -23,6 +23,6 @@
             ],
             "style": 2
         },
-        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
     }
 ]

--- a/blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -5,7 +5,7 @@
             "style": "2"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote is-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-2.parsed.json
+++ b/blocks/test/fixtures/core__quote__style-2.parsed.json
@@ -5,7 +5,7 @@
             "style": "2"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>\n"
+        "innerHTML": "\n<blockquote class=\"wp-block-quote blocks-quote-style-2\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,4 +1,4 @@
 <!-- wp:quote {"style":2} -->
-<blockquote class="wp-block-quote blocks-quote-style-2">
+<blockquote class="wp-block-quote is-large">
     <p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:quote -->

--- a/blocks/test/fixtures/core__quote__style-2.serialized.html
+++ b/blocks/test/fixtures/core__quote__style-2.serialized.html
@@ -1,6 +1,4 @@
 <!-- wp:quote {"style":2} -->
 <blockquote class="wp-block-quote blocks-quote-style-2">
-    <p>There is no greater agony than bearing an untold story inside you.</p>
-    <footer>Maya Angelou</footer>
-</blockquote>
+    <p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
 <!-- /wp:quote -->

--- a/phpunit/fixtures/long-content.html
+++ b/phpunit/fixtures/long-content.html
@@ -56,7 +56,7 @@
 <!-- wp:quote -->
 <blockquote class="wp-block-quote blocks-quote-style-1">
 <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
-<footer>Matt Mullenweg, 2017</footer>
+<cite>Matt Mullenweg, 2017</cite>
 </blockquote>
 <!-- /wp:quote -->
 <!-- wp:paragraph -->

--- a/post-content.js
+++ b/post-content.js
@@ -72,7 +72,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:quote {"style":1} -->',
-		'<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>',
+		'<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>',
 		'<!-- /wp:quote -->',
 
 		'<!-- wp:paragraph -->',

--- a/post-content.js
+++ b/post-content.js
@@ -72,7 +72,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:quote {"style":1} -->',
-		'<blockquote class="wp-block-quote blocks-quote-style-1"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>',
+		'<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>',
 		'<!-- /wp:quote -->',
 
 		'<!-- wp:paragraph -->',


### PR DESCRIPTION
refs #2541 alternative to #3327 

Instead of adding a "version" to the block comment and upgrading blocks version by version, this uses a simpler alternative where:

 - A block adds keeps a list of deprecated versions ( `save`, `attributes` and `support` )
 - When parsing a block if it's invalid, we try to find a "valid" deprecated version
 - If we find a corresponding version, we use its definition to parse the block attributes.

**Testing instructions**

 - Paste this in to the code editor (old quote HTML)

```html
<!-- wp:quote {"style":1} -->
<blockquote class="wp-block-quote blocks-quote-style-1">
    <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
<!-- /wp:quote -->
```

 - Click outside the editable area
 - You'll notice the block is "migrated" to the last version with `cite` and you can still edit the block as expected in the visual editor 