### PR TITLE
Components: Use flatMap for mapping toolbar controls

### DIFF
--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { flatMap } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,9 +26,8 @@ function Toolbar( { controls = [], children, className } ) {
 
 	return (
 		<div className={ classnames( 'components-toolbar', className ) }>
-			{ controlSets.reduce( ( result, controlSet, setIndex ) => [
-				...result,
-				...controlSet.map( ( control, controlIndex ) => (
+			{ flatMap( controlSets, ( controlSet, setIndex ) => (
+				controlSet.map( ( control, controlIndex ) => (
 					<div
 						key={ [ setIndex, controlIndex ].join() }
 						className={ setIndex > 0 && controlIndex === 0 ? 'has-left-divider' : null }
@@ -48,8 +48,8 @@ function Toolbar( { controls = [], children, className } ) {
 						/>
 						{ control.children }
 					</div>
-				) ),
-			], [] ) }
+				) )
+			) ) }
 			{ children }
 		</div>
 	);


### PR DESCRIPTION
Related: #3185

This pull request seeks to refactor the Toolbar component to achieve a minor performance and semantic meaning improvement, using [Lodash's `_.flatMap`](https://lodash.com/docs/4.17.4#flatMap) in place of a combination of `Array#reduce` + `Array#concat`.

See: https://jsperf.com/lodash-flatmap-vs-array-reduce/1

__Testing instructions:__

Verify that Toolbar unit tests pass:

```
npm run test-unit components/toolbar
```

Ensure that there are no regressions in the behavior of block or other toolbar controls.