### PR TITLE
Compatibility: Support Custom Media Buttons

### DIFF
--- a/editor/edit-post/media-buttons/index.js
+++ b/editor/edit-post/media-buttons/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import jQuery from 'jquery';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { withContext } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class MediaButtons extends Component {
+	constructor() {
+		super( ...arguments );
+		this.bindContainer = this.bindContainer.bind( this );
+	}
+
+	componentDidMount() {
+		if ( this.props.mediaButtons ) {
+			// Using jQuery to ensure the scripts are being executed
+			jQuery( this.container ).html( this.props.mediaButtons );
+			// eslint-disable-next-line no-console
+			console.warn( 'Media Buttons are deprecated, create custom blocks instead. https://wordpress.org/gutenberg/handbook/blocks/' );
+		}
+	}
+
+	bindContainer( ref ) {
+		this.container = ref;
+	}
+
+	render() {
+		return (
+			<div className="editor-media-buttons" ref={ this.bindContainer } />
+		);
+	}
+}
+
+export default withContext( 'editor' )( ( settings ) => {
+	const { mediaButtons } = settings;
+
+	return {
+		mediaButtons,
+	};
+} )( MediaButtons );

--- a/editor/edit-post/media-buttons/style.scss
+++ b/editor/edit-post/media-buttons/style.scss
@@ -1,0 +1,8 @@
+.editor-media-buttons:not(:empty) {
+	font-family: $default-font;
+	margin-bottom: 10px;
+
+	.button {
+		margin-right: 5px;
+	}
+}

--- a/editor/edit-post/modes/visual-editor/index.js
+++ b/editor/edit-post/modes/visual-editor/index.js
@@ -14,6 +14,7 @@ import { Component, findDOMNode } from '@wordpress/element';
 import './style.scss';
 import { BlockList, PostTitle, WritingFlow, DefaultBlockAppender, EditorGlobalKeyboardShortcuts } from '../../../components';
 import VisualEditorInserter from './inserter';
+import MediaButtons from '../../media-buttons';
 import { hasFixedToolbar } from '../../../store/selectors';
 import { clearSelectedBlock } from '../../../store/actions';
 
@@ -54,6 +55,7 @@ class VisualEditor extends Component {
 				ref={ this.bindContainer }
 			>
 				<EditorGlobalKeyboardShortcuts />
+				<MediaButtons />
 				<WritingFlow>
 					<PostTitle />
 					<BlockList

--- a/editor/edit-post/modes/visual-editor/style.scss
+++ b/editor/edit-post/modes/visual-editor/style.scss
@@ -126,3 +126,14 @@
 		}
 	}
 }
+
+.editor-visual-editor .editor-media-buttons {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
+	padding: 5px $block-padding;
+
+	@include break-small() {
+		padding: 5px ( $block-mover-padding-visible + $block-padding );
+	}
+}

--- a/editor/edit-post/shim-media-editor.js
+++ b/editor/edit-post/shim-media-editor.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import jQuery from 'jquery';
+
+/**
+ * Internal dependencies
+ */
+import { insertHtml } from '../store/actions';
+
+const shimpMediaEditor = ( store ) => {
+	jQuery( document ).ready( () => {
+		wp.media.editor.insert = ( content ) => {
+			store.dispatch( insertHtml( content ) );
+		};
+	} );
+};
+
+export default shimpMediaEditor;

--- a/editor/index.js
+++ b/editor/index.js
@@ -20,6 +20,7 @@ import { initializeMetaBoxState } from './store/actions';
 
 export * from './components';
 import store from './store'; // Registers the state tree
+import shimMediaEditor from './edit-post/shim-media-editor';
 
 // Configure moment globally
 moment.locale( dateSettings.l10n.locale );
@@ -83,6 +84,7 @@ export function recreateEditorInstance( target, settings ) {
 export function createEditorInstance( id, post, settings ) {
 	const target = document.getElementById( id );
 	const reboot = recreateEditorInstance.bind( null, target, settings );
+	shimMediaEditor( store );
 
 	render(
 		<EditorProvider settings={ settings } post={ post }>

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -190,6 +190,19 @@ export function insertBlocks( blocks, position ) {
 }
 
 /**
+ * Returns an action object signaling new HTML inserted at the current position.
+ *
+ * @param  {String}  html  HTML to insert
+ * @return {Object}        Action object
+ */
+export function insertHtml( html ) {
+	return {
+		type: 'INSERT_HTML',
+		html,
+	};
+}
+
+/**
  * Returns an action object showing the insertion point at a given index
  *
  * @param  {Number?} index  Index of the insertion point
@@ -558,7 +571,7 @@ export function saveReusableBlock( id ) {
 
 /**
  * Returns an action object used to delete a reusable block via the REST API.
- * 
+ *
  * @param {number} id  The ID of the reusable block to delete.
  * @return {Object}    Action object.
  */

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -16,6 +16,7 @@ import {
 	createReusableBlock,
 	isReusableBlock,
 	getDefaultBlockName,
+	getUnknownTypeHandlerName,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
@@ -53,6 +54,7 @@ import {
 	getBlock,
 	getBlocks,
 	getReusableBlock,
+	getBlockInsertionPoint,
 	POST_UPDATE_TRANSACTION_ID,
 } from './selectors';
 
@@ -451,5 +453,10 @@ export default {
 	CREATE_NOTICE( { notice: { content, spokenMessage } } ) {
 		const message = spokenMessage || content;
 		speak( message, 'assertive' );
+	},
+	INSERT_HTML( { html }, store ) {
+		const block = createBlock( getUnknownTypeHandlerName(), { content: html } );
+
+		return insertBlock( block, getBlockInsertionPoint( store.getState() ) );
 	},
 };

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -866,11 +866,26 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	 */
 	$allowed_block_types = apply_filters( 'allowed_block_types', true );
 
+	// Remove the default media buttion.
+	remove_action( 'media_buttons', 'media_buttons' );
+	ob_start();
+	/**
+	 * Fires after the default media button(s) are displayed.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @param string $editor_id Unique editor identifier, e.g. 'content'.
+	 */
+	do_action( 'media_buttons', 'content' );
+	$media_buttons = ob_get_contents();
+	ob_end_clean();
+
 	$editor_settings = array(
 		'alignWide'        => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
 		'colors'           => $color_palette,
 		'blockTypes'       => $allowed_block_types,
 		'titlePlaceholder' => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
+		'mediaButtons'     => $media_buttons,
 	);
 
 	$post_type_object = get_post_type_object( $post_to_edit['type'] );


### PR DESCRIPTION
Most of the plugin compatibility issues here https://github.com/danielbachhuber/gutenberg-plugin-compatibility/issues are due to Media Buttons not showing up.

I noticed that almost all media buttons work similarly, hook to `media_buttons` and call `wp.media.editor.insert` when inserting content.

This PR adds basic support to the custom media buttons by:

 - Showing them above the post title
 - Warning as "deprecated API, move to custom blocks instead"
 - Create content as a classic block. I considered using the "pasting" behavior but because it can create content loss and this is just basic support anyway, I left it as a classic block for now.
 - Remove the default "Add Media" button. (even if it works)

This will not fix all those plugins but I'm optimistic most of them should work.

<img width="741" alt="screen shot 2018-01-08 at 11 25 24" src="https://user-images.githubusercontent.com/272444/34666861-a9ff15e8-f466-11e7-93cf-1a375b3360b9.png">


**Testing instructions**

- Install plugins adding custom media buttions like "Shortcodes ultimate"
- Notice the custom media buttons above the post title
- Try using these buttons to insert content.

  
  