### PR TITLE
Tests: Update cypress and use the newly introduced Cypress.platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,6 +1728,12 @@
         }
       }
     },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
+    },
     "check-node-version": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.1.1.tgz",
@@ -2473,16 +2479,17 @@
       }
     },
     "cypress": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-1.0.2.tgz",
-      "integrity": "sha1-3p6Jx3vhrJxoUIBGbdBpomyBQ5Q=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-1.1.4.tgz",
+      "integrity": "sha1-eC/ex+m++Dw+CBr/o5DdG5zlJWs=",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
         "@cypress/xvfb": "1.0.4",
         "bluebird": "3.5.0",
         "chalk": "2.1.0",
-        "commander": "2.9.0",
+        "check-more-types": "2.24.0",
+        "commander": "2.11.0",
         "common-tags": "1.4.0",
         "debug": "2.6.8",
         "dev-null": "0.1.1",
@@ -2492,6 +2499,7 @@
         "glob": "7.1.2",
         "is-ci": "1.0.10",
         "is-installed-globally": "0.1.0",
+        "lazy-ass": "1.6.0",
         "listr": "0.12.0",
         "lodash": "4.17.4",
         "minimist": "1.2.0",
@@ -2522,15 +2530,6 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
           }
         },
         "has-flag": {
@@ -4886,9 +4885,9 @@
       }
     },
     "global-dirs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
-      "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
         "ini": "1.3.4"
@@ -4937,12 +4936,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -5444,7 +5437,7 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.0",
+        "global-dirs": "0.1.1",
         "is-path-inside": "1.0.0"
       }
     },
@@ -6982,6 +6975,12 @@
         "is-buffer": "1.1.5"
       }
     },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -7039,7 +7038,7 @@
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
-        "rxjs": "5.5.2",
+        "rxjs": "5.5.5",
         "stream-to-observable": "0.1.0",
         "strip-ansi": "3.0.1"
       },
@@ -9653,12 +9652,20 @@
       }
     },
     "rxjs": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
-      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.4"
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "codecov": "2.3.0",
     "concurrently": "3.5.0",
     "cross-env": "3.2.4",
-    "cypress": "1.0.2",
+    "cypress": "1.1.4",
     "deep-freeze": "0.0.1",
     "enzyme": "3.1.0",
     "enzyme-adapter-react-16": "1.0.2",

--- a/test/e2e/integration/003-multi-block-selection.js
+++ b/test/e2e/integration/003-multi-block-selection.js
@@ -37,9 +37,12 @@ describe( 'Multi-block selection', () => {
 		cy.get( lastBlockContainerSelector ).should( 'not.have.class', multiSelectedCssClass );
 
 		// Multiselect via keyboard
-		// Mac uses meta modifier so we press both here
-		cy.get( 'body' ).type( '{ctrl}a' );
-		cy.get( 'body' ).type( '{meta}a' );
+		const isMacOs = Cypress.platform === 'darwin';
+		if ( isMacOs ) {
+			cy.get( 'body' ).type( '{meta}a' );
+		} else {
+			cy.get( 'body' ).type( '{ctrl}a' );
+		}
 
 		// Verify selection
 		cy.get( firstBlockContainerSelector ).should( 'have.class', multiSelectedCssClass );


### PR DESCRIPTION
Cypress released the `Cypress.platform` variable which allows us to switch keyboard shortcuts if necessary.