### PR TITLE
Block List: Ignore previous prop selected state when preserving scroll offset

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -130,8 +130,7 @@ class BlockListBlock extends Component {
 	componentWillReceiveProps( newProps ) {
 		if (
 			this.props.order !== newProps.order &&
-			( ( this.props.isSelected && newProps.isSelected ) ||
-			( this.props.isFirstMultiSelected && newProps.isFirstMultiSelected ) )
+			( newProps.isSelected || newProps.isFirstMultiSelected )
 		) {
 			this.previousOffset = this.node.getBoundingClientRect().top;
 		}


### PR DESCRIPTION
Closes #3595 

This pull request seeks to improve the behavior of the scroll offset preservation when moving a block, specifically when moving a block without first having selected it.

__Implementation notes:__

It's not clear to me why prior to these changes we had checked that the block was selected both before and after the move occurred to decide whether to preserve offset. The changes here merely check the incoming props to see if the block will become selected, which is the case when using the block mover without first selecting the block.

__Testing instructions:__

Verify that reordering a block with the block movers preserves scroll offset, even without first selecting the block.