### PR TITLE
VisualEditorInserter: Clear block selection on open

### DIFF
--- a/editor/edit-post/modes/visual-editor/inserter.js
+++ b/editor/edit-post/modes/visual-editor/inserter.js
@@ -17,7 +17,7 @@ import { createBlock, BlockIcon } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { Inserter } from '../../../components';
-import { insertBlock } from '../../../store/actions';
+import { clearSelectedBlock, insertBlock } from '../../../store/actions';
 import { getMostFrequentlyUsedBlocks, getBlockCount, getBlocks } from '../../../store/selectors';
 
 export class VisualEditorInserter extends Component {
@@ -34,11 +34,14 @@ export class VisualEditorInserter extends Component {
 
 	toggleControls( isShowingControls ) {
 		this.setState( { isShowingControls } );
+
+		if ( isShowingControls && this.props.clearSelectedBlock ) {
+			this.props.clearSelectedBlock();
+		}
 	}
 
 	insertBlock( name ) {
-		const { onInsertBlock } = this.props;
-		onInsertBlock( createBlock( name ) );
+		this.props.insertBlock( createBlock( name ) );
 	}
 
 	isDisabledBlock( block ) {
@@ -96,7 +99,10 @@ export default compose(
 				blocks: getBlocks( state ),
 			};
 		},
-		{ onInsertBlock: insertBlock },
+		{
+			insertBlock,
+			clearSelectedBlock,
+		},
 	),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;

--- a/editor/edit-post/modes/visual-editor/test/inserter.js
+++ b/editor/edit-post/modes/visual-editor/test/inserter.js
@@ -15,11 +15,13 @@ import { VisualEditorInserter } from '../inserter';
 
 describe( 'VisualEditorInserter', () => {
 	it( 'should show controls when receiving focus', () => {
-		const wrapper = shallow( <VisualEditorInserter /> );
+		const clearSelectedBlock = jest.fn();
+		const wrapper = shallow( <VisualEditorInserter clearSelectedBlock={ clearSelectedBlock } /> );
 
 		wrapper.simulate( 'focus' );
 
 		expect( wrapper.state( 'isShowingControls' ) ).toBe( true );
+		expect( clearSelectedBlock ).toHaveBeenCalled();
 	} );
 
 	it( 'should hide controls when losing focus', () => {
@@ -32,10 +34,10 @@ describe( 'VisualEditorInserter', () => {
 	} );
 
 	it( 'should insert frequently used blocks', () => {
-		const onInsertBlock = jest.fn();
+		const insertBlock = jest.fn();
 		const mostFrequentlyUsedBlocks = [ getBlockType( 'core/paragraph' ), getBlockType( 'core/image' ) ];
 		const wrapper = shallow(
-			<VisualEditorInserter onInsertBlock={ onInsertBlock } mostFrequentlyUsedBlocks={ mostFrequentlyUsedBlocks } />
+			<VisualEditorInserter insertBlock={ insertBlock } mostFrequentlyUsedBlocks={ mostFrequentlyUsedBlocks } />
 		);
 		wrapper.state.preferences = {
 			blockUsage: {
@@ -48,7 +50,7 @@ describe( 'VisualEditorInserter', () => {
 			.findWhere( ( node ) => node.prop( 'children' ) === 'Paragraph' )
 			.simulate( 'click' );
 
-		expect( onInsertBlock ).toHaveBeenCalled();
-		expect( onInsertBlock.mock.calls[ 0 ][ 0 ].name ).toBe( 'core/paragraph' );
+		expect( insertBlock ).toHaveBeenCalled();
+		expect( insertBlock.mock.calls[ 0 ][ 0 ].name ).toBe( 'core/paragraph' );
 	} );
 } );


### PR DESCRIPTION
Fixes #2432 
Related: #4294 

## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):
![gutenberg-bottom-inserter-clear-selection](https://user-images.githubusercontent.com/150562/34611316-e122f504-f21c-11e7-87ab-7818f55d1747.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.