### PR TITLE
Clarify allowed_block_types filter

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -805,8 +805,8 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	}
 
 	/**
-	 * Filters the allowed block types for the editor, defaulting to true (all
-	 * block types supported).
+	 * Filters the allowed block types for the inserter, defaulting to true (all
+	 * block types present in the inserter).
 	 *
 	 * @param bool|array $allowed_block_types Array of block type slugs, or
 	 *                                        boolean to enable/disable all.


### PR DESCRIPTION
## Description
As per [conversation in Slack](https://wordpress.slack.com/archives/C02QB2JS7/p1513708566000210), this PR updates the docblock of the `allowed_block_types` filter to clarify existing behaviour.

## How Has This Been Tested?
This PR does not affect functionality; it just changes code comments for clarity.

## Types of changes
This PR does not affect functionality; it just changes code comments for clarity.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.