### PR TITLE
Build: Add node and npm version check before build gets started

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,6 +1728,64 @@
         }
       }
     },
+    "check-node-version": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.1.1.tgz",
+      "integrity": "sha512-52fHDe/0pbidY3InI33Beyb/oarySfLANlXxLGBl9lLVrLIW88XWIwu4jGJrQ1imuWzX5ukNGWXUyCgmgVUD8A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "map-values": "1.0.1",
+        "minimist": "1.2.0",
+        "object-filter": "1.0.2",
+        "object.assign": "4.0.4",
+        "run-parallel": "1.1.6",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "cheerio": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
@@ -7366,6 +7424,12 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "map-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
+      "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA=",
+      "dev": true
+    },
     "material-colors": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.5.tgz",
@@ -7871,6 +7935,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-filter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+      "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
+      "dev": true
     },
     "object-is": {
       "version": "1.0.1",
@@ -9554,6 +9624,12 @@
       "requires": {
         "is-promise": "2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+      "dev": true
     },
     "rx": {
       "version": "2.3.24",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "WordPress",
     "editor"
   ],
+  "engines": {
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
+  },
   "dependencies": {
     "@wordpress/a11y": "0.1.0-beta.1",
     "@wordpress/hooks": "1.0.1",
@@ -60,6 +64,7 @@
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.6.0",
     "babel-traverse": "6.26.0",
+    "check-node-version": "3.1.1",
     "codecov": "2.3.0",
     "concurrently": "3.5.0",
     "cross-env": "3.2.4",
@@ -125,9 +130,11 @@
     "verbose": true
   },
   "scripts": {
+    "prebuild": "check-node-version --package",
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
     "gettext-strings": "cross-env BABEL_ENV=gettext webpack",
     "lint": "eslint .",
+    "predev": "check-node-version --package",
     "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "npm run lint && npm run test-unit",
     "ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",


### PR DESCRIPTION
## Description

Originally raised by @aduth in #3757:

> Noting that we technically don't support versions of Node lower than 8:
>
> >You should be running a Node version matching the [current active LTS release](https://github.com/nodejs/Release#release-schedule) or newer for this plugin to work correctly.
>
> https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md#getting-started

## How Has This Been Tested?

Manually:

- Install node using the version lower than 8.0.0.
- Execute `npm run build` and `npm run dev`.
- Make sure you see the error on the console.

Grzegorzs-MacBook-Pro:plugins gziolo$ npm run build

> node: 6.11.2
> Error: Wanted node version >=8.0.0 (>=8.0.0)
> To install node, run `nvm install >=8.0.0` or see https://nodejs.org/

- Install npm using the version lower than 5.0.0.
- Execute `npm run build` and `npm run dev`.
- Make sure you see the error on the console.

> npm: 5.5.1
> Error: Wanted npm version >= 6.0.0 (>=6.0.0)
> To install npm, run `npm install -g npm@>= 6.0.0`

(yes, I updated the version to check against 😛 )

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.