### PR TITLE
Cover Image: Fix style regression in textual placeholder

### DIFF
--- a/blocks/library/cover-image/editor.scss
+++ b/blocks/library/cover-image/editor.scss
@@ -19,7 +19,7 @@
 		font-weight: 300;
 	}
 
-	.components-placeholder h2 {
+	&.components-placeholder h2 {
 		color: inherit;
 	}
 }


### PR DESCRIPTION
## Description
When transforming a Heading into a Cover Image block (#4129), the text from the Heading is carried over into a newly introduced placeholder view of the Cover Image block. This placeholder view prompts to pick an image while showing the text. A style regression recently slipped in wherein the text would render in Cover Image's default white:

Regression | With fix
-----------|---------
<img width="642" alt="screen shot 2018-01-05 at 14 52 41" src="https://user-images.githubusercontent.com/150562/34614097-2b414888-f228-11e7-9351-f1cbc72b59bd.png"> | <img width="664" alt="screen shot 2018-01-05 at 14 52 17" src="https://user-images.githubusercontent.com/150562/34614098-2f9c9144-f228-11e7-8023-13b63aa68d06.png">

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.