### PR TITLE
Update copy in table of contents to describe the outline section.

### DIFF
--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -59,7 +59,7 @@ function TableOfContents( { blocks } ) {
 				headings.length > 0 && (
 					<div key="headings">
 						<hr />
-						<span className="table-of-contents__title">{ __( 'Table of Contents' ) }</span>
+						<span className="table-of-contents__title">{ __( 'Document Outline' ) }</span>
 						<DocumentOutline />
 					</div>
 				),


### PR DESCRIPTION
Now that the tooltip itself is called "table of contents" it makes more sense to describe this one as "document outline" instead:

![image](https://user-images.githubusercontent.com/548849/34606716-c1b72160-f210-11e7-8b76-f3bb09048cb3.png)
