### PR TITLE
Fixed paste bugs on headings and lists

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -34,9 +34,10 @@ import shortcodeConverter from './shortcode-converter';
  *                                            * 'AUTO': Decide based on the content passed.
  *                                            * 'INLINE': Always handle as inline content, and return string.
  *                                            * 'BLOCKS': Always handle as blocks, and return array of blocks.
+ * @param  {Array}         [options.tagName]  The tag into which content will be inserted.
  * @return {Array|String}                     A list of blocks or a string, depending on `handlerMode`.
  */
-export default function rawHandler( { HTML, plainText = '', mode = 'AUTO' } ) {
+export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagName } ) {
 	// First of all, strip any meta tags.
 	HTML = HTML.replace( /<meta[^>]+>/, '' );
 
@@ -65,7 +66,7 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO' } ) {
 	const hasShortcodes = pieces.length > 1;
 
 	// True if mode is auto, no shortcode is included and HTML verifies the isInlineContent condition
-	const isAutoModeInline = mode === 'AUTO' && isInlineContent( HTML ) && ! hasShortcodes;
+	const isAutoModeInline = mode === 'AUTO' && isInlineContent( HTML, tagName ) && ! hasShortcodes;
 
 	// Return filtered HTML if condition is true
 	if ( mode === 'INLINE' || isAutoModeInline ) {
@@ -74,7 +75,7 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO' } ) {
 			formattingTransformer,
 			stripAttributes,
 			commentRemover,
-			createUnwrapper( ( node ) => ! isInline( node ) ),
+			createUnwrapper( ( node ) => ! isInline( node, tagName ) ),
 		] );
 
 		// Allows us to ask for this information when we get a report.

--- a/blocks/api/raw-handling/is-inline-content.js
+++ b/blocks/api/raw-handling/is-inline-content.js
@@ -3,19 +3,19 @@
  */
 import { isInline, isDoubleBR } from './utils';
 
-export default function( HTML ) {
+export default function( HTML, tagName ) {
 	const doc = document.implementation.createHTMLDocument( '' );
 
 	doc.body.innerHTML = HTML;
 
 	const nodes = Array.from( doc.body.children );
 
-	return ! nodes.some( isDoubleBR ) && deepCheck( nodes );
+	return ! nodes.some( isDoubleBR ) && deepCheck( nodes, tagName );
 }
 
-function deepCheck( nodes ) {
+function deepCheck( nodes, tagName ) {
 	return nodes.every( ( node ) => {
-		return ( 'SPAN' === node.nodeName || isInline( node ) ) &&
-			deepCheck( Array.from( node.children ) );
+		return ( 'SPAN' === node.nodeName || isInline( node, tagName ) ) &&
+			deepCheck( Array.from( node.children ), tagName );
 	} );
 }

--- a/blocks/api/raw-handling/test/is-inline-content.js
+++ b/blocks/api/raw-handling/test/is-inline-content.js
@@ -12,6 +12,7 @@ describe( 'stripWrappers', () => {
 	it( 'should be inline content', () => {
 		equal( isInlineContent( '<em>test</em>' ), true );
 		equal( isInlineContent( '<span>test</span>' ), true );
+		equal( isInlineContent( '<li>test</li>', 'ul' ), true );
 	} );
 
 	it( 'should not be inline content', () => {
@@ -19,5 +20,8 @@ describe( 'stripWrappers', () => {
 		equal( isInlineContent( '<em>test</em><div>test</div>' ), false );
 		equal( isInlineContent( 'test<br><br>test' ), false );
 		equal( isInlineContent( '<em><div>test</div></em>' ), false );
+		equal( isInlineContent( '<li>test</li>', 'p' ), false );
+		equal( isInlineContent( '<li>test</li>', 'h1' ), false );
+		equal( isInlineContent( '<h1>test</h1>', 'li' ), false );
 	} );
 } );

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -14,6 +14,8 @@ const { ELEMENT_NODE, TEXT_NODE } = window.Node;
  * @type {Array}
  */
 const inlineWhitelistTagGroups = [
+	[ 'ul', 'li', 'ol' ],
+	[ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],
 ];
 
 const inlineWhitelist = {

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -1,7 +1,20 @@
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * Browser dependencies
  */
 const { ELEMENT_NODE, TEXT_NODE } = window.Node;
+
+/**
+ * An array of tag groups used by isInlineForTag function.
+ * If tagName and nodeName are present in the same group, the node should be treated as inline.
+ * @type {Array}
+ */
+const inlineWhitelistTagGroups = [
+];
 
 const inlineWhitelist = {
 	strong: {},
@@ -63,8 +76,26 @@ export function isAttributeWhitelisted( tag, attribute ) {
 	);
 }
 
-export function isInline( node ) {
-	return !! inlineWhitelist[ node.nodeName.toLowerCase() ];
+/**
+ * Checks if nodeName should be treated as inline when being added to tagName.
+ * This happens if nodeName and tagName are in the same group defined in inlineWhitelistTagGroups.
+ *
+ * @param  {String}  nodeName Node name.
+ * @param  {String}  tagName  Tag name.
+ * @return {Boolean}          True if nodeName is inline in the context of tagName and false otherwise.
+ */
+function isInlineForTag( nodeName, tagName ) {
+	if ( ! tagName || ! nodeName ) {
+		return false;
+	}
+	return inlineWhitelistTagGroups.some( tagGroup =>
+		includes( tagGroup, nodeName ) && includes( tagGroup, tagName )
+	);
+}
+
+export function isInline( node, tagName ) {
+	const nodeName = node.nodeName.toLowerCase();
+	return !! inlineWhitelist[ nodeName ] || isInlineForTag( nodeName, tagName );
 }
 
 export function isInlineWrapper( node ) {

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -352,6 +352,7 @@ export default class Editable extends Component {
 			HTML: this.pastedContent || HTML,
 			plainText: this.pastedPlainText,
 			mode,
+			tagName: this.props.tagName,
 		} );
 
 		if ( typeof content === 'string' ) {


### PR DESCRIPTION
## Description
This PR aims to fix https://github.com/WordPress/gutenberg/issues/3241, https://github.com/WordPress/gutenberg/issues/3726, and https://github.com/WordPress/gutenberg/issues/3351. Affecting paste on headings and list blocks.
It proposes an alternative approach to https://github.com/WordPress/gutenberg/pull/3842, this alternative is generic and requires very low effort from block creators.


The idea behind this PR is that our definition of what HTML elements are inline elements should not be static. We should allow blocks to set HTML elements they would like to be treated as inline elements.
So list block can set list elements to be interpreted as inline, this way when we paste a list into an empty list block we will not create a new list as it happens right now. Also when we paste list items in the middle of list block we "merge" the items as it would be expected.

This PR misses the addition of test cases and updates in the documentation, they will be added as soon as we are more confident we can follow this approach.


## How Has This Been Tested?
Paste an HTML list in an empty list block see no new list was created and the list was correctly pasted.
Paste an HTML list in the middle of a list block see the list was correctly merged.
Paste an HTML heading block in an empty heading block see no new headings were created.
Paste an HTML heading block in a non-empty heading block see contents were correctly merged.

## After Screenshots:
### Empty list paste
![dec-12-2017 13-27-15](https://user-images.githubusercontent.com/11271197/33886973-32013fb6-df40-11e7-87ca-b22f69ec96ff.gif)
### Non-Empty list paste
![dec-12-2017 13-22-41](https://user-images.githubusercontent.com/11271197/33887320-5182584c-df41-11e7-967c-1cbafc58618b.gif)
### Heading paste
![dec-12-2017 13-29-55](https://user-images.githubusercontent.com/11271197/33887167-cc2ff384-df40-11e7-96f1-104ae63c891a.gif)


## Before Screenshots:
### Empty list paste
![dec-12-2017 13-26-21](https://user-images.githubusercontent.com/11271197/33887000-41a90098-df40-11e7-933c-2e0265b8f8cf.gif)
### Non-Empty list paste
![dec-12-2017 13-24-27](https://user-images.githubusercontent.com/11271197/33887313-49dec3be-df41-11e7-87b9-f91d7b90db23.gif)
### Heading paste
![dec-12-2017 13-30-40](https://user-images.githubusercontent.com/11271197/33887161-c66d6e86-df40-11e7-8fcd-d753dce3f256.gif)



