### PR TITLE
Block API: Adding a description property to the block API

### DIFF
--- a/blocks/block-description/index.js
+++ b/blocks/block-description/index.js
@@ -1,12 +1,27 @@
 /**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+/**
  * Internal dependencies
  */
 import './style.scss';
 
-export default function BlockDescription( { children } ) {
-	return (
-		<div className="components-block-description">
-			{ children }
-		</div>
-	);
+class BlockDescription extends Component {
+	constructor() {
+		super( ...arguments );
+		// eslint-disable-next-line no-console
+		console.warn( 'The wp.blocks.BlockDescription component is deprecated. Use the "description" block property instead.' );
+	}
+
+	render() {
+		const { children } = this.props;
+		return (
+			<div className="components-block-description">
+				{ children }
+			</div>
+		);
+	}
 }
+
+export default BlockDescription;

--- a/blocks/block-description/test/index.js
+++ b/blocks/block-description/test/index.js
@@ -8,6 +8,13 @@ import { shallow } from 'enzyme';
  */
 import BlockDescription from '../';
 
+/* eslint-disable no-console */
+function expectWarning() {
+	expect( console.warn ).toHaveBeenCalled();
+	console.warn.mockClear();
+}
+/* eslint-enable no-console */
+
 describe( 'BlockDescription', () => {
 	describe( 'basic rendering', () => {
 		it( 'should render a <p> element with some content', () => {
@@ -15,6 +22,7 @@ describe( 'BlockDescription', () => {
 			expect( blockDescription.hasClass( 'components-block-description' ) ).toBe( true );
 			expect( blockDescription.type() ).toBe( 'div' );
 			expect( blockDescription.text() ).toBe( 'Hello World' );
+			expectWarning();
 		} );
 	} );
 } );

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -18,11 +18,11 @@ import MediaUploadButton from '../../media-upload-button';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/audio', {
 	title: __( 'Audio' ),
+
+	description: __( 'The Audio block allows you to embed audio files and play them back using a simple player.' ),
 
 	icon: 'format-audio',
 
@@ -88,7 +88,7 @@ registerBlockType( 'core/audio', {
 				}
 				return false;
 			};
-			const controls = focus && [
+			const controls = focus && (
 				<BlockControls key="controls">
 					<BlockAlignmentToolbar
 						value={ align }
@@ -104,14 +104,8 @@ registerBlockType( 'core/audio', {
 							<Dashicon icon="edit" />
 						</Button>
 					</Toolbar>
-				</BlockControls>,
-
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'The Audio block allows you to embed audio files and play them back using a simple player.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>,
-			];
+				</BlockControls>
+			);
 
 			const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );
 

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -19,7 +19,6 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import ColorPalette from '../../color-palette';
 import ContrastChecker from '../../contrast-checker';
 import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 const { getComputedStyle } = window;
 
@@ -99,10 +98,6 @@ class ButtonBlock extends Component {
 				/>
 				{ focus &&
 					<InspectorControls key="inspector">
-						<BlockDescription>
-							<p>{ __( 'A nice little button. Call something out with it.' ) }</p>
-						</BlockDescription>
-
 						<ToggleControl
 							label={ __( 'Stand on a line' ) }
 							checked={ !! clear }
@@ -148,6 +143,8 @@ class ButtonBlock extends Component {
 
 registerBlockType( 'core/button', {
 	title: __( 'Button' ),
+
+	description: __( 'A nice little button. Call something out with it.' ),
 
 	icon: 'button',
 

--- a/blocks/library/categories/block.js
+++ b/blocks/library/categories/block.js
@@ -13,7 +13,6 @@ import './editor.scss';
 import './style.scss';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
-import BlockDescription from '../../block-description';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
@@ -175,9 +174,6 @@ class CategoriesBlock extends Component {
 			),
 			focus && (
 				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Shows a list of your site\'s categories.' ) }</p>
-					</BlockDescription>
 					<h3>{ __( 'Categories Settings' ) }</h3>
 					<ToggleControl
 						label={ __( 'Display as dropdown' ) }

--- a/blocks/library/categories/index.js
+++ b/blocks/library/categories/index.js
@@ -14,6 +14,8 @@ import CategoriesBlock from './block';
 registerBlockType( 'core/categories', {
 	title: __( 'Categories' ),
 
+	description: __( 'Shows a list of your site\'s categories.' ),
+
 	icon: 'list-view',
 
 	category: 'widgets',

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -13,11 +13,11 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 import { registerBlockType, createBlock } from '../../api';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/code', {
 	title: __( 'Code' ),
+
+	description: __( 'The code block maintains spaces and tabs, great for showing code snippets.' ),
 
 	icon: 'editor-code',
 
@@ -55,24 +55,17 @@ registerBlockType( 'core/code', {
 		],
 	},
 
-	edit( { attributes, setAttributes, focus, className } ) {
-		return [
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'The code block maintains spaces and tabs, great for showing code snippets.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
-			),
-			<div className={ className } key="block">
+	edit( { attributes, setAttributes, className } ) {
+		return (
+			<div className={ className }>
 				<TextareaAutosize
 					value={ attributes.content }
 					onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
 					placeholder={ __( 'Write code…' ) }
 					aria-label={ __( 'Code' ) }
 				/>
-			</div>,
-		];
+			</div>
+		);
 	},
 
 	save( { attributes } ) {

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -19,12 +19,13 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import RangeControl from '../../inspector-controls/range-control';
-import BlockDescription from '../../block-description';
 
 const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
 
 registerBlockType( 'core/cover-image', {
 	title: __( 'Cover Image' ),
+
+	description: __( 'Cover Image is a bold image block with an optional title.' ),
 
 	icon: 'format-image',
 
@@ -124,9 +125,6 @@ registerBlockType( 'core/cover-image', {
 				</Toolbar>
 			</BlockControls>,
 			<InspectorControls key="inspector">
-				<BlockDescription>
-					<p>{ __( 'Cover Image is a bold image block with an optional title.' ) }</p>
-				</BlockDescription>
 				<h2>{ __( 'Cover Image Settings' ) }</h2>
 				<ToggleControl
 					label={ __( 'Fixed Background' ) }

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -21,8 +21,6 @@ import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 // These embeds do not work in sandboxes
 const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
@@ -30,6 +28,8 @@ const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, keywords = [] } ) {
 	return {
 		title,
+
+		description: __( 'The Embed block allows you to easily add videos, images, tweets, audio, and other content to your post or page.' ),
 
 		icon,
 
@@ -134,23 +134,14 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				const { setAttributes, focus, setFocus } = this.props;
 				const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
-				const controls = [
-					focus && (
-						<BlockControls key="controls">
-							<BlockAlignmentToolbar
-								value={ align }
-								onChange={ updateAlignment }
-							/>
-						</BlockControls>
-					),
-					focus && (
-						<InspectorControls key="inspector">
-							<BlockDescription>
-								<p>{ __( 'The Embed block allows you to easily add videos, images, tweets, audio, and other content to your post or page.' ) }</p>
-							</BlockDescription>
-						</InspectorControls>
-					),
-				];
+				const controls = focus && (
+					<BlockControls key="controls">
+						<BlockAlignmentToolbar
+							value={ align }
+							onChange={ updateAlignment }
+						/>
+					</BlockControls>
+				);
 
 				if ( fetching ) {
 					return [

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -13,6 +13,8 @@ import OldEditor from './old-editor';
 registerBlockType( 'core/freeform', {
 	title: __( 'Classic' ),
 
+	desription: __( 'The classic editor, in block form.' ),
+
 	icon: 'editor-kitchensink',
 
 	category: 'formatting',

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -10,12 +10,6 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { keycodes } from '@wordpress/utils';
 
-/**
- * Internal dependencies
- */
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
-
 const { BACKSPACE, DELETE } = keycodes;
 
 function isTmceEmpty( editor ) {
@@ -185,13 +179,6 @@ export default class OldEditor extends Component {
 		const { focus, id, className } = this.props;
 
 		return [
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'The classic editor, in block form.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
-			),
 			<div
 				key="toolbar"
 				id={ id + '-toolbar' }

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -22,7 +22,6 @@ import SelectControl from '../../inspector-controls/select-control';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import GalleryImage from './gallery-image';
-import BlockDescription from '../../block-description';
 
 const isGallery = true;
 const MAX_COLUMNS = 8;
@@ -132,22 +131,6 @@ class GalleryBlock extends Component {
 		const { attributes, focus, className } = this.props;
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
 
-		const blockDescription = (
-			<BlockDescription>
-				<p>
-					{__( 'Image galleries are a great way to share groups of pictures on your site.' )}
-				</p>
-			</BlockDescription>
-		);
-
-		const inspectorControls = (
-			focus && (
-				<InspectorControls key="inspector">
-					{blockDescription}
-				</InspectorControls>
-			)
-		);
-
 		const dropZone = (
 			<DropZone
 				onFilesDrop={ this.dropFiles }
@@ -187,7 +170,6 @@ class GalleryBlock extends Component {
 
 			return [
 				controls,
-				inspectorControls,
 				<Placeholder
 					key="placeholder"
 					instructions={ __( 'Drag images here or insert from media library' ) }
@@ -221,7 +203,6 @@ class GalleryBlock extends Component {
 			controls,
 			focus && (
 				<InspectorControls key="inspector">
-					{blockDescription}
 					<h2>{ __( 'Gallery Settings' ) }</h2>
 					{ images.length > 1 && <RangeControl
 						label={ __( 'Columns' ) }

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -19,6 +19,7 @@ import { default as GalleryBlock, defaultColumnsNumber } from './block';
 
 registerBlockType( 'core/gallery', {
 	title: __( 'Gallery' ),
+	description: __( 'Image galleries are a great way to share groups of pictures on your site.' ),
 	icon: 'format-gallery',
 	category: 'common',
 	keywords: [ __( 'images' ), __( 'photos' ) ],

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -14,10 +14,11 @@ import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import InspectorControls from '../../inspector-controls';
 import AlignmentToolbar from '../../alignment-toolbar';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/heading', {
 	title: __( 'Heading' ),
+
+	description: __( 'Search engines use the headings to index the structure and content of your web pages.' ),
 
 	icon: 'heading',
 
@@ -118,9 +119,6 @@ registerBlockType( 'core/heading', {
 			),
 			focus && (
 				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Search engines use the headings to index the structure and content of your web pages.' ) }</p>
-					</BlockDescription>
 					<h3>{ __( 'Heading Settings' ) }</h3>
 					<p>{ __( 'Size' ) }</p>
 					<Toolbar

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -15,11 +15,11 @@ import { withState } from '@wordpress/components';
 import './editor.scss';
 import { registerBlockType } from '../../api';
 import BlockControls from '../../block-controls';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/html', {
 	title: __( 'Custom HTML' ),
+
+	description: __( 'Add custom HTML code and preview it right here in the editor.' ),
 
 	icon: 'html',
 
@@ -70,13 +70,6 @@ registerBlockType( 'core/html', {
 				onChange={ ( event ) => setAttributes( { content: event.target.value } ) }
 				aria-label={ __( 'HTML' ) }
 			/>,
-		focus && (
-			<InspectorControls key="inspector">
-				<BlockDescription>
-					<p>{ __( 'Add custom HTML code and preview it right here in the editor.' ) }</p>
-				</BlockDescription>
-			</InspectorControls>
-		),
 	] ),
 
 	save( { attributes } ) {

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -36,7 +36,6 @@ import TextControl from '../../inspector-controls/text-control';
 import SelectControl from '../../inspector-controls/select-control';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
-import BlockDescription from '../../block-description';
 import UrlInputButton from '../../url-input/button';
 import ImageSize from './image-size';
 
@@ -122,12 +121,6 @@ class ImageBlock extends Component {
 		const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setAttributes );
 		const dropFiles = ( files ) => mediaUpload( files, setAttributes );
 
-		const blockDescription = (
-			<BlockDescription>
-				<p>{ __( 'Worth a thousand words.' ) }</p>
-			</BlockDescription>
-		);
-
 		const controls = (
 			focus && (
 				<BlockControls key="controls">
@@ -157,11 +150,6 @@ class ImageBlock extends Component {
 		if ( ! url ) {
 			return [
 				controls,
-				focus && (
-					<InspectorControls key="inspector">
-						{ blockDescription }
-					</InspectorControls>
-				),
 				<Placeholder
 					key="placeholder"
 					instructions={ __( 'Drag image here or insert from media library' ) }
@@ -204,7 +192,6 @@ class ImageBlock extends Component {
 			controls,
 			focus && (
 				<InspectorControls key="inspector">
-					{ blockDescription }
 					<h2>{ __( 'Image Settings' ) }</h2>
 					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) } />
 					{ ! isEmpty( availableSizes ) && (

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -15,6 +15,8 @@ import ImageBlock from './block';
 registerBlockType( 'core/image', {
 	title: __( 'Image' ),
 
+	description: __( 'Worth a thousand words.' ),
+
 	icon: 'format-image',
 
 	category: 'common',

--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -23,7 +23,6 @@ import QueryPanel from '../../query-panel';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import RangeControl from '../../inspector-controls/range-control';
-import BlockDescription from '../../block-description';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
@@ -50,9 +49,6 @@ class LatestPostsBlock extends Component {
 
 		const inspectorControls = focus && (
 			<InspectorControls key="inspector">
-				<BlockDescription>
-					<p>{ __( 'Shows a list of your site\'s most recent posts.' ) }</p>
-				</BlockDescription>
 				<h3>{ __( 'Latest Posts Settings' ) }</h3>
 				<QueryPanel
 					{ ...{ order, orderBy } }

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -14,6 +14,8 @@ import LatestPostsBlock from './block';
 registerBlockType( 'core/latest-posts', {
 	title: __( 'Latest Posts' ),
 
+	description: __( 'Shows a list of your site\'s most recent posts.' ),
+
 	icon: 'list-view',
 
 	category: 'widgets',

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -16,8 +16,6 @@ import './editor.scss';
 import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 const fromBrDelimitedContent = ( content ) => {
 	if ( undefined === content ) {
@@ -75,6 +73,7 @@ const toBrDelimitedContent = ( values ) => {
 
 registerBlockType( 'core/list', {
 	title: __( 'List' ),
+	description: __( 'List. Numbered or bulleted.' ),
 	icon: 'editor-ul',
 	category: 'common',
 	keywords: [ __( 'bullet list' ), __( 'ordered list' ), __( 'numbered list' ) ],
@@ -320,14 +319,6 @@ registerBlockType( 'core/list', {
 							},
 						] }
 					/>
-				),
-				focus && (
-					<InspectorControls key="inspector">
-						<BlockDescription>
-							<p>{ __( 'List. Numbered or bulleted.' ) }</p>
-						</BlockDescription>
-						<p>{ __( 'No advanced options.' ) }</p>
-					</InspectorControls>
 				),
 				<Editable
 					multiline="li"

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -9,11 +9,12 @@ import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import { registerBlockType } from '../../api';
 import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 import ToggleControl from '../../inspector-controls/toggle-control';
 
 registerBlockType( 'core/more', {
 	title: __( 'More' ),
+
+	description: __( '"More" allows you to break your post into a part shown on index pages, and the subsequent after clicking a "Read More" link.' ),
 
 	icon: 'editor-insertmore',
 
@@ -48,9 +49,6 @@ registerBlockType( 'core/more', {
 		return [
 			focus && (
 				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( '"More" allows you to break your post into a part shown on index pages, and the subsequent after clicking a "Read More" link.' ) }</p>
-					</BlockDescription>
 					<ToggleControl
 						label={ __( 'Hide the teaser before the "More" tag' ) }
 						checked={ !! noTeaser }

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -25,7 +25,6 @@ import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import RangeControl from '../../inspector-controls/range-control';
 import ColorPalette from '../../color-palette';
-import BlockDescription from '../../block-description';
 import ContrastChecker from '../../contrast-checker';
 
 const { getComputedStyle } = window;
@@ -99,9 +98,6 @@ class ParagraphBlock extends Component {
 			),
 			focus && (
 				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'This is a simple text only block for inserting a single paragraph of content.' ) }</p>
-					</BlockDescription>
 					<PanelBody title={ __( 'Text Settings' ) }>
 						<ToggleControl
 							label={ __( 'Drop Cap' ) }
@@ -198,6 +194,8 @@ class ParagraphBlock extends Component {
 
 registerBlockType( 'core/paragraph', {
 	title: __( 'Paragraph' ),
+
+	description: __( 'This is a simple text only block for inserting a single paragraph of content.' ),
 
 	icon: 'editor-paragraph',
 

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -9,11 +9,11 @@ import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/preformatted', {
 	title: __( 'Preformatted' ),
+
+	description: __( 'Preformatted text keeps your spaces, tabs and linebreaks as they are.' ),
 
 	icon: 'text',
 
@@ -60,13 +60,6 @@ registerBlockType( 'core/preformatted', {
 		const { content } = attributes;
 
 		return [
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Preformatted text keeps your spaces, tabs and linebreaks as they are.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
-			),
 			<Editable
 				key="block"
 				tagName="pre"

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -17,8 +17,6 @@ import { registerBlockType } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 const toEditableValue = value => map( value, ( subValue => subValue.children ) );
 const fromEditableValue = value => map( value, ( subValue ) => ( {
@@ -50,6 +48,8 @@ registerBlockType( 'core/pullquote', {
 
 	title: __( 'Pullquote' ),
 
+	description: __( 'A pullquote is a brief, attention-catching quotation taken from the main text of an article and used as a subheading or graphic feature.' ),
+
 	icon: 'format-quote',
 
 	category: 'formatting',
@@ -68,13 +68,6 @@ registerBlockType( 'core/pullquote', {
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
 		return [
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'A pullquote is a brief, attention-catching quotation taken from the main text of an article and used as a subheading or graphic feature.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
-			),
 			focus && (
 				<BlockControls key="controls">
 					<BlockAlignmentToolbar

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -19,8 +19,6 @@ import { registerBlockType, createBlock } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import Editable from '../../editable';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 const toEditableValue = value => value.map( ( subValue => subValue.children ) );
 const fromEditableValue = value => value.map( ( subValue ) => ( {
@@ -55,6 +53,7 @@ const blockAttributes = {
 
 registerBlockType( 'core/quote', {
 	title: __( 'Quote' ),
+	description: __( 'Quote. In quoting others, we cite ourselves. (Julio Cortázar)' ),
 	icon: 'format-quote',
 	category: 'common',
 
@@ -175,13 +174,6 @@ registerBlockType( 'core/quote', {
 						} }
 					/>
 				</BlockControls>
-			),
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Quote. In quoting others, we cite ourselves. (Julio Cortázar)' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
 			),
 			<blockquote
 				key="quote"

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -8,11 +8,11 @@ import { __ } from '@wordpress/i18n';
  */
 import './style.scss';
 import { registerBlockType, createBlock } from '../../api';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/separator', {
 	title: __( 'Separator' ),
+
+	description: __( 'Use the separator to indicate a thematic change in the content.' ),
 
 	icon: 'minus',
 
@@ -35,17 +35,8 @@ registerBlockType( 'core/separator', {
 		],
 	},
 
-	edit( { focus, className } ) {
-		return [
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Use the separator to indicate a thematic change in the content.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
-			),
-			<hr key="hr" className={ className } />,
-		];
+	edit( { className } ) {
+		return <hr className={ className } />;
 	},
 
 	save() {

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -14,11 +14,11 @@ import { withInstanceId, Dashicon } from '@wordpress/components';
  */
 import './editor.scss';
 import { registerBlockType } from '../../api';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/shortcode', {
 	title: __( 'Shortcode' ),
+
+	description: __( 'A shortcode is a WordPress-specific code snippet that is written between square brackets as [shortcode]. ' ),
 
 	icon: 'marker',
 
@@ -62,7 +62,7 @@ registerBlockType( 'core/shortcode', {
 	},
 
 	edit: withInstanceId(
-		( { attributes, setAttributes, instanceId, focus } ) => {
+		( { attributes, setAttributes, instanceId } ) => {
 			const inputId = `blocks-shortcode-input-${ instanceId }`;
 
 			return (
@@ -80,14 +80,6 @@ registerBlockType( 'core/shortcode', {
 							text: event.target.value,
 						} ) }
 					/>
-					{ focus &&
-						<InspectorControls>
-							<BlockDescription>
-								<p>{ __( 'A shortcode is a WordPress-specific code snippet that is written between square brackets as [shortcode]. ' ) }</p>
-							</BlockDescription>
-							<p>{ __( 'No advanced options.' ) }</p>
-						</InspectorControls>
-					}
 				</div>
 			);
 		}

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -12,11 +12,10 @@ import { registerBlockType } from '../../api';
 import TableBlock from './table-block';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/table', {
 	title: __( 'Table' ),
+	description: __( 'Tables. Best used for tabular data.' ),
 	icon: 'editor-table',
 	category: 'formatting',
 
@@ -57,13 +56,6 @@ registerBlockType( 'core/table', {
 		const { content } = attributes;
 		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 		return [
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Tables. Best used for tabular data.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
-			),
 			focus && (
 				<BlockControls key="toolbar">
 					<BlockAlignmentToolbar

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -19,10 +19,11 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import RangeControl from '../../inspector-controls/range-control';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/text-columns', {
 	title: __( 'Text Columns' ),
+
+	description: __( 'Add text across columns. This block is experimental' ),
 
 	icon: 'columns',
 
@@ -71,9 +72,6 @@ registerBlockType( 'core/text-columns', {
 			),
 			focus && (
 				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Add text across columns. This block is experimental' ) }</p>
-					</BlockDescription>
 					<RangeControl
 						label={ __( 'Columns' ) }
 						value={ columns }

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -9,11 +9,11 @@ import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/verse', {
 	title: __( 'Verse' ),
+
+	description: __( 'Write poetry and other literary expressions honoring all spaces and line-breaks.' ),
 
 	icon: 'edit',
 
@@ -51,17 +51,9 @@ registerBlockType( 'core/verse', {
 	edit( { attributes, setAttributes, focus, setFocus, className } ) {
 		const { content } = attributes;
 
-		return [
-			focus && (
-				<InspectorControls key="inspector">
-					<BlockDescription>
-						<p>{ __( 'Write poetry and other literary expressions honoring all spaces and line-breaks.' ) }</p>
-					</BlockDescription>
-				</InspectorControls>
-			),
+		return (
 			<Editable
 				tagName="pre"
-				key="editable"
 				value={ content }
 				onChange={ ( nextContent ) => {
 					setAttributes( {
@@ -73,8 +65,8 @@ registerBlockType( 'core/verse', {
 				placeholder={ __( 'Write…' ) }
 				wrapperClassName={ className }
 				formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
-			/>,
-		];
+			/>
+		);
 	},
 
 	save( { attributes, className } ) {

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -17,11 +17,11 @@ import MediaUploadButton from '../../media-upload-button';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
-import InspectorControls from '../../inspector-controls';
-import BlockDescription from '../../block-description';
 
 registerBlockType( 'core/video', {
 	title: __( 'Video' ),
+
+	description: __( 'Video, locally hosted, locally sourced.' ),
 
 	icon: 'format-video',
 
@@ -90,12 +90,6 @@ registerBlockType( 'core/video', {
 					</MediaUploadButton>
 				</Toolbar>
 			</BlockControls>,
-
-			<InspectorControls key="inspector">
-				<BlockDescription>
-					<p>{ __( 'Video, locally hosted, locally sourced.' ) }</p>
-				</BlockDescription>
-			</InspectorControls>,
 		];
 
 		if ( ! src ) {

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -40,6 +40,16 @@ This is the display title for your block, which can be translated with our trans
 title: 'Book'
 ```
 
+#### Description (optional)
+
+* **Type:** `String`
+
+This is a short description for your block, which can be translated with our translation functions. This will be shown in the block inspector.
+
+```js
+description: 'Block showing a Book card.'
+```
+
 #### Category
 
 * **Type:** `String [ common | formatting | layout | widgets | embed ]`

--- a/editor/components/block-inspector/index.js
+++ b/editor/components/block-inspector/index.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
  */
 import { __ } from '@wordpress/i18n';
 import { Slot } from '@wordpress/components';
+import { getBlockType, BlockIcon } from '@wordpress/blocks';
 
 /**
  * Internal Dependencies
@@ -24,9 +25,20 @@ const BlockInspector = ( { selectedBlock, count } ) => {
 		return <span className="editor-block-inspector__no-blocks">{ __( 'No block selected.' ) }</span>;
 	}
 
-	return (
-		<Slot name="Inspector.Controls" />
-	);
+	const blockType = getBlockType( selectedBlock.name );
+
+	return [
+		<div className="editor-block-inspector__card" key="card">
+			<div className="editor-block-inspector__card-icon">
+				<BlockIcon icon={ blockType.icon } />
+			</div>
+			<div className="editor-block-inspector__card-content">
+				<div className="editor-block-inspector__card-title">{ blockType.title }</div>
+				<div className="editor-block-inspector__card-description">{ blockType.description }</div>
+			</div>
+		</div>,
+		<Slot name="Inspector.Controls" key="inspector-controls" />,
+	];
 };
 
 export default connect(

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -7,3 +7,33 @@
 	border-bottom: 1px solid $light-gray-500;
 	text-align: center;
 }
+
+
+.editor-block-inspector__card {
+	display: flex;
+	align-items: flex-start;
+	border-bottom: 1px solid $light-gray-500;
+	margin: -16px -16px 16px -16px;
+	padding: 16px;
+}
+
+.editor-block-inspector__card-icon {
+	border: 1px solid $light-gray-700;
+	padding: 8px;
+	margin-right: 10px;
+	height: 36px;
+	width: 36px;
+}
+
+.editor-block-inspector__card-content {
+	flex-grow: 1;
+}
+
+.editor-block-inspector__card-title {
+	font-weight: 500;
+	margin-bottom: 5px;
+}
+
+.editor-block-inspector__card-description {
+	font-size: 12px;
+}


### PR DESCRIPTION
closes #3081 and closes #2814 and closes #3375

This PR adds a `description` property to the Block API. This property replaces the `BlockDescription` component we used to use to show a block's description in the block inspector.

At the same time, this PR shows the icon, title and description of the selected block in the inspector

<img width="285" alt="screen shot 2017-12-25 at 12 32 54" src="https://user-images.githubusercontent.com/272444/34339027-c07f0e1a-e96f-11e7-9da3-bca48e11bd67.png">

**Testing instructions**

 - Select a block (try several types)
 - A block "card" containing the icon, title and description should show up in the inspector.