### PR TITLE
Update links blue for better contrast.

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -23,7 +23,7 @@
 	}
 
 	a {
-		color: $blue-medium-500;
+		color: $blue-dark-900;
 	}
 
 	&:focus a[data-mce-selected] {

--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -23,7 +23,7 @@
 	}
 
 	a {
-		color: $blue-dark-900;
+		color: $blue-medium-700;
 	}
 
 	&:focus a[data-mce-selected] {

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -59,7 +59,7 @@
 	}
 
 	a {
-		color: $blue-dark-900;
+		color: $blue-medium-700;
 	}
 
 	&:focus a[data-mce-selected] {

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -59,7 +59,7 @@
 	}
 
 	a {
-		color: $blue-medium-500;
+		color: $blue-dark-900;
 	}
 
 	&:focus a[data-mce-selected] {

--- a/editor/assets/stylesheets/_colors.scss
+++ b/editor/assets/stylesheets/_colors.scss
@@ -30,6 +30,11 @@ $white: #fff;
 $blue-wordpress-700: #00669b;
 $blue-wordpress: #0073aa;
 $blue-dark-900: #0071a1;
+
+$blue-medium-900: #006589;
+$blue-medium-800: #00739C;
+$blue-medium-700: #007FAC;
+$blue-medium-600: #008DBE;
 $blue-medium-500: #00a0d2;
 $blue-medium-400: #33B3DB;
 $blue-medium-300: #66C6E4;


### PR DESCRIPTION
This PR changes the blue used for links in the UI from the current `$blue-medium-500` to the darker `$blue-dark-900`. For now, it changes it just in a couple places.

Worth noting the gallery block, when an image is selected, displays a "remove image" button that uses `$blue-medium-500` as background and a white "X" as text: this contrast ratio is not sufficient and should be changed. I guess it would need some design feedback so I haven't changed it for now. /cc @mtias 

![screen shot 2017-12-03 at 15 03 50](https://user-images.githubusercontent.com/1682452/33530138-75f2d060-d840-11e7-899b-0542c6fb15e2.png)


There are other places where `$blue-medium-500` is used for borders etc., where I think it's ok to have a lower contrast. Trying to list them for reference:
- some hover color changes replicating the core styling
- image resize handlers
- animation on the publish/update button
- the `components-form-toggle` 
- block drop zone and insertion point
- inserter tabs active tab / sidebar tabs active tab
- `editor-post-featured-image__toggle` (actually not used, overridden by a core rule)
- `editor-post-text-editor__link` (actually not used, overridden by .editor-post-text-editor__toolbar button)

Fixes #3701 