### PR TITLE
Remove inline style colors atributes from paragraph.

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -1,7 +1,7 @@
 export { createBlock, switchToBlockType, createReusableBlock } from './factory';
 export { default as parse, getBlockAttributes } from './parser';
 export { default as rawHandler } from './raw-handling';
-export { default as serialize, getBlockDefaultClassname, getBlockContent } from './serializer';
+export { default as serialize, getBlockDefaultClassname, getBlockRandomAnchor, getBlockContent } from './serializer';
 export { isValidBlock } from './validation';
 export { getCategories } from './categories';
 export {

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, isObject, castArray, compact, startsWith } from 'lodash';
+import { isEmpty, reduce, isObject, castArray, compact, startsWith, random } from 'lodash';
 import { html as beautifyHtml } from 'js-beautify';
 
 /**
@@ -16,14 +16,44 @@ import { applyFilters } from '@wordpress/hooks';
 import { getBlockType, getUnknownTypeHandlerName } from './registration';
 
 /**
+ * Returns the block's name with common prefixes: 'core/' or 'core-' (in 'core-embed/') dropped
+ *
+ * @param {String}   blockName  The block name
+ * @return {string}             Friendly name
+ */
+function friendlyBlockName( blockName ) {
+	return blockName.replace( /\//, '-' ).replace( /^core-/, '' );
+}
+
+/**
  * Returns the block's default classname from its name
  *
  * @param {String}   blockName  The block name
  * @return {string}             The block's default class
  */
 export function getBlockDefaultClassname( blockName ) {
-	// Drop common prefixes: 'core/' or 'core-' (in 'core-embed/')
-	return 'wp-block-' + blockName.replace( /\//, '-' ).replace( /^core-/, '' );
+	return `wp-block-${ friendlyBlockName( blockName ) }`;
+}
+
+/**
+ * Returns a random base 36 string, 36^7 possible strings, maximum seven chars
+ * According to the birthday paradox the probability of repetition is given by 1 - e^(-k*(k-1)/(2*36^7)) where k is the number of strings generated
+ * If used to generate ids it's relatively safe as the expected number of ids we have to generate before finding the first collision is approximately 350848
+ *
+ * @return {string}             Random string
+ */
+function randomBase36String() {
+	return random( 0, Math.pow( 36, 7 ), false ).toString( 36 );
+}
+
+/**
+ * Returns random anchor for the block
+ *
+ * @param {String}   blockName  The block name
+ * @return {string}             The block's default class
+ */
+export function getBlockRandomAnchor( blockName ) {
+	return `${ friendlyBlockName( blockName ) }-${ randomBase36String() }`;
 }
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -16,7 +16,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { getBlockType, getUnknownTypeHandlerName } from './registration';
 
 /**
- * Returns the block's name with common prefixes: 'core/' or 'core-' (in 'core-embed/') dropped
+ * Returns the block's name with common prefixes ('core/', 'core-') dropped
  *
  * @param {String}   blockName  The block name
  * @return {string}             Friendly name

--- a/blocks/hooks/anchor.js
+++ b/blocks/hooks/anchor.js
@@ -36,9 +36,6 @@ export function addAttribute( settings ) {
 		settings.attributes = assign( settings.attributes, {
 			anchor: {
 				type: 'string',
-				source: 'attribute',
-				attribute: 'id',
-				selector: '*',
 			},
 		} );
 	}

--- a/blocks/hooks/custom-styles.js
+++ b/blocks/hooks/custom-styles.js
@@ -6,57 +6,44 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, getWrapperDisplayName } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-import { getBlockRandomAnchor, hasBlockSupport, getBlockType } from '../api';
+import { getBlockRandomAnchor, hasBlockSupport } from '../api';
 
 const CUSTOM_STYLE_ATTRIBUTES = [ 'backgroundColor', 'textColor' ];
 
-const hasCustomStyles = ( attributes ) => (
+const hasCustomStyleAttributes = ( attributes ) => (
 	CUSTOM_STYLE_ATTRIBUTES.some( attr => attributes[ attr ] )
 );
 
-class AddAnchorWhenNeeded extends Component {
-	componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.attributes.anchor && hasCustomStyles( nextProps.attributes ) ) {
-			nextProps.setAttributes( {
-				anchor: getBlockRandomAnchor( nextProps.name ),
-			} );
-		}
-	}
-
-	render() {
-		return null;
-	}
-}
-
-export function addAnchorWhenStylesNeed( BlockEdit ) {
-	const WrappedBlockEdit = ( props ) => {
-		let hasAnchor = false;
-		if ( hasBlockSupport( props.name, 'anchor' ) ) {
-			const blockType = getBlockType( props.name );
-			if ( blockType && hasCustomStyles( blockType.attributes ) ) {
-				hasAnchor = true;
+function withCustomStylesAnchor( BlockEdit ) {
+	return class CustomStylesAnchor extends Component {
+		componentWillReceiveProps( nextProps ) {
+			if ( hasBlockSupport( nextProps.name, 'anchor' ) &&
+				hasBlockSupport( nextProps.name, 'customStyles' ) &&
+				! nextProps.attributes.anchor &&
+				hasCustomStyleAttributes( nextProps.attributes )
+			) {
+				nextProps.setAttributes( {
+					anchor: getBlockRandomAnchor( nextProps.name ),
+				} );
 			}
 		}
 
-		return [
-			<BlockEdit key="block-edit-add-anchor" { ...props } />,
-			hasAnchor && <AddAnchorWhenNeeded key="add-anchor" { ...props } />,
-		];
+		render() {
+			return (
+				<BlockEdit { ...this.props } />
+			);
+		}
 	};
-
-	WrappedBlockEdit.displayName = getWrapperDisplayName( BlockEdit, 'add-anchor' );
-
-	return WrappedBlockEdit;
 }
 
 export function addCustomStylesClass( extraProps, blockType, attributes ) {
-	if ( hasCustomStyles( attributes ) ) {
+	if ( hasBlockSupport( blockType.name, 'customStyles' ) && hasCustomStyleAttributes( attributes ) ) {
 		extraProps.className = classnames( extraProps.className, 'has-custom-styles' );
 	}
 
@@ -64,6 +51,6 @@ export function addCustomStylesClass( extraProps, blockType, attributes ) {
 }
 
 export default function customAnchorStyles() {
-	addFilter( 'blocks.BlockEdit', 'core/custom-styles/inspector-control', addAnchorWhenStylesNeed );
+	addFilter( 'blocks.BlockEdit', 'core/custom-styles/inspector-control', withCustomStylesAnchor );
 	addFilter( 'blocks.getSaveContent.extraProps', 'core/custom-styles/save-props', addCustomStylesClass );
 }

--- a/blocks/hooks/custom-styles.js
+++ b/blocks/hooks/custom-styles.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, getWrapperDisplayName } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { getBlockRandomAnchor, hasBlockSupport, getBlockType } from '../api';
+
+const CUSTOM_STYLE_ATTRIBUTES = [ 'backgroundColor', 'textColor' ];
+
+const hasCustomStyles = ( attributes ) => (
+	CUSTOM_STYLE_ATTRIBUTES.some( attr => attributes[ attr ] )
+);
+
+class AddAnchorWhenNeeded extends Component {
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.attributes.anchor && hasCustomStyles( nextProps.attributes ) ) {
+			nextProps.setAttributes( {
+				anchor: getBlockRandomAnchor( nextProps.name ),
+			} );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export function addAnchorWhenStylesNeed( BlockEdit ) {
+	const WrappedBlockEdit = ( props ) => {
+		let hasAnchor = false;
+		if ( hasBlockSupport( props.name, 'anchor' ) ) {
+			const blockType = getBlockType( props.name );
+			if ( blockType && hasCustomStyles( blockType.attributes ) ) {
+				hasAnchor = true;
+			}
+		}
+
+		return [
+			BlockEdit,
+			hasAnchor && <AddAnchorWhenNeeded key="add-anchor" { ...props } />,
+		];
+	};
+
+	WrappedBlockEdit.displayName = getWrapperDisplayName( BlockEdit, 'add-anchor' );
+
+	return WrappedBlockEdit;
+}
+
+export function addCustomStylesClass( extraProps, blockType, attributes ) {
+	if ( hasCustomStyles( attributes ) ) {
+		extraProps.className = classnames( extraProps.className, 'has-custom-styles' );
+	}
+
+	return extraProps;
+}
+
+export default function customAnchorStyles() {
+	addFilter( 'blocks.BlockEdit', 'core/custom-styles/inspector-control', addAnchorWhenStylesNeed );
+	addFilter( 'blocks.getSaveContent.extraProps', 'core/custom-styles/save-props', addCustomStylesClass );
+}

--- a/blocks/hooks/custom-styles.js
+++ b/blocks/hooks/custom-styles.js
@@ -45,7 +45,7 @@ export function addAnchorWhenStylesNeed( BlockEdit ) {
 		}
 
 		return [
-			BlockEdit,
+			<BlockEdit key="block-edit-add-anchor" { ...props } />,
 			hasAnchor && <AddAnchorWhenNeeded key="add-anchor" { ...props } />,
 		];
 	};

--- a/blocks/hooks/index.js
+++ b/blocks/hooks/index.js
@@ -3,10 +3,12 @@
  */
 import anchor from './anchor';
 import customClassName from './custom-class-name';
+import customStyles from './custom-styles';
 import generatedClassName from './generated-class-name';
 import matchers from './matchers';
 
 anchor();
 customClassName();
+customStyles();
 generatedClassName();
 matchers();

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -206,6 +206,7 @@ registerBlockType( 'core/paragraph', {
 
 	supports: {
 		className: false,
+		anchor: true,
 	},
 
 	attributes: {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -268,15 +268,13 @@ registerBlockType( 'core/paragraph', {
 	edit: ParagraphBlock,
 
 	save( { attributes } ) {
-		const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
+		const { width, align, content, dropCap, backgroundColor, fontSize } = attributes;
 		const className = classnames( {
 			[ `align${ width }` ]: width,
 			'has-background': backgroundColor,
 			'has-drop-cap': dropCap,
 		} );
 		const styles = {
-			backgroundColor: backgroundColor,
-			color: textColor,
 			fontSize: fontSize,
 			textAlign: align,
 		};

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -207,6 +207,7 @@ registerBlockType( 'core/paragraph', {
 	supports: {
 		className: false,
 		anchor: true,
+		customStyles: true,
 	},
 
 	attributes: {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -180,7 +180,7 @@ function gutenberg_render_block( $block ) {
  *
  * @return string CSS style block or empty string
  */
-function compute_styles( $blocks ) {
+function do_blocks_styles( $blocks ) {
 	$map_attrs_styles = array(
 		'textColor'       => 'color',
 		'backgroundColor' => 'background-color',
@@ -215,7 +215,7 @@ function compute_styles( $blocks ) {
 function do_blocks( $content ) {
 	$blocks = gutenberg_parse_blocks( $content );
 
-	$content_after_blocks = compute_styles( $blocks );
+	$content_after_blocks = do_blocks_styles( $blocks );
 	foreach ( $blocks as $block ) {
 		$content_after_blocks .= gutenberg_render_block( $block );
 	}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -172,6 +172,39 @@ function gutenberg_render_block( $block ) {
 }
 
 /**
+ * Given an array of parsed blocks, returns the css styles they require.
+ *
+ * @since 1.8.1
+ *
+ * @param array $blocks Parsed block array.
+ *
+ * @return string CSS style block or empty string
+ */
+function compute_styles( $blocks ) {
+	$map_attrs_styles = array(
+		'textColor'       => 'color',
+		'backgroundColor' => 'background-color',
+	);
+
+	$styles = '';
+	foreach ( $blocks as $block ) {
+		$attributes = is_array( $block['attrs'] ) ? $block['attrs'] : array();
+		if ( isset( $attributes['anchor'] ) ) {
+			$rules = '';
+			foreach ( $map_attrs_styles as $attr_key => $css_property ) {
+				if ( isset( $attributes[ $attr_key ] ) ) {
+					$rules .= "\n\t" . esc_attr( sprintf( '%1$s: %2$s;', $css_property, $attributes[ $attr_key ] ) );
+				}
+			}
+			if ( '' !== $rules ) {
+				$styles .= sprintf( "\n.has-custom-styles#%1\$s { %2\$s\n}", esc_attr( $attributes['anchor'] ), $rules );
+			}
+		}
+	}
+	return '' !== $styles ? sprintf( "<style type\"text/css\">%1\$s\n</style>", $styles ) : '';
+}
+
+/**
  * Parses dynamic blocks out of `post_content` and re-renders them.
  *
  * @since 0.1.0
@@ -182,7 +215,7 @@ function gutenberg_render_block( $block ) {
 function do_blocks( $content ) {
 	$blocks = gutenberg_parse_blocks( $content );
 
-	$content_after_blocks = '';
+	$content_after_blocks = compute_styles( $blocks );
 	foreach ( $blocks as $block ) {
 		$content_after_blocks .= gutenberg_render_block( $block );
 	}


### PR DESCRIPTION
## Description
This is a second take on https://github.com/WordPress/gutenberg/pull/3669 and tries to accomplish the first step of the tasks discussed in  https://github.com/WordPress/gutenberg/issues/2862
. The objective is to remove inline styles. Here we are using #ids instead of .classes so our custom attributes have higher specificity. The styles are not saved at all in the post content they are generated by PHP on render time.

The styles are targeted using anchor if the user set one that anchor is used, if not anchor exists, one is automatically generated when needed (and the user is able to change it, but not remove it).
The inline styles remaining in paragraph size and align will be replaced by classes.

This is a WIP in progress when adding the anchor support to paragraph (even just than change) we starting getting tinymce erros in the console, but things work as expected. This changes the markup of paragraph so some blocks may now be invalid some migration/version should be added.

## How Has This Been Tested?
Add a paragraph write some text.
Add other paragraphs change text color in one, background color in other and both attributes in another. Verify HTML anchors are automatically added when the first style is chosen. Verify you can change the anchor.
Save the post and view it verify it shows as expected.

## Types of changes
Added anchor support to paragraph.
Added a hook to implements automatic addition of anchors when needed.
Added a PHP mechanism to generate the styles in the server.
Remove in style colors from paragraph block saving.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.