### PR TITLE
Try to fix Webpack config issue on Node 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 build
 coverage
 cypress
-hooks
+/hooks
 node_modules
 gutenberg.zip
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,7 @@ const config = {
 		packageNames.reduce( ( memo, packageName ) => {
 			memo[ packageName ] = `./node_modules/@wordpress/${ packageName }`;
 			return memo;
-		}, {} ),
+		}, {} )
 	),
 	output: {
 		filename: '[name]/build/index.js',


### PR DESCRIPTION
## Description

From @mkaz:
> There is a known incompatibility with older version of node Just updated to latest Gutenberg 1.8.1 and building using node 6.11.1 on my sandbox and getting the following error:
>
> npm run dev
> 
> > gutenberg@1.8.1 dev /home/wpcom/public_html/wp-content/a8c-plugins/gutenberg
> > cross-env BABEL_ENV=default webpack --watch
> 
> /home/wpcom/public_html/wp-content/a8c-plugins/gutenberg/webpack.config.js:84
>     ),
>     ^
> SyntaxError: Unexpected token )