### PR TITLE
Force JSX children expressions to have spacing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -152,7 +152,10 @@
 		"prefer-const": "error",
 		"quote-props": [ "error", "as-needed" ],
 		"react/display-name": "off",
-		"react/jsx-curly-spacing": [ "error", "always" ],
+		"react/jsx-curly-spacing": [ "error", {
+			"when": "always",
+			"children": true
+		} ],
 		"react/jsx-equals-spacing": "error",
 		"react/jsx-indent": [ "error", "tab" ],
 		"react/jsx-indent-props": [ "error", "tab" ],


### PR DESCRIPTION
This change forces us to write:

```jsx
{ isVisible && (
    <Something
        foo="bar"
    />
) }
```

Instead of:

```jsx
{isVisible && (
    <Something
        foo="bar"
    />
)}
```

It does this by setting the [children property on the react/jsx-curly-spacing rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md#rule-options).

### To test:

1. Open up e.g. `editor/index.js`
2. Insert `{post}` underneath line 88
3. Run `npm run lint`
4. It should complain that you didn't write `{ post }`