### PR TITLE
Blocks: Fix unsetting block alignment flagging block as invalid

### DIFF
--- a/blocks/alignment-toolbar/index.js
+++ b/blocks/alignment-toolbar/index.js
@@ -32,7 +32,7 @@ export default function AlignmentToolbar( { value, onChange } ) {
 				return {
 					...control,
 					isActive,
-					onClick: () => onChange( isActive ? null : align ),
+					onClick: () => onChange( isActive ? undefined : align ),
 				};
 			} ) }
 		/>

--- a/blocks/alignment-toolbar/test/index.js
+++ b/blocks/alignment-toolbar/test/index.js
@@ -24,13 +24,13 @@ describe( 'AlignmentToolbar', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	test( 'should call on change with null when a control is already active', () => {
+	test( 'should call on change with undefined when a control is already active', () => {
 		const activeControl = controls.find( ( { isActive } ) => isActive );
 		activeControl.onClick();
 
 		expect( activeControl.align ).toBe( alignment );
 		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
-		expect( onChangeSpy ).toHaveBeenCalledWith( null );
+		expect( onChangeSpy ).toHaveBeenCalledWith( undefined );
 	} );
 
 	test( 'should call on change a new value when the control is not active', () => {


### PR DESCRIPTION
This pull request seeks to resolve an issue where unsetting a block's alignment by clicking the currently selected value would cause the block to save as invalid.

__Implementation notes:__

A block with a defined attribute type will coerce its value to that type, [except in the case that the value is `undefined`](https://github.com/WordPress/gutenberg/blob/255fe64cbca0143cec3f7f2764387c6a43ac53da/blocks/api/serializer.js#L106-L109). A `null` value is therefore coerced since there may be cases where the developer wants to explicitly save an empty value into attributes. This is an issue for blocks using the alignment toolbar because previously the unset would set the alignment value to `null`, which would be coerced to the string type as `"null"` (later serializing as `<p style="text-align: null;"></span>`. The changes here respect this behavior, passing `undefined` as the unset value when toggling the already-active alignment.

__Testing instructions:__

Verify that upon toggling a block's alignment on and off, saving the post, and reloading the editor, the block appears as valid:

1. Navigate to Posts > New Post
2. Insert a new Paragraph block
3. Press Align Center in the block toolbar to toggle center alignment
4. Press Align Center in the block toolbar to unset alignment
5. Save the post
6. Refresh the page