### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -481,8 +481,6 @@ function gutenberg_replace_default_add_new_button() {
 			<?php endif; ?>
 			position: relative;
 			vertical-align: top;
-			-webkit-font-smoothing: antialiased;
-			-moz-osx-font-smoothing: grayscale;
 			text-decoration: none !important;
 			padding: 4px 5px 4px 3px;
 		}


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`
 
See discussion on woocommerce/storefront#698 for details on why this outdated non-standard CSS should not be used.
