### PR TITLE
Post visibility: remove duplicated button-link styles

### DIFF
--- a/editor/edit-post/sidebar/post-visibility/style.scss
+++ b/editor/edit-post/sidebar/post-visibility/style.scss
@@ -2,19 +2,6 @@
 	width: 100%;
 }
 
-.editor-post-visibility__toggle.button-link {
-	text-decoration: underline;
-	color: $blue-wordpress;
-
-	&:focus {
-		outline: none;
-	}
-
-	&:hover {
-		color: $blue-medium-500;
-	}
-}
-
 .editor-post-visibility__dialog .components-popover__content {
 	padding: 10px;
 


### PR DESCRIPTION
## Description
Removes duplicated `.button-link` styles. They are already defined in the global `.button-link` style.

Same like in #3890