### PR TITLE
Block List: Avoid transition delay for inserter toggle on focus

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -380,7 +380,10 @@
 	.editor-inserter__toggle {
 		opacity: 0;
 		transition: opacity 0.25s ease-in-out;
-		transition-delay: 0.3s;
+
+		&:not( :focus ) {
+			transition-delay: 0.3s;
+		}
 	}
 
 	&.is-forced-visible .editor-inserter__toggle,


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/3503#issuecomment-346380426

This pull request seeks to improve the behavior of the between-inserter toggle visibility delay to take effect only for non-keyboard-focus usage (i.e. hover delay).

__Testing instructions:__

Verify that a delay occurs in displaying the editor inserter only if accessed via cursor hover. Keyboard tabbing should cause the toggle transition to occur immediately upon focus.