### PR TITLE
Allow transform shortcode tag to be array

### DIFF
--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, dropRight, last, mapValues, pickBy } from 'lodash';
+import { castArray, find, get, dropRight, last, mapValues, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ export default function( HTML ) {
 			return acc;
 		}
 
-		const transformTags = transform.tag instanceof Array ? transform.tag : [ transform.tag ];
+		const transformTags = castArray( transform.tag );
 
 		let match;
 		let lastIndex = 0;

--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -25,33 +25,37 @@ export default function( HTML ) {
 			return acc;
 		}
 
+		const transformTags = transform.tag instanceof Array ? transform.tag : [ transform.tag ];
+
 		let match;
 		let lastIndex = 0;
 
-		while ( ( match = shortcode.next( transform.tag, HTML, lastIndex ) ) ) {
-			lastIndex = match.index + match.content.length;
+		for ( const transformTag of transformTags ) {
+			while ( ( match = shortcode.next( transformTag, HTML, lastIndex ) ) ) {
+				lastIndex = match.index + match.content.length;
 
-			const attributes = mapValues(
-				pickBy( transform.attributes, ( schema ) => schema.shortcode ),
-				// Passing all of `match` as second argument is intentionally
-				// broad but shouldn't be too relied upon. See
-				// https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
-				( schema ) => schema.shortcode( match.shortcode.attrs, match ),
-			);
+				const attributes = mapValues(
+					pickBy( transform.attributes, ( schema ) => schema.shortcode ),
+					// Passing all of `match` as second argument is intentionally
+					// broad but shouldn't be too relied upon. See
+					// https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
+					( schema ) => schema.shortcode( match.shortcode.attrs, match ),
+				);
 
-			const block = createBlock(
-				blockType.name,
-				getBlockAttributes(
-					{
-						...blockType,
-						attributes: transform.attributes,
-					},
-					match.shortcode.content,
-					attributes,
-				)
-			);
+				const block = createBlock(
+					blockType.name,
+					getBlockAttributes(
+						{
+							...blockType,
+							attributes: transform.attributes,
+						},
+						match.shortcode.content,
+						attributes,
+					)
+				);
 
-			acc[ match.index ] = { block, lastIndex };
+				acc[ match.index ] = { block, lastIndex };
+			}
 		}
 
 		return acc;


### PR DESCRIPTION
## Description
This PR lets the shortcode tag defined for a transform be an array instead of only a string, allowing you to utilize one set of rules for multiple shortcode tags. This is helpful for instances where a shortcode has aliases (e.g. `[gravityform]` and `[gravityforms]`). The transform's tag is converted to an array if set as a string allowing for simply defining a single tag.

## How Has This Been Tested?
Tested using a shortcode transform on a custom block where the transform was defined as a string and then changed to be defined as an array.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.
  