### PR TITLE
Fix the radio control checked property

### DIFF
--- a/blocks/inspector-controls/radio-control/index.js
+++ b/blocks/inspector-controls/radio-control/index.js
@@ -32,7 +32,7 @@ function RadioControl( { label, selected, help, instanceId, onChange, options = 
 						name={ id }
 						value={ option.value }
 						onChange={ onChangeValue }
-						selected={ option.value === selected }
+						checked={ option.value === selected }
 						aria-describedby={ !! help ? id + '__help' : undefined }
 					/>
 					<label key={ option.value } htmlFor={ ( id + '-' + index ) }>


### PR DESCRIPTION
## Description
The radio control is currently not displaying the checked value. This PR fixes the issue by changing the `selected` property to `checked`.

## How Has This Been Tested?
Tested by adding a radio control to an inspector panel. The selected radio button is now displayed correctly when moving away and returning to the panel.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [] My code has proper inline documentation.