### PR TITLE
Framework: Bootstrap Block Templates

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -6,15 +6,17 @@ import { partial, castArray } from 'lodash';
 
 /**
  * Returns an action object used in signalling that editor has initialized with
- * the specified post object.
+ * the specified post object and editor settings.
  *
- * @param  {Object} post Post object
- * @return {Object}      Action object
+ * @param  {Object} post     Post object
+ * @param  {Object} settings Editor settings object
+ * @return {Object}          Action object
  */
-export function setupEditor( post ) {
+export function setupEditor( post, settings ) {
 	return {
 		type: 'SETUP_EDITOR',
 		post,
+		settings,
 	};
 }
 

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -42,19 +42,17 @@ class EditorProvider extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
-		const store = createReduxStore( props.initialState );
-
-		// If initial state is passed, assume that we don't need to initialize,
-		// as in the case of an error recovery.
-		if ( ! props.initialState ) {
-			store.dispatch( setupEditor( props.post ) );
-		}
-
-		this.store = store;
+		this.store = createReduxStore( props.initialState );
 		this.settings = {
 			...DEFAULT_SETTINGS,
 			...props.settings,
 		};
+
+		// If initial state is passed, assume that we don't need to initialize,
+		// as in the case of an error recovery.
+		if ( ! props.initialState ) {
+			this.store.dispatch( setupEditor( props.post, this.settings ) );
+		}
 	}
 
 	getChildContext() {

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -275,7 +275,7 @@ export default {
 		if ( post.content.raw ) {
 			effects.push( resetBlocks( parse( post.content.raw ) ) );
 		} else if ( settings.template ) {
-			const blocks = map( settings.template.blocks, ( { name, attributes } ) => {
+			const blocks = map( settings.template, ( [ name, attributes ] ) => {
 				const block = createBlock( name );
 				block.attributes = {
 					...block.attributes,

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -268,12 +268,22 @@ export default {
 		dispatch( savePost() );
 	},
 	SETUP_EDITOR( action ) {
-		const { post } = action;
+		const { post, settings } = action;
 		const effects = [];
 
 		// Parse content as blocks
 		if ( post.content.raw ) {
 			effects.push( resetBlocks( parse( post.content.raw ) ) );
+		} else if ( settings.template ) {
+			const blocks = map( settings.template.blocks, ( { name, attributes } ) => {
+				const block = createBlock( name );
+				block.attributes = {
+					...block.attributes,
+					...attributes,
+				};
+				return block;
+			} );
+			effects.push( resetBlocks( blocks ) );
 		}
 
 		// Resetting post should occur after blocks have been reset, since it's

--- a/editor/test/effects.js
+++ b/editor/test/effects.js
@@ -342,7 +342,7 @@ describe( 'effects', () => {
 				status: 'draft',
 			};
 
-			const result = handler( { post } );
+			const result = handler( { post, settings: {} } );
 
 			expect( result ).toEqual( [
 				resetPost( post ),
@@ -362,7 +362,7 @@ describe( 'effects', () => {
 				status: 'draft',
 			};
 
-			const result = handler( { post } );
+			const result = handler( { post, settings: {} } );
 
 			expect( result ).toHaveLength( 2 );
 			expect( result ).toContainEqual( resetPost( post ) );
@@ -383,7 +383,7 @@ describe( 'effects', () => {
 				status: 'auto-draft',
 			};
 
-			const result = handler( { post } );
+			const result = handler( { post, settings: {} } );
 
 			expect( result ).toEqual( [
 				resetPost( post ),

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -782,6 +782,11 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'blockTypes' => $allowed_block_types,
 	);
 
+	$post_type_object = get_post_type_object( $post_to_edit['type'] );
+	if ( $post_type_object->template ) {
+		$editor_settings['template'] = $post_type_object->template;
+	}
+
 	$script  = '( function() {';
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
 	$script .= <<<JS


### PR DESCRIPTION
This PR is the first one introducing the Block Templates. (details on those here #3588 )
This first iteration allows:

 - Defining a template for a CPT
 - Initialize the editor with a predefined list of blocks if a template is found.

A template object looks like this:

```js
const template = [
  [ 'block/name', {} ], // [ blockName, attributes ]
];
```

**Testing instructions**

 - Add A CPT like this:

```php
function register_book_type() {
	$args = array(
		'public' => true,
		'label'  => 'Books',
		'show_in_rest' => true,
		'template' => array(
			array( 'core/image' ),
			array( 'core/paragraph', array(
				'placeholder' => 'Add a book description',
			) ),
			array( 'core/quote' ),
		),
	);
	register_post_type( 'book', $args );
}
add_action( 'init', 'register_book_type' );
```

 - Create a new post with the registered CPT
 - The editor should initialize with the predefined list of blocks defined in this template.

**Notes**

 - Block Attributes need to be initialized properly server-side, we should move away from our Editable Value as React Elements to be able to do so for these attributes (related #3048)
