### PR TITLE
Fix horizontal overflow for selects with long names in sidebar

### DIFF
--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -111,6 +111,8 @@
 
 	label {
 		margin-right: 10px;
+		flex-shrink: 0;
+		max-width: 75%;
 	}
 
 	&:empty {

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -104,6 +104,11 @@
 	align-items: center;
 	margin-top: 20px;
 
+	select {
+		// Necessary for select to respond to flexbox
+		min-width: 0;
+	}
+
 	label {
 		margin-right: 10px;
 	}


### PR DESCRIPTION
## Description
Fix for #3518. 
The select element was not responding to Flexbox appropriately in Webkit browsers. 

## How Has This Been Tested?
Device: MacBook Pro 2015
Browsers: Chrome 62.0.3202.94, Safari 11.0.1, FireFox 57.0.1

## Screenshots (jpeg or gifs if applicable):
<img width="271" alt="sidebar-author-select" src="https://user-images.githubusercontent.com/445861/33529569-3d715b92-d838-11e7-8e3b-f0661d031038.png">

## Types of changes
Adding a `min-width: 0;` to select elements solves this issue. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.