### PR TITLE
Fixed bug on empty cover image placeholder.

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Placeholder, Toolbar, Dashicon, DropZone } from '@wordpress/components';
@@ -146,8 +151,9 @@ registerBlockType( 'core/cover-image', {
 
 		if ( ! url ) {
 			const uploadButtonProps = { isLarge: true };
-			const icon = title ? undefined : 'format-image';
-			const label = title ? (
+			const hasTitle = ! isEmpty( title );
+			const icon = hasTitle ? undefined : 'format-image';
+			const label = hasTitle ? (
 				<Editable
 					tagName="h2"
 					value={ title }


### PR DESCRIPTION
The cover image block was displaying incorrectly when loading a saved block with no content.

## How Has This Been Tested?
Create a new post, add cover image block, don't write anything and save the post. Re-open the post and see cover image placeholder displays correctly.


## Screenshots (jpeg or gifs if applicable):

Before:
<img width="562" alt="screen shot 2018-01-10 at 18 50 40" src="https://user-images.githubusercontent.com/11271197/34789751-6490b372-f637-11e7-8785-f6e4ee82df77.png">
After:
<img width="653" alt="screen shot 2018-01-10 at 18 48 03" src="https://user-images.githubusercontent.com/11271197/34789759-6d5fe572-f637-11e7-9f58-5339b54529fd.png">
