### PR TITLE
Blocks: Style the "footer" in quotes to ensure backwards compatibility

### DIFF
--- a/blocks/library/pullquote/style.scss
+++ b/blocks/library/pullquote/style.scss
@@ -20,7 +20,8 @@
 		line-height: 1.6;
 	}
 
-	cite {
+	cite,
+	footer {
 		color: $dark-gray-600;
 		position: relative;
 		font-weight: 900;

--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -1,7 +1,8 @@
 .wp-block-quote {
 	margin: 0 0 16px;
 
-	cite {
+	cite,
+	footer {
 		color: $dark-gray-300;
 		margin-top: 1em;
 		position: relative;
@@ -17,7 +18,9 @@
 			font-style: italic;
 			line-height: 1.6;
 		}
-		cite {
+
+		cite,
+		footer {
 			font-size: 19px;
 			text-align: right;
 		}


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/3851#discussion_r157050519

The quote and pullquote blocks have been updated to use `cite` instead of `footer`. To ensure old blocks still show up properly on the frontend, we bring the `footer` styles back in this PR.