### PR TITLE
Check if mac when displaying editor mode toggle shortcut

### DIFF
--- a/editor/edit-post/keyboard-shortcuts.js
+++ b/editor/edit-post/keyboard-shortcuts.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line
-const isMac = navigator.platform.toUpperCase().indexOf( 'MAC' ) >= 0;
+const isMac = window.navigator.platform.toUpperCase().indexOf( 'MAC' ) >= 0;
 const mod = isMac ? '⌘' : 'Ctrl';
 
 export default {

--- a/editor/edit-post/keyboard-shortcuts.js
+++ b/editor/edit-post/keyboard-shortcuts.js
@@ -1,6 +1,10 @@
+// eslint-disable-next-line
+const isMac = navigator.platform.toUpperCase().indexOf( 'MAC' ) >= 0;
+const mod = isMac ? '⌘' : 'Ctrl';
+
 export default {
 	toggleEditorMode: {
 		value: 'mod+shift+alt+m',
-		label: '⌘+Shift+Alt+M',
+		label: `${ mod }+Shift+Alt+M`,
 	},
 };


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Related to https://github.com/WordPress/gutenberg/pull/3755
Detecting Mac when displaying editor mode toggle shortcut.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on Mac and Linux.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature (non-breaking change which adds functionality)
