### PR TITLE
Audio Block: Changes edit buttonProps to html attributes

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -96,10 +96,8 @@ registerBlockType( 'core/audio', {
 					/>
 					<Toolbar>
 						<Button
-							buttonProps={ {
-								className: 'components-icon-button components-toolbar__control',
-								'aria-label': __( 'Edit audio' ),
-							} }
+							className="components-icon-button components-toolbar__control"
+							aria-label={ __( 'Edit audio' ) }
 							type="audio"
 							onClick={ switchToEditing }
 						>


### PR DESCRIPTION
## Description
The edit button attributes weren't changed in #2521, when the button was changed from MediaUploadButton to Button. This PR changes the buttonProps to html attributes.
fixes #4019 