### PR TITLE
Test: Introduce jest matchers for console object

### DIFF
--- a/blocks/api/test/parser.js
+++ b/blocks/api/test/parser.js
@@ -16,15 +16,6 @@ import {
 	setUnknownTypeHandlerName,
 } from '../registration';
 
-const expectFailingBlockValidation = () => {
-	/* eslint-disable no-console */
-	expect( console.error ).toHaveBeenCalled();
-	expect( console.warn ).toHaveBeenCalled();
-	console.warn.mockClear();
-	console.error.mockClear();
-	/* eslint-enable no-console */
-};
-
 describe( 'block parser', () => {
 	const defaultBlockSettings = {
 		attributes: {
@@ -206,7 +197,8 @@ describe( 'block parser', () => {
 				{},
 			);
 			expect( attributes ).toBeUndefined();
-			expectFailingBlockValidation();
+			expect( console ).toHaveErrored();
+			expect( console ).toHaveWarned();
 		} );
 
 		it( 'should return the attributes parsed by the deprecated version', () => {
@@ -316,7 +308,8 @@ describe( 'block parser', () => {
 			expect( block.name ).toEqual( 'core/test-block' );
 			expect( block.attributes ).toEqual( { fruit: 'Bananas' } );
 			expect( block.isValid ).toBe( true );
-			expectFailingBlockValidation();
+			expect( console ).toHaveErrored();
+			expect( console ).toHaveWarned();
 		} );
 	} );
 

--- a/blocks/api/test/validation.js
+++ b/blocks/api/test/validation.js
@@ -30,18 +30,6 @@ describe( 'validation', () => {
 		title: 'block title',
 	};
 
-	/* eslint-disable no-console */
-	function expectError() {
-		expect( console.error ).toHaveBeenCalled();
-		console.error.mockClear();
-	}
-
-	function expectWarning() {
-		expect( console.warn ).toHaveBeenCalled();
-		console.warn.mockClear();
-	}
-	/* eslint-enable no-console */
-
 	afterEach( () => {
 		setUnknownTypeHandlerName( undefined );
 		getBlockTypes().forEach( ( block ) => {
@@ -114,7 +102,7 @@ describe( 'validation', () => {
 				{ chars: 'a \n c \t b  ' },
 			);
 
-			expectWarning();
+			expect( console ).toHaveWarned();
 			expect( isEqual ).toBe( false );
 		} );
 
@@ -214,7 +202,7 @@ describe( 'validation', () => {
 				]
 			);
 
-			expectWarning();
+			expect( console ).toHaveWarned();
 			expect( isEqual ).toBe( false );
 		} );
 
@@ -242,7 +230,7 @@ describe( 'validation', () => {
 					{ tagName: 'section' }
 				);
 
-				expectWarning();
+				expect( console ).toHaveWarned();
 				expect( isEqual ).toBe( false );
 			} );
 
@@ -263,7 +251,7 @@ describe( 'validation', () => {
 					}
 				);
 
-				expectWarning();
+				expect( console ).toHaveWarned();
 				expect( isEqual ).toBe( false );
 			} );
 
@@ -322,7 +310,7 @@ describe( 'validation', () => {
 				'<div>Hello <span class="a">World!</span></div>'
 			);
 
-			expectWarning();
+			expect( console ).toHaveWarned();
 			expect( isEquivalent ).toBe( false );
 		} );
 
@@ -341,7 +329,7 @@ describe( 'validation', () => {
 				'<div>Hello'
 			);
 
-			expectWarning();
+			expect( console ).toHaveWarned();
 			expect( isEquivalent ).toBe( false );
 		} );
 
@@ -351,7 +339,7 @@ describe( 'validation', () => {
 				'<div>Hello</div>'
 			);
 
-			expectWarning();
+			expect( console ).toHaveWarned();
 			expect( isEquivalent ).toBe( false );
 		} );
 
@@ -388,7 +376,7 @@ describe( 'validation', () => {
 				'<input>'
 			);
 
-			expectWarning();
+			expect( console ).toHaveWarned();
 			expect( isEquivalent ).toBe( false );
 		} );
 
@@ -398,7 +386,7 @@ describe( 'validation', () => {
 				'<div>'
 			);
 
-			expectWarning();
+			expect( console ).toHaveWarned();
 			expect( isEquivalent ).toBe( false );
 		} );
 
@@ -408,7 +396,7 @@ describe( 'validation', () => {
 				'<div>'
 			);
 
-			expectWarning();
+			expect( console ).toHaveWarned();
 			expect( isEquivalent ).toBe( false );
 		} );
 	} );
@@ -423,8 +411,8 @@ describe( 'validation', () => {
 				{ fruit: 'Bananas' }
 			);
 
-			expectWarning();
-			expectError();
+			expect( console ).toHaveWarned();
+			expect( console ).toHaveErrored();
 			expect( isValid ).toBe( false );
 		} );
 
@@ -442,7 +430,7 @@ describe( 'validation', () => {
 				{ fruit: 'Bananas' }
 			);
 
-			expectError();
+			expect( console ).toHaveErrored();
 			expect( isValid ).toBe( false );
 		} );
 

--- a/blocks/block-description/test/index.js
+++ b/blocks/block-description/test/index.js
@@ -8,13 +8,6 @@ import { shallow } from 'enzyme';
  */
 import BlockDescription from '../';
 
-/* eslint-disable no-console */
-function expectWarning() {
-	expect( console.warn ).toHaveBeenCalled();
-	console.warn.mockClear();
-}
-/* eslint-enable no-console */
-
 describe( 'BlockDescription', () => {
 	describe( 'basic rendering', () => {
 		it( 'should render a <p> element with some content', () => {
@@ -22,7 +15,9 @@ describe( 'BlockDescription', () => {
 			expect( blockDescription.hasClass( 'components-block-description' ) ).toBe( true );
 			expect( blockDescription.type() ).toBe( 'div' );
 			expect( blockDescription.text() ).toBe( 'Hello World' );
-			expectWarning();
+			expect( console ).toHaveWarnedWith(
+				'The wp.blocks.BlockDescription component is deprecated. Use the "description" block property instead.'
+			);
 		} );
 	} );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6286,6 +6286,12 @@
         "pretty-format": "22.0.3"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -6311,6 +6317,22 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
+        },
+        "jest-get-type": {
+          "version": "22.0.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.3.tgz",
+          "integrity": "sha512-TaJnc/lnJQ3jwry+NUWkqaJmKrM/Ut3XdK89HfiqdI3DMRLd6Zb4wyKjwuNP37MEQqlNg0YWH4sbBR8D4exjCA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "22.0.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.0.3.tgz",
+          "integrity": "sha512-qXbDFJ2/Kk3HFIaLdOblbsCKQ09kZu4MKbXB+m/EaqD7PZ/wXe2XcRREmQleMh4wmerxlma6eJTh3nxCXYUmmA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0",
+            "ansi-styles": "3.2.0"
+          }
         },
         "supports-color": {
           "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "gettext-parser": "1.3.0",
     "jest": "22.0.4",
     "jest-enzyme": "4.0.2",
+    "jest-matcher-utils": "22.0.3",
     "node-sass": "4.7.2",
     "pegjs": "0.10.0",
     "pegjs-loader": "0.5.4",

--- a/test/unit/console/index.js
+++ b/test/unit/console/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import { isEqual, some } from 'lodash';
+
+// Sets spies on console object to make it possible to convert them into test failures.
+const spyError = jest.spyOn( console, 'error' );
+const spyWarn = jest.spyOn( console, 'warn' );
+
+const createToBeCalledWithMatcher = ( matcherName, methodName ) =>
+	( received, ...expected ) => {
+		const spy = received[ methodName ];
+		const calls = spy.mock.calls;
+		const pass = some(
+			calls,
+			objects => isEqual( objects, expected )
+		);
+		const message = pass ?
+			() => matcherHint( `.not${ matcherName }`, spy.getMockName() ) +
+				'\n\n' +
+				'Expected mock function not to have been called with:\n' +
+				printExpected( expected ) :
+			() =>
+				matcherHint( matcherName, spy.getMockName() ) +
+				'\n\n' +
+				'Expected mock function to have been called with:\n' +
+				printExpected( expected ) + '\n' +
+				'but have been called with:\n' +
+				calls.map( printReceived );
+
+		spy.mockReset();
+
+		return {
+			message,
+			pass,
+		};
+	};
+
+expect.extend( {
+	toHaveErroredWith: createToBeCalledWithMatcher( '.toHaveErroredWith', 'error' ),
+	toHaveWarnedWith: createToBeCalledWithMatcher( '.toHaveWarnedWith', 'warn' ),
+} );
+
+beforeEach( () => {
+	spyError.mockReset();
+	spyWarn.mockReset();
+} );
+
+afterEach( () => {
+	expect( spyError ).not.toHaveBeenCalled();
+	expect( spyWarn ).not.toHaveBeenCalled();
+} );

--- a/test/unit/setup-test-framework.js
+++ b/test/unit/setup-test-framework.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import './console';
+
 // It "mocks" enzyme, so that we can delay loading of
 // the utility functions until enzyme is imported in tests.
 // Props to @gdborton for sharing this technique in his article:
@@ -17,18 +22,4 @@ jest.mock( 'enzyme', () => {
 		require.requireActual( 'jest-enzyme' );
 	}
 	return actualEnzyme;
-} );
-
-// Sets spies on console object to make it possible to convert them into test failures.
-const spyError = jest.spyOn( console, 'error' );
-const spyWarn = jest.spyOn( console, 'warn' );
-
-beforeEach( () => {
-	spyError.mockReset();
-	spyWarn.mockReset();
-} );
-
-afterEach( () => {
-	expect( spyError ).not.toHaveBeenCalled();
-	expect( spyWarn ).not.toHaveBeenCalled();
 } );


### PR DESCRIPTION
## Description
Implements #4251, where @aduth raised the following:

> In a few places we're asserting that console logging is called, which requires a bit of finesse to properly temporarily disable ESLint rules and reset mock calls (in order to [avoid tripping the global unintended console logging assertions](https://github.com/WordPress/gutenberg/blob/eb7b0b771924c6d0cae2cc001e7790caf8bfe9c6/test/unit/setup-test-framework.js#L34-L37)):
> 
> - https://github.com/WordPress/gutenberg/blob/eb7b0b7/blocks/api/test/parser.js#L19-L26
> - https://github.com/WordPress/gutenberg/blob/eb7b0b7/blocks/api/test/validation.js#L33-L43
> - https://github.com/WordPress/gutenberg/blob/eb7b0b7/blocks/block-description/test/index.js#L11-L16
>
> We should plan to refactor these into a custom Jest matcher.
> 
> Possible usage:
> 
> ```js
> // expect( console ).toHaveLogged( [ level[, expectedMessage ] ] );
> expect( console ).toHaveLogged( 'warn', 'Should not do that!' );
> expect( console ).toHaveLogged( 'error', 'Cannot do that!' );
> ```
> 
> See: https://facebook.github.io/jest/docs/en/expect.html#expectextendmatchers


I implemented the following API:

```js
expect( console ).toHaveWarnedWith( 'Should not do that!' );
expect( console ).toHaveErroredWith( 'Cannot do that!' );
```

I think we will need also `toHaveWarned` and `toHaveErrored` to replace other existing checks and README file for the API introduced. I will work on it next week unless someone wants to do it earlier. Feel free to contribute :)

## How Has This Been Tested?
`npm test` + Travis run.

## Types of changes
Test changes only, no production code updated.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.