### PR TITLE
Inserter: Pressing Down in Tab moves focus to Panel

### DIFF
--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -121,6 +121,7 @@ class NavigableContainer extends Component {
 export class NavigableMenu extends Component {
 	render() {
 		const { role = 'menu', orientation = 'vertical', ...rest } = this.props;
+
 		const eventToOffset = ( evt ) => {
 			const { keyCode } = evt;
 
@@ -163,6 +164,21 @@ export class TabbableContainer extends Component {
 			const { keyCode, shiftKey } = evt;
 			if ( TAB === keyCode ) {
 				return shiftKey ? -1 : 1;
+			}
+
+			// Allow custom handling of keys besides Tab.
+			//
+			// By default, TabbableContainer will move focus forward on Tab and
+			// backward on Shift+Tab. The handler below will be used for all other
+			// events. The semantics for `this.props.eventToOffset`'s return
+			// values are the following:
+			//
+			// - +1: move focus forward
+			// - -1: move focus backward
+			// -  0: don't move focus, but acknowledge event and thus stop it
+			// - undefined: do nothing, let the event propagate
+			if ( this.props.eventToOffset ) {
+				return this.props.eventToOffset( evt );
 			}
 		};
 

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -302,16 +302,25 @@ export class InserterMenu extends Component {
 		return this.renderCategories( visibleBlocksByCategory );
 	}
 
-	interceptArrows( event ) {
-		if ( includes( ARROWS, event.keyCode ) ) {
-			// Prevent cases of focus being unexpectedly stolen up in the tree,
-			// notably when using VisualEditorSiblingInserter, where focus is
-			// moved to sibling blocks.
-			//
-			// We don't need to stop the native event, which has its uses, e.g.
-			// allowing window scrolling.
-			event.stopPropagation();
+	// Passed to TabbableContainer, extending its event-handling logic
+	eventToOffset( event ) {
+		// If a tab (Recent, Blocks, …) is focused, pressing the down arrow
+		// moves focus to the selected panel below.
+		if (
+			event.keyCode === keycodes.DOWN &&
+			document.activeElement.getAttribute( 'role' ) === 'tab'
+		) {
+			return 1; // Move focus forward
 		}
+
+		// Prevent cases of focus being unexpectedly stolen up in the tree,
+		// notably when using VisualEditorSiblingInserter, where focus is
+		// moved to sibling blocks.
+		if ( includes( ARROWS, event.keyCode ) ) {
+			return 0; // Don't move focus, but prevent event propagation
+		}
+
+		// Implicit `undefined` return: let the event propagate
 	}
 
 	render() {
@@ -320,7 +329,7 @@ export class InserterMenu extends Component {
 
 		return (
 			<TabbableContainer className="editor-inserter__menu" deep
-				onKeyDown={ this.interceptArrows }
+				eventToOffset={ this.eventToOffset }
 			>
 				<label htmlFor={ `editor-inserter__search-${ instanceId }` } className="screen-reader-text">
 					{ __( 'Search for a block' ) }


### PR DESCRIPTION
## Description
Fixes #3849. Per https://github.com/WordPress/gutenberg/issues/3849#issuecomment-351683781, the remaining task was to allow pressing the arrow down key (`↓`) when focusing an inserter tab (Recent, Blocks, &c.) to move focus to the selected panel.

## How Has This Been Tested?

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.