### PR TITLE
Polish various polish

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -1,6 +1,4 @@
 .editor-block-list__block[data-type="core/freeform"] .blocks-editable__tinymce {
-	margin-top: $item-spacing;
-
 	p {
 		line-height: $editor-line-height;
 	}
@@ -86,25 +84,26 @@
 	}
 }
 
+// freeform toolbar
 .freeform-toolbar {
 	position: sticky;
 	width: auto;
-	top: $header-height;
-	margin: 0;
-	margin-top: -$block-controls-height;
+	top: -1px;	// stack borders
+	margin-top: -$block-controls-height - 16px;
 	border: 1px solid $light-gray-500;
 	z-index: z-index( '.freeform-toolbar' );
 	background-color: $white;
 	min-height: $block-controls-height;
-
-	@include break-medium() {
-		top: $item-spacing;
-	}
+	margin-bottom: 14px;
 
 	@include break-small() {
 		margin-left: - $block-padding - 1px;
 		margin-right: - $block-padding - 1px;
 	}
+}
+
+.freeform-toolbar.has-advanced-toolbar {
+	margin-top: -89px;	// pull upwards the classic text toolbar when enabled, height is manually entered
 }
 
 // Overwrite inline styles.
@@ -147,10 +146,6 @@
 
 .freeform-toolbar.has-advanced-toolbar .mce-toolbar-grp .mce-toolbar {
 	display: block;
-}
-
-.freeform-toolbar.has-advanced-toolbar {
-	margin-top: -85px;	/* Pull upwards the classic text toolbar when enabled */
 }
 
 .freeform-toolbar div.mce-btn-group {

--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -66,7 +66,7 @@ $text-editor-max-width: 760px;
 /* Editor */
 $text-editor-max-width: 760px;
 $visual-editor-max-width: 636px;
-$block-controls-height: 38px;
+$block-controls-height: 36px;
 $icon-button-size: 36px;
 
 /* Blocks */

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -25,6 +25,11 @@ body.gutenberg-editor-page {
 	svg {
 		fill: currentColor;
 	}
+
+	ul#adminmenu a.wp-has-current-submenu:after,
+	ul#adminmenu>li.current>a.current:after {
+		border-right-color: $white;
+	}
 }
 
 .gutenberg {

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -1,7 +1,6 @@
 .editor-block-list__block {
 	margin-bottom: $block-spacing;
 	position: relative;
-
 	padding: $block-padding;
 
 	@include break-small {

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -418,7 +418,7 @@ $sticky-bottom-offset: 20px;
 	text-align: left;
 	pointer-events: none;
 	height: $block-toolbar-height;
-	top: $header-height - 1px;
+	top: -1px;	// stack borders
 
 	.editor-block-toolbar {
 		border: 1px solid $light-gray-500;
@@ -446,10 +446,6 @@ $sticky-bottom-offset: 20px;
 	@include break-small() {
 		margin-left: - $block-padding - 1px;
 		margin-right: - $block-padding - 1px;
-	}
-
-	@include break-medium() {
-		top: $item-spacing;
 	}
 }
 

--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -1,5 +1,17 @@
 $empty-paragraph-height: $text-editor-font-size * 4;
 
+.editor-default-block-appender {
+	@include break-small() {
+		padding: 0 ( $block-mover-padding-visible - 1px );	// subtract 1px for border
+		padding: 0 $block-mover-padding-visible;
+
+		.editor-default-block-appender__content {
+			padding: 0 ( $block-padding - 1px );	// subtract 1px for border
+			padding: 0 $block-padding;
+		}
+	}
+}
+
 input[type=text].editor-default-block-appender__content {
 	border: none;
 	background: none;
@@ -7,14 +19,18 @@ input[type=text].editor-default-block-appender__content {
 	display: block;
 	width: 100%;
 	font-size: $editor-font-size;
-	line-height: $editor-line-height;
 	cursor: text;
 	max-width: none;	// fixes a bleed issue from the admin
-
 	height: $empty-paragraph-height;
 	color: $dark-gray-300;
 	outline: 1px solid transparent;
 	transition: 0.2s outline;
+
+	// subtract 1px for border
+	position: relative;
+	top: -1px;
+	left: -1px;
+	margin-bottom: $block-spacing - 1px;
 
 	&:focus, &:hover {
 		outline: 1px solid $light-gray-500;

--- a/editor/components/post-publish-button/label.js
+++ b/editor/components/post-publish-button/label.js
@@ -24,6 +24,7 @@ import {
 export function PublishButtonLabel( {
 	isPublished,
 	isBeingScheduled,
+	isSaving,
 	isPublishing,
 	user,
 } ) {
@@ -31,6 +32,8 @@ export function PublishButtonLabel( {
 
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
+	} else if ( isPublished && isSaving ) {
+		return __( 'Updating…' );
 	}
 
 	if ( isContributor ) {
@@ -49,7 +52,6 @@ const applyConnect = connect(
 		isPublished: isCurrentPostPublished( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		isSaving: isSavingPost( state ),
-		// Need a selector
 		isPublishing: isPublishingPost( state ),
 	} )
 );

--- a/editor/components/post-publish-button/label.js
+++ b/editor/components/post-publish-button/label.js
@@ -24,7 +24,6 @@ import {
 export function PublishButtonLabel( {
 	isPublished,
 	isBeingScheduled,
-	isSaving,
 	isPublishing,
 	user,
 } ) {
@@ -32,8 +31,6 @@ export function PublishButtonLabel( {
 
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
-	} else if ( isSaving ) {
-		return __( 'Updating…' );
 	}
 
 	if ( isContributor ) {

--- a/editor/components/post-publish-button/test/label.js
+++ b/editor/components/post-publish-button/test/label.js
@@ -36,6 +36,11 @@ describe( 'PublishButtonLabel', () => {
 		expect( label ).toBe( 'Updating…' );
 	} );
 
+	it( 'should show publish if not published and saving in progress', () => {
+		const label = PublishButtonLabel( { user, isPublished: false, isSaving: true } );
+		expect( label ).toBe( 'Publish' );
+	} );
+
 	it( 'should show publish if user unknown', () => {
 		const label = PublishButtonLabel( { user: {} } );
 		expect( label ).toBe( 'Publish' );

--- a/editor/components/post-publish-button/test/label.js
+++ b/editor/components/post-publish-button/test/label.js
@@ -31,8 +31,8 @@ describe( 'PublishButtonLabel', () => {
 		expect( label ).toBe( 'Publishing…' );
 	} );
 
-	it( 'should show updating if saving in progress', () => {
-		const label = PublishButtonLabel( { user, isSaving: true } );
+	it( 'should show updating if published and saving in progress', () => {
+		const label = PublishButtonLabel( { user, isPublished: true, isSaving: true } );
 		expect( label ).toBe( 'Updating…' );
 	} );
 

--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -128,14 +128,7 @@
 .editor-visual-editor .editor-default-block-appender {
 	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
 	clear: left;
-	margin: 0 auto;
+	margin-left: auto;
+	margin-right: auto;
 	position: relative;
-
-	@include break-small() {
-		padding: 0 $block-mover-padding-visible;
-
-		.editor-default-block-appender__content {
-			padding: 0 $block-padding;
-		}
-	}
 }

--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -4,7 +4,7 @@
 	margin: 0 auto;
 	margin-left: auto;
 	margin-right: auto;
-	padding: 50px 0 0;
+	padding: 50px 0;
 
 	&,
 	& p {


### PR DESCRIPTION
This PR does a few things:

- It makes it so that the Publish button doesn't change label when it's just saving. This likely needs more work, as we actually _do_ want this label to change when you are clicking _update_ on an already published post. 
- It adds bottom padding to the post, which makes for a better experience on longer posts — as you near the end, there's space to scroll down so the Inserter doesn't sit too snuggly near the bottom of the post.
- It fixes issues with the Placeholder block paddings and margins, so it now looks _exactly_ like the text block it's supposed to emulate. It no longer jumps in paddings.
- It polishes the toolbar on the Classic Text block, so it's also no longer jumpy.
- It colorizes the little arrow on the left in the admin menu white, so it matches the body content.

Screenshots

<img width="285" alt="screen shot 2017-11-29 at 13 14 32" src="https://user-images.githubusercontent.com/1204802/33374648-522c258c-d507-11e7-9e14-20b21f224745.png">

<img width="805" alt="screen shot 2017-11-29 at 13 14 44" src="https://user-images.githubusercontent.com/1204802/33374652-53c6d842-d507-11e7-84f4-a9fd5bd762b5.png">

<img width="390" alt="screen shot 2017-11-29 at 13 14 53" src="https://user-images.githubusercontent.com/1204802/33374654-55569a80-d507-11e7-9148-d1a536bdcb4b.png">
