### PR TITLE
Allow scrolling when Table of Contents is too long

### DIFF
--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -1,8 +1,12 @@
 .table-of-contents__popover.components-popover:not(.is-mobile) .components-popover__content {
 	min-width: 380px;
+	height: 100%;
+	overflow-y: auto;
 }
 
 .table-of-contents__popover {
+	height: calc(100% - 85.5px);
+
 	.components-popover__content {
 		padding: 16px;
 	}

--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -1,6 +1,6 @@
 .table-of-contents__popover.components-popover:not(.is-mobile) .components-popover__content {
 	min-width: 380px;
-	height: 100%;
+	max-height: 100%;
 	overflow-y: auto;
 }
 

--- a/editor/components/table-of-contents/style.scss
+++ b/editor/components/table-of-contents/style.scss
@@ -1,12 +1,13 @@
 .table-of-contents__popover.components-popover:not(.is-mobile) .components-popover__content {
 	min-width: 380px;
-	max-height: 100%;
+	height: auto;
 	overflow-y: auto;
+	@include break-medium {
+		max-height: 320px;
+	}
 }
 
 .table-of-contents__popover {
-	height: calc(100% - 85.5px);
-
 	.components-popover__content {
 		padding: 16px;
 	}


### PR DESCRIPTION
## Description

Allow scrolling when Table of Contents is too long. Fix #4308 .

![screenshot from 2018-01-05 11-30-18](https://user-images.githubusercontent.com/6010232/34611264-ee786ae2-f20b-11e7-9ed1-ed90b5900422.png)

I calculated the height of table of content this way: calc(100% - 85.5px); when 85.5px = 77.5px (top of .table-of-contents__popover) + 8px (margin-top of .components-popover:not(.is-mobile).is-bottom).

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation. #
  