### PR TITLE
Gallery: deselect images when losing focus.

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -127,6 +127,15 @@ class GalleryBlock extends Component {
 		);
 	}
 
+	componentWillReceiveProps( nextProps ) {
+		// Deselect images when losing focus
+		if ( ! nextProps.focus && this.props.focus ) {
+			this.setState( {
+				selectedImage: null,
+			} );
+		}
+	}
+
 	render() {
 		const { attributes, focus, className } = this.props;
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;


### PR DESCRIPTION
## Description
This PR should close issue "Clicking outside block should deselect image item in gallery -
 https://github.com/WordPress/gutenberg/issues/4315".
It uses componentWillReceiveProps to check when focus is lost and in this situations unselects the image. A simpler approach would be to change the isSelected condition to also require focus but when returning to the block without pressing an image e.g: keyboard or clicking the ellipsis the selection would magically return which is not desirable.

## How Has This Been Tested?
Add a gallery with images select an image move the focus to another block, verify the image becomes unselected.