### PR TITLE
Change non-loop `while` into simple `if`

### DIFF
--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -401,7 +401,7 @@ export function isEquivalentHTML( actual, expected ) {
 		}
 	}
 
-	while ( ( expectedToken = getNextNonWhitespaceToken( expectedTokens ) ) ) {
+	if ( ( expectedToken = getNextNonWhitespaceToken( expectedTokens ) ) ) {
 		// If any non-whitespace tokens remain in expected token set, this
 		// indicates inequality
 		log.warning( 'Expected %o, instead saw end of content.', expectedToken );


### PR DESCRIPTION
## Description

Change a non-looping `while` statement into a simple `if` condition.

Resolves #4258

## How Has This Been Tested?

All tests are still passing.

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
