### PR TITLE
Consistency of tooltip text with Classic Editor

### DIFF
--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -43,7 +43,7 @@ class UrlInputButton extends Component {
 			<div className="blocks-url-input__button">
 				<IconButton
 					icon="admin-links"
-					label={ __( 'Edit Link' ) }
+					label={ __( 'Insert/edit link' ) }
 					onClick={ this.toggle }
 					className={ classnames( 'components-toolbar__control', {
 						'is-active': url,


### PR DESCRIPTION
## Description

When I insert an image the tooltip show "Edit Link" but there is no link yet.

![screenshot from 2018-01-15 08-56-21](https://user-images.githubusercontent.com/6010232/34940174-ba78bb9e-f9d5-11e7-8c6b-b14401d98f6d.png)

In Classic Editor the tooltip show "Insert/edit link".

![screenshot from 2018-01-15 08-57-14](https://user-images.githubusercontent.com/6010232/34940199-cd9c38cc-f9d5-11e7-9e6c-94f7995344c2.png)

So I changed from "Edit Link" to "Insert/edit link".

![screenshot from 2018-01-15 08-59-26](https://user-images.githubusercontent.com/6010232/34940228-e621d7e4-f9d5-11e7-9888-d151543c72cd.png)

Partial Fix #4325.

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation. #
  