### PR TITLE
Try accessible excerpt

### DIFF
--- a/editor/components/post-excerpt/index.js
+++ b/editor/components/post-excerpt/index.js
@@ -17,7 +17,7 @@ import { getEditedPostExcerpt } from '../../selectors';
 import { editPost } from '../../actions';
 
 function PostExcerpt( { excerpt, onUpdateExcerpt, instanceId } ) {
-	const id = 'editor-post-excerpt-' + instanceId;
+	const id = `editor-post-excerpt-${ instanceId }`;
 	const onChange = ( event ) => onUpdateExcerpt( event.target.value );
 
 	return (

--- a/editor/components/post-excerpt/index.js
+++ b/editor/components/post-excerpt/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, withInstanceId } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -16,19 +16,18 @@ import './style.scss';
 import { getEditedPostExcerpt } from '../../selectors';
 import { editPost } from '../../actions';
 
-function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
+function PostExcerpt( { excerpt, onUpdateExcerpt, instanceId } ) {
+	const id = 'editor-post-excerpt-' + instanceId;
 	const onChange = ( event ) => onUpdateExcerpt( event.target.value );
-	const excerptTextareaId = 'editor-post-excerpt';
 
 	return (
 		<div>
-			<label key="label" htmlFor={ excerptTextareaId }>{ __( 'Write an excerpt (optional)' ) }</label>
+			<label key="label" htmlFor={ id }>{ __( 'Write an excerpt (optional)' ) }</label>
 			<textarea
+				id={ id }
 				className="editor-post-excerpt__textarea"
 				onChange={ onChange }
 				value={ excerpt }
-				aria-label={ __( 'Excerpt' ) }
-				id={ excerptTextareaId }
 			/>
 			<ExternalLink href="https://codex.wordpress.org/Excerpt">
 				{ __( 'Learn more about manual excerpts' ) }
@@ -48,4 +47,4 @@ export default connect(
 			return editPost( { excerpt } );
 		},
 	}
-)( PostExcerpt );
+)( withInstanceId( PostExcerpt ) );

--- a/editor/components/post-excerpt/index.js
+++ b/editor/components/post-excerpt/index.js
@@ -18,15 +18,17 @@ import { editPost } from '../../actions';
 
 function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 	const onChange = ( event ) => onUpdateExcerpt( event.target.value );
+	const excerptTextareaId = 'editor-post-excerpt';
 
 	return (
 		<div>
+			<label key="label" htmlFor={ excerptTextareaId }>{ __( 'Write an excerpt (optional)' ) }</label>
 			<textarea
 				className="editor-post-excerpt__textarea"
 				onChange={ onChange }
 				value={ excerpt }
-				placeholder={ __( 'Write an excerpt (optional)' ) }
 				aria-label={ __( 'Excerpt' ) }
+				id={ excerptTextareaId }
 			/>
 			<ExternalLink href="https://codex.wordpress.org/Excerpt">
 				{ __( 'Learn more about manual excerpts' ) }
@@ -47,4 +49,3 @@ export default connect(
 		},
 	}
 )( PostExcerpt );
-

--- a/editor/components/post-excerpt/style.scss
+++ b/editor/components/post-excerpt/style.scss
@@ -1,6 +1,5 @@
 .editor-post-excerpt__textarea {
 	width: 100%;
 	height: 80px;
-	margin-top: 20px;
 	margin-bottom: 10px;
 }


### PR DESCRIPTION
This is an attempt to fix #1371.

CC: @afercia, does this address the fundamental issue?

Screenshot:

<img width="402" alt="screen shot 2017-12-05 at 12 15 10" src="https://user-images.githubusercontent.com/1204802/33604392-1f8c22fe-d9b6-11e7-9863-81fc5f6c3817.png">

Rendered markup:

```
<label for="editor-post-excerpt">Write an excerpt (optional)</label>
<textarea class="editor-post-excerpt__textarea" aria-label="Excerpt" id="editor-post-excerpt"></textarea>
```