### PR TITLE
Made inspector controls available when categories are loading.

### DIFF
--- a/blocks/library/categories/block.js
+++ b/blocks/library/categories/block.js
@@ -143,24 +143,46 @@ class CategoriesBlock extends Component {
 	}
 
 	render() {
-		const { setAttributes } = this.props;
+		const { attributes, focus, setAttributes } = this.props;
+		const { align, displayAsDropdown, showHierarchy, showPostCounts } = attributes;
 		const categories = this.getCategories();
 
+		const inspectorControls = focus && (
+			<InspectorControls key="inspector">
+				<h3>{ __( 'Categories Settings' ) }</h3>
+				<ToggleControl
+					label={ __( 'Display as dropdown' ) }
+					checked={ displayAsDropdown }
+					onChange={ this.toggleDisplayAsDropdown }
+				/>
+				<ToggleControl
+					label={ __( 'Show post counts' ) }
+					checked={ showPostCounts }
+					onChange={ this.toggleShowPostCounts }
+				/>
+				<ToggleControl
+					label={ __( 'Show hierarchy' ) }
+					checked={ showHierarchy }
+					onChange={ this.toggleShowHierarchy }
+				/>
+			</InspectorControls>
+		);
+
 		if ( ! categories.length ) {
-			return (
+			return [
+				inspectorControls,
 				<Placeholder
+					key="placeholder"
 					icon="admin-post"
 					label={ __( 'Categories' ) }
 				>
 					<Spinner />
-				</Placeholder>
-			);
+				</Placeholder>,
+			];
 		}
 
-		const { focus } = this.props;
-		const { align, displayAsDropdown, showHierarchy, showPostCounts } = this.props.attributes;
-
 		return [
+			inspectorControls,
 			focus && (
 				<BlockControls key="controls">
 					<BlockAlignmentToolbar
@@ -171,26 +193,6 @@ class CategoriesBlock extends Component {
 						controls={ [ 'left', 'center', 'right', 'full' ] }
 					/>
 				</BlockControls>
-			),
-			focus && (
-				<InspectorControls key="inspector">
-					<h3>{ __( 'Categories Settings' ) }</h3>
-					<ToggleControl
-						label={ __( 'Display as dropdown' ) }
-						checked={ displayAsDropdown }
-						onChange={ this.toggleDisplayAsDropdown }
-					/>
-					<ToggleControl
-						label={ __( 'Show post counts' ) }
-						checked={ showPostCounts }
-						onChange={ this.toggleShowPostCounts }
-					/>
-					<ToggleControl
-						label={ __( 'Show hierarchy' ) }
-						checked={ showHierarchy }
-						onChange={ this.toggleShowHierarchy }
-					/>
-				</InspectorControls>
 			),
 			<div key="categories" className={ this.props.className }>
 				{


### PR DESCRIPTION
This PR makes inspector controls available even when categories are loading. This change makes the categories block, consistent with other blocks like latest-posts. And fixes a bug where class input may appear before other fields. And come back to last when selecting other block and reselecting categories.
The issue https://github.com/WordPress/gutenberg/issues/4023 should be fixed by this changes.

## How Has This Been Tested?
Create a new post, add a categories block, verify the class input field is the last field shown in the inspector controls.
Verify categories block still work as before.

## Screenshots (jpeg or gifs if applicable):
Before: 
![jan-03-2018 18-15-44](https://user-images.githubusercontent.com/11271197/34534165-0ef5e504-f0b5-11e7-9547-48ed9021d97b.gif)
After:
![jan-03-2018 18-07-19](https://user-images.githubusercontent.com/11271197/34534175-160cd398-f0b5-11e7-9678-72ae1f8796f2.gif)
