### PR TITLE
fix-commas-in-page-atts-panel

### DIFF
--- a/editor/components/page-attributes/index.js
+++ b/editor/components/page-attributes/index.js
@@ -31,14 +31,14 @@ export function PageAttributes( { onUpdateOrder, instanceId, order } ) {
 		<PageAttributesCheck>
 			<label htmlFor={ inputId }>
 				{ __( 'Order' ) }
-			</label>,
+			</label>
 			<input
 				type="text"
 				value={ order || 0 }
 				onChange={ setUpdatedOrder }
 				id={ inputId }
 				size={ 6 }
-			/>,
+			/>
 		</PageAttributesCheck>
 	);
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes https://github.com/WordPress/gutenberg/issues/3921

Removing the extra commas.


