### PR TITLE
SiblingInserter: Opening should clear block selection

### DIFF
--- a/editor/components/block-list/sibling-inserter.js
+++ b/editor/components/block-list/sibling-inserter.js
@@ -19,6 +19,9 @@ import {
 	isBlockInsertionPointVisible,
 	isBlockWithinSelection,
 } from '../../store/selectors';
+import {
+	clearSelectedBlock,
+} from '../../store/actions';
 
 class BlockListSiblingInserter extends Component {
 	constructor() {
@@ -35,6 +38,10 @@ class BlockListSiblingInserter extends Component {
 		// Prevent mouseout and blur while navigating the open inserter menu
 		// from causing the inserter to be unmounted.
 		this.setState( { isForcedVisible: isOpen } );
+
+		if ( isOpen ) {
+			this.props.clearSelectedBlock();
+		}
 	}
 
 	render() {
@@ -81,5 +88,8 @@ export default connect(
 				getBlockInsertionPoint( state ) === insertIndex
 			),
 		};
+	},
+	{
+		clearSelectedBlock,
 	}
 )( BlockListSiblingInserter );


### PR DESCRIPTION
… thus hiding any selected block's chrome.

Fixes #3847

## Description

<!-- Please describe your changes -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):
![gutenberg-inserter-hide-chrome](https://user-images.githubusercontent.com/150562/34575160-a0cc4e16-f171-11e7-987b-9f62981271d1.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.