### PR TITLE
Fixing defect when trying to create a post using Classic Editor on Posts page

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -493,7 +493,7 @@ function gutenberg_replace_default_add_new_button() {
 			<?php else : ?>
 			padding-right: 9px;
 			<?php endif; ?>
-		}
+		}	
 
 	</style>
 	<script type="text/javascript">
@@ -505,19 +505,23 @@ function gutenberg_replace_default_add_new_button() {
 				return;
 			}
 
-			var url = button.href;
-			var newUrl = url.replace( /[&\?]?classic-editor/, '' );
+			var url = button.href; 
+			var classicUrl = button.href + "?classic-editor";
+			/* Gutenberg is now the default editor. 
+			 * The Classic Editor requires the 
+			 * appropriate query string to appear.
+			 */
 
 			var newbutton = '<span id="split-page-title-action" class="split-page-title-action">';
-			newbutton += '<a href="' + newUrl + '">' + button.innerText + '</a>';
+			newbutton += '<a href="' + url + '">' + button.innerText + '</a>';
 			newbutton += '<span class="expander" tabindex="0" role="button" aria-haspopup="true" aria-label="<?php echo esc_js( __( 'Toggle editor selection menu', 'gutenberg' ) ); ?>"></span>';
-			newbutton += '<span class="dropdown"><a href="' + newUrl + '">Gutenberg</a>';
-			newbutton += '<a href="' + url + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span><span class="page-title-action" style="display:none;"></span>';
+			newbutton += '<span class="dropdown"><a href="' + url + '">Gutenberg</a>';
+			newbutton += '<a href="' + classicUrl + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span><span class="page-title-action" style="display:none;"></span>';
 
 			button.insertAdjacentHTML( 'afterend', newbutton );
 			button.remove();
 
-			var expander = document.getElementById( 'split-page-title-action' ).getElementsByClassName( 'expander' ).item( 0 );
+			var expander = document.egtElementById( 'split-page-title-action' ).getElementsByClassName( 'expander' ).item( 0 );
 			expander.addEventListener( 'click', function( e ) {
 				e.preventDefault();
 				e.target.parentNode.getElementsByClassName( 'dropdown' ).item( 0 ).classList.toggle( 'visible' );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -521,7 +521,7 @@ function gutenberg_replace_default_add_new_button() {
 			button.insertAdjacentHTML( 'afterend', newbutton );
 			button.remove();
 
-			var expander = document.egtElementById( 'split-page-title-action' ).getElementsByClassName( 'expander' ).item( 0 );
+			var expander = document.getElementById( 'split-page-title-action' ).getElementsByClassName( 'expander' ).item( 0 );
 			expander.addEventListener( 'click', function( e ) {
 				e.preventDefault();
 				e.target.parentNode.getElementsByClassName( 'dropdown' ).item( 0 ).classList.toggle( 'visible' );


### PR DESCRIPTION
## Description
Fixes a defect that prevents users from adding a new post using the "Classic Editor" (CE) when Gutenberg (GB) is active. Appends the appropriate query string as documented below with a note inline explaining why.

## How Has This Been Tested?
Yep! Tested locally on a few browser while running a vanilla WordPress, built locally, only using the Twenty Seventeen theme.

## Screenshots (jpeg or gifs if applicable):
![screenshot from 2017-12-19 17-14-56](https://user-images.githubusercontent.com/963672/34186692-214de4ec-e4e2-11e7-87b2-72add6501cf1.png)
^ Highlighted in Inspector and on screen.

## Types of changes
This replaces the old logic for Gutenberg's editor on the Posts listing:
```
var url = button.href; \\ supposed to make CE appear but doesn't
var newUrl = url.replace( /[&\?]?classic-editor/, '' );  \\ supposed to enable GB by disabling CE using this unnecessary regex
```
With working code to allow creation for CE again:
```
var url = button.href; \\ no additional code is needed to call GB
var classicUrl = button.href + "?classic-editor"; \\ A query string is required to call the CE
```
The appropriate code a few lines down to call URLs has also been appropriately adjusted.

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style.
- [ x ] My code follows has proper inline documentation.