### PR TITLE
Made notices always visible

### DIFF
--- a/editor/assets/stylesheets/_mixins.scss
+++ b/editor/assets/stylesheets/_mixins.scss
@@ -143,3 +143,60 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 	box-shadow: 0 0 0 1px $dark-gray-500;
 	color: $dark-gray-900;
 }
+
+/**
+ * Applies editor left position to the selector passed as argument
+ */
+@mixin editor-left( $selector ) {
+	.sticky-menu #{$selector} {	/* Sticky is when on smaller breakpoints, nav menu is manually opened */
+		@include break-medium() {
+			left: $admin-sidebar-width;
+		}
+	}
+
+	.auto-fold #{$selector} {		/* Auto fold is when on smaller breakpoints, nav menu auto colllapses */
+		@include break-medium() {
+			left: $admin-sidebar-width-collapsed;
+		}
+
+		@include break-large() {
+			left: $admin-sidebar-width;
+		}
+	}
+
+	/* Sidebar manually collapsed */
+	.folded #{$selector} {
+		left: 0;
+
+		@include break-medium() {
+			left: $admin-sidebar-width-collapsed;
+		}
+	}
+
+	/* Mobile menu opened */
+	@media ( max-width: #{ ( $break-medium ) } ) {
+		.auto-fold .wp-responsive-open #{$selector} {
+			left: $admin-sidebar-width-big;
+		}
+	}
+
+	/* In small screens with resposive menu expanded there is small white space */
+	@media ( max-width: #{ ( $break-small ) } ) {
+		.auto-fold .wp-responsive-open #{$selector} {
+			margin-left: -18px;
+		}
+	}
+}
+
+/**
+ * Applies editor right position to the selector passed as argument
+ */
+ @mixin editor-right( $selector ) {
+	#{$selector} {
+		right: 0;
+	}
+
+	.editor-layout.is-sidebar-opened #{$selector} {
+		right: $sidebar-width;
+	}
+}

--- a/editor/edit-post/header/style.scss
+++ b/editor/edit-post/header/style.scss
@@ -25,42 +25,9 @@
 	@include break-medium() {
 		top: $admin-bar-height;
 	}
-
-	@include break-large() {
-		left: $admin-sidebar-width;
-	}
 }
 
-.sticky-menu .editor-header {	/* Sticky is when on smaller breakpoints, nav menu is manually opened */
-	@include break-medium() {
-		left: $admin-sidebar-width;
-	}
-}
-
-.auto-fold .editor-header {		/* Auto fold is when on smaller breakpoints, nav menu auto colllapses */
-	@include break-medium() {
-		left: $admin-sidebar-width-collapsed;
-	}
-
-	@include break-large() {
-		left: $admin-sidebar-width;
-	}
-}
-
-/* Sidebar manually collapsed */
-.folded .editor-header {
-	left: 0;
-
-	@include break-medium() {
-		left: $admin-sidebar-width-collapsed;
-	}
-}
-
-/* Mobile menu opened */
-.auto-fold .wp-responsive-open .editor-header {
-	left: $admin-sidebar-width-big;
-	right: -$admin-sidebar-width-big;
-}
+@include editor-left('.editor-header');
 
 .editor-header__settings {
 	display: inline-flex;

--- a/editor/edit-post/layout/style.scss
+++ b/editor/edit-post/layout/style.scss
@@ -7,10 +7,15 @@
 	position: relative;
 
 	.components-notice-list {
-		position: absolute;
-		top: 0;
+		position: sticky;
+		top: $header-height;
 		left: 0;
 		right: 0;
+
+		@include break-small {
+			position: fixed;
+			top: inherit;
+		}
 
 		.notice {
 			margin: 0 0 5px;
@@ -47,6 +52,9 @@
 		}
 	}
 }
+
+@include editor-left('.components-notice-list');
+@include editor-right('.components-notice-list');
 
 .editor-layout__metaboxes:not(:empty) {
 	border-top: 1px solid $light-gray-500;


### PR DESCRIPTION
## Description
This PR aims to fix the visual issue described in https://github.com/WordPress/gutenberg/issues/4128 and https://github.com/WordPress/gutenberg/issues/3777. It makes the notices always visible even when the post is scrolled.
Besides being fixed sticky behavior has required for things to look as expected in resolutions < 600px.

## How Has This Been Tested?
Add a post with much content (requires scroll).
Save the post, resize the window to width < 600px scroll from the top until the end and verify the notice is correctly shown and the sticky behavior looks as expected.
Resize the window to points between this set of number {600, 782, 960, >960}, verify that notice always adapts and is always shown in the correct position even the look changes (elements are hidden shown)

## Screenshots (jpeg or gifs if applicable):

<img width="473" alt="screen shot 2017-12-21 at 16 46 35" src="https://user-images.githubusercontent.com/11271197/34266672-fe303140-e671-11e7-8080-e4ffce910aaf.png">
<img width="476" alt="screen shot 2017-12-21 at 16 46 58" src="https://user-images.githubusercontent.com/11271197/34266673-fe4fdc98-e671-11e7-97bf-e4f45d07997c.png">
<img width="530" alt="screen shot 2017-12-21 at 16 47 19" src="https://user-images.githubusercontent.com/11271197/34266674-fe6ef402-e671-11e7-9d6e-19c03ade4878.png">
<img width="627" alt="screen shot 2017-12-21 at 16 47 40" src="https://user-images.githubusercontent.com/11271197/34266675-fe970122-e671-11e7-8d43-cf424bb28854.png">
<img width="766" alt="screen shot 2017-12-21 at 16 47 56" src="https://user-images.githubusercontent.com/11271197/34266677-feb3cbe0-e671-11e7-83b2-303f8c9ff58b.png">

cc: @afercia 

