### PR TITLE
Editable: Abort focus update when editor not yet initialized

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -700,6 +700,12 @@ export default class Editable extends Component {
 	}
 
 	updateFocus() {
+		// We can't update focus if the editor hasn't finished initializing.
+		// Initialization callback `onInit` will call this function anyways.
+		if ( ! this.editor ) {
+			return;
+		}
+
 		const { focus } = this.props;
 		const isActive = this.isActive();
 


### PR DESCRIPTION
This pull request seeks to resolve a block rendering error which can occur when focusing the block's `Editable` component before TinyMCE has finished initializing. Specifically, many event handlers in `Editable` assume that `this.editor` is assigned to the TinyMCE instance. However, this is not set until setup completes. Fortunately, most event handlers are bound by TinyMCE itself, so are not fired until after initialization. This is not true for focus changes, however, so the changes proposed here update the `updateFocus` callback to first check that the editor has initialized. Since the editor's initialization callback `onInit` will call `updateFocus` anyways, it is okay that this is skipped for the pre-initialized change.

Alternatively, we could consider being more cautious with our use of `this.editor` in `Editable`, first checking in all cases that it exists (or providing fallback behaviors).

__Testing instructions:__

Verify that no errors occur if you focus a block very quickly, before TinyMCE finishes initializing.

1. Navigate to **Posts** > **Add New**
2. Create a new paragraph block with some text
3. Save the post
4. Refresh the page
5. Very quickly focus the text block upon page load
6. Note that no errors occur