### PR TITLE
Use Table of Contents terminology for icon

### DIFF
--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -33,7 +33,7 @@ function TableOfContents( { blocks } ) {
 					onClick={ onToggle }
 					icon="info-outline"
 					aria-expanded={ isOpen }
-					label={ __( 'Content Structure' ) }
+					label={ __( 'Table of Contents' ) }
 					disabled={ blocks.length === 0 }
 				/>
 			) }


### PR DESCRIPTION
Per https://github.com/WordPress/gutenberg/issues/4176, the icon should have the new uniformed label "Table of Contents".

<img width="307" alt="toc" src="https://user-images.githubusercontent.com/8536129/34593802-17a89674-f19b-11e7-8e45-fa194363fe95.png">
