### PR TITLE
Remove unknown `isMobile` argument from docblock

### DIFF
--- a/editor/utils/mobile/index.js
+++ b/editor/utils/mobile/index.js
@@ -7,10 +7,8 @@ import { toggleSidebar } from '../../store/actions';
 /**
  * Disables isSidebarOpened on rehydrate payload if the user is on a mobile screen size.
  *
- * @param  {Object}  payload   rehydrate payload
- * @param  {Boolean} isMobile  flag indicating if executing on mobile screen sizes or not
- *
- * @return {Object}            rehydrate payload with isSidebarOpened disabled if on mobile
+ * @param  {Object} payload rehydrate payload
+ * @return {Object}         rehydrate payload with isSidebarOpened disabled if on mobile
  */
 export const disableIsSidebarOpenedOnMobile = ( payload ) => (
 	payload.isSidebarOpenedMobile ? { ...payload, isSidebarOpenedMobile: false } : payload


### PR DESCRIPTION
## Description

The function `disableIsSidebarOpenedOnMobile()` (`editor/utils/mobile/index.js`) contains a second argument `{Boolean} isMobile` that is not accepted or used.

This patch removes that argument.

Resolves #4262

## How Has This Been Tested?

All tests are still passing.

## Types of changes

Docblock change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.