### PR TITLE
Components: Center all popovers relative anchor parent

### DIFF
--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -69,22 +69,30 @@ class Dropdown extends Component {
 			contentClassName,
 			expandOnMobile,
 		} = this.props;
+
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
+
 		return (
 			<div className={ className } ref={ this.bindContainer }>
-				{ renderToggle( args ) }
-				<Popover
-					className={ contentClassName }
-					isOpen={ isOpen }
-					position={ position }
-					onClose={ this.close }
-					onClickOutside={ this.clickOutside }
-					expandOnMobile={ expandOnMobile }
-				>
-					<FocusManaged>
-						{ renderContent( args ) }
-					</FocusManaged>
-				</Popover>
+				{ /**
+				   * This seemingly redundant wrapper node avoids root return
+				   * element styling impacting popover positioning.
+				   */ }
+				<div>
+					{ renderToggle( args ) }
+					<Popover
+						className={ contentClassName }
+						isOpen={ isOpen }
+						position={ position }
+						onClose={ this.close }
+						onClickOutside={ this.clickOutside }
+						expandOnMobile={ expandOnMobile }
+					>
+						<FocusManaged>
+							{ renderContent( args ) }
+						</FocusManaged>
+					</Popover>
+				</div>
 			</div>
 		);
 	}

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -24,13 +24,6 @@ const FocusManaged = withFocusReturn( ( { children } ) => children );
 const { ESCAPE } = keycodes;
 
 /**
- * Offset by which popover should adjust horizontally to account for tail.
- *
- * @type {Number}
- */
-const ARROW_OFFSET = 20;
-
-/**
  * Name of slot in which popover should fill.
  *
  * @type {String}
@@ -194,14 +187,8 @@ class Popover extends Component {
 		popover.style.bottom = 'auto';
 		popover.style.right = 'auto';
 
-		if ( isRight ) {
-			popover.style.left = rect.left + ARROW_OFFSET + 'px';
-		} else if ( isLeft ) {
-			popover.style.left = ( rect.right - ARROW_OFFSET ) + 'px';
-		} else {
-			// Set popover at parent node center
-			popover.style.left = Math.round( rect.left + ( rect.width / 2 ) ) + 'px';
-		}
+		// Set popover at parent node center
+		popover.style.left = Math.round( rect.left + ( rect.width / 2 ) ) + 'px';
 
 		// Set at top or bottom of parent node based on popover position
 		popover.style.top = rect[ yAxis ] + 'px';

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -4,6 +4,8 @@
 	left: 50%;
 
 	&:not(.is-mobile) {
+		margin-left: 2px;
+
 		&:before {
 			border: 8px solid $light-gray-500;
 		}


### PR DESCRIPTION
Fixes #3862 

This pull request seeks to improve popover tail rendering alignment. We had previously attempted to offset the value by an arbitrary number in an attempt to center the tail with the icon under which it would be shown, but in-fact it was never the intention that the popover was center aligned on the anchor when opening to the left or right. Rather, the popover was meant to be flush with the edge against which it opened. The revisions here change this behavior to always center the popover relative its anchor parent.

Before|After
![Before](https://user-images.githubusercontent.com/1779930/33904542-d5603ea6-df49-11e7-81be-58240708c6a1.png)|
![After](https://user-images.githubusercontent.com/1779930/33904568-e70d95fe-df49-11e7-83c5-c41753c8177f.png)

One notable impact here is that Visibility and Publish time popovers will open at different horizontal offsets, since the parent labels are not the same size (the calendar popover will be shown further to the left).

__Testing instructions:__

Verify that there are no regressions in the visual display of popovers or tooltips, and that they always open centered relative its anchor parent (i.e. the toggling button).