### PR TITLE
Blocks: Add regression check for block edit using snapshot testing

### DIFF
--- a/blocks/library/audio/test/__snapshots__/index.js.snap
+++ b/blocks/library/audio/test/__snapshots__/index.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/audio block edit matches snapshot 1`] = `
+<div
+  class="components-placeholder wp-block-audio"
+>
+  <div
+    class="components-placeholder__label"
+  >
+    <svg
+      aria-hidden="true"
+      class="dashicon dashicons-media-audio"
+      focusable="false"
+      height="20"
+      role="img"
+      viewBox="0 0 20 20"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2l4 4v12H4V2h8zm0 4h3l-3-3v3zm1 7.26V8.09c0-.11-.04-.21-.12-.29-.07-.08-.16-.11-.27-.1 0 0-3.97.71-4.25.78C8.07 8.54 8 8.8 8 9v3.37c-.2-.09-.42-.07-.6-.07-.38 0-.7.13-.96.39-.26.27-.4.58-.4.96 0 .37.14.69.4.95.26.27.58.4.96.4.34 0 .7-.04.96-.26.26-.23.64-.65.64-1.12V10.3l3-.6V12c-.67-.2-1.17.04-1.44.31-.26.26-.39.58-.39.95 0 .38.13.69.39.96.27.26.71.39 1.08.39.38 0 .7-.13.96-.39.26-.27.4-.58.4-.96z"
+      />
+    </svg>
+    Audio
+  </div>
+  <div
+    class="components-placeholder__instructions"
+  >
+    Select an audio file from your library, or upload a new one:
+  </div>
+  <div
+    class="components-placeholder__fieldset"
+  >
+    <form>
+      <input
+        class="components-placeholder__input"
+        placeholder="Enter URL of audio file here…"
+        type="url"
+        value=""
+      />
+      <button
+        class="components-button button button-large"
+        type="submit"
+      >
+        Use URL
+      </button>
+    </form>
+    *** Mock(Media upload button) ***
+  </div>
+</div>
+`;

--- a/blocks/library/audio/test/index.js
+++ b/blocks/library/audio/test/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+jest.mock( 'blocks/media-upload-button', () => () => '*** Mock(Media upload button) ***' );
+
+describe( 'core/audio', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/audio' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/button/test/__snapshots__/index.js.snap
+++ b/blocks/library/button/test/__snapshots__/index.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/button block edit matches snapshot 1`] = `
+<span
+  class="wp-block-button"
+>
+  <div
+    class="blocks-editable"
+  >
+    <span
+      aria-label="Add text…"
+      class="wp-block-button__link blocks-editable__tinymce"
+      contenteditable="true"
+    />
+    <span
+      class="blocks-editable__tinymce wp-block-button__link"
+    >
+      Add text…
+    </span>
+  </div>
+</span>
+`;

--- a/blocks/library/button/test/index.js
+++ b/blocks/library/button/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/button', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/button' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/code/test/__snapshots__/index.js.snap
+++ b/blocks/library/code/test/__snapshots__/index.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/code block edit matches snapshot 1`] = `
+<div
+  class="wp-block-code"
+>
+  <textarea
+    aria-label="Code"
+    placeholder="Write code…"
+    rows="1"
+  />
+</div>
+`;

--- a/blocks/library/code/test/index.js
+++ b/blocks/library/code/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/code', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/code' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/cover-image/test/__snapshots__/index.js.snap
+++ b/blocks/library/cover-image/test/__snapshots__/index.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/cover-image block edit matches snapshot 1`] = `
+<div
+  class="components-placeholder wp-block-cover-image"
+>
+  <div
+    class="components-placeholder__label"
+  >
+    <svg
+      aria-hidden="true"
+      class="dashicon dashicons-format-image"
+      focusable="false"
+      height="20"
+      role="img"
+      viewBox="0 0 20 20"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M2.25 1h15.5c.69 0 1.25.56 1.25 1.25v15.5c0 .69-.56 1.25-1.25 1.25H2.25C1.56 19 1 18.44 1 17.75V2.25C1 1.56 1.56 1 2.25 1zM17 17V3H3v14h14zM10 6c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2 2-.9 2-2zm3 5s0-6 3-6v10c0 .55-.45 1-1 1H5c-.55 0-1-.45-1-1V8c2 0 3 4 3 4s1-3 3-3 3 2 3 2z"
+      />
+    </svg>
+    Cover Image
+  </div>
+  <div
+    class="components-placeholder__instructions"
+  >
+    Drag image here or add from media library
+  </div>
+  <div
+    class="components-placeholder__fieldset"
+  >
+    <div
+      class="components-drop-zone"
+    >
+      <div
+        class="components-drop-zone__content"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload components-drop-zone__content-icon"
+          focusable="false"
+          height="40"
+          role="img"
+          viewBox="0 0 20 20"
+          width="40"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        <span
+          class="components-drop-zone__content-text"
+        >
+          Drop files to upload
+        </span>
+      </div>
+    </div>
+    <div
+      class="components-form-file-upload"
+    >
+      <button
+        class="components-button components-icon-button wp-block-image__upload-button button button-large"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload"
+          focusable="false"
+          height="20"
+          role="img"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        Upload
+      </button>
+      <input
+        accept="image/*"
+        style="display:none"
+        type="file"
+      />
+    </div>
+    *** Mock(Media upload button) ***
+  </div>
+</div>
+`;

--- a/blocks/library/cover-image/test/index.js
+++ b/blocks/library/cover-image/test/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+jest.mock( 'blocks/media-upload-button', () => () => '*** Mock(Media upload button) ***' );
+
+describe( 'core/cover-image', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/cover-image' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/embed/test/__snapshots__/index.js.snap
+++ b/blocks/library/embed/test/__snapshots__/index.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/embed block edit matches snapshot 1`] = `
+<div
+  class="components-placeholder wp-block-embed"
+>
+  <div
+    class="components-placeholder__label"
+  >
+    <svg
+      aria-hidden="true"
+      class="dashicon dashicons-embed-generic"
+      focusable="false"
+      height="20"
+      role="img"
+      viewBox="0 0 20 20"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M17 4H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-3 6.5L12.5 12l1.5 1.5V15l-3-3 3-3v1.5zm1 4.5v-1.5l1.5-1.5-1.5-1.5V9l3 3-3 3z"
+      />
+    </svg>
+    Embed URL
+  </div>
+  <div
+    class="components-placeholder__fieldset"
+  >
+    <form>
+      <input
+        aria-label="Embed URL"
+        class="components-placeholder__input"
+        placeholder="Enter URL to embed here…"
+        type="url"
+        value=""
+      />
+      <button
+        class="components-button button button-large"
+        type="submit"
+      >
+        Embed
+      </button>
+    </form>
+  </div>
+</div>
+`;

--- a/blocks/library/embed/test/index.js
+++ b/blocks/library/embed/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/embed', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/embed' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/freeform/test/__snapshots__/index.js.snap
+++ b/blocks/library/freeform/test/__snapshots__/index.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/freeform block edit matches snapshot 1`] = `
+Array [
+  <div
+    class="freeform-toolbar"
+    id="undefined-toolbar"
+    style="display:none"
+  />,
+  <div
+    class="wp-block-freeform blocks-editable__tinymce"
+  />,
+]
+`;

--- a/blocks/library/freeform/test/index.js
+++ b/blocks/library/freeform/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/freeform', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/freeform' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/gallery/test/__snapshots__/index.js.snap
+++ b/blocks/library/gallery/test/__snapshots__/index.js.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/gallery block edit matches snapshot 1`] = `
+<div
+  class="components-placeholder wp-block-gallery"
+>
+  <div
+    class="components-placeholder__label"
+  >
+    <svg
+      aria-hidden="true"
+      class="dashicon dashicons-format-gallery"
+      focusable="false"
+      height="20"
+      role="img"
+      viewBox="0 0 20 20"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M16 4h1.96c.57 0 1.04.47 1.04 1.04v12.92c0 .57-.47 1.04-1.04 1.04H5.04C4.47 19 4 18.53 4 17.96V16H2.04C1.47 16 1 15.53 1 14.96V2.04C1 1.47 1.47 1 2.04 1h12.92c.57 0 1.04.47 1.04 1.04V4zM3 14h11V3H3v11zm5-8.5C8 4.67 7.33 4 6.5 4S5 4.67 5 5.5 5.67 7 6.5 7 8 6.33 8 5.5zm2 4.5s1-5 3-5v8H4V7c2 0 2 3 2 3s.33-2 2-2 2 2 2 2zm7 7V6h-1v8.96c0 .57-.47 1.04-1.04 1.04H6v1h11z"
+      />
+    </svg>
+    Gallery
+  </div>
+  <div
+    class="components-placeholder__instructions"
+  >
+    Drag images here or add from media library
+  </div>
+  <div
+    class="components-placeholder__fieldset"
+  >
+    <div
+      class="components-drop-zone"
+    >
+      <div
+        class="components-drop-zone__content"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload components-drop-zone__content-icon"
+          focusable="false"
+          height="40"
+          role="img"
+          viewBox="0 0 20 20"
+          width="40"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        <span
+          class="components-drop-zone__content-text"
+        >
+          Drop files to upload
+        </span>
+      </div>
+    </div>
+    <div
+      class="components-form-file-upload"
+    >
+      <button
+        class="components-button components-icon-button wp-block-image__upload-button button button-large"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload"
+          focusable="false"
+          height="20"
+          role="img"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        Upload
+      </button>
+      <input
+        accept="image/*"
+        multiple=""
+        style="display:none"
+        type="file"
+      />
+    </div>
+    *** Mock(Media upload button) ***
+  </div>
+</div>
+`;

--- a/blocks/library/gallery/test/index.js
+++ b/blocks/library/gallery/test/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+jest.mock( 'blocks/media-upload-button', () => () => '*** Mock(Media upload button) ***' );
+
+describe( 'core/gallery', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/gallery' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/heading/test/__snapshots__/index.js.snap
+++ b/blocks/library/heading/test/__snapshots__/index.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/heading block edit matches snapshot 1`] = `
+<div
+  class="wp-block-heading blocks-editable"
+>
+  <h2
+    aria-label="Write heading…"
+    class="blocks-editable__tinymce"
+    contenteditable="true"
+  />
+  <h2
+    class="blocks-editable__tinymce"
+  >
+    Write heading…
+  </h2>
+</div>
+`;

--- a/blocks/library/heading/test/index.js
+++ b/blocks/library/heading/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/heading', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/heading' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/html/test/__snapshots__/index.js.snap
+++ b/blocks/library/html/test/__snapshots__/index.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/html block edit matches snapshot 1`] = `
+<textarea
+  aria-label="HTML"
+  class="wp-block-html"
+  rows="1"
+/>
+`;

--- a/blocks/library/html/test/index.js
+++ b/blocks/library/html/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/html', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/html' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/list/test/__snapshots__/index.js.snap
+++ b/blocks/library/list/test/__snapshots__/index.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/list block edit matches snapshot 1`] = `
+<div
+  class="blocks-list blocks-editable"
+>
+  <ul
+    aria-label="Write list…"
+    class="blocks-editable__tinymce"
+    contenteditable="true"
+  />
+  <ul
+    class="blocks-editable__tinymce"
+  >
+    <li>
+      Write list…
+    </li>
+  </ul>
+</div>
+`;

--- a/blocks/library/list/test/index.js
+++ b/blocks/library/list/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/list', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/list' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/more/test/__snapshots__/index.js.snap
+++ b/blocks/library/more/test/__snapshots__/index.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/more block edit matches snapshot 1`] = `
+<div
+  class="wp-block-more"
+>
+  <input
+    size="10"
+    type="text"
+    value="Read more"
+  />
+</div>
+`;

--- a/blocks/library/more/test/index.js
+++ b/blocks/library/more/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/more', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/more' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/paragraph/test/__snapshots__/index.js.snap
+++ b/blocks/library/paragraph/test/__snapshots__/index.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/paragraph block edit matches snapshot 1`] = `
+<div>
+  <div>
+    <div
+      class="components-autocomplete"
+    >
+      <div
+        class="blocks-editable"
+      >
+        <p
+          aria-autocomplete="list"
+          aria-expanded="false"
+          aria-label="Add text or type / to add content"
+          class="wp-block-paragraph blocks-editable__tinymce"
+          contenteditable="true"
+        />
+        <p
+          class="blocks-editable__tinymce wp-block-paragraph"
+        >
+          Add text or type / to add content
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/blocks/library/paragraph/test/index.js
+++ b/blocks/library/paragraph/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/paragraph', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/paragraph' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/preformatted/test/__snapshots__/index.js.snap
+++ b/blocks/library/preformatted/test/__snapshots__/index.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/preformatted block edit matches snapshot 1`] = `
+<div
+  class="wp-block-preformatted blocks-editable"
+>
+  <pre
+    aria-label="Write preformatted text…"
+    class="blocks-editable__tinymce"
+    contenteditable="true"
+  />
+  <pre
+    class="blocks-editable__tinymce"
+  >
+    Write preformatted text…
+  </pre>
+</div>
+`;

--- a/blocks/library/preformatted/test/index.js
+++ b/blocks/library/preformatted/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/preformatted', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/preformatted' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/pullquote/test/__snapshots__/index.js.snap
+++ b/blocks/library/pullquote/test/__snapshots__/index.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/pullquote block edit matches snapshot 1`] = `
+<blockquote
+  class="wp-block-pullquote"
+>
+  <div
+    class="blocks-pullquote__content blocks-editable"
+  >
+    <div
+      aria-label="Write quote…"
+      class="blocks-editable__tinymce"
+      contenteditable="true"
+    />
+    <div
+      class="blocks-editable__tinymce"
+    >
+      <p>
+        Write quote…
+      </p>
+    </div>
+  </div>
+</blockquote>
+`;

--- a/blocks/library/pullquote/test/index.js
+++ b/blocks/library/pullquote/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/pullquote', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/pullquote' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/quote/test/__snapshots__/index.js.snap
+++ b/blocks/library/quote/test/__snapshots__/index.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/quote block edit matches snapshot 1`] = `
+<blockquote
+  class="wp-block-quote"
+>
+  <div
+    class="blocks-editable"
+  >
+    <div
+      aria-label="Write quote…"
+      class="blocks-editable__tinymce"
+      contenteditable="true"
+    />
+    <div
+      class="blocks-editable__tinymce"
+    >
+      <p>
+        Write quote…
+      </p>
+    </div>
+  </div>
+</blockquote>
+`;

--- a/blocks/library/quote/test/index.js
+++ b/blocks/library/quote/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/quote', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/quote' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/separator/test/__snapshots__/index.js.snap
+++ b/blocks/library/separator/test/__snapshots__/index.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/separator block edit matches snapshot 1`] = `
+<hr
+  class="wp-block-separator"
+/>
+`;

--- a/blocks/library/separator/test/index.js
+++ b/blocks/library/separator/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/separator', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/separator' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/shortcode/test/__snapshots__/index.js.snap
+++ b/blocks/library/shortcode/test/__snapshots__/index.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/shortcode block edit matches snapshot 1`] = `
+<div
+  class="wp-block-shortcode"
+>
+  <label
+    for="blocks-shortcode-input-0"
+  >
+    <svg
+      aria-hidden="true"
+      class="dashicon dashicons-editor-code"
+      focusable="false"
+      height="20"
+      role="img"
+      viewBox="0 0 20 20"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 6l-4 4 4 4-1 2-6-6 6-6zm2 8l4-4-4-4 1-2 6 6-6 6z"
+      />
+    </svg>
+    Shortcode
+  </label>
+  <textarea
+    autocomplete="off"
+    id="blocks-shortcode-input-0"
+    placeholder="Write shortcode here…"
+    rows="1"
+  />
+</div>
+`;

--- a/blocks/library/shortcode/test/index.js
+++ b/blocks/library/shortcode/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/shortcode', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/shortcode' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/table/test/__snapshots__/index.js.snap
+++ b/blocks/library/table/test/__snapshots__/index.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/embed block edit matches snapshot 1`] = `
+<div
+  class="wp-block-table blocks-editable"
+>
+  <table
+    class="blocks-editable__tinymce"
+    contenteditable="true"
+  >
+    <tbody>
+      <tr>
+        <td>
+          <br />
+        </td>
+        <td>
+          <br />
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <br />
+        </td>
+        <td>
+          <br />
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/blocks/library/table/test/index.js
+++ b/blocks/library/table/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/embed', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/table' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/text-columns/test/__snapshots__/index.js.snap
+++ b/blocks/library/text-columns/test/__snapshots__/index.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/text-columns block edit matches snapshot 1`] = `
+<div
+  class="wp-block-text-columns alignundefined columns-2"
+>
+  <div
+    class="wp-block-column"
+  >
+    <div
+      class="blocks-editable"
+    >
+      <p
+        aria-label="New Column"
+        class="blocks-editable__tinymce"
+        contenteditable="true"
+      />
+      <p
+        class="blocks-editable__tinymce"
+      >
+        New Column
+      </p>
+    </div>
+  </div>
+  <div
+    class="wp-block-column"
+  >
+    <div
+      class="blocks-editable"
+    >
+      <p
+        aria-label="New Column"
+        class="blocks-editable__tinymce"
+        contenteditable="true"
+      />
+      <p
+        class="blocks-editable__tinymce"
+      >
+        New Column
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/blocks/library/text-columns/test/index.js
+++ b/blocks/library/text-columns/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/text-columns', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/text-columns' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/verse/test/__snapshots__/index.js.snap
+++ b/blocks/library/verse/test/__snapshots__/index.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/verse block edit matches snapshot 1`] = `
+<div
+  class="wp-block-verse blocks-editable"
+>
+  <pre
+    aria-label="Write…"
+    class="blocks-editable__tinymce"
+    contenteditable="true"
+  />
+  <pre
+    class="blocks-editable__tinymce"
+  >
+    Write…
+  </pre>
+</div>
+`;

--- a/blocks/library/verse/test/index.js
+++ b/blocks/library/verse/test/index.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+describe( 'core/verse', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/verse' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/library/video/test/__snapshots__/index.js.snap
+++ b/blocks/library/video/test/__snapshots__/index.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`core/video block edit matches snapshot 1`] = `
+<div
+  class="components-placeholder wp-block-video"
+>
+  <div
+    class="components-placeholder__label"
+  >
+    <svg
+      aria-hidden="true"
+      class="dashicon dashicons-media-video"
+      focusable="false"
+      height="20"
+      role="img"
+      viewBox="0 0 20 20"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2l4 4v12H4V2h8zm0 4h3l-3-3v3zm-1 8v-3c0-.27-.1-.51-.29-.71-.2-.19-.44-.29-.71-.29H7c-.27 0-.51.1-.71.29-.19.2-.29.44-.29.71v3c0 .27.1.51.29.71.2.19.44.29.71.29h3c.27 0 .51-.1.71-.29.19-.2.29-.44.29-.71zm3 1v-5l-2 2v1z"
+      />
+    </svg>
+    Video
+  </div>
+  <div
+    class="components-placeholder__instructions"
+  >
+    Select a video file from your library, or upload a new one:
+  </div>
+  <div
+    class="components-placeholder__fieldset"
+  >
+    <form>
+      <input
+        class="components-placeholder__input"
+        placeholder="Enter URL of video file here…"
+        type="url"
+        value=""
+      />
+      <button
+        class="components-button button button-large"
+        type="submit"
+      >
+        Use URL
+      </button>
+    </form>
+    *** Mock(Media upload button) ***
+  </div>
+</div>
+`;

--- a/blocks/library/video/test/index.js
+++ b/blocks/library/video/test/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+import { blockEditRender } from 'blocks/test/helpers';
+
+jest.mock( 'blocks/media-upload-button', () => () => '*** Mock(Media upload button) ***' );
+
+describe( 'core/video', () => {
+	test( 'block edit matches snapshot', () => {
+		const wrapper = blockEditRender( 'core/video' );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/blocks/test/helpers/index.js
+++ b/blocks/test/helpers/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencie
+ */
+import { render } from 'enzyme';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { createBlock, BlockEdit } from '../..';
+
+export const blockEditRender = ( name, initialAttributes = {} ) => {
+	const block = createBlock( name, initialAttributes );
+
+	return render(
+		<BlockEdit
+			name={ name }
+			focus={ false }
+			attributes={ block.attributes }
+			setAttributes={ noop }
+		/>
+	);
+};


### PR DESCRIPTION
## Description
This PR is inspired by @youknowriad work in #4246. It introduces `blockEditRender` test helper which renders block using `<BlockEdit />` component to simulate how it looks in the editor. This helper is ready to support `example` option which #4246 is going to introduce.

I skipped all blocks that use `withApiData` HOC, because it throws errors when executed in tests context. This should be further investigated in the future.

I also mocked `<MediaUploadButton />` in a few places because it depends on `wp.media` object. In the future, we could figure out if we can mock `wp.media` object instead, but I think it's also good as it is.

## How Has This Been Tested?
`npm test`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.