### PR TITLE
chore: add `cypress.env.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ gutenberg.zip
 phpcs.xml
 yarn.lock
 docker-compose.override.yml
+cypress.env.json


### PR DESCRIPTION
## Description

Cypress has to ability to overwrite `cypress.json` environment variables via a `cypress-env.json` file

https://docs.cypress.io/guides/guides/environment-variables.html#Option-2-cypress-env-json

This is a follow up to #4457 in allowing for a customised local development setup when Cypress environment variables need to be overwritten such as `baseUrl`

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.