### PR TITLE
Put the block-appender styles where they belong

### DIFF
--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -1,17 +1,5 @@
 $empty-paragraph-height: $text-editor-font-size * 4;
 
-.editor-default-block-appender {
-	@include break-small() {
-		padding: 0 ( $block-mover-padding-visible - 1px );	// subtract 1px for border
-		padding: 0 $block-mover-padding-visible;
-
-		.editor-default-block-appender__content {
-			padding: 0 ( $block-padding - 1px );	// subtract 1px for border
-			padding: 0 $block-padding;
-		}
-	}
-}
-
 input[type=text].editor-default-block-appender__content {
 	border: none;
 	background: none;

--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -104,4 +104,14 @@
 	margin-left: auto;
 	margin-right: auto;
 	position: relative;
+
+	@include break-small() {
+		padding: 0 ( $block-mover-padding-visible - 1px );	// subtract 1px for border
+		padding: 0 $block-mover-padding-visible;
+
+		.editor-default-block-appender__content {
+			padding: 0 ( $block-padding - 1px );	// subtract 1px for border
+			padding: 0 $block-padding;
+		}
+	}
 }


### PR DESCRIPTION
This is a tiny PR to address feedback from https://github.com/WordPress/gutenberg/pull/3717#pullrequestreview-79976399. It puts CSS styles where they belong, for component reusability.