### PR TITLE
Prevent "Add New" dropdown from overriding other plugin functionality

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -501,7 +501,7 @@ function gutenberg_replace_default_add_new_button() {
 			newbutton += '<a href="' + newUrl + '">' + button.innerText + '</a>';
 			newbutton += '<span class="expander" tabindex="0" role="button" aria-haspopup="true" aria-label="<?php echo esc_js( __( 'Toggle editor selection menu', 'gutenberg' ) ); ?>"></span>';
 			newbutton += '<span class="dropdown"><a href="' + newUrl + '">Gutenberg</a>';
-			newbutton += '<a href="' + url + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span>';
+			newbutton += '<a href="' + url + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span><span class="page-title-action" style="display:none;"></span>';
 
 			button.insertAdjacentHTML( 'afterend', newbutton );
 			button.remove();


### PR DESCRIPTION
This PR adds an empty span with class `page-title-action` for plugins using this class to add more page actions. 

Fixes #3723 – WooCommerce looks for this class and uses it to inject Import & Export buttons. Gutenberg removes this class when it adds the dropdown to Add New. This simple fix just adds an empty, hidden span so that other plugins can continue to use it.

**To test:**

- Enable Gutenberg
- Enable WooCommerce (3.2.5)
- Navigate to All Products
- Should see Import and Export available next to Add New buttons

**Screenshots**

<img width="370" alt="screen shot 2017-12-03 at 11 23 23 am" src="https://user-images.githubusercontent.com/541093/33527832-f94c6ff8-d81c-11e7-987a-407af3004c7a.png">
<img width="358" alt="screen shot 2017-12-03 at 11 23 09 am" src="https://user-images.githubusercontent.com/541093/33527833-f957d064-d81c-11e7-98d6-8e5e3db28bf0.png">