### PR TITLE
Allow pressing ENTER to change Reusable Block name

### DIFF
--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -16,34 +16,34 @@ function ReusableBlockEditPanel( props ) {
 	const { isEditing, title, isSaving, onEdit, onDetach, onChangeTitle, onSave, onCancel } = props;
 
 	return [
-		! isEditing && ! isSaving && <div className="reusable-block-edit-panel">
-			<span key="info" className="reusable-block-edit-panel__info">
-				<b>{ title }</b>
-			</span>
-			<Button
-				key="edit"
-				isLarge
-				className="reusable-block-edit-panel__button"
-				onClick={ onEdit }>
-				{ __( 'Edit' ) }
-			</Button>
-			<Button
-				key="detach"
-				isLarge
-				className="reusable-block-edit-panel__button"
-				onClick={ onDetach }>
-				{ __( 'Detach' ) }
-			</Button>
-		</div>,
+		( ! isEditing && ! isSaving ) && (
+			<div key="view" className="reusable-block-edit-panel">
+				<span className="reusable-block-edit-panel__info">
+					<b>{ title }</b>
+				</span>
+				<Button
+					isLarge
+					className="reusable-block-edit-panel__button"
+					onClick={ onEdit }>
+					{ __( 'Edit' ) }
+				</Button>
+				<Button
+					isLarge
+					className="reusable-block-edit-panel__button"
+					onClick={ onDetach }>
+					{ __( 'Detach' ) }
+				</Button>
+			</div>
+		),
 		( isEditing || isSaving ) && (
 			<form
+				key="edit"
 				className="reusable-block-edit-panel"
 				onSubmit={ ( event ) => {
 					event.preventDefault();
 					onSave();
 				} }>
 				<input
-					key="title"
 					type="text"
 					disabled={ isSaving }
 					className="reusable-block-edit-panel__title"
@@ -56,7 +56,6 @@ function ReusableBlockEditPanel( props ) {
 						}
 					} } />
 				<Button
-					key="save"
 					type="submit"
 					isPrimary
 					isLarge
@@ -67,7 +66,6 @@ function ReusableBlockEditPanel( props ) {
 					{ __( 'Save' ) }
 				</Button>
 				<Button
-					key="cancel"
 					isLarge
 					disabled={ isSaving }
 					className="reusable-block-edit-panel__button"

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -3,46 +3,61 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
+const { ESCAPE } = keycodes;
+
 function ReusableBlockEditPanel( props ) {
 	const { isEditing, title, isSaving, onEdit, onDetach, onChangeTitle, onSave, onCancel } = props;
 
-	return (
-		<div className="reusable-block-edit-panel">
-			{ ! isEditing && ! isSaving && [
-				<span key="info" className="reusable-block-edit-panel__info">
-					<b>{ title }</b>
-				</span>,
-				<Button
-					key="edit"
-					isLarge
-					className="reusable-block-edit-panel__button"
-					onClick={ onEdit }>
-					{ __( 'Edit' ) }
-				</Button>,
-				<Button
-					key="detach"
-					isLarge
-					className="reusable-block-edit-panel__button"
-					onClick={ onDetach }>
-					{ __( 'Detach' ) }
-				</Button>,
-			] }
-			{ ( isEditing || isSaving ) && [
+	return [
+		! isEditing && ! isSaving && <div className="reusable-block-edit-panel">
+			<span key="info" className="reusable-block-edit-panel__info">
+				<b>{ title }</b>
+			</span>
+			<Button
+				key="edit"
+				isLarge
+				className="reusable-block-edit-panel__button"
+				onClick={ onEdit }>
+				{ __( 'Edit' ) }
+			</Button>
+			<Button
+				key="detach"
+				isLarge
+				className="reusable-block-edit-panel__button"
+				onClick={ onDetach }>
+				{ __( 'Detach' ) }
+			</Button>
+		</div>,
+		( isEditing || isSaving ) && (
+			<form
+				className="reusable-block-edit-panel"
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					onSave();
+				} }>
 				<input
 					key="title"
 					type="text"
 					disabled={ isSaving }
 					className="reusable-block-edit-panel__title"
 					value={ title }
-					onChange={ ( event ) => onChangeTitle( event.target.value ) } />,
+					onChange={ ( event ) => onChangeTitle( event.target.value ) }
+					onKeyDown={ ( event ) => {
+						if ( event.keyCode === ESCAPE ) {
+							event.stopPropagation();
+							onCancel();
+						}
+					} } />
 				<Button
 					key="save"
+					type="submit"
 					isPrimary
 					isLarge
 					isBusy={ isSaving }
@@ -50,7 +65,7 @@ function ReusableBlockEditPanel( props ) {
 					className="reusable-block-edit-panel__button"
 					onClick={ onSave }>
 					{ __( 'Save' ) }
-				</Button>,
+				</Button>
 				<Button
 					key="cancel"
 					isLarge
@@ -58,10 +73,10 @@ function ReusableBlockEditPanel( props ) {
 					className="reusable-block-edit-panel__button"
 					onClick={ onCancel }>
 					{ __( 'Cancel' ) }
-				</Button>,
-			] }
-		</div>
-	);
+				</Button>
+			</form>
+		),
+	];
 }
 
 export default ReusableBlockEditPanel;


### PR DESCRIPTION
When the Reusable Block name field is focused, pressing ENTER should save the block. Similarly, pressing ESCAPE should cancel editing the block.

![enter-to-save-block](https://user-images.githubusercontent.com/612155/33976798-7f0e2e3e-e0eb-11e7-80d8-6fd7582c556b.gif)
