### PR TITLE
Add transforms between Heading & Cover Image

### DIFF
--- a/blocks/library/cover-image/editor.scss
+++ b/blocks/library/cover-image/editor.scss
@@ -18,4 +18,8 @@
 	.blocks-editable strong {
 		font-weight: 300;
 	}
+
+	.components-placeholder h2 {
+		color: inherit;
+	}
 }

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -10,7 +10,7 @@ import classnames from 'classnames';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType } from '../../api';
+import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
 import BlockControls from '../../block-controls';
@@ -52,6 +52,27 @@ registerBlockType( 'core/cover-image', {
 			type: 'number',
 			default: 50,
 		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/heading' ],
+				transform: ( { content } ) => (
+					createBlock( 'core/cover-image', { title: content } )
+				),
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/heading' ],
+				transform: ( { title } ) => (
+					createBlock( 'core/heading', { content: title } )
+				),
+			},
+		],
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -123,13 +144,25 @@ registerBlockType( 'core/cover-image', {
 
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
+			const icon = title ? undefined : 'format-image';
+			const label = title ? (
+				<Editable
+					tagName="h2"
+					value={ title }
+					focus={ focus }
+					onFocus={ setFocus }
+					onChange={ ( value ) => setAttributes( { title: value } ) }
+					inlineToolbar
+				/>
+			) : __( 'Cover Image' );
+
 			return [
 				controls,
 				<Placeholder
 					key="placeholder"
 					instructions={ __( 'Drag image here or insert from media library' ) }
-					icon="format-image"
-					label={ __( 'Cover Image' ) }
+					icon={ icon }
+					label={ label }
 					className={ className }>
 					<MediaUploadButton
 						buttonProps={ uploadButtonProps }


### PR DESCRIPTION
## Description
Fixes #4003

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):
![gutenberg-heading-cover-image-transform](https://user-images.githubusercontent.com/150562/34262231-b326fdfe-e663-11e7-9226-fb1f27ff9f5b.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.