### PR TITLE
Chrome: Do not show the publish panel when updating/scheduling/submitting a post

### DIFF
--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -34,6 +34,7 @@ export { default as PostSchedule } from './post-schedule';
 export { default as PostScheduleLabel } from './post-schedule/label';
 export { default as PostSticky } from './post-sticky';
 export { default as PostStickyCheck } from './post-sticky/check';
+export { default as PostSwitchToDraftButton } from './post-switch-to-draft-button';
 export { default as PostTaxonomies } from './post-taxonomies';
 export { default as PostTaxonomiesCheck } from './post-taxonomies/check';
 export { default as PostTextEditor } from './post-text-editor';

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -19,7 +19,6 @@ import PostVisibilityLabel from '../post-visibility/label';
 import PostSchedule from '../post-schedule';
 import PostScheduleLabel from '../post-schedule/label';
 import PostPublishButton from '../post-publish-button';
-import PostSwitchToDraftButton from '../post-switch-to-draft-button';
 import { getCurrentPostType } from '../../store/selectors';
 
 function PostPublishPanel( { onClose, user } ) {
@@ -63,10 +62,6 @@ function PostPublishPanel( { onClose, user } ) {
 						<PostSchedule />
 					</PanelBody>
 				}
-			</div>
-
-			<div className="editor-post-publish-panel__footer">
-				<PostSwitchToDraftButton />
 			</div>
 		</div>
 	);

--- a/editor/components/post-publish-panel/style.scss
+++ b/editor/components/post-publish-panel/style.scss
@@ -37,10 +37,6 @@
 	text-align: right;
 }
 
-.editor-post-publish-panel__footer {
-	padding: 16px;
-}
-
 .wp-core-ui .editor-post-publish-panel__toggle.button-primary {
 	display: inline-flex;
 	align-items: center;

--- a/editor/components/post-publish-panel/style.scss
+++ b/editor/components/post-publish-panel/style.scss
@@ -42,7 +42,6 @@
 }
 
 .wp-core-ui .editor-post-publish-panel__toggle.button-primary {
-	margin: 0 10px;
 	display: inline-flex;
 	align-items: center;
 

--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -9,11 +9,11 @@ import { get } from 'lodash';
  */
 import { Button, withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal Dependencies
  */
-import PostPublishButtonLabel from '../post-publish-button/label';
 import PostPublishButton from '../post-publish-button';
 import {
 	isSavingPost,
@@ -46,7 +46,7 @@ function PostPublishPanelToggle( { user, isSaving, isPublishable, isSaveable, is
 			disabled={ ! isButtonEnabled }
 			isBusy={ isSaving && isPublished }
 		>
-			<PostPublishButtonLabel />...
+			{ __( 'Publish...' ) }
 		</Button>
 	);
 }

--- a/editor/components/post-saved-state/index.js
+++ b/editor/components/post-saved-state/index.js
@@ -14,6 +14,7 @@ import { Dashicon, Button } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
+import PostSwitchToDraftButton from '../post-switch-to-draft-button';
 import { editPost, savePost } from '../../store/actions';
 import {
 	isEditedPostNew,
@@ -36,7 +37,11 @@ export function PostSavedState( { isNew, isPublished, isDirty, isSaving, isSavea
 		);
 	}
 
-	if ( ! isSaveable || isPublished ) {
+	if ( isPublished ) {
+		return <PostSwitchToDraftButton className={ classnames( className, 'button-link' ) } />;
+	}
+
+	if ( ! isSaveable ) {
 		return null;
 	}
 

--- a/editor/components/post-saved-state/style.scss
+++ b/editor/components/post-saved-state/style.scss
@@ -11,6 +11,11 @@
 
 	.wp-core-ui &.button-link {
 		margin-right: $item-spacing;
+		padding: 0;
+
+		&:hover {
+			background: none;
+		}
 	}
 }
 

--- a/editor/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/editor/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostSavedState returns a switch to draft link if the post is published 1`] = `
+<Connect(PostSwitchToDraftButton)
+  className="editor-post-saved-state button-link"
+/>
+`;

--- a/editor/components/post-saved-state/test/index.js
+++ b/editor/components/post-saved-state/test/index.js
@@ -33,10 +33,10 @@ describe( 'PostSavedState', () => {
 		expect( wrapper.type() ).toBeNull();
 	} );
 
-	it( 'returns null if the post is published', () => {
+	it( 'returns a switch to draft link if the post is published', () => {
 		const wrapper = shallow( <PostSavedState isPublished /> );
 
-		expect( wrapper.type() ).toBeNull();
+		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	it( 'should return Saved text if not new and not dirty', () => {

--- a/editor/components/post-switch-to-draft-button/index.js
+++ b/editor/components/post-switch-to-draft-button/index.js
@@ -12,21 +12,20 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import { editPost, savePost } from '../../store/actions';
 import {
 	isSavingPost,
 	isCurrentPostPublished,
 } from '../../store/selectors';
 
-function PostSwitchToDraftButton( { isSaving, isPublished, onClick } ) {
+function PostSwitchToDraftButton( { className, isSaving, isPublished, onClick } ) {
 	if ( ! isPublished ) {
 		return null;
 	}
 
 	return (
 		<Button
-			className="editor-post-publish-dropdown__switch-to-draft"
+			className={ className }
 			isLarge
 			onClick={ onClick }
 			disabled={ isSaving }

--- a/editor/components/post-switch-to-draft-button/style.scss
+++ b/editor/components/post-switch-to-draft-button/style.scss
@@ -1,5 +1,0 @@
-.editor-post-publish-dropdown__publish-button-container {
-	.editor-post-publish-dropdown__switch-to-draft {
-		margin-right: 16px;
-	}
-}

--- a/editor/edit-post/header/index.js
+++ b/editor/edit-post/header/index.js
@@ -23,7 +23,12 @@ import HeaderToolbar from './header-toolbar';
 import { isSidebarOpened } from '../../store/selectors';
 import { toggleSidebar } from '../../store/actions';
 
-function Header( { onToggleSidebar, isDefaultSidebarOpened, isPublishSidebarOpened } ) {
+function Header( {
+	onToggleDefaultSidebar,
+	onTogglePublishSidebar,
+	isDefaultSidebarOpened,
+	isPublishSidebarOpened,
+} ) {
 	return (
 		<div
 			role="region"
@@ -38,11 +43,11 @@ function Header( { onToggleSidebar, isDefaultSidebarOpened, isPublishSidebarOpen
 					<PostPreviewButton />
 					<PostPublishPanelToggle
 						isOpen={ isPublishSidebarOpened }
-						onToggle={ () => onToggleSidebar( 'publish' ) }
+						onToggle={ onTogglePublishSidebar }
 					/>
 					<IconButton
 						icon="admin-generic"
-						onClick={ () => onToggleSidebar() }
+						onClick={ onToggleDefaultSidebar }
 						isToggled={ isDefaultSidebarOpened }
 						label={ __( 'Settings' ) }
 						aria-expanded={ isDefaultSidebarOpened }
@@ -60,6 +65,7 @@ export default connect(
 		isPublishSidebarOpened: isSidebarOpened( state, 'publish' ),
 	} ),
 	{
-		onToggleSidebar: toggleSidebar,
+		onToggleDefaultSidebar: () => toggleSidebar(),
+		onTogglePublishSidebar: () => toggleSidebar( 'publish' ),
 	}
 )( Header );

--- a/editor/edit-post/header/style.scss
+++ b/editor/edit-post/header/style.scss
@@ -62,11 +62,16 @@
 		background: $dark-gray-500;
 	}
 
+	&.editor-post-publish-button, &.editor-post-publish-panel__toggle {
+		margin: 2px;
+		height: 33px;
+		line-height: 32px;
+		padding: 0 12px 2px;
+	}
+
 	@include break-medium() {
 		&.editor-post-publish-button, &.editor-post-publish-panel__toggle {
 			margin: 0 10px;
-			height: 33px;
-			line-height: 32px;
 		}
 	}
 }

--- a/editor/edit-post/header/style.scss
+++ b/editor/edit-post/header/style.scss
@@ -64,6 +64,7 @@
 
 	@include break-medium() {
 		&.editor-post-publish-button, &.editor-post-publish-panel__toggle {
+			margin: 0 10px;
 			height: 33px;
 			line-height: 32px;
 		}

--- a/editor/edit-post/layout/index.js
+++ b/editor/edit-post/layout/index.js
@@ -41,13 +41,12 @@ function Layout( {
 	isDefaultSidebarOpened,
 	isPublishSidebarOpened,
 	fixedToolbarActive,
-	onToggleSidebar,
+	onClosePublishPanel,
 } ) {
 	const className = classnames( 'editor-layout', {
 		'is-sidebar-opened': layoutHasOpenSidebar,
 		'has-fixed-toolbar': fixedToolbarActive,
 	} );
-	const closePublishPanel = () => onToggleSidebar( 'publish', false );
 
 	return (
 		<div className={ className }>
@@ -70,7 +69,7 @@ function Layout( {
 				</div>
 			</div>
 			{ isDefaultSidebarOpened && <Sidebar /> }
-			{ isPublishSidebarOpened && <PostPublishPanel onClose={ closePublishPanel } /> }
+			{ isPublishSidebarOpened && <PostPublishPanel onClose={ onClosePublishPanel } /> }
 			<Popover.Slot />
 		</div>
 	);
@@ -84,5 +83,7 @@ export default connect(
 		isPublishSidebarOpened: isSidebarOpened( state, 'publish' ),
 		fixedToolbarActive: hasFixedToolbar( state ),
 	} ),
-	{ onToggleSidebar: toggleSidebar }
+	{
+		onClosePublishPanel: () => toggleSidebar( 'publish', false ),
+	}
 )( navigateRegions( Layout ) );

--- a/editor/edit-post/sidebar/post-status/index.js
+++ b/editor/edit-post/sidebar/post-status/index.js
@@ -12,6 +12,7 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal Dependencies
  */
+import './style.scss';
 import PostVisibility from '../post-visibility';
 import PostTrash from '../post-trash';
 import PostSchedule from '../post-schedule';
@@ -19,6 +20,7 @@ import PostSticky from '../post-sticky';
 import PostAuthor from '../post-author';
 import PostFormat from '../post-format';
 import PostPendingStatus from '../post-pending-status';
+import { PostSwitchToDraftButton } from '../../../components';
 import {
 	isEditorSidebarPanelOpened,
 } from '../../../store/selectors';
@@ -31,7 +33,7 @@ const PANEL_NAME = 'post-status';
 
 function PostStatus( { isOpened, onTogglePanel } ) {
 	return (
-		<PanelBody title={ __( 'Status & Visibility' ) } opened={ isOpened } onToggle={ onTogglePanel }>
+		<PanelBody className="editor-post-status" title={ __( 'Status & Visibility' ) } opened={ isOpened } onToggle={ onTogglePanel }>
 			<PostVisibility />
 			<PostSchedule />
 			<PostFormat />
@@ -39,6 +41,7 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 			<PostPendingStatus />
 			<PostAuthor />
 			<PostTrash />
+			<PostSwitchToDraftButton />
 		</PanelBody>
 	);
 }

--- a/editor/edit-post/sidebar/post-status/index.js
+++ b/editor/edit-post/sidebar/post-status/index.js
@@ -20,7 +20,6 @@ import PostSticky from '../post-sticky';
 import PostAuthor from '../post-author';
 import PostFormat from '../post-format';
 import PostPendingStatus from '../post-pending-status';
-import { PostSwitchToDraftButton } from '../../../components';
 import {
 	isEditorSidebarPanelOpened,
 } from '../../../store/selectors';
@@ -41,7 +40,6 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 			<PostPendingStatus />
 			<PostAuthor />
 			<PostTrash />
-			<PostSwitchToDraftButton />
 		</PanelBody>
 	);
 }

--- a/editor/edit-post/sidebar/post-status/style.scss
+++ b/editor/edit-post/sidebar/post-status/style.scss
@@ -1,0 +1,5 @@
+.editor-post-status .editor-post-publish-dropdown__switch-to-draft {
+	margin-top: 15px;
+	width: 100%;
+	text-align: center;
+}

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -334,15 +334,15 @@ export function stopTyping() {
 /**
  * Returns an action object used in signalling that the user toggled the sidebar
  *
- * @param  {String} sidebar  Name of the sidebar to toggle (desktop, mobile or publish)
- * @param  {Boolean?} force  Force a sidebar state
- * @return {Object}          Action object
+ * @param  {String}   sidebar      Name of the sidebar to toggle (desktop, mobile or publish)
+ * @param  {Boolean?} forcedValue  Force a sidebar state
+ * @return {Object}                Action object
  */
-export function toggleSidebar( sidebar, force ) {
+export function toggleSidebar( sidebar, forcedValue ) {
 	return {
 		type: 'TOGGLE_SIDEBAR',
 		sidebar,
-		force,
+		forcedValue,
 	};
 }
 

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -509,7 +509,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 				...state,
 				sidebars: {
 					...state.sidebars,
-					[ action.sidebar ]: action.force !== undefined ? action.force : ! state.sidebars[ action.sidebar ],
+					[ action.sidebar ]: action.forcedValue !== undefined ? action.forcedValue : ! state.sidebars[ action.sidebar ],
 				},
 			};
 		case 'TOGGLE_SIDEBAR_PANEL':

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -383,7 +383,7 @@ describe( 'actions', () => {
 			expect( toggleSidebar( 'publish', true ) ).toEqual( {
 				type: 'TOGGLE_SIDEBAR',
 				sidebar: 'publish',
-				force: true,
+				forcedValue: true,
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -941,7 +941,7 @@ describe( 'state', () => {
 			} } ), {
 				type: 'TOGGLE_SIDEBAR',
 				sidebar: 'desktop',
-				force: false,
+				forcedValue: false,
 			} );
 
 			expect( state.sidebars ).toEqual( {

--- a/editor/utils/mobile/index.js
+++ b/editor/utils/mobile/index.js
@@ -26,7 +26,7 @@ export const mobileMiddleware = ( { getState } ) => next => action => {
 		} );
 	}
 	if ( action.type === 'TOGGLE_SIDEBAR' && action.sidebar === undefined ) {
-		return next( toggleSidebar( isMobile( getState() ) ? 'mobile' : 'desktop', action.force ) );
+		return next( toggleSidebar( isMobile( getState() ) ? 'mobile' : 'desktop', action.forcedValue ) );
 	}
 	return next( action );
 };


### PR DESCRIPTION
This PR updates the publish panel behavior.
The panel is now only shown when "publishing" a post. It's not shown when we update an existing post, schedule a post or submit for review.

Related #3496 (comment)

**Testing instructions**

 - Create a new post
 - Click publish
 - The publish panel should show up
 - Publish the post
 - Edit the post
 - Click update
 - The publish panel should not show up