### PR TITLE
Latest Posts: Use `columns-x` class only for grid layout

### DIFF
--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -128,8 +128,9 @@ class LatestPostsBlock extends Component {
 				</BlockControls>
 			),
 			<ul
-				className={ classnames( this.props.className, 'columns-' + columns, {
+				className={ classnames( this.props.className, {
 					'is-grid': layout === 'grid',
+					[ `columns-${ columns }` ]: layout === 'grid',
 				} ) }
 				key="latest-posts"
 			>

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -52,7 +52,7 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 		$class .= ' is-grid';
 	}
 
-	if ( isset( $attributes['columns'] ) ) {
+	if ( isset( $attributes['columns'] ) && 'grid' === $attributes['layout'] ) {
 		$class .= ' columns-' . $attributes['columns'];
 	}
 


### PR DESCRIPTION
## Description
This PR adds the `columns-x` class only for the grid layout in the Latest Posts block.
Fixes #4015
