### PR TITLE
Run e2e tests with the examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - ./bin/run-wp-unit-tests.sh
 
     - stage: test
-	  env: INSTALL_GUTENBERG_EXAMPLES=true
+      env: INSTALL_GUTENBERG_EXAMPLES=true
       script:
         - npm install || exit 1
         - npm run build || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ jobs:
         - ./bin/run-wp-unit-tests.sh
 
     - stage: test
+	  env: INSTALL_GUTENBERG_EXAMPLES=true
       script:
         - npm install || exit 1
         - npm run build || exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,11 @@ If you're using another local environment setup, you can still run the e2e tests
 cypress_base_url=http://my-custom-basee-url cypress_username=myusername cypress_password=mypassword npm run test-e2e
 ```
 
+If you have the [gutenberg examples](https://github.com/WordPress/gutenberg-examples) installed, you can also run tests for them by setting the `INSTALL_GUTENBERG_EXAMPLES` enviormental variable to true. This is usefull if you are making changes to the exposed API. You can do so like so:
+
+```bash
+INSTALL_GUTENBERG_EXAMPLES=true npm run test-e2e
+```
 
 ### PHP Testing
 

--- a/docker/examples-compose.yml
+++ b/docker/examples-compose.yml
@@ -1,0 +1,7 @@
+version: '3.1'
+
+services:
+  wordpress:
+    volumes:
+      - ../../gutenberg-examples:/var/www/html/wp-content/plugins/gutenberg-examples
+      - ../:/var/www/html/wp-content/plugins/gutenberg

--- a/docs/testing-overview.md
+++ b/docs/testing-overview.md
@@ -161,3 +161,7 @@ components that are directly rendered by the component we want to test.
 
 [snapshot testing]: https://facebook.github.io/jest/docs/en/snapshot-testing.html
 [update snapshots]: https://facebook.github.io/jest/docs/en/snapshot-testing.html#updating-snapshots
+
+## Testing with the Example Plugins
+
+The [gutenberg examples](https://github.com/WordPress/gutenberg-examples) can be tested by setting the `INSTALL_GUTENBERG_EXAMPLES` enviormental variable to true. In order for the examples to be installed, the initial run of `./bin/setup-local-env.sh` should also have `INSTALL_GUTENBERG_EXAMPLES` set to true. This can be done by running the command as `INSTALL_GUTENBERG_EXAMPLES=true ./bin/setup-local-env.sh`.

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "test-unit:coverage": "jest --coverage",
     "test-unit:coverage-ci": "jest --coverage --maxWorkers 1 && codecov",
     "test-unit:watch": "jest --watch",
-    "test-e2e": "cypress run --browser chrome",
-    "test-e2e:watch": "cypress open"
+    "test-e2e": "cypress run --browser chrome -e EXAMPLES=$INSTALL_GUTENBERG_EXAMPLES",
+    "test-e2e:watch": "cypress open -e EXAMPLES=$INSTALL_GUTENBERG_EXAMPLES"
   }
 }

--- a/test/e2e/integration/004-gutenberg-examples.js
+++ b/test/e2e/integration/004-gutenberg-examples.js
@@ -1,0 +1,30 @@
+let conditionalDescribe = Cypress.env( 'EXAMPLES' ) ? describe : describe.skip;
+conditionalDescribe( 'Example Blocks', () => {
+	before( () => {
+		cy.newPost();
+	} );
+
+	it( 'Should insert example blocks', () => {
+		const lastBlockSelector = '.editor-block-list__block-edit:last [contenteditable="true"]:first';
+
+		cy.get( '.editor-header [aria-label="Insert block"]' ).click();
+		cy.get( '[placeholder="Search for a block"]' ).type( 'example' );
+		cy.get( '.editor-inserter__block' ).contains( 'Example' ).click();
+
+		cy.get( '.editor-header [aria-label="Insert block"]' ).click();
+		cy.get( '[placeholder="Search for a block"]' ).type( 'Example: Basic (esnext)' );
+		cy.get( '.editor-inserter__block' ).contains( 'Example: Basic (esnext)' ).click();
+
+
+		// Switch to Text Mode to check HTML Output
+		cy.get( '.editor-ellipsis-menu [aria-label="More"]' ).click();
+		cy.get( 'button' ).contains( 'Code Editor' ).click();
+
+
+		// Assertions
+		cy.get( '.editor-post-text-editor' )
+			.should( 'contain', 'wp-block-gutenberg-examples-example-01-basic' )
+			.should( 'contain', 'wp-block-gutenberg-examples-example-01-basic-esnext' )
+	});
+
+});

--- a/test/e2e/integration/004-gutenberg-examples.js
+++ b/test/e2e/integration/004-gutenberg-examples.js
@@ -1,12 +1,10 @@
-let conditionalDescribe = Cypress.env( 'EXAMPLES' ) ? describe : describe.skip;
+const conditionalDescribe = Cypress.env( 'EXAMPLES' ) ? describe : describe.skip;
 conditionalDescribe( 'Example Blocks', () => {
 	before( () => {
 		cy.newPost();
 	} );
 
 	it( 'Should insert example blocks', () => {
-		const lastBlockSelector = '.editor-block-list__block-edit:last [contenteditable="true"]:first';
-
 		cy.get( '.editor-header [aria-label="Insert block"]' ).click();
 		cy.get( '[placeholder="Search for a block"]' ).type( 'example' );
 		cy.get( '.editor-inserter__block' ).contains( 'Example' ).click();
@@ -15,16 +13,13 @@ conditionalDescribe( 'Example Blocks', () => {
 		cy.get( '[placeholder="Search for a block"]' ).type( 'Example: Basic (esnext)' );
 		cy.get( '.editor-inserter__block' ).contains( 'Example: Basic (esnext)' ).click();
 
-
 		// Switch to Text Mode to check HTML Output
 		cy.get( '.editor-ellipsis-menu [aria-label="More"]' ).click();
 		cy.get( 'button' ).contains( 'Code Editor' ).click();
 
-
 		// Assertions
 		cy.get( '.editor-post-text-editor' )
 			.should( 'contain', 'wp-block-gutenberg-examples-example-01-basic' )
-			.should( 'contain', 'wp-block-gutenberg-examples-example-01-basic-esnext' )
-	});
-
-});
+			.should( 'contain', 'wp-block-gutenberg-examples-example-01-basic-esnext' );
+	} );
+} );


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
As the API becomes more and more stable, it's important to ensure that the [examples](https://github.com/WordPress/gutenberg-examples) accurately represent how Gutenberg is extended. Since Gutenberg is designed to be extended, true e2e integration tests also test this extensibility.

## How Has This Been Tested?
By building and running the e2e tests with and without the `INSTALL_GUTENBERG_EXAMPLES` env variable. Also [travis](https://travis-ci.org/WordPress/gutenberg/jobs/314352646) 

## Types of changes
- Adjusts docker to optional add a volume with the [examples](https://github.com/WordPress/gutenberg-examples) installed. This is based on a new env variable.
- Adds some basic e2e tests for the gutenberg examples, this also depends on the new env variable. 
~
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.