### PR TITLE
Framework: Check post type template as non-empty

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -783,7 +783,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	);
 
 	$post_type_object = get_post_type_object( $post_to_edit['type'] );
-	if ( $post_type_object->template ) {
+	if ( ! empty( $post_type_object->template ) ) {
 		$editor_settings['template'] = $post_type_object->template;
 	}
 


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/pull/3668/files#r153223493

This pull request seeks to resolve a notice which appears when editing a post in Gutenberg with high error reporting. Since the post type `$template` variable is not set, a warning is logged:

```
Notice: Undefined property: WP_Post_Type::$template in /srv/www/editor/htdocs/wp-content/plugins/gutenberg/lib/client-assets.php on line 786
```

This pull request seeks to use the [`empty` function](http://php.net/manual/en/function.empty.php) to test whether the `$template` property is both assigned and truthy.

__Testing instructions:__

Repeat testing instructions from #3668 

Verify that there are no warnings logged with high error reporting on the editor.