### PR TITLE
Editable: separate out content ops and switch to using tinymce tree output

### DIFF
--- a/blocks/api/matchers.js
+++ b/blocks/api/matchers.js
@@ -6,7 +6,7 @@ import { createElement } from '@wordpress/element';
 /**
  * External dependencies
  */
-import { nodeListToReact, nodeToReact } from 'dom-react';
+import { domreact } from '@wordpress/utils';
 export { attr, prop, html, text, query } from 'hpq';
 
 export const children = ( selector ) => {
@@ -18,7 +18,7 @@ export const children = ( selector ) => {
 		}
 
 		if ( match ) {
-			return nodeListToReact( match.childNodes || [], createElement );
+			return domreact.nodeListToReact( match.childNodes || [], createElement );
 		}
 
 		return [];
@@ -33,6 +33,6 @@ export const node = ( selector ) => {
 			match = domNode.querySelector( selector );
 		}
 
-		return nodeToReact( match, createElement );
+		return domreact.nodeToReact( match, createElement );
 	};
 };

--- a/blocks/editable/content.js
+++ b/blocks/editable/content.js
@@ -78,8 +78,8 @@ export function splitAtCaret( editor ) {
 	afterRange.setStart( selectionRange.endContainer, selectionRange.endOffset );
 	afterRange.setEnd( rootNode, dom.nodeIndex( rootNode.lastChild ) + 1 );
 
-	const beforeFragment = beforeRange.extractContents();
-	const afterFragment = afterRange.extractContents();
+	const beforeFragment = beforeRange.cloneContents();
+	const afterFragment = afterRange.cloneContents();
 
 	const beforeElement = domreact.nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
 	const afterElement = isLinkBoundary( afterFragment ) ? [] : domreact.nodeListToReact( afterFragment.childNodes, createTinyMCEElement );

--- a/blocks/editable/content.js
+++ b/blocks/editable/content.js
@@ -1,0 +1,129 @@
+import { renderToString, createElement } from '@wordpress/element';
+import { domreact } from '@wordpress/utils';
+import { omitBy, last } from 'lodash';
+
+function createTinyMCEElement( type, props, ...children ) {
+	if ( props[ 'data-mce-bogus' ] === 'all' ) {
+		return null;
+	}
+
+	if ( props.hasOwnProperty( 'data-mce-bogus' ) ) {
+		return children;
+	}
+
+	return createElement(
+		type,
+		omitBy( props, ( value, key ) => key.indexOf( 'data-mce-' ) === 0 ),
+		...children
+	);
+}
+
+function isLinkBoundary( fragment ) {
+	return fragment.childNodes && fragment.childNodes.length === 1 &&
+		fragment.childNodes[ 0 ].nodeName === 'A' && fragment.childNodes[ 0 ].text.length === 1 &&
+		fragment.childNodes[ 0 ].text[ 0 ] === '\uFEFF';
+}
+
+function splitResult( before, after ) {
+	return { before: before, after: after };
+}
+
+export function setContent( editor, content ) {
+	if ( ! content ) {
+		content = '';
+	}
+
+	content = renderToString( content );
+	editor.setContent( content, { format: 'raw' } );
+}
+
+export function getContent( editor ) {
+	return domreact.nodeListToReact( editor.getBody().childNodes || [], createTinyMCEElement );
+}
+
+export function getSplitAtLine( editor ) {
+	const rootNode = editor.getBody();
+	const selectedNode = editor.selection.getNode();
+
+	if ( selectedNode.parentNode !== rootNode ) {
+		return;
+	}
+
+	const dom = editor.dom;
+
+	if ( ! dom.isEmpty( selectedNode ) ) {
+		return null;
+	}
+
+	const childNodes = Array.from( rootNode.childNodes );
+	const index = dom.nodeIndex( selectedNode );
+	const beforeNodes = childNodes.slice( 0, index );
+	const afterNodes = childNodes.slice( index + 1 );
+	const beforeElement = domreact.nodeListToReact( beforeNodes, createTinyMCEElement );
+	const afterElement = domreact.nodeListToReact( afterNodes, createTinyMCEElement );
+
+	return splitResult( beforeElement, afterElement );
+}
+
+export function splitAtCaret( editor ) {
+	const { dom } = editor;
+	const rootNode = editor.getBody();
+	const beforeRange = dom.createRng();
+	const afterRange = dom.createRng();
+	const selectionRange = editor.selection.getRng();
+
+	beforeRange.setStart( rootNode, 0 );
+	beforeRange.setEnd( selectionRange.startContainer, selectionRange.startOffset );
+
+	afterRange.setStart( selectionRange.endContainer, selectionRange.endOffset );
+	afterRange.setEnd( rootNode, dom.nodeIndex( rootNode.lastChild ) + 1 );
+
+	const beforeFragment = beforeRange.extractContents();
+	const afterFragment = afterRange.extractContents();
+
+	const beforeElement = domreact.nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
+	const afterElement = isLinkBoundary( afterFragment ) ? [] : domreact.nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
+
+	return splitResult( beforeElement, afterElement );
+}
+
+export function splitAtBlock( editor ) {
+	// Getting the content before and after the cursor
+	const childNodes = Array.from( editor.getBody().childNodes );
+	let selectedChild = editor.selection.getStart();
+	while ( childNodes.indexOf( selectedChild ) === -1 && selectedChild.parentNode ) {
+		selectedChild = selectedChild.parentNode;
+	}
+	const splitIndex = childNodes.indexOf( selectedChild );
+	if ( splitIndex === -1 ) {
+		return null;
+	}
+	const beforeNodes = childNodes.slice( 0, splitIndex );
+	const lastNodeBeforeCursor = last( beforeNodes );
+	// Avoid splitting on single enter
+	if (
+		! lastNodeBeforeCursor ||
+			beforeNodes.length < 2 ||
+			!! lastNodeBeforeCursor.textContent
+	) {
+		return null;
+	}
+
+	const before = beforeNodes.slice( 0, beforeNodes.length - 1 );
+
+	// Removing empty nodes from the beginning of the "after"
+	// avoids empty paragraphs at the beginning of newly created blocks.
+	const after = childNodes.slice( splitIndex ).reduce( ( memo, node ) => {
+		if ( ! memo.length && ! node.textContent ) {
+			return memo;
+		}
+
+		memo.push( node );
+		return memo;
+	}, [] );
+
+	const beforeElement = domreact.nodeListToReact( before, createTinyMCEElement );
+	const afterElement = domreact.nodeListToReact( after, createTinyMCEElement );
+
+	return splitResult( beforeElement, afterElement );
+}

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -14,14 +14,13 @@ import {
 	defer,
 	noop,
 } from 'lodash';
-import { nodeListToReact } from 'dom-react';
 import 'element-closest';
 
 /**
  * WordPress dependencies
  */
 import { createElement, Component, renderToString } from '@wordpress/element';
-import { keycodes, createBlobURL } from '@wordpress/utils';
+import { keycodes, createBlobURL, domreact } from '@wordpress/utils';
 import { Slot, Fill } from '@wordpress/components';
 
 /**
@@ -543,8 +542,8 @@ export default class Editable extends Component {
 				const index = dom.nodeIndex( selectedNode );
 				const beforeNodes = childNodes.slice( 0, index );
 				const afterNodes = childNodes.slice( index + 1 );
-				const beforeElement = nodeListToReact( beforeNodes, createTinyMCEElement );
-				const afterElement = nodeListToReact( afterNodes, createTinyMCEElement );
+				const beforeElement = domreact.nodeListToReact( beforeNodes, createTinyMCEElement );
+				const afterElement = domreact.nodeListToReact( afterNodes, createTinyMCEElement );
 
 				this.setContent( beforeElement );
 				this.props.onSplit( beforeElement, afterElement );
@@ -597,8 +596,8 @@ export default class Editable extends Component {
 			const beforeFragment = beforeRange.extractContents();
 			const afterFragment = afterRange.extractContents();
 
-			const beforeElement = nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
-			const afterElement = isLinkBoundary( afterFragment ) ? [] : nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
+			const beforeElement = domreact.nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
+			const afterElement = isLinkBoundary( afterFragment ) ? [] : domreact.nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
 
 			this.setContent( beforeElement );
 			this.props.onSplit( beforeElement, afterElement, ...blocks );
@@ -651,8 +650,8 @@ export default class Editable extends Component {
 		this.setContent( this.props.value );
 
 		this.props.onSplit(
-			nodeListToReact( before, createTinyMCEElement ),
-			nodeListToReact( after, createTinyMCEElement )
+			domreact.nodeListToReact( before, createTinyMCEElement ),
+			domreact.nodeListToReact( after, createTinyMCEElement )
 		);
 	}
 
@@ -692,7 +691,7 @@ export default class Editable extends Component {
 	}
 
 	getContent() {
-		return nodeListToReact( this.editor.getBody().childNodes || [], createTinyMCEElement );
+		return domreact.nodeListToReact( this.editor.getBody().childNodes || [], createTinyMCEElement );
 	}
 
 	updateFocus() {

--- a/blocks/editable/tree.js
+++ b/blocks/editable/tree.js
@@ -1,0 +1,46 @@
+import { createElement } from '@wordpress/element';
+import { domreact } from '@wordpress/utils';
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+function attributesToReact( attributes ) {
+	const reactAttrs = {};
+
+	attributes.forEach( ( { name, value } ) => {
+		const canonicalKey = domreact.toCanonical( name );
+		const key = canonicalKey ? canonicalKey : name;
+		reactAttrs[ key ] = key === 'style' ? domreact.styleStringToJSON( value ) : value;
+	} );
+
+	return reactAttrs;
+}
+
+function elementToReact( node ) {
+	const props = node.attributes ? attributesToReact( node.attributes ) : {};
+	const children = node.firstChild ? childrenToReact( node ) : [];
+
+	return createElement( node.name, props, ...children );
+}
+
+function nodeToReact( node ) {
+	if ( ! node ) {
+		return null;
+	} else if ( node.type === ELEMENT_NODE ) {
+		return elementToReact( node );
+	} else if ( node.type === TEXT_NODE ) {
+		return node.value;
+	}
+
+	return null;
+}
+
+export function childrenToReact( node ) {
+	const children = [];
+
+	for ( let child = node.firstChild; child; child = child.next ) {
+		children.push( nodeToReact( child ) );
+	}
+
+	return children;
+}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -241,7 +241,7 @@ function gutenberg_register_vendor_scripts() {
 		'https://unpkg.com/moment@2.18.1/' . $moment_script,
 		array( 'react' )
 	);
-	$tinymce_version = '4.7.2';
+	$tinymce_version = '4.7.3';
 	gutenberg_register_vendor_script(
 		'tinymce-latest',
 		'https://fiddle.azurewebsites.net/tinymce/' . $tinymce_version . '/tinymce' . $suffix . '.js'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@wordpress/url": "0.1.0-beta.1",
     "classnames": "2.2.5",
     "clipboard": "1.7.1",
-    "dom-react": "2.2.0",
     "dom-scroll-into-view": "1.2.1",
     "element-closest": "2.0.2",
     "escape-string-regexp": "1.0.5",
@@ -90,7 +89,7 @@
     "sass-variables-loader": "0.1.3",
     "sprintf-js": "1.1.1",
     "style-loader": "0.18.2",
-    "tinymce": "4.7.2",
+    "tinymce": "4.7.3",
     "webpack": "3.8.1"
   },
   "jest": {

--- a/utils/domreact/attrs.js
+++ b/utils/domreact/attrs.js
@@ -1,0 +1,84 @@
+const HTML_ATTRIBUTES = [
+	'accept', 'acceptCharset', 'accessKey', 'action', 'allowFullScreen', 'allowTransparency',
+	'alt', 'async', 'autoComplete', 'autoFocus', 'autoPlay', 'capture', 'cellPadding',
+	'cellSpacing', 'challenge', 'charSet', 'checked', 'cite', 'classID', 'className',
+	'colSpan', 'cols', 'content', 'contentEditable', 'contextMenu', 'controls', 'coords',
+	'crossOrigin', 'data', 'dateTime', 'default', 'defer', 'dir', 'disabled', 'download',
+	'draggable', 'encType', 'form', 'formAction', 'formEncType', 'formMethod', 'formNoValidate',
+	'formTarget', 'frameBorder', 'headers', 'height', 'hidden', 'high', 'href', 'hrefLang',
+	'htmlFor', 'httpEquiv', 'icon', 'id', 'inputMode', 'integrity', 'is', 'keyParams', 'keyType',
+	'kind', 'label', 'lang', 'list', 'loop', 'low', 'manifest', 'marginHeight', 'marginWidth',
+	'max', 'maxLength', 'media', 'mediaGroup', 'method', 'min', 'minLength', 'multiple', 'muted',
+	'name', 'noValidate', 'nonce', 'open', 'optimum', 'pattern', 'placeholder', 'poster',
+	'preload', 'profile', 'radioGroup', 'readOnly', 'rel', 'required', 'reversed', 'role',
+	'rowSpan', 'rows', 'sandbox', 'scope', 'scoped', 'scrolling', 'seamless', 'selected',
+	'shape', 'size', 'sizes', 'span', 'spellCheck', 'src', 'srcDoc', 'srcLang', 'srcSet', 'start',
+	'step', 'style', 'summary', 'tabIndex', 'target', 'title', 'type', 'useMap', 'value', 'width',
+	'wmode', 'wrap',
+];
+
+const NON_STANDARD_ATTRIBUTES = [
+	'autoCapitalize', 'autoCorrect', 'color', 'itemProp', 'itemScope', 'itemType', 'itemRef',
+	'itemID', 'security', 'unselectable', 'results', 'autoSave',
+];
+
+const SVG_ATTRIBUTES = [
+	'accentHeight', 'accumulate', 'additive', 'alignmentBaseline', 'allowReorder', 'alphabetic',
+	'amplitude', 'arabicForm', 'ascent', 'attributeName', 'attributeType', 'autoReverse',
+	'azimuth', 'baseFrequency', 'baseProfile', 'baselineShift', 'bbox', 'begin', 'bias', 'by',
+	'calcMode', 'capHeight', 'clip', 'clipPath', 'clipPathUnits', 'clipRule', 'colorInterpolation',
+	'colorInterpolationFilters', 'colorProfile', 'colorRendering', 'contentScriptType',
+	'contentStyleType', 'cursor', 'cx', 'cy', 'd', 'decelerate', 'descent', 'diffuseConstant',
+	'direction', 'display', 'divisor', 'dominantBaseline', 'dur', 'dx', 'dy', 'edgeMode',
+	'elevation', 'enableBackground', 'end', 'exponent', 'externalResourcesRequired', 'fill',
+	'fillOpacity', 'fillRule', 'filter', 'filterRes', 'filterUnits', 'floodColor', 'floodOpacity',
+	'focusable', 'fontFamily', 'fontSize', 'fontSizeAdjust', 'fontStretch', 'fontStyle',
+	'fontVariant', 'fontWeight', 'format', 'from', 'fx', 'fy', 'g1', 'g2', 'glyphName',
+	'glyphOrientationHorizontal', 'glyphOrientationVertical', 'glyphRef', 'gradientTransform',
+	'gradientUnits', 'hanging', 'horizAdvX', 'horizOriginX', 'ideographic', 'imageRendering',
+	'in', 'in2', 'intercept', 'k', 'k1', 'k2', 'k3', 'k4', 'kernelMatrix', 'kernelUnitLength',
+	'kerning', 'keyPoints', 'keySplines', 'keyTimes', 'lengthAdjust', 'letterSpacing',
+	'lightingColor', 'limitingConeAngle', 'local', 'markerEnd', 'markerHeight', 'markerMid',
+	'markerStart', 'markerUnits', 'markerWidth', 'mask', 'maskContentUnits', 'maskUnits',
+	'mathematical', 'mode', 'numOctaves', 'offset', 'opacity', 'operator', 'order',
+	'orient', 'orientation', 'origin', 'overflow', 'overlinePosition', 'overlineThickness',
+	'paintOrder', 'panose1', 'pathLength', 'patternContentUnits', 'patternTransform',
+	'patternUnits', 'pointerEvents', 'points', 'pointsAtX', 'pointsAtY', 'pointsAtZ',
+	'preserveAlpha', 'preserveAspectRatio', 'primitiveUnits', 'r', 'radius', 'refX', 'refY',
+	'renderingIntent', 'repeatCount', 'repeatDur', 'requiredExtensions', 'requiredFeatures',
+	'restart', 'result', 'rotate', 'rx', 'ry', 'scale', 'seed', 'shapeRendering', 'slope',
+	'spacing', 'specularConstant', 'specularExponent', 'speed', 'spreadMethod', 'startOffset',
+	'stdDeviation', 'stemh', 'stemv', 'stitchTiles', 'stopColor', 'stopOpacity',
+	'strikethroughPosition', 'strikethroughThickness', 'string', 'stroke', 'strokeDasharray',
+	'strokeDashoffset', 'strokeLinecap', 'strokeLinejoin', 'strokeMiterlimit',
+	'strokeOpacity', 'strokeWidth', 'surfaceScale', 'systemLanguage', 'tableValues', 'targetX',
+	'targetY', 'textAnchor', 'textDecoration', 'textLength', 'textRendering', 'to', 'transform',
+	'u1', 'u2', 'underlinePosition', 'underlineThickness', 'unicode', 'unicodeBidi',
+	'unicodeRange', 'unitsPerEm', 'vAlphabetic', 'vHanging', 'vIdeographic', 'vMathematical',
+	'values', 'vectorEffect', 'version', 'vertAdvY', 'vertOriginX', 'vertOriginY', 'viewBox',
+	'viewTarget', 'visibility', 'widths', 'wordSpacing', 'writingMode', 'x', 'x1', 'x2',
+	'xChannelSelector', 'xHeight', 'xlinkActuate', 'xlinkArcrole', 'xlinkHref', 'xlinkRole',
+	'xlinkShow', 'xlinkTitle', 'xlinkType', 'xmlBase', 'xmlLang', 'xmlSpace', 'y', 'y1', 'y2',
+	'yChannelSelector', 'z', 'zoomAndPan',
+];
+
+const attributeMap = [
+	...HTML_ATTRIBUTES,
+	...NON_STANDARD_ATTRIBUTES,
+	...SVG_ATTRIBUTES,
+].reduce( ( accumulator, attribute ) => {
+	const lowerCase = attribute.toLowerCase();
+
+	if ( attribute !== lowerCase ) {
+		accumulator[ lowerCase ] = attribute;
+	}
+
+	return accumulator;
+}, {} );
+
+attributeMap.class = 'className';
+
+export function toCanonical( name ) {
+	const normalizedName = name.toLowerCase().replace( /[-:]/, '' );
+	return attributeMap[ normalizedName ];
+}

--- a/utils/domreact/index.js
+++ b/utils/domreact/index.js
@@ -1,0 +1,88 @@
+import { toCanonical } from './attrs';
+
+function camelCase( string ) {
+	return string.toLowerCase().replace( /-([a-z])/g, ( match, $1 ) => $1.toUpperCase() );
+}
+
+export function styleStringToJSON( string = '' ) {
+	return string.split( ';' ).reduce( ( accumulator, piece ) => {
+		const pair = piece.split( ':' );
+		const key = camelCase( pair[ 0 ] || '' ).trim();
+		const value = ( pair[ 1 ] || '' ).trim();
+
+		if ( key && value ) {
+			accumulator[ key ] = value;
+		}
+
+		return accumulator;
+	}, {} );
+}
+
+export function attributeListToReact( attributeList ) {
+	return [ ...attributeList ].reduce( ( accumulator, { name, value } ) => {
+		const key = toCanonical( name ) || name;
+
+		if ( key === 'style' ) {
+			value = styleStringToJSON( value );
+		}
+
+		accumulator[ key ] = value;
+
+		return accumulator;
+	}, {} );
+}
+
+let keyCounter = 0;
+
+export function nodeListToReact( nodeList, createElement ) {
+	return [ ...nodeList ].reduce( ( accumulator, node ) => {
+		if ( ! node._domReactKey ) {
+			node._domReactKey = '_domReact' + String( keyCounter++ );
+		}
+
+		const child = nodeToReact( node, createElement );
+
+		if ( Array.isArray( child ) ) {
+			accumulator.push( ...child );
+		} else {
+			accumulator.push( child );
+		}
+
+		return accumulator;
+	}, [] );
+}
+
+export function nodeToReact( node, createElement ) {
+	if ( ! node ) {
+		return null;
+	}
+
+	if ( node.nodeType === 3 ) {
+		return node.nodeValue;
+	}
+
+	if ( node.nodeType !== 1 ) {
+		return null;
+	}
+
+	const type = node.nodeName.toLowerCase();
+
+	let props = {};
+	let children = [];
+
+	if ( node.hasAttributes() ) {
+		props = attributeListToReact( node.attributes );
+	}
+
+	if ( node._domReactKey ) {
+		props.key = node._domReactKey;
+	}
+
+	if ( node.hasChildNodes() ) {
+		children = nodeListToReact( node.childNodes, createElement );
+	}
+
+	return createElement( type, props, ...children );
+}
+
+export { toCanonical };

--- a/utils/domreact/test/index.js
+++ b/utils/domreact/test/index.js
@@ -1,0 +1,118 @@
+import { createElement, renderToString } from '@wordpress/element';
+import { nodeListToReact, nodeToReact } from '../index';
+
+describe( 'nodeToReact()', () => {
+	[ // Empty
+		{
+			description: 'should return null for null',
+			value: null,
+		},
+		{
+			description: 'should return null for non-node',
+			value: 'not a node',
+		},
+	].forEach( ( { description, text } ) => {
+		it( description, () => {
+			expect( nodeToReact( text, createElement ) ).toEqual( null );
+		} );
+	} );
+
+	[ // Text
+		{
+			description: 'should return empty string for empty text node',
+			text: '',
+		},
+		{
+			description: 'should return string for text node',
+			text: 'test',
+		},
+	].forEach( ( { description, text } ) => {
+		it( description, () => {
+			expect( nodeToReact( document.createTextNode( text ), createElement ) ).toEqual( text );
+		} );
+	} );
+
+	[ // Elements
+		{
+			description: 'should return React element for DOM element',
+			HTML: '<p>test</p>',
+		},
+		{
+			description: 'should return React element with props for DOM element with attributes',
+			HTML: '<p class="test">test</p>',
+		},
+		{
+			description: 'should return React element with children for DOM element with children',
+			HTML: '<p>test <strong>test</strong></p>',
+		},
+		{
+			description: 'should return React element with children for DOM element with children',
+			HTML: '<p>test <strong>test</strong></p>',
+		},
+		{
+			description: 'should return React element with style for DOM element with style',
+			HTML: '<p style="-webkit-box-shadow:1px 1px 1px rgba(0,0,0,0.75)">test</p>',
+		},
+	].forEach( ( { description, HTML } ) => {
+		it( description, () => {
+			document.body.innerHTML = HTML;
+			expect( renderToString( nodeToReact( document.body.firstChild, createElement ) ) ).toEqual( HTML );
+		} );
+	} );
+
+	it( 'should return React element without filtered attribute', () => {
+		document.body.innerHTML = '<p data-test="true">test</p>';
+		expect( renderToString( nodeToReact( document.body.firstChild, ( type, props, ...children ) => {
+			delete props[ 'data-test' ];
+			return createElement( type, props, ...children );
+		} ) ) ).toEqual( '<p>test</p>' );
+	} );
+
+	it( 'should return React element without filtered child', () => {
+		document.body.innerHTML = '<p>test <span data-test="true">test <strong>test</strong></span></p>';
+		expect( renderToString( nodeToReact( document.body.firstChild, ( type, props, ...children ) => {
+			if ( ! props[ 'data-test' ] ) {
+				return createElement( type, props, ...children );
+			}
+		} ) ) ).toEqual( '<p>test </p>' );
+	} );
+
+	it( 'should return React element without filtered tag', () => {
+		document.body.innerHTML = '<p>test <span data-test="true">test <strong>test</strong></span></p>';
+		expect( renderToString( nodeToReact( document.body.firstChild, ( type, props, ...children ) => {
+			if ( ! props[ 'data-test' ] ) {
+				return createElement( type, props, ...children );
+			}
+			return children;
+		} ) ) ).toEqual( '<p>test test <strong>test</strong></p>' );
+	} );
+} );
+
+describe( 'nodeListToReact', () => {
+	const rxKey = /^_domReact\d+$/;
+	function assertKey( key ) {
+		expect( rxKey.test( key ) ).toEqual( true );
+	}
+
+	it( 'should return array of React element with key assigned by child index', () => {
+		document.body.innerHTML = '<p>test <span>test</span></p><strong>test</strong>';
+		const elements = nodeListToReact( document.body.childNodes, createElement );
+
+		assertKey( elements[ 0 ].key );
+		expect( typeof elements[ 0 ].props.children[ 0 ] ).toEqual( 'string' );
+		assertKey( elements[ 0 ].props.children[ 1 ].key );
+		assertKey( elements[ 1 ].key );
+	} );
+
+	it( 'should reuse assigned key for same elements reference', () => {
+		document.body.innerHTML = '<ul><li>one</li><li>two</li></ul>';
+		const list = document.body.firstChild;
+		const before = nodeListToReact( list.childNodes, createElement );
+
+		// Rearrange second list item before first
+		list.insertBefore( list.lastChild, list.firstChild );
+
+		const after = nodeListToReact( list.childNodes, createElement );
+		expect( before.map( ( { key } ) => key ) ).toEqual( after.map( ( { key } ) => key ).reverse() );
+	} );
+} );

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,11 +1,13 @@
 import * as focus from './focus';
 import * as keycodes from './keycodes';
 import * as viewPort from './viewport';
+import * as domreact from './domreact';
 import { decodeEntities } from './entities';
 
 export { focus };
 export { keycodes };
 export { decodeEntities };
+export { domreact };
 
 export * from './blob-cache';
 export * from './mediaupload';


### PR DESCRIPTION
## Description
Creating this PR more as discussion point. Can make a separate PR later depending on what comes out of this one.

The benefits of using the filtering in tiny is:
* Removes invalid HTML elements it follows the HTML5 specification by default.
* Removes internal elements such as placeholders, UI elements etc, zwnbsp:s.
* Removes XSS elements and attributes such as scripts or event handlers.
* Removes or pads invisible elements for example empty spans.
* Removes or pads empty block elements such as an empty paragraph or h1.
* Converts legacy elements like font and u to span elements.
* Normalizes urls based on config absolute/relative etc.

Did some performance comparisons and the change is barely noticeable and since the blocks in gutenberg are mostly smaller chunks I don't think it will be a problem.

The performance is very content and browser dependent some browsers are slower at traversing the dom than parsing the html. IE/Edge/Firefox has a slower dom Chrome has a faster dom for example.

We have done some major optimizations in the tinymce 4.7.3 core and added the ability to get the intermediate node tree out this bypasses a few steps in the filtering process.

## How Has This Been Tested?
I ported over the tests for domreact but if we expose the attributes and style to json in that dom-react package we don't need to move those over.
Other than that I did some manual testing of pressing enter in various blocks and saving contents. This is where the content operations occur.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
* Separated out content operations from editable.js to a separate file content.js.
* Normalized the output of split operations to a single data structure.
* Moved domreact into gutenberg. This might not be needed.
* Swapped out the gutenberg specific filtering of nodes with tinymce filtering.

## Checklist:
- [Y] My code is tested.
- [Y] My code follows the WordPress code style.
- [N] My code follows has proper inline documentation.