### PR TITLE
Sidebar: Pad revisions to occupy entire panel body

### DIFF
--- a/editor/edit-post/sidebar/last-revision/index.js
+++ b/editor/edit-post/sidebar/last-revision/index.js
@@ -6,12 +6,13 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import { PostLastRevision, PostLastRevisionCheck } from '../../../components';
 
 function LastRevision() {
 	return (
 		<PostLastRevisionCheck>
-			<PanelBody>
+			<PanelBody className="editor-last-revision__panel">
 				<PostLastRevision />
 			</PanelBody>
 		</PostLastRevisionCheck>

--- a/editor/edit-post/sidebar/last-revision/style.scss
+++ b/editor/edit-post/sidebar/last-revision/style.scss
@@ -1,0 +1,5 @@
+.editor-last-revision__panel .editor-post-last-revision__title {
+	box-sizing: content-box;
+	margin: #{ -1 * $panel-padding };
+	padding: $panel-padding;
+}


### PR DESCRIPTION
Closes #2297

This pull request seeks to improve the tappable area of the Revisions sidebar panel to match other section headings.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/33957204-f90e840a-e00e-11e7-975a-4a86a9f36177.png)|![After](https://user-images.githubusercontent.com/1779930/33957180-e32041ba-e00e-11e7-8e43-1e2e3ad9f110.png)

__Testing instructions:__

Verify that the focus styles of the Revisions sidebar button occupy the full bounds of the panel.