### PR TITLE
Improve dashed outline when Reusable Block is selected

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -61,10 +61,18 @@
 		right: 6px;
 	}
 
+	&.is-reusable.is-selected > .editor-block-mover:before {
+		border-right: none;
+	}
+
 	&.is-selected > .editor-block-settings-menu:before,
 	&.is-hovered > .editor-block-settings-menu:before {
 		border-left: 1px solid $light-gray-500;
 		left: 6px;
+	}
+
+	&.is-reusable.is-selected > .editor-block-settings-menu:before {
+		border-left: none;
 	}
 
 	// focused block-style


### PR DESCRIPTION
This hides the solid line that appears next to the block mover and block settings menu button so that Reusable Blocks have a consistent dashed outline when selected.

Before:

<img width="709" alt="screen shot 2017-12-14 at 14 43 18" src="https://user-images.githubusercontent.com/612155/33974561-42e2a13c-e0dd-11e7-9920-060506eebc65.png">

After:

<img width="715" alt="screen shot 2017-12-14 at 14 42 58" src="https://user-images.githubusercontent.com/612155/33974562-43ffec5a-e0dd-11e7-8101-b3b1eb9eb59f.png">