### PR TITLE
Use Post Type capabilities instead of All capabilities.

### DIFF
--- a/editor/components/post-author/test/check.js
+++ b/editor/components/post-author/test/check.js
@@ -37,7 +37,7 @@ describe( 'PostAuthorCheck', () => {
 
 	const user = {
 		data: {
-			capabilities: {
+			post_type_capabilities: {
 				publish_posts: true,
 			},
 		},
@@ -48,7 +48,7 @@ describe( 'PostAuthorCheck', () => {
 		expect( wrapper.type() ).toBe( null );
 		wrapper = shallow(
 			<PostAuthorCheck users={ users } user={
-				{ data: { capabilities: { publish_posts: false } } }
+				{ data: { post_type_capabilities: { publish_posts: false } } }
 			}>
 				authors
 			</PostAuthorCheck>

--- a/editor/components/post-pending-status/check.js
+++ b/editor/components/post-pending-status/check.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,10 +13,12 @@ import { compose } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { isCurrentPostPublished } from '../../store/selectors';
+import { isCurrentPostPublished, getCurrentPostType } from '../../store/selectors';
 
 export function PostPendingStatusCheck( { isPublished, children, user } ) {
-	if ( isPublished || ! user.data || ! user.data.capabilities.publish_posts ) {
+	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
+
+	if ( isPublished || ! userCanPublishPosts ) {
 		return null;
 	}
 
@@ -25,12 +28,15 @@ export function PostPendingStatusCheck( { isPublished, children, user } ) {
 const applyConnect = connect(
 	( state ) => ( {
 		isPublished: isCurrentPostPublished( state ),
+		postType: getCurrentPostType( state ),
 	} ),
 );
 
-const applyWithAPIData = withAPIData( () => {
+const applyWithAPIData = withAPIData( ( props ) => {
+	const { postType } = props;
+
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 	};
 } );
 

--- a/editor/components/post-pending-status/test/check.js
+++ b/editor/components/post-pending-status/test/check.js
@@ -11,7 +11,7 @@ import { PostPendingStatusCheck } from '../check';
 describe( 'PostPendingStatusCheck', () => {
 	const user = {
 		data: {
-			capabilities: {
+			post_type_capabilities: {
 				publish_posts: true,
 			},
 		},
@@ -22,7 +22,7 @@ describe( 'PostPendingStatusCheck', () => {
 		expect( wrapper.type() ).toBe( null );
 		wrapper = shallow(
 			<PostPendingStatusCheck user={
-				{ data: { capabilities: { publish_posts: false } } }
+				{ data: { post_type_capabilities: { publish_posts: false } } }
 			}>
 				status
 			</PostPendingStatusCheck>

--- a/editor/components/post-publish-button/index.js
+++ b/editor/components/post-publish-button/index.js
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { noop } from 'lodash';
+import { noop, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -23,6 +23,7 @@ import {
 	getEditedPostVisibility,
 	isEditedPostSaveable,
 	isEditedPostPublishable,
+	getCurrentPostType,
 } from '../../store/selectors';
 
 export function PostPublishButton( {
@@ -37,7 +38,7 @@ export function PostPublishButton( {
 	onSubmit = noop,
 } ) {
 	const isButtonEnabled = user.data && ! isSaving && isPublishable && isSaveable;
-	const isContributor = user.data && ! user.data.capabilities.publish_posts;
+	const isContributor = ! get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
 
 	let publishStatus;
 	if ( isContributor ) {
@@ -80,6 +81,7 @@ const applyConnect = connect(
 		visibility: getEditedPostVisibility( state ),
 		isSaveable: isEditedPostSaveable( state ),
 		isPublishable: isEditedPostPublishable( state ),
+		postType: getCurrentPostType( state ),
 	} ),
 	{
 		onStatusChange: ( status ) => editPost( { status } ),
@@ -87,9 +89,11 @@ const applyConnect = connect(
 	}
 );
 
-const applyWithAPIData = withAPIData( () => {
+const applyWithAPIData = withAPIData( ( props ) => {
+	const { postType } = props;
+
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 	};
 } );
 

--- a/editor/components/post-publish-button/label.js
+++ b/editor/components/post-publish-button/label.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,6 +20,7 @@ import {
 	isEditedPostBeingScheduled,
 	isSavingPost,
 	isPublishingPost,
+	getCurrentPostType,
 } from '../../store/selectors';
 
 export function PublishButtonLabel( {
@@ -28,7 +30,8 @@ export function PublishButtonLabel( {
 	isPublishing,
 	user,
 } ) {
-	const isContributor = user.data && ! user.data.capabilities.publish_posts;
+	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
+	const isContributor = user.data && ! userCanPublishPosts;
 
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
@@ -53,12 +56,15 @@ const applyConnect = connect(
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		isSaving: isSavingPost( state ),
 		isPublishing: isPublishingPost( state ),
+		postType: getCurrentPostType( state ),
 	} )
 );
 
-const applyWithAPIData = withAPIData( () => {
+const applyWithAPIData = withAPIData( ( props ) => {
+	const { postType } = props;
+
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 	};
 } );
 

--- a/editor/components/post-publish-button/test/index.js
+++ b/editor/components/post-publish-button/test/index.js
@@ -13,7 +13,7 @@ describe( 'PostPublishButton', () => {
 	const user = {
 		data: {
 			id: 1,
-			capabilities: {
+			post_type_capabilities: {
 				publish_posts: true,
 			},
 		},
@@ -21,7 +21,7 @@ describe( 'PostPublishButton', () => {
 
 	const contributor = merge( {}, user, {
 		data: {
-			capabilities: {
+			post_type_capabilities: {
 				publish_posts: false,
 			},
 		},

--- a/editor/components/post-publish-button/test/label.js
+++ b/editor/components/post-publish-button/test/label.js
@@ -12,7 +12,7 @@ describe( 'PublishButtonLabel', () => {
 	const user = {
 		data: {
 			id: 1,
-			capabilities: {
+			post_type_capabilities: {
 				publish_posts: true,
 			},
 		},
@@ -20,7 +20,7 @@ describe( 'PublishButtonLabel', () => {
 
 	const contributor = merge( {}, user, {
 		data: {
-			capabilities: {
+			post_type_capabilities: {
 				publish_posts: false,
 			},
 		},

--- a/editor/components/post-publish-dropdown/index.js
+++ b/editor/components/post-publish-dropdown/index.js
@@ -1,8 +1,15 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { withAPIData, PanelBody } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,9 +21,10 @@ import PostSchedule from '../post-schedule';
 import PostScheduleLabel from '../post-schedule/label';
 import PostPublishButton from '../post-publish-button';
 import PostSwitchToDraftButton from '../post-switch-to-draft-button';
+import { getCurrentPostType } from '../../store/selectors';
 
 function PostPublishDropdown( { user, onSubmit } ) {
-	const canPublish = user.data && user.data.capabilities.publish_posts;
+	const canPublish = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
 
 	return (
 		<div className="editor-post-publish-dropdown">
@@ -51,8 +59,23 @@ function PostPublishDropdown( { user, onSubmit } ) {
 	);
 }
 
-export default withAPIData( () => {
+const applyConnect = connect(
+	( state ) => {
+		return {
+			postType: getCurrentPostType( state ),
+		};
+	},
+);
+
+const applyWithAPIData = withAPIData( ( props ) => {
+	const { postType } = props;
+
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 	};
-} )( PostPublishDropdown );
+} );
+
+export default compose( [
+	applyConnect,
+	applyWithAPIData,
+] )( PostPublishDropdown );

--- a/editor/components/post-sticky/check.js
+++ b/editor/components/post-sticky/check.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,11 +16,12 @@ import { compose } from '@wordpress/element';
 import { getCurrentPostType } from '../../store/selectors';
 
 export function PostStickyCheck( { postType, children, user } ) {
+	const userCan = get( user.data, 'post_type_capabilities', false );
+
 	if (
 		postType !== 'post' ||
-		! user.data ||
-		! user.data.capabilities.publish_posts ||
-		! user.data.capabilities.edit_others_posts
+		! userCan.publish_posts ||
+		! userCan.edit_others_posts
 	) {
 		return null;
 	}
@@ -35,9 +37,11 @@ const applyConnect = connect(
 	},
 );
 
-const applyWithAPIData = withAPIData( () => {
+const applyWithAPIData = withAPIData( ( props ) => {
+	const { postType } = props;
+
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 	};
 } );
 

--- a/editor/components/post-sticky/test/index.js
+++ b/editor/components/post-sticky/test/index.js
@@ -11,7 +11,7 @@ import { PostStickyCheck } from '../check';
 describe( 'PostSticky', () => {
 	const user = {
 		data: {
-			capabilities: {
+			post_type_capabilities: {
 				edit_others_posts: true,
 				publish_posts: true,
 			},
@@ -37,7 +37,7 @@ describe( 'PostSticky', () => {
 
 		wrapper = shallow(
 			<PostStickyCheck postType="post" user={
-				{ data: { capabilities: { edit_others_posts: false, publish_posts: true } } }
+				{ data: { post_type_capabilities: { edit_others_posts: false, publish_posts: true } } }
 			}>
 				Can Toggle Sticky
 			</PostStickyCheck>
@@ -46,7 +46,7 @@ describe( 'PostSticky', () => {
 
 		wrapper = shallow(
 			<PostStickyCheck postType="post" user={
-				{ data: { capabilities: { edit_others_posts: true, publish_posts: false } } }
+				{ data: { post_type_capabilities: { edit_others_posts: true, publish_posts: false } } }
 			}>
 				Can Toggle Sticky
 			</PostStickyCheck>

--- a/editor/edit-post/sidebar/post-schedule/test/index.js
+++ b/editor/edit-post/sidebar/post-schedule/test/index.js
@@ -11,7 +11,7 @@ import { PostSchedule } from '../';
 describe( 'PostSchedule', () => {
 	const user = {
 		data: {
-			capabilities: {
+			post_type_capabilities: {
 				publish_posts: true,
 			},
 		},
@@ -21,7 +21,7 @@ describe( 'PostSchedule', () => {
 		let wrapper = shallow( <PostSchedule user={ {} } /> );
 		expect( wrapper.type() ).toBe( null );
 		wrapper = shallow( <PostSchedule user={
-			{ data: { capabilities: { publish_posts: false } } }
+			{ data: { post_type_capabilities: { publish_posts: false } } }
 		} /> );
 		expect( wrapper.type() ).toBe( null );
 	} );

--- a/editor/edit-post/sidebar/post-visibility/index.js
+++ b/editor/edit-post/sidebar/post-visibility/index.js
@@ -1,17 +1,25 @@
 /**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { PanelRow, Dropdown, withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
 import { PostVisibility as PostVisibilityForm, PostVisibilityLabel } from '../../../components';
+import { getCurrentPostType } from '../../../store/selectors';
 
 export function PostVisibility( { user } ) {
-	const canEdit = user.data && user.data.capabilities.publish_posts;
+	const canEdit = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
 
 	return (
 		<PanelRow className="editor-post-visibility">
@@ -38,8 +46,23 @@ export function PostVisibility( { user } ) {
 	);
 }
 
-export default withAPIData( () => {
+const applyConnect = connect(
+	( state ) => {
+		return {
+			postType: getCurrentPostType( state ),
+		};
+	},
+);
+
+const applyWithAPIData = withAPIData( ( props ) => {
+	const { postType } = props;
+
 	return {
-		user: '/wp/v2/users/me?context=edit',
+		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
 	};
-} )( PostVisibility );
+} );
+
+export default compose( [
+	applyConnect,
+	applyWithAPIData,
+] )( PostVisibility );

--- a/editor/edit-post/sidebar/post-visibility/test/index.js
+++ b/editor/edit-post/sidebar/post-visibility/test/index.js
@@ -11,7 +11,7 @@ import { PostVisibility } from '../';
 describe( 'PostVisibility', () => {
 	const user = {
 		data: {
-			capabilities: {
+			post_type_capabilities: {
 				publish_posts: true,
 			},
 		},
@@ -21,7 +21,7 @@ describe( 'PostVisibility', () => {
 		let wrapper = shallow( <PostVisibility user={ {} } /> );
 		expect( wrapper.find( 'a' ) ).toHaveLength( 0 );
 		wrapper = shallow( <PostVisibility postType="post" user={
-			{ data: { capabilities: { publish_posts: false } } }
+			{ data: { post_type_capabilities: { publish_posts: false } } }
 		} /> );
 		expect( wrapper.find( 'Dropdown' ) ).toHaveLength( 0 );
 	} );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -743,9 +743,12 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		$post_to_edit['content']['raw'] = gutenberg_wpautop_block_content( $post_to_edit['content']['raw'] );
 	}
 
+	// Set the post type name.
+	$post_type = get_post_type( $post );
+
 	// Preload common data.
 	$preload_paths = array(
-		'/wp/v2/users/me?context=edit',
+		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
 		'/wp/v2/taxonomies?context=edit',
 		gutenberg_get_rest_link( $post_to_edit, 'about', 'edit' ),
 	);

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -191,3 +191,63 @@ function gutenberg_wpautop( $content ) {
 }
 remove_filter( 'the_content', 'wpautop' );
 add_filter( 'the_content', 'gutenberg_wpautop', 8 );
+
+/**
+ * Includes the value for the custom field `post_type_capabities` inside the REST API response of user.
+ *
+ * TODO: This is a temporary solution. Next step would be to edit the WP_REST_Users_Controller,
+ * once merged into Core.
+ *
+ * @since ?
+ *
+ * @param array           $user An array containing user properties.
+ * @param string          $name The name of the custom field.
+ * @param WP_REST_Request $request Full details about the REST API request.
+ * @return object The Post Type capabilities.
+ */
+function gutenberg_get_post_type_capabilities( $user, $name, $request ) {
+	$post_type = $request->get_param( 'post_type' );
+	$value     = new stdClass;
+
+	if ( ! empty( $user['id'] ) && $post_type && post_type_exists( $post_type ) ) {
+		// The Post Type object contains the Post Type's specific caps.
+		$post_type_object = get_post_type_object( $post_type );
+
+		// Loop in the Post Type's caps to validate the User's caps for it.
+		foreach ( $post_type_object->cap as $post_cap => $post_type_cap ) {
+			// Ignore caps requiring a post ID.
+			if ( in_array( $post_cap, array( 'edit_post', 'read_post', 'delete_post' ) ) ) {
+				continue;
+			}
+
+			// Set the User's post type capability.
+			$value->{$post_cap} = user_can( $user['id'], $post_type_cap );
+		}
+	}
+
+	return $value;
+}
+
+/**
+ * Adds the custom field `post_type_capabities` to the REST API response of user.
+ *
+ * TODO: This is a temporary solution. Next step would be to edit the WP_REST_Users_Controller,
+ * once merged into Core.
+ *
+ * @since ?
+ */
+function gutenberg_register_rest_api_post_type_capabilities() {
+	register_rest_field( 'user',
+		'post_type_capabilities',
+		array(
+			'get_callback' => 'gutenberg_get_post_type_capabilities',
+			'schema'       => array(
+				'description' => __( 'Post Type capabilities for the user.', 'gutenberg' ),
+				'type'        => 'object',
+				'context'     => array( 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_type_capabilities' );


### PR DESCRIPTION
#3895 showed there was an issue with SuperAdmins not having a role on a site of a multisite network. After some discussions, we think it is best to check the post type capabilities for the connected user and the current post type being edited.
A new parameter is added to the users/me REST API route containing the post type name. This parameter is used to get the corresponding post type capabilities.
Capability checks have been updated accordingly into Gutenberg editor components

## Description
See #3895

## How Has This Been Tested?
See #3895

## Screenshots (jpeg or gifs if applicable):
See #3895

## Types of changes
See #3895

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.

@youknowriad Here's the new PR, i've found the time to do it during my lunch break :wink: 