### PR TITLE
Gallery: Support for ID-less shortcode

### DIFF
--- a/core-blocks/gallery/index.js
+++ b/core-blocks/gallery/index.js
@@ -59,6 +59,13 @@ const blockAttributes = {
 			},
 		},
 	},
+	// To be set only by the shortcode transform to signal the intent to
+	// converting `[shortcode]` to a Gallery block with images filled in as
+	// attributes.
+	useAttachedImages: {
+		type: 'boolean',
+		default: false,
+	},
 	columns: {
 		type: 'number',
 	},
@@ -113,6 +120,10 @@ export const settings = {
 								id: parseInt( id, 10 ),
 							} ) );
 						},
+					},
+					useAttachedImages: {
+						type: 'boolean',
+						shortcode: ( { named: { ids } } ) => ! ids,
 					},
 					columns: {
 						type: 'number',

--- a/core-blocks/test/fixtures/core__gallery.json
+++ b/core-blocks/test/fixtures/core__gallery.json
@@ -17,6 +17,7 @@
                     "caption": []
                 }
             ],
+            "useAttachedImages": false,
             "imageCrop": true,
             "linkTo": "none"
         },

--- a/core-blocks/test/fixtures/core__gallery__columns.json
+++ b/core-blocks/test/fixtures/core__gallery__columns.json
@@ -17,6 +17,7 @@
                     "caption": []
                 }
             ],
+            "useAttachedImages": false,
             "columns": 1,
             "imageCrop": true,
             "linkTo": "none"

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -36,6 +36,17 @@ export async function* getMedia( state, id ) {
 }
 
 /**
+ * Requests all media elements attached to a post from the REST API.
+ *
+ * @param {Object} state  State tree.
+ * @param {number} postId Post id.
+ */
+export async function* getPostMedia( state, postId ) {
+	const media = await apiRequest( { path: `/wp/v2/media?parent=${ postId }` } );
+	yield receiveMedia( media );
+}
+
+/**
  * Requests a post type element from the REST API.
  *
  * @param {Object} state State tree

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
  * Returns all the available terms for the given taxonomy.
  *
  * @param {Object} state    Data state.
@@ -56,6 +61,18 @@ export function isRequestingCategories( state ) {
  */
 export function getMedia( state, id ) {
 	return state.media[ id ];
+}
+
+/**
+ * Returns media objects attached to a post, given a post ID.
+ *
+ * @param {Object} state  Data state.
+ * @param {number} postId Post id.
+ *
+ * @return {Array} Media list.
+ */
+export function getPostMedia( state, postId ) {
+	return filter( state.media, { post: postId } );
 }
 
 /**

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -6,7 +6,7 @@ import apiRequest from '@wordpress/api-request';
 /**
  * Internal dependencies
  */
-import { getCategories, getMedia, getPostType } from '../resolvers';
+import { getCategories, getMedia, getPostMedia, getPostType } from '../resolvers';
 import { setRequested, receiveTerms, receiveMedia, receivePostTypes } from '../actions';
 
 jest.mock( '@wordpress/api-request' );
@@ -44,6 +44,24 @@ describe( 'getMedia', () => {
 
 	it( 'yields with requested media', async () => {
 		const fulfillment = getMedia( {}, 1 );
+		const received = ( await fulfillment.next() ).value;
+		expect( received ).toEqual( receiveMedia( MEDIA ) );
+	} );
+} );
+
+describe( 'getPostMedia', () => {
+	const MEDIA = [ { id: 10 }, { id: 20 } ];
+
+	beforeAll( () => {
+		apiRequest.mockImplementation( ( options ) => {
+			if ( options.path === '/wp/v2/media?parent=1' ) {
+				return Promise.resolve( MEDIA );
+			}
+		} );
+	} );
+
+	it( 'yields with requested media', async () => {
+		const fulfillment = getPostMedia( {}, 1 );
 		const received = ( await fulfillment.next() ).value;
 		expect( received ).toEqual( receiveMedia( MEDIA ) );
 	} );

--- a/core-data/test/selectors.js
+++ b/core-data/test/selectors.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getTerms, isRequestingTerms, getMedia, getPostType } from '../selectors';
+import { getTerms, isRequestingTerms, getMedia, getPostMedia, getPostType } from '../selectors';
 
 describe( 'getTerms()', () => {
 	it( 'returns value of terms by taxonomy', () => {
@@ -72,6 +72,30 @@ describe( 'getMedia', () => {
 			},
 		} );
 		expect( getMedia( state, 1 ) ).toEqual( { id: 1 } );
+	} );
+} );
+
+describe( 'getPostMedia', () => {
+	it( 'should return undefined for unknown media', () => {
+		const state = deepFreeze( {
+			media: {},
+		} );
+		expect( getPostMedia( state, 1 ) ).toEqual( [] );
+	} );
+
+	it( 'should return a media element by id', () => {
+		const state = deepFreeze( {
+			media: {
+				1: { id: 1, post: 42 },
+				2: { id: 2, post: 42 },
+				3: { id: 3, post: 84 },
+				4: { id: 4 },
+			},
+		} );
+		expect( getPostMedia( state, 42 ) ).toEqual( [
+			{ id: 1, post: 42 },
+			{ id: 2, post: 42 },
+		] );
 	} );
 } );
 


### PR DESCRIPTION
Per the WP Codex, the [gallery] shortcode should be supported when no IDs are provided:

> The default behavior, if no ID is specified, is to display images attached to the current post.

— https://codex.wordpress.org/Gallery_Shortcode

## Description
Pasting `[gallery]` with no extra attributes, namely `ids`, generates a Gallery block with the post's attached media. Same goes for converting from classic post to blocks.

## Approach
1. A new attribute, `useAttachedImages`, is added to Gallery. It defaults to false.
2. The shortcode transform for Gallery recognizes when no IDs are provided, in which case `useAttachedImages` is set to true for the generated Gallery block. (This transform kicks in when pasting shortcodes, but also when converting classic content to blocks.)
3. If a Gallery block has `useAttachedImages` as true, request information on the images attached to the current post from the core media endpoint. This request is performed via `withAPIData`.
4. Once the data is ready, write it to the block's attributes, after which the block behaves as a regular image-provided Gallery.

## How Has This Been Tested?
1. Create a post with the classic editor.
2. Upload images to the post by dragging and dropping them from your filesystem.
3. Save the post, for good measure.
4. Delete its contents, save again.
5. Open the post with Gutenberg.
6. In the empty Paragraph, paste `[gallery]`.

**It should** be rendered as a Gallery block comprising the images originally attached to the post.

## Screenshots (jpeg or gifs if applicable):

![gutenberg-gallery-attached](https://user-images.githubusercontent.com/150562/33727292-75aa4f8e-db6f-11e7-83b2-831c78f1a4ca.gif)

## Caveat / To fix

- [ ] As I was preparing this summary, I realized that the process described above fails after the first time in a given Gutenberg session, and the block gets stuck "loading" the attached media:

![gutenberg-gallery-attached-spinner](https://user-images.githubusercontent.com/150562/33727406-d0771366-db6f-11e7-95dc-1d0bb8e0adbd.gif)

- [ ] Allow dynamic behavior (https://github.com/WordPress/gutenberg/pull/3852#issuecomment-350101792)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.