### PR TITLE
Keep and handle image alignment classes for raw transforms

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -26,15 +26,17 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getBlockType, getBlockTypes } from './registration';
+import { getBlockAttributes } from './parser';
 
 /**
  * Returns a block object given its type and attributes.
  *
- * @param  {String} name             Block name
- * @param  {Object} blockAttributes  Block attributes
- * @return {Object}                  Block object
+ * @param  {String}  name             Block name
+ * @param  {Object}  blockAttributes  Block attributes
+ * @param  {?String} innerHTML        Block HTML
+ * @return {Object}                   Block object
  */
-export function createBlock( name, blockAttributes = {} ) {
+export function createBlock( name, blockAttributes = {}, innerHTML ) {
 	// Get the type definition associated with a registered block.
 	const blockType = getBlockType( name );
 
@@ -57,7 +59,7 @@ export function createBlock( name, blockAttributes = {} ) {
 		uid: uuid(),
 		name,
 		isValid: true,
-		attributes,
+		attributes: innerHTML ? getBlockAttributes( blockType, innerHTML, attributes ) : attributes,
 	};
 }
 

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -26,17 +26,15 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getBlockType, getBlockTypes } from './registration';
-import { getBlockAttributes } from './parser';
 
 /**
  * Returns a block object given its type and attributes.
  *
- * @param  {String}  name             Block name
- * @param  {Object}  blockAttributes  Block attributes
- * @param  {?String} innerHTML        Block HTML
- * @return {Object}                   Block object
+ * @param  {String} name             Block name
+ * @param  {Object} blockAttributes  Block attributes
+ * @return {Object}                  Block object
  */
-export function createBlock( name, blockAttributes = {}, innerHTML ) {
+export function createBlock( name, blockAttributes = {} ) {
 	// Get the type definition associated with a registered block.
 	const blockType = getBlockType( name );
 
@@ -59,7 +57,7 @@ export function createBlock( name, blockAttributes = {}, innerHTML ) {
 		uid: uuid(),
 		name,
 		isValid: true,
-		attributes: innerHTML ? getBlockAttributes( blockType, innerHTML, attributes ) : attributes,
+		attributes,
 	};
 }
 

--- a/blocks/api/raw-handling/strip-attributes.js
+++ b/blocks/api/raw-handling/strip-attributes.js
@@ -6,7 +6,7 @@ const { ELEMENT_NODE } = window.Node;
 /**
  * Internal dependencies
  */
-import { isAttributeWhitelisted } from './utils';
+import { isAttributeWhitelisted, isClassWhitelisted } from './utils';
 
 export default function( node ) {
 	if ( node.nodeType !== ELEMENT_NODE ) {
@@ -20,10 +20,27 @@ export default function( node ) {
 	const tag = node.nodeName.toLowerCase();
 
 	Array.from( node.attributes ).forEach( ( { name } ) => {
-		if ( isAttributeWhitelisted( tag, name ) ) {
+		if ( name === 'class' || isAttributeWhitelisted( tag, name ) ) {
 			return;
 		}
 
 		node.removeAttribute( name );
 	} );
+
+	const oldClasses = node.getAttribute( 'class' );
+
+	if ( ! oldClasses ) {
+		return;
+	}
+
+	const newClasses = oldClasses
+		.split( ' ' )
+		.filter( ( name ) => name && isClassWhitelisted( tag, name ) )
+		.join( ' ' );
+
+	if ( newClasses.length ) {
+		node.setAttribute( 'class', newClasses );
+	} else {
+		node.removeAttribute( 'class' );
+	}
 }

--- a/blocks/api/raw-handling/test/strip-attributes.js
+++ b/blocks/api/raw-handling/test/strip-attributes.js
@@ -29,4 +29,8 @@ describe( 'stripAttributes', () => {
 	it( 'should keep some attributes', () => {
 		equal( deepFilterHTML( '<a href="#keep">test</a>', [ stripAttributes ] ), '<a href="#keep">test</a>' );
 	} );
+
+	it( 'should keep some classes', () => {
+		equal( deepFilterHTML( '<img class="alignright test" src="">', [ stripAttributes ] ), '<img class="alignright" src="">' );
+	} );
 } );

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -49,7 +49,7 @@ const inlineWrapperWhiteList = {
 const whitelist = {
 	...inlineWhitelist,
 	...inlineWrapperWhiteList,
-	img: { attributes: [ 'src', 'alt' ] },
+	img: { attributes: [ 'src', 'alt' ], classes: [ 'alignleft', 'aligncenter', 'alignright', 'alignnone' ] },
 	figure: {},
 	blockquote: {},
 	hr: {},
@@ -98,6 +98,14 @@ function isInlineForTag( nodeName, tagName ) {
 export function isInline( node, tagName ) {
 	const nodeName = node.nodeName.toLowerCase();
 	return !! inlineWhitelist[ nodeName ] || isInlineForTag( nodeName, tagName );
+}
+
+export function isClassWhitelisted( tag, name ) {
+	return (
+		whitelist[ tag ] &&
+		whitelist[ tag ].classes &&
+		whitelist[ tag ].classes.indexOf( name ) !== -1
+	);
 }
 
 export function isInlineWrapper( node ) {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -63,12 +63,19 @@ registerBlockType( 'core/image', {
 		from: [
 			{
 				type: 'raw',
-				isMatch: ( node ) => {
+				isMatch( node ) {
 					const tag = node.nodeName.toLowerCase();
 					const hasText = !! node.textContent.trim();
 					const hasImage = node.querySelector( 'img' );
 
 					return tag === 'img' || ( hasImage && ! hasText ) || ( hasImage && tag === 'figure' );
+				},
+				transform( node ) {
+					const targetNode = node.parentNode.querySelector( 'figure,img' );
+					const matches = /align(left|center|right)/.exec( targetNode.className );
+					const align = matches ? matches[ 1 ] : undefined;
+
+					return createBlock( 'core/image', { align }, targetNode.outerHTML );
 				},
 			},
 			{

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -9,7 +9,7 @@ import { createMediaFromFile } from '@wordpress/utils';
  */
 import './style.scss';
 import './editor.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { registerBlockType, createBlock, getBlockAttributes, getBlockType } from '../../api';
 import ImageBlock from './block';
 
 registerBlockType( 'core/image', {
@@ -74,8 +74,10 @@ registerBlockType( 'core/image', {
 					const targetNode = node.parentNode.querySelector( 'figure,img' );
 					const matches = /align(left|center|right)/.exec( targetNode.className );
 					const align = matches ? matches[ 1 ] : undefined;
+					const blockType = getBlockType( 'core/image' );
+					const attributes = getBlockAttributes( blockType, targetNode.outerHTML, { align } );
 
-					return createBlock( 'core/image', { align }, targetNode.outerHTML );
+					return createBlock( 'core/image', attributes );
 				},
 			},
 			{


### PR DESCRIPTION
## Description
This PR updates raw handling to preserve WordPress alignment classes and updates the image block transformation to detect the classes and set the align attribute.

## How Has This Been Tested?
Paste the following structure:

```html
<p><img src="https://cldup.com/YLYhpou2oq.jpg" alt="Beautiful landscape" class="alignleft" /></p>
```

This would previously not preserve alignment.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.