### PR TITLE
Improve paragraph block description.

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -100,7 +100,7 @@ class ParagraphBlock extends Component {
 			focus && (
 				<InspectorControls key="inspector">
 					<BlockDescription>
-						<p>{ __( 'Text. Great things start here.' ) }</p>
+						<p>{ __( 'This is a simple text only block for inserting a single paragraph of content.' ) }</p>
 					</BlockDescription>
 					<PanelBody title={ __( 'Text Settings' ) }>
 						<ToggleControl

--- a/docs/design.md
+++ b/docs/design.md
@@ -122,7 +122,7 @@ Selected state:
 
 Advanced block options:
 
-- Has description: "Text. Great things start here."
+- Has description: "This is a simple text only block for inserting a single paragraph of content."
 - Has option to enable or disable a drop-cap. Note that the drop-cap is only visible in the blocks unselected (preview) state.
 
 _Because the drop-cap feature is not critical to the basic operation of the block, it's in the advanced sidebar, thus keeping the Quick Toolbar light-weight._


### PR DESCRIPTION
Tiny PR to improve the description of the paragraph block:

<img width="357" alt="screen shot 2017-12-20 at 11 06 03" src="https://user-images.githubusercontent.com/1204802/34201779-e78ec7d2-e575-11e7-85d1-9368d18872cf.png">


Props @maddisondesigns for text.