### PR TITLE
Rename "Insert" to "Add"

### DIFF
--- a/blocks/editable/format-toolbar/index.js
+++ b/blocks/editable/format-toolbar/index.js
@@ -130,7 +130,7 @@ class FormatToolbar extends Component {
 		event.preventDefault();
 		this.props.onChange( { link: { value: this.state.newLinkValue, target: this.state.opensInNewWindow ? '_blank' : '' } } );
 		if ( this.state.isAddingLink ) {
-			this.props.speak( __( 'Link inserted.' ), 'assertive' );
+			this.props.speak( __( 'Link added.' ), 'assertive' );
 		}
 	}
 

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -139,7 +139,7 @@ registerBlockType( 'core/audio', {
 							type="audio"
 							value={ id }
 						>
-							{ __( 'Insert from Media Library' ) }
+							{ __( 'Add from Media Library' ) }
 						</MediaUploadButton>
 					</Placeholder>,
 				];

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -162,7 +162,7 @@ registerBlockType( 'core/cover-image', {
 				controls,
 				<Placeholder
 					key="placeholder"
-					instructions={ __( 'Drag image here or insert from media library' ) }
+					instructions={ __( 'Drag image here or add from media library' ) }
 					icon={ icon }
 					label={ label }
 					className={ className }>
@@ -174,7 +174,7 @@ registerBlockType( 'core/cover-image', {
 						onSelect={ onSelectImage }
 						type="image"
 					>
-						{ __( 'Insert from Media Library' ) }
+						{ __( 'Add from Media Library' ) }
 					</MediaUploadButton>
 				</Placeholder>,
 			];

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -183,7 +183,7 @@ class GalleryBlock extends Component {
 				controls,
 				<Placeholder
 					key="placeholder"
-					instructions={ __( 'Drag images here or insert from media library' ) }
+					instructions={ __( 'Drag images here or add from media library' ) }
 					icon="format-gallery"
 					label={ __( 'Gallery' ) }
 					className={ className }>
@@ -204,7 +204,7 @@ class GalleryBlock extends Component {
 						multiple
 						gallery
 					>
-						{ __( 'Insert from Media Library' ) }
+						{ __( 'Add from Media Library' ) }
 					</MediaUploadButton>
 				</Placeholder>,
 			];

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -154,7 +154,7 @@ class ImageBlock extends Component {
 				controls,
 				<Placeholder
 					key="placeholder"
-					instructions={ __( 'Drag image here or insert from media library' ) }
+					instructions={ __( 'Drag image here or add from media library' ) }
 					icon="format-image"
 					label={ __( 'Image' ) }
 					className={ className }>
@@ -174,7 +174,7 @@ class ImageBlock extends Component {
 						onSelect={ this.onSelectImage }
 						type="image"
 					>
-						{ __( 'Insert from Media Library' ) }
+						{ __( 'Add from Media Library' ) }
 					</MediaUploadButton>
 				</Placeholder>,
 			];

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -179,7 +179,7 @@ class ParagraphBlock extends Component {
 							onMerge={ mergeBlocks }
 							onReplace={ onReplace }
 							onRemove={ () => onReplace( [] ) }
-							placeholder={ placeholder || __( 'Add text or type / to insert content' ) }
+							placeholder={ placeholder || __( 'Add text or type / to add content' ) }
 							aria-autocomplete="list"
 							aria-expanded={ isExpanded }
 							aria-owns={ listBoxId }
@@ -195,7 +195,7 @@ class ParagraphBlock extends Component {
 registerBlockType( 'core/paragraph', {
 	title: __( 'Paragraph' ),
 
-	description: __( 'This is a simple text only block for inserting a single paragraph of content.' ),
+	description: __( 'This is a simple text only block for adding a single paragraph of content.' ),
 
 	icon: 'editor-paragraph',
 

--- a/blocks/library/table/table-block.js
+++ b/blocks/library/table/table-block.js
@@ -42,12 +42,12 @@ function execCommand( command ) {
 const TABLE_CONTROLS = [
 	{
 		icon: 'table-row-before',
-		title: __( 'Insert Row Before' ),
+		title: __( 'Add Row Before' ),
 		onClick: execCommand( 'mceTableInsertRowBefore' ),
 	},
 	{
 		icon: 'table-row-after',
-		title: __( 'Insert Row After' ),
+		title: __( 'Add Row After' ),
 		onClick: execCommand( 'mceTableInsertRowAfter' ),
 	},
 	{
@@ -57,12 +57,12 @@ const TABLE_CONTROLS = [
 	},
 	{
 		icon: 'table-col-before',
-		title: __( 'Insert Column Before' ),
+		title: __( 'Add Column Before' ),
 		onClick: execCommand( 'mceTableInsertColBefore' ),
 	},
 	{
 		icon: 'table-col-after',
-		title: __( 'Insert Column After' ),
+		title: __( 'Add Column After' ),
 		onClick: execCommand( 'mceTableInsertColAfter' ),
 	},
 	{

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -140,7 +140,7 @@ registerBlockType( 'core/video', {
 							type="video"
 							id={ id }
 						>
-							{ __( 'Insert from Media Library' ) }
+							{ __( 'Add from Media Library' ) }
 						</MediaUploadButton>
 					</Placeholder>,
 				];

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -72,7 +72,7 @@ class Inserter extends Component {
 				renderToggle={ ( { onToggle, isOpen } ) => (
 					<IconButton
 						icon="insert"
-						label={ __( 'Insert block' ) }
+						label={ __( 'Add block' ) }
 						onClick={ onToggle }
 						className="editor-inserter__toggle"
 						aria-haspopup="true"

--- a/editor/edit-post/modes/visual-editor/inserter.js
+++ b/editor/edit-post/modes/visual-editor/inserter.js
@@ -74,7 +74,7 @@ export class VisualEditorInserter extends Component {
 						key={ 'frequently_used_' + block.name }
 						className="editor-inserter__block"
 						onClick={ () => this.insertBlock( block.name ) }
-						label={ sprintf( __( 'Insert %s' ), block.title ) }
+						label={ sprintf( __( 'Add %s' ), block.title ) }
 						disabled={ this.isDisabledBlock( block ) }
 						icon={ (
 							<span className="editor-visual-editor__inserter-block-icon">

--- a/phpunit/fixtures/long-content.html
+++ b/phpunit/fixtures/long-content.html
@@ -29,10 +29,10 @@
 <h2>The <em>Inserter</em> Tool</h2>
 <!-- /wp:heading -->
 <!-- wp:paragraph -->
-<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That&#x27;s the spirit behind the inserter—the <code>(+)</code> button you&#x27;ll see around the editor—which allows you to browse all available content blocks and insert them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>
+<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That&#x27;s the spirit behind the inserter—the <code>(+)</code> button you&#x27;ll see around the editor—which allows you to browse all available content blocks and add them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>
 <!-- /wp:paragraph -->
 <!-- wp:paragraph -->
-<p>Go give it a try, you may discover things WordPress can already insert into your posts that you didn&#x27;t know about. Here&#x27;s a short list of what you can currently find there:</p>
+<p>Go give it a try, you may discover things WordPress can already add into your posts that you didn&#x27;t know about. Here&#x27;s a short list of what you can currently find there:</p>
 <!-- /wp:paragraph -->
 <!-- wp:list -->
 <ul>
@@ -63,7 +63,7 @@
 <p>The information corresponding to the source of the quote is a separate text field, similar to captions under images, so the structure of the quote is protected even if you select, modify, or remove the source. It&#x27;s always easy to add it back.</p>
 <!-- /wp:paragraph -->
 <!-- wp:paragraph -->
-<p>Blocks can be anything you need. For instance, you may want to insert a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>
+<p>Blocks can be anything you need. For instance, you may want to add a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>
 <!-- /wp:paragraph -->
 <!-- wp:gallery {"columns":2} -->
 <div class="wp-block-gallery alignnone columns-2 is-cropped">

--- a/post-content.js
+++ b/post-content.js
@@ -48,11 +48,11 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:heading -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That&#x27;s the spirit behind the inserter—the <code>(+)</code> button you&#x27;ll see around the editor—which allows you to browse all available content blocks and insert them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>',
+		'<p>Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That&#x27;s the spirit behind the inserter—the <code>(+)</code> button you&#x27;ll see around the editor—which allows you to browse all available content blocks and add them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>Go give it a try, you may discover things WordPress can already insert into your posts that you didn&#x27;t know about. Here&#x27;s a short list of what you can currently find there:</p>',
+		'<p>Go give it a try, you may discover things WordPress can already add into your posts that you didn&#x27;t know about. Here&#x27;s a short list of what you can currently find there:</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:list -->',
@@ -80,7 +80,7 @@ window._wpGutenbergPost.content = {
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:paragraph -->',
-		'<p>Blocks can be anything you need. For instance, you may want to insert a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>',
+		'<p>Blocks can be anything you need. For instance, you may want to add a subdued quote as part of the composition of your text, or you may prefer to display a giant stylized one. All of these options are available in the inserter.</p>',
 		'<!-- /wp:paragraph -->',
 
 		'<!-- wp:gallery {"columns":2} -->',

--- a/test/e2e/integration/002-adding-blocks.js
+++ b/test/e2e/integration/002-adding-blocks.js
@@ -11,12 +11,12 @@ describe( 'Adding blocks', () => {
 		cy.get( lastBlockSelector ).type( 'Paragraph block' );
 
 		// Using the slash command
-		cy.get( '.editor-visual-editor__inserter [aria-label="Insert Paragraph"]' ).click();
+		cy.get( '.editor-visual-editor__inserter [aria-label="Add Paragraph"]' ).click();
 		cy.get( lastBlockSelector ).type( '/quote{enter}' );
 		cy.get( lastBlockSelector ).type( 'Quote block' );
 
 		// Using the regular inserter
-		cy.get( '.editor-header [aria-label="Insert block"]' ).click();
+		cy.get( '.editor-header [aria-label="Add block"]' ).click();
 		cy.get( '[placeholder="Search for a block"]' ).type( 'code' );
 		cy.get( '.editor-inserter__block' ).contains( 'Code' ).click();
 		cy.get( '[placeholder="Write code…"]' ).type( 'Code block' );

--- a/test/e2e/integration/003-multi-block-selection.js
+++ b/test/e2e/integration/003-multi-block-selection.js
@@ -12,7 +12,7 @@ describe( 'Multi-block selection', () => {
 		// Creating test blocks
 		cy.get( '.editor-default-block-appender' ).click();
 		cy.get( lastBlockSelector ).type( 'First Paragraph' );
-		cy.get( '.editor-visual-editor__inserter [aria-label="Insert Paragraph"]' ).click();
+		cy.get( '.editor-visual-editor__inserter [aria-label="Add Paragraph"]' ).click();
 		cy.get( lastBlockSelector ).type( 'Second Paragraph' );
 
 		// Default: No selection


### PR DESCRIPTION
## Description
Intent of PR is a copy change. To rename "Insert" to "Add" as discussed and agreed upon in #2975
- This change only affects copy seen by users. 
- No changes have been made to functions, class names, the component named "Inserter" nor any developer documentation. Those changes would warrant separate, future issues as pointed out by @jasmussen in #2975 

## Screenshot Examples of Changes

Before
<img width="1004" alt="screen shot 2018-01-10 at 10 34 37 am" src="https://user-images.githubusercontent.com/7691812/34803706-fe67d922-f631-11e7-8643-936a6ec451bb.png">

After
<img width="1180" alt="screen shot 2018-01-10 at 6 10 53 pm" src="https://user-images.githubusercontent.com/7691812/34803707-fffcaeac-f631-11e7-839e-15a9b51776a9.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.