### PR TITLE
Fix reusable block endless loop

### DIFF
--- a/blocks/library/block/index.php
+++ b/blocks/library/block/index.php
@@ -17,12 +17,7 @@ function gutenberg_render_block_core_reusable_block( $attributes ) {
 		return '';
 	}
 
-	$reusable_block_id = absint( $attributes['ref'] );
-	if ( ! $reusable_block_id ) {
-		return '';
-	}
-
-	$reusable_block = get_post( $reusable_block_id );
+	$reusable_block = get_post( $attributes['ref'] );
 	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
 		return '';
 	}

--- a/blocks/library/block/index.php
+++ b/blocks/library/block/index.php
@@ -13,8 +13,17 @@
  * @return string Rendered HTML of the referenced block.
  */
 function gutenberg_render_block_core_reusable_block( $attributes ) {
-	$reusable_block = get_post( $attributes['ref'] );
-	if ( ! $reusable_block ) {
+	if ( empty( $attributes['ref'] ) ) {
+		return '';
+	}
+
+	$reusable_block_id = absint( $attributes['ref'] );
+	if ( ! $reusable_block_id ) {
+		return '';
+	}
+
+	$reusable_block = get_post( $reusable_block_id );
+	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
 		return '';
 	}
 


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/3880

When `$attributes['ref']` is empty, `get_post()` returns
the *current* post by default; i.e., the post you're editing,
which is obviously not a `wp_block` post type. That results in
an unanticipated scenario, such as an endless loop.

Corrected by making sure `$attributes['ref']` is not empty,
and that `get_post()` does indeed return a `wp_block` post type.