### PR TITLE
Improved paste behavior of simple text.

### DIFF
--- a/blocks/api/raw-handling/is-inline-content.js
+++ b/blocks/api/raw-handling/is-inline-content.js
@@ -15,6 +15,7 @@ export default function( HTML ) {
 
 function deepCheck( nodes ) {
 	return nodes.every( ( node ) => {
-		return isInline( node ) && deepCheck( Array.from( node.children ) );
+		return ( 'SPAN' === node.nodeName || isInline( node ) ) &&
+			deepCheck( Array.from( node.children ) );
 	} );
 }

--- a/blocks/api/raw-handling/test/is-inline-content.js
+++ b/blocks/api/raw-handling/test/is-inline-content.js
@@ -11,6 +11,7 @@ import isInlineContent from '../is-inline-content';
 describe( 'stripWrappers', () => {
 	it( 'should be inline content', () => {
 		equal( isInlineContent( '<em>test</em>' ), true );
+		equal( isInlineContent( '<span>test</span>' ), true );
 	} );
 
 	it( 'should not be inline content', () => {


### PR DESCRIPTION
The majority of simple text we copy contains a plain text version and an HTML/rich text version (e.g when we copy text from the browser or even from some text/editors like VSCode) this makes our plain text verification.
Normally the HTML version of the simple text just adds a span around. The span element cannot be added to our inlineWhitelist otherwise some cleanup functions will stop removing redundant spans (discovered because of our unit tests :) ), so we did threat spans as inline content. When pasting simple text e.g: "this test" the browser copies it with a span around so we ended up diving the block where we are pasting and creating a new paragraph block for the pasted content.

This PR just adds a span verification in the isInlineContent function so spans are treated as inline content when pasting content.

## How Has This Been Tested?
Copy normal text (e.g no headings or complete paragraphs from external sources e.g:"this text" into an existing block see we interpret the text plain text and we add it to block where we are pasting.
Paste other contents and verify things worked as before.

## Screenshots (jpeg or gifs if applicable):
### Before:
![dec-08-2017 15-15-43](https://user-images.githubusercontent.com/11271197/33772278-0227ed9c-dc2c-11e7-9097-de72f75d7ae7.gif)


### After:
![dec-08-2017 15-12-24](https://user-images.githubusercontent.com/11271197/33772286-08844adc-dc2c-11e7-9a08-a8f7a1d62e1c.gif)

