### PR TITLE
Fix cursor jumps in link-editing dialog (UrlInput)

### DIFF
--- a/components/slot-fill/fill.js
+++ b/components/slot-fill/fill.js
@@ -25,6 +25,11 @@ class Fill extends Component {
 		if ( ! this.occurrence ) {
 			this.occurrence = ++occurrences;
 		}
+		const { getSlot = noop } = this.context;
+		const slot = getSlot( this.props.name );
+		if ( slot && ! slot.props.bubblesVirtually ) {
+			slot.forceUpdate();
+		}
 	}
 
 	componentWillUnmount() {
@@ -43,14 +48,6 @@ class Fill extends Component {
 		if ( this.props.name !== name ) {
 			unregisterFill( this.props.name, this );
 			registerFill( name, this );
-		}
-	}
-
-	componentDidUpdate() {
-		const { getSlot = noop } = this.context;
-		const slot = getSlot( this.props.name );
-		if ( slot && ! slot.props.bubblesVirtually ) {
-			slot.forceUpdate();
 		}
 	}
 


### PR DESCRIPTION
## Description
Cause a slot to be updated during the ~~render~~ componentWilUpdate step of its fill so it doesn't get rendered with out-of-date props. Please see Morgan's comment for our explanation on why we think this works:
https://github.com/WordPress/gutenberg/issues/3839#issuecomment-349895872

This fixes the bug where typing in the middle of a URL input would cause the cursor to reset to the end. 

Fixes #3839 

## How Has This Been Tested?
Manually tested in Firefox and Chrome on Linux mint. We were unable to create a cypress test to check this (see comments in #3839 ) but I plan to create a selenium test in my #3664 branch.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Bug fix.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
  