### PR TITLE
Trigger typing mode when ENTER is pressed

### DIFF
--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -548,7 +548,6 @@ export default class Editable extends Component {
 			}
 
 			event.preventDefault();
-			event.stopImmediatePropagation();
 		}
 
 		// If we click shift+Enter on inline Editables, we avoid creating two contenteditables

--- a/blocks/editable/index.js
+++ b/blocks/editable/index.js
@@ -586,7 +586,6 @@ export default class Editable extends Component {
 				if ( event.shiftKey || ! this.props.onSplit ) {
 					this.editor.execCommand( 'InsertLineBreak', false, event );
 				} else {
-					event.stopImmediatePropagation();
 					this.splitContent();
 				}
 			}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -263,6 +263,10 @@ export class BlockListBlock extends Component {
 		} else {
 			onMerge( previousBlock, block );
 		}
+
+		// Manually trigger typing mode, since merging will remove this block and
+		// cause onKeyDown to not fire
+		this.maybeStartTyping();
 	}
 
 	insertBlocksAfter( blocks ) {
@@ -335,6 +339,9 @@ export class BlockListBlock extends Component {
 						}
 					}
 				}
+
+				// Pressing backspace should trigger typing mode
+				this.maybeStartTyping();
 				break;
 
 			case ESCAPE:

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -223,12 +223,9 @@ export class BlockListBlock extends Component {
 	}
 
 	maybeStartTyping() {
-		// We do not want to dispatch start typing if...
-		//  - State value already reflects that we're typing (dispatch noise)
-		//  - The current block is not selected (e.g. after a split occurs,
-		//    we'll still receive the keyDown event, but the focus has since
-		//    shifted to the newly created block)
-		if ( ! this.props.isTyping && this.props.isSelected ) {
+		// We do not want to dispatch start typing if state value already reflects
+		// that we're typing (dispatch noise)
+		if ( ! this.props.isTyping ) {
 			this.props.onStartTyping();
 		}
 	}
@@ -310,6 +307,9 @@ export class BlockListBlock extends Component {
 						createBlock( 'core/paragraph' ),
 					], this.props.order + 1 );
 				}
+
+				// Pressing enter should trigger typing mode after the content has split
+				this.maybeStartTyping();
 				break;
 
 			case UP:


### PR DESCRIPTION
Fixes #3846.

Makes pressing ENTER to create a new block or split content trigger typing mode.

#### Before:

![typing-mode-old](https://user-images.githubusercontent.com/612155/34809233-d5d11ecc-f6e7-11e7-9997-7423a17bc7c7.gif)

#### After:

![typing-mode](https://user-images.githubusercontent.com/612155/34809234-d91354b0-f6e7-11e7-9940-f1b68f1397fd.gif)

#### To test:

1. Place your cursor in the middle of some text
2. Press ENTER
3. The block controls should go away
4. Test other parts of the writing flow to make sure there aren't any regressions

#### Questions:

1. Should pressing BACKSPACE trigger typing mode as well?
2. In this implementation, typing mode is triggered when a non-text block (e.g. image) is selected and ENTER is pressed. Is this correct?