### PR TITLE
State: Deduplicate notices by distinct ID

### DIFF
--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -19,6 +19,7 @@ import {
 	without,
 	mapValues,
 	findIndex,
+	reject,
 } from 'lodash';
 
 /**
@@ -592,7 +593,10 @@ export function saving( state = {}, action ) {
 export function notices( state = [], action ) {
 	switch ( action.type ) {
 		case 'CREATE_NOTICE':
-			return [ ...state, action.notice ];
+			return [
+				...reject( state, { id: action.notice.id } ),
+				action.notice,
+			];
 
 		case 'REMOVE_NOTICE':
 			const { noticeId } = action;

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -1115,6 +1115,41 @@ describe( 'state', () => {
 				originalState[ 1 ],
 			] );
 		} );
+
+		it( 'should dedupe distinct ids', () => {
+			const originalState = [
+				{
+					id: 'a',
+					content: 'Post saved',
+					status: 'success',
+				},
+				{
+					id: 'b',
+					content: 'Error saving',
+					status: 'error',
+				},
+			];
+			const state = notices( deepFreeze( originalState ), {
+				type: 'CREATE_NOTICE',
+				notice: {
+					id: 'a',
+					content: 'Post updated',
+					status: 'success',
+				},
+			} );
+			expect( state ).toEqual( [
+				{
+					id: 'b',
+					content: 'Error saving',
+					status: 'error',
+				},
+				{
+					id: 'a',
+					content: 'Post updated',
+					status: 'success',
+				},
+			] );
+		} );
 	} );
 
 	describe( 'blocksMode', () => {


### PR DESCRIPTION
This pull request seeks to update the behavior of notices reducer to respect ID as a unique identifier, removing duplicate entries. The revised behavior appends the latest notice as the last value in the set, removing any prior entries which share the same ID.

__Testing instructions:__

Ensure that unit tests pass:

```
npm run test
```

Currently there do not appear to be any situations in which a duplicate notice would be shown, only because the behavior of saving explicitly calls to remove the existing notice.

https://github.com/WordPress/gutenberg/blob/c4444e4957d42ebf53846619b19091ed4129c4d2/editor/effects.js#L76

However, this has shown to be an issue in #3378 where saving a reusable block displays a notice with a common ID.