### PR TITLE
Blocks: Fix meta attributes selector not returning the correct value if edited

### DIFF
--- a/editor/selectors.js
+++ b/editor/selectors.js
@@ -466,8 +466,8 @@ export const getBlock = createSelector(
 );
 
 function getPostMeta( state, key ) {
-	return has( state, [ 'editor', 'edits', 'present', 'meta', key ] ) ?
-		get( state, [ 'editor', 'edits', 'present', 'meta', key ] ) :
+	return has( state, [ 'editor', 'present', 'edits', 'meta', key ] ) ?
+		get( state, [ 'editor', 'present', 'edits', 'meta', key ] ) :
 		get( state, [ 'currentPost', 'meta', key ] );
 }
 


### PR DESCRIPTION
I think the editor's state has been refactored at some point which introduced this regression. This is probably worth a unit test but I have to go to WCUS right now. Feel free to add it if possible.

**Testing instructions**

 - Add a block with a "meta" attribute
 - Try to update the value
 - The value should update as soon as you type.