### PR TITLE
Framework: Replace flowRight occurences with compose for HOCs

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -8,14 +8,13 @@ import {
 	isEmpty,
 	map,
 	get,
-	flowRight,
 } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { mediaUpload, createMediaFromFile, getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
 import {
 	Placeholder,
@@ -298,7 +297,7 @@ class ImageBlock extends Component {
 	}
 }
 
-export default flowRight( [
+export default compose( [
 	withContext( 'editor' )( ( settings ) => {
 		return { settings };
 	} ),

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { escapeRegExp, find, filter, map, flowRight } from 'lodash';
+import { escapeRegExp, find, filter, map } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Component, renderToString } from '@wordpress/element';
+import { Component, compose, renderToString } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
@@ -497,7 +497,7 @@ export class Autocomplete extends Component {
 	}
 }
 
-export default flowRight( [
+export default compose( [
 	withSpokenMessages,
 	withInstanceId,
 	withFocusOutside, // this MUST be the innermost HOC as it calls handleFocusOutside

--- a/editor/components/block-drop-zone/index.js
+++ b/editor/components/block-drop-zone/index.js
@@ -2,13 +2,14 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import { reduce, get, find, flow } from 'lodash';
+import { reduce, get, find } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { DropZone, withContext } from '@wordpress/components';
 import { getBlockTypes } from '@wordpress/blocks';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -49,7 +50,7 @@ function BlockDropZone( { index, isLocked, ...props } ) {
 	);
 }
 
-export default flow(
+export default compose(
 	connect(
 		undefined,
 		{ insertBlocks }

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { first, last, flow } from 'lodash';
+import { first, last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,6 +10,7 @@ import { first, last, flow } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { IconButton, withContext } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -64,7 +65,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 	);
 }
 
-export default flow(
+export default compose(
 	connect(
 		( state, ownProps ) => {
 			const block = getBlock( state, first( ownProps.uids ) );

--- a/editor/components/block-settings-menu/block-delete-button.js
+++ b/editor/components/block-settings-menu/block-delete-button.js
@@ -9,6 +9,7 @@ import { flow, noop } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton, withContext } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,7 +35,7 @@ export function BlockDeleteButton( { onDelete, onClick = noop, isLocked, small =
 	);
 }
 
-export default flow(
+export default compose(
 	connect(
 		undefined,
 		( dispatch, ownProps ) => ( {

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { every, uniq, get, reduce, find, flow } from 'lodash';
+import { every, uniq, get, reduce, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,6 +10,7 @@ import { every, uniq, get, reduce, find, flow } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Dropdown, Dashicon, IconButton, Toolbar, NavigableMenu, withContext } from '@wordpress/components';
 import { getBlockType, getBlockTypes, switchToBlockType, BlockIcon } from '@wordpress/blocks';
+import { compose } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -126,7 +127,7 @@ function BlockSwitcher( { blocks, onTransform, isLocked } ) {
 	);
 }
 
-export default flow(
+export default compose(
 	connect(
 		( state, ownProps ) => {
 			return {

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`DefaultBlockAppender no block present should match snapshot 1`] = `
 <div
   className="editor-default-block-appender"
 >
-  <WrappedComponent />
+  <Connect(WrappedComponent) />
   <input
     className="editor-default-block-appender__content"
     onClick={[Function]}

--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { first, last, flow } from 'lodash';
+import { first, last } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { KeyboardShortcuts, withContext } from '@wordpress/components';
 
 /**
@@ -65,7 +65,7 @@ class EditorGlobalKeyboardShortcuts extends Component {
 	}
 }
 
-export default flow(
+export default compose(
 	connect(
 		( state ) => {
 			return {

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { flowRight, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,7 +11,7 @@ import { flowRight, isEmpty } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton, withContext } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -106,7 +106,7 @@ class Inserter extends Component {
 	}
 }
 
-export default flowRight( [
+export default compose( [
 	connect(
 		( state ) => {
 			return {

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import {
 	TabPanel,
 	TabbableContainer,
@@ -365,9 +365,9 @@ const connectComponent = connect(
 	{ showInsertionPoint, hideInsertionPoint, fetchReusableBlocks }
 );
 
-export default flow(
-	withInstanceId,
-	withSpokenMessages,
+export default compose(
+	connectComponent,
 	withContext( 'editor' )( ( settings ) => pick( settings, 'blockTypes' ) ),
-	connectComponent
+	withSpokenMessages,
+	withInstanceId
 )( InserterMenu );

--- a/editor/components/page-attributes/check.js
+++ b/editor/components/page-attributes/check.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get, flowRight } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -44,7 +45,7 @@ const applyWithAPIData = withAPIData( ( props ) => {
 	};
 } );
 
-export default flowRight( [
+export default compose( [
 	applyConnect,
 	applyWithAPIData,
 ] )( PageAttributesCheck );

--- a/editor/components/page-attributes/index.js
+++ b/editor/components/page-attributes/index.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { withInstanceId } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -58,7 +58,7 @@ const applyConnect = connect(
 	}
 );
 
-export default flowRight( [
+export default compose( [
 	applyConnect,
 	withInstanceId,
 ] )( PageAttributes );

--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { flowRight, filter } from 'lodash';
+import { filter } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withAPIData, withInstanceId } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 export function PostAuthorCheck( { user, users, children } ) {
 	const authors = filter( users.data, ( { capabilities } ) => capabilities.level_1 );
@@ -24,7 +25,7 @@ const applyWithAPIData = withAPIData( () => {
 	};
 } );
 
-export default flowRight( [
+export default compose( [
 	applyWithAPIData,
 	withInstanceId,
 ] )( PostAuthorCheck );

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { filter, flowRight } from 'lodash';
+import { filter } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { withAPIData, withInstanceId } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -89,7 +89,7 @@ const applyWithAPIData = withAPIData( () => {
 	};
 } );
 
-export default flowRight( [
+export default compose( [
 	applyConnect,
 	applyWithAPIData,
 	withInstanceId,

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,6 +10,7 @@ import { flowRight, get } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { Button, Spinner, ResponsiveWrapper, withAPIData } from '@wordpress/components';
 import { MediaUploadButton } from '@wordpress/blocks';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -92,7 +93,7 @@ const applyWithAPIData = withAPIData( ( { featuredImageId, postTypeName } ) => {
 	};
 } );
 
-export default flowRight(
+export default compose(
 	applyConnect,
 	applyWithAPIData,
 )( PostFeaturedImage );

--- a/editor/components/post-format/check.js
+++ b/editor/components/post-format/check.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get, flowRight } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ function PostFormatCheck( { postType, children } ) {
 	return children;
 }
 
-export default flowRight( [
+export default compose( [
 	connect(
 		( state ) => {
 			return {

--- a/editor/components/post-format/index.js
+++ b/editor/components/post-format/index.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { find, flowRight } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { withInstanceId } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -68,7 +69,7 @@ function PostFormat( { onUpdatePostFormat, postFormat = 'standard', suggestedFor
 	/* eslint-enable jsx-a11y/no-onchange */
 }
 
-export default flowRight( [
+export default compose( [
 	connect(
 		( state ) => {
 			return {

--- a/editor/components/post-pending-status/check.js
+++ b/editor/components/post-pending-status/check.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ const applyWithAPIData = withAPIData( () => {
 	};
 } );
 
-export default flowRight(
+export default compose(
 	applyConnect,
 	applyWithAPIData
 )( PostPendingStatusCheck );

--- a/editor/components/post-pending-status/index.js
+++ b/editor/components/post-pending-status/index.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FormToggle, withInstanceId } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -48,7 +48,7 @@ const applyConnect = connect(
 	}
 );
 
-export default flowRight(
+export default compose(
 	applyConnect,
 	withInstanceId
 )( PostPendingStatus );

--- a/editor/components/post-publish-button/index.js
+++ b/editor/components/post-publish-button/index.js
@@ -3,12 +3,13 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { flowRight, noop } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { Button, withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -92,7 +93,7 @@ const applyWithAPIData = withAPIData( () => {
 	};
 } );
 
-export default flowRight( [
+export default compose( [
 	applyConnect,
 	applyWithAPIData,
 ] )( PostPublishButton );

--- a/editor/components/post-publish-button/label.js
+++ b/editor/components/post-publish-button/label.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -62,7 +62,7 @@ const applyWithAPIData = withAPIData( () => {
 	};
 } );
 
-export default flowRight( [
+export default compose( [
 	applyConnect,
 	applyWithAPIData,
 ] )( PublishButtonLabel );

--- a/editor/components/post-sticky/check.js
+++ b/editor/components/post-sticky/check.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,7 +41,7 @@ const applyWithAPIData = withAPIData( () => {
 	};
 } );
 
-export default flowRight( [
+export default compose( [
 	applyConnect,
 	applyWithAPIData,
 ] )( PostStickyCheck );

--- a/editor/components/post-sticky/index.js
+++ b/editor/components/post-sticky/index.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FormToggle, withInstanceId } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -49,7 +49,7 @@ const applyConnect = connect(
 	},
 );
 
-export default flowRight( [
+export default compose( [
 	applyConnect,
 	withInstanceId,
 ] )( PostSticky );

--- a/editor/components/post-taxonomies/index.js
+++ b/editor/components/post-taxonomies/index.js
@@ -2,12 +2,13 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight, filter } from 'lodash';
+import { filter } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -49,7 +50,7 @@ const applyWithAPIData = withAPIData( () => ( {
 	taxonomies: '/wp/v2/taxonomies?context=edit',
 } ) );
 
-export default flowRight( [
+export default compose( [
 	applyConnect,
 	applyWithAPIData,
 ] )( PostTaxonomies );

--- a/editor/components/post-visibility/index.js
+++ b/editor/components/post-visibility/index.js
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flowRight } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/components';
 
 /**
@@ -147,7 +146,7 @@ const applyConnect = connect(
 	}
 );
 
-export default flowRight(
+export default compose(
 	applyConnect,
 	withInstanceId
 )( PostVisibility );

--- a/editor/edit-post/modes/visual-editor/inserter.js
+++ b/editor/edit-post/modes/visual-editor/inserter.js
@@ -3,14 +3,13 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { flow } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { IconButton, withContext } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { createBlock, BlockIcon } from '@wordpress/blocks';
 
 /**
@@ -82,7 +81,7 @@ export class VisualEditorInserter extends Component {
 	}
 }
 
-export default flow(
+export default compose(
 	connect(
 		( state ) => {
 			return {


### PR DESCRIPTION
## Description

In #3493 new utility method `compose` was introduced to be used with Higher-Order Components. This PR refactors all occurrences of `flowRight` around HOCs to be replaced with `compose`.

## How Has This Been Tested?

Manually. All tests should still pass, linter should be happy and editor should work without errors.

## Types of changes

Refactoring only. No changes in the existing functionalities.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.