### PR TITLE
Extensibility: Defer applying filters for component until it is about to be mounted

### DIFF
--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -8,7 +8,7 @@ import { withFilters } from '@wordpress/components';
  */
 import { getBlockType } from '../api';
 
-function BlockEdit( props ) {
+export function BlockEdit( props ) {
 	const { name, ...editProps } = props;
 	const blockType = getBlockType( name );
 

--- a/blocks/block-edit/test/index.js
+++ b/blocks/block-edit/test/index.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import BlockEdit from '../';
+import { BlockEdit } from '../';
 import {
 	registerBlockType,
 	unregisterBlockType,

--- a/components/higher-order/with-filters/index.js
+++ b/components/higher-order/with-filters/index.js
@@ -1,16 +1,30 @@
 /**
  * WordPress dependencies
  */
+import { Component, getWrapperDisplayName } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Creates a higher-order component which adds filtering capability to the wrapped component.
+ * Filters get applied when the original component is about to be mounted.
  *
  * @param {String} hookName Hook name exposed to be used by filters.
- * @return {Function}      Higher-order component factory.
+ * @return {Function}       Higher-order component factory.
  */
 export default function withFilters( hookName ) {
 	return ( OriginalComponent ) => {
-		return applyFilters( hookName, OriginalComponent );
+		class FilteredComponent extends Component {
+			constructor( props ) {
+				super( props );
+				this.Component = applyFilters( hookName, OriginalComponent );
+			}
+
+			render() {
+				return <this.Component { ...this.props } />;
+			}
+		}
+		FilteredComponent.displayName = getWrapperDisplayName( OriginalComponent, 'filters' );
+
+		return FilteredComponent;
 	};
 }


### PR DESCRIPTION
## Description

Tries to address the issue raised by @kmgalanakis and confirmed by @andreiglingeanu in #3800:

> Correct me if I'm wrong, but it's also impossible to hook to the `blocks.BlockEdit` hook, after the last update (1.9)

This PR tries to postpone applying filters to all components wrapped with `withFilters` Higher-Order Component until the original component is about to be rendered. In most of the cases, it will happen when the editor is rendered. This should give enough flexibility to make adding filters straightforward.

I'm planning to explore if we could also rerender such components whenever filters get added or removed. It might be provided in its own PR.

## How Has This Been Tested?
Manually, unit tests.

I tested it by loading Gutenberg and clicking around to make sure everything works without errors. 

The best way is to register your own filter in the console which replaces the block and add new block to make sure it works:

```js
wp.hooks.addFilter( 'blocks.BlockEdit', 'my/filters', () => () => wp.element.createElement( 'h1', {}, 'My block' ) );
```

You should see sth like:

![screen shot 2017-12-14 at 14 50 37](https://user-images.githubusercontent.com/699132/33995407-2fa719b2-e0de-11e7-9f79-ee3bf6d7b7e9.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.