### PR TITLE
Fix issue where black rectangle would briefly blink on new paragraphs

### DIFF
--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -41,7 +41,7 @@
 // like for example an image block that receives arrowkey focus.
 .editor-visual-editor .editor-block-list__block:not( .is-selected ) .editor-block-list__block-edit  {
 	box-shadow: 0 0 0 0 $white, 0 0 0 0 $dark-gray-900;
-	transition: .1s box-shadow;
+	transition: .1s box-shadow .05s;
 
 	&:focus {
 		box-shadow: 0 0 0 1px $white, 0 0 0 3px $dark-gray-900;


### PR DESCRIPTION
In master, if you press enter a lot and type a lot, a black rectangle sometimes briefly appears. This is the isEditing rectangle we use to indicate where the cursor is, if it's not in text, i.e. if you have a placeholder selected.

This PR adds a teensy delay to this so it shouldn't show up.
