### PR TITLE
Fix keyboard trap in the form token component and improve accessibility

### DIFF
--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -50,8 +50,9 @@ class FormTokenField extends Component {
 	}
 
 	componentDidUpdate() {
+		// Make sure to focus the input when the isActive state is true.
 		if ( this.state.isActive && ! this.input.hasFocus() ) {
-			this.input.focus(); // make sure focus is on input
+			this.input.focus();
 		}
 	}
 
@@ -73,7 +74,18 @@ class FormTokenField extends Component {
 	}
 
 	onFocus( event ) {
-		this.setState( { isActive: true } );
+		// If focus is on the input or on the container, set the isActive state to true.
+		if ( this.input.hasFocus() || event.target === this.tokensAndInput ) {
+			this.setState( { isActive: true } );
+		} else {
+			/*
+			 * Otherwise, focus is on one of the token "remove" buttons and we
+			 * set the isActive state to false to prevent the input to be
+			 * re-focused, see componentDidUpdate().
+			 */
+			this.setState( { isActive: false } );
+		}
+
 		if ( 'function' === typeof this.props.onFocus ) {
 			this.props.onFocus( event );
 		}
@@ -154,6 +166,7 @@ class FormTokenField extends Component {
 
 	onTokenClickRemove( event ) {
 		this.deleteToken( event.value );
+		this.input.focus();
 	}
 
 	onSuggestionHovered( suggestion ) {

--- a/components/form-token-field/index.js
+++ b/components/form-token-field/index.js
@@ -24,6 +24,7 @@ const initialState = {
 	incompleteTokenValue: '',
 	inputOffsetFromEnd: 0,
 	isActive: false,
+	isExpanded: false,
 	selectedSuggestionIndex: -1,
 	selectedSuggestionScroll: false,
 };
@@ -198,13 +199,17 @@ class FormTokenField extends Component {
 			incompleteTokenValue: tokenValue,
 			selectedSuggestionIndex: -1,
 			selectedSuggestionScroll: false,
+			isExpanded: false,
 		} );
 
 		this.props.onInputChange( tokenValue );
 
-		const showMessage = tokenValue.trim().length > 1;
-		if ( showMessage ) {
+		const inputHasMinimumChars = tokenValue.trim().length > 1;
+		if ( inputHasMinimumChars ) {
 			const matchingSuggestions = this.getMatchingSuggestions( tokenValue );
+
+			this.setState( { isExpanded: !! matchingSuggestions.length } );
+
 			if ( !! matchingSuggestions.length ) {
 				this.props.debouncedSpeak( sprintf( _n(
 					'%d result found, use up and down arrow keys to navigate.',
@@ -479,7 +484,7 @@ class FormTokenField extends Component {
 			disabled: this.props.disabled,
 			value: this.state.incompleteTokenValue,
 			onBlur: this.onBlur,
-			isExpanded: this.state.isActive,
+			isExpanded: this.state.isExpanded,
 			selectedSuggestionIndex: this.state.selectedSuggestionIndex,
 		};
 
@@ -513,7 +518,8 @@ class FormTokenField extends Component {
 			tabIndex: '-1',
 		};
 		const matchingSuggestions = this.getMatchingSuggestions();
-		const showSuggestions = this.state.incompleteTokenValue.trim().length > 1;
+		const inputHasMinimumChars = this.state.incompleteTokenValue.trim().length > 1;
+		const showSuggestions = inputHasMinimumChars && !! matchingSuggestions.length;
 
 		if ( ! disabled ) {
 			tokenFieldProps = Object.assign( {}, tokenFieldProps, {
@@ -549,7 +555,6 @@ class FormTokenField extends Component {
 						suggestions={ matchingSuggestions }
 						selectedIndex={ this.state.selectedSuggestionIndex }
 						scrollIntoView={ this.state.selectedSuggestionScroll }
-						isExpanded={ this.state.isActive }
 						onHover={ this.onSuggestionHovered }
 						onSelect={ this.onSuggestionSelected }
 					/>

--- a/components/form-token-field/style.scss
+++ b/components/form-token-field/style.scss
@@ -159,18 +159,13 @@ input[type="text"].components-form-token-field__input {
 // Suggestion list
 .components-form-token-field__suggestions-list {
 	background: $white;
-	max-height: 0;
+	max-height: 9em;
 	overflow-y: scroll;
 	transition: all .15s ease-in-out;
 	list-style: none;
+	border-top: 1px solid $dark-gray-300;
 	margin: 0;
-
-	&.is-expanded {
-		background: $white;
-		border-top: 1px solid $dark-gray-300;
-		max-height: 9em;
-		padding-top: 3px;
-	}
+	padding-top: 3px;
 }
 
 .components-form-token-field__suggestion {

--- a/components/form-token-field/suggestions-list.js
+++ b/components/form-token-field/suggestions-list.js
@@ -17,10 +17,10 @@ class SuggestionsList extends Component {
 		this.bindList = this.bindList.bind( this );
 	}
 
-	componentDidUpdate( prevProps ) {
+	componentDidUpdate() {
 		// only have to worry about scrolling selected suggestion into view
 		// when already expanded
-		if ( prevProps.isExpanded && this.props.isExpanded && this.props.selectedIndex > -1 && this.props.scrollIntoView ) {
+		if ( this.props.selectedIndex > -1 && this.props.scrollIntoView ) {
 			this.scrollingIntoView = true;
 			scrollIntoView( this.list.children[ this.props.selectedIndex ], this.list, {
 				onlyScrollIfNeeded: true,
@@ -72,10 +72,6 @@ class SuggestionsList extends Component {
 	}
 
 	render() {
-		const classes = classnames( 'components-form-token-field__suggestions-list', {
-			'is-expanded': this.props.isExpanded && this.props.suggestions.length > 0,
-		} );
-
 		// We set `tabIndex` here because otherwise Firefox sets focus on this
 		// div when tabbing off of the input in `TokenField` -- not really sure
 		// why, since usually a div isn't focusable by default
@@ -83,8 +79,7 @@ class SuggestionsList extends Component {
 		return (
 			<ul
 				ref={ this.bindList }
-				className={ classes }
-				tabIndex="-1"
+				className="components-form-token-field__suggestions-list"
 				id={ `components-form-token-suggestions-${ this.props.instanceId }` }
 				role="listbox"
 			>
@@ -100,7 +95,6 @@ class SuggestionsList extends Component {
 							<li
 								id={ `components-form-token-suggestions-${ this.props.instanceId }-${ index }` }
 								role="option"
-								tabIndex="-1"
 								className={ classeName }
 								key={ suggestion }
 								onMouseDown={ this.handleMouseDown }
@@ -131,7 +125,6 @@ class SuggestionsList extends Component {
 }
 
 SuggestionsList.defaultProps = {
-	isExpanded: false,
 	match: '',
 	onHover: () => {},
 	onSelect: () => {},

--- a/components/form-token-field/token-input.js
+++ b/components/form-token-field/token-input.js
@@ -46,7 +46,7 @@ class TokenInput extends Component {
 				role="combobox"
 				aria-expanded={ isExpanded }
 				aria-autocomplete="list"
-				aria-owns={ `components-form-token-suggestions-${ instanceId }` }
+				aria-owns={ isExpanded ? `components-form-token-suggestions-${ instanceId }` : undefined }
 				aria-activedescendant={ selectedSuggestionIndex !== -1 ? `components-form-token-suggestions-${ instanceId }-${ selectedSuggestionIndex }` : undefined }
 				aria-describedby={ `components-form-token-suggestions-howto-${ instanceId }` }
 			/>

--- a/components/form-token-field/token.js
+++ b/components/form-token-field/token.js
@@ -39,7 +39,6 @@ function Token( {
 	return (
 		<span
 			className={ tokenClasses }
-			tabIndex="-1"
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
 			title={ title }


### PR DESCRIPTION
This PR tries to partially address #1339 fixing a couple issues, specifically:
- keyboard trap when there's a token added and tabbing backwards with Shift+Tab
- the aria-expanded attribute should be true only when the suggestions list is rendered

additionally:
- renders the list `<ul>` only when there are matches, avoiding to render an empty `<ul>`
- removes some unnecessary props

Re: the keyboard trap, what happens right now is that when there is one (or multiple) token added, tabbing backwards from the field:
- focuses the token "remove" button
- the `onFocus` callback triggers a state update
- `componentDidUpdate()` kicks in and focus is moved back to the input field
- every time Shift+Tab get used, this produces a sort of "focus loop" that continuously moves back focus to the input field

To fix this, I'm making `isActive: false` when the token "remove" button is focused. From a visual perspective, when one of the token "remove" buttons is focused, this removes the focus style from the wrapper but I'm OK with this since the element actually focused is the remove button:

![screen shot 2017-12-08 at 11 52 48](https://user-images.githubusercontent.com/1682452/33764134-76bced74-dc13-11e7-8ba2-45b2b3c6927d.png)

If desired, styling improvements can go in a separate issue.

Testing with NVDA, the aria-expanded state is announced correctly:

![screenshot 20](https://user-images.githubusercontent.com/1682452/33764178-9e9deabe-dc13-11e7-85e0-07e5ec61e2ed.png)

Note:
I had hard time to figure out what's going on in this component, mainly because lack of documentation and some naming that could be improved. For example, things like `isActive` and `saveTransform` don't tell me exactly what they do.
I guess this component could benefit from some polishing, given also the other issues mentioned on 1339 and still to address.

See #1339