### PR TITLE
Add block-level keyboard shortcuts

### DIFF
--- a/blocks/alignment-shortcuts/index.js
+++ b/blocks/alignment-shortcuts/index.js
@@ -15,9 +15,9 @@ export default map( {
 }, ( shortcut, value ) => ( {
 	type: 'shortcut',
 	shortcut,
-	transform( attributes ) {
-		const firstAlign = first( attributes ).align;
-		const isSame = attributes.every( ( { align } ) => align === firstAlign );
+	transform( blocks ) {
+		const firstAlign = first( blocks ).attributes.align;
+		const isSame = blocks.every( ( { attributes: { align } } ) => align === firstAlign );
 
 		// If already aligned, set back to default.
 		if ( isSame && firstAlign === value ) {

--- a/blocks/alignment-shortcuts/index.js
+++ b/blocks/alignment-shortcuts/index.js
@@ -3,16 +3,18 @@
  */
 import { map, first } from 'lodash';
 
+export const shortcuts = {
+	left: 'l',
+	center: 'c',
+	right: 'r',
+};
+
 /**
  * Holds an array of alignment shortcut transforms.
  *
  * @return {Array} Array of transforms.
  */
-export default map( {
-	left: 'l',
-	center: 'c',
-	right: 'r',
-}, ( shortcut, value ) => ( {
+export default map( shortcuts, ( shortcut, value ) => ( {
 	type: 'shortcut',
 	shortcut,
 	transform( blocks ) {

--- a/blocks/alignment-shortcuts/index.js
+++ b/blocks/alignment-shortcuts/index.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { map, first } from 'lodash';
+
+/**
+ * Holds an array of alignment shortcut transforms.
+ *
+ * @return {Array} Array of transforms.
+ */
+export default map( {
+	left: 'l',
+	center: 'c',
+	right: 'r',
+}, ( shortcut, value ) => ( {
+	type: 'shortcut',
+	shortcut,
+	transform( attributes ) {
+		const firstAlign = first( attributes ).align;
+		const isSame = attributes.every( ( { align } ) => align === firstAlign );
+
+		// If already aligned, set back to default.
+		if ( isSame && firstAlign === value ) {
+			return { align: undefined };
+		}
+
+		return { align: value };
+	},
+} ) );

--- a/blocks/alignment-toolbar/index.js
+++ b/blocks/alignment-toolbar/index.js
@@ -8,16 +8,19 @@ const ALIGNMENT_CONTROLS = [
 	{
 		icon: 'editor-alignleft',
 		title: __( 'Align left' ),
+		shortcut: 'l',
 		align: 'left',
 	},
 	{
 		icon: 'editor-aligncenter',
 		title: __( 'Align center' ),
+		shortcut: 'c',
 		align: 'center',
 	},
 	{
 		icon: 'editor-alignright',
 		title: __( 'Align right' ),
+		shortcut: 'r',
 		align: 'right',
 	},
 ];

--- a/blocks/alignment-toolbar/index.js
+++ b/blocks/alignment-toolbar/index.js
@@ -4,23 +4,25 @@
 import { __ } from '@wordpress/i18n';
 import { Toolbar } from '@wordpress/components';
 
+import { shortcuts } from '../alignment-shortcuts';
+
 const ALIGNMENT_CONTROLS = [
 	{
 		icon: 'editor-alignleft',
 		title: __( 'Align left' ),
-		shortcut: 'l',
+		shortcut: shortcuts.left,
 		align: 'left',
 	},
 	{
 		icon: 'editor-aligncenter',
 		title: __( 'Align center' ),
-		shortcut: 'c',
+		shortcut: shortcuts.center,
 		align: 'center',
 	},
 	{
 		icon: 'editor-alignright',
 		title: __( 'Align right' ),
-		shortcut: 'r',
+		shortcut: shortcuts.right,
 		align: 'right',
 	},
 ];

--- a/blocks/alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/blocks/alignment-toolbar/test/__snapshots__/index.js.snap
@@ -10,6 +10,7 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
         "isActive": true,
         "onClick": [Function],
         "title": "Align left",
+        "shortcut": "l",
       },
       Object {
         "align": "center",
@@ -17,6 +18,7 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
         "isActive": false,
         "onClick": [Function],
         "title": "Align center",
+        "shortcut": "c",
       },
       Object {
         "align": "right",
@@ -24,6 +26,7 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
         "isActive": false,
         "onClick": [Function],
         "title": "Align right",
+        "shortcut": "r",
       },
     ]
   }

--- a/blocks/alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/blocks/alignment-toolbar/test/__snapshots__/index.js.snap
@@ -9,24 +9,24 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
         "icon": "editor-alignleft",
         "isActive": true,
         "onClick": [Function],
-        "title": "Align left",
         "shortcut": "l",
+        "title": "Align left",
       },
       Object {
         "align": "center",
         "icon": "editor-aligncenter",
         "isActive": false,
         "onClick": [Function],
-        "title": "Align center",
         "shortcut": "c",
+        "title": "Align center",
       },
       Object {
         "align": "right",
         "icon": "editor-alignright",
         "isActive": false,
         "onClick": [Function],
-        "title": "Align right",
         "shortcut": "r",
+        "title": "Align right",
       },
     ]
   }

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -150,8 +150,7 @@ export function getPossibleBlockTransformations( blocks ) {
  * @return {Array}       Array of transforms.
  */
 export function getPossibleShortcutTransformations( name ) {
-	const transformsFrom = getBlockTypes()
-		.reduce( ( acc, blockType ) => [ ...acc, ...get( blockType, 'transforms.from', [] ) ], [] )
+	const transformsFrom = flatMap( getBlockTypes(), ( blockType ) => get( blockType, 'transforms.from', [] ) )
 		.filter( isTransformForBlockSource( name, 'shortcut', false ) );
 	const transformsTo = get( getBlockType( name ), 'transforms.to', [] )
 		.filter( ( { type } ) => type === 'shortcut' );

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -67,9 +67,9 @@ export function createBlock( name, blockAttributes = {} ) {
  * given transformation is able to execute in the situation specified in the
  * params.
  *
- * @param {String}  sourceName    Block name
- * @param {String}  transformType The transform type to check for.
- * @param {Boolean} isMultiBlock  Array of possible block transformations
+ * @param {string}  sourceName    Block name
+ * @param {string}  transformType The transform type to check for.
+ * @param {boolean} isMultiBlock  Array of possible block transformations
  *
  * @returns {Function} Predicate that receives a block type.
  */
@@ -84,9 +84,9 @@ const isTransformForBlockSource = ( sourceName, transformType, isMultiBlock = fa
  * block type contains a transformation able to execute in the situation
  * specified in the params.
  *
- * @param {String}  sourceName    Block name
- * @param {String}  transformType The transform type to check for.
- * @param {Boolean} isMultiBlock  Array of possible block transformations
+ * @param {string}  sourceName    Block name
+ * @param {string}  transformType The transform type to check for.
+ * @param {boolean} isMultiBlock  Array of possible block transformations
  *
  * @returns {Function} Predicate that receives a block type.
  */
@@ -148,8 +148,9 @@ export function getPossibleBlockTransformations( blocks ) {
 /**
  * Gets all possible shortcut transforms based on a block name.
  *
- * @param  {String} name Block name.
- * @return {Array}       Array of transforms.
+ * @param {string} name Block name.
+ *
+ * @returns {Array}       Array of transforms.
  */
 export function getPossibleShortcutTransformations( name ) {
 	const transformsFrom = flatMap( getBlockTypes(), ( blockType ) => get( blockType, 'transforms.from', [] ) )

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -67,8 +67,9 @@ export function createBlock( name, blockAttributes = {} ) {
  * given transformation is able to execute in the situation specified in the
  * params.
  *
- * @param {string}  sourceName   Block name.
- * @param {boolean} isMultiBlock Array of possible block transformations.
+ * @param {String}  sourceName    Block name
+ * @param {String}  transformType The transform type to check for.
+ * @param {Boolean} isMultiBlock  Array of possible block transformations
  *
  * @returns {Function} Predicate that receives a block type.
  */
@@ -83,8 +84,9 @@ const isTransformForBlockSource = ( sourceName, transformType, isMultiBlock = fa
  * block type contains a transformation able to execute in the situation
  * specified in the params.
  *
- * @param {string}  sourceName   Block name.
- * @param {boolean} isMultiBlock Array of possible block transformations.
+ * @param {String}  sourceName    Block name
+ * @param {String}  transformType The transform type to check for.
+ * @param {Boolean} isMultiBlock  Array of possible block transformations
  *
  * @returns {Function} Predicate that receives a block type.
  */

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -72,8 +72,8 @@ export function createBlock( name, blockAttributes = {} ) {
  *
  * @returns {Function} Predicate that receives a block type.
  */
-const isTransformForBlockSource = ( sourceName, isMultiBlock = false ) => ( transform ) => (
-	transform.type === 'block' &&
+const isTransformForBlockSource = ( sourceName, transformType, isMultiBlock = false ) => ( transform ) => (
+	transform.type === transformType &&
 	transform.blocks.indexOf( sourceName ) !== -1 &&
 	( ! isMultiBlock || transform.isMultiBlock )
 );
@@ -88,10 +88,10 @@ const isTransformForBlockSource = ( sourceName, isMultiBlock = false ) => ( tran
  *
  * @returns {Function} Predicate that receives a block type.
  */
-const createIsTypeTransformableFrom = ( sourceName, isMultiBlock = false ) => ( type ) => (
+const createIsTypeTransformableFrom = ( sourceName, transformType, isMultiBlock = false ) => ( type ) => (
 	!! find(
 		get( type, 'transforms.from', [] ),
-		isTransformForBlockSource( sourceName, isMultiBlock ),
+		isTransformForBlockSource( sourceName, transformType, isMultiBlock ),
 	)
 );
 
@@ -118,7 +118,7 @@ export function getPossibleBlockTransformations( blocks ) {
 	//compute the block that have a from transformation able to transfer blocks passed as argument.
 	const blocksToBeTransformedFrom = filter(
 		getBlockTypes(),
-		createIsTypeTransformableFrom( sourceBlockName, isMultiBlock ),
+		createIsTypeTransformableFrom( sourceBlockName, 'block', isMultiBlock ),
 	).map( type => type.name );
 
 	const blockType = getBlockType( sourceBlockName );
@@ -141,6 +141,22 @@ export function getPossibleBlockTransformations( blocks ) {
 		}
 		return result;
 	}, [] );
+}
+
+/**
+ * Gets all possible shortcut transforms based on a block name.
+ *
+ * @param  {String} name Block name.
+ * @return {Array}       Array of transforms.
+ */
+export function getPossibleShortcutTransformations( name ) {
+	const transformsFrom = getBlockTypes()
+		.reduce( ( acc, blockType ) => [ ...acc, ...get( blockType, 'transforms.from', [] ) ], [] )
+		.filter( isTransformForBlockSource( name, 'shortcut', false ) );
+	const transformsTo = get( getBlockType( name ), 'transforms.to', [] )
+		.filter( ( { type } ) => type === 'shortcut' );
+
+	return [ ...transformsFrom, ...transformsTo ];
 }
 
 /**

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -1,4 +1,10 @@
-export { createBlock, getPossibleBlockTransformations, switchToBlockType, createReusableBlock } from './factory';
+export {
+	createBlock,
+	getPossibleBlockTransformations,
+	getPossibleShortcutTransformations,
+	switchToBlockType,
+	createReusableBlock,
+} from './factory';
 export { default as parse, getBlockAttributes } from './parser';
 export { default as rawHandler } from './raw-handling';
 export {

--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -4,21 +4,26 @@
 import { __ } from '@wordpress/i18n';
 import { Toolbar, withContext } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { shortcuts } from '../alignment-shortcuts';
+
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	left: {
 		icon: 'align-left',
 		title: __( 'Align left' ),
-		shortcut: 'l',
+		shortcut: shortcuts.left,
 	},
 	center: {
 		icon: 'align-center',
 		title: __( 'Align center' ),
-		shortcut: 'c',
+		shortcut: shortcuts.center,
 	},
 	right: {
 		icon: 'align-right',
 		title: __( 'Align right' ),
-		shortcut: 'r',
+		shortcut: shortcuts.right,
 	},
 	wide: {
 		icon: 'align-wide',

--- a/blocks/block-alignment-toolbar/index.js
+++ b/blocks/block-alignment-toolbar/index.js
@@ -8,14 +8,17 @@ const BLOCK_ALIGNMENTS_CONTROLS = {
 	left: {
 		icon: 'align-left',
 		title: __( 'Align left' ),
+		shortcut: 'l',
 	},
 	center: {
 		icon: 'align-center',
 		title: __( 'Align center' ),
+		shortcut: 'c',
 	},
 	right: {
 		icon: 'align-right',
 		title: __( 'Align right' ),
+		shortcut: 'r',
 	},
 	wide: {
 		icon: 'align-wide',

--- a/blocks/block-alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/blocks/block-alignment-toolbar/test/__snapshots__/index.js.snap
@@ -8,18 +8,21 @@ exports[`BlockAlignmentToolbar should match snapshot 1`] = `
         "icon": "align-left",
         "isActive": true,
         "onClick": [Function],
+        "shortcut": "l",
         "title": "Align left",
       },
       Object {
         "icon": "align-center",
         "isActive": false,
         "onClick": [Function],
+        "shortcut": "c",
         "title": "Align center",
       },
       Object {
         "icon": "align-right",
         "isActive": false,
         "onClick": [Function],
+        "shortcut": "r",
         "title": "Align right",
       },
     ]

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -14,6 +14,7 @@ import './hooks';
 // and then stored as objects in state, from which it is then rendered for editing.
 export * from './api';
 export { registerCoreBlocks } from './library';
+export { default as alignmentShortcuts } from './alignment-shortcuts';
 export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockControls } from './block-controls';

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -18,6 +18,7 @@ import MediaUpload from '../../media-upload';
 import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 export const name = 'core/audio';
 
@@ -48,6 +49,10 @@ export const settings = {
 		id: {
 			type: 'number',
 		},
+	},
+
+	transforms: {
+		to: alignmentShortcuts,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -18,6 +18,7 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import ColorPalette from '../../color-palette';
 import ContrastChecker from '../../contrast-checker';
 import InspectorControls from '../../inspector-controls';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 const { getComputedStyle } = window;
 
@@ -184,6 +185,10 @@ export const settings = {
 	category: 'layout',
 
 	attributes: blockAttributes,
+
+	transforms: {
+		to: alignmentShortcuts,
+	},
 
 	getEditWrapperProps( attributes ) {
 		const { align, clear } = attributes;

--- a/blocks/library/categories/index.js
+++ b/blocks/library/categories/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import './style.scss';
 import CategoriesBlock from './block';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 export const name = 'core/categories';
 
@@ -37,6 +38,10 @@ export const settings = {
 		align: {
 			type: 'string',
 		},
+	},
+
+	transforms: {
+		to: alignmentShortcuts,
 	},
 
 	supports: {

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -25,6 +25,7 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 import RangeControl from '../../inspector-controls/range-control';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
 
@@ -86,6 +87,7 @@ export const settings = {
 					createBlock( 'core/heading', { content: title } )
 				),
 			},
+			...alignmentShortcuts,
 		],
 	},
 

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -21,11 +21,12 @@ import { createBlock } from '../../api';
 import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 // These embeds do not work in sandboxes
 const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
 
-function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, keywords = [] } ) {
+function getEmbedBlockSettings( { title, icon, category = 'embed', transforms = {}, keywords = [] } ) {
 	return {
 		title,
 
@@ -52,7 +53,10 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			},
 		},
 
-		transforms,
+		transforms: {
+			from: transforms.from,
+			to: alignmentShortcuts,
+		},
 
 		getEditWrapperProps( attributes ) {
 			const { align } = attributes;

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -16,6 +16,7 @@ import './editor.scss';
 import './style.scss';
 import { createBlock } from '../../api';
 import { default as GalleryBlock, defaultColumnsNumber } from './block';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 const blockAttributes = {
 	align: {
@@ -149,6 +150,7 @@ export const settings = {
 					return createBlock( 'core/image' );
 				},
 			},
+			...alignmentShortcuts,
 		],
 	},
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -81,6 +81,19 @@ export const settings = {
 					} );
 				},
 			},
+			...'23456'.split( '' ).map( ( level ) => ( {
+				type: 'shortcut',
+				blocks: [ 'core/paragraph' ],
+				shortcut: level,
+				transform( blockAttributes ) {
+					return blockAttributes.map( ( { content } ) => {
+						return createBlock( 'core/heading', {
+							nodeName: `H${ level }`,
+							content,
+						} );
+					} );
+				},
+			} ) ),
 		],
 		to: [
 			{
@@ -92,6 +105,24 @@ export const settings = {
 					} );
 				},
 			},
+			...'23456'.split( '' ).map( ( level ) => ( {
+				type: 'shortcut',
+				shortcut: level,
+				transform( blockAttributes ) {
+					return blockAttributes.map( ( { content, nodeName } ) => {
+						if ( nodeName === `H${ level }` ) {
+							return createBlock( 'core/paragraph', {
+								content,
+							} );
+						} else {
+							return createBlock( 'core/heading', {
+								nodeName: `H${ level }`,
+								content,
+							} );
+						}
+					} );
+				},
+			} ) ),
 		],
 	},
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -114,17 +114,38 @@ export const settings = {
 							return createBlock( 'core/paragraph', {
 								content,
 							} );
-						} else {
-							return createBlock( 'core/heading', {
-								nodeName: `H${ level }`,
-								content,
-							} );
 						}
+
+						return createBlock( 'core/heading', {
+							nodeName: `H${ level }`,
+							content,
+						} );
 					} );
 				},
 			} ) ),
 		],
 	},
+
+	shortcuts: [
+		{
+			shortcut: 'l',
+			attributes: {
+				align: 'left',
+			},
+		},
+		{
+			shortcut: 'c',
+			attributes: {
+				align: 'center',
+			},
+		},
+		{
+			shortcut: 'r',
+			attributes: {
+				align: 'right',
+			},
+		},
+	],
 
 	merge( attributes, attributesToMerge ) {
 		return {
@@ -143,6 +164,7 @@ export const settings = {
 						'234'.split( '' ).map( ( level ) => ( {
 							icon: 'heading',
 							title: sprintf( __( 'Heading %s' ), level ),
+							shortcut: level,
 							isActive: 'H' + level === nodeName,
 							onClick: () => setAttributes( { nodeName: 'H' + level } ),
 							subscript: level,
@@ -159,6 +181,7 @@ export const settings = {
 							'123456'.split( '' ).map( ( level ) => ( {
 								icon: 'heading',
 								title: sprintf( __( 'Heading %s' ), level ),
+								shortcut: level === '1' ? undefined : level,
 								isActive: 'H' + level === nodeName,
 								onClick: () => setAttributes( { nodeName: 'H' + level } ),
 								subscript: level,

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -91,8 +91,8 @@ export const settings = {
 				type: 'shortcut',
 				blocks: [ 'core/paragraph' ],
 				shortcut: level,
-				transform( blockAttributes ) {
-					return blockAttributes.map( ( { content } ) => {
+				transform( blocks ) {
+					return blocks.map( ( { attributes: { content } } ) => {
 						return createBlock( 'core/heading', {
 							nodeName: `H${ level }`,
 							content,
@@ -114,13 +114,13 @@ export const settings = {
 			...'23456'.split( '' ).map( ( level ) => ( {
 				type: 'shortcut',
 				shortcut: level,
-				transform( attributes ) {
-					const firstNodeName = first( attributes ).nodeName;
-					const isSame = attributes.every( ( { nodeName } ) => nodeName === firstNodeName );
+				transform( blocks ) {
+					const firstNodeName = first( blocks ).attributes.nodeName;
+					const isSame = blocks.every( ( { attributes: { nodeName } } ) => nodeName === firstNodeName );
 
 					// If already at level, set back to paragraphs.
 					if ( isSame && firstNodeName === `H${ level }` ) {
-						return attributes.map( ( { content } ) => {
+						return blocks.map( ( { attributes: { content } } ) => {
 							return createBlock( 'core/paragraph', {
 								content,
 							} );

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -19,6 +19,7 @@ import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
 import InspectorControls from '../../inspector-controls';
 import AlignmentToolbar from '../../alignment-toolbar';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 export const name = 'core/heading';
 
@@ -129,21 +130,7 @@ export const settings = {
 					return { nodeName: `H${ level }` };
 				},
 			} ) ),
-			...[ 'left', 'center', 'right' ].map( ( value ) => ( {
-				type: 'shortcut',
-				shortcut: value.charAt( 0 ),
-				transform( attributes ) {
-					const firstAlign = first( attributes ).align;
-					const isSame = attributes.every( ( { align } ) => align === firstAlign );
-
-					// If already aligned, set back to default.
-					if ( isSame && firstAlign === value ) {
-						return { align: undefined };
-					}
-
-					return { align: value };
-				},
-			} ) ),
+			...alignmentShortcuts,
 		],
 	},
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { first } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -108,44 +113,39 @@ export const settings = {
 			...'23456'.split( '' ).map( ( level ) => ( {
 				type: 'shortcut',
 				shortcut: level,
-				transform( blockAttributes ) {
-					return blockAttributes.map( ( { content, nodeName } ) => {
-						if ( nodeName === `H${ level }` ) {
+				transform( attributes ) {
+					const firstNodeName = first( attributes ).nodeName;
+					const isSame = attributes.every( ( { nodeName } ) => nodeName === firstNodeName );
+
+					// If already at level, set back to paragraphs.
+					if ( isSame && firstNodeName === `H${ level }` ) {
+						return attributes.map( ( { content } ) => {
 							return createBlock( 'core/paragraph', {
 								content,
 							} );
-						}
-
-						return createBlock( 'core/heading', {
-							nodeName: `H${ level }`,
-							content,
 						} );
-					} );
+					}
+
+					return { nodeName: `H${ level }` };
+				},
+			} ) ),
+			...[ 'left', 'center', 'right' ].map( ( value ) => ( {
+				type: 'shortcut',
+				shortcut: value.charAt( 0 ),
+				transform( attributes ) {
+					const firstAlign = first( attributes ).align;
+					const isSame = attributes.every( ( { align } ) => align === firstAlign );
+
+					// If already aligned, set back to default.
+					if ( isSame && firstAlign === value ) {
+						return { align: undefined };
+					}
+
+					return { align: value };
 				},
 			} ) ),
 		],
 	},
-
-	shortcuts: [
-		{
-			shortcut: 'l',
-			attributes: {
-				align: 'left',
-			},
-		},
-		{
-			shortcut: 'c',
-			attributes: {
-				align: 'center',
-			},
-		},
-		{
-			shortcut: 'r',
-			attributes: {
-				align: 'right',
-			},
-		},
-	],
 
 	merge( attributes, attributesToMerge ) {
 		return {

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -11,6 +11,7 @@ import './style.scss';
 import './editor.scss';
 import { createBlock, getBlockAttributes, getBlockType } from '../../api';
 import ImageBlock from './block';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 export const name = 'core/image';
 
@@ -150,6 +151,7 @@ export const settings = {
 				},
 			},
 		],
+		to: alignmentShortcuts,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import './style.scss';
 import LatestPostsBlock from './block';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 export const name = 'core/latest-posts';
 
@@ -25,6 +26,10 @@ export const settings = {
 
 	supports: {
 		html: false,
+	},
+
+	transforms: {
+		to: alignmentShortcuts,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, compact, get, initial, last, isEmpty, first, map } from 'lodash';
+import { find, compact, get, initial, last, isEmpty, first, map, flatMap } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -152,19 +152,19 @@ export const settings = {
 
 					// All lists already with tag, set back to paragraphs.
 					if ( isSame && firstNodeName === tag ) {
-						return blocks.reduce( ( acc, { attributes: { values } } ) => [
-							...acc,
-							...compact( values.map( ( value ) => get( value, 'props.children', null ) ) )
+						return flatMap( blocks, ( { attributes: { values } } ) =>
+							compact( values.map( ( value ) => get( value, 'props.children', null ) ) )
 								.map( ( content ) => createBlock( 'core/paragraph', {
 									content: [ content ],
 								} ) ),
-						], [] );
+						);
 					}
 
 					// Merge list.
 					return createBlock( 'core/list', {
 						nodeName: tag,
-						values: blocks.reduce( ( acc, { attributes: { values } } ) => [ ...acc, ...values ], [] ),
+						values: flatMap( blocks, ( { attributes: { values } } ) => values )
+							.map( ( value, i ) => <li key={ i }>{ get( value, 'props.children', null ) }</li> ),
 					} );
 				},
 			} ) ),

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -61,6 +61,19 @@ export const settings = {
 					} );
 				},
 			},
+			...[ 'OL', 'UL' ].map( ( tag ) => ( {
+				type: 'shortcut',
+				blocks: [ 'core/paragraph' ],
+				shortcut: tag.charAt( 0 ).toLowerCase(),
+				transform( blockAttributes ) {
+					const items = blockAttributes.map( ( { content } ) => content );
+					const hasItems = ! items.every( isEmpty );
+					return createBlock( 'core/list', {
+						nodeName: tag,
+						values: hasItems ? items.map( ( content, index ) => <li key={ index }>{ content }</li> ) : [],
+					} );
+				},
+			} ) ),
 			{
 				type: 'block',
 				blocks: [ 'core/quote' ],
@@ -123,6 +136,16 @@ export const settings = {
 					} );
 				},
 			},
+			...[ 'OL', 'UL' ].map( ( tag ) => ( {
+				type: 'shortcut',
+				shortcut: tag.charAt( 0 ).toLowerCase(),
+				transform( blockAttributes ) {
+					return createBlock( 'core/list', {
+						nodeName: 'OL',
+						values: blockAttributes.reduce( ( acc, { values } ) => [ ...acc, ...values ], [] ),
+					} );
+				},
+			} ) ),
 		],
 	},
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { first } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -27,6 +26,7 @@ import ToggleControl from '../../inspector-controls/toggle-control';
 import RangeControl from '../../inspector-controls/range-control';
 import ColorPalette from '../../color-palette';
 import ContrastChecker from '../../contrast-checker';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 const { getComputedStyle } = window;
 
@@ -251,21 +251,7 @@ export const settings = {
 				),
 			},
 		],
-		to: [ 'left', 'center', 'right' ].map( ( value ) => ( {
-			type: 'shortcut',
-			shortcut: value.charAt( 0 ),
-			transform( attributes ) {
-				const firstAlign = first( attributes ).align;
-				const isSame = attributes.every( ( { align } ) => align === firstAlign );
-
-				// If already aligned, set back to default.
-				if ( isSame && firstAlign === value ) {
-					return { align: undefined };
-				}
-
-				return { align: value };
-			},
-		} ) ),
+		to: alignmentShortcuts,
 	},
 
 	merge( attributes, attributesToMerge ) {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { first } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -250,6 +251,21 @@ export const settings = {
 				),
 			},
 		],
+		to: [ 'left', 'center', 'right' ].map( ( value ) => ( {
+			type: 'shortcut',
+			shortcut: value.charAt( 0 ),
+			transform( attributes ) {
+				const firstAlign = first( attributes ).align;
+				const isSame = attributes.every( ( { align } ) => align === firstAlign );
+
+				// If already aligned, set back to default.
+				if ( isSame && firstAlign === value ) {
+					return { align: undefined };
+				}
+
+				return { align: value };
+			},
+		} ) ),
 	},
 
 	merge( attributes, attributesToMerge ) {

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -16,6 +16,7 @@ import './style.scss';
 import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 const toRichTextValue = value => map( value, ( subValue => subValue.children ) );
 const fromRichTextValue = value => map( value, ( subValue ) => ( {
@@ -56,6 +57,10 @@ export const settings = {
 	category: 'formatting',
 
 	attributes: blockAttributes,
+
+	transforms: {
+		to: alignmentShortcuts,
+	},
 
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -104,9 +104,9 @@ export const settings = {
 				type: 'shortcut',
 				blocks: [ 'core/paragraph' ],
 				shortcut: 'q',
-				transform( multiAttributes ) {
+				transform( blocks ) {
 					return createBlock( 'core/quote', {
-						value: multiAttributes.map( ( { content, i } ) => ( {
+						value: blocks.map( ( { attributes: { content }, i } ) => ( {
 							children: <p key={ i }>{ content }</p>,
 						} ) ),
 					} );
@@ -166,8 +166,8 @@ export const settings = {
 				type: 'shortcut',
 				blocks: [ 'core/paragraph' ],
 				shortcut: 'q',
-				transform( multiAttributes ) {
-					return multiAttributes.reduce( ( acc, { value, citation } ) => {
+				transform( blocks ) {
+					return blocks.reduce( ( acc, { attributes: { value, citation } } ) => {
 						value.forEach( ( paragraph ) => {
 							acc.push( createBlock( 'core/paragraph', {
 								content: [ get( paragraph, 'children.props.children', '' ) ],
@@ -176,7 +176,7 @@ export const settings = {
 
 						if ( citation ) {
 							acc.push( createBlock( 'core/paragraph', {
-								content: citation
+								content: citation,
 							} ) );
 						}
 

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -19,6 +19,7 @@ import { createBlock } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import RichText from '../../rich-text';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 const toRichTextValue = value => value.map( ( subValue => subValue.children ) );
 const fromRichTextValue = value => value.map( ( subValue ) => ( {
@@ -176,6 +177,7 @@ export const settings = {
 					] );
 				},
 			},
+			...alignmentShortcuts,
 		],
 	},
 

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -164,7 +164,6 @@ export const settings = {
 			},
 			{
 				type: 'shortcut',
-				blocks: [ 'core/paragraph' ],
 				shortcut: 'q',
 				transform( blocks ) {
 					return flatMap( blocks, ( { attributes: { value, citation } } ) => [

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -100,6 +100,18 @@ export const settings = {
 				type: 'raw',
 				isMatch: ( node ) => node.nodeName === 'BLOCKQUOTE',
 			},
+			{
+				type: 'shortcut',
+				blocks: [ 'core/paragraph' ],
+				shortcut: 'q',
+				transform( multiAttributes ) {
+					return createBlock( 'core/quote', {
+						value: multiAttributes.map( ( { content, i } ) => ( {
+							children: <p key={ i }>{ content }</p>,
+						} ) ),
+					} );
+				},
+			},
 		],
 		to: [
 			{
@@ -148,6 +160,28 @@ export const settings = {
 					return createBlock( 'core/heading', {
 						content: textContent,
 					} );
+				},
+			},
+			{
+				type: 'shortcut',
+				blocks: [ 'core/paragraph' ],
+				shortcut: 'q',
+				transform( multiAttributes ) {
+					return multiAttributes.reduce( ( acc, { value, citation } ) => {
+						value.forEach( ( paragraph ) => {
+							acc.push( createBlock( 'core/paragraph', {
+								content: [ get( paragraph, 'children.props.children', '' ) ],
+							} ) );
+						} );
+
+						if ( citation ) {
+							acc.push( createBlock( 'core/paragraph', {
+								content: citation
+							} ) );
+						}
+
+						return acc;
+					}, [] );
 				},
 			},
 		],

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString, get } from 'lodash';
+import { isString, get, flatMap } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -167,21 +167,14 @@ export const settings = {
 				blocks: [ 'core/paragraph' ],
 				shortcut: 'q',
 				transform( blocks ) {
-					return blocks.reduce( ( acc, { attributes: { value, citation } } ) => {
-						value.forEach( ( paragraph ) => {
-							acc.push( createBlock( 'core/paragraph', {
-								content: [ get( paragraph, 'children.props.children', '' ) ],
-							} ) );
-						} );
-
-						if ( citation ) {
-							acc.push( createBlock( 'core/paragraph', {
-								content: citation,
-							} ) );
-						}
-
-						return acc;
-					}, [] );
+					return flatMap( blocks, ( { attributes: { value, citation } } ) => [
+						...value.map( ( paragraph ) => createBlock( 'core/paragraph', {
+							content: [ get( paragraph, 'children.props.children', '' ) ],
+						} ) ),
+						...( citation ? [ createBlock( 'core/paragraph', {
+							content: citation,
+						} ) ] : [] ),
+					] );
 				},
 			},
 		],

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -11,6 +11,7 @@ import './style.scss';
 import TableBlock from './table-block';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 export const name = 'core/table';
 
@@ -44,6 +45,7 @@ export const settings = {
 				isMatch: ( node ) => node.nodeName === 'TABLE',
 			},
 		],
+		to: alignmentShortcuts,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -18,6 +18,7 @@ import MediaUpload from '../../media-upload';
 import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import alignmentShortcuts from '../../alignment-shortcuts';
 
 export const name = 'core/video';
 
@@ -48,6 +49,10 @@ export const settings = {
 			source: 'children',
 			selector: 'figcaption',
 		},
+	},
+
+	transforms: {
+		to: alignmentShortcuts,
 	},
 
 	getEditWrapperProps( attributes ) {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -192,6 +192,9 @@ export default class RichText extends Component {
 	onInit() {
 		this.updateFocus();
 		this.registerCustomFormatters();
+
+		// Remove all default block-level shortcuts.
+		'123456789'.split( '' ).forEach( ( number ) => this.editor.shortcuts.remove( `access+${ number }` ) );
 	}
 
 	adaptFormatter( options ) {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -35,7 +35,7 @@ import { pickAriaProps } from './aria';
 import patterns from './patterns';
 import { EVENTS } from './constants';
 
-const { BACKSPACE, DELETE, ENTER } = keycodes;
+const { BACKSPACE, DELETE, ENTER, isAccess } = keycodes;
 
 function createTinyMCEElement( type, props, ...children ) {
 	if ( props[ 'data-mce-bogus' ] === 'all' ) {
@@ -531,6 +531,10 @@ export default class RichText extends Component {
 	onKeyDown( event ) {
 		const dom = this.editor.dom;
 		const rootNode = this.editor.getBody();
+
+		if ( isAccess( event ) ) {
+			this.fireChange();
+		}
 
 		if (
 			( event.keyCode === BACKSPACE && this.isStartOfEditor() ) ||

--- a/components/icon-button/index.js
+++ b/components/icon-button/index.js
@@ -21,7 +21,7 @@ import Dashicon from '../dashicon';
 // is common to apply a ref to the button element (only supported in class)
 class IconButton extends Component {
 	render() {
-		const { icon, children, label, className, tooltip, focus, ...additionalProps } = this.props;
+		const { icon, children, label, className, tooltip, focus, shortcut, ...additionalProps } = this.props;
 		const classes = classnames( 'components-icon-button', className );
 		const tooltipText = tooltip || label;
 
@@ -42,7 +42,11 @@ class IconButton extends Component {
 		);
 
 		if ( showTooltip ) {
-			element = <Tooltip text={ tooltipText }>{ element }</Tooltip>;
+			element = (
+				<Tooltip text={ tooltipText } shortcut={ shortcut }>
+					{ element }
+				</Tooltip>
+			);
 		}
 
 		return element;

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -35,6 +35,7 @@ function Toolbar( { controls = [], children, className } ) {
 						<IconButton
 							icon={ control.icon }
 							label={ control.title }
+							shortcut={ control.shortcut }
 							data-subscript={ control.subscript }
 							onClick={ ( event ) => {
 								event.stopPropagation();

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -13,12 +13,15 @@ import {
 	findDOMNode,
 	concatChildren,
 } from '@wordpress/element';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import Popover from '../popover';
+
+const { getAccessCombination } = keycodes;
 
 /**
  * Time over children to wait before showing tooltip
@@ -150,7 +153,7 @@ class Tooltip extends Component {
 	}
 
 	render() {
-		const { children, position, text } = this.props;
+		const { children, position, text, shortcut } = this.props;
 		if ( Children.count( children ) !== 1 ) {
 			if ( 'development' === process.env.NODE_ENV ) {
 				// eslint-disable-next-line no-console
@@ -179,6 +182,7 @@ class Tooltip extends Component {
 					aria-hidden="true"
 				>
 					{ text }
+					{ shortcut && <span className="components-tooltip__shortcut">{ getAccessCombination( shortcut ) }</span> }
 				</Popover>,
 			),
 		} );

--- a/components/tooltip/style.scss
+++ b/components/tooltip/style.scss
@@ -6,17 +6,17 @@
 	}
 
 	&.is-top:after {
-		border-top-color: $dark-gray-400;
+		border-top-color: $dark-gray-900;
 	}
 
 	&.is-bottom:after {
-		border-bottom-color: $dark-gray-400;
+		border-bottom-color: $dark-gray-900;
 	}
 }
 
 .components-tooltip .components-popover__content {
 	padding: 4px 12px;
-	background: $dark-gray-400;
+	background: $dark-gray-900;
 	border-width: 0;
 	color: white;
 	white-space: nowrap;
@@ -24,4 +24,10 @@
 
 .components-tooltip:not(.is-mobile) .components-popover__content {
 	min-width: 0;
+}
+
+.components-tooltip__shortcut {
+	display: block;
+	text-align: center;
+	color: $dark-gray-200;
 }

--- a/edit-post/keyboard-shortcuts.js
+++ b/edit-post/keyboard-shortcuts.js
@@ -1,9 +1,15 @@
-const isMac = window.navigator.platform.toUpperCase().indexOf( 'MAC' ) >= 0;
-const mod = isMac ? '⌘' : 'Ctrl';
+/**
+ * WordPress dependencies
+ */
+import { keycodes } from '@wordpress/utils';
+
+const { getAccessCombination } = keycodes;
+
+const combination = getAccessCombination( 'm' );
 
 export default {
 	toggleEditorMode: {
-		value: 'mod+shift+alt+m',
-		label: `${ mod }+Shift+Alt+M`,
+		value: combination.toLowerCase(),
+		label: combination,
 	},
 };

--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -286,11 +286,7 @@ class BlockList extends Component {
 	onKeyDown( event ) {
 		const { onReplace, onChange } = this.props;
 
-		if ( ! this.shortcutTransforms ) {
-			return;
-		}
-
-		if ( ! isAccess( event ) ) {
+		if ( ! this.shortcutTransforms || ! isAccess( event ) ) {
 			return;
 		}
 
@@ -300,11 +296,11 @@ class BlockList extends Component {
 			return;
 		}
 
-		const result = transform.transform( this.blocks.map( ( { attributes } ) => attributes ) );
+		const result = transform.transform( map( this.blocks, 'attributes' ) );
 
 		// Check if we received blocks or attributes.
 		if ( result.uid || Array.isArray( result ) ) {
-			onReplace( this.blocks.map( ( { uid } ) => uid ), castArray( result ) );
+			onReplace( map( this.blocks, 'uid' ), castArray( result ) );
 		} else {
 			this.blocks.forEach( ( { uid } ) => {
 				onChange( uid, result );

--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -10,10 +10,6 @@ import {
 	mapValues,
 	sortBy,
 	throttle,
-	find,
-	first,
-	castArray,
-	every,
 } from 'lodash';
 import scrollIntoView from 'dom-scroll-into-view';
 import 'element-closest';
@@ -22,8 +18,7 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { serialize, getPossibleShortcutTransformations } from '@wordpress/blocks';
-import { keycodes } from '@wordpress/utils';
+import { serialize } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -32,6 +27,7 @@ import './style.scss';
 import BlockListBlock from './block';
 import BlockInsertionPoint from './insertion-point';
 import BlockSelectionClearer from '../block-selection-clearer';
+import BlockListShortcuts from './shortcuts';
 import {
 	getBlockUids,
 	getMultiSelectedBlocksStartUid,
@@ -42,10 +38,8 @@ import {
 	isSelectionEnabled,
 	isMultiSelecting,
 } from '../../store/selectors';
-import { startMultiSelect, stopMultiSelect, multiSelect, selectBlock, replaceBlocks, updateBlockAttributes } from '../../store/actions';
+import { startMultiSelect, stopMultiSelect, multiSelect, selectBlock } from '../../store/actions';
 import { documentHasSelection } from '../../utils/dom';
-
-const { isAccess } = keycodes;
 
 class BlockList extends Component {
 	constructor( props ) {
@@ -62,7 +56,6 @@ class BlockList extends Component {
 		// Browser does not fire `*move` event when the pointer position changes
 		// relative to the document, so fire it with the last known position.
 		this.onScroll = () => this.onPointerMove( { clientY: this.lastClientY } );
-		this.onKeyDown = this.onKeyDown.bind( this );
 
 		this.lastClientY = 0;
 		this.nodes = {};
@@ -72,45 +65,15 @@ class BlockList extends Component {
 		document.addEventListener( 'copy', this.onCopy );
 		document.addEventListener( 'cut', this.onCut );
 		window.addEventListener( 'mousemove', this.setLastClientY );
-		// Needs document to also work in inspector.
-		// In other words, if there is selection, but no focus.
-		document.addEventListener( 'keydown', this.onKeyDown );
 	}
 
 	componentWillUnmount() {
 		document.removeEventListener( 'copy', this.onCopy );
 		document.removeEventListener( 'cut', this.onCut );
 		window.removeEventListener( 'mousemove', this.setLastClientY );
-		document.removeEventListener( 'keydown', this.onKeyDown );
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const prevCommonName = this.commonName;
-
-		if ( nextProps.selectedBlock ) {
-			this.blocks = [ nextProps.selectedBlock ];
-			this.commonName = nextProps.selectedBlock.name;
-		} else if ( nextProps.multiSelectedBlocks.length ) {
-			this.blocks = nextProps.multiSelectedBlocks;
-
-			const firstName = first( nextProps.multiSelectedBlocks ).name;
-
-			if ( every( nextProps.multiSelectedBlocks, ( { name } ) => name === firstName ) ) {
-				this.commonName = firstName;
-			} else {
-				delete this.commonName;
-			}
-		} else {
-			delete this.blocks;
-			delete this.commonName;
-		}
-
-		if ( ! this.commonName ) {
-			delete this.shortcutTransforms;
-		} else if ( this.commonName !== prevCommonName ) {
-			this.shortcutTransforms = getPossibleShortcutTransformations( this.commonName );
-		}
-
 		if ( isEqual( this.props.multiSelectedBlockUids, nextProps.multiSelectedBlockUids ) ) {
 			return;
 		}
@@ -283,36 +246,15 @@ class BlockList extends Component {
 		}
 	}
 
-	onKeyDown( event ) {
-		const { onReplace, onChange } = this.props;
-
-		if ( ! this.shortcutTransforms || ! isAccess( event ) ) {
-			return;
-		}
-
-		const transform = find( this.shortcutTransforms, ( { shortcut } ) => isAccess( event, shortcut ) );
-
-		if ( ! transform ) {
-			return;
-		}
-
-		const result = transform.transform( map( this.blocks, 'attributes' ) );
-
-		// Check if we received blocks or attributes.
-		if ( result.uid || Array.isArray( result ) ) {
-			onReplace( map( this.blocks, 'uid' ), castArray( result ) );
-		} else {
-			this.blocks.forEach( ( { uid } ) => {
-				onChange( uid, result );
-			} );
-		}
-	}
-
 	render() {
-		const { blocks, showContextualToolbar, renderBlockMenu } = this.props;
+		const { blocks, showContextualToolbar, renderBlockMenu, selectedBlock, multiSelectedBlocks } = this.props;
 
 		return (
 			<BlockSelectionClearer>
+				<BlockListShortcuts
+					selectedBlock={ selectedBlock }
+					multiSelectedBlocks={ multiSelectedBlocks }
+				/>
 				{ !! blocks.length && <BlockInsertionPoint /> }
 				{ map( blocks, ( uid ) => (
 					<BlockListBlock
@@ -356,12 +298,6 @@ export default connect(
 		},
 		onRemove( uids ) {
 			dispatch( { type: 'REMOVE_BLOCKS', uids } );
-		},
-		onReplace( uids, blocks ) {
-			dispatch( replaceBlocks( uids, blocks ) );
-		},
-		onChange( uid, attributes ) {
-			dispatch( updateBlockAttributes( uid, attributes ) );
 		},
 	} )
 )( BlockList );

--- a/editor/components/block-list/shortcuts.js
+++ b/editor/components/block-list/shortcuts.js
@@ -91,6 +91,8 @@ class BlockListShortcuts extends Component {
 				onChange( uid, result );
 			} );
 		}
+
+		event.preventDefault();
 	}
 
 	render() {

--- a/editor/components/block-list/shortcuts.js
+++ b/editor/components/block-list/shortcuts.js
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import {
+	map,
+	find,
+	first,
+	castArray,
+	every,
+} from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { getPossibleShortcutTransformations } from '@wordpress/blocks';
+import { keycodes } from '@wordpress/utils';
+
+/**
+ * Internal dependencies
+ */
+import { replaceBlocks, updateBlockAttributes } from '../../store/actions';
+
+const { isAccess } = keycodes;
+
+class BlockListShortcuts extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onKeyDown = this.onKeyDown.bind( this );
+	}
+
+	componentDidMount() {
+		// Needs document to also work in inspector.
+		// In other words, if there is selection, but no focus.
+		document.addEventListener( 'keydown', this.onKeyDown );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'keydown', this.onKeyDown );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		const prevCommonName = this.commonName;
+
+		if ( nextProps.selectedBlock ) {
+			this.blocks = [ nextProps.selectedBlock ];
+			this.commonName = nextProps.selectedBlock.name;
+		} else if ( nextProps.multiSelectedBlocks.length ) {
+			this.blocks = nextProps.multiSelectedBlocks;
+
+			const firstName = first( nextProps.multiSelectedBlocks ).name;
+
+			if ( every( nextProps.multiSelectedBlocks, ( { name } ) => name === firstName ) ) {
+				this.commonName = firstName;
+			} else {
+				delete this.commonName;
+			}
+		} else {
+			delete this.blocks;
+			delete this.commonName;
+		}
+
+		if ( ! this.commonName ) {
+			delete this.shortcutTransforms;
+		} else if ( this.commonName !== prevCommonName ) {
+			this.shortcutTransforms = getPossibleShortcutTransformations( this.commonName );
+		}
+	}
+
+	onKeyDown( event ) {
+		const { onReplace, onChange } = this.props;
+
+		if ( ! this.shortcutTransforms || ! isAccess( event ) ) {
+			return;
+		}
+
+		const transform = find( this.shortcutTransforms, ( { shortcut } ) => isAccess( event, shortcut ) );
+
+		if ( ! transform ) {
+			return;
+		}
+
+		const result = transform.transform( map( this.blocks, 'attributes' ) );
+
+		// Check if we received blocks or attributes.
+		if ( result.uid || Array.isArray( result ) ) {
+			onReplace( map( this.blocks, 'uid' ), castArray( result ) );
+		} else {
+			this.blocks.forEach( ( { uid } ) => {
+				onChange( uid, result );
+			} );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	null,
+	( dispatch ) => ( {
+		onReplace( uids, blocks ) {
+			dispatch( replaceBlocks( uids, blocks ) );
+		},
+		onChange( uid, attributes ) {
+			dispatch( updateBlockAttributes( uid, attributes ) );
+		},
+	} )
+)( BlockListShortcuts );

--- a/editor/components/block-list/shortcuts.js
+++ b/editor/components/block-list/shortcuts.js
@@ -98,14 +98,7 @@ class BlockListShortcuts extends Component {
 	}
 }
 
-export default connect(
-	null,
-	( dispatch ) => ( {
-		onReplace( uids, blocks ) {
-			dispatch( replaceBlocks( uids, blocks ) );
-		},
-		onChange( uid, attributes ) {
-			dispatch( updateBlockAttributes( uid, attributes ) );
-		},
-	} )
-)( BlockListShortcuts );
+export default connect( null, {
+	onReplace: replaceBlocks,
+	onChange: updateBlockAttributes,
+} )( BlockListShortcuts );

--- a/editor/components/block-list/shortcuts.js
+++ b/editor/components/block-list/shortcuts.js
@@ -81,7 +81,7 @@ class BlockListShortcuts extends Component {
 			return;
 		}
 
-		const result = transform.transform( map( this.blocks, 'attributes' ) );
+		const result = transform.transform( this.blocks );
 
 		// Check if we received blocks or attributes.
 		if ( result.uid || Array.isArray( result ) ) {

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -434,11 +434,12 @@ export function blockSelection( state = {
 			if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.start ) === -1 ) {
 				return state;
 			}
+
 			return {
 				...state,
-				start: action.blocks[ 0 ].uid,
-				end: action.blocks[ 0 ].uid,
-				focus: {},
+				start: first( action.blocks ).uid,
+				end: last( action.blocks ).uid,
+				focus: action.blocks.length > 1 ? null : {},
 				isMultiSelecting: false,
 			};
 		case 'TOGGLE_SELECTION':

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -941,6 +941,23 @@ describe( 'state', () => {
 			expect( state ).toEqual( { start: 'wings', end: 'wings', focus: {}, isMultiSelecting: false } );
 		} );
 
+		it( 'should replace the multi selected blocks', () => {
+			const original = deepFreeze( { start: 'chicken', end: 'chicken', focus: { editable: 'citation' } } );
+			const state = blockSelection( original, {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'chicken' ],
+				blocks: [ {
+					uid: 'wings',
+					name: 'core/freeform',
+				}, {
+					uid: 'feather',
+					name: 'core/freeform',
+				} ],
+			} );
+
+			expect( state ).toEqual( { start: 'wings', end: 'feather', focus: null, isMultiSelecting: false } );
+		} );
+
 		it( 'should keep the selected block', () => {
 			const original = deepFreeze( { start: 'chicken', end: 'chicken', focus: { editable: 'citation' } } );
 			const state = blockSelection( original, {

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -21,8 +21,9 @@ export const F10 = 121;
 /**
  * Converts a character to a key code.
  *
- * @param  {String} character A single character.
- * @return {Number}           The corresponding key code.
+ * @param {string} character A single character.
+ *
+ * @returns {number}           The corresponding key code.
  */
 function characterToKeyCode( character ) {
 	return character.toUpperCase().charCodeAt( 0 );
@@ -31,9 +32,10 @@ function characterToKeyCode( character ) {
 /**
  * Check if the access keys and the given character are presssed.
  *
- * @param  {KeyboardEvent} event     The event object.
- * @param  {String}        character The character to check.
- * @return {Boolean}                 True if the combination is pressed, false if not.
+ * @param {KeyboardEvent} event     The event object.
+ * @param {string}        character The character to check.
+ *
+ * @returns {boolean}                 True if the combination is pressed, false if not.
  */
 export function isAccess( event, character ) {
 	if ( ! event[ isMac ? 'ctrlKey' : 'shiftKey' ] || ! event.altKey ) {
@@ -46,8 +48,9 @@ export function isAccess( event, character ) {
 /**
  * Get an access key combination based on a character.
  *
- * @param  {String} character The character for the access combination.
- * @return {String}           The access combination.
+ * @param {string} character The character for the access combination.
+ *
+ * @returns {string}           The access combination.
  */
 export function getAccessCombination( character ) {
 	const access = isMac ? 'Ctrl+Alt' : 'Shift+Alt';

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -19,13 +19,13 @@ export const DELETE = 46;
 export const F10 = 121;
 
 /**
- * Check if the access keys and the gives letter are presssed.
+ * Check if the access keys and the given character are presssed.
  *
- * @param  {KeyboardEvent} event  The event object.
- * @param  {String}        letter The letter to check.
- * @return {Boolean}              True if the combination is pressed, false if not.
+ * @param  {KeyboardEvent} event     The event object.
+ * @param  {String}        character The character to check.
+ * @return {Boolean}                 True if the combination is pressed, false if not.
  */
-export function isAccess( event, letter ) {
+export function isAccess( event, character ) {
 	if ( isMac ) {
 		if ( ! event.ctrlKey || ! event.altKey ) {
 			return;
@@ -34,5 +34,19 @@ export function isAccess( event, letter ) {
 		return;
 	}
 
-	return event.keyCode === letter.toUpperCase().charCodeAt( 0 );
+	return character ? event.keyCode === character.toUpperCase().charCodeAt( 0 ) : true;
+}
+
+/**
+ * Get an access key combination based on a character.
+ *
+ * @param  {String} character The character for the access combination.
+ * @return {String}           The access combination.
+ */
+export function getAccessCombination( character ) {
+	const access = isMac ? 'Ctrl+Alt' : 'Shift+Alt';
+
+	character = character.toUpperCase();
+
+	return `${ access }+${ character }`;
 }

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -1,3 +1,10 @@
+/**
+ * Browser dependencies
+ */
+const { userAgent } = window.navigator;
+
+const isMac = userAgent.indexOf( 'Mac' ) !== -1;
+
 export const BACKSPACE = 8;
 export const TAB = 9;
 export const ENTER = 13;
@@ -10,3 +17,22 @@ export const DOWN = 40;
 export const DELETE = 46;
 
 export const F10 = 121;
+
+/**
+ * Check if the access keys and the gives letter are presssed.
+ *
+ * @param  {KeyboardEvent} event  The event object.
+ * @param  {String}        letter The letter to check.
+ * @return {Boolean}              True if the combination is pressed, false if not.
+ */
+export function isAccess( event, letter ) {
+	if ( isMac ) {
+		if ( ! event.ctrlKey || ! event.altKey ) {
+			return;
+		}
+	} else if ( ! event.shiftKey || ! event.altKey ) {
+		return;
+	}
+
+	return event.keyCode === letter.toUpperCase().charCodeAt( 0 );
+}

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -28,10 +28,10 @@ export const F10 = 121;
 export function isAccess( event, character ) {
 	if ( isMac ) {
 		if ( ! event.ctrlKey || ! event.altKey ) {
-			return;
+			return false;
 		}
 	} else if ( ! event.shiftKey || ! event.altKey ) {
-		return;
+		return false;
 	}
 
 	return character ? event.keyCode === character.toUpperCase().charCodeAt( 0 ) : true;

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -19,6 +19,16 @@ export const DELETE = 46;
 export const F10 = 121;
 
 /**
+ * Converts a character to a key code.
+ *
+ * @param  {String} character A single character.
+ * @return {Number}           The corresponding key code.
+ */
+function characterToKeyCode( character ) {
+	return character.toUpperCase().charCodeAt( 0 );
+}
+
+/**
  * Check if the access keys and the given character are presssed.
  *
  * @param  {KeyboardEvent} event     The event object.
@@ -26,15 +36,11 @@ export const F10 = 121;
  * @return {Boolean}                 True if the combination is pressed, false if not.
  */
 export function isAccess( event, character ) {
-	if ( isMac ) {
-		if ( ! event.ctrlKey || ! event.altKey ) {
-			return false;
-		}
-	} else if ( ! event.shiftKey || ! event.altKey ) {
+	if ( ! event[ isMac ? 'ctrlKey' : 'shiftKey' ] || ! event.altKey ) {
 		return false;
 	}
 
-	return character ? event.keyCode === character.toUpperCase().charCodeAt( 0 ) : true;
+	return ! character || ( event.keyCode === characterToKeyCode( character ) );
 }
 
 /**


### PR DESCRIPTION
## Description

This PR aims to add all block-level shortcuts mentioned in #71.

* Align center `^⌥C`
* Align left `^⌥L`
* Align right `^⌥R`
* Bullets `^⌥U`
* Ordered list `^⌥O`
* Heading 1-6 `^⌥1-6`
* Quote `^⌥Q`

These are block level shortcuts, as opposed to `Editable` shortcuts, because they change block attributes other than the `Editable` value.

## How Has This Been Tested?
* Test alignment shortcuts on heading and paragraph. If already aligned, it should undo. Should work with multi-selection.
* Test Heading shortcuts from paragraph to heading, and changing the level within a heading block. If already at the level, it should go back to a paragraph block. Also try multi-selection.
* Test list shortcuts form paragraphs to list. Try changing the list type. If already the type, it should go back to paragraphs. Multi-selection should also work here. If two lists are selected, it will merge the lists.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.