### PR TITLE
Fix/vertical arrows in horizontal menu when toolbar is fixed to block

### DIFF
--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -123,14 +123,19 @@ export class NavigableMenu extends Component {
 		const { role = 'menu', orientation = 'vertical', ...rest } = this.props;
 		const eventToOffset = ( evt ) => {
 			const { keyCode } = evt;
-			if ( LEFT === keyCode && orientation === 'horizontal' ) {
-				return -1;
-			} else if ( UP === keyCode && orientation === 'vertical' ) {
-				return -1;
-			} else if ( RIGHT === keyCode && orientation === 'horizontal' ) {
-				return +1;
-			} else if ( DOWN === keyCode && orientation === 'vertical' ) {
-				return +1;
+
+			const isVertical = orientation === 'vertical';
+			const isHorizontal = orientation === 'horizontal';
+
+			// Still handle any arrow keys, even if the opposite orientation
+			if ( LEFT === keyCode ) {
+				return isHorizontal ? -1 : 0;
+			} else if ( UP === keyCode ) {
+				return isVertical ? -1 : 0;
+			} else if ( RIGHT === keyCode ) {
+				return isHorizontal ? +1 : 0;
+			} else if ( DOWN === keyCode ) {
+				return isVertical ? +1 : 0;
 			}
 		};
 

--- a/components/navigable-container/test/index.js
+++ b/components/navigable-container/test/index.js
@@ -14,7 +14,7 @@ import { keycodes } from '@wordpress/utils';
  */
 import { TabbableContainer, NavigableMenu } from '../';
 
-const { UP, DOWN, TAB, LEFT, RIGHT } = keycodes;
+const { UP, DOWN, TAB, LEFT, RIGHT, SPACE } = keycodes;
 
 function simulateVisible( wrapper, selector ) {
 	const elements = wrapper.getDOMNode().querySelectorAll( selector );
@@ -38,390 +38,523 @@ function fireKeyDown( container, keyCode, shiftKey ) {
 describe( 'NavigableMenu', () => {
 	it( 'vertical: should navigate by up and down', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<NavigableMenu onNavigate={ ( index ) => currentIndex = index }>
-				<button id="btn1">One</button>
-				<button id="btn2">Two</button>
-				<button id="btn3">Three</button>
-			</NavigableMenu >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<NavigableMenu onNavigate={ ( index ) => currentIndex = index }>
+					<button id="btn1">One</button>
+					<button id="btn2">Two</button>
+					<button id="btn3">Three</button>
+				</NavigableMenu >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div' );
+		const container = wrapper.find( '.outer-container NavigableMenu' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex ) {
-			fireKeyDown( container, keyCode );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
+			fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( DOWN, 1 );
-		assertKeyDown( DOWN, 2 );
-		assertKeyDown( DOWN, 0 );
-		assertKeyDown( UP, 2 );
-		assertKeyDown( UP, 1 );
-		assertKeyDown( UP, 0 );
-		assertKeyDown( LEFT, 0 );
-		assertKeyDown( RIGHT, 0 );
+		assertKeyDown( DOWN, 1, 0 );
+		assertKeyDown( DOWN, 2, 0 );
+		assertKeyDown( DOWN, 0, 0 );
+		assertKeyDown( UP, 2, 0 );
+		assertKeyDown( UP, 1, 0 );
+		assertKeyDown( UP, 0, 0 );
+		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( RIGHT, 0, 0 );
+		assertKeyDown( SPACE, 0, 1 );
 	} );
 
 	it( 'vertical: should navigate by up and down, and skip deep candidates', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<NavigableMenu orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
-				<span tabIndex="-1" id="btn1">One</span>
-				<span tabIndex="-1" id="btn2">Two</span>
-				<span id="btn-deep-wrapper">
-					<span id="btn-deep" tabIndex="-1">Deep</span>
-				</span>
-				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<NavigableMenu orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
+					<span tabIndex="-1" id="btn1">One</span>
+					<span tabIndex="-1" id="btn2">Two</span>
+					<span id="btn-deep-wrapper">
+						<span id="btn-deep" tabIndex="-1">Deep</span>
+					</span>
+					<span tabIndex="-1" id="btn3">Three</span>
+				</NavigableMenu >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div' );
+		const container = wrapper.find( '.outer-container NavigableMenu' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( DOWN, 1 );
-		assertKeyDown( DOWN, 2 );
-		assertKeyDown( DOWN, 0 );
-		assertKeyDown( UP, 2 );
-		assertKeyDown( UP, 1 );
-		assertKeyDown( UP, 0 );
-		assertKeyDown( LEFT, 0 );
-		assertKeyDown( RIGHT, 0 );
+		assertKeyDown( DOWN, 1, 0 );
+		assertKeyDown( DOWN, 2, 0 );
+		assertKeyDown( DOWN, 0, 0 );
+		assertKeyDown( UP, 2, 0 );
+		assertKeyDown( UP, 1, 0 );
+		assertKeyDown( UP, 0, 0 );
+		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( RIGHT, 0, 0 );
 	} );
 
 	it( 'vertical: should navigate by up and down, and explore deep candidates', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<NavigableMenu deep={ true } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
-				<span tabIndex="-1" id="btn1">One</span>
-				<span tabIndex="-1" id="btn2">Two</span>
-				<span id="btn-deep-wrapper">
-					<span id="btn-deep" tabIndex="-1">Deep</span>
-				</span>
-				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<NavigableMenu deep={ true } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
+					<span tabIndex="-1" id="btn1">One</span>
+					<span tabIndex="-1" id="btn2">Two</span>
+					<span id="btn-deep-wrapper">
+						<span id="btn-deep" tabIndex="-1">Deep</span>
+					</span>
+					<span tabIndex="-1" id="btn3">Three</span>
+				</NavigableMenu >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div' );
+		const container = wrapper.find( '.outer-container NavigableMenu' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( DOWN, 1 );
-		assertKeyDown( DOWN, 2 );
-		assertKeyDown( DOWN, 3 );
-		assertKeyDown( DOWN, 0 );
-		assertKeyDown( UP, 3 );
-		assertKeyDown( UP, 2 );
-		assertKeyDown( UP, 1 );
-		assertKeyDown( UP, 0 );
-		assertKeyDown( LEFT, 0 );
-		assertKeyDown( RIGHT, 0 );
+		assertKeyDown( DOWN, 1, 0 );
+		assertKeyDown( DOWN, 2, 0 );
+		assertKeyDown( DOWN, 3, 0 );
+		assertKeyDown( DOWN, 0, 0 );
+		assertKeyDown( UP, 3, 0 );
+		assertKeyDown( UP, 2, 0 );
+		assertKeyDown( UP, 1, 0 );
+		assertKeyDown( UP, 0, 0 );
+		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( RIGHT, 0, 0 );
 	} );
 
 	it( 'vertical: should navigate by up and down, and stop at edges', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<NavigableMenu cycle={ false } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
-				<span tabIndex="-1" id="btn1">One</span>
-				<span tabIndex="-1" id="btn2">Two</span>
-				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<NavigableMenu cycle={ false } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
+					<span tabIndex="-1" id="btn1">One</span>
+					<span tabIndex="-1" id="btn2">Two</span>
+					<span tabIndex="-1" id="btn3">Three</span>
+				</NavigableMenu >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div' );
+		const container = wrapper.find( '.outer-container NavigableMenu' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( DOWN, 1 );
-		assertKeyDown( DOWN, 2 );
-		assertKeyDown( DOWN, 2 );
-		assertKeyDown( UP, 1 );
-		assertKeyDown( UP, 0 );
-		assertKeyDown( UP, 0 );
-		assertKeyDown( LEFT, 0 );
-		assertKeyDown( RIGHT, 0 );
+		assertKeyDown( DOWN, 1, 0 );
+		assertKeyDown( DOWN, 2, 0 );
+		assertKeyDown( DOWN, 2, 0 );
+		assertKeyDown( UP, 1, 0 );
+		assertKeyDown( UP, 0, 0 );
+		assertKeyDown( UP, 0, 0 );
+		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( RIGHT, 0, 0 );
 	} );
 
 	it( 'horizontal: should navigate by left and right', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-				<button id="btn1">One</button>
-				<button id="btn2">Two</button>
-				<button id="btn3">Three</button>
-			</NavigableMenu >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
+					<button id="btn1">One</button>
+					<button id="btn2">Two</button>
+					<button id="btn3">Three</button>
+				</NavigableMenu >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div' );
+		const container = wrapper.find( '.outer-container NavigableMenu' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( RIGHT, 1 );
-		assertKeyDown( RIGHT, 2 );
-		assertKeyDown( RIGHT, 0 );
-		assertKeyDown( LEFT, 2 );
-		assertKeyDown( LEFT, 1 );
-		assertKeyDown( LEFT, 0 );
-		assertKeyDown( UP, 0 );
-		assertKeyDown( DOWN, 0 );
+		assertKeyDown( RIGHT, 1, 0 );
+		assertKeyDown( RIGHT, 2, 0 );
+		assertKeyDown( RIGHT, 0, 0 );
+		assertKeyDown( LEFT, 2, 0 );
+		assertKeyDown( LEFT, 1, 0 );
+		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( UP, 0, 0 );
+		assertKeyDown( DOWN, 0, 0 );
 	} );
 
 	it( 'horizontal: should navigate by left and right, and skip deep candidates', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-				<span tabIndex="-1" id="btn1">One</span>
-				<span tabIndex="-1" id="btn2">Two</span>
-				<span id="btn-deep-wrapper">
-					<span id="btn-deep" tabIndex="-1">Deep</span>
-				</span>
-				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
+					<span tabIndex="-1" id="btn1">One</span>
+					<span tabIndex="-1" id="btn2">Two</span>
+					<span id="btn-deep-wrapper">
+						<span id="btn-deep" tabIndex="-1">Deep</span>
+					</span>
+					<span tabIndex="-1" id="btn3">Three</span>
+				</NavigableMenu >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div' );
+		const container = wrapper.find( '.outer-container NavigableMenu' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( RIGHT, 1 );
-		assertKeyDown( RIGHT, 2 );
-		assertKeyDown( RIGHT, 0 );
-		assertKeyDown( LEFT, 2 );
-		assertKeyDown( LEFT, 1 );
-		assertKeyDown( LEFT, 0 );
-		assertKeyDown( UP, 0 );
-		assertKeyDown( DOWN, 0 );
+		assertKeyDown( RIGHT, 1, 0 );
+		assertKeyDown( RIGHT, 2, 0 );
+		assertKeyDown( RIGHT, 0, 0 );
+		assertKeyDown( LEFT, 2, 0 );
+		assertKeyDown( LEFT, 1, 0 );
+		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( UP, 0, 0 );
+		assertKeyDown( DOWN, 0, 0 );
 	} );
 
 	it( 'horizontal: should navigate by left and right, and explore deep candidates', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<NavigableMenu deep={ true } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-				<span tabIndex="-1" id="btn1">One</span>
-				<span tabIndex="-1" id="btn2">Two</span>
-				<span id="btn-deep-wrapper">
-					<span id="btn-deep" tabIndex="-1">Deep</span>
-				</span>
-				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<NavigableMenu deep={ true } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
+					<span tabIndex="-1" id="btn1">One</span>
+					<span tabIndex="-1" id="btn2">Two</span>
+					<span id="btn-deep-wrapper">
+						<span id="btn-deep" tabIndex="-1">Deep</span>
+					</span>
+					<span tabIndex="-1" id="btn3">Three</span>
+				</NavigableMenu >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div' );
+		const container = wrapper.find( '.outer-container NavigableMenu' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( RIGHT, 1 );
-		assertKeyDown( RIGHT, 2 );
-		assertKeyDown( RIGHT, 3 );
-		assertKeyDown( RIGHT, 0 );
-		assertKeyDown( LEFT, 3 );
-		assertKeyDown( LEFT, 2 );
-		assertKeyDown( LEFT, 1 );
-		assertKeyDown( LEFT, 0 );
-		assertKeyDown( UP, 0 );
-		assertKeyDown( DOWN, 0 );
+		assertKeyDown( RIGHT, 1, 0 );
+		assertKeyDown( RIGHT, 2, 0 );
+		assertKeyDown( RIGHT, 3, 0 );
+		assertKeyDown( RIGHT, 0, 0 );
+		assertKeyDown( LEFT, 3, 0 );
+		assertKeyDown( LEFT, 2, 0 );
+		assertKeyDown( LEFT, 1, 0 );
+		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( UP, 0, 0 );
+		assertKeyDown( DOWN, 0, 0 );
 	} );
 
 	it( 'horizontal: should navigate by left and right, and stop at edges', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<NavigableMenu cycle={ false } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-				<span tabIndex="-1" id="btn1">One</span>
-				<span tabIndex="-1" id="btn2">Two</span>
-				<span tabIndex="-1" id="btn3">Three</span>
-			</NavigableMenu >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<NavigableMenu cycle={ false } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
+					<span tabIndex="-1" id="btn1">One</span>
+					<span tabIndex="-1" id="btn2">Two</span>
+					<span tabIndex="-1" id="btn3">Three</span>
+				</NavigableMenu >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div' );
+		const container = wrapper.find( '.outer-container NavigableMenu' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( RIGHT, 1 );
-		assertKeyDown( RIGHT, 2 );
-		assertKeyDown( RIGHT, 2 );
-		assertKeyDown( LEFT, 1 );
-		assertKeyDown( LEFT, 0 );
-		assertKeyDown( LEFT, 0 );
+		assertKeyDown( RIGHT, 1, 0 );
+		assertKeyDown( RIGHT, 2, 0 );
+		assertKeyDown( RIGHT, 2, 0 );
+		assertKeyDown( LEFT, 1, 0 );
+		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( LEFT, 0, 0 );
 	} );
 } );
 
 describe( 'TabbableContainer', () => {
 	it( 'should navigate by keypresses', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-				<div className="section" id="section1" tabIndex="0">Section One</div>
-				<div className="section" id="section2a" tabIndex="0">Section Two</div>
-				<div className="section" id="section2b" tabIndex="-1">Section to Skip</div>
-				<div className="section" id="section3" tabIndex="0">Section Three</div>
-			</TabbableContainer >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
+					<div className="section" id="section1" tabIndex="0">Section One</div>
+					<div className="section" id="section2a" tabIndex="0">Section Two</div>
+					<div className="section" id="section2b" tabIndex="-1">Section to Skip</div>
+					<div className="section" id="section3" tabIndex="0">Section Three</div>
+				</TabbableContainer >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div.wrapper' );
+		const container = wrapper.find( '.outer-container TabbableContainer' );
 		wrapper.getDOMNode().querySelector( '#section1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, shiftKey );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( TAB, false, 1 );
-		assertKeyDown( TAB, false, 2 );
-		assertKeyDown( TAB, false, 0 );
-		assertKeyDown( TAB, true, 2 );
-		assertKeyDown( TAB, true, 1 );
-		assertKeyDown( TAB, true, 0 );
+		assertKeyDown( TAB, false, 1, 0 );
+		assertKeyDown( TAB, false, 2, 0 );
+		assertKeyDown( TAB, false, 0, 0 );
+		assertKeyDown( TAB, true, 2, 0 );
+		assertKeyDown( TAB, true, 1, 0 );
+		assertKeyDown( TAB, true, 0, 0 );
 	} );
 
 	it( 'should navigate by keypresses and overlook deep candidates', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-				<div className="section" id="section1" tabIndex="0">Section One</div>
-				<div className="section" id="section2" tabIndex="0">Section Two</div>
-				<div className="deep-section">
-					<div className="section" id="section-deep" tabIndex="0">Section to Skip</div>
-				</div>
-				<div className="section" id="section3" tabIndex="0">Section Three</div>
-			</TabbableContainer >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
+					<div className="section" id="section1" tabIndex="0">Section One</div>
+					<div className="section" id="section2" tabIndex="0">Section Two</div>
+					<div className="deep-section">
+						<div className="section" id="section-deep" tabIndex="0">Section to Skip</div>
+					</div>
+					<div className="section" id="section3" tabIndex="0">Section Three</div>
+				</TabbableContainer >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div.wrapper' );
+		const container = wrapper.find( '.outer-container TabbableContainer' );
 		wrapper.getDOMNode().querySelector( '#section1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, shiftKey );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( TAB, false, 1 );
-		assertKeyDown( TAB, false, 2 );
-		assertKeyDown( TAB, false, 0 );
-		assertKeyDown( TAB, true, 2 );
-		assertKeyDown( TAB, true, 1 );
-		assertKeyDown( TAB, true, 0 );
+		assertKeyDown( TAB, false, 1, 0 );
+		assertKeyDown( TAB, false, 2, 0 );
+		assertKeyDown( TAB, false, 0, 0 );
+		assertKeyDown( TAB, true, 2, 0 );
+		assertKeyDown( TAB, true, 1, 0 );
+		assertKeyDown( TAB, true, 0, 0 );
 	} );
 
 	it( 'should navigate by keypresses and explore deep candidates', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<TabbableContainer deep={ true } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-				<div className="section" id="section1" tabIndex="0">Section One</div>
-				<div className="section" id="section2" tabIndex="0">Section Two</div>
-				<div className="deep-section-wrapper">
-					<div className="section" id="section-deep" tabIndex="0">Section to <strong>not</strong> skip</div>
-				</div>
-				<div className="section" id="section3" tabIndex="0">Section Three</div>
-			</TabbableContainer >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<TabbableContainer deep={ true } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
+					<div className="section" id="section1" tabIndex="0">Section One</div>
+					<div className="section" id="section2" tabIndex="0">Section Two</div>
+					<div className="deep-section-wrapper">
+						<div className="section" id="section-deep" tabIndex="0">Section to <strong>not</strong> skip</div>
+					</div>
+					<div className="section" id="section3" tabIndex="0">Section Three</div>
+				</TabbableContainer >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div.wrapper' );
+		const container = wrapper.find( '.outer-container TabbableContainer' );
 		wrapper.getDOMNode().querySelector( '#section1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, shiftKey );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( TAB, false, 1 );
-		assertKeyDown( TAB, false, 2 );
-		assertKeyDown( TAB, false, 3 );
-		assertKeyDown( TAB, false, 0 );
-		assertKeyDown( TAB, true, 3 );
-		assertKeyDown( TAB, true, 2 );
-		assertKeyDown( TAB, true, 1 );
-		assertKeyDown( TAB, true, 0 );
+		assertKeyDown( TAB, false, 1, 0 );
+		assertKeyDown( TAB, false, 2, 0 );
+		assertKeyDown( TAB, false, 3, 0 );
+		assertKeyDown( TAB, false, 0, 0 );
+		assertKeyDown( TAB, true, 3, 0 );
+		assertKeyDown( TAB, true, 2, 0 );
+		assertKeyDown( TAB, true, 1, 0 );
+		assertKeyDown( TAB, true, 0, 0 );
 	} );
 
 	it( 'should navigate by keypresses and stop at edges', () => {
 		let currentIndex = 0;
+
+		let numKeyDowns = 0;
+		const onOuterKeyDown = () => {
+			numKeyDowns++;
+		};
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<TabbableContainer cycle={ false } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-				<div className="section" id="section1" tabIndex="0">Section One</div>
-				<div className="section" id="section2" tabIndex="0">Section Two</div>
-				<div className="section" id="section3" tabIndex="0">Section Three</div>
-			</TabbableContainer >
+			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
+				<TabbableContainer cycle={ false } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
+					<div className="section" id="section1" tabIndex="0">Section One</div>
+					<div className="section" id="section2" tabIndex="0">Section Two</div>
+					<div className="section" id="section3" tabIndex="0">Section Three</div>
+				</TabbableContainer >
+			</div>
 		) );
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( 'div.wrapper' );
+		const container = wrapper.find( '.outer-container TabbableContainer' );
 		wrapper.getDOMNode().querySelector( '#section1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex ) {
+		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedEventCount ) {
 			fireKeyDown( container, keyCode, shiftKey );
 			expect( currentIndex ).toBe( expectedActiveIndex );
+			expect( numKeyDowns ).toBe( expectedEventCount );
 		}
 
-		assertKeyDown( TAB, false, 1 );
-		assertKeyDown( TAB, false, 2 );
-		assertKeyDown( TAB, false, 2 );
-		assertKeyDown( TAB, true, 1 );
-		assertKeyDown( TAB, true, 0 );
-		assertKeyDown( TAB, true, 0 );
+		assertKeyDown( TAB, false, 1, 0 );
+		assertKeyDown( TAB, false, 2, 0 );
+		assertKeyDown( TAB, false, 2, 0 );
+		assertKeyDown( TAB, true, 1, 0 );
+		assertKeyDown( TAB, true, 0, 0 );
+		assertKeyDown( TAB, true, 0, 0 );
 	} );
 } );

--- a/components/navigable-container/test/index.js
+++ b/components/navigable-container/test/index.js
@@ -24,8 +24,14 @@ function simulateVisible( wrapper, selector ) {
 }
 
 function fireKeyDown( container, keyCode, shiftKey ) {
+	const interaction = {
+		stopped: false,
+	};
+
 	container.simulate( 'keydown', {
-		stopPropagation: () => {},
+		stopPropagation: () => {
+			interaction.stopped = true;
+		},
 		preventDefault: () => {},
 		nativeEvent: {
 			stopImmediatePropagation: () => { },
@@ -33,528 +39,423 @@ function fireKeyDown( container, keyCode, shiftKey ) {
 		keyCode,
 		shiftKey,
 	} );
+
+	return interaction;
 }
 
 describe( 'NavigableMenu', () => {
 	it( 'vertical: should navigate by up and down', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<NavigableMenu onNavigate={ ( index ) => currentIndex = index }>
-					<button id="btn1">One</button>
-					<button id="btn2">Two</button>
-					<button id="btn3">Three</button>
-				</NavigableMenu >
-			</div>
+			<NavigableMenu onNavigate={ ( index ) => currentIndex = index }>
+				<button id="btn1">One</button>
+				<button id="btn2">Two</button>
+				<button id="btn3">Three</button>
+			</NavigableMenu >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container NavigableMenu' );
+		const container = wrapper.find( 'div' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, false );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( DOWN, 1, 0 );
-		assertKeyDown( DOWN, 2, 0 );
-		assertKeyDown( DOWN, 0, 0 );
-		assertKeyDown( UP, 2, 0 );
-		assertKeyDown( UP, 1, 0 );
-		assertKeyDown( UP, 0, 0 );
-		assertKeyDown( LEFT, 0, 0 );
-		assertKeyDown( RIGHT, 0, 0 );
-		assertKeyDown( SPACE, 0, 1 );
+		assertKeyDown( DOWN, 1, true );
+		assertKeyDown( DOWN, 2, true );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( UP, 2, true );
+		assertKeyDown( UP, 1, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( RIGHT, 0, true );
+		assertKeyDown( SPACE, 0, false );
 	} );
 
 	it( 'vertical: should navigate by up and down, and skip deep candidates', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<NavigableMenu orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
-					<span tabIndex="-1" id="btn1">One</span>
-					<span tabIndex="-1" id="btn2">Two</span>
-					<span id="btn-deep-wrapper">
-						<span id="btn-deep" tabIndex="-1">Deep</span>
-					</span>
-					<span tabIndex="-1" id="btn3">Three</span>
-				</NavigableMenu >
-			</div>
+			<NavigableMenu orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
+				<span tabIndex="-1" id="btn1">One</span>
+				<span tabIndex="-1" id="btn2">Two</span>
+				<span id="btn-deep-wrapper">
+					<span id="btn-deep" tabIndex="-1">Deep</span>
+				</span>
+				<span tabIndex="-1" id="btn3">Three</span>
+			</NavigableMenu >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container NavigableMenu' );
+		const container = wrapper.find( 'div' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, false );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( DOWN, 1, 0 );
-		assertKeyDown( DOWN, 2, 0 );
-		assertKeyDown( DOWN, 0, 0 );
-		assertKeyDown( UP, 2, 0 );
-		assertKeyDown( UP, 1, 0 );
-		assertKeyDown( UP, 0, 0 );
-		assertKeyDown( LEFT, 0, 0 );
-		assertKeyDown( RIGHT, 0, 0 );
+		assertKeyDown( DOWN, 1, true );
+		assertKeyDown( DOWN, 2, true );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( UP, 2, true );
+		assertKeyDown( UP, 1, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( RIGHT, 0, true );
+		assertKeyDown( SPACE, 0, false );
 	} );
 
 	it( 'vertical: should navigate by up and down, and explore deep candidates', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<NavigableMenu deep={ true } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
-					<span tabIndex="-1" id="btn1">One</span>
-					<span tabIndex="-1" id="btn2">Two</span>
-					<span id="btn-deep-wrapper">
-						<span id="btn-deep" tabIndex="-1">Deep</span>
-					</span>
-					<span tabIndex="-1" id="btn3">Three</span>
-				</NavigableMenu >
-			</div>
+			<NavigableMenu deep={ true } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
+				<span tabIndex="-1" id="btn1">One</span>
+				<span tabIndex="-1" id="btn2">Two</span>
+				<span id="btn-deep-wrapper">
+					<span id="btn-deep" tabIndex="-1">Deep</span>
+				</span>
+				<span tabIndex="-1" id="btn3">Three</span>
+			</NavigableMenu >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container NavigableMenu' );
+		const container = wrapper.find( 'div' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, false );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( DOWN, 1, 0 );
-		assertKeyDown( DOWN, 2, 0 );
-		assertKeyDown( DOWN, 3, 0 );
-		assertKeyDown( DOWN, 0, 0 );
-		assertKeyDown( UP, 3, 0 );
-		assertKeyDown( UP, 2, 0 );
-		assertKeyDown( UP, 1, 0 );
-		assertKeyDown( UP, 0, 0 );
-		assertKeyDown( LEFT, 0, 0 );
-		assertKeyDown( RIGHT, 0, 0 );
+		assertKeyDown( DOWN, 1, true );
+		assertKeyDown( DOWN, 2, true );
+		assertKeyDown( DOWN, 3, true );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( UP, 3, true );
+		assertKeyDown( UP, 2, true );
+		assertKeyDown( UP, 1, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( RIGHT, 0, true );
+		assertKeyDown( SPACE, 0, false );
 	} );
 
 	it( 'vertical: should navigate by up and down, and stop at edges', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<NavigableMenu cycle={ false } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
-					<span tabIndex="-1" id="btn1">One</span>
-					<span tabIndex="-1" id="btn2">Two</span>
-					<span tabIndex="-1" id="btn3">Three</span>
-				</NavigableMenu >
-			</div>
+			<NavigableMenu cycle={ false } orientation="vertical" onNavigate={ ( index ) => currentIndex = index }>
+				<span tabIndex="-1" id="btn1">One</span>
+				<span tabIndex="-1" id="btn2">Two</span>
+				<span tabIndex="-1" id="btn3">Three</span>
+			</NavigableMenu >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container NavigableMenu' );
+		const container = wrapper.find( 'div' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, false );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( DOWN, 1, 0 );
-		assertKeyDown( DOWN, 2, 0 );
-		assertKeyDown( DOWN, 2, 0 );
-		assertKeyDown( UP, 1, 0 );
-		assertKeyDown( UP, 0, 0 );
-		assertKeyDown( UP, 0, 0 );
-		assertKeyDown( LEFT, 0, 0 );
-		assertKeyDown( RIGHT, 0, 0 );
+		assertKeyDown( DOWN, 1, true );
+		assertKeyDown( DOWN, 2, true );
+		assertKeyDown( DOWN, 2, true );
+		assertKeyDown( UP, 1, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( RIGHT, 0, true );
+		assertKeyDown( SPACE, 0, false );
 	} );
 
 	it( 'horizontal: should navigate by left and right', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-					<button id="btn1">One</button>
-					<button id="btn2">Two</button>
-					<button id="btn3">Three</button>
-				</NavigableMenu >
-			</div>
+			<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
+				<button id="btn1">One</button>
+				<button id="btn2">Two</button>
+				<button id="btn3">Three</button>
+			</NavigableMenu >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container NavigableMenu' );
+		const container = wrapper.find( 'div' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, false );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( RIGHT, 1, 0 );
-		assertKeyDown( RIGHT, 2, 0 );
-		assertKeyDown( RIGHT, 0, 0 );
-		assertKeyDown( LEFT, 2, 0 );
-		assertKeyDown( LEFT, 1, 0 );
-		assertKeyDown( LEFT, 0, 0 );
-		assertKeyDown( UP, 0, 0 );
-		assertKeyDown( DOWN, 0, 0 );
+		assertKeyDown( RIGHT, 1, true );
+		assertKeyDown( RIGHT, 2, true );
+		assertKeyDown( RIGHT, 0, true );
+		assertKeyDown( LEFT, 2, true );
+		assertKeyDown( LEFT, 1, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( SPACE, 0, false );
 	} );
 
 	it( 'horizontal: should navigate by left and right, and skip deep candidates', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-					<span tabIndex="-1" id="btn1">One</span>
-					<span tabIndex="-1" id="btn2">Two</span>
-					<span id="btn-deep-wrapper">
-						<span id="btn-deep" tabIndex="-1">Deep</span>
-					</span>
-					<span tabIndex="-1" id="btn3">Three</span>
-				</NavigableMenu >
-			</div>
+			<NavigableMenu orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
+				<span tabIndex="-1" id="btn1">One</span>
+				<span tabIndex="-1" id="btn2">Two</span>
+				<span id="btn-deep-wrapper">
+					<span id="btn-deep" tabIndex="-1">Deep</span>
+				</span>
+				<span tabIndex="-1" id="btn3">Three</span>
+			</NavigableMenu >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container NavigableMenu' );
+		const container = wrapper.find( 'div' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, false );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( RIGHT, 1, 0 );
-		assertKeyDown( RIGHT, 2, 0 );
-		assertKeyDown( RIGHT, 0, 0 );
-		assertKeyDown( LEFT, 2, 0 );
-		assertKeyDown( LEFT, 1, 0 );
-		assertKeyDown( LEFT, 0, 0 );
-		assertKeyDown( UP, 0, 0 );
-		assertKeyDown( DOWN, 0, 0 );
+		assertKeyDown( RIGHT, 1, true );
+		assertKeyDown( RIGHT, 2, true );
+		assertKeyDown( RIGHT, 0, true );
+		assertKeyDown( LEFT, 2, true );
+		assertKeyDown( LEFT, 1, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( SPACE, 0, false );
 	} );
 
 	it( 'horizontal: should navigate by left and right, and explore deep candidates', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<NavigableMenu deep={ true } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-					<span tabIndex="-1" id="btn1">One</span>
-					<span tabIndex="-1" id="btn2">Two</span>
-					<span id="btn-deep-wrapper">
-						<span id="btn-deep" tabIndex="-1">Deep</span>
-					</span>
-					<span tabIndex="-1" id="btn3">Three</span>
-				</NavigableMenu >
-			</div>
+			<NavigableMenu deep={ true } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
+				<span tabIndex="-1" id="btn1">One</span>
+				<span tabIndex="-1" id="btn2">Two</span>
+				<span id="btn-deep-wrapper">
+					<span id="btn-deep" tabIndex="-1">Deep</span>
+				</span>
+				<span tabIndex="-1" id="btn3">Three</span>
+			</NavigableMenu >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container NavigableMenu' );
+		const container = wrapper.find( 'div' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, false );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( RIGHT, 1, 0 );
-		assertKeyDown( RIGHT, 2, 0 );
-		assertKeyDown( RIGHT, 3, 0 );
-		assertKeyDown( RIGHT, 0, 0 );
-		assertKeyDown( LEFT, 3, 0 );
-		assertKeyDown( LEFT, 2, 0 );
-		assertKeyDown( LEFT, 1, 0 );
-		assertKeyDown( LEFT, 0, 0 );
-		assertKeyDown( UP, 0, 0 );
-		assertKeyDown( DOWN, 0, 0 );
+		assertKeyDown( RIGHT, 1, true );
+		assertKeyDown( RIGHT, 2, true );
+		assertKeyDown( RIGHT, 3, true );
+		assertKeyDown( RIGHT, 0, true );
+		assertKeyDown( LEFT, 3, true );
+		assertKeyDown( LEFT, 2, true );
+		assertKeyDown( LEFT, 1, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( SPACE, 0, false );
 	} );
 
 	it( 'horizontal: should navigate by left and right, and stop at edges', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<NavigableMenu cycle={ false } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
-					<span tabIndex="-1" id="btn1">One</span>
-					<span tabIndex="-1" id="btn2">Two</span>
-					<span tabIndex="-1" id="btn3">Three</span>
-				</NavigableMenu >
-			</div>
+			<NavigableMenu cycle={ false } orientation="horizontal" onNavigate={ ( index ) => currentIndex = index }>
+				<span tabIndex="-1" id="btn1">One</span>
+				<span tabIndex="-1" id="btn2">Two</span>
+				<span tabIndex="-1" id="btn3">Three</span>
+			</NavigableMenu >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container NavigableMenu' );
+		const container = wrapper.find( 'div' );
 		wrapper.getDOMNode().querySelector( '#btn1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, false );
+		function assertKeyDown( keyCode, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, false );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( RIGHT, 1, 0 );
-		assertKeyDown( RIGHT, 2, 0 );
-		assertKeyDown( RIGHT, 2, 0 );
-		assertKeyDown( LEFT, 1, 0 );
-		assertKeyDown( LEFT, 0, 0 );
-		assertKeyDown( LEFT, 0, 0 );
+		assertKeyDown( RIGHT, 1, true );
+		assertKeyDown( RIGHT, 2, true );
+		assertKeyDown( RIGHT, 2, true );
+		assertKeyDown( LEFT, 1, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( LEFT, 0, true );
+		assertKeyDown( DOWN, 0, true );
+		assertKeyDown( UP, 0, true );
+		assertKeyDown( SPACE, 0, false );
 	} );
 } );
 
 describe( 'TabbableContainer', () => {
 	it( 'should navigate by keypresses', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-					<div className="section" id="section1" tabIndex="0">Section One</div>
-					<div className="section" id="section2a" tabIndex="0">Section Two</div>
-					<div className="section" id="section2b" tabIndex="-1">Section to Skip</div>
-					<div className="section" id="section3" tabIndex="0">Section Three</div>
-				</TabbableContainer >
-			</div>
+			<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
+				<div className="section" id="section1" tabIndex="0">Section One</div>
+				<div className="section" id="section2a" tabIndex="0">Section Two</div>
+				<div className="section" id="section2b" tabIndex="-1">Section to Skip</div>
+				<div className="section" id="section3" tabIndex="0">Section Three</div>
+			</TabbableContainer >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container TabbableContainer' );
+		const container = wrapper.find( 'div.wrapper' );
 		wrapper.getDOMNode().querySelector( '#section1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, shiftKey );
+		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, shiftKey );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( TAB, false, 1, 0 );
-		assertKeyDown( TAB, false, 2, 0 );
-		assertKeyDown( TAB, false, 0, 0 );
-		assertKeyDown( TAB, true, 2, 0 );
-		assertKeyDown( TAB, true, 1, 0 );
-		assertKeyDown( TAB, true, 0, 0 );
+		assertKeyDown( TAB, false, 1, true );
+		assertKeyDown( TAB, false, 2, true );
+		assertKeyDown( TAB, false, 0, true );
+		assertKeyDown( TAB, true, 2, true );
+		assertKeyDown( TAB, true, 1, true );
+		assertKeyDown( TAB, true, 0, true );
+		assertKeyDown( SPACE, false, 0, false );
 	} );
 
 	it( 'should navigate by keypresses and overlook deep candidates', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-					<div className="section" id="section1" tabIndex="0">Section One</div>
-					<div className="section" id="section2" tabIndex="0">Section Two</div>
-					<div className="deep-section">
-						<div className="section" id="section-deep" tabIndex="0">Section to Skip</div>
-					</div>
-					<div className="section" id="section3" tabIndex="0">Section Three</div>
-				</TabbableContainer >
-			</div>
+			<TabbableContainer className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
+				<div className="section" id="section1" tabIndex="0">Section One</div>
+				<div className="section" id="section2" tabIndex="0">Section Two</div>
+				<div className="deep-section">
+					<div className="section" id="section-deep" tabIndex="0">Section to Skip</div>
+				</div>
+				<div className="section" id="section3" tabIndex="0">Section Three</div>
+			</TabbableContainer >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container TabbableContainer' );
+		const container = wrapper.find( 'div.wrapper' );
 		wrapper.getDOMNode().querySelector( '#section1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, shiftKey );
+		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, shiftKey );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( TAB, false, 1, 0 );
-		assertKeyDown( TAB, false, 2, 0 );
-		assertKeyDown( TAB, false, 0, 0 );
-		assertKeyDown( TAB, true, 2, 0 );
-		assertKeyDown( TAB, true, 1, 0 );
-		assertKeyDown( TAB, true, 0, 0 );
+		assertKeyDown( TAB, false, 1, true );
+		assertKeyDown( TAB, false, 2, true );
+		assertKeyDown( TAB, false, 0, true );
+		assertKeyDown( TAB, true, 2, true );
+		assertKeyDown( TAB, true, 1, true );
+		assertKeyDown( TAB, true, 0, true );
+		assertKeyDown( SPACE, false, 0, false );
 	} );
 
 	it( 'should navigate by keypresses and explore deep candidates', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<TabbableContainer deep={ true } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-					<div className="section" id="section1" tabIndex="0">Section One</div>
-					<div className="section" id="section2" tabIndex="0">Section Two</div>
-					<div className="deep-section-wrapper">
-						<div className="section" id="section-deep" tabIndex="0">Section to <strong>not</strong> skip</div>
-					</div>
-					<div className="section" id="section3" tabIndex="0">Section Three</div>
-				</TabbableContainer >
-			</div>
+			<TabbableContainer deep={ true } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
+				<div className="section" id="section1" tabIndex="0">Section One</div>
+				<div className="section" id="section2" tabIndex="0">Section Two</div>
+				<div className="deep-section-wrapper">
+					<div className="section" id="section-deep" tabIndex="0">Section to <strong>not</strong> skip</div>
+				</div>
+				<div className="section" id="section3" tabIndex="0">Section Three</div>
+			</TabbableContainer >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container TabbableContainer' );
+		const container = wrapper.find( 'div.wrapper' );
 		wrapper.getDOMNode().querySelector( '#section1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, shiftKey );
+		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, shiftKey );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( TAB, false, 1, 0 );
-		assertKeyDown( TAB, false, 2, 0 );
-		assertKeyDown( TAB, false, 3, 0 );
-		assertKeyDown( TAB, false, 0, 0 );
-		assertKeyDown( TAB, true, 3, 0 );
-		assertKeyDown( TAB, true, 2, 0 );
-		assertKeyDown( TAB, true, 1, 0 );
-		assertKeyDown( TAB, true, 0, 0 );
+		assertKeyDown( TAB, false, 1, true );
+		assertKeyDown( TAB, false, 2, true );
+		assertKeyDown( TAB, false, 3, true );
+		assertKeyDown( TAB, false, 0, true );
+		assertKeyDown( TAB, true, 3, true );
+		assertKeyDown( TAB, true, 2, true );
+		assertKeyDown( TAB, true, 1, true );
+		assertKeyDown( TAB, true, 0, true );
+		assertKeyDown( SPACE, false, 0, false );
 	} );
 
 	it( 'should navigate by keypresses and stop at edges', () => {
 		let currentIndex = 0;
-
-		let numKeyDowns = 0;
-		const onOuterKeyDown = () => {
-			numKeyDowns++;
-		};
-
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		const wrapper = mount( (
-			<div className="outer-container" onKeyDown={ onOuterKeyDown }>
-				<TabbableContainer cycle={ false } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
-					<div className="section" id="section1" tabIndex="0">Section One</div>
-					<div className="section" id="section2" tabIndex="0">Section Two</div>
-					<div className="section" id="section3" tabIndex="0">Section Three</div>
-				</TabbableContainer >
-			</div>
+			<TabbableContainer cycle={ false } className="wrapper" onNavigate={ ( index ) => currentIndex = index }>
+				<div className="section" id="section1" tabIndex="0">Section One</div>
+				<div className="section" id="section2" tabIndex="0">Section Two</div>
+				<div className="section" id="section3" tabIndex="0">Section Three</div>
+			</TabbableContainer >
 		) );
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
 		simulateVisible( wrapper, '*' );
 
-		const container = wrapper.find( '.outer-container TabbableContainer' );
+		const container = wrapper.find( 'div.wrapper' );
 		wrapper.getDOMNode().querySelector( '#section1' ).focus();
 
 		// Navigate options
-		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedEventCount ) {
-			fireKeyDown( container, keyCode, shiftKey );
+		function assertKeyDown( keyCode, shiftKey, expectedActiveIndex, expectedStop ) {
+			const interaction = fireKeyDown( container, keyCode, shiftKey );
 			expect( currentIndex ).toBe( expectedActiveIndex );
-			expect( numKeyDowns ).toBe( expectedEventCount );
+			expect( interaction.stopped ).toBe( expectedStop );
 		}
 
-		assertKeyDown( TAB, false, 1, 0 );
-		assertKeyDown( TAB, false, 2, 0 );
-		assertKeyDown( TAB, false, 2, 0 );
-		assertKeyDown( TAB, true, 1, 0 );
-		assertKeyDown( TAB, true, 0, 0 );
-		assertKeyDown( TAB, true, 0, 0 );
+		assertKeyDown( TAB, false, 1, true );
+		assertKeyDown( TAB, false, 2, true );
+		assertKeyDown( TAB, false, 2, true );
+		assertKeyDown( TAB, true, 1, true );
+		assertKeyDown( TAB, true, 0, true );
+		assertKeyDown( TAB, true, 0, true );
+		assertKeyDown( SPACE, false, 0, false );
 	} );
 } );


### PR DESCRIPTION
Fixes #3783 

## Description
<!-- Please describe your changes -->
Update NavigableMenu so that it handles arrow events that are not in line with its orientation. This is required because otherwise up and down can propagate to things like `WritingFlow` when in "Fixed to block" toolbar mode.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Unit testing.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Change to an internal function, and behaviour change. Updated unit tests.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.