### PR TITLE
Components: Fix the timepicker, only update the values on blur

### DIFF
--- a/components/date-time/date.js
+++ b/components/date-time/date.js
@@ -4,13 +4,21 @@
 import ReactDatePicker from 'react-datepicker';
 import moment from 'moment';
 
-export function DatePicker( { currentDate, onChange, ...args } ) {
+/**
+ * Module Constants
+ */
+const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
+function DatePicker( { currentDate, onChange, ...args } ) {
 	const momentDate = currentDate ? moment( currentDate ) : moment();
+	const onChangeMoment = ( newDate ) => onChange( newDate.format( TIMEZONELESS_FORMAT ) );
 
 	return <ReactDatePicker
 		inline
 		selected={ momentDate }
-		onChange={ onChange }
+		onChange={ onChangeMoment }
 		{ ...args }
 	/>;
 }
+
+export default DatePicker;

--- a/components/date-time/index.js
+++ b/components/date-time/index.js
@@ -2,8 +2,8 @@
  * Internal dependencies
  */
 import './style.scss';
-import { DatePicker } from './date';
-import { TimePicker } from './time';
+import { default as DatePicker } from './date';
+import { default as TimePicker } from './time';
 
 export { DatePicker, TimePicker };
 

--- a/components/date-time/test/time.js
+++ b/components/date-time/test/time.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import TimePicker from '../time';
+
+describe( 'TimePicker', () => {
+	it( 'should not call onChange if we enter dummy text', () => {
+		const onChangeSpy = jest.fn();
+		const button = shallow( <TimePicker currentTime="1986-10-18T11:00:00" onChange={ onChangeSpy } is12Hour /> );
+		const input = button.find( '.components-time-picker__input' ).at( 0 );
+		input.simulate( 'change', { target: { value: 'My new value' } } );
+		input.simulate( 'blur' );
+		expect( onChangeSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should call onChange with the updated hours', () => {
+		const onChangeSpy = jest.fn();
+		const button = shallow( <TimePicker currentTime="1986-10-18T11:00:00" onChange={ onChangeSpy } is12Hour /> );
+		const input = button.find( '.components-time-picker__input' ).at( 0 );
+		input.simulate( 'change', { target: { value: '10' } } );
+		input.simulate( 'blur' );
+		expect( onChangeSpy ).toHaveBeenCalledWith( '1986-10-18T10:00:00' );
+	} );
+
+	it( 'should call onChange with the updated minutes', () => {
+		const onChangeSpy = jest.fn();
+		const button = shallow( <TimePicker currentTime="1986-10-18T11:00:00" onChange={ onChangeSpy } is12Hour /> );
+		const input = button.find( '.components-time-picker__input' ).at( 1 );
+		input.simulate( 'change', { target: { value: '10' } } );
+		input.simulate( 'blur' );
+		expect( onChangeSpy ).toHaveBeenCalledWith( '1986-10-18T11:10:00' );
+	} );
+
+	it( 'should switch to PM properly', () => {
+		const onChangeSpy = jest.fn();
+		const button = shallow( <TimePicker currentTime="1986-10-18T11:00:00" onChange={ onChangeSpy } is12Hour /> );
+		const pmButton = button.find( '.components-time-picker__pm-button' );
+		pmButton.simulate( 'click' );
+		expect( onChangeSpy ).toHaveBeenCalledWith( '1986-10-18T23:00:00' );
+	} );
+
+	it( 'should switch to AM properly', () => {
+		const onChangeSpy = jest.fn();
+		const button = shallow( <TimePicker currentTime="1986-10-18T23:00:00" onChange={ onChangeSpy } is12Hour /> );
+		const pmButton = button.find( '.components-time-picker__am-button' );
+		pmButton.simulate( 'click' );
+		expect( onChangeSpy ).toHaveBeenCalledWith( '1986-10-18T11:00:00' );
+	} );
+
+	it( 'should call onChange with the updated hours (24 hours time)', () => {
+		const onChangeSpy = jest.fn();
+		const button = shallow( <TimePicker currentTime="1986-10-18T11:00:00" onChange={ onChangeSpy } /> );
+		const input = button.find( '.components-time-picker__input' ).at( 0 );
+		input.simulate( 'change', { target: { value: '22' } } );
+		input.simulate( 'blur' );
+		expect( onChangeSpy ).toHaveBeenCalledWith( '1986-10-18T22:00:00' );
+	} );
+
+	it( 'should not call onChange with the updated hours if invalid 12 hour', () => {
+		const onChangeSpy = jest.fn();
+		const button = shallow( <TimePicker currentTime="1986-10-18T11:00:00" onChange={ onChangeSpy } is12Hour /> );
+		const input = button.find( '.components-time-picker__input' ).at( 0 );
+		input.simulate( 'change', { target: { value: '22' } } );
+		input.simulate( 'blur' );
+		expect( onChangeSpy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/components/date-time/time.js
+++ b/components/date-time/time.js
@@ -8,87 +8,158 @@ import moment from 'moment';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import Button from '../button';
 
-export function TimePicker( { currentTime, onChange, is12Hour } ) {
-	const selected = currentTime ? moment( currentTime ) : moment();
+/**
+ * Module Constants
+ */
+const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
-	const minutes = selected.format( 'mm' );
-	const am = selected.format( 'A' );
-	const hours = selected.format( is12Hour ? 'hh' : 'HH' );
+class TimePicker extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			hours: '',
+			minutes: '',
+			am: true,
+			date: null,
+		};
+		this.updateHours = this.updateHours.bind( this );
+		this.updateMinutes = this.updateMinutes.bind( this );
+		this.onChangeHours = this.onChangeHours.bind( this );
+		this.onChangeMinutes = this.onChangeMinutes.bind( this );
+	}
 
-	const updateHours = ( event ) => {
-		const value = parseInt( event.target.value, 10 );
+	componentDidMount() {
+		this.syncState( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		const { currentTime, is12Hour } = nextProps;
+		if (
+			currentTime !== this.props.currentTime ||
+			is12Hour !== this.props.is12Hour
+		) {
+			this.syncState( nextProps );
+		}
+	}
+
+	syncState( { currentTime, is12Hour } ) {
+		const selected = currentTime ? moment( currentTime ) : moment();
+		const minutes = selected.format( 'mm' );
+		const am = selected.format( 'A' );
+		const hours = selected.format( is12Hour ? 'hh' : 'HH' );
+		const date = currentTime ? moment( currentTime ) : moment();
+		this.setState( { minutes, hours, am, date } );
+	}
+
+	updateHours() {
+		const { is12Hour, onChange } = this.props;
+		const { am, hours, date } = this.state;
+		const value = parseInt( hours, 10 );
 		if (
 			! isInteger( value ) ||
 			( is12Hour && ( value < 1 || value > 12 ) ) ||
 			( ! is12Hour && ( value < 0 || value > 23 ) )
 		) {
+			this.syncState( this.props );
 			return;
 		}
 
 		const newDate = is12Hour ?
-			selected.clone().hours( am === 'AM' ? value % 12 : ( ( ( value % 12 ) + 12 ) % 24 ) ) :
-			selected.clone().hours( value );
-		onChange( newDate );
-	};
+			date.clone().hours( am === 'AM' ? value % 12 : ( ( ( value % 12 ) + 12 ) % 24 ) ) :
+			date.clone().hours( value );
+		this.setState( { date: newDate } );
+		const formattedDate = newDate.format( TIMEZONELESS_FORMAT );
+		onChange( formattedDate );
+	}
 
-	const updateMinutes = ( event ) => {
-		const value = parseInt( event.target.value, 10 );
+	updateMinutes() {
+		const { onChange } = this.props;
+		const { minutes, date } = this.state;
+		const value = parseInt( minutes, 10 );
 		if ( ! isInteger( value ) || value < 0 || value > 59 ) {
+			this.syncState( this.props );
 			return;
 		}
-		const newDate = selected.clone().minutes( value );
-		onChange( newDate );
-	};
+		const newDate = date.clone().minutes( value );
+		this.setState( { date: newDate } );
+		const formattedDate = newDate.format( TIMEZONELESS_FORMAT );
+		onChange( formattedDate );
+	}
 
-	const setAM = () => {
-		if ( am === 'AM' ) {
-			return;
-		}
-		const newDate = selected.clone().hours( parseInt( hours, 10 ) % 12 );
-		onChange( newDate );
-	};
+	updateAmPm( value ) {
+		return () => {
+			const { onChange } = this.props;
+			const { am, date, hours } = this.state;
+			if ( am === value ) {
+				return;
+			}
+			let newDate;
+			if ( value === 'PM' ) {
+				newDate = date.clone().hours( ( ( parseInt( hours, 10 ) % 12 ) + 12 ) % 24 );
+			} else {
+				newDate = date.clone().hours( parseInt( hours, 10 ) % 12 );
+			}
+			this.setState( { date: newDate } );
+			const formattedDate = newDate.format( TIMEZONELESS_FORMAT );
+			onChange( formattedDate );
+		};
+	}
 
-	const setPM = () => {
-		if ( am === 'PM' ) {
-			return;
-		}
-		const newDate = selected.clone().hours( ( ( parseInt( hours, 10 ) % 12 ) + 12 ) % 24 );
-		onChange( newDate );
-	};
+	onChangeHours( event ) {
+		this.setState( { hours: event.target.value } );
+	}
 
-	return (
-		<div className="components-time-picker">
-			<input
-				className="components-time-picker__input"
-				type="text"
-				value={ hours }
-				onChange={ updateHours }
-			/>
-			<span className="components-time-picker__separator">:</span>
-			<input
-				className="components-time-picker__input"
-				type="text"
-				value={ minutes }
-				onChange={ updateMinutes }
-			/>
-			{ is12Hour && <div>
-				<Button
-					className="button components-time-picker__am-button"
-					isToggled={ am === 'AM' }
-					onClick={ setAM }
-				>
-					{ __( 'AM' ) }
-				</Button>
-				<Button
-					className="button components-time-picker__pm-button"
-					isToggled={ am === 'PM' }
-					onClick={ setPM }
-				>
-					{ __( 'PM' ) }
-				</Button>
-			</div> }
-		</div>
-	);
+	onChangeMinutes( event ) {
+		this.setState( { minutes: event.target.value } );
+	}
+
+	render() {
+		const { is12Hour } = this.props;
+		const { minutes, hours, am } = this.state;
+
+		return (
+			<div className="components-time-picker">
+				<input
+					className="components-time-picker__input"
+					type="text"
+					value={ hours }
+					onChange={ this.onChangeHours }
+					onBlur={ this.updateHours }
+				/>
+				<span className="components-time-picker__separator">:</span>
+				<input
+					className="components-time-picker__input"
+					type="text"
+					value={ minutes }
+					onChange={ this.onChangeMinutes }
+					onBlur={ this.updateMinutes }
+				/>
+				{ is12Hour && <div>
+					<Button
+						className="button components-time-picker__am-button"
+						isToggled={ am === 'AM' }
+						onClick={ this.updateAmPm( 'AM' ) }
+					>
+						{ __( 'AM' ) }
+					</Button>
+					<Button
+						className="button components-time-picker__pm-button"
+						isToggled={ am === 'PM' }
+						onClick={ this.updateAmPm( 'PM' ) }
+					>
+						{ __( 'PM' ) }
+					</Button>
+				</div> }
+			</div>
+		);
+	}
 }
+
+export default TimePicker;

--- a/editor/components/post-schedule/index.js
+++ b/editor/components/post-schedule/index.js
@@ -16,10 +16,6 @@ import { getEditedPostAttribute } from '../../store/selectors';
 import { editPost } from '../../store/actions';
 
 export function PostSchedule( { date, onUpdateDate } ) {
-	const handleChange = ( newDate ) => {
-		onUpdateDate( newDate.format( 'YYYY-MM-DDTHH:mm:ss' ) );
-	};
-
 	// To know if the current timezone is a 12 hour time with look for "a" in the time format
 	// We also make sure this a is not escaped by a "/"
 	const is12HourTime = /a(?!\\)/i.test(
@@ -33,7 +29,7 @@ export function PostSchedule( { date, onUpdateDate } ) {
 		<DateTimePicker
 			key="date-time-picker"
 			currentDate={ date }
-			onChange={ handleChange }
+			onChange={ onUpdateDate }
 			locale={ settings.l10n.locale }
 			is12Hour={ is12HourTime }
 		/>


### PR DESCRIPTION
closes #3661

This PR changes the behavior of the TimPicker to be able to edit it freely and do the validation and updates on blur only.

This also makes the Component API more consistent, the format of the input and output value is made consistent. (Moment is only internal while the API expects timezone-less dates)

**Testing instructions**

 - Check that you can type anything in the time field and it resets on blur
 - Check that you can clear the input and type an hour
