### PR TITLE
Try: State: Allow for save blocking

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -227,7 +227,14 @@ export function clearBlockInsertionPoint() {
 	};
 }
 
-export function editPost( edits ) {
+/**
+ * Returns an action object used in signalling that properties of the edited
+ * post have been updated.
+ *
+ * @param  {?Object} edits Updated post properties
+ * @return {Object}        Action object
+ */
+export function editPost( edits = {} ) {
 	return {
 		type: 'EDIT_POST',
 		edits,
@@ -237,6 +244,20 @@ export function editPost( edits ) {
 export function savePost() {
 	return {
 		type: 'REQUEST_POST_UPDATE',
+	};
+}
+
+/**
+ * Returns an action object used in signalling that save blocking should be
+ * toggled to the specified state.
+ *
+ * @param  {Boolean} isBlocked Whether saving is to be blocked
+ * @return {Object}            Action object
+ */
+export function toggleSavingBlocked( isBlocked ) {
+	return {
+		type: 'TOGGLE_SAVING_BLOCKED',
+		isBlocked,
 	};
 }
 

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -37,6 +37,7 @@ import {
 	updateReusableBlock,
 	saveReusableBlock,
 	insertBlock,
+	toggleSavingBlocked,
 } from './actions';
 import {
 	getCurrentPost,
@@ -50,6 +51,7 @@ import {
 	isEditedPostSaveable,
 	getBlock,
 	getReusableBlock,
+	isSavingBlocked,
 	POST_UPDATE_TRANSACTION_ID,
 } from './selectors';
 
@@ -153,6 +155,16 @@ export default {
 				'Post ' + post.id,
 				getPostEditUrl( post.id )
 			);
+		}
+	},
+	EDIT_POST( action, store ) {
+		if ( action.edits.hasOwnProperty( 'content' ) && ! isSavingBlocked( store.getState() ) ) {
+			return toggleSavingBlocked( true );
+		}
+	},
+	RESET_BLOCKS( action, store ) {
+		if ( isSavingBlocked( store.getState() ) ) {
+			return toggleSavingBlocked( false );
 		}
 	},
 	REQUEST_POST_UPDATE_FAILURE( action, store ) {

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -613,6 +613,16 @@ export function saving( state = {}, action ) {
 				successful: false,
 				error: action.error,
 			};
+
+		case 'TOGGLE_SAVING_BLOCKED':
+			if ( action.isBlocked === state.blocked ) {
+				return state;
+			}
+
+			return {
+				...state,
+				blocked: action.isBlocked,
+			};
 	}
 
 	return state;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -338,14 +338,15 @@ export function isEditedPostPublishable( state ) {
 }
 
 /**
- * Returns true if the post can be saved, or false otherwise. A post must
- * contain a title, an excerpt, or non-empty content to be valid for save.
+ * Returns true if the post can be saved, or false otherwise. To be valid for
+ * save, a post must contain a non-empty title, an excerpt, or content, and
+ * save blocking must not be in effect.
  *
  * @param  {Object}  state Global application state
  * @return {Boolean}       Whether the post can be saved
  */
 export function isEditedPostSaveable( state ) {
-	return (
+	return ! isSavingBlocked( state ) && (
 		!! getEditedPostTitle( state ) ||
 		!! getEditedPostExcerpt( state ) ||
 		!! getEditedPostContent( state )
@@ -1146,4 +1147,14 @@ export function isPublishingPost( state ) {
 	// Consider as publishing when current post prior to request was not
 	// considered published
 	return !! stateBeforeRequest && ! isCurrentPostPublished( stateBeforeRequest );
+}
+
+/**
+ * Returns true if saving is currently blocked.
+ *
+ * @param  {Object}  state Global application state
+ * @return {Boolean}       Whether saving is blocked
+ */
+export function isSavingBlocked( state ) {
+	return !! state.saving.blocked;
 }

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1106,6 +1106,29 @@ describe( 'state', () => {
 				},
 			} );
 		} );
+
+		it( 'should toggle blocking', () => {
+			const state = saving( undefined, {
+				type: 'TOGGLE_SAVING_BLOCKED',
+				isBlocked: true,
+			} );
+
+			expect( state ).toEqual( {
+				blocked: true,
+			} );
+		} );
+
+		it( 'should skip blocking toggle if the same', () => {
+			const original = deepFreeze( {
+				blocked: true,
+			} );
+			const state = saving( original, {
+				type: 'TOGGLE_SAVING_BLOCKED',
+				isBlocked: true,
+			} );
+
+			expect( state ).toBe( original );
+		} );
 	} );
 
 	describe( 'notices()', () => {

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -81,6 +81,7 @@ import {
 	getReusableBlocks,
 	getStateBeforeOptimisticTransaction,
 	isPublishingPost,
+	isSavingBlocked,
 	POST_UPDATE_TRANSACTION_ID,
 } from '../selectors';
 
@@ -1089,6 +1090,27 @@ describe( 'selectors', () => {
 					},
 				},
 				currentPost: {},
+				saving: {},
+			};
+
+			expect( isEditedPostSaveable( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if saving is blocked', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUid: {},
+						blockOrder: [],
+						edits: {},
+					},
+				},
+				currentPost: {
+					title: 'sassel',
+				},
+				saving: {
+					blocked: true,
+				},
 			};
 
 			expect( isEditedPostSaveable( state ) ).toBe( false );
@@ -1106,6 +1128,7 @@ describe( 'selectors', () => {
 				currentPost: {
 					title: 'sassel',
 				},
+				saving: {},
 			};
 
 			expect( isEditedPostSaveable( state ) ).toBe( true );
@@ -1123,6 +1146,7 @@ describe( 'selectors', () => {
 				currentPost: {
 					excerpt: 'sassel',
 				},
+				saving: {},
 			};
 
 			expect( isEditedPostSaveable( state ) ).toBe( true );
@@ -1146,6 +1170,7 @@ describe( 'selectors', () => {
 					},
 				},
 				currentPost: {},
+				saving: {},
 			};
 
 			expect( isEditedPostSaveable( state ) ).toBe( true );
@@ -2448,6 +2473,36 @@ describe( 'selectors', () => {
 			} );
 
 			expect( isPublishing ).toBe( true );
+		} );
+	} );
+
+	describe( 'isSavingBlocked()', () => {
+		it( 'returns false if saving blocked is not set', () => {
+			const isBlocked = isSavingBlocked( {
+				saving: {},
+			} );
+
+			expect( isBlocked ).toBe( false );
+		} );
+
+		it( 'returns false if saving is not blocked', () => {
+			const isBlocked = isSavingBlocked( {
+				saving: {
+					blocked: false,
+				},
+			} );
+
+			expect( isBlocked ).toBe( false );
+		} );
+
+		it( 'returns true if saving is blocked', () => {
+			const isBlocked = isSavingBlocked( {
+				saving: {
+					blocked: true,
+				},
+			} );
+
+			expect( isBlocked ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
Closes #2978

This pull request seeks to explore an option for resolving autosave clobbering of Text mode content. It introduces a new save blocking mechanism which prevents saves from occurring while active. For the moment, this is implemented while changing the Text mode textarea. In the future, it could potentially be used as a mechanism for preventing autosave from occurring when an upload is in progress.

__Design notes:__

One major drawback of this approach is that it is not intuitive for a user to save their changes when editing within the Text mode. Further, it may be desirable for autosave to occur while editing the Text mode textarea, as long as it takes edits from the Text mode as precedent over the pending Visual mode changes. To achieve the latter, this would require some signalling from the editor to the Text mode to indicate that a save is about to occur.

__Testing instructions:__

Repeat testing instructions from #2978, verifying that autosave does not kick in when making edits in the textarea after switching to Text mode.