### PR TITLE
Accessibility: Warn if multiple H1 headings used

### DIFF
--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -25,9 +25,13 @@ const incorrectLevelContent = [
 	<br key="incorrect-break" />,
 	<em key="incorrect-message">{ __( '(Incorrect heading level)' ) }</em>,
 ];
-const multipleH1Headings = [
+const singleH1Headings = [
 	<br key="incorrect-break-h1" />,
-	<em key="incorrect-message-h1">{ __( '(Multiple H1 headings)' ) }</em>,
+	<em key="incorrect-message-h1">{ __( '(Your theme may already use a H1 for the post title)' ) }</em>,
+];
+const multipleH1Headings = [
+	<br key="incorrect-break-multiple-h1" />,
+	<em key="incorrect-message-multiple-h1">{ __( '(Multiple H1 headings are not recommended)' ) }</em>,
 ];
 
 const getHeadingLevel = heading => {
@@ -104,7 +108,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect } ) => {
 						! item.isEmpty &&
 						! isIncorrectLevel &&
 						!! item.level &&
-						( item.level !== 1 || ! hasMultipleH1 )
+						( item.level !== 1 || ( ! hasMultipleH1 && ! title ) )
 					);
 					prevHeadingLevel = item.level;
 
@@ -118,6 +122,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect } ) => {
 							{ item.isEmpty ? emptyHeadingContent : item.attributes.content }
 							{ isIncorrectLevel && incorrectLevelContent }
 							{ item.level === 1 && hasMultipleH1 && multipleH1Headings }
+							{ title && item.level === 1 && ! hasMultipleH1 && singleH1Headings }
 						</DocumentOutlineItem>
 					);
 				} ) }

--- a/editor/components/document-outline/test/__snapshots__/index.js.snap
+++ b/editor/components/document-outline/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
 >
   <ul>
     <TableOfContentsItem
-      isValid={2}
+      isValid={true}
       key="0"
       level="H2"
       onClick={[Function]}
@@ -14,12 +14,53 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
       Heading parent
     </TableOfContentsItem>
     <TableOfContentsItem
-      isValid={3}
+      isValid={true}
       key="1"
       level="H3"
       onClick={[Function]}
     >
       Heading child
+    </TableOfContentsItem>
+  </ul>
+</div>
+`;
+
+exports[`DocumentOutline header blocks present should render warnings for multiple h1 heaedings 1`] = `
+<div
+  className="document-outline"
+>
+  <ul>
+    <TableOfContentsItem
+      isValid={false}
+      key="0"
+      level={1}
+      onClick={[Function]}
+    >
+      Heading 1
+      <br
+        key="incorrect-break-h1"
+      />
+      <em
+        key="incorrect-message-h1"
+      >
+        (Multiple H1 headings)
+      </em>
+    </TableOfContentsItem>
+    <TableOfContentsItem
+      isValid={false}
+      key="1"
+      level={1}
+      onClick={[Function]}
+    >
+      Heading 1
+      <br
+        key="incorrect-break-h1"
+      />
+      <em
+        key="incorrect-message-h1"
+      >
+        (Multiple H1 headings)
+      </em>
     </TableOfContentsItem>
   </ul>
 </div>

--- a/editor/components/document-outline/test/__snapshots__/index.js.snap
+++ b/editor/components/document-outline/test/__snapshots__/index.js.snap
@@ -25,7 +25,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
 </div>
 `;
 
-exports[`DocumentOutline header blocks present should render warnings for multiple h1 heaedings 1`] = `
+exports[`DocumentOutline header blocks present should render warnings for multiple h1 headings 1`] = `
 <div
   className="document-outline"
 >
@@ -33,33 +33,33 @@ exports[`DocumentOutline header blocks present should render warnings for multip
     <TableOfContentsItem
       isValid={false}
       key="0"
-      level={1}
+      level="H1"
       onClick={[Function]}
     >
       Heading 1
       <br
-        key="incorrect-break-h1"
+        key="incorrect-break-multiple-h1"
       />
       <em
-        key="incorrect-message-h1"
+        key="incorrect-message-multiple-h1"
       >
-        (Multiple H1 headings)
+        (Multiple H1 headings are not recommended)
       </em>
     </TableOfContentsItem>
     <TableOfContentsItem
       isValid={false}
       key="1"
-      level={1}
+      level="H1"
       onClick={[Function]}
     >
       Heading 1
       <br
-        key="incorrect-break-h1"
+        key="incorrect-break-multiple-h1"
       />
       <em
-        key="incorrect-message-h1"
+        key="incorrect-message-multiple-h1"
       >
-        (Multiple H1 headings)
+        (Multiple H1 headings are not recommended)
       </em>
     </TableOfContentsItem>
   </ul>

--- a/editor/components/document-outline/test/index.js
+++ b/editor/components/document-outline/test/index.js
@@ -15,6 +15,10 @@ import { DocumentOutline } from '../';
 
 describe( 'DocumentOutline', () => {
 	const paragraph = createBlock( 'core/paragraph' );
+	const headingH1 = createBlock( 'core/heading', {
+		content: 'Heading 1',
+		nodeName: 'H1',
+	} );
 	const headingParent = createBlock( 'core/heading', {
 		content: 'Heading parent',
 		nodeName: 'H2',
@@ -59,6 +63,13 @@ describe( 'DocumentOutline', () => {
 			const wrapper = shallow( <DocumentOutline blocks={ blocks } /> );
 
 			expect( wrapper.find( 'TableOfContentsItem' ) ).toHaveLength( 2 );
+		} );
+
+		it( 'should render warnings for multiple h1 heaedings', () => {
+			const blocks = [ headingH1, paragraph, headingH1, paragraph ];
+			const wrapper = shallow( <DocumentOutline blocks={ blocks } /> );
+
+			expect( wrapper ).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/editor/components/document-outline/test/index.js
+++ b/editor/components/document-outline/test/index.js
@@ -65,7 +65,7 @@ describe( 'DocumentOutline', () => {
 			expect( wrapper.find( 'TableOfContentsItem' ) ).toHaveLength( 2 );
 		} );
 
-		it( 'should render warnings for multiple h1 heaedings', () => {
+		it( 'should render warnings for multiple h1 headings', () => {
 			const blocks = [ headingH1, paragraph, headingH1, paragraph ];
 			const wrapper = shallow( <DocumentOutline blocks={ blocks } /> );
 


### PR DESCRIPTION
closes #4230

This PR updates the document outline to mark `h1`s as invalid if we use more than one `h1`s.

**Testing instructions**

 - Add two `h1` headings to the post content
 - Open the document outline
 - Notice the headings are marked invalids with a message.