### PR TITLE
Meta Boxes: Fix Dirty Detection in Safari

### DIFF
--- a/editor/components/meta-boxes/meta-boxes-area/index.js
+++ b/editor/components/meta-boxes/meta-boxes-area/index.js
@@ -4,6 +4,7 @@
 import { isEqual } from 'lodash';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
+import jQuery from 'jquery';
 
 /**
  * WordPress dependencies
@@ -26,7 +27,7 @@ class MetaBoxesArea extends Component {
 		this.state = {
 			loading: false,
 		};
-		this.originalFormData = [];
+		this.originalFormData = '';
 		this.bindNode = this.bindNode.bind( this );
 		this.checkState = this.checkState.bind( this );
 	}
@@ -89,9 +90,7 @@ class MetaBoxesArea extends Component {
 	}
 
 	getFormData() {
-		const data = new window.FormData( this.form );
-		const entries = Array.from( data.entries() );
-		return entries;
+		return jQuery( this.form ).serialize();
 	}
 
 	checkState() {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -614,7 +614,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	wp_enqueue_script(
 		'wp-editor',
 		gutenberg_url( 'editor/build/index.js' ),
-		array( 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
+		array( 'jquery', 'wp-api', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
 		filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
 		true // enqueue in the footer.
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4894,7 +4894,7 @@
     "function.prototype.name": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
-      "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
+      "integrity": "sha1-AJmuVXLp3W8DyX0CP9krzF5jnqw=",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
@@ -6946,6 +6946,11 @@
           }
         }
       }
+    },
+    "jquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
     },
     "js-base64": {
       "version": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "escape-string-regexp": "1.0.5",
     "hpq": "1.2.0",
     "jed": "1.1.1",
+    "jquery": "3.2.1",
     "js-beautify": "1.6.14",
     "lodash": "4.17.4",
     "memize": "1.0.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,7 @@ const externals = {
 	'react-dom/server': 'ReactDOMServer',
 	tinymce: 'tinymce',
 	moment: 'moment',
+	jquery: 'jQuery',
 };
 
 [ ...entryPointNames, ...packageNames ].forEach( name => {


### PR DESCRIPTION
closes #3929

Dirty Detection of Meta Boxes forms was broken in Safari because it was relying on FormData `entries`API which is not available in all browsers yet. This PR uses `jQuery.serialize` as a cross-browser alternative.

**Testing instructions**

 - Install Gutenberg and Seo Press
 - Open Gutenberg
 - It should not break