### PR TITLE
Move data logic out of the inserter

### DIFF
--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual, find } from 'lodash';
+import { isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -29,9 +29,13 @@ export default class InserterGroup extends Component {
 	componentWillReceiveProps( nextProps ) {
 		if ( ! isEqual( this.props.items, nextProps.items ) ) {
 			this.activeItems = deriveActiveItems( nextProps.items );
+
 			// Try and preserve any still valid selected state.
-			const current = find( this.activeItems, ( item ) => isEqual( item, this.state.current ) );
-			if ( ! current ) {
+			const currentIsStillActive = this.state.current && this.activeItems.some( item =>
+				item.id === this.state.current.id
+			);
+
+			if ( ! currentIsStillActive ) {
 				this.setState( {
 					current: this.activeItems.length > 0 ? this.activeItems[ 0 ] : null,
 				} );
@@ -39,17 +43,19 @@ export default class InserterGroup extends Component {
 		}
 	}
 
-	renderItem( item, index ) {
+	renderItem( item ) {
 		const { current } = this.state;
 		const { onSelectItem } = this.props;
+
+		const isCurrent = current && current.id === item.id;
 
 		return (
 			<button
 				role="menuitem"
-				key={ index }
+				key={ item.id }
 				className="editor-inserter__block"
 				onClick={ () => onSelectItem( item ) }
-				tabIndex={ isEqual( current, item ) || item.isDisabled ? null : '-1' }
+				tabIndex={ isCurrent || item.isDisabled ? null : '-1' }
 				disabled={ item.isDisabled }
 			>
 				<BlockIcon icon={ item.icon } />

--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -10,8 +10,8 @@ import { Component } from '@wordpress/element';
 import { NavigableMenu } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/blocks';
 
-function deriveActiveBlocks( blocks ) {
-	return blocks.filter( ( block ) => ! block.disabled );
+function deriveActiveItems( items ) {
+	return items.filter( ( item ) => ! item.isDisabled );
 }
 
 export default class InserterGroup extends Component {
@@ -20,61 +20,56 @@ export default class InserterGroup extends Component {
 
 		this.onNavigate = this.onNavigate.bind( this );
 
-		this.activeBlocks = deriveActiveBlocks( this.props.blockTypes );
+		this.activeItems = deriveActiveItems( this.props.items );
 		this.state = {
-			current: this.activeBlocks.length > 0 ? this.activeBlocks[ 0 ].name : null,
+			current: this.activeItems.length > 0 ? this.activeItems[ 0 ] : null,
 		};
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( this.props.blockTypes, nextProps.blockTypes ) ) {
-			this.activeBlocks = deriveActiveBlocks( nextProps.blockTypes );
+		if ( ! isEqual( this.props.items, nextProps.items ) ) {
+			this.activeItems = deriveActiveItems( nextProps.items );
 			// Try and preserve any still valid selected state.
-			const current = find( this.activeBlocks, { name: this.state.current } );
+			const current = find( this.activeItems, ( item ) => isEqual( item, this.state.current ) );
 			if ( ! current ) {
 				this.setState( {
-					current: this.activeBlocks.length > 0 ? this.activeBlocks[ 0 ].name : null,
+					current: this.activeItems.length > 0 ? this.activeItems[ 0 ] : null,
 				} );
 			}
 		}
 	}
 
-	renderItem( block ) {
+	renderItem( item, index ) {
 		const { current } = this.state;
-		const { selectBlock, bindReferenceNode } = this.props;
-		const { disabled } = block;
+		const { onSelectItem } = this.props;
 
 		return (
 			<button
 				role="menuitem"
-				key={ block.name === 'core/block' && block.initialAttributes ?
-					block.name + block.initialAttributes.ref :
-					block.name
-				}
+				key={ index }
 				className="editor-inserter__block"
-				onClick={ selectBlock( block ) }
-				ref={ bindReferenceNode( block.name ) }
-				tabIndex={ current === block.name || disabled ? null : '-1' }
-				disabled={ disabled }
+				onClick={ () => onSelectItem( item ) }
+				tabIndex={ isEqual( current, item ) || item.isDisabled ? null : '-1' }
+				disabled={ item.isDisabled }
 			>
-				<BlockIcon icon={ block.icon } />
-				{ block.title }
+				<BlockIcon icon={ item.icon } />
+				{ item.title }
 			</button>
 		);
 	}
 
 	onNavigate( index ) {
-		const { activeBlocks } = this;
-		const dest = activeBlocks[ index ];
+		const { activeItems } = this;
+		const dest = activeItems[ index ];
 		if ( dest ) {
 			this.setState( {
-				current: dest.name,
+				current: dest,
 			} );
 		}
 	}
 
 	render() {
-		const { labelledBy, blockTypes } = this.props;
+		const { labelledBy, items } = this.props;
 
 		return (
 			<NavigableMenu
@@ -83,7 +78,7 @@ export default class InserterGroup extends Component {
 				aria-labelledby={ labelledBy }
 				cycle={ false }
 				onNavigate={ this.onNavigate }>
-				{ blockTypes.map( this.renderItem, this ) }
+				{ items.map( this.renderItem, this ) }
 			</NavigableMenu>
 		);
 	}

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -82,17 +82,12 @@ class Inserter extends Component {
 					</IconButton>
 				) }
 				renderContent={ ( { onClose } ) => {
-					const onInsert = ( name, initialAttributes ) => {
-						onInsertBlock(
-							name,
-							initialAttributes,
-							insertionPoint
-						);
-
+					const onSelect = ( item ) => {
+						onInsertBlock( item, insertionPoint );
 						onClose();
 					};
 
-					return <InserterMenu onSelect={ onInsert } />;
+					return <InserterMenu onSelect={ onSelect } />;
 				} }
 			/>
 		);
@@ -108,9 +103,9 @@ export default compose( [
 			};
 		},
 		( dispatch ) => ( {
-			onInsertBlock( name, initialAttributes, position ) {
+			onInsertBlock( item, position ) {
 				dispatch( insertBlock(
-					createBlock( name, initialAttributes ),
+					createBlock( item.name, item.initialAttributes ),
 					position
 				) );
 			},

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -3,7 +3,6 @@
  */
 import {
 	filter,
-	find,
 	findIndex,
 	flow,
 	groupBy,
@@ -27,7 +26,7 @@ import {
 	withSpokenMessages,
 	withContext,
 } from '@wordpress/components';
-import { getCategories, getBlockTypes } from '@wordpress/blocks';
+import { getCategories } from '@wordpress/blocks';
 import { keycodes } from '@wordpress/utils';
 
 /**
@@ -35,16 +34,16 @@ import { keycodes } from '@wordpress/utils';
  */
 import './style.scss';
 
-import { getBlocks, getRecentlyUsedBlocks, getReusableBlocks } from '../../store/selectors';
+import { getInserterItems, getRecentInserterItems } from '../../store/selectors';
 import { fetchReusableBlocks } from '../../store/actions';
 import { default as InserterGroup } from './group';
 
-export const searchBlocks = ( blocks, searchTerm ) => {
+export const searchItems = ( items, searchTerm ) => {
 	const normalizedSearchTerm = searchTerm.toLowerCase().trim();
 	const matchSearch = ( string ) => string.toLowerCase().indexOf( normalizedSearchTerm ) !== -1;
 
-	return blocks.filter( ( block ) =>
-		matchSearch( block.title ) || some( block.keywords, matchSearch )
+	return items.filter( ( item ) =>
+		matchSearch( item.title ) || some( item.keywords, matchSearch )
 	);
 };
 
@@ -62,11 +61,10 @@ export class InserterMenu extends Component {
 			tab: 'recent',
 		};
 		this.filter = this.filter.bind( this );
-		this.searchBlocks = this.searchBlocks.bind( this );
-		this.getBlocksForTab = this.getBlocksForTab.bind( this );
-		this.sortBlocks = this.sortBlocks.bind( this );
-		this.bindReferenceNode = this.bindReferenceNode.bind( this );
-		this.selectBlock = this.selectBlock.bind( this );
+		this.searchItems = this.searchItems.bind( this );
+		this.getItemsForTab = this.getItemsForTab.bind( this );
+		this.sortItems = this.sortItems.bind( this );
+		this.selectItem = this.selectItem.bind( this );
 
 		this.tabScrollTop = { recent: 0, blocks: 0, embeds: 0 };
 		this.switchTab = this.switchTab.bind( this );
@@ -77,8 +75,8 @@ export class InserterMenu extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const searchResults = this.searchBlocks( this.getBlockTypes() );
-		// Announce the blocks search results to screen readers.
+		const searchResults = this.searchItems( this.props.items );
+		// Announce the search results to screen readers.
 		if ( this.state.filterValue && !! searchResults.length ) {
 			this.props.debouncedSpeak( sprintf( _n(
 				'%d result found',
@@ -94,152 +92,91 @@ export class InserterMenu extends Component {
 		}
 	}
 
-	isDisabledBlock( blockType ) {
-		return blockType.useOnce && find( this.props.blocks, ( { name } ) => blockType.name === name );
-	}
-
-	bindReferenceNode( nodeName ) {
-		return ( node ) => this.nodes[ nodeName ] = node;
-	}
-
 	filter( event ) {
 		this.setState( {
 			filterValue: event.target.value,
 		} );
 	}
 
-	selectBlock( block ) {
-		return () => {
-			this.props.onSelect( block.name, block.initialAttributes );
-			this.setState( {
-				filterValue: '',
-			} );
-		};
-	}
-
-	getStaticBlockTypes() {
-		const { blockTypes } = this.props;
-
-		// If all block types disabled, return empty set
-		if ( ! blockTypes ) {
-			return [];
-		}
-
-		// Block types that are marked as private should not appear in the inserter
-		return getBlockTypes().filter( ( block ) => {
-			if ( block.isPrivate ) {
-				return false;
-			}
-
-			// Block types defined as either `true` or array:
-			//  - True: Allow
-			//  - Array: Check block name within whitelist
-			return (
-				! Array.isArray( blockTypes ) ||
-				includes( blockTypes, block.name )
-			);
+	selectItem( item ) {
+		this.props.onSelect( item );
+		this.setState( {
+			filterValue: '',
 		} );
 	}
 
-	getReusableBlockTypes() {
-		const { reusableBlocks } = this.props;
-
-		// Display reusable blocks that we've fetched in the inserter
-		return reusableBlocks.map( ( reusableBlock ) => ( {
-			name: 'core/block',
-			initialAttributes: {
-				ref: reusableBlock.id,
-			},
-			title: reusableBlock.title,
-			icon: 'layout',
-			category: 'reusable-blocks',
-		} ) );
+	searchItems( items ) {
+		return searchItems( items, this.state.filterValue );
 	}
 
-	getBlockTypes() {
-		return [
-			...this.getStaticBlockTypes(),
-			...this.getReusableBlockTypes(),
-		];
-	}
+	getItemsForTab( tab ) {
+		const { items, recentItems } = this.props;
 
-	searchBlocks( blockTypes ) {
-		return searchBlocks( blockTypes, this.state.filterValue );
-	}
-
-	getBlocksForTab( tab ) {
-		const blockTypes = this.getBlockTypes();
-		// if we're searching, use everything, otherwise just get the blocks visible in this tab
+		// If we're searching, use everything, otherwise just get the items visible in this tab
 		if ( this.state.filterValue ) {
-			return blockTypes;
+			return items;
 		}
 
 		let predicate;
 		switch ( tab ) {
 			case 'recent':
-				return filter( this.props.recentlyUsedBlocks,
-					( { name } ) => find( blockTypes, { name } ) );
+				return recentItems;
 
 			case 'blocks':
-				predicate = ( block ) => block.category !== 'embed' && block.category !== 'reusable-blocks';
+				predicate = ( item ) => item.category !== 'embed' && item.category !== 'reusable-blocks';
 				break;
 
 			case 'embeds':
-				predicate = ( block ) => block.category === 'embed';
+				predicate = ( item ) => item.category === 'embed';
 				break;
 
 			case 'saved':
-				predicate = ( block ) => block.category === 'reusable-blocks';
+				predicate = ( item ) => item.category === 'reusable-blocks';
 				break;
 		}
 
-		return filter( blockTypes, predicate );
+		return filter( items, predicate );
 	}
 
-	sortBlocks( blockTypes ) {
+	sortItems( items ) {
 		if ( 'recent' === this.state.tab && ! this.state.filterValue ) {
-			return blockTypes;
+			return items;
 		}
 
 		const getCategoryIndex = ( item ) => {
 			return findIndex( getCategories(), ( category ) => category.slug === item.category );
 		};
 
-		return sortBy( blockTypes, getCategoryIndex );
+		return sortBy( items, getCategoryIndex );
 	}
 
-	groupByCategory( blockTypes ) {
-		return groupBy( blockTypes, ( blockType ) => blockType.category );
+	groupByCategory( items ) {
+		return groupBy( items, ( item ) => item.category );
 	}
 
-	getVisibleBlocksByCategory( blockTypes ) {
+	getVisibleItemsByCategory( items ) {
 		return flow(
-			this.searchBlocks,
-			this.sortBlocks,
+			this.searchItems,
+			this.sortItems,
 			this.groupByCategory
-		)( blockTypes );
+		)( items );
 	}
 
-	renderBlocks( blockTypes, separatorSlug ) {
+	renderItems( items, separatorSlug ) {
 		const { instanceId } = this.props;
 		const labelledBy = separatorSlug === undefined ? null : `editor-inserter__separator-${ separatorSlug }-${ instanceId }`;
-		const blockTypesInfo = blockTypes.map( ( blockType ) => (
-			{ ...blockType, disabled: this.isDisabledBlock( blockType ) }
-		) );
-
 		return (
 			<InserterGroup
-				blockTypes={ blockTypesInfo }
+				items={ items }
 				labelledBy={ labelledBy }
-				bindReferenceNode={ this.bindReferenceNode }
-				selectBlock={ this.selectBlock }
+				onSelectItem={ this.selectItem }
 			/>
 		);
 	}
 
-	renderCategory( category, blockTypes ) {
+	renderCategory( category, items ) {
 		const { instanceId } = this.props;
-		return blockTypes && (
+		return items && (
 			<div key={ category.slug }>
 				<div
 					className="editor-inserter__separator"
@@ -248,13 +185,13 @@ export class InserterMenu extends Component {
 				>
 					{ category.title }
 				</div>
-				{ this.renderBlocks( blockTypes, category.slug ) }
+				{ this.renderItems( items, category.slug ) }
 			</div>
 		);
 	}
 
-	renderCategories( visibleBlocksByCategory ) {
-		if ( isEmpty( visibleBlocksByCategory ) ) {
+	renderCategories( visibleItemsByCategory ) {
+		if ( isEmpty( visibleItemsByCategory ) ) {
 			return (
 				<span className="editor-inserter__no-results">
 					{ __( 'No blocks found' ) }
@@ -263,7 +200,7 @@ export class InserterMenu extends Component {
 		}
 
 		return getCategories().map(
-			( category ) => this.renderCategory( category, visibleBlocksByCategory[ category.slug ] )
+			( category ) => this.renderCategory( category, visibleItemsByCategory[ category.slug ] )
 		);
 	}
 
@@ -274,15 +211,15 @@ export class InserterMenu extends Component {
 	}
 
 	renderTabView( tab ) {
-		const blocksForTab = this.getBlocksForTab( tab );
+		const itemsForTab = this.getItemsForTab( tab );
 
 		// If the Recent tab is selected, don't render category headers
 		if ( 'recent' === tab ) {
-			return this.renderBlocks( blocksForTab );
+			return this.renderItems( itemsForTab );
 		}
 
 		// If the Saved tab is selected and we have no results, display a friendly message
-		if ( 'saved' === tab && blocksForTab.length === 0 ) {
+		if ( 'saved' === tab && itemsForTab.length === 0 ) {
 			return (
 				<p className="editor-inserter__no-tab-content-message">
 					{ __( 'No saved blocks.' ) }
@@ -290,16 +227,16 @@ export class InserterMenu extends Component {
 			);
 		}
 
-		const visibleBlocksByCategory = this.getVisibleBlocksByCategory( blocksForTab );
+		const visibleItemsByCategory = this.getVisibleItemsByCategory( itemsForTab );
 
-		// If our results have only blocks from one category, don't render category headers
-		const categories = Object.keys( visibleBlocksByCategory );
+		// If our results have only items from one category, don't render category headers
+		const categories = Object.keys( visibleItemsByCategory );
 		if ( categories.length === 1 ) {
 			const [ soleCategory ] = categories;
-			return this.renderBlocks( visibleBlocksByCategory[ soleCategory ] );
+			return this.renderItems( visibleItemsByCategory[ soleCategory ] );
 		}
 
-		return this.renderCategories( visibleBlocksByCategory );
+		return this.renderCategories( visibleItemsByCategory );
 	}
 
 	// Passed to TabbableContainer, extending its event-handling logic
@@ -324,7 +261,7 @@ export class InserterMenu extends Component {
 	}
 
 	render() {
-		const { instanceId } = this.props;
+		const { instanceId, items } = this.props;
 		const isSearching = this.state.filterValue;
 
 		return (
@@ -340,7 +277,6 @@ export class InserterMenu extends Component {
 					placeholder={ __( 'Search for a block' ) }
 					className="editor-inserter__search"
 					onChange={ this.filter }
-					ref={ this.bindReferenceNode( 'search' ) }
 				/>
 				{ ! isSearching &&
 					<TabPanel className="editor-inserter__tabs" activeClass="is-active"
@@ -377,7 +313,7 @@ export class InserterMenu extends Component {
 				}
 				{ isSearching &&
 					<div role="menu" className="editor-inserter__search-results">
-						{ this.renderCategories( this.getVisibleBlocksByCategory( this.getBlockTypes() ) ) }
+						{ this.renderCategories( this.getVisibleItemsByCategory( items ) ) }
 					</div>
 				}
 			</TabbableContainer>
@@ -385,20 +321,23 @@ export class InserterMenu extends Component {
 	}
 }
 
-const connectComponent = connect(
-	( state ) => {
-		return {
-			recentlyUsedBlocks: getRecentlyUsedBlocks( state ),
-			blocks: getBlocks( state ),
-			reusableBlocks: getReusableBlocks( state ),
-		};
-	},
-	{ fetchReusableBlocks }
-);
-
 export default compose(
-	connectComponent,
-	withContext( 'editor' )( ( settings ) => pick( settings, 'blockTypes' ) ),
+	withContext( 'editor' )( ( settings ) => {
+		const { blockTypes } = settings;
+
+		return {
+			enabledBlockTypes: blockTypes,
+		};
+	} ),
+	connect(
+		( state, ownProps ) => {
+			return {
+				items: getInserterItems( state, ownProps.enabledBlockTypes ),
+				recentItems: getRecentInserterItems( state, ownProps.enabledBlockTypes ),
+			};
+		},
+		{ fetchReusableBlocks }
+	),
 	withSpokenMessages,
 	withInstanceId
 )( InserterMenu );

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -10,6 +10,7 @@ import { noop } from 'lodash';
 import { InserterMenu, searchItems } from '../menu';
 
 const textItem = {
+	id: 'core/text-block',
 	name: 'core/text-block',
 	initialAttributes: {},
 	title: 'Text',
@@ -18,6 +19,7 @@ const textItem = {
 };
 
 const advancedTextItem = {
+	id: 'core/advanced-text-block',
 	name: 'core/advanced-text-block',
 	initialAttributes: {},
 	title: 'Advanced Text',
@@ -26,6 +28,7 @@ const advancedTextItem = {
 };
 
 const someOtherItem = {
+	id: 'core/some-other-block',
 	name: 'core/some-other-block',
 	initialAttributes: {},
 	title: 'Some Other Block',
@@ -34,6 +37,7 @@ const someOtherItem = {
 };
 
 const moreItem = {
+	id: 'core/more-block',
 	name: 'core/more-block',
 	initialAttributes: {},
 	title: 'More',
@@ -42,6 +46,7 @@ const moreItem = {
 };
 
 const youtubeItem = {
+	id: 'core-embed/youtube',
 	name: 'core-embed/youtube',
 	initialAttributes: {},
 	title: 'YouTube',
@@ -51,6 +56,7 @@ const youtubeItem = {
 };
 
 const textEmbedItem = {
+	id: 'core-embed/a-text-embed',
 	name: 'core-embed/a-text-embed',
 	initialAttributes: {},
 	title: 'A Text Embed',
@@ -59,6 +65,7 @@ const textEmbedItem = {
 };
 
 const reusableItem = {
+	id: 'core/block/123',
 	name: 'core/block',
 	initialAttributes: { ref: 123 },
 	title: 'My reusable block',

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -5,98 +5,89 @@ import { mount } from 'enzyme';
 import { noop } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import { registerBlockType, unregisterBlockType, getBlockTypes } from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
-import { InserterMenu, searchBlocks } from '../menu';
+import { InserterMenu, searchItems } from '../menu';
 
-const textBlock = {
+const textItem = {
 	name: 'core/text-block',
+	initialAttributes: {},
 	title: 'Text',
-	save: noop,
-	edit: noop,
 	category: 'common',
+	isDisabled: false,
 };
 
-const advancedTextBlock = {
+const advancedTextItem = {
 	name: 'core/advanced-text-block',
+	initialAttributes: {},
 	title: 'Advanced Text',
-	save: noop,
-	edit: noop,
 	category: 'common',
+	isDisabled: false,
 };
 
-const someOtherBlock = {
+const someOtherItem = {
 	name: 'core/some-other-block',
+	initialAttributes: {},
 	title: 'Some Other Block',
-	save: noop,
-	edit: noop,
 	category: 'common',
+	isDisabled: false,
 };
 
-const moreBlock = {
+const moreItem = {
 	name: 'core/more-block',
+	initialAttributes: {},
 	title: 'More',
-	save: noop,
-	edit: noop,
 	category: 'layout',
-	useOnce: 'true',
+	isDisabled: true,
 };
 
-const youtubeBlock = {
+const youtubeItem = {
 	name: 'core-embed/youtube',
+	initialAttributes: {},
 	title: 'YouTube',
-	save: noop,
-	edit: noop,
 	category: 'embed',
 	keywords: [ 'google' ],
+	isDisabled: false,
 };
 
-const textEmbedBlock = {
+const textEmbedItem = {
 	name: 'core-embed/a-text-embed',
+	initialAttributes: {},
 	title: 'A Text Embed',
-	save: noop,
-	edit: noop,
 	category: 'embed',
+	isDisabled: false,
 };
+
+const reusableItem = {
+	name: 'core/block',
+	initialAttributes: { ref: 123 },
+	title: 'My reusable block',
+	category: 'reusable-blocks',
+	isDisabled: false,
+};
+
+const items = [
+	textItem,
+	advancedTextItem,
+	someOtherItem,
+	moreItem,
+	youtubeItem,
+	textEmbedItem,
+	reusableItem,
+];
 
 describe( 'InserterMenu', () => {
 	// NOTE: Due to https://github.com/airbnb/enzyme/issues/1174, some of the selectors passed through to
 	// wrapper.find have had to be strengthened (and the filterWhere strengthened also), otherwise two
 	// results would be returned even though only one was in the DOM.
 
-	const unregisterAllBlocks = () => {
-		getBlockTypes().forEach( ( block ) => {
-			unregisterBlockType( block.name );
-		} );
-	};
-
-	afterEach( () => {
-		unregisterAllBlocks();
-	} );
-
-	beforeEach( () => {
-		unregisterAllBlocks();
-		registerBlockType( textBlock.name, textBlock );
-		registerBlockType( advancedTextBlock.name, advancedTextBlock );
-		registerBlockType( someOtherBlock.name, someOtherBlock );
-		registerBlockType( moreBlock.name, moreBlock );
-		registerBlockType( youtubeBlock.name, youtubeBlock );
-		registerBlockType( textEmbedBlock.name, textEmbedBlock );
-	} );
-
 	it( 'should show the recent tab by default', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ [] }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
 				blockTypes
@@ -110,17 +101,15 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 0 );
 	} );
 
-	it( 'should show no blocks if all block types disabled', () => {
+	it( 'should show nothing if there are no items', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [ advancedTextBlock ] }
+				items={ [] }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes={ false }
 			/>
 		);
 
@@ -128,64 +117,34 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks ).toHaveLength( 0 );
 	} );
 
-	it( 'should show filtered block types', () => {
+	it( 'should show the recently used items in the recent tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [ textBlock, advancedTextBlock ] }
+				items={ items }
+				recentItems={ [ advancedTextItem, textItem, someOtherItem ] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes={ [ textBlock.name ] }
-			/>
-		);
-
-		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
-		expect( visibleBlocks ).toHaveLength( 1 );
-		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Text' );
-	} );
-
-	it( 'should show the recently used blocks in the recent tab', () => {
-		const wrapper = mount(
-			<InserterMenu
-				position={ 'top center' }
-				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [
-					// Actually recently used by user, thus present at the top.
-					advancedTextBlock,
-					// Blocks of category 'common' injected on SETUP_EDITOR.
-					// These have to be listed here in the order in which they
-					// are registered.
-					textBlock,
-					someOtherBlock,
-				] }
-				debouncedSpeak={ noop }
-				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
 		expect( visibleBlocks ).toHaveLength( 3 );
-		expect( visibleBlocks.at( 0 ).childAt( 0 ).name() ).toBe( 'BlockIcon' );
 		expect( visibleBlocks.at( 0 ).text() ).toBe( 'Advanced Text' );
+		expect( visibleBlocks.at( 1 ).text() ).toBe( 'Text' );
+		expect( visibleBlocks.at( 2 ).text() ).toBe( 'Some Other Block' );
 	} );
 
-	it( 'should show blocks from the embed category in the embed tab', () => {
+	it( 'should show items from the embed category in the embed tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
 		const embedTab = wrapper.find( '.editor-inserter__tab' )
@@ -201,17 +160,38 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'A Text Embed' );
 	} );
 
-	it( 'should show all blocks except embeds in the blocks tab', () => {
+	it( 'should show reusable items in the saved tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
+			/>
+		);
+		const embedTab = wrapper.find( '.editor-inserter__tab' )
+			.filterWhere( ( node ) => node.text() === 'Saved' && node.name() === 'button' );
+		embedTab.simulate( 'click' );
+
+		const activeCategory = wrapper.find( '.editor-inserter__tab button.is-active' );
+		expect( activeCategory.text() ).toBe( 'Saved' );
+
+		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
+		expect( visibleBlocks ).toHaveLength( 1 );
+		expect( visibleBlocks.at( 0 ).text() ).toBe( 'My reusable block' );
+	} );
+
+	it( 'should show all items except embeds and reusable blocks in the blocks tab', () => {
+		const wrapper = mount(
+			<InserterMenu
+				position={ 'top center' }
+				instanceId={ 1 }
+				items={ items }
+				recentItems={ [] }
+				debouncedSpeak={ noop }
+				fetchReusableBlocks={ noop }
 			/>
 		);
 		const blocksTab = wrapper.find( '.editor-inserter__tab' )
@@ -229,40 +209,32 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 3 ).text() ).toBe( 'More' );
 	} );
 
-	it( 'should disable already used blocks with `usedOnce`', () => {
+	it( 'should disable items with `isDisabled`', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [ { name: moreBlock.name } ] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ items }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
-		const blocksTab = wrapper.find( '.editor-inserter__tab' )
-			.filterWhere( ( node ) => node.text() === 'Blocks' && node.name() === 'button' );
-		blocksTab.simulate( 'click' );
-		wrapper.update();
 
-		const disabledBlocks = wrapper.find( '.editor-inserter__block[disabled]' );
+		const disabledBlocks = wrapper.find( '.editor-inserter__block[disabled=true]' );
 		expect( disabledBlocks ).toHaveLength( 1 );
 		expect( disabledBlocks.at( 0 ).text() ).toBe( 'More' );
 	} );
 
-	it( 'should allow searching for blocks', () => {
+	it( 'should allow searching for items', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
 		wrapper.setState( { filterValue: 'text' } );
@@ -282,12 +254,10 @@ describe( 'InserterMenu', () => {
 			<InserterMenu
 				position={ 'top center' }
 				instanceId={ 1 }
-				blocks={ [] }
-				reusableBlocks={ [] }
-				recentlyUsedBlocks={ [] }
+				items={ items }
+				recentItems={ [] }
 				debouncedSpeak={ noop }
 				fetchReusableBlocks={ noop }
-				blockTypes
 			/>
 		);
 		wrapper.setState( { filterValue: ' text' } );
@@ -303,18 +273,16 @@ describe( 'InserterMenu', () => {
 	} );
 } );
 
-describe( 'searchBlocks', () => {
-	it( 'should search blocks using the title ignoring case', () => {
-		const blocks = [ textBlock, advancedTextBlock, moreBlock, youtubeBlock, textEmbedBlock ];
-		expect( searchBlocks( blocks, 'TEXT' ) ).toEqual(
-			[ textBlock, advancedTextBlock, textEmbedBlock ]
+describe( 'searchItems', () => {
+	it( 'should search items using the title ignoring case', () => {
+		expect( searchItems( items, 'TEXT' ) ).toEqual(
+			[ textItem, advancedTextItem, textEmbedItem ]
 		);
 	} );
 
-	it( 'should search blocks using the keywords', () => {
-		const blocks = [ textBlock, advancedTextBlock, moreBlock, youtubeBlock, textEmbedBlock ];
-		expect( searchBlocks( blocks, 'GOOGL' ) ).toEqual(
-			[ youtubeBlock ]
+	it( 'should search items using the keywords', () => {
+		expect( searchItems( items, 'GOOGL' ) ).toEqual(
+			[ youtubeItem ]
 		);
 	} );
 } );

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1115,6 +1115,7 @@ export function getNotices( state ) {
  * block. Inserter items encapsulate both regular blocks and reusable blocks.
  * 
  * @typedef {Object} Editor.InserterItem
+ * @property {string}   id                Unique identifier for the item.
  * @property {string}   name              The type of block to create.
  * @property {Object}   initialAttributes Attributes to pass to the newly created block.
  * @property {string}   title             Title of the item, as it appears in the inserter.
@@ -1147,6 +1148,7 @@ function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
 	}
 
 	return {
+		id: blockType.name,
 		name: blockType.name,
 		initialAttributes: {},
 		title: blockType.title,
@@ -1180,6 +1182,7 @@ function buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock ) 
 	}
 
 	return {
+		id: `core/block/${ reusableBlock.id }`,
 		name: 'core/block',
 		initialAttributes: { ref: reusableBlock.id },
 		title: reusableBlock.title,

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2285,6 +2285,7 @@ describe( 'selectors', () => {
 
 			expect( getInserterItems( state, [ 'core/test-block' ] ) ).toEqual( [
 				{
+					id: 'core/test-block',
 					name: 'core/test-block',
 					initialAttributes: {},
 					title: 'test block',
@@ -2336,6 +2337,7 @@ describe( 'selectors', () => {
 
 			expect( getInserterItems( state, [ 'core/block' ] ) ).toEqual( [
 				{
+					id: 'core/block/123',
 					name: 'core/block',
 					initialAttributes: { ref: 123 },
 					title: 'My reusable block',


### PR DESCRIPTION
### 💃 What 

Fixes #4221. Fixes #4303.

Currently, `InserterMenu`, `VisualEditorInserter`, and `blocksAutocompleter` all directly call `getBlockTypes()` and `getReusableBlocks()` to determine what blocks should be shown.

This means that we duplicate the same logic in a few different places:

* Checking, if the block has `useOnce` set, whether it's been already used or not
* Checking whether or not the block has `isPrivate` set
* Checking whether or not the block is in the editor config's list of enabled block types
* Mixing in the list of available reusable blocks with the list of regular blocks

This approach is pretty error-prone: it's very easy to change the behaviour of one inserter and forget about another.

To start addressing this, I've changed `InserterMenu` to source its data from two new selectors:

* `getInserterItems` - used to populate the inserter's search results
* `getRecentInserterItems` - used to populate the 'Recent' tab

Both selectors filter out private/disabled blocks, correctly set `isDisabled`, and are unit tested.

### ✅ How to test

1. Insert some static blocks and reusable blocks
2. Recently inserted blocks should move to the top of the Recent tab in the main inserter