### PR TITLE
Change "Size" to "Level" in Heading Block settings

### DIFF
--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -120,7 +120,7 @@ registerBlockType( 'core/heading', {
 			focus && (
 				<InspectorControls key="inspector">
 					<h3>{ __( 'Heading Settings' ) }</h3>
-					<p>{ __( 'Size' ) }</p>
+					<p>{ __( 'Level' ) }</p>
 					<Toolbar
 						controls={
 							'123456'.split( '' ).map( ( level ) => ( {


### PR DESCRIPTION
## Description
PR to support #4407 

- Intent of PR is a copy change as suggested by @afercia. 

- Within the settings menu of the Heading block; to change the label "Size" to "Level"

## Screenshot Examples of Changes

**Before**
<img width="242" alt="screen shot 2018-01-12 at 9 06 38 am" src="https://user-images.githubusercontent.com/7691812/34884415-e95b5b00-f779-11e7-8c48-71398ac5c245.png">


**After**
<img width="256" alt="screen shot 2018-01-12 at 9 09 13 am" src="https://user-images.githubusercontent.com/7691812/34884421-ecff4aaa-f779-11e7-96fd-49eb06cd89d6.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.