### PR TITLE
Fix button line break causes unexpected behaviour

### DIFF
--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -1,4 +1,5 @@
 $blocks-button__height: 46px;
+$blocks-button__line-height: $big-font-size + 6px;
 
 .wp-block-button {
 	margin-bottom: 1.5em;
@@ -12,12 +13,13 @@ $blocks-button__height: 46px;
 		cursor: pointer;
 		display: inline-block;
 		font-size: $big-font-size;
-		height: $blocks-button__height;
-		line-height: $blocks-button__height;
+		line-height: $blocks-button__line-height;
 		margin: 0;
-		padding: 0 24px;
+		padding: ( $blocks-button__height - $blocks-button__line-height ) / 2 24px;
+		text-align: center;
 		text-decoration: none !important;
 		white-space: nowrap;
+		word-break: break-word;
 
 		&:hover,
 		&:focus,


### PR DESCRIPTION
## Description
This PR fixes  "Button line break causes unexpected behavior" - https://github.com/WordPress/gutenberg/issues/4295. 
In order to solve the problem, the case was updated to allow multiple lines: 
![image](https://user-images.githubusercontent.com/11271197/35747763-6e38c2e8-0843-11e8-88fa-60ac62c8f2f1.png). 

## How Has This Been Tested?
Add a button block, write some text, press enter and verify the block expanded to shown that line.