### PR TITLE
Rename "Classic Text" to "Classic".

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -103,7 +103,7 @@
 }
 
 .freeform-toolbar.has-advanced-toolbar {
-	margin-top: -89px;	// pull upwards the classic text toolbar when enabled, height is manually entered
+	margin-top: -89px;	// pull upwards the classic block toolbar when enabled, height is manually entered
 }
 
 // Overwrite inline styles.

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -11,7 +11,7 @@ import { registerBlockType, setUnknownTypeHandlerName } from '../../api';
 import OldEditor from './old-editor';
 
 registerBlockType( 'core/freeform', {
-	title: __( 'Classic Text' ),
+	title: __( 'Classic' ),
 
 	icon: 'editor-kitchensink',
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -122,11 +122,11 @@ We realize it's a big change. We also think there will be many new opportunities
 
 We are looking at ways to make Gutenberg configurable for many use cases, including disabling different aspects (like blocks, panels, etc.).
 
-There is also be a "Classic Text" block, which is virtually the same as the current editor, except in block form. There’s also likely to be a very popular plugin in the repository to replace Gutenberg with the classic editor.
+There is also be a "Classic" block, which is virtually the same as the current editor, except in block form. There’s also likely to be a very popular plugin in the repository to replace Gutenberg with the classic editor.
 
 ## How will custom TinyMCE buttons work in Gutenberg?
 
-Custom TinyMCE buttons will still work in the "Classic Text" block, which is a block version of the classic editor you know today.
+Custom TinyMCE buttons will still work in the "Classic" block, which is a block version of the classic editor you know today.
 
 (Gutenberg comes with a new universal inserter tool, which gives you access to every block available, searchable, sorted by recency and categories. This inserter tool levels the playing field for every plugin that adds content to the editor, and provides a single interface to learn how to use.)
 


### PR DESCRIPTION
Fixes #2956.

This renames the "Classic Text" block to just "Classic", because it can do more than just text.

![classic](https://user-images.githubusercontent.com/1204802/34201952-87851908-e576-11e7-88a1-c180a5e2ad6e.gif)
