### PR TITLE
Exit edit mode when unfocusing a reusable block

### DIFF
--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -41,6 +41,15 @@ class ReusableBlockEdit extends Component {
 		}
 	}
 
+	/**
+	 * @inheritdoc
+	 */
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.focus && ! nextProps.focus ) {
+			this.stopEditing();
+		}
+	}
+
 	startEditing() {
 		this.setState( { isEditing: true } );
 	}


### PR DESCRIPTION
![deselect](https://user-images.githubusercontent.com/612155/34801507-37150f0c-f6bd-11e7-832b-4540ce4e3e3c.gif)

When a reusable block is unfocused, it should exit edit mode.

#### To test:

1. Create a reusable block
2. Click 'Edit'
3. Unfocus the block
4. Focus the block
5. It should not be in edit mode, i.e. the 'Edit' button should be shown again