### PR TITLE
Block API: Reimplement align as common extension

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -24,6 +24,7 @@ export {
 	getDefaultBlockName,
 	getBlockType,
 	getBlockTypes,
+	getBlockSupport,
 	hasBlockSupport,
 	isReusableBlock,
 } from './registration';

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -228,6 +228,26 @@ export function getBlockTypes() {
 }
 
 /**
+ * Returns the block support value for a feature, if defined.
+ *
+ * @param  {(string|Object)} nameOrType      Block name or type object
+ * @param  {string}          feature         Feature to retrieve
+ * @param  {*}               defaultSupports Default value to return if not
+ *                                           explicitly defined
+ * @return {?*}                              Block support value
+ */
+export function getBlockSupport( nameOrType, feature, defaultSupports ) {
+	const blockType = 'string' === typeof nameOrType ?
+		getBlockType( nameOrType ) :
+		nameOrType;
+
+	return get( blockType, [
+		'supports',
+		feature,
+	], defaultSupports );
+}
+
+/**
  * Returns true if the block defines support for a feature, or false otherwise.
  *
  * @param {(string|Object)} nameOrType      Block name or type object.
@@ -238,14 +258,7 @@ export function getBlockTypes() {
  * @return {boolean} Whether block supports feature.
  */
 export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
-	const blockType = 'string' === typeof nameOrType ?
-		getBlockType( nameOrType ) :
-		nameOrType;
-
-	return !! get( blockType, [
-		'supports',
-		feature,
-	], defaultSupports );
+	return !! getBlockSupport( nameOrType, feature, defaultSupports );
 }
 
 /**

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -17,6 +17,7 @@ import {
 	getDefaultBlockName,
 	getBlockType,
 	getBlockTypes,
+	getBlockSupport,
 	hasBlockSupport,
 	isReusableBlock,
 } from '../registration';
@@ -375,6 +376,41 @@ describe( 'blocks', () => {
 					},
 				},
 			] );
+		} );
+	} );
+
+	describe( 'getBlockSupport', () => {
+		it( 'should return undefined if block has no supports', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				supports: {
+					bar: true,
+				},
+			} );
+
+			expect( getBlockSupport( 'core/test-block', 'foo' ) ).toBe( undefined );
+		} );
+
+		it( 'should return block supports value', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				supports: {
+					bar: true,
+				},
+			} );
+
+			expect( getBlockSupport( 'core/test-block', 'bar' ) ).toBe( true );
+		} );
+
+		it( 'should return custom default supports if block does not define support by name', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				supports: {
+					bar: true,
+				},
+			} );
+
+			expect( getBlockSupport( 'core/test-block', 'foo', true ) ).toBe( true );
 		} );
 	} );
 

--- a/blocks/hooks/align.js
+++ b/blocks/hooks/align.js
@@ -78,8 +78,8 @@ export function withToolbarControls( BlockEdit ) {
 		const updateAlignment = ( nextAlign ) => props.setAttributes( { align: nextAlign } );
 
 		return [
-			validAlignments.length > 0 && props.focus && (
-				<BlockControls key="controls">
+			validAlignments.length > 0 && props.isSelected && (
+				<BlockControls key="align-controls">
 					<BlockAlignmentToolbar
 						value={ props.attributes.align }
 						onChange={ updateAlignment }
@@ -90,7 +90,7 @@ export function withToolbarControls( BlockEdit ) {
 			<BlockEdit key="edit" { ...props } />,
 		];
 	};
-	WrappedBlockEdit.displayName = getWrapperDisplayName( BlockEdit, 'customClassName' );
+	WrappedBlockEdit.displayName = getWrapperDisplayName( BlockEdit, 'align' );
 
 	return WrappedBlockEdit;
 }
@@ -141,5 +141,5 @@ export function addAssignedAlign( props, blockType, attributes ) {
 addFilter( 'blocks.registerBlockType', 'core/align/addAttribute', addAttribute );
 addFilter( 'editor.BlockListBlock', 'core/align/withAlign', withAlign );
 addFilter( 'blocks.BlockEdit', 'core/align/withToolbarControls', withToolbarControls );
-addFilter( 'blocks.getSaveContent.extraProps', 'core/align/extraProps', addAssignedAlign );
+addFilter( 'blocks.getSaveContent.extraProps', 'core/align/addAssignedAlign', addAssignedAlign );
 

--- a/blocks/hooks/align.js
+++ b/blocks/hooks/align.js
@@ -83,6 +83,7 @@ export function withToolbarControls( BlockEdit ) {
 					<BlockAlignmentToolbar
 						value={ props.attributes.align }
 						onChange={ updateAlignment }
+						controls={ validAlignments }
 					/>
 				</BlockControls>
 			),

--- a/blocks/hooks/align.js
+++ b/blocks/hooks/align.js
@@ -40,8 +40,8 @@ export function addAttribute( settings ) {
  * Returns an array of valid alignments for a block type depending on its
  * defined supports. Returns an empty array if block does not support align.
  *
- * @param  {String}   blockName Block name to check
- * @return {String[]}           Valid alignments for block
+ * @param  {string}   blockName Block name to check
+ * @return {string[]}           Valid alignments for block
  */
 export function getBlockValidAlignments( blockName ) {
 	// Explicitly defined array set of valid alignments

--- a/blocks/hooks/align.js
+++ b/blocks/hooks/align.js
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { assign, includes } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { getWrapperDisplayName } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+import BlockControls from '../block-controls';
+import BlockAlignmentToolbar from '../block-alignment-toolbar';
+
+/**
+ * Internal dependencies
+ */
+import { getBlockSupport, hasBlockSupport } from '../api';
+
+/**
+ * Filters registered block settings, extending attributes to include `align`.
+ *
+ * @param  {Object} settings Original block settings
+ * @return {Object}          Filtered block settings
+ */
+export function addAttribute( settings ) {
+	if ( hasBlockSupport( settings, 'align' ) ) {
+		// Use Lodash's assign to gracefully handle if attributes are undefined
+		settings.attributes = assign( settings.attributes, {
+			align: {
+				type: 'string',
+			},
+		} );
+	}
+
+	return settings;
+}
+
+/**
+ * Returns an array of valid alignments for a block type depending on its
+ * defined supports. Returns an empty array if block does not support align.
+ *
+ * @param  {String}   blockName Block name to check
+ * @return {String[]}           Valid alignments for block
+ */
+export function getBlockValidAlignments( blockName ) {
+	// Explicitly defined array set of valid alignments
+	const blockAlign = getBlockSupport( blockName, 'align' );
+	if ( Array.isArray( blockAlign ) ) {
+		return blockAlign;
+	}
+
+	const validAlignments = [];
+	if ( true === blockAlign ) {
+		// `true` includes all alignments...
+		validAlignments.push( 'left', 'center', 'right' );
+
+		// ...including wide alignments unless explicitly `false`.
+		if ( hasBlockSupport( blockName, 'wideAlign', true ) ) {
+			validAlignments.push( 'wide', 'full' );
+		}
+	}
+
+	return validAlignments;
+}
+
+/**
+ * Override the default edit UI to include new toolbar controls for block
+ * alignment, if block defines support.
+ *
+ * @param  {Function} BlockEdit Original component
+ * @return {Function}           Wrapped component
+ */
+export function withToolbarControls( BlockEdit ) {
+	const WrappedBlockEdit = ( props ) => {
+		const validAlignments = getBlockValidAlignments( props.name );
+
+		const updateAlignment = ( nextAlign ) => props.setAttributes( { align: nextAlign } );
+
+		return [
+			validAlignments.length > 0 && props.focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar
+						value={ props.attributes.align }
+						onChange={ updateAlignment }
+					/>
+				</BlockControls>
+			),
+			<BlockEdit key="edit" { ...props } />,
+		];
+	};
+	WrappedBlockEdit.displayName = getWrapperDisplayName( BlockEdit, 'customClassName' );
+
+	return WrappedBlockEdit;
+}
+
+/**
+ * Override the default block element to add alignment wrapper props.
+ *
+ * @param  {Function} BlockListBlock Original component
+ * @return {Function}                Wrapped component
+ */
+export function withAlign( BlockListBlock ) {
+	const WrappedComponent = ( props ) => {
+		const { align } = props.block.attributes;
+		const validAlignments = getBlockValidAlignments( props.block.name );
+
+		let wrapperProps = props.wrapperProps;
+		if ( includes( validAlignments, align ) ) {
+			wrapperProps = { ...wrapperProps, 'data-align': align };
+		}
+
+		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
+	};
+
+	WrappedComponent.displayName = getWrapperDisplayName( BlockListBlock, 'align' );
+
+	return WrappedComponent;
+}
+
+/**
+ * Override props assigned to save component to inject alignment class name if
+ * block supports it.
+ *
+ * @param  {Object} props      Additional props applied to save element
+ * @param  {Object} blockType  Block type
+ * @param  {Object} attributes Block attributes
+ * @return {Object}            Filtered props applied to save element
+ */
+export function addAssignedAlign( props, blockType, attributes ) {
+	const { align } = attributes;
+
+	if ( includes( getBlockValidAlignments( blockType ), align ) ) {
+		props.className = classnames( `align${ align }`, props.className );
+	}
+
+	return props;
+}
+
+addFilter( 'blocks.registerBlockType', 'core/align/addAttribute', addAttribute );
+addFilter( 'editor.BlockListBlock', 'core/align/withAlign', withAlign );
+addFilter( 'blocks.BlockEdit', 'core/align/withToolbarControls', withToolbarControls );
+addFilter( 'blocks.getSaveContent.extraProps', 'core/align/extraProps', addAssignedAlign );
+

--- a/blocks/hooks/index.js
+++ b/blocks/hooks/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './align';
 import './anchor';
 import './custom-class-name';
 import './deprecated';

--- a/blocks/hooks/test/align.js
+++ b/blocks/hooks/test/align.js
@@ -116,7 +116,7 @@ describe( 'align', () => {
 				<EnhancedComponent
 					name="core/foo"
 					attributes={ {} }
-					focus
+					isSelected
 				/>
 			);
 
@@ -140,7 +140,7 @@ describe( 'align', () => {
 				<EnhancedComponent
 					name="core/foo"
 					attributes={ {} }
-					focus
+					isSelected
 				/>
 			);
 

--- a/blocks/hooks/test/align.js
+++ b/blocks/hooks/test/align.js
@@ -1,0 +1,243 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getBlockTypes,
+	registerBlockType,
+	unregisterBlockType,
+} from '../../api';
+import {
+	getBlockValidAlignments,
+	withToolbarControls,
+	withAlign,
+	addAssignedAlign,
+} from '../align';
+
+describe( 'align', () => {
+	const blockSettings = {
+		save: noop,
+		category: 'common',
+		title: 'block title',
+	};
+
+	afterEach( () => {
+		getBlockTypes().forEach( block => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'addAttribute()', () => {
+		const filterRegisterBlockType = applyFilters.bind( null, 'blocks.registerBlockType' );
+
+		it( 'should do nothing if the block settings does not define align support', () => {
+			const settings = filterRegisterBlockType( blockSettings );
+
+			expect( settings.attributes ).toBeUndefined();
+		} );
+
+		it( 'should assign a new align attribute', () => {
+			const settings = filterRegisterBlockType( {
+				...blockSettings,
+				supports: {
+					align: true,
+				},
+			} );
+
+			expect( settings.attributes ).toHaveProperty( 'align' );
+		} );
+	} );
+
+	describe( 'getBlockValidAlignments()', () => {
+		it( 'should return an empty array if block does not define align support', () => {
+			registerBlockType( 'core/foo', blockSettings );
+			const validAlignments = getBlockValidAlignments( 'core/foo' );
+
+			expect( validAlignments ).toEqual( [] );
+		} );
+
+		it( 'should return all custom align set', () => {
+			registerBlockType( 'core/foo', {
+				...blockSettings,
+				supports: {
+					align: [ 'left', 'right' ],
+				},
+			} );
+			const validAlignments = getBlockValidAlignments( 'core/foo' );
+
+			expect( validAlignments ).toEqual( [ 'left', 'right' ] );
+		} );
+
+		it( 'should return all aligns if block defines align support', () => {
+			registerBlockType( 'core/foo', {
+				...blockSettings,
+				supports: {
+					align: true,
+				},
+			} );
+			const validAlignments = getBlockValidAlignments( 'core/foo' );
+
+			expect( validAlignments ).toEqual( [ 'left', 'center', 'right', 'wide', 'full' ] );
+		} );
+
+		it( 'should return all aligns except wide if wide align explicitly false', () => {
+			registerBlockType( 'core/foo', {
+				...blockSettings,
+				supports: {
+					align: true,
+					wideAlign: false,
+				},
+			} );
+			const validAlignments = getBlockValidAlignments( 'core/foo' );
+
+			expect( validAlignments ).toEqual( [ 'left', 'center', 'right' ] );
+		} );
+	} );
+
+	describe( 'withToolbarControls', () => {
+		it( 'should do nothing if no valid alignments', () => {
+			registerBlockType( 'core/foo', blockSettings );
+
+			const EnhancedComponent = withToolbarControls( ( { wrapperProps } ) => (
+				<div { ...wrapperProps } />
+			) );
+
+			const wrapper = mount(
+				<EnhancedComponent
+					name="core/foo"
+					attributes={ {} }
+					focus
+				/>
+			);
+
+			expect( wrapper.children() ).toHaveLength( 1 );
+		} );
+
+		it( 'should render toolbar controls if valid alignments', () => {
+			registerBlockType( 'core/foo', {
+				...blockSettings,
+				supports: {
+					align: true,
+					wideAlign: false,
+				},
+			} );
+
+			const EnhancedComponent = withToolbarControls( ( { wrapperProps } ) => (
+				<div { ...wrapperProps } />
+			) );
+
+			const wrapper = mount(
+				<EnhancedComponent
+					name="core/foo"
+					attributes={ {} }
+					focus
+				/>
+			);
+
+			expect( wrapper.children() ).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( 'withAlign', () => {
+		it( 'should render with wrapper props', () => {
+			registerBlockType( 'core/foo', {
+				...blockSettings,
+				supports: {
+					align: true,
+					wideAlign: false,
+				},
+			} );
+
+			const EnhancedComponent = withAlign( ( { wrapperProps } ) => (
+				<div { ...wrapperProps } />
+			) );
+
+			const wrapper = mount(
+				<EnhancedComponent
+					block={ {
+						name: 'core/foo',
+						attributes: {
+							align: 'left',
+						},
+					} }
+				/>
+			);
+
+			expect( wrapper.childAt( 0 ).prop( 'wrapperProps' ) ).toEqual( {
+				'data-align': 'left',
+			} );
+		} );
+
+		it( 'should not render invalid align', () => {
+			registerBlockType( 'core/foo', {
+				...blockSettings,
+				supports: {
+					align: true,
+					wideAlign: false,
+				},
+			} );
+
+			const EnhancedComponent = withAlign( ( { wrapperProps } ) => (
+				<div { ...wrapperProps } />
+			) );
+
+			const wrapper = mount(
+				<EnhancedComponent
+					block={ {
+						name: 'core/foo',
+						attributes: {
+							align: 'wide',
+						},
+					} }
+				/>
+			);
+
+			expect( wrapper.childAt( 0 ).prop( 'wrapperProps' ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'addAssignedAlign', () => {
+		it( 'should do nothing if block does not support align', () => {
+			registerBlockType( 'core/foo', blockSettings );
+
+			const props = addAssignedAlign( {
+				className: 'foo',
+			}, 'core/foo', {
+				align: 'wide',
+			} );
+
+			expect( props ).toEqual( {
+				className: 'foo',
+			} );
+		} );
+
+		it( 'should do add align classname if block supports align', () => {
+			registerBlockType( 'core/foo', {
+				...blockSettings,
+				supports: {
+					align: true,
+				},
+			} );
+
+			const props = addAssignedAlign( {
+				className: 'foo',
+			}, 'core/foo', {
+				align: 'wide',
+			} );
+
+			expect( props ).toEqual( {
+				className: 'alignwide foo',
+			} );
+		} );
+	} );
+} );

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -17,7 +17,6 @@ import './editor.scss';
 import MediaUpload from '../../media-upload';
 import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
-import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
 export const name = 'core/audio';
 
@@ -37,9 +36,6 @@ export const settings = {
 			selector: 'audio',
 			attribute: 'src',
 		},
-		align: {
-			type: 'string',
-		},
 		caption: {
 			type: 'array',
 			source: 'children',
@@ -50,11 +46,8 @@ export const settings = {
 		},
 	},
 
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
-			return { 'data-align': align };
-		}
+	supports: {
+		align: true,
 	},
 
 	edit: class extends Component {
@@ -69,10 +62,9 @@ export const settings = {
 			};
 		}
 		render() {
-			const { align, caption, id } = this.props.attributes;
+			const { caption, id } = this.props.attributes;
 			const { setAttributes, isSelected } = this.props;
 			const { editing, className, src } = this.state;
-			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 			const switchToEditing = () => {
 				this.setState( { editing: true } );
 			};
@@ -95,10 +87,6 @@ export const settings = {
 			};
 			const controls = isSelected && (
 				<BlockControls key="controls">
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ updateAlignment }
-					/>
 					<Toolbar>
 						<IconButton
 							className="components-icon-button components-toolbar__control"
@@ -168,9 +156,9 @@ export const settings = {
 	},
 
 	save( { attributes } ) {
-		const { align, src, caption } = attributes;
+		const { src, caption } = attributes;
 		return (
-			<figure className={ align ? `align${ align }` : null }>
+			<figure>
 				<audio controls="controls" src={ src } />
 				{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 			</figure>

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -471,9 +471,12 @@ export class BlockListBlock extends Component {
 		const { onMouseLeave, onReplace } = this.props;
 
 		// Determine whether the block has props to apply to the wrapper.
-		let wrapperProps;
+		let wrapperProps = this.props.wrapperProps;
 		if ( blockType.getEditWrapperProps ) {
-			wrapperProps = blockType.getEditWrapperProps( block.attributes );
+			wrapperProps = {
+				...wrapperProps,
+				...blockType.getEditWrapperProps( block.attributes ),
+			};
 		}
 
 		// Disable reasons:


### PR DESCRIPTION
This pull request seeks to explore a refactoring of block alignment as a common `supports` feature, responsible for managing:

- Attribute definition
- Rendering toolbar controls
- Rendering editor wrapper control with additional props
- Serializing with `alignleft` etc. class name

Included is a single ported example to demonstrate the new behavior. See the Audio block changes for an example of how this can help simplify common alignment behavior. This is part of an effort toward eliminating `getEditWrapperProps` altogether.

__Implementation notes:__

A new block API `getBlockSupport` has been added, complementing `hasBlockSupport` and intended to be used in cases where a block support is defined as a non-boolean type ([mimicking `...args` of `add_theme_support`](https://developer.wordpress.org/reference/functions/add_theme_support/)), used to allow granular control of specific supported alignments.

The theme supports feature for wide alignment has been renamed with these changes from `wide-images` to `wide-align` to better reflect that wide alignment can apply to other block types (audio, etc).

__Testing instructions:__

Verify that there are no regressions in the alignment behavior of the Audio block.

Ensure unit tests pass:

```
npm test
```