### PR TITLE
Audio Block: Hide Edit button if no src selected

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -97,8 +97,10 @@ registerBlockType( 'core/audio', {
 					/>
 					<Toolbar>
 						{ src && <Button
-							className="components-icon-button components-toolbar__control"
-							aria-label={ __( 'Edit audio' ) }
+							buttonProps={ {
+								className: 'components-icon-button components-toolbar__control',
+								'aria-label': __( 'Edit audio' ),
+							} }
 							type="audio"
 							onClick={ switchToEditing }
 						>

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -69,7 +69,8 @@ registerBlockType( 'core/audio', {
 			const { editing, className, src } = this.state;
 			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 			const switchToEditing = () => {
-				this.setState( { editing: true } );
+				setAttributes( { src: '' } );
+				this.setState( { editing: true, src: '' } );
 			};
 			const onSelectAudio = ( media ) => {
 				if ( media && media.url ) {
@@ -95,16 +96,14 @@ registerBlockType( 'core/audio', {
 						onChange={ updateAlignment }
 					/>
 					<Toolbar>
-						<Button
-							buttonProps={ {
-								className: 'components-icon-button components-toolbar__control',
-								'aria-label': __( 'Edit audio' ),
-							} }
+						{ src && <Button
+							className="components-icon-button components-toolbar__control"
+							aria-label={ __( 'Edit audio' ) }
 							type="audio"
 							onClick={ switchToEditing }
 						>
 							<Dashicon icon="edit" />
-						</Button>
+						</Button> }
 					</Toolbar>
 				</BlockControls>,
 


### PR DESCRIPTION
## Description
In the Audio block you can insert an URL or select a file. So the edit button should bring back the placeholder, to change the URL or select another file. To solve #4021 we should hide the edit button when the placeholder is visible.
fixes #4021

