### PR TITLE
Fix image handlers from being unclickable

### DIFF
--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -29,6 +29,7 @@
 
 	.wp-block-image.is-focused & {
 		display: block;
+		z-index: 1;
 	}
 }
 

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -29,7 +29,7 @@
 
 	.wp-block-image.is-focused & {
 		display: block;
-		z-index: 1;
+		z-index: z-index( '.wp-block-image__resize-handlers' );
 	}
 }
 

--- a/editor/assets/stylesheets/_z-index.scss
+++ b/editor/assets/stylesheets/_z-index.scss
@@ -26,6 +26,7 @@ $z-layers: (
 	'.editor-block-settings-menu__popover': 20, // Below the header
 	'.editor-header': 30,
 	'.editor-text-editor__formatting': 30,
+	'.wp-block-image__resize-handlers': 1, // Resize handlers above sibling inserter
 
 	// Show drop zone above most standard content, but below any overlays
 	'.components-drop-zone': 100,


### PR DESCRIPTION
## Description
Fixes problem where the `before` pseudo-element from the previous block overlaps the top of the image handlers and makes them unclickable.

## How Has This Been Tested?
- I'm running WordPress locally using Valet 2.0.6 (nginx + mysql)

## Screenshots (jpeg or gifs if applicable):
- Before, when you tried to resize an image from either the top left or top right handlers, here's the overlap that I was seeing:
<img width="799" alt="screen shot 2018-01-05 at 10 51 39 am" src="https://user-images.githubusercontent.com/3220162/34623493-7359680c-f206-11e7-81d6-b720d8708e5f.png">

As you can see, the handlers were mostly underneath this `before` element and so they were very hard to click:
![image-handler-click](https://user-images.githubusercontent.com/3220162/34623536-9e7e5182-f206-11e7-922c-574b2fd42a46.gif)

With this change, the image handlers are now on top of the `before` element so they are clickable!
![image-handlers-fixed](https://user-images.githubusercontent.com/3220162/34623580-cb9d6c8e-f206-11e7-981c-72e0772e2368.gif)


## Types of changes
- Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.