### PR TITLE
Add format prop to DateTimePicker

### DIFF
--- a/components/date-time/README.md
+++ b/components/date-time/README.md
@@ -58,6 +58,13 @@ The localization for the display of the date and time.
 - Type: `string`
 - Required: No
 
+### format
+
+The format to transform the date and time to on save.
+
+- Type: `string`
+- Required: No
+
 ### is12Hour
 
 Whether the current timezone is a 12 hour time.

--- a/components/date-time/date.js
+++ b/components/date-time/date.js
@@ -9,9 +9,9 @@ import moment from 'moment';
  */
 const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
-function DatePicker( { currentDate, onChange, ...args } ) {
+function DatePicker( { currentDate, onChange, format, ...args } ) {
 	const momentDate = currentDate ? moment( currentDate ) : moment();
-	const onChangeMoment = ( newDate ) => onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+	const onChangeMoment = ( newDate ) => onChange( newDate.format( format || TIMEZONELESS_FORMAT ) );
 
 	return <ReactDatePicker
 		inline

--- a/components/date-time/index.js
+++ b/components/date-time/index.js
@@ -7,12 +7,13 @@ import { default as TimePicker } from './time';
 
 export { DatePicker, TimePicker };
 
-export function DateTimePicker( { currentDate, onChange, is12Hour, ...args } ) {
+export function DateTimePicker( { currentDate, onChange, is12Hour, format, ...args } ) {
 	return [
 		<DatePicker
 			key="date-picker"
 			currentDate={ currentDate }
 			onChange={ onChange }
+			format={ format }
 			{ ...args }
 		/>,
 		<TimePicker
@@ -20,6 +21,7 @@ export function DateTimePicker( { currentDate, onChange, is12Hour, ...args } ) {
 			currentTime={ currentDate }
 			onChange={ onChange }
 			is12Hour={ is12Hour }
+			format={ format }
 		/>,
 	];
 }

--- a/components/date-time/time.js
+++ b/components/date-time/time.js
@@ -59,7 +59,7 @@ class TimePicker extends Component {
 	}
 
 	updateHours() {
-		const { is12Hour, onChange } = this.props;
+		const { is12Hour, onChange, format } = this.props;
 		const { am, hours, date } = this.state;
 		const value = parseInt( hours, 10 );
 		if (
@@ -75,12 +75,12 @@ class TimePicker extends Component {
 			date.clone().hours( am === 'AM' ? value % 12 : ( ( ( value % 12 ) + 12 ) % 24 ) ) :
 			date.clone().hours( value );
 		this.setState( { date: newDate } );
-		const formattedDate = newDate.format( TIMEZONELESS_FORMAT );
+		const formattedDate = newDate.format( format || TIMEZONELESS_FORMAT );
 		onChange( formattedDate );
 	}
 
 	updateMinutes() {
-		const { onChange } = this.props;
+		const { onChange, format } = this.props;
 		const { minutes, date } = this.state;
 		const value = parseInt( minutes, 10 );
 		if ( ! isInteger( value ) || value < 0 || value > 59 ) {
@@ -89,13 +89,13 @@ class TimePicker extends Component {
 		}
 		const newDate = date.clone().minutes( value );
 		this.setState( { date: newDate } );
-		const formattedDate = newDate.format( TIMEZONELESS_FORMAT );
+		const formattedDate = newDate.format( format || TIMEZONELESS_FORMAT );
 		onChange( formattedDate );
 	}
 
 	updateAmPm( value ) {
 		return () => {
-			const { onChange } = this.props;
+			const { onChange, format } = this.props;
 			const { am, date, hours } = this.state;
 			if ( am === value ) {
 				return;
@@ -107,7 +107,7 @@ class TimePicker extends Component {
 				newDate = date.clone().hours( parseInt( hours, 10 ) % 12 );
 			}
 			this.setState( { date: newDate } );
-			const formattedDate = newDate.format( TIMEZONELESS_FORMAT );
+			const formattedDate = newDate.format( format || TIMEZONELESS_FORMAT );
 			onChange( formattedDate );
 		};
 	}


### PR DESCRIPTION
## Description
As a recent change to the `DateTimePicker` component forces the date to a predefined format on update, this PR introduces a new `format` prop to the component allowing for custom date formats to be used. It defaults to `TIMEZONELESS_FORMAT` if not defined.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.