### PR TITLE
UrlInput: Decode Post Title special chars

### DIFF
--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -10,7 +10,7 @@ import scrollIntoView from 'dom-scroll-into-view';
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { keycodes } from '@wordpress/utils';
+import { keycodes, decodeEntities } from '@wordpress/utils';
 import { Spinner, withInstanceId, withSpokenMessages } from '@wordpress/components';
 
 const { UP, DOWN, ENTER } = keycodes;
@@ -220,7 +220,7 @@ class UrlInput extends Component {
 								onClick={ () => this.selectLink( post.link ) }
 								aria-selected={ index === selectedSuggestion }
 							>
-								{ post.title.rendered || __( '(no title)' ) }
+								{ decodeEntities( post.title.rendered ) || __( '(no title)' ) }
 							</button>
 						) ) }
 					</div>


### PR DESCRIPTION
closes #3877

This PR decodes the HTML characters of the "Post Title" in the URL Link Suggestions

**Testing instructions**

 - Create a post with quotes in the title
 - Publish the post
 - Try to add a link to this post from another post
 - The original post's title should show up properly in the suggestions.