### PR TITLE
Fixed some bugs affecting bullet point position on list.

### DIFF
--- a/blocks/library/list/editor.scss
+++ b/blocks/library/list/editor.scss
@@ -1,6 +1,7 @@
 .blocks-list .blocks-editable__tinymce,
 .blocks-list .blocks-editable__tinymce ul,
 .blocks-list .blocks-editable__tinymce ol {
-	padding-left: 2.5em;
+	padding-left: 1.3em;
+	list-style-position: inside;
 	margin-left: 0;
 }


### PR DESCRIPTION
Added CSS rule "list-style-position: inside;" Changed existing rule to "padding-left: 1.3em;" So the design effect of line style position is unnoticeable.

These changes aim to fix bugs reported in https://github.com/WordPress/gutenberg/issues/3727 and https://github.com/WordPress/gutenberg/issues/3707.

## How Has This Been Tested?
Follow the steps described in both issues verify, they are not happening now.
Add some lists verify that you can add content to the lists and select the editable to start writing was not impacted.
Try to resize the screen and verify the list appears normally.
Try to use the list options e.g numbered, unnumbered and ident and verify things work normally.