### PR TITLE
Featured image: remove unused fields from media modal

### DIFF
--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -59,7 +59,7 @@ const slimImageObject = ( img ) => {
 };
 
 class MediaUploadButton extends Component {
-	constructor( { multiple = false, type, gallery = false, title = __( 'Select or Upload Media' ) } ) {
+	constructor( { multiple = false, type, gallery = false, title = __( 'Select or Upload Media' ), modalClass } ) {
 		super( ...arguments );
 		this.openModal = this.openModal.bind( this );
 		this.onSelect = this.onSelect.bind( this );
@@ -87,6 +87,10 @@ class MediaUploadButton extends Component {
 			wp.media.frame = this.frame;
 		} else {
 			this.frame = wp.media( frameConfig );
+		}
+
+		if ( modalClass ) {
+			this.frame.$el.addClass( modalClass );
 		}
 
 		// When an image is selected in the media frame...

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -36,6 +36,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 						buttonProps={ { className: 'button-link editor-post-featured-image__preview' } }
 						onSelect={ onUpdateImage }
 						type="image"
+						modalClass="editor-post-featured-image__media-modal"
 					>
 						{ media && !! media.data &&
 							<ResponsiveWrapper
@@ -59,6 +60,7 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 						buttonProps={ { className: 'editor-post-featured-image__toggle button-link' } }
 						onSelect={ onUpdateImage }
 						type="image"
+						modalClass="editor-post-featured-image__media-modal"
 					>
 						{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
 					</MediaUploadButton>

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -30,3 +30,10 @@
 	font-style: italic;
 	margin: 10px 0;
 }
+
+// Should be replaced with a config in media modal.
+.editor-post-featured-image__media-modal {
+	.setting[data-setting="caption"], .setting[data-setting="description"] {
+		display: none;
+	}
+}


### PR DESCRIPTION
## Description
This PR aims to fix https://github.com/WordPress/gutenberg/issues/2330 it removes the option to change the caption and description when setting the featured image.

## How Has This Been Tested?
Set a featured image and verify fields caption and description do not appear on media modal.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/11271197/34414738-d24de308-ebe2-11e7-93ce-f52a7ef17018.png)

## Types of changes
Added the ability to set an additional class to media modal in MediaUploadButton component.
Added CSS to hide caption and description on featured image modal.
