### PR TITLE
Remove redundant CSS property updates.

### DIFF
--- a/editor/components/meta-boxes/meta-boxes-area/style.scss
+++ b/editor/components/meta-boxes/meta-boxes-area/style.scss
@@ -79,7 +79,6 @@
 		right: 0;
 		bottom: 0;
 		content: '';
-		z-index: 1;
 		background: transparent;
 		z-index: z-index( '.editor-meta-boxes-area.is-loading:before');
 	}

--- a/editor/components/post-text-editor/style.scss
+++ b/editor/components/post-text-editor/style.scss
@@ -23,7 +23,6 @@
 
 	button {
 		height: 30px;
-		border: none;
 		background: none;
 		padding: 0 8px;
 		margin: 3px 4px;

--- a/editor/edit-post/layout/style.scss
+++ b/editor/edit-post/layout/style.scss
@@ -87,7 +87,6 @@
 	right: 0;
 	left: 0;
 	overflow: auto;
-	position: fixed;
 
 	@include break-medium() {
 		top: $admin-bar-height;

--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -2,8 +2,6 @@
 	position: relative;
 	height: 100%;
 	margin: 0 auto;
-	margin-left: auto;
-	margin-right: auto;
 	padding: 50px 0;
 
 	&,
@@ -121,11 +119,9 @@
 	position: relative;
 
 	@include break-small() {
-		padding: 0 ( $block-mover-padding-visible - 1px );	// subtract 1px for border
 		padding: 0 $block-mover-padding-visible;
 
 		.editor-default-block-appender__content {
-			padding: 0 ( $block-padding - 1px );	// subtract 1px for border
 			padding: 0 $block-padding;
 		}
 	}

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -443,7 +443,6 @@ function gutenberg_replace_default_add_new_button() {
 			position: relative;
 			top: -3px;
 			text-decoration: none;
-			border: none;
 			border: 1px solid #ccc;
 			border-radius: 2px;
 			background: #f7f7f7;


### PR DESCRIPTION
## Description

Some CSS properties are set twice, with the last one overwriting the previous one.

This patch optimizes the source files to only contain the needed properties once.

Resolves #4260

## How Has This Been Tested?

All tests are still passing.

## Types of changes

Removal of unneeded CSS properties.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
