### PR TITLE
Force wp-api.js to use HTTP/1.0

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -502,6 +502,12 @@ JS;
 			wp_json_encode( $schema_response->get_data() )
 		), 'before' );
 	}
+
+	/*
+	 * For API requests to happen over HTTP/1.0 methods,
+	 * as HTTP/1.1 methods are blocked in a variety of situations.
+	 */
+	wp_add_inline_script( 'wp-api', 'Backbone.emulateHTTP = true;', 'before' );
 }
 
 /**


### PR DESCRIPTION
## Description

We've had several problems in the past where HTTP/1.1 methods are blocked, due to server oddities, or firewall rules. In particular, #2704 is an ongoing issue where Cloudflare firewall rules block `PUT` requests, to mitigate a security issue that existed in WordPress 4.7 and 4.7.1.

Switching to `POST` requests may help work around this issue.