### PR TITLE
Remove unnecessary padding on top of editor when fixed toolbar is off

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -64,7 +64,6 @@ body.gutenberg-editor-page {
 	bottom: 0;
 	left: 0;
 	min-height: calc( 100vh - #{ $admin-bar-height-big } );
-	padding-top: $header-height + $block-toolbar-height;
 
 	// The parent relative container changes
 	@include break-small {
@@ -74,11 +73,6 @@ body.gutenberg-editor-page {
 	// The WP header height changes at this breakpoint
 	@include break-medium {
 		min-height: calc( 100vh - #{ $admin-bar-height } );
-	}
-
-	// The block toolbar disappears at this breakpoint
-	@include break-large {
-		padding-top: $header-height;
 	}
 
 	img {

--- a/editor/edit-post/layout/index.js
+++ b/editor/edit-post/layout/index.js
@@ -23,11 +23,13 @@ import { MetaBoxes, AutosaveMonitor, UnsavedChangesWarning, EditorNotices } from
 import {
 	getEditorMode,
 	isEditorSidebarOpened,
+	isFeatureActive,
 } from '../../selectors';
 
-function Layout( { mode, isSidebarOpened } ) {
+function Layout( { mode, isSidebarOpened, hasFixedToolbar } ) {
 	const className = classnames( 'editor-layout', {
 		'is-sidebar-opened': isSidebarOpened,
+		'has-fixed-toolbar': hasFixedToolbar,
 	} );
 
 	return (
@@ -56,5 +58,6 @@ export default connect(
 	( state ) => ( {
 		mode: getEditorMode( state ),
 		isSidebarOpened: isEditorSidebarOpened( state ),
+		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
 	} ),
 )( navigateRegions( Layout ) );

--- a/editor/edit-post/layout/style.scss
+++ b/editor/edit-post/layout/style.scss
@@ -4,6 +4,7 @@
 }
 
 .editor-layout {
+	padding-top: $header-height;
 	position: relative;
 
 	.components-notice-list {
@@ -20,6 +21,14 @@
 			.notice-dismiss {
 				margin: 5px;
 			}
+		}
+	}
+
+	&.has-fixed-toolbar {
+		padding-top: $header-height + $block-toolbar-height; 
+
+		@include break-large {
+			padding-top: $header-height;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #3719.

When the formatting toolbar is fixed to the top, the Editor bar, on smaller breakpoints we stack the formatting toolbar below the editor bar itself, to make room for it:

<img width="914" alt="screen shot 2017-11-29 at 13 19 52" src="https://user-images.githubusercontent.com/1204802/33374863-23f831aa-d508-11e7-9f11-2733b5af1d3a.png">

This has the side-effect of having empty space up there, when the formatting toolbar is docked to the block (default as of 1.8):

<img width="900" alt="screen shot 2017-11-29 at 13 19 19" src="https://user-images.githubusercontent.com/1204802/33374901-44d38802-d508-11e7-9667-8511e26aef8d.png">

By moving the `padding-top` to `.editor_layout` instead of `.gutenberg__editor`, we can toggle the presence of `.has-fixed-toolbar` in order to conditionally set the amount of this padding:

| Toolbar on | Toolbar off |
| --- | --- |
| ![local wordpress test_wp-admin_post-new  #php_gutenberg-demo](https://user-images.githubusercontent.com/612155/33410363-f9b33b98-d5d3-11e7-92d6-3a61108bf10f.png) | ![local wordpress test_wp-admin_post-new php_gutenberg-demo 1](https://user-images.githubusercontent.com/612155/33410364-fb5a2178-d5d3-11e7-80a0-12e6120caf4c.png) |

### How to test

1. Toggle 'Fix toolbar to block' ON and check that everything looks OK at various viewport sizes 
1. Toggle 'Fix toolbar to block' OFF and check that everything looks OK at various viewport sizes