### PR TITLE
Stop the Custom Color button from looking like a pancake

### DIFF
--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -22,6 +22,12 @@ $color-palette-circle-spacing: 14px;
 	&:hover {
 		transform: scale( 1.2 );
 	}
+
+	// Ensure that the <div> that <Dropdown> wraps our toggle button with is full height
+	& > div {
+		height: 100%;
+		width: 100%;
+	}
 }
 
 .blocks-color-palette__item {


### PR DESCRIPTION
Fixes #4388. This is a regression caused by #3958.

#### Before:

<img width="259" alt="screen shot 2018-01-11 at 12 16 51" src="https://user-images.githubusercontent.com/612155/34803823-84551404-f6c9-11e7-8264-24246975b51e.png">

#### After:

<img width="262" alt="screen shot 2018-01-11 at 12 18 09" src="https://user-images.githubusercontent.com/612155/34803825-86ad009a-f6c9-11e7-846f-1ad6ea49bd83.png">

#### To test:

1. Add a Paragraph block
2. Go to block's inspector controls
3. Expand Background Color panel