### PR TITLE
Docs: Dynamic blocks - Remove wp.element from ESNext/JSX example

### DIFF
--- a/docs/blocks-dynamic.md
+++ b/docs/blocks-dynamic.md
@@ -49,7 +49,6 @@ registerBlockType( 'my-plugin/latest-post', {
 ```js
 // myblock.js
 
-const { el } = wp.element;
 const { registerBlockType } = wp.blocks;
 const { withAPIData } = wp.components;
 


### PR DESCRIPTION
## Description
`wp.element` is not required in ESNext/JSX example.

