### PR TITLE
Make component unit test for editor/components/warning/index.js

### DIFF
--- a/editor/components/warning/test/__snapshots__/index.js.snap
+++ b/editor/components/warning/test/__snapshots__/index.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Warning should match snapshot 1`] = `
+<div
+  className="editor-warning"
+>
+  <Dashicon
+    icon="warning"
+  />
+  error
+</div>
+`;

--- a/editor/components/warning/test/index.js
+++ b/editor/components/warning/test/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Warning from '../index';
+
+describe( 'Warning', () => {
+	it( 'should match snapshot', () => {
+		const wrapper = shallow( <Warning>error</Warning> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+	it( 'should has valid class', () => {
+		const wrapper = shallow( <Warning /> );
+		expect( wrapper.hasClass( 'editor-warning' ) ).toBe( true );
+	} );
+	it( 'should show child error message element', () => {
+		const wrapper = shallow( <Warning><p>message</p></Warning> );
+		expect( wrapper.find( 'p' ).text() ).toBe( 'message' );
+	} );
+} );


### PR DESCRIPTION
## Description
Related to progress on the issue -> Unit Testing Components #641

Added some unit test scripts for [Warning](https://github.com/WordPress/gutenberg/blob/master/editor/components/warning/index.js) component.

## How Has This Been Tested?
Run unit test command.

```
$ npm test

 PASS  editor/components/warning/test/index.js
  Warning
    ✓ should match snapshot (16ms)
    ✓ should has valid class (2ms)
    ✓ should show child error message element (6ms)

----------------------------------------------------|----------|----------|----------|----------|----------------|
File                                                |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------------------------------------|----------|----------|----------|----------|----------------|
editor/components/warning                          |      100 |      100 |      100 |      100 |                |
 index.js                                          |      100 |      100 |      100 |      100 |                |
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.