### PR TITLE
[Try] Remove inline style attributes paragraph and button.

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -18,6 +18,7 @@ const categories = [
 	{ slug: 'widgets', title: __( 'Widgets' ) },
 	{ slug: 'embed', title: __( 'Embed' ) },
 	{ slug: 'reusable-blocks', title: __( 'My Reusable Blocks' ) },
+	{ slug: 'hidden', title: __( 'Hidden blocks' ) },
 ];
 
 /**

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -163,7 +163,7 @@ export function createBlockWithFallback( name, innerHTML, attributes ) {
 
 	// Include in set only if type were determined.
 	// TODO do we ever expect there to not be an unknown type handler?
-	if ( blockType && ( innerHTML || name !== fallbackBlock ) ) {
+	if ( blockType && ( innerHTML || name !== fallbackBlock ) && ! blockType.isComputedBlock ) {
 		// TODO allow blocks to opt-in to receiving a tree instead of a string.
 		// Gradually convert all blocks to this new format, then remove the
 		// string serialization.

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -11,6 +15,7 @@ import { Dashicon, IconButton, PanelColor, withFallbackStyles } from '@wordpress
 import './editor.scss';
 import './style.scss';
 import { registerBlockType } from '../../api';
+import { generateClassBackgroundColor, generateClassColor, generateStyleBackgroundColor, generateStyleColor } from '../../style-generator';
 import Editable from '../../editable';
 import UrlInput from '../../url-input';
 import BlockControls from '../../block-controls';
@@ -202,13 +207,25 @@ registerBlockType( 'core/button', {
 
 	save( { attributes } ) {
 		const { url, text, title, align, color, textColor } = attributes;
-
+		const className = classnames( {
+			[ `align${ align }` ]: align,
+			[ generateClassBackgroundColor( color ) ]: color,
+		} );
 		return (
-			<div className={ `align${ align }` } style={ { backgroundColor: color } }>
-				<a href={ url } title={ title } style={ { color: textColor } }>
+			<div className={ className ? className : undefined }>
+				<a href={ url } className={ textColor ? `custom-color ${ generateClassColor( textColor ) }` : undefined } title={ title }>
 					{ text }
 				</a>
 			</div>
 		);
 	},
+
+	saveStyles( { attributes } ) {
+		const { color, textColor } = attributes;
+		return {
+			...generateStyleBackgroundColor( color ),
+			...generateStyleColor( textColor ),
+		};
+	},
+
 } );

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -20,9 +20,12 @@ $blocks-button__height: 46px;
 
 	a {
 		box-shadow: none !important;
-		color: $white;
 		cursor: pointer;
 		text-decoration: none !important;
+	}
+
+	a:not(.custom-color) {
+		color: $white;
 	}
 
 	&.aligncenter {

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -23,3 +23,4 @@ import './video';
 import './audio';
 import './reusable-block';
 import './paragraph';
+import './style';

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -17,6 +17,7 @@ import './editor.scss';
 import './style.scss';
 import { registerBlockType, createBlock, setDefaultBlockName } from '../../api';
 import { blockAutocompleter, userAutocompleter } from '../../autocompleters';
+import { generateClass, generateStyle } from '../../style-generator';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import BlockControls from '../../block-controls';
@@ -265,20 +266,34 @@ registerBlockType( 'core/paragraph', {
 
 	save( { attributes } ) {
 		const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
+		const styles = {
+			backgroundColor: backgroundColor,
+			color: textColor,
+			fontSize: fontSize && fontSize + 'px',
+			textAlign: align,
+		};
+		const customClass = generateClass( styles, 'custom-paragraph-' );
 		const className = classnames( {
 			[ `align${ width }` ]: width,
 			'has-background': backgroundColor,
 			'has-drop-cap': dropCap,
+			[ customClass ]: customClass,
 		} );
+
+		return <p className={ className ? className : undefined }>{ content }</p>;
+	},
+
+	saveStyles( { attributes } ) {
+		const { align, backgroundColor, textColor, fontSize } = attributes;
 		const styles = {
 			backgroundColor: backgroundColor,
 			color: textColor,
-			fontSize: fontSize,
+			fontSize: fontSize && fontSize + 'px',
 			textAlign: align,
 		};
-
-		return <p style={ styles } className={ className ? className : undefined }>{ content }</p>;
+		return generateStyle( styles, generateClass( styles, 'custom-paragraph-' ) );
 	},
+
 } );
 
 setDefaultBlockName( 'core/paragraph' );

--- a/blocks/library/style/index.js
+++ b/blocks/library/style/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '../../api';
+
+registerBlockType( 'core/style', {
+	title: __( 'Style' ),
+
+	icon: 'editor-code',
+
+	category: 'formatting',
+
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+		},
+	},
+
+	isComputedBlock: true,
+
+	supportHTML: true,
+
+	edit( ) {
+		return [];
+	},
+
+	save( { attributes } ) {
+		return `<style type="text/css">${ attributes.content }</style>\n`;
+	},
+} );

--- a/blocks/library/style/index.js
+++ b/blocks/library/style/index.js
@@ -13,7 +13,7 @@ registerBlockType( 'core/style', {
 
 	icon: 'editor-code',
 
-	category: 'formatting',
+	category: 'hidden',
 
 	attributes: {
 		content: {

--- a/blocks/style-generator/index.js
+++ b/blocks/style-generator/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import {
+	kebabCase,
+	reduce,
+} from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { hash, hashColor } from '@wordpress/utils';
+
+export function generateClass( styleObject, prefix = '' ) {
+	const hashString = hash( styleObject );
+	return hashString ? prefix + hashString : undefined;
+}
+
+export function generateStyle( styleObject, className ) {
+	if ( ! styleObject ) {
+		return undefined;
+	}
+	const styleString = reduce( styleObject, ( memo, value, property ) => (
+		value ? `${ memo }\n\t${ kebabCase( property ) }: ${ value };` : memo
+	), '' );
+	if ( ! styleString ) {
+		return undefined;
+	}
+	const useClass = className || generateClass( styleObject );
+	return {
+		[ useClass ]: `.${ useClass } {${ styleString }\n}`,
+	};
+}
+
+export function generateClassBackgroundColor( color ) {
+	return color ? `background-color-${ hashColor( color ) }` : undefined;
+}
+
+export function generateStyleBackgroundColor( color, className ) {
+	return color ? generateStyle( { backgroundColor: color }, className || generateClassBackgroundColor( color ) ) : undefined;
+}
+
+export function generateClassColor( color ) {
+	return color ? `color-${ hashColor( color ) }` : undefined;
+}
+
+export function generateStyleColor( color, className ) {
+	return color ? generateStyle( { color }, className || generateClassColor( color ) ) : undefined;
+}

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -220,7 +220,7 @@ export class InserterMenu extends Component {
 	}
 
 	renderCategories( visibleBlocksByCategory ) {
-		return getCategories().map(
+		return getCategories().filter( category => category.slug !== 'hidden' ).map(
 			( category ) => this.renderCategory( category, visibleBlocksByCategory[ category.slug ] )
 		);
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4801,6 +4801,11 @@
         "inherits": "2.0.3"
       }
     },
+    "hash-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hash-string/-/hash-string-1.0.0.tgz",
+      "integrity": "sha1-w/oV8Hjd0WvBULQXb95wkWIPLH8="
+    },
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dom-scroll-into-view": "1.2.1",
     "element-closest": "2.0.2",
     "escape-string-regexp": "1.0.5",
+    "hash-string": "1.0.0",
     "hpq": "1.2.0",
     "jed": "1.1.1",
     "js-beautify": "1.6.14",

--- a/utils/hash.js
+++ b/utils/hash.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import tinycolor from 'tinycolor2';
+import hashString from 'hash-string';
+import {
+	reduce,
+	some,
+} from 'lodash';
+
+export function hash( collection ) {
+	if ( ! some( collection ) ) {
+		return undefined;
+	}
+	return hashString(
+		reduce( collection, ( memo, value ) => memo + value, '' )
+	).toString( 36 );
+}
+
+export function hashColor( color ) {
+	const tinyColor = tinycolor( color );
+	const colorName = tinyColor.toName();
+	if ( colorName ) {
+		return colorName;
+	}
+	return hash( { color } );
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -9,5 +9,6 @@ export { decodeEntities };
 
 export * from './blob-cache';
 export * from './mediaupload';
+export * from './hash';
 
 export { viewPort };


### PR DESCRIPTION
## Description
This PR removes inline style attributes from paragraph and button. The approach is generic and is able to remove inline style attributes from any block. It is a first step in the list proposed by @mtias in https://github.com/WordPress/gutenberg/issues/2862. It is a work in progress and things are subject to change any inputs/thoughts are welcome.

As we are discussing in https://github.com/WordPress/gutenberg/issues/2862 and https://github.com/WordPress/gutenberg/pull/3090, this approach is used when setting very specific custom styles e.g a unique color not provided by theme/Gutenberg, parallel efforts will happen to allow themes and/or Gutenberg to provide readable human-friendly classes in font-sizes and common colors. Themes will also be allowed to remove the custom styles created.

**The class names are generated using a short hash of the attributes.**  If we have the same styles used in many blocks only one class is generated. The output of the block is a function of its attributes including the classes. As the class is a function of its attributes if there is a set of attributes that when changing theme does not look nice, theme developers can overwrite that class changing all the blocks using this attributes. Although "hacky", this provides a simple mechanism to fix things when migrating designs.

Button and paragraph use different logic. In the paragraph, we generate one style class per custom paragraph e.g: "custom-paragraph-d6hya" so styles can be reused between blocks of the same type. In button, we generate a style class for the different styles needed: e.g: "background-color-red, background-color-y6j2, color-blue". This increases reusability as the same class can be used even in different block types but generates more classes. Blocks should do a tradeoff between this logic to maximize reusability. E.g: for colors, color classes may make sense because the same color may be used in different block type, for more specific styles, aggregating them in the same class may be better. Helper functions should be provided to allow reusable styles (as we are doing for colors).

**Right now it is possible to customize paragraphs and buttons, 
 and apply custom styles. We can see the generated classes and the associated CSS, in the code view**.  We can publish and see the styles working exactly as before when they were an inline style attribute. **We use one style HTML tag in the post.** We may, in the future, add logic in the server to remove our style element when showing the post and add an end-point that outputs a CSS file for a given post id. I like to save the CSS in the content because if we render the content we should see exactly the same that we were supposed to see before.

In order to implement custom styles, **blocks need to add a function called saveStyles** that receives the attributes (as the save) and returns the styles. **Some simple helpers were created so generating styles is easier**. It is possible to see the changes blocks need to make to remove inline style attributes in paragraph and button blocks. If we follow this approach, an equivalent save styles function needs to be created in PHP so server-side blocks can make use of a similar mechanism.

Right now styles are saved in the post in a "style" block, that is ignored when parsing and is computed when serializing. If we follow this approach this concept needs to be polished. I'm thinking about the concept a "computed block", or a "higher order block", a block that when saving receives the other blocks to generate the output. It depends on the attributes present in the other blocks. The style would be one of this blocks, as it depends on the customization attributes of the other blocks to generate the CSS. This concept may also provide other advanced ways of customization and extensibility. But maybe a better concept exists.

### What I would like to discuss in this work in progress review is:

Is the saveStyles function in the blocks an acceptable interface or we should follow an alternative?
E.g: when save returns react components, we can recursively iterate on them, remove the inline style attribute and add classes. The classes can be generated from the react styles using renderToString+ parsing/processing. This approach is react specific and for now, we need to offer a generic one but it is food for thought maybe a generic one can be created based on this.

What do you think of the approach to generate CSS/class names? Is a simpler approach possible? Can we provide more human-friendly class names?

Do you predict a problem if this approach is widely used?

When polishing the concepts for the CSS computing mechanism, is the concept of a computed block (a block that receives other blocks) something we can pursue?
Or we should follow alternative approach:  e.g: update our post grammar to return the styles so javascript can ignore them on load and PHP can do it's logic e.g remove them, append styles generated in PHP side, and/or use an end-point that generates a CSS file.

Are our helper functions to generate styles something useful for block creators and the effort when using/not using inline style attributes equivalent?

Any problem arose when executing the manual tests bellow? 

## How Has This Been Tested?
- Add a button and a paragraph change content but not styles. Verify in the code view that no CSS is generated.
- Add some styles to paragraph and button, verify classes are now applied and the CSS is now visible in the code view.
- Repeat the same customization in another paragraph/button verify classes are reused and no duplicate CSS is created.
- Use a named color, in the button e.g. #ff0000 and verify a readable class is used.
- Publish the post with customizations applied and verify that the post looks as expected after publishing.

## Screenshots
<img width="698" alt="screen shot 2017-11-27 at 12 32 51" src="https://user-images.githubusercontent.com/11271197/33266894-36bdafd0-d36f-11e7-853b-fa321129ac73.png">
<img width="788" alt="screen shot 2017-11-27 at 12 32 37" src="https://user-images.githubusercontent.com/11271197/33266925-5d2bd156-d36f-11e7-918c-5181f0670f7a.png">



cc: @samikeijonen, @mike-schut, @geoconklin