### PR TITLE
Framework: Disable codecov commenting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,4 @@ coverage:
         threshold: 0.5%
     patch: off
 
-comment:
-  require_changes: true
+comment: false


### PR DESCRIPTION
This pull request seeks to disable codecov bot commenting. It has not shown to provide valuable insights and therefore is considered unnecessary noise.