### PR TITLE
Registration: Add server script, style block type property

### DIFF
--- a/docs/blocks-basic.md
+++ b/docs/blocks-basic.md
@@ -6,19 +6,23 @@ Blocks containing static content are implemented entirely in JavaScript using th
 
 ## Enqueuing Block Scripts
 
-While the block type itself is implemented in JavaScript, you'll need to use the `enqueue_block_editor_assets` [WordPress action](https://codex.wordpress.org/Glossary#Action) to have your scripts included in the editor. This is similar to the [`wp_enqueue_scripts` action](https://developer.wordpress.org/reference/hooks/wp_enqueue_scripts/), but specifically targeting editor scripts and styles.
+While the block's editor behaviors are implemented in JavaScript, you'll need to register your block server-side to ensure that the script is enqueued when the editor loads. Register scripts and styles using [`wp_register_script`](https://developer.wordpress.org/reference/functions/wp_register_script/) and [`wp_register_style`](https://developer.wordpress.org/reference/functions/wp_register_style/), then assign these as handles associated with your block using the `script`, `style`, `editor_script`, and `editor_style` block type registration settings. The `editor_`-prefixed handles will only be enqueued in the context of the editor, while `script` and `style` will be enqueued both in the editor and when viewing a post on the front of your site.
 
 ```php
 <?php
 
-function gutenberg_boilerplate_enqueue_block_editor_assets() {
-	wp_enqueue_script(
+function gutenberg_boilerplate_block() {
+	wp_register_script(
 		'gutenberg-boilerplate-es5-step01',
 		plugins_url( 'step-01/block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-element' )
 	);
+
+	register_block_type( 'gutenberg-boilerplate-es5/hello-world-step-01', array(
+		'editor_script' => 'gutenberg-boilerplate-es5-step01',
+	) );
 }
-add_action( 'enqueue_block_editor_assets', 'gutenberg_boilerplate_enqueue_block_editor_assets' );
+add_action( 'init', 'gutenberg_boilerplate_block' );
 ```
 
 Note the two script dependencies:

--- a/docs/blocks-stylesheet.md
+++ b/docs/blocks-stylesheet.md
@@ -68,20 +68,20 @@ Like scripts, your block's editor-specific styles should be enqueued by assignin
 
 function gutenberg_boilerplate_block() {
 	wp_register_script(
-		'gutenberg-boilerplate-es5-step02-editor-script',
+		'gutenberg-boilerplate-es5-step02-editor',
 		plugins_url( 'step-02/block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-element' )
 	);
 	wp_register_style(
-		'gutenberg-boilerplate-es5-step02-editor-style',
+		'gutenberg-boilerplate-es5-step02-editor',
 		plugins_url( 'step-02/editor.css', __FILE__ ),
 		array( 'wp-edit-blocks' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'step-02/editor.css' )
 	);
 
 	register_block_type( 'gutenberg-boilerplate-esnext/hello-world-step-02', array(
-		'editor_script' => 'gutenberg-boilerplate-es5-step02-editor-script',
-		'editor_style'  => 'gutenberg-boilerplate-es5-step02-editor-style',
+		'editor_script' => 'gutenberg-boilerplate-es5-step02-editor',
+		'editor_style'  => 'gutenberg-boilerplate-es5-step02-editor',
 	) );
 }
 add_action( 'init', 'gutenberg_boilerplate_block' );
@@ -98,14 +98,14 @@ When registering a block, you can assign one or both of `style` and `editor_styl
 
 function gutenberg_boilerplate_block() {
 	wp_register_style(
-		'gutenberg-boilerplate-es5-step02-style',
+		'gutenberg-boilerplate-es5-step02',
 		plugins_url( 'step-02/style.css', __FILE__ ),
 		array( 'wp-blocks' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'step-02/style.css' )
 	);
 
 	register_block_type( 'gutenberg-boilerplate-esnext/hello-world-step-02', array(
-		'style' => 'gutenberg-boilerplate-es5-step02-style',
+		'style' => 'gutenberg-boilerplate-es5-step02',
 	) );
 }
 add_action( 'init', 'gutenberg_boilerplate_block' );

--- a/docs/blocks-stylesheet.md
+++ b/docs/blocks-stylesheet.md
@@ -61,47 +61,54 @@ The class name is generated using the block's name prefixed with `wp-block-`, re
 
 ## Enqueueing Editor-only Block Assets
 
-Like scripts, your block's editor-specific styles should be enqueued during the `enqueue_block_editor_assets` action.
+Like scripts, your block's editor-specific styles should be enqueued by assigning the `editor_styles` setting of the registered block type:
 
 ```php
 <?php
 
-function gutenberg_boilerplate_enqueue_block_editor_assets() {
-	wp_enqueue_script(
-		'gutenberg-boilerplate-es5-step02',
+function gutenberg_boilerplate_block() {
+	wp_register_script(
+		'gutenberg-boilerplate-es5-step02-editor-script',
 		plugins_url( 'step-02/block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-element' )
 	);
-	wp_enqueue_style(
-		'gutenberg-boilerplate-es5-step02-editor',
+	wp_register_style(
+		'gutenberg-boilerplate-es5-step02-editor-style',
 		plugins_url( 'step-02/editor.css', __FILE__ ),
 		array( 'wp-edit-blocks' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'step-02/editor.css' )
 	);
+
+	register_block_type( 'gutenberg-boilerplate-esnext/hello-world-step-02', array(
+		'editor_script' => 'gutenberg-boilerplate-es5-step02-editor-script',
+		'editor_style'  => 'gutenberg-boilerplate-es5-step02-editor-style',
+	) );
 }
-add_action( 'enqueue_block_editor_assets', 'gutenberg_boilerplate_enqueue_block_editor_assets' );
+add_action( 'init', 'gutenberg_boilerplate_block' );
 ```
 
 ## Enqueueing Editor and Front end Assets
 
-While a block's scripts are only necessary to load in the editor, you'll want to load styles both on the front of your site and in the editor. You may even want distinct styles in each context.
+While a block's scripts are usually only necessary to load in the editor, you'll want to load styles both on the front of your site and in the editor. You may even want distinct styles in each context.
 
-The `enqueue_block_editor_assets` action will only be triggered when the editor is loading. To enqueue styles for your block when viewing the front of your site, you should do so during the `enqueue_block_assets` action.
+When registering a block, you can assign one or both of `style` and `editor_style` to respectively assign styles always loaded for a block or styles only loaded in the editor.
 
 ```php
 <?php
 
-function gutenberg_boilerplate_es5_enqueue_common_assets() {
-	wp_enqueue_style(
-		'gutenberg-boilerplate-es5-step02',
+function gutenberg_boilerplate_block() {
+	wp_register_style(
+		'gutenberg-boilerplate-es5-step02-style',
 		plugins_url( 'step-02/style.css', __FILE__ ),
 		array( 'wp-blocks' ),
 		filemtime( plugin_dir_path( __FILE__ ) . 'step-02/style.css' )
 	);
+
+	register_block_type( 'gutenberg-boilerplate-esnext/hello-world-step-02', array(
+		'style' => 'gutenberg-boilerplate-es5-step02-style',
+	) );
 }
-add_action( 'enqueue_block_assets', 'gutenberg_boilerplate_es5_enqueue_common_assets' );
+add_action( 'init', 'gutenberg_boilerplate_block' );
 ```
 
-The `enqueue_block_assets` action is triggered both in the editor and on the front of the site. Since your block is likely to share some styles in both contexts, you can consider `style.css` as the base stylesheet, placing editor-specific styles in `editor.css`.
-
-If you'd like the scripts to be limited to your site's front end only, you can use `enqueue_block_assets` and enqueue your scripts only if [`! is_admin()`](https://developer.wordpress.org/reference/functions/is_admin/) applies.
+Since your block is likely to share some styles in both contexts, you can consider `style.css` as the base stylesheet, placing editor-specific styles in `editor.css`.

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -42,6 +42,42 @@ class WP_Block_Type {
 	public $attributes;
 
 	/**
+	 * Block type editor script handle.
+	 *
+	 * @since 2.0.0
+	 * @access public
+	 * @var string
+	 */
+	public $editor_script;
+
+	/**
+	 * Block type front end script handle.
+	 *
+	 * @since 2.0.0
+	 * @access public
+	 * @var string
+	 */
+	public $script;
+
+	/**
+	 * Block type editor style handle.
+	 *
+	 * @since 2.0.0
+	 * @access public
+	 * @var string
+	 */
+	public $editor_style;
+
+	/**
+	 * Block type front end style handle.
+	 *
+	 * @since 2.0.0
+	 * @access public
+	 * @var string
+	 */
+	public $style;
+
+	/**
 	 * Constructor.
 	 *
 	 * Will populate object properties from the provided arguments.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -598,6 +598,41 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
 add_action( 'admin_enqueue_scripts', 'gutenberg_common_scripts_and_styles' );
 
 /**
+ * Enqueues registered block scripts and styles, depending on current rendered
+ * context (only enqueuing editor scripts while in context of the editor).
+ *
+ * @since 2.0.0
+ */
+function gutenberg_enqueue_registered_block_scripts_and_styles() {
+	$is_editor = ( 'enqueue_block_editor_assets' === current_action() );
+
+	$block_registry = WP_Block_Type_Registry::get_instance();
+	foreach ( $block_registry->get_all_registered() as $block_name => $block_type ) {
+		// Front-end styles.
+		if ( ! empty( $block_type->style ) ) {
+			wp_enqueue_style( $block_type->style );
+		}
+
+		// Front-end script.
+		if ( ! empty( $block_type->script ) ) {
+			wp_enqueue_script( $block_type->script );
+		}
+
+		// Editor styles.
+		if ( $is_editor && ! empty( $block_type->editor_style ) ) {
+			wp_enqueue_style( $block_type->editor_style );
+		}
+
+		// Editor script.
+		if ( $is_editor && ! empty( $block_type->editor_script ) ) {
+			wp_enqueue_script( $block_type->editor_script );
+		}
+	}
+}
+add_action( 'enqueue_block_assets', 'gutenberg_enqueue_registered_block_scripts_and_styles' );
+add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_registered_block_scripts_and_styles' );
+
+/**
  * Returns a default color palette.
  *
  * @return array Color strings in hex format.


### PR DESCRIPTION
Closes #2756
Related: #2751

This pull request seeks to implement and document an alternative approach to enqueueing block assets, integrating new settings into the `register_block_type` server-side API to help manage context-specific script and style enqueues.

The `register_block_type` API now supports the following properties:

- `editor_script`
- `editor_style`
- `script`
- `style`

Assigning one or more of these to registered script or style handles will cause them to be enqueued in the corresponding render contexts (editor-specific or always).

This is intended as part of an effort to coalesce initial block implementations toward the server-side block registration API, as proposed in #2751 to be the default for new blocks.

__Testing instructions:__

Since this simply builds on existing APIs and no core blocks have been ported to using it (unclear whether this is a direction we'd want to go), there should be no expected impact of these changes.

You may try including a third-party block code and changing to implement with the `register_block_type` API.

Example:

https://gist.github.com/pento/19b35d621709042fc899e394a9387a54

```diff
diff --git a/stars-block.php b/stars-block.php
index da5598c..9ea8cfd 100755
--- a/stars-block.php
+++ b/stars-block.php
@@ -9,15 +9,6 @@
  * Description: Everyone loves stars! Let's add stars (now with more meta)!
  */
 
-function stars_block_enqueue_block_editor_assets() {
-       wp_enqueue_script(
-               'stars-block',
-               plugins_url( 'stars-block.js', __FILE__ ),
-               array( 'wp-blocks' )
-       );
-}
-add_action( 'enqueue_block_editor_assets', 'stars_block_enqueue_block_editor_assets' );
-
 function stars_block_init() {
        // Register the postmeta key that we'll store our data in
        register_meta( 'post', 'stars', array(
@@ -25,5 +16,15 @@ function stars_block_init() {
                'single'       => true,
                'type'         => 'number',
        ) );
+
+       wp_register_script(
+               'stars-block',
+               plugins_url( 'stars-block.js', __FILE__ ),
+               array( 'wp-blocks' )
+       );
+
+       register_block_type( 'stars/stars-block', array(
+               'editor_script' => 'stars-block',
+       ) );
 }
 add_action( 'init', 'stars_block_init' );
```