### PR TITLE
Fix isInputField

### DIFF
--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -312,8 +312,8 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
  */
 export function isInputField( { nodeName, contentEditable } ) {
 	return (
-		nodeName === 'input' ||
-		nodeName === 'textarea' ||
+		nodeName === 'INPUT' ||
+		nodeName === 'TEXTAREA' ||
 		contentEditable === 'true'
 	);
 }

--- a/editor/utils/test/dom.js
+++ b/editor/utils/test/dom.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isHorizontalEdge, placeCaretAtHorizontalEdge } from '../dom';
+import { isHorizontalEdge, placeCaretAtHorizontalEdge, isInputField } from '../dom';
 
 describe( 'DOM', () => {
 	let parent;
@@ -89,6 +89,28 @@ describe( 'DOM', () => {
 			input.value = 'value';
 			placeCaretAtHorizontalEdge( input, false );
 			expect( isHorizontalEdge( input, true ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isInputfield', () => {
+		it( 'should return true for an input element', () => {
+			expect( isInputField( document.createElement( 'input' ) ) ).toBe( true );
+		} );
+
+		it( 'should return true for an textarea element', () => {
+			expect( isInputField( document.createElement( 'textarea' ) ) ).toBe( true );
+		} );
+
+		it( 'should return true for a contenteditable element', () => {
+			const div = document.createElement( 'div' );
+
+			div.contentEditable = 'true';
+
+			expect( isInputField( div ) ).toBe( true );
+		} );
+
+		it( 'should return true for a normal div element', () => {
+			expect( isInputField( document.createElement( 'div' ) ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
Fixes #4268. I accidentally checked for lower case names in `nodeName`. 🙈 Adds tests too.

## How Has This Been Tested?
Select a block, then select some text in an input field inside the block or in the inspector. The content of the section should be copied, not the whole block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.