### PR TITLE
Fixed matches sorting in shortcodeConverter.

### DIFF
--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -60,7 +60,7 @@ export default function( HTML ) {
 	let negativeI = 0;
 
 	// Sort the matches and return an array of text pieces and blocks.
-	return Object.keys( matches ).sort().reduce( ( acc, index ) => {
+	return Object.keys( matches ).sort( ( a, b ) => a - b ).reduce( ( acc, index ) => {
 		const match = matches[ index ];
 
 		acc = [


### PR DESCRIPTION
It looks like the algorithm to compute and return shortcode pieces array is dependent on ascending sorting of the matches and the sorting was not ascending causing a series of bugs and unexpected behaviours.
This change should fix issue https://github.com/WordPress/gutenberg/issues/4215 and the "Problems converting a Bootstrap page" section referred in issue https://github.com/WordPress/gutenberg/issues/4219.
## Description
This PR just changes sorting in shortcodeConverter function to be ascending as it looks like is what the algorithm expects.

## How Has This Been Tested?

Paste into a simple text editor first to make sure pasting is plain text. Copying from here escapes content.
Paste the following text :
```
<div>
[caption id="attachment_915" align="aligncenter" width="50"]<a href="/another-page/"><img src="https://dummyimage.com/50x50/333333/09f09f.jpg&amp;text=image+1" alt="“My alt” alt 1" width="50" height="50" /></a> “My caption” caption 1[/caption]

[caption id="attachment_936" align="aligncenter" width="50"]<a href="/another-page/"><img src="https://dummyimage.com/50x50/000000/ffffff.jpg&amp;text=image+2" alt="“My alt” alt 2" width="50" height="50" /></a> “My caption” caption 2[/caption]
</div> 
```
Verify the output is an image block as expected.

Create a post in the classic editor with the following content provided by @ElectricFeet in issue https://github.com/WordPress/gutenberg/issues/4219:
```
<div class="row">

<div class="col-xs-12 col-md-6 col-lg-4">
[caption id="attachment_915" align="aligncenter" width="400"]<a href="/another-page/"><img src="https://dummyimage.com/400x400/333333/09f09f.jpg&text=image+1" alt="“My alt” alt 1" width="400" height="400" /></a> “My caption” caption 1[/caption]
</div>

<div class="col-xs-12 col-md-6 col-lg-4">
[caption id="attachment_936" align="aligncenter" width="400"]<a href="/another-page/"><img src="https://dummyimage.com/400x400/000000/ffffff.jpg&text=image+2" alt="“My alt” alt 2" width="400" height="400" /></a> “My caption” caption 2[/caption]
</div>

<div class="col-xs-12 col-md-12 col-lg-4">
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p> 
<p style="text-align: right;"><a title="More" href="/another-page/">...More</a></p>
</div>

</div>
```
Load the post in Gutenberg use convert to blocks option and verify the result is similar to what we add in the classic editor.

Verify "simple" shortcode pasting works as before.

## Screenshots (jpeg or gifs if applicable):
Before:
![image](https://user-images.githubusercontent.com/11271197/34541373-d7593d4c-f0cf-11e7-84c8-f7e517509520.png)
After:
![image](https://user-images.githubusercontent.com/11271197/34541379-e16d4800-f0cf-11e7-9129-dd50a065092c.png)

Before:
![image](https://user-images.githubusercontent.com/11271197/34541402-f6c52178-f0cf-11e7-9348-7a9e939f9e17.png)

After:
![image](https://user-images.githubusercontent.com/11271197/34541390-eddb97f4-f0cf-11e7-978d-694a411737ee.png)


  
  
  