### PR TITLE
Don't intercept rendering of removed meta boxes

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -206,6 +206,9 @@ function gutenberg_intercept_meta_box_render() {
 		foreach ( $contexts as $context => $priorities ) {
 			foreach ( $priorities as $priority => $boxes ) {
 				foreach ( $boxes as $id => $box ) {
+					if ( ! is_array( $box ) ) {
+						continue;
+					}
 					if ( ! is_array( $wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args'] ) ) {
 						$wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args'] = array();
 					}

--- a/phpunit/class-meta-box-test.php
+++ b/phpunit/class-meta-box-test.php
@@ -247,6 +247,6 @@ class Meta_Box_Test extends WP_UnitTestCase {
 
 		gutenberg_intercept_meta_box_render();
 
-		$this->assertFalse( $wp_meta_boxes[ 'post' ][ 'side' ][ 'default' ][ 'test-intercept-box' ] );
+		$this->assertFalse( $wp_meta_boxes['post']['side']['default']['test-intercept-box'] );
 	}
 }

--- a/phpunit/class-meta-box-test.php
+++ b/phpunit/class-meta-box-test.php
@@ -235,4 +235,18 @@ class Meta_Box_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * Test that a removed meta box remains empty after gutenberg_intercept_meta_box_render() fires.
+	 */
+	public function test_gutenberg_intercept_meta_box_render_skips_empty_boxes() {
+		global $wp_meta_boxes;
+
+		add_meta_box( 'test-intercept-box', 'Test Intercept box', '__return_empty_string', 'post', 'side', 'default' );
+		remove_meta_box( 'test-intercept-box', 'post', 'side' );
+
+		gutenberg_intercept_meta_box_render();
+
+		$this->assertFalse( $wp_meta_boxes[ 'post' ][ 'side' ][ 'default' ][ 'test-intercept-box' ] );
+	}
 }


### PR DESCRIPTION
## Description

When a metabox is removed with `remove_metabox()`, the meta box array is updated as:

`$wp_meta_boxes[$page][$context][$priority][$id] = false;`

When `gutenberg_intercept_meta_box_render()` loops through each of these contexts, priorities, and boxes, it partially rebuilds the previously removed metabox.

Code like `do_meta_boxes()` then loops through the data and can generate a notice when `$box` is no longer falsey or `$box['title']` is not available.

We can avoid this by skipping the rebuild of any metaboxes that do not have a `$box` array available.

Introduced in #3554.

## How Has This Been Tested?

Remove previously registered metaboxes with `remove_metabox()` and loading an editor page.

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.