### PR TITLE
Handle image data paste early

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -301,7 +301,8 @@ export default class Editable extends Component {
 			window.console.log( 'Received item:\n\n', blob );
 
 			if ( isEmpty && this.props.onReplace ) {
-				this.props.onReplace( content );
+				// Necessary to allow the paste bin to be removed without errors.
+				setTimeout( () => this.props.onReplace( content ) );
 			} else {
 				// Necessary to get the right range.
 				// Also done in the TinyMCE paste plugin.


### PR DESCRIPTION
## Description
Fixes #3537. In Chrome, image data paste fails because the `onPastePreProcess` event does not happen. TinyMCE has different paste logic and image data handling, so it would be better if we handle data paste early instead of letting it pass unnecessarily through TinyMCE.

## How Has This Been Tested?
Copy an image in Chrome and paste it in Gutenberg.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
  