### PR TITLE
Polish mobile, notably iPhone

### DIFF
--- a/editor/assets/stylesheets/_variables.scss
+++ b/editor/assets/stylesheets/_variables.scss
@@ -12,6 +12,7 @@ $editor-font-size: 16px;
 $text-editor-font-size: 14px;
 $editor-line-height: 1.8;
 $big-font-size: 18px;
+$mobile-text-min-font-size: 16px;	// Any font size below 16px will cause Mobile Safari to "zoom in"
 
 // Widths, heights & dimensions
 $item-spacing: 10px;

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -1,6 +1,12 @@
 body.gutenberg-editor-page {
 	background: $white;
 
+	// on mobile the main content area has to scroll
+	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
+	@include break-small {
+		overflow: hidden;
+	}
+
 	#update-nag, .update-nag {
 		display: none;
 	}
@@ -58,16 +64,15 @@ body.gutenberg-editor-page {
 }
 
 .gutenberg__editor {
-	position: absolute;
-	top: $admin-bar-height-big;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	min-height: calc( 100vh - #{ $admin-bar-height-big } );
-
-	// The parent relative container changes
+	// on mobile the main content area has to scroll
+	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
 	@include break-small {
+		position: absolute;
 		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		min-height: calc( 100vh - #{ $admin-bar-height-big } );
 	}
 
 	// The WP header height changes at this breakpoint

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -465,7 +465,20 @@ $sticky-bottom-offset: 20px;
 	text-align: left;
 	pointer-events: none;
 	height: $block-toolbar-height;
-	top: -1px;	// stack borders
+
+	// put toolbar snugly to edge on mobile
+	margin-left: -$block-padding - 1px;	// stack borders
+	margin-right: -$block-padding - 1px;
+	@include break-small() {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	// on mobile, toolbars fix differently
+	top: $header-height - 1px; // stack borders
+	@include break-small() {
+		top: -1px;	// stack borders
+	}
 
 	.editor-block-toolbar {
 		border: 1px solid $light-gray-500;

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -32,11 +32,16 @@ input[type="search"].editor-inserter__search {
 	width: 100%;
 	margin: 0;
 	padding: 8px 11px;
-	font-size: $default-font-size;
 	position: relative;
 	z-index: 1;
 	border: none;
 	box-shadow: 0 1px 0 0 $light-gray-500;
+
+	// fonts smaller than 16px causes mobile safari to zoom
+	font-size: $mobile-text-min-font-size;
+	@include break-small {
+		font-size: $default-font-size;
+	}
 
 	&:focus {
 		@include input-style__focus-active;

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -31,7 +31,6 @@ input[type="search"].editor-inserter__search {
 	display: block;
 	width: 100%;
 	margin: 0;
-	box-shadow: none;
 	padding: 8px 11px;
 	font-size: $default-font-size;
 	position: relative;
@@ -135,6 +134,7 @@ input[type="search"].editor-inserter__search {
 		background: $light-gray-300;
 		border-bottom: 1px solid $light-gray-500;
 		flex-shrink: 0;
+		margin-top: 1px;
 	}
 }
 

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -7,6 +7,14 @@
 	font-family: $default-font;
 	font-size: $default-font-size;
 	height: 40px;
+
+	// put toolbar snugly to edge on mobile
+	margin-left: -$block-padding - 1px;	// stack borders
+	margin-right: -$block-padding - 1px;
+	@include break-small() {
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 .editor-post-permalink__label {

--- a/editor/components/post-publish-with-dropdown/style.scss
+++ b/editor/components/post-publish-with-dropdown/style.scss
@@ -9,6 +9,7 @@
 .wp-core-ui .editor-post-publish-with-dropdown__button.button-primary {
 	display: inline-flex;
 	align-items: center;
+	margin-bottom: 0;
 
 	&.is-busy .dashicon {
 		display: none;

--- a/editor/edit-post/header/ellipsis-menu/style.scss
+++ b/editor/edit-post/header/ellipsis-menu/style.scss
@@ -1,9 +1,12 @@
 .editor-ellipsis-menu {
 	// the padding and margin of the ellipsis menu is intentionally non-standard
-	margin-left: 4px;
+	@include break-small() {
+		margin-left: 4px;
+	}
 
 	.components-icon-button {
 		padding: 8px 4px;
+		width: auto;
 	}
 
 	.components-button svg {

--- a/editor/edit-post/header/style.scss
+++ b/editor/edit-post/header/style.scss
@@ -11,8 +11,16 @@
 	left: 0;
 	right: 0;
 
-	top: $admin-bar-height-big;
-	position: fixed;
+	// mobile edgecase for toolbar
+	top: 0;
+	position: sticky;
+
+	// on mobile the main content area has to scroll
+	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
+	@include break-small {
+		position: fixed;
+		top: $admin-bar-height-big;
+	}
 
 	@include break-medium() {
 		top: $admin-bar-height;

--- a/editor/edit-post/layout/style.scss
+++ b/editor/edit-post/layout/style.scss
@@ -4,7 +4,6 @@
 }
 
 .editor-layout {
-	padding-top: $header-height;
 	position: relative;
 
 	.components-notice-list {
@@ -24,8 +23,16 @@
 		}
 	}
 
+	// on mobile, toolbars behave differently
+	@include break-small {
+		padding-top: $header-height;
+	}
+
 	&.has-fixed-toolbar {
-		padding-top: $header-height + $block-toolbar-height;
+		// on mobile, toolbars behave differently
+		@include break-small {
+			padding-top: $header-height + $block-toolbar-height;
+		}
 
 		@include break-large {
 			padding-top: $header-height;
@@ -47,6 +54,11 @@
 
 .editor-layout__content {
 	position: relative;
-	overflow-y: auto;
-	-webkit-overflow-scrolling: touch;
+
+	// on mobile the main content area has to scroll
+	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
+	@include break-small {
+		overflow-y: auto;
+		-webkit-overflow-scrolling: touch;
+	}
 }

--- a/editor/edit-post/layout/style.scss
+++ b/editor/edit-post/layout/style.scss
@@ -29,9 +29,17 @@
 	}
 
 	&.has-fixed-toolbar {
+		.editor-layout__content {
+			padding-top: $block-controls-height;
+		}
+
 		// on mobile, toolbars behave differently
 		@include break-small {
 			padding-top: $header-height + $block-toolbar-height;
+
+			.editor-layout__content {
+				padding-top: 0;
+			}
 		}
 
 		@include break-large {


### PR DESCRIPTION
This is sort of a kitchen sink PR of small fixes. It:

- Polishes the inserter tabs so the focus style isn't clippsed
- Tweaks margins in the toolbar on mobile, so things aren't shifted around
- It undoes that individually scrolling content area and makes the `body` scroll. More on this in a second.
- It polishes how the fixed-to-block toolbar looks on mobile
- It changs how the fixed position toolbars behave, making them sticky, otherwise it wouldn't work with the WP admin bar properly
- It rotates the ellipsis button that shows mobile tools so it matches the top ellipsis. This needs more work separately, with the idea of instead showing these tools when the block is selected. 
- It prevents Mobile Safari from zooming the entire page when you open the inserter (it does this because the textfield receives focus, and Mobile Safari deems the 13px font too small, so it zooms)

As such, the above fixes part of the issues described in #4077, notably the zooming and scrolling issues.


## How Has This Been Tested?

Tested in Chrome simulator, as well as the Xcode iPhone 8 simulator.

## Screenshots

![screen shot 2017-12-19 at 11 46 40](https://user-images.githubusercontent.com/1204802/34153431-56d24304-e4b2-11e7-9728-59b3d4a41fda.png)
![screen shot 2017-12-19 at 11 46 45](https://user-images.githubusercontent.com/1204802/34153435-584537fa-e4b2-11e7-88f6-151d9d78f22d.png)
![screen shot 2017-12-19 at 11 46 50](https://user-images.githubusercontent.com/1204802/34153438-5970f25e-e4b2-11e7-8c52-81d92e212a09.png)
![screen shot 2017-12-19 at 11 46 59](https://user-images.githubusercontent.com/1204802/34153442-5a71a19e-e4b2-11e7-8c14-dd56a7551228.png)

Here's a video showing the iOS simulator:

https://cloudup.com/ccvLjdy6cT3

Outside of the iOS changes, which make Gutenberg usable, I'm going to open a separate ticket about modal improvements (some work to be done there). But because these changes also affect the desktop breakpoints, we should be sure to test this PR fairly widely. 