### PR TITLE
RTL: fix image resizing handles in RTL mode

### DIFF
--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -32,6 +32,7 @@
 	}
 }
 
+/*!rtl:begin:ignore*/
 .wp-block-image__resize-handler-top-right {
 	top: -6px !important;
 	right: -6px !important;
@@ -51,6 +52,7 @@
 	bottom: -6px !important;
 	left: -6px !important;
 }
+/*!rtl:end:ignore*/
 
 .editor-block-list__block[data-type="core/image"] {
 	.blocks-format-toolbar__link-modal {


### PR DESCRIPTION
## Description
Prevent the handle positions in the CSS from being flipped in RTL mode.
This is necessary after #3844 since the position of the handles is handled in JS.

## Screenshots (jpeg or gifs if applicable):
**Before:**
<img width="635" alt="screen shot 2017-12-11 at 16 06 59" src="https://user-images.githubusercontent.com/844866/33835626-bc39346a-de8f-11e7-90e9-be27addb91a5.png">

**After:**
<img width="678" alt="screen shot 2017-12-11 at 16 18 15" src="https://user-images.githubusercontent.com/844866/33835621-b9c19a7e-de8f-11e7-81e6-9a5a2d47aaaa.png">

## Types of changes
CSS change to prevent automatic flipping of CSS properties.
The `!` before the rtlcss directive is necessary ~since the positions are set in the css with `!important`.~ Actually, because of scss.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.