### PR TITLE
HTML Mode: Fix styling

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -319,7 +319,7 @@
 	}
 }
 
-.editor-block-list__block .blocks-visual-editor__block-html-textarea {
+.editor-block-list__block .editor-block-list__block-html-textarea {
 	display: block;
 	margin: 0;
 	width: 100%;


### PR DESCRIPTION
I guess this broke when we extracted the block list as a reusable component.
This fixes the style of the HTML mode per block.

<img width="701" alt="screen shot 2017-12-02 at 10 00 45" src="https://user-images.githubusercontent.com/272444/33517313-aee1b75a-d747-11e7-93cf-b42542f4bf67.png">
