### PR TITLE
Update plugin version to 1.8.1.

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core. <strong>Meant for development, do not run on real sites.</strong>
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gutenberg",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A new WordPress editor experience",
   "main": "build/app.js",
   "repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
## Changelog

* Add ability to switch published post back to draft.
* Fix issue with when changing column count in "text columns" block.
* Prioritize common items in the autocomplete inserter.
* Avoid changing publish/update button label when saving draft.
* Add bottom padding to the editor container to improve experience of writing long posts.
* Adjust the Classic block toolbar so it's doesn't jump.
* Colorize the little arrow on the left of the admin menu to white to match body content.
* Abort focus update when editor is not yet initialized.
* Update autocomplete suggestions colors to have a sufficient color contrast ratio.