### PR TITLE
Switch method of matching post types to models

### DIFF
--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -74,7 +74,7 @@ class FlatTermSelector extends Component {
 
 	fetchTerms( params = {} ) {
 		const query = { ...DEFAULT_QUERY, ...params };
-		const Collection = wp.api.getTaxonomyCollection( this.props.slug );
+		const Collection = wp.api.getCollectionByType( this.props.slug );
 		const request = new Collection().fetch( { data: query } );
 		request.then( ( terms ) => {
 			this.setState( ( state ) => ( {
@@ -101,7 +101,7 @@ class FlatTermSelector extends Component {
 	findOrCreateTerm( termName ) {
 		return new Promise( ( resolve, reject ) => {
 			// Tries to create a term or fetch it if it already exists
-			const Model = wp.api.getTaxonomyModel( this.props.slug );
+			const Model = wp.api.getModelByType( this.props.slug );
 			new Model( { name: termName } ).save()
 				.then( resolve, ( xhr ) => {
 					const errorCode = xhr.responseJSON && xhr.responseJSON.code;

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -104,7 +104,7 @@ class HierarchicalTermSelector extends Component {
 				adding: true,
 			} );
 			// Tries to create a term or fetch it if it already exists
-			const Model = wp.api.getTaxonomyModel( this.props.slug );
+			const Model = wp.api.getModelByType( this.props.slug );
 			this.addRequest = new Model( {
 				name: formName,
 				parent: formParent ? formParent : undefined,
@@ -156,7 +156,7 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	componentDidMount() {
-		const Collection = wp.api.getTaxonomyCollection( this.props.slug );
+		const Collection = wp.api.getCollectionByType( this.props.slug );
 		this.fetchRequest = new Collection()
 			.fetch( { data: DEFAULT_QUERY } )
 			.done( ( terms ) => {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -83,7 +83,7 @@ export default {
 			optimist: { type: BEGIN, id: POST_UPDATE_TRANSACTION_ID },
 		} );
 		dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
-		const Model = wp.api.getPostTypeModel( getCurrentPostType( state ) );
+		const Model = wp.api.getModelByType( getCurrentPostType( state ) );
 		new Model( toSend ).save().done( ( newPost ) => {
 			dispatch( resetPost( newPost ) );
 			dispatch( {
@@ -180,7 +180,7 @@ export default {
 	TRASH_POST( action, store ) {
 		const { dispatch, getState } = store;
 		const { postId } = action;
-		const Model = wp.api.getPostTypeModel( getCurrentPostType( getState() ) );
+		const Model = wp.api.getModelByType( getCurrentPostType( getState() ) );
 		dispatch( removeNotice( TRASH_POST_NOTICE_ID ) );
 		new Model( { id: postId } ).destroy().then(
 			() => {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -555,18 +555,20 @@ function gutenberg_extend_wp_api_backbone_client() {
 
 	// Type to Model Mapping, only need to map types that name differs from model.
 	// For example, no need to map post => post, or page => page.
-	$type_model_mapping               = array();
-	$type_model_mapping['attachment'] = 'media';
-	$type_model_mapping['post_tag']   = 'tag';
+	$type_model_mapping = array(
+		'attachment' => 'media',
+		'post_tag'   => 'tag',
+	);
 	// You can use the filter to extend or map a custom type to another.
 	$type_model_mapping = apply_filters( 'type_model_mapping', $type_model_mapping );
 
 	// Type to Collection Mapping, only need to map types that name differs from collection.
-	$type_collection_mapping             = array();
-	$type_collection_mapping['category'] = 'categories';
-	$type_collection_mapping['page']     = 'pages';
-	$type_collection_mapping['post']     = 'posts';
-	$type_collection_mapping['post_tag'] = 'tags';
+	$type_collection_mapping = array(
+		'category' => 'categories',
+		'page'     => 'pages',
+		'post'     => 'posts',
+		'post_tag' => 'tags',
+	);
 	// You can use the filter to extend or map a custom type to another.
 	$type_collection_mapping = apply_filters( 'type_collection_mapping', $type_collection_mapping );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -553,9 +553,9 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
  */
 function gutenberg_extend_wp_api_backbone_client() {
 	// Post Types Mapping.
-	$post_type_rest_base_mapping = array();
-	$post_type_rest_base_mapping[ 'attachment' ] = "media";
-	$post_type_rest_base_mapping = apply_filters( 'post_type_rest_base_mapping', $post_type_rest_base_mapping );
+	$post_type_rest_base_mapping               = array();
+	$post_type_rest_base_mapping['attachment'] = 'media';
+	$post_type_rest_base_mapping               = apply_filters( 'post_type_rest_base_mapping', $post_type_rest_base_mapping );
 
 	// Taxonomies Mapping.
 	$taxonomy_rest_base_mapping = array();


### PR DESCRIPTION
## Description

This change shows a different way of mapping post type to the wp.api.models. I'm including here for a discussion, since I'm not sure why the current method is in place and if there is something I'm missing.

The current method, including [core change #41111](https://core.trac.wordpress.org/ticket/41111) constructs API routes with regular expressions and then tries to determine the model based on those routes. The routes are then compared against each other as strings, and not tested as regular expressions.

This is troublesome because the API routes can be different per install, for example I'm working on bringing Gutenberg to WordPress.com which uses an external API server, and includes a `sites/BLOG_ID/` parameter in the routes. So 

The routes are also based off the wp.api.versionString which can be changed, and was recently in  #3377 as [you can see here](https://github.com/WordPress/gutenberg/blob/master/lib/client-assets.php#L793) it was changed from `wp/v2` to `gutenberg/v1` which I don't think is a valid API route. The only reason I think this doesn't break the mapping function is written to the page source prior to the versionString change.

This change does away with the routes mapping, and simple maps the types to objects that need to be mapped, in this case it is primarily `attachment => media`

I also added a filter which could be used to extend the mapping or override any that is necessary.

Additionally this change should make it much quicker, since the _.find has to traverse the prototype for each object which in this case is quite deep to find and check the route.

