### PR TITLE
RTL: Fix left/right alignments of blocks

### DIFF
--- a/core-blocks/button/editor.scss
+++ b/core-blocks/button/editor.scss
@@ -4,6 +4,7 @@
 	}
 
 	&[data-align="right"] {
+		/*!rtl:ignore*/
 		text-align: right;
 	}
 }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -366,7 +366,7 @@
 			}
 		}
 
-		// The padding collapses, but the outline is still 1px to compensate for. 
+		// The padding collapses, but the outline is still 1px to compensate for.
 		.editor-block-contextual-toolbar {
 			margin-bottom: 1px;
 		}
@@ -473,7 +473,7 @@
 		> .editor-block-list__breadcrumb {
 			right: -$border-width;
 		}
-		
+
 		// Compensate for main container padding and subtract border.
 		@include break-small() {
 			margin-left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance - $border-width;
@@ -868,11 +868,14 @@
 
 	// This prevents floats from messing up the position.
 	position: absolute;
+	/*!rtl:ignore*/
 	left: 0;
 
 	.editor-block-list__block[data-align="right"] & {
+		/*!rtl:begin:ignore*/
 		left: auto;
 		right: 0;
+		/*!rtl:end:ignore*/
 	}
 
 	@include break-small() {

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -375,19 +375,24 @@
 	// Left
 	&[data-align="left"] {
 		.editor-block-list__block-edit {	// This is in the editor only, on the frontend, the img should be floated
+			/*!rtl:begin:ignore*/
 			float: left;
 			margin-right: 2em;
+			/*!rtl:end:ignore*/
 		}
 	}
 
 	// Right
 	&[data-align="right"] {
 		.editor-block-list__block-edit {	// This is in the editor only, on the frontend, the img should be floated
+			/*!rtl:begin:ignore*/
 			float: right;
 			margin-left: 2em;
+			/*!rtl:end:ignore*/
 		}
 
 		.editor-block-toolbar {
+			/*!rtl:ignore*/
 			float: right;
 		}
 	}
@@ -606,7 +611,7 @@
 	.editor-block-list__block-mobile-toolbar {
 		display: flex;
 		flex-direction: row;
-		margin-top: $item-spacing + $block-toolbar-height; // Make room for the height of the block toolbar above. 
+		margin-top: $item-spacing + $block-toolbar-height; // Make room for the height of the block toolbar above.
 		margin-right: -$block-padding;
 		margin-bottom: -$block-padding - $border-width;
 		margin-left: -$block-padding;
@@ -906,7 +911,7 @@
 		padding: 4px 4px;
 		background: theme( outlines );
 		color: $white;
-	
+
 		// Animate in
 		.editor-block-list__block:hover & {
 			@include fade_in( .1s );

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -868,7 +868,6 @@
 
 	// This prevents floats from messing up the position.
 	position: absolute;
-	/*!rtl:ignore*/
 	left: 0;
 
 	.editor-block-list__block[data-align="right"] & {
@@ -877,6 +876,14 @@
 		right: 0;
 		/*!rtl:end:ignore*/
 	}
+
+	.editor-block-list__block[data-align="left"] & {
+		/*!rtl:begin:ignore*/
+		right: auto;
+		left: 0;
+		/*!rtl:end:ignore*/
+	}
+
 
 	@include break-small() {
 		width: auto;


### PR DESCRIPTION
## Description
Prevent RTLCSS from reversing specific CSS rules related to left/right alignment of blocks
Similar to #3909, necessry after #3844 

Without this change, left aligning a block puts on the right and vice versa.

## Types of changes
CSS comments to prevent automatic flipping of CSS properties.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.