### PR TITLE
Try `eslint-plugin-require-jsdoc-except` drop-in `require-jsdoc` ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
 	"plugins": [
 		"wordpress",
 		"react",
+		"require-jsdoc-except",
 		"jsx-a11y",
 		"jest"
 	],
@@ -180,14 +181,17 @@
 		"template-curly-spacing": [ "error", "always" ],
 		"valid-jsdoc": [ "error", { "requireReturn": false } ],
 		"valid-typeof": "error",
-		"yoda": "off"
-	},
-	"overrides": [
-		{
-			"files": [ "{blocks,components,date,editor,element,i18n,data,utils}/**/test/*.js" ],
-			"rules": {
-				"require-jsdoc": "off"
-			}
-		}
-	]
+		"yoda": "off",
+		"require-jsdoc": "off",
+		"require-jsdoc-except/require-jsdoc": [ "error", {
+			"require": {
+				"FunctionDeclaration": true,
+				"MethodDefinition": false,
+				"ClassDeclaration": true,
+				"ArrowFunctionExpression": true,
+				"FunctionExpression": true
+			},
+			"ignore": ["constructor", "render"]
+		} ]
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,16 +169,6 @@
 			"integrity": "sha512-Ey34vw8L2L1tFBLAsjCYlv24TVjzuU+sCUwONj8xMdlM5iNEHgj+AoMPR6C1LCijm/9Ue/FNAMffDe/lmKYWTA==",
 			"dev": true
 		},
-		"@romainberger/css-diff": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@romainberger/css-diff/-/css-diff-1.0.3.tgz",
-			"integrity": "sha1-ztOHU11PQqQqwf4TwJ3pf1rhNEw=",
-			"dev": true,
-			"requires": {
-				"lodash.merge": "4.6.0",
-				"postcss": "5.2.18"
-			}
-		},
 		"@types/autosize": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/@types/autosize/-/autosize-3.0.6.tgz",
@@ -326,12 +316,6 @@
 				"longest": "1.0.1",
 				"repeat-string": "1.6.1"
 			}
-		},
-		"alphanum-sort": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
-			"dev": true
 		},
 		"amdefine": {
 			"version": "1.0.1",
@@ -1671,18 +1655,6 @@
 				}
 			}
 		},
-		"caniuse-api": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-			"dev": true,
-			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-db": "1.0.30000783",
-				"lodash.memoize": "4.1.2",
-				"lodash.uniq": "4.5.0"
-			}
-		},
 		"caniuse-db": {
 			"version": "1.0.30000783",
 			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
@@ -1861,15 +1833,6 @@
 			"integrity": "sha1-yfTjffdKZVztckXTECC/W1zTTvY=",
 			"dev": true
 		},
-		"clap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3"
-			}
-		},
 		"classnames": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
@@ -1951,12 +1914,6 @@
 				}
 			}
 		},
-		"clone": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
-			"dev": true
-		},
 		"clone-deep": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
@@ -1986,15 +1943,6 @@
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
-		"coa": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-			"dev": true,
-			"requires": {
-				"q": "1.5.1"
-			}
-		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -2011,17 +1959,6 @@
 				"urlgrey": "0.4.4"
 			}
 		},
-		"color": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-			"dev": true,
-			"requires": {
-				"clone": "1.0.3",
-				"color-convert": "1.9.1",
-				"color-string": "0.3.0"
-			}
-		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -2034,26 +1971,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"color-string": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"colormin": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-			"dev": true,
-			"requires": {
-				"color": "0.11.4",
-				"css-color-names": "0.0.4",
-				"has": "1.0.1"
-			}
 		},
 		"colors": {
 			"version": "0.5.1",
@@ -2369,12 +2286,6 @@
 				"randomfill": "1.0.3"
 			}
 		},
-		"css-color-names": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-			"dev": true
-		},
 		"css-select": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -2392,56 +2303,6 @@
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
 			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
 			"dev": true
-		},
-		"cssnano": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
-			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-			"dev": true,
-			"requires": {
-				"autoprefixer": "6.7.7",
-				"decamelize": "1.2.0",
-				"defined": "1.0.0",
-				"has": "1.0.1",
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-calc": "5.3.1",
-				"postcss-colormin": "2.2.2",
-				"postcss-convert-values": "2.6.1",
-				"postcss-discard-comments": "2.0.4",
-				"postcss-discard-duplicates": "2.1.0",
-				"postcss-discard-empty": "2.1.0",
-				"postcss-discard-overridden": "0.1.1",
-				"postcss-discard-unused": "2.2.3",
-				"postcss-filter-plugins": "2.0.2",
-				"postcss-merge-idents": "2.1.7",
-				"postcss-merge-longhand": "2.0.2",
-				"postcss-merge-rules": "2.1.2",
-				"postcss-minify-font-values": "1.0.5",
-				"postcss-minify-gradients": "1.0.5",
-				"postcss-minify-params": "1.2.2",
-				"postcss-minify-selectors": "2.1.1",
-				"postcss-normalize-charset": "1.1.1",
-				"postcss-normalize-url": "3.0.8",
-				"postcss-ordered-values": "2.2.3",
-				"postcss-reduce-idents": "2.4.0",
-				"postcss-reduce-initial": "1.0.1",
-				"postcss-reduce-transforms": "1.0.4",
-				"postcss-svgo": "2.1.6",
-				"postcss-unique-selectors": "2.0.2",
-				"postcss-value-parser": "3.3.0",
-				"postcss-zindex": "2.2.0"
-			}
-		},
-		"csso": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-			"dev": true,
-			"requires": {
-				"clap": "1.2.3",
-				"source-map": "0.5.7"
-			}
 		},
 		"cssom": {
 			"version": "0.3.2",
@@ -2672,12 +2533,6 @@
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
 			}
-		},
-		"defined": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-			"dev": true
 		},
 		"del": {
 			"version": "2.2.2",
@@ -3464,6 +3319,16 @@
 				}
 			}
 		},
+		"eslint-plugin-require-jsdoc-except": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-require-jsdoc-except/-/eslint-plugin-require-jsdoc-except-1.1.0.tgz",
+			"integrity": "sha512-s2dT/DwtRA0+wbrhXBvghB5Q0pjThSo2j336RUJ7QhhiBmZPwiEcOUIe55N57ZuyOTorHsPQhr1uedmQeVBuPQ==",
+			"dev": true,
+			"requires": {
+				"lodash.assignin": "4.2.0",
+				"lodash.get": "4.4.2"
+			}
+		},
 		"eslint-plugin-wordpress": {
 			"version": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#327b6bdec434177a6e841bd3210e87627ccfcecb",
 			"requires": {
@@ -3912,30 +3777,6 @@
 				"pinkie-promise": "2.0.1"
 			}
 		},
-		"findup": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-			"integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
-			"dev": true,
-			"requires": {
-				"colors": "0.6.2",
-				"commander": "2.1.0"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-					"integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-					"dev": true
-				},
-				"commander": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-					"integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
-					"dev": true
-				}
-			}
-		},
 		"flat-cache": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
@@ -3947,12 +3788,6 @@
 				"graceful-fs": "4.1.11",
 				"write": "0.2.1"
 			}
-		},
-		"flatten": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
-			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -4022,13 +3857,15 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
 					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4038,18 +3875,21 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4059,42 +3899,49 @@
 				},
 				"asn1": {
 					"version": "0.2.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
 					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
 					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
 					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
 					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
 					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4103,7 +3950,8 @@
 				},
 				"block-stream": {
 					"version": "0.0.9",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
@@ -4111,7 +3959,8 @@
 				},
 				"boom": {
 					"version": "2.10.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
@@ -4119,7 +3968,8 @@
 				},
 				"brace-expansion": {
 					"version": "1.1.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
 					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
@@ -4128,29 +3978,34 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
 					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
@@ -4158,22 +4013,26 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
@@ -4181,7 +4040,8 @@
 				},
 				"dashdash": {
 					"version": "1.14.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4190,7 +4050,8 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -4198,7 +4059,8 @@
 				},
 				"debug": {
 					"version": "2.6.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4207,30 +4069,35 @@
 				},
 				"deep-extend": {
 					"version": "0.4.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
 					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+					"integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
 					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4239,24 +4106,28 @@
 				},
 				"extend": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
 					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
 					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4267,12 +4138,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
@@ -4283,7 +4156,8 @@
 				},
 				"fstream-ignore": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4294,7 +4168,8 @@
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4310,7 +4185,8 @@
 				},
 				"getpass": {
 					"version": "0.1.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4319,7 +4195,8 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -4327,7 +4204,8 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
@@ -4340,18 +4218,21 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
 					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4361,13 +4242,15 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
@@ -4378,12 +4261,14 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
 					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4394,7 +4279,8 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"requires": {
 						"once": "1.4.0",
@@ -4403,18 +4289,21 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
@@ -4422,24 +4311,28 @@
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4448,19 +4341,22 @@
 				},
 				"jsbn": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4469,19 +4365,22 @@
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
 					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4493,7 +4392,8 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -4501,12 +4401,14 @@
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
 					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
 					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
@@ -4514,7 +4416,8 @@
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
@@ -4522,12 +4425,14 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -4535,13 +4440,15 @@
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+					"integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4560,7 +4467,8 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4570,7 +4478,8 @@
 				},
 				"npmlog": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4582,24 +4491,28 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
@@ -4607,19 +4520,22 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4629,35 +4545,41 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
 					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4669,7 +4591,8 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
 						}
@@ -4677,7 +4600,8 @@
 				},
 				"readable-stream": {
 					"version": "2.2.9",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
 					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
@@ -4691,7 +4615,8 @@
 				},
 				"request": {
 					"version": "2.81.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4721,7 +4646,8 @@
 				},
 				"rimraf": {
 					"version": "2.6.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
@@ -4729,30 +4655,35 @@
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
 					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
@@ -4760,7 +4691,8 @@
 				},
 				"sshpk": {
 					"version": "1.13.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4777,7 +4709,8 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -4785,7 +4718,8 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
@@ -4795,7 +4729,8 @@
 				},
 				"string_decoder": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
 					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -4803,13 +4738,15 @@
 				},
 				"stringstream": {
 					"version": "0.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
 					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
@@ -4817,13 +4754,15 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
@@ -4833,7 +4772,8 @@
 				},
 				"tar-pack": {
 					"version": "3.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4849,7 +4789,8 @@
 				},
 				"tough-cookie": {
 					"version": "2.3.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4858,7 +4799,8 @@
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4867,30 +4809,35 @@
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
 					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
 					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4899,7 +4846,8 @@
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -4908,7 +4856,8 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				}
 			}
@@ -5291,12 +5240,6 @@
 			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.2.0.tgz",
 			"integrity": "sha1-nGGLI5YqLXPW6Cugh0l4vLNov6I="
 		},
-		"html-comment-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
-			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
-			"dev": true
-		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -5373,12 +5316,6 @@
 			"requires": {
 				"repeating": "2.0.1"
 			}
-		},
-		"indexes-of": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-			"dev": true
 		},
 		"indexof": {
 			"version": "0.0.1",
@@ -5541,12 +5478,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-		},
-		"is-absolute-url": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
-			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
-			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -5711,12 +5642,6 @@
 				"path-is-inside": "1.0.2"
 			}
 		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
-		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -5783,15 +5708,6 @@
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
 			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
 			"dev": true
-		},
-		"is-svg": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-			"dev": true,
-			"requires": {
-				"html-comment-regex": "1.1.1"
-			}
 		},
 		"is-symbol": {
 			"version": "1.0.1",
@@ -7368,6 +7284,12 @@
 			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
 			"dev": true
 		},
+		"lodash.assignin": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+			"dev": true
+		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -7383,6 +7305,12 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
 		},
 		"lodash.isarguments": {
@@ -7424,18 +7352,6 @@
 				"lodash.isarray": "3.0.4"
 			}
 		},
-		"lodash.memoize": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
-		},
-		"lodash.merge": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-			"integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
-			"dev": true
-		},
 		"lodash.mergewith": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
@@ -7452,12 +7368,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
 			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
-			"dev": true
-		},
-		"lodash.uniq": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -7511,12 +7421,6 @@
 				"pseudomap": "1.0.2"
 			}
 		},
-		"macaddress": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-			"dev": true
-		},
 		"make-dir": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
@@ -7559,12 +7463,6 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.5.tgz",
 			"integrity": "sha1-UpJZPmdUyxvMK5gDDk4Najr8nqE="
-		},
-		"math-expression-evaluator": {
-			"version": "1.2.17",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
-			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.4",
@@ -8097,18 +7995,6 @@
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
 			"dev": true
 		},
-		"normalize-url": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"dev": true,
-			"requires": {
-				"object-assign": "4.1.1",
-				"prepend-http": "1.0.4",
-				"query-string": "4.3.4",
-				"sort-keys": "1.1.2"
-			}
-		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -8567,94 +8453,6 @@
 				"supports-color": "3.2.3"
 			}
 		},
-		"postcss-calc": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-message-helpers": "2.0.0",
-				"reduce-css-calc": "1.3.0"
-			}
-		},
-		"postcss-colormin": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
-			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-			"dev": true,
-			"requires": {
-				"colormin": "1.1.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-convert-values": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
-			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-discard-comments": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
-			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-discard-duplicates": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
-			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-discard-empty": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
-			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-discard-overridden": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
-			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-discard-unused": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			}
-		},
-		"postcss-filter-plugins": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"uniqid": "4.1.1"
-			}
-		},
 		"postcss-load-config": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
@@ -8753,212 +8551,16 @@
 				}
 			}
 		},
-		"postcss-merge-idents": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
-			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-			"dev": true,
-			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-merge-longhand": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
-			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-merge-rules": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
-			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-			"dev": true,
-			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-api": "1.6.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3",
-				"vendors": "1.0.1"
-			}
-		},
-		"postcss-message-helpers": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
-			"dev": true
-		},
-		"postcss-minify-font-values": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
-			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-			"dev": true,
-			"requires": {
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-minify-gradients": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
-			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-minify-params": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
-			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-			"dev": true,
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"uniqs": "2.0.0"
-			}
-		},
-		"postcss-minify-selectors": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
-			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-			"dev": true,
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3"
-			}
-		},
-		"postcss-normalize-charset": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
-			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-normalize-url": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
-			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-			"dev": true,
-			"requires": {
-				"is-absolute-url": "2.1.0",
-				"normalize-url": "1.9.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-ordered-values": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
-			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-reduce-idents": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
-			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-reduce-initial": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
-			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-reduce-transforms": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
-			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-			"dev": true,
-			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-			"dev": true,
-			"requires": {
-				"flatten": "1.0.2",
-				"indexes-of": "1.0.1",
-				"uniq": "1.0.1"
-			}
-		},
-		"postcss-svgo": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
-			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-			"dev": true,
-			"requires": {
-				"is-svg": "2.1.0",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"svgo": "0.7.2"
-			}
-		},
-		"postcss-unique-selectors": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-			"dev": true,
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			}
-		},
 		"postcss-value-parser": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
 			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
 			"dev": true
 		},
-		"postcss-zindex": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
-			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-			"dev": true,
-			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			}
-		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
 		"preserve": {
@@ -9078,27 +8680,11 @@
 			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 			"dev": true
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
-		},
 		"qs": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
 			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
 			"dev": true
-		},
-		"query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"dev": true,
-			"requires": {
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
-			}
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -9463,42 +9049,6 @@
 				"strip-indent": "1.0.1"
 			}
 		},
-		"reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "0.4.2",
-				"math-expression-evaluator": "1.2.17",
-				"reduce-function-call": "1.0.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
-			}
-		},
-		"reduce-function-call": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "0.4.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
-			}
-		},
 		"redux": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
@@ -9782,73 +9332,6 @@
 			"requires": {
 				"lodash.flattendeep": "4.4.0",
 				"nearley": "2.11.0"
-			}
-		},
-		"rtlcss": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.2.1.tgz",
-			"integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
-			"dev": true,
-			"requires": {
-				"chalk": "2.3.0",
-				"findup": "0.1.5",
-				"mkdirp": "0.5.1",
-				"postcss": "6.0.14",
-				"strip-json-comments": "2.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
-				},
-				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
-					}
-				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "6.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-					"integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-					"dev": true,
-					"requires": {
-						"chalk": "2.3.0",
-						"source-map": "0.6.1",
-						"supports-color": "4.5.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "2.0.0"
-					}
-				}
 			}
 		},
 		"run-async": {
@@ -10282,15 +9765,6 @@
 				"hoek": "2.16.3"
 			}
 		},
-		"sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "1.1.0"
-			}
-		},
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -10416,12 +9890,6 @@
 			"integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
 			"dev": true
 		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"dev": true
-		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -10542,45 +10010,6 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "1.0.0"
-			}
-		},
-		"svgo": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-			"dev": true,
-			"requires": {
-				"coa": "1.0.4",
-				"colors": "1.1.2",
-				"csso": "2.3.2",
-				"js-yaml": "3.7.0",
-				"mkdirp": "0.5.1",
-				"sax": "1.2.4",
-				"whet.extend": "0.9.9"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-					"dev": true
-				},
-				"esprima": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-					"dev": true,
-					"requires": {
-						"argparse": "1.0.9",
-						"esprima": "2.7.3"
-					}
-				}
 			}
 		},
 		"symbol-observable": {
@@ -11016,27 +10445,6 @@
 			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
 			"dev": true
 		},
-		"uniq": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-			"dev": true
-		},
-		"uniqid": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-			"dev": true,
-			"requires": {
-				"macaddress": "0.2.8"
-			}
-		},
-		"uniqs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
-			"dev": true
-		},
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -11112,12 +10520,6 @@
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
 			}
-		},
-		"vendors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
-			"integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
-			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -11261,36 +10663,6 @@
 				}
 			}
 		},
-		"webpack-rtl-plugin": {
-			"version": "github:yoavf/webpack-rtl-plugin#fc5a2f20dd99fde8f86f297844aefde601780fa3",
-			"dev": true,
-			"requires": {
-				"@romainberger/css-diff": "1.0.3",
-				"async": "2.1.4",
-				"cssnano": "3.10.0",
-				"postcss": "5.2.18",
-				"rtlcss": "2.2.1",
-				"webpack-sources": "0.1.5"
-			},
-			"dependencies": {
-				"source-list-map": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
-					"integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
-					"dev": true
-				},
-				"webpack-sources": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
-					"integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-					"dev": true,
-					"requires": {
-						"source-list-map": "0.1.8",
-						"source-map": "0.5.7"
-					}
-				}
-			}
-		},
 		"webpack-sources": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
@@ -11333,12 +10705,6 @@
 				"tr46": "1.0.1",
 				"webidl-conversions": "4.0.2"
 			}
-		},
-		"whet.extend": {
-			"version": "0.9.9",
-			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
-			"dev": true
 		},
 		"which": {
 			"version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"eslint-plugin-jest": "21.5.0",
 		"eslint-plugin-jsx-a11y": "6.0.2",
 		"eslint-plugin-react": "7.5.1",
+		"eslint-plugin-require-jsdoc-except": "1.1.0",
 		"expose-loader": "0.7.3",
 		"extract-text-webpack-plugin": "3.0.0",
 		"gettext-parser": "1.3.0",


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Have ESLint not throw `require-jsdoc` for methods.

Try `eslint-plugin-require-jsdoc-except` drop-in `require-jsdoc` ESLint rule

Reference: #4504 #4245  

Bumped into this https://github.com/MaienM/eslint-plugin-require-jsdoc-except `require-jsdoc` drop-in rule that allows you to exclude certain methods from requiring a JSDoc.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

run `npm run lint`

I've also left in the `"ignore": ["constructor", "render"]` option for completeness though it's not required as `MethodDefinition` has been defined `false`

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

ESLint JSDoc linting

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.