### PR TITLE
Use explicit v7.0.0 `promise-polyfill`

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -284,7 +284,7 @@ function gutenberg_register_vendor_scripts() {
 	);
 	gutenberg_register_vendor_script(
 		'promise',
-		'https://unpkg.com/promise-polyfill/promise' . $suffix . '.js'
+		'https://unpkg.com/promise-polyfill@7.0.0/dist/promise.min.js'
 	);
 
 	// TODO: This is only necessary so long as WordPress 4.9 is not yet stable,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -284,7 +284,7 @@ function gutenberg_register_vendor_scripts() {
 	);
 	gutenberg_register_vendor_script(
 		'promise',
-		'https://unpkg.com/promise-polyfill@7.0.0/dist/promise.min.js'
+		'https://unpkg.com/promise-polyfill@7.0.0/dist/promise' . $suffix . '.js'
 	);
 
 	// TODO: This is only necessary so long as WordPress 4.9 is not yet stable,


### PR DESCRIPTION
## Description

The previous URL `'https://unpkg.com/promise-polyfill/promise' . $suffix . '.js'` was 404'ing

This change updates the URL to specifically use the `7.0.0` version of `promise-polyfill`

• `https://unpkg.com/promise-polyfill@7.0.0/dist/promise.min.js`

This patch was proposed by @aduth in [Slack here](https://wordpress.slack.com/archives/C02QB2JS7/p1515523969000212)

See also Slack discussion: https://wordpress.slack.com/archives/C02QB2JS7/p1515522541000785


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Removed `node_modules` folder and ran `npm install`

Followed up by `npm run package-plugin` with terminal output:
```
https://unpkg.com/promise-polyfill@7.0.0/dist/promise.min.js
 > vendor/promise.min.0f2d5308.js ... done!
```
No errors observed and build generated successfully. 

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
  