### PR TITLE
Components: Switch the orientation of the Popover Component only if there's more space

### DIFF
--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -208,20 +208,27 @@ class Popover extends Component {
 	}
 
 	setForcedPositions() {
+		const anchor = this.getAnchorRect();
 		const rect = this.nodes.content.getBoundingClientRect();
 
-		// Check exceeding top or bottom of viewport
-		if ( rect.top < 0 ) {
-			this.setState( { forcedYAxis: 'bottom' } );
-		} else if ( rect.bottom > window.innerHeight ) {
-			this.setState( { forcedYAxis: 'top' } );
+		// Check exceeding top or bottom of viewport and switch direction if the space is begger
+		if ( rect.top < 0 || rect.bottom > window.innerHeight ) {
+			const overflowBottom = window.innerHeight - ( anchor.bottom + rect.height );
+			const overflowTop = anchor.top - rect.height;
+			const direction = overflowTop < overflowBottom ? 'bottom' : 'top';
+			if ( direction !== this.state.forcedYAxis ) {
+				this.setState( { forcedYAxis: direction } );
+			}
 		}
 
-		// Check exceeding left or right of viewport
-		if ( rect.left < 0 ) {
-			this.setState( { forcedXAxis: 'right' } );
-		} else if ( rect.right > window.innerWidth ) {
-			this.setState( { forcedXAxis: 'left' } );
+		// Check exceeding left or right of viewport and switch direction if the space is begger
+		if ( rect.left < 0 || rect.right > window.innerWidth ) {
+			const overflowLeft = anchor.left - rect.width;
+			const overflowRight = window.innerWidth - ( anchor.right + rect.width );
+			const direction = overflowLeft < overflowRight ? 'right' : 'left';
+			if ( direction !== this.state.forcedXAxis ) {
+				this.setState( { forcedXAxis: direction } );
+			}
 		}
 	}
 

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -110,7 +110,7 @@ describe( 'Popover', () => {
 	} );
 
 	describe( '#setForcedPositions()', () => {
-		function getInstanceWithContentBounds( nodeBounds ) {
+		function getInstanceWithContentBounds( contentNodeBounds, anchorNodeBounds = {} ) {
 			const instance = new Popover( {} );
 
 			instance.nodes.content = {
@@ -120,10 +120,18 @@ describe( 'Popover', () => {
 						right: 0,
 						bottom: 0,
 						left: 0,
-						...nodeBounds,
+						...contentNodeBounds,
 					};
 				},
 			};
+
+			instance.getAnchorRect = () => ( {
+				top: 0,
+				right: 0,
+				bottom: 0,
+				left: 0,
+				...anchorNodeBounds,
+			} );
 
 			instance.setState = jest.fn();
 
@@ -138,7 +146,10 @@ describe( 'Popover', () => {
 		} );
 
 		it( 'should flip y axis to bottom if exceeding top', () => {
-			const instance = getInstanceWithContentBounds( { top: -1 } );
+			const instance = getInstanceWithContentBounds(
+				{ top: -1, bottom: 9, height: 20 },
+				{ top: 5, bottom: 10, height: 5 }
+			);
 			instance.setForcedPositions();
 
 			expect( instance.setState ).toHaveBeenCalledTimes( 1 );
@@ -148,7 +159,10 @@ describe( 'Popover', () => {
 		} );
 
 		it( 'should flip y axis to top if exceeding bottom', () => {
-			const instance = getInstanceWithContentBounds( { bottom: window.innerHeight + 1 } );
+			const instance = getInstanceWithContentBounds(
+				{ bottom: window.innerHeight + 1, height: 20 },
+				{ top: 30, bottom: window.innerHeight - 10, height: window.innerHeight - 20 }
+			);
 			instance.setForcedPositions();
 
 			expect( instance.setState ).toHaveBeenCalledTimes( 1 );
@@ -158,7 +172,10 @@ describe( 'Popover', () => {
 		} );
 
 		it( 'should flip x axis to right if exceeding left', () => {
-			const instance = getInstanceWithContentBounds( { left: -1 } );
+			const instance = getInstanceWithContentBounds(
+				{ left: -1, right: 9, width: 20 },
+				{ left: 5, right: 10, width: 5 }
+			);
 			instance.setForcedPositions();
 
 			expect( instance.setState ).toHaveBeenCalledTimes( 1 );
@@ -168,7 +185,10 @@ describe( 'Popover', () => {
 		} );
 
 		it( 'should flip x axis to left if exceeding right', () => {
-			const instance = getInstanceWithContentBounds( { right: window.innerWidth + 1 } );
+			const instance = getInstanceWithContentBounds(
+				{ right: window.innerWidth + 1, width: 20 },
+				{ left: 30, right: window.innerWidth - 10, width: window.innerWidth - 20 }
+			);
 			instance.setForcedPositions();
 
 			expect( instance.setState ).toHaveBeenCalledTimes( 1 );
@@ -178,7 +198,10 @@ describe( 'Popover', () => {
 		} );
 
 		it( 'should flip x and y axis', () => {
-			const instance = getInstanceWithContentBounds( { top: -1, left: -1 } );
+			const instance = getInstanceWithContentBounds(
+				{ top: -1, bottom: 9, height: 20, left: -1, right: 9, width: 20 },
+				{ top: 5, bottom: 10, height: 5, left: 5, right: 10, width: 5 },
+			);
 			instance.setForcedPositions();
 
 			expect( instance.setState ).toHaveBeenCalledTimes( 2 );


### PR DESCRIPTION
Sometimes on small screens popovers keep switching their orientation because there's not enough space in both directions, this PR tackes this issue by switching the direction only if there's more space than the current direction.

As a follow-up we may try to limit the height/width of the popover if the available space is not big enough.

(Pretty sure there's an issue about this bug, but can't find it)

**Testing instructions**

 - On a small screen
 - Open/close popovers several times, they should not change their position constantly if there's not enough space on both sides (left/right, top/bottom).

(Some popovers to try: post visibility, post schedule, inserter).

