### PR TITLE
Gallery Block: Drag and drop multiple images create a gallery block

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { filter } from 'lodash';
+import { filter, every } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createMediaFromFile } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -104,6 +105,21 @@ registerBlockType( 'core/gallery', {
 							return link === 'file' ? 'media' : link;
 						},
 					},
+				},
+			},
+			{
+				type: 'files',
+				isMatch( files ) {
+					return files.length !== 1 && every( files, ( file ) => file.type.indexOf( 'image/' ) === 0 );
+				},
+				transform( files ) {
+					return Promise.all( files.map( ( file ) => createMediaFromFile( file ) ) )
+						.then( ( medias ) => createBlock( 'core/gallery', {
+							images: medias.map( media => ( {
+								id: media.id,
+								url: media.source_url,
+							} ) ),
+						} ) );
 				},
 			},
 		],

--- a/components/drop-zone/style.scss
+++ b/components/drop-zone/style.scss
@@ -53,3 +53,8 @@
 	margin: 0 auto;
 	line-height: 0;
 }
+
+
+.components-drop-zone__content-text {
+	font-family: $default-font;
+}

--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -24,3 +24,7 @@ input[type=text].editor-default-block-appender__content {
 		outline: 1px solid $light-gray-500;
 	}
 }
+
+.editor-default-block-appender .components-drop-zone__content-icon {
+	display: none;
+}


### PR DESCRIPTION
closes #3364 

This PR adds a "transformation" to allow drag and dropping multiple images to the editor canvas in order to create a gallery block.

This doesn't solve the lack of feedback while the upload is in progress, this issue is not specific to the gallery block and I believe is tracked in a separate issue.

**Testing instructions**

 - Drag multiple images to the editor canvas
 - After the images upload, A gallery block should appear.