### PR TITLE
Disable mobile sidebar from  REDUX_REHYDRATE payload.

### DIFF
--- a/editor/utils/mobile/index.js
+++ b/editor/utils/mobile/index.js
@@ -1,17 +1,24 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { isMobile } from '../../store/selectors';
 import { toggleSidebar } from '../../store/actions';
 
 /**
- * Disables isSidebarOpened on rehydrate payload if the user is on a mobile screen size.
+ * Disables mobile sidebar if it is present on the payload.
  *
  * @param  {Object} payload rehydrate payload
- * @return {Object}         rehydrate payload with isSidebarOpened disabled if on mobile
+ * @return {Object}         rehydrate payload with mobile sidebar disabled
  */
-export const disableIsSidebarOpenedOnMobile = ( payload ) => (
-	payload.isSidebarOpenedMobile ? { ...payload, isSidebarOpenedMobile: false } : payload
+export const disableMobileSidebar = ( payload ) => (
+	get( payload, 'sidebars.mobile' ) ?
+		{ ...payload, ...{ sidebars: { ...payload.sidebars, mobile: false } } } :
+		payload
 );
 
 /**
@@ -22,7 +29,7 @@ export const mobileMiddleware = ( { getState } ) => next => action => {
 	if ( action.type === 'REDUX_REHYDRATE' ) {
 		return next( {
 			type: 'REDUX_REHYDRATE',
-			payload: disableIsSidebarOpenedOnMobile( action.payload ),
+			payload: disableMobileSidebar( action.payload ),
 		} );
 	}
 	if ( action.type === 'TOGGLE_SIDEBAR' && action.sidebar === undefined ) {

--- a/editor/utils/mobile/test/mobile.js
+++ b/editor/utils/mobile/test/mobile.js
@@ -1,43 +1,59 @@
 /**
  * Internal dependencies
  */
-import { disableIsSidebarOpenedOnMobile } from '../';
+import { disableMobileSidebar } from '../';
 
-describe( 'disableIsSidebarOpenOnMobile()', () => {
-	it( 'should disable isSidebarOpenedMobile and keep other properties as before', () => {
+describe( 'disableMobileSidebar()', () => {
+	it( 'should disable mobile sidebar and keep other properties as before', () => {
 		const input = {
-				isSidebarOpenedMobile: true,
+				sidebars: {
+					mobile: true,
+					desktop: false,
+				},
 				dummyPref: 'dummy',
 			},
 			output = {
-				isSidebarOpenedMobile: false,
+				sidebars: {
+					mobile: false,
+					desktop: false,
+				},
 				dummyPref: 'dummy',
 			};
 
-		expect( disableIsSidebarOpenedOnMobile( input ) ).toEqual( output );
+		expect( disableMobileSidebar( input ) ).toEqual( output );
 	} );
 
-	it( 'should keep isSidebarOpenedMobile as false if it was false', () => {
+	it( 'should keep mobile sidebar false if it was false', () => {
 		const input = {
-				isSidebarOpenedMobile: false,
+				sidebars: {
+					mobile: false,
+					desktop: false,
+				},
+				dummyPref: 'dummy',
+			},
+			output = {
+				sidebars: {
+					mobile: false,
+					desktop: false,
+				},
+				dummyPref: 'dummy',
+			};
+		expect( disableMobileSidebar( input ) ).toEqual( output );
+	} );
+
+	it( 'should not make any change if the payload does not contain mobile sidebar flag', () => {
+		const input = {
+				sidebars: {
+					chicken: 'ribs',
+				},
 				dummy: 'non-dummy',
 			},
 			output = {
-				isSidebarOpenedMobile: false,
+				sidebars: {
+					chicken: 'ribs',
+				},
 				dummy: 'non-dummy',
 			};
-		expect( disableIsSidebarOpenedOnMobile( input ) ).toEqual( output );
-	} );
-
-	it( 'should not make any change if the payload does not contain isSidebarOpenedMobile flag', () => {
-		const input = {
-				isSidebarOpened: true,
-				dummy: 'non-dummy',
-			},
-			output = {
-				isSidebarOpened: true,
-				dummy: 'non-dummy',
-			};
-		expect( disableIsSidebarOpenedOnMobile( input ) ).toEqual( output );
+		expect( disableMobileSidebar( input ) ).toEqual( output );
 	} );
 } );


### PR DESCRIPTION
The mobile sidebar should be closed on reload even if it was opened before. This behavior was implemented, but during a refactor to the sidebars a regression made the logic invalid.

## How Has This Been Tested?
Resize to mobile resolutions, open the sidebar, reload the page, and see the sidebar is now closed.
Try to open and close sidebar in desktop and mobile see that things still work.
See that on the desktop the sidebar opened state is still persisted when reloading.
