### PR TITLE
Document Outline: Use "title" instead of "h1" for the post's title

### DIFF
--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -90,7 +90,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect } ) => {
 		return (
 			<DocumentOutlineItem
 				key={ index }
-				level={ headingLevel }
+				level={ `H${ headingLevel }` }
 				isValid={ isValid }
 				onClick={ () => onSelectHeading( heading.uid ) }
 			>
@@ -105,7 +105,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect } ) => {
 			<ul>
 				{ title && (
 					<DocumentOutlineItem
-						level={ 1 }
+						level="Title"
 						isValid
 						onClick={ focusTitle }
 					>

--- a/editor/components/document-outline/item.js
+++ b/editor/components/document-outline/item.js
@@ -17,7 +17,7 @@ const TableOfContentsItem = ( {
 	<li
 		className={ classnames(
 			'document-outline__item',
-			`is-h${ level }`,
+			`is-${ level.toLowerCase() }`,
 			{
 				'is-invalid': ! isValid,
 			}
@@ -29,7 +29,7 @@ const TableOfContentsItem = ( {
 		>
 			<span className="document-outline__emdash" aria-hidden="true"></span>
 			<strong className="document-outline__level">
-				H{ level }
+				{ level }
 			</strong>
 			<span className="document-outline__item-content">
 				{ children }

--- a/editor/components/document-outline/test/__snapshots__/index.js.snap
+++ b/editor/components/document-outline/test/__snapshots__/index.js.snap
@@ -8,7 +8,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
     <TableOfContentsItem
       isValid={2}
       key="0"
-      level={2}
+      level="H2"
       onClick={[Function]}
     >
       Heading parent
@@ -16,7 +16,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
     <TableOfContentsItem
       isValid={3}
       key="1"
-      level={3}
+      level="H3"
       onClick={[Function]}
     >
       Heading child


### PR DESCRIPTION
Themes can use any markup for post titles, we can't assume `h1`. Thus, in this PR I use "title" next to the Post Title in the DocumentOutline component.

related https://github.com/WordPress/gutenberg/pull/4191#issuecomment-354673232