### PR TITLE
Block versioning: Introduce a migration function

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -147,10 +147,16 @@ export function getAttributesFromDeprecatedVersion( blockType, innerHTML, attrib
 			...omit( blockType, [ 'attributes', 'save', 'supports' ] ), // Parsing/Serialization properties
 			...blockType.deprecated[ i ],
 		};
-		const deprecatedBlockAttributes = getBlockAttributes( deprecatedBlockType, innerHTML, attributes );
-		const isValid = isValidBlock( innerHTML, deprecatedBlockType, deprecatedBlockAttributes );
-		if ( isValid ) {
-			return deprecatedBlockAttributes;
+
+		try {
+			const deprecatedBlockAttributes = getBlockAttributes( deprecatedBlockType, innerHTML, attributes );
+			const migratedBlockAttributes = deprecatedBlockType.migrate ? deprecatedBlockType.migrate( deprecatedBlockAttributes ) : deprecatedBlockAttributes;
+			const isValid = isValidBlock( innerHTML, deprecatedBlockType, deprecatedBlockAttributes );
+			if ( isValid ) {
+				return migratedBlockAttributes;
+			}
+		} catch ( error ) {
+			// ignore error, it means this deprecated version is invalid
 		}
 	}
 }

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -149,6 +149,9 @@ export function getAttributesFromDeprecatedVersion( blockType, innerHTML, attrib
 		};
 
 		try {
+			// Parse using the deprecated block version .
+			// Try to validate the parsed block using this same deprecated version.
+			// Ignore this version if the the validation fails.
 			const deprecatedBlockAttributes = getBlockAttributes( deprecatedBlockType, innerHTML, attributes );
 			const migratedBlockAttributes = deprecatedBlockType.migrate ? deprecatedBlockType.migrate( deprecatedBlockAttributes ) : deprecatedBlockAttributes;
 			const isValid = isValidBlock( innerHTML, deprecatedBlockType, deprecatedBlockAttributes );

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -304,6 +304,7 @@ describe( 'block parser', () => {
 							},
 						},
 						save: ( { attributes } ) => <span>{ attributes.fruit }</span>,
+						migrate: ( attributes ) => ( { fruit: 'Big ' + attributes.fruit } ),
 					},
 				],
 			} );
@@ -314,7 +315,7 @@ describe( 'block parser', () => {
 				{ fruit: 'Bananas' }
 			);
 			expect( block.name ).toEqual( 'core/test-block' );
-			expect( block.attributes ).toEqual( { fruit: 'Bananas' } );
+			expect( block.attributes ).toEqual( { fruit: 'Big Bananas' } );
 			expect( block.isValid ).toBe( true );
 			expectFailingBlockValidation();
 		} );


### PR DESCRIPTION
This adds a `migrate` function to deprecated blocks in case they need to change the attributes values when migrating to a new version.

An example implemented here. Transforming the `style` attribute of the quote to a an `isLarge` boolean attribute