### PR TITLE
Post saved state: remove duplicated button-link styles

### DIFF
--- a/editor/components/post-saved-state/style.scss
+++ b/editor/components/post-saved-state/style.scss
@@ -10,17 +10,7 @@
 	}
 
 	.wp-core-ui &.button-link {
-		text-decoration: underline;
-		color: $blue-wordpress;
-		margin-right: $item-spacing;	// needs specificity to override core CSS bleed
-
-		&:focus {
-			outline: none;
-		}
-
-		&:hover {
-			color: $blue-medium-500;
-		}
+		margin-right: $item-spacing;
 	}
 }
 


### PR DESCRIPTION
## Description
Removes duplicated `.button-link` styles. They are already defined in the global .button-link style.

Same like in #3890 and #3914