### PR TITLE
Added drag&drop upload to cover image.

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { Placeholder, Toolbar, Dashicon } from '@wordpress/components';
+import { Placeholder, Toolbar, Dashicon, DropZone } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
+import { mediaUpload } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -67,6 +68,7 @@ registerBlockType( 'core/cover-image', {
 		const onSelectImage = ( media ) => setAttributes( { url: media.url, id: media.id } );
 		const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
 		const setDimRatio = ( ratio ) => setAttributes( { dimRatio: ratio } );
+		const dropFiles = ( files ) => mediaUpload( files, setAttributes );
 		const style = url ?
 			{ backgroundImage: `url(${ url })` } :
 			undefined;
@@ -131,6 +133,9 @@ registerBlockType( 'core/cover-image', {
 					icon="format-image"
 					label={ __( 'Cover Image' ) }
 					className={ className }>
+					<DropZone
+						onFilesDrop={ dropFiles }
+					/>
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }
 						onSelect={ onSelectImage }


### PR DESCRIPTION
Although cover-image block says "Drag image here or insert from media library", drag & drop upload was missing.

## How Has This Been Tested?
Add a cover image verify, it is possible to set the image on it by dragging an image from the desktop.


## Types of changes
This is a very simple PR just uses our DropZone to allow drap&drop upload.