### PR TITLE
RTL: Flip some dashicons that have directionality

### DIFF
--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -6,6 +6,11 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 !!! */
 
 /**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
  * External dependencies
  */
 export default class Dashicon extends wp.element.Component {

--- a/components/dashicon/style.scss
+++ b/components/dashicon/style.scss
@@ -1,0 +1,10 @@
+body.rtl .gutenberg .dashicon {
+  &.dashicons-editor-outdent,
+  &.dashicons-editor-indent,
+  &.dashicons-list-view,
+  &.dashicons-editor-ul {
+	transform: scaleX(-1);
+	-ms-filter: fliph;
+	filter: FlipH;
+  }
+}

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -133,14 +133,3 @@
 .components-panel .circle-picker {
 	padding-bottom: 20px;
 }
-
-body.rtl .gutenberg .dashicon {
-	&.dashicons-editor-outdent,
-	&.dashicons-editor-indent,
-	&.dashicons-list-view,
-	&.dashicons-editor-ul {
-		transform: scaleX(-1);
-		-ms-filter: fliph;
-		filter: FlipH;
-	}
-}

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -133,3 +133,14 @@
 .components-panel .circle-picker {
 	padding-bottom: 20px;
 }
+
+body.rtl .gutenberg .dashicon {
+	&.dashicons-editor-outdent,
+	&.dashicons-editor-indent,
+	&.dashicons-list-view,
+	&.dashicons-editor-ul {
+		transform: scaleX(-1);
+		-ms-filter: fliph;
+		filter: FlipH;
+	}
+}


### PR DESCRIPTION
## Description
- `editor-outdent`, `editor-indent`, `list-view`, and `editor-ul` can and should be flipped in RTL.
- `editor-ol` (not taken care of yet) needs an RTL version: https://github.com/WordPress/dashicons/issues/250

## How Has This Been Tested?
Manual testing in LTR and RTL mode

## Screenshots (jpeg or gifs if applicable):
**Before:**
<img width="337" alt="before-list" src="https://user-images.githubusercontent.com/844866/33838328-ee90d1c2-de97-11e7-8d82-e9a84d4a3371.png">
<img width="107" alt="before-blocks" src="https://user-images.githubusercontent.com/844866/33838329-eeb987d4-de97-11e7-9437-a90d8f154835.png">

**After**
<img width="666" alt="after-list" src="https://user-images.githubusercontent.com/844866/33838336-f52ade10-de97-11e7-9d82-9448dc707c13.png">
<img width="110" alt="after-blocks" src="https://user-images.githubusercontent.com/844866/33838337-f54c94d8-de97-11e7-9256-8d5d9209a511.png">

## Types of changes
CSS that will affect the RTL version, and will flip the icons.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.