### PR TITLE
Fix shortcode sorting

### DIFF
--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -60,22 +60,25 @@ export default function( HTML ) {
 	let negativeI = 0;
 
 	// Sort the matches and return an array of text pieces and blocks.
-	return Object.keys( matches ).sort().reduce( ( acc, index ) => {
-		const match = matches[ index ];
+	return Object
+		.keys( matches )
+		.sort( ( a, b ) => parseInt( a, 10 ) - parseInt( b, 10 ) )
+		.reduce( ( acc, index ) => {
+			const match = matches[ index ];
 
-		acc = [
-			// Add all pieces except the last text piece.
-			...dropRight( acc ),
-			// Add the start of the last text piece.
-			last( acc ).slice( 0, index - negativeI ),
-			// Add the block.
-			match.block,
-			// Add the rest of the last text piece.
-			last( acc ).slice( match.lastIndex - negativeI ),
-		];
+			acc = [
+				// Add all pieces except the last text piece.
+				...dropRight( acc ),
+				// Add the start of the last text piece.
+				last( acc ).slice( 0, index - negativeI ),
+				// Add the block.
+				match.block,
+				// Add the rest of the last text piece.
+				last( acc ).slice( match.lastIndex - negativeI ),
+			];
 
-		negativeI = match.lastIndex;
+			negativeI = match.lastIndex;
 
-		return acc;
-	}, [ HTML ] );
+			return acc;
+		}, [ HTML ] );
 }


### PR DESCRIPTION
## Description
Fixes #4215. adds a sorting function so that object keys (index of shortcode in string) are sorted numerically instead of alphabetically.

`sort()` => `sort( ( a, b ) => parseInt( a, 10 ) - parseInt( b, 10 ) )`.

## How Has This Been Tested?
Paste the following:

```
<div>
[caption id="attachment_915" align="aligncenter" width="400"]<a href="/another-page/"><img src="https://dummyimage.com/400x400/333333/09f09f.jpg&amp;text=image+1" alt="“My alt” alt 1" width="400" height="400" /></a> “My caption” caption 1[/caption]
</div>
<div>
[caption id="attachment_936" align="aligncenter" width="400"]<a href="/another-page/"><img src="https://dummyimage.com/400x400/000000/ffffff.jpg&amp;text=image+2" alt="“My alt” alt 2" width="400" height="400" /></a> “My caption” caption 2[/caption]
</div> 
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.