### PR TITLE
Latest Posts Block: Hardcode class for post date

### DIFF
--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -182,7 +182,7 @@ registerBlockType( 'core/latest-posts', {
 						<li key={ i }>
 							<a href={ post.link } target="_blank">{ decodeEntities( post.title.rendered.trim() ) || __( '(Untitled)' ) }</a>
 							{ displayPostDate && post.date_gmt &&
-								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ `${ this.props.className }__post-date` }>
+								<time dateTime={ moment( post.date_gmt ).utc().format() } className={ 'wp-block-latest-posts__post-date' }>
 									{ moment( post.date_gmt ).local().format( 'MMMM DD, Y' ) }
 								</time>
 							}


### PR DESCRIPTION
## Description
The class for the post date in the Latest posts block should always be `wp-block-latest-posts__post-date`. Without this PR the class changes, when the user adds an additional class to the block.