### PR TITLE
Chrome: Hide The Taxonomies Panel if no taxonomy is available for the current CPT

### DIFF
--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -33,6 +33,7 @@ export { default as PostScheduleLabel } from './post-schedule/label';
 export { default as PostSticky } from './post-sticky';
 export { default as PostStickyCheck } from './post-sticky/check';
 export { default as PostTaxonomies } from './post-taxonomies';
+export { default as PostTaxonomiesCheck } from './post-taxonomies/check';
 export { default as PostTextEditor } from './post-text-editor';
 export { default as PostTextEditorToolbar } from './post-text-editor/toolbar';
 export { default as PostTitle } from './post-title';

--- a/editor/components/post-taxonomies/check.js
+++ b/editor/components/post-taxonomies/check.js
@@ -1,0 +1,43 @@
+/**
+ * External Dependencies
+ */
+import { connect } from 'react-redux';
+import { some, includes } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withAPIData } from '@wordpress/components';
+import { compose } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentPostType } from '../../store/selectors';
+
+export function PostTaxonomiesCheck( { postType, taxonomies, children } ) {
+	const hasTaxonomies = some( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
+	if ( ! hasTaxonomies ) {
+		return null;
+	}
+
+	return children;
+}
+
+const applyConnect = connect(
+	( state ) => {
+		return {
+			postType: getCurrentPostType( state ),
+		};
+	},
+);
+
+const applyWithAPIData = withAPIData( () => ( {
+	taxonomies: '/wp/v2/taxonomies?context=edit',
+} ) );
+
+export default compose( [
+	applyConnect,
+	applyWithAPIData,
+] )( PostTaxonomiesCheck );
+

--- a/editor/edit-post/sidebar/post-taxonomies/index.js
+++ b/editor/edit-post/sidebar/post-taxonomies/index.js
@@ -12,7 +12,7 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { PostTaxonomies as PostTaxonomiesForm } from '../../../components';
+import { PostTaxonomies as PostTaxonomiesForm, PostTaxonomiesCheck } from '../../../components';
 import { isEditorSidebarPanelOpened } from '../../../store/selectors';
 import { toggleSidebarPanel } from '../../../store/actions';
 
@@ -23,13 +23,15 @@ const PANEL_NAME = 'post-taxonomies';
 
 function PostTaxonomies( { isOpened, onTogglePanel } ) {
 	return (
-		<PanelBody
-			title={ __( 'Categories & Tags' ) }
-			opened={ isOpened }
-			onToggle={ onTogglePanel }
-		>
-			<PostTaxonomiesForm />
-		</PanelBody>
+		<PostTaxonomiesCheck>
+			<PanelBody
+				title={ __( 'Categories & Tags' ) }
+				opened={ isOpened }
+				onToggle={ onTogglePanel }
+			>
+				<PostTaxonomiesForm />
+			</PanelBody>
+		</PostTaxonomiesCheck>
 	);
 }
 


### PR DESCRIPTION
closes #3943

This PR hides the taxonomies panel if the CPT doesn't support any taxonomy.

**Testing instructions**

 - Create a CPT without any assigned taxonomy
 - Create a post with this CPT.
 - The taxonomies panel should not show up.