### PR TITLE
Latest posts: Request only required post fields.

### DIFF
--- a/blocks/library/latest-posts/block.js
+++ b/blocks/library/latest-posts/block.js
@@ -155,6 +155,7 @@ export default withAPIData( ( props ) => {
 		order,
 		orderBy,
 		per_page: postsToShow,
+		_fields: [ 'date_gmt', 'link', 'title' ],
 	}, value => ! isUndefined( value ) ) );
 	return {
 		latestPosts: `/wp/v2/posts?${ queryString }`,


### PR DESCRIPTION
The latest posts block was requesting all post fields (including content) making the request huge while only requiring a few fields.

## How Has This Been Tested?
Use the latest posts bock, and verify change the settings in the query panel and verify no regressions happened. 
