### PR TITLE
Implement webpack hot module reloading.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ To enable webpack hot module reloading, place the following line in `wp-config.p
 define( 'GUTENBERG_WEBPACK_HMR', true );
 ```
 
-Build the project ( `npm run build` ), and start the hmr development server by running `npm run hot`. Any changes to files used by the editor ( `/editor` ), should be reflected in the browser without hot reloading.
+Build the project ( `npm run build` ), and start the hmr development server by running `npm run hot`. Any changes to files used by the editor ( `/editor` ), should be reflected in the browser without reloading the page.
 
 *Warning*: This is still an experimental development feature.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ Next, open a terminal (or if on Windows, a command prompt) and navigate to the r
 
 Webpack hot module reloading (hmr) with is available for the editor. While developing this allows you to see your changes without having to refresh the page.
 
-To enable webpack hot module reloading, place the following line in `gutenberg.php`:
+To enable webpack hot module reloading, place the following line in `wp-config.php` (in the root of your WordPress installation):
 
 ```php
-define( 'WEBPACK_HMR', true );
+define( 'GUTENBERG_WEBPACK_HMR', true );
 ```
 
 Build the project ( `npm run build` ), and start the hmr development server by running `npm run hot`. Any changes to files used by the editor ( `/editor` ), should be reflected in the browser without hot reloading.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ define( 'GUTENBERG_WEBPACK_HMR', true );
 
 Build the project ( `npm run build` ), and start the hmr development server by running `npm run hot`. Any changes to files used by the editor ( `/editor` ), should be reflected in the browser without reloading the page.
 
+If the Webpack server is running on a different port than 3000, you need to configure Gutenberg to refer to the correct port. You can do this using the `GUTENBERG_WEBPACK_DEV_SERVER` constant:
+
+```php
+define( 'GUTENBERG_WEBPACK_DEV_SERVER', 'http://localhost:[your-port]' );
+```
+
 *Warning*: This is still an experimental development feature.
 
 ### On A Remote Server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,20 @@ Alternatively, you can use your own local WordPress environment and clone this r
 
 Next, open a terminal (or if on Windows, a command prompt) and navigate to the repository you cloned. Now type `npm install` to get the dependencies all set up. Then you can type `npm run dev` in your terminal or command prompt to keep the plugin building in the background as you work on it.
 
+### Hot reloading
+
+Webpack hot module reloading (hmr) with is available for the editor. While developing this allows you to see your changes without having to refresh the page.
+
+To enable webpack hot module reloading, place the following line in `gutenberg.php`:
+
+```php
+define( 'WEBPACK_HMR', true );
+```
+
+Build the project ( `npm run build` ), and start the hmr development server by running `npm run hot`. Any changes to files used by the editor ( `/editor` ), should be reflected in the browser without hot reloading.
+
+*Warning*: This is still an experimental development feature.
+
 ### On A Remote Server
 
 Open a terminal (or if on Windows, a command prompt) and navigate to the repository you cloned. Now type `npm install` to get the dependencies all set up. Once that finishes, you can type `npm run build`. You can now upload the entire repository to your `wp-content/plugins` directory on your webserver and activate the plugin from the WordPress admin.

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -80,10 +80,14 @@ export function registerBlockType( name, settings ) {
 		return;
 	}
 	if ( blocks[ name ] ) {
-		console.error(
-			'Block "' + name + '" is already registered.'
-		);
-		return;
+		if ( module.hot ) {
+			delete( blocks[ name ] );
+		} else {
+			console.error(
+				'Block "' + name + '" is already registered.'
+			);
+			return;
+		}
 	}
 	if ( 'keywords' in settings && settings.keywords.length > 3 ) {
 		console.error(

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -31,3 +31,11 @@ export { default as UrlInputButton } from './url-input/button';
 // Deprecated matchers
 import { attr, prop, text, html, query, node, children } from './hooks/matchers';
 export const source = { attr, prop, text, html, query, node, children };
+
+if ( module.hot ) {
+	module.hot.accept();
+
+	if ( wp && wp.editor && wp.editor.__reRenderEditor ) {
+		wp.editor.__reRenderEditor();
+	}
+}

--- a/editor/components/editor/index.js
+++ b/editor/components/editor/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import Layout from '../../edit-post/layout';
+import { EditorProvider, ErrorBoundary } from '..';
+
+class Editor extends React.Component {
+	render() {
+		const { settings, onError, post, recovery } = this.props;
+		return (
+			<EditorProvider settings={ settings } post={ post } recovery={ recovery }>
+				<ErrorBoundary onError={ onError }>
+					<Layout />
+				</ErrorBoundary>
+			</EditorProvider>
+		);
+	}
+}
+
+export default Editor;

--- a/editor/index.js
+++ b/editor/index.js
@@ -79,6 +79,11 @@ export function recreateEditorInstance( target, settings ) {
 	);
 }
 
+let renderFunction = () => {};
+export function __reRenderEditor() {
+	renderFunction();
+}
+
 /**
  * Initializes and returns an instance of Editor.
  *
@@ -100,11 +105,14 @@ export function createEditorInstance( id, post, settings ) {
 		onError: reboot,
 	};
 
-	render( Editor, props, target );
+	renderFunction = () => {
+		render( Editor, props, target );
+	};
+	renderFunction();
 
 	if ( module.hot ) {
 		module.hot.accept( './components/editor', () => {
-			render( Editor, props, target );
+			renderFunction();
 		} );
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -12,10 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Webpack hot module reloading
 if ( ! defined( 'WEBPACK_HMR' ) ) {
-	define( 'WEBPACK_HMR', false );
+	define( 'GUTENBERG_WEBPACK_HMR', false );
 }
 if ( ! defined( 'WEBPACK_DEV_SERVER' ) ) {
-	define( 'WEBPACK_DEV_SERVER', 'http://localhost:3000/' );
+	define( 'GUTENBERG_WEBPACK_DEV_SERVER', 'http://localhost:3000/' );
 }
 
 /**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -11,10 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Webpack hot module reloading
-if ( ! defined( 'WEBPACK_HMR' ) ) {
+if ( ! defined( 'GUTENBERG_WEBPACK_HMR' ) ) {
 	define( 'GUTENBERG_WEBPACK_HMR', false );
 }
-if ( ! defined( 'WEBPACK_DEV_SERVER' ) ) {
+if ( ! defined( 'GUTENBERG_WEBPACK_DEV_SERVER' ) ) {
 	define( 'GUTENBERG_WEBPACK_DEV_SERVER', 'http://localhost:3000/' );
 }
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-// Webpack hot module reloading
+// Webpack hot module reloading.
 if ( ! defined( 'WEBPACK_HMR' ) ) {
 	define( 'GUTENBERG_WEBPACK_HMR', false );
 }
@@ -39,7 +39,7 @@ function gutenberg_dir_path() {
  * @since 0.1.0
  */
 function gutenberg_url( $path, $hot = false ) {
-	if( $hot ) {
+	if ( $hot ) {
 		return GUTENBERG_WEBPACK_DEV_SERVER . $path;
 	}
 	return plugins_url( $path, dirname( __FILE__ ) );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -10,6 +10,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+// Webpack hot module reloading
+if ( ! defined( 'WEBPACK_HMR' ) ) {
+	define( 'WEBPACK_HMR', false );
+}
+if ( ! defined( 'WEBPACK_DEV_SERVER' ) ) {
+	define( 'WEBPACK_DEV_SERVER', 'http://localhost:3000/' );
+}
+
 /**
  * Retrieves the root plugin path.
  *
@@ -25,12 +33,15 @@ function gutenberg_dir_path() {
  * Retrieves a URL to a file in the gutenberg plugin.
  *
  * @param  string $path Relative path of the desired file.
- *
- * @return string       Fully qualified URL pointing to the desired file.
+ * @param  bool   $hot  Serve the file from webpack dev server.
+ * @return string Fully qualified URL pointing to the desired file.
  *
  * @since 0.1.0
  */
-function gutenberg_url( $path ) {
+function gutenberg_url( $path, $hot = false ) {
+	if( $hot ) {
+		return WEBPACK_DEV_SERVER . $path;
+	}
 	return plugins_url( $path, dirname( __FILE__ ) );
 }
 
@@ -146,9 +157,9 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_register_script(
 		'wp-blocks',
-		gutenberg_url( 'blocks/build/index.js' ),
+		gutenberg_url( 'blocks/build/index.js', WEBPACK_HMR ),
 		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-hooks', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models', 'shortcode' ),
-		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
+		WEBPACK_HMR ? false : filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 	wp_add_inline_script(
 		'wp-blocks',
@@ -648,9 +659,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// The editor code itself.
 	wp_enqueue_script(
 		'wp-editor',
-		gutenberg_url( 'editor/build/index.js' ),
+		gutenberg_url( 'editor/build/index.js', WEBPACK_HMR ),
 		array( 'jquery', 'wp-api', 'wp-data', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
-		filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
+		WEBPACK_HMR ? false : filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
 		true // enqueue in the footer.
 	);
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -157,10 +157,11 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_register_script(
 		'wp-blocks',
-		gutenberg_url( 'blocks/build/index.js' ),
+		gutenberg_url( 'blocks/build/index.js', GUTENBERG_WEBPACK_HMR  ),
 		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-hooks', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models', 'shortcode' ),
-		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
+        GUTENBERG_WEBPACK_HMR ? false : filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
+
 	wp_add_inline_script(
 		'wp-blocks',
 		gutenberg_get_script_polyfill( array(

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -40,7 +40,7 @@ function gutenberg_dir_path() {
  */
 function gutenberg_url( $path, $hot = false ) {
 	if( $hot ) {
-		return WEBPACK_DEV_SERVER . $path;
+		return GUTENBERG_WEBPACK_DEV_SERVER . $path;
 	}
 	return plugins_url( $path, dirname( __FILE__ ) );
 }
@@ -157,9 +157,9 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	wp_register_script(
 		'wp-blocks',
-		gutenberg_url( 'blocks/build/index.js', WEBPACK_HMR ),
+		gutenberg_url( 'blocks/build/index.js' ),
 		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-hooks', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models', 'shortcode' ),
-		WEBPACK_HMR ? false : filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
+		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 	wp_add_inline_script(
 		'wp-blocks',
@@ -659,9 +659,9 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// The editor code itself.
 	wp_enqueue_script(
 		'wp-editor',
-		gutenberg_url( 'editor/build/index.js', WEBPACK_HMR ),
+		gutenberg_url( 'editor/build/index.js', GUTENBERG_WEBPACK_HMR ),
 		array( 'jquery', 'wp-api', 'wp-data', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
-		WEBPACK_HMR ? false : filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
+		GUTENBERG_WEBPACK_HMR ? false : filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
 		true // enqueue in the footer.
 	);
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "postcss-loader": "2.0.6",
     "prismjs": "1.6.0",
     "raw-loader": "0.5.1",
+    "react-hot-loader": "3.1.3",
     "react-markdown": "2.5.0",
     "react-test-renderer": "16.0.0",
     "sass-loader": "6.0.6",
@@ -98,6 +99,7 @@
     "style-loader": "0.18.2",
     "tinymce": "4.7.2",
     "webpack": "3.10.0",
+    "webpack-dev-server": "2.9.7",
     "webpack-rtl-plugin": "github:yoavf/webpack-rtl-plugin#develop"
   },
   "jest": {
@@ -137,6 +139,7 @@
     "lint": "eslint .",
     "predev": "check-node-version --package",
     "dev": "cross-env BABEL_ENV=default webpack --watch",
+    "hot": "cross-env BABEL_ENV=default webpack-dev-server --config ./webpack.config.hot.js",
     "test": "npm run lint && npm run test-unit",
     "ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",
     "fixtures:clean": "rimraf \"blocks/test/fixtures/*.+(json|serialized.html)\"",

--- a/webpack.config.hot.js
+++ b/webpack.config.hot.js
@@ -1,0 +1,46 @@
+const webpack = require( 'webpack' );
+const config = require( './webpack.config' );
+
+const entryPointNames = [
+	'blocks',
+	'components',
+	'date',
+	'editor',
+	'element',
+	'i18n',
+	'utils',
+	'data',
+];
+
+const devServerConfig = {
+	port: 3000,
+	hot: true,
+	headers: {
+		'Access-Control-Allow-Origin': '*',
+	},
+};
+
+const hrPlugins = [
+	new webpack.HotModuleReplacementPlugin(),
+	new webpack.NamedModulesPlugin(),
+];
+
+const hrEntries = [
+	'react-hot-loader/patch',
+	'webpack/hot/only-dev-server',
+	'webpack-dev-server/client?http://localhost:3000',
+];
+
+// Update config
+config.devServer = devServerConfig;
+config.plugins = config.plugins.concat( hrPlugins );
+config.output.publicPath = 'http://localhost:3000/';
+
+for ( let i = 0; i < entryPointNames.length; i++ ) {
+	const entryPointName = entryPointNames[ i ];
+	config.entry[ entryPointName ] = [ ...hrEntries, config.entry[ entryPointName ] ];
+}
+config.entry.hooks = [ config.entry.hooks ];
+
+module.exports = config;
+


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR implements webpack hot module reloading (HMR) for the editor.

Currently, the hot reloading works only for the actual editor itself and not other parts that are exposed through global variables such as blocks. I will be looking into how to do that at a later stage.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've tested this mainly by editing react components that are being used by the actual editor in `/editor/index.js`.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New development feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [] My code follows has proper inline documentation.