### PR TITLE
Accessibility: Add missing tooltips to icon buttons

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Dashicon, Placeholder, Toolbar } from '@wordpress/components';
+import { Button, IconButton, Placeholder, Toolbar } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 
 /**
@@ -99,13 +99,12 @@ registerBlockType( 'core/audio', {
 						onChange={ updateAlignment }
 					/>
 					<Toolbar>
-						<Button
+						<IconButton
 							className="components-icon-button components-toolbar__control"
-							aria-label={ __( 'Edit audio' ) }
+							label={ __( 'Edit audio' ) }
 							onClick={ switchToEditing }
-						>
-							<Dashicon icon="edit" />
-						</Button>
+							icon="edit"
+						/>
 					</Toolbar>
 				</BlockControls>
 			);

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -103,6 +103,7 @@ registerBlockType( 'core/cover-image', {
 			}
 		);
 
+		const editButtonLabel = __( 'Edit image' );
 		const controls = focus && [
 			<BlockControls key="controls">
 				<BlockAlignmentToolbar
@@ -114,11 +115,12 @@ registerBlockType( 'core/cover-image', {
 					<MediaUploadButton
 						buttonProps={ {
 							className: 'components-icon-button components-toolbar__control',
-							'aria-label': __( 'Edit image' ),
+							'aria-label': editButtonLabel,
 						} }
 						onSelect={ onSelectImage }
 						type="image"
 						value={ id }
+						tooltip={ editButtonLabel }
 					>
 						<Dashicon icon="edit" />
 					</MediaUploadButton>

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -234,10 +234,28 @@
 	}
 }
 
-.mce-tooltip {
-	display: none;
-}
-
 .components-toolbar__control .dashicon {
 	display: block;
+}
+
+
+.mce-widget.mce-tooltip {
+	display: block;
+	opacity: initial;
+
+	.mce-tooltip-inner {
+		padding: 4px 12px;
+		background: $dark-gray-400;
+		border-width: 0;
+		color: white;
+		white-space: nowrap;
+		box-shadow: none;
+		font-size: $default-font-size;
+		border-radius: 0;
+	}
+
+	.mce-tooltip-arrow {
+		border-top-color: $dark-gray-400;
+		border-bottom-color: $dark-gray-400;
+	}
 }

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -137,6 +137,7 @@ class GalleryBlock extends Component {
 			/>
 		);
 
+		const editButtonLabel = __( 'Edit Gallery' );
 		const controls = (
 			focus && (
 				<BlockControls key="controls">
@@ -149,13 +150,14 @@ class GalleryBlock extends Component {
 							<MediaUploadButton
 								buttonProps={ {
 									className: 'components-icon-button components-toolbar__control',
-									'aria-label': __( 'Edit Gallery' ),
+									'aria-label': editButtonLabel,
 								} }
 								onSelect={ this.onSelectImages }
 								type="image"
 								multiple
 								gallery
 								value={ images.map( ( img ) => img.id ) }
+								tooltip={ editButtonLabel }
 							>
 								<Dashicon icon="edit" />
 							</MediaUploadButton>

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -121,6 +121,7 @@ class ImageBlock extends Component {
 		const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setAttributes );
 		const dropFiles = ( files ) => mediaUpload( files, setAttributes );
 
+		const editButtonLabel = __( 'Edit image' );
 		const controls = (
 			focus && (
 				<BlockControls key="controls">
@@ -133,11 +134,12 @@ class ImageBlock extends Component {
 						<MediaUploadButton
 							buttonProps={ {
 								className: 'components-icon-button components-toolbar__control',
-								'aria-label': __( 'Edit image' ),
+								'aria-label': editButtonLabel,
 							} }
 							onSelect={ this.onSelectImage }
 							type="image"
 							value={ id }
+							tooltip={ editButtonLabel }
 						>
 							<Dashicon icon="edit" />
 						</MediaUploadButton>

--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -70,7 +70,7 @@ class LatestPostsBlock extends Component {
 						value={ columns }
 						onChange={ ( value ) => setAttributes( { columns: value } ) }
 						min={ 2 }
-						max={ Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
+						max={ ! hasPosts ? MAX_POSTS_COLUMNS : Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
 					/>
 				}
 			</InspectorControls>

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Placeholder, Toolbar, Dashicon, Button } from '@wordpress/components';
+import { Placeholder, Toolbar, IconButton, Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 
 /**
@@ -100,13 +100,12 @@ registerBlockType( 'core/video', {
 						onChange={ updateAlignment }
 					/>
 					<Toolbar>
-						<Button
+						<IconButton
 							className="components-icon-button components-toolbar__control"
-							aria-label={ __( 'Edit video' ) }
+							label={ __( 'Edit video' ) }
 							onClick={ switchToEditing }
-						>
-							<Dashicon icon="edit" />
-						</Button>
+							icon="edit"
+						/>
 					</Toolbar>
 				</BlockControls>
 			);

--- a/blocks/media-upload-button/index.js
+++ b/blocks/media-upload-button/index.js
@@ -3,7 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { pick } from 'lodash';
 
 // Getter for the sake of unit tests.
@@ -149,13 +149,19 @@ class MediaUploadButton extends Component {
 	}
 
 	render() {
-		const { children, buttonProps } = this.props;
+		const { children, buttonProps, tooltip } = this.props;
 
-		return (
+		let element = (
 			<Button onClick={ this.openModal } { ...buttonProps }>
 				{ children }
 			</Button>
 		);
+
+		if ( tooltip ) {
+			element = <Tooltip text={ tooltip }>{ element }</Tooltip>;
+		}
+
+		return element;
 	}
 }
 

--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -54,6 +54,7 @@ function DropdownMenu( {
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						label={ label }
+						tooltip={ label }
 					>
 						<Dashicon icon="arrow-down" />
 					</IconButton>

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -23,6 +23,8 @@ class IconButton extends Component {
 	render() {
 		const { icon, children, label, className, tooltip, focus, ...additionalProps } = this.props;
 		const classes = classnames( 'components-icon-button', className );
+		const tooltipText = tooltip || label;
+		const showTooltip = !! tooltip || ( label && ! children && false !== tooltip );
 
 		let element = (
 			<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>
@@ -31,8 +33,8 @@ class IconButton extends Component {
 			</Button>
 		);
 
-		if ( label && ! children && false !== tooltip ) {
-			element = <Tooltip text={ tooltip || label }>{ element }</Tooltip>;
+		if ( showTooltip ) {
+			element = <Tooltip text={ tooltipText }>{ element }</Tooltip>;
 		}
 
 		return element;

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isString } from 'lodash';
+import { isString, isArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,7 +24,15 @@ class IconButton extends Component {
 		const { icon, children, label, className, tooltip, focus, ...additionalProps } = this.props;
 		const classes = classnames( 'components-icon-button', className );
 		const tooltipText = tooltip || label;
-		const showTooltip = !! tooltip || ( label && ! children && false !== tooltip );
+
+		// Should show the tooltip if an explicit tooltip is passed
+		// or if there's a label and the children are empty and the tooltip is not explicitely disabled
+		const showTooltip = !! tooltip ||
+			(
+				label &&
+				( ! children || ( isArray( children ) && ! children.length ) ) &&
+				false !== tooltip
+			);
 
 		let element = (
 			<Button { ...additionalProps } aria-label={ label } className={ classes } focus={ focus }>

--- a/components/icon-button/test/index.js
+++ b/components/icon-button/test/index.js
@@ -61,5 +61,11 @@ describe( 'IconButton', () => {
 			expect( iconButton.name() ).toBe( 'Button' );
 			expect( iconButton.prop( 'aria-label' ) ).toBe( 'WordPress' );
 		} );
+
+		it( 'should show the tooltip for empty children', () => {
+			const iconButton = shallow( <IconButton label="WordPress" children={ [] } /> );
+			expect( iconButton.name() ).toBe( 'Tooltip' );
+			expect( iconButton.prop( 'text' ) ).toBe( 'WordPress' );
+		} );
 	} );
 } );

--- a/editor/components/block-switcher/index.js
+++ b/editor/components/block-switcher/index.js
@@ -46,6 +46,7 @@ function BlockSwitcher( { blocks, onTransform, isLocked } ) {
 						onToggle();
 					}
 				};
+				const label = __( 'Change block type' );
 
 				return (
 					<Toolbar>
@@ -55,7 +56,8 @@ function BlockSwitcher( { blocks, onTransform, isLocked } ) {
 							onClick={ onToggle }
 							aria-haspopup="true"
 							aria-expanded={ isOpen }
-							label={ __( 'Change block type' ) }
+							label={ label }
+							tooltip={ label }
 							onKeyDown={ openOnArrowDown }
 						>
 							<Dashicon icon="arrow-down" />


### PR DESCRIPTION
closes #3384

This PR adds the missing tooltips to icon-only buttons.

 - The block switcher
 - Some media upload buttons

If you notice another missing tooltip, let me know.