### PR TITLE
fix text columns undefined index

### DIFF
--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -88,7 +88,7 @@ registerBlockType( 'core/text-columns', {
 					<div className="wp-block-column" key={ `column-${ index }` }>
 						<Editable
 							tagName="p"
-							value={ content && content[ index ].children }
+							value={ content && content[ index ] && content[ index ].children }
 							onChange={ ( nextContent ) => {
 								setAttributes( {
 									content: [


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes https://github.com/WordPress/gutenberg/issues/3710

When adding new columns new index does not exist in the content array.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
npm run test-unit
Manually tested in the browser

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Checking for the index before use. That seemed like an easiest fix. I could maybe try to push empty array to content on RangeControl change?

