### PR TITLE
Reorganize docs navigation.

### DIFF
--- a/blocks/README.md
+++ b/blocks/README.md
@@ -239,7 +239,7 @@ editor interface where blocks are implemented.
 - `attributes: Object | Function` - An object of attribute schemas, where the
   keys of the object define the shape of attributes, and each value an object
   schema describing the `type`, `default` (optional), and
-  [`source`](https://wordpress.org/gutenberg/handbook/reference/attributes/)
+  [`source`](https://wordpress.org/gutenberg/handbook/block-api/attributes/)
   (optional) of the attribute. If `source` is omitted, the attribute is
   serialized into the block's comment delimiters. Alternatively, define
   `attributes` as a function which returns the attributes object.

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -84,7 +84,7 @@ export default class Editable extends Component {
 				`Invalid value of type ${ typeof value } passed to Editable ` +
 				'(expected array). Attribute values should be sourced using ' +
 				'the `children` source when used with Editable.\n\n' +
-				'See: https://wordpress.org/gutenberg/handbook/reference/attributes/#children'
+				'See: https://wordpress.org/gutenberg/handbook/block-api/attributes/#children'
 			);
 		}
 

--- a/blocks/hooks/matchers.js
+++ b/blocks/hooks/matchers.js
@@ -12,7 +12,7 @@ function warnAboutDeprecatedMatcher() {
 	// eslint-disable-next-line no-console
 	console.warn(
 		'Attributes matchers are deprecated and they will be removed in a future version of Gutenberg. ' +
-		'Please update your attributes definition https://wordpress.org/gutenberg/handbook/reference/attributes/'
+		'Please update your attributes definition https://wordpress.org/gutenberg/handbook/block-api/attributes/'
 	);
 }
 

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -105,7 +105,7 @@ attributes: {
 },
 ```
 
-* **See: [Attributes](https://wordpress.org/gutenberg/handbook/reference/attributes/).**
+* **See: [Attributes](https://wordpress.org/gutenberg/handbook/block-api/attributes/).**
 
 #### Transforms (optional)
 

--- a/docs/blocks-editable.md
+++ b/docs/blocks-editable.md
@@ -105,7 +105,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 ```
 {% end %}
 
-When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [source function](../../reference/attributes) to find the desired value from the markup of the block.
+When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [source function](../../block-api/attributes) to find the desired value from the markup of the block.
 
 In the code snippet above, when loading the editor, we will extract the `content` value as the children of the paragraph element in the saved post's markup.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -97,7 +97,7 @@ Blocks will be able to provide base structural CSS styles, and themes can add st
 
 Other features, like the new _wide_ and _full-wide_ alignment options, will simply be CSS classes applied to blocks that offer this alignment. We are looking at how a theme can opt in to this feature, for example using `add_theme_support`.
 
-*See:* [Theme Support](https://wordpress.org/gutenberg/handbook/reference/theme-support/)
+*See:* [Theme Support](https://wordpress.org/gutenberg/handbook/extensibility/theme-support/)
 
 ## How will editor styles work?
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -79,7 +79,7 @@ After running this through the parser we're left with a simple object we can man
 
 This has dramatic implications for how simple and performant we can make our parser. These explicit boundaries also protect damage in a single block from bleeding into other blocks or tarnishing the entire document. It also allows the system to identify unrecognized blocks before rendering them.
 
-_N.B.:_ The defining aspect of blocks are their semantics and the isolation mechanism they provide; in other words, their identity. On the other hand, where their data is stored is a more liberal aspect. Blocks support more than just static local data (via JSON literals inside the HTML comment or within the block's HTML), and more mechanisms (_e.g._, global blocks or otherwise resorting to storage in complementary `WP_Post` objects) are expected. See [attributes](../reference/attributes) for details.
+_N.B.:_ The defining aspect of blocks are their semantics and the isolation mechanism they provide; in other words, their identity. On the other hand, where their data is stored is a more liberal aspect. Blocks support more than just static local data (via JSON literals inside the HTML comment or within the block's HTML), and more mechanisms (_e.g._, global blocks or otherwise resorting to storage in complementary `WP_Post` objects) are expected. See [attributes](../block-api/attributes) for details.
 
 ## The Anatomy of a Serialized Block
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -42,6 +42,12 @@
 		"parent": "extensibility"
 	},
 	{
+		"title": "Theme Support",
+		"slug": "theme-support",
+		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/themes.md",
+		"parent": "extensibility"
+	},
+	{
 		"title": "Creating Block Types",
 		"slug": "blocks",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/blocks.md",
@@ -82,12 +88,6 @@
 		"slug": "reference",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/reference.md",
 		"parent": null
-	},
-	{
-		"title": "Theme Support",
-		"slug": "theme-support",
-		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/themes.md",
-		"parent": "reference"
 	},
 	{
 		"title": "Glossary",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -12,22 +12,34 @@
 		"parent": null
 	},
 	{
-		"title": "Extensibility",
-		"slug": "extensibility",
-		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/extensibility.md",
-		"parent": null
-	},
-	{
 		"title": "Block API",
 		"slug": "block-api",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/block-api.md",
 		"parent": null
 	},
 	{
+		"title": "Attributes",
+		"slug": "attributes",
+		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/attributes.md",
+		"parent": "block-api"
+	},
+	{
 		"title": "Edit and Save",
 		"slug": "block-edit-save",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/block-edit-save.md",
+		"parent": "block-api"
+	},
+	{
+		"title": "Extensibility",
+		"slug": "extensibility",
+		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/extensibility.md",
 		"parent": null
+	},
+	{
+		"title": "Meta Boxes",
+		"slug": "meta-box",
+		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/meta-box.md",
+		"parent": "extensibility"
 	},
 	{
 		"title": "Creating Block Types",
@@ -72,21 +84,9 @@
 		"parent": null
 	},
 	{
-		"title": "Attributes",
-		"slug": "attributes",
-		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/attributes.md",
-		"parent": "reference"
-	},
-	{
 		"title": "Theme Support",
 		"slug": "theme-support",
 		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/themes.md",
-		"parent": "reference"
-	},
-	{
-		"title": "Meta Boxes",
-		"slug": "meta-box",
-		"markdown_source": "https:\/\/raw.githubusercontent.com\/WordPress\/gutenberg\/master\/docs\/meta-box.md",
 		"parent": "reference"
 	},
 	{

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,6 +1,5 @@
 # Reference
 
-- [Attributes](./reference/attributes)
 - [Glossary](./reference/glossary)
 - [Design Principles](./reference/design-principles)
 - [Coding Guidelines](./reference/coding-guidelines)

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -852,7 +852,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		wp_add_inline_script(
 			'wp-editor',
 			'console.warn( "' .
-				__( 'Adding theme support using the `gutenberg` array is deprecated. See https://wordpress.org/gutenberg/handbook/reference/theme-support/ for details.', 'gutenberg' ) .
+				__( 'Adding theme support using the `gutenberg` array is deprecated. See https://wordpress.org/gutenberg/handbook/extensibility/theme-support/ for details.', 'gutenberg' ) .
 			'");'
 		);
 	}


### PR DESCRIPTION
This PR seeks to group some related items in the handbook documentation.

- Block API groups existing "attributes" and "edit and save" docs.
- Extensibility groups "meta-boxes" and "theme support".

Note: have to check links.