### PR TITLE
Inserter: Show messaging when no blocks found

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -11,6 +11,7 @@ import {
 	pick,
 	some,
 	sortBy,
+	isEmpty,
 } from 'lodash';
 import { connect } from 'react-redux';
 
@@ -255,6 +256,14 @@ export class InserterMenu extends Component {
 	}
 
 	renderCategories( visibleBlocksByCategory ) {
+		if ( isEmpty( visibleBlocksByCategory ) ) {
+			return (
+				<span className="editor-inserter__no-results">
+					{ __( 'No blocks found' ) }
+				</span>
+			);
+		}
+
 		return getCategories().map(
 			( category ) => this.renderCategory( category, visibleBlocksByCategory[ category.slug ] )
 		);

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -115,6 +115,13 @@ input[type="search"].editor-inserter__search {
 	overflow: auto;
 }
 
+.editor-inserter__no-results {
+	display: block;
+	text-align: center;
+	font-style: italic;
+	padding: 8px;
+}
+
 .editor-inserter__tabs {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
This pull request seeks to add messaging when searching using the inserter reveals no available block options.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/34047655-f2801ca4-e17e-11e7-926d-5cc04586ad09.png)|![After](https://user-images.githubusercontent.com/1779930/34047627-e2346cb0-e17e-11e7-9d75-695f0382994c.png)

__Testing instructions:__

Verify that if no blocks are found by searching the inserter menu that a "No blocks found" message is shown instead.