### PR TITLE
fix editor image default width

### DIFF
--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -4,7 +4,6 @@
 
 	img {
 		display: block;
-		max-width: 100%;
 	}
 
 	&.is-transient img {

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -4,7 +4,7 @@
 
 	img {
 		display: block;
-		width: 100%;
+		max-width: 100%;
 	}
 
 	&.is-transient img {


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes https://github.com/WordPress/gutenberg/issues/3651

When loading a page that has a small image in it, for a moment an enlarged (pixelated) version is shown. Than it goes back to original size.

I changed width to max-width.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested in the browser.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)
