### PR TITLE
Fixed quote paragraph transformations.

### DIFF
--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString } from 'lodash';
+import { isString, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -101,33 +101,17 @@ registerBlockType( 'core/quote', {
 			{
 				type: 'block',
 				blocks: [ 'core/paragraph' ],
-				transform: ( { value, citation, ...attrs } ) => {
-					const textElement = value[ 0 ];
-					if ( ! textElement ) {
-						return createBlock( 'core/paragraph', {
-							content: citation,
-						} );
+				transform: ( { value, citation } ) => {
+					// transforming an empty quote
+					if ( ( ! value || ! value.length ) && ! citation ) {
+						return createBlock( 'core/paragraph' );
 					}
-					const textContent = isString( textElement.children ) ?
-						textElement.children :
-						textElement.children.props.children;
-					if ( Array.isArray( value ) || citation ) {
-						const text = createBlock( 'core/paragraph', {
-							content: textContent,
-						} );
-						const quote = createBlock( 'core/quote', {
-							...attrs,
-							citation,
-							value: Array.isArray( value ) ?
-								value.slice( 1 ) :
-								[],
-						} );
-
-						return [ text, quote ];
-					}
-					return createBlock( 'core/paragraph', {
-						content: textContent,
-					} );
+					// transforming a quote with content
+					return ( value || [] ).map( item => createBlock( 'core/paragraph', {
+						content: [ get( item, 'children.props.children', '' ) ],
+					} ) ).concat( citation ? createBlock( 'core/paragraph', {
+						content: citation,
+					} ) : [] );
 				},
 			},
 			{


### PR DESCRIPTION


This PR aims to fix issues https://github.com/WordPress/gutenberg/issues/3559 and https://github.com/WordPress/gutenberg/issues/1765 affecting quote->paragraph transformations.
Before when transforming a quote into a paragraph the result was a paragraph and the remaining a quote. Now the quote is transformed into several paragraphs. The logic was also simplified.
The strategy used in this PR is identical to the one used to transform between quote and list.

## How Has This Been Tested?
Follow the steps described in both issues and verify both are now resolved.
Add an empty a quote verify it transforms to empty paragraph
Add a quote with one line of text verify it transforms to one paragraph.
Add a quote with a citation verify it transforms to one paragraph.
Add a quote with many lines and custom formats (e.g bold links etc...) verify it transforms each line to a paragraph the citation if present is the last paragraph.


## Screenshots:
![dec-04-2017 15-05-40](https://user-images.githubusercontent.com/11271197/33559686-8515e08a-d905-11e7-9111-7a41f62f5344.gif)


