### PR TITLE
Don't try to parse strings that don't contain blocks

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -53,6 +53,19 @@ function unregister_block_type( $name ) {
  * @return array  Array of parsed block objects.
  */
 function gutenberg_parse_blocks( $content ) {
+	/*
+	 * If there are no blocks in the content, return a single block, rather
+	 * than wasting time trying to parse the string.
+	 */
+	if ( false === strpos( $content, '<!-- wp:' ) ) {
+		return array(
+				array(
+					'attrs' => array(),
+					'innerHTML' => $content,
+				),
+		);
+	}
+
 	$parser = new Gutenberg_PEG_Parser;
 	return $parser->parse( _gutenberg_utf8_split( $content ) );
 }

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -57,7 +57,7 @@ function gutenberg_parse_blocks( $content ) {
 	 * If there are no blocks in the content, return a single block, rather
 	 * than wasting time trying to parse the string.
 	 */
-	if ( ! preg_match( '/<!--\s*(wp:|more|noteaser)/', $content ) ) {
+	if ( ! gutenberg_content_has_blocks( $content ) ) {
 		return array(
 			array(
 				'attrs'     => array(),

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -59,10 +59,10 @@ function gutenberg_parse_blocks( $content ) {
 	 */
 	if ( false === strpos( $content, '<!-- wp:' ) ) {
 		return array(
-				array(
-					'attrs' => array(),
-					'innerHTML' => $content,
-				),
+			array(
+				'attrs'     => array(),
+				'innerHTML' => $content,
+			),
 		);
 	}
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -57,7 +57,7 @@ function gutenberg_parse_blocks( $content ) {
 	 * If there are no blocks in the content, return a single block, rather
 	 * than wasting time trying to parse the string.
 	 */
-	if ( false === strpos( $content, '<!-- wp:' ) ) {
+	if ( ! preg_match( '/<!--\s*(wp:|more|noteaser)/', $content ) ) {
 		return array(
 			array(
 				'attrs'     => array(),

--- a/phpunit/class-parsing-test.php
+++ b/phpunit/class-parsing-test.php
@@ -58,7 +58,8 @@ class Parsing_Test extends WP_UnitTestCase {
 		$html            = self::strip_r( file_get_contents( $html_path ) );
 		$expected_parsed = json_decode( self::strip_r( file_get_contents( $parsed_json_path ) ), true );
 
-		$result = gutenberg_parse_blocks( $html );
+		$parser = new Gutenberg_PEG_Parser;
+		$result = $parser->parse( _gutenberg_utf8_split( $html ) );
 
 		$this->assertEquals(
 			$expected_parsed,


### PR DESCRIPTION
## Description

As reported in #3799, parsing long strings that don't contain blocks cause significantly increased memory usage.

As ~100% of posts published prior to the release of WordPresss 5.0 fit this description, it's worth adding a special case to bail early, before even trying to parse the unparseable.

## How Has This Been Tested?

Creating a post in the classic editor with [this sample data](https://github.com/WordPress/gutenberg/files/1527889/post.html.txt), viewing the post, and observing memory usage under different conditions:

With Gutenberg disabled: 4.5MB, ~0.1s
With Gutenberg `master` enabled: 46.1MB, ~0.3s
With this PR enabled: 4.6MB, ~0.1s

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.