### PR TITLE
Enable TinyMCE sanitization when setting HTML content

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -705,7 +705,7 @@ export default class Editable extends Component {
 		}
 
 		content = renderToString( content );
-		this.editor.setContent( content, { format: 'raw' } );
+		this.editor.setContent( content );
 	}
 
 	getContent() {


### PR DESCRIPTION
Fixes #4205.

When a reusable list block is updated, blank `<li>`s end up in the DOM:

![issue-extraline-reusableblocks](https://user-images.githubusercontent.com/253067/34443002-fa74a6ba-ecbd-11e7-8d8b-e796d53798a6.png)

This is due to a bug in the list block.

When a list block is `serialize()`d, it generates markup that looks like this:

```html
<!-- wp:list -->
<ul>
    <li>A</li>
    <li>B</li>
</ul>
<!-- /wp:list -->
```

Note that the markup is nicely indented. When we later `parse()` this markup, we get attributes that look like this:

```js
values: {
    0: '    ',
    1: { type: 'li', props: { children: 'A' } ... },
    2: '    ',
    3: { type: 'li', props: { children: 'B' } ... },
    4: '    ',
}
```
 
Note the empty values: they're there because we've sourced from `children` which picks up both the _text nodes_ and _element nodes_ that exist as children of the `<ul>`.

This isn't ordinarily a problem because we pass `values` into `Editable.defaultValue` which is smart enough to consider only element nodes. But, when a reusable block is updated, we call `editor.setContent( content, { format: 'raw' } )` (see https://github.com/WordPress/gutenberg/pull/667). Since we're disabling TinyMCE's sanitisation, the text nodes aren't filtered out and so we end up with empty `<li>`s.

I outlined some potential fixes in https://github.com/WordPress/gutenberg/issues/4205#issuecomment-355169202, but the simplest approach, which I've opted for, is to just re-enable TinyMCE's sanitisation. 

#### How to test

1. Convert a list to a reusable block
2. Open the inserter
3. The list should remain the same
  
  