### PR TITLE
Extensibility: Convert all filters for components to behave like HOCs

### DIFF
--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -6,9 +6,13 @@
 import { get, isFunction, some } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
-import { applyFilters } from '../hooks';
 import { getCategories } from './categories';
 
 /**

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -119,7 +119,7 @@ export function registerBlockType( name, settings ) {
 		...settings,
 	};
 
-	settings = applyFilters( 'registerBlockType', settings, name );
+	settings = applyFilters( 'blocks.registerBlockType', settings, name );
 
 	return blocks[ name ] = settings;
 }

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -8,11 +8,11 @@ import { html as beautifyHtml } from 'js-beautify';
  * WordPress dependencies
  */
 import { Component, createElement, renderToString, cloneElement, Children } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-import { applyFilters } from '../hooks';
 import { getBlockType, getUnknownTypeHandlerName } from './registration';
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -55,7 +55,7 @@ export function getSaveContent( blockType, attributes ) {
 		}
 
 		// Applying the filters adding extra props
-		const props = applyFilters( 'getSaveContent.extraProps', { ...element.props }, blockType, attributes );
+		const props = applyFilters( 'blocks.getSaveContent.extraProps', { ...element.props }, blockType, attributes );
 
 		return cloneElement( element, props );
 	};

--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -49,6 +49,11 @@ describe( 'block parser', () => {
 		save: ( { attributes } ) => attributes.content,
 	};
 
+	beforeAll( () => {
+		// Load all hooks that modify blocks
+		require( 'blocks/hooks' );
+	} );
+
 	afterEach( () => {
 		setUnknownTypeHandlerName( undefined );
 		getBlockTypes().forEach( ( block ) => {

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -1,7 +1,11 @@
 /**
+ * WordPress dependencies
+ */
+import { withFilters } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
-import { applyFilters } from '../hooks';
 import { getBlockType } from '../api';
 
 function BlockEdit( props ) {
@@ -17,7 +21,7 @@ function BlockEdit( props ) {
 	// them preferencially as the render value for the block.
 	const Edit = blockType.edit || blockType.save;
 
-	return applyFilters( 'BlockEdit', <Edit key="edit" { ...editProps } />, props );
+	return <Edit { ...editProps } />;
 }
 
-export default BlockEdit;
+export default withFilters( 'BlockEdit' )( BlockEdit );

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -24,4 +24,4 @@ function BlockEdit( props ) {
 	return <Edit { ...editProps } />;
 }
 
-export default withFilters( 'BlockEdit' )( BlockEdit );
+export default withFilters( 'blocks.BlockEdit' )( BlockEdit );

--- a/blocks/hooks/anchor.js
+++ b/blocks/hooks/anchor.js
@@ -94,7 +94,7 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 }
 
 export default function anchor( { addFilter } ) {
-	addFilter( 'registerBlockType', 'core-anchor-attribute', addAttribute );
-	addFilter( 'BlockEdit', 'core-anchor-inspector-control', addInspectorControl );
-	addFilter( 'getSaveContent.extraProps', 'core-anchor-save-props', addSaveProps );
+	addFilter( 'registerBlockType', 'core/anchor/attribute', addAttribute );
+	addFilter( 'BlockEdit', 'core/anchor/inspector-control', addInspectorControl );
+	addFilter( 'getSaveContent.extraProps', 'core/anchor/save-props', addSaveProps );
 }

--- a/blocks/hooks/anchor.js
+++ b/blocks/hooks/anchor.js
@@ -7,6 +7,7 @@ import { assign } from 'lodash';
  * WordPress dependencies
  */
 import { getWrapperDisplayName } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -97,8 +98,8 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 	return extraProps;
 }
 
-export default function anchor( { addFilter } ) {
-	addFilter( 'registerBlockType', 'core/anchor/attribute', addAttribute );
-	addFilter( 'BlockEdit', 'core/anchor/inspector-control', withInspectorControl );
-	addFilter( 'getSaveContent.extraProps', 'core/anchor/save-props', addSaveProps );
+export default function anchor() {
+	addFilter( 'blocks.registerBlockType', 'core/anchor/attribute', addAttribute );
+	addFilter( 'blocks.BlockEdit', 'core/anchor/inspector-control', withInspectorControl );
+	addFilter( 'blocks.getSaveContent.extraProps', 'core/anchor/save-props', addSaveProps );
 }

--- a/blocks/hooks/anchor.js
+++ b/blocks/hooks/anchor.js
@@ -55,13 +55,11 @@ export function addAttribute( settings ) {
  */
 export function withInspectorControl( BlockEdit ) {
 	const WrappedBlockEdit = ( props ) => {
-		if ( ! hasBlockSupport( props.name, 'anchor' ) || ! props.focus ) {
-			return <BlockEdit { ...props } />;
-		}
+		const hasAnchor = hasBlockSupport( props.name, 'anchor' ) && props.focus;
 
 		return [
-			<BlockEdit key="edit-block-anchor" { ...props } />,
-			<InspectorControls key="inspector-anchor">
+			<BlockEdit key="block-edit-anchor" { ...props } />,
+			hasAnchor && <InspectorControls key="inspector-anchor">
 				<InspectorControls.TextControl
 					label={ __( 'HTML Anchor' ) }
 					help={ __( 'Anchors lets you link directly to a section on a page.' ) }

--- a/blocks/hooks/custom-class-name.js
+++ b/blocks/hooks/custom-class-name.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { getWrapperDisplayName } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -37,16 +38,19 @@ export function addAttribute( settings ) {
 
 /**
  * Override the default edit UI to include a new block inspector control for
- * assigning the anchor ID, if block supports anchor
+ * assigning the custom class name, if block supports custom class name.
  *
- * @param  {Element} element Original edit element
- * @param  {Object}  props   Props passed to BlockEdit
- * @return {Element}         Filtered edit element
+ * @param  {function|Component} BlockEdit Original component
+ * @return {function}                     Wrapped component
  */
-export function addInspectorControl( element, props ) {
-	if ( hasBlockSupport( props.name, 'customClassName', true ) && props.focus ) {
-		element = [
-			element,
+export function withInspectorControl( BlockEdit ) {
+	const WrappedBlockEdit = ( props ) => {
+		if ( ! hasBlockSupport( props.name, 'customClassName', true ) || ! props.focus ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		return [
+			<BlockEdit key="edit-block-custom-class-name" { ...props } />,
 			<InspectorControls key="inspector-custom-class-name">
 				<InspectorControls.TextControl
 					label={ __( 'Additional CSS Class' ) }
@@ -59,9 +63,10 @@ export function addInspectorControl( element, props ) {
 				/>
 			</InspectorControls>,
 		];
-	}
+	};
+	WrappedBlockEdit.displayName = getWrapperDisplayName( BlockEdit, 'customClassName' );
 
-	return element;
+	return WrappedBlockEdit;
 }
 
 /**
@@ -84,6 +89,6 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 
 export default function customClassName( { addFilter } ) {
 	addFilter( 'registerBlockType', 'core/custom-class-name/attribute', addAttribute );
-	addFilter( 'BlockEdit', 'core/custom-class-name/inspector-control', addInspectorControl );
+	addFilter( 'BlockEdit', 'core/custom-class-name/inspector-control', withInspectorControl );
 	addFilter( 'getSaveContent.extraProps', 'core/custom-class-name/save-props', addSaveProps );
 }

--- a/blocks/hooks/custom-class-name.js
+++ b/blocks/hooks/custom-class-name.js
@@ -83,7 +83,7 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 }
 
 export default function customClassName( { addFilter } ) {
-	addFilter( 'registerBlockType', 'core-custom-class-name-attribute', addAttribute );
-	addFilter( 'BlockEdit', 'core-custom-class-name-inspector-control', addInspectorControl );
-	addFilter( 'getSaveContent.extraProps', 'core-custom-class-name-save-props', addSaveProps );
+	addFilter( 'registerBlockType', 'core/custom-class-name/attribute', addAttribute );
+	addFilter( 'BlockEdit', 'core/custom-class-name/inspector-control', addInspectorControl );
+	addFilter( 'getSaveContent.extraProps', 'core/custom-class-name/save-props', addSaveProps );
 }

--- a/blocks/hooks/custom-class-name.js
+++ b/blocks/hooks/custom-class-name.js
@@ -46,13 +46,11 @@ export function addAttribute( settings ) {
  */
 export function withInspectorControl( BlockEdit ) {
 	const WrappedBlockEdit = ( props ) => {
-		if ( ! hasBlockSupport( props.name, 'customClassName', true ) || ! props.focus ) {
-			return <BlockEdit { ...props } />;
-		}
+		const hasCustomClassName = hasBlockSupport( props.name, 'customClassName', true ) && props.focus;
 
 		return [
-			<BlockEdit key="edit-block-custom-class-name" { ...props } />,
-			<InspectorControls key="inspector-custom-class-name">
+			<BlockEdit key="block-edit-custom-class-name" { ...props } />,
+			hasCustomClassName && <InspectorControls key="inspector-custom-class-name">
 				<InspectorControls.TextControl
 					label={ __( 'Additional CSS Class' ) }
 					value={ props.attributes.className || '' }

--- a/blocks/hooks/custom-class-name.js
+++ b/blocks/hooks/custom-class-name.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { getWrapperDisplayName } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -87,8 +88,8 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 	return extraProps;
 }
 
-export default function customClassName( { addFilter } ) {
-	addFilter( 'registerBlockType', 'core/custom-class-name/attribute', addAttribute );
-	addFilter( 'BlockEdit', 'core/custom-class-name/inspector-control', withInspectorControl );
-	addFilter( 'getSaveContent.extraProps', 'core/custom-class-name/save-props', addSaveProps );
+export default function customClassName() {
+	addFilter( 'blocks.registerBlockType', 'core/custom-class-name/attribute', addAttribute );
+	addFilter( 'blocks.BlockEdit', 'core/custom-class-name/inspector-control', withInspectorControl );
+	addFilter( 'blocks.getSaveContent.extraProps', 'core/custom-class-name/save-props', addSaveProps );
 }

--- a/blocks/hooks/generated-class-name.js
+++ b/blocks/hooks/generated-class-name.js
@@ -4,6 +4,11 @@
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import { hasBlockSupport, getBlockDefaultClassname } from '../api';
@@ -30,6 +35,6 @@ export function addGeneratedClassName( extraProps, blockType ) {
 	return extraProps;
 }
 
-export default function generatedClassName( { addFilter } ) {
-	addFilter( 'getSaveContent.extraProps', 'core/generated-class-name/save-props', addGeneratedClassName );
+export default function generatedClassName() {
+	addFilter( 'blocks.getSaveContent.extraProps', 'core/generated-class-name/save-props', addGeneratedClassName );
 }

--- a/blocks/hooks/generated-class-name.js
+++ b/blocks/hooks/generated-class-name.js
@@ -31,5 +31,5 @@ export function addGeneratedClassName( extraProps, blockType ) {
 }
 
 export default function generatedClassName( { addFilter } ) {
-	addFilter( 'getSaveContent.extraProps', 'core-generated-class-name-save-props', addGeneratedClassName );
+	addFilter( 'getSaveContent.extraProps', 'core/generated-class-name/save-props', addGeneratedClassName );
 }

--- a/blocks/hooks/index.js
+++ b/blocks/hooks/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createHooks } from '@wordpress/hooks';
+import * as hooks from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -10,28 +10,6 @@ import anchor from './anchor';
 import customClassName from './custom-class-name';
 import generatedClassName from './generated-class-name';
 import matchers from './matchers';
-
-const hooks = createHooks();
-
-const {
-	addFilter,
-	removeFilter,
-	removeAllFilters,
-	applyFilters,
-	doingFilter,
-	didFilter,
-	hasFilter,
-} = hooks;
-
-export {
-	addFilter,
-	removeFilter,
-	removeAllFilters,
-	applyFilters,
-	doingFilter,
-	didFilter,
-	hasFilter,
-};
 
 anchor( hooks );
 customClassName( hooks );

--- a/blocks/hooks/index.js
+++ b/blocks/hooks/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import * as hooks from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
 import anchor from './anchor';
@@ -11,7 +6,7 @@ import customClassName from './custom-class-name';
 import generatedClassName from './generated-class-name';
 import matchers from './matchers';
 
-anchor( hooks );
-customClassName( hooks );
-generatedClassName( hooks );
-matchers( hooks );
+anchor();
+customClassName();
+generatedClassName();
+matchers();

--- a/blocks/hooks/matchers.js
+++ b/blocks/hooks/matchers.js
@@ -3,6 +3,11 @@
  */
 import { isFunction, mapValues } from 'lodash';
 
+/**
+ * WordPress dependecies
+ */
+import { addFilter } from '@wordpress/hooks';
+
 function warnAboutDeprecatedMatcher() {
 	// eslint-disable-next-line no-console
 	console.warn(
@@ -91,6 +96,6 @@ export function resolveAttributes( settings ) {
 	return settings;
 }
 
-export default function matchers( { addFilter } ) {
-	addFilter( 'registerBlockType', 'core/matchers', resolveAttributes );
+export default function matchers() {
+	addFilter( 'blocks.registerBlockType', 'core/matchers', resolveAttributes );
 }

--- a/blocks/hooks/matchers.js
+++ b/blocks/hooks/matchers.js
@@ -92,5 +92,5 @@ export function resolveAttributes( settings ) {
 }
 
 export default function matchers( { addFilter } ) {
-	addFilter( 'registerBlockType', 'core-matchers', resolveAttributes );
+	addFilter( 'registerBlockType', 'core/matchers', resolveAttributes );
 }

--- a/blocks/hooks/test/anchor.js
+++ b/blocks/hooks/test/anchor.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createHooks } from '@wordpress/hooks';
+import { applyFilters, removeAllFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -14,11 +14,9 @@ import { createHooks } from '@wordpress/hooks';
 import anchor from '../anchor';
 
 describe( 'anchor', () => {
-	const hooks = createHooks();
-
 	let blockSettings;
 	beforeEach( () => {
-		anchor( hooks );
+		anchor();
 
 		blockSettings = {
 			save: noop,
@@ -28,12 +26,12 @@ describe( 'anchor', () => {
 	} );
 
 	afterEach( () => {
-		hooks.removeAllFilters( 'registerBlockType' );
-		hooks.removeAllFilters( 'getSaveContent.extraProps' );
+		removeAllFilters( 'blocks.registerBlockType' );
+		removeAllFilters( 'blocks.getSaveContent.extraProps' );
 	} );
 
 	describe( 'addAttribute()', () => {
-		const addAttribute = hooks.applyFilters.bind( null, 'registerBlockType' );
+		const addAttribute = applyFilters.bind( null, 'blocks.registerBlockType' );
 
 		it( 'should do nothing if the block settings do not define anchor support', () => {
 			const settings = addAttribute( blockSettings );
@@ -54,7 +52,7 @@ describe( 'anchor', () => {
 	} );
 
 	describe( 'addSaveProps', () => {
-		const addSaveProps = hooks.applyFilters.bind( null, 'getSaveContent.extraProps' );
+		const addSaveProps = applyFilters.bind( null, 'blocks.getSaveContent.extraProps' );
 
 		it( 'should do nothing if the block settings do not define anchor support', () => {
 			const attributes = { anchor: 'foo' };

--- a/blocks/hooks/test/custom-class-name.js
+++ b/blocks/hooks/test/custom-class-name.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createHooks } from '@wordpress/hooks';
+import { applyFilters, removeAllFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -14,11 +14,9 @@ import { createHooks } from '@wordpress/hooks';
 import customClassName from '../custom-class-name';
 
 describe( 'custom className', () => {
-	const hooks = createHooks();
-
 	let blockSettings;
 	beforeEach( () => {
-		customClassName( hooks );
+		customClassName();
 
 		blockSettings = {
 			save: noop,
@@ -28,12 +26,12 @@ describe( 'custom className', () => {
 	} );
 
 	afterEach( () => {
-		hooks.removeAllFilters( 'registerBlockType' );
-		hooks.removeAllFilters( 'getSaveContent.extraProps' );
+		removeAllFilters( 'blocks.registerBlockType' );
+		removeAllFilters( 'blocks.getSaveContent.extraProps' );
 	} );
 
 	describe( 'addAttribute()', () => {
-		const addAttribute = hooks.applyFilters.bind( null, 'registerBlockType' );
+		const addAttribute = applyFilters.bind( null, 'blocks.registerBlockType' );
 
 		it( 'should do nothing if the block settings disable custom className support', () => {
 			const settings = addAttribute( {
@@ -54,7 +52,7 @@ describe( 'custom className', () => {
 	} );
 
 	describe( 'addSaveProps', () => {
-		const addSaveProps = hooks.applyFilters.bind( null, 'getSaveContent.extraProps' );
+		const addSaveProps = applyFilters.bind( null, 'blocks.getSaveContent.extraProps' );
 
 		it( 'should do nothing if the block settings do not define custom className support', () => {
 			const attributes = { className: 'foo' };

--- a/blocks/hooks/test/geenerated-class-name.js
+++ b/blocks/hooks/test/geenerated-class-name.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * External dependencies
  */
-import { createHooks } from '@wordpress/hooks';
+import { applyFilters, removeAllFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -14,11 +14,9 @@ import { createHooks } from '@wordpress/hooks';
 import generatedClassName from '../generated-class-name';
 
 describe( 'generated className', () => {
-	const hooks = createHooks();
-
 	let blockSettings;
 	beforeEach( () => {
-		generatedClassName( hooks );
+		generatedClassName();
 
 		blockSettings = {
 			name: 'chicken/ribs',
@@ -29,11 +27,11 @@ describe( 'generated className', () => {
 	} );
 
 	afterEach( () => {
-		hooks.removeAllFilters( 'getSaveContent.extraProps' );
+		removeAllFilters( 'blocks.getSaveContent.extraProps' );
 	} );
 
 	describe( 'addSaveProps', () => {
-		const addSaveProps = hooks.applyFilters.bind( null, 'getSaveContent.extraProps' );
+		const addSaveProps = applyFilters.bind( null, 'blocks.getSaveContent.extraProps' );
 
 		it( 'should do nothing if the block settings do not define generated className support', () => {
 			const attributes = { className: 'foo' };

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './hooks';
 import './library';
 
 // A "block" is the abstract term used to describe units of markup that,
@@ -13,7 +14,6 @@ import './library';
 // Blocks are inferred from the HTML source of a post through a parsing mechanism
 // and then stored as objects in state, from which it is then rendered for editing.
 export * from './api';
-export * from './hooks';
 export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockControls } from './block-controls';

--- a/components/higher-order/with-filters/index.js
+++ b/components/higher-order/with-filters/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { getWrapperDisplayName } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
@@ -11,14 +10,7 @@ import { applyFilters } from '@wordpress/hooks';
  * @return {Function}      Higher-order component factory.
  */
 export default function withFilters( hookName ) {
-	return ( WrappedComponent ) => {
-		const FiltersComponent = ( props ) => {
-			const EnhancedComponent = applyFilters( hookName, WrappedComponent, props );
-
-			return <EnhancedComponent { ...props } />;
-		};
-		FiltersComponent.displayName = getWrapperDisplayName( WrappedComponent, 'filters' );
-
-		return FiltersComponent;
+	return ( OriginalComponent ) => {
+		return applyFilters( hookName, OriginalComponent );
 	};
 }

--- a/components/higher-order/with-filters/index.js
+++ b/components/higher-order/with-filters/index.js
@@ -13,7 +13,9 @@ import { applyFilters } from '@wordpress/hooks';
 export default function withFilters( hookName ) {
 	return ( WrappedComponent ) => {
 		const FiltersComponent = ( props ) => {
-			return applyFilters( hookName, <WrappedComponent { ...props } />, props );
+			const EnhancedComponent = applyFilters( hookName, WrappedComponent, props );
+
+			return <EnhancedComponent { ...props } />;
 		};
 		FiltersComponent.displayName = getWrapperDisplayName( WrappedComponent, 'filters' );
 

--- a/components/higher-order/with-filters/test/index.js
+++ b/components/higher-order/with-filters/test/index.js
@@ -1,12 +1,11 @@
 /**
  * External dependencies
  */
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 
 /**
  * WordPress dependencies
  */
-import { concatChildren } from '@wordpress/element';
 import { addFilter, removeAllFilters } from '@wordpress/hooks';
 
 /**
@@ -30,10 +29,11 @@ describe( 'withFilters', () => {
 	} );
 
 	it( 'should display a component overridden by the filter', () => {
+		const OverriddenComponent = () => <div>Overridden component</div>;
 		addFilter(
 			'EnhancedComponent',
-			'test\enhanced-component-override',
-			() => <div>Overridden component</div>
+			'test/enhanced-component-override',
+			() => OverriddenComponent
 		);
 
 		const wrapper = shallow( <EnhancedComponent /> );
@@ -45,13 +45,17 @@ describe( 'withFilters', () => {
 		const ComposedComponent = () => <div>Composed component</div>;
 		addFilter(
 			hookName,
-			'test\enhanced-component-compose',
-			( element ) => concatChildren( element, <ComposedComponent /> )
+			'test/enhanced-component-compose',
+			( FilteredComponent ) => () => (
+				<div>
+					<FilteredComponent />
+					<ComposedComponent />
+				</div>
+			)
 		);
 
-		const wrapper = mount( <EnhancedComponent /> );
+		const wrapper = shallow( <EnhancedComponent /> );
 
-		expect( wrapper.find( MyComponent ) ).toBePresent();
-		expect( wrapper.find( ComposedComponent ) ).toBePresent();
+		expect( wrapper.html() ).toBe( '<div><div>My component</div><div>Composed component</div></div>' );
 	} );
 } );

--- a/components/higher-order/with-filters/test/index.js
+++ b/components/higher-order/with-filters/test/index.js
@@ -16,13 +16,13 @@ import withFilters from '../';
 describe( 'withFilters', () => {
 	const hookName = 'EnhancedComponent';
 	const MyComponent = () => <div>My component</div>;
-	const EnhancedComponent = withFilters( hookName )( MyComponent );
 
 	afterEach( () => {
 		removeAllFilters( hookName );
 	} );
 
 	it( 'should display original component when no filters applied', () => {
+		const EnhancedComponent = withFilters( hookName )( MyComponent );
 		const wrapper = shallow( <EnhancedComponent /> );
 
 		expect( wrapper.html() ).toBe( '<div>My component</div>' );
@@ -35,6 +35,7 @@ describe( 'withFilters', () => {
 			'test/enhanced-component-override',
 			() => OverriddenComponent
 		);
+		const EnhancedComponent = withFilters( hookName )( MyComponent );
 
 		const wrapper = shallow( <EnhancedComponent /> );
 
@@ -53,6 +54,7 @@ describe( 'withFilters', () => {
 				</div>
 			)
 		);
+		const EnhancedComponent = withFilters( hookName )( MyComponent );
 
 		const wrapper = shallow( <EnhancedComponent /> );
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -92,11 +92,11 @@ add_filter( 'allowed_block_types', function() {
 
 To modify the behaviour of existing blocks, Gutenberg exposes a list of filters:
 
-- `registerBlockType`: Used to filter the block settings. It receives the block settings and the name of the block the registered block as arguments.
+- `blocks.registerBlockType`: Used to filter the block settings. It receives the block settings and the name of the block the registered block as arguments.
 
-- `getSaveContent.extraProps`: A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block Type and the block attributes as arguments.
+- `blocks.getSaveContent.extraProps`: A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block Type and the block attributes as arguments.
 
-- `BlockEdit`: Used to modify the block's `edit` component. It receives the original block `edit` component and returns a new wrapped component.
+- `blocks.BlockEdit`: Used to modify the block's `edit` component. It receives the original block `edit` component and returns a new wrapped component.
 
 **Example**
 
@@ -110,7 +110,7 @@ function addBackgroundProp( props ) {
 
 // Adding the filter
 wp.hooks.addFilter(
-	'getSaveContent.extraProps',
+	'blocks.getSaveContent.extraProps',
 	'myplugin/add-background',
 	addBackgroundProp
 );

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -96,7 +96,7 @@ To modify the behaviour of existing blocks, Gutenberg exposes a list of filters:
 
 - `getSaveContent.extraProps`: A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block Type and the block attributes as arguments.
 
-- `BlockEdit`: Used to filter the block's `edit` function receiving the WP element returned from the original block `edit` element.
+- `BlockEdit`: Used to modify the block's `edit` component. It receives the original block `edit` component and returns a new wrapped component.
 
 **Example**
 
@@ -109,9 +109,9 @@ function addBackgroundProp( props ) {
 }
 
 // Adding the filter
-wp.blocks.addFilter(
+wp.hooks.addFilter(
 	'getSaveContent.extraProps',
-	'myplugin\add-background',
+	'myplugin/add-background',
 	addBackgroundProp
 );
 ```

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -525,7 +525,6 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 } );
 
 export default compose(
-	withFilters( 'Editor.BlockItem' ),
 	connect( mapStateToProps, mapDispatchToProps ),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;
@@ -534,4 +533,5 @@ export default compose(
 			isLocked: !! templateLock,
 		};
 	} ),
+	withFilters( 'editor.BlockListBlock' ),
 )( BlockListBlock );

--- a/element/index.js
+++ b/element/index.js
@@ -4,7 +4,7 @@
 import { createElement, Component, cloneElement, Children } from 'react';
 import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { flowRight, isString, startCase } from 'lodash';
+import { camelCase, flowRight, isString, upperFirst } from 'lodash';
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -135,5 +135,5 @@ export { flowRight as compose };
 export function getWrapperDisplayName( BaseComponent, wrapperName ) {
 	const { displayName = BaseComponent.name || 'Component' } = BaseComponent;
 
-	return `${ startCase( wrapperName ) }(${ displayName })`;
+	return `${ upperFirst( camelCase( wrapperName ) ) }(${ displayName })`;
 }

--- a/element/index.js
+++ b/element/index.js
@@ -126,7 +126,7 @@ export { flowRight as compose };
 
 /**
  * Returns a wrapped version of a React component's display name.
- * Higher-order components use wrapDisplayName().
+ * Higher-order components use getWrapperDisplayName().
  *
  * @param {Function|Component} BaseComponent used to detect the existing display name.
  * @param {String} wrapperName Wrapper name to prepend to the display name.

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -99,6 +99,10 @@ describe( 'element', () => {
 			expect( getWrapperDisplayName( () => <div />, 'test' ) ).toBe( 'Test(Component)' );
 		} );
 
+		it( 'should use camel case starting with upper for wrapper prefix ', () => {
+			expect( getWrapperDisplayName( () => <div />, 'one-two_threeFOUR' ) ).toBe( 'OneTwoThreeFour(Component)' );
+		} );
+
 		it( 'should use function name', () => {
 			function SomeComponent() {
 				return <div />;


### PR DESCRIPTION
## Description

This PR tries to bring idea exercised when working on Collaborative Editing in #3741. It turned out that it would be a better idea to use Higher-Order Components approach for using filtering hook with the existing components. This seems like a more natural way of dealing with React component and is de facto a community standard. This PR also tries to address other issues mentioned in other places:

https://github.com/WordPress/gutenberg/issues/3800#issuecomment-349433646:
> Alternatively we change blocks hooks to operate on the global hooks instance, then simply encourage plugin authors to register their hooks prior to the `wp-blocks` handle being loaded.
>
> Related: https://github.com/WordPress/gutenberg/pull/3493#discussion_r153968061

It's going to be updated with this PR. `wp-hooks` is always registered before `wp-blocks`, so it should be possible. This change enforces plugin developer to always register a hook before the modified module is going to to be imported.

https://github.com/WordPress/gutenberg/pull/3621#issuecomment-349433069
> Let's make sure to reverse these changes now that the `/` hooks namespacing has been published.

https://github.com/WordPress/gutenberg/pull/3827/commits/c9310eb32696c4b9d733d05c06a6de4a481ecea8 addresses it.

## How Has This Been Tested?
Manually, e2e and unit tests.

## Types of changes

Refactoring. No visual changes. Everything should work as before.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.