### PR TITLE
Added class information for core/embed in the frontend

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { parse } from 'url';
-import { includes } from 'lodash';
+import { includes, kebabCase, toLower } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component, renderToString } from '@wordpress/element';
 import { Button, Placeholder, Spinner, SandBox } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -50,6 +51,12 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			align: {
 				type: 'string',
 			},
+			type: {
+				type: 'string',
+			},
+			providerNameSlug: {
+				type: 'string',
+			},
 		},
 
 		transforms,
@@ -70,6 +77,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 					type: '',
 					error: false,
 					fetching: false,
+					providerName: '',
 				};
 			}
 
@@ -100,6 +108,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 					event.preventDefault();
 				}
 				const { url } = this.props.attributes;
+				const { setAttributes } = this.props;
 				const apiURL = addQueryArgs( wpApiSettings.root + 'oembed/1.0/proxy', {
 					url: url,
 					_wpnonce: wpApiSettings.nonce,
@@ -114,11 +123,15 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 							return;
 						}
 						response.json().then( ( obj ) => {
-							const { html, type } = obj;
+							const { html, type, provider_name: providerName } = obj;
+							const providerNameSlug = kebabCase( toLower( providerName ) );
+
 							if ( html ) {
-								this.setState( { html, type } );
+								this.setState( { html, type, providerNameSlug } );
+								setAttributes( { type, providerNameSlug } );
 							} else if ( 'photo' === type ) {
-								this.setState( { html: this.getPhotoHtml( obj ), type } );
+								this.setState( { html: this.getPhotoHtml( obj ), type, providerNameSlug } );
+								setAttributes( { type, providerNameSlug } );
 							} else {
 								this.setState( { error: true } );
 							}
@@ -219,14 +232,20 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 		},
 
 		save( { attributes } ) {
-			const { url, caption, align } = attributes;
+			const { url, caption, align, type, providerNameSlug } = attributes;
 
 			if ( ! url ) {
 				return;
 			}
 
+			const embedClassName = classnames( 'wp-block-embed', {
+				[ `is-align${ align }` ]: align,
+				[ `is-type-${ type }` ]: type,
+				[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,
+			} );
+
 			return (
-				<figure className={ align ? `align${ align }` : null }>
+				<figure className={ embedClassName }>
 					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
 					{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
 				</figure>

--- a/blocks/test/fixtures/core-embed__animoto.html
+++ b/blocks/test/fixtures/core-embed__animoto.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/animoto {"url":"https://animoto.com/"} -->
-<figure class="wp-block-embed-animoto">
+<figure class="wp-block-embed-animoto wp-block-embed">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__animoto.json
+++ b/blocks/test/fixtures/core-embed__animoto.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-animoto\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-animoto wp-block-embed\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__animoto.parsed.json
+++ b/blocks/test/fixtures/core-embed__animoto.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://animoto.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-animoto\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-animoto wp-block-embed\">\n    https://animoto.com/\n    <figcaption>Embedded content from animoto</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__animoto.serialized.html
+++ b/blocks/test/fixtures/core-embed__animoto.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/animoto {"url":"https://animoto.com/"} -->
-<figure class="wp-block-embed-animoto">
+<figure class="wp-block-embed-animoto wp-block-embed">
     https://animoto.com/
     <figcaption>Embedded content from animoto</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__cloudup.html
+++ b/blocks/test/fixtures/core-embed__cloudup.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/cloudup {"url":"https://cloudup.com/"} -->
-<figure class="wp-block-embed-cloudup">
+<figure class="wp-block-embed-cloudup wp-block-embed">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__cloudup.json
+++ b/blocks/test/fixtures/core-embed__cloudup.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-cloudup\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-cloudup wp-block-embed\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__cloudup.parsed.json
+++ b/blocks/test/fixtures/core-embed__cloudup.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://cloudup.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-cloudup\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-cloudup wp-block-embed\">\n    https://cloudup.com/\n    <figcaption>Embedded content from cloudup</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__cloudup.serialized.html
+++ b/blocks/test/fixtures/core-embed__cloudup.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/cloudup {"url":"https://cloudup.com/"} -->
-<figure class="wp-block-embed-cloudup">
+<figure class="wp-block-embed-cloudup wp-block-embed">
     https://cloudup.com/
     <figcaption>Embedded content from cloudup</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__collegehumor.html
+++ b/blocks/test/fixtures/core-embed__collegehumor.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/collegehumor {"url":"https://collegehumor.com/"} -->
-<figure class="wp-block-embed-collegehumor">
+<figure class="wp-block-embed-collegehumor wp-block-embed">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__collegehumor.json
+++ b/blocks/test/fixtures/core-embed__collegehumor.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-collegehumor\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-collegehumor wp-block-embed\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__collegehumor.parsed.json
+++ b/blocks/test/fixtures/core-embed__collegehumor.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://collegehumor.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-collegehumor\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-collegehumor wp-block-embed\">\n    https://collegehumor.com/\n    <figcaption>Embedded content from collegehumor</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__collegehumor.serialized.html
+++ b/blocks/test/fixtures/core-embed__collegehumor.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/collegehumor {"url":"https://collegehumor.com/"} -->
-<figure class="wp-block-embed-collegehumor">
+<figure class="wp-block-embed-collegehumor wp-block-embed">
     https://collegehumor.com/
     <figcaption>Embedded content from collegehumor</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__dailymotion.html
+++ b/blocks/test/fixtures/core-embed__dailymotion.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/dailymotion {"url":"https://dailymotion.com/"} -->
-<figure class="wp-block-embed-dailymotion">
+<figure class="wp-block-embed-dailymotion wp-block-embed">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__dailymotion.json
+++ b/blocks/test/fixtures/core-embed__dailymotion.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-dailymotion\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-dailymotion wp-block-embed\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__dailymotion.parsed.json
+++ b/blocks/test/fixtures/core-embed__dailymotion.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://dailymotion.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-dailymotion\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-dailymotion wp-block-embed\">\n    https://dailymotion.com/\n    <figcaption>Embedded content from dailymotion</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__dailymotion.serialized.html
+++ b/blocks/test/fixtures/core-embed__dailymotion.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/dailymotion {"url":"https://dailymotion.com/"} -->
-<figure class="wp-block-embed-dailymotion">
+<figure class="wp-block-embed-dailymotion wp-block-embed">
     https://dailymotion.com/
     <figcaption>Embedded content from dailymotion</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__facebook.html
+++ b/blocks/test/fixtures/core-embed__facebook.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/facebook {"url":"https://facebook.com/"} -->
-<figure class="wp-block-embed-facebook">
+<figure class="wp-block-embed-facebook wp-block-embed">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__facebook.json
+++ b/blocks/test/fixtures/core-embed__facebook.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-facebook\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-facebook wp-block-embed\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__facebook.parsed.json
+++ b/blocks/test/fixtures/core-embed__facebook.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://facebook.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-facebook\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-facebook wp-block-embed\">\n    https://facebook.com/\n    <figcaption>Embedded content from facebook</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__facebook.serialized.html
+++ b/blocks/test/fixtures/core-embed__facebook.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/facebook {"url":"https://facebook.com/"} -->
-<figure class="wp-block-embed-facebook">
+<figure class="wp-block-embed-facebook wp-block-embed">
     https://facebook.com/
     <figcaption>Embedded content from facebook</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__flickr.html
+++ b/blocks/test/fixtures/core-embed__flickr.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/flickr {"url":"https://flickr.com/"} -->
-<figure class="wp-block-embed-flickr">
+<figure class="wp-block-embed-flickr wp-block-embed">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__flickr.json
+++ b/blocks/test/fixtures/core-embed__flickr.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-flickr\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-flickr wp-block-embed\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__flickr.parsed.json
+++ b/blocks/test/fixtures/core-embed__flickr.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://flickr.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-flickr\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-flickr wp-block-embed\">\n    https://flickr.com/\n    <figcaption>Embedded content from flickr</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__flickr.serialized.html
+++ b/blocks/test/fixtures/core-embed__flickr.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/flickr {"url":"https://flickr.com/"} -->
-<figure class="wp-block-embed-flickr">
+<figure class="wp-block-embed-flickr wp-block-embed">
     https://flickr.com/
     <figcaption>Embedded content from flickr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__funnyordie.html
+++ b/blocks/test/fixtures/core-embed__funnyordie.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/funnyordie {"url":"https://funnyordie.com/"} -->
-<figure class="wp-block-embed-funnyordie">
+<figure class="wp-block-embed-funnyordie wp-block-embed">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__funnyordie.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-funnyordie\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-funnyordie wp-block-embed\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__funnyordie.parsed.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://funnyordie.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-funnyordie\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-funnyordie wp-block-embed\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__funnyordie.serialized.html
+++ b/blocks/test/fixtures/core-embed__funnyordie.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/funnyordie {"url":"https://funnyordie.com/"} -->
-<figure class="wp-block-embed-funnyordie">
+<figure class="wp-block-embed-funnyordie wp-block-embed">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__hulu.html
+++ b/blocks/test/fixtures/core-embed__hulu.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/hulu {"url":"https://hulu.com/"} -->
-<figure class="wp-block-embed-hulu">
+<figure class="wp-block-embed-hulu wp-block-embed">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__hulu.json
+++ b/blocks/test/fixtures/core-embed__hulu.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-hulu\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-hulu wp-block-embed\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__hulu.parsed.json
+++ b/blocks/test/fixtures/core-embed__hulu.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://hulu.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-hulu\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-hulu wp-block-embed\">\n    https://hulu.com/\n    <figcaption>Embedded content from hulu</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__hulu.serialized.html
+++ b/blocks/test/fixtures/core-embed__hulu.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/hulu {"url":"https://hulu.com/"} -->
-<figure class="wp-block-embed-hulu">
+<figure class="wp-block-embed-hulu wp-block-embed">
     https://hulu.com/
     <figcaption>Embedded content from hulu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__imgur.html
+++ b/blocks/test/fixtures/core-embed__imgur.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/imgur {"url":"https://imgur.com/"} -->
-<figure class="wp-block-embed-imgur">
+<figure class="wp-block-embed-imgur wp-block-embed">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__imgur.json
+++ b/blocks/test/fixtures/core-embed__imgur.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-imgur\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-imgur wp-block-embed\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__imgur.parsed.json
+++ b/blocks/test/fixtures/core-embed__imgur.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://imgur.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-imgur\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-imgur wp-block-embed\">\n    https://imgur.com/\n    <figcaption>Embedded content from imgur</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__imgur.serialized.html
+++ b/blocks/test/fixtures/core-embed__imgur.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/imgur {"url":"https://imgur.com/"} -->
-<figure class="wp-block-embed-imgur">
+<figure class="wp-block-embed-imgur wp-block-embed">
     https://imgur.com/
     <figcaption>Embedded content from imgur</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__instagram.html
+++ b/blocks/test/fixtures/core-embed__instagram.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/instagram {"url":"https://instagram.com/"} -->
-<figure class="wp-block-embed-instagram">
+<figure class="wp-block-embed-instagram wp-block-embed">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__instagram.json
+++ b/blocks/test/fixtures/core-embed__instagram.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-instagram\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-instagram wp-block-embed\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__instagram.parsed.json
+++ b/blocks/test/fixtures/core-embed__instagram.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://instagram.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-instagram\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-instagram wp-block-embed\">\n    https://instagram.com/\n    <figcaption>Embedded content from instagram</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__instagram.serialized.html
+++ b/blocks/test/fixtures/core-embed__instagram.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/instagram {"url":"https://instagram.com/"} -->
-<figure class="wp-block-embed-instagram">
+<figure class="wp-block-embed-instagram wp-block-embed">
     https://instagram.com/
     <figcaption>Embedded content from instagram</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__issuu.html
+++ b/blocks/test/fixtures/core-embed__issuu.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/issuu {"url":"https://issuu.com/"} -->
-<figure class="wp-block-embed-issuu">
+<figure class="wp-block-embed-issuu wp-block-embed">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__issuu.json
+++ b/blocks/test/fixtures/core-embed__issuu.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-issuu\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-issuu wp-block-embed\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__issuu.parsed.json
+++ b/blocks/test/fixtures/core-embed__issuu.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://issuu.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-issuu\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-issuu wp-block-embed\">\n    https://issuu.com/\n    <figcaption>Embedded content from issuu</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__issuu.serialized.html
+++ b/blocks/test/fixtures/core-embed__issuu.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/issuu {"url":"https://issuu.com/"} -->
-<figure class="wp-block-embed-issuu">
+<figure class="wp-block-embed-issuu wp-block-embed">
     https://issuu.com/
     <figcaption>Embedded content from issuu</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__kickstarter.html
+++ b/blocks/test/fixtures/core-embed__kickstarter.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/kickstarter {"url":"https://kickstarter.com/"} -->
-<figure class="wp-block-embed-kickstarter">
+<figure class="wp-block-embed-kickstarter wp-block-embed">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__kickstarter.json
+++ b/blocks/test/fixtures/core-embed__kickstarter.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-kickstarter\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-kickstarter wp-block-embed\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__kickstarter.parsed.json
+++ b/blocks/test/fixtures/core-embed__kickstarter.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://kickstarter.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-kickstarter\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-kickstarter wp-block-embed\">\n    https://kickstarter.com/\n    <figcaption>Embedded content from kickstarter</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__kickstarter.serialized.html
+++ b/blocks/test/fixtures/core-embed__kickstarter.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/kickstarter {"url":"https://kickstarter.com/"} -->
-<figure class="wp-block-embed-kickstarter">
+<figure class="wp-block-embed-kickstarter wp-block-embed">
     https://kickstarter.com/
     <figcaption>Embedded content from kickstarter</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__meetup-com.html
+++ b/blocks/test/fixtures/core-embed__meetup-com.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/meetup-com {"url":"https://meetup.com/"} -->
-<figure class="wp-block-embed-meetup-com">
+<figure class="wp-block-embed-meetup-com wp-block-embed">
     https://meetup.com/
     <figcaption>Embedded content from meetup-com</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__meetup-com.json
+++ b/blocks/test/fixtures/core-embed__meetup-com.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-meetup-com\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-meetup-com wp-block-embed\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__meetup-com.parsed.json
+++ b/blocks/test/fixtures/core-embed__meetup-com.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://meetup.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-meetup-com\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-meetup-com wp-block-embed\">\n    https://meetup.com/\n    <figcaption>Embedded content from meetup-com</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__meetup-com.serialized.html
+++ b/blocks/test/fixtures/core-embed__meetup-com.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/meetup-com {"url":"https://meetup.com/"} -->
-<figure class="wp-block-embed-meetup-com">
+<figure class="wp-block-embed-meetup-com wp-block-embed">
     https://meetup.com/
     <figcaption>Embedded content from meetup-com</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__mixcloud.html
+++ b/blocks/test/fixtures/core-embed__mixcloud.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/mixcloud {"url":"https://mixcloud.com/"} -->
-<figure class="wp-block-embed-mixcloud">
+<figure class="wp-block-embed-mixcloud wp-block-embed">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__mixcloud.json
+++ b/blocks/test/fixtures/core-embed__mixcloud.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-mixcloud\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-mixcloud wp-block-embed\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__mixcloud.parsed.json
+++ b/blocks/test/fixtures/core-embed__mixcloud.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://mixcloud.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-mixcloud\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-mixcloud wp-block-embed\">\n    https://mixcloud.com/\n    <figcaption>Embedded content from mixcloud</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__mixcloud.serialized.html
+++ b/blocks/test/fixtures/core-embed__mixcloud.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/mixcloud {"url":"https://mixcloud.com/"} -->
-<figure class="wp-block-embed-mixcloud">
+<figure class="wp-block-embed-mixcloud wp-block-embed">
     https://mixcloud.com/
     <figcaption>Embedded content from mixcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__photobucket.html
+++ b/blocks/test/fixtures/core-embed__photobucket.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/photobucket {"url":"https://photobucket.com/"} -->
-<figure class="wp-block-embed-photobucket">
+<figure class="wp-block-embed-photobucket wp-block-embed">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__photobucket.json
+++ b/blocks/test/fixtures/core-embed__photobucket.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-photobucket\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-photobucket wp-block-embed\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__photobucket.parsed.json
+++ b/blocks/test/fixtures/core-embed__photobucket.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://photobucket.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-photobucket\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-photobucket wp-block-embed\">\n    https://photobucket.com/\n    <figcaption>Embedded content from photobucket</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__photobucket.serialized.html
+++ b/blocks/test/fixtures/core-embed__photobucket.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/photobucket {"url":"https://photobucket.com/"} -->
-<figure class="wp-block-embed-photobucket">
+<figure class="wp-block-embed-photobucket wp-block-embed">
     https://photobucket.com/
     <figcaption>Embedded content from photobucket</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__polldaddy.html
+++ b/blocks/test/fixtures/core-embed__polldaddy.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/polldaddy {"url":"https://polldaddy.com/"} -->
-<figure class="wp-block-embed-polldaddy">
+<figure class="wp-block-embed-polldaddy wp-block-embed">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__polldaddy.json
+++ b/blocks/test/fixtures/core-embed__polldaddy.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-polldaddy\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-polldaddy wp-block-embed\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__polldaddy.parsed.json
+++ b/blocks/test/fixtures/core-embed__polldaddy.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://polldaddy.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-polldaddy\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-polldaddy wp-block-embed\">\n    https://polldaddy.com/\n    <figcaption>Embedded content from polldaddy</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__polldaddy.serialized.html
+++ b/blocks/test/fixtures/core-embed__polldaddy.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/polldaddy {"url":"https://polldaddy.com/"} -->
-<figure class="wp-block-embed-polldaddy">
+<figure class="wp-block-embed-polldaddy wp-block-embed">
     https://polldaddy.com/
     <figcaption>Embedded content from polldaddy</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__reddit.html
+++ b/blocks/test/fixtures/core-embed__reddit.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/reddit {"url":"https://reddit.com/"} -->
-<figure class="wp-block-embed-reddit">
+<figure class="wp-block-embed-reddit wp-block-embed">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__reddit.json
+++ b/blocks/test/fixtures/core-embed__reddit.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-reddit\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-reddit wp-block-embed\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__reddit.parsed.json
+++ b/blocks/test/fixtures/core-embed__reddit.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://reddit.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-reddit\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-reddit wp-block-embed\">\n    https://reddit.com/\n    <figcaption>Embedded content from reddit</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__reddit.serialized.html
+++ b/blocks/test/fixtures/core-embed__reddit.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/reddit {"url":"https://reddit.com/"} -->
-<figure class="wp-block-embed-reddit">
+<figure class="wp-block-embed-reddit wp-block-embed">
     https://reddit.com/
     <figcaption>Embedded content from reddit</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__reverbnation.html
+++ b/blocks/test/fixtures/core-embed__reverbnation.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/reverbnation {"url":"https://reverbnation.com/"} -->
-<figure class="wp-block-embed-reverbnation">
+<figure class="wp-block-embed-reverbnation wp-block-embed">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__reverbnation.json
+++ b/blocks/test/fixtures/core-embed__reverbnation.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-reverbnation\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-reverbnation wp-block-embed\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__reverbnation.parsed.json
+++ b/blocks/test/fixtures/core-embed__reverbnation.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://reverbnation.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-reverbnation\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-reverbnation wp-block-embed\">\n    https://reverbnation.com/\n    <figcaption>Embedded content from reverbnation</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__reverbnation.serialized.html
+++ b/blocks/test/fixtures/core-embed__reverbnation.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/reverbnation {"url":"https://reverbnation.com/"} -->
-<figure class="wp-block-embed-reverbnation">
+<figure class="wp-block-embed-reverbnation wp-block-embed">
     https://reverbnation.com/
     <figcaption>Embedded content from reverbnation</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__screencast.html
+++ b/blocks/test/fixtures/core-embed__screencast.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/screencast {"url":"https://screencast.com/"} -->
-<figure class="wp-block-embed-screencast">
+<figure class="wp-block-embed-screencast wp-block-embed">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__screencast.json
+++ b/blocks/test/fixtures/core-embed__screencast.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-screencast\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-screencast wp-block-embed\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__screencast.parsed.json
+++ b/blocks/test/fixtures/core-embed__screencast.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://screencast.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-screencast\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-screencast wp-block-embed\">\n    https://screencast.com/\n    <figcaption>Embedded content from screencast</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__screencast.serialized.html
+++ b/blocks/test/fixtures/core-embed__screencast.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/screencast {"url":"https://screencast.com/"} -->
-<figure class="wp-block-embed-screencast">
+<figure class="wp-block-embed-screencast wp-block-embed">
     https://screencast.com/
     <figcaption>Embedded content from screencast</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__scribd.html
+++ b/blocks/test/fixtures/core-embed__scribd.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/scribd {"url":"https://scribd.com/"} -->
-<figure class="wp-block-embed-scribd">
+<figure class="wp-block-embed-scribd wp-block-embed">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__scribd.json
+++ b/blocks/test/fixtures/core-embed__scribd.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-scribd\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-scribd wp-block-embed\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__scribd.parsed.json
+++ b/blocks/test/fixtures/core-embed__scribd.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://scribd.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-scribd\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-scribd wp-block-embed\">\n    https://scribd.com/\n    <figcaption>Embedded content from scribd</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__scribd.serialized.html
+++ b/blocks/test/fixtures/core-embed__scribd.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/scribd {"url":"https://scribd.com/"} -->
-<figure class="wp-block-embed-scribd">
+<figure class="wp-block-embed-scribd wp-block-embed">
     https://scribd.com/
     <figcaption>Embedded content from scribd</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__slideshare.html
+++ b/blocks/test/fixtures/core-embed__slideshare.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/slideshare {"url":"https://slideshare.com/"} -->
-<figure class="wp-block-embed-slideshare">
+<figure class="wp-block-embed-slideshare wp-block-embed">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__slideshare.json
+++ b/blocks/test/fixtures/core-embed__slideshare.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-slideshare\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-slideshare wp-block-embed\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__slideshare.parsed.json
+++ b/blocks/test/fixtures/core-embed__slideshare.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://slideshare.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-slideshare\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-slideshare wp-block-embed\">\n    https://slideshare.com/\n    <figcaption>Embedded content from slideshare</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__slideshare.serialized.html
+++ b/blocks/test/fixtures/core-embed__slideshare.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/slideshare {"url":"https://slideshare.com/"} -->
-<figure class="wp-block-embed-slideshare">
+<figure class="wp-block-embed-slideshare wp-block-embed">
     https://slideshare.com/
     <figcaption>Embedded content from slideshare</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__smugmug.html
+++ b/blocks/test/fixtures/core-embed__smugmug.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/smugmug {"url":"https://smugmug.com/"} -->
-<figure class="wp-block-embed-smugmug">
+<figure class="wp-block-embed-smugmug wp-block-embed">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__smugmug.json
+++ b/blocks/test/fixtures/core-embed__smugmug.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-smugmug\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-smugmug wp-block-embed\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__smugmug.parsed.json
+++ b/blocks/test/fixtures/core-embed__smugmug.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://smugmug.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-smugmug\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-smugmug wp-block-embed\">\n    https://smugmug.com/\n    <figcaption>Embedded content from smugmug</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__smugmug.serialized.html
+++ b/blocks/test/fixtures/core-embed__smugmug.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/smugmug {"url":"https://smugmug.com/"} -->
-<figure class="wp-block-embed-smugmug">
+<figure class="wp-block-embed-smugmug wp-block-embed">
     https://smugmug.com/
     <figcaption>Embedded content from smugmug</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__soundcloud.html
+++ b/blocks/test/fixtures/core-embed__soundcloud.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/soundcloud {"url":"https://soundcloud.com/"} -->
-<figure class="wp-block-embed-soundcloud">
+<figure class="wp-block-embed-soundcloud wp-block-embed">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__soundcloud.json
+++ b/blocks/test/fixtures/core-embed__soundcloud.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-soundcloud\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-soundcloud wp-block-embed\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__soundcloud.parsed.json
+++ b/blocks/test/fixtures/core-embed__soundcloud.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://soundcloud.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-soundcloud\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-soundcloud wp-block-embed\">\n    https://soundcloud.com/\n    <figcaption>Embedded content from soundcloud</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__soundcloud.serialized.html
+++ b/blocks/test/fixtures/core-embed__soundcloud.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/soundcloud {"url":"https://soundcloud.com/"} -->
-<figure class="wp-block-embed-soundcloud">
+<figure class="wp-block-embed-soundcloud wp-block-embed">
     https://soundcloud.com/
     <figcaption>Embedded content from soundcloud</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__speaker.html
+++ b/blocks/test/fixtures/core-embed__speaker.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/speaker {"url":"https://speaker.com/"} -->
-<figure class="wp-block-embed-speaker">
+<figure class="wp-block-embed-speaker wp-block-embed">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__speaker.json
+++ b/blocks/test/fixtures/core-embed__speaker.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-speaker\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-speaker wp-block-embed\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__speaker.parsed.json
+++ b/blocks/test/fixtures/core-embed__speaker.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://speaker.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-speaker\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-speaker wp-block-embed\">\n    https://speaker.com/\n    <figcaption>Embedded content from speaker</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__speaker.serialized.html
+++ b/blocks/test/fixtures/core-embed__speaker.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/speaker {"url":"https://speaker.com/"} -->
-<figure class="wp-block-embed-speaker">
+<figure class="wp-block-embed-speaker wp-block-embed">
     https://speaker.com/
     <figcaption>Embedded content from speaker</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__spotify.html
+++ b/blocks/test/fixtures/core-embed__spotify.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/spotify {"url":"https://spotify.com/"} -->
-<figure class="wp-block-embed-spotify">
+<figure class="wp-block-embed-spotify wp-block-embed">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__spotify.json
+++ b/blocks/test/fixtures/core-embed__spotify.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-spotify\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-spotify wp-block-embed\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__spotify.parsed.json
+++ b/blocks/test/fixtures/core-embed__spotify.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://spotify.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-spotify\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-spotify wp-block-embed\">\n    https://spotify.com/\n    <figcaption>Embedded content from spotify</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__spotify.serialized.html
+++ b/blocks/test/fixtures/core-embed__spotify.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/spotify {"url":"https://spotify.com/"} -->
-<figure class="wp-block-embed-spotify">
+<figure class="wp-block-embed-spotify wp-block-embed">
     https://spotify.com/
     <figcaption>Embedded content from spotify</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__ted.html
+++ b/blocks/test/fixtures/core-embed__ted.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/ted {"url":"https://ted.com/"} -->
-<figure class="wp-block-embed-ted">
+<figure class="wp-block-embed-ted wp-block-embed">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__ted.json
+++ b/blocks/test/fixtures/core-embed__ted.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-ted\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-ted wp-block-embed\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__ted.parsed.json
+++ b/blocks/test/fixtures/core-embed__ted.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://ted.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-ted\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-ted wp-block-embed\">\n    https://ted.com/\n    <figcaption>Embedded content from ted</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__ted.serialized.html
+++ b/blocks/test/fixtures/core-embed__ted.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/ted {"url":"https://ted.com/"} -->
-<figure class="wp-block-embed-ted">
+<figure class="wp-block-embed-ted wp-block-embed">
     https://ted.com/
     <figcaption>Embedded content from ted</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__tumblr.html
+++ b/blocks/test/fixtures/core-embed__tumblr.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/tumblr {"url":"https://tumblr.com/"} -->
-<figure class="wp-block-embed-tumblr">
+<figure class="wp-block-embed-tumblr wp-block-embed">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__tumblr.json
+++ b/blocks/test/fixtures/core-embed__tumblr.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-tumblr\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-tumblr wp-block-embed\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__tumblr.parsed.json
+++ b/blocks/test/fixtures/core-embed__tumblr.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://tumblr.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-tumblr\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-tumblr wp-block-embed\">\n    https://tumblr.com/\n    <figcaption>Embedded content from tumblr</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__tumblr.serialized.html
+++ b/blocks/test/fixtures/core-embed__tumblr.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/tumblr {"url":"https://tumblr.com/"} -->
-<figure class="wp-block-embed-tumblr">
+<figure class="wp-block-embed-tumblr wp-block-embed">
     https://tumblr.com/
     <figcaption>Embedded content from tumblr</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__twitter.html
+++ b/blocks/test/fixtures/core-embed__twitter.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/twitter {"url":"https://twitter.com/automattic"} -->
-<figure class="wp-block-embed-twitter">
+<figure class="wp-block-embed-twitter wp-block-embed">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__twitter.json
+++ b/blocks/test/fixtures/core-embed__twitter.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-twitter\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-twitter wp-block-embed\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__twitter.parsed.json
+++ b/blocks/test/fixtures/core-embed__twitter.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://twitter.com/automattic"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-twitter\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-twitter wp-block-embed\">\n    https://twitter.com/automattic\n    <figcaption>We are Automattic</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__twitter.serialized.html
+++ b/blocks/test/fixtures/core-embed__twitter.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/twitter {"url":"https://twitter.com/automattic"} -->
-<figure class="wp-block-embed-twitter">
+<figure class="wp-block-embed-twitter wp-block-embed">
     https://twitter.com/automattic
     <figcaption>We are Automattic</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__videopress.html
+++ b/blocks/test/fixtures/core-embed__videopress.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/videopress {"url":"https://videopress.com/"} -->
-<figure class="wp-block-embed-videopress">
+<figure class="wp-block-embed-videopress wp-block-embed">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__videopress.json
+++ b/blocks/test/fixtures/core-embed__videopress.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-videopress\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-videopress wp-block-embed\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__videopress.parsed.json
+++ b/blocks/test/fixtures/core-embed__videopress.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://videopress.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-videopress\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-videopress wp-block-embed\">\n    https://videopress.com/\n    <figcaption>Embedded content from videopress</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__videopress.serialized.html
+++ b/blocks/test/fixtures/core-embed__videopress.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/videopress {"url":"https://videopress.com/"} -->
-<figure class="wp-block-embed-videopress">
+<figure class="wp-block-embed-videopress wp-block-embed">
     https://videopress.com/
     <figcaption>Embedded content from videopress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__vimeo.html
+++ b/blocks/test/fixtures/core-embed__vimeo.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/vimeo {"url":"https://vimeo.com/"} -->
-<figure class="wp-block-embed-vimeo">
+<figure class="wp-block-embed-vimeo wp-block-embed">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__vimeo.json
+++ b/blocks/test/fixtures/core-embed__vimeo.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-vimeo\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-vimeo wp-block-embed\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__vimeo.parsed.json
+++ b/blocks/test/fixtures/core-embed__vimeo.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://vimeo.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-vimeo\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-vimeo wp-block-embed\">\n    https://vimeo.com/\n    <figcaption>Embedded content from vimeo</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__vimeo.serialized.html
+++ b/blocks/test/fixtures/core-embed__vimeo.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/vimeo {"url":"https://vimeo.com/"} -->
-<figure class="wp-block-embed-vimeo">
+<figure class="wp-block-embed-vimeo wp-block-embed">
     https://vimeo.com/
     <figcaption>Embedded content from vimeo</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__wordpress-tv.html
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/wordpress-tv {"url":"https://wordpress.tv/"} -->
-<figure class="wp-block-embed-wordpress-tv">
+<figure class="wp-block-embed-wordpress-tv wp-block-embed">
     https://wordpress.tv/
     <figcaption>Embedded content from wordpress-tv</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__wordpress-tv.json
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-wordpress-tv\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-wordpress-tv wp-block-embed\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress-tv.parsed.json
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://wordpress.tv/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-wordpress-tv\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-wordpress-tv wp-block-embed\">\n    https://wordpress.tv/\n    <figcaption>Embedded content from wordpress-tv</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__wordpress-tv.serialized.html
+++ b/blocks/test/fixtures/core-embed__wordpress-tv.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/wordpress-tv {"url":"https://wordpress.tv/"} -->
-<figure class="wp-block-embed-wordpress-tv">
+<figure class="wp-block-embed-wordpress-tv wp-block-embed">
     https://wordpress.tv/
     <figcaption>Embedded content from wordpress-tv</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__wordpress.html
+++ b/blocks/test/fixtures/core-embed__wordpress.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/wordpress {"url":"https://wordpress.com/"} -->
-<figure class="wp-block-embed-wordpress">
+<figure class="wp-block-embed-wordpress wp-block-embed">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__wordpress.json
+++ b/blocks/test/fixtures/core-embed__wordpress.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-wordpress\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-wordpress wp-block-embed\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__wordpress.parsed.json
+++ b/blocks/test/fixtures/core-embed__wordpress.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://wordpress.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-wordpress\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-wordpress wp-block-embed\">\n    https://wordpress.com/\n    <figcaption>Embedded content from WordPress</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__wordpress.serialized.html
+++ b/blocks/test/fixtures/core-embed__wordpress.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/wordpress {"url":"https://wordpress.com/"} -->
-<figure class="wp-block-embed-wordpress">
+<figure class="wp-block-embed-wordpress wp-block-embed">
     https://wordpress.com/
     <figcaption>Embedded content from WordPress</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__youtube.html
+++ b/blocks/test/fixtures/core-embed__youtube.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/youtube {"url":"https://youtube.com/"} -->
-<figure class="wp-block-embed-youtube">
+<figure class="wp-block-embed-youtube wp-block-embed">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__youtube.json
+++ b/blocks/test/fixtures/core-embed__youtube.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-youtube\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-youtube wp-block-embed\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__youtube.parsed.json
+++ b/blocks/test/fixtures/core-embed__youtube.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://youtube.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-youtube\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-youtube wp-block-embed\">\n    https://youtube.com/\n    <figcaption>Embedded content from youtube</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__youtube.serialized.html
+++ b/blocks/test/fixtures/core-embed__youtube.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/youtube {"url":"https://youtube.com/"} -->
-<figure class="wp-block-embed-youtube">
+<figure class="wp-block-embed-youtube wp-block-embed">
     https://youtube.com/
     <figcaption>Embedded content from youtube</figcaption>
 </figure>

--- a/blocks/test/fixtures/core__audio.json
+++ b/blocks/test/fixtures/core__audio.json
@@ -5,8 +5,8 @@
         "isValid": true,
         "attributes": {
             "src": "https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3",
-            "align": "right",
-            "caption": []
+            "caption": [],
+            "align": "right"
         },
         "innerBlocks": [],
         "originalContent": "<figure class=\"wp-block-audio alignright\">\n    <audio controls=\"\" src=\"https://media.simplecast.com/episodes/audio/80564/draft-podcast-51-livePublish2.mp3\"></audio>\n</figure>"


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This piece of code extends the core/embed block to fetch the information provided by the oEmbed endpoint and adds information about the embed type and embed provider to the block wrapper. 

```
<figure class="wp-block-embed-youtube wp-block-embed type-video provider-youtube">
    [...]
</figure>
```
This should provide precise information about what is being embedded to frontend developers and give them the ability to better style according to embedded content.

Please see #4107 for a more detailed description.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
This has been tested locally and manually. No automated tests were built or run.

## Types of changes
New feature: Descriptive css classes for the frontend rendering of an embed block

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
  