### PR TITLE
History: Batch title and text editor edit undo history

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -227,10 +227,24 @@ export function clearBlockInsertionPoint() {
 	};
 }
 
-export function editPost( edits ) {
+/**
+ * Returns an action object used in signalling that the post has been edited.
+ *
+ * @param  {Object}  edits   Key-value pairs of edited post attributes
+ * @param  {?Object} options Optional object of options, currently supporting
+ *                           batch flag (for grouping sequential edits)
+ * @return {Object}          Action object
+ */
+export function editPost( edits, options ) {
+	let meta;
+	if ( options && options.batch ) {
+		meta = { batchHistory: true };
+	}
+
 	return {
 		type: 'EDIT_POST',
 		edits,
+		meta,
 	};
 }
 

--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -65,7 +65,7 @@ export default connect(
 	} ),
 	{
 		onChange( content ) {
-			return editPost( { content } );
+			return editPost( { content }, { batch: true } );
 		},
 		onPersist( content ) {
 			return resetBlocks( parse( content ) );

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -136,7 +136,7 @@ export default connect(
 			return insertBlock( createBlock( getDefaultBlockName() ), 0 );
 		},
 		onUpdate( title ) {
-			return editPost( { title } );
+			return editPost( { title }, { batch: true } );
 		},
 		clearSelectedBlock,
 	}

--- a/editor/utils/with-history/test/index.js
+++ b/editor/utils/with-history/test/index.js
@@ -118,4 +118,53 @@ describe( 'withHistory', () => {
 
 		expect( state ).toBe( original );
 	} );
+
+	it( 'should allow history batching', () => {
+		const reducer = withHistory( counter );
+
+		let state;
+		state = reducer( undefined, {} );
+
+		state = reducer( state, { type: 'INCREMENT', meta: { batchHistory: true } } );
+		expect( state ).toEqual( {
+			past: [ 0 ],
+			present: 1,
+			future: [],
+		} );
+
+		state = reducer( state, { type: 'INCREMENT', meta: { batchHistory: true } } );
+		expect( state ).toEqual( {
+			past: [ 0 ],
+			present: 2,
+			future: [],
+		} );
+
+		state = reducer( state, { type: 'INCREMENT' } );
+		expect( state ).toEqual( {
+			past: [ 0, 2 ],
+			present: 3,
+			future: [],
+		} );
+
+		state = reducer( state, { type: 'INCREMENT', meta: { batchHistory: true } } );
+		expect( state ).toEqual( {
+			past: [ 0, 2, 3 ],
+			present: 4,
+			future: [],
+		} );
+
+		state = reducer( state, { type: 'INCREMENT', meta: { batchHistory: true } } );
+		expect( state ).toEqual( {
+			past: [ 0, 2, 3 ],
+			present: 5,
+			future: [],
+		} );
+
+		state = reducer( state, { type: 'UNDO' } );
+		expect( state ).toEqual( {
+			past: [ 0, 2 ],
+			present: 3,
+			future: [ 5 ],
+		} );
+	} );
 } );


### PR DESCRIPTION
Closes #4057
Partially addresses #2932

This pull request seeks to improve the behavior of editing the title and text editor to limit the number of undo levels created when typing within the field. Prior to these changes, an undo level was created for each character pressed in the field. With these changes, the `withHistory` higher-order reducer has been enhanced to support batching, such that multiple sequential edits will be grouped into a single history level.

__Testing instructions:__

Repeat Steps to Reproduce from #2932, verifying both for the text mode and title field that undoing applies to all edits made while the field was changed.