### PR TITLE
Fix blocks when useOnce is true

### DIFF
--- a/editor/edit-post/modes/visual-editor/inserter.js
+++ b/editor/edit-post/modes/visual-editor/inserter.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { find } from 'lodash';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 
@@ -17,7 +18,7 @@ import { createBlock, BlockIcon } from '@wordpress/blocks';
  */
 import { Inserter } from '../../../components';
 import { insertBlock } from '../../../actions';
-import { getMostFrequentlyUsedBlocks, getBlockCount } from '../../../selectors';
+import { getMostFrequentlyUsedBlocks, getBlockCount, getBlocks } from '../../../selectors';
 
 export class VisualEditorInserter extends Component {
 	constructor() {
@@ -38,6 +39,10 @@ export class VisualEditorInserter extends Component {
 	insertBlock( name ) {
 		const { onInsertBlock } = this.props;
 		onInsertBlock( createBlock( name ) );
+	}
+
+	isDisabledBlock( block ) {
+		return block.useOnce && find( this.props.blocks, ( { name } ) => block.name === name );
 	}
 
 	render() {
@@ -67,7 +72,7 @@ export class VisualEditorInserter extends Component {
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( block.name ) }
 						label={ sprintf( __( 'Insert %s' ), block.title ) }
-						disabled={ block.useOnce }
+						disabled={ this.isDisabledBlock( block ) }
 						icon={ (
 							<span className="editor-visual-editor__inserter-block-icon">
 								<BlockIcon icon={ block.icon } />
@@ -88,6 +93,7 @@ export default compose(
 			return {
 				mostFrequentlyUsedBlocks: getMostFrequentlyUsedBlocks( state ),
 				blockCount: getBlockCount( state ),
+				blocks: getBlocks( state ),
 			};
 		},
 		{ onInsertBlock: insertBlock },

--- a/editor/edit-post/modes/visual-editor/inserter.js
+++ b/editor/edit-post/modes/visual-editor/inserter.js
@@ -67,6 +67,7 @@ export class VisualEditorInserter extends Component {
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( block.name ) }
 						label={ sprintf( __( 'Insert %s' ), block.title ) }
+						disabled={ block.useOnce }
 						icon={ (
 							<span className="editor-visual-editor__inserter-block-icon">
 								<BlockIcon icon={ block.icon } />

--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -80,6 +80,10 @@
 	&:hover > .editor-inserter__block,
 	&.is-showing-controls > .editor-inserter__block {
 		opacity: 1;
+
+		&:disabled {
+			@include button-style__disabled;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
Blocks can still be inserted from the list next to the inserter even if useOnce is true #3968 

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.