### PR TITLE
Update `composer.json` indentation to use tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,9 +12,5 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[composer.json]
-indent_style = space
-indent_size = 4
-
 [*.md]
 trim_trailing_whitespace = false

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,22 @@
 {
-  "name": "wordpress/gutenberg",
-  "type": "wordpress-plugin",
-  "license": "GPL-2.0+",
-  "description": "Prototyping since 1440. Development hub for the editor focus in core.",
-  "homepage": "https://wordpress.github.io/gutenberg/",
-  "keywords": [
-    "gutenberg", "wordpress", "editor", "wp", "react", "javascript"
-  ],
-  "support": {
-    "issues": "https://github.com/WordPress/gutenberg/issues"
-  },
-  "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-    "squizlabs/php_codesniffer": "^3.1",
-    "wimg/php-compatibility": "^8",
-    "wp-coding-standards/wpcs": "^0.14.0"
-  },
-  "require": {
-    "composer/installers": "~1.0"
-  }
+	"name": "wordpress/gutenberg",
+	"type": "wordpress-plugin",
+	"license": "GPL-2.0+",
+	"description": "Prototyping since 1440. Development hub for the editor focus in core.",
+	"homepage": "https://wordpress.github.io/gutenberg/",
+	"keywords": [
+		"gutenberg", "wordpress", "editor", "wp", "react", "javascript"
+	],
+	"support": {
+		"issues": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
+		"squizlabs/php_codesniffer": "^3.1",
+		"wimg/php-compatibility": "^8",
+		"wp-coding-standards/wpcs": "^0.14.0"
+	},
+	"require": {
+		"composer/installers": "~1.0"
+	}
 }


### PR DESCRIPTION
## Description

Switches from _spaces_ to _tabs_ for indentation in `composer.json`

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

By manually removing the `"wimg/php-compatibility": "^8",` line from `composer.json` and then running `composer require wimg/php-compatibility:^8 --dev` to have Composer install that dependency and then confirming that it was added back to `composer.json` using a _tab_ for indentation.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This change had been previously merged via https://github.com/WordPress/gutenberg/pull/1067/commits/09b849bac97b84694423b94858c75ea3abcef875 but was reverted again in https://github.com/WordPress/gutenberg/pull/2611/commits/89086e530f41d8aed45a778aa7b069c11ffca15d 

Composer has no issue when using _tabs_ for indentation as originally noted in https://github.com/WordPress/gutenberg/pull/1067#issuecomment-307132628

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.