### PR TITLE
fix: Link modal z-index bug

### DIFF
--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -64,7 +64,7 @@ class FormatToolbar extends Component {
 
 	onKeyDown( event ) {
 		if ( event.keyCode === ESCAPE ) {
-			if ( this.state.isEditingLink ) {
+			if ( this.state.isAddingLink || this.state.isEditingLink ) {
 				event.stopPropagation();
 				this.dropLink();
 			}
@@ -145,9 +145,9 @@ class FormatToolbar extends Component {
 				<Toolbar controls={ toolbarControls } />
 
 				{ ( isAddingLink || isEditingLink ) &&
-					// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+					// Disable reason: KeyPress should be suppressed so parents are unaffected.
 					/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-					<Fill name="RichText.Siblings">
+					<Fill name="VisualEditor.LastChild">
 						<form
 							className="blocks-format-toolbar__link-modal"
 							style={ linkStyle }
@@ -165,9 +165,9 @@ class FormatToolbar extends Component {
 				}
 
 				{ !! formats.link && ! isAddingLink && ! isEditingLink &&
-					// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+					// Disable reason: KeyPress should be suppressed so parents are unaffected.
 					/* eslint-disable jsx-a11y/no-static-element-interactions */
-					<Fill name="RichText.Siblings">
+					<Fill name="VisualEditor.LastChild">
 						<div
 							className="blocks-format-toolbar__link-modal"
 							style={ linkStyle }

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -405,27 +405,13 @@ export default class RichText extends Component {
 	}
 
 	/**
-	 * Calculates the relative position where the link toolbar should be.
+	 * Calculates relative position for a link modal in the formatting toolbar.
 	 *
-	 * Based on the selection of the text inside this element a position is
-	 * calculated where the toolbar should be. This can be used downstream to
-	 * absolutely position the toolbar. It does this by finding the closest
-	 * relative element.
-	 *
-	 * @return {{top: number, left: number}} The desired position of the toolbar.
+	 * @return {{top: number, left: number}} Link modal position.
 	 */
 	getFocusPosition() {
 		const position = this.getEditorSelectionRect();
-
-		// Find the parent "relative" or "absolute" positioned container
-		const findRelativeParent = ( node ) => {
-			const style = window.getComputedStyle( node );
-			if ( style.position === 'relative' || style.position === 'absolute' ) {
-				return node;
-			}
-			return findRelativeParent( node.parentNode );
-		};
-		const container = findRelativeParent( this.editor.getBody() );
+		const container = this.editor.getBody().closest( '.edit-post-visual-editor' );
 		const containerPosition = container.getBoundingClientRect();
 		const toolbarOffset = { top: 10, left: 0 };
 		const linkModalWidth = 298;

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -182,6 +182,9 @@ export default class RichText extends Component {
 
 	onInit() {
 		this.registerCustomFormatters();
+
+		const focusPosition = this.getFocusPosition();
+		this.setState( { focusPosition } );
 	}
 
 	adaptFormatter( options ) {

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -16,7 +16,7 @@ $z-layers: (
 	'.components-panel__header': 1,
 	'.editor-meta-boxes-area.is-loading:before': 1,
 	'.editor-meta-boxes-area .spinner': 2,
-	'.blocks-format-toolbar__link-modal': 2,
+	'.blocks-format-toolbar__link-modal': 21, // Above aligned blocks
 	'.editor-block-contextual-toolbar': 2,
 	'.editor-block-switcher__menu': 2,
 	'.components-popover__close': 2,

--- a/edit-post/components/modes/visual-editor/index.js
+++ b/edit-post/components/modes/visual-editor/index.js
@@ -14,6 +14,7 @@ import {
 	BlockSelectionClearer,
 } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
+import { Slot } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -38,6 +39,7 @@ function VisualEditor( props ) {
 					) }
 				/>
 			</WritingFlow>
+			<Slot name="VisualEditor.LastChild" />
 		</BlockSelectionClearer>
 	);
 }


### PR DESCRIPTION
## Description
See: [#2206 Link modal box z-index bug](https://github.com/WordPress/gutenberg/issues/2206)

## Screenshots

### This PR resolves the link modal z-index problem.

Link modal now appears _above_ aligned blocks; e.g., floated image blocks.

![after](https://user-images.githubusercontent.com/1563559/34976882-f66c6aa0-fa44-11e7-9838-89bb1a7cbb68.png)

---

### Before, there was a bug in z-index.

Link modal appeared behind aligned blocks; e.g., floated image blocks.

![before](https://user-images.githubusercontent.com/1563559/34976859-e04dc3e0-fa44-11e7-8476-cbc6f50dd957.png)

## Types of changes
- Move link modal out of a block-specific stacking context,
  and into a new Slot, and therefore into a new stacking context.

- Now it becomes possible to set a proper z-index on
  the link modal, raising it above aligned blocks in
  the list; e.g., floated image blocks.

- Adjust calculation of focus position. Must account for the new
  stacking context we have in the new Slot `VisualEditor.LastChild`.

## How Has This Been Tested?
Tested in Chrome to confirm that positioning matches what was previously being calculated from the old stacking context, and that a link modal now appears above a sibling image block that's been aligned. I also tested the link modal when used in an inlineToolbar context; e.g., an image caption.

## Next Actions
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
---
- [x] Rebase on master branch.
- [x] Move `<Slot name="BlockList.Siblings" />` up two levels in the DOM and consider a different name for the Slot, see: https://github.com/WordPress/gutenberg/pull/4503#discussion_r164302129. Went with `VisualEditor.LastChild`.
- [x] Fix link modal position when linking a cover image, which appears to be a problem in the new `VisualEditor.LastChild`. Avoid problems by setting `focusPosition` on tinyMCE init.