### PR TITLE
fix the pending flag for cached requests in withAPIData hoc

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -176,6 +176,8 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 				route.methods.forEach( ( method ) => {
 					// Add request initiater into data props
 					const requestKey = this.getRequestKey( method );
+					const pendingKey = this.getPendingKey( method );
+
 					result[ propName ][ requestKey ] = this.request.bind(
 						this,
 						propName,
@@ -183,15 +185,17 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 						path
 					);
 
-					// Initialize pending flags as explicitly false
-					const pendingKey = this.getPendingKey( method );
-					result[ propName ][ pendingKey ] = false;
+					// Initialize pending flags as explicitly `true` since we are starting an async request
+					result[ propName ][ pendingKey ] = true;
 
 					// If cached data already exists, populate in result
 					const cachedResponse = getCachedResponse( { path, method } );
 					if ( cachedResponse ) {
 						const dataKey = this.getResponseDataKey( method );
 						result[ propName ][ dataKey ] = cachedResponse.body;
+
+						// Make pending flags as explicitly `false` for cached requests, they aren't async
+						result[ propName ][ pendingKey ] = false;
 					}
 
 					// Track path for future map skipping


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
I was following the example provided in the README.md's of [withAPIData ](https://github.com/WordPress/gutenberg/tree/master/components/higher-order/with-api-data), but I was getting an error because `post.data` was undefined. While I was trying to debug it, this discussion started on the #core-editor Slack channel.

![postloading talk](https://user-images.githubusercontent.com/1893980/34651472-41e2085e-f3d9-11e7-92fa-5c8da21e7378.png)

I think that I was wrong in Slack, `post.data` should be available when ` post.isLoading` is false. Sorry @mboynes, I think that #4337 is invalid in this case.

After some research, I think that `withAPIData` was setting the pending flag to false even if `cachedResponse` was undefined. This is why I moved it in that if block, and initialized it with true.

@aduth can you please let me know if I'm wrong about it?

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Unfortunately, Jest is a thing that I'm just starting to learn it at this moment, and I think that it will take me more than days to figure it out how to build a test case for this one. 
Also, I don't know why the 4th test is falling for the `withAPIData` component :(

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.