### PR TITLE
Add `humanTimeDiff()` date utility

### DIFF
--- a/date/index.js
+++ b/date/index.js
@@ -314,6 +314,29 @@ export function dateI18n( dateFormat, dateValue = new Date(), gmt = false ) {
 	return format( dateFormat, dateMoment );
 }
 
+/**
+ * Human time difference (like `human_time_diff()` in PHP).
+ *
+ * @param  {?(Date|String|Number|Moment|null)} from    Value parsable by moment.js or 'now'. Default is now.
+ * @param  {?(Date|String|Number|Moment|null)} to      Value parsable by moment.js or 'now'. Default is now.
+ * @param  {?Boolean}                          verbose True to add an an 'ago' (past) or 'from now' (future) suffix.
+ *                                                     Defaults to false so it matches `human_time_diff()` in PHP,
+ *                                                     which doesn't support this additional argument yet.
+ *
+ * @return {String}                                    Difference; e.g., 3 days, in 3 days, 3 days ago, 3 days from now.
+ */
+export function humanTimeDiff( from, to, verbose = false ) {
+	// Establish 'from' and 'to' times.
+	from = ! from || from === 'now' ? new Date() : from;
+	to = ! to || to === 'now' ? new Date() : to;
+	// Convert to moment.
+	const fromMoment = moment( from );
+	// Set the locale.
+	fromMoment.locale( window._wpDateSettings.l10n.locale );
+	// Format and return.
+	return fromMoment.to( to, ! verbose ? true : false );
+}
+
 export const settings = window._wpDateSettings;
 
 // Initialize.

--- a/date/index.js
+++ b/date/index.js
@@ -197,22 +197,24 @@ function setupLocale( settings ) {
 			LLL: settings.formats.datetime,
 			LLLL: null,
 		},
-		// From human_time_diff?
-		// Set to `(number, withoutSuffix, key, isFuture) => {}` instead.
+		// Required by humanTimeDiff() utility in this file.
+		// Maybe set to `(number, withoutSuffix, key, isFuture) => {}` in the future?
+		// i.e., Moment allows this to be a callback Function also: https://git.io/vN8EL
 		relativeTime: {
 			future: settings.l10n.relative.future,
 			past: settings.l10n.relative.past,
-			s: 'seconds',
-			m: 'a minute',
-			mm: '%d minutes',
-			h: 'an hour',
-			hh: '%d hours',
-			d: 'a day',
-			dd: '%d days',
-			M: 'a month',
-			MM: '%d months',
-			y: 'a year',
-			yy: '%d years',
+			s: settings.l10n.relative.s,
+			ss: settings.l10n.relative.ss,
+			m: settings.l10n.relative.m,
+			mm: settings.l10n.relative.mm,
+			h: settings.l10n.relative.h,
+			hh: settings.l10n.relative.hh,
+			d: settings.l10n.relative.d,
+			dd: settings.l10n.relative.dd,
+			M: settings.l10n.relative.M,
+			MM: settings.l10n.relative.MM,
+			y: settings.l10n.relative.y,
+			yy: settings.l10n.relative.yy,
 		},
 	} );
 	moment.locale( currentLocale );
@@ -333,7 +335,7 @@ export function humanTimeDiff( from, to, verbose = false ) {
 	const fromMoment = moment( from );
 	// Set the locale.
 	fromMoment.locale( window._wpDateSettings.l10n.locale );
-	// Format and return.
+	// Return human time difference.
 	return fromMoment.to( to, ! verbose ? true : false );
 }
 

--- a/date/test/date.js
+++ b/date/test/date.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { humanTimeDiff } from '../';
+
+describe( 'date', () => {
+	describe( 'humanTimeDiff', () => {
+		it( 'should be a difference of "3 days"', () => {
+			const to = moment().subtract( 3, 'days' );
+			expect( humanTimeDiff( 'now', to ) ).toBe( '3 days' );
+		} );
+		it( 'should be a suffixed difference of "seconds ago"', () => {
+			const to = moment().subtract( 3, 'seconds' );
+			expect( humanTimeDiff( 'now', to, true ) ).toBe( 'seconds ago' );
+		} );
+		it( 'should be a suffixed difference of "3 days ago"', () => {
+			const to = moment().subtract( 3, 'days' );
+			expect( humanTimeDiff( 'now', to, true ) ).toBe( '3 days ago' );
+		} );
+		it( 'should also be a suffixed difference of "3 days ago"', () => {
+			const from = moment().subtract( 3, 'days' );
+			const to = moment().subtract( 6, 'days' );
+			expect( humanTimeDiff( from, to, true ) ).toBe( '3 days ago' );
+		} );
+		it( 'should be a suffixed difference of "a month from now"', () => {
+			const to = moment().add( 5, 'weeks' );
+			expect( humanTimeDiff( 'now', to, true ) ).toBe( 'a month from now' );
+		} );
+		it( 'should be a suffixed difference of "a day from now"', () => {
+			const to = moment().add( 1, 'days' );
+			expect( humanTimeDiff( 'now', to, true ) ).toBe( 'a day from now' );
+		} );
+		it( 'should be a suffixed difference of "3 days from now"', () => {
+			const to = moment().add( 3, 'days' );
+			expect( humanTimeDiff( 'now', to, true ) ).toBe( '3 days from now' );
+		} );
+	} );
+} );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -114,6 +114,26 @@ function gutenberg_register_scripts_and_styles() {
 				'future' => __( '%s from now', 'default' ),
 				/* translators: %s: duration */
 				'past'   => __( '%s ago', 'default' ),
+
+				's'      => __( 'seconds', 'gutenberg' ),
+				'm'      => __( 'a minute', 'gutenberg' ),
+				'h'      => __( 'an hour', 'gutenberg' ),
+				'd'      => __( 'a day', 'gutenberg' ),
+				'M'      => __( 'a month', 'gutenberg' ),
+				'y'      => __( 'a year', 'gutenberg' ),
+
+				/* translators: %d: number of seconds */
+				'ss'     => __( '%d seconds', 'gutenberg' ),
+				/* translators: %d: number of minutes */
+				'mm'     => __( '%d minutes', 'gutenberg' ),
+				/* translators: %d: number of hours */
+				'hh'     => __( '%d hours', 'gutenberg' ),
+				/* translators: %d: number of days */
+				'dd'     => __( '%d days', 'gutenberg' ),
+				/* translators: %d: number of months */
+				'MM'     => __( '%d months', 'gutenberg' ),
+				/* translators: %d: number of years */
+				'yy'     => __( '%d years', 'gutenberg' ),
 			),
 		),
 		'formats'  => array(

--- a/test/unit/setup-globals.js
+++ b/test/unit/setup-globals.js
@@ -34,6 +34,18 @@ global.window._wpDateSettings = {
 		relative: {
 			future: '%s from now',
 			past: '%s ago',
+			s: 'seconds',
+			m: 'a minute',
+			h: 'an hour',
+			d: 'a day',
+			M: 'a month',
+			y: 'a year',
+			ss: '%d seconds',
+			mm: '%d minutes',
+			hh: '%d hours',
+			dd: '%d days',
+			MM: '%d months',
+			yy: '%d years',
 		},
 	},
 	timezone: {


### PR DESCRIPTION
## Description
The `humanTimeDiff()` utility is like [`human_time_diff()`](https://developer.wordpress.org/reference/functions/human_time_diff/) in PHP. However, this version also supports a third argument that enables an automatic suffix of 'ago' (past) or 'from now' (future) — taken from the current locale, via `window._wpDateSettings`.

## Where is this used?
It currently is not used. I'm just submitting this for consideration, because I found this new utility to be helpful while working on Annotations in https://github.com/WordPress/gutenberg/pull/4068

## How Has This Been Tested?
Unit tests are included in this PR.

## Types of changes
New date utility.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.