### PR TITLE
Used image placeholder in gallery block.

### DIFF
--- a/blocks/image-placeholder/index.js
+++ b/blocks/image-placeholder/index.js
@@ -23,8 +23,8 @@ import { rawHandler } from '../api';
  *
  * @returns {Object} Rendered placeholder.
  */
-export default function ImagePlaceHolder( { className, icon, label, onSelectImage } ) {
-	const setImage = ( [ image ] ) => onSelectImage( image );
+export default function ImagePlaceHolder( { className, icon, label, onSelectImage, multiple = false } ) {
+	const setImage = multiple ? onSelectImage : ( [ image ] ) => onSelectImage( image );
 	const onFilesDrop = ( files ) => mediaUpload( files, setImage );
 	const onHTMLDrop = ( HTML ) => setImage( map(
 		rawHandler( { HTML, mode: 'BLOCKS' } )
@@ -35,7 +35,9 @@ export default function ImagePlaceHolder( { className, icon, label, onSelectImag
 	return (
 		<Placeholder
 			className={ className }
-			instructions={ __( 'Drag image here or add from media library' ) }
+			instructions={ multiple ?
+				__( 'Drag images here or add from media library' ) :
+				__( 'Drag image here or add from media library' ) }
 			icon={ icon }
 			label={ label } >
 			<DropZone
@@ -43,6 +45,7 @@ export default function ImagePlaceHolder( { className, icon, label, onSelectImag
 				onHTMLDrop={ onHTMLDrop }
 			/>
 			<FormFileUpload
+				multiple={ multiple }
 				isLarge
 				className="wp-block-image__upload-button"
 				onChange={ uploadFromFiles }
@@ -51,6 +54,8 @@ export default function ImagePlaceHolder( { className, icon, label, onSelectImag
 				{ __( 'Upload' ) }
 			</FormFileUpload>
 			<MediaUpload
+				gallery={ multiple }
+				multiple={ multiple }
 				onSelect={ onSelectImage }
 				type="image"
 				render={ ( { open } ) => (

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -9,12 +9,13 @@ import { filter } from 'lodash';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { mediaUpload } from '@wordpress/utils';
-import { IconButton, Button, DropZone, Toolbar, Placeholder, FormFileUpload } from '@wordpress/components';
+import { IconButton, DropZone, Toolbar } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import MediaUpload from '../../media-upload';
+import ImagePlaceHolder from '../../image-placeholder';
 import InspectorControls from '../../inspector-controls';
 import RangeControl from '../../inspector-controls/range-control';
 import ToggleControl from '../../inspector-controls/toggle-control';
@@ -44,7 +45,6 @@ class GalleryBlock extends Component {
 		this.setColumnsNumber = this.setColumnsNumber.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
-		this.uploadFromFiles = this.uploadFromFiles.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.dropFiles = this.dropFiles.bind( this );
@@ -91,12 +91,6 @@ class GalleryBlock extends Component {
 
 	toggleImageCrop() {
 		this.props.setAttributes( { imageCrop: ! this.props.attributes.imageCrop } );
-	}
-
-	uploadFromFiles( event ) {
-		mediaUpload( event.target.files, ( images ) => {
-			this.props.setAttributes( { images } );
-		} );
 	}
 
 	setImageAttributes( index, attributes ) {
@@ -179,34 +173,13 @@ class GalleryBlock extends Component {
 		if ( images.length === 0 ) {
 			return [
 				controls,
-				<Placeholder
-					key="placeholder"
-					instructions={ __( 'Drag images here or add from media library' ) }
+				<ImagePlaceHolder key="gallery-placeholder"
+					className={ className }
 					icon="format-gallery"
 					label={ __( 'Gallery' ) }
-					className={ className }>
-					{ dropZone }
-					<FormFileUpload
-						isLarge
-						className="wp-block-image__upload-button"
-						onChange={ this.uploadFromFiles }
-						accept="image/*"
-						multiple="true"
-					>
-						{ __( 'Upload' ) }
-					</FormFileUpload>
-					<MediaUpload
-						onSelect={ this.onSelectImages }
-						type="image"
-						multiple
-						gallery
-						render={ ( { open } ) => (
-							<Button isLarge onClick={ open }>
-								{ __( 'Add from Media Library' ) }
-							</Button>
-						) }
-					/>
-				</Placeholder>,
+					onSelectImage={ this.onSelectImages }
+					multiple
+				/>,
 			];
 		}
 


### PR DESCRIPTION
## Description
This PR makes the image placeholder handle multiple images. And uses the image placeholder in the gallery block, removing duplicate logic.
No visual changes expected.

## How Has This Been Tested?
Add images from the gallery, using the upload button, and using drop-down, in the cover image, image, and gallery blocks. Verify in every upload things worked as expected.