### PR TITLE
Extensibility: Respect the 'enter_title_here' hook

### DIFF
--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -9,9 +9,10 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { withContext } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -97,7 +98,7 @@ class PostTitle extends Component {
 	}
 
 	render() {
-		const { title } = this.props;
+		const { title, placeholder } = this.props;
 		const { isSelected } = this.state;
 		const className = classnames( 'editor-post-title', { 'is-selected': isSelected } );
 
@@ -116,7 +117,7 @@ class PostTitle extends Component {
 						className="editor-post-title__input"
 						value={ title }
 						onChange={ this.onChange }
-						placeholder={ __( 'Add title' ) }
+						placeholder={ placeholder || __( 'Add title' ) }
 						onClick={ this.onSelect }
 						onKeyDown={ this.onKeyDown }
 						onKeyPress={ this.onUnselect }
@@ -127,7 +128,7 @@ class PostTitle extends Component {
 	}
 }
 
-export default connect(
+const applyConnect = connect(
 	( state ) => ( {
 		title: getEditedPostTitle( state ),
 	} ),
@@ -140,4 +141,15 @@ export default connect(
 		},
 		clearSelectedBlock,
 	}
+);
+
+const applyEditorSettings = withContext( 'editor' )(
+	( settings ) => ( {
+		placeholder: settings.titlePlaceholder,
+	} )
+);
+
+export default compose(
+	applyConnect,
+	applyEditorSettings
 )( PostTitle );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -814,9 +814,10 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$allowed_block_types = apply_filters( 'allowed_block_types', true );
 
 	$editor_settings = array(
-		'wideImages' => ! empty( $gutenberg_theme_support[0]['wide-images'] ),
-		'colors'     => $color_palette,
-		'blockTypes' => $allowed_block_types,
+		'wideImages'       => ! empty( $gutenberg_theme_support[0]['wide-images'] ),
+		'colors'           => $color_palette,
+		'blockTypes'       => $allowed_block_types,
+		'titlePlaceholder' => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
 	);
 
 	$post_type_object = get_post_type_object( $post_to_edit['type'] );


### PR DESCRIPTION
closes #4042 

This PR adds the `enter_title_here` to the editor's settings object and overrides the default title placeholder using this value.

**Testing instructions**

 - Add a filter like this

```php
function change_title_text( $title ){
     return "my custom text";
}
  
add_filter( 'enter_title_here', 'change_title_text' );
```

 - Open Gutenberg and notice the title's placeholder displaying "my custom text"