### PR TITLE
Writing Flow: 'Down' key at bottom creates new paragraph

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -593,3 +593,9 @@ export function convertBlockToReusable( uid ) {
 		uid,
 	};
 }
+
+export function appendDefaultBlock() {
+	return {
+		type: 'APPEND_DEFAULT_BLOCK',
+	};
+}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -90,7 +90,7 @@ function getScrollContainer( node ) {
 	return getScrollContainer( node.parentNode );
 }
 
-class BlockListBlock extends Component {
+export class BlockListBlock extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -409,7 +409,7 @@ class BlockListBlock extends Component {
 					onMouseDown={ this.onPointerDown }
 					onKeyDown={ this.onKeyDown }
 					onFocus={ this.onFocus }
-					className="editor-block-list__block-edit"
+					className={ BlockListBlock.className }
 					tabIndex="0"
 					aria-label={ blockLabel }
 				>
@@ -531,6 +531,8 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 		dispatch( toggleSelection( selectionEnabled ) );
 	},
 } );
+
+BlockListBlock.className = 'editor-block-list__block-edit';
 
 export default compose(
 	connect( mapStateToProps, mapDispatchToProps ),

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -9,27 +9,16 @@ import 'element-closest';
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import BlockDropZone from '../block-drop-zone';
-import { insertBlock } from '../../actions';
+import { appendDefaultBlock } from '../../actions';
 import { getBlockCount } from '../../selectors';
 
 export class DefaultBlockAppender extends Component {
-	constructor( props ) {
-		super( props );
-		this.appendDefaultBlock = this.appendDefaultBlock.bind( this );
-	}
-
-	appendDefaultBlock() {
-		const newBlock = createBlock( getDefaultBlockName() );
-		this.props.onInsertBlock( newBlock );
-	}
-
 	render() {
 		const { count } = this.props;
 		if ( count !== 0 ) {
@@ -43,9 +32,9 @@ export class DefaultBlockAppender extends Component {
 					className="editor-default-block-appender__content"
 					type="text"
 					readOnly
-					onFocus={ this.appendDefaultBlock }
-					onClick={ this.appendDefaultBlock }
-					onKeyDown={ this.appendDefaultBlock }
+					onFocus={ this.props.appendDefaultBlock }
+					onClick={ this.props.appendDefaultBlock }
+					onKeyDown={ this.props.appendDefaultBlock }
 					value={ __( 'Write your story' ) }
 				/>
 			</div>
@@ -57,5 +46,5 @@ export default connect(
 	( state ) => ( {
 		count: getBlockCount( state ),
 	} ),
-	{ onInsertBlock: insertBlock }
+	{ appendDefaultBlock }
 )( DefaultBlockAppender );

--- a/editor/components/default-block-appender/test/index.js
+++ b/editor/components/default-block-appender/test/index.js
@@ -9,39 +9,35 @@ import { shallow } from 'enzyme';
 import { DefaultBlockAppender } from '../';
 
 describe( 'DefaultBlockAppender', () => {
-	const expectInsertBlockCalled = ( insertBlock ) => {
-		expect( insertBlock ).toHaveBeenCalledTimes( 1 );
-		expect( insertBlock ).toHaveBeenCalledWith( expect.objectContaining( {
-			attributes: {},
-			isValid: true,
-			name: 'core/paragraph',
-			uid: expect.any( String ),
-		} ) );
+	const expectAppendDefaultBlockCalled = ( appendDefaultBlock ) => {
+		expect( appendDefaultBlock ).toHaveBeenCalledTimes( 1 );
+		expect( appendDefaultBlock ).toHaveBeenCalledWith();
 	};
 
 	describe( 'no block present', () => {
 		it( 'should match snapshot', () => {
-			const wrapper = shallow( <DefaultBlockAppender count={ 0 } /> );
+			const appendDefaultBlock = jest.fn();
+			const wrapper = shallow( <DefaultBlockAppender count={ 0 } appendDefaultBlock={ appendDefaultBlock } /> );
 
 			expect( wrapper ).toMatchSnapshot();
 		} );
 
 		it( 'should append a default block when input clicked', () => {
-			const insertBlock = jest.fn();
-			const wrapper = shallow( <DefaultBlockAppender count={ 0 } onInsertBlock={ insertBlock } /> );
+			const appendDefaultBlock = jest.fn();
+			const wrapper = shallow( <DefaultBlockAppender count={ 0 } appendDefaultBlock={ appendDefaultBlock } /> );
 
 			wrapper.find( 'input.editor-default-block-appender__content' ).simulate( 'click' );
 
-			expectInsertBlockCalled( insertBlock );
+			expectAppendDefaultBlockCalled( appendDefaultBlock );
 		} );
 
 		it( 'should append a default block when input focused', () => {
-			const insertBlock = jest.fn();
-			const wrapper = shallow( <DefaultBlockAppender count={ 0 } onInsertBlock={ insertBlock } /> );
+			const appendDefaultBlock = jest.fn();
+			const wrapper = shallow( <DefaultBlockAppender count={ 0 } appendDefaultBlock={ appendDefaultBlock } /> );
 
 			wrapper.find( 'input.editor-default-block-appender__content' ).simulate( 'focus' );
 
-			expectInsertBlockCalled( insertBlock );
+			expectAppendDefaultBlockCalled( appendDefaultBlock );
 		} );
 	} );
 

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -13,6 +13,7 @@ import { keycodes, focus } from '@wordpress/utils';
 /**
  * Internal dependencies
  */
+import { BlockListBlock } from '../block-list/block';
 import {
 	computeCaretRect,
 	isHorizontalEdge,
@@ -112,7 +113,7 @@ class WritingFlow extends Component {
 		}
 
 		// Find block-level ancestor of said last tabbable
-		const blockEl = lastTabbable.closest( '.editor-block-list__block-edit' );
+		const blockEl = lastTabbable.closest( '.' + BlockListBlock.className );
 		const blockIndex = tabbables.indexOf( blockEl );
 
 		// Unexpected, so we'll leave quietly.

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -7,7 +7,6 @@ import { find, last, reverse } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { keycodes, focus } from '@wordpress/utils';
 
@@ -28,7 +27,7 @@ import {
 	getMultiSelectedBlocks,
 	getSelectedBlock,
 } from '../../selectors';
-import { multiSelect, insertBlock } from '../../actions';
+import { multiSelect, appendDefaultBlock } from '../../actions';
 
 /**
  * Module Constants
@@ -192,13 +191,8 @@ export default connect(
 		hasMultiSelection: getMultiSelectedBlocks( state ).length > 1,
 		selectedBlock: getSelectedBlock( state ),
 	} ),
-	( dispatch ) => ( {
-		onMultiSelect( start, end ) {
-			dispatch( multiSelect( start, end ) );
-		},
-		onBottomReached() {
-			const newBlock = createBlock( getDefaultBlockName() );
-			dispatch( insertBlock( newBlock ) );
-		},
-	} )
+	{
+		onMultiSelect: multiSelect,
+		onBottomReached: appendDefaultBlock,
+	}
 )( WritingFlow );

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -14,6 +14,7 @@ import {
 	createBlock,
 	serialize,
 	createReusableBlock,
+	getDefaultBlockName,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -35,6 +36,7 @@ import {
 	requestMetaBoxUpdates,
 	updateReusableBlock,
 	saveReusableBlock,
+	insertBlock,
 } from './actions';
 import {
 	getCurrentPost,
@@ -387,5 +389,8 @@ export default {
 		dispatch( updateReusableBlock( reusableBlock.id, reusableBlock ) );
 		dispatch( saveReusableBlock( reusableBlock.id ) );
 		dispatch( replaceBlocks( [ oldBlock.uid ], [ newBlock ] ) );
+	},
+	APPEND_DEFAULT_BLOCK() {
+		return insertBlock( createBlock( getDefaultBlockName() ) );
 	},
 };


### PR DESCRIPTION
## Description
Keyboard-only alternative to #3623 (see #3078).

- When at the bottom of the editor's content, pressing the down arrow `↓` focuses a brand new paragraph (or whichever is the default block type).
- The initial motivation was the fact that, whenever relying on the keyboard for quick editing and insertion of blocks, it becomes cumbersome to manually _break out_ of most blocks and create a new one.
- Blocks like Paragraph, Heading or List allow the user to split into a new empty block by pressing `Enter` at the edge of the block, but this isn't the case for other blocks.
- However, pressing `Enter` at the edge of a Quote block just adds a line within the citation field of that Quote. And while `Enter` does work for e.g. Image, right now this isn't visually clear (see #3951 for improvements).
- We could try to generically pick up these `Enter` events and append an empty block, but maybe there is value in adding this `↓`-based mechanism—regardless of `Enter` improvements.

## How Has This Been Tested?
1. Add a Quote
2. Fill fields _quote_ and _citation_
3. From the _citation_ field, expect to press `Enter` to move on to a new paragraph (or indeed _any_ block thanks to `/` autocompletion, which I use with a passion).
4. Notice how `Enter` adds a line break within _citation_, so press `Backspace` to undo
5. Press `↓`, notice how the caret has moved into a new empty block.

## Screenshots (jpeg or gifs if applicable):
![gutenberg-writing-flow-down-arrow](https://user-images.githubusercontent.com/150562/33943183-46b5229e-e010-11e7-824b-fca8e4310587.gif)

## Types of changes
Writing flow enhancement.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.