### PR TITLE
Updated string for publish box

### DIFF
--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -39,7 +39,7 @@ function PostPublishPanel( { onClose, user } ) {
 			</div>
 
 			<div className="editor-post-publish-panel__content">
-				<div><strong>{ __( 'All ready to go?' ) }</strong></div>
+				<div><strong>{ __( 'Are you ready to publish?' ) }</strong></div>
 				<p>{ __( 'Here, you can do a last-minute check up of your settings below, before you publish.' ) }</p>
 				{ ! canPublish &&
 					<div>


### PR DESCRIPTION
## Description
In the publish post popup box, I've changed the text from `All ready to go?` to `Are you ready to publish?` as this seems more appropriate given the context and makes more sense. `All ready to go?` doesn't seem quite right here.

## How Has This Been Tested?
I've had problem getting NPM to work but I've only made a text change so it shouldn't impact anything too much (I don't think...?). Let me know if I need to do anything else.

## Screenshots (jpeg or gifs if applicable):
Not applicable.

## Types of changes
Improvement to one text string.

## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.