### PR TITLE
Add links to specific sections of Redux docs

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -10,16 +10,16 @@ This module holds a global state variable and exposes a "Redux-like" API contain
 
 If your module or plugin needs to store and manipulate client-side data, you'll have to register a "reducer" to do so. A reducer is a function taking the previous `state` and `action` and returns an update `state`. You can learn more about reducers on the [Redux Documentation](https://redux.js.org/docs/basics/Reducers.html)
 
-This function takes two arguments: a `key` to identify the module (example: `myAwesomePlugin`) and the reducer function. It returns a Redux-like store object with the following methods:
+This function takes two arguments: a `key` to identify the module (example: `myAwesomePlugin`) and the reducer function. It returns a [Redux-like store object](https://redux.js.org/docs/basics/Store.html) with the following methods:
 
 #### `store.getState()`
 
-Returns the state object of the registered reducer.
+Returns the [state object](https://redux.js.org/docs/Glossary.html#state) of the registered reducer. See: https://redux.js.org/docs/api/Store.html#getState
 
 #### `store.subscribe( listener: function )`
 
-Registers a `listener` function called everytime the state is updated.
+Registers a [`listener`](https://redux.js.org/docs/api/Store.html#subscribe) function called everytime the state is updated.
 
 #### `store.dispatch( action: object )`
 
-The dispatch function should be called to trigger the registered reducers function and update the state. An `action` object should be passed to this action. This action is passed to the registered reducers in addition to the previous state.
+The dispatch function should be called to trigger the registered reducers function and update the state. An [`action`](https://redux.js.org/docs/api/Store.html#dispatch)object should be passed to this action. This action is passed to the registered reducers in addition to the previous state.


### PR DESCRIPTION
#4452

## Description
This adds links to Redux documentation for concepts mentioned in the article that are native to Redux.

## How Has This Been Tested?
Using the preview in Github.

## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style.
- [x ] My code follows has proper inline documentation.