### PR TITLE
Fixed images to gallery transform bug for ID-less images.

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -67,7 +67,7 @@ registerBlockType( 'core/gallery', {
 				isMultiBlock: true,
 				blocks: [ 'core/image' ],
 				transform: ( blockAttributes ) => {
-					const validImages = filter( blockAttributes, ( { id, url } ) => id && url );
+					const validImages = filter( blockAttributes, ( { url } ) => url );
 					if ( validImages.length > 0 ) {
 						return createBlock( 'core/gallery', {
 							images: validImages.map( ( { id, url, alt } ) => ( { id, url, alt } ) ),


### PR DESCRIPTION
The transformation considered valid images the ones with id and URL and it should consider valid images the ones with URL, because of the external images.
 This aims to fix https://github.com/WordPress/gutenberg/issues/3698.

cc: @mcsf 