### PR TITLE
Remove superfluous parentheses from include statements.

### DIFF
--- a/bin/get-server-blocks.php
+++ b/bin/get-server-blocks.php
@@ -17,17 +17,17 @@ define( 'ABSPATH', $abspath ? $abspath : dirname( dirname( dirname( dirname( dir
 define( 'WPINC', 'wp-includes' );
 define( 'WP_SETUP_CONFIG', true );
 define( 'WP_USE_THEMES', false );
-require_once( ABSPATH . WPINC . '/load.php' );
-require_once( ABSPATH . WPINC . '/default-constants.php' );
+require_once ABSPATH . WPINC . '/load.php';
+require_once ABSPATH . WPINC . '/default-constants.php';
 wp_fix_server_vars();
 wp_initial_constants();
-require_once( ABSPATH . WPINC . '/functions.php' );
+require_once ABSPATH . WPINC . '/functions.php';
 wp_load_translations_early();
 wp_set_lang_dir();
-require_once( dirname( dirname( __FILE__ ) ) . '/lib/blocks.php' );
-require_once( dirname( dirname( __FILE__ ) ) . '/lib/class-wp-block-type-registry.php' );
-require_once( dirname( dirname( __FILE__ ) ) . '/lib/class-wp-block-type.php' );
-require_once( dirname( dirname( __FILE__ ) ) . '/lib/client-assets.php' );
+require_once dirname( dirname( __FILE__ ) ) . '/lib/blocks.php';
+require_once dirname( dirname( __FILE__ ) ) . '/lib/class-wp-block-type-registry.php';
+require_once dirname( dirname( __FILE__ ) ) . '/lib/class-wp-block-type.php';
+require_once dirname( dirname( __FILE__ ) ) . '/lib/client-assets.php';
 
 // Register server-side code for individual blocks.
 foreach ( glob( dirname( dirname( __FILE__ ) ) . '/blocks/library/*/index.php' ) as $block_logic ) {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -115,7 +115,7 @@ function gutenberg_pre_init() {
 	}
 
 	// Get unmodified $wp_version.
-	include( ABSPATH . WPINC . '/version.php' );
+	include ABSPATH . WPINC . '/version.php';
 
 	// Strip '-src' from the version string. Messes up version_compare().
 	$version = str_replace( '-src', '', $wp_version );
@@ -161,7 +161,7 @@ function gutenberg_init( $return, $post ) {
 	add_filter( 'screen_options_show_screen', '__return_false' );
 	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
 
-	require_once( ABSPATH . 'wp-admin/admin-header.php' );
+	require_once ABSPATH . 'wp-admin/admin-header.php';
 	the_gutenberg_project();
 
 	return true;
@@ -247,7 +247,7 @@ function gutenberg_intercept_edit_post() {
 	}
 
 	if ( gutenberg_init( false, $post ) ) {
-		include( ABSPATH . 'wp-admin/admin-footer.php' );
+		include ABSPATH . 'wp-admin/admin-footer.php';
 		exit;
 	}
 }
@@ -311,7 +311,7 @@ function gutenberg_intercept_post_new() {
 	$post_ID = $post->ID;
 
 	if ( gutenberg_init( false, $post ) ) {
-		include( ABSPATH . 'wp-admin/admin-footer.php' );
+		include ABSPATH . 'wp-admin/admin-footer.php';
 		exit;
 	}
 }


### PR DESCRIPTION
## Description
This removes the superfluous parentheses from all the PHP include statements.

Resolves #4252

## How Has This Been Tested?
All tests still pass.

## Types of changes

Removal of unneeded parentheses.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
