### PR TITLE
Fix z-index rebase

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -140,6 +140,9 @@ const config = {
 		// Create RTL files with a -rtl suffix
 		new WebpackRTLPlugin( {
 			suffix: '-rtl',
+			minify: {
+				safe: true,
+			},
 		} ),
 		new webpack.LoaderOptionsPlugin( {
 			minimize: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
z-index values rebased in build styles in Gutenberg 1.9.0

The issue seems to be a regression from version 1.8.1 caused by introduction of webpack-rtl-plugin. This plugin is using cssnano which has a default option set to rebase z-index values http://cssnano.co/optimisations/zindex/
This regression can be seen when comparing build styles from last 2 versions
https://plugins.trac.wordpress.org/browser/gutenberg/tags/1.9.0/components/build/style.css
https://plugins.trac.wordpress.org/browser/gutenberg/tags/1.8.1/components/build/style.css
Search for .components-popover{position:fixed;z-index to see the difference.
In 1.8.1 z-index is 1000000 and in 1.9.0 it is rebased to 6.

webpack-rtl-plugin accepts configuration for minifying which are passed to cssnano as options. I'm setting the safe:true which will disable z-index rebase.

The effects of z-index rebase can be seen here:
![screen shot 2017-12-09 at 18 14 38](https://user-images.githubusercontent.com/1592693/33862741-87cae39a-dee4-11e7-9356-473d49ecc258.png)
![screen shot 2017-12-09 at 18 22 44](https://user-images.githubusercontent.com/1592693/33862743-89a51938-dee4-11e7-904d-e90c7c2cf80a.png)

Also reported here https://github.com/WordPress/gutenberg/issues/3897




