### PR TITLE
Try: Editor Grid

### DIFF
--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -25,10 +25,14 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 		icon: 'align-full-width',
 		title: __( 'Full width' ),
 	},
+	card: {
+		icon: 'align-full-width',
+		title: __( 'Card' ),
+	},
 };
 
-const DEFAULT_CONTROLS = [ 'left', 'center', 'right', 'wide', 'full' ];
-const WIDE_CONTROLS = [ 'wide', 'full' ];
+const DEFAULT_CONTROLS = [ 'left', 'center', 'right', 'wide', 'full', 'card' ];
+const WIDE_CONTROLS = [ 'wide', 'full', 'card' ];
 
 export function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CONTROLS, wideControlsEnabled = false } ) {
 	function applyOrUnset( align ) {

--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -25,14 +25,22 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 		icon: 'align-full-width',
 		title: __( 'Full width' ),
 	},
-	card: {
-		icon: 'align-full-width',
-		title: __( 'Card' ),
+	pullLeft: {
+		icon: 'align-pull-left',
+		title: __( 'Pull left' ),
+	},
+	pullRight: {
+		icon: 'align-pull-right',
+		title: __( 'Pull right' ),
+	},
+	twoFold: {
+		icon: 'layout-two-fold',
+		title: __( 'Two Fold' ),
 	},
 };
 
-const DEFAULT_CONTROLS = [ 'left', 'center', 'right', 'wide', 'full', 'card' ];
-const WIDE_CONTROLS = [ 'wide', 'full', 'card' ];
+const DEFAULT_CONTROLS = [ 'left', 'center', 'right', 'pullLeft', 'pullRight', 'wide', 'full', 'twoFold' ];
+const WIDE_CONTROLS = [ 'pullLeft', 'pullRight', 'wide', 'full', 'twoFold' ];
 
 export function BlockAlignmentToolbar( { value, onChange, controls = DEFAULT_CONTROLS, wideControlsEnabled = false } ) {
 	function applyOrUnset( align ) {

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -126,7 +126,7 @@ class ImageBlock extends Component {
 	}
 
 	updateAlignment( nextAlign ) {
-		const extraUpdatedAttributes = [ 'wide', 'full' ].indexOf( nextAlign ) !== -1 ?
+		const extraUpdatedAttributes = [ 'wide', 'full', 'card' ].indexOf( nextAlign ) !== -1 ?
 			{ width: undefined, height: undefined } :
 			{};
 		this.props.setAttributes( { ...extraUpdatedAttributes, align: nextAlign } );

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -76,7 +76,7 @@ export const settings = {
 					return tag === 'img' || ( hasImage && tag === 'figure' );
 				},
 				transform( node ) {
-					const matches = /align(left|center|right)/.exec( node.className );
+					const matches = /align(left|center|right|card)/.exec( node.className );
 					const align = matches ? matches[ 1 ] : undefined;
 					const blockType = getBlockType( 'core/image' );
 					const attributes = getBlockAttributes( blockType, node.outerHTML, { align } );
@@ -150,7 +150,7 @@ export const settings = {
 
 	getEditWrapperProps( attributes ) {
 		const { align, width } = attributes;
-		if ( 'left' === align || 'center' === align || 'right' === align || 'wide' === align || 'full' === align ) {
+		if ( 'left' === align || 'center' === align || 'right' === align || 'wide' === align || 'full' === align || 'card' === align ) {
 			return { 'data-align': align, 'data-resized': !! width };
 		}
 	},

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -76,7 +76,7 @@ export const settings = {
 					return tag === 'img' || ( hasImage && tag === 'figure' );
 				},
 				transform( node ) {
-					const matches = /align(left|center|right|card)/.exec( node.className );
+					const matches = /align(left|center|right|pullLeft|pullRight|twoFold)/.exec( node.className );
 					const align = matches ? matches[ 1 ] : undefined;
 					const blockType = getBlockType( 'core/image' );
 					const attributes = getBlockAttributes( blockType, node.outerHTML, { align } );
@@ -150,7 +150,7 @@ export const settings = {
 
 	getEditWrapperProps( attributes ) {
 		const { align, width } = attributes;
-		if ( 'left' === align || 'center' === align || 'right' === align || 'wide' === align || 'full' === align || 'card' === align ) {
+		if ( 'left' === align || 'pullLeft' === align || 'center' === align || 'right' === align || 'pullRight' === align || 'wide' === align || 'full' === align || 'twoFold' === align ) {
 			return { 'data-align': align, 'data-resized': !! width };
 		}
 	},

--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -102,6 +102,12 @@ export default class Dashicon extends wp.element.Component {
 			case 'align-none':
 				path = 'M3 5h14V3H3v2zm10 8V7H3v6h10zM3 17h14v-2H3v2z';
 				break;
+			case 'align-pull-left':
+				path = 'M11 5h6V3h-6v2zm-2 6V3H3v8h6zm2-2h6V7h-6v2zm0 4h6v-2h-6v2zm0 4h6v-2h-6v2z';
+				break;
+			case 'align-pull-right':
+				path = 'M9 3H3v2h6V3zm8 8V3h-6v8h6zM9 7H3v2h6V7zm0 4H3v2h6v-2zm0 4H3v2h6v-2z';
+				break;
 			case 'align-right':
 				path = 'M3 5h14V3H3v2zm0 4h3V7H3v2zm14 4V7H8v6h9zM3 13h3v-2H3v2zm0 4h14v-2H3v2z';
 				break;
@@ -551,6 +557,9 @@ export default class Dashicon extends wp.element.Component {
 				break;
 			case 'laptop':
 				path = 'M3 3h14c.6 0 1 .4 1 1v10c0 .6-.4 1-1 1H3c-.6 0-1-.4-1-1V4c0-.6.4-1 1-1zm13 2H4v8h12V5zm-3 1H5v4zm6 11v-1H1v1c0 .6.5 1 1.1 1h15.8c.6 0 1.1-.4 1.1-1z';
+				break;
+			case 'layout-two-fold':
+				path = 'M9 16V4H3v12h6zm2-7h6V7h-6v2zm0 4h6v-2h-6v2z';
 				break;
 			case 'layout':
 				path = 'M2 2h5v11H2V2zm6 0h5v5H8V2zm6 0h4v16h-4V2zM8 8h5v5H8V8zm-6 6h11v4H2v-4z';

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -74,7 +74,7 @@
 		}
 	}
 
-	&[data-align="card"] {
+	&[data-align="twoFold"] {
 		grid-column: wide-start / middle;
 
 
@@ -84,14 +84,28 @@
 		}
 	}
 
-	&[data-align="left"] {
+	&[data-align="pullLeft"] {
 		grid-column: wide-start / content-start;
 		height: 0;
+		align-self: start;
+	}
+
+	&[data-align="pullRight"] {
+		grid-column: content-end / wide-end;
+		height: 0;
+		align-self: end;
+	}
+
+	&[data-align="left"] {
+		grid-column: content-start / middle;
+
+		+ div {
+			grid-column: middle / content-end;
+		}
 	}
 
 	&[data-align="right"] {
 		grid-column: content-end / wide-end;
-		height: 0;
 	}
 
 	&[data-align="wide"] {

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -6,12 +6,15 @@
 	grid-template-columns:
 	  [full-start] minmax(1em, 1fr)
 	  [wide-start] minmax(0, 1fr)
-	  [content-start] minmax(0, 700px) [content-end]
+	  [content-start] minmax(0, 350px) [middle] minmax(0, 350px) [content-end]
 	  minmax(0, 1fr) [wide-end]
 	  minmax(1em, 1fr) [full-end];
 
-	> div,
-	> div > .block-list {
+	.editor-writing-flow,
+	.editor-writing-flow > div,
+	.editor-writing-flow > div > div,
+	.editor-writing-flow > div > div > div,
+	.editor-writing-flow .editor-block-list__layout {
 		grid-column: full;
 		display: inherit;
 		grid-template-columns: inherit;
@@ -69,6 +72,26 @@
 			margin-left: auto;
 			margin-right: auto;
 		}
+	}
+
+	&[data-align="card"] {
+		grid-column: wide-start / middle;
+
+
+		+ div {
+			grid-column: middle / wide-end;
+			align-self: center;
+		}
+	}
+
+	&[data-align="left"] {
+		grid-column: wide-start / content-start;
+		height: 0;
+	}
+
+	&[data-align="right"] {
+		grid-column: content-end / wide-end;
+		height: 0;
 	}
 
 	&[data-align="wide"] {

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -1,6 +1,21 @@
 .edit-post-visual-editor {
 	position: relative;
 	padding: 50px 0;
+	margin: 0 auto;
+	display: grid;
+	grid-template-columns:
+	  [full-start] minmax(1em, 1fr)
+	  [wide-start] minmax(0, 1fr)
+	  [content-start] minmax(0, 700px) [content-end]
+	  minmax(0, 1fr) [wide-end]
+	  minmax(1em, 1fr) [full-end];
+
+	> div,
+	> div > .block-list {
+		grid-column: full;
+		display: inherit;
+		grid-template-columns: inherit;
+	}
 
 	&,
 	& p {
@@ -38,9 +53,9 @@
 }
 
 .edit-post-visual-editor .editor-block-list__block {
-	margin-left: auto;
-	margin-right: auto;
-	max-width: $content-width;
+	// margin-left: auto;
+	// margin-right: auto;
+	// max-width: $content-width;
 
 	@include break-small() {
 		.editor-block-list__block-edit {
@@ -57,11 +72,13 @@
 	}
 
 	&[data-align="wide"] {
-		max-width: 1100px;
+		// max-width: 1100px;
+		grid-column: wide;
 	}
 
 	&[data-align="full"] {
 		max-width: none;
+		grid-column: full;
 	}
 }
 
@@ -79,9 +96,12 @@
 }
 
 .edit-post-visual-editor .editor-post-title {
-	margin-left: auto;
-	margin-right: auto;
-	max-width: $content-width + ( 2 * $block-side-ui-padding );
+	// margin-left: auto;
+	// margin-right: auto;
+	// max-width: $content-width + ( 2 * $block-side-ui-padding );
+	grid-column: content;
+	justify-self: left;
+	width: 100%;
 
 	.editor-post-permalink {
 		left: $block-padding;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -259,55 +259,55 @@
 	 * Alignments
 	 */
 
-	&[data-align="left"],
-	&[data-align="right"] {
-		// Without z-index, won't be clickable as "above" adjacent content
-		z-index: z-index( '.editor-block-list__block {core/image aligned left or right}' );
-		width: 100%;
-
-		// When images are floated, the block itself should collapse to zero height
-		margin-bottom: 0;
-
-		// Hide block outline when an image is floated
-		&:before {
-			content: none;
-		}
-	}
-
-	// Apply max-width to floated items that have no intrinsic width, like Cover Image or Gallery
-	&[data-align="left"],
-	&[data-align="right"] {
-		> .editor-block-list__block-edit {
-			max-width: 360px;
-			width: 100%;
-		}
-
-		// reset when data-resized
-		&[data-resized="true"] > .editor-block-list__block-edit {
-			max-width: none;
-			width: auto;
-		}
-	}
-
-	// Left
-	&[data-align="left"] {
-		.editor-block-list__block-edit {	// This is in the editor only, on the frontend, the img should be floated
-			float: left;
-			margin-right: 2em;
-		}
-	}
-
-	// Right
-	&[data-align="right"] {
-		.editor-block-list__block-edit {	// This is in the editor only, on the frontend, the img should be floated
-			float: right;
-			margin-left: 2em;
-		}
-
-		.editor-block-toolbar {
-			float: right;
-		}
-	}
+	// &[data-align="left"],
+	// &[data-align="right"] {
+	// 	// Without z-index, won't be clickable as "above" adjacent content
+	// 	z-index: z-index( '.editor-block-list__block {core/image aligned left or right}' );
+	// 	width: 100%;
+	//
+	// 	// When images are floated, the block itself should collapse to zero height
+	// 	margin-bottom: 0;
+	//
+	// 	// Hide block outline when an image is floated
+	// 	&:before {
+	// 		content: none;
+	// 	}
+	// }
+	//
+	// // Apply max-width to floated items that have no intrinsic width, like Cover Image or Gallery
+	// &[data-align="left"],
+	// &[data-align="right"] {
+	// 	> .editor-block-list__block-edit {
+	// 		max-width: 360px;
+	// 		width: 100%;
+	// 	}
+	//
+	// 	// reset when data-resized
+	// 	&[data-resized="true"] > .editor-block-list__block-edit {
+	// 		max-width: none;
+	// 		width: auto;
+	// 	}
+	// }
+	//
+	// // Left
+	// &[data-align="left"] {
+	// 	.editor-block-list__block-edit {	// This is in the editor only, on the frontend, the img should be floated
+	// 		float: left;
+	// 		margin-right: 2em;
+	// 	}
+	// }
+	//
+	// // Right
+	// &[data-align="right"] {
+	// 	.editor-block-list__block-edit {	// This is in the editor only, on the frontend, the img should be floated
+	// 		float: right;
+	// 		margin-left: 2em;
+	// 	}
+	//
+	// 	.editor-block-toolbar {
+	// 		float: right;
+	// 	}
+	// }
 
 	// Wide and full-wide
 	&[data-align="full"],

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -102,6 +102,7 @@
 	position: relative;
 	padding-left: $block-padding;
 	padding-right: $block-padding;
+	grid-column: content;
 
 	@include break-small() {
 		// The block mover needs to stay inside the block to allow clicks when hovering the block


### PR DESCRIPTION
### _In progress_ (Highly Experimental)

This PR seeks to explore setting up a grid as the layout manager for the editor content. It absorbs the responsibility of handling `wide` and `full` widths. A theme should be able to overwrite the grid and every block would fall into place. This should greatly simplify calculations for presence of sidebar (collapsed or not). The biggest challenge is accommodating floats without changing the editor markup.

This follows early explorations by @mor10.

## Extra Alignment Options

Another thing this enables is registering extra alignment options (pulled content, side-by-side cards, etc) that a user can easily toggle with one click.

See this rough video for some of these explorations: https://cloudup.com/cxerBaTpMI9

 ### Themes

A theme should be able to overwrite the grid template definition and, if using the same named areas, all content and alignment possibilities should follow through.

### Concerns

The grid paradigm is fundamentally incompatible with floating and wrapping direct descendant nodes. That means if we want to support both, we need to add a container wrapper to the elements that want to interact in a float context.