### PR TITLE
Fixed errors when adding duplicate tags.

### DIFF
--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -106,8 +106,13 @@ class FlatTermSelector extends Component {
 				.then( resolve, ( xhr ) => {
 					const errorCode = xhr.responseJSON && xhr.responseJSON.code;
 					if ( errorCode === 'term_exists' ) {
-						return new Model( { id: xhr.responseJSON.data } )
-							.fetch().then( resolve, reject );
+						// search the new category created since last fetch
+						this.addRequest = new Model().fetch(
+							{ data: { ...DEFAULT_QUERY, search: termName } }
+						);
+						return this.addRequest.then( searchResult => {
+							resolve( find( searchResult, result => result.name === termName ) );
+						}, reject );
 					}
 					reject( xhr );
 				} );


### PR DESCRIPTION
Now we issue a request to the server, if we get an error saying we have a duplicate tag/flat term (tag may have been added by other used since last time we fetched), we search the server for the new tag and we add it to our list.
It applies the same fix, applied to categories in https://github.com/WordPress/gutenberg/pull/4372, but in tags, as we are constantly refreshing the tag list while the user is typing the bug does not manifest most of the times in normal usage.

## How Has This Been Tested?
Open two post creation windows. Add a new tag to one post, copy the tag text.
Open the developer console, in the network requests viewer. Add the same tag (by pasting and pressing enter we have to be fast so the tag is not requested), verify we got a 409 response saying we had a conflict. But no other error appeared in the console and the tag was correctly added.