### PR TITLE
Inserter: Respect recency order when display Recent blocks

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -150,8 +150,8 @@ export class InserterMenu extends Component {
 		let predicate;
 		switch ( tab ) {
 			case 'recent':
-				predicate = ( block ) => find( this.props.recentlyUsedBlocks, { name: block.name } );
-				break;
+				return filter( this.props.recentlyUsedBlocks,
+					( { name } ) => find( blockTypes, { name } ) );
 
 			case 'blocks':
 				predicate = ( block ) => block.category !== 'embed';

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -147,14 +147,22 @@ describe( 'InserterMenu', () => {
 				position={ 'top center' }
 				instanceId={ 1 }
 				blocks={ [] }
-				recentlyUsedBlocks={ [ advancedTextBlock ] }
+				recentlyUsedBlocks={ [
+					// Actually recently used by user, thus present at the top.
+					advancedTextBlock,
+					// Blocks of category 'common' injected on SETUP_EDITOR.
+					// These have to be listed here in the order in which they
+					// are registered.
+					textBlock,
+					someOtherBlock,
+				] }
 				debouncedSpeak={ noop }
 				blockTypes
 			/>
 		);
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
-		expect( visibleBlocks.length ).toBe( 1 );
+		expect( visibleBlocks.length ).toBe( 3 );
 		expect( visibleBlocks.at( 0 ).childAt( 0 ).name() ).toBe( 'BlockIcon' );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Advanced Text' );
 	} );


### PR DESCRIPTION
## Description
Addresses #3737 

## How Has This Been Tested?

### Unit tests

Make sure the changes to `editor/components/inserter/test/menu.js` highlight the parent issue.

### Manual testing

To replicate the initial conditions described in #3737, set your local preferences with the browser console:

```js
parsedPrefs = JSON.parse( localStorage.getItem( 'GUTENBERG_PREFERENCES_1' ) );
newPrefs = Object.assign( {}, parsedPrefs, { recentlyUsedBlocks: [ 'core/paragraph' ] } );
localStorage.setItem( 'GUTENBERG_PREFERENCES_1', JSON.stringify( newPrefs ) );
```

Make sure that Paragraph is the first block in Recent (see screenshot below).

## Screenshots (jpeg or gifs if applicable):
<img width="462" alt="gutenberg-recent-blocks-fix" src="https://user-images.githubusercontent.com/150562/33443663-0e324340-d5f0-11e7-8f54-3371496dbfaf.png">

## Types of changes
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.