### PR TITLE
Inserter: Remove duplicated and simplify sibling inserter styles

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -307,9 +307,6 @@
 
 .editor-block-list__insertion-point {
 	position: relative;
-	width: $visual-editor-max-width - $block-padding - $block-padding;
-	margin-left: auto;
-	margin-right: auto;
 
 	&:before {
 		position: absolute;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -305,7 +305,7 @@
 	}
 }
 
-.editor-block-list .editor-block-list__insertion-point {
+.editor-block-list__insertion-point {
 	position: relative;
 	width: $visual-editor-max-width - $block-padding - $block-padding;
 	margin-left: auto;

--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -39,33 +39,6 @@
 	}
 }
 
-.editor-visual-editor .editor-inserter {
-	.editor-inserter__toggle {
-		color: $dark-gray-300;
-	}
-
-	.editor-inserter__toggle.components-icon-button:not(:disabled):hover {
-		@include button-style__hover;
-	}
-}
-
-.editor-visual-editor .editor-block-list__insertion-point {
-	position: relative;
-	width: $visual-editor-max-width - $block-padding - $block-padding;
-	margin-left: auto;
-	margin-right: auto;
-
-	&:before {
-		position: absolute;
-		top: -1px;
-		height: 2px;
-		left: 0;
-		right: 0;
-		background: $blue-medium-500;
-		content: '';
-	}
-}
-
 .editor-visual-editor__inserter {
 	display: flex;
 	align-items: baseline;


### PR DESCRIPTION
Related: #3546

This pull request seeks to eliminate duplicated styles which were left-over in `VisualEditor` styles after `BlockList` was extracted to a separate component in #3546. Further, it simplifies width styling of the sibling inserter to not assume visual editor width, but instead apply padded centering via margins. This eliminates the implicit dependency between block list and visual editor, and is more accommodating to other inserter contexts (nesting).

__Testing instructions:__

Verify that there are no visual regressions in the display of the block list inserter, for inserting between blocks, and when using the global and end-of-content inserters.