### PR TITLE
[Doc] Define setAttributes before using it.

### DIFF
--- a/docs/block-edit-save.md
+++ b/docs/block-edit-save.md
@@ -65,7 +65,7 @@ This function allows the block to update individual attributes based on user int
 
 ```js
 // Defining the edit interface
-edit( { attributes, className, focus } ) {
+edit( { attributes, setAttributes, className, focus } ) {
 	// Simplify access to attributes
 	const { content, mySetting } = attributes;
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Following sample code raise error because `setAttributes()` is not defined.

```
// Defining the edit interface
edit( { attributes, className, focus } ) {
    // Simplify access to attributes
    const { content, mySetting } = attributes;

    // Toggle a setting when the user clicks the button
    const toggleSetting = () => setAttributes( { mySetting: ! mySetting } );
    return (
        <div className={ className }>
            { content }
            { focus &&
                <button onClick={ toggleSetting }>Toggle setting</button>
            }
        </div>
    );
}
```
https://wordpress.org/gutenberg/handbook/block-edit-save/

`setAttributes()` is contained in `edit()` function's first argument so we can easily get it:

```
edit( { attributes, setAttributes, className, focus } ) {
```