### PR TITLE
Meta Boxes: Show the "advanced" metaboxes location

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -449,7 +449,7 @@ export function initializeMetaBoxState( metaBoxes ) {
 /**
  * Returns an action object used to signify that a meta box finished reloading.
  *
- * @param {String} location Location of meta box: 'normal', 'side'.
+ * @param {String} location Location of meta box: 'normal', 'side' or 'advanced'.
  *
  * @return {Object} Action object
  */
@@ -463,7 +463,7 @@ export function handleMetaBoxReload( location ) {
 /**
  * Returns an action object used to signify that a meta box finished loading.
  *
- * @param {String} location Location of meta box: 'normal', 'side'.
+ * @param {String} location Location of meta box: 'normal', 'side' or 'advanced'.
  *
  * @return {Object} Action object
  */
@@ -477,7 +477,7 @@ export function metaBoxLoaded( location ) {
 /**
  * Returns an action object used to request meta box update.
  *
- * @param {Array} locations Locations of meta boxes: ['normal', 'side' ].
+ * @param {Array} locations Locations of meta boxes: ['normal', 'side', 'advanced' ].
  *
  * @return {Object}     Action object
  */
@@ -491,7 +491,7 @@ export function requestMetaBoxUpdates( locations ) {
 /**
  * Returns an action object used to set meta box state changed.
  *
- * @param {String}  location   Location of meta box: 'normal', 'side'.
+ * @param {String}  location   Location of meta box: 'normal', 'side' or 'advanced'.
  * @param {Boolean} hasChanged Whether the meta box has changed.
  *
  * @return {Object} Action object

--- a/editor/edit-post/layout/index.js
+++ b/editor/edit-post/layout/index.js
@@ -47,6 +47,9 @@ function Layout( { mode, isSidebarOpened, hasFixedToolbar } ) {
 				<div className="editor-layout__metaboxes">
 					<MetaBoxes location="normal" />
 				</div>
+				<div className="editor-layout__metaboxes">
+					<MetaBoxes location="advanced" />
+				</div>
 			</div>
 			{ isSidebarOpened && <Sidebar /> }
 			<Popover.Slot />

--- a/editor/edit-post/layout/style.scss
+++ b/editor/edit-post/layout/style.scss
@@ -25,7 +25,7 @@
 	}
 
 	&.has-fixed-toolbar {
-		padding-top: $header-height + $block-toolbar-height; 
+		padding-top: $header-height + $block-toolbar-height;
 
 		@include break-large {
 			padding-top: $header-height;
@@ -36,7 +36,8 @@
 .editor-layout__metaboxes:not(:empty) {
 	border-top: 1px solid $light-gray-500;
 	margin-top: 10px;
-	padding: 10px 0;
+	padding: 10px 0 10px;
+	clear: both;
 
 	.editor-meta-boxes-area {
 		max-width: $visual-editor-max-width;

--- a/editor/reducer.js
+++ b/editor/reducer.js
@@ -645,6 +645,7 @@ export function notices( state = [], action ) {
 const locations = [
 	'normal',
 	'side',
+	'advanced',
 ];
 
 const defaultMetaBoxState = locations.reduce( ( result, key ) => {

--- a/editor/test/reducer.js
+++ b/editor/test/reducer.js
@@ -1229,6 +1229,11 @@ describe( 'state', () => {
 					isDirty: false,
 					isUpdating: false,
 				},
+				advanced: {
+					isActive: false,
+					isDirty: false,
+					isUpdating: false,
+				},
 			};
 
 			expect( actual ).toEqual( expected );
@@ -1255,6 +1260,12 @@ describe( 'state', () => {
 				},
 				side: {
 					isActive: true,
+					isDirty: false,
+					isUpdating: false,
+					isLoaded: false,
+				},
+				advanced: {
+					isActive: false,
 					isDirty: false,
 					isUpdating: false,
 					isLoaded: false,


### PR DESCRIPTION
closes #3966

The "advanced" location was not added to the original Meta Boxes implementation because of the "iframe" issue. Now, that we're not using an iframe, let's add this location.

**Testing instructions**

 - Register a meta box in the "advanced" location (example here https://developer.wordpress.org/reference/functions/add_meta_box/#comment-1861)
 - Make sure the meta box show up in the post editor.