### PR TITLE
Cover image: added upload button.

### DIFF
--- a/blocks/image-placeholder/index.js
+++ b/blocks/image-placeholder/index.js
@@ -10,9 +10,16 @@ import { __ } from '@wordpress/i18n';
  */
 import MediaUploadButton from '../media-upload-button';
 
-export default function ImagePlaceHolder( { className, setAttributes, icon, label, onSelectImage } ) {
-	const dropFiles = ( files ) => mediaUpload( files, setAttributes );
-	const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setAttributes );
+/**
+ *  ImagePlaceHolder is a react component used by blocks containing user configurable images e.g: image and cover image.
+ *
+ * @param   {Object} props  React props passed to the component.
+ * @returns {Object}        Rendered placeholder.
+ */
+export default function ImagePlaceHolder( { className, icon, label, onSelectImage } ) {
+	const setImage = ( [ image ] ) => onSelectImage( image );
+	const dropFiles = ( files ) => mediaUpload( files, setImage );
+	const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setImage );
 	return (
 		<Placeholder
 			className={ className }

--- a/blocks/image-placeholder/index.js
+++ b/blocks/image-placeholder/index.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { DropZone, FormFileUpload, Placeholder } from '@wordpress/components';
+import { mediaUpload } from '@wordpress/utils';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import MediaUploadButton from '../media-upload-button';
+
+export default function ImagePlaceHolder( { className, setAttributes, icon, label, onSelectImage } ) {
+	const dropFiles = ( files ) => mediaUpload( files, setAttributes );
+	const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setAttributes );
+	return (
+		<Placeholder
+			className={ className }
+			instructions={ __( 'Drag image here or add from media library' ) }
+			icon={ icon }
+			label={ label } >
+			<DropZone
+				onFilesDrop={ dropFiles }
+			/>
+			<FormFileUpload
+				isLarge
+				className="wp-block-image__upload-button"
+				onChange={ uploadFromFiles }
+				accept="image/*"
+			>
+				{ __( 'Upload' ) }
+			</FormFileUpload>
+			<MediaUploadButton
+				buttonProps={ { isLarge: true } }
+				onSelect={ onSelectImage }
+				type="image"
+			>
+				{ __( 'Add from Media Library' ) }
+			</MediaUploadButton>
+		</Placeholder>
+	);
+}

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -6,10 +6,9 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Placeholder, Toolbar, Dashicon, DropZone } from '@wordpress/components';
+import { Dashicon, Toolbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { mediaUpload } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -19,6 +18,7 @@ import './style.scss';
 import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
 import MediaUploadButton from '../../media-upload-button';
+import ImagePlaceHolder from '../../image-placeholder';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import InspectorControls from '../../inspector-controls';
@@ -95,7 +95,7 @@ registerBlockType( 'core/cover-image', {
 		const onSelectImage = ( media ) => setAttributes( { url: media.url, id: media.id } );
 		const toggleParallax = () => setAttributes( { hasParallax: ! hasParallax } );
 		const setDimRatio = ( ratio ) => setAttributes( { dimRatio: ratio } );
-		const dropFiles = ( files ) => mediaUpload( files, setAttributes );
+
 		const style = url ?
 			{ backgroundImage: `url(${ url })` } :
 			undefined;
@@ -150,7 +150,6 @@ registerBlockType( 'core/cover-image', {
 		];
 
 		if ( ! url ) {
-			const uploadButtonProps = { isLarge: true };
 			const hasTitle = ! isEmpty( title );
 			const icon = hasTitle ? undefined : 'format-image';
 			const label = hasTitle ? (
@@ -166,23 +165,9 @@ registerBlockType( 'core/cover-image', {
 
 			return [
 				controls,
-				<Placeholder
-					key="placeholder"
-					instructions={ __( 'Drag image here or add from media library' ) }
-					icon={ icon }
-					label={ label }
-					className={ className }>
-					<DropZone
-						onFilesDrop={ dropFiles }
-					/>
-					<MediaUploadButton
-						buttonProps={ uploadButtonProps }
-						onSelect={ onSelectImage }
-						type="image"
-					>
-						{ __( 'Add from Media Library' ) }
-					</MediaUploadButton>
-				</Placeholder>,
+				<ImagePlaceHolder key="cover-image-placeholder"
+					{ ...{ className, icon, label, setAttributes, onSelectImage } }
+				/>,
 			];
 		}
 

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -166,7 +166,7 @@ registerBlockType( 'core/cover-image', {
 			return [
 				controls,
 				<ImagePlaceHolder key="cover-image-placeholder"
-					{ ...{ className, icon, label, setAttributes, onSelectImage } }
+					{ ...{ className, icon, label, onSelectImage } }
 				/>,
 			];
 		}

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -23,7 +23,6 @@ import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import GalleryImage from './gallery-image';
 
-const isGallery = true;
 const MAX_COLUMNS = 8;
 const linkOptions = [
 	{ value: 'attachment', label: __( 'Attachment Page' ) },
@@ -95,7 +94,9 @@ class GalleryBlock extends Component {
 	}
 
 	uploadFromFiles( event ) {
-		mediaUpload( event.target.files, this.props.setAttributes, isGallery );
+		mediaUpload( event.target.files, ( images ) => {
+			this.props.setAttributes( { images } );
+		} );
 	}
 
 	setImageAttributes( index, attributes ) {
@@ -118,12 +119,11 @@ class GalleryBlock extends Component {
 		const { setAttributes } = this.props;
 		mediaUpload(
 			files,
-			( { images } ) => {
+			( images ) => {
 				setAttributes( {
 					images: currentImages.concat( images ),
 				} );
-			},
-			isGallery
+			}
 		);
 	}
 

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -153,7 +153,6 @@ class ImageBlock extends Component {
 					icon="format-image"
 					label={ __( 'Image' ) }
 					onSelectImage={ this.onSelectImage }
-					setAttributes={ setAttributes }
 				/>,
 			];
 		}

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -15,13 +15,10 @@ import {
  */
 import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
-import { mediaUpload, createMediaFromFile, getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
+import { createMediaFromFile, getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
 import {
-	Placeholder,
 	Dashicon,
 	Toolbar,
-	DropZone,
-	FormFileUpload,
 	withAPIData,
 	withContext,
 } from '@wordpress/components';
@@ -30,6 +27,7 @@ import {
  * Internal dependencies
  */
 import Editable from '../../editable';
+import ImagePlaceHolder from '../../image-placeholder';
 import MediaUploadButton from '../../media-upload-button';
 import InspectorControls from '../../inspector-controls';
 import TextControl from '../../inspector-controls/text-control';
@@ -117,9 +115,6 @@ class ImageBlock extends Component {
 		const availableSizes = this.getAvailableSizes();
 		const figureStyle = width ? { width } : {};
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && ( ! viewPort.isExtraSmall() );
-		const uploadButtonProps = { isLarge: true };
-		const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setAttributes );
-		const dropFiles = ( files ) => mediaUpload( files, setAttributes );
 
 		const editButtonLabel = __( 'Edit image' );
 		const controls = (
@@ -152,31 +147,14 @@ class ImageBlock extends Component {
 		if ( ! url ) {
 			return [
 				controls,
-				<Placeholder
-					key="placeholder"
-					instructions={ __( 'Drag image here or add from media library' ) }
+				<ImagePlaceHolder
+					className={ className }
+					key="image-placeholder"
 					icon="format-image"
 					label={ __( 'Image' ) }
-					className={ className }>
-					<DropZone
-						onFilesDrop={ dropFiles }
-					/>
-					<FormFileUpload
-						isLarge
-						className="wp-block-image__upload-button"
-						onChange={ uploadFromFiles }
-						accept="image/*"
-					>
-						{ __( 'Upload' ) }
-					</FormFileUpload>
-					<MediaUploadButton
-						buttonProps={ uploadButtonProps }
-						onSelect={ this.onSelectImage }
-						type="image"
-					>
-						{ __( 'Add from Media Library' ) }
-					</MediaUploadButton>
-				</Placeholder>,
+					onSelectImage={ this.onSelectImage }
+					setAttributes={ setAttributes }
+				/>,
 			];
 		}
 

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -1,19 +1,26 @@
-/* mediaupload.js
-	Media Upload is used by image and gallery blocks to handle uploading an image
-	when a file upload button is activated.
+/**
+ * External Dependencies
+ */
+import { compact } from 'lodash';
 
-	The gallery flag is needed since the gallery and image blocks have different
-	attributes and can not simply be keyed off the number of images, since a
-	single image gallery is possible
-
-	TODO: future enhancement to add an upload indicator
-*/
-
-export function mediaUpload( filesList, setAttributes, gallery = false ) {
+/**
+ *	Media Upload is used by image and gallery blocks to handle uploading an image
+ *	when a file upload button is activated.
+ *
+ *	TODO: future enhancement to add an upload indicator
+ *
+ * @param  {Array}    filesList       List of files.
+ * @param  {Function} onImagesChange  Function to be called each time a file or a temporary representation of the file is available.
+ */
+export function mediaUpload( filesList, onImagesChange ) {
 	// Cast filesList to array
 	const files = [ ...filesList ];
 
-	const gallerySet = [];
+	const imagesSet = [];
+	const setAndUpdateImages = ( idx, value ) => {
+		imagesSet[ idx ] = value;
+		onImagesChange( compact( imagesSet ) );
+	};
 	files.forEach( ( mediaFile, idx ) => {
 		// Only allow image uploads, may need updating if used for video
 		if ( ! /^image\//.test( mediaFile.type ) ) {
@@ -22,41 +29,17 @@ export function mediaUpload( filesList, setAttributes, gallery = false ) {
 
 		// Set temporary URL to create placeholder image, this is replaced
 		// with final image from media gallery when upload is `done` below
-		const tempUrl = window.URL.createObjectURL( mediaFile );
-		const media = { url: tempUrl };
-		if ( gallery ) {
-			gallerySet.push( media );
-			setAttributes( { images: gallerySet } );
-		} else {
-			setAttributes( media );
-		}
+		imagesSet.push( { url: window.URL.createObjectURL( mediaFile ) } );
+		onImagesChange( imagesSet );
 
 		return createMediaFromFile( mediaFile ).then(
 			( savedMedia ) => {
-				media.id = savedMedia.id;
-				media.url = savedMedia.source_url;
-				if ( gallery ) {
-					setAttributes( { images: [
-						...gallerySet.slice( 0, idx ),
-						media,
-						...gallerySet.slice( idx + 1 ),
-					] } );
-				} else {
-					setAttributes( media );
-				}
+				setAndUpdateImages( idx, { id: savedMedia.id, url: savedMedia.source_url } );
 			},
 			() => {
 				// Reset to empty on failure.
 				// TODO: Better failure messaging
-				media.url = null;
-				if ( gallery ) {
-					setAttributes( { images: [
-						...gallerySet.slice( 0, idx ),
-						...gallerySet.slice( idx + 1 ),
-					] } );
-				} else {
-					setAttributes( media );
-				}
+				setAndUpdateImages( idx, null );
 			}
 		);
 	} );

--- a/utils/test/mediaupload.js
+++ b/utils/test/mediaupload.js
@@ -8,7 +8,7 @@ import { mediaUpload } from '../mediaupload';
 // mediaUpload is passed the setAttributes function
 // so we can stub that out have it pass the data to
 // console.error to check if proper thing is called
-const setAttributesStub = ( obj ) => console.error( obj );
+const onImagesChange = ( obj ) => console.error( obj );
 
 const invalidMediaObj = {
 	url: 'https://cldup.com/uuUqE_dXzy.jpg',
@@ -29,12 +29,12 @@ describe( 'mediaUpload', () => {
 	} );
 
 	it( 'should do nothing on no files', () => {
-		mediaUpload( [ ], setAttributesStub );
+		mediaUpload( [ ], onImagesChange );
 		expect( console.error ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should do nothing on invalid image type', () => {
-		mediaUpload( [ invalidMediaObj ], setAttributesStub );
+		mediaUpload( [ invalidMediaObj ], onImagesChange );
 		expect( console.error ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
This PR adds an upload button to cover image to make it consistent with the image block.
Fixes: https://github.com/WordPress/gutenberg/issues/4341


## How Has This Been Tested?
Add a cover image, use the upload button select an image and verify the image was used in the cover image block.

## Screenshots (jpeg or gifs if applicable):
<img width="633" alt="screen shot 2018-01-08 at 23 01 15" src="https://user-images.githubusercontent.com/11271197/34696813-12bdf958-f4c8-11e7-8b21-9340eec223f1.png">
