### PR TITLE
fix: `applyOrUnset()` inconsistency.

### DIFF
--- a/blocks/alignment-toolbar/index.js
+++ b/blocks/alignment-toolbar/index.js
@@ -23,6 +23,10 @@ const ALIGNMENT_CONTROLS = [
 ];
 
 export default function AlignmentToolbar( { value, onChange } ) {
+	function applyOrUnset( align ) {
+		return () => onChange( value === align ? undefined : align );
+	}
+
 	return (
 		<Toolbar
 			controls={ ALIGNMENT_CONTROLS.map( ( control ) => {
@@ -32,7 +36,7 @@ export default function AlignmentToolbar( { value, onChange } ) {
 				return {
 					...control,
 					isActive,
-					onClick: () => onChange( isActive ? undefined : align ),
+					onClick: applyOrUnset( align ),
 				};
 			} ) }
 		/>

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -18,6 +18,10 @@ import './style.scss';
 export function ColorPalette( { defaultColors, colors, value, onChange } ) {
 	const usedColors = colors || defaultColors;
 
+	function applyOrUnset( color ) {
+		return () => onChange( value === color ? undefined : color );
+	}
+
 	return (
 		<div className="blocks-color-palette">
 			{ usedColors.map( ( color ) => {
@@ -30,7 +34,7 @@ export function ColorPalette( { defaultColors, colors, value, onChange } ) {
 							type="button"
 							className={ className }
 							style={ style }
-							onClick={ () => onChange( value === color ? undefined : color ) }
+							onClick={ applyOrUnset( color ) }
 							aria-label={ sprintf( __( 'Color: %s' ), color ) }
 							aria-pressed={ value === color }
 						/>


### PR DESCRIPTION
## Description
See: [#3859: Add consistency between AlignmentToolbar and BlockAlignment](https://github.com/WordPress/gutenberg/issues/3859)

## Types of changes
Use an `applyOrUnset()` function to improve code clarity/consistency. These two components now match the approach taken by `BlockAlignmentToolbar`.

## How Has This Been Tested?
Tested changes in Chrome to confirm that alignment continues to work as expected in each block, in the sidebar for each block, and that colors continue to toggle properly.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.