### PR TITLE
Add the Post Title to the Document Outline

### DIFF
--- a/editor/components/document-outline/check.js
+++ b/editor/components/document-outline/check.js
@@ -12,7 +12,7 @@ import { getBlocks } from '../../store/selectors';
 function DocumentOutlineCheck( { blocks, children } ) {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
 
-	if ( headings.length <= 1 ) {
+	if ( headings.length < 1 ) {
 		return null;
 	}
 

--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import './style.scss';
 import DocumentOutlineItem from './item';
-import { getBlocks } from '../../store/selectors';
+import { getBlocks, getEditedPostTitle } from '../../store/selectors';
 import { selectBlock } from '../../store/actions';
 
 /**
@@ -51,7 +51,7 @@ const getHeadingLevel = heading => {
 
 const isEmptyHeading = heading => ! heading.attributes.content || heading.attributes.content.length === 0;
 
-export const DocumentOutline = ( { blocks = [], onSelect } ) => {
+export const DocumentOutline = ( { blocks = [], title, onSelect } ) => {
 	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
 
 	if ( headings.length < 1 ) {
@@ -63,6 +63,13 @@ export const DocumentOutline = ( { blocks = [], onSelect } ) => {
 	// Select the corresponding block in the main editor
 	// when clicking on a heading item from the list.
 	const onSelectHeading = ( uid ) => onSelect( uid );
+	const focusTitle = () => {
+		// Not great but it's the simplest way to focus the title right now.
+		const titleNode = document.querySelector( '.editor-post-title__input' );
+		if ( titleNode ) {
+			titleNode.focus();
+		}
+	};
 
 	const items = headings.map( ( heading, index ) => {
 		const headingLevel = getHeadingLevel( heading );
@@ -95,7 +102,18 @@ export const DocumentOutline = ( { blocks = [], onSelect } ) => {
 
 	return (
 		<div className="document-outline">
-			<ul>{ items }</ul>
+			<ul>
+				{ title && (
+					<DocumentOutlineItem
+						level={ 1 }
+						isValid
+						onClick={ focusTitle }
+					>
+						{ title }
+					</DocumentOutlineItem>
+				) }
+				{ items }
+			</ul>
 		</div>
 	);
 };
@@ -103,6 +121,7 @@ export const DocumentOutline = ( { blocks = [], onSelect } ) => {
 export default connect(
 	( state ) => {
 		return {
+			title: getEditedPostTitle( state ),
 			blocks: getBlocks( state ),
 		};
 	},

--- a/editor/edit-post/sidebar/document-outline-panel/index.js
+++ b/editor/edit-post/sidebar/document-outline-panel/index.js
@@ -24,7 +24,7 @@ const PANEL_NAME = 'table-of-contents';
 function DocumentOutlinePanel( { isOpened, onTogglePanel } ) {
 	return (
 		<DocumentOutlineCheck>
-			<PanelBody title={ __( 'Document Outline' ) } opened={ isOpened } onToggle={ onTogglePanel }>
+			<PanelBody title={ __( 'Table of Contents' ) } opened={ isOpened } onToggle={ onTogglePanel }>
 				<DocumentOutline />
 			</PanelBody>
 		</DocumentOutlineCheck>


### PR DESCRIPTION
closes #4177 and closes #4176

This PR adds the Post title as a `h1` heading to the document outline.

**Testing instructions**

- Create a post with a title and at least a heading
- Check that the document outline shows the post title
- Click the post title to focus the post title's input.