### PR TITLE
Removed duplicate of buildTermsTree in HierarchicalTermSelector.

### DIFF
--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { unescape as unescapeString, without, groupBy, map, repeat, find } from 'lodash';
+import { unescape as unescapeString, without, map, repeat, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,6 +10,7 @@ import { unescape as unescapeString, without, groupBy, map, repeat, find } from 
 import { __, _x } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { withInstanceId, withSpokenMessages } from '@wordpress/components';
+import { buildTermsTree } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -40,23 +41,6 @@ class HierarchicalTermSelector extends Component {
 			formParent: '',
 			showForm: false,
 		};
-	}
-
-	buildTermsTree( flatTerms ) {
-		const termsByParent = groupBy( flatTerms, 'parent' );
-		const fillWithChildren = ( terms ) => {
-			return terms.map( ( term ) => {
-				const children = termsByParent[ term.id ];
-				return {
-					...term,
-					children: children && children.length ?
-						fillWithChildren( children ) :
-						[],
-				};
-			} );
-		};
-
-		return fillWithChildren( termsByParent[ 0 ] || [] );
 	}
 
 	onChange( event ) {
@@ -122,7 +106,7 @@ class HierarchicalTermSelector extends Component {
 					formName: '',
 					formParent: '',
 					availableTerms: newAvailableTerms,
-					availableTermsTree: this.buildTermsTree( newAvailableTerms ),
+					availableTermsTree: buildTermsTree( newAvailableTerms ),
 				} );
 				onUpdateTerms( [ ...terms, term.id ], restBase );
 			}, ( xhr ) => {
@@ -140,7 +124,7 @@ class HierarchicalTermSelector extends Component {
 		this.fetchRequest = new Collection()
 			.fetch( { data: DEFAULT_QUERY } )
 			.done( ( terms ) => {
-				const availableTermsTree = this.buildTermsTree( terms );
+				const availableTermsTree = buildTermsTree( terms );
 
 				this.setState( {
 					loading: false,


### PR DESCRIPTION
## Description
This change was left out of scope when creating buildTermsTree in query-panel addition to have a simpler diff and less to review.

Here we are just removing buildTermsTree from HierarchicalTermSelector which is a duplicate of the util buildTermsTree.

## How Has This Been Tested?
See it is possible to select post categories normally.

## Types of changes
Removed duplicate code.