### PR TITLE
Handle copy for single block selection

### DIFF
--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -36,6 +36,7 @@ import {
 	isSelectionEnabled,
 } from '../../store/selectors';
 import { startMultiSelect, stopMultiSelect, multiSelect, selectBlock } from '../../store/actions';
+import { isInputField } from '../../utils/dom';
 
 class BlockList extends Component {
 	constructor( props ) {
@@ -108,15 +109,23 @@ class BlockList extends Component {
 	}
 
 	onCopy( event ) {
-		const { multiSelectedBlocks } = this.props;
+		const { multiSelectedBlocks, selectedBlock } = this.props;
 
-		if ( multiSelectedBlocks.length ) {
-			const serialized = serialize( multiSelectedBlocks );
-
-			event.clipboardData.setData( 'text/plain', serialized );
-			event.clipboardData.setData( 'text/html', serialized );
-			event.preventDefault();
+		if ( ! multiSelectedBlocks.length && ! selectedBlock ) {
+			return;
 		}
+
+		// Let native copy behaviour take over in input fields.
+		if ( selectedBlock && isInputField( document.activeElement ) ) {
+			return;
+		}
+
+		const serialized = serialize( selectedBlock || multiSelectedBlocks );
+
+		event.clipboardData.setData( 'text/plain', serialized );
+		event.clipboardData.setData( 'text/html', serialized );
+
+		event.preventDefault();
 	}
 
 	onCut( event ) {

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -303,3 +303,17 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 	selection.removeAllRanges();
 	selection.addRange( range );
 }
+
+/**
+ * Check whether the given node in an input field.
+ *
+ * @param  {HTMLElement} element The HTML element.
+ * @return {Boolean}             True if the element is an input field, false if not.
+ */
+export function isInputField( { nodeName, contentEditable } ) {
+	return (
+		nodeName === 'input' ||
+		nodeName === 'textarea' ||
+		contentEditable === 'true'
+	);
+}


### PR DESCRIPTION
## Description
This PR allows you to copy a single block.

## How Has This Been Tested?
Select only one block, e.g. an image block. Copy using the copy shortcut. The contents should now be in the clipboard (try to paste somewhere else). Make sure copying a piece of text from a block still works.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.