### PR TITLE
Blocks: Reduce sibling inserter initial height

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -405,7 +405,7 @@
 		position: absolute;
 		left: 0;
 		width: 100%;
-		height: 44px;
+		height: 28px;
 		transition: 0.1s height;
 		transform: translateY( -50% );
 	}


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/3074#discussion_r160570042
Related: #2890
Fixes #4312
Fixes #3355

This pull request seeks to improve the hover behavior of the sibling inserter in hopes of making it easier to select content of blocks with short height. In #2890, a technique was employed to increase the hover area of the sibling inserter while already hovered, in order to make it less easy to lose the inserter hover when quickly moving the mouse around. Later in #3074 this was set as the default height for the sibling inserter, which is problematic because it overlaps with content of the block itself.

Since each block has padding of `14px` top and bottom and the natural height of the sibling inserter is `28px`, this was chosen as the default height. It still expands to `44px` on hover to preserve the original intent of #2890.

__Open questions:__

- A block has `margin-bottom: 4px` . Do we need this? It makes the sibling inserter positioning slightly uneven.

__Testing instructions:__

Verify that there are no regressions in the behavior of the sibling inserter, and that it is less difficult to select a short block (e.g. paragraph block with a single line of text).