### PR TITLE
Embeds: Detect focus on embed sandbox

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -205,7 +205,12 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 							</Placeholder>
 						) : (
 							<div className="wp-block-embed__wrapper">
-								<SandBox html={ html } title={ iframeTitle } type={ type } />
+								<SandBox
+									html={ html }
+									title={ iframeTitle }
+									type={ type }
+									onFocus={ () => setFocus() }
+								/>
 							</div>
 						) }
 						{ ( caption && caption.length > 0 ) || !! focus ? (

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -6,12 +6,15 @@ import { Component, renderToString } from '@wordpress/element';
 export default class Sandbox extends Component {
 	constructor() {
 		super( ...arguments );
+
+		this.trySandbox = this.trySandbox.bind( this );
+		this.checkMessageForResize = this.checkMessageForResize.bind( this );
+		this.checkFocus = this.checkFocus.bind( this );
+
 		this.state = {
 			width: 0,
 			height: 0,
 		};
-		this.trySandbox = this.trySandbox.bind( this );
-		this.checkMessageForResize = this.checkMessageForResize.bind( this );
 	}
 
 	isFrameAccessible() {
@@ -50,6 +53,7 @@ export default class Sandbox extends Component {
 
 	componentDidMount() {
 		window.addEventListener( 'message', this.checkMessageForResize, false );
+		window.addEventListener( 'blur', this.checkFocus );
 		this.trySandbox();
 	}
 
@@ -59,6 +63,13 @@ export default class Sandbox extends Component {
 
 	componentWillUnmount() {
 		window.removeEventListener( 'message', this.checkMessageForResize );
+		window.removeEventListener( 'blur', this.checkFocus );
+	}
+
+	checkFocus() {
+		if ( this.props.onFocus && document.activeElement === this.iframe ) {
+			this.props.onFocus();
+		}
 	}
 
 	trySandbox() {


### PR DESCRIPTION
This pull request seeks to improve the behavior of focusing embed blocks, allowing block selection by clicking on the embed.

__Implementation notes:__

Detecting click events on iframe is not normally possible, but this uses a technique to detect blur from the host window and whether at the point of blur the active element is the iframe, inferring that this implies that the iframe has received focus.

__Testing instructions:__

Verify that clicking an embed block selects it.