### PR TITLE
Adjust horizontal edge detection for element nodes

### DIFF
--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -55,7 +55,9 @@ export function isHorizontalEdge( container, isReverse, collapseRanges = false )
 		return false;
 	}
 
-	if ( ! isReverse && offset !== node.textContent.length ) {
+	const maxOffset = node.nodeType === TEXT_NODE ? node.nodeValue.length : node.childNodes.length;
+
+	if ( ! isReverse && offset !== maxOffset ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Description
Fixes #4300. We currently don't check the offset correctly if a node is an element node. The maximum offset will then be the length of its children.

## How Has This Been Tested?
Follow the steps in #4300. It should work now.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.