### PR TITLE
Parse Markdown and HTML without requiring a double line break

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -46,16 +46,30 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 		return parseWithGrammar( HTML );
 	}
 
-	// If there is a plain text version, the HTML version has no formatting,
-	// and there is at least a double line break,
-	// parse any Markdown inside the plain text.
-	if ( plainText && isPlain( HTML ) && plainText.indexOf( '\n\n' ) !== -1 ) {
+	// Parse Markdown (and HTML) if:
+	// * There is a plain text version.
+	// * The HTML version has no formatting.
+	if ( plainText && isPlain( HTML ) ) {
 		const converter = new showdown.Converter();
 
 		converter.setOption( 'noHeaderId', true );
 		converter.setOption( 'tables', true );
 
 		HTML = converter.makeHtml( plainText );
+
+		// Switch to inline mode if:
+		// * The current mode is AUTO.
+		// * The original plain text had no line breaks.
+		// * The original plain text was not an HTML paragraph.
+		// * The converted text is just a paragraph.
+		if (
+			mode === 'AUTO' &&
+			plainText.indexOf( '\n' ) === -1 &&
+			plainText.indexOf( '<p>' ) !== 0 &&
+			HTML.indexOf( '<p>' ) === 0
+		) {
+			mode = 'INLINE';
+		}
 	}
 
 	// An array of HTML strings and block objects. The blocks replace matched shortcodes.

--- a/blocks/api/raw-handling/test/index.js
+++ b/blocks/api/raw-handling/test/index.js
@@ -9,6 +9,7 @@ import { equal, deepEqual } from 'assert';
 import rawHandler from '../index';
 import { registerBlockType, unregisterBlockType, setUnknownTypeHandlerName } from '../../registration';
 import { createBlock } from '../../factory';
+import { getBlockContent } from '../../serializer';
 
 describe( 'rawHandler', () => {
 	it( 'should convert recognised raw content', () => {
@@ -104,13 +105,34 @@ describe( 'rawHandler', () => {
 		equal( filtered, '<em>test</em>' );
 	} );
 
-	it( 'should always return blocks', () => {
-		const blocks = rawHandler( {
-			HTML: 'test',
-			mode: 'BLOCKS',
+	it( 'should parse Markdown', () => {
+		const filtered = rawHandler( {
+			HTML: '* one<br>* two<br>* three',
+			plainText: '* one\n* two\n* three',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		equal( filtered, '<ul>\n    <li>one</li>\n    <li>two</li>\n    <li>three</li>\n</ul>' );
+	} );
+
+	it( 'should parse inline Markdown', () => {
+		const filtered = rawHandler( {
+			HTML: 'Some **bold** text.',
+			plainText: 'Some **bold** text.',
+			mode: 'AUTO',
 		} );
 
-		equal( Array.isArray( blocks ), true );
+		equal( filtered, 'Some <strong>bold</strong> text.' );
+	} );
+
+	it( 'should parse HTML in plainText', () => {
+		const filtered = rawHandler( {
+			HTML: '&lt;p&gt;Some &lt;strong&gt;bold&lt;/strong&gt; text.&lt;/p&gt;',
+			plainText: '<p>Some <strong>bold</strong> text.</p>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		equal( filtered, '<p>Some <strong>bold</strong> text.</p>' );
 	} );
 } );
 


### PR DESCRIPTION
## Description
See https://github.com/WordPress/gutenberg/pull/3949#issuecomment-354671422. The removes the double line check for plain text Markdown/HTML parsing. Instead, we'll force inline pasting if the plain text did not contain a lie break and the result is a paragraph.

## How Has This Been Tested?

Pasting the following should create a list.

```
* one
* two
* three
```

A piece of Markdown without a line break should be pasted inline:

```some **bold** text```

A piece of plain text HTML should not be pasted inline, it should create a new paragraph block.

```<p>This is <strong>bold</strong>.</p>```

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.