### PR TITLE
Inserter: Show the insertion point when the inserter is opened

### DIFF
--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -55,8 +55,6 @@ export default class InserterGroup extends Component {
 				onClick={ selectBlock( block ) }
 				ref={ bindReferenceNode( block.name ) }
 				tabIndex={ current === block.name || disabled ? null : '-1' }
-				onMouseEnter={ ! disabled ? this.props.showInsertionPoint : null }
-				onMouseLeave={ ! disabled ? this.props.hideInsertionPoint : null }
 				disabled={ disabled }
 			>
 				<BlockIcon icon={ block.icon } />

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -20,9 +20,8 @@ import InserterMenu from './menu';
 import { getBlockInsertionPoint, getEditorMode } from '../../store/selectors';
 import {
 	insertBlock,
-	setBlockInsertionPoint,
-	clearBlockInsertionPoint,
 	hideInsertionPoint,
+	showInsertionPoint,
 } from '../../store/actions';
 
 class Inserter extends Component {
@@ -35,19 +34,13 @@ class Inserter extends Component {
 	onToggle( isOpen ) {
 		const {
 			insertIndex,
-			setInsertionPoint,
-			clearInsertionPoint,
 			onToggle,
 		} = this.props;
 
-		// When inserting at specific index, assign as insertion point when
-		// the inserter is opened, clearing on close.
-		if ( insertIndex !== undefined ) {
-			if ( isOpen ) {
-				setInsertionPoint( insertIndex );
-			} else {
-				clearInsertionPoint();
-			}
+		if ( isOpen ) {
+			this.props.showInsertionPoint( insertIndex );
+		} else {
+			this.props.hideInsertionPoint();
 		}
 
 		// Surface toggle callback to parent component
@@ -116,15 +109,14 @@ export default compose( [
 		},
 		( dispatch ) => ( {
 			onInsertBlock( name, initialAttributes, position ) {
-				dispatch( hideInsertionPoint() );
 				dispatch( insertBlock(
 					createBlock( name, initialAttributes ),
 					position
 				) );
 			},
 			...bindActionCreators( {
-				setInsertionPoint: setBlockInsertionPoint,
-				clearInsertionPoint: clearBlockInsertionPoint,
+				showInsertionPoint,
+				hideInsertionPoint,
 			}, dispatch ),
 		} )
 	),

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -35,7 +35,7 @@ import { keycodes } from '@wordpress/utils';
 import './style.scss';
 
 import { getBlocks, getRecentlyUsedBlocks, getReusableBlocks } from '../../store/selectors';
-import { showInsertionPoint, hideInsertionPoint, fetchReusableBlocks } from '../../store/actions';
+import { fetchReusableBlocks } from '../../store/actions';
 import { default as InserterGroup } from './group';
 
 export const searchBlocks = ( blocks, searchTerm ) => {
@@ -232,8 +232,6 @@ export class InserterMenu extends Component {
 				labelledBy={ labelledBy }
 				bindReferenceNode={ this.bindReferenceNode }
 				selectBlock={ this.selectBlock }
-				showInsertionPoint={ this.props.showInsertionPoint }
-				hideInsertionPoint={ this.props.hideInsertionPoint }
 			/>
 		);
 	}
@@ -362,7 +360,7 @@ const connectComponent = connect(
 			reusableBlocks: getReusableBlocks( state ),
 		};
 	},
-	{ showInsertionPoint, hideInsertionPoint, fetchReusableBlocks }
+	{ fetchReusableBlocks }
 );
 
 export default compose(

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -189,41 +189,27 @@ export function insertBlocks( blocks, position ) {
 	};
 }
 
-export function showInsertionPoint() {
+/**
+ * Returns an action object showing the insertion point at a given index
+ *
+ * @param  {Number?} index  Index of the insertion point
+ * @return {Object}         Action object
+ */
+export function showInsertionPoint( index ) {
 	return {
 		type: 'SHOW_INSERTION_POINT',
+		index,
 	};
 }
 
+/**
+ * Returns an action object hiding the insertion point
+ *
+ * @return {Object}         Action object
+ */
 export function hideInsertionPoint() {
 	return {
 		type: 'HIDE_INSERTION_POINT',
-	};
-}
-
-/**
- * Returns an action object used in signalling that block insertion should
- * occur at the specified block index position.
- *
- * @param  {Number} position Position at which to insert
- * @return {Object}          Action object
- */
-export function setBlockInsertionPoint( position ) {
-	return {
-		type: 'SET_BLOCK_INSERTION_POINT',
-		position,
-	};
-}
-
-/**
- * Returns an action object used in signalling that the block insertion point
- * should be reset.
- *
- * @return {Object} Action object
- */
-export function clearBlockInsertionPoint() {
-	return {
-		type: 'CLEAR_BLOCK_INSERTION_POINT',
 	};
 }
 

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -482,18 +482,11 @@ export function blocksMode( state = {}, action ) {
  */
 export function blockInsertionPoint( state = {}, action ) {
 	switch ( action.type ) {
-		case 'SET_BLOCK_INSERTION_POINT':
-			const { position } = action;
-			return { ...state, position };
-
-		case 'CLEAR_BLOCK_INSERTION_POINT':
-			return { ...state, position: null };
-
 		case 'SHOW_INSERTION_POINT':
-			return { ...state, visible: true };
+			return { ...state, visible: true, position: action.index };
 
 		case 'HIDE_INSERTION_POINT':
-			return { ...state, visible: false };
+			return { ...state, visible: false, position: null };
 	}
 
 	return state;

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -32,8 +32,6 @@ import {
 	insertBlocks,
 	showInsertionPoint,
 	hideInsertionPoint,
-	setBlockInsertionPoint,
-	clearBlockInsertionPoint,
 	editPost,
 	savePost,
 	trashPost,
@@ -248,8 +246,9 @@ describe( 'actions', () => {
 
 	describe( 'showInsertionPoint', () => {
 		it( 'should return the SHOW_INSERTION_POINT action', () => {
-			expect( showInsertionPoint() ).toEqual( {
+			expect( showInsertionPoint( 1 ) ).toEqual( {
 				type: 'SHOW_INSERTION_POINT',
+				index: 1,
 			} );
 		} );
 	} );
@@ -258,24 +257,6 @@ describe( 'actions', () => {
 		it( 'should return the HIDE_INSERTION_POINT action', () => {
 			expect( hideInsertionPoint() ).toEqual( {
 				type: 'HIDE_INSERTION_POINT',
-			} );
-		} );
-	} );
-
-	describe( 'setBlockInsertionPoint', () => {
-		it( 'should return the SET_BLOCK_INSERTION_POINT action', () => {
-			const position = 1;
-			expect( setBlockInsertionPoint( position ) ).toEqual( {
-				type: 'SET_BLOCK_INSERTION_POINT',
-				position,
-			} );
-		} );
-	} );
-
-	describe( 'clearBlockInsertionPoint', () => {
-		it( 'should return the CLEAR_BLOCK_INSERTION_POINT action', () => {
-			expect( clearBlockInsertionPoint() ).toEqual( {
-				type: 'CLEAR_BLOCK_INSERTION_POINT',
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -689,36 +689,14 @@ describe( 'state', () => {
 
 		it( 'should set insertion point position', () => {
 			const state = blockInsertionPoint( undefined, {
-				type: 'SET_BLOCK_INSERTION_POINT',
-				position: 5,
-			} );
-
-			expect( state ).toEqual( {
-				position: 5,
-			} );
-		} );
-
-		it( 'should clear insertion point position', () => {
-			const original = blockInsertionPoint( undefined, {
-				type: 'SET_BLOCK_INSERTION_POINT',
-				position: 5,
-			} );
-
-			const state = blockInsertionPoint( deepFreeze( original ), {
-				type: 'CLEAR_BLOCK_INSERTION_POINT',
-			} );
-
-			expect( state ).toEqual( {
-				position: null,
-			} );
-		} );
-
-		it( 'should show the insertion point', () => {
-			const state = blockInsertionPoint( undefined, {
 				type: 'SHOW_INSERTION_POINT',
+				index: 5,
 			} );
 
-			expect( state ).toEqual( { visible: true } );
+			expect( state ).toEqual( {
+				position: 5,
+				visible: true,
+			} );
 		} );
 
 		it( 'should clear the insertion point', () => {
@@ -726,23 +704,7 @@ describe( 'state', () => {
 				type: 'HIDE_INSERTION_POINT',
 			} );
 
-			expect( state ).toEqual( { visible: false } );
-		} );
-
-		it( 'should merge position and visible', () => {
-			const original = blockInsertionPoint( undefined, {
-				type: 'SHOW_INSERTION_POINT',
-			} );
-
-			const state = blockInsertionPoint( deepFreeze( original ), {
-				type: 'SET_BLOCK_INSERTION_POINT',
-				position: 5,
-			} );
-
-			expect( state ).toEqual( {
-				visible: true,
-				position: 5,
-			} );
+			expect( state ).toEqual( { visible: false, position: null } );
 		} );
 	} );
 


### PR DESCRIPTION
closes #4102

This PR updates the inserter to show the insertion point whenever the block inspector is opened, not waiting for the user to hover a block before doing so.

**Testing instructions**

 - Open any inserter
 - The insertion point should be visible
 - Close the inserter or insert a block
 - The insertion point should disappear.