### PR TITLE
Framework: Apply content autop disabling filter before do_blocks

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -166,7 +166,7 @@ function do_blocks( $content ) {
 
 	return $content_after_blocks;
 }
-add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode() and wpautop().
+add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode().
 
 /**
  * Given a string, returns content normalized with automatic paragraphs applied

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -190,4 +190,4 @@ function gutenberg_wpautop( $content ) {
 	return wpautop( $content );
 }
 remove_filter( 'the_content', 'wpautop' );
-add_filter( 'the_content', 'gutenberg_wpautop' );
+add_filter( 'the_content', 'gutenberg_wpautop', 8 );


### PR DESCRIPTION
Fixes #3760
Props @rajuahmmedbd

This pull request seeks to resolve an issue where wpautop is always applied to front-end content, even if the post contains blocks, where autop is intended to be skipped. The reason this occurs, as described in https://github.com/WordPress/gutenberg/issues/3760#issuecomment-348743577, is because block delimiters are stripped before `gutenberg_wpautop` is called, and therefore the test to see if the content contains blocks will always fail, and default `wpautop` is applied unintentionally.

__Testing instructions:__

Repeat the testing instructions from #3760, verifying that superfluous paragraph tags are not shown in the front-end when previewing a post.