### PR TITLE
Validation: Fix tag name warning ordering

### DIFF
--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -331,7 +331,7 @@ export function isEqualTagAttributePairs( actual, expected ) {
 export const isEqualTokensOfType = {
 	StartTag: ( actual, expected ) => {
 		if ( actual.tagName !== expected.tagName ) {
-			log.warning( 'Expected tag name `%s`, instead saw `%s`.', actual.tagName, expected.tagName );
+			log.warning( 'Expected tag name `%s`, instead saw `%s`.', expected.tagName, actual.tagName );
 			return false;
 		}
 


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/issues/3922#issuecomment-351150607

This pull request seeks to resolve an issue with incorrect ordering in the validation message for unexpected tag name. The ordering of the expected and actual names are reversed.

__Testing instructions:__

Change the `<p>` of a paragraph tag in `post-content.js`, then verify the validation console error reads correctly when navigating to Gutenberg > Demo.

- **Before:** "Block validation: Expected tag name `span`, instead saw `p`."
- **After:** "Block validation: Expected tag name `p`, instead saw `span`."