### PR TITLE
Rename toolbar feature toggle

### DIFF
--- a/editor/edit-post/header/fixed-toolbar-toggle/index.js
+++ b/editor/edit-post/header/fixed-toolbar-toggle/index.js
@@ -24,7 +24,7 @@ function FeatureToggle( { onToggle, active, onMobile } ) {
 			label={ __( 'Toolbar' ) }
 		>
 			<MenuItemsToggle
-				label={ __( 'Fix toolbar to block' ) }
+				label={ __( 'Fix toolbar to top' ) }
 				isSelected={ active }
 				onClick={ onToggle }
 			/>


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/4306

Here is a quick demo video: http://cld.wthms.co/T4fFrv