### PR TITLE
Components: Prioritize common category in autocomplete block options

### DIFF
--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { sortBy } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -56,7 +61,11 @@ import BlockIcon from '../block-icon';
  * @returns {Completer}          Completer object used by the Autocomplete component.
  */
 export function blockAutocompleter( { onReplace } ) {
-	const options = getBlockTypes().map( ( blockType ) => {
+	// Prioritize common category in block type options
+	const options = sortBy(
+		getBlockTypes(),
+		( { category } ) => 'common' !== category
+	).map( ( blockType ) => {
 		const { name, title, icon, keywords = [] } = blockType;
 		return {
 			value: name,

--- a/blocks/autocompleters/test/index.js
+++ b/blocks/autocompleters/test/index.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../../block-icon';
+import { registerBlockType, unregisterBlockType, getBlockTypes } from '../../api';
+import { blockAutocompleter } from '../';
+
+describe( 'blockAutocompleter', () => {
+	beforeEach( () => {
+		registerBlockType( 'core/foo', {
+			save: noop,
+			category: 'common',
+			title: 'foo',
+			keywords: [ 'keyword' ],
+		} );
+
+		registerBlockType( 'core/bar', {
+			save: noop,
+			category: 'layout',
+			title: 'bar',
+		} );
+
+		registerBlockType( 'core/baz', {
+			save: noop,
+			category: 'common',
+			title: 'baz',
+		} );
+	} );
+
+	afterEach( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'should prioritize common blocks in options', () => {
+		return blockAutocompleter( {} ).getOptions().then( ( options ) => {
+			// Exclude React element from label for assertion, since we can't
+			// easily test equality.
+			options = options.map( ( option ) => {
+				expect( option.label[ 0 ].type ).toBe( BlockIcon );
+
+				return {
+					...option,
+					label: option.label.slice( 1 ),
+				};
+			} );
+
+			expect( options ).toEqual( [
+				{
+					keywords: [ 'keyword', 'foo' ],
+					label: [
+						'foo',
+					],
+					value: 'core/foo',
+				},
+				{
+					keywords: [ 'baz' ],
+					label: [
+						'baz',
+					],
+					value: 'core/baz',
+				},
+				{
+					keywords: [ 'bar' ],
+					label: [
+						'bar',
+					],
+					value: 'core/bar',
+				},
+			] );
+		} );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to change the ordering of the block autocompleter to prioritize common block types, while still enabling search to discover non-common types.

__Testing instructions:__

Verify that common blocks are shown first in the autocompleter when triggered via `/`, not, for example, "shortcode". Verify still that searching non-common blocks works as expected.

Ensure that unit tests pass:

```
npm run test-unit blocks/autocompleters/test/index.js
```