### PR TITLE
Adds gutenberg_post_has_block( ) and gutenberg_content_has_block() functions.

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -372,6 +372,42 @@ function gutenberg_content_has_blocks( $content ) {
 }
 
 /**
+ * Determine whether a post has a specific block. This test optimizes for
+ * performance rather than strict accuracy, detecting the pattern of a block
+ * but not validating its structure. For strict accuracy, you should use the
+ * block parser on post content.
+ *
+ * @see gutenberg_parse_blocks()
+ *
+ * @since 1.9
+ *
+ * @param object $post Post.
+ * @param string $block_name Full Block name to look for.
+ * @return bool Whether the content contain the specified block.
+ */
+function gutenberg_post_has_block( $post, $block_name ) {
+	$post = get_post( $post );
+	return $post && gutenberg_content_has_block( $post->post_content, $block_name );
+}
+
+/**
+ * Determine whether a content string contains a specific block. This test
+ * optimizes for performance rather than strict accuracy, detecting the
+ * pattern of a block but not validating its structure. For strict accuracy,
+ * you should use the block parser on post content.
+ *
+ * @since 1.9
+ * @see gutenberg_parse_blocks()
+ *
+ * @param string $content Content to test.
+ * @param string $block_name Full Block name to look for.
+ * @return bool Whether the content contain the specified block.
+ */
+function gutenberg_content_has_block( $content, $block_name ) {
+	return false !== strpos( $content, '<!-- wp:' . $block_name );
+}
+
+/**
  * Adds a "Gutenberg" post state for post tables, if the post contains blocks.
  *
  * @param  array   $post_states An array of post display states.


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Uses gutenberg_post_has_blocks() and gutenberg_content_has_blocks() for reference. The block name is appended to the strpos search.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
You can test with this gist:
https://gist.github.com/ideadude/84f0b08e41f612c5137596785bc698a6
1. Add the gist into a custom plugin or theme's functions.php/etc
2. Create a post with a code block.
3. Notice that this is detected and the GPL message is appended to the post content.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.