### PR TITLE
Updating capitalization to match other menu items

### DIFF
--- a/editor/edit-post/header/fixed-toolbar-toggle/index.js
+++ b/editor/edit-post/header/fixed-toolbar-toggle/index.js
@@ -24,7 +24,7 @@ function FeatureToggle( { onToggle, active, onMobile } ) {
 			label={ __( 'Toolbar' ) }
 		>
 			<MenuItemsToggle
-				label={ __( 'Fix toolbar to top' ) }
+				label={ __( 'Fix Toolbar to Top' ) }
 				isSelected={ active }
 				onClick={ onToggle }
 			/>


### PR DESCRIPTION
Hi everyone,

I have been working on some documentation and saw something small but wanted to bring it up. 

After looking at the other menu items in the document menu I noticed the capitalization was not consistent. 
![screenshot 2018-01-11 04 32 44](https://user-images.githubusercontent.com/128621/34819022-952e6594-f68a-11e7-9889-ff2c10f23bb7.png)

I also looked at other areas of labeling in menus with more then one word and came to the same conclusion.
![screenshot 2018-01-11 04 33 08](https://user-images.githubusercontent.com/128621/34819023-95402aa4-f68a-11e7-8a26-636526fc732d.png)

Example: In the Status & Visibility section in the Document Settings Sidebar "Stick to the Front Page".

Hope this helps.

## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.


