### PR TITLE
Try: Custom save serializer, Editable as array tree

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -42,3 +42,4 @@ export {
 	doBlocksMatchTemplate,
 	synchronizeBlocksWithTemplate,
 } from './templates';
+export { nodeListToTree } from './matchers';

--- a/blocks/api/matchers.js
+++ b/blocks/api/matchers.js
@@ -1,13 +1,60 @@
 /**
- * WordPress dependencies
- */
-import { createElement } from '@wordpress/element';
-
-/**
  * External dependencies
  */
-import { nodeListToReact, nodeToReact } from 'dom-react';
 export { attr, prop, html, text, query } from 'hpq';
+
+export function buildTree( type, attributes, ...children ) {
+	children = children.map( ( child ) => {
+		if ( 'boolean' === typeof child ) {
+			child = null;
+		}
+
+		if ( null === child || undefined === child ) {
+			child = '';
+		} else if ( 'number' === typeof child ) {
+			child = String( child );
+		}
+
+		if ( 'string' === typeof child ) {
+			return child;
+		}
+
+		return buildTree( child );
+	} );
+
+	return [ type, attributes, children ];
+}
+
+export function nodeListToTree( nodeList, createElement ) {
+	return [ ...nodeList ].map( ( node ) => nodeToTree( node, createElement ) );
+}
+
+export function elementAsArray( type, attributes, children ) {
+	return [ type, attributes, children ];
+}
+
+export function nodeToTree( node, createElement = elementAsArray ) {
+	if ( ! node ) {
+		return null;
+	}
+
+	if ( node.nodeType === 3 ) {
+		return node.nodeValue;
+	}
+
+	if ( node.nodeType !== 1 ) {
+		return null;
+	}
+
+	const type = node.nodeName.toLowerCase();
+	const attributes = [ ...node.attributes ].reduce( ( result, { name, value } ) => {
+		result[ name ] = value;
+		return result;
+	}, {} );
+	const children = nodeListToTree( node.childNodes );
+
+	return createElement( type, attributes, children );
+}
 
 export const children = ( selector ) => {
 	return ( domNode ) => {
@@ -18,7 +65,7 @@ export const children = ( selector ) => {
 		}
 
 		if ( match ) {
-			return nodeListToReact( match.childNodes || [], createElement );
+			return nodeListToTree( match.childNodes );
 		}
 
 		return [];
@@ -33,6 +80,6 @@ export const node = ( selector ) => {
 			match = domNode.querySelector( selector );
 		}
 
-		return nodeToReact( match, createElement );
+		return nodeToTree( match );
 	};
 };

--- a/blocks/api/raw-handling/test/integration/evernote-out.html
+++ b/blocks/api/raw-handling/test/integration/evernote-out.html
@@ -56,5 +56,5 @@
 <!-- /wp:table -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="" alt="" /></figure>
+<figure class="wp-block-image"><img src="" /></figure>
 <!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/google-docs-out.html
+++ b/blocks/api/raw-handling/test/integration/google-docs-out.html
@@ -60,6 +60,6 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" alt="" /></figure>
+<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" /></figure>
 <!-- /wp:image -->
 

--- a/blocks/api/raw-handling/test/integration/ms-word-online-out.html
+++ b/blocks/api/raw-handling/test/integration/ms-word-online-out.html
@@ -50,5 +50,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="" alt="" /></figure>
+<figure class="wp-block-image"><img src="" /></figure>
 <!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/ms-word-out.html
+++ b/blocks/api/raw-handling/test/integration/ms-word-out.html
@@ -85,5 +85,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="" alt="" /></figure>
+<figure class="wp-block-image"><img src="" /></figure>
 <!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/one-image-out.html
+++ b/blocks/api/raw-handling/test/integration/one-image-out.html
@@ -1,3 +1,3 @@
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" /></figure>
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" /></figure>
 <!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/two-images-out.html
+++ b/blocks/api/raw-handling/test/integration/two-images-out.html
@@ -1,7 +1,7 @@
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" /></figure>
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" /></figure>
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" /></figure>
 <!-- /wp:image -->

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -173,7 +173,7 @@ export const settings = {
 		const { src, caption } = attributes;
 		return (
 			<figure>
-				<audio controls="controls" src={ src } />
+				<audio controls src={ src } />
 				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 			</figure>
 		);

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -120,9 +120,7 @@ export const settings = {
 
 		return (
 			<blockquote className={ `align${ align }` }>
-				{ value && value.map( ( paragraph, i ) =>
-					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-				) }
+				{ value.map( ( paragraph ) => paragraph.children ) }
 				{ citation && citation.length > 0 && (
 					<cite>{ citation }</cite>
 				) }
@@ -145,9 +143,7 @@ export const settings = {
 
 			return (
 				<blockquote className={ `align${ align }` }>
-					{ value && value.map( ( paragraph, i ) =>
-						<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-					) }
+					{ value.map( ( paragraph ) => paragraph.children ) }
 					{ citation && citation.length > 0 && (
 						<footer>{ citation }</footer>
 					) }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -242,9 +242,7 @@ export const settings = {
 				className={ style === 2 ? 'is-large' : '' }
 				style={ { textAlign: align ? align : null } }
 			>
-				{ value.map( ( paragraph, i ) => (
-					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-				) ) }
+				{ value.map( ( paragraph ) => paragraph.children ) }
 				{ citation && citation.length > 0 && (
 					<cite>{ citation }</cite>
 				) }
@@ -271,9 +269,7 @@ export const settings = {
 						className={ `blocks-quote-style-${ style }` }
 						style={ { textAlign: align ? align : null } }
 					>
-						{ value.map( ( paragraph, i ) => (
-							<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-						) ) }
+						{ value.map( ( paragraph ) => paragraph.children ) }
 						{ citation && citation.length > 0 && (
 							<footer>{ citation }</footer>
 						) }

--- a/blocks/rich-text/test/__snapshots__/index.js.snap
+++ b/blocks/rich-text/test/__snapshots__/index.js.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`createTinyMCEElement should render a TinyMCE element 1`] = `
-<p
-  a-prop="hi"
->
-  <p>
-    Child
-  </p>
-</p>
+Array [
+  "p",
+  Object {
+    "a-prop": "hi",
+  },
+  Array [
+    Array [
+      "p",
+      Object {},
+      Array [
+        "Child",
+      ],
+    ],
+  ],
+]
 `;

--- a/blocks/rich-text/test/index.js
+++ b/blocks/rich-text/test/index.js
@@ -18,7 +18,7 @@ import { diffAriaProps, pickAriaProps } from '../aria';
 
 describe( 'createTinyMCEElement', () => {
 	const type = 'p';
-	const children = <p>Child</p>;
+	const children = createTinyMCEElement( 'p', {}, 'Child' );
 
 	test( 'should return null', () => {
 		const props = {
@@ -42,7 +42,7 @@ describe( 'createTinyMCEElement', () => {
 			'a-prop': 'hi',
 		};
 
-		const wrapper = shallow( createTinyMCEElement( type, props, children ) );
+		const wrapper = createTinyMCEElement( type, props, children );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 } );

--- a/blocks/test/fixtures/core__audio.html
+++ b/blocks/test/fixtures/core__audio.html
@@ -1,5 +1,5 @@
 <!-- wp:core/audio {"align":"right"} -->
 <figure class="wp-block-audio alignright">
-    <audio controls="" src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3"></audio>
+    <audio controls="true" src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3"></audio>
 </figure>
 <!-- /wp:core/audio -->

--- a/blocks/test/fixtures/core__audio.json
+++ b/blocks/test/fixtures/core__audio.json
@@ -9,6 +9,6 @@
             "align": "right"
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"true\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core__audio.parsed.json
+++ b/blocks/test/fixtures/core__audio.parsed.json
@@ -5,7 +5,7 @@
             "align": "right"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"true\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__audio.serialized.html
+++ b/blocks/test/fixtures/core__audio.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:audio {"align":"right"} -->
-<figure class="wp-block-audio alignright"><audio controls="" src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3"></audio></figure>
+<figure class="wp-block-audio alignright"><audio controls="true" src="https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3"></audio></figure>
 <!-- /wp:audio -->

--- a/blocks/test/fixtures/core__code.serialized.html
+++ b/blocks/test/fixtures/core__code.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:code -->
 <pre class="wp-block-code"><code>export default function MyButton() {
-	return &lt;Button&gt;Click Me!&lt;/Button&gt;;
+	return &lt;Button>Click Me!&lt;/Button>;
 }</code></pre>
 <!-- /wp:code -->

--- a/blocks/test/fixtures/core__heading__h2-em.json
+++ b/blocks/test/fixtures/core__heading__h2-em.json
@@ -6,10 +6,13 @@
         "attributes": {
             "content": [
                 "The ",
-                {
-                    "type": "em",
-                    "children": "Inserter"
-                },
+                [
+                    "em",
+                    {},
+                    [
+                        "Inserter"
+                    ]
+                ],
                 " Tool"
             ],
             "nodeName": "H2"

--- a/blocks/test/fixtures/core__image.serialized.html
+++ b/blocks/test/fixtures/core__image.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="" /></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
 <!-- /wp:image -->

--- a/blocks/test/fixtures/core__image__center-caption.serialized.html
+++ b/blocks/test/fixtures/core__image__center-caption.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:image {"align":"center"} -->
-<figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt="" />
-    <figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption>
+<figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" />
+    <figcaption>Give it a try. Press the "really wide" button on the image toolbar.</figcaption>
 </figure>
 <!-- /wp:image -->

--- a/blocks/test/fixtures/core__list__ul.json
+++ b/blocks/test/fixtures/core__list__ul.json
@@ -6,37 +6,56 @@
         "attributes": {
             "nodeName": "UL",
             "values": [
-                {
-                    "type": "li",
-                    "children": "Text & Headings"
-                },
-                {
-                    "type": "li",
-                    "children": "Images & Videos"
-                },
-                {
-                    "type": "li",
-                    "children": "Galleries"
-                },
-                {
-                    "type": "li",
-                    "children": "Embeds, like YouTube, Tweets, or other WordPress posts."
-                },
-                {
-                    "type": "li",
-                    "children": "Layout blocks, like Buttons, Hero Images, Separators, etc."
-                },
-                {
-                    "type": "li",
-                    "children": [
+                [
+                    "li",
+                    {},
+                    [
+                        "Text & Headings"
+                    ]
+                ],
+                [
+                    "li",
+                    {},
+                    [
+                        "Images & Videos"
+                    ]
+                ],
+                [
+                    "li",
+                    {},
+                    [
+                        "Galleries"
+                    ]
+                ],
+                [
+                    "li",
+                    {},
+                    [
+                        "Embeds, like YouTube, Tweets, or other WordPress posts."
+                    ]
+                ],
+                [
+                    "li",
+                    {},
+                    [
+                        "Layout blocks, like Buttons, Hero Images, Separators, etc."
+                    ]
+                ],
+                [
+                    "li",
+                    {},
+                    [
                         "And ",
-                        {
-                            "type": "em",
-                            "children": "Lists"
-                        },
+                        [
+                            "em",
+                            {},
+                            [
+                                "Lists"
+                            ]
+                        ],
                         " like this one of course :)"
                     ]
-                }
+                ]
             ]
         },
         "innerBlocks": [],

--- a/blocks/test/fixtures/core__preformatted.json
+++ b/blocks/test/fixtures/core__preformatted.json
@@ -6,14 +6,19 @@
         "attributes": {
             "content": [
                 "Some ",
-                {
-                    "type": "em",
-                    "children": "preformatted"
-                },
+                [
+                    "em",
+                    {},
+                    [
+                        "preformatted"
+                    ]
+                ],
                 " text...",
-                {
-                    "type": "br"
-                },
+                [
+                    "br",
+                    {},
+                    []
+                ],
                 "And more!"
             ]
         },

--- a/blocks/test/fixtures/core__pullquote.json
+++ b/blocks/test/fixtures/core__pullquote.json
@@ -6,16 +6,13 @@
         "attributes": {
             "value": [
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "Testing pullquote block..."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "children": [
+                        "p",
+                        {},
+                        [
+                            "Testing pullquote block..."
+                        ]
+                    ]
                 }
             ],
             "citation": [

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -6,40 +6,29 @@
         "attributes": {
             "value": [
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": [
-                                "Paragraph ",
-                                {
-                                    "type": "strong",
-                                    "key": "_domReact71",
-                                    "ref": null,
-                                    "props": {
-                                        "children": "one"
-                                    },
-                                    "_owner": null,
-                                    "_store": {}
-                                }
+                    "children": [
+                        "p",
+                        {},
+                        [
+                            "Paragraph ",
+                            [
+                                "strong",
+                                {},
+                                [
+                                    "one"
+                                ]
                             ]
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                        ]
+                    ]
                 },
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "Paragraph two"
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "children": [
+                        "p",
+                        {},
+                        [
+                            "Paragraph two"
+                        ]
+                    ]
                 }
             ],
             "citation": [

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -6,16 +6,13 @@
         "attributes": {
             "value": [
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "children": [
+                        "p",
+                        {},
+                        [
+                            "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
+                        ]
+                    ]
                 }
             ],
             "citation": [

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -6,16 +6,13 @@
         "attributes": {
             "value": [
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "There is no greater agony than bearing an untold story inside you."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "children": [
+                        "p",
+                        {},
+                        [
+                            "There is no greater agony than bearing an untold story inside you."
+                        ]
+                    ]
                 }
             ],
             "citation": [

--- a/blocks/test/fixtures/core__subhead.json
+++ b/blocks/test/fixtures/core__subhead.json
@@ -6,10 +6,13 @@
         "attributes": {
             "content": [
                 "This is a ",
-                {
-                    "type": "em",
-                    "children": "subhead"
-                },
+                [
+                    "em",
+                    {},
+                    [
+                        "subhead"
+                    ]
+                ],
                 "."
             ]
         },

--- a/blocks/test/fixtures/core__table.json
+++ b/blocks/test/fixtures/core__table.json
@@ -5,195 +5,291 @@
         "isValid": true,
         "attributes": {
             "content": [
-                {
-                    "type": "thead",
-                    "children": {
-                        "type": "tr",
-                        "children": [
-                            {
-                                "type": "th",
-                                "children": "Version"
-                            },
-                            {
-                                "type": "th",
-                                "children": "Musician"
-                            },
-                            {
-                                "type": "th",
-                                "children": "Date"
-                            }
+                [
+                    "thead",
+                    {},
+                    [
+                        [
+                            "tr",
+                            {},
+                            [
+                                [
+                                    "th",
+                                    {},
+                                    [
+                                        "Version"
+                                    ]
+                                ],
+                                [
+                                    "th",
+                                    {},
+                                    [
+                                        "Musician"
+                                    ]
+                                ],
+                                [
+                                    "th",
+                                    {},
+                                    [
+                                        "Date"
+                                    ]
+                                ]
+                            ]
                         ]
-                    }
-                },
-                {
-                    "type": "tbody",
-                    "children": [
-                        {
-                            "type": "tr",
-                            "children": [
-                                {
-                                    "type": "td",
-                                    "children": {
-                                        "type": "a",
-                                        "attributes": {
-                                            "href": "https://wordpress.org/news/2003/05/wordpress-now-available/"
-                                        },
-                                        "children": ".70"
-                                    }
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "No musician chosen."
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "May 27, 2003"
-                                }
+                    ]
+                ],
+                [
+                    "tbody",
+                    {},
+                    [
+                        [
+                            "tr",
+                            {},
+                            [
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        [
+                                            "a",
+                                            {
+                                                "href": "https://wordpress.org/news/2003/05/wordpress-now-available/"
+                                            },
+                                            [
+                                                ".70"
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "No musician chosen."
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "May 27, 2003"
+                                    ]
+                                ]
                             ]
-                        },
-                        {
-                            "type": "tr",
-                            "children": [
-                                {
-                                    "type": "td",
-                                    "children": {
-                                        "type": "a",
-                                        "attributes": {
-                                            "href": "https://wordpress.org/news/2004/01/wordpress-10/"
-                                        },
-                                        "children": "1.0"
-                                    }
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "Miles Davis"
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "January 3, 2004"
-                                }
+                        ],
+                        [
+                            "tr",
+                            {},
+                            [
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        [
+                                            "a",
+                                            {
+                                                "href": "https://wordpress.org/news/2004/01/wordpress-10/"
+                                            },
+                                            [
+                                                "1.0"
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "Miles Davis"
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "January 3, 2004"
+                                    ]
+                                ]
                             ]
-                        },
-                        {
-                            "type": "tr",
-                            "children": [
-                                {
-                                    "type": "td",
-                                    "children": [
+                        ],
+                        [
+                            "tr",
+                            {},
+                            [
+                                [
+                                    "td",
+                                    {},
+                                    [
                                         "Lots of versions skipped, see ",
-                                        {
-                                            "type": "a",
-                                            "attributes": {
+                                        [
+                                            "a",
+                                            {
                                                 "href": "https://codex.wordpress.org/WordPress_Versions"
                                             },
-                                            "children": "the full list"
-                                        }
+                                            [
+                                                "the full list"
+                                            ]
+                                        ]
                                     ]
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "…"
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "…"
-                                }
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "…"
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "…"
+                                    ]
+                                ]
                             ]
-                        },
-                        {
-                            "type": "tr",
-                            "children": [
-                                {
-                                    "type": "td",
-                                    "children": {
-                                        "type": "a",
-                                        "attributes": {
-                                            "href": "https://wordpress.org/news/2015/12/clifford/"
-                                        },
-                                        "children": "4.4"
-                                    }
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "Clifford Brown"
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "December 8, 2015"
-                                }
+                        ],
+                        [
+                            "tr",
+                            {},
+                            [
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        [
+                                            "a",
+                                            {
+                                                "href": "https://wordpress.org/news/2015/12/clifford/"
+                                            },
+                                            [
+                                                "4.4"
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "Clifford Brown"
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "December 8, 2015"
+                                    ]
+                                ]
                             ]
-                        },
-                        {
-                            "type": "tr",
-                            "children": [
-                                {
-                                    "type": "td",
-                                    "children": {
-                                        "type": "a",
-                                        "attributes": {
-                                            "href": "https://wordpress.org/news/2016/04/coleman/"
-                                        },
-                                        "children": "4.5"
-                                    }
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "Coleman Hawkins"
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "April 12, 2016"
-                                }
+                        ],
+                        [
+                            "tr",
+                            {},
+                            [
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        [
+                                            "a",
+                                            {
+                                                "href": "https://wordpress.org/news/2016/04/coleman/"
+                                            },
+                                            [
+                                                "4.5"
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "Coleman Hawkins"
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "April 12, 2016"
+                                    ]
+                                ]
                             ]
-                        },
-                        {
-                            "type": "tr",
-                            "children": [
-                                {
-                                    "type": "td",
-                                    "children": {
-                                        "type": "a",
-                                        "attributes": {
-                                            "href": "https://wordpress.org/news/2016/08/pepper/"
-                                        },
-                                        "children": "4.6"
-                                    }
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "Pepper Adams"
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "August 16, 2016"
-                                }
+                        ],
+                        [
+                            "tr",
+                            {},
+                            [
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        [
+                                            "a",
+                                            {
+                                                "href": "https://wordpress.org/news/2016/08/pepper/"
+                                            },
+                                            [
+                                                "4.6"
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "Pepper Adams"
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "August 16, 2016"
+                                    ]
+                                ]
                             ]
-                        },
-                        {
-                            "type": "tr",
-                            "children": [
-                                {
-                                    "type": "td",
-                                    "children": {
-                                        "type": "a",
-                                        "attributes": {
-                                            "href": "https://wordpress.org/news/2016/12/vaughan/"
-                                        },
-                                        "children": "4.7"
-                                    }
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "Sarah Vaughan"
-                                },
-                                {
-                                    "type": "td",
-                                    "children": "December 6, 2016"
-                                }
+                        ],
+                        [
+                            "tr",
+                            {},
+                            [
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        [
+                                            "a",
+                                            {
+                                                "href": "https://wordpress.org/news/2016/12/vaughan/"
+                                            },
+                                            [
+                                                "4.7"
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "Sarah Vaughan"
+                                    ]
+                                ],
+                                [
+                                    "td",
+                                    {},
+                                    [
+                                        "December 6, 2016"
+                                    ]
+                                ]
                             ]
-                        }
+                        ]
                     ]
-                }
+                ]
             ]
         },
         "innerBlocks": [],

--- a/blocks/test/fixtures/core__text__converts-to-paragraph.json
+++ b/blocks/test/fixtures/core__text__converts-to-paragraph.json
@@ -6,10 +6,13 @@
         "attributes": {
             "content": [
                 "This is an old-style text block.  Changed to ",
-                {
-                    "type": "code",
-                    "children": "paragraph"
-                },
+                [
+                    "code",
+                    {},
+                    [
+                        "paragraph"
+                    ]
+                ],
                 " in #2135."
             ],
             "dropCap": false

--- a/blocks/test/fixtures/core__verse.json
+++ b/blocks/test/fixtures/core__verse.json
@@ -6,14 +6,19 @@
         "attributes": {
             "content": [
                 "A ",
-                {
-                    "type": "em",
-                    "children": "verse"
-                },
+                [
+                    "em",
+                    {},
+                    [
+                        "verse"
+                    ]
+                ],
                 "…",
-                {
-                    "type": "br"
-                },
+                [
+                    "br",
+                    {},
+                    []
+                ],
                 "And more!"
             ]
         },

--- a/blocks/test/fixtures/core__video.html
+++ b/blocks/test/fixtures/core__video.html
@@ -1,3 +1,3 @@
 <!-- wp:core/video -->
-<figure class="wp-block-video"><video src="https://awesome-fake.video/file.mp4" controls=""></video></figure>
+<figure class="wp-block-video"><video src="https://awesome-fake.video/file.mp4" controls="true"></video></figure>
 <!-- /wp:core/video -->

--- a/blocks/test/fixtures/core__video.json
+++ b/blocks/test/fixtures/core__video.json
@@ -8,6 +8,6 @@
             "caption": []
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"\"></video></figure>"
+        "originalContent": "<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"true\"></video></figure>"
     }
 ]

--- a/blocks/test/fixtures/core__video.parsed.json
+++ b/blocks/test/fixtures/core__video.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/video",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"\"></video></figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-video\"><video src=\"https://awesome-fake.video/file.mp4\" controls=\"true\"></video></figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__video.serialized.html
+++ b/blocks/test/fixtures/core__video.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:video -->
-<figure class="wp-block-video"><video controls="" src="https://awesome-fake.video/file.mp4"></video></figure>
+<figure class="wp-block-video"><video controls="true" src="https://awesome-fake.video/file.mp4"></video></figure>
 <!-- /wp:video -->

--- a/element/index.js
+++ b/element/index.js
@@ -3,7 +3,6 @@
  */
 import { createElement, Component, cloneElement, Children, Fragment } from 'react';
 import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
-import { renderToStaticMarkup } from 'react-dom/server';
 import {
 	camelCase,
 	flowRight,
@@ -11,6 +10,11 @@ import {
 	upperFirst,
 	isEmpty,
 } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import serialize from './serialize';
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -89,7 +93,7 @@ export { createPortal };
  * @return {string} HTML.
  */
 export function renderToString( element ) {
-	let rendered = renderToStaticMarkup( element );
+	let rendered = serialize( element );
 
 	// Drop raw HTML wrappers (support dangerous inner HTML without wrapper)
 	rendered = rendered.replace( /<\/?wp-raw-html>/g, '' );

--- a/element/serialize.js
+++ b/element/serialize.js
@@ -1,0 +1,455 @@
+/**
+ * Parts of this source were derived and modified from fast-react-render,
+ * released under the MIT license.
+ *
+ * https://github.com/alt-j/fast-react-render
+ *
+ * Copyright (c) 2016 Andrey Morozov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * External dependencies
+ */
+import { flow, includes, castArray, kebabCase } from 'lodash';
+
+/**
+ * Valid attribute types.
+ *
+ * @type {String[]}
+ */
+const ATTRIBUTES_TYPES = [
+	'string',
+	'boolean',
+	'number',
+];
+
+/**
+ * Element tags which can be self-closing.
+ *
+ * @type {String[]}
+ */
+const SELF_CLOSING_TAGS = [
+	'area',
+	'base',
+	'br',
+	'col',
+	'command',
+	'embed',
+	'hr',
+	'img',
+	'input',
+	'keygen',
+	'link',
+	'meta',
+	'param',
+	'source',
+	'track',
+	'wbr',
+];
+
+/**
+ * Boolean attributes are attributes whose presence as being assigned is
+ * meaningful, even if only empty.
+ *
+ * See: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
+ * Extracted from: https://html.spec.whatwg.org/multipage/indices.html#attributes-3
+ *
+ * [ ...document.querySelectorAll( '#attributes-1 > tbody > tr' ) ]
+ *     .filter( ( tr ) => tr.lastChild.textContent.indexOf( 'Boolean attribute' ) !== -1 )
+ *     .map( ( tr ) => tr.firstChild.textContent.trim() )
+ *
+ * @type {Array}
+ */
+const BOOLEAN_ATTRIBUTES = [
+	'allowfullscreen',
+	'allowpaymentrequest',
+	'allowusermedia',
+	'async',
+	'autofocus',
+	'autoplay',
+	'checked',
+	'controls',
+	'default',
+	'defer',
+	'disabled',
+	'formnovalidate',
+	'hidden',
+	'ismap',
+	'itemscope',
+	'loop',
+	'multiple',
+	'muted',
+	'nomodule',
+	'novalidate',
+	'open',
+	'open',
+	'playsinline',
+	'readonly',
+	'required',
+	'reversed',
+	'selected',
+	'typemustmatch',
+];
+
+/**
+ * Enumerated attributes are attributes which must be of a specific value form.
+ * Like boolean attributes, these are meaningful if specified, even if not of a
+ * valid enumerated value.
+ *
+ * See: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute
+ * Extracted from: https://html.spec.whatwg.org/multipage/indices.html#attributes-3
+ *
+ * [ ...document.querySelectorAll( '#attributes-1 > tbody > tr' ) ]
+ *     filter( ( tr ) => /("(.+?)";?\s*)+/.test( tr.lastChild.textContent ) )
+ *     .map( ( tr ) => tr.firstChild.textContent.trim() )
+ *
+ * Some notable omissions:
+ *
+ *  - `alt`: https://blog.whatwg.org/omit-alt
+ *
+ * @type {Array}
+ */
+const ENUMERATED_ATTRIBUTES = [
+	'autocomplete',
+	'contenteditable',
+	'crossorigin',
+	'dir',
+	'dir',
+	'draggable',
+	'enctype',
+	'formenctype',
+	'formmethod',
+	'inputmode',
+	'kind',
+	'method',
+	'preload',
+	'sandbox',
+	'scope',
+	'shape',
+	'spellcheck',
+	'step',
+	'translate',
+	'type',
+	'type',
+	'workertype',
+	'wrap',
+];
+
+/**
+ * Set of named pattern pairs for use in escaping replacements.
+ *
+ * @type {Object}
+ */
+const REPLACEMENTS = {
+	/**
+	 * Pattern pair to replace ambiguous ampersand with encoded ampersand. Not
+	 * strictly faithful to the specification, instead opting to a mix of HTML4
+	 * and HTML5, substituting encoded ampersand where ampersand is standalone
+	 * or an invalid character reference sequence (not ending with semicolon).
+	 *
+	 * @link https://w3c.github.io/html/syntax.html#ambiguous-ampersand
+	 * @link https://w3c.github.io/html/syntax.html#character-references
+	 * @link https://mathiasbynens.be/notes/ambiguous-ampersands
+	 *
+	 * @type {Array}
+	 */
+	ambiguousAmpersand: [ /&(?!#?[a-z0-9]+;)/gi, '&amp;' ],
+
+	/**
+	 * Pattern pair replacing "literal U+0022 QUOTATION MARK characters" with
+	 * encoded quotation mark.
+	 *
+	 * @type {Array}
+	 */
+	quotationMark: [ /"/g, '&quot;' ],
+
+	/**
+	 * Pattern pair replacing "U+003C LESS-THAN SIGN (<)" with
+	 * encoded quotation mark.
+	 *
+	 * @type {Array}
+	 */
+	lessThanSign: [ /</g, '&lt;' ],
+};
+
+function createReplacer( replacements ) {
+	return flow( replacements.map( ( replacement ) => {
+		const [ pattern, substitute ] = replacement;
+		return ( value ) => value.replace( pattern, substitute );
+	} ) );
+}
+
+/**
+ * Returns an escaped attribute value.
+ *
+ * @link https://w3c.github.io/html/syntax.html#elements-attributes
+ *
+ * "[...] the text cannot contain an ambiguous ampersand [...] must not contain
+ * any literal U+0022 QUOTATION MARK characters (")"
+ *
+ * @param {string} value Attribute value.
+ *
+ * @return {string} Escaped attribute value.
+ */
+const escapeAttribute = createReplacer( [
+	REPLACEMENTS.ambiguousAmpersand,
+	REPLACEMENTS.quotationMark,
+] );
+
+/**
+ * Returns an escaped HTML element value.
+ *
+ * @link https://w3c.github.io/html/syntax.html#writing-html-documents-elements
+ * @link https://w3c.github.io/html/syntax.html#ambiguous-ampersand
+ *
+ * "the text must not contain the character U+003C LESS-THAN SIGN (<) or an
+ * ambiguous ampersand."
+ *
+ * @param {string} value Element value.
+ *
+ * @return {string} Escaped HTML element value.
+ */
+const escapeHTML = createReplacer( [
+	REPLACEMENTS.lessThanSign,
+	REPLACEMENTS.ambiguousAmpersand,
+] );
+
+/**
+ * Returns true if the specified string is prefixed by one of an array of
+ * possible prefixes.
+ *
+ * @param {string}   string   String to check.
+ * @param {string[]} prefixes Possible prefixes.
+ *
+ * @return {boolean} Whether string has prefix.
+ */
+function hasPrefixes( string, prefixes ) {
+	return prefixes.some( ( prefix ) => string.indexOf( prefix ) === 0 );
+}
+
+/**
+ * Returns true if the given prop name should be ignored in attributes
+ * serialization, or false otherwise.
+ *
+ * @param {string} attribute Attribute to check.
+ *
+ * @return {boolean} Whether attribute should be ignored.
+ */
+function shouldIgnoreAttribute( attribute ) {
+	return 'key' === attribute || 'children' === attribute;
+}
+
+/**
+ * Serializes a React element to string.
+ *
+ * @param {WPElement} element Element to serialize.
+ * @param {?Object}   context Context object.
+ *
+ * @return {string} Serialized element.
+ */
+function renderElement( element, context = {} ) {
+	if ( null === element || undefined === element || false === element ) {
+		return '';
+	}
+
+	if ( Array.isArray( element ) ) {
+		return element.map( ( childElement ) => (
+			renderElement( childElement, context )
+		) ).join( '' );
+	}
+
+	if ( typeof element === 'string' ) {
+		return element;
+	}
+
+	if ( typeof element === 'number' ) {
+		return element.toString();
+	}
+
+	const { type, props } = element;
+
+	if ( typeof type === 'string' ) {
+		return renderNativeComponent( type, props, context );
+	} else if ( typeof type === 'function' ) {
+		if ( type.prototype && typeof type.prototype.render === 'function' ) {
+			return renderComponent( type, props, context );
+		}
+
+		return renderElement( type( props, context ), context );
+	}
+
+	return '';
+}
+
+/**
+ * Serializes a native component type to string.
+ *
+ * @param {string}  type    Native component type to serialize.
+ * @param {Object}  props   Props object.
+ * @param {?Object} context Context object.
+ *
+ * @return {string} Serialized element.
+ */
+function renderNativeComponent( type, props, context = {} ) {
+	let content = '';
+	if ( type === 'textarea' ) {
+		content = renderChildren( [ props.value ], context );
+	} else if ( props.dangerouslySetInnerHTML ) {
+		content = props.dangerouslySetInnerHTML.__html;
+	} else if ( typeof props.children !== 'undefined' ) {
+		content = renderChildren( castArray( props.children ), context );
+	}
+
+	const attributes = renderAttributes( props );
+
+	if ( includes( SELF_CLOSING_TAGS, type ) ) {
+		return '<' + type + attributes + '/>' + content;
+	}
+
+	return '<' + type + attributes + '>' + content + '</' + type + '>';
+}
+
+/**
+ * Serializes a non-native component type to string.
+ *
+ * @param {Function} Component Component type to serialize.
+ * @param {Object}   props     Props object.
+ * @param {?Object}  context   Context object.
+ *
+ * @return {string} Serialized element
+ */
+function renderComponent( Component, props, context = {} ) {
+	const instance = new Component( props, context );
+
+	if ( typeof instance.componentWillMount === 'function' ) {
+		instance.componentWillMount();
+	}
+
+	if ( typeof instance.getChildContext === 'function' ) {
+		Object.assign( context, instance.getChildContext() );
+	}
+
+	const html = renderElement( instance.render(), context );
+
+	return html;
+}
+
+/**
+ * Serializes an array of children to string.
+ *
+ * @param {Array}   children Children to serialize.
+ * @param {?Object} context  Context object.
+ *
+ * @return {string} Serialized children.
+ */
+function renderChildren( children, context = {} ) {
+	let result = '';
+
+	for ( let i = 0; i < children.length; i++ ) {
+		const child = children[ i ];
+
+		if ( typeof child === 'string' ) {
+			result += escapeHTML( child );
+		} else if ( Array.isArray( child ) ) {
+			result += renderChildren( child, context );
+		} else if ( typeof child === 'object' && child ) {
+			result += renderElement( child, context );
+		} else if ( typeof child === 'number' ) {
+			result += child;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Renders a props object as a string of HTML attributes.
+ *
+ * @param {Object} props Props object.
+ *
+ * @return {string} Attributes string.
+ */
+function renderAttributes( props ) {
+	let result = '';
+
+	for ( const key in props ) {
+		const value = key === 'style' ? renderStyle( props[ key ] ) : props[ key ];
+
+		const isBooleanAttribute = (
+			( typeof value === 'boolean' && hasPrefixes( key, [ 'data-', 'aria-' ] ) ) ||
+			includes( BOOLEAN_ATTRIBUTES, key )
+		);
+
+		const isAsIsRenderAttribute = (
+			isBooleanAttribute ||
+			'src' === key ||
+			includes( ENUMERATED_ATTRIBUTES, key )
+		);
+
+		if ( ( ! value && ! isAsIsRenderAttribute ) || shouldIgnoreAttribute( key ) ||
+				! includes( ATTRIBUTES_TYPES, typeof value ) ) {
+			continue;
+		}
+
+		let attribute = key;
+		if ( key === 'htmlFor' ) {
+			attribute = 'for';
+		} else if ( key === 'className' ) {
+			attribute = 'class';
+		}
+
+		result += ' ' + attribute;
+
+		if ( typeof value !== 'boolean' || isBooleanAttribute ) {
+			result += '="' + ( typeof value === 'string' ? escapeAttribute( value ) : value ) + '"';
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Renders a style object as a string attribute value.
+ *
+ * @param {Object} style Style object.
+ *
+ * @return {string} Style attribute value.
+ */
+function renderStyle( style ) {
+	let result = '';
+
+	for ( const property in style ) {
+		const value = style[ property ];
+		if ( null === value || undefined === value ) {
+			continue;
+		}
+
+		if ( result ) {
+			result += ';';
+		}
+
+		result += kebabCase( property ) + ':' + value;
+	}
+
+	return result;
+}
+
+export default renderElement;

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -51,6 +51,21 @@ describe( 'element', () => {
 			) ).toBe( '<strong>Courgette</strong>' );
 		} );
 
+		it( 'should escape attributes and html', () => {
+			const result = renderToString( createElement( 'a', {
+				href: '/index.php?foo=bar&qux=<"scary">',
+				style: {
+					backgroundColor: 'red',
+				},
+			}, '&copy (sic) &#169; &copy; 2018 <"WordPress" & Friends>' ) );
+
+			expect( result ).toBe(
+				'<a href="/index.php?foo=bar&amp;qux=<&quot;scary&quot;>" style="background-color:red">' +
+				'&amp;copy (sic) &#169; &copy; 2018 &lt;"WordPress" &amp; Friends>' +
+				'</a>'
+			);
+		} );
+
 		it( 'strips raw html wrapper', () => {
 			const html = '<p>So scary!</p>';
 

--- a/element/test/serialize.js
+++ b/element/test/serialize.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { Component } from '../';
+import serialize from '../serialize';
+
+describe( 'serialize', () => {
+	it( 'should render with context', () => {
+		class Provider extends Component {
+			getChildContext() {
+				return {
+					greeting: 'Hello!',
+				};
+			}
+
+			render() {
+				return this.props.children;
+			}
+		}
+
+		Provider.childContextTypes = {
+			greeting: noop,
+		};
+
+		// NOTE: Technically, a component should only receive context if it
+		// explicitly defines `contextTypes`. This requirement is ignored in
+		// our implementation.
+
+		function FunctionComponent( props, context ) {
+			return 'FunctionComponent: ' + context.greeting;
+		}
+
+		class ClassComponent extends Component {
+			render() {
+				return 'ClassComponent: ' + this.context.greeting;
+			}
+		}
+
+		const result = serialize(
+			<Provider>
+				<FunctionComponent />
+				<ClassComponent />
+			</Provider>
+		);
+
+		expect( result ).toBe(
+			'FunctionComponent: Hello!' +
+			'ClassComponent: Hello!'
+		);
+	} );
+} );

--- a/post-content.js
+++ b/post-content.js
@@ -8,11 +8,11 @@ window._wpGutenbergPost.title = {
 window._wpGutenbergPost.content = {
 	raw: [
 		'<!-- wp:cover-image {"url":"https://cldup.com/Fz-ASbo2s3.jpg","align":"wide"} -->',
-		'<div class="wp-block-cover-image has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><p class="wp-block-cover-image-text">Of Mountains &amp; Printing Presses</p></div>',
+		'<div class="wp-block-cover-image has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><p class="wp-block-cover-image-text">Of Mountains & Printing Presses</p></div>',
 		'<!-- /wp:cover-image -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you&#x27;ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>',
+		'<p>The goal of this new editor is to make adding rich content to WordPress simple and enjoyable. This whole post is composed of <em>pieces of content</em>—somewhat similar to LEGO bricks—that you can move around and interact with. Move your cursor around and you\'ll notice the different blocks light up with outlines and arrows. Press the arrows to reposition blocks quickly, without fearing about losing things in the process of copying and pasting.</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:paragraph -->',
@@ -32,15 +32,15 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:heading -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>Handling images and media with the utmost care is a primary focus of the new editor. Hopefully, you&#x27;ll find aspects of adding captions or going full-width with your pictures much easier and robust than before.</p>',
+		'<p>Handling images and media with the utmost care is a primary focus of the new editor. Hopefully, you\'ll find aspects of adding captions or going full-width with your pictures much easier and robust than before.</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:image {"align":"center"} -->',
-		'<figure class="wp-block-image aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>Give it a try. Press the &quot;wide&quot; button on the image toolbar.</figcaption></figure>',
+		'<figure class="wp-block-image aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape" /><figcaption>Give it a try. Press the "wide" button on the image toolbar.</figcaption></figure>',
 		'<!-- /wp:image -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>Try selecting and removing or editing the caption, now you don&#x27;t have to be careful about selecting the image or other text by mistake and ruining the presentation.</p>',
+		'<p>Try selecting and removing or editing the caption, now you don\'t have to be careful about selecting the image or other text by mistake and ruining the presentation.</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:heading -->',
@@ -48,15 +48,15 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:heading -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That&#x27;s the spirit behind the inserter—the <code>(+)</code> button you&#x27;ll see around the editor—which allows you to browse all available content blocks and add them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>',
+		'<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That\'s the spirit behind the inserter—the <code>(+)</code> button you\'ll see around the editor—which allows you to browse all available content blocks and add them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>Go give it a try, you may discover things WordPress can already add into your posts that you didn&#x27;t know about. Here&#x27;s a short list of what you can currently find there:</p>',
+		'<p>Go give it a try, you may discover things WordPress can already add into your posts that you didn\'t know about. Here\'s a short list of what you can currently find there:</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:list -->',
-		'<ul><li>Text &amp; Headings</li><li>Images &amp; Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>',
+		'<ul><li>Text & Headings</li><li>Images & Videos</li><li>Galleries</li><li>Embeds, like YouTube, Tweets, or other WordPress posts.</li><li>Layout blocks, like Buttons, Hero Images, Separators, etc.</li><li>And <em>Lists</em> like this one of course :)</li></ul>',
 		'<!-- /wp:list -->',
 
 		'<!-- wp:separator -->',
@@ -76,7 +76,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:quote -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>The information corresponding to the source of the quote is a separate text field, similar to captions under images, so the structure of the quote is protected even if you select, modify, or remove the source. It&#x27;s always easy to add it back.</p>',
+		'<p>The information corresponding to the source of the quote is a separate text field, similar to captions under images, so the structure of the quote is protected even if you select, modify, or remove the source. It\'s always easy to add it back.</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:paragraph -->',
@@ -104,7 +104,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:image {"align":"full"} -->',
-		'<figure class="wp-block-image alignfull"><img src="https://cldup.com/8lhI-gKnI2.jpg" alt="Accessibility is important don&#x27;t forget image alt attribute" /></figure>',
+		'<figure class="wp-block-image alignfull"><img src="https://cldup.com/8lhI-gKnI2.jpg" alt="Accessibility is important don\'t forget image alt attribute" /></figure>',
 		'<!-- /wp:image -->',
 
 		'<!-- wp:paragraph -->',


### PR DESCRIPTION
Closes #3353
Closes #2750
Related: #3048, #2463, #3713

This pull request seeks to explore using a custom element serializer without markup escaping and with built-in support for the "vanilla" element tree described in #2463, enabling us to represent the value of Editable as a simple object type, not a React element tree (enabling better collaborative editing via serializable values, server-side block templating of editable attributes).

React doesn't expose hooks for its server serialization, so I instead resorted to a custom implementation, a modified version of a [library which implemented a simplified server renderer](https://github.com/alt-j/fast-react-render).