### PR TITLE
Insert `@username` for user mention autocomplete

### DIFF
--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -119,7 +119,7 @@ export function userAutocompleter() {
 	};
 
 	const allowNode = ( textNode ) => {
-		true;
+		return true;
 	};
 
 	const onSelect = ( user ) => {

--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -119,7 +119,7 @@ export function userAutocompleter() {
 	};
 
 	const allowNode = ( textNode ) => {
-		return textNode.parentElement.closest( 'a' ) === null;
+		true;
 	};
 
 	const onSelect = ( user ) => {

--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -118,12 +118,12 @@ export function userAutocompleter() {
 		} );
 	};
 
-	const allowNode = ( textNode ) => {
+	const allowNode = () => {
 		return true;
 	};
 
 	const onSelect = ( user ) => {
-		return <span class="wp-user-mention">{ '@' + user.slug }</span>;
+		return <span className="wp-user-mention">{ '@' + user.slug }</span>;
 	};
 
 	return {

--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -123,7 +123,7 @@ export function userAutocompleter() {
 	};
 
 	const onSelect = ( user ) => {
-		return <span className="wp-user-mention">{ '@' + user.slug }</span>;
+		return ( '@' + user.slug );
 	};
 
 	return {

--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -96,7 +96,7 @@ export function blockAutocompleter( { onReplace } ) {
 	};
 }
 /**
- * Returns a "completer" definition for inserting links to the posts of a user.
+ * Returns a "completer" definition for inserting a user mention.
  * The definition can be understood by the Autocomplete component.
  *
  * @returns {Completer} Completer object used by the Autocomplete component.
@@ -123,7 +123,7 @@ export function userAutocompleter() {
 	};
 
 	const onSelect = ( user ) => {
-		return <a href={ user.link }>{ '@' + user.name }</a>;
+		return { '@' + user.slug };
 	};
 
 	return {

--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -123,7 +123,7 @@ export function userAutocompleter() {
 	};
 
 	const onSelect = ( user ) => {
-		return { '@' + user.slug };
+		return <span class="wp-user-mention">{ '@' + user.slug }</span>;
 	};
 
 	return {


### PR DESCRIPTION
Rather than inserting a static link and the display name, both of which may change over time and lead to stale content, follow the pattern of existing user mentions in WordPress projects and insert a plaintext mention using the username.

Bringing this over from #4406:

I think that this feature should switch to inserting just @username, no link. Maybe a surrounding span at most. My reasoning for this is:

* Don’t break what exists.
* Links / other alterations to the mention text are better done at runtime for reasons including highlighting mentions for the current user and permalink changes.
* Usernames are much easier to programmatically process and target because they are unique and more efficient to query against (for instance, on my end we have a “shadow taxonomy” that associates mentions with users for future reference, and don’t highlight/link users that are no longer part of the site).
* The complication of changing display names and permalinks affecting existing content.
* Not yet having a tried-and-true method of altering what Gutenberg does.

One thing I didn’t try messing with in my first attempt at a Gutenberg PR was with what `allowNode` actually does. I don’t know if that needs changing.