### PR TITLE
Taxonomies: Use Lodash includes to find available taxonomies

### DIFF
--- a/editor/components/post-taxonomies/index.js
+++ b/editor/components/post-taxonomies/index.js
@@ -18,7 +18,7 @@ import HierarchicalTermSelector from './hierarchical-term-selector';
 import FlatTermSelector from './flat-term-selector';
 import { getCurrentPostType } from '../../selectors';
 
-function PostTaxonomies( { postType, taxonomies } ) {
+export function PostTaxonomies( { postType, taxonomies } ) {
 	const availableTaxonomies = filter( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
 
 	return (

--- a/editor/components/post-taxonomies/index.js
+++ b/editor/components/post-taxonomies/index.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import { filter } from 'lodash';
+import { filter, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,7 +19,7 @@ import FlatTermSelector from './flat-term-selector';
 import { getCurrentPostType } from '../../selectors';
 
 function PostTaxonomies( { postType, taxonomies } ) {
-	const availableTaxonomies = filter( taxonomies.data, ( taxonomy ) => taxonomy.types.indexOf( postType ) !== -1 );
+	const availableTaxonomies = filter( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
 
 	return (
 		<div>

--- a/editor/components/post-taxonomies/test/index.js
+++ b/editor/components/post-taxonomies/test/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { PostTaxonomies } from '../';
+
+describe( 'PostTaxonomies', () => {
+	it( 'should render no children if taxonomy data not available', () => {
+		const taxonomies = {};
+
+		const wrapper = shallow(
+			<PostTaxonomies postType="page" taxonomies={ taxonomies } />
+		);
+
+		expect( wrapper.children() ).toHaveLength( 0 );
+	} );
+
+	it( 'should render taxonomy components for taxonomies assigned to post type', () => {
+		const taxonomies = {
+			data: [
+				{
+					name: 'Categories',
+					slug: 'category',
+					types: [ 'post', 'page' ],
+					hierarchical: true,
+					rest_base: 'categories',
+				},
+				{
+					name: 'Genres',
+					slug: 'genre',
+					types: [ 'book' ],
+					hierarchical: true,
+					rest_base: 'genres',
+				},
+			],
+		};
+
+		const wrapper = shallow(
+			<PostTaxonomies postType="page" taxonomies={ taxonomies } />
+		);
+
+		expect( wrapper.children() ).toHaveLength( 1 );
+		expect( wrapper.childAt( 0 ).props() ).toEqual( {
+			label: 'Categories',
+			slug: 'category',
+			restBase: 'categories',
+		} );
+	} );
+} );


### PR DESCRIPTION
Workaround for #3953

This pull request seeks to change the filtering behavior of the `PostTaxonomies` component to use [Lodash's `_.includes`](https://lodash.com/docs/4.17.4#includes) to detect whether the current post type is contained within a taxonomy's assigned `types`. This is a workaround for #3953 in that the root cause of the issue is a non-schema-conforming API endpoint result. However, this provides a more immediate fix than resolving the bug in the plugin, and `includes` is arguably a more readable alternative to `Array#indexOf !== -1`.

__Testing instructions:__

Verify that there are no regressions in the display of taxonomies relevant for the current post type in the Gutenberg editor.

If you have Yoast SEO Premium available, verify that no crashes occur when displaying the Categories & Tags field.

Ensure that included unit tests pass:

```
npm run test-unit editor/components/post-taxonomies/test/index.js
```