### PR TITLE
Try/custom class dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 build
 coverage
 cypress
-hooks
 node_modules
 gutenberg.zip
 

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -3,6 +3,7 @@
  */
 import { applyFilters } from '../hooks';
 import { getBlockType } from '../api';
+import { withContext } from '@wordpress/components';
 
 function BlockEdit( props ) {
 	const { name, ...editProps } = props;
@@ -20,4 +21,8 @@ function BlockEdit( props ) {
 	return applyFilters( 'BlockEdit', <Edit key="edit" { ...editProps } />, props );
 }
 
-export default BlockEdit;
+export default withContext( 'editor' )(
+	( settings ) => ( {
+		customClassDropdown: settings.customClassDropdown,
+	} )
+)( BlockEdit );

--- a/blocks/hooks/custom-class-dropdown.js
+++ b/blocks/hooks/custom-class-dropdown.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { assign } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { hasBlockSupport } from '../api';
+import InspectorControls from '../inspector-controls';
+
+/**
+ * Filters registered block settings, extending attributes with classDropdown
+ *
+ * @param  {Object} settings Original block settings
+ * @return {Object}          Filtered block settings
+ */
+export function addAttribute( settings ) {
+	if ( hasBlockSupport( settings, 'customClassDropdown', true ) ) {
+		// Use Lodash's assign to gracefully handle if attributes are undefined
+		settings.attributes = assign( settings.attributes, {
+			classDropdown: {
+				type: 'string',
+			},
+		} );
+	}
+
+	return settings;
+}
+
+/**
+ * Override the default edit UI to include a new block inspector control for
+ * assigning custom class dropdown
+ *
+ * @param  {Element} element Original edit element
+ * @param  {Object}  props   Props passed to BlockEdit
+ * @return {Element}         Filtered edit element
+ */
+export function addInspectorControl( element, props ) {
+
+	if ( hasBlockSupport( props.name, 'customClassDropdown', true ) && props.focus ) {
+
+		let options = props.customClassDropdown && props.customClassDropdown[props.name] 
+			? props.customClassDropdown[props.name] 
+			: false;
+
+		if ( options.length ) { 
+			options = [ { label: __( 'Default' ), value: '' } ].concat( options );
+		}
+
+		element = [
+			element,
+			options && <InspectorControls key="inspector-custom-class-dropdown">
+				<InspectorControls.SelectControl
+					label={ __( 'Custom Style' ) }
+					value={ props.attributes.classDropdown || '' }
+					options={ options }
+					onChange={ ( nextValue ) => {
+						props.setAttributes( {
+							classDropdown: nextValue,
+						} );
+					} }
+				/>
+			</InspectorControls>,
+		];
+	}
+
+	return element;
+}
+
+/**
+ * Override props assigned to save component to add custom class dropdown.
+ * This is only applied if the block's save result is an
+ * element and not a markup string.
+ *
+ * @param  {Object} extraProps Additional props applied to save element
+ * @param  {Object} blockType  Block type
+ * @param  {Object} attributes Current block attributes
+ * @return {Object}            Filtered props applied to save element
+ */
+export function addSaveProps( extraProps, blockType, attributes ) {
+	if ( hasBlockSupport( blockType, 'customClassDropdown', true ) && attributes.classDropdown ) {
+		extraProps.className = classnames( extraProps.className, attributes.classDropdown );
+	}
+
+	return extraProps;
+}
+
+export default function customClassDropdown( { addFilter } ) {
+	addFilter( 'registerBlockType', 'core-custom-class-dropdown-attribute', addAttribute );
+	addFilter( 'BlockEdit', 'core-custom-class-dropdown-inspector-control', addInspectorControl );
+	addFilter( 'getSaveContent.extraProps', 'core-custom-class-dropdown-save-props', addSaveProps );
+}

--- a/blocks/hooks/index.js
+++ b/blocks/hooks/index.js
@@ -9,6 +9,7 @@ import { createHooks } from '@wordpress/hooks';
 import anchor from './anchor';
 import customClassName from './custom-class-name';
 import generatedClassName from './generated-class-name';
+import customClassDropdown from './custom-class-dropdown';
 import matchers from './matchers';
 
 const hooks = createHooks();
@@ -35,5 +36,6 @@ export {
 
 anchor( hooks );
 customClassName( hooks );
+customClassDropdown( hooks );
 generatedClassName( hooks );
 matchers( hooks );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -781,11 +781,13 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	 *                                        boolean to enable/disable all.
 	 */
 	$allowed_block_types = apply_filters( 'allowed_block_types', true );
+	$custom_class_dropdown = apply_filters( 'custom_class_dropdown', array() );
 
 	$editor_settings = array(
-		'wideImages' => ! empty( $gutenberg_theme_support[0]['wide-images'] ),
-		'colors'     => $color_palette,
-		'blockTypes' => $allowed_block_types,
+		'wideImages'          => ! empty( $gutenberg_theme_support[0]['wide-images'] ),
+		'colors'              => $color_palette,
+		'blockTypes'          => $allowed_block_types,
+		'customClassDropdown' => is_array( $custom_class_dropdown ) ? $custom_class_dropdown : false,
 	);
 
 	$post_type_object = get_post_type_object( $post_to_edit['type'] );


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

This is an attempt to add a conditional block control in the inspector which should present a dropdown of available theme styling for a particular block type.
Theme or plugin would add a filter to attach their pairs of label/class-name for a block type:
PHP example:

```php

add_filter( 'custom_class_dropdown', function ( $custom_class_dropdown ) {

	$custom_class_dropdown['core/paragraph'][] = array( 'label' => 'Paragraph Style 1', 'value' => 'paragraph-style-1' );
	$custom_class_dropdown['core/paragraph'][] = array( 'label' => 'Paragraph Style 2', 'value' => 'paragraph-style-2' );

	$custom_class_dropdown['core/text-columns'][] = array( 'label' => 'Text Columns Style 1', 'value' => 'text-columns-style-1' );
	$custom_class_dropdown['core/text-columns'][] = array( 'label' => 'Text Columns Style 2', 'value' => 'text-columns-style-2' );

	$custom_class_dropdown['core/pullquote'][] = array( 'label' => 'Pullquote Style 1', 'value' => 'pullquote-style-1' );
	$custom_class_dropdown['core/pullquote'][] = array( 'label' => 'Pullquote Style 2', 'value' => 'pullquote-style-2' );

	return $custom_class_dropdown;
} );
```

That will cause a dropdown to show in the specified block inspector tab offering the user to select an alternative styling for the block. When the style is selected a predefined css class will be printed on the block instance. If corresponding css rules are loaded in the editor the style changes should be immediately visible. 
![paragraph-custom-class-dropdown](https://user-images.githubusercontent.com/1592693/33604764-70634eb8-d9b7-11e7-8178-ef1b80d55ff4.png)


This feature should drastically improve theme author experience in providing alternative styling for existing blocks.
This approach is basically the same as adding a custom css class already available but that approach is assuming that the end user knows all available css classes that theme has prepared which is rarely the case, even with good theme documentation. Also, custom class approach seems more suitable for users who want to add new styling and are familiar with basic html/css.
This approach drastically simplifies style changes/application for the end user who does not want to be bothered with unlimited styling options, he will just use theme prepared styles.



I am not sure about the naming I chose and there are some code decisions that are working but maybe better solutions can be found, like using withContext in EditBlock. I'm also not sure about the structure of php filter but I needed something done quickly to sketch an idea.

I also needed to remove hooks from .gitignore in order to commit the file. Not sure why were they ignored?

Maybe this feature does not belong to Gutenberg Core but presenting it here anyway.
Thanks.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually tested in the browser

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature (non-breaking change which adds functionality)
