### PR TITLE
Fix undefined index `title` on meta box

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -206,6 +206,9 @@ function gutenberg_intercept_meta_box_render() {
 		foreach ( $contexts as $context => $priorities ) {
 			foreach ( $priorities as $priority => $boxes ) {
 				foreach ( $boxes as $id => $box ) {
+					if ( false === $box ) {
+						continue; // remove_meta_box() sets a box to `false`.
+					}
 					if ( ! is_array( $wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args'] ) ) {
 						$wp_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ]['args'] = array();
 					}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/3813 and https://github.com/xwp/wp-customize-snapshots/issues/172

`remove_meta_box()` in WP core sets the box value to `false`,
but leaves the array element. This is now taken into consideration
by explicitly testing for a `false` value as we walk through each box.

---

Referencing: https://developer.wordpress.org/reference/functions/remove_meta_box/

Where `remove_meta_box()` does the following...

```php
foreach ( array('high', 'core', 'default', 'low') as $priority )
        $wp_meta_boxes[$page][$context][$priority][$id] = false;
```