### PR TITLE
Fix PHPUnit block deletion test failure

### DIFF
--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -174,7 +174,7 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			array(
 				'deleted'  => true,
 				'previous' => array(
-					'id'      => 8,
+					'id'      => self::$post_id,
 					'title'   => 'My cool block',
 					'content' => '<!-- wp:core/paragraph --><p>Hello!</p><!-- /wp:core/paragraph -->',
 				),


### PR DESCRIPTION
Fixes a failing PHPUnit test. Failing on hard-coded `8` for deleted post ID whenever tests were run on a WordPress installation that wasn't brand new with a completely empty posts table.

## Description
Use dynamic post ID in assertion instead of the hard-coded `8`,
which was leading to a failed test when running PHPUnit.

## How Has This Been Tested?
PHPUnit

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
  