### PR TITLE
Fix CSS bleed from admin-specific gallery styles

### DIFF
--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -1,3 +1,7 @@
+.wp-block-gallery:not( .components-placeholder ) {
+	margin: -8px;
+}
+
 .blocks-gallery-image {
 	position: relative;
 

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -1,7 +1,3 @@
-.wp-block-gallery:not( .components-placeholder ) {
-	margin: -8px;
-}
-
 .wp-block-gallery,
 .wp-block-gallery.alignleft,
 .wp-block-gallery.alignright,


### PR DESCRIPTION
I had thought this would be a bigger PR, but did not find any other big issues with frontent styles.

So this is a teensy change: since placeholders are admin only, the style for them should be in the admin only stylesheet.