### PR TITLE
Add FAQ regarding meta box breakage

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,7 +65,7 @@ We plan to continue supporting existing meta boxes while providing new ways to e
 
 ## What are some reasons why an existing PHP meta box might not work in Gutenberg?
 
-Most PHP meta boxes should continue to work in Gutenberg, however some meta boxes that include advanced functionality could break. The following list describes some of the most common reasons why meta boxes might not work as expected in Gutenberg.
+Most PHP meta boxes should continue to work in Gutenberg, however some meta boxes that include advanced functionality could break. The following list describes some of the most common reasons why meta boxes might not work as expected in Gutenberg:
 
 - Plugins relying on selectors that target the post title, post content fields, and other metaboxes (of the old editor).
 - Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in Gutenberg.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,11 +57,19 @@ The API for creating blocks is a crucial aspect of the project. We are working o
 
 No, we are designing Gutenberg primarily as a replacement for the post and page editing screens. That said, front-end editing is often confused with an editor that looks exactly like the front end. And that is something that Gutenberg will allow as themes customize individual blocks and provide those styles to the editor. Since content is designed to be distributed across so many different experiences—from desktop and mobile to full-text feeds and syndicated article platforms—we believe it's not ideal to create or design posts from just one front-end experience.
 
-## Given Gutenberg is built in JavaScript, how will old metaboxes (PHP) work?
+## Given Gutenberg is built in JavaScript, how will old meta boxes (PHP) work?
 
-We plan to continue supporting existing metaboxes while providing new ways to extend the interface.
+We plan to continue supporting existing meta boxes while providing new ways to extend the interface.
 
 *See:* [Pull request #2804](https://github.com/WordPress/gutenberg/pull/2804)
+
+## What are some reasons why an existing PHP meta box might not work in Gutenberg?
+
+Most PHP meta boxes should continue to work in Gutenberg, however some meta boxes that include advanced functionality could break. The following list describes some of the most common reasons why meta boxes might not work as expected in Gutenberg.
+
+- Plugins relying on selectors that target the post title, post content fields, and other metaboxes (of the old editor).
+- Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in Gutenberg.
+- Plugins making updates to their DOM on "submit" or on "save".
 
 ## How can plugins extend the Gutenberg UI?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,14 +63,6 @@ We plan to continue supporting existing meta boxes while providing new ways to e
 
 *See:* [Pull request #2804](https://github.com/WordPress/gutenberg/pull/2804)
 
-## What are some reasons why an existing PHP meta box might not work in Gutenberg?
-
-Most PHP meta boxes should continue to work in Gutenberg, however some meta boxes that include advanced functionality could break. The following list describes some of the most common reasons why meta boxes might not work as expected in Gutenberg:
-
-- Plugins relying on selectors that target the post title, post content fields, and other metaboxes (of the old editor).
-- Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in Gutenberg.
-- Plugins making updates to their DOM on "submit" or on "save".
-
 ## How can plugins extend the Gutenberg UI?
 
 The main extension point we want to emphasize is creating new blocks. We are still working on how to extend the rest of the UI that is built in JS. We are tracking it here: [Issue #1352](https://github.com/WordPress/gutenberg/issues/1352)

--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -76,3 +76,12 @@ So an example url would look like:
 This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
 
 Thus page page mimics the `post.php` post form, so when it is submitted it will normally fire all of the necessary hooks and actions, and have the proper global state to correctly fire any PHP meta box mumbo jumbo without needing to modify any existing code. On successful submission, React will signal a `handleMetaBoxReload` to set up the new form state for dirty checking, remove the updating overlay, and set the store to no longer be updating the meta box area.
+
+
+### Common Compatibility Issues
+
+Most PHP meta boxes should continue to work in Gutenberg, however some meta boxes that include advanced functionality could break. The following list describes some of the most common reasons why meta boxes might not work as expected in Gutenberg:
+
+- Plugins relying on selectors that target the post title, post content fields, and other metaboxes (of the old editor).
+- Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in Gutenberg.
+- Plugins making updates to their DOM on "submit" or on "save".


### PR DESCRIPTION
## Description

This answer is paraphrased from a comment that Riad left in the Advanced WordPress Facebook Group. I also changed "metabox" to "meta box" throughout the FAQ for consistency with other official docs.

## Types of changes

Documentation