### PR TITLE
Update theme progress color bar to match theme

### DIFF
--- a/editor/assets/stylesheets/_admin-schemes.scss
+++ b/editor/assets/stylesheets/_admin-schemes.scss
@@ -51,6 +51,19 @@ $scheme-sunrise__spot-color: #de823f;
 				border-color: $spot-color;
 			}
 		}
+
+		// Saving state indicators
+		.editor-post-publish-button.is-saving,
+		.editor-post-publish-button.is-saving:disabled {
+			// Yes, these need to be !important because they !important upstream too ¯\_(ツ)_/¯
+			border-color: darken( $spot-color, 10 ) darken( $spot-color, 20 ) darken( $spot-color, 20 ) !important;
+			box-shadow: 0 1px 0 darken( $spot-color, 20 ) !important;
+			text-shadow: 0 -1px 1px darken( $spot-color, 20 ), 1px 0 1px darken( $spot-color, 20 ), 0 1px 1px darken( $spot-color, 20 ), -1px 0 1px darken( $spot-color, 20 ) !important;
+
+			&:before {
+				background-image: repeating-linear-gradient( -45deg, darken( $spot-color, 20 ), darken( $spot-color, 20 ) 11px, darken( $spot-color, 10 ) 10px, darken( $spot-color, 10 ) 20px );
+			}
+		}
 	}
 }
 

--- a/editor/components/post-publish-button/style.scss
+++ b/editor/components/post-publish-button/style.scss
@@ -3,13 +3,13 @@
 	position: relative;
 
 	// These styles overrides the disabled state with the button primary styles
-	background: none !important;
-	border-color: #0073aa #006799 #006799 !important;
-	box-shadow: 0 1px 0 #006799 !important;
-	color: #fff !important;
-	text-decoration: none !important;
-	text-shadow: 0 -1px 1px #006799, 1px 0 1px #006799, 0 1px 1px #006799, -1px 0 1px #006799 !important;
 	opacity: 1;
+	background: none !important;
+	text-decoration: none !important;
+	color: $white !important;
+	border-color: $blue-wordpress $blue-wordpress-700 $blue-wordpress-700 !important;
+	box-shadow: 0 1px 0 $blue-wordpress-700 !important;
+	text-shadow: 0 -1px 1px $blue-wordpress-700, 1px 0 1px $blue-wordpress-700, 0 1px 1px $blue-wordpress-700, -1px 0 1px $blue-wordpress-700 !important;
 	// End of the overriding
 
 	&:hover {


### PR DESCRIPTION
This makes it so the animated updater matches the WordPress admin color scheme.

Screenshots:

![yellow](https://user-images.githubusercontent.com/1204802/34985861-d0607984-fab5-11e7-962f-460974c313e4.gif)

![brown](https://user-images.githubusercontent.com/1204802/34985865-d1b48b2c-fab5-11e7-8ede-dd267098ed6b.gif)

![ecto](https://user-images.githubusercontent.com/1204802/34985868-d333a942-fab5-11e7-8443-8c6575a2abee.gif)

![midnight](https://user-images.githubusercontent.com/1204802/34985872-d5423280-fab5-11e7-8128-1aca671ad550.gif)
