### PR TITLE
Components: withAPIData: Don't restrict endpoints to /wp/v2

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -484,7 +484,7 @@ JS;
 	wp_add_inline_script( 'wp-api', $script );
 
 	// Localize the wp-api settings and schema.
-	$schema_response = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2' ) );
+	$schema_response = rest_do_request( new WP_REST_Request( 'GET', '/' ) );
 	if ( ! $schema_response->is_error() ) {
 		wp_add_inline_script( 'wp-api', sprintf(
 			'wpApiSettings.cacheSchema = true; wpApiSettings.schema = %s;',


### PR DESCRIPTION
## Description
Fixes #3209.

## How Has This Been Tested?

1. Set up a site with the appropriate branches of Sensei and Sensei Courses according to the instructions in the parent issue. Set up a post/page in Gutenberg according to the instructions and use the Network inspector.
2. Make sure that a successful request to /sensei/v1/courses is found alongside the request to /wp/v2/course-category.
3. Make sure core blocks aren't affected by this (e.g. Latest Posts), nor other consumers of withAPIData within the framework (e.g. sidebar controls).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.