### PR TITLE
Blocks: Add the missing alignments classNames to the Cover Image Block's markup

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -166,7 +166,7 @@ registerBlockType( 'core/cover-image', {
 	},
 
 	save( { attributes, className } ) {
-		const { url, title, hasParallax, dimRatio } = attributes;
+		const { url, title, hasParallax, dimRatio, align } = attributes;
 		const style = url ?
 			{ backgroundImage: `url(${ url })` } :
 			undefined;
@@ -176,7 +176,8 @@ registerBlockType( 'core/cover-image', {
 			{
 				'has-background-dim': dimRatio !== 0,
 				'has-parallax': hasParallax,
-			}
+			},
+			align ? `align${ align }` : null,
 		);
 
 		return (

--- a/post-content.js
+++ b/post-content.js
@@ -8,7 +8,7 @@ window._wpGutenbergPost.title = {
 window._wpGutenbergPost.content = {
 	raw: [
 		'<!-- wp:cover-image {"url":"https://cldup.com/Fz-ASbo2s3.jpg","align":"wide"} -->',
-		'<section class="wp-block-cover-image has-background-dim" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><h2>Of Mountains &amp; Printing Presses</h2></section>',
+		'<section class="wp-block-cover-image has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><h2>Of Mountains &amp; Printing Presses</h2></section>',
 		'<!-- /wp:cover-image -->',
 
 		'<!-- wp:paragraph -->',


### PR DESCRIPTION
closes #2650

Tiny PR adding the missing alignment classNames to the cover image block. It also declares a "deprecated" version to avoid invalidating old cover image blocks.

**Testing instructions**

 - Declare wide alignment support for your theme:

```php
add_theme_support( 'gutenberg', array(
        'wide-images' => true,
) );
```

 - Add a cover image
 - Click "full alignment" button
 - Switch to the Code editor, you should see a "alignfull" className on the cover-image's figure wrapper.