### PR TITLE
Fix: Cover image: Hide Settings if no image is selected

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -133,11 +133,12 @@ registerBlockType( 'core/cover-image', {
 			</BlockControls>,
 			<InspectorControls key="inspector">
 				<h2>{ __( 'Cover Image Settings' ) }</h2>
+				{url && [
 				<ToggleControl
 					label={ __( 'Fixed Background' ) }
 					checked={ !! hasParallax }
 					onChange={ toggleParallax }
-				/>
+				/>,
 				<RangeControl
 					label={ __( 'Background Dimness' ) }
 					value={ dimRatio }
@@ -146,6 +147,9 @@ registerBlockType( 'core/cover-image', {
 					max={ 100 }
 					step={ 10 }
 				/>
+				]
+				}
+				
 			</InspectorControls>,
 		];
 

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -131,14 +131,13 @@ registerBlockType( 'core/cover-image', {
 					</MediaUploadButton>
 				</Toolbar>
 			</BlockControls>,
-			<InspectorControls key="inspector">
+			!!url && <InspectorControls key="inspector">
 				<h2>{ __( 'Cover Image Settings' ) }</h2>
-				{url && [
 				<ToggleControl
 					label={ __( 'Fixed Background' ) }
 					checked={ !! hasParallax }
 					onChange={ toggleParallax }
-				/>,
+				/>
 				<RangeControl
 					label={ __( 'Background Dimness' ) }
 					value={ dimRatio }
@@ -147,9 +146,6 @@ registerBlockType( 'core/cover-image', {
 					max={ 100 }
 					step={ 10 }
 				/>
-				]
-				}
-				
 			</InspectorControls>,
 		];
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR is referencing this issue #4433

Conditional added to show "Fixed Background" and "Background Dimmess" only if image has selected

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Inserted two "Cover Image" block one with image and other without.

## Screenshots (jpeg or gifs if applicable):
![fix4433](https://user-images.githubusercontent.com/3788221/34888218-80548fc8-f7b0-11e7-8eca-70d3d1e184c6.JPG)

## Checklist:
- [X] My code is tested.
- [x] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.