### PR TITLE
Dry up 'No saved blocks' and 'No blocks found' messages

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -284,8 +284,8 @@ export class InserterMenu extends Component {
 		// If the Saved tab is selected and we have no results, display a friendly message
 		if ( 'saved' === tab && blocksForTab.length === 0 ) {
 			return (
-				<p className="editor-inserter__no-tab-content-message">
-					{ __( 'No saved blocks.' ) }
+				<p className="editor-inserter__no-results">
+					{ __( 'No blocks found.' ) }
 				</p>
 			);
 		}

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -148,12 +148,6 @@ input[type="search"].editor-inserter__search {
 		flex-shrink: 0;
 		margin-top: 1px;
 	}
-
-	.editor-inserter__no-tab-content-message {
-		font-style: italic;
-		margin-top: 3em;
-		text-align: center;
-	}
 }
 
 .editor-inserter__tab {


### PR DESCRIPTION
## Description
I changed from "No saved blocks" to "No blocks found" message when there are no saved blocks. Fixes #4273 

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation. #
  