### PR TITLE
Make sure the WP embeds security process is applied

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -123,9 +123,13 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 							return;
 						}
 						response.json().then( ( obj ) => {
-							const { html, type, provider_name: providerName } = obj;
+							const { html, provider_name: providerName } = obj;
 							const providerNameSlug = kebabCase( toLower( providerName ) );
+							let { type } = obj;
 
+							if ( includes( html, 'class="wp-embedded-content" data-secret' ) ) {
+								type = 'wp-embed';
+							}
 							if ( html ) {
 								this.setState( { html, type, providerNameSlug } );
 								setAttributes( { type, providerNameSlug } );
@@ -194,6 +198,20 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				const parsedUrl = parse( url );
 				const cannotPreview = includes( HOSTS_NO_PREVIEWS, parsedUrl.host.replace( /^www\./, '' ) );
 				const iframeTitle = sprintf( __( 'Embedded content from %s' ), parsedUrl.host );
+				const embedWrapper = 'wp-embed' === type ? (
+					<div
+						className="wp-block-embed__wrapper"
+						dangerouslySetInnerHTML={ { __html: html } }
+					/>
+				) : (
+					<div className="wp-block-embed__wrapper">
+						<SandBox
+							html={ html }
+							title={ iframeTitle }
+							type={ type }
+						/>
+					</div>
+				);
 				let typeClassName = 'wp-block-embed';
 				if ( 'video' === type ) {
 					typeClassName += ' is-video';
@@ -207,15 +225,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 								<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>
 								<p className="components-placeholder__error">{ __( 'Previews for this are unavailable in the editor, sorry!' ) }</p>
 							</Placeholder>
-						) : (
-							<div className="wp-block-embed__wrapper">
-								<SandBox
-									html={ html }
-									title={ iframeTitle }
-									type={ type }
-								/>
-							</div>
-						) }
+						) : embedWrapper }
 						{ ( caption && caption.length > 0 ) || isSelected ? (
 							<RichText
 								tagName="figcaption"

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -238,7 +238,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-edit-post',
 		gutenberg_url( 'edit-post/build/index.js' ),
-		array( 'jquery', 'heartbeat', 'wp-element', 'wp-components', 'wp-editor', 'wp-i18n', 'wp-date', 'wp-utils', 'wp-data' ),
+		array( 'jquery', 'heartbeat', 'wp-element', 'wp-components', 'wp-editor', 'wp-i18n', 'wp-date', 'wp-utils', 'wp-data', 'wp-embed' ),
 		filemtime( gutenberg_dir_path() . 'edit-post/build/index.js' ),
 		true
 	);


### PR DESCRIPTION
## Description

In #3548 @PareshRadadiya suggested a css fix to remove the link above the WordPress embed posts. @swissspidy advised to have a look at the wp-embed.js script and @aduth suggested to inject this script into the Sandbox component instead of adding some css rules.
After exploring another issue about the fact it is not possible to embed posts from the same site, it appears the security mechanism @swissspidy is probably thinking about when saying "it does a bit more", is not applied during REST requests made with the WP_oEmbed_Controller class that Gutenberg uses to fetch WordPress embeds.
The current PR is my attempt to fix both issues: the remaining top link and "self" embeds.

## How Has This Been Tested?

I've tested this PR on a regular AMP on my Macbook on a Multisite config.

## Screenshots (jpeg or gifs if applicable):

![self-embed](https://user-images.githubusercontent.com/1834524/34474409-a35d8d9c-ef7e-11e7-98ba-93410062710d.png)

Self embeds can be previewed with this PR and the above blockquote is removed as the security process is applied.

![external-embeds](https://user-images.githubusercontent.com/1834524/34474427-e1734f5e-ef7e-11e7-8e83-4428e7e46e0f.png)

Embeds from other WordPress sites are still failing because, imho, the WordPress site does not include one of the function of this PR: `gutenberg_filter_oembed_result()`. I've added inline comments above this function.

## Types of changes

Fixes self embedding WP posts and the remaining `blockquote` above the `iframe` for these kind of WP Embeds.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.