### PR TITLE
Design Update for Table of Contents

### DIFF
--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -40,20 +40,20 @@ function TableOfContents( { blocks } ) {
 			renderContent={ () => ( [
 				<div key="counts" className="table-of-contents__counts">
 					<div className="table-of-contents__count">
-						<WordCount />
 						{ __( 'Words' ) }
+						<WordCount />
 					</div>
 					<div className="table-of-contents__count">
-						<span className="table-of-contents__number">{ headings.length }</span>
 						{ __( 'Headings' ) }
+						<span className="table-of-contents__number">{ headings.length }</span>
 					</div>
 					<div className="table-of-contents__count">
-						<span className="table-of-contents__number">{ paragraphs.length }</span>
 						{ __( 'Paragraphs' ) }
+						<span className="table-of-contents__number">{ paragraphs.length }</span>
 					</div>
 					<div className="table-of-contents__count">
-						<span className="table-of-contents__number">{ blocks.length }</span>
 						{ __( 'Blocks' ) }
+						<span className="table-of-contents__number">{ blocks.length }</span>
 					</div>
 				</div>,
 				headings.length > 0 && (

--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -41,11 +41,7 @@ function TableOfContents( { blocks } ) {
 				<div key="counts" className="table-of-contents__counts">
 					<div className="table-of-contents__count">
 						<WordCount />
-						{ __( 'Word Count' ) }
-					</div>
-					<div className="table-of-contents__count">
-						<span className="table-of-contents__number">{ blocks.length }</span>
-						{ __( 'Blocks' ) }
+						{ __( 'Words' ) }
 					</div>
 					<div className="table-of-contents__count">
 						<span className="table-of-contents__number">{ headings.length }</span>
@@ -54,6 +50,10 @@ function TableOfContents( { blocks } ) {
 					<div className="table-of-contents__count">
 						<span className="table-of-contents__number">{ paragraphs.length }</span>
 						{ __( 'Paragraphs' ) }
+					</div>
+					<div className="table-of-contents__count">
+						<span className="table-of-contents__number">{ blocks.length }</span>
+						{ __( 'Blocks' ) }
 					</div>
 				</div>,
 				headings.length > 0 && (

--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -31,7 +31,6 @@
 	font-weight: 400;
 	line-height: 30px;
 	color: $dark-gray-500;
-	order: 2;
 }
 
 .table-of-contents__title {

--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -8,21 +8,19 @@
 	}
 
 	hr {
-		margin: 0 -16px;
+		margin: 10px -16px 0;
 	}
 }
 
 .table-of-contents__counts {
 	display: flex;
 	flex-wrap: wrap;
-	margin-bottom: 10px;
 }
 
 .table-of-contents__count {
 	width: 25%;
 	display: flex;
 	flex-direction: column;
-	margin-bottom: 10px;
 	font-size: 12px;
 	color: $dark-gray-300;
 }

--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -1,5 +1,15 @@
-.table-of-contents__popover .components-popover__content {
-	padding: 16px;
+.table-of-contents__popover.components-popover:not(.is-mobile) .components-popover__content {
+	min-width: 380px;
+}
+
+.table-of-contents__popover {
+	.components-popover__content {
+		padding: 16px;
+	}
+
+	hr {
+		margin: 0 -16px;
+	}
 }
 
 .table-of-contents__counts {
@@ -9,18 +19,21 @@
 }
 
 .table-of-contents__count {
-	width: 50%;
+	width: 25%;
 	display: flex;
 	flex-direction: column;
 	margin-bottom: 10px;
+	font-size: 12px;
+	color: $dark-gray-300;
 }
 
 .table-of-contents__number,
 .table-of-contents__popover .word-count {
-	font-size: 40px;
-	font-weight: 100;
-	line-height: 50px;
-	color: $dark-gray-300;
+	font-size: 21px;
+	font-weight: 400;
+	line-height: 30px;
+	color: $dark-gray-500;
+	order: 2;
 }
 
 .table-of-contents__title {


### PR DESCRIPTION
- Change document counts to be a single row.
- Reduce count sizes and invert order of count/number.
- Increase width of panel — this is better for readability and preventing heading items from wrapping too soon. cc @afercia 
- Rename "word count" to just "words".
- Makes line-divider full-width.

![image](https://user-images.githubusercontent.com/548849/34566792-2e73ba54-f160-11e7-9508-f2a1216ac54f.png)

cc @jasmussen @karmatosed
  