### PR TITLE
Dev mode: hint if no files are built

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -80,7 +80,7 @@ function gutenberg_menu() {
 add_action( 'admin_menu', 'gutenberg_menu' );
 
 /**
- * Display a notice and deactivate the Gutenberg plugin.
+ * Display a version notice and deactivate the Gutenberg plugin.
  *
  * @since 0.1.0
  */
@@ -93,11 +93,27 @@ function gutenberg_wordpress_version_notice() {
 }
 
 /**
+ * Display a build notice.
+ *
+ * @since 0.1.0
+ */
+function gutenberg_build_files_notice() {
+	echo '<div class="error"><p>';
+	echo __( 'Gutenberg development mode requires files to be built. Run <code>npm install</code> to install dependencies, and <code>npm run dev</code> to build and watch the files. Read the <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md">contributing</a> file for more information.', 'gutenberg' );
+	echo '</p></div>';
+}
+
+/**
  * Verify that we can initialize the Gutenberg editor , then load it.
  *
  * @since 1.5.0
  */
 function gutenberg_pre_init() {
+	if ( GUTENBERG_DEVELOPMENT_MODE && ! file_exists( dirname( __FILE__ ) . '/blocks/build' ) ) {
+		add_action( 'admin_notices', 'gutenberg_build_files_notice' );
+		return;
+	}
+
 	// Get unmodified $wp_version.
 	include( ABSPATH . WPINC . '/version.php' );
 


### PR DESCRIPTION
## Description
During WCUS contributor day someone got stuck after installing Gutenberg from GitHub, with a bunch of `filemtime` waring on non existing files. Would it be nice to hint next steps?

Code just checks one build file... maybe there are more elegant solutions.

## How Has This Been Tested?

Delete all build files. Reload the page.
