### PR TITLE
Improved paste behaviour on empty heading blocks.

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get, tail } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -98,7 +103,7 @@ registerBlockType( 'core/heading', {
 		};
 	},
 
-	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlocksAfter } ) {
+	edit( { attributes, setAttributes, focus, setFocus, mergeBlocks, insertBlocksAfter, onReplace } ) {
 		const { align, content, nodeName, placeholder } = attributes;
 
 		return [
@@ -157,6 +162,25 @@ registerBlockType( 'core/heading', {
 						...blocks,
 						createBlock( 'core/paragraph', { content: after } ),
 					] );
+				} }
+				onReplace={ ( blocks ) => {
+					const firstBlockType = get( blocks, [ 0, 'name' ] );
+					switch ( firstBlockType ) {
+						case 'core/heading':
+							onReplace( blocks );
+							return;
+						case 'core/paragraph':
+							onReplace( [
+								createBlock(
+									'core/heading',
+									{ ...attributes, content: get( blocks, [ 0, 'attributes', 'content' ] ) }
+								),
+								...tail( blocks ),
+							] );
+							return;
+						default:
+							onReplace( [ createBlock( 'core/heading', attributes ), ...blocks ] );
+					}
 				} }
 				style={ { textAlign: align } }
 				placeholder={ placeholder || __( 'Write heading…' ) }


### PR DESCRIPTION
## Description
This PR aims to fix https://github.com/WordPress/gutenberg/issues/3351. It improves the paste behavior on empty heading blocks.
Now, when copying headings from external sources no heading block is repeated. Also when copying text from an external source e.g: this GitHub text into a heading the text is added to the heading instead of keeping the heading empty and adding a paragraph.


## How Has This Been Tested?
Add heading block, paste a heading from an external editor, e.g: editor see no empty heading block is kept.
Past normal text from an external source and see the first paragraph of text is added to the heading.

## Screenshots
![dec-07-2017 11-47-32](https://user-images.githubusercontent.com/11271197/33713974-3672279e-db45-11e7-8cd1-2ae727ba2683.gif)
![dec-07-2017 11-47-54](https://user-images.githubusercontent.com/11271197/33713976-394ce95e-db45-11e7-8d82-90f5c74f7181.gif)

