### PR TITLE
normaliseBlocks: Don't break between inline siblings

### DIFF
--- a/blocks/api/raw-handling/normalise-blocks.js
+++ b/blocks/api/raw-handling/normalise-blocks.js
@@ -58,7 +58,9 @@ export default function( HTML ) {
 					accu.appendChild( node );
 				}
 			} else if ( isInline( node ) ) {
-				accu.appendChild( document.createElement( 'P' ) );
+				if ( ! accu.lastChild || accu.lastChild.nodeName !== 'P' ) {
+					accu.appendChild( document.createElement( 'P' ) );
+				}
 				accu.lastChild.appendChild( node );
 			} else {
 				accu.appendChild( node );

--- a/blocks/api/raw-handling/test/normalise-blocks.js
+++ b/blocks/api/raw-handling/test/normalise-blocks.js
@@ -35,6 +35,10 @@ describe( 'normaliseBlocks', () => {
 		equal( normaliseBlocks( '<a href="#">test</a>' ), '<p><a href="#">test</a></p>' );
 	} );
 
+	it( 'should not break between inline siblings', () => {
+		equal( normaliseBlocks( '<strong>test</strong>&nbsp;is a test of&nbsp;<a href="#">test</a>&nbsp;using a&nbsp;<a href="#">test</a>.' ), '<p><strong>test</strong>&nbsp;is a test of&nbsp;<a href="#">test</a>&nbsp;using a&nbsp;<a href="#">test</a>.</p>' );
+	} );
+
 	it( 'should not append empty text nodes', () => {
 		equal( normaliseBlocks( '<p>test</p>\n' ), '<p>test</p>' );
 	} );

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -39,7 +39,10 @@ registerBlockType( 'core/shortcode', {
 				// letters, but numbers and underscores should work fine too.
 				// Be wary of using hyphens (dashes), you'll be better off not
 				// using them." in https://codex.wordpress.org/Shortcode_API
-				tag: '[a-z0-9_-]+',
+				// Require that the first character be a letter. This notably
+				// prevents footnote markings ([1]) from being caught as
+				// shortcodes.
+				tag: '[a-z][a-z0-9_-]*',
 				attributes: {
 					text: {
 						type: 'string',


### PR DESCRIPTION
## Description

When pasting rich content, blocks are split where new inline elements start, such as `<a>`:

Before | After
------- | -----
<img width="766" alt="screen shot 2017-12-06 at 01 57 47" src="https://user-images.githubusercontent.com/150562/33640545-276520a2-da29-11e7-929b-c484f83c924e.png"> | <img width="766" alt="screen shot 2017-12-06 at 01 58 11" src="https://user-images.githubusercontent.com/150562/33640551-2c4a4066-da29-11e7-99f0-d7e0b4b98f4c.png">

## How Has This Been Tested?

Copy the first paragraph from Wikipedia's entry on [letterpress printing](https://en.wikipedia.org/wiki/Letterpress_printing), paste to an empty post. Make sure that only one Paragraph is created, and that no formatting or content was lost from the source.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.