### PR TITLE
Inserter: Fix React warning when saving reusable blocks

### DIFF
--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -43,10 +43,14 @@ export default class InserterGroup extends Component {
 		const { current } = this.state;
 		const { selectBlock, bindReferenceNode } = this.props;
 		const { disabled } = block;
+
 		return (
 			<button
 				role="menuitem"
-				key={ block.name }
+				key={ block.name === 'core/block' && block.initialAttributes ?
+					block.name + block.initialAttributes.ref :
+					block.name
+				}
 				className="editor-inserter__block"
 				onClick={ selectBlock( block ) }
 				ref={ bindReferenceNode( block.name ) }


### PR DESCRIPTION
When we have several saved blocks, the block name is not enough as a React key, we need to append the id of the reusable blocks.

**Testing instructions**

 - Save two or more reusable blocks
 - Open the saved tab in the inserter
 - You shouldn't see any React warning
 