### PR TITLE
Fixed bug when changing number of Latests Posts rapidly was leading to some numbers being defunct.

### DIFF
--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -93,10 +93,9 @@ class LatestPostsBlock extends Component {
 		}
 
 		// Removing posts from display should be instant.
-		const postsDifference = latestPosts.length - postsToShow;
-		if ( postsDifference > 0 ) {
-			latestPosts.splice( postsToShow, postsDifference );
-		}
+		const displayPosts = latestPosts.length > postsToShow ?
+			latestPosts.slice( 0, postsToShow ) :
+			latestPosts;
 
 		const layoutControls = [
 			{
@@ -133,7 +132,7 @@ class LatestPostsBlock extends Component {
 				} ) }
 				key="latest-posts"
 			>
-				{ latestPosts.map( ( post, i ) =>
+				{ displayPosts.map( ( post, i ) =>
 					<li key={ i }>
 						<a href={ post.link } target="_blank">{ decodeEntities( post.title.rendered.trim() ) || __( '(Untitled)' ) }</a>
 						{ displayPostDate && post.date_gmt &&


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/4328

Latest posts block was using splice operation changing the original data array passed to it. This data array was the same being used in withAPIData cache leading to the cache being corrupted, so when returning to the same number of posts that were cached some posts were deleted.

## How Has This Been Tested?
Increase and decrease the number of latest posts to show very fast (easy to with up&down keys) verify the number of posts being show is always the expected one and problems described in https://github.com/WordPress/gutenberg/issues/4328 are not happening.
