### PR TITLE
fix/3795: Stop the link modal from triggering maybeStartTyping

### DIFF
--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -42,6 +42,13 @@ const FORMATTING_CONTROLS = [
 // Default controls shown if no `enabledControls` prop provided
 const DEFAULT_CONTROLS = [ 'bold', 'italic', 'strikethrough', 'link' ];
 
+/* We need to stop the keypress event here, because block.js is firing
+	 a maybeStartTyping on keypress, and that hides the "fixed-to-block" toolbar
+	 which unregisters the slot, so when Editable tries to re-render its input
+	 dialog, the slot is no longer in the system, and the dialog disappears
+ */
+const stopKeyPressPropagation = ( event ) => event.stopPropagation();
+
 class FormatToolbar extends Component {
 	constructor() {
 		super( ...arguments );
@@ -172,10 +179,13 @@ class FormatToolbar extends Component {
 				<Toolbar controls={ toolbarControls } />
 
 				{ ( isAddingLink || isEditingLink ) &&
+					// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+					/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 					<Fill name="Editable.Siblings">
 						<form
 							className="blocks-format-toolbar__link-modal"
 							style={ linkStyle }
+							onKeyPress={ stopKeyPressPropagation }
 							onSubmit={ this.submitLink }>
 							<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
 							<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
@@ -191,8 +201,13 @@ class FormatToolbar extends Component {
 				}
 
 				{ !! formats.link && ! isAddingLink && ! isEditingLink &&
+					// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+					/* eslint-disable jsx-a11y/no-static-element-interactions */
 					<Fill name="Editable.Siblings">
-						<div className="blocks-format-toolbar__link-modal" style={ linkStyle }>
+						<div
+							className="blocks-format-toolbar__link-modal"
+							style={ linkStyle }
+							onKeyPress={ stopKeyPressPropagation }>
 							<a
 								className="blocks-format-toolbar__link-value"
 								href={ formats.link.value }

--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -198,6 +198,7 @@ class FormatToolbar extends Component {
 							{ linkSettings }
 						</form>
 					</Fill>
+					/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
 				}
 
 				{ !! formats.link && ! isAddingLink && ! isEditingLink &&
@@ -225,6 +226,7 @@ class FormatToolbar extends Component {
 							{ linkSettings }
 						</div>
 					</Fill>
+					/* eslint-enable jsx-a11y/no-static-element-interactions */
 				}
 			</div>
 		);

--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -42,11 +42,7 @@ const FORMATTING_CONTROLS = [
 // Default controls shown if no `enabledControls` prop provided
 const DEFAULT_CONTROLS = [ 'bold', 'italic', 'strikethrough', 'link' ];
 
-/* We need to stop the keypress event here, because block.js is firing
-	 a maybeStartTyping on keypress, and that hides the "fixed-to-block" toolbar
-	 which unregisters the slot, so when Editable tries to re-render its input
-	 dialog, the slot is no longer in the system, and the dialog disappears
- */
+// Stop the keypress event from propagating up to maybeStartTyping in BlockListBlock
 const stopKeyPressPropagation = ( event ) => event.stopPropagation();
 
 class FormatToolbar extends Component {


### PR DESCRIPTION
## Description
When the toolbar is attached to the block any typing in the link modal would trigger the maybeStartTyping event which would hide the toolbar and in process also hide the link modal. This fixes the problem by suppressing the KeyPress event.

Fixes #3795 

## How Has This Been Tested?
Manually tested in Firefox and Chrome on Linux mint.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.