### PR TITLE
Meta Boxes: Allow collapsing/sorting the meta boxes panels

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, includes, map, castArray, uniqueId } from 'lodash';
+import { get, includes, map, castArray, uniqueId, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -451,5 +451,11 @@ export default {
 	CREATE_NOTICE( { notice: { content, spokenMessage } } ) {
 		const message = spokenMessage || content;
 		speak( message, 'assertive' );
+	},
+	INITIALIZE_META_BOX_STATE( action ) {
+		// Allow toggling metaboxes panels
+		if ( some( action.metaBoxes ) ) {
+			window.postboxes.add_postbox_toggles( 'post' );
+		}
 	},
 };

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -684,7 +684,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	wp_enqueue_script(
 		'wp-editor',
 		gutenberg_url( 'editor/build/index.js' ),
-		array( 'jquery', 'wp-api', 'wp-data', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
+		array( 'postbox', 'jquery', 'wp-api', 'wp-data', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor', 'heartbeat' ),
 		filemtime( gutenberg_dir_path() . 'editor/build/index.js' ),
 		true // enqueue in the footer.
 	);


### PR DESCRIPTION
This PR enables the meta boxes collapsing/sorting behavior we have in the classic editor.
It's as simple as calling `window.postboxes.add_postbox_toggles( 'post' );` when we load the meta boxes.

**Testing instructions**

 - Add some metaboxes
 - Notice you can collapse/expand the panels