### PR TITLE
Fixed "Hide Advanced Settings" in block menu.

### DIFF
--- a/editor/components/block-settings-menu/block-inspector-button.js
+++ b/editor/components/block-settings-menu/block-inspector-button.js
@@ -19,7 +19,7 @@ import { toggleSidebar, setActivePanel } from '../../store/actions';
 export function BlockInspectorButton( {
 	isDefaultSidebarOpened,
 	panel,
-	onOpenSidebar,
+	toggleDefaultSidebar,
 	onShowInspector,
 	onClick = noop,
 	small = false,
@@ -27,7 +27,9 @@ export function BlockInspectorButton( {
 } ) {
 	const toggleInspector = () => {
 		onShowInspector();
-		onOpenSidebar( undefined, true );
+		if ( ! isDefaultSidebarOpened || panel === 'block' ) {
+			toggleDefaultSidebar();
+		}
 	};
 
 	const speakMessage = () => {
@@ -61,8 +63,8 @@ export default connect(
 		onShowInspector() {
 			dispatch( setActivePanel( 'block' ) );
 		},
-		onOpenSidebar() {
-			dispatch( toggleSidebar( undefined, true ) );
+		toggleDefaultSidebar() {
+			dispatch( toggleSidebar() );
 		},
 	} )
 )( withSpokenMessages( BlockInspectorButton ) );


### PR DESCRIPTION
## Description
This PR should fix the issue: "Hide Advanced Settings" option does nothing  https://github.com/WordPress/gutenberg/issues/4310.

## How Has This Been Tested?
Press the block menu if the sidebar is not on inspector controls press "Show advanced settings". Press "Hide Advanced Settings" and verify the sidebar gets closed.
Try to hide on desktop and mobile resolutions.
