### PR TITLE
Polish the demo post

### DIFF
--- a/phpunit/fixtures/long-content.html
+++ b/phpunit/fixtures/long-content.html
@@ -1,131 +1,130 @@
-<!-- wp:core/cover-image { "url": "https://cldup.com/GCwahb3aOb.jpg", "align": "full", "hasParallax": true } -->
-<section className="cover-image wp-block-cover-image" style={ { backgroundImage: 'url("https://cldup.com/GCwahb3aOb.jpg");' } }><h2>Of mountains & printing presses</h2></section>
-<!-- /wp:core/cover-image -->
-<!-- more Keep on reading! -->
-<!-- noteaser -->
-<!-- wp:core/paragraph { "project": { "name": "gutenberg", "for": "WordPress" }, "isAwesome": true } -->
-<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you'll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/paragraph -->
+<!-- wp:cover-image {"url":"https://cldup.com/Fz-ASbo2s3.jpg","align":"wide"} -->
+<section class="wp-block-cover-image has-background-dim" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><h2>Of Mountains &amp; Printing Presses</h2></section>
+<!-- /wp:cover-image -->
+<!-- wp:paragraph -->
+<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you&#x27;ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph -->
 <p>What you are reading now is a <strong>text block</strong>, the most basic block of all. The text block has its own controls to be moved freely around the post...</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/paragraph { "align": "right" } -->
-<p style="text-align:right;">... like this one, which is right aligned.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/more /-->
-<!-- wp:core/paragraph -->
+<!-- /wp:paragraph -->
+<!-- wp:paragraph {"align":"right"} -->
+<p style="text-align:right">... like this one, which is right aligned.</p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph -->
 <p>Headings are separate blocks as well, which helps with the outline and organization of your content.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/heading -->
-<h2>A picture is worth a thousand words, or so the saying goes</h2>
-<!-- /wp:core/heading -->
-<!-- wp:core/paragraph -->
-<p>Handling images and media with the utmost care is a primary focus of the new editor. Hopefully, you'll find aspects of adding captions or going full-width with your pictures much easier and robust than before.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/image { "align": "center" } -->
-<figure class="wp-block-image"><img alt="Beautiful landscape" src="https://cldup.com/YLYhpou2oq.jpg" class="aligncenter"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
-<!-- /wp:core/image -->
-<!-- wp:core/paragraph -->
-<p>Try selecting and removing or editing the caption, now you don't have to be careful about selecting the image or other text by mistake and ruining the presentation.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/heading -->
+<!-- /wp:paragraph -->
+<!-- wp:heading -->
+<h2>A Picture is worth a Thousand Words</h2>
+<!-- /wp:heading -->
+<!-- wp:paragraph -->
+<p>Handling images and media with the utmost care is a primary focus of the new editor. Hopefully, you&#x27;ll find aspects of adding captions or going full-width with your pictures much easier and robust than before.</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"align":"center"} -->
+<figure class="wp-block-image aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>Give it a try. Press the &quot;wide&quot; button on the image toolbar.</figcaption></figure>
+<!-- /wp:image -->
+<!-- wp:paragraph -->
+<p>Try selecting and removing or editing the caption, now you don&#x27;t have to be careful about selecting the image or other text by mistake and ruining the presentation.</p>
+<!-- /wp:paragraph -->
+<!-- wp:heading -->
 <h2>The <em>Inserter</em> Tool</h2>
-<!-- /wp:core/heading -->
-<!-- wp:core/paragraph -->
-<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That's the spirit behind the inserter—the <code>(+)</code> button you'll see around the editor—which allows you to browse all available content blocks and insert them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/paragraph -->
-<p>Go give it a try, you may discover things WordPress can already insert into your posts that you didn't know about. Here's a short list of what you can currently find there:</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/list -->
-<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>
-<!-- /wp:core/list -->
-<!-- wp:core/paragraph -->
-<p>If you want to learn more about how to build additional blocks, or if you are interested in helping with the project, head over to the <a href="https://github.com/WordPress/gutenberg">GitHub repository</a>.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/button { "align": "center" } -->
-<div class="aligncenter wp-block-button"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>
-<!-- /wp:core/button -->
-<!-- wp:core/separator -->
+<!-- /wp:heading -->
+<!-- wp:paragraph -->
+<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That&#x27;s the spirit behind the inserter—the <code>(+)</code> button you&#x27;ll see around the editor—which allows you to browse all available content blocks and insert them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph -->
+<p>Go give it a try, you may discover things WordPress can already insert into your posts that you didn&#x27;t know about. Here&#x27;s a short list of what you can currently find there:</p>
+<!-- /wp:paragraph -->
+<!-- wp:list -->
+<ul>
+<li>Text &amp; Headings</li>
+<li>Images &amp; Videos</li>
+<li>Galleries</li>
+<li>Embeds, like YouTube, Tweets, or other WordPress posts.</li>
+<li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li>
+<li>And <em>Lists</em> like this one of course :)</li>
+</ul>
+<!-- /wp:list -->
+<!-- wp:separator -->
 <hr class="wp-block-separator" />
-<!-- /wp:core/separator -->
-<!-- wp:core/heading -->
+<!-- /wp:separator -->
+<!-- wp:heading -->
 <h2>Visual Editing</h2>
-<!-- /wp:core/heading -->
-<!-- wp:core/paragraph -->
+<!-- /wp:heading -->
+<!-- wp:paragraph -->
 <p>A huge benefit of blocks is that you can edit them in place and manipulate your content directly. Instead of having fields for editing things like the source of a quote, or the text of a button, you can directly change the content. Try editing the following quote:</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/quote { "style": 1 } -->
-<blockquote class="blocks-quote-style-1 wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer>Matt Mullenweg, 2017</footer></blockquote>
-<!-- /wp:core/quote -->
-<!-- wp:core/paragraph -->
-<p>The information corresponding to the source of the quote is a separate text field, similar to captions under images, so the structure of the quote is protected even if you select, modify, or remove the source. It's always easy to add it back.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/paragraph -->
+<!-- /wp:paragraph -->
+<!-- wp:quote -->
+<blockquote class="wp-block-quote blocks-quote-style-1">
+<p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
+<footer>Matt Mullenweg, 2017</footer>
+</blockquote>
+<!-- /wp:quote -->
+<!-- wp:paragraph -->
+<p>The information corresponding to the source of the quote is a separate text field, similar to captions under images, so the structure of the quote is protected even if you select, modify, or remove the source. It&#x27;s always easy to add it back.</p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph -->
 <p>Blocks can be anything you need. For instance, you may want to insert a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/quote { "style": 2 } -->
-<blockquote class="blocks-quote-style-2 wp-block-quote"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>
-<!-- /wp:core/quote -->
-<!-- wp:core/separator -->
-<hr class="wp-block-separator" />
-<!-- /wp:core/separator -->
-<!-- wp:core/heading -->
-<h2>Sea id autem nominavi deseruisse</h2>
-<!-- /wp:core/heading -->
-<!-- wp:core/paragraph -->
-<p>Ea veniam homero eam. Ex inimicus molestiae cum, debet scaevola at eos. Vis assum veritus ut, has ea nostrud accusata, offendit appareat comprehensam ea pro. Ad quo quem veritus appellantur, te est quas phaedrum, eum alia habeo ad. Ei est erroribus imperdiet, omnis dicam propriae sed no. His vitae oratio fierent ne, cu duo tota eligendi, electram rationibus in qui.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/image { "align": "wide" } -->
-<figure class="wp-block-image"><img alt="Accessibility is important don't forget image alt attribute" src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
-<!-- /wp:core/image -->
-<!-- wp:core/paragraph -->
-<p>Est quis reque cetero ad. Sea id autem nominavi deseruisse. <strong>Veniam qualisque definitionem pri id</strong>, ea autem feugiat delenit ius, mei at loem affert accumsan. Dicat eruditi cu est, te pro dicant pericula conclusionemque, ei vim detracto euripidis intellegam. Eius postea volumus mei ad.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/paragraph -->
-<p>Prima ridens denique his te, ferri illum volumus an his. Eu vel dicat homero qualisqu, vitae regione deserunt vis ei. Graeci incorrupte liberavisse no mea, saepe voluptaria usu ex, vis dicant euismod id. At dolor reprimique eos, quo altera detraxit moderatius id. Quo iudico utinam eu, ad alia munere mel.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/code -->
-<pre class="wp-block-code"><code>export default function MyButton() {
-	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
-}</code></pre>
-<!-- /wp:core/code -->
-<!-- wp:core/gallery {"align":"wide"} -->
-<div class="blocks-gallery alignwide columns-2 wp-block-gallery">
-<figure class="blocks-gallery-image"><img src="https://cldup.com/GCwahb3aOb.jpg" alt="" /></figure>
-<figure class="blocks-gallery-image"><img src="https://cldup.com/lUUQPv6w9c.jpg" alt="" /></figure>
+<!-- /wp:paragraph -->
+<!-- wp:gallery {"columns":2} -->
+<div class="wp-block-gallery alignnone columns-2 is-cropped">
+<figure class="blocks-gallery-image"><img src="https://cldup.com/n0g6ME5VKC.jpg" alt="" /></figure>
+<figure class="blocks-gallery-image"><img src="https://cldup.com/ZjESfxPI3R.jpg" alt="" /></figure>
+<figure class="blocks-gallery-image"><img src="https://cldup.com/EKNF8xD2UM.jpg" alt="" /></figure>
 </div>
-<!-- /wp:core/gallery -->
-<!-- wp:core/preformatted -->
-<pre class="wp-block-preformatted">An old silent pond...<br>A frog jumps into the pond,<br>splash! Silence again.</pre>
-<!-- /wp:core/preformatted -->
-<!-- wp:core/paragraph -->
-<p>Eu integre accusata prodesset est, <em>sed te impetus gubergren conceptam</em>, ex sed wisi nostrum ocurreret. Esse velit omittantur ius te, alii dissentias ei vis. At sed unum veritus fabellas. Te volutpat appellantur duo. Ad natum fuisset intellegebat eam, causae invidunt usu id, et vis impetus appetere.</p>
-<!-- /wp:core/paragraph -->
-<!-- wp:core/heading -->
-<h6>Nominavi deseruisse</h6>
-<!-- /wp:core/heading -->
-<!-- wp:core/list -->
-<ul><li>Est quis reque cetero ad</li><li>Sea id autem nominavi deseruisse</li><li>Veniam qualisque definitionem pri id, ea autem feugiat delenit ius, mei at loem affert accumsan</li><li>Dicat eruditi cu est, te pro dicant pericula conclusionemque</li><li>Eius postea volumus mei ad</li></ul>
-<!-- /wp:core/list -->
-<!-- wp:core/pullquote -->
-<blockquote class="blocks-pullquote wp-block-pullquote"><p>Code is Poetry</p><footer>The WordPress community</footer></blockquote>
-<!-- /wp:core/pullquote -->
-<!-- wp:core/separator -->
+<!-- /wp:gallery -->
+<!-- wp:paragraph -->
+<p>You can change the amount of columns in your galleries by dragging a slider in the block inspector in the sidebar.</p>
+<!-- /wp:paragraph -->
+<!-- wp:heading -->
+<h2>Media Rich</h2>
+<!-- /wp:heading -->
+<!-- wp:paragraph -->
+<p>If you combine the new <strong>wide</strong> and <strong>full-wide</strong> alignments with galleries, you can create a very media rich layout, very quickly:</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"align":"full"} -->
+<figure class="wp-block-image alignfull"><img src="https://cldup.com/8lhI-gKnI2.jpg" alt="Accessibility is important don&#x27;t forget image alt attribute" /></figure>
+<!-- /wp:image -->
+<!-- wp:paragraph -->
+<p>Sure, the full-wide image can be pretty big. But sometimes the image is worth it.</p>
+<!-- /wp:paragraph -->
+<!-- wp:gallery {"align":"wide"} -->
+<div class="wp-block-gallery alignwide columns-2 is-cropped">
+<figure class="blocks-gallery-image"><img src="https://cldup.com/_rSwtEeDGD.jpg" alt="" /></figure>
+<figure class="blocks-gallery-image"><img src="https://cldup.com/L-cC3qX2DN.jpg" alt="" /></figure>
+</div>
+<!-- /wp:gallery -->
+<!-- wp:paragraph -->
+<p>The above is a gallery with just two images. It&#x27;s an easier way to create visually appealing layouts, without having to deal with floats. You can also easily convert the gallery back to individual images again, by using the block switcher.</p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph -->
+<p>Any block can opt into these alignments. The embed block has them also, and is responsive out of the box:</p>
+<!-- /wp:paragraph -->
+<!-- wp:embed {"url":"https://vimeo.com/22439234","align":"wide"} -->
+<figure class="wp-block-embed alignwide">
+https://vimeo.com/22439234
+</figure>
+<!-- /wp:embed -->
+<!-- wp:paragraph -->
+<p>You can build any block you like, static or dynamic, decorative or plain. Here&#x27;s a pullquote block:</p>
+<!-- /wp:paragraph -->
+<!-- wp:pullquote -->
+<blockquote class="wp-block-pullquote alignnone">
+<p>Code is Poetry</p>
+<footer>The WordPress community</footer>
+</blockquote>
+<!-- /wp:pullquote -->
+<!-- wp:paragraph {"align":"center"} -->
+<p style="text-align:center"><em>If you want to learn more about how to build additional blocks, or if you are interested in helping with the project, head over to the <a href="https://github.com/WordPress/gutenberg">GitHub repository</a>.</em></p>
+<!-- /wp:paragraph -->
+<!-- wp:button {"align":"center"} -->
+<div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>
+<!-- /wp:button -->
+<!-- wp:separator -->
 <hr class="wp-block-separator" />
-<!-- /wp:core/separator -->
-<!-- wp:core/table -->
-<table class="widefat wp-block-table"><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><th><a href="https://wordpress.org/news/2015/12/clifford/">4.4</a></th><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr class="alt"><th><a href="https://wordpress.org/news/2016/04/coleman/">4.5</a></th><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><th><a href="https://wordpress.org/news/2016/08/pepper/">4.6</a></th><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr class="alt"><th><a href="https://wordpress.org/news/2016/12/vaughan/">4.7</a></th><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>
-<!-- /wp:core/table -->
-<!-- wp:core/heading -->
-<h2>All that you can embed!</h2>
-<!-- /wp:core/heading -->
-<!-- wp:core/embed { "url": "https://www.youtube.com/watch?v=Nl6U7UotA-M" } -->
-<figure class="wp-block-embed">https://www.youtube.com/watch?v=Nl6U7UotA-M<figcaption>State of the Word 2016</figcaption></figure>
-<!-- /wp:core/embed -->
-<!-- wp:core/embed { "url": "https://twitter.com/photomatt/status/868657763970404352" } -->
-https://twitter.com/photomatt/status/868657763970404352
-<!-- /wp:core/embed -->
-<!-- wp:core/embed { "url": "https://make.wordpress.org/core/2017/01/17/editor-technical-overview/" } -->
-https://make.wordpress.org/core/2017/01/17/editor-technical-overview/
-<!-- /wp:core/embed -->
+<!-- /wp:separator -->
+<!-- wp:paragraph {"align":"center"} -->
+<p style="text-align:center">Thanks for testing Gutenberg!</p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph {"align":"center"} -->
+<p style="text-align:center"><img draggable="false" class="emoji" alt="👋" src="https://s.w.org/images/core/emoji/2.3/svg/1f44b.svg" /></p>
+<!-- /wp:paragraph -->

--- a/post-content.js
+++ b/post-content.js
@@ -7,8 +7,8 @@ window._wpGutenbergPost.title = {
 
 window._wpGutenbergPost.content = {
 	raw: [
-		'<!-- wp:cover-image {"url":"https://cldup.com/GCwahb3aOb.jpg","align":"full","hasParallax":true,"hasBackgroundDim":true} -->',
-		'<section class="wp-block-cover-image has-parallax has-background-dim" style="background-image:url(https://cldup.com/GCwahb3aOb.jpg)"><h2>Of mountains &amp; printing presses</h2></section>',
+		'<!-- wp:cover-image {"url":"https://cldup.com/Fz-ASbo2s3.jpg","align":"wide"} -->',
+		'<section class="wp-block-cover-image has-background-dim" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><h2>Of Mountains &amp; Printing Presses</h2></section>',
 		'<!-- /wp:cover-image -->',
 
 		'<!-- wp:paragraph -->',
@@ -28,7 +28,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:heading -->',
-		'<h2>A picture is worth a thousand words, or so the saying goes</h2>',
+		'<h2>A Picture is worth a Thousand Words</h2>',
 		'<!-- /wp:heading -->',
 
 		'<!-- wp:paragraph -->',
@@ -36,7 +36,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:image {"align":"center"} -->',
-		'<figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt="Beautiful landscape" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>',
+		'<figure class="wp-block-image aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>Give it a try. Press the &quot;wide&quot; button on the image toolbar.</figcaption></figure>',
 		'<!-- /wp:image -->',
 
 		'<!-- wp:paragraph -->',
@@ -58,14 +58,6 @@ window._wpGutenbergPost.content = {
 		'<!-- wp:list -->',
 		'<ul><li>Text &amp; Headings</li><li>Images &amp; Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>',
 		'<!-- /wp:list -->',
-
-		'<!-- wp:paragraph -->',
-		'<p>If you want to learn more about how to build additional blocks, or if you are interested in helping with the project, head over to the <a href="https://github.com/WordPress/gutenberg">GitHub repository</a>.</p>',
-		'<!-- /wp:paragraph -->',
-
-		'<!-- wp:button { "align": "center" } -->',
-		'<div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>',
-		'<!-- /wp:button -->',
 
 		'<!-- wp:separator -->',
 		'<hr class="wp-block-separator" />',
@@ -91,91 +83,80 @@ window._wpGutenbergPost.content = {
 		'<p>Blocks can be anything you need. For instance, you may want to insert a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>',
 		'<!-- /wp:paragraph -->',
 
-		'<!-- wp:quote {"style":2} -->',
-		'<blockquote class="wp-block-quote blocks-quote-style-2"><p>There is no greater agony than bearing an untold story inside you.</p><footer>Maya Angelou</footer></blockquote>',
-		'<!-- /wp:quote -->',
-
-		'<!-- wp:separator -->',
-		'<hr class="wp-block-separator" />',
-		'<!-- /wp:separator -->',
-
-		'<!-- wp:heading -->',
-		'<h2>Sea id autem nominavi deseruisse</h2>',
-		'<!-- /wp:heading -->',
-
-		'<!-- wp:paragraph -->',
-		'<p>Ea veniam homero eam. Ex inimicus molestiae cum, debet scaevola at eos. Vis assum veritus ut, has ea nostrud accusata, offendit appareat comprehensam ea pro. Ad quo quem veritus appellantur, te est quas phaedrum, eum alia habeo ad. Ei est erroribus imperdiet, omnis dicam propriae sed no. His vitae oratio fierent ne, cu duo tota eligendi, electram rationibus in qui.</p>',
-		'<!-- /wp:paragraph -->',
-
-		'<!-- wp:image {"align":"wide"} -->',
-		'<figure class="wp-block-image alignwide"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Accessibility is important don&#x27;t forget image alt attribute" /></figure>',
-		'<!-- /wp:image -->',
-
-		'<!-- wp:paragraph -->',
-		'<p>Est quis reque cetero ad. Sea id autem nominavi deseruisse. <strong>Veniam qualisque definitionem pri id</strong>, ea autem feugiat delenit ius, mei at loem affert accumsan. Dicat eruditi cu est, te pro dicant pericula conclusionemque, ei vim detracto euripidis intellegam. Eius postea volumus mei ad.</p>',
-		'<!-- /wp:paragraph -->',
-
-		'<!-- wp:paragraph -->',
-		'<p>Prima ridens denique his te, ferri illum volumus an his. Eu vel dicat homero qualisqu, vitae regione deserunt vis ei. Graeci incorrupte liberavisse no mea, saepe voluptaria usu ex, vis dicant euismod id. At dolor reprimique eos, quo altera detraxit moderatius id. Quo iudico utinam eu, ad alia munere mel.</p>',
-		'<!-- /wp:paragraph -->',
-
-		'<!-- wp:code -->',
-		'<pre class="wp-block-code"><code>export default function MyButton() {\n\
-return &lt;Button&gt;Click Me!&lt;/Button&gt;;\n\
-}</code></pre>',
-
-		'<!-- /wp:code -->',
-
-		'<!-- wp:gallery {"align":"wide","images":[{"url":"https://cldup.com/GCwahb3aOb.jpg","alt":""},{"url":"https://cldup.com/lUUQPv6w9c.jpg","alt":""}]} -->',
-		'<div class="wp-block-gallery alignwide columns-2 is-cropped">',
-		'<figure class="blocks-gallery-image"><img src="https://cldup.com/GCwahb3aOb.jpg" alt="" /></figure>',
-		'<figure class="blocks-gallery-image"><img src="https://cldup.com/lUUQPv6w9c.jpg" alt="" /></figure>',
+		'<!-- wp:gallery {"columns":2} -->',
+		'<div class="wp-block-gallery alignnone columns-2 is-cropped">',
+		'<figure class="blocks-gallery-image"><img src="https://cldup.com/n0g6ME5VKC.jpg" alt="" /></figure>',
+		'<figure class="blocks-gallery-image"><img src="https://cldup.com/ZjESfxPI3R.jpg" alt="" /></figure>',
+		'<figure class="blocks-gallery-image"><img src="https://cldup.com/EKNF8xD2UM.jpg" alt="" /></figure>',
 		'</div>',
 		'<!-- /wp:gallery -->',
 
-		'<!-- wp:preformatted -->',
-		'<pre class="wp-block-preformatted">An old silent pond...<br/>A frog jumps into the pond,<br/>splash! Silence again.</pre>',
-		'<!-- /wp:preformatted -->',
-
 		'<!-- wp:paragraph -->',
-		'<p>Eu integre accusata prodesset est, <em>sed te impetus gubergren conceptam</em>, ex sed wisi nostrum ocurreret. Esse velit omittantur ius te, alii dissentias ei vis. At sed unum veritus fabellas. Te volutpat appellantur duo. Ad natum fuisset intellegebat eam, causae invidunt usu id, et vis impetus appetere.</p>',
+		'<p>You can change the amount of columns in your galleries by dragging a slider in the block inspector in the sidebar.</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:heading -->',
-		'<h6>Nominavi deseruisse</h6>',
+		'<h2>Media Rich</h2>',
 		'<!-- /wp:heading -->',
 
-		'<!-- wp:list -->',
-		'<ul><li>Est quis reque cetero ad</li><li>Sea id autem nominavi deseruisse</li><li>Veniam qualisque definitionem pri id, ea autem feugiat delenit ius, mei at loem affert accumsan</li><li>Dicat eruditi cu est, te pro dicant pericula conclusionemque</li><li>Eius postea volumus mei ad</li></ul>',
-		'<!-- /wp:list -->',
+		'<!-- wp:paragraph -->',
+		'<p>If you combine the new <strong>wide</strong> and <strong>full-wide</strong> alignments with galleries, you can create a very media rich layout, very quickly:</p>',
+		'<!-- /wp:paragraph -->',
+
+		'<!-- wp:image {"align":"full"} -->',
+		'<figure class="wp-block-image alignfull"><img src="https://cldup.com/8lhI-gKnI2.jpg" alt="Accessibility is important don&#x27;t forget image alt attribute" /></figure>',
+		'<!-- /wp:image -->',
+
+		'<!-- wp:paragraph -->',
+		'<p>Sure, the full-wide image can be pretty big. But sometimes the image is worth it.</p>',
+		'<!-- /wp:paragraph -->',
+
+		'<!-- wp:gallery {"align":"wide","images":[{"url":"https://cldup.com/_rSwtEeDGD.jpg","alt":""},{"url":"https://cldup.com/L-cC3qX2DN.jpg","alt":""}]} -->',
+		'<div class="wp-block-gallery alignwide columns-2 is-cropped">',
+		'<figure class="blocks-gallery-image"><img src="https://cldup.com/_rSwtEeDGD.jpg" alt="" /></figure>',
+		'<figure class="blocks-gallery-image"><img src="https://cldup.com/L-cC3qX2DN.jpg" alt="" /></figure>',
+		'</div>',
+		'<!-- /wp:gallery -->',
+
+		'<!-- wp:paragraph -->',
+		'<p>The above is a gallery with just two images. It\'s an easier way to create visually appealing layouts, without having to deal with floats. You can also easily convert the gallery back to individual images again, by using the block switcher.</p>',
+		'<!-- /wp:paragraph -->',
+
+		'<!-- wp:paragraph -->',
+		'<p>Any block can opt into these alignments. The embed block has them also, and is responsive out of the box:</p>',
+		'<!-- /wp:paragraph -->',
+
+		'<!-- wp:embed {"url":"https://vimeo.com/22439234","align":"wide"} -->',
+		'<figure class="wp-block-embed alignwide">https://vimeo.com/22439234</figure>',
+		'<!-- /wp:embed -->',
+
+		'<!-- wp:paragraph -->',
+		'<p>You can build any block you like, static or dynamic, decorative or plain. Here\'s a pullquote block:</p>',
+		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:pullquote -->',
 		'<blockquote class="wp-block-pullquote alignnone"><p>Code is Poetry</p><footer>The WordPress community</footer></blockquote>',
 		'<!-- /wp:pullquote -->',
 
+		'<!-- wp:paragraph {"align":"center"} -->',
+		'<p style="text-align:center"><em>If you want to learn more about how to build additional blocks, or if you are interested in helping with the project, head over to the <a href="https://github.com/WordPress/gutenberg">GitHub repository</a>.</em></p>',
+		'<!-- /wp:paragraph -->',
+
+		'<!-- wp:button { "align": "center" } -->',
+		'<div class="wp-block-button aligncenter"><a href="https://github.com/WordPress/gutenberg"><span>Help build Gutenberg</span></a></div>',
+		'<!-- /wp:button -->',
+
 		'<!-- wp:separator -->',
 		'<hr class="wp-block-separator" />',
 		'<!-- /wp:separator -->',
 
-		'<!-- wp:table -->',
-		'<table class="wp-block-table"><thead><tr><th>Version</th><th>Musician</th><th>Date</th></tr></thead><tbody><tr><th><a href="https://wordpress.org/news/2015/12/clifford/">4.4</a></th><td>Clifford Brown</td><td>December 8, 2015</td></tr><tr class="alt"><th><a href="https://wordpress.org/news/2016/04/coleman/">4.5</a></th><td>Coleman Hawkins</td><td>April 12, 2016</td></tr><tr><th><a href="https://wordpress.org/news/2016/08/pepper/">4.6</a></th><td>Pepper Adams</td><td>August 16, 2016</td></tr><tr class="alt"><th><a href="https://wordpress.org/news/2016/12/vaughan/">4.7</a></th><td>Sarah Vaughan</td><td>December 6, 2016</td></tr></tbody></table>',
-		'<!-- /wp:table -->',
+		'<!-- wp:paragraph {"align":"center"} -->',
+		'<p style="text-align:center">Thanks for testing Gutenberg!</p>',
+		'<!-- /wp:paragraph -->',
 
-		'<!-- wp:heading -->',
-		'<h2>All that you can embed!</h2>',
-		'<!-- /wp:heading -->',
-
-		'<!-- wp:embed {"url":"https://www.youtube.com/watch?v=Nl6U7UotA-M"} -->',
-		'<figure class="wp-block-embed">\nhttps://www.youtube.com/watch?v=Nl6U7UotA-M\n<figcaption>State of the Word 2016</figcaption></figure>',
-		'<!-- /wp:embed -->',
-
-		'<!-- wp:embed {"url":"https://twitter.com/photomatt/status/868657763970404352"} -->',
-		'<figure class="wp-block-embed">\nhttps://twitter.com/photomatt/status/868657763970404352\n</figure>',
-		'<!-- /wp:embed -->',
-
-		'<!-- wp:embed {"url":"https://make.wordpress.org/core/2017/01/17/editor-technical-overview/"} -->',
-		'<figure class="wp-block-embed">\nhttps://make.wordpress.org/core/2017/01/17/editor-technical-overview/\n</figure>',
-		'<!-- /wp:embed -->',
+		'<!-- wp:paragraph {"align":"center"} -->',
+		'<p style="text-align:center"><img draggable="false" class="emoji" alt="👋" src="https://s.w.org/images/core/emoji/2.3/svg/1f44b.svg" /></p>',
+		'<!-- /wp:paragraph -->',
 
 	].join( '' ),
 };


### PR DESCRIPTION
This PR updates the demo content post, to make it more visually appealing. It tweaks a few phrasings, adds some new images, fixes a couple of typos, removes a couple of blocks and embeds, uses some new fancy alignments, and adds a bit more descriptive text.
![screenshot](https://user-images.githubusercontent.com/1204802/33476682-2050e354-d683-11e7-9a97-a8189ea765c0.gif)
