### PR TITLE
When autosaving drafts, don't create revisions.

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -234,9 +234,10 @@ export function editPost( edits ) {
 	};
 }
 
-export function savePost() {
+export function savePost( options ) {
 	return {
 		type: 'REQUEST_POST_UPDATE',
+		options,
 	};
 }
 

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -17,6 +17,7 @@ import {
 	getDefaultBlockName,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -79,7 +80,9 @@ export default {
 		const newModel = new Model( toSend );
 
 		// Tag the autosave action to avoid creating revisions.
-		newModel.url = newModel.url() + '?gutenberg_autosave=' + ( action.options && action.options.autosave ? '1' : '' );
+		if ( action.options && action.options.autosave ) {
+			newModel.url = addQueryArgs( newModel.url(), { 'gutenberg_autosave': '1' } );
+		}
 		newModel.save().done( ( newPost ) => {
 			dispatch( {
 				type: 'RESET_POST',

--- a/editor/effects.js
+++ b/editor/effects.js
@@ -76,7 +76,11 @@ export default {
 		} );
 		dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
 		const Model = wp.api.getPostTypeModel( getCurrentPostType( state ) );
-		new Model( toSend ).save().done( ( newPost ) => {
+		const newModel = new Model( toSend );
+
+		// Tag the autosave action to avoid creating revisions.
+		newModel.url = newModel.url() + '?gutenberg_autosave=' + ( action.options && action.options.autosave ? '1' : '' );
+		newModel.save().done( ( newPost ) => {
 			dispatch( {
 				type: 'RESET_POST',
 				post: newPost,
@@ -278,7 +282,7 @@ export default {
 			dispatch( editPost( { status: 'draft' } ) );
 		}
 
-		dispatch( savePost() );
+		dispatch( savePost( { 'autosave': 1 } ) );
 	},
 	SETUP_EDITOR( action ) {
 		const { post, settings } = action;

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -547,8 +547,10 @@ function gutenberg_add_admin_body_class( $classes ) {
 }
 
 /**
- * Filter the number of revisikons for posts, skipping revisions when autosaving.
+ * Filter the number of revisions for posts, skipping revisions when autosaving.
+ *
  * @param  int $count The number of revisions to save.
+ *
  * @return int        The original count, or zero if this is a Gutenberg autosave.
  */
 function gutenberg_filter_revisions( $count ) {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -545,3 +545,17 @@ add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_b
 function gutenberg_add_admin_body_class( $classes ) {
 	return "$classes gutenberg-editor-page";
 }
+
+/**
+ * Filter the number of revisikons for posts, skipping revisions when autosaving.
+ * @param  int $count The number of revisions to save.
+ * @return int        The original count, or zero if this is a Gutenberg autosave.
+ */
+function gutenberg_filter_revisions( $count ) {
+
+	if ( isset( $_REQUEST['gutenberg_autosave'] ) && '1' ===  $_REQUEST['gutenberg_autosave'] ) {
+		return 0;
+	}
+	return $count;
+}
+add_filter( 'wp_revisions_to_keep', 'gutenberg_filter_revisions' );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -555,7 +555,7 @@ function gutenberg_add_admin_body_class( $classes ) {
  */
 function gutenberg_filter_revisions( $count ) {
 
-	if ( isset( $_REQUEST['gutenberg_autosave'] ) && '1' ===  $_REQUEST['gutenberg_autosave'] ) {
+	if ( isset( $_REQUEST['gutenberg_autosave'] ) && '1' === $_REQUEST['gutenberg_autosave'] ) {
 		return 0;
 	}
 	return $count;


### PR DESCRIPTION
## Description
When dispatching the autosave event, pass a query var, then skip revisions for that save event.

## How Has This Been Tested?
Creating and saving draft posts, monitoring the database.

## Types of changes
* when dispatching savePost from autosave add an option autoupdate=1
* when initiating a save, add a gutenberg_autosave query var if the autoupdate option is set
* filter the number of revisions for WordPress to create, set at 0 if the gutenberg_autosave query var is present.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.