### PR TITLE
Align both the quote and the citation in the visual editor

### DIFF
--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -178,6 +178,7 @@ registerBlockType( 'core/quote', {
 			<blockquote
 				key="quote"
 				className={ containerClassname }
+				style={ { textAlign: align } }
 			>
 				<Editable
 					multiline="p"
@@ -196,14 +197,12 @@ registerBlockType( 'core/quote', {
 							onReplace( [] );
 						}
 					} }
-					style={ { textAlign: align } }
 					placeholder={ __( 'Write quote…' ) }
 				/>
 				{ ( ( citation && citation.length > 0 ) || !! focus ) && (
 					<Editable
 						tagName="cite"
 						value={ citation }
-						placeholder={ __( 'Write citation…' ) }
 						onChange={
 							( nextCitation ) => setAttributes( {
 								citation: nextCitation,
@@ -216,6 +215,7 @@ registerBlockType( 'core/quote', {
 								setFocus( { ...focus, editable: 'value' } );
 							}
 						} }
+						placeholder={ __( 'Write citation…' ) }
 					/>
 				) }
 			</blockquote>,


### PR DESCRIPTION
Fixes #4378. By making the alignment of the citation match the alignment of the quote, we match how quote blocks behave on the frontend.

![quote](https://user-images.githubusercontent.com/612155/34804214-7b8ba3c2-f6cb-11e7-9d1d-ec89fbb97e13.gif)

#### To test:

1. Insert Quote Block
2. Enter paragraph and citation
3. Apply alignment option