### PR TITLE
Add missing alt attribute to image (and gallery) blocks when alt return an empty value

### DIFF
--- a/blocks/api/raw-handling/test/integration/google-docs-out.html
+++ b/blocks/api/raw-handling/test/integration/google-docs-out.html
@@ -60,6 +60,6 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" /></figure>
+<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" alt="" /></figure>
 <!-- /wp:image -->
 

--- a/blocks/api/raw-handling/test/integration/ms-word-online-out.html
+++ b/blocks/api/raw-handling/test/integration/ms-word-online-out.html
@@ -50,5 +50,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="" /></figure>
+<figure class="wp-block-image"><img src="" alt="" /></figure>
 <!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/ms-word-out.html
+++ b/blocks/api/raw-handling/test/integration/ms-word-out.html
@@ -85,5 +85,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="" /></figure>
+<figure class="wp-block-image"><img src="" alt="" /></figure>
 <!-- /wp:image -->

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -42,6 +42,7 @@ registerBlockType( 'core/gallery', {
 				alt: {
 					source: 'attribute',
 					attribute: 'alt',
+					default: '',
 				},
 				id: {
 					source: 'attribute',

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -35,6 +35,7 @@ registerBlockType( 'core/image', {
 			source: 'attribute',
 			selector: 'img',
 			attribute: 'alt',
+			default: '',
 		},
 		caption: {
 			type: 'array',

--- a/blocks/test/fixtures/core__image.html
+++ b/blocks/test/fixtures/core__image.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image -->
-<figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="" /></figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core__image.json
+++ b/blocks/test/fixtures/core__image.json
@@ -5,8 +5,9 @@
         "isValid": true,
         "attributes": {
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
-            "caption": []
+            "caption": [],
+            "alt": ""
         },
-        "originalContent": "<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" /></figure>"
+        "originalContent": "<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"\" /></figure>"
     }
 ]

--- a/blocks/test/fixtures/core__image.parsed.json
+++ b/blocks/test/fixtures/core__image.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/image",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" /></figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"\" /></figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__image.serialized.html
+++ b/blocks/test/fixtures/core__image.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" /></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="" /></figure>
 <!-- /wp:image -->

--- a/blocks/test/fixtures/core__image__center-caption.html
+++ b/blocks/test/fixtures/core__image__center-caption.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"align":"center"} -->
-<figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
+<figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt="" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
 <!-- /wp:core/image -->

--- a/blocks/test/fixtures/core__image__center-caption.json
+++ b/blocks/test/fixtures/core__image__center-caption.json
@@ -8,8 +8,9 @@
             "caption": [
                 "Give it a try. Press the \"really wide\" button on the image toolbar."
             ],
-            "align": "center"
+            "align": "center",
+            "alt": ""
         },
-        "originalContent": "<figure class=\"wp-block-image aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>"
+        "originalContent": "<figure class=\"wp-block-image aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>"
     }
 ]

--- a/blocks/test/fixtures/core__image__center-caption.parsed.json
+++ b/blocks/test/fixtures/core__image__center-caption.parsed.json
@@ -5,7 +5,7 @@
             "align": "center"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-image aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\"/><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-image aligncenter\"><img src=\"https://cldup.com/YLYhpou2oq.jpg\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__image__center-caption.serialized.html
+++ b/blocks/test/fixtures/core__image__center-caption.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:image {"align":"center"} -->
-<figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" />
+<figure class="wp-block-image aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt="" />
     <figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption>
 </figure>
 <!-- /wp:image -->

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -13,8 +13,6 @@ Under the hood, attribute sources are a superset of functionality provided by [h
 Use `attribute` to extract the value of an attribute from markup.
 
 _Example_: Extract the `src` attribute from an image found in the block's markup. 
-`default` parameter can be used to set a default value. 
-Images alt attribute default value should be set to `default: ''` (empty value) to follow WCAG criterias.
 
 ```js
 {
@@ -22,7 +20,6 @@ Images alt attribute default value should be set to `default: ''` (empty value) 
 		source: 'attribute',
 		selector: 'img',
 		attribute: 'src',
-		default: 'https://example.com/image.png',
 	}
 }
 // { "url": "https://lorempixel.com/1200/800/" }

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -12,7 +12,9 @@ Under the hood, attribute sources are a superset of functionality provided by [h
 
 Use `attribute` to extract the value of an attribute from markup.
 
-_Example_: Extract the `src` attribute from an image found in the block's markup.
+_Example_: Extract the `src` attribute from an image found in the block's markup. 
+`default` parameter can be used to set a default value. 
+Images alt attribute default value should be set to `default: ''` (empty value) to follow WCAG criterias.
 
 ```js
 {
@@ -20,6 +22,7 @@ _Example_: Extract the `src` attribute from an image found in the block's markup
 		source: 'attribute',
 		selector: 'img',
 		attribute: 'src',
+		default: 'https://example.com/image.png',
 	}
 }
 // { "url": "https://lorempixel.com/1200/800/" }

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -12,7 +12,7 @@ Under the hood, attribute sources are a superset of functionality provided by [h
 
 Use `attribute` to extract the value of an attribute from markup.
 
-_Example_: Extract the `src` attribute from an image found in the block's markup. 
+_Example_: Extract the `src` attribute from an image found in the block's markup.
 
 ```js
 {


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Related: issue #4359 
Add a default empty alt text to image block.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I run this fix with npm in a local installation. Looks fine: uploaded images without alt text now have an empty alt text.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
  