### PR TITLE
Framework: Fix block creation with falsey default attribute

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -44,7 +44,7 @@ export function createBlock( name, blockAttributes = {} ) {
 		const value = blockAttributes[ key ];
 		if ( undefined !== value ) {
 			result[ key ] = value;
-		} else if ( source.default ) {
+		} else if ( source.hasOwnProperty( 'default' ) ) {
 			result[ key ] = source.default;
 		}
 

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -44,6 +44,10 @@ describe( 'block factory', () => {
 						type: 'boolean',
 						default: true,
 					},
+					includesFalseyDefault: {
+						type: 'number',
+						default: 0,
+					},
 				},
 				save: noop,
 				category: 'common',
@@ -56,6 +60,7 @@ describe( 'block factory', () => {
 			expect( block.name ).toEqual( 'core/test-block' );
 			expect( block.attributes ).toEqual( {
 				includesDefault: true,
+				includesFalseyDefault: 0,
 				align: 'left',
 			} );
 			expect( block.isValid ).toBe( true );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/4046#pullrequestreview-84223334

This pull request seeks to resolve a bug where calling `createBlock` would not respect falsey default values of a block attribute. This was observed in some blocks where using an inspector toggle control would log a React warning, only because the default value of the attribute was being skipped, therefore the toggle would change the underlying input value from `undefined` to `true`.

__Testing instructions:__

Ensure that tests pass:

```
npm test
```

Verify that creating a Categories block, then toggling any of its block inspector controls does not log a warning, and saves correctly.