### PR TITLE
Rename theme support for wide images to `align-wide`.

### DIFF
--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -56,6 +56,6 @@ export function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CON
 
 export default withContext( 'editor' )(
 	( settings ) => ( {
-		wideControlsEnabled: settings.wideImages,
+		wideControlsEnabled: settings.alignWide,
 	} )
 )( BlockAlignmentToolbar );

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -4,18 +4,16 @@ By default, blocks provide their styles to enable basic support for blocks in th
 
 Some advanced block features require opt-in support in the theme itself as it's difficult for the block to provide these styles, they may require some architecting of the theme itself, in order to work well.
 
-To opt-in for one of these features, we should call `add_theme_support( 'gutenberg', $features )` in the `functions.php` file of the theme. For example:
+To opt-in for one of these features, we should call `add_theme_support( 'feature-name', $optional-parameters )` in the `functions.php` file of the theme. For example:
 
 ```php
 function mytheme_setup_theme_supported_features() {
-	add_theme_support( 'gutenberg', array(
-		'colors' => array(
-			'#a156b4',
-			'#d0a5db',
-			'#eee',
-			'#444',
-		),
-	) );
+	add_theme_support( 'editor-color-palette',
+		'#a156b4',
+		'#d0a5db',
+		'#eee',
+		'#444'
+	);
 }
 
 add_action( 'after_setup_theme', 'mytheme_setup_theme_supported_features' );
@@ -31,19 +29,17 @@ Some blocks such as the image block have the possibility to define a "wide" or "
 add_theme_support( 'align-wide' );
 ```
 
-### Colors:
+### Block Color Palettes:
 
 Different blocks have the possibility of customizing colors. Gutenberg provides a default palette, but a theme can overwrite it and provide its own:
 
 ```php
-add_theme_support( 'gutenberg', array(
-	'colors' => array(
-		'#a156b4',
-		'#d0a5db',
-		'#eee',
-		'#444',
-	),
-) );
+add_theme_support( 'editor-color-palette',
+	'#a156b4',
+	'#d0a5db',
+	'#eee',
+	'#444'
+);
 ```
 
 The colors will be shown in order on the palette, and there's no limit to how many can be specified.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -9,7 +9,12 @@ To opt-in for one of these features, we should call `add_theme_support( 'gutenbe
 ```php
 function mytheme_setup_theme_supported_features() {
 	add_theme_support( 'gutenberg', array(
-		'wide-images' => true,
+		'colors' => array(
+			'#a156b4',
+			'#d0a5db',
+			'#eee',
+			'#444',
+		),
 	) );
 }
 
@@ -18,14 +23,12 @@ add_action( 'after_setup_theme', 'mytheme_setup_theme_supported_features' );
 
 ## Opt-in features
 
-### Wide Images:
+### Wide Alignment:
 
 Some blocks such as the image block have the possibility to define a "wide" or "full" alignment by adding the corresponding classname to the block's wrapper ( `alignwide` or `alignfull` ). A theme can opt-in for this feature by calling:
 
 ```php
-add_theme_support( 'gutenberg', array(
-   'wide-images' => true,
-) );
+add_theme_support( 'align-wide' );
 ```
 
 ### Colors:
@@ -34,7 +37,7 @@ Different blocks have the possibility of customizing colors. Gutenberg provides 
 
 ```php
 add_theme_support( 'gutenberg', array(
-   'colors' => array(
+	'colors' => array(
 		'#a156b4',
 		'#d0a5db',
 		'#eee',

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -4,7 +4,7 @@ By default, blocks provide their styles to enable basic support for blocks in th
 
 Some advanced block features require opt-in support in the theme itself as it's difficult for the block to provide these styles, they may require some architecting of the theme itself, in order to work well.
 
-To opt-in for one of these features, we should call `add_theme_support( 'feature-name', $optional-parameters )` in the `functions.php` file of the theme. For example:
+To opt-in for one of these features, call `add_theme_support` in the `functions.php` file of the theme. For example:
 
 ```php
 function mytheme_setup_theme_supported_features() {

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -26,12 +26,12 @@ import store from '../../store';
  * The default editor settings
  * You can override any default settings when calling createEditorInstance
  *
- *  wideImages   boolean   Enable/Disable Wide/Full Alignments
+ *  alignWide   boolean   Enable/Disable Wide/Full Alignments
  *
  * @var {Object} DEFAULT_SETTINGS
  */
 const DEFAULT_SETTINGS = {
-	wideImages: false,
+	alignWide: false,
 
 	// This is current max width of the block inner area
 	// It's used to constraint image resizing and this value could be overriden later by themes

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -53,9 +53,11 @@ class EditorProvider extends Component {
 		// Provide Backwards compatibility for enabling wide image support with `wide-images`.
 		if ( ! this.settings.alignWide && this.settings.wideImages === true ) {
 			this.settings.alignWide = true;
-			console.warn( __( "Adding theme support for `wide-images` inside the `gutenberg` array is deprecated.\n" +
-				"Instead, use `add_theme_support( 'align-wide' );`.\n" +
-				"See https://wordpress.org/gutenberg/handbook/reference/theme-support/"
+
+			// eslint-disable-next-line no-console
+			console.warn( __( 'Adding theme support for `wide-images` inside the `gutenberg` array is deprecated.\n' +
+				'Instead, use `add_theme_support( \'align-wide\' );`.\n' +
+				'See https://wordpress.org/gutenberg/handbook/reference/theme-support/'
 			) );
 		}
 

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -8,6 +8,7 @@ import { flow, pick, noop } from 'lodash';
 /**
  * WordPress Dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { createElement, Component } from '@wordpress/element';
 import { EditableProvider } from '@wordpress/blocks';
 import {
@@ -48,6 +49,15 @@ class EditorProvider extends Component {
 			...DEFAULT_SETTINGS,
 			...props.settings,
 		};
+
+		// Provide Backwards compatibility for enabling wide image support with `wide-images`.
+		if ( ! this.settings.alignWide && this.settings.wideImages === true ) {
+			this.settings.alignWide = true;
+			console.warn( __( "Adding theme support for `wide-images` inside the `gutenberg` array is deprecated.\n" +
+				"Instead, use `add_theme_support( 'align-wide' );`.\n" +
+				"See https://wordpress.org/gutenberg/handbook/reference/theme-support/"
+			) );
+		}
 
 		// Assume that we don't need to initialize in the case of an error recovery.
 		if ( ! props.recovery ) {

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -8,7 +8,6 @@ import { flow, pick, noop } from 'lodash';
 /**
  * WordPress Dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { createElement, Component } from '@wordpress/element';
 import { EditableProvider } from '@wordpress/blocks';
 import {
@@ -49,17 +48,6 @@ class EditorProvider extends Component {
 			...DEFAULT_SETTINGS,
 			...props.settings,
 		};
-
-		// Provide Backwards compatibility for enabling wide image support with `wide-images`.
-		if ( ! this.settings.alignWide && this.settings.wideImages === true ) {
-			this.settings.alignWide = true;
-
-			// eslint-disable-next-line no-console
-			console.warn( __( 'Adding theme support for `wide-images` inside the `gutenberg` array is deprecated.\n' +
-				'Instead, use `add_theme_support( \'align-wide\' );`.\n' +
-				'See https://wordpress.org/gutenberg/handbook/reference/theme-support/'
-			) );
-		}
 
 		// Assume that we don't need to initialize in the case of an error recovery.
 		if ( ! props.recovery ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -801,6 +801,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
+	$align_wide              = get_theme_support( 'align-wide' );
 	$color_palette           = gutenberg_color_palette();
 
 	if ( ! empty( $gutenberg_theme_support[0]['colors'] ) ) {
@@ -817,7 +818,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$allowed_block_types = apply_filters( 'allowed_block_types', true );
 
 	$editor_settings = array(
-		'wideImages'       => ! empty( $gutenberg_theme_support[0]['wide-images'] ),
+		'alignWide'        => $align_wide,
 		'colors'           => $color_palette,
 		'blockTypes'       => $allowed_block_types,
 		'titlePlaceholder' => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -819,6 +819,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	$editor_settings = array(
 		'alignWide'        => $align_wide,
+		'wideImages'       => ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide`.
 		'colors'           => $color_palette,
 		'blockTypes'       => $allowed_block_types,
 		'titlePlaceholder' => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -802,10 +802,24 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );
 	$align_wide              = get_theme_support( 'align-wide' );
-	$color_palette           = gutenberg_color_palette();
+	$color_palette           = get_theme_support( 'editor-color-palette' );
 
-	if ( ! empty( $gutenberg_theme_support[0]['colors'] ) ) {
-		$color_palette = $gutenberg_theme_support[0]['colors'];
+	// Backcompat for Color Palette set through `gutenberg` array.
+	if ( empty( $color_palette ) ) {
+		if ( ! empty( $gutenberg_theme_support[0]['colors'] ) ) {
+			$color_palette = $gutenberg_theme_support[0]['colors'];
+		} else {
+			$color_palette = gutenberg_color_palette();
+		}
+	}
+
+	if ( ! empty( $gutenberg_theme_support ) ) {
+		wp_add_inline_script(
+			'wp-editor',
+			'console.warn( "' .
+				__( 'Adding theme support using the `gutenberg` array is deprecated. See https://wordpress.org/gutenberg/handbook/reference/theme-support/ for details.', 'gutenberg' ) .
+			'");'
+		);
 	}
 
 	/**
@@ -818,8 +832,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$allowed_block_types = apply_filters( 'allowed_block_types', true );
 
 	$editor_settings = array(
-		'alignWide'        => $align_wide,
-		'wideImages'       => ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide`.
+		'alignWide'        => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
 		'colors'           => $color_palette,
 		'blockTypes'       => $allowed_block_types,
 		'titlePlaceholder' => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),


### PR DESCRIPTION
## Description
Changes theme support for wide images from being within the `gutenberg` theme support array with a `wide-images` bool to adding it with: `add_theme_support( 'align-wide' );`

Additionally, updates documentation and related JS variable names to match.

## How Has This Been Tested?
This was tested by adding theme support for `align-wide` to Twenty Seventeen.
Caveat: The demo content still has a wide image included, and it displays this way whether or not `align-wide` is enabled in the theme. As far as I can tell, this was also the case with the previous name.

## Types of changes
This is a breaking change for themes that have been added wide image support using the previously supported method. They would need to change to the new naming for the wide and full image controls to display.
Fixes: #4113

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.