### PR TITLE
fix inserter navigate between blocks with left and right arrows

### DIFF
--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -124,19 +124,28 @@ export class NavigableMenu extends Component {
 		const eventToOffset = ( evt ) => {
 			const { keyCode } = evt;
 
-			const isVertical = orientation === 'vertical';
-			const isHorizontal = orientation === 'horizontal';
+			const offsetMap = {
+				vertical: {
+					[ LEFT ]: 0,
+					[ RIGHT ]: 0,
+					[ UP ]: -1,
+					[ DOWN ]: +1,
+				},
+				horizontal: {
+					[ LEFT ]: -1,
+					[ RIGHT ]: +1,
+					[ UP ]: 0,
+					[ DOWN ]: 0,
+				},
+				vertical_two_columns: {
+					[ LEFT ]: -1,
+					[ RIGHT ]: +1,
+					[ UP ]: -2,
+					[ DOWN ]: +2,
+				},
+			};
 
-			// Still handle any arrow keys, even if the opposite orientation
-			if ( LEFT === keyCode ) {
-				return isHorizontal ? -1 : 0;
-			} else if ( UP === keyCode ) {
-				return isVertical ? -1 : 0;
-			} else if ( RIGHT === keyCode ) {
-				return isHorizontal ? +1 : 0;
-			} else if ( DOWN === keyCode ) {
-				return isVertical ? +1 : 0;
-			}
+			return offsetMap.hasOwnProperty( orientation ) ? offsetMap[ orientation ][ keyCode ] : 0;
 		};
 
 		return (

--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -77,7 +77,7 @@ export default class InserterGroup extends Component {
 		return (
 			<NavigableMenu
 				className="editor-inserter__category-blocks"
-				orientation="vertical"
+				orientation="vertical_two_columns"
 				aria-labelledby={ labelledBy }
 				cycle={ false }
 				onNavigate={ this.onNavigate }>


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes https://github.com/WordPress/gutenberg/issues/3850

Navigable menu used in the this context had orientation set to "vertical". That enables only moving with up/down keys.
Another orientation available is "horizontal" which enables only left/right keys.
Here we needed both up/down and left/right combinations so I introduced a third "orientation" or type which I named "vertical_two_columns" which fits this use case.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
npm run test-unit
Manually tested in the browser
