### PR TITLE
Set image size in percentages

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -112,7 +112,8 @@ class ImageBlock extends Component {
 
 	render() {
 		const { attributes, setAttributes, focus, setFocus, className, settings, toggleSelection } = this.props;
-		const { url, alt, caption, align, id, href, width, height } = attributes;
+		const { url, alt, caption, align, id, href, size } = attributes;
+		const width = size ? size * settings.maxWidth / 100 : undefined;
 
 		const availableSizes = this.getAvailableSizes();
 		const figureStyle = width ? { width } : {};
@@ -226,10 +227,11 @@ class ImageBlock extends Component {
 							return img;
 						}
 
-						const currentWidth = width || imageWidthWithinContainer;
-						const currentHeight = height || imageHeightWithinContainer;
-
 						const ratio = imageWidth / imageHeight;
+
+						const currentWidth = width || imageWidthWithinContainer;
+						const currentHeight = ( width / ratio ) || imageHeightWithinContainer;
+
 						const minWidth = imageWidth < imageHeight ? MIN_SIZE : MIN_SIZE * ratio;
 						const minHeight = imageHeight < imageWidth ? MIN_SIZE : MIN_SIZE / ratio;
 
@@ -256,9 +258,9 @@ class ImageBlock extends Component {
 								} }
 								onResizeStop={ ( event, direction, elt, delta ) => {
 									setAttributes( {
-										width: parseInt( currentWidth + delta.width, 10 ),
-										height: parseInt( currentHeight + delta.height, 10 ),
+										size: parseInt( currentWidth + delta.width, 10 ) * 100 / settings.maxWidth,
 									} );
+
 									toggleSelection( true );
 								} }
 							>

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -44,6 +44,7 @@ class ImageBlock extends Component {
 		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSetHref = this.onSetHref.bind( this );
 		this.updateImageURL = this.updateImageURL.bind( this );
+		this.updateSize = this.updateSize.bind( this );
 	}
 
 	componentDidMount() {
@@ -96,6 +97,10 @@ class ImageBlock extends Component {
 
 	updateImageURL( url ) {
 		this.props.setAttributes( { url } );
+	}
+
+	updateSize( size ) {
+		this.props.setAttributes( { size } );
 	}
 
 	render() {
@@ -169,7 +174,7 @@ class ImageBlock extends Component {
 		const focusCaption = ( focusValue ) => setFocus( { editable: 'caption', ...focusValue } );
 		const classes = classnames( className, {
 			'is-transient': 0 === url.indexOf( 'blob:' ),
-			'is-resized': !! width,
+			'is-resized': !! size,
 			'is-focused': !! focus,
 		} );
 
@@ -182,6 +187,15 @@ class ImageBlock extends Component {
 				<InspectorControls key="inspector">
 					<h2>{ __( 'Image Settings' ) }</h2>
 					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) } />
+					<TextControl
+						label={ __( 'Size' ) }
+						type={ 'number' }
+						min={ 5 }
+						max={ 100 }
+						value={ size }
+						onChange={ this.updateSize }
+						help={ __( 'Set the image width as a percentage of the content width.' ) }
+					/>
 				</InspectorControls>
 			),
 			<figure key="image" className={ classes } style={ figureStyle }>
@@ -233,10 +247,7 @@ class ImageBlock extends Component {
 									toggleSelection( false );
 								} }
 								onResizeStop={ ( event, direction, elt, delta ) => {
-									setAttributes( {
-										size: parseInt( currentWidth + delta.width, 10 ) * 100 / settings.maxWidth,
-									} );
-
+									this.updateSize( Math.round( ( currentWidth + delta.width ) * 100 / settings.maxWidth ) );
 									toggleSelection( true );
 								} }
 							>

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -3,12 +3,6 @@
  */
 import classnames from 'classnames';
 import ResizableBox from 're-resizable';
-import {
-	startCase,
-	isEmpty,
-	map,
-	get,
-} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,7 +16,6 @@ import {
 	Toolbar,
 	DropZone,
 	FormFileUpload,
-	withAPIData,
 	withContext,
 } from '@wordpress/components';
 
@@ -33,7 +26,6 @@ import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
 import TextControl from '../../inspector-controls/text-control';
-import SelectControl from '../../inspector-controls/select-control';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import UrlInputButton from '../../url-input/button';
@@ -106,16 +98,11 @@ class ImageBlock extends Component {
 		this.props.setAttributes( { url } );
 	}
 
-	getAvailableSizes() {
-		return get( this.props.image, [ 'data', 'media_details', 'sizes' ], {} );
-	}
-
 	render() {
 		const { attributes, setAttributes, focus, setFocus, className, settings, toggleSelection } = this.props;
 		const { url, alt, caption, align, id, href, size } = attributes;
 		const width = size ? size * settings.maxWidth / 100 : undefined;
 
-		const availableSizes = this.getAvailableSizes();
 		const figureStyle = width ? { width } : {};
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && ( ! viewPort.isExtraSmall() );
 		const uploadButtonProps = { isLarge: true };
@@ -195,17 +182,6 @@ class ImageBlock extends Component {
 				<InspectorControls key="inspector">
 					<h2>{ __( 'Image Settings' ) }</h2>
 					<TextControl label={ __( 'Textual Alternative' ) } value={ alt } onChange={ this.updateAlt } help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) } />
-					{ ! isEmpty( availableSizes ) && (
-						<SelectControl
-							label={ __( 'Size' ) }
-							value={ url }
-							options={ map( availableSizes, ( size, name ) => ( {
-								value: size.source_url,
-								label: startCase( name ),
-							} ) ) }
-							onChange={ this.updateImageURL }
-						/>
-					) }
 				</InspectorControls>
 			),
 			<figure key="image" className={ classes } style={ figureStyle }>
@@ -289,15 +265,5 @@ class ImageBlock extends Component {
 export default compose( [
 	withContext( 'editor' )( ( settings ) => {
 		return { settings };
-	} ),
-	withAPIData( ( props ) => {
-		const { id } = props.attributes;
-		if ( ! id ) {
-			return {};
-		}
-
-		return {
-			image: `/wp/v2/media/${ id }`,
-		};
 	} ),
 ] )( ImageBlock );

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -89,10 +89,14 @@ class ImageBlock extends Component {
 	}
 
 	updateAlignment( nextAlign ) {
-		const extraUpdatedAttributes = [ 'wide', 'full' ].indexOf( nextAlign ) !== -1 ?
-			{ width: undefined, height: undefined } :
-			{};
-		this.props.setAttributes( { ...extraUpdatedAttributes, align: nextAlign } );
+		const nextSize = [ 'left', 'center', 'right' ].indexOf( nextAlign ) !== -1 ?
+			this.props.attributes.size || 50 :
+			undefined;
+
+		this.props.setAttributes( {
+			align: nextAlign,
+			size: nextSize,
+		} );
 	}
 
 	updateImageURL( url ) {
@@ -100,6 +104,10 @@ class ImageBlock extends Component {
 	}
 
 	updateSize( size ) {
+		if ( ! size || size === 100 ) {
+			size = undefined;
+		}
+
 		this.props.setAttributes( { size } );
 	}
 
@@ -192,7 +200,7 @@ class ImageBlock extends Component {
 						type={ 'number' }
 						min={ 5 }
 						max={ 100 }
-						value={ size }
+						value={ size || 100 }
 						onChange={ this.updateSize }
 						help={ __( 'Set the image width as a percentage of the content width.' ) }
 					/>

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -82,3 +82,7 @@
 		max-width: 370px !important;
 	}
 }
+
+.editor-block-list__block[data-type="core/image"][data-align="center"] figure {
+	margin: 0 auto;
+}

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -53,10 +53,7 @@ registerBlockType( 'core/image', {
 		align: {
 			type: 'string',
 		},
-		width: {
-			type: 'number',
-		},
-		height: {
+		size: {
 			type: 'number',
 		},
 	},
@@ -153,10 +150,9 @@ registerBlockType( 'core/image', {
 	edit: ImageBlock,
 
 	save( { attributes } ) {
-		const { url, alt, caption, align, href, width, height } = attributes;
-		const extraImageProps = width || height ? { width, height } : {};
-		const figureStyle = width ? { width } : {};
-		const image = <img src={ url } alt={ alt } { ...extraImageProps } />;
+		const { url, alt, caption, align, href, size } = attributes;
+		const figureStyle = size ? { width: size + '%' } : {};
+		const image = <img src={ url } alt={ alt } />;
 
 		return (
 			<figure className={ align ? `align${ align }` : null } style={ figureStyle }>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -150,9 +150,10 @@ registerBlockType( 'core/image', {
 	edit: ImageBlock,
 
 	save( { attributes } ) {
-		const { url, alt, caption, align, href, size } = attributes;
+		const { url, alt, caption, align, href, size, id } = attributes;
 		const figureStyle = size ? { width: size + '%' } : {};
-		const image = <img src={ url } alt={ alt } />;
+		// Class is important to set srcset with front-end filter.
+		const image = <img src={ url } alt={ alt } className={ id ? `wp-image-${ id }` : null } />;
 
 		return (
 			<figure className={ align ? `align${ align }` : null } style={ figureStyle }>

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -12,6 +12,38 @@ import './editor.scss';
 import { registerBlockType, createBlock, getBlockAttributes, getBlockType } from '../../api';
 import ImageBlock from './block';
 
+const blockAttributes = {
+	url: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'img',
+		attribute: 'src',
+	},
+	alt: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'img',
+		attribute: 'alt',
+	},
+	caption: {
+		type: 'array',
+		source: 'children',
+		selector: 'figcaption',
+	},
+	href: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a',
+		attribute: 'href',
+	},
+	id: {
+		type: 'number',
+	},
+	align: {
+		type: 'string',
+	},
+};
+
 registerBlockType( 'core/image', {
 	title: __( 'Image' ),
 
@@ -24,35 +56,7 @@ registerBlockType( 'core/image', {
 	keywords: [ __( 'photo' ) ],
 
 	attributes: {
-		url: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'img',
-			attribute: 'src',
-		},
-		alt: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'img',
-			attribute: 'alt',
-		},
-		caption: {
-			type: 'array',
-			source: 'children',
-			selector: 'figcaption',
-		},
-		href: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'a',
-			attribute: 'href',
-		},
-		id: {
-			type: 'number',
-		},
-		align: {
-			type: 'string',
-		},
+		...blockAttributes,
 		size: {
 			type: 'number',
 		},
@@ -162,4 +166,32 @@ registerBlockType( 'core/image', {
 			</figure>
 		);
 	},
+
+	deprecated: [
+		{
+			attributes: {
+				...blockAttributes,
+				width: {
+					type: 'number',
+				},
+				height: {
+					type: 'number',
+				},
+			},
+
+			save( { attributes } ) {
+				const { url, alt, caption, align, href, width, height } = attributes;
+				const extraImageProps = width || height ? { width, height } : {};
+				const figureStyle = width ? { width } : {};
+				const image = <img src={ url } alt={ alt } { ...extraImageProps } />;
+
+				return (
+					<figure className={ align ? `align${ align }` : null } style={ figureStyle }>
+						{ href ? <a href={ href }>{ image }</a> : image }
+						{ caption && caption.length > 0 && <figcaption>{ caption }</figcaption> }
+					</figure>
+				);
+			},
+		},
+	],
 } );

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -141,9 +141,9 @@ registerBlockType( 'core/image', {
 	},
 
 	getEditWrapperProps( attributes ) {
-		const { align, width } = attributes;
+		const { align, size } = attributes;
 		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
-			return { 'data-align': align, 'data-resized': !! width };
+			return { 'data-align': align, 'data-resized': !! size };
 		}
 	},
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -142,7 +142,7 @@ registerBlockType( 'core/image', {
 
 	getEditWrapperProps( attributes ) {
 		const { align, size } = attributes;
-		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
+		if ( 'left' === align || 'center' === align || 'right' === align || 'wide' === align || 'full' === align ) {
 			return { 'data-align': align, 'data-resized': !! size };
 		}
 	},


### PR DESCRIPTION
## Description

This PR attempts to fix the issue where the width of the editor is different from the front-end, in which case the image might be a lot bigger or smaller than expected. This is especially an issue on small screen devices.

## How Has This Been Tested?
Resize an image and verify that the size is set as a percentage of the content width.


