### PR TITLE
Added drag and drop upload to gallery block

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -9,7 +9,7 @@ import { filter } from 'lodash';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { mediaUpload } from '@wordpress/utils';
-import { Dashicon, Toolbar, Placeholder, FormFileUpload } from '@wordpress/components';
+import { Dashicon, DropZone, Toolbar, Placeholder, FormFileUpload } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -49,6 +49,7 @@ class GalleryBlock extends Component {
 		this.uploadFromFiles = this.uploadFromFiles.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
+		this.dropFiles = this.dropFiles.bind( this );
 
 		this.state = {
 			selectedImage: null,
@@ -113,6 +114,20 @@ class GalleryBlock extends Component {
 		} );
 	}
 
+	dropFiles( files ) {
+		const currentImages = this.props.attributes.images || [];
+		const { setAttributes } = this.props;
+		mediaUpload(
+			files,
+			( { images } ) => {
+				setAttributes( {
+					images: currentImages.concat( images ),
+				} );
+			},
+			isGallery
+		);
+	}
+
 	render() {
 		const { attributes, focus, className } = this.props;
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
@@ -131,6 +146,12 @@ class GalleryBlock extends Component {
 					{blockDescription}
 				</InspectorControls>
 			)
+		);
+
+		const dropZone = (
+			<DropZone
+				onFilesDrop={ this.dropFiles }
+			/>
 		);
 
 		const controls = (
@@ -173,6 +194,7 @@ class GalleryBlock extends Component {
 					icon="format-gallery"
 					label={ __( 'Gallery' ) }
 					className={ className }>
+					{ dropZone }
 					<FormFileUpload
 						isLarge
 						className="wp-block-image__upload-button"
@@ -222,6 +244,7 @@ class GalleryBlock extends Component {
 				</InspectorControls>
 			),
 			<div key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
+				{ dropZone }
 				{ images.map( ( img, index ) => (
 					<GalleryImage
 						key={ img.id || img.url }


### PR DESCRIPTION
This change address part of the concerns raised on https://github.com/WordPress/gutenberg/issues/1704. It provides a way to add new images to a gallery without going to media through the media library.

## How Has This Been Tested?
Create a gallery block drag&drop some images to it, see the images were added to the gallery. Add more images and see it is possible to use this mechanism even in galleries with content.
See existing gallery functionality still works as expected e.g: remove images/ change images.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/11271197/33622457-c6a36cbc-d9e5-11e7-9fd3-827a649b461e.png)
