### PR TITLE
TinyMCE: Use the same version used in Core

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -247,11 +247,8 @@ function gutenberg_register_vendor_scripts() {
 		'https://unpkg.com/moment@2.18.1/' . $moment_script,
 		array( 'react' )
 	);
-	$tinymce_version = '4.7.2';
-	gutenberg_register_vendor_script(
-		'tinymce-latest',
-		'https://fiddle.azurewebsites.net/tinymce/' . $tinymce_version . '/tinymce' . $suffix . '.js'
-	);
+	$tinymce_version = '4.6.7';
+	wp_register_script( 'tinymce-latest', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array( 'jquery' ), false, true );
 	gutenberg_register_vendor_script(
 		'tinymce-latest-lists',
 		'https://fiddle.azurewebsites.net/tinymce/' . $tinymce_version . '/plugins/lists/plugin' . $suffix . '.js',


### PR DESCRIPTION
This PR updates the TinyMCE script used in Gutenberg to match the TinyMCE used in the classic editor and other metaboxes. The Core version is slightly older (it probably has some bugs already fixed in newer versions) but this change fixes some errors we have right now due to using multiple TinyMCE versions:

 - #3512 No more JS errors when you add some metaboxes
 - #3731 Makes the ACF Wysiwyg field work

I think if we were to update the TinyMCE version, we should find a way to do it globally.

closes #3512 #3731 