### PR TITLE
MetaBoxes: Remove dirty-checking metaboxes state

### DIFF
--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -57,11 +57,9 @@ When rendering the Gutenberg Page, the metaboxes are rendered to a hidden div `#
 
 #### MetaBoxArea Component
 
-When the component renders it will store a ref to the metaboxes container, retrieve the metaboxes HTML from the prefetch location and watches input and changes.
+When the component renders it will store a ref to the metaboxes container, retrieve the metaboxes HTML from the prefetch location.
 
-The change detection will store the current form's `FormData`, then whenever a change is detected the current form data will be checked vs, the original form data. This serves as a way to see if the meta box state is dirty. When the meta box state has been detected to have changed, a Redux action `META_BOX_STATE_CHANGED` is dispatched, updating the store setting the isDirty flag to `true`. If the state ever returns back to the original form data, `META_BOX_STATE_CHANGED` is dispatched again to set the isDirty flag to `false`. A selector `isMetaBoxStateDirty()` is used to help check whether the post can be updated. It checks each meta box for whether it is dirty, and if there is at least one dirty meta box, it will return true. This dirty detection does not impact creating new posts, as the content will have to change before meta boxes can trigger the overall dirty state.
-
-When the post is updated, only meta boxes areas that are active and dirty, will be submitted. This removes any unnecessary requests being made. No extra revisions, are created either by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any dirty meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta boxes' state to `isUpdating`, the `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
+When the post is updated, only meta boxes areas that are active will be submitted. This removes any unnecessary requests being made. No extra revisions, are created either by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any active meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta boxes' state to `isUpdating`, the `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
 
 If the metabox area is saving, we display an updating overlay, to prevent users from changing the form values while the meta box is submitting.
 
@@ -75,7 +73,7 @@ So an example url would look like:
 
 This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
 
-Thus page page mimics the `post.php` post form, so when it is submitted it will normally fire all of the necessary hooks and actions, and have the proper global state to correctly fire any PHP meta box mumbo jumbo without needing to modify any existing code. On successful submission, React will signal a `handleMetaBoxReload` to set up the new form state for dirty checking, remove the updating overlay, and set the store to no longer be updating the meta box area.
+Thus page page mimics the `post.php` post form, so when it is submitted it will normally fire all of the necessary hooks and actions, and have the proper global state to correctly fire any PHP meta box mumbo jumbo without needing to modify any existing code. On successful submission, React will signal a `handleMetaBoxReload` to remove the updating overlay, and set the store to no longer be updating the meta box area.
 
 
 ### Common Compatibility Issues

--- a/editor/components/meta-boxes/meta-boxes-area/index.js
+++ b/editor/components/meta-boxes/meta-boxes-area/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isEqual } from 'lodash';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import jQuery from 'jquery';
@@ -17,7 +16,7 @@ import { Spinner } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
-import { handleMetaBoxReload, metaBoxStateChanged, metaBoxLoaded } from '../../../store/actions';
+import { handleMetaBoxReload, metaBoxLoaded } from '../../../store/actions';
 import { getMetaBox, isSavingPost } from '../../../store/selectors';
 
 class MetaBoxesArea extends Component {
@@ -29,7 +28,6 @@ class MetaBoxesArea extends Component {
 		};
 		this.originalFormData = '';
 		this.bindNode = this.bindNode.bind( this );
-		this.checkState = this.checkState.bind( this );
 	}
 
 	bindNode( node ) {
@@ -43,15 +41,7 @@ class MetaBoxesArea extends Component {
 
 	componentWillUnmount() {
 		this.mounted = false;
-		this.unbindFormEvents();
 		document.querySelector( '#metaboxes' ).appendChild( this.form );
-	}
-
-	unbindFormEvents() {
-		if ( this.form ) {
-			this.form.removeEventListener( 'change', this.checkState );
-			this.form.removeEventListener( 'input', this.checkState );
-		}
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -84,28 +74,11 @@ class MetaBoxesArea extends Component {
 		this.node.appendChild( this.form );
 		this.form.onSubmit = ( event ) => event.preventDefault();
 		this.originalFormData = this.getFormData();
-		this.form.addEventListener( 'change', this.checkState );
-		this.form.addEventListener( 'input', this.checkState );
 		this.props.metaBoxLoaded( location );
 	}
 
 	getFormData() {
 		return jQuery( this.form ).serialize();
-	}
-
-	checkState() {
-		const { loading } = this.state;
-		const { isDirty, changedMetaBoxState, location } = this.props;
-
-		const newIsDirty = ! isEqual( this.originalFormData, this.getFormData() );
-
-		/**
-		 * If we are not updating, then if dirty and equal to original, then set not dirty.
-		 * If we are not updating, then if not dirty and not equal to original, set as dirty.
-		 */
-		if ( ! loading && isDirty !== newIsDirty ) {
-			changedMetaBoxState( location, newIsDirty );
-		}
 	}
 
 	render() {
@@ -132,10 +105,9 @@ class MetaBoxesArea extends Component {
 
 function mapStateToProps( state, ownProps ) {
 	const metaBox = getMetaBox( state, ownProps.location );
-	const { isDirty, isUpdating } = metaBox;
+	const { isUpdating } = metaBox;
 
 	return {
-		isDirty,
 		isUpdating,
 		isPostSaving: isSavingPost( state ) ? true : false,
 	};
@@ -145,7 +117,6 @@ function mapDispatchToProps( dispatch ) {
 	return {
 		// Used to set the reference to the MetaBox in redux, fired when the component mounts.
 		metaBoxReloaded: ( location ) => dispatch( handleMetaBoxReload( location ) ),
-		changedMetaBoxState: ( location, hasChanged ) => dispatch( metaBoxStateChanged( location, hasChanged ) ),
 		metaBoxLoaded: ( location ) => dispatch( metaBoxLoaded( location ) ),
 	};
 }

--- a/editor/components/meta-boxes/meta-boxes-area/index.js
+++ b/editor/components/meta-boxes/meta-boxes-area/index.js
@@ -96,7 +96,7 @@ class MetaBoxesArea extends Component {
 		return (
 			<div className={ classes }>
 				{ loading && <Spinner /> }
-				<div ref={ this.bindNode } />
+				<div className="editor-meta-boxes-area__container" ref={ this.bindNode } />
 				<div className="editor-meta-boxes-area__clear" />
 			</div>
 		);

--- a/editor/components/meta-boxes/meta-boxes-area/index.js
+++ b/editor/components/meta-boxes/meta-boxes-area/index.js
@@ -22,7 +22,7 @@ class MetaBoxesArea extends Component {
 	 */
 	constructor() {
 		super( ...arguments );
-		this.bindNode = this.bindNode.bind( this );
+		this.bindContainerNode = this.bindContainerNode.bind( this );
 	}
 
 	/**
@@ -30,14 +30,18 @@ class MetaBoxesArea extends Component {
 	 */
 	componentDidMount() {
 		this.form = document.querySelector( '.metabox-location-' + this.props.location );
-		this.node.appendChild( this.form );
+		if ( this.form ) {
+			this.container.appendChild( this.form );
+		}
 	}
 
 	/**
 	 * Get the meta box location form from the original location.
 	 */
 	componentWillUnmount() {
-		document.querySelector( '#metaboxes' ).appendChild( this.form );
+		if ( this.form ) {
+			document.querySelector( '#metaboxes' ).appendChild( this.form );
+		}
 	}
 
 	/**
@@ -45,8 +49,8 @@ class MetaBoxesArea extends Component {
 	 *
 	 * @param {Element} node DOM Node.
 	 */
-	bindNode( node ) {
-		this.node = node;
+	bindContainerNode( node ) {
+		this.container = node;
 	}
 
 	/**
@@ -66,7 +70,7 @@ class MetaBoxesArea extends Component {
 		return (
 			<div className={ classes }>
 				{ isSaving && <Spinner /> }
-				<div className="editor-meta-boxes-area__container" ref={ this.bindNode } />
+				<div className="editor-meta-boxes-area__container" ref={ this.bindContainerNode } />
 				<div className="editor-meta-boxes-area__clear" />
 			</div>
 		);

--- a/editor/components/post-saved-state/index.js
+++ b/editor/components/post-saved-state/index.js
@@ -27,6 +27,12 @@ import {
 	hasMetaBoxes,
 } from '../../store/selectors';
 
+/**
+ * Component showing whether the post is saved or not and displaying save links.
+ *
+ * @param   {Object}    Props Component Props.
+ * @returns {WPElement}       WordPress Element.
+ */
 export function PostSavedState( { hasActiveMetaboxes, isNew, isPublished, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
 	const className = 'editor-post-saved-state';
 

--- a/editor/components/post-saved-state/index.js
+++ b/editor/components/post-saved-state/index.js
@@ -24,9 +24,10 @@ import {
 	isEditedPostSaveable,
 	getCurrentPost,
 	getEditedPostAttribute,
+	hasMetaBoxes,
 } from '../../store/selectors';
 
-export function PostSavedState( { isNew, isPublished, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
+export function PostSavedState( { hasActiveMetaboxes, isNew, isPublished, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
 	const className = 'editor-post-saved-state';
 
 	if ( isSaving ) {
@@ -45,7 +46,7 @@ export function PostSavedState( { isNew, isPublished, isDirty, isSaving, isSavea
 		return null;
 	}
 
-	if ( ! isNew && ! isDirty ) {
+	if ( ! isNew && ! isDirty && ! hasActiveMetaboxes ) {
 		return (
 			<span className={ className }>
 				<Dashicon icon="saved" />
@@ -79,6 +80,7 @@ export default connect(
 		isSaving: isSavingPost( state ),
 		isSaveable: isEditedPostSaveable( state ),
 		status: getEditedPostAttribute( state, 'status' ),
+		hasActiveMetaboxes: hasMetaBoxes( state ),
 	} ),
 	{
 		onStatusChange: ( status ) => editPost( { status } ),

--- a/editor/components/unsaved-changes-warning/index.js
+++ b/editor/components/unsaved-changes-warning/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,7 +13,8 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { isEditedPostDirty } from '../../store/selectors';
+import { isEditedPostDirty, getMetaBoxes } from '../../store/selectors';
+import { getLocationHtml } from '../../edit-post/meta-boxes';
 
 class UnsavedChangesWarning extends Component {
 	constructor() {
@@ -29,7 +31,10 @@ class UnsavedChangesWarning extends Component {
 	}
 
 	warnIfUnsavedChanges( event ) {
-		if ( this.props.isDirty ) {
+		const areMetaBoxesDirty = some( this.props.metaBoxes, ( metaBoxe, location ) => {
+			return metaBoxe.isActive && getLocationHtml( location ) !== metaBoxe.html;
+		} );
+		if ( this.props.isDirty || areMetaBoxesDirty ) {
 			event.returnValue = __( 'You have unsaved changes. If you proceed, they will be lost.' );
 			return event.returnValue;
 		}
@@ -43,5 +48,6 @@ class UnsavedChangesWarning extends Component {
 export default connect(
 	( state ) => ( {
 		isDirty: isEditedPostDirty( state ),
+		metaBoxes: getMetaBoxes( state ),
 	} )
 )( UnsavedChangesWarning );

--- a/editor/components/unsaved-changes-warning/index.js
+++ b/editor/components/unsaved-changes-warning/index.js
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { some } from 'lodash';
+import jQuery from 'jquery';
 
 /**
  * WordPress dependencies
@@ -14,25 +15,41 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import { isEditedPostDirty, getMetaBoxes } from '../../store/selectors';
-import { getLocationHtml } from '../../edit-post/meta-boxes';
+import { getMetaBoxContainer } from '../../edit-post/meta-boxes';
 
 class UnsavedChangesWarning extends Component {
+	/**
+	 * @inheritdoc
+	 */
 	constructor() {
 		super( ...arguments );
 		this.warnIfUnsavedChanges = this.warnIfUnsavedChanges.bind( this );
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	componentDidMount() {
 		window.addEventListener( 'beforeunload', this.warnIfUnsavedChanges );
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	componentWillUnmount() {
 		window.removeEventListener( 'beforeunload', this.warnIfUnsavedChanges );
 	}
 
+	/**
+	 * Warns the user if there are unsaved changes before leaving the editor.
+	 *
+	 * @param   {Event}   event Event Object.
+	 * @returns {string?}       Warning message.
+	 */
 	warnIfUnsavedChanges( event ) {
-		const areMetaBoxesDirty = some( this.props.metaBoxes, ( metaBoxe, location ) => {
-			return metaBoxe.isActive && getLocationHtml( location ) !== metaBoxe.html;
+		const areMetaBoxesDirty = some( this.props.metaBoxes, ( metaBox, location ) => {
+			return metaBox.isActive &&
+				jQuery( getMetaBoxContainer( location ) ).serialize() !== metaBox.html;
 		} );
 		if ( this.props.isDirty || areMetaBoxesDirty ) {
 			event.returnValue = __( 'You have unsaved changes. If you proceed, they will be lost.' );
@@ -40,6 +57,9 @@ class UnsavedChangesWarning extends Component {
 		}
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	render() {
 		return null;
 	}

--- a/editor/components/unsaved-changes-warning/index.js
+++ b/editor/components/unsaved-changes-warning/index.js
@@ -49,7 +49,7 @@ class UnsavedChangesWarning extends Component {
 	warnIfUnsavedChanges( event ) {
 		const areMetaBoxesDirty = some( this.props.metaBoxes, ( metaBox, location ) => {
 			return metaBox.isActive &&
-				jQuery( getMetaBoxContainer( location ) ).serialize() !== metaBox.html;
+				jQuery( getMetaBoxContainer( location ) ).serialize() !== metaBox.data;
 		} );
 		if ( this.props.isDirty || areMetaBoxesDirty ) {
 			event.returnValue = __( 'You have unsaved changes. If you proceed, they will be lost.' );

--- a/editor/edit-post/meta-boxes.js
+++ b/editor/edit-post/meta-boxes.js
@@ -1,16 +1,16 @@
 /**
- * Function returning the current Meta Boxes HTML in the editor
+ * Function returning the current Meta Boxes DOM Node in the editor
  * whether the meta box area is opened or not.
- * This is not so clear, but I believe it's the only way to have this data synchronously
+ * If the MetaBox Area is visible returns it, and returns the original container instead.
  *
- * @param   {String} location Meta Box location
- * @returns {String}          HTML content
+ * @param   {string} location Meta Box location.
+ * @returns {string}          HTML content.
  */
-export const getLocationHtml = ( location ) => {
-	const area = document.querySelector( `.editor-meta-boxes-area.is-${ location } .editor-meta-boxes-area__container` );
+export const getMetaBoxContainer = ( location ) => {
+	const area = document.querySelector( `.editor-meta-boxes-area.is-${ location } .metabox-location-${ location }` );
 	if ( area ) {
-		return area.innerHTML;
+		return area;
 	}
 
-	return document.querySelector( '.metabox-location-' + location ).innerHTML;
+	return document.querySelector( '#metaboxes .metabox-location-' + location );
 };

--- a/editor/edit-post/meta-boxes.js
+++ b/editor/edit-post/meta-boxes.js
@@ -1,0 +1,16 @@
+/**
+ * Function returning the current Meta Boxes HTML in the editor
+ * whether the meta box area is opened or not.
+ * This is not so clear, but I believe it's the only way to have this data synchronously
+ *
+ * @param   {String} location Meta Box location
+ * @returns {String}          HTML content
+ */
+export const getLocationHtml = ( location ) => {
+	const area = document.querySelector( `.editor-meta-boxes-area.is-${ location } .editor-meta-boxes-area__container` );
+	if ( area ) {
+		return area.innerHTML;
+	}
+
+	return document.querySelector( '.metabox-location-' + location ).innerHTML;
+};

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -447,44 +447,14 @@ export function removeNotice( id ) {
  *
  * This indicates that the sidebar has a meta box but the normal area does not.
  *
- * @param {Object} metaBoxes Whether meta box locations are active.
+ * @param   {Object} metaBoxes Whether meta box locations are active.
  *
- * @returns {Object} Action object.
+ * @returns {Object}           Action object.
  */
 export function initializeMetaBoxState( metaBoxes ) {
 	return {
 		type: 'INITIALIZE_META_BOX_STATE',
 		metaBoxes,
-	};
-}
-
-/**
- * Returns an action object used to signify that a meta box finished reloading.
- *
- * @param {string} location Location of meta box: 'normal', 'side'
- *                          or 'advanced'.
- *
- * @returns {Object} Action object.
- */
-export function handleMetaBoxReload( location ) {
-	return {
-		type: 'HANDLE_META_BOX_RELOAD',
-		location,
-	};
-}
-
-/**
- * Returns an action object used to signify that a meta box finished loading.
- *
- * @param {string} location Location of meta box: 'normal', 'side'
- *                          or 'advanced'.
- *
- * @returns {Object} Action object.
- */
-export function metaBoxLoaded( location ) {
-	return {
-		type: 'META_BOX_LOADED',
-		location,
 	};
 }
 
@@ -496,6 +466,31 @@ export function metaBoxLoaded( location ) {
 export function requestMetaBoxUpdates() {
 	return {
 		type: 'REQUEST_META_BOX_UPDATES',
+	};
+}
+
+/**
+ * Returns an action object used signal a successfull meta nox update.
+ *
+ * @returns {Object} Action object.
+ */
+export function metaBoxUpdatesSuccess() {
+	return {
+		type: 'META_BOX_UPDATES_SUCCESS',
+	};
+}
+
+/**
+ * Returns an action object used set the saved meta boxes data.
+ * This is used to check if the meta boxes have been touched when leaving the editor.
+ *
+ * @param   {Object} dataPerLocation Meta Boxes Data per location.
+ * @returns {Object}                 Action object.
+ */
+export function metaBoxSetSavedData( dataPerLocation ) {
+	return {
+		type: 'META_BOX_SET_SAVED_DATA',
+		dataPerLocation,
 	};
 }
 

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -447,9 +447,9 @@ export function removeNotice( id ) {
  *
  * This indicates that the sidebar has a meta box but the normal area does not.
  *
- * @param   {Object} metaBoxes Whether meta box locations are active.
+ * @param {Object} metaBoxes Whether meta box locations are active.
  *
- * @returns {Object}           Action object.
+ * @returns {Object} Action object.
  */
 export function initializeMetaBoxState( metaBoxes ) {
 	return {
@@ -487,7 +487,7 @@ export function metaBoxUpdatesSuccess() {
  * @param   {Object} dataPerLocation Meta Boxes Data per location.
  * @returns {Object}                 Action object.
  */
-export function metaBoxSetSavedData( dataPerLocation ) {
+export function setMetaBoxSavedData( dataPerLocation ) {
 	return {
 		type: 'META_BOX_SET_SAVED_DATA',
 		dataPerLocation,

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -491,32 +491,11 @@ export function metaBoxLoaded( location ) {
 /**
  * Returns an action object used to request meta box update.
  *
- * @param {Array} locations Locations of meta boxes: ['normal', 'side',
- *                          'advanced' ].
- *
  * @returns {Object} Action object.
  */
-export function requestMetaBoxUpdates( locations ) {
+export function requestMetaBoxUpdates() {
 	return {
 		type: 'REQUEST_META_BOX_UPDATES',
-		locations,
-	};
-}
-
-/**
- * Returns an action object used to set meta box state changed.
- *
- * @param {string}  location   Location of meta box: 'normal', 'side'
- *                             or 'advanced'.
- * @param {boolean} hasChanged Whether the meta box has changed.
- *
- * @returns {Object} Action object.
- */
-export function metaBoxStateChanged( location, hasChanged ) {
-	return {
-		type: 'META_BOX_STATE_CHANGED',
-		location,
-		hasChanged,
 	};
 }
 

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -40,7 +40,7 @@ import {
 	updateReusableBlock,
 	saveReusableBlock,
 	insertBlock,
-	metaBoxSetSavedData,
+	setMetaBoxSavedData,
 } from './actions';
 import {
 	getCurrentPost,
@@ -466,7 +466,7 @@ export default {
 			}
 			return memo;
 		}, {} );
-		store.dispatch( metaBoxSetSavedData( dataPerLocation ) );
+		store.dispatch( setMetaBoxSavedData( dataPerLocation ) );
 	},
 	REQUEST_META_BOX_UPDATES( action, store ) {
 		const dataPerLocation = reduce( getMetaBoxes( store.getState() ), ( memo, metabox, location ) => {
@@ -475,7 +475,7 @@ export default {
 			}
 			return memo;
 		}, {} );
-		store.dispatch( metaBoxSetSavedData( dataPerLocation ) );
+		store.dispatch( setMetaBoxSavedData( dataPerLocation ) );
 
 		// To save the metaboxes, we serialize each one of the location forms and combine them
 		// We also add the "common" hidden fields from the base .metabox-base-form

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -43,7 +43,6 @@ import {
 import {
 	getCurrentPost,
 	getCurrentPostType,
-	getDirtyMetaBoxes,
 	getEditedPostContent,
 	getPostEdits,
 	isCurrentPostPublished,
@@ -108,7 +107,7 @@ export default {
 	},
 	REQUEST_POST_UPDATE_SUCCESS( action, store ) {
 		const { previousPost, post } = action;
-		const { dispatch, getState } = store;
+		const { dispatch } = store;
 
 		const publishStatus = [ 'publish', 'private', 'future' ];
 		const isPublished = includes( publishStatus, previousPost.status );
@@ -148,7 +147,7 @@ export default {
 		}
 
 		// Update dirty meta boxes.
-		dispatch( requestMetaBoxUpdates( getDirtyMetaBoxes( getState() ) ) );
+		dispatch( requestMetaBoxUpdates() );
 
 		if ( get( window.history.state, 'id' ) !== post.id ) {
 			window.history.replaceState(

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -669,11 +669,13 @@ const defaultMetaBoxState = locations.reduce( ( result, key ) => {
 }, {} );
 
 /**
- * Reducer keeping track of the meta boxes saving state.
+ * Reducer keeping track of the meta boxes isSaving state.
+ * A "true" value means the meta boxes saving request is in-flight.
  *
- * @param {boolean} state  Previous state.
- * @param {Object } action Action Object.
- * @returns {Object}        Updated state.
+ *
+ * @param {boolean}  state   Previous state.
+ * @param {Object}   action  Action Object.
+ * @returns {Object}         Updated state.
  */
 export function isSavingMetaBoxes( state = false, action ) {
 	switch ( action.type ) {
@@ -687,12 +689,16 @@ export function isSavingMetaBoxes( state = false, action ) {
 }
 
 /**
+ * Reducer keeping track of the state of each meta box location.
+ * This includes:
+ *  - isActive: Whether the location is active or not.
+ *  - data: The last saved form data for this location.
+ *    This is used to check whether the form is dirty
+ *    before leaving the page.
  *
- * Reducer keeping track of the meta boxes state.
- *
- * @param {boolean} state  Previous state.
- * @param {Object } action Action Object.
- * @returns {Object}        Updated state.
+ * @param {boolean}  state   Previous state.
+ * @param {Object}   action  Action Object.
+ * @returns {Object}         Updated state.
  */
 export function metaBoxes( state = defaultMetaBoxState, action ) {
 	switch ( action.type ) {

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -663,7 +663,6 @@ const locations = [
 const defaultMetaBoxState = locations.reduce( ( result, key ) => {
 	result[ key ] = {
 		isActive: false,
-		isDirty: false,
 		isUpdating: false,
 	};
 
@@ -688,7 +687,6 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 					...state[ action.location ],
 					isLoaded: true,
 					isUpdating: false,
-					isDirty: false,
 				},
 			};
 		case 'HANDLE_META_BOX_RELOAD':
@@ -697,26 +695,15 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 				[ action.location ]: {
 					...state[ action.location ],
 					isUpdating: false,
-					isDirty: false,
 				},
 			};
 		case 'REQUEST_META_BOX_UPDATES':
-			return action.locations.reduce( ( newState, location ) => {
-				newState[ location ] = {
-					...state[ location ],
-					isUpdating: true,
-					isDirty: false,
+			return mapValues( state, ( metaBox ) => {
+				return {
+					...metaBox,
+					isUpdating: metaBox.isActive,
 				};
-				return newState;
-			}, { ...state } );
-		case 'META_BOX_STATE_CHANGED':
-			return {
-				...state,
-				[ action.location ]: {
-					...state[ action.location ],
-					isDirty: action.hasChanged,
-				},
-			};
+			} );
 		default:
 			return state;
 	}

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -32,6 +32,7 @@ import { getBlockTypes, getBlockType } from '@wordpress/blocks';
 import withHistory from '../utils/with-history';
 import withChangeDetection from '../utils/with-change-detection';
 import { PREFERENCES_DEFAULTS } from './defaults';
+import { getLocationHtml } from '../edit-post/meta-boxes';
 
 /***
  * Module constants
@@ -677,6 +678,7 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 					...state[ location ],
 					isLoaded: false,
 					isActive: action.metaBoxes[ location ],
+					html: getLocationHtml( location ),
 				};
 				return newState;
 			}, { ...state } );
@@ -695,6 +697,7 @@ export function metaBoxes( state = defaultMetaBoxState, action ) {
 				[ action.location ]: {
 					...state[ action.location ],
 					isUpdating: false,
+					html: getLocationHtml( action.location ),
 				},
 			};
 		case 'REQUEST_META_BOX_UPDATES':

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -12,6 +12,7 @@ import {
 	without,
 	compact,
 	find,
+	some,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -63,34 +64,34 @@ export function getMetaBox( state, location ) {
 }
 
 /**
- * Returns a list of dirty meta box locations.
+ * Returns true if the post is using Meta Boxes
  *
- * @param {Object} state Global application state.
- *
- * @returns {Array} Array of locations for dirty meta boxes.
+ * @param  {Object} state Global application state
+ * @return {boolean}      Whether there are metaboxes or not.
  */
-export const getDirtyMetaBoxes = createSelector(
+export const hasMetaBoxes = createSelector(
 	( state ) => {
-		return reduce( getMetaBoxes( state ), ( result, metaBox, location ) => {
-			return metaBox.isDirty && metaBox.isActive ?
-				[ ...result, location ] :
-				result;
-		}, [] );
+		return some( getMetaBoxes( state ), ( metaBox ) => {
+			return metaBox.isActive;
+		} );
 	},
 	( state ) => state.metaBoxes,
 );
 
 /**
- * Returns the dirty state of legacy meta boxes.
+ * Returns true if the the Meta Boxes are being saved
  *
- * Checks whether the entire meta box state is dirty. So if a sidebar is dirty,
- * but a normal area is not dirty, this will overall return dirty.
- *
- * @param {Object} state Global application state.
- *
- * @returns {boolean} Whether state is dirty. True if dirty, false if not.
+ * @param  {Object} state Global application state
+ * @return {boolean}      Whether the metaboxes are being saved.
  */
-export const isMetaBoxStateDirty = ( state ) => getDirtyMetaBoxes( state ).length > 0;
+export const isSavingMetaBoxes = createSelector(
+	( state ) => {
+		return some( getMetaBoxes( state ), ( metaBox ) => {
+			return metaBox.isUpdating;
+		} );
+	},
+	( state ) => state.metaBoxes,
+);
 
 /**
  * Returns the current active panel for the sidebar.
@@ -216,7 +217,7 @@ export function isEditedPostNew( state ) {
  * @returns {boolean} Whether unsaved values exist.
  */
 export function isEditedPostDirty( state ) {
-	return state.editor.isDirty || isMetaBoxStateDirty( state );
+	return state.editor.isDirty;
 }
 
 /**
@@ -374,7 +375,7 @@ export function isCurrentPostPublished( state ) {
  */
 export function isEditedPostPublishable( state ) {
 	const post = getCurrentPost( state );
-	return isEditedPostDirty( state ) || [ 'publish', 'private', 'future' ].indexOf( post.status ) === -1;
+	return isEditedPostDirty( state ) || hasMetaBoxes( state ) || [ 'publish', 'private', 'future' ].indexOf( post.status ) === -1;
 }
 
 /**
@@ -999,7 +1000,7 @@ export function isBlockInsertionPointVisible( state ) {
  * @returns {boolean} Whether post is being saved.
  */
 export function isSavingPost( state ) {
-	return state.saving.requesting;
+	return state.saving.requesting || isSavingMetaBoxes( state );
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -43,9 +43,8 @@ export function getEditorMode( state ) {
 /**
  * Returns the state of legacy meta boxes.
  *
- * @param {Object} state Global application state.
- *
- * @returns {Object} State of meta boxes.
+ * @param   {Object} state Global application state.
+ * @returns {Object}       State of meta boxes.
  */
 export function getMetaBoxes( state ) {
 	return state.metaBoxes;
@@ -79,19 +78,14 @@ export const hasMetaBoxes = createSelector(
 );
 
 /**
- * Returns true if the the Meta Boxes are being saved
+ * Returns true if the the Meta Boxes are being saved.
  *
- * @param  {Object} state Global application state
- * @return {boolean}      Whether the metaboxes are being saved.
+ * @param   {Object}  state Global application state.
+ * @returns {boolean}       Whether the metaboxes are being saved.
  */
-export const isSavingMetaBoxes = createSelector(
-	( state ) => {
-		return some( getMetaBoxes( state ), ( metaBox ) => {
-			return metaBox.isUpdating;
-		} );
-	},
-	( state ) => state.metaBoxes,
-);
+export function isSavingMetaBoxes( state ) {
+	return state.isSavingMetaBoxes;
+}
 
 /**
  * Returns the current active panel for the sidebar.

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -8,7 +8,6 @@ import {
 	stopTyping,
 	requestMetaBoxUpdates,
 	handleMetaBoxReload,
-	metaBoxStateChanged,
 	initializeMetaBoxState,
 	fetchReusableBlocks,
 	updateReusableBlock,
@@ -537,9 +536,8 @@ describe( 'actions', () => {
 
 	describe( 'requestMetaBoxUpdates', () => {
 		it( 'should return the REQUEST_META_BOX_UPDATES action', () => {
-			expect( requestMetaBoxUpdates( [ 'normal' ] ) ).toEqual( {
+			expect( requestMetaBoxUpdates() ).toEqual( {
 				type: 'REQUEST_META_BOX_UPDATES',
-				locations: [ 'normal' ],
 			} );
 		} );
 	} );
@@ -549,16 +547,6 @@ describe( 'actions', () => {
 			expect( handleMetaBoxReload( 'normal' ) ).toEqual( {
 				type: 'HANDLE_META_BOX_RELOAD',
 				location: 'normal',
-			} );
-		} );
-	} );
-
-	describe( 'metaBoxStateChanged', () => {
-		it( 'should return the META_BOX_STATE_CHANGED action with a hasChanged flag', () => {
-			expect( metaBoxStateChanged( 'normal', true ) ).toEqual( {
-				type: 'META_BOX_STATE_CHANGED',
-				location: 'normal',
-				hasChanged: true,
 			} );
 		} );
 	} );

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -7,7 +7,6 @@ import {
 	startTyping,
 	stopTyping,
 	requestMetaBoxUpdates,
-	handleMetaBoxReload,
 	initializeMetaBoxState,
 	fetchReusableBlocks,
 	updateReusableBlock,
@@ -51,7 +50,6 @@ import {
 	createErrorNotice,
 	createWarningNotice,
 	removeNotice,
-	metaBoxLoaded,
 	toggleFeature,
 } from '../actions';
 
@@ -514,16 +512,6 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'metaBoxLoaded', () => {
-		it( 'should return META_BOX_LOADED action', () => {
-			const location = 'normal';
-			expect( metaBoxLoaded( location ) ).toEqual( {
-				type: 'META_BOX_LOADED',
-				location,
-			} );
-		} );
-	} );
-
 	describe( 'toggleFeature', () => {
 		it( 'should return TOGGLE_FEATURE action', () => {
 			const feature = 'name';
@@ -538,15 +526,6 @@ describe( 'actions', () => {
 		it( 'should return the REQUEST_META_BOX_UPDATES action', () => {
 			expect( requestMetaBoxUpdates() ).toEqual( {
 				type: 'REQUEST_META_BOX_UPDATES',
-			} );
-		} );
-	} );
-
-	describe( 'handleMetaBoxReload', () => {
-		it( 'should return the HANDLE_META_BOX_RELOAD action with a location and node', () => {
-			expect( handleMetaBoxReload( 'normal' ) ).toEqual( {
-				type: 'HANDLE_META_BOX_RELOAD',
-				location: 'normal',
 			} );
 		} );
 	} );

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -283,7 +283,7 @@ describe( 'effects', () => {
 
 	describe( '.REQUEST_POST_UPDATE_SUCCESS', () => {
 		const handler = effects.REQUEST_POST_UPDATE_SUCCESS;
-		let getDirtyMetaBoxesSpy, replaceStateSpy;
+		let replaceStateSpy;
 
 		const defaultPost = {
 			id: 1,
@@ -304,18 +304,14 @@ describe( 'effects', () => {
 		} );
 
 		beforeAll( () => {
-			getDirtyMetaBoxesSpy = jest.spyOn( selectors, 'getDirtyMetaBoxes' );
 			replaceStateSpy = jest.spyOn( window.history, 'replaceState' );
 		} );
 
 		beforeEach( () => {
-			getDirtyMetaBoxesSpy.mockReset();
-			getDirtyMetaBoxesSpy.mockReturnValue( [ 'normal', 'side' ] );
 			replaceStateSpy.mockReset();
 		} );
 
 		afterAll( () => {
-			getDirtyMetaBoxesSpy.mockRestore();
 			replaceStateSpy.mockRestore();
 		} );
 
@@ -328,7 +324,7 @@ describe( 'effects', () => {
 			handler( { post: post, previousPost: post }, store );
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( requestMetaBoxUpdates( [ 'normal', 'side' ] ) );
+			expect( dispatch ).toHaveBeenCalledWith( requestMetaBoxUpdates() );
 		} );
 
 		it( 'should dispatch notices when publishing or scheduling a post', () => {

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1242,23 +1242,21 @@ describe( 'state', () => {
 			const expected = {
 				normal: {
 					isActive: false,
-					isDirty: false,
 					isUpdating: false,
 				},
 				side: {
 					isActive: false,
-					isDirty: false,
 					isUpdating: false,
 				},
 				advanced: {
 					isActive: false,
-					isDirty: false,
 					isUpdating: false,
 				},
 			};
 
 			expect( actual ).toEqual( expected );
 		} );
+
 		it( 'should set the sidebar to active', () => {
 			const theMetaBoxes = {
 				normal: false,
@@ -1275,19 +1273,16 @@ describe( 'state', () => {
 			const expected = {
 				normal: {
 					isActive: false,
-					isDirty: false,
 					isUpdating: false,
 					isLoaded: false,
 				},
 				side: {
 					isActive: true,
-					isDirty: false,
 					isUpdating: false,
 					isLoaded: false,
 				},
 				advanced: {
 					isActive: false,
-					isDirty: false,
 					isUpdating: false,
 					isLoaded: false,
 				},
@@ -1295,53 +1290,33 @@ describe( 'state', () => {
 
 			expect( actual ).toEqual( expected );
 		} );
+
 		it( 'should switch updating to off', () => {
 			const action = {
 				type: 'HANDLE_META_BOX_RELOAD',
 				location: 'normal',
 			};
 
-			const theMetaBoxes = metaBoxes( { normal: { isUpdating: true, isActive: false, isDirty: true } }, action );
+			const theMetaBoxes = metaBoxes( { normal: { isUpdating: true, isActive: false } }, action );
 			const actual = theMetaBoxes.normal;
 			const expected = {
 				isActive: false,
 				isUpdating: false,
-				isDirty: false,
 			};
 
 			expect( actual ).toEqual( expected );
 		} );
+
 		it( 'should switch updating to on', () => {
 			const action = {
 				type: 'REQUEST_META_BOX_UPDATES',
-				locations: [ 'normal' ],
 			};
 
-			const theMetaBoxes = metaBoxes( undefined, action );
-			const actual = theMetaBoxes.normal;
-			const expected = {
-				isActive: false,
-				isUpdating: true,
-				isDirty: false,
-			};
-
-			expect( actual ).toEqual( expected );
-		} );
-		it( 'should return with the isDirty flag as true', () => {
-			const action = {
-				type: 'META_BOX_STATE_CHANGED',
-				location: 'normal',
-				hasChanged: true,
-			};
-			const theMetaBoxes = metaBoxes( undefined, action );
-			const actual = theMetaBoxes.normal;
-			const expected = {
-				isActive: false,
-				isDirty: true,
-				isUpdating: false,
-			};
-
-			expect( actual ).toEqual( expected );
+			const theMetaBoxes = metaBoxes( { normal: { isActive: true }, side: { isActive: false } }, action );
+			expect( theMetaBoxes ).toEqual( {
+				normal: { isActive: true, isUpdating: true },
+				side: { isActive: false, isUpdating: false },
+			} );
 		} );
 	} );
 

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -28,6 +28,12 @@ import {
 	reusableBlocks,
 } from '../reducer';
 
+jest.mock( '../../edit-post/meta-boxes', () => {
+	return {
+		getLocationHtml: () => 'meta boxes content',
+	};
+} );
+
 describe( 'state', () => {
 	describe( 'getPostRawValue', () => {
 		it( 'returns original value for non-rendered content', () => {
@@ -1275,16 +1281,19 @@ describe( 'state', () => {
 					isActive: false,
 					isUpdating: false,
 					isLoaded: false,
+					html: 'meta boxes content',
 				},
 				side: {
 					isActive: true,
 					isUpdating: false,
 					isLoaded: false,
+					html: 'meta boxes content',
 				},
 				advanced: {
 					isActive: false,
 					isUpdating: false,
 					isLoaded: false,
+					html: 'meta boxes content',
 				},
 			};
 
@@ -1302,6 +1311,7 @@ describe( 'state', () => {
 			const expected = {
 				isActive: false,
 				isUpdating: false,
+				html: 'meta boxes content',
 			};
 
 			expect( actual ).toEqual( expected );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -24,13 +24,14 @@ import {
 	notices,
 	blocksMode,
 	blockInsertionPoint,
+	isSavingMetaBoxes,
 	metaBoxes,
 	reusableBlocks,
 } from '../reducer';
 
 jest.mock( '../../edit-post/meta-boxes', () => {
 	return {
-		getLocationHtml: () => 'meta boxes content',
+		getMetaBoxContainer: () => ( { innerHTML: 'meta boxes content' } ),
 	};
 } );
 
@@ -1242,21 +1243,43 @@ describe( 'state', () => {
 		} );
 	} );
 
+	describe( 'isSavingMetaBoxes', () => {
+		it( 'should return default state', () => {
+			const actual = isSavingMetaBoxes( undefined, {} );
+			expect( actual ).toBe( false );
+		} );
+
+		it( 'should set saving flag to true', () => {
+			const action = {
+				type: 'REQUEST_META_BOX_UPDATES',
+			};
+			const actual = isSavingMetaBoxes( false, action );
+
+			expect( actual ).toBe( true );
+		} );
+
+		it( 'should set saving flag to false', () => {
+			const action = {
+				type: 'META_BOX_UPDATES_SUCCESS',
+			};
+			const actual = isSavingMetaBoxes( true, action );
+
+			expect( actual ).toBe( false );
+		} );
+	} );
+
 	describe( 'metaBoxes()', () => {
 		it( 'should return default state', () => {
 			const actual = metaBoxes( undefined, {} );
 			const expected = {
 				normal: {
 					isActive: false,
-					isUpdating: false,
 				},
 				side: {
 					isActive: false,
-					isUpdating: false,
 				},
 				advanced: {
 					isActive: false,
-					isUpdating: false,
 				},
 			};
 
@@ -1279,53 +1302,31 @@ describe( 'state', () => {
 			const expected = {
 				normal: {
 					isActive: false,
-					isUpdating: false,
-					isLoaded: false,
-					html: 'meta boxes content',
 				},
 				side: {
 					isActive: true,
-					isUpdating: false,
-					isLoaded: false,
-					html: 'meta boxes content',
 				},
 				advanced: {
 					isActive: false,
-					isUpdating: false,
-					isLoaded: false,
-					html: 'meta boxes content',
 				},
 			};
 
 			expect( actual ).toEqual( expected );
 		} );
 
-		it( 'should switch updating to off', () => {
+		it( 'should set the meta boxes saved data', () => {
 			const action = {
-				type: 'HANDLE_META_BOX_RELOAD',
-				location: 'normal',
-			};
-
-			const theMetaBoxes = metaBoxes( { normal: { isUpdating: true, isActive: false } }, action );
-			const actual = theMetaBoxes.normal;
-			const expected = {
-				isActive: false,
-				isUpdating: false,
-				html: 'meta boxes content',
-			};
-
-			expect( actual ).toEqual( expected );
-		} );
-
-		it( 'should switch updating to on', () => {
-			const action = {
-				type: 'REQUEST_META_BOX_UPDATES',
+				type: 'META_BOX_SET_SAVED_DATA',
+				dataPerLocation: {
+					side: 'a=b',
+				},
 			};
 
 			const theMetaBoxes = metaBoxes( { normal: { isActive: true }, side: { isActive: false } }, action );
 			expect( theMetaBoxes ).toEqual( {
-				normal: { isActive: true, isUpdating: true },
-				side: { isActive: false, isUpdating: false },
+				advanced: { data: undefined },
+				normal: { isActive: true, data: undefined },
+				side: { isActive: false, data: 'a=b' },
 			} );
 		} );
 	} );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -169,16 +169,7 @@ describe( 'selectors', () => {
 	describe( 'isSavingMetaBoxes', () => {
 		it( 'should return true if some meta boxes are saving', () => {
 			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: false,
-						isUpdating: false,
-					},
-					side: {
-						isActive: true,
-						isUpdating: true,
-					},
-				},
+				isSavingMetaBoxes: true,
 			};
 
 			expect( isSavingMetaBoxes( state ) ).toBe( true );
@@ -186,16 +177,7 @@ describe( 'selectors', () => {
 
 		it( 'should return false if no meta boxes are saving', () => {
 			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: false,
-						isUpdating: false,
-					},
-					side: {
-						isActive: true,
-						isUpdating: false,
-					},
-				},
+				isSavingMetaBoxes: false,
 			};
 
 			expect( isSavingMetaBoxes( state ) ).toBe( false );
@@ -207,24 +189,20 @@ describe( 'selectors', () => {
 			const state = {
 				metaBoxes: {
 					normal: {
-						isDirty: false,
-						isUpdating: false,
+						isActive: true,
 					},
 					side: {
-						isDirty: false,
-						isUpdating: false,
+						isActive: true,
 					},
 				},
 			};
 
 			expect( getMetaBoxes( state ) ).toEqual( {
 				normal: {
-					isDirty: false,
-					isUpdating: false,
+					isActive: true,
 				},
 				side: {
-					isDirty: false,
-					isUpdating: false,
+					isActive: true,
 				},
 			} );
 		} );
@@ -236,21 +214,15 @@ describe( 'selectors', () => {
 				metaBoxes: {
 					normal: {
 						isActive: false,
-						isDirty: false,
-						isUpdating: false,
 					},
 					side: {
 						isActive: true,
-						isDirty: false,
-						isUpdating: false,
 					},
 				},
 			};
 
 			expect( getMetaBox( state, 'side' ) ).toEqual( {
 				isActive: true,
-				isDirty: false,
-				isUpdating: false,
 			} );
 		} );
 	} );
@@ -554,7 +526,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isCleanNewPost', () => {
-		const metaBoxes = { isDirty: false, isUpdating: false };
+		const metaBoxes = {};
 
 		it( 'should return true when the post is not dirty and has not been saved before', () => {
 			const state = {
@@ -751,7 +723,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getDocumentTitle', () => {
-		const metaBoxes = { isDirty: false, isUpdating: false };
+		const metaBoxes = {};
 		it( 'should return current title unedited existing post', () => {
 			const state = {
 				currentPost: {
@@ -977,7 +949,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditedPostPublishable', () => {
-		const metaBoxes = { isDirty: false, isUpdating: false };
+		const metaBoxes = {};
 
 		it( 'should return true for pending posts', () => {
 			const state = {
@@ -1968,6 +1940,7 @@ describe( 'selectors', () => {
 				saving: {
 					requesting: true,
 				},
+				isSavingMetaBoxes: false,
 			};
 
 			expect( isSavingPost( state ) ).toBe( true );
@@ -1978,21 +1951,18 @@ describe( 'selectors', () => {
 				saving: {
 					requesting: false,
 				},
+				isSavingMetaBoxes: false,
 			};
 
 			expect( isSavingPost( state ) ).toBe( false );
 		} );
 
-		it( 'should return true if the post is notcurrently being saved but meta boxes are saving', () => {
+		it( 'should return true if the post is not currently being saved but meta boxes are saving', () => {
 			const state = {
 				saving: {
 					requesting: false,
 				},
-				metaBoxes: {
-					normal: {
-						isUpdating: true,
-					},
-				},
+				isSavingMetaBoxes: true,
 			};
 
 			expect( isSavingPost( state ) ).toBe( true );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -74,9 +74,9 @@ import {
 	getMostFrequentlyUsedBlocks,
 	getRecentInserterItems,
 	getMetaBoxes,
-	getDirtyMetaBoxes,
+	hasMetaBoxes,
+	isSavingMetaBoxes,
 	getMetaBox,
-	isMetaBoxStateDirty,
 	getReusableBlock,
 	isSavingReusableBlock,
 	isSelectionEnabled,
@@ -105,7 +105,6 @@ describe( 'selectors', () => {
 	} );
 
 	beforeEach( () => {
-		getDirtyMetaBoxes.clear();
 		getBlock.clear();
 		getBlocks.clear();
 		getEditedPostContent.clear();
@@ -135,24 +134,71 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getDirtyMetaBoxes', () => {
-		it( 'should return array of just the side location', () => {
+	describe( 'hasMetaBoxes', () => {
+		it( 'should return true if there are active meta boxes', () => {
 			const state = {
 				metaBoxes: {
 					normal: {
 						isActive: false,
-						isDirty: false,
+					},
+					side: {
+						isActive: true,
+					},
+				},
+			};
+
+			expect( hasMetaBoxes( state ) ).toBe( true );
+		} );
+
+		it( 'should return false if there are no active meta boxes', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: false,
+					},
+					side: {
+						isActive: false,
+					},
+				},
+			};
+
+			expect( hasMetaBoxes( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isSavingMetaBoxes', () => {
+		it( 'should return true if some meta boxes are saving', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: false,
 						isUpdating: false,
 					},
 					side: {
 						isActive: true,
-						isDirty: true,
+						isUpdating: true,
+					},
+				},
+			};
+
+			expect( isSavingMetaBoxes( state ) ).toBe( true );
+		} );
+
+		it( 'should return false if no meta boxes are saving', () => {
+			const state = {
+				metaBoxes: {
+					normal: {
+						isActive: false,
+						isUpdating: false,
+					},
+					side: {
+						isActive: true,
 						isUpdating: false,
 					},
 				},
 			};
 
-			expect( getDirtyMetaBoxes( state ) ).toEqual( [ 'side' ] );
+			expect( isSavingMetaBoxes( state ) ).toBe( false );
 		} );
 	} );
 
@@ -206,103 +252,6 @@ describe( 'selectors', () => {
 				isDirty: false,
 				isUpdating: false,
 			} );
-		} );
-	} );
-
-	describe( 'isMetaBoxStateDirty', () => {
-		it( 'should return false', () => {
-			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: false,
-						isDirty: false,
-						isUpdating: false,
-					},
-					side: {
-						isActive: false,
-						isDirty: false,
-						isUpdating: false,
-					},
-				},
-			};
-
-			expect( isMetaBoxStateDirty( state ) ).toEqual( false );
-		} );
-
-		it( 'should return false when a dirty meta box is not active.', () => {
-			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: false,
-						isDirty: true,
-						isUpdating: false,
-					},
-					side: {
-						isActive: false,
-						isDirty: false,
-						isUpdating: false,
-					},
-				},
-			};
-
-			expect( isMetaBoxStateDirty( state ) ).toEqual( false );
-		} );
-
-		it( 'should return false when both meta boxes are dirty but inactive.', () => {
-			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: false,
-						isDirty: true,
-						isUpdating: false,
-					},
-					side: {
-						isActive: false,
-						isDirty: true,
-						isUpdating: false,
-					},
-				},
-			};
-
-			expect( isMetaBoxStateDirty( state ) ).toEqual( false );
-		} );
-
-		it( 'should return false when a dirty meta box is active.', () => {
-			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: true,
-						isDirty: true,
-						isUpdating: false,
-					},
-					side: {
-						isActive: false,
-						isDirty: false,
-						isUpdating: false,
-					},
-				},
-			};
-
-			expect( isMetaBoxStateDirty( state ) ).toEqual( true );
-		} );
-
-		it( 'should return false when both meta boxes are dirty and active.', () => {
-			const state = {
-				metaBoxes: {
-					normal: {
-						isActive: true,
-						isDirty: true,
-						isUpdating: false,
-					},
-					side: {
-						isActive: true,
-						isDirty: true,
-						isUpdating: false,
-					},
-				},
-			};
-
-			expect( isMetaBoxStateDirty( state ) ).toEqual( true );
 		} );
 	} );
 
@@ -583,38 +532,11 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditedPostDirty', () => {
-		const metaBoxes = {
-			normal: {
-				isActive: false,
-				isDirty: false,
-				isUpdating: false,
-			},
-			side: {
-				isActive: false,
-				isDirty: false,
-				isUpdating: false,
-			},
-		};
-		// Those dirty dang meta boxes.
-		const dirtyMetaBoxes = {
-			normal: {
-				isActive: true,
-				isDirty: true,
-				isUpdating: false,
-			},
-			side: {
-				isActive: false,
-				isDirty: false,
-				isUpdating: false,
-			},
-		};
-
 		it( 'should return true when post saved state dirty', () => {
 			const state = {
 				editor: {
 					isDirty: true,
 				},
-				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( true );
@@ -625,21 +547,9 @@ describe( 'selectors', () => {
 				editor: {
 					isDirty: false,
 				},
-				metaBoxes,
 			};
 
 			expect( isEditedPostDirty( state ) ).toBe( false );
-		} );
-
-		it( 'should return true when post saved state not dirty, but meta box state has changed.', () => {
-			const state = {
-				editor: {
-					isDirty: false,
-				},
-				metaBoxes: dirtyMetaBoxes,
-			};
-
-			expect( isEditedPostDirty( state ) ).toBe( true );
 		} );
 	} );
 
@@ -2063,7 +1973,7 @@ describe( 'selectors', () => {
 			expect( isSavingPost( state ) ).toBe( true );
 		} );
 
-		it( 'should return false if the post is currently being saved', () => {
+		it( 'should return false if the post is not currently being saved', () => {
 			const state = {
 				saving: {
 					requesting: false,
@@ -2071,6 +1981,21 @@ describe( 'selectors', () => {
 			};
 
 			expect( isSavingPost( state ) ).toBe( false );
+		} );
+
+		it( 'should return true if the post is notcurrently being saved but meta boxes are saving', () => {
+			const state = {
+				saving: {
+					requesting: false,
+				},
+				metaBoxes: {
+					normal: {
+						isUpdating: true,
+					},
+				},
+			};
+
+			expect( isSavingPost( state ) ).toBe( true );
 		} );
 	} );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -837,6 +837,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'post'           => $post_to_edit['id'],
 		'action'         => 'edit',
 		'classic-editor' => true,
+		'meta_box'       => true,
 	), $meta_box_url );
 	wp_localize_script( 'wp-editor', '_wpMetaBoxUrl', $meta_box_url );
 

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -308,10 +308,10 @@ function the_gutenberg_metaboxes() {
 
 	// Render meta boxes.
 	?>
-		<form class="metabox-base-form">
-		<?php gutenberg_meta_box_post_form_hidden_fields( $post ); ?>
-		</form>
-		<?php foreach ( $locations as $location ) { ?>
+	<form class="metabox-base-form">
+	<?php gutenberg_meta_box_post_form_hidden_fields( $post ); ?>
+	</form>
+	<?php foreach ( $locations as $location ) : ?>
 		<form class="metabox-location-<?php echo esc_attr( $location ); ?>">
 			<div id="poststuff" class="sidebar-open">
 				<div id="postbox-container-2" class="postbox-container">
@@ -325,7 +325,7 @@ function the_gutenberg_metaboxes() {
 				</div>
 			</div>
 		</form>
-		<?php } ?>
+	<?php endforeach; ?>
 	<?php
 
 	// Reset meta box data.

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -16,9 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.8.0
  *
  * @param string $post_type Current post type.
- * @param string $meta_box_context  The context location of the meta box. Referred to as context in core.
  */
-function gutenberg_meta_box_save( $post_type, $meta_box_context ) {
+function gutenberg_meta_box_save( $post_type ) {
 	/**
 	 * Needs classic editor to be active.
 	 *
@@ -45,33 +44,9 @@ function gutenberg_meta_box_save( $post_type, $meta_box_context ) {
 		return;
 	}
 
-	/**
-	 * Prevent over firing of the meta box rendering.
-	 *
-	 * The hook do_action( 'do_meta_boxes', ... ) fires three times in
-	 * edit-form-advanced.php
-	 *
-	 * To make sure we properly fire on all three meta box locations, except
-	 * advanced, as advanced is tied in with normal for ease of use reasons, we
-	 * need to verify that the action location/context matches our requests
-	 * meta box location/context. We then exit early if they do not match.
-	 * This will prevent execution thread from dieing, so the subsequent calls
-	 * to do_meta_boxes can fire.
-	 */
-	if ( $_REQUEST['meta_box'] !== $meta_box_context ) {
-		return;
-	}
-
 	// Ths action is not needed since it's an XHR call.
 	remove_action( 'admin_head', 'wp_admin_canonical_url' );
-
-	$location = $_REQUEST['meta_box'];
-
-	if ( ! in_array( $_REQUEST['meta_box'], array( 'side', 'normal', 'advanced' ) ) ) {
-		wp_die( __( 'The `meta_box` parameter should be one of "side", "normal", or "advanced".', 'gutenberg' ) );
-	}
-
-	the_gutenberg_metaboxes( array( $location ) );
+	the_gutenberg_metaboxes();
 }
 
 add_action( 'do_meta_boxes', 'gutenberg_meta_box_save', 1000, 2 );
@@ -88,13 +63,10 @@ add_action( 'do_meta_boxes', 'gutenberg_meta_box_save', 1000, 2 );
  * @hooked redirect_post_location priority 10
  */
 function gutenberg_meta_box_save_redirect( $location, $post_id ) {
-	if ( isset( $_REQUEST['gutenberg_meta_boxes'] )
-			&& isset( $_REQUEST['gutenberg_meta_box_location'] )
-			&& 'gutenberg_meta_boxes' === $_REQUEST['gutenberg_meta_boxes'] ) {
-		$meta_box_location = $_REQUEST['gutenberg_meta_box_location'];
-		$location          = add_query_arg(
+	if ( isset( $_REQUEST['gutenberg_meta_boxes'] ) ) {
+		$location = add_query_arg(
 			array(
-				'meta_box'       => $meta_box_location,
+				'meta_box'       => true,
 				'action'         => 'edit',
 				'classic-editor' => true,
 				'post'           => $post_id,
@@ -313,10 +285,8 @@ function gutenberg_show_meta_box_warning( $callback ) {
  * Renders the WP meta boxes forms.
  *
  * @since 1.8.0
- *
- * @param string $locations The metaboxes locations to render.
  */
-function the_gutenberg_metaboxes( $locations = array( 'advanced', 'normal', 'side' ) ) {
+function the_gutenberg_metaboxes() {
 	global $post, $current_screen, $wp_meta_boxes;
 
 	// Handle meta box state.
@@ -334,28 +304,29 @@ function the_gutenberg_metaboxes( $locations = array( 'advanced', 'normal', 'sid
 	 * @param array $wp_meta_boxes Global meta box state.
 	 */
 	$wp_meta_boxes = apply_filters( 'filter_gutenberg_meta_boxes', $wp_meta_boxes );
+	$locations     = array( 'side', 'normal', 'advanced' );
 
 	// Render meta boxes.
-	if ( ! empty( $locations ) ) {
-		foreach ( $locations as $location ) {
-			?>
-			<form class="metabox-location-<?php echo $location; ?>">
-				<div id="poststuff" class="sidebar-open">
-					<div id="postbox-container-2" class="postbox-container">
-						<?php
-						gutenberg_meta_box_post_form_hidden_fields( $post, $location );
-						do_meta_boxes(
-							$current_screen,
-							$location,
-							$post
-						);
-						?>
-					</div>
+	?>
+		<form class="metabox-base-form">
+		<?php gutenberg_meta_box_post_form_hidden_fields( $post ); ?>
+		</form>
+		<?php foreach ( $locations as $location ) { ?>
+		<form class="metabox-location-<?php echo esc_attr( $location ); ?>">
+			<div id="poststuff" class="sidebar-open">
+				<div id="postbox-container-2" class="postbox-container">
+					<?php
+					do_meta_boxes(
+						$current_screen,
+						$location,
+						$post
+					);
+					?>
 				</div>
-			</form>
-			<?php
-		}
-	}
+			</div>
+		</form>
+		<?php } ?>
+	<?php
 
 	// Reset meta box data.
 	$wp_meta_boxes = $_original_meta_boxes;
@@ -365,11 +336,10 @@ function the_gutenberg_metaboxes( $locations = array( 'advanced', 'normal', 'sid
  * Renders the hidden form required for the meta boxes form.
  *
  * @param WP_Post $post     Current post object.
- * @param string  $location The metaboxes location to render.
  *
  * @since 1.8.0
  */
-function gutenberg_meta_box_post_form_hidden_fields( $post, $location ) {
+function gutenberg_meta_box_post_form_hidden_fields( $post ) {
 	$form_extra = '';
 	if ( 'auto-draft' === $post->post_status ) {
 		$form_extra .= "<input type='hidden' id='auto_draft' name='auto_draft' value='1' />";
@@ -391,7 +361,6 @@ function gutenberg_meta_box_post_form_hidden_fields( $post, $location ) {
 	<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>" />
 	<!-- These fields are not part of the standard post form. Used to redirect back to this page on save. -->
 	<input type="hidden" name="gutenberg_meta_boxes" value="gutenberg_meta_boxes" />
-	<input type="hidden" name="gutenberg_meta_box_location" value="<?php echo esc_attr( $location ); ?>" />
 	<?php if ( ! empty( $active_post_lock ) ) : ?>
 	<input type="hidden" id="active_post_lock" value="<?php echo esc_attr( implode( ':', $active_post_lock ) ); ?>" />
 	<?php endif; ?>


### PR DESCRIPTION
closes #4183 and closes #3975 

Due to how MetaBoxes work it's not possible to dirty-check them properly. It's not possible to know if they contain default values as well. Thus, this PR removes the meta boxes dirty checking making Gutenberg work like the classic editor when there are active meta boxes which means:

 - The "save draft" and "update" button are never disabled
 - If you try to leave the editor's page with changes in the meta boxes area, you're not prompted with the confirmation box.