### PR TITLE
Fixed url input on images.

### DIFF
--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -53,18 +53,20 @@ class UrlInputButton extends Component {
 					<form
 						className="blocks-format-toolbar__link-modal"
 						onSubmit={ this.submitLink }>
-						<IconButton
-							className="blocks-url-input__back"
-							icon="arrow-left-alt"
-							label={ __( 'Close' ) }
-							onClick={ this.toggle }
-						/>
-						<UrlInput value={ url || '' } onChange={ onChange } data-test="UrlInput" />
-						<IconButton
-							icon="editor-break"
-							label={ __( 'Submit' ) }
-							type="submit"
-						/>
+						<div className="blocks-format-toolbar__link-modal-line">
+							<IconButton
+								className="blocks-url-input__back"
+								icon="arrow-left-alt"
+								label={ __( 'Close' ) }
+								onClick={ this.toggle }
+							/>
+							<UrlInput value={ url || '' } onChange={ onChange } data-test="UrlInput" />
+							<IconButton
+								icon="editor-break"
+								label={ __( 'Submit' ) }
+								type="submit"
+							/>
+						</div>
 					</form>
 				}
 			</div>


### PR DESCRIPTION
A wrapper div with the correct class was missing in UrlInput component.
This PR should fix issue https://github.com/WordPress/gutenberg/issues/4253 and https://github.com/WordPress/gutenberg/issues/4327.

## How Has This Been Tested?
Add an image block, press the link input in the toolbar verify it appears as expected.
  