### PR TITLE
Improve RTL rendering

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -1,3 +1,5 @@
+	// If we don't ignore this part we'll have a style ordering issue
+	/* rtl:begin:ignore */
 .components-button {
 	background: none;
 	border: none;
@@ -5,7 +7,10 @@
 	text-decoration: none;
 	margin: 0;
 	border-radius: 0;
+}
+/* rtl:end:ignore */
 
+.components-button {
 	&:active {
 		color: currentColor;
 	}

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -73,11 +73,28 @@
 	font-weight: 600;
 	text-align: left;
 
+	body.rtl & {
+		text-align: right;
+	}
+
 	.dashicon {
 		position: absolute;
-		right: 10px;
+		right: $item-spacing;
 		top: 50%;
 		transform: translateY( -50% );
+
+		body.rtl & {
+			right: auto;
+			left: $item-spacing;
+		}
+	}
+
+	// mirror the arrow horizontally in RTL languages
+	body.rtl & .dashicons-arrow-right {
+		transform: scaleX(-1);
+		-ms-filter: fliph;
+		filter: FlipH;
+		margin-top: -10px;
 	}
 }
 

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -73,29 +73,22 @@
 	font-weight: 600;
 	text-align: left;
 
-	body.rtl & {
-		text-align: right;
-	}
-
 	.dashicon {
 		position: absolute;
 		right: $item-spacing;
 		top: 50%;
 		transform: translateY( -50% );
-
-		body.rtl & {
-			right: auto;
-			left: $item-spacing;
-		}
 	}
 
 	// mirror the arrow horizontally in RTL languages
+	/* rtl:begin:ignore */
 	body.rtl & .dashicons-arrow-right {
 		transform: scaleX(-1);
 		-ms-filter: fliph;
 		filter: FlipH;
 		margin-top: -10px;
 	}
+	/* rtl:end:ignore */
 }
 
 .components-panel__body-toggle-icon {

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -30,6 +30,12 @@ body.gutenberg-editor-page {
 	ul#adminmenu>li.current>a.current:after {
 		border-right-color: $white;
 	}
+
+	&.rtl ul#adminmenu a.wp-has-current-submenu:after,
+	&.rtl ul#adminmenu>li.current>a.current:after {
+		border-right-color: transparent;
+		border-left-color: $white;
+	}
 }
 
 .gutenberg {

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -30,12 +30,6 @@ body.gutenberg-editor-page {
 	ul#adminmenu>li.current>a.current:after {
 		border-right-color: $white;
 	}
-
-	&.rtl ul#adminmenu a.wp-has-current-submenu:after,
-	&.rtl ul#adminmenu>li.current>a.current:after {
-		border-right-color: transparent;
-		border-left-color: $white;
-	}
 }
 
 .gutenberg {

--- a/editor/edit-post/header/style.scss
+++ b/editor/edit-post/header/style.scss
@@ -20,6 +20,11 @@
 
 	@include break-large() {
 		left: $admin-sidebar-width;
+
+		body.rtl & {
+			left: 0;
+			right: $admin-sidebar-width;
+		}
 	}
 }
 

--- a/editor/edit-post/header/style.scss
+++ b/editor/edit-post/header/style.scss
@@ -34,13 +34,30 @@
 	}
 }
 
+body.rtl.sticky-menu .editor-header {
+	@include break-medium() {
+		left: 0;
+		right: $admin-sidebar-width;
+	}
+}
+
 .auto-fold .editor-header {		/* Auto fold is when on smaller breakpoints, nav menu auto colllapses */
 	@include break-medium() {
 		left: $admin-sidebar-width-collapsed;
+
+		body.rtl & {
+			left: 0;
+			right: $admin-sidebar-width-collapsed;
+		}
 	}
 
 	@include break-large() {
 		left: $admin-sidebar-width;
+
+		body.rtl & {
+			left: 0;
+			right: $admin-sidebar-width;
+		}
 	}
 }
 
@@ -48,8 +65,17 @@
 .folded .editor-header {
 	left: 0;
 
+	body.rtl & {
+		right: 0;
+	}
+
 	@include break-medium() {
 		left: $admin-sidebar-width-collapsed;
+
+		body.rtl & {
+			left: 0;
+			right: $admin-sidebar-width-collapsed;
+		}
 	}
 }
 
@@ -57,24 +83,11 @@
 .auto-fold .wp-responsive-open .editor-header {
 	left: $admin-sidebar-width-big;
 	right: -$admin-sidebar-width-big;
-}
 
-/* RTL */
-.rtl.auto-fold .editor-header {
-	@include break-medium() {
-		left: 0;
-		right: $admin-sidebar-width-collapsed;
+	body.rtl & {
+		left: -$admin-sidebar-width-big;
+		right: $admin-sidebar-width-big;
 	}
-
-	@include break-large() {
-		left: 0;
-		right: $admin-sidebar-width;
-	}
-}
-
-.rtl.auto-fold .wp-responsive-open .editor-header {
-	left: -$admin-sidebar-width-big;
-	right: $admin-sidebar-width-big;
 }
 
 .editor-header__settings {

--- a/editor/edit-post/header/style.scss
+++ b/editor/edit-post/header/style.scss
@@ -20,11 +20,6 @@
 
 	@include break-large() {
 		left: $admin-sidebar-width;
-
-		body.rtl & {
-			left: 0;
-			right: $admin-sidebar-width;
-		}
 	}
 }
 
@@ -34,30 +29,13 @@
 	}
 }
 
-body.rtl.sticky-menu .editor-header {
-	@include break-medium() {
-		left: 0;
-		right: $admin-sidebar-width;
-	}
-}
-
 .auto-fold .editor-header {		/* Auto fold is when on smaller breakpoints, nav menu auto colllapses */
 	@include break-medium() {
 		left: $admin-sidebar-width-collapsed;
-
-		body.rtl & {
-			left: 0;
-			right: $admin-sidebar-width-collapsed;
-		}
 	}
 
 	@include break-large() {
 		left: $admin-sidebar-width;
-
-		body.rtl & {
-			left: 0;
-			right: $admin-sidebar-width;
-		}
 	}
 }
 
@@ -65,17 +43,8 @@ body.rtl.sticky-menu .editor-header {
 .folded .editor-header {
 	left: 0;
 
-	body.rtl & {
-		right: 0;
-	}
-
 	@include break-medium() {
 		left: $admin-sidebar-width-collapsed;
-
-		body.rtl & {
-			left: 0;
-			right: $admin-sidebar-width-collapsed;
-		}
 	}
 }
 
@@ -83,11 +52,6 @@ body.rtl.sticky-menu .editor-header {
 .auto-fold .wp-responsive-open .editor-header {
 	left: $admin-sidebar-width-big;
 	right: -$admin-sidebar-width-big;
-
-	body.rtl & {
-		left: -$admin-sidebar-width-big;
-		right: $admin-sidebar-width-big;
-	}
 }
 
 .editor-header__settings {

--- a/editor/edit-post/sidebar/style.scss
+++ b/editor/edit-post/sidebar/style.scss
@@ -11,13 +11,6 @@
 	height: 100vh;
 	overflow: hidden;
 
-	body.rtl & {
-		right: auto;
-		left: 0;
-		border-left: none;
-		border-right: 1px solid $light-gray-500;
-	}
-
 	@include break-small() {
 		top: $admin-bar-height-big + $header-height;
 		z-index: auto;
@@ -93,11 +86,6 @@
 .editor-layout.is-sidebar-opened .editor-layout__content {
 	@include break-medium() {
 		margin-right: $sidebar-width;
-
-		body.rtl & {
-			margin-right: 0;
-			margin-left: $sidebar-width;
-		}
 	}
 }
 
@@ -114,11 +102,6 @@
 /* Text Editor specific */
 .editor-layout.is-sidebar-opened .editor-text-editor__formatting {
 	margin-right: $sidebar-width;
-
-	body.rtl & {
-		margin-right: 0;
-		margin-left: $sidebar-width;
-	}
 }
 
 .components-panel__header.editor-sidebar__panel-tabs {
@@ -127,18 +110,8 @@
 	padding-left: 0;
 	padding-right: $panel-padding / 2;
 
-	body.rtl & {
-		padding-right: 0;
-		padding-left: $panel-padding / 2;
-	}
-
 	.components-icon-button {
 		margin-left: auto;
-
-		body.rtl & {
-			margin-left: 0;
-			margin-right: auto;
-		}
 	}
 }
 

--- a/editor/edit-post/sidebar/style.scss
+++ b/editor/edit-post/sidebar/style.scss
@@ -11,6 +11,13 @@
 	height: 100vh;
 	overflow: hidden;
 
+	body.rtl & {
+		right: auto;
+		left: 0;
+		border-left: none;
+		border-right: 1px solid $light-gray-500;
+	}
+
 	@include break-small() {
 		top: $admin-bar-height-big + $header-height;
 		z-index: auto;
@@ -86,6 +93,11 @@
 .editor-layout.is-sidebar-opened .editor-layout__content {
 	@include break-medium() {
 		margin-right: $sidebar-width;
+
+		body.rtl & {
+			margin-right: 0;
+			margin-left: $sidebar-width;
+		}
 	}
 }
 
@@ -102,16 +114,31 @@
 /* Text Editor specific */
 .editor-layout.is-sidebar-opened .editor-text-editor__formatting {
 	margin-right: $sidebar-width;
+
+	body.rtl & {
+		margin-right: 0;
+		margin-left: $sidebar-width;
+	}
 }
 
 .components-panel__header.editor-sidebar__panel-tabs {
 	justify-content: flex-start;
+	border-top: 0;
 	padding-left: 0;
 	padding-right: $panel-padding / 2;
-	border-top: 0;
+
+	body.rtl & {
+		padding-right: 0;
+		padding-left: $panel-padding / 2;
+	}
 
 	.components-icon-button {
 		margin-left: auto;
+
+		body.rtl & {
+			margin-left: 0;
+			margin-right: auto;
+		}
 	}
 }
 

--- a/editor/index.js
+++ b/editor/index.js
@@ -99,3 +99,9 @@ export function createEditorInstance( id, post, settings ) {
 		},
 	};
 }
+
+// Hack to fix LTR, This should be done in WP Core automatically
+const isRtl = document.documentElement.getAttribute( 'dir' ) === 'rtl';
+if ( ! isRtl ) {
+	document.documentElement.setAttribute( 'dir', 'ltr' );
+}

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -532,5 +532,6 @@ add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_b
  * @return string The $classes string, with gutenberg-editor-page appended.
  */
 function gutenberg_add_admin_body_class( $classes ) {
-	return "$classes gutenberg-editor-page";
+	$ltr_rtl_class = is_rtl() ? 'dir-rtl' : 'dir-ltr';
+	return "$classes gutenberg-editor-page $ltr_rtl_class";
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -620,7 +620,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 			'baseURL'  => includes_url( 'js/tinymce' ),
 			'suffix'   => SCRIPT_DEBUG ? '' : '.min',
 			'settings' => apply_filters( 'tiny_mce_before_init', array(
-				'plugins'          => array_unique( apply_filters( 'tiny_mce_plugins', array(
+				'plugins'          => implode( ',', array_unique( apply_filters( 'tiny_mce_plugins', array(
 					'charmap',
 					'colorpicker',
 					'hr',
@@ -639,7 +639,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 					'wpdialogs',
 					'wptextpattern',
 					'wpview',
-				) ) ),
+				) ) ) ),
 				'toolbar1'         => implode( ',', array_merge( apply_filters( 'mce_buttons', array(
 					'formatselect',
 					'bold',

--- a/package-lock.json
+++ b/package-lock.json
@@ -3530,6 +3530,30 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "findup": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "commander": "2.1.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
+          "dev": true
+        }
+      }
+    },
     "flat-cache": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
@@ -8136,6 +8160,15 @@
         }
       }
     },
+    "postcss-rtl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-rtl/-/postcss-rtl-1.1.3.tgz",
+      "integrity": "sha512-vKYVnkyzN9v9LE+YM55SzbWML07sXXqM+DEwyx92325pPywsPjdqd9OeGVVg7UeZRbxQTzLclXQuaRGLcoOPww==",
+      "dev": true,
+      "requires": {
+        "rtlcss": "2.2.1"
+      }
+    },
     "postcss-value-parser": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
@@ -8904,6 +8937,73 @@
       "requires": {
         "lodash.flattendeep": "4.4.0",
         "nearley": "2.11.0"
+      }
+    },
+    "rtlcss": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.2.1.tgz",
+      "integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "findup": "0.1.5",
+        "mkdirp": "0.5.1",
+        "postcss": "6.0.14",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "pegjs-loader": "0.5.4",
     "phpegjs": "1.0.0-beta7",
     "postcss-loader": "2.0.6",
+    "postcss-rtl": "1.1.3",
     "prismjs": "1.6.0",
     "raw-loader": "0.5.1",
     "react-markdown": "2.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ const extractConfig = {
 			options: {
 				plugins: [
 					require( 'autoprefixer' ),
+					require( 'postcss-rtl' )(),
 				],
 			},
 		},


### PR DESCRIPTION
## Description

This PR improves the RTL appearance of Gutenberg:

<img width="1366" alt="screen shot 2017-12-06 at 13 09 05" src="https://user-images.githubusercontent.com/1204802/33661148-e4754a3e-da86-11e7-99e8-4c8927e21533.png">

Additionally, it might fix #1565, as it also flips horizontally the arrow icon.

## How Has This Been Tested?

Chrome on Mac.

## Steps to test

- Set your admin language to an RTL language, like Arabic
- Edit or write a post in Gutenberg