### PR TITLE
Meta Boxes: When the metaboxes are saving ensure the overlay covers t…

### DIFF
--- a/editor/components/meta-boxes/meta-boxes-area/index.js
+++ b/editor/components/meta-boxes/meta-boxes-area/index.js
@@ -124,6 +124,7 @@ class MetaBoxesArea extends Component {
 			<div className={ classes }>
 				{ loading && <Spinner /> }
 				<div ref={ this.bindNode } />
+				<div className="editor-meta-boxes-area__clear" />
 			</div>
 		);
 	}

--- a/editor/components/meta-boxes/meta-boxes-area/style.scss
+++ b/editor/components/meta-boxes/meta-boxes-area/style.scss
@@ -91,3 +91,7 @@
 		z-index: z-index( '.editor-meta-boxes-area .spinner');
 	}
 }
+
+.editor-meta-boxes-area__clear {
+	clear: both;
+}


### PR DESCRIPTION
closes #3771

When meta boxes are saving an invisible overlay is added to avoid editing their content while saving is in progress. Some meta boxes can use "float" alignments (ACF) which caused the overlay to not cover the whole area.

**Testing instructions**

 - Add an ACF field
 - Create, edit and save the post
 - While the meta box is being saved, ensure that you can't focus and type in the field.