### PR TITLE
Image: set width if aligned but unresized

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -155,8 +155,15 @@ registerBlockType( 'core/image', {
 	save( { attributes } ) {
 		const { url, alt, caption, align, href, width, height } = attributes;
 		const extraImageProps = width || height ? { width, height } : {};
-		const figureStyle = width ? { width } : {};
 		const image = <img src={ url } alt={ alt } { ...extraImageProps } />;
+
+		let figureStyle = {};
+
+		if ( width ) {
+			figureStyle = { width };
+		} else if ( align === 'left' || align === 'right' ) {
+			figureStyle = { maxWidth: '50%' };
+		}
 
 		return (
 			<figure className={ align ? `align${ align }` : null } style={ figureStyle }>


### PR DESCRIPTION
## Description

This PR adds a width to the image on the front-end if the image is aligned but not resized. Currently we set a width of 370px in the Gutenberg editor, but we don't set anything on the front-end, so it doesn't feel like the image is aligned at all.

## How Has This Been Tested?
Create an image block, align it left or right, and save. View it on the front-end. The image should float and take up 50% of the space.
