### PR TITLE
Toolbar: Refactor to simplify block toolbar rendering

### DIFF
--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -16,16 +16,14 @@ import BlockSwitcher from '../block-switcher';
 import { getBlockMode, getSelectedBlock } from '../../store/selectors';
 
 function BlockToolbar( { block, mode } ) {
-	if ( ! block || ! block.isValid ) {
+	if ( ! block || ! block.isValid || mode !== 'visual' ) {
 		return null;
 	}
 
 	return (
 		<div className="editor-block-toolbar">
-			{ mode === 'visual' && [
-				<BlockSwitcher key="switcher" uids={ [ block.uid ] } />,
-				<Slot key="slot" name="Formatting.Toolbar" />,
-			] }
+			<BlockSwitcher uids={ [ block.uid ] } />
+			<Slot name="Formatting.Toolbar" />
 		</div>
 	);
 }

--- a/editor/components/block-toolbar/index.js
+++ b/editor/components/block-toolbar/index.js
@@ -20,9 +20,6 @@ function BlockToolbar( { block, mode } ) {
 		return null;
 	}
 
-	// Disable reason: Toolbar itself is non-interactive, but must capture
-	// bubbling events from children to determine focus shift intents.
-	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
 		<div className="editor-block-toolbar">
 			{ mode === 'visual' && [
@@ -31,7 +28,6 @@ function BlockToolbar( { block, mode } ) {
 			] }
 		</div>
 	);
-	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }
 
 export default connect( ( state ) => {


### PR DESCRIPTION
This pull request seeks to refactor the `EditorBlockToolbar` component to simplify its rendering logic. Specifically, there is an ESLint rule disabling which is unnecessary, and the component renders a wrapper with a fragment of elements only when editing a block visually; this has been simplified to render nothing from the component at all unless editing a block visually, assuming that an empty wrapper is not necessary.

__Testing instructions:__

Verify that there are no regressions in the display and use of the block editor, contextually or bound to the top toolbar, and that the toolbar only displays when editing a block visually.