### PR TITLE
Blocks: Unify the UI of the audio and video blocks

### DIFF
--- a/blocks/library/audio/editor.scss
+++ b/blocks/library/audio/editor.scss
@@ -1,0 +1,20 @@
+.wp-block-audio .components-placeholder__input {
+	margin-top: 0.5em;
+}
+
+.wp-block-audio .button.button-large {
+	margin-top: 0.5em;
+}
+
+.wp-block-audio audio {
+	width: 100%;
+}
+
+.wp-block-audio .components-placeholder__fieldset {
+	display: block;
+	max-width: 400px;
+
+	form {
+		max-width: none;
+	}
+}

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -13,6 +13,7 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
+import './editor.scss';
 import { registerBlockType } from '../../api';
 import MediaUploadButton from '../../media-upload-button';
 import Editable from '../../editable';
@@ -43,6 +44,9 @@ registerBlockType( 'core/audio', {
 			source: 'children',
 			selector: 'figcaption',
 		},
+		id: {
+			type: 'number',
+		},
 	},
 
 	getEditWrapperProps( attributes ) {
@@ -64,7 +68,7 @@ registerBlockType( 'core/audio', {
 			};
 		}
 		render() {
-			const { align, caption } = this.props.attributes;
+			const { align, caption, id } = this.props.attributes;
 			const { setAttributes, focus, setFocus } = this.props;
 			const { editing, className, src } = this.state;
 			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
@@ -75,7 +79,7 @@ registerBlockType( 'core/audio', {
 				if ( media && media.url ) {
 					// sets the block's attribure and updates the edit component from the
 					// selected media, then switches off the editing UI
-					setAttributes( { src: media.url } );
+					setAttributes( { src: media.url, id: media.id } );
 					this.setState( { src: media.url, editing: false } );
 				}
 			};
@@ -98,7 +102,6 @@ registerBlockType( 'core/audio', {
 						<Button
 							className="components-icon-button components-toolbar__control"
 							aria-label={ __( 'Edit audio' ) }
-							type="audio"
 							onClick={ switchToEditing }
 						>
 							<Dashicon icon="edit" />
@@ -135,6 +138,7 @@ registerBlockType( 'core/audio', {
 							buttonProps={ { isLarge: true } }
 							onSelect={ onSelectAudio }
 							type="audio"
+							value={ id }
 						>
 							{ __( 'Insert from Media Library' ) }
 						</MediaUploadButton>

--- a/blocks/library/audio/style.scss
+++ b/blocks/library/audio/style.scss
@@ -1,15 +1,3 @@
-.wp-block-audio .components-placeholder__input {
-	margin-top: 0.5em;
-}
-
-.wp-block-audio .button.button-large {
-	margin-top: 0.5em;
-}
-
-.wp-block-audio audio {
-	width: 100%;
-}
-
 .wp-block-audio figcaption {
 	margin-top: 0.5em;
 	color: $dark-gray-300;

--- a/blocks/library/video/editor.scss
+++ b/blocks/library/video/editor.scss
@@ -1,0 +1,20 @@
+.wp-block-video .components-placeholder__input {
+	margin-top: 0.5em;
+}
+
+.wp-block-video .button.button-large {
+	margin-top: 0.5em;
+}
+
+.wp-block-video audio {
+	width: 100%;
+}
+
+.wp-block-video .components-placeholder__fieldset {
+	display: block;
+	max-width: 400px;
+
+	form {
+		max-width: none;
+	}
+}


### PR DESCRIPTION
closes #3386 

This PR updates the video block to matches the audio block UI.  I asked myself if I should factorize those blocks using a factory function, but decided not (to allow custom UI if needed in the future).

**Testing instructions**

 - Check that the audio and video blocks look and behave similarly