### PR TITLE
Add 'No saved blocks' message to Inserter

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -268,16 +268,31 @@ export class InserterMenu extends Component {
 
 	renderTabView( tab ) {
 		const blocksForTab = this.getBlocksForTab( tab );
+
+		// If the Recent tab is selected, don't render category headers
 		if ( 'recent' === tab ) {
 			return this.renderBlocks( blocksForTab );
 		}
 
-		const visibleBlocks = this.getVisibleBlocksByCategory( blocksForTab );
-		if ( 'embed' === tab ) {
-			return this.renderBlocks( visibleBlocks.embed );
+		// If the Saved tab is selected and we have no results, display a friendly message
+		if ( 'saved' === tab && blocksForTab.length === 0 ) {
+			return (
+				<p className="editor-inserter__no-tab-content-message">
+					{ __( 'No saved blocks.' ) }
+				</p>
+			);
 		}
 
-		return this.renderCategories( visibleBlocks );
+		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( blocksForTab );
+
+		// If our results have only blocks from one category, don't render category headers
+		const categories = Object.keys( visibleBlocksByCategory );
+		if ( categories.length === 1 ) {
+			const [ soleCategory ] = categories;
+			return this.renderBlocks( visibleBlocksByCategory[ soleCategory ] );
+		}
+
+		return this.renderCategories( visibleBlocksByCategory );
 	}
 
 	interceptArrows( event ) {

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -141,6 +141,12 @@ input[type="search"].editor-inserter__search {
 		flex-shrink: 0;
 		margin-top: 1px;
 	}
+
+	.editor-inserter__no-tab-content-message {
+		font-style: italic;
+		margin-top: 3em;
+		text-align: center;
+	}
 }
 
 .editor-inserter__tab {


### PR DESCRIPTION
Fixes #3994.

Previously, a brand new user would encounter a completely blank tab when selecting the _Saved_ tab in the inserter.

I've fixed this by adding a simple message that indicates that there are no saved blocks:

| Before | After |
| --- | --- |
| <img width="361" alt="screen shot 2017-12-27 at 14 35 46" src="https://user-images.githubusercontent.com/612155/34369817-433735ae-eb13-11e7-9e8c-c59f52ee898a.png"> | <img width="370" alt="screen shot 2017-12-27 at 14 24 54" src="https://user-images.githubusercontent.com/612155/34369712-57623ebc-eb12-11e7-9e2c-c3847f2badae.png"> |

I also removed the category headers from the _Embed_ and _Saved_ tabs, which I think looks cleaner:

| Before | After |
| --- | --- |
| <img width="367" alt="screen shot 2017-12-27 at 14 35 32" src="https://user-images.githubusercontent.com/612155/34369819-47855410-eb13-11e7-9620-9d990cba7263.png"> | <img width="363" alt="screen shot 2017-12-27 at 14 32 30" src="https://user-images.githubusercontent.com/612155/34369774-f0b2d1f8-eb12-11e7-8d8d-f576ce466328.png"> |

I assume that this was the intended design based on the presence of an `if ( 'embed' === tab )` check that was never executing (because of a typo: it should be `embeds`).

#### How to test

1. Ensure you have no reusable blocks. You could do this by testing on a new site, running `wp site empty`, or executing a `DELETE FROM wp_posts WHERE post_type = 'wp_block'`.
2. Open the inserter and click on _Saved_ — you should see the message.
3. Check that other parts of the inserter work correctly.