### PR TITLE
Make block toolbar by the block always on mobile 

### DIFF
--- a/editor/edit-post/header/fixed-toolbar-toggle/index.js
+++ b/editor/edit-post/header/fixed-toolbar-toggle/index.js
@@ -12,10 +12,13 @@ import { MenuItemsGroup, MenuItemsToggle, withInstanceId } from '@wordpress/comp
 /**
  * Internal Dependencies
  */
-import { isFeatureActive } from '../../../store/selectors';
+import { isFeatureActive, isMobile } from '../../../store/selectors';
 import { toggleFeature } from '../../../store/actions';
 
-function FeatureToggle( { onToggle, active } ) {
+function FeatureToggle( { onToggle, active, onMobile } ) {
+	if ( onMobile ) {
+		return null;
+	}
 	return (
 		<MenuItemsGroup
 			label={ __( 'Toolbar' ) }
@@ -32,6 +35,7 @@ function FeatureToggle( { onToggle, active } ) {
 export default connect(
 	( state ) => ( {
 		active: ! isFeatureActive( state, 'fixedToolbar' ),
+		onMobile: isMobile( state ),
 	} ),
 	( dispatch, ownProps ) => ( {
 		onToggle() {

--- a/editor/edit-post/header/fixed-toolbar-toggle/index.js
+++ b/editor/edit-post/header/fixed-toolbar-toggle/index.js
@@ -12,7 +12,7 @@ import { MenuItemsGroup, MenuItemsToggle, withInstanceId } from '@wordpress/comp
 /**
  * Internal Dependencies
  */
-import { isFeatureActive, isMobile } from '../../../store/selectors';
+import { hasFixedToolbar, isMobile } from '../../../store/selectors';
 import { toggleFeature } from '../../../store/actions';
 
 function FeatureToggle( { onToggle, active, onMobile } ) {
@@ -34,7 +34,7 @@ function FeatureToggle( { onToggle, active, onMobile } ) {
 
 export default connect(
 	( state ) => ( {
-		active: ! isFeatureActive( state, 'fixedToolbar' ),
+		active: hasFixedToolbar( state ),
 		onMobile: isMobile( state ),
 	} ),
 	( dispatch, ownProps ) => ( {

--- a/editor/edit-post/header/header-toolbar/index.js
+++ b/editor/edit-post/header/header-toolbar/index.js
@@ -21,9 +21,9 @@ import {
 	MultiBlocksSwitcher,
 } from '../../../components';
 import NavigableToolbar from '../../../components/navigable-toolbar';
-import { isFeatureActive } from '../../../store/selectors';
+import { hasFixedToolbar } from '../../../store/selectors';
 
-function HeaderToolbar( { hasFixedToolbar } ) {
+function HeaderToolbar( { fixedToolbarActive } ) {
 	return (
 		<NavigableToolbar
 			className="editor-header-toolbar"
@@ -34,7 +34,7 @@ function HeaderToolbar( { hasFixedToolbar } ) {
 			<EditorHistoryRedo />
 			<TableOfContents />
 			<MultiBlocksSwitcher />
-			{ hasFixedToolbar && (
+			{ fixedToolbarActive && (
 				<div className="editor-header-toolbar__block-toolbar">
 					<BlockToolbar />
 				</div>
@@ -45,6 +45,6 @@ function HeaderToolbar( { hasFixedToolbar } ) {
 
 export default connect(
 	( state ) => ( {
-		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
+		fixedToolbarActive: hasFixedToolbar( state ),
 	} )
 )( HeaderToolbar );

--- a/editor/edit-post/layout/index.js
+++ b/editor/edit-post/layout/index.js
@@ -29,9 +29,9 @@ import {
 } from '../../components';
 import {
 	getEditorMode,
+	hasFixedToolbar,
 	hasOpenSidebar,
 	isSidebarOpened,
-	isFeatureActive,
 } from '../../store/selectors';
 import { toggleSidebar } from '../../store/actions';
 
@@ -40,12 +40,12 @@ function Layout( {
 	layoutHasOpenSidebar,
 	isDefaultSidebarOpened,
 	isPublishSidebarOpened,
-	hasFixedToolbar,
+	fixedToolbarActive,
 	onToggleSidebar,
 } ) {
 	const className = classnames( 'editor-layout', {
 		'is-sidebar-opened': layoutHasOpenSidebar,
-		'has-fixed-toolbar': hasFixedToolbar,
+		'has-fixed-toolbar': fixedToolbarActive,
 	} );
 	const closePublishPanel = () => onToggleSidebar( 'publish', false );
 
@@ -82,7 +82,7 @@ export default connect(
 		layoutHasOpenSidebar: hasOpenSidebar( state ),
 		isDefaultSidebarOpened: isSidebarOpened( state ),
 		isPublishSidebarOpened: isSidebarOpened( state, 'publish' ),
-		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
+		fixedToolbarActive: hasFixedToolbar( state ),
 	} ),
 	{ onToggleSidebar: toggleSidebar }
 )( navigateRegions( Layout ) );

--- a/editor/edit-post/modes/visual-editor/index.js
+++ b/editor/edit-post/modes/visual-editor/index.js
@@ -14,7 +14,7 @@ import { Component, findDOMNode } from '@wordpress/element';
 import './style.scss';
 import { BlockList, PostTitle, WritingFlow, DefaultBlockAppender, EditorGlobalKeyboardShortcuts } from '../../../components';
 import VisualEditorInserter from './inserter';
-import { isFeatureActive } from '../../../store/selectors';
+import { hasFixedToolbar } from '../../../store/selectors';
 import { clearSelectedBlock } from '../../../store/actions';
 
 class VisualEditor extends Component {
@@ -72,7 +72,7 @@ class VisualEditor extends Component {
 export default connect(
 	( state ) => {
 		return {
-			hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
+			hasFixedToolbar: hasFixedToolbar( state ),
 		};
 	},
 	{

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1072,6 +1072,16 @@ export const getMostFrequentlyUsedBlocks = createSelector(
 );
 
 /**
+ * Returns whether the toolbar should be fixed or not.
+ *
+ * @param  {Object}    state   Global application state.
+ * @return {Boolean}          True if toolbar is fixed.
+ */
+export function hasFixedToolbar( state ) {
+	return ! isMobile( state ) && isFeatureActive( state, 'fixedToolbar' );
+}
+
+/**
  * Returns whether the given feature is enabled or not
  *
  * @param {Object}    state   Global application state

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -81,6 +81,7 @@ import {
 	isSelectionEnabled,
 	getReusableBlocks,
 	getStateBeforeOptimisticTransaction,
+	hasFixedToolbar,
 	isFeatureActive,
 	isPublishingPost,
 	POST_UPDATE_TRANSACTION_ID,
@@ -2292,6 +2293,60 @@ describe( 'selectors', () => {
 
 			const reusableBlock = getReusableBlock( state, '358b59ee-bab3-4d6f-8445-e8c6971a5605' );
 			expect( reusableBlock ).toBeNull();
+		} );
+	} );
+
+	describe( 'hasFixedToolbar', () => {
+		it( 'should return true if fixedToolbar is active and is not mobile screen size', () => {
+			const state = {
+				mobile: false,
+				preferences: {
+					features: {
+						fixedToolbar: true,
+					},
+				},
+			};
+
+			expect( hasFixedToolbar( state ) ).toBe( true );
+		} );
+
+		it( 'should return false if fixedToolbar is active and is mobile screen size', () => {
+			const state = {
+				mobile: true,
+				preferences: {
+					features: {
+						fixedToolbar: true,
+					},
+				},
+			};
+
+			expect( hasFixedToolbar( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if fixedToolbar is disable and is not mobile screen size', () => {
+			const state = {
+				mobile: false,
+				preferences: {
+					features: {
+						fixedToolbar: false,
+					},
+				},
+			};
+
+			expect( hasFixedToolbar( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if fixedToolbar is disable and is mobile screen size', () => {
+			const state = {
+				mobile: true,
+				preferences: {
+					features: {
+						fixedToolbar: false,
+					},
+				},
+			};
+
+			expect( hasFixedToolbar( state ) ).toBe( false );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -81,6 +81,7 @@ import {
 	isSelectionEnabled,
 	getReusableBlocks,
 	getStateBeforeOptimisticTransaction,
+	isFeatureActive,
 	isPublishingPost,
 	POST_UPDATE_TRANSACTION_ID,
 } from '../selectors';
@@ -2291,6 +2292,43 @@ describe( 'selectors', () => {
 
 			const reusableBlock = getReusableBlock( state, '358b59ee-bab3-4d6f-8445-e8c6971a5605' );
 			expect( reusableBlock ).toBeNull();
+		} );
+	} );
+
+	describe( 'isFeatureActive', () => {
+		it( 'should return true if feature is active', () => {
+			const state = {
+				preferences: {
+					features: {
+						chicken: true,
+					},
+				},
+			};
+
+			expect( isFeatureActive( state, 'chicken' ) ).toBe( true );
+		} );
+
+		it( 'should return false if feature is not active', () => {
+			const state = {
+				preferences: {
+					features: {
+						chicken: false,
+					},
+				},
+			};
+
+			expect( isFeatureActive( state, 'chicken' ) ).toBe( false );
+		} );
+
+		it( 'should return false if feature is not referred', () => {
+			const state = {
+				preferences: {
+					features: {
+					},
+				},
+			};
+
+			expect( isFeatureActive( state, 'chicken' ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
This PR aims to fix https://github.com/WordPress/gutenberg/issues/4079.
It disables the UI to change fixedToolbar on mobile and adds a new selector hasFixedToolbar to verify if the toolbar is fixed or not (on mobile it is never fixed).

## How Has This Been Tested?
Enable fixedToolbar feature resizes to mobile see the feature is disabled and the UI to enable it is not present.
Enable fixedToolbar toolbar feature on a desktop resolution, reload and verify the feature is still enabled, close the window, resize to mobile, open Gutenberg on mobile resolution and see the feature is disabled.
 cc: @karmatosed 