### PR TITLE
docs: add preceding line break and remove superfluous spacing in JSDoc `@returns` descriptions

### DIFF
--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -19,12 +19,14 @@ import BlockIcon from '../block-icon';
 
 /**
  * @callback FnGetOptions
+ *
  * @returns {Promise.<Array.<CompleterOption>>} A promise that resolves to the list of completer options.
  */
 
 /**
  * @callback FnAllowNode
  * @param {Node} textNode check if the completer can handle this text node.
+ *
  * @returns {boolean} true if the completer can handle this text node.
  */
 
@@ -32,6 +34,7 @@ import BlockIcon from '../block-icon';
  * @callback FnAllowContext
  * @param {Range} before the range before the auto complete trigger and query.
  * @param {Range} after the range after the autocomplete trigger and query.
+ *
  * @returns {boolean} true if the completer can handle these ranges.
  */
 
@@ -40,6 +43,7 @@ import BlockIcon from '../block-icon';
  * @param {*} value the value of the completer option.
  * @param {Range} range the nodes included in the autocomplete trigger and query.
  * @param {String} query the text value of the autocomplete query.
+ *
  * @returns {?Component} optional html to replace the range.
  */
 
@@ -58,7 +62,8 @@ import BlockIcon from '../block-icon';
  * The definition can be understood by the Autocomplete component.
  *
  * @param  {Function} onReplace  Callback to replace the current block.
- * @returns {Completer}          Completer object used by the Autocomplete component.
+ *
+ * @returns {Completer} Completer object used by the Autocomplete component.
  */
 export function blockAutocompleter( { onReplace } ) {
 	// Prioritize common category in block type options

--- a/blocks/image-placeholder/index.js
+++ b/blocks/image-placeholder/index.js
@@ -14,7 +14,8 @@ import MediaUploadButton from '../media-upload-button';
  *  ImagePlaceHolder is a react component used by blocks containing user configurable images e.g: image and cover image.
  *
  * @param   {Object} props  React props passed to the component.
- * @returns {Object}        Rendered placeholder.
+ *
+ * @returns {Object} Rendered placeholder.
  */
 export default function ImagePlaceHolder( { className, icon, label, onSelectImage } ) {
 	const setImage = ( [ image ] ) => onSelectImage( image );

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -26,6 +26,7 @@ const { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT, SPACE } = keycodes;
 /**
  * Recursively select the firstChild until hitting a leaf node.
  * @param {Node} node the node to find the recursive first child.
+ *
  * @returns {Node} the first leaf-node >= node in the ordering.
  */
 function descendFirst( node ) {
@@ -39,6 +40,7 @@ function descendFirst( node ) {
 /**
  * Recursively select the lastChild until hitting a leaf node.
  * @param {Node} node the node to find the recursive last child.
+ *
  * @returns {Node} the first leaf-node <= node in the ordering.
  */
 function descendLast( node ) {
@@ -52,6 +54,7 @@ function descendLast( node ) {
 /**
  * Is the node a text node.
  * @param {?Node} node the node to check.
+ *
  * @returns {boolean} true if the node is a text node.
  */
 function isTextNode( node ) {
@@ -61,6 +64,7 @@ function isTextNode( node ) {
 /**
  * Return the node only if it is a text node, otherwise return null.
  * @param {?Node} node the node to filter.
+ *
  * @returns {?Node} the node or null if it is not a text node.
  */
 function onlyTextNode( node ) {
@@ -70,6 +74,7 @@ function onlyTextNode( node ) {
 /**
  * Find the index of the last charater in the text that is whitespace.
  * @param {String} text the text to search.
+ *
  * @returns {Number} the last index of a white space character in the text or -1.
  */
 function lastIndexOfSpace( text ) {

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -55,6 +55,7 @@ function makeAutocompleter( completers, AutocompleteComponent = Autocomplete ) {
 /**
  * Create a text node
  * @param {String} text text of text node.
+
  * @returns {Node} a text node.
  */
 function tx( text ) {
@@ -63,6 +64,7 @@ function tx( text ) {
 
 /**
  * Create a paragraph node with the arguments as children
+
  * @returns {Node} a paragraph node.
  */
 function par( /* arguments */ ) {

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -10,7 +10,8 @@ import { partial, castArray } from 'lodash';
  *
  * @param  {Object} post     Post object
  * @param  {Object} settings Editor settings object
- * @returns {Object}         Action object
+ *
+ * @returns {Object} Action object.
  */
 export function setupEditor( post, settings ) {
 	return {


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Follow up to #4464 where a handful of spacing issues were missed.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.