### PR TITLE
Update Outreach docs

### DIFF
--- a/docs/articles.md
+++ b/docs/articles.md
@@ -2,6 +2,26 @@
 
 This includes useful articles for those wanting to run a meetup or promote Gutenberg.
 
-- Articles about Gutenberg: https://github.com/WordPress/gutenberg/issues/1419
-- Gutenberg articles on ManageWP.org: https://managewp.org/search?q=gutenberg
-- Storify stream: https://storify.com/bph/wordpress-gutenberg-early-comments
+## Overviews of Gutenberg
+
+- [Gutenberg, or the Ship of Theseus](https://matiasventura.com/post/gutenberg-or-the-ship-of-theseus/), Matías Ventura Bausero (October 2017)
+- [We Called It Gutenberg for a Reason](https://ma.tt/2017/08/we-called-it-gutenberg-for-a-reason/), Matt Mullenweg (August 2017)
+- [How Gutenberg is Changing WordPress Development](https://riad.blog/2017/10/06/how-gutenberg-is-changing-wordpress-development/), Riad Benguella (October 2017)
+- [How Gutenberg Will Shape the Future of WordPress](https://www.linkedin.com/pulse/gutenberg-morten-rand-hendriksen/), Morten Rand-Henrikson (August 2017)
+
+## Extending Gutenberg
+
+- [With Gutenberg, what happens to my Custom Fields?](https://riad.blog/2017/12/11/with-gutenberg-what-happens-to-my-custom-fields/), Riad Benguella (December 2017)
+- [One thousand and one ways to extend Gutenberg today](https://riad.blog/2017/10/16/one-thousand-and-one-way-to-extend-gutenberg-today/), Riad Benguella (October 2017)
+- [Gutenberg Plugin Boilerplate](https://github.com/ahmadawais/Gutenberg-Boilerplate/), Ahmad Awais (August 2017)
+
+## Community Contribution
+
+- [Contributing to Gutenberg Without Code](https://wordimpress.com/a-pot-stirrer-amongst-chefs-contributing-to-gutenberg-without-code/), Kevin Hoffman (August 2017)
+- [Testing Flow in Gutenberg: Instructions for how to contribute to usability testing](https://make.wordpress.org/test/2017/11/22/testing-flow-in-gutenberg/), Anna Harrison (November 2017)
+
+## Article Compilations
+
+- [Articles about Gutenberg](https://github.com/WordPress/gutenberg/issues/1419) (Github Issue thread with links)
+- [Gutenberg articles on ManageWP.org](https://managewp.org/search?q=gutenberg)
+- [Storify stream](https://storify.com/bph/wordpress-gutenberg-early-comments)

--- a/docs/meetups.md
+++ b/docs/meetups.md
@@ -2,11 +2,11 @@
 
 A list of meetups about Gutenberg so far:
 
-- https://www.meetup.com/Vancouver-WordPress-Meetup-Group/events/241575161/
-- https://www.meetup.com/Turku-WordPress-Meetup/events/241195076/
-- https://www.facebook.com/events/278785795934302/
-- https://wpleeds.co.uk/events/plugins-gutenberg-wordpress-leeds-july-2017/
-- https://www.meetup.com/WordPress-Melbourne/events/241543639/
-- https://wpmeetups.de/termin/29-wp-meetup-stuttgart-gutenberg-editor-rueckblick-wordcamp-europe/
-- https://www.meetup.com/Big-Media-Enterprise-WordPress-London-Meetup/events/243302081/
-- https://www.meetup.com/Tuscaloosa-WordPress-Meetup/events/244584939/
+- [Gutenberg and the Future of WordPress](https://www.meetup.com/Vancouver-WordPress-Meetup-Group/events/241575161/), Vancouver, CA
+- [Page builders and the upcoming Gutenberg Editor](https://www.meetup.com/Turku-WordPress-Meetup/events/241195076/), Turku, Finland
+- [Discussion about Gutenberg](https://www.facebook.com/events/278785795934302/), Andria, Italy
+- [Plugins and Gutenberg](https://wpleeds.co.uk/events/plugins-gutenberg-wordpress-leeds-july-2017/), Leeds, UK
+- [Gutenberg Introduction & Demo](https://www.meetup.com/WordPress-Melbourne/events/241543639/), Melbourne, Australia
+- [Gutenberg Editor & Review](https://wpmeetups.de/termin/29-wp-meetup-stuttgart-gutenberg-editor-rueckblick-wordcamp-europe/), WordCamp Europe
+- [Diving into Gutenberg by Tammie Lister](https://www.meetup.com/Big-Media-Enterprise-WordPress-London-Meetup/events/243302081/), London, UK
+- [What's New In WordPress 4.9 and Gutenberg 1.5](https://www.meetup.com/Tuscaloosa-WordPress-Meetup/events/244584939/), Tuscaloosa, Alabama, USA


### PR DESCRIPTION
## Description
Updated the Outreach docs by adding text for links instead of raw URLs, and added some structure and explicit articles to the articles page. The categorization and listed articles can evolve over time, but for now, these changes make the pages more usable.

## How Has This Been Tested?
Tested links through local Markdown rendering. 

## Types of changes
Updates to Markdown files.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.