### PR TITLE
Framework: Adding the possibility to lock the editor

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -151,13 +151,17 @@ registerBlockType( 'core/heading', {
 				onFocus={ setFocus }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				onSplit={ ( before, after, ...blocks ) => {
-					setAttributes( { content: before } );
-					insertBlocksAfter( [
-						...blocks,
-						createBlock( 'core/paragraph', { content: after } ),
-					] );
-				} }
+				onSplit={
+					insertBlocksAfter ?
+						( before, after, ...blocks ) => {
+							setAttributes( { content: before } );
+							insertBlocksAfter( [
+								...blocks,
+								createBlock( 'core/paragraph', { content: after } ),
+							] );
+						} :
+						undefined
+				}
 				style={ { textAlign: align } }
 				placeholder={ placeholder || __( 'Write heading…' ) }
 			/>,

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -332,21 +332,25 @@ registerBlockType( 'core/list', {
 					wrapperClassName="blocks-list"
 					placeholder={ __( 'Write list…' ) }
 					onMerge={ mergeBlocks }
-					onSplit={ ( before, after, ...blocks ) => {
-						if ( ! blocks.length ) {
-							blocks.push( createBlock( 'core/paragraph' ) );
-						}
+					onSplit={
+						insertBlocksAfter ?
+							( before, after, ...blocks ) => {
+								if ( ! blocks.length ) {
+									blocks.push( createBlock( 'core/paragraph' ) );
+								}
 
-						if ( after.length ) {
-							blocks.push( createBlock( 'core/list', {
-								nodeName,
-								values: after,
-							} ) );
-						}
+								if ( after.length ) {
+									blocks.push( createBlock( 'core/list', {
+										nodeName,
+										values: after,
+									} ) );
+								}
 
-						setAttributes( { values: before } );
-						insertBlocksAfter( blocks );
-					} }
+								setAttributes( { values: before } );
+								insertBlocksAfter( blocks );
+							} :
+							undefined
+					}
 				/>,
 			];
 		}

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -170,13 +170,16 @@ class ParagraphBlock extends Component {
 							} }
 							focus={ focus }
 							onFocus={ setFocus }
-							onSplit={ ( before, after, ...blocks ) => {
-								setAttributes( { content: before } );
-								insertBlocksAfter( [
-									...blocks,
-									createBlock( 'core/paragraph', { content: after } ),
-								] );
-							} }
+							onSplit={ insertBlocksAfter ?
+								( before, after, ...blocks ) => {
+									setAttributes( { content: before } );
+									insertBlocksAfter( [
+										...blocks,
+										createBlock( 'core/paragraph', { content: after } ),
+									] );
+								} :
+								undefined
+							}
 							onMerge={ mergeBlocks }
 							onReplace={ onReplace }
 							placeholder={ placeholder || __( 'Add text or type / to insert content' ) }

--- a/editor/components/block-drop-zone/index.js
+++ b/editor/components/block-drop-zone/index.js
@@ -2,12 +2,12 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import { reduce, get, find } from 'lodash';
+import { reduce, get, find, flow } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { DropZone } from '@wordpress/components';
+import { DropZone, withContext } from '@wordpress/components';
 import { getBlockTypes } from '@wordpress/blocks';
 
 /**
@@ -15,7 +15,11 @@ import { getBlockTypes } from '@wordpress/blocks';
  */
 import { insertBlocks } from '../../actions';
 
-function BlockDropZone( { index, ...props } ) {
+function BlockDropZone( { index, isLocked, ...props } ) {
+	if ( isLocked ) {
+		return null;
+	}
+
 	const dropFiles = ( files, position ) => {
 		const transformation = reduce( getBlockTypes(), ( ret, blockType ) => {
 			if ( ret ) {
@@ -45,7 +49,16 @@ function BlockDropZone( { index, ...props } ) {
 	);
 }
 
-export default connect(
-	undefined,
-	{ insertBlocks }
+export default flow(
+	connect(
+		undefined,
+		{ insertBlocks }
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
+
+		return {
+			isLocked: !! templateLock,
+		};
+	} )
 )( BlockDropZone );

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { get, partial, reduce, size, flow } from 'lodash';
+import { get, partial, reduce, size } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,9 +11,8 @@ import { get, partial, reduce, size, flow } from 'lodash';
 import { Component, compose, createElement } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 import { getBlockType, BlockEdit, getBlockDefaultClassname, createBlock, hasBlockSupport } from '@wordpress/blocks';
-import { withFilters } from '@wordpress/components';
+import { withFilters, withContext } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { withContext } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -525,14 +524,14 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	},
 } );
 
-export default flow(
+export default compose(
 	withFilters( 'Editor.BlockItem' ),
 	connect( mapStateToProps, mapDispatchToProps ),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;
 
 		return {
-			isLocked: true === templateLock,
+			isLocked: !! templateLock,
 		};
 	} ),
 )( BlockListBlock );

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { get, partial, reduce, size } from 'lodash';
+import { get, partial, reduce, size, flow } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +13,7 @@ import { keycodes } from '@wordpress/utils';
 import { getBlockType, BlockEdit, getBlockDefaultClassname, createBlock, hasBlockSupport } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { withContext } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -296,7 +297,7 @@ class BlockListBlock extends Component {
 			case ENTER:
 				// Insert default block after current block if enter and event
 				// not already handled by descendant.
-				if ( target === this.node ) {
+				if ( target === this.node && ! this.props.isLocked ) {
 					event.preventDefault();
 
 					this.props.onInsertBlocks( [
@@ -318,12 +319,14 @@ class BlockListBlock extends Component {
 			case DELETE:
 				// Remove block on backspace.
 				if ( target === this.node ) {
+					const { uid, onRemove, previousBlock, onFocus, isLocked } = this.props;
 					event.preventDefault();
-					const { uid, onRemove, previousBlock, onFocus } = this.props;
-					onRemove( uid );
+					if ( ! isLocked ) {
+						onRemove( uid );
 
-					if ( previousBlock ) {
-						onFocus( previousBlock.uid, { offset: -1 } );
+						if ( previousBlock ) {
+							onFocus( previousBlock.uid, { offset: -1 } );
+						}
 					}
 				}
 				break;
@@ -340,7 +343,7 @@ class BlockListBlock extends Component {
 	}
 
 	render() {
-		const { block, order, mode, showContextualToolbar } = this.props;
+		const { block, order, mode, showContextualToolbar, isLocked } = this.props;
 		const { name: blockName, isValid } = block;
 		const blockType = getBlockType( blockName );
 		// translators: %s: Type of block (i.e. Text, Image etc)
@@ -410,10 +413,10 @@ class BlockListBlock extends Component {
 								focus={ focus }
 								attributes={ block.attributes }
 								setAttributes={ this.setAttributes }
-								insertBlocksAfter={ this.insertBlocksAfter }
-								onReplace={ onReplace }
+								insertBlocksAfter={ isLocked ? undefined : this.insertBlocksAfter }
+								onReplace={ isLocked ? undefined : onReplace }
 								setFocus={ partial( onFocus, block.uid ) }
-								mergeBlocks={ this.mergeBlocks }
+								mergeBlocks={ isLocked ? undefined : this.mergeBlocks }
 								className={ className }
 								id={ block.uid }
 								isSelectionEnabled={ this.props.isSelectionEnabled }
@@ -522,7 +525,14 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	},
 } );
 
-export default compose(
+export default flow(
 	withFilters( 'Editor.BlockItem' ),
-	connect( mapStateToProps, mapDispatchToProps )
+	connect( mapStateToProps, mapDispatchToProps ),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
+
+		return {
+			isLocked: true === templateLock,
+		};
+	} ),
 )( BlockListBlock );

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -103,7 +103,7 @@ export default flow(
 		const { templateLock } = settings;
 
 		return {
-			isLocked: true === templateLock,
+			isLocked: templateLock === 'all',
 		};
 	} ),
 )( BlockMover );

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { first, last } from 'lodash';
+import { first, last, flow } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { IconButton, withContext } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 
 /**
@@ -19,7 +19,11 @@ import { getBlockMoverLabel } from './mover-label';
 import { isFirstBlock, isLastBlock, getBlockIndex, getBlock } from '../../selectors';
 import { selectBlock } from '../../actions';
 
-export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex } ) {
+export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked } ) {
+	if ( isLocked ) {
+		return null;
+	}
+
 	// We emulate a disabled state because forcefully applying the `disabled`
 	// attribute on the button while it has focus causes the screen to change
 	// to an unfocused state (body as active element) without firing blur on,
@@ -60,37 +64,46 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 	);
 }
 
-export default connect(
-	( state, ownProps ) => {
-		const block = getBlock( state, first( ownProps.uids ) );
+export default flow(
+	connect(
+		( state, ownProps ) => {
+			const block = getBlock( state, first( ownProps.uids ) );
 
-		return ( {
-			isFirst: isFirstBlock( state, first( ownProps.uids ) ),
-			isLast: isLastBlock( state, last( ownProps.uids ) ),
-			firstIndex: getBlockIndex( state, first( ownProps.uids ) ),
-			blockType: block ? getBlockType( block.name ) : null,
-		} );
-	},
-	( dispatch, ownProps ) => ( {
-		onMoveDown() {
-			if ( ownProps.uids.length === 1 ) {
-				dispatch( selectBlock( first( ownProps.uids ) ) );
-			}
-
-			dispatch( {
-				type: 'MOVE_BLOCKS_DOWN',
-				uids: ownProps.uids,
+			return ( {
+				isFirst: isFirstBlock( state, first( ownProps.uids ) ),
+				isLast: isLastBlock( state, last( ownProps.uids ) ),
+				firstIndex: getBlockIndex( state, first( ownProps.uids ) ),
+				blockType: block ? getBlockType( block.name ) : null,
 			} );
 		},
-		onMoveUp() {
-			if ( ownProps.uids.length === 1 ) {
-				dispatch( selectBlock( first( ownProps.uids ) ) );
-			}
+		( dispatch, ownProps ) => ( {
+			onMoveDown() {
+				if ( ownProps.uids.length === 1 ) {
+					dispatch( selectBlock( first( ownProps.uids ) ) );
+				}
 
-			dispatch( {
-				type: 'MOVE_BLOCKS_UP',
-				uids: ownProps.uids,
-			} );
-		},
-	} )
+				dispatch( {
+					type: 'MOVE_BLOCKS_DOWN',
+					uids: ownProps.uids,
+				} );
+			},
+			onMoveUp() {
+				if ( ownProps.uids.length === 1 ) {
+					dispatch( selectBlock( first( ownProps.uids ) ) );
+				}
+
+				dispatch( {
+					type: 'MOVE_BLOCKS_UP',
+					uids: ownProps.uids,
+				} );
+			},
+		} )
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
+
+		return {
+			isLocked: true === templateLock,
+		};
+	} ),
 )( BlockMover );

--- a/editor/components/block-mover/test/index.js
+++ b/editor/components/block-mover/test/index.js
@@ -16,6 +16,11 @@ describe( 'BlockMover', () => {
 			title: 'yolo-block',
 		};
 
+		it( 'should not render if the editor is locked', () => {
+			const wrapper = shallow( <BlockMover isLocked /> );
+			expect( wrapper.type() ).toBe( null );
+		} );
+
 		it( 'should render two IconButton components with the following props', () => {
 			const blockMover = shallow( <BlockMover uids={ selectedUids } blockType={ blockType } firstIndex={ 0 } /> );
 			expect( blockMover.hasClass( 'editor-block-mover' ) ).toBe( true );

--- a/editor/components/block-settings-menu/block-delete-button.js
+++ b/editor/components/block-settings-menu/block-delete-button.js
@@ -47,7 +47,7 @@ export default flow(
 		const { templateLock } = settings;
 
 		return {
-			isLocked: true === templateLock,
+			isLocked: !! templateLock,
 		};
 	} ),
 )( BlockDeleteButton );

--- a/editor/components/block-settings-menu/block-delete-button.js
+++ b/editor/components/block-settings-menu/block-delete-button.js
@@ -8,14 +8,18 @@ import { flow, noop } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { IconButton, withContext } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { removeBlocks } from '../../actions';
 
-export function BlockDeleteButton( { onDelete, onClick = noop, small = false } ) {
+export function BlockDeleteButton( { onDelete, onClick = noop, isLocked, small = false } ) {
+	if ( isLocked ) {
+		return null;
+	}
+
 	const label = __( 'Delete' );
 
 	return (
@@ -30,11 +34,20 @@ export function BlockDeleteButton( { onDelete, onClick = noop, small = false } )
 	);
 }
 
-export default connect(
-	undefined,
-	( dispatch, ownProps ) => ( {
-		onDelete() {
-			dispatch( removeBlocks( ownProps.uids ) );
-		},
-	} )
+export default flow(
+	connect(
+		undefined,
+		( dispatch, ownProps ) => ( {
+			onDelete() {
+				dispatch( removeBlocks( ownProps.uids ) );
+			},
+		} )
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
+
+		return {
+			isLocked: true === templateLock,
+		};
+	} ),
 )( BlockDeleteButton );

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { every, uniq, get, reduce, find } from 'lodash';
+import { every, uniq, get, reduce, find, flow } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu } from '@wordpress/components';
+import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu, withContext } from '@wordpress/components';
 import { getBlockType, getBlockTypes, switchToBlockType, BlockIcon } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
 
@@ -24,8 +24,8 @@ import { getBlock } from '../../selectors';
  */
 const { DOWN } = keycodes;
 
-function BlockSwitcher( { blocks, onTransform } ) {
-	if ( ! blocks || ! blocks[ 0 ] ) {
+function BlockSwitcher( { blocks, onTransform, isLocked } ) {
+	if ( ! blocks || ! blocks[ 0 ] || isLocked ) {
 		return null;
 	}
 	const isMultiBlock = blocks.length > 1;
@@ -126,18 +126,27 @@ function BlockSwitcher( { blocks, onTransform } ) {
 	);
 }
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			blocks: ownProps.uids.map( ( uid ) => getBlock( state, uid ) ),
-		};
-	},
-	( dispatch, ownProps ) => ( {
-		onTransform( blocks, name ) {
-			dispatch( replaceBlocks(
-				ownProps.uids,
-				switchToBlockType( blocks, name )
-			) );
+export default flow(
+	connect(
+		( state, ownProps ) => {
+			return {
+				blocks: ownProps.uids.map( ( uid ) => getBlock( state, uid ) ),
+			};
 		},
-	} )
+		( dispatch, ownProps ) => ( {
+			onTransform( blocks, name ) {
+				dispatch( replaceBlocks(
+					ownProps.uids,
+					switchToBlockType( blocks, name )
+				) );
+			},
+		} )
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
+
+		return {
+			isLocked: true === templateLock,
+		};
+	} ),
 )( BlockSwitcher );

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -146,7 +146,7 @@ export default flow(
 		const { templateLock } = settings;
 
 		return {
-			isLocked: true === templateLock,
+			isLocked: !! templateLock,
 		};
 	} ),
 )( BlockSwitcher );

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`DefaultBlockAppender no block present should match snapshot 1`] = `
 <div
   className="editor-default-block-appender"
 >
-  <Connect(BlockDropZone) />
+  <WrappedComponent />
   <input
     className="editor-default-block-appender__content"
     onClick={[Function]}

--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -85,7 +85,7 @@ export default flow(
 		const { templateLock } = settings;
 
 		return {
-			isLocked: true === templateLock,
+			isLocked: !! templateLock,
 		};
 	} ),
 )( EditorGlobalKeyboardShortcuts );

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -132,7 +132,7 @@ export default flowRight( [
 
 		return {
 			hasSupportedBlocks: true === blockTypes || ! isEmpty( blockTypes ),
-			isLocked: true === templateLock,
+			isLocked: !! templateLock,
 		};
 	} ),
 ] )( Inserter );

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -63,9 +63,10 @@ class Inserter extends Component {
 			onInsertBlock,
 			insertionPoint,
 			hasSupportedBlocks,
+			isLocked,
 		} = this.props;
 
-		if ( ! hasSupportedBlocks ) {
+		if ( ! hasSupportedBlocks || isLocked ) {
 			return null;
 		}
 
@@ -127,10 +128,11 @@ export default flowRight( [
 		} )
 	),
 	withContext( 'editor' )( ( settings ) => {
-		const { blockTypes } = settings;
+		const { blockTypes, templateLock } = settings;
 
 		return {
 			hasSupportedBlocks: true === blockTypes || ! isEmpty( blockTypes ),
+			isLocked: true === templateLock,
 		};
 	} ),
 ] )( Inserter );

--- a/editor/edit-post/modes/visual-editor/inserter.js
+++ b/editor/edit-post/modes/visual-editor/inserter.js
@@ -96,7 +96,7 @@ export default flow(
 		const { templateLock } = settings;
 
 		return {
-			isLocked: true === templateLock,
+			isLocked: !! templateLock,
 		};
 	} ),
 )( VisualEditorInserter );

--- a/editor/edit-post/modes/visual-editor/inserter.js
+++ b/editor/edit-post/modes/visual-editor/inserter.js
@@ -3,12 +3,13 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import { flow } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { IconButton, withContext } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { createBlock, BlockIcon } from '@wordpress/blocks';
 
@@ -41,12 +42,16 @@ export class VisualEditorInserter extends Component {
 	}
 
 	render() {
-		const { blockCount } = this.props;
+		const { blockCount, isLocked } = this.props;
 		const { isShowingControls } = this.state;
 		const { mostFrequentlyUsedBlocks } = this.props;
 		const classes = classnames( 'editor-visual-editor__inserter', {
 			'is-showing-controls': isShowingControls,
 		} );
+
+		if ( isLocked ) {
+			return null;
+		}
 
 		return (
 			<div
@@ -77,12 +82,21 @@ export class VisualEditorInserter extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
+export default flow(
+	connect(
+		( state ) => {
+			return {
+				mostFrequentlyUsedBlocks: getMostFrequentlyUsedBlocks( state ),
+				blockCount: getBlockCount( state ),
+			};
+		},
+		{ onInsertBlock: insertBlock },
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
+
 		return {
-			mostFrequentlyUsedBlocks: getMostFrequentlyUsedBlocks( state ),
-			blockCount: getBlockCount( state ),
+			isLocked: true === templateLock,
 		};
-	},
-	{ onInsertBlock: insertBlock },
+	} ),
 )( VisualEditorInserter );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -791,7 +791,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$post_type_object = get_post_type_object( $post_to_edit['type'] );
 	if ( ! empty( $post_type_object->template ) ) {
 		$editor_settings['template']     = $post_type_object->template;
-		$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) && $post_type_object->template_lock;
+		$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) ? $post_type_object->template_lock : false;
 	}
 
 	$script  = '( function() {';

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -790,7 +790,8 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	$post_type_object = get_post_type_object( $post_to_edit['type'] );
 	if ( ! empty( $post_type_object->template ) ) {
-		$editor_settings['template'] = $post_type_object->template;
+		$editor_settings['template']     = $post_type_object->template;
+		$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) && $post_type_object->template_lock;
 	}
 
 	$script  = '( function() {';


### PR DESCRIPTION
This PR is the first one introducing the Block Templates Locking. (details on those here #3588 ).
Locking the editor means, you can't add new blocks, you can't move blocks, you can't remove blocks.

**Testing instructions**

 - Add A CPT like this:

```php
function register_post_type() {
	$args = array(
		'public' => true,
		'label'  => 'Books',
		'show_in_rest' => true,
		'template' => array(
			array( 'core/image' ),
			array( 'core/paragraph', array(
				'placeholder' => 'Add a book description',
			) ),
			array( 'core/quote' ),
		),
		'template_lock' => 'all', // or 'insert' to allow moving
	);
	register_post_type( 'book', $args );
}
add_action( 'init', 'register_post_type' );
```

 - Create a new post with the registered CPT
 - The editor should initialize with the predefined list of blocks defined in this template.
 - You can't add/remove or move blocks.

**Notes**

 - I was wondering if I should disable the global HTML mode when the editor is locked
 - Hiding the buttons is easy enough, but it's easy to miss keyboard interactions
 
**Next**

 - We should add a validation step when opening existing posts with a locked editor. If the post doesn't match the template, we should raise a warning.
