### PR TITLE
Update post_to_edit to use a blank post if not on admin screen

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -715,8 +715,19 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	array_push( $word_count_script->deps, 'wp-utils' );
 
 	global $post;
+	// On admin pages, global $post is the only post.
+	if ( is_admin() ) {
+		$post_to_edit = $post;
+	} else {
+		// On front-end editing, global $post might be last post in the_loop
+		// which is probably not what we want to edit especially in the case
+		// for a site like P2 which creates posts on the front-end.
+		// Use admin function get_default_post_to_edit() to get new empty post.
+		require_once( ABSPATH . '/wp-admin/includes/post.php' );
+		$post_to_edit = get_default_post_to_edit( 'post', true );
+	}
 	// Generate API-prepared post.
-	$post_to_edit = gutenberg_get_post_to_edit( $post );
+	$post_to_edit = gutenberg_get_post_to_edit( $post_to_edit );
 	if ( is_wp_error( $post_to_edit ) ) {
 		wp_die( $post_to_edit->get_error_message() );
 	}


### PR DESCRIPTION
## Description
Using global $post to load the post to edit works if Gutenberg is only used within wp-admin, it does not work if Gutenberg is used for front-end editing, for example in the P2 theme.

When using the global $post to determine what to edit, Gutenberg ends up loading the last post from `the_loop` and not a new blank post.

This change uses the same `global $post` if on an admin screen (is_admin()) and will use the `get_default_post_to_edit()` if not on an admin screen.

## How Has This Been Tested?
* Confirmed editing works the same on admin screens, creating new posts and editing existing posts.
* Confirmed editing works for front-end editing for creating new posts

