### PR TITLE
Make component unit test for component/panel/color.js

### DIFF
--- a/components/panel/test/__snapshots__/color.js.snap
+++ b/components/panel/test/__snapshots__/color.js.snap
@@ -21,3 +21,23 @@ exports[`PanelColor should match snapshot 1`] = `
   }
 />
 `;
+
+exports[`PanelColor should match snapshot when colorValue is empty 1`] = `
+<PanelBody
+  title={
+    Array [
+      <span
+        className="components-panel__color-title"
+      />,
+      <span
+        className="components-panel__color-area"
+        style={
+          Object {
+            "background": "red",
+          }
+        }
+      />,
+    ]
+  }
+/>
+`;

--- a/components/panel/test/__snapshots__/color.js.snap
+++ b/components/panel/test/__snapshots__/color.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PanelColor should match snapshot 1`] = `
+<PanelBody
+  title={
+    Array [
+      <span
+        className="components-panel__color-title"
+      >
+        sample title
+      </span>,
+      <span
+        className="components-panel__color-area"
+        style={
+          Object {
+            "background": "red",
+          }
+        }
+      />,
+    ]
+  }
+/>
+`;

--- a/components/panel/test/__snapshots__/color.js.snap
+++ b/components/panel/test/__snapshots__/color.js.snap
@@ -22,7 +22,7 @@ exports[`PanelColor should match snapshot 1`] = `
 />
 `;
 
-exports[`PanelColor should match snapshot when colorValue is empty 1`] = `
+exports[`PanelColor should match snapshot when title is empty 1`] = `
 <PanelBody
   title={
     Array [

--- a/components/panel/test/color.js
+++ b/components/panel/test/color.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import PanelColor from '../color';
+
+describe( 'PanelColor', () => {
+	it( 'should match snapshot', () => {
+		const wrapper = shallow( <PanelColor colorValue="red" title="sample title" /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/components/panel/test/color.js
+++ b/components/panel/test/color.js
@@ -13,4 +13,8 @@ describe( 'PanelColor', () => {
 		const wrapper = shallow( <PanelColor colorValue="red" title="sample title" /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
+	it( 'should match snapshot when title is empty', () => {
+		const wrapper = shallow( <PanelColor colorValue="red" /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description
Related to progress on the issue -> Unit Testing Components #641

Added some unit test scripts for [PanelColor](https://github.com/WordPress/gutenberg/blob/master/components/panel/color.js) component.

## How Has This Been Tested?
Run unit test command.

```
$ npm test
 PASS  components/panel/test/color.js
  PanelColor
    ✓ should match snapshot (19ms)
    ✓ should match snapshot when title is empty (3ms)
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.