### PR TITLE
Framework: Bump refx to 3.x

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -206,13 +206,10 @@ export default {
 	TRASH_POST_SUCCESS( action ) {
 		const { postId, postType } = action;
 
-		// Delay redirect to ensure store has been updated with the successful trash.
-		setTimeout( () => {
-			window.location.href = getWPAdminURL( 'edit.php', {
-				trashed: 1,
-				post_type: postType,
-				ids: postId,
-			} );
+		window.location.href = getWPAdminURL( 'edit.php', {
+			trashed: 1,
+			post_type: postType,
+			ids: postId,
 		} );
 	},
 	TRASH_POST_FAILURE( action, store ) {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -305,16 +305,16 @@ export default {
 			effects.push( resetBlocks( blocks ) );
 		}
 
-		// Resetting post should occur after blocks have been reset, since it's
-		// the post reset that restarts history (used in dirty detection).
-		effects.push( resetPost( post ) );
-
 		// Include auto draft title in edits while not flagging post as dirty
 		if ( post.status === 'auto-draft' ) {
 			effects.push( setupNewPost( {
 				title: post.title.raw,
 			} ) );
 		}
+
+		// Resetting post should occur after blocks have been reset, since it's
+		// the post reset that restarts history (used in dirty detection).
+		effects.push( resetPost( post ) );
 
 		return effects;
 	},

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -72,9 +72,9 @@ export const editor = flow( [
 	// Track undo history, starting at editor initialization.
 	partialRight( withHistory, { resetTypes: [ 'SETUP_EDITOR' ] } ),
 
-	// Track whether changes exist, starting at editor initialization and
-	// resetting at each post save.
-	partialRight( withChangeDetection, { resetTypes: [ 'SETUP_EDITOR', 'RESET_POST' ] } ),
+	// Track whether changes exist, resetting at each post save. Relies on
+	// editor initialization firing post reset as an effect.
+	partialRight( withChangeDetection, { resetTypes: [ 'RESET_POST' ] } ),
 ] )( {
 	edits( state = {}, action ) {
 		switch ( action.type ) {

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -469,8 +469,8 @@ describe( 'effects', () => {
 			const result = handler( { post, settings: {} } );
 
 			expect( result ).toEqual( [
-				resetPost( post ),
 				setupNewPost( { title: 'A History of Pork' } ),
+				resetPost( post ),
 			] );
 		} );
 	} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9584,9 +9584,9 @@
       "integrity": "sha1-cNoX6GPFOoYE1YHKIKJpCL2haX4="
     },
     "refx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/refx/-/refx-2.1.0.tgz",
-      "integrity": "sha512-E3+04cMfJkrnDb8LQVA68nn070NKXpU5Lkl0WPEM6x+RWoH2vCTDBJQjl04UV2ix//TEQDVoZoQ0FJTpksa+Dw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/refx/-/refx-3.0.0.tgz",
+      "integrity": "sha512-qmd73YvYiVWfKPECtE90ujmPwwtAnmtEOkBKgfNEuqJ4trTeKbqFV2UY878yFvHBvU7BBu4/w/Q8pk/t0zDpYA=="
     },
     "regenerate": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"redux": "3.7.2",
 		"redux-multi": "0.1.12",
 		"redux-optimist": "0.0.2",
-		"refx": "2.1.0",
+		"refx": "3.0.0",
 		"rememo": "2.3.4",
 		"showdown": "1.7.4",
 		"simple-html-tokenizer": "0.4.1",


### PR DESCRIPTION
This pull request seeks to bump the `refx` dependency from `2.1.0` to `3.0.0`.

[View Changelog](https://github.com/aduth/refx/blob/master/CHANGELOG.md#300-2017-11-15)

3.0.0 introduces changed call order of the effect, occurring _after_ an action has been applied to state rather than _before_. This avoids the need for a `setTimeout` artificial delay in `effects.js`.

It could also enable refactoring the jQuery meta box `holdReady` behavior, as described at https://github.com/WordPress/gutenberg/pull/3476#pullrequestreview-76440084.

__Testing instructions:__

Verify there are no regressions in the behavior of side-effects, notably save behaviors.