### PR TITLE
Sibling inserter: Fix the inserter position for floated blocks

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -33,6 +33,7 @@ import BlockHtml from './block-html';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import BlockMultiControls from './multi-controls';
 import BlockMobileToolbar from './block-mobile-toolbar';
+import BlockListSiblingInserter from './sibling-inserter';
 import {
 	clearSelectedBlock,
 	editPost,
@@ -439,6 +440,7 @@ export class BlockListBlock extends Component {
 					{ showUI && <BlockMobileToolbar uid={ block.uid } /> }
 				</div>
 				{ !! error && <BlockCrashWarning /> }
+				<BlockListSiblingInserter uid={ block.uid } />
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */

--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import {
 	findLast,
-	flatMap,
+	map,
 	invert,
 	isEqual,
 	mapValues,
@@ -211,7 +211,7 @@ class BlockList extends Component {
 		return (
 			<div>
 				{ !! blocks.length && <BlockListSiblingInserter /> }
-				{ flatMap( blocks, ( uid ) => [
+				{ map( blocks, ( uid ) => (
 					<BlockListBlock
 						key={ 'block-' + uid }
 						uid={ uid }
@@ -219,12 +219,8 @@ class BlockList extends Component {
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
 						showContextualToolbar={ showContextualToolbar }
-					/>,
-					<BlockListSiblingInserter
-						key={ 'sibling-inserter-' + uid }
-						uid={ uid }
-					/>,
-				] ) }
+					/>
+				) ) }
 			</div>
 		);
 	}

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -391,15 +391,13 @@
 .editor-block-list__sibling-inserter {
 	z-index: z-index( '.editor-block-list__sibling-inserter' );
 	position: relative;
-	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible ) - ( 2 * $block-padding );
-	margin: 0 auto;
 
-	@include break-small {
-		max-width: $visual-editor-max-width - ( 2 * $block-padding );
-	}
-
-	&:not( [data-insert-index="0"] ) {
-		top: #{ -1 * ( $block-spacing / 2 ) };
+	&[data-insert-index="0"] {
+		max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible ) - ( 2 * $block-padding );
+		margin: 0 auto;
+		@include break-small {
+			max-width: $visual-editor-max-width - ( 2 * $block-padding );
+		}
 	}
 
 	&:before {
@@ -451,6 +449,19 @@
 		.dashicon {
 			vertical-align: bottom;
 		}
+	}
+}
+
+.editor-block-list__block > .editor-block-list__sibling-inserter {
+	position: absolute;
+	bottom: 0;
+	top: auto;
+	left: 0;
+	right: 0;
+
+	@include break-small {
+		left: $block-mover-padding-visible;
+		right: $block-mover-padding-visible;
 	}
 }
 


### PR DESCRIPTION
closes #4142  

This PR fixes the sibling inserter for floated blocks by moving the sibling inserter inside the `BlockEdit` component, that way we can position it relative to its container.

**Testing instructions**

 - Add a block button
 - Alight it right
 - Check that the inserter is showing up when you hover the border bottom of the block.