### PR TITLE
Initial drop event, and transform for images in HTML mode

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -72,6 +72,25 @@ registerBlockType( 'core/image', {
 				},
 			},
 			{
+				type: 'html',
+				isMatch( html ) {
+					const wrapper = document.createElement( 'div' );
+					wrapper.innerHTML = html;
+					return wrapper.childNodes.length === 1 && wrapper.childNodes[ 0 ].nodeName.toLowerCase() === 'img';
+				},
+				transform( html ) {
+					const wrapper = document.createElement( 'div' );
+					wrapper.innerHTML = html;
+					const img = wrapper.querySelector( 'img' );
+					return Promise.resolve(
+						createBlock( 'core/image', {
+							id: img.id,
+							url: img.src,
+						} )
+					);
+				},
+			},
+			{
 				type: 'files',
 				isMatch( files ) {
 					return files.length === 1 && files[ 0 ].type.indexOf( 'image/' ) === 0;

--- a/editor/components/block-drop-zone/index.js
+++ b/editor/components/block-drop-zone/index.js
@@ -38,9 +38,38 @@ function BlockDropZone( { index, ...props } ) {
 		}
 	};
 
+	const drop = ( event, position ) => {
+		const numFiles = event.dataTransfer ? event.dataTransfer.files.length : 0;
+
+		if ( numFiles === 0 ) {
+			const html = event.dataTransfer.getData( 'text/html' );
+			const transformation = reduce( getBlockTypes(), ( ret, blockType ) => {
+				if ( ret ) {
+					return ret;
+				}
+
+				return find( get( blockType, 'transforms.from', [] ), ( transform ) => {
+					return transform.type === 'html' && transform.isMatch( html );
+				} );
+			}, false );
+
+			if ( transformation ) {
+				let insertPosition;
+				if ( index !== undefined ) {
+					insertPosition = position.y === 'top' ? index : index + 1;
+				}
+
+				transformation.transform( html ).then( ( blocks ) => {
+					props.insertBlocks( blocks, insertPosition );
+				} );
+			}
+		}
+	}
+
 	return (
 		<DropZone
 			onFilesDrop={ dropFiles }
+			onDrop={ drop }
 		/>
 	);
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Exploring #3744 

There are two parts of this PR.

1. Exploring defining a transform type `html` that transform HTML passed via `dataTransfer`
2. Supporting the`html` source transform for image blocks.

It's currently hooking into `onDrop` in `BlockDropZone`. It only does something if it detects there are no files being transferred, but that's not exactly an elegant way of deciding which drop handler to execute. They probably need to be orchestrated properly.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.