### PR TITLE
Update licenses in `package.json` & `composer.json` to adhere to SPDX v3.0 specification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "wordpress/gutenberg",
   "type": "wordpress-plugin",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "description": "Prototyping since 1440. Development hub for the editor focus in core.",
   "homepage": "https://wordpress.github.io/gutenberg/",
   "keywords": [


### PR DESCRIPTION
## Description

The SPDX `GPL-2.0+` license string has been deprecated, the new string is `GPL-2.0-or-later`

See also:
• https://spdx.org/news/news/2018/01/license-list-30-released
• https://spdx.org/licenses/
• WordPress Ticket [#43032](https://core.trac.wordpress.org/ticket/43032)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

By running `composer validate`

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
  