### PR TITLE
Fix categories block per_page limit

### DIFF
--- a/blocks/library/categories/data.js
+++ b/blocks/library/categories/data.js
@@ -6,7 +6,7 @@
 export function getCategories() {
 	const categoriesCollection = new wp.api.collections.Categories();
 
-	const categories = categoriesCollection.fetch();
+	const categories = categoriesCollection.fetch( { data: { per_page: 100 } } );
 
 	return categories;
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Fixes https://github.com/WordPress/gutenberg/issues/4022

As per api documentation I'm setting the per_page arg to max 100

https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested in the browser.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)
