### PR TITLE
Add dynamic block documentation

### DIFF
--- a/docs/blocks-dynamic.md
+++ b/docs/blocks-dynamic.md
@@ -90,7 +90,7 @@ Because it is a dynamic block it also needs a server component. The rendering ca
 <?php
 // block.php
 
-function riad_render_block_latest_post( $attribites ) {
+function my_plugin_render_block_latest_post( $attribites ) {
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => 1,
 		'post_status' => 'publish',
@@ -101,14 +101,14 @@ function riad_render_block_latest_post( $attribites ) {
 	$post = $recent_posts[ 0 ];
 	$post_id = $post['ID'];
 	return sprintf(
-		'<a class="wp-block-riad-latest-post" href="%1$s">%2$s</a>',
+		'<a class="wp-block-my-plugin-latest-post" href="%1$s">%2$s</a>',
 		esc_url( get_permalink( $post_id ) ),
 		esc_html( get_the_title( $post_id ) )
 	);
 }
 
-register_block_type( 'riad/latest-post', array(
-	'render_callback' => 'riad_render_block_latest_post',
+register_block_type( 'my-plugin/latest-post', array(
+	'render_callback' => 'my_plugin_render_block_latest_post',
 ) );
 ```
 

--- a/docs/blocks-dynamic.md
+++ b/docs/blocks-dynamic.md
@@ -1,3 +1,5 @@
+# Creating dynamic blocks
+
 It is also possible to create dynamic blocks. These are blocks that can change their content even if the post is not saved. One example from WordPress itself is the latest posts block. This block will update everywhere it is used whena new post is published.
 
 The following code example shows how to create the latest post block dynamic block.

--- a/docs/blocks-dynamic.md
+++ b/docs/blocks-dynamic.md
@@ -2,6 +2,8 @@ It is also possible to create dynamic blocks. These are blocks that can change t
 
 The following code example shows how to create the latest post block dynamic block.
 
+{% codetabs %}
+{% ES5 %}
 ```js
 // myblock.js
 
@@ -9,7 +11,7 @@ var el = wp.element.createElement,
 	registerBlockType = wp.blocks.registerBlockType,
 	withAPIData = wp.components.withAPIData;
 
-registerBlockType( 'riad/latest-post', {
+registerBlockType( 'my-plugin/latest-post', {
 	title: 'Latest Post',
 	icon: 'megaphone',
 	category: 'widgets',
@@ -41,6 +43,44 @@ registerBlockType( 'riad/latest-post', {
 	},
 } );
 ```
+{% ESNext %}
+```js
+// myblock.js
+
+const { el } = wp.element;
+const { registerBlockType } = wp.blocks;
+const { withAPIData } = wp.components;
+
+registerBlockType( 'my-plugin/latest-post', {
+	title: 'Latest Post',
+	icon: 'megaphone',
+	category: 'widgets',
+
+	edit: withAPIData( () => {
+		return {
+			posts: '/wp/v2/posts?per_page=1'
+		};
+	} )( ( { posts, className } ) => {
+		if ( ! posts.data ) {
+			return "loading !";
+		}
+		if ( posts.data.length === 0 ) {
+			return "No posts";
+		}
+		var post = posts.data[ 0 ];
+		
+		return <a className={ className } href={ post.link }>
+			{ post.title.rendered }
+		</a>;
+	} ),
+
+	save() {
+		// Rendering in PHP
+		return null;
+	},
+} );
+```
+{% end %}
 
 Because it is a dynamic block it also needs a server component. The rendering can be added using the `render_callback` property when using the `register_block_type` function.
 

--- a/docs/blocks-dynamic.md
+++ b/docs/blocks-dynamic.md
@@ -90,7 +90,7 @@ Because it is a dynamic block it also needs a server component. The rendering ca
 <?php
 // block.php
 
-function my_plugin_render_block_latest_post( $attribites ) {
+function my_plugin_render_block_latest_post( $attributes ) {
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => 1,
 		'post_status' => 'publish',

--- a/docs/blocks-dynamic.md
+++ b/docs/blocks-dynamic.md
@@ -1,6 +1,6 @@
 # Creating dynamic blocks
 
-It is also possible to create dynamic blocks. These are blocks that can change their content even if the post is not saved. One example from WordPress itself is the latest posts block. This block will update everywhere it is used whena new post is published.
+It is possible to create dynamic blocks. These are blocks that can change their content even if the post is not saved. One example from WordPress itself is the latest posts block. This block will update everywhere it is used when a new post is published.
 
 The following code example shows how to create the latest post block dynamic block.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -60,6 +60,12 @@
 		"parent": "blocks"
 	},
 	{
+		"title": "Creating dynamic blocks",
+		"slug": "creating-dynamic-blocks",
+		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/blocks-dynamic.md",
+		"parent": "blocks"
+	},
+	{
 		"title": "Reference",
 		"slug": "reference",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/reference.md",


### PR DESCRIPTION
I wanted to onboard one of our developers onto writing a dynamic Gutenberg block, but I couldn't find the documentation. So I've added the documentation from @youknowriad's blog to the handbook. Taken from https://riad.blog/2017/10/16/one-thousand-and-one-way-to-extend-gutenberg-today/#dynamic-block. I've rewritten some sentences to better fit the handbook.