### PR TITLE
Latest posts: Only request required category fields.

### DIFF
--- a/blocks/query-panel/category-select.js
+++ b/blocks/query-panel/category-select.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { get } from 'lodash';
+import { stringify } from 'querystringify';
 
 /**
  * WordPress dependencies
@@ -24,8 +25,14 @@ function CategorySelect( { label, noOptionLabel, categories, selectedCategory, o
 	);
 }
 
-const applyWithAPIData = withAPIData( () => ( {
-	categories: '/wp/v2/categories',
-} ) );
+const applyWithAPIData = withAPIData( () => {
+	const query = stringify( {
+		per_page: 100,
+		_fields: [ 'id', 'name', 'parent' ],
+	} );
+	return {
+		categories: `/wp/v2/categories?${ query }`,
+	};
+} );
 
 export default applyWithAPIData( CategorySelect );


### PR DESCRIPTION
We were requesting all category fields while needing three of them, this change makes sure we request only the fields we need.

Related to #3913 but happens only when we have the latest posts block, applies the same fix as in https://github.com/WordPress/gutenberg/pull/4167.

## How Has This Been Tested?
Add a latest post block, verify that it is still possible to filter by category.
