### PR TITLE
Fix the Custom HTML Block's toolbar style

### DIFF
--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -67,18 +67,14 @@ registerBlockType( 'core/html', {
 				<div>
 					{ focus &&
 						<BlockControls key="controls">
-							<ul className="components-toolbar">
-								<li>
-									<button className={ `components-tab-button ${ ! preview ? 'is-active' : '' }` } onClick={ this.edit }>
-										<span>HTML</span>
-									</button>
-								</li>
-								<li>
-									<button className={ `components-tab-button ${ preview ? 'is-active' : '' }` } onClick={ this.preview }>
-										<span>{ __( 'Preview' ) }</span>
-									</button>
-								</li>
-							</ul>
+							<div className="components-toolbar">
+								<button className={ `components-tab-button ${ ! preview ? 'is-active' : '' }` } onClick={ this.edit }>
+									<span>HTML</span>
+								</button>
+								<button className={ `components-tab-button ${ preview ? 'is-active' : '' }` } onClick={ this.preview }>
+									<span>{ __( 'Preview' ) }</span>
+								</button>
+							</div>
 						</BlockControls>
 					}
 					{ preview ?


### PR DESCRIPTION
We're not using list nodes for the  `.components-toolbar` elements anymore. This was causing a small styling issue for the custom block's toolbar.

<img width="153" alt="screen shot 2017-12-02 at 09 53 49" src="https://user-images.githubusercontent.com/272444/33517280-d8add1d2-d746-11e7-84da-122487df66c1.png">
