### PR TITLE
Taxonomiees: Improve Tags/Categories response size by limiting the requested fields

### DIFF
--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -21,6 +21,7 @@ const DEFAULT_QUERY = {
 	per_page: 100,
 	orderby: 'count',
 	order: 'desc',
+	_fields: [ 'id', 'name' ],
 };
 const MAX_TERMS_SUGGESTIONS = 20;
 

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -22,6 +22,7 @@ const DEFAULT_QUERY = {
 	per_page: 100,
 	orderby: 'count',
 	order: 'desc',
+	_fields: [ 'id', 'name', 'parent' ],
 };
 
 class HierarchicalTermSelector extends Component {


### PR DESCRIPTION
closes #3913

Request only the required data from the taxonomies endpoints.

**Testing instructions**

 - Create a post
 - Create a tag
 - Type in the tags input
 - Check that the triggered requests only return `id`and `name` for each tag
 - Assign tags and check that it saves properly.