### PR TITLE
Verify 'upload_files' capability when displaying upload UI in media blocks

### DIFF
--- a/docs/data/data-core.md
+++ b/docs/data/data-core.md
@@ -206,6 +206,7 @@ Action triggered to save an entity record.
  * kind: Kind of the received entity.
  * name: Name of the received entity.
  * record: Record to be saved.
+
 ### receiveUploadPermissions
 
 Returns an action object used in signalling that Upload permissions have been received.

--- a/docs/data/data-core.md
+++ b/docs/data/data-core.md
@@ -136,6 +136,18 @@ get back from the oEmbed preview API.
 
 Is the preview for the URL an oEmbed link fallback.
 
+### hasUploadPermissions
+
+Return Upload Permissions.
+
+*Parameters*
+
+ * state: State tree.
+
+*Returns*
+
+Upload Permissions.
+
 ## Actions
 
 ### receiveUserQuery
@@ -194,3 +206,10 @@ Action triggered to save an entity record.
  * kind: Kind of the received entity.
  * name: Name of the received entity.
  * record: Record to be saved.
+### receiveUploadPermissions
+
+Returns an action object used in signalling that Upload permissions have been received.
+
+*Parameters*
+
+ * hasUploadPermissions: Does the user have permission to upload files?

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -908,12 +908,22 @@ function gutenberg_preload_api_request( $memo, $path ) {
 		return $memo;
 	}
 
+	$method = 'GET';
+	if ( is_array( $path ) ) {
+		$method = end( $path );
+		$path   = reset( $path );
+
+		if ( ! in_array( $method, array( 'GET', 'OPTIONS' ), true ) ) {
+			$method = 'GET';
+		}
+	}
+
 	$path_parts = parse_url( $path );
 	if ( false === $path_parts ) {
 		return $memo;
 	}
 
-	$request = new WP_REST_Request( 'GET', $path_parts['path'] );
+	$request = new WP_REST_Request( $method, $path_parts['path'] );
 	if ( ! empty( $path_parts['query'] ) ) {
 		parse_str( $path_parts['query'], $query_params );
 		$request->set_query_params( $query_params );
@@ -928,10 +938,19 @@ function gutenberg_preload_api_request( $memo, $path ) {
 			$data['_links'] = $links;
 		}
 
-		$memo[ $path ] = array(
-			'body'    => $data,
-			'headers' => $response->headers,
-		);
+		if ( 'OPTIONS' === $method ) {
+			$response = rest_send_allow_header( $response, $server, $request );
+
+			$memo[ $method ][ $path ] = array(
+				'body'    => $data,
+				'headers' => $response->headers,
+			);
+		} else {
+			$memo[ $path ] = array(
+				'body'    => $data,
+				'headers' => $response->headers,
+			);
+		}
 	}
 
 	return $memo;
@@ -1431,6 +1450,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		sprintf( '/wp/v2/%s/%s?context=edit', $rest_base, $post->ID ),
 		sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
 		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
+		array( '/wp/v2/media', 'OPTIONS' ),
 	);
 
 	/**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -909,7 +909,7 @@ function gutenberg_preload_api_request( $memo, $path ) {
 	}
 
 	$method = 'GET';
-	if ( is_array( $path ) ) {
+	if ( is_array( $path ) && 2 === count( $path ) ) {
 		$method = end( $path );
 		$path   = reset( $path );
 

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -28,12 +28,14 @@ const createPreloadingMiddleware = ( preloadedData ) => ( options, next ) => {
 	}
 
 	const { parse = true } = options;
-	if ( typeof options.path === 'string' && parse ) {
+	if ( typeof options.path === 'string' ) {
 		const method = options.method || 'GET';
 		const path = getStablePath( options.path );
 
-		if ( 'GET' === method && preloadedData[ path ] ) {
+		if ( parse && 'GET' === method && preloadedData[ path ] ) {
 			return Promise.resolve( preloadedData[ path ].body );
+		} else if ( 'OPTIONS' === method && preloadedData[ method ][ path ] ) {
+			return Promise.resolve( preloadedData[ method ][ path ] );
 		}
 	}
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -127,3 +127,17 @@ export function* saveEntityRecord( kind, name, record ) {
 
 	return updatedRecord;
 }
+
+/**
+ * Returns an action object used in signalling that Upload permissions have been received.
+ *
+ * @param {boolean} hasUploadPermissions Does the user have permission to upload files?
+ *
+ * @return {Object} Action object.
+ */
+export function receiveUploadPermissions( hasUploadPermissions ) {
+	return {
+		type: 'RECEIVE_UPLOAD_PERMISSIONS',
+		hasUploadPermissions,
+	};
+}

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -217,6 +217,23 @@ export function embedPreviews( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Reducer managing Upload permissions.
+ *
+ * @param  {Object}  state  Current state.
+ * @param  {Object}  action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function hasUploadPermissions( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_UPLOAD_PERMISSIONS':
+			return action.hasUploadPermissions;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	terms,
 	users,
@@ -224,4 +241,5 @@ export default combineReducers( {
 	themeSupports,
 	entities,
 	embedPreviews,
+	hasUploadPermissions,
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { find, includes, get, hasIn } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,6 +16,7 @@ import {
 	receiveEntityRecords,
 	receiveThemeSupports,
 	receiveEmbedPreview,
+	receiveUploadPermissions,
 } from './actions';
 import { getKindEntities } from './entities';
 import { apiFetch } from './controls';
@@ -96,4 +97,24 @@ export function* getEmbedPreview( url ) {
 		// Embed API 404s if the URL cannot be embedded, so we have to catch the error from the apiRequest here.
 		yield receiveEmbedPreview( url, false );
 	}
+}
+
+/**
+ * Requests Upload Permissions from the REST API.
+ */
+export function* hasUploadPermissions() {
+	const response = yield apiFetch( { path: '/wp/v2/media', method: 'OPTIONS', parse: false } );
+
+	let allowHeader;
+	if ( hasIn( response, [ 'headers', 'get' ] ) ) {
+		// If the request is fetched using the fetch api, the header can be
+		// retrieved using the 'get' method.
+		allowHeader = response.headers.get( 'allow' );
+	} else {
+		// If the request was preloaded server-side and is returned by the
+		// preloading middleware, the header will be a simple property.
+		allowHeader = get( response, [ 'headers', 'Allow' ], '' );
+	}
+
+	yield receiveUploadPermissions( includes( allowHeader, 'POST' ) );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -169,3 +169,14 @@ export function isPreviewEmbedFallback( state, url ) {
 	}
 	return preview.html === oEmbedLinkCheck;
 }
+
+/**
+ * Return Upload Permissions.
+ *
+ * @param  {Object}  state State tree.
+ *
+ * @return {boolean} Upload Permissions.
+ */
+export function hasUploadPermissions( state ) {
+	return state.hasUploadPermissions;
+}

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -27,6 +27,7 @@ export {
 export { default as ServerSideRender } from './server-side-render';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
+export { default as MediaUploadCheck } from './media-upload/check';
 export { default as URLInput } from './url-input';
 export { default as URLInputButton } from './url-input/button';
 export { default as URLPopover } from './url-popover';

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -258,8 +258,13 @@ class MediaPlaceholder extends Component {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
+	let hasUploadPermissions = false;
+	if ( undefined !== select( 'core' ) ) {
+		hasUploadPermissions = select( 'core' ).hasUploadPermissions();
+	}
+
 	return {
-		hasUploadPermissions: select( 'core' ).hasUploadPermissions(),
+		hasUploadPermissions: hasUploadPermissions,
 	};
 } );
 

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -17,11 +17,14 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import MediaUpload from '../media-upload';
+import MediaUploadCheck from '../media-upload/check';
 import URLPopover from '../url-popover';
 import { mediaUpload } from '../../utils/';
 
@@ -132,6 +135,7 @@ class MediaPlaceholder extends Component {
 			multiple = false,
 			notices,
 			allowedTypes = [],
+			hasUploadPermissions,
 		} = this.props;
 
 		const {
@@ -141,6 +145,11 @@ class MediaPlaceholder extends Component {
 
 		let instructions = labels.instructions || '';
 		let title = labels.title || '';
+
+		if ( ! hasUploadPermissions && ! onSelectURL ) {
+			instructions = __( 'To edit this block, you need permission to upload media.' );
+		}
+
 		if ( ! instructions || ! title ) {
 			const isOneType = 1 === allowedTypes.length;
 			const isAudio = isOneType && 'audio' === allowedTypes[ 0 ];
@@ -148,14 +157,26 @@ class MediaPlaceholder extends Component {
 			const isVideo = isOneType && 'video' === allowedTypes[ 0 ];
 
 			if ( ! instructions ) {
-				instructions = __( 'Drag a media file, upload a new one or select a file from your library.' );
+				if ( hasUploadPermissions ) {
+					instructions = __( 'Drag a media file, upload a new one or select a file from your library.' );
 
-				if ( isAudio ) {
-					instructions = __( 'Drag an audio, upload a new one or select a file from your library.' );
-				} else if ( isImage ) {
-					instructions = __( 'Drag an image, upload a new one or select a file from your library.' );
-				} else if ( isVideo ) {
-					instructions = __( 'Drag a video, upload a new one or select a file from your library.' );
+					if ( isAudio ) {
+						instructions = __( 'Drag an audio, upload a new one or select a file from your library.' );
+					} else if ( isImage ) {
+						instructions = __( 'Drag an image, upload a new one or select a file from your library.' );
+					} else if ( isVideo ) {
+						instructions = __( 'Drag a video, upload a new one or select a file from your library.' );
+					}
+				} else if ( ! hasUploadPermissions && onSelectURL ) {
+					instructions = __( 'Given your current role, you can only link a media file, you cannot upload.' );
+
+					if ( isAudio ) {
+						instructions = __( 'Given your current role, you can only link an audio, you cannot upload.' );
+					} else if ( isImage ) {
+						instructions = __( 'Given your current role, you can only link an image, you cannot upload.' );
+					} else if ( isVideo ) {
+						instructions = __( 'Given your current role, you can only link a video, you cannot upload.' );
+					}
 				}
 			}
 
@@ -180,35 +201,37 @@ class MediaPlaceholder extends Component {
 				className={ classnames( 'editor-media-placeholder', className ) }
 				notices={ notices }
 			>
-				<DropZone
-					onFilesDrop={ this.onFilesUpload }
-					onHTMLDrop={ onHTMLDrop }
-				/>
-				<FormFileUpload
-					isLarge
-					className="editor-media-placeholder__button"
-					onChange={ this.onUpload }
-					accept={ accept }
-					multiple={ multiple }
-				>
-					{ __( 'Upload' ) }
-				</FormFileUpload>
-				<MediaUpload
-					gallery={ multiple && this.onlyAllowsImages() }
-					multiple={ multiple }
-					onSelect={ onSelect }
-					allowedTypes={ allowedTypes }
-					value={ value.id }
-					render={ ( { open } ) => (
-						<Button
-							isLarge
-							className="editor-media-placeholder__button"
-							onClick={ open }
-						>
-							{ __( 'Media Library' ) }
-						</Button>
-					) }
-				/>
+				<MediaUploadCheck>
+					<DropZone
+						onFilesDrop={ this.onFilesUpload }
+						onHTMLDrop={ onHTMLDrop }
+					/>
+					<FormFileUpload
+						isLarge
+						className="editor-media-placeholder__button"
+						onChange={ this.onUpload }
+						accept={ accept }
+						multiple={ multiple }
+					>
+						{ __( 'Upload' ) }
+					</FormFileUpload>
+					<MediaUpload
+						gallery={ multiple && this.onlyAllowsImages() }
+						multiple={ multiple }
+						onSelect={ onSelect }
+						allowedTypes={ allowedTypes }
+						value={ value.id }
+						render={ ( { open } ) => (
+							<Button
+								isLarge
+								className="editor-media-placeholder__button"
+								onClick={ open }
+							>
+								{ __( 'Media Library' ) }
+							</Button>
+						) }
+					/>
+				</MediaUploadCheck>
 				{ onSelectURL && (
 					<div className="editor-media-placeholder__url-input-container">
 						<Button
@@ -234,4 +257,13 @@ class MediaPlaceholder extends Component {
 	}
 }
 
-export default withFilters( 'editor.MediaPlaceholder' )( MediaPlaceholder );
+const applyWithSelect = withSelect( ( select ) => {
+	return {
+		hasUploadPermissions: select( 'core' ).hasUploadPermissions(),
+	};
+} );
+
+export default compose(
+	applyWithSelect,
+	withFilters( 'editor.MediaPlaceholder' ),
+)( MediaPlaceholder );

--- a/packages/editor/src/components/media-upload/check.js
+++ b/packages/editor/src/components/media-upload/check.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+
+export function MediaUploadCheck( { hasUploadPermissions, fallback, children } ) {
+	const optionalFallback = fallback || null;
+	return hasUploadPermissions ? children : optionalFallback;
+}
+
+export default withSelect( ( select ) => {
+	return {
+		hasUploadPermissions: select( 'core' ).hasUploadPermissions(),
+	};
+} )( MediaUploadCheck );

--- a/packages/editor/src/components/media-upload/check.js
+++ b/packages/editor/src/components/media-upload/check.js
@@ -3,13 +3,17 @@
  */
 import { withSelect } from '@wordpress/data';
 
-export function MediaUploadCheck( { hasUploadPermissions, fallback, children } ) {
-	const optionalFallback = fallback || null;
-	return hasUploadPermissions ? children : optionalFallback;
+export function MediaUploadCheck( { hasUploadPermissions, fallback = null, children } ) {
+	return hasUploadPermissions ? children : fallback;
 }
 
 export default withSelect( ( select ) => {
+	let hasUploadPermissions = false;
+	if ( undefined !== select( 'core' ) ) {
+		hasUploadPermissions = select( 'core' ).hasUploadPermissions();
+	}
+
 	return {
-		hasUploadPermissions: select( 'core' ).hasUploadPermissions(),
+		hasUploadPermissions: hasUploadPermissions,
 	};
 } )( MediaUploadCheck );

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -17,6 +17,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
  */
 import PostFeaturedImageCheck from './check';
 import MediaUpload from '../media-upload';
+import MediaUploadCheck from '../media-upload/check';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
@@ -27,6 +28,7 @@ const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
 
 function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
+	const instructions = <p>{ __( 'To edit the featured image, you need permission to upload media.' ) }</p>;
 
 	let mediaWidth, mediaHeight, mediaSourceUrl;
 	if ( media ) {
@@ -46,59 +48,67 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 		<PostFeaturedImageCheck>
 			<div className="editor-post-featured-image">
 				{ !! featuredImageId &&
-					<MediaUpload
-						title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
-						onSelect={ onUpdateImage }
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						modalClass="editor-post-featured-image__media-modal"
-						render={ ( { open } ) => (
-							<Button className="editor-post-featured-image__preview" onClick={ open } aria-label={ __( 'Edit or update the image' ) }>
-								{ media &&
-									<ResponsiveWrapper
-										naturalWidth={ mediaWidth }
-										naturalHeight={ mediaHeight }
-									>
-										<img src={ mediaSourceUrl } alt="" />
-									</ResponsiveWrapper>
-								}
-								{ ! media && <Spinner /> }
-							</Button>
-						) }
-						value={ featuredImageId }
-					/>
-				}
-				{ !! featuredImageId && media && ! media.isLoading &&
-				<MediaUpload
-					title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
-					onSelect={ onUpdateImage }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					modalClass="editor-post-featured-image__media-modal"
-					render={ ( { open } ) => (
-						<Button onClick={ open } isDefault isLarge>
-							{ __( 'Replace image' ) }
-						</Button>
-					) }
-				/>
-				}
-				{ ! featuredImageId &&
-					<div>
+					<MediaUploadCheck fallback={ instructions }>
 						<MediaUpload
 							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
-								<Button className="editor-post-featured-image__toggle" onClick={ open }>
-									{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+								<Button className="editor-post-featured-image__preview" onClick={ open } aria-label={ __( 'Edit or update the image' ) }>
+									{ media &&
+										<ResponsiveWrapper
+											naturalWidth={ mediaWidth }
+											naturalHeight={ mediaHeight }
+										>
+											<img src={ mediaSourceUrl } alt="" />
+										</ResponsiveWrapper>
+									}
+									{ ! media && <Spinner /> }
+								</Button>
+							) }
+							value={ featuredImageId }
+						/>
+					</MediaUploadCheck>
+				}
+				{ !! featuredImageId && media && ! media.isLoading &&
+					<MediaUploadCheck>
+						<MediaUpload
+							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
+							onSelect={ onUpdateImage }
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							modalClass="editor-post-featured-image__media-modal"
+							render={ ( { open } ) => (
+								<Button onClick={ open } isDefault isLarge>
+									{ __( 'Replace image' ) }
 								</Button>
 							) }
 						/>
+					</MediaUploadCheck>
+				}
+				{ ! featuredImageId &&
+					<div>
+						<MediaUploadCheck fallback={ instructions }>
+							<MediaUpload
+								title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
+								onSelect={ onUpdateImage }
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								modalClass="editor-post-featured-image__media-modal"
+								render={ ( { open } ) => (
+									<Button className="editor-post-featured-image__toggle" onClick={ open }>
+										{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
 					</div>
 				}
 				{ !! featuredImageId &&
-					<Button onClick={ onRemoveImage } isLink isDestructive>
-						{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
-					</Button>
+					<MediaUploadCheck>
+						<Button onClick={ onRemoveImage } isLink isDestructive>
+							{ postLabel.remove_featured_image || DEFAULT_REMOVE_FEATURE_IMAGE_LABEL }
+						</Button>
+					</MediaUploadCheck>
 				}
 			</div>
 		</PostFeaturedImageCheck>

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -5,7 +5,7 @@ import { Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Fragment, Component } from '@wordpress/element';
 import { insertObject } from '@wordpress/rich-text';
-import { MediaUpload, RichTextInserterItem } from '@wordpress/editor';
+import { MediaUpload, RichTextInserterItem, MediaUploadCheck } from '@wordpress/editor';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
@@ -46,34 +46,36 @@ export const image = {
 			const { value, onChange } = this.props;
 
 			return (
-				<Fragment>
-					<RichTextInserterItem
-						name={ name }
-						icon={ <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M4 16h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2zM4 5h10v9H4V5zm14 9v2h4v-2h-4zM2 20h20v-2H2v2zm6.4-8.8L7 9.4 5 12h8l-2.6-3.4-2 2.6z" /></SVG> }
-						title={ __( 'Inline Image' ) }
-						onClick={ this.openModal }
-					/>
-					{ this.state.modal && <MediaUpload
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						onSelect={ ( { id, url, alt, width } ) => {
-							this.closeModal();
-							onChange( insertObject( value, {
-								type: name,
-								attributes: {
-									className: `wp-image-${ id }`,
-									style: `width: ${ Math.min( width, 150 ) }px;`,
-									url,
-									alt,
-								},
-							} ) );
-						} }
-						onClose={ this.closeModal }
-						render={ ( { open } ) => {
-							open();
-							return null;
-						} }
-					/> }
-				</Fragment>
+				<MediaUploadCheck>
+					<Fragment>
+						<RichTextInserterItem
+							name={ name }
+							icon={ <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M4 16h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2zM4 5h10v9H4V5zm14 9v2h4v-2h-4zM2 20h20v-2H2v2zm6.4-8.8L7 9.4 5 12h8l-2.6-3.4-2 2.6z" /></SVG> }
+							title={ __( 'Inline Image' ) }
+							onClick={ this.openModal }
+						/>
+						{ this.state.modal && <MediaUpload
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							onSelect={ ( { id, url, alt, width } ) => {
+								this.closeModal();
+								onChange( insertObject( value, {
+									type: name,
+									attributes: {
+										className: `wp-image-${ id }`,
+										style: `width: ${ Math.min( width, 150 ) }px;`,
+										url,
+										alt,
+									},
+								} ) );
+							} }
+							onClose={ this.closeModal }
+							render={ ( { open } ) => {
+								open();
+								return null;
+							} }
+						/> }
+					</Fragment>
+				</MediaUploadCheck>
 			);
 		}
 	},

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -3,7 +3,7 @@
  */
 import { Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Fragment, Component } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { insertObject } from '@wordpress/rich-text';
 import { MediaUpload, RichTextInserterItem, MediaUploadCheck } from '@wordpress/editor';
 
@@ -47,34 +47,32 @@ export const image = {
 
 			return (
 				<MediaUploadCheck>
-					<Fragment>
-						<RichTextInserterItem
-							name={ name }
-							icon={ <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M4 16h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2zM4 5h10v9H4V5zm14 9v2h4v-2h-4zM2 20h20v-2H2v2zm6.4-8.8L7 9.4 5 12h8l-2.6-3.4-2 2.6z" /></SVG> }
-							title={ __( 'Inline Image' ) }
-							onClick={ this.openModal }
-						/>
-						{ this.state.modal && <MediaUpload
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							onSelect={ ( { id, url, alt, width } ) => {
-								this.closeModal();
-								onChange( insertObject( value, {
-									type: name,
-									attributes: {
-										className: `wp-image-${ id }`,
-										style: `width: ${ Math.min( width, 150 ) }px;`,
-										url,
-										alt,
-									},
-								} ) );
-							} }
-							onClose={ this.closeModal }
-							render={ ( { open } ) => {
-								open();
-								return null;
-							} }
-						/> }
-					</Fragment>
+					<RichTextInserterItem
+						name={ name }
+						icon={ <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M4 16h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2zM4 5h10v9H4V5zm14 9v2h4v-2h-4zM2 20h20v-2H2v2zm6.4-8.8L7 9.4 5 12h8l-2.6-3.4-2 2.6z" /></SVG> }
+						title={ __( 'Inline Image' ) }
+						onClick={ this.openModal }
+					/>
+					{ this.state.modal && <MediaUpload
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						onSelect={ ( { id, url, alt, width } ) => {
+							this.closeModal();
+							onChange( insertObject( value, {
+								type: name,
+								attributes: {
+									className: `wp-image-${ id }`,
+									style: `width: ${ Math.min( width, 150 ) }px;`,
+									url,
+									alt,
+								},
+							} ) );
+						} }
+						onClose={ this.closeModal }
+						render={ ( { open } ) => {
+							open();
+							return null;
+						} }
+					/> }
 				</MediaUploadCheck>
 			);
 		}


### PR DESCRIPTION
Closes #1536 
Closes #3672

I've been looking for a way to solve this issue #3672 and I think one possible way is to add a capability attribute to blocks and check the current user has this cap before registering the block.

## Description
In the classic editor, the upload button is disabled if the current user does not have the `upload_files` capability (eg: contributor). But when a contributor uses Gutenberg he can use "file" relative blocks. When he tries to use one of them as this role hasn't got the `upload_files` capability, the REST reply to site.url/wp-json/wp/v2/media is rest_cannot_create (403).

## How Has This Been Tested?
I have tested this PR for the contributor role. A contributor does not have the `upload_files` capability and the PR is making sure he can't use blocks involving a file upload (eg: image, core-image, audio, video, gallery).

## Screenshots (jpeg or gifs if applicable):
See #3672 for a video of the issue.

## Types of changes
I think this PR is first a bug fix, but i also think it could be interesting to be able to restrict block usage according to the user's role.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.