### PR TITLE
chore: remove unused `react-markdown` npm module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,6 +2075,14 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
 			"integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
 		},
+		"comment-parser": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
+			"integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
 		"common-tags": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
@@ -2089,29 +2097,6 @@
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
-		},
-		"commonmark": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.24.0.tgz",
-			"integrity": "sha1-uA3gGCxUY1VkOqFdsSv7KCNoJ48=",
-			"dev": true,
-			"requires": {
-				"entities": "1.1.1",
-				"mdurl": "1.0.1",
-				"string.prototype.repeat": "0.2.0"
-			}
-		},
-		"commonmark-react-renderer": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/commonmark-react-renderer/-/commonmark-react-renderer-4.3.4.tgz",
-			"integrity": "sha512-+/Rzo3sI37NR8LaVdkUiqBH3+CEW75hc86shwY4E9eEERg78VCy4rSkaP/p7OG5bTvosUMkvhn5d1ZJ5iyt/ag==",
-			"dev": true,
-			"requires": {
-				"lodash.assign": "4.2.0",
-				"lodash.isplainobject": "4.0.6",
-				"pascalcase": "0.1.1",
-				"xss-filters": "1.2.7"
-			}
 		},
 		"computed-style": {
 			"version": "0.1.4",
@@ -2264,8 +2249,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "2.2.2",
@@ -3172,6 +3156,44 @@
 				"estraverse": "4.2.0"
 			}
 		},
+		"eslines": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslines/-/eslines-1.1.0.tgz",
+			"integrity": "sha1-eA3YIE5bluBb3I8BUCzVJ1q/xGQ=",
+			"dev": true,
+			"requires": {
+				"jest-docblock": "20.0.3",
+				"optionator": "0.8.1"
+			},
+			"dependencies": {
+				"fast-levenshtein": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
+					"integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
+					"dev": true
+				},
+				"jest-docblock": {
+					"version": "20.0.3",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
+					"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+					"dev": true
+				},
+				"optionator": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
+					"integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
+					"dev": true,
+					"requires": {
+						"deep-is": "0.1.3",
+						"fast-levenshtein": "1.1.4",
+						"levn": "0.3.0",
+						"prelude-ls": "1.1.2",
+						"type-check": "0.3.2",
+						"wordwrap": "1.0.0"
+					}
+				}
+			}
+		},
 		"eslint": {
 			"version": "4.9.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
@@ -3329,6 +3351,11 @@
 				"pkg-dir": "1.0.0"
 			}
 		},
+		"eslint-plugin-i18n": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-i18n/-/eslint-plugin-i18n-1.1.0.tgz",
+			"integrity": "sha1-q+48yBH2PD3JVIgQHf0hetYnUDI="
+		},
 		"eslint-plugin-import": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
@@ -3351,6 +3378,15 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.5.0.tgz",
 			"integrity": "sha512-4fxfe2RcqzU+IVNQL5n4pqibLcUhKKxihYsA510+6kC/FTdGInszDDHgO4ntBzPWu8mcHAvKJLs8o3AQw6eHTg==",
 			"dev": true
+		},
+		"eslint-plugin-jsdoc": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.1.3.tgz",
+			"integrity": "sha512-ujXBhNQz57tLP0bs99QTDPiCX54EypczVhgg9CMJVD9iwfDeFZk5LkQHk+iPfKlV5tk8+dMm+Soxq8QmQK99ZA==",
+			"requires": {
+				"comment-parser": "0.4.2",
+				"lodash": "4.17.4"
+			}
 		},
 		"eslint-plugin-jsx-a11y": {
 			"version": "6.0.2",
@@ -3426,6 +3462,42 @@
 						"object-assign": "4.1.1"
 					}
 				}
+			}
+		},
+		"eslint-plugin-wordpress": {
+			"version": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#327b6bdec434177a6e841bd3210e87627ccfcecb",
+			"requires": {
+				"eslint-plugin-i18n": "1.1.0",
+				"eslint-plugin-jsdoc": "3.1.3",
+				"eslint-plugin-node": "5.1.1",
+				"eslint-plugin-wpcalypso": "3.4.1",
+				"merge": "1.2.0"
+			},
+			"dependencies": {
+				"eslint-plugin-node": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.1.1.tgz",
+					"integrity": "sha512-3xdoEbPyyQNyGhhqttjgSO3cU/non8QDBJF8ttGaHM2h8CaY5zFIngtqW6ZbLEIvhpoFPDVwiQg61b8zanx5zQ==",
+					"requires": {
+						"ignore": "3.3.7",
+						"minimatch": "3.0.4",
+						"resolve": "1.5.0",
+						"semver": "5.3.0"
+					}
+				},
+				"semver": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+				}
+			}
+		},
+		"eslint-plugin-wpcalypso": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-wpcalypso/-/eslint-plugin-wpcalypso-3.4.1.tgz",
+			"integrity": "sha512-rHbCINm3qJmCgASUDKdmRiulwt06EcJTy9Hd+MpZMS4o9eFfS23Q1z1bBYVsJ4nFexvWswqcfCsgRQnFPtT5pQ==",
+			"requires": {
+				"requireindex": "1.1.0"
 			}
 		},
 		"eslint-scope": {
@@ -5327,8 +5399,7 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -7336,12 +7407,6 @@
 				"lodash._bindcallback": "3.0.1"
 			}
 		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-			"dev": true
-		},
 		"lodash.istypedarray": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
@@ -7523,12 +7588,6 @@
 				}
 			}
 		},
-		"mdurl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-			"dev": true
-		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -7635,8 +7694,7 @@
 		"merge": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-			"dev": true
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
 		},
 		"merge-stream": {
 			"version": "1.0.1",
@@ -8350,12 +8408,6 @@
 				"@types/node": "8.5.1"
 			}
 		},
-		"pascalcase": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
-		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
@@ -8966,8 +9018,7 @@
 		"process-nextick-args": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-			"dev": true
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
 		},
 		"progress": {
 			"version": "1.1.8",
@@ -9286,18 +9337,6 @@
 				}
 			}
 		},
-		"react-markdown": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-2.5.0.tgz",
-			"integrity": "sha1-scYZBP7liViGgDvZ332yPD3DqJ4=",
-			"dev": true,
-			"requires": {
-				"commonmark": "0.24.0",
-				"commonmark-react-renderer": "4.3.4",
-				"in-publish": "2.0.0",
-				"prop-types": "15.5.10"
-			}
-		},
 		"react-onclickoutside": {
 			"version": "6.7.0",
 			"resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.0.tgz",
@@ -9383,7 +9422,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -9673,6 +9711,11 @@
 				"resolve-from": "1.0.1"
 			}
 		},
+		"requireindex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+			"integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
+		},
 		"resolve": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -9864,8 +9907,7 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-			"dev": true
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 		},
 		"sane": {
 			"version": "2.2.0",
@@ -10436,17 +10478,10 @@
 				}
 			}
 		},
-		"string.prototype.repeat": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
-			"integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8=",
-			"dev": true
-		},
 		"string_decoder": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -11052,8 +11087,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.0",
@@ -11404,12 +11438,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
 			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-			"dev": true
-		},
-		"xss-filters": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/xss-filters/-/xss-filters-1.2.7.tgz",
-			"integrity": "sha1-Wfod4gHzby80cNysX1jMwoMLCpo=",
 			"dev": true
 		},
 		"xtend": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
 		"postcss-loader": "2.0.6",
 		"prismjs": "1.6.0",
 		"raw-loader": "0.5.1",
-		"react-markdown": "2.5.0",
 		"react-test-renderer": "16.0.0",
 		"sass-loader": "6.0.6",
 		"sass-variables-loader": "0.1.3",


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

`react-markdown` was originally added when Storybook was added in https://github.com/WordPress/gutenberg/commit/57b4c0abf5810d602d8b1b3885dc39d7fc6ee1f0, Storybook has since been removed in https://github.com/WordPress/gutenberg/commit/7779f79b844ed9ce13bdbddebeff88df0d5c7628 though the `react-markdown` module was not removed at the time.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Grep'd the repo to find instances of `react-markdown` and there are (now) no longer any.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Removal of unused npm module dependency 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.