### PR TITLE
Make the block settings menu item dynamic

### DIFF
--- a/editor/components/block-settings-menu/block-inspector-button.js
+++ b/editor/components/block-settings-menu/block-inspector-button.js
@@ -8,7 +8,7 @@ import { flow, noop } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { IconButton, withSpokenMessages } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -23,6 +23,7 @@ export function BlockInspectorButton( {
 	onShowInspector,
 	onClick = noop,
 	small = false,
+	speak,
 } ) {
 	const toggleInspector = () => {
 		onShowInspector();
@@ -30,12 +31,21 @@ export function BlockInspectorButton( {
 			onToggleSidebar();
 		}
 	};
+
+	const speakMessage = () => {
+		if ( ! isSidebarOpened || ( isSidebarOpened && panel !== 'block' ) ) {
+			speak( __( 'Additional settings are now available in the Editor advanced settings sidebar' ) );
+		} else {
+			speak( __( 'Advanced settings closed' ) );
+		}
+	};
+
 	const label = ( isSidebarOpened && panel === 'block' ) ? __( 'Hide Advanced Settings' ) : __( 'Show Advanced Settings' );
 
 	return (
 		<IconButton
 			className="editor-block-settings-menu__control"
-			onClick={ flow( toggleInspector, onClick ) }
+			onClick={ flow( toggleInspector, speakMessage, onClick ) }
 			icon="admin-generic"
 			label={ small ? label : undefined }
 		>
@@ -57,4 +67,4 @@ export default connect(
 			dispatch( toggleSidebar() );
 		},
 	} )
-)( BlockInspectorButton );
+)( withSpokenMessages( BlockInspectorButton ) );

--- a/editor/components/block-settings-menu/block-inspector-button.js
+++ b/editor/components/block-settings-menu/block-inspector-button.js
@@ -13,11 +13,12 @@ import { IconButton } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { isEditorSidebarOpened } from '../../selectors';
+import { isEditorSidebarOpened, getActivePanel } from '../../selectors';
 import { toggleSidebar, setActivePanel } from '../../actions';
 
 export function BlockInspectorButton( {
 	isSidebarOpened,
+	panel,
 	onToggleSidebar,
 	onShowInspector,
 	onClick = noop,
@@ -25,11 +26,11 @@ export function BlockInspectorButton( {
 } ) {
 	const toggleInspector = () => {
 		onShowInspector();
-		if ( ! isSidebarOpened ) {
+		if ( ! isSidebarOpened || ( isSidebarOpened && panel === 'block' ) ) {
 			onToggleSidebar();
 		}
 	};
-	const label = __( 'Settings' );
+	const label = ( isSidebarOpened && panel === 'block' ) ? __( 'Hide Advanced Settings' ) : __( 'Show Advanced Settings' );
 
 	return (
 		<IconButton
@@ -46,6 +47,7 @@ export function BlockInspectorButton( {
 export default connect(
 	( state ) => ( {
 		isSidebarOpened: isEditorSidebarOpened( state ),
+		panel: getActivePanel( state ),
 	} ),
 	( dispatch ) => ( {
 		onShowInspector() {

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -44,7 +44,7 @@ function BlockSettingsMenu( { uids, onSelect, focus } ) {
 							onToggle();
 						} }
 						icon="ellipsis"
-						label={ isOpen ? __( 'Close Settings Menu' ) : __( 'Open Settings Menu' ) }
+						label={ __( 'More Options' ) }
 						aria-expanded={ isOpen }
 						focus={ focus }
 					/>

--- a/editor/edit-post/sidebar/index.js
+++ b/editor/edit-post/sidebar/index.js
@@ -24,7 +24,7 @@ const Sidebar = ( { panel } ) => {
 		<div
 			className="editor-sidebar"
 			role="region"
-			aria-label={ __( 'Editor settings' ) }
+			aria-label={ __( 'Editor advanced settings' ) }
 			tabIndex="-1"
 		>
 			<Header />


### PR DESCRIPTION
This PR tries to improve the interaction with the "Settings" menu item in the blocks "ellipsis" menu as detailed in https://github.com/WordPress/gutenberg/issues/3340#issuecomment-351367842

TODO: add a `speak` message when the sidebar block tab opens.

It's a first try to test if the new interaction makes sense, can be improved later.

Basically the item label and action are "dynamic" meaning they change based on the sidebar tab state:

![screen shot 2017-12-13 at 19 57 43](https://user-images.githubusercontent.com/1682452/33957098-f077a006-e040-11e7-84a4-8931c5e60469.png)

![screen shot 2017-12-13 at 19 57 54](https://user-images.githubusercontent.com/1682452/33957099-f0c5455e-e040-11e7-8d3a-206de307c78b.png)

![screen shot 2017-12-13 at 19 57 59](https://user-images.githubusercontent.com/1682452/33957100-f0df57fa-e040-11e7-8c1e-ac6e3b22040c.png)

Also, renames the label (and tooltip) for the block ellipsis menu: I've opted for "More options", inspired by a similar control in Gmail > compose:

![more options](https://user-images.githubusercontent.com/1682452/33957169-22f425c2-e041-11e7-896b-503c7e335dfc.png)

Note: when a control uses `aria-expanded`, it's better to not change its label as, for example:
`Open Settings Menu - collapsed`
`Close Settings Menu - expanded`

would sound a bit weird. Note that the similar control in Gmail uses aria-expanded and doesn't change the label.

Also renames the sidebar ARIA region to `Editor advanced settings`.

Fixes #3340
