### PR TITLE
Post schedule: remove duplicated button-link styles

### DIFF
--- a/editor/edit-post/sidebar/post-schedule/style.scss
+++ b/editor/edit-post/sidebar/post-schedule/style.scss
@@ -3,18 +3,8 @@
 	position: relative;
 }
 
-.editor-post-schedule__toggle.button-link {
-	text-decoration: underline;
-	color: $blue-wordpress;
+.wp-core-ui .editor-post-schedule__toggle.button-link {
 	text-align: right;
-
-	&:focus {
-		outline: none;
-	}
-
-	&:hover {
-		color: $blue-medium-500;
-	}
 }
 
 .editor-post-schedule__dialog .components-popover__content {


### PR DESCRIPTION
## Description
The post schedule `.button-link` styles were overridden by `.wp-core-ui .button-link`. 
This PR removes the duplicated `.button-link` styles and makes it possible for `.editor-post-schedule__toggle.button-link` to override the global `.wp-core-ui .button-link`.

## Screenshots (jpeg or gifs if applicable):
Before:
![before](https://user-images.githubusercontent.com/695201/33796286-8fb451c6-dcf1-11e7-9460-cba0861a85c0.png)

After:
![after](https://user-images.githubusercontent.com/695201/33796290-9178d86a-dcf1-11e7-8160-9a3c5712c38e.png)
