### PR TITLE
Remove commas from page attributes

### DIFF
--- a/editor/components/page-attributes/index.js
+++ b/editor/components/page-attributes/index.js
@@ -31,14 +31,14 @@ export function PageAttributes( { onUpdateOrder, instanceId, order } ) {
 		<PageAttributesCheck>
 			<label htmlFor={ inputId }>
 				{ __( 'Order' ) }
-			</label>,
+			</label>
 			<input
 				type="text"
 				value={ order || 0 }
 				onChange={ setUpdatedOrder }
 				id={ inputId }
 				size={ 6 }
-			/>,
+			/>
 		</PageAttributesCheck>
 	);
 }


### PR DESCRIPTION
## Description
Removes unnecessary commas in page attributes. 
Fixes #3918