### PR TITLE
Avoid setting font-family on pullquotes (not matched by the editor).

### DIFF
--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -15,7 +15,6 @@
 	}
 
 	> p {
-		font-family: $default-font;
 		font-size: 24px;
 		font-weight: 900;
 		line-height: 1.6;
@@ -27,9 +26,5 @@
 		font-weight: 900;
 		text-transform: uppercase;
 		font-size: 13px;
-	}
-
-	cite p {
-		font-family: $default-font;
 	}
 }


### PR DESCRIPTION
Closes #4094.