### PR TITLE
Refactor InserterMenu & VisualEditorInserter; allow recent/frequent reusable blocks to be inserted

### DIFF
--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -10,8 +10,8 @@ import { Component } from '@wordpress/element';
 import { NavigableMenu } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/blocks';
 
-function deriveActiveBlocks( blocks ) {
-	return blocks.filter( ( block ) => ! block.disabled );
+function deriveActiveItems( items ) {
+	return items.filter( ( item ) => ! item.isDisabled );
 }
 
 export default class InserterGroup extends Component {
@@ -20,61 +20,56 @@ export default class InserterGroup extends Component {
 
 		this.onNavigate = this.onNavigate.bind( this );
 
-		this.activeBlocks = deriveActiveBlocks( this.props.blockTypes );
+		this.activeItems = deriveActiveItems( this.props.items );
 		this.state = {
-			current: this.activeBlocks.length > 0 ? this.activeBlocks[ 0 ].name : null,
+			current: this.activeItems.length > 0 ? this.activeItems[ 0 ] : null,
 		};
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( this.props.blockTypes, nextProps.blockTypes ) ) {
-			this.activeBlocks = deriveActiveBlocks( nextProps.blockTypes );
+		if ( ! isEqual( this.props.items, nextProps.items ) ) {
+			this.activeItems = deriveActiveItems( nextProps.items );
 			// Try and preserve any still valid selected state.
-			const current = find( this.activeBlocks, { name: this.state.current } );
+			const current = find( this.activeItems, ( item ) => isEqual( item, this.state.current ) );
 			if ( ! current ) {
 				this.setState( {
-					current: this.activeBlocks.length > 0 ? this.activeBlocks[ 0 ].name : null,
+					current: this.activeItems.length > 0 ? this.activeItems[ 0 ] : null,
 				} );
 			}
 		}
 	}
 
-	renderItem( block ) {
+	renderItem( item, index ) {
 		const { current } = this.state;
-		const { selectBlock, bindReferenceNode } = this.props;
-		const { disabled } = block;
+		const { selectItem } = this.props;
 
 		return (
 			<button
 				role="menuitem"
-				key={ block.name === 'core/block' && block.initialAttributes ?
-					block.name + block.initialAttributes.ref :
-					block.name
-				}
+				key={ index }
 				className="editor-inserter__block"
-				onClick={ selectBlock( block ) }
-				ref={ bindReferenceNode( block.name ) }
-				tabIndex={ current === block.name || disabled ? null : '-1' }
-				disabled={ disabled }
+				onClick={ selectItem( item ) }
+				tabIndex={ isEqual( current, item ) || item.isDisabled ? null : '-1' }
+				disabled={ item.isDisabled }
 			>
-				<BlockIcon icon={ block.icon } />
-				{ block.title }
+				<BlockIcon icon={ item.icon } />
+				{ item.title }
 			</button>
 		);
 	}
 
 	onNavigate( index ) {
-		const { activeBlocks } = this;
-		const dest = activeBlocks[ index ];
+		const { activeItems } = this;
+		const dest = activeItems[ index ];
 		if ( dest ) {
 			this.setState( {
-				current: dest.name,
+				current: dest,
 			} );
 		}
 	}
 
 	render() {
-		const { labelledBy, blockTypes } = this.props;
+		const { labelledBy, items } = this.props;
 
 		return (
 			<NavigableMenu
@@ -83,7 +78,7 @@ export default class InserterGroup extends Component {
 				aria-labelledby={ labelledBy }
 				cycle={ false }
 				onNavigate={ this.onNavigate }>
-				{ blockTypes.map( this.renderItem, this ) }
+				{ items.map( this.renderItem, this ) }
 			</NavigableMenu>
 		);
 	}

--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -10,11 +10,21 @@ import { Component } from '@wordpress/element';
 import { NavigableMenu } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/blocks';
 
+/**
+ * Determines the inserter items that are able to be selected. These are the
+ * inserter items which are not disabled.
+ * 
+ * @param {Editor.InserterItem[]}   items Inserter items to filter.
+ * @returns {Editor.InserterItem[]}       Active inserter items.
+ */
 function deriveActiveItems( items ) {
 	return items.filter( ( item ) => ! item.isDisabled );
 }
 
 export default class InserterGroup extends Component {
+	/**
+	 * @inheritdoc
+	 */
 	constructor() {
 		super( ...arguments );
 
@@ -26,6 +36,9 @@ export default class InserterGroup extends Component {
 		};
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	componentWillReceiveProps( nextProps ) {
 		if ( ! isEqual( this.props.items, nextProps.items ) ) {
 			this.activeItems = deriveActiveItems( nextProps.items );
@@ -39,6 +52,13 @@ export default class InserterGroup extends Component {
 		}
 	}
 
+	/**
+	 * Renders a single inserter item as it ought to appear in the menu.
+	 * 
+	 * @param {Editor.InserterItem} item  Inserter item.
+	 * @param {number}              index Index of the item.
+	 * @returns {JSX.Element}             Rendered menu button.
+	 */
 	renderItem( item, index ) {
 		const { current } = this.state;
 		const { selectItem } = this.props;
@@ -58,6 +78,11 @@ export default class InserterGroup extends Component {
 		);
 	}
 
+	/**
+	 * Callback invoked when the user navigates the menu using their keyboard.
+	 * 
+	 * @param {number} index Index of the item selected by the user.
+	 */
 	onNavigate( index ) {
 		const { activeItems } = this;
 		const dest = activeItems[ index ];

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -82,17 +82,12 @@ class Inserter extends Component {
 					</IconButton>
 				) }
 				renderContent={ ( { onClose } ) => {
-					const onInsert = ( name, initialAttributes ) => {
-						onInsertBlock(
-							name,
-							initialAttributes,
-							insertionPoint
-						);
-
+					const onSelect = ( item ) => {
+						onInsertBlock( item, insertionPoint );
 						onClose();
 					};
 
-					return <InserterMenu onSelect={ onInsert } />;
+					return <InserterMenu onSelect={ onSelect } />;
 				} }
 			/>
 		);
@@ -108,9 +103,9 @@ export default compose( [
 			};
 		},
 		( dispatch ) => ( {
-			onInsertBlock( name, initialAttributes, position ) {
+			onInsertBlock( item, position ) {
 				dispatch( insertBlock(
-					createBlock( name, initialAttributes ),
+					createBlock( item.name, item.initialAttributes ),
 					position
 				) );
 			},

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -98,6 +98,12 @@ export class InserterMenu extends Component {
 		} );
 	}
 
+	/**
+	 * Constructs a callback that is invoked when an inserter item is selected.
+	 * 
+	 * @param {Editor.InserterItem} item Selected inserter item.
+	 * @returns {Function}               Callback to invoke when the item is selected.
+	 */
 	selectItem( item ) {
 		return () => {
 			this.props.onSelect( item );
@@ -107,10 +113,22 @@ export class InserterMenu extends Component {
 		};
 	}
 
+	/**
+	 * Determines which items should be visible based on the currently searched query.
+	 * 
+	 * @param {Editor.InserterItem[]}   items All inserter items.
+	 * @returns {Editor.InserterItem[]}       Visible inserter items.
+	 */
 	searchItems( items ) {
 		return searchItems( items, this.state.filterValue );
 	}
 
+	/**
+	 * Retrieves the inserter items that should appear in the given tab.
+	 * 
+	 * @param {string}                  tab Slug of the current tab, e.g. 'recent'.
+	 * @returns {Editor.InserterItem[]}     Inserter items belonging to this tab.
+	 */
 	getItemsForTab( tab ) {
 		const { items, recentItems } = this.props;
 
@@ -140,6 +158,12 @@ export class InserterMenu extends Component {
 		return filter( items, predicate );
 	}
 
+	/**
+	 * Sorts the given items into to the order that they should be displayed in the inserter.
+	 * 
+	 * @param {Editor.InserterItem[]}   items Items to sort.
+	 * @returns {Editor.InserterItem[]}       Sorted items.
+	 */
 	sortItems( items ) {
 		if ( 'recent' === this.state.tab && ! this.state.filterValue ) {
 			return items;
@@ -152,10 +176,22 @@ export class InserterMenu extends Component {
 		return sortBy( items, getCategoryIndex );
 	}
 
+	/**
+	 * Groups the given items by their category slug.
+	 * 
+	 * @param {Editor.InserterItem[]}                    items Items to group.
+	 * @returns {Object.<string, Editor.InserterItem[]>}       Grouped items.
+	 */
 	groupByCategory( items ) {
 		return groupBy( items, ( item ) => item.category );
 	}
 
+	/**
+	 * Determines which items should be visible based on the current state of the inserter.
+	 * 
+	 * @param {Editor.InserterItem[]}   items All inserter items.
+	 * @returns {Editor.InserterItem[]}       Visible inserter items.
+	 */
 	getVisibleItemsByCategory( items ) {
 		return flow(
 			this.searchItems,
@@ -164,6 +200,13 @@ export class InserterMenu extends Component {
 		)( items );
 	}
 
+	/**
+	 * Renders a list of items within a category.
+	 * 
+	 * @param {Editor.InserterItem[]} items         Inserter items to render.
+	 * @param {string}                separatorSlug Category slug that these items belong to.
+	 * @returns {JSX.Element}                       Rendered items.
+	 */
 	renderItems( items, separatorSlug ) {
 		const { instanceId } = this.props;
 		const labelledBy = separatorSlug === undefined ? null : `editor-inserter__separator-${ separatorSlug }-${ instanceId }`;
@@ -176,6 +219,13 @@ export class InserterMenu extends Component {
 		);
 	}
 
+	/**
+	 * Renders a group of menu items which share the same category.
+	 * 
+	 * @param {Object}                category Category slug that these items belong to.
+	 * @param {Editor.InserterItem[]} items    Inserter items belonging to this category.
+	 * @returns {JSX.Element}                  Rendered category.
+	 */
 	renderCategory( category, items ) {
 		const { instanceId } = this.props;
 		return items && (
@@ -192,6 +242,13 @@ export class InserterMenu extends Component {
 		);
 	}
 
+	/**
+	 * Renders a list of menu items grouped into their categories.
+	 * 
+	 * @param {Object.<string, Editor.InserterItem[]>} visibleItemsByCategory The items to render, grouped by their
+	 *                                                                        category slug.
+	 * @returns {JSX.Element}                                                 Rendered categories.
+	 */
 	renderCategories( visibleItemsByCategory ) {
 		if ( isEmpty( visibleItemsByCategory ) ) {
 			return (
@@ -206,6 +263,11 @@ export class InserterMenu extends Component {
 		);
 	}
 
+	/**
+	 * Switch the currently selected inserter tab.
+	 * 
+	 * @param {string} tab Tab identifier.
+	 */
 	switchTab( tab ) {
 		// store the scrollTop of the tab switched from
 		this.tabScrollTop[ this.state.tab ] = this.tabContainer.scrollTop;
@@ -262,6 +324,9 @@ export class InserterMenu extends Component {
 		// Implicit `undefined` return: let the event propagate
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	render() {
 		const { instanceId, items } = this.props;
 		const isSearching = this.state.filterValue;

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -3,7 +3,6 @@
  */
 import {
 	filter,
-	find,
 	findIndex,
 	flow,
 	groupBy,
@@ -27,7 +26,7 @@ import {
 	withSpokenMessages,
 	withContext,
 } from '@wordpress/components';
-import { getCategories, getBlockTypes } from '@wordpress/blocks';
+import { getCategories } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -35,16 +34,16 @@ import { keycodes } from '@wordpress/utils';
  */
 import './style.scss';
 
-import { getBlocks, getRecentlyUsedBlocks, getReusableBlocks } from '../../store/selectors';
+import { getInserterItems, getRecentInserterItems } from '../../store/selectors';
 import { fetchReusableBlocks } from '../../store/actions';
 import { default as InserterGroup } from './group';
 
-export const searchBlocks = ( blocks, searchTerm ) => {
+export const searchItems = ( items, searchTerm ) => {
 	const normalizedSearchTerm = searchTerm.toLowerCase().trim();
 	const matchSearch = ( string ) => string.toLowerCase().indexOf( normalizedSearchTerm ) !== -1;
 
-	return blocks.filter( ( block ) =>
-		matchSearch( block.title ) || some( block.keywords, matchSearch )
+	return items.filter( ( item ) =>
+		matchSearch( item.title ) || some( item.keywords, matchSearch )
 	);
 };
 
@@ -62,11 +61,10 @@ export class InserterMenu extends Component {
 			tab: 'recent',
 		};
 		this.filter = this.filter.bind( this );
-		this.searchBlocks = this.searchBlocks.bind( this );
-		this.getBlocksForTab = this.getBlocksForTab.bind( this );
-		this.sortBlocks = this.sortBlocks.bind( this );
-		this.bindReferenceNode = this.bindReferenceNode.bind( this );
-		this.selectBlock = this.selectBlock.bind( this );
+		this.searchItems = this.searchItems.bind( this );
+		this.getItemsForTab = this.getItemsForTab.bind( this );
+		this.sortItems = this.sortItems.bind( this );
+		this.selectItem = this.selectItem.bind( this );
 
 		this.tabScrollTop = { recent: 0, blocks: 0, embeds: 0 };
 		this.switchTab = this.switchTab.bind( this );
@@ -77,8 +75,8 @@ export class InserterMenu extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const searchResults = this.searchBlocks( this.getBlockTypes() );
-		// Announce the blocks search results to screen readers.
+		const searchResults = this.searchItems( this.props.items );
+		// Announce the item search results to screen readers.
 		if ( this.state.filterValue && !! searchResults.length ) {
 			this.props.debouncedSpeak( sprintf( _n(
 				'%d result found',
@@ -94,152 +92,93 @@ export class InserterMenu extends Component {
 		}
 	}
 
-	isDisabledBlock( blockType ) {
-		return blockType.useOnce && find( this.props.blocks, ( { name } ) => blockType.name === name );
-	}
-
-	bindReferenceNode( nodeName ) {
-		return ( node ) => this.nodes[ nodeName ] = node;
-	}
-
 	filter( event ) {
 		this.setState( {
 			filterValue: event.target.value,
 		} );
 	}
 
-	selectBlock( block ) {
+	selectItem( item ) {
 		return () => {
-			this.props.onSelect( block.name, block.initialAttributes );
+			this.props.onSelect( item );
 			this.setState( {
 				filterValue: '',
 			} );
 		};
 	}
 
-	getStaticBlockTypes() {
-		const { blockTypes } = this.props;
-
-		// If all block types disabled, return empty set
-		if ( ! blockTypes ) {
-			return [];
-		}
-
-		// Block types that are marked as private should not appear in the inserter
-		return getBlockTypes().filter( ( block ) => {
-			if ( block.isPrivate ) {
-				return false;
-			}
-
-			// Block types defined as either `true` or array:
-			//  - True: Allow
-			//  - Array: Check block name within whitelist
-			return (
-				! Array.isArray( blockTypes ) ||
-				includes( blockTypes, block.name )
-			);
-		} );
+	searchItems( items ) {
+		return searchItems( items, this.state.filterValue );
 	}
 
-	getReusableBlockTypes() {
-		const { reusableBlocks } = this.props;
+	getItemsForTab( tab ) {
+		const { items, recentItems } = this.props;
 
-		// Display reusable blocks that we've fetched in the inserter
-		return reusableBlocks.map( ( reusableBlock ) => ( {
-			name: 'core/block',
-			initialAttributes: {
-				ref: reusableBlock.id,
-			},
-			title: reusableBlock.title,
-			icon: 'layout',
-			category: 'reusable-blocks',
-		} ) );
-	}
-
-	getBlockTypes() {
-		return [
-			...this.getStaticBlockTypes(),
-			...this.getReusableBlockTypes(),
-		];
-	}
-
-	searchBlocks( blockTypes ) {
-		return searchBlocks( blockTypes, this.state.filterValue );
-	}
-
-	getBlocksForTab( tab ) {
-		const blockTypes = this.getBlockTypes();
-		// if we're searching, use everything, otherwise just get the blocks visible in this tab
+		// If we're searching, use everything, otherwise just get the items visible in this tab
 		if ( this.state.filterValue ) {
-			return blockTypes;
+			return items;
 		}
 
 		let predicate;
 		switch ( tab ) {
 			case 'recent':
-				return filter( this.props.recentlyUsedBlocks,
-					( { name } ) => find( blockTypes, { name } ) );
+				return recentItems;
 
 			case 'blocks':
-				predicate = ( block ) => block.category !== 'embed' && block.category !== 'reusable-blocks';
+				predicate = ( item ) => item.category !== 'embed' && item.category !== 'reusable-blocks';
 				break;
 
 			case 'embeds':
-				predicate = ( block ) => block.category === 'embed';
+				predicate = ( item ) => item.category === 'embed';
 				break;
 
 			case 'saved':
-				predicate = ( block ) => block.category === 'reusable-blocks';
+				predicate = ( item ) => item.category === 'reusable-blocks';
 				break;
 		}
 
-		return filter( blockTypes, predicate );
+		return filter( items, predicate );
 	}
 
-	sortBlocks( blockTypes ) {
+	sortItems( items ) {
 		if ( 'recent' === this.state.tab && ! this.state.filterValue ) {
-			return blockTypes;
+			return items;
 		}
 
 		const getCategoryIndex = ( item ) => {
 			return findIndex( getCategories(), ( category ) => category.slug === item.category );
 		};
 
-		return sortBy( blockTypes, getCategoryIndex );
+		return sortBy( items, getCategoryIndex );
 	}
 
-	groupByCategory( blockTypes ) {
-		return groupBy( blockTypes, ( blockType ) => blockType.category );
+	groupByCategory( items ) {
+		return groupBy( items, ( item ) => item.category );
 	}
 
-	getVisibleBlocksByCategory( blockTypes ) {
+	getVisibleItemsByCategory( items ) {
 		return flow(
-			this.searchBlocks,
-			this.sortBlocks,
+			this.searchItems,
+			this.sortItems,
 			this.groupByCategory
-		)( blockTypes );
+		)( items );
 	}
 
-	renderBlocks( blockTypes, separatorSlug ) {
+	renderItems( items, separatorSlug ) {
 		const { instanceId } = this.props;
 		const labelledBy = separatorSlug === undefined ? null : `editor-inserter__separator-${ separatorSlug }-${ instanceId }`;
-		const blockTypesInfo = blockTypes.map( ( blockType ) => (
-			{ ...blockType, disabled: this.isDisabledBlock( blockType ) }
-		) );
-
 		return (
 			<InserterGroup
-				blockTypes={ blockTypesInfo }
+				items={ items }
 				labelledBy={ labelledBy }
-				bindReferenceNode={ this.bindReferenceNode }
-				selectBlock={ this.selectBlock }
+				selectItem={ this.selectItem }
 			/>
 		);
 	}
 
-	renderCategory( category, blockTypes ) {
+	renderCategory( category, items ) {
 		const { instanceId } = this.props;
-		return blockTypes && (
+		return items && (
 			<div key={ category.slug }>
 				<div
 					className="editor-inserter__separator"
@@ -248,13 +187,13 @@ export class InserterMenu extends Component {
 				>
 					{ category.title }
 				</div>
-				{ this.renderBlocks( blockTypes, category.slug ) }
+				{ this.renderItems( items, category.slug ) }
 			</div>
 		);
 	}
 
-	renderCategories( visibleBlocksByCategory ) {
-		if ( isEmpty( visibleBlocksByCategory ) ) {
+	renderCategories( visibleItemsByCategory ) {
+		if ( isEmpty( visibleItemsByCategory ) ) {
 			return (
 				<span className="editor-inserter__no-results">
 					{ __( 'No blocks found' ) }
@@ -263,7 +202,7 @@ export class InserterMenu extends Component {
 		}
 
 		return getCategories().map(
-			( category ) => this.renderCategory( category, visibleBlocksByCategory[ category.slug ] )
+			( category ) => this.renderCategory( category, visibleItemsByCategory[ category.slug ] )
 		);
 	}
 
@@ -274,15 +213,15 @@ export class InserterMenu extends Component {
 	}
 
 	renderTabView( tab ) {
-		const blocksForTab = this.getBlocksForTab( tab );
+		const itemsForTab = this.getItemsForTab( tab );
 
 		// If the Recent tab is selected, don't render category headers
 		if ( 'recent' === tab ) {
-			return this.renderBlocks( blocksForTab );
+			return this.renderItems( itemsForTab );
 		}
 
 		// If the Saved tab is selected and we have no results, display a friendly message
-		if ( 'saved' === tab && blocksForTab.length === 0 ) {
+		if ( 'saved' === tab && itemsForTab.length === 0 ) {
 			return (
 				<p className="editor-inserter__no-tab-content-message">
 					{ __( 'No saved blocks.' ) }
@@ -290,16 +229,16 @@ export class InserterMenu extends Component {
 			);
 		}
 
-		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( blocksForTab );
+		const visibleItemsByCategory = this.getVisibleItemsByCategory( itemsForTab );
 
-		// If our results have only blocks from one category, don't render category headers
-		const categories = Object.keys( visibleBlocksByCategory );
+		// If our results have only items from one category, don't render category headers
+		const categories = Object.keys( visibleItemsByCategory );
 		if ( categories.length === 1 ) {
 			const [ soleCategory ] = categories;
-			return this.renderBlocks( visibleBlocksByCategory[ soleCategory ] );
+			return this.renderItems( visibleItemsByCategory[ soleCategory ] );
 		}
 
-		return this.renderCategories( visibleBlocksByCategory );
+		return this.renderCategories( visibleItemsByCategory );
 	}
 
 	// Passed to TabbableContainer, extending its event-handling logic
@@ -324,7 +263,7 @@ export class InserterMenu extends Component {
 	}
 
 	render() {
-		const { instanceId } = this.props;
+		const { instanceId, items } = this.props;
 		const isSearching = this.state.filterValue;
 
 		return (
@@ -340,7 +279,6 @@ export class InserterMenu extends Component {
 					placeholder={ __( 'Search for a block' ) }
 					className="editor-inserter__search"
 					onChange={ this.filter }
-					ref={ this.bindReferenceNode( 'search' ) }
 				/>
 				{ ! isSearching &&
 					<TabPanel className="editor-inserter__tabs" activeClass="is-active"
@@ -377,7 +315,7 @@ export class InserterMenu extends Component {
 				}
 				{ isSearching &&
 					<div role="menu" className="editor-inserter__search-results">
-						{ this.renderCategories( this.getVisibleBlocksByCategory( this.getBlockTypes() ) ) }
+						{ this.renderCategories( this.getVisibleItemsByCategory( items ) ) }
 					</div>
 				}
 			</TabbableContainer>
@@ -385,20 +323,23 @@ export class InserterMenu extends Component {
 	}
 }
 
-const connectComponent = connect(
-	( state ) => {
-		return {
-			recentlyUsedBlocks: getRecentlyUsedBlocks( state ),
-			blocks: getBlocks( state ),
-			reusableBlocks: getReusableBlocks( state ),
-		};
-	},
-	{ fetchReusableBlocks }
-);
-
 export default compose(
-	connectComponent,
-	withContext( 'editor' )( ( settings ) => pick( settings, 'blockTypes' ) ),
+	withContext( 'editor' )( ( settings ) => {
+		const { blockTypes } = settings;
+
+		return {
+			enabledBlockTypes: blockTypes,
+		};
+	} ),
+	connect(
+		( state, ownProps ) => {
+			return {
+				items: getInserterItems( state, ownProps.enabledBlockTypes ),
+				recentItems: getRecentInserterItems( state, ownProps.enabledBlockTypes ),
+			};
+		},
+		{ fetchReusableBlocks }
+	),
 	withSpokenMessages,
 	withInstanceId
 )( InserterMenu );

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -5,98 +5,89 @@ import { mount } from 'enzyme';
 import { noop } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import { registerBlockType, unregisterBlockType, getBlockTypes } from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
-import { InserterMenu, searchBlocks } from '../menu';
+import { InserterMenu, searchItems } from '../menu';
 
-const textBlock = {
+const textItem = {
 	name: 'core/text-block',
+	initialAttributes: {},
 	title: 'Text',
-	save: noop,
-	edit: noop,
 	category: 'common',
+	isDisabled: false,
 };
 
-const advancedTextBlock = {
+const advancedTextItem = {
 	name: 'core/advanced-text-block',
+	initialAttributes: {},
 	title: 'Advanced Text',
-	save: noop,
-	edit: noop,
 	category: 'common',
+	isDisabled: false,
 };
 
-const someOtherBlock = {
+const someOtherItem = {
 	name: 'core/some-other-block',
+	initialAttributes: {},
 	title: 'Some Other Block',
-	save: noop,
-	edit: noop,
 	category: 'common',
+	isDisabled: false,
 };
 
-const moreBlock = {
+const moreItem = {
 	name: 'core/more-block',
+	initialAttributes: {},
 	title: 'More',
-	save: noop,
-	edit: noop,
 	category: 'layout',
-	useOnce: 'true',
+	isDisabled: true,
 };
 
-const youtubeBlock = {
+const youtubeItem = {
 	name: 'core-embed/youtube',
+	initialAttributes: {},
 	title: 'YouTube',
-	save: noop,
-	edit: noop,
 	category: 'embed',
 	keywords: [ 'google' ],
+	isDisabled: false,
 };
 
-const textEmbedBlock = {
+const textEmbedItem = {
 	name: 'core-embed/a-text-embed',
+	initialAttributes: {},
 	title: 'A Text Embed',
-	save: noop,
-	edit: noop,
 	category: 'embed',
+	isDisabled: false,
 };
+
+const reusableItem = {
+	name: 'core/block',
+	initialAttributes: { ref: 123 },
+	title: 'My reusable block',
+	category: 'reusable-blocks',
+	isDisabled: false,
+};
+
+const items = [
+	textItem,
+	advancedTextItem,
+	someOtherItem,
+	moreItem,
+	youtubeItem,
+	textEmbedItem,
+	reusableItem,
+];
 
 describe( 'InserterMenu', () => {
 	// NOTE: Due to https://github.com/airbnb/enzyme/issues/1174, some of the selectors passed through to
 	// wrapper.find have had to be strengthened (and the filterWhere strengthened also), otherwise two
 	// results would be returned even though only one was in the DOM.
 
-	const unregisterAllBlocks = () => {
-		getBlockTypes().forEach( ( block ) => {
-			unregisterBlockType( block.name );
-		} );
-	};
-
-	afterEach( () => {
-		unregisterAllBlocks();
-	} );
-
-	beforeEach( () => {
-		unregisterAllBlocks();
-		registerBlockType( textBlock.name, textBlock );
-		registerBlockType( advancedTextBlock.name, advancedTextBlock );
-		registerBlockType( someOtherBlock.name, someOtherBlock );
-		registerBlockType( moreBlock.name, moreBlock );
-		registerBlockType( youtubeBlock.name, youtubeBlock );
-		registerBlockType( textEmbedBlock.name, textEmbedBlock );
-	} );
-
 	it( 'should show the recent tab by default', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ [] }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
 				blockTypes
@@ -110,17 +101,15 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 0 );
 	} );
 
-	it( 'should show no blocks if all block types disabled', () => {
+	it( 'should show nothing if there are no items', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [ advancedTextBlock ] }
+				items={ [] }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes={ false }
 			/>
 		);
 
@@ -128,64 +117,34 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 0 );
 	} );
 
-	it( 'should show filtered block types', () => {
+	it( 'should show the recently used items in the recent tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [ textBlock, advancedTextBlock ] }
+				items={ items }
+				recentItems={ [ advancedTextItem, textItem, someOtherItem ] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes={ [ textBlock.name ] }
-			/>
-		);
-
-		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
-		expect( visibleBlocks ).toHaveLength( 1 );
-		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
-	} );
-
-	it( 'should show the recently used blocks in the recent tab', () => {
-		const wrapper = mount(
-			<InserterMenu
-				position={ 'top center' }
-				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [
-					// Actually recently used by user, thus present at the top.
-					advancedTextBlock,
-					// Blocks of category 'common' injected on SETUP_EDITOR.
-					// These have to be listed here in the order in which they
-					// are registered.
-					textBlock,
-					someOtherBlock,
-				] }
-				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
 		expect( visibleBlocks ).toHaveLength( 3 );
-		expect( visibleBlocks.at( 0 ).childAt( 0 ).name() ).toBe( 'BlockIcon' );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Advanced Text' );
+		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Text' );
+		expect( visibleBlocks.at( 2 ).text() ).toBe( 'Some Other Block' );
 	} );
 
-	it( 'should show blocks from the embed category in the embed tab', () => {
+	it( 'should show items from the embed category in the embed tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
 		const embedTab = wrapper.find( '.editor-inserter__tab' )
@@ -201,17 +160,38 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'A Text Embed' );
 	} );
 
-	it( 'should show all blocks except embeds in the blocks tab', () => {
+	it( 'should show reusable items in the saved tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
+			/>
+		);
+		const embedTab = wrapper.find( '.editor-inserter__tab' )
+			.filterWhere( ( node ) => node.text() === 'Saved' && node.name() === 'button' );
+		embedTab.simulate( 'click' );
+
+		const activeCategory = wrapper.find( '.editor-inserter__tab button.is-active' );
+		expect( activeCategory.text() ).toBe( 'Saved' );
+
+		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
+		expect( visibleBlocks ).toHaveLength( 1 );
+		expect( visibleBlocks.at( 0 ).text() ).toBe( 'My reusable block' );
+	} );
+
+	it( 'should show all items except embeds and reusable blocks in the blocks tab', () => {
+		const wrapper = mount(
+			<InserterMenu
+				position={ 'top center' }
+				instanceId={ 1 }
+				items={ items }
+				recentItems={ [] }
+				debouncedSpeak={ noop }
+				fetchReusableBlocks={ noop }
 			/>
 		);
 		const blocksTab = wrapper.find( '.editor-inserter__tab' )
@@ -229,40 +209,32 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 3 ).text() ).toBe( 'More' );
 	} );
 
-	it( 'should disable already used blocks with `usedOnce`', () => {
+	it( 'should disable items with `isDisabled`', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [ { name: moreBlock.name } ] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ items }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
-		const blocksTab = wrapper.find( '.editor-inserter__tab' )
-			.filterWhere( ( node ) => node.text() === 'Blocks' && node.name() === 'button' );
-		blocksTab.simulate( 'click' );
-		wrapper.update();
 
-		const disabledBlocks = wrapper.find( '.editor-inserter__block[disabled]' );
+		const disabledBlocks = wrapper.find( '.editor-inserter__block[disabled=true]' );
 		expect( disabledBlocks ).toHaveLength( 1 );
 		expect( disabledBlocks.at( 0 ).text() ).toBe( 'More' );
 	} );
 
-	it( 'should allow searching for blocks', () => {
+	it( 'should allow searching for items', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
 		wrapper.setState( { filterValue: 'text' } );
@@ -282,12 +254,10 @@ describe( 'InserterMenu', () => {
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
 		wrapper.setState( { filterValue: ' text' } );
@@ -303,18 +273,16 @@ describe( 'InserterMenu', () => {
 	} );
 } );
 
-describe( 'searchBlocks', () => {
-	it( 'should search blocks using the title ignoring case', () => {
-		const blocks = [ textBlock, advancedTextBlock, moreBlock, youtubeBlock, textEmbedBlock ];
-		expect( searchBlocks( blocks, 'TEXT' ) ).toEqual(
-			[ textBlock, advancedTextBlock, textEmbedBlock ]
+describe( 'searchItems', () => {
+	it( 'should search items using the title ignoring case', () => {
+		expect( searchItems( items, 'TEXT' ) ).toEqual(
+			[ textItem, advancedTextItem, textEmbedItem ]
 		);
 	} );
 
-	it( 'should search blocks using the keywords', () => {
-		const blocks = [ textBlock, advancedTextBlock, moreBlock, youtubeBlock, textEmbedBlock ];
-		expect( searchBlocks( blocks, 'GOOGL' ) ).toEqual(
-			[ youtubeBlock ]
+	it( 'should search items using the keywords', () => {
+		expect( searchItems( items, 'GOOGL' ) ).toEqual(
+			[ youtubeItem ]
 		);
 	} );
 } );

--- a/editor/edit-post/modes/visual-editor/inserter.js
+++ b/editor/edit-post/modes/visual-editor/inserter.js
@@ -39,6 +39,12 @@ export class VisualEditorInserter extends Component {
 		}
 	}
 
+	/**
+	 * Invoked when a inserter item is selected from the quick inserter.
+	 * Dispatches an action to create the necessary block.
+	 * 
+	 * @param {Editor.InserterItem} item Selected inserter item.
+	 */
 	insertItem( { name, initialAttributes } ) {
 		this.props.insertBlock( createBlock( name, initialAttributes ) );
 	}

--- a/editor/edit-post/modes/visual-editor/test/inserter.js
+++ b/editor/edit-post/modes/visual-editor/test/inserter.js
@@ -4,11 +4,6 @@
 import { shallow } from 'enzyme';
 
 /**
- * WordPress dependencies
- */
-import { getBlockType } from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
 import { VisualEditorInserter } from '../inserter';
@@ -16,7 +11,9 @@ import { VisualEditorInserter } from '../inserter';
 describe( 'VisualEditorInserter', () => {
 	it( 'should show controls when receiving focus', () => {
 		const clearSelectedBlock = jest.fn();
-		const wrapper = shallow( <VisualEditorInserter clearSelectedBlock={ clearSelectedBlock } /> );
+		const wrapper = shallow(
+			<VisualEditorInserter clearSelectedBlock={ clearSelectedBlock } frequentInserterItems={ [] } />
+		);
 
 		wrapper.simulate( 'focus' );
 
@@ -25,7 +22,7 @@ describe( 'VisualEditorInserter', () => {
 	} );
 
 	it( 'should hide controls when losing focus', () => {
-		const wrapper = shallow( <VisualEditorInserter /> );
+		const wrapper = shallow( <VisualEditorInserter frequentInserterItems={ [] } /> );
 
 		wrapper.simulate( 'focus' );
 		wrapper.simulate( 'blur' );
@@ -35,22 +32,23 @@ describe( 'VisualEditorInserter', () => {
 
 	it( 'should insert frequently used blocks', () => {
 		const insertBlock = jest.fn();
-		const mostFrequentlyUsedBlocks = [ getBlockType( 'core/paragraph' ), getBlockType( 'core/image' ) ];
+		const frequentInserterItems = [
+			{ name: 'core/paragraph', title: 'Paragraph' },
+			{ name: 'core/block', title: 'My block', initialAttributes: { ref: 123 } },
+		];
 		const wrapper = shallow(
-			<VisualEditorInserter insertBlock={ insertBlock } mostFrequentlyUsedBlocks={ mostFrequentlyUsedBlocks } />
+			<VisualEditorInserter insertBlock={ insertBlock } frequentInserterItems={ frequentInserterItems } />
 		);
-		wrapper.state.preferences = {
-			blockUsage: {
-				'core/paragraph': 42,
-				'core/image': 34,
-			},
-		};
 
 		wrapper
-			.findWhere( ( node ) => node.prop( 'children' ) === 'Paragraph' )
+			.findWhere( ( node ) => node.prop( 'children' ) === 'My block' )
 			.simulate( 'click' );
 
 		expect( insertBlock ).toHaveBeenCalled();
-		expect( insertBlock.mock.calls[ 0 ][ 0 ].name ).toBe( 'core/paragraph' );
+		expect( insertBlock.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			uid: expect.any( String ),
+			name: 'core/block',
+			attributes: { ref: 123 },
+		} );
 	} );
 } );

--- a/editor/store/defaults.js
+++ b/editor/store/defaults.js
@@ -6,8 +6,8 @@ export const PREFERENCES_DEFAULTS = {
 		publish: false,
 	},
 	panels: { 'post-status': true },
-	recentlyUsedBlocks: [],
-	blockUsage: {},
+	recentInserts: [],
+	insertFrequency: {},
 	features: {
 		fixedToolbar: false,
 	},

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -6,25 +6,23 @@ import { combineReducers } from 'redux';
 import {
 	flow,
 	partialRight,
-	difference,
 	get,
 	reduce,
 	keyBy,
-	keys,
 	first,
 	last,
 	omit,
-	pick,
 	without,
 	mapValues,
 	findIndex,
 	reject,
+	isEqual,
 } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { getBlockTypes, getBlockType } from '@wordpress/blocks';
+import { isReusableBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -32,11 +30,6 @@ import { getBlockTypes, getBlockType } from '@wordpress/blocks';
 import withHistory from '../utils/with-history';
 import withChangeDetection from '../utils/with-change-detection';
 import { PREFERENCES_DEFAULTS } from './defaults';
-
-/***
- * Module constants
- */
-const MAX_RECENT_BLOCKS = 8;
 
 /**
  * Returns a post attribute value, flattening nested rendered content using its
@@ -532,36 +525,22 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 				mode: action.mode,
 			};
 		case 'INSERT_BLOCKS':
-			// record the block usage and put the block in the recently used blocks
-			let blockUsage = state.blockUsage;
-			let recentlyUsedBlocks = [ ...state.recentlyUsedBlocks ];
-			action.blocks.forEach( ( block ) => {
-				const uses = ( blockUsage[ block.name ] || 0 ) + 1;
-				blockUsage = omit( blockUsage, block.name );
-				blockUsage[ block.name ] = uses;
-				recentlyUsedBlocks = [ block.name, ...without( recentlyUsedBlocks, block.name ) ].slice( 0, MAX_RECENT_BLOCKS );
-			} );
-			return {
-				...state,
-				blockUsage,
-				recentlyUsedBlocks,
-			};
-		case 'SETUP_EDITOR':
-			const isBlockDefined = name => getBlockType( name ) !== undefined;
-			const filterInvalidBlocksFromList = list => list.filter( isBlockDefined );
-			const filterInvalidBlocksFromObject = obj => pick( obj, keys( obj ).filter( isBlockDefined ) );
-			const commonBlocks = getBlockTypes()
-				.filter( ( blockType ) => 'common' === blockType.category )
-				.map( ( blockType ) => blockType.name );
-
-			return {
-				...state,
-				// recently used gets filled up to `MAX_RECENT_BLOCKS` with blocks from the common category
-				recentlyUsedBlocks: filterInvalidBlocksFromList( [ ...state.recentlyUsedBlocks ] )
-					.concat( difference( commonBlocks, state.recentlyUsedBlocks ) )
-					.slice( 0, MAX_RECENT_BLOCKS ),
-				blockUsage: filterInvalidBlocksFromObject( state.blockUsage ),
-			};
+			return action.blocks.reduce( ( prevState, block ) => {
+				const { name } = block;
+				const insert = isReusableBlock( block ) ? { name, ref: block.attributes.ref } : { name };
+				const key = JSON.stringify( insert );
+				return {
+					...prevState,
+					recentInserts: [
+						insert,
+						...reject( prevState.recentInserts, recentInsert => isEqual( insert, recentInsert ) ),
+					],
+					insertFrequency: {
+						...prevState.insertFrequency,
+						[ key ]: ( prevState.insertFrequency[ key ] || 0 ) + 1,
+					},
+				};
+			}, state );
 		case 'TOGGLE_FEATURE':
 			return {
 				...state,

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -12,6 +12,7 @@ import {
 	first,
 	last,
 	omit,
+	omitBy,
 	without,
 	mapValues,
 	findIndex,
@@ -541,6 +542,16 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					},
 				};
 			}, state );
+		case 'REMOVE_REUSABLE_BLOCK':
+			const { id } = action;
+			return {
+				...state,
+				recentInserts: reject( state.recentInserts, ( { ref } ) => ref === id ),
+				insertFrequency: omitBy( state.insertFrequency, ( frequency, key ) => {
+					const { ref } = JSON.parse( key );
+					return ref === id;
+				} ),
+			};
 		case 'TOGGLE_FEATURE':
 			return {
 				...state,

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1080,6 +1080,28 @@ const getFrequentInserts = createSelector(
 	state => state.preferences.insertFrequency
 );
 
+/**
+ * An inserter item is an object that encapsulates something that can be
+ * inserted into the editor via one of our inserter UIs.
+ * 
+ * @typedef {Object} Editor.InserterItem
+ * @property {string}   name              Name of the block type to create when this isnerter item is selected.
+ * @property {Object}   initialAttributes Attributes which should be set on the created block when this item is selected.
+ * @property {string}   title             Text displayed on any UI components that select this inserter item.
+ * @property {string}   icon              Dashicon displayed on any UI components that select this inserter item.
+ * @property {string}   category          Slug of the block category that this inserter item is associated with.
+ * @property {string[]} keywords          Keywords that describe this inserter item, for search.
+ * @property {boolean}  isDisabled        Whether or not the user should be prevented from inserting this item.
+ */
+
+/**
+ * Constructs an inserter item from a static block type.
+ * 
+ * @param {State} state                        Global application state.
+ * @param {string[]|boolean} enabledBlockTypes Enabled block type names, or true/false to enable/disable all types.
+ * @param {Object} blockType                   Block type, likely from `getBlockType()`.
+ * @returns {?Editor.InserterItem}             Built inserter item, or null.
+ */
 function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
 	if ( ! enabledBlockTypes || ! blockType ) {
 		return null;
@@ -1095,21 +1117,23 @@ function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
 	}
 
 	return {
-		// Attributes used for insertion
 		name: blockType.name,
 		initialAttributes: {},
-
-		// Attributes shown in the inserter
 		title: blockType.title,
 		icon: blockType.icon,
 		category: blockType.category,
-
-		// Metadata
 		keywords: blockType.keywords,
 		isDisabled: !! blockType.useOnce && getBlocks( state ).some( block => block.name === blockType.name ),
 	};
 }
 
+/**
+ * Constructs an inserter item from a reusable block.
+ * 
+ * @param {string[]|boolean} enabledBlockTypes Enabled block type names, or true/false to enable/disable all types.
+ * @param {Object} reusableBlock               Reusable block, likely from `getReusableBlock()`.
+ * @returns {?Editor.InserterItem}             Built inserter item, or null.
+ */
 function buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock ) {
 	if ( ! enabledBlockTypes || ! reusableBlock ) {
 		return null;
@@ -1126,21 +1150,26 @@ function buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock ) 
 	}
 
 	return {
-		// Attributes used for insertion
 		name: 'core/block',
 		initialAttributes: { ref: reusableBlock.id },
-
-		// Attributes shown in the inserter
 		title: reusableBlock.title,
 		icon: referencedBlockType.icon,
 		category: 'reusable-blocks',
-
-		// Metadata
 		keywords: [],
 		isDisabled: false,
 	};
 }
 
+/**
+ * Constructs an inserter item from an 'insert' object. These are the objects
+ * that are stored in `state.preferences.recentInserts` or
+ * `state.preferences.insertFrequency`.
+ * 
+ * @param {State} state                        Global application state.
+ * @param {string[]|boolean} enabledBlockTypes Enabled block type names, or true/false to enable/disable all types.
+ * @param {Object} insert                      Object representing a recent or frequent insert made by the user.
+ * @returns {?Editor.InserterItem}             Built inserter item, or null.
+ */
 function buildInserterItemFromInsert( state, enabledBlockTypes, insert ) {
 	switch ( insert.name ) {
 		case 'core/block':
@@ -1158,9 +1187,9 @@ function buildInserterItemFromInsert( state, enabledBlockTypes, insert ) {
  * and dynamic (i.e. reusable) blocks are sourced from. Each item contains
  * properties that are useful for rendering it in an inserter.
  * 
- * @param {Object} state                         Global application state
- * @param {String[]|Boolean} [enabledBlockTypes] Enabled block type names, or true/false to enable/disable all types
- * @returns {Object[]}                           Inserter items that ought to appear in the Frequent inserter
+ * @param {Object} state                         Global application state.
+ * @param {string[]|boolean} [enabledBlockTypes] Enabled block type names, or true/false to enable/disable all types.
+ * @returns {Editor.InserterItem[]}              Inserter items that ought to appear in the Frequent inserter.
  */
 export function getInserterItems( state, enabledBlockTypes = true ) {
 	if ( ! enabledBlockTypes ) {
@@ -1181,9 +1210,9 @@ export function getInserterItems( state, enabledBlockTypes = true ) {
  * Generates a list of items that should appear in an inserter that allows the
  * user to quickly insert *recently* used blocks.
  * 
- * @param {Object} state                         Global application state
- * @param {String[]|Boolean} [enabledBlockTypes] Enabled block type names, or true/false to enable/disable all types
- * @returns {Object[]}                           Inserter items that ought to appear in the Frequent inserter
+ * @param {Object} state                         Global application state.
+ * @param {string[]|boolean} [enabledBlockTypes] Enabled block type names, or true/false to enable/disable all types.
+ * @returns {Editor.InserterItem[]}              Inserter items that ought to appear in the Frequent inserter.
  */
 export function getRecentInserterItems( state, enabledBlockTypes = true ) {
 	if ( ! enabledBlockTypes ) {
@@ -1199,9 +1228,9 @@ export function getRecentInserterItems( state, enabledBlockTypes = true ) {
  * Generates a list of items that should appear in an inserter that allows the
  * user to quickly insert *frequntly* used blocks.
  * 
- * @param {Object} state                         Global application state
- * @param {String[]|Boolean} [enabledBlockTypes] Enabled block type names, or true/false to enable/disable all types
- * @returns {Object[]}                           Inserter items that ought to appear in the Frequent inserter
+ * @param {Object} state                         Global application state.
+ * @param {string[]|boolean} [enabledBlockTypes] Enabled block type names, or true/false to enable/disable all types.
+ * @returns {Editor.InserterItem[]}              Inserter items that ought to appear in the Frequent inserter.
  */
 export function getFrequentInserterItems( state, enabledBlockTypes = true ) {
 	if ( ! enabledBlockTypes ) {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1120,6 +1120,11 @@ function buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock ) 
 		return null;
 	}
 
+	const referencedBlockType = getBlockType( reusableBlock.type );
+	if ( ! referencedBlockType ) {
+		return null;
+	}
+
 	return {
 		// Attributes used for insertion
 		name: 'core/block',
@@ -1127,7 +1132,7 @@ function buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock ) 
 
 		// Attributes shown in the inserter
 		title: reusableBlock.title,
-		icon: 'layout',
+		icon: referencedBlockType.icon,
 		category: 'reusable-blocks',
 
 		// Metadata

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1055,6 +1055,37 @@ describe( 'state', () => {
 			} );
 		} );
 
+		it( 'should remove usage stats for reusable blocks that are removed', () => {
+			const initialState = {
+				recentInserts: [
+					{ name: 'core/paragraph' },
+					{ name: 'core/block', ref: 123 },
+					{ name: 'core/block', ref: 456 },
+				],
+				insertFrequency: {
+					[ JSON.stringify( { name: 'core/paragraph' } ) ]: 4,
+					[ JSON.stringify( { name: 'core/block', ref: 123 } ) ]: 2,
+					[ JSON.stringify( { name: 'core/block', ref: 456 } ) ]: 2,
+				},
+			};
+
+			const state = preferences( deepFreeze( initialState ), {
+				type: 'REMOVE_REUSABLE_BLOCK',
+				id: 123,
+			} );
+
+			expect( state ).toEqual( {
+				recentInserts: [
+					{ name: 'core/paragraph' },
+					{ name: 'core/block', ref: 456 },
+				],
+				insertFrequency: {
+					[ JSON.stringify( { name: 'core/paragraph' } ) ]: 4,
+					[ JSON.stringify( { name: 'core/block', ref: 456 } ) ]: 2,
+				},
+			} );
+		} );
+
 		it( 'should toggle a feature flag', () => {
 			const state = preferences( deepFreeze( { features: { chicken: true } } ), {
 				type: 'TOGGLE_FEATURE',

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -7,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * WordPress dependencies
  */
-import { registerBlockType, unregisterBlockType, getBlockType } from '@wordpress/blocks';
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -922,8 +922,8 @@ describe( 'state', () => {
 			const state = preferences( undefined, {} );
 
 			expect( state ).toEqual( {
-				blockUsage: {},
-				recentlyUsedBlocks: [],
+				recentInserts: [],
+				insertFrequency: {},
 				mode: 'visual',
 				sidebars: {
 					desktop: true,
@@ -1007,75 +1007,52 @@ describe( 'state', () => {
 		} );
 
 		it( 'should record recently used blocks', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: {} } ), {
-				type: 'INSERT_BLOCKS',
-				blocks: [ {
-					uid: 'bacon',
-					name: 'core-embed/twitter',
-				} ],
-			} );
-
-			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
-
-			const twoRecentBlocks = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: {} } ), {
+			const twoRecentBlocks = preferences( deepFreeze( { recentInserts: [], insertFrequency: {} } ), {
 				type: 'INSERT_BLOCKS',
 				blocks: [ {
 					uid: 'eggs',
-					name: 'core-embed/twitter',
+					name: 'core/block',
+					attributes: { ref: 123 },
 				}, {
 					uid: 'bacon',
 					name: 'core-embed/youtube',
+					attributes: {},
 				} ],
 			} );
 
-			expect( twoRecentBlocks.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
-			expect( twoRecentBlocks.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/twitter' );
+			expect( twoRecentBlocks.recentInserts ).toEqual( [
+				{ name: 'core-embed/youtube' },
+				{ name: 'core/block', ref: 123 },
+			] );
 		} );
 
 		it( 'should record block usage', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: {} } ), {
+			const state = preferences( deepFreeze( { recentInserts: [], insertFrequency: {} } ), {
 				type: 'INSERT_BLOCKS',
 				blocks: [ {
 					uid: 'eggs',
 					name: 'core-embed/twitter',
+					attributes: {},
 				}, {
 					uid: 'bacon',
 					name: 'core-embed/youtube',
+					attributes: {},
 				}, {
 					uid: 'milk',
 					name: 'core-embed/youtube',
+					attributes: {},
+				}, {
+					uid: 'juice',
+					name: 'core/block',
+					attributes: { ref: 123 },
 				} ],
 			} );
 
-			expect( state.blockUsage ).toEqual( { 'core-embed/youtube': 2, 'core-embed/twitter': 1 } );
-		} );
-
-		it( 'should populate recentlyUsedBlocks, filling up with common blocks, on editor setup', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [ 'core-embed/twitter', 'core-embed/youtube' ] } ), {
-				type: 'SETUP_EDITOR',
+			expect( state.insertFrequency ).toEqual( {
+				[ JSON.stringify( { name: 'core-embed/youtube' } ) ]: 2,
+				[ JSON.stringify( { name: 'core-embed/twitter' } ) ]: 1,
+				[ JSON.stringify( { name: 'core/block', ref: 123 } ) ]: 1,
 			} );
-
-			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
-			expect( state.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/youtube' );
-
-			state.recentlyUsedBlocks.slice( 2 ).forEach(
-				block => expect( getBlockType( block ).category ).toEqual( 'common' )
-			);
-			expect( state.recentlyUsedBlocks ).toHaveLength( 8 );
-		} );
-
-		it( 'should remove unregistered blocks from persisted recent usage', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [ 'core-embed/i-do-not-exist', 'core-embed/youtube' ] } ), {
-				type: 'SETUP_EDITOR',
-			} );
-			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
-		} );
-
-		it( 'should remove unregistered blocks from persisted block usage stats', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [], blockUsage: { 'core/i-do-not-exist': 42, 'core-embed/youtube': 88 } } ), {
-				type: 'SETUP_EDITOR',
-			} );
-			expect( state.blockUsage ).toEqual( { 'core-embed/youtube': 88 } );
 		} );
 
 		it( 'should toggle a feature flag', () => {

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -7,7 +7,7 @@ import moment from 'moment';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+import { registerBlockType, unregisterBlockType, getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -70,8 +70,6 @@ import {
 	didPostSaveRequestFail,
 	getSuggestedPostFormat,
 	getNotices,
-	getMostFrequentlyUsedBlocks,
-	getRecentlyUsedBlocks,
 	getMetaBoxes,
 	getDirtyMetaBoxes,
 	getMetaBox,
@@ -85,6 +83,9 @@ import {
 	isFeatureActive,
 	isPublishingPost,
 	POST_UPDATE_TRANSACTION_ID,
+	getRecentInserterItems,
+	getFrequentInserterItems,
+	getInserterItems,
 } from '../selectors';
 
 jest.mock( '../constants', () => ( {
@@ -97,6 +98,8 @@ describe( 'selectors', () => {
 			save: ( props ) => props.attributes.text,
 			category: 'common',
 			title: 'test block',
+			keywords: [ 'testing' ],
+			useOnce: true,
 		} );
 	} );
 
@@ -2219,45 +2222,202 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getMostFrequentlyUsedBlocks', () => {
-		it( 'should have paragraph and image to bring frequently used blocks up to three blocks', () => {
-			const noUsage = { preferences: { blockUsage: {} } };
-			const someUsage = { preferences: { blockUsage: { 'core/paragraph': 1 } } };
-
-			expect( getMostFrequentlyUsedBlocks( noUsage ).map( ( block ) => block.name ) )
-				.toEqual( [ 'core/paragraph', 'core/image' ] );
-
-			expect( getMostFrequentlyUsedBlocks( someUsage ).map( ( block ) => block.name ) )
-				.toEqual( [ 'core/paragraph', 'core/image' ] );
-		} );
-		it( 'should return the top 3 most recently used blocks', () => {
+	describe( 'getInserterItems', () => {
+		it( 'should list all public static blocks', () => {
 			const state = {
-				preferences: {
-					blockUsage: {
-						'core/deleted-block': 20,
-						'core/paragraph': 4,
-						'core/image': 11,
-						'core/quote': 2,
-						'core/gallery': 1,
+				editor: {
+					present: {
+						blocksByUid: {},
+						blockOrder: [],
+					},
+				},
+				reusableBlocks: {
+					data: {},
+				},
+			};
+
+			const publicBlockTypes = getBlockTypes().filter( blockType => ! blockType.isPrivate );
+			expect( getInserterItems( state ) ).toHaveLength( publicBlockTypes.length );
+		} );
+
+		it( 'should properly list a static block', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUid: {},
+						blockOrder: [],
+					},
+				},
+				reusableBlocks: {
+					data: {},
+				},
+			};
+
+			expect( getInserterItems( state, [ 'core/test-block' ] ) ).toEqual( [
+				{
+					name: 'core/test-block',
+					initialAttributes: {},
+					title: 'test block',
+					icon: 'block-default',
+					category: 'common',
+					keywords: [ 'testing' ],
+					isDisabled: false,
+				},
+			] );
+		} );
+
+		it( 'should set isDisabled when a static block with useOnce has been used', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUid: {
+							1: { uid: 1, name: 'core/test-block', attributes: {} },
+						},
+						blockOrder: [ 1 ],
+					},
+				},
+				reusableBlocks: {
+					data: {},
+				},
+			};
+
+			const items = getInserterItems( state, [ 'core/test-block' ] );
+			expect( items[ 0 ].isDisabled ).toBe( true );
+		} );
+
+		it( 'should properly list all reusable blocks', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUid: {},
+						blockOrder: [],
+					},
+				},
+				reusableBlocks: {
+					data: {
+						123: { id: 123, title: 'My reusable block' },
 					},
 				},
 			};
 
-			expect( getMostFrequentlyUsedBlocks( state ).map( ( block ) => block.name ) )
-				.toEqual( [ 'core/image', 'core/paragraph', 'core/quote' ] );
+			expect( getInserterItems( state, [ 'core/block' ] ) ).toEqual( [
+				{
+					name: 'core/block',
+					initialAttributes: { ref: 123 },
+					title: 'My reusable block',
+					icon: 'layout',
+					category: 'reusable-blocks',
+					keywords: [],
+					isDisabled: false,
+				},
+			] );
+		} );
+
+		it( 'should return nothing when all blocks are disabled', () => {
+			expect( getInserterItems( {}, false ) ).toEqual( [] );
 		} );
 	} );
 
-	describe( 'getRecentlyUsedBlocks', () => {
-		it( 'should return the most recently used blocks', () => {
+	describe( 'getRecentInserterItems', () => {
+		it( 'should return the 8 most recent inserts', () => {
 			const state = {
 				preferences: {
-					recentlyUsedBlocks: [ 'core/deleted-block', 'core/paragraph', 'core/image' ],
+					recentInserts: [
+						{ name: 'core/paragraph' },
+						{ name: 'core/block', ref: 123 },
+						{ name: 'core/image' },
+						{ name: 'core/quote' },
+						{ name: 'core/gallery' },
+						{ name: 'core/heading' },
+						{ name: 'core/list' },
+						{ name: 'core/video' },
+						{ name: 'core/audio' },
+						{ name: 'core/code' },
+					],
+				},
+				reusableBlocks: {
+					data: {
+						123: { id: 123 },
+					},
 				},
 			};
 
-			expect( getRecentlyUsedBlocks( state ).map( ( block ) => block.name ) )
-				.toEqual( [ 'core/paragraph', 'core/image' ] );
+			expect( getRecentInserterItems( state ) ).toMatchObject( [
+				{ name: 'core/paragraph', initialAttributes: {} },
+				{ name: 'core/block', initialAttributes: { ref: 123 } },
+				{ name: 'core/image', initialAttributes: {} },
+				{ name: 'core/quote', initialAttributes: {} },
+				{ name: 'core/gallery', initialAttributes: {} },
+				{ name: 'core/heading', initialAttributes: {} },
+				{ name: 'core/list', initialAttributes: {} },
+				{ name: 'core/video', initialAttributes: {} },
+			] );
+		} );
+
+		it( 'should pad list out with blocks from the common category', () => {
+			const state = {
+				preferences: {
+					recentInserts: [
+						{ name: 'core/deleted-block' },
+						{ name: 'core/audio' },
+					],
+				},
+			};
+
+			expect( getRecentInserterItems( state ) ).toMatchObject( [
+				{ name: 'core/audio', initialAttributes: {} },
+				{ name: 'core/image', initialAttributes: {} },
+				{ name: 'core/gallery', initialAttributes: {} },
+				{ name: 'core/heading', initialAttributes: {} },
+				{ name: 'core/quote', initialAttributes: {} },
+				{ name: 'core/list', initialAttributes: {} },
+				{ name: 'core/cover-image', initialAttributes: {} },
+				{ name: 'core/video', initialAttributes: {} },
+			] );
+		} );
+	} );
+
+	describe( 'getFrequentInserterItems', () => {
+		it( 'should return the 3 most frequent inserts', () => {
+			const state = {
+				preferences: {
+					insertFrequency: {
+						[ JSON.stringify( { name: 'core/deleted-block' } ) ]: 10,
+						[ JSON.stringify( { name: 'core/paragraph' } ) ]: 3,
+						[ JSON.stringify( { name: 'core/image' } ) ]: 2,
+						[ JSON.stringify( { name: 'core/block', ref: 123 } ) ]: 5,
+						[ JSON.stringify( { name: 'core/quote' } ) ]: 1,
+					},
+				},
+				reusableBlocks: {
+					data: {
+						123: { id: 123 },
+					},
+				},
+			};
+
+			expect( getFrequentInserterItems( state ) ).toMatchObject( [
+				{ name: 'core/block', initialAttributes: { ref: 123 } },
+				{ name: 'core/paragraph', initialAttributes: {} },
+				{ name: 'core/image', initialAttributes: {} },
+			] );
+		} );
+
+		it( 'should pad list out with common blocks', () => {
+			const state = {
+				preferences: {
+					insertFrequency: {
+						[ JSON.stringify( { name: 'core/quote' } ) ]: 5,
+						[ JSON.stringify( { name: 'core/image' } ) ]: 2,
+					},
+				},
+			};
+
+			expect( getFrequentInserterItems( state ) ).toMatchObject( [
+				{ name: 'core/quote', initialAttributes: {} },
+				{ name: 'core/image', initialAttributes: {} },
+				{ name: 'core/paragraph', initialAttributes: {} },
+			] );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -98,6 +98,7 @@ describe( 'selectors', () => {
 			save: ( props ) => props.attributes.text,
 			category: 'common',
 			title: 'test block',
+			icon: 'test',
 			keywords: [ 'testing' ],
 			useOnce: true,
 		} );
@@ -2258,7 +2259,7 @@ describe( 'selectors', () => {
 					name: 'core/test-block',
 					initialAttributes: {},
 					title: 'test block',
-					icon: 'block-default',
+					icon: 'test',
 					category: 'common',
 					keywords: [ 'testing' ],
 					isDisabled: false,
@@ -2295,7 +2296,11 @@ describe( 'selectors', () => {
 				},
 				reusableBlocks: {
 					data: {
-						123: { id: 123, title: 'My reusable block' },
+						123: {
+							id: 123,
+							title: 'My reusable block',
+							type: 'core/test-block',
+						},
 					},
 				},
 			};
@@ -2305,7 +2310,7 @@ describe( 'selectors', () => {
 					name: 'core/block',
 					initialAttributes: { ref: 123 },
 					title: 'My reusable block',
-					icon: 'layout',
+					icon: 'test',
 					category: 'reusable-blocks',
 					keywords: [],
 					isDisabled: false,
@@ -2337,7 +2342,7 @@ describe( 'selectors', () => {
 				},
 				reusableBlocks: {
 					data: {
-						123: { id: 123 },
+						123: { id: 123, type: 'core/test-block' },
 					},
 				},
 			};
@@ -2391,7 +2396,7 @@ describe( 'selectors', () => {
 				},
 				reusableBlocks: {
 					data: {
-						123: { id: 123 },
+						123: { id: 123, type: 'core/test-block' },
 					},
 				},
 			};


### PR DESCRIPTION
### 🕺 What 

Currently, `InserterMenu`, `VisualEditorInserter`, and `blocksAutocompleter` all directly call `getBlockTypes()` and `getReusableBlocks()` to determine what blocks should be shown as something that can be inserted.

This means that we duplicate some logic in three different places:

1. Checking, if the block has `useOnce` set, whether it's been already used or not
2. Checking whether or not the block has `isPrivate` set
3. Checking whether or not the block is in the editor config's list of enabled block types
4. Mixing in the list of available Reusable Blocks with the list of available static blocks

This approach is pretty error-prone: it's very easy to change the behaviour of one inserter and forget about the other three inserters.

To start addressing this, I've changed `InserterMenu` and `VisualEditorInserter` to source their blocks from three new selectors:

- `getInserterItems` - returns all items that are insertable, filters out private and disabled blocks, correctly sets `isDisabled`
- `getRecentInserterItems` - returns recently inserted items (e.g. for use in the Recent tab), filters out private and disabled blocks, correctly sets `isDisabled`
- `getFrequentInserterItems` - returns frequently inserted items (e.g. for use in `VisualEditorInserter`), filters out private and disabled blocks, correctly sets `isDisabled`

All three selectors select from both dynamic (reusable) blocks and static blocks. That means that we fix #3793 and fix #4221.

Having one place to assemble how a reusable block appears in an inserter lets us also easily fix #4303.

### 📅 Future work

The next step is to make `blocksAutocompleter` pull from `getInserterItems`. I've not done this yet as doing so would rely on being able to access editor state from the `blocks` module—something that we haven't figured out yet.

### ✅ How to test

1. Insert some static blocks and reusable blocks
2. Recently inserted blocks should move to the top of the Recent tab in the main inserter
3. Frequently inserted blocks should appear at the bottom of the visual editor
    1. Double check that a block can be inserted by clicking one of these items
4. Recent and frequent blocks should persist if you create a new post
  