### PR TITLE
Update autocomplete suggestions colors to have a sufficient color contrast ratio

### DIFF
--- a/blocks/url-input/style.scss
+++ b/blocks/url-input/style.scss
@@ -57,7 +57,7 @@
 	text-align: left;
 
 	&.is-selected {
-		background: $blue-medium-500;
+		background: $blue-dark-900;
 		color: $white;
 	}
 }

--- a/components/form-token-field/style.scss
+++ b/components/form-token-field/style.scss
@@ -181,11 +181,11 @@ input[type="text"].components-form-token-field__input {
 	cursor: pointer;
 
 	&.is-selected {
-		background: $blue-medium-500;
+		background: $blue-dark-900;
 		color: $white;
 	}
 }
 
 .components-form-token-field__suggestion-match {
-	color: $dark-gray-800;
+	text-decoration: underline;
 }


### PR DESCRIPTION
Updates the background blue used for the suggestions lists `$blue-dark-500` to the darker `$blue-dark-900` to have a sufficient color contrast ratio. It is now increased from 3.02:1 to 5.42:1. The threshold is 4.5:1.

For the tags suggestions, updates also the matched part to use an underline instead of a black text color, that would be unreadable on top of the darker blue background:

<img width="349" alt="screen shot 2017-11-28 at 17 05 22" src="https://user-images.githubusercontent.com/1682452/33330515-57c49090-d45f-11e7-9d5d-7b8d894f68d2.png">

This could also use an intermediate blue, but I guess that would require some designers touch to introduce a new color in the palette 🙂 

Fixes #3631 