### PR TITLE
Audio/Video Block: Remove colon from placeholder text.

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -118,7 +118,7 @@ registerBlockType( 'core/audio', {
 						key="placeholder"
 						icon="media-audio"
 						label={ __( 'Audio' ) }
-						instructions={ __( 'Select an audio file from your library, or upload a new one:' ) }
+						instructions={ __( 'Select an audio file from your library, or upload a new one' ) }
 						className={ className }>
 						<form onSubmit={ onSelectUrl }>
 							<input

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -119,7 +119,7 @@ registerBlockType( 'core/video', {
 						key="placeholder"
 						icon="media-video"
 						label={ __( 'Video' ) }
-						instructions={ __( 'Select a video file from your library, or upload a new one:' ) }
+						instructions={ __( 'Select a video file from your library, or upload a new one' ) }
 						className={ className }>
 						<form onSubmit={ onSelectUrl }>
 							<input


### PR DESCRIPTION
## Description
Removes the colon from the video and audio block placeholder.
Fixes #4427

## Screenshots (jpeg or gifs if applicable):
Before
![before](https://user-images.githubusercontent.com/695201/34875178-7500a580-f79c-11e7-8ea2-c1e3300405c4.png)
After
![after](https://user-images.githubusercontent.com/695201/34875181-7937fa68-f79c-11e7-9413-e07f44606b2e.png)
