### PR TITLE
Chrome: Hide the Excerpt Panel if the CPT doesn't support it

### DIFF
--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -13,6 +13,7 @@ export { default as PostAuthor } from './post-author';
 export { default as PostAuthorCheck } from './post-author/check';
 export { default as PostComments } from './post-comments';
 export { default as PostExcerpt } from './post-excerpt';
+export { default as PostExcerptCheck } from './post-excerpt/check';
 export { default as PostFeaturedImage } from './post-featured-image';
 export { default as PostFormat } from './post-format';
 export { default as PostFormatCheck } from './post-format/check';

--- a/editor/components/post-excerpt/check.js
+++ b/editor/components/post-excerpt/check.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import PostTypeSupportCheck from '../post-type-support-check';
+
+function PostExcerptCheck( props ) {
+	return <PostTypeSupportCheck { ...props } supportKey="excerpt" />;
+}
+
+export default PostExcerptCheck;

--- a/editor/components/post-type-support-check/index.js
+++ b/editor/components/post-type-support-check/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentPostType } from '../../store/selectors';
+
+function PostTypeSupportCheck( { postType, children, supportKey } ) {
+	const isSupported = get( postType, [ 'data', 'supports', supportKey ], false );
+
+	if ( ! isSupported ) {
+		return null;
+	}
+
+	return children;
+}
+
+const applyConnect = connect(
+	( state ) => {
+		return {
+			postTypeName: getCurrentPostType( state ),
+		};
+	}
+);
+
+const applyWithAPIData = withAPIData( ( { postTypeName } ) => {
+	return {
+		postType: postTypeName ? `/wp/v2/types/${ postTypeName }?context=edit` : undefined,
+	};
+} );
+
+export default compose(
+	applyConnect,
+	applyWithAPIData,
+)( PostTypeSupportCheck );

--- a/editor/edit-post/sidebar/post-excerpt/index.js
+++ b/editor/edit-post/sidebar/post-excerpt/index.js
@@ -12,7 +12,7 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal Dependencies
  */
-import { PostExcerpt as PostExcerptForm } from '../../../components';
+import { PostExcerpt as PostExcerptForm, PostExcerptCheck } from '../../../components';
 import { isEditorSidebarPanelOpened } from '../../../store/selectors';
 import { toggleSidebarPanel } from '../../../store/actions';
 
@@ -23,9 +23,11 @@ const PANEL_NAME = 'post-excerpt';
 
 function PostExcerpt( { isOpened, onTogglePanel } ) {
 	return (
-		<PanelBody title={ __( 'Excerpt' ) } opened={ isOpened } onToggle={ onTogglePanel }>
-			<PostExcerptForm />
-		</PanelBody>
+		<PostExcerptCheck>
+			<PanelBody title={ __( 'Excerpt' ) } opened={ isOpened } onToggle={ onTogglePanel }>
+				<PostExcerptForm />
+			</PanelBody>
+		</PostExcerptCheck>
 	);
 }
 


### PR DESCRIPTION
This PR adds a generic component to check for CPT supported features and uses this component to check for the Excerpt support.

related #3989