### PR TITLE
Try new button outline & focus styles

### DIFF
--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -857,7 +857,6 @@ export default class Dashicon extends wp.element.Component {
 
 		return (
 			<svg
-				tabindex="-1"
 				aria-hidden
 				role="img"
 				focusable="false"

--- a/components/dashicon/index.js
+++ b/components/dashicon/index.js
@@ -857,6 +857,7 @@ export default class Dashicon extends wp.element.Component {
 
 		return (
 			<svg
+				tabindex="-1"
 				aria-hidden
 				role="img"
 				focusable="false"

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -22,4 +22,14 @@
 	&:not( :disabled ):hover {
 		@include button-style__hover;
 	}
+
+	&:not( :disabled ):active {
+		@include button-style__active;
+	}
+
+	&[aria-disabled=true]:focus,
+	&:disabled:focus {
+		box-shadow: none;
+	}
+
 }

--- a/editor/assets/stylesheets/_mixins.scss
+++ b/editor/assets/stylesheets/_mixins.scss
@@ -121,31 +121,25 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 }
 
 @mixin button-style__hover {
-	color: $dark-gray-900;	// previously $blue-medium-500
+	color: $dark-gray-900;
 	box-shadow: inset 0 0 0 1px $light-gray-500, inset 0 0 0 2px $white;
 }
 
 @mixin button-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;
-	//box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
-	//background: $light-gray-300;
 	box-shadow: inset 0 0 0 1px $dark-gray-300, inset 0 0 0 2px $white;
 }
 
 @mixin button-style__active() {
 	outline: none;
 	color: $dark-gray-900;
-	//box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
-	//background: $light-gray-300;
 	box-shadow: inset 0 0 0 1px $dark-gray-400, inset 0 0 0 2px $white, 0 1px 1px rgba( $dark-gray-900, .2 );
 }
 
 @mixin tab-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;
-	//box-shadow: 0 0 0 1px $dark-gray-500;
-	//background: $light-gray-300;
 	box-shadow: inset 0 0 0 1px $dark-gray-300;
 }
 

--- a/editor/assets/stylesheets/_mixins.scss
+++ b/editor/assets/stylesheets/_mixins.scss
@@ -125,16 +125,16 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 	box-shadow: inset 0 0 0 1px $light-gray-500, inset 0 0 0 2px $white;
 }
 
+@mixin button-style__active() {
+	outline: none;
+	color: $dark-gray-900;
+	box-shadow: inset 0 0 0 1px $light-gray-700, inset 0 0 0 2px $white, 0 1px 1px rgba( $dark-gray-900, .2 );
+}
+
 @mixin button-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;
 	box-shadow: inset 0 0 0 1px $dark-gray-300, inset 0 0 0 2px $white;
-}
-
-@mixin button-style__active() {
-	outline: none;
-	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $dark-gray-400, inset 0 0 0 2px $white, 0 1px 1px rgba( $dark-gray-900, .2 );
 }
 
 @mixin tab-style__focus-active() {
@@ -146,7 +146,6 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 @mixin input-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;
-	//box-shadow: 0 0 0 1px $dark-gray-500;
 	box-shadow: 0 0 0 1px $dark-gray-300;
 }
 

--- a/editor/assets/stylesheets/_mixins.scss
+++ b/editor/assets/stylesheets/_mixins.scss
@@ -122,13 +122,13 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 
 @mixin button-style__hover {
 	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $light-gray-500, inset 0 0 0 2px $white;
+	box-shadow: inset 0 0 0 1px $light-gray-500, inset 0 0 0 2px $white, 0 1px 1px rgba( $dark-gray-900, .2 );
 }
 
 @mixin button-style__active() {
 	outline: none;
 	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $light-gray-700, inset 0 0 0 2px $white, 0 1px 1px rgba( $dark-gray-900, .2 );
+	box-shadow: inset 0 0 0 1px $light-gray-700, inset 0 0 0 2px $white;
 }
 
 @mixin button-style__focus-active() {

--- a/editor/assets/stylesheets/_mixins.scss
+++ b/editor/assets/stylesheets/_mixins.scss
@@ -122,26 +122,38 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 
 @mixin button-style__hover {
 	color: $dark-gray-900;	// previously $blue-medium-500
+	box-shadow: inset 0 0 0 1px $light-gray-500, inset 0 0 0 2px $white;
 }
 
 @mixin button-style__focus-active() {
 	outline: none;
-	box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
 	color: $dark-gray-900;
-	background: $light-gray-300;
+	//box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
+	//background: $light-gray-300;
+	box-shadow: inset 0 0 0 1px $dark-gray-300, inset 0 0 0 2px $white;
+}
+
+@mixin button-style__active() {
+	outline: none;
+	color: $dark-gray-900;
+	//box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
+	//background: $light-gray-300;
+	box-shadow: inset 0 0 0 1px $dark-gray-400, inset 0 0 0 2px $white, 0 1px 1px rgba( $dark-gray-900, .2 );
 }
 
 @mixin tab-style__focus-active() {
 	outline: none;
-	box-shadow: 0 0 0 1px $dark-gray-500;
 	color: $dark-gray-900;
-	background: $light-gray-300;
+	//box-shadow: 0 0 0 1px $dark-gray-500;
+	//background: $light-gray-300;
+	box-shadow: inset 0 0 0 1px $dark-gray-300;
 }
 
 @mixin input-style__focus-active() {
 	outline: none;
-	box-shadow: 0 0 0 1px $dark-gray-500;
 	color: $dark-gray-900;
+	//box-shadow: 0 0 0 1px $dark-gray-500;
+	box-shadow: 0 0 0 1px $dark-gray-300;
 }
 
 /**

--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -30,6 +30,7 @@ body.gutenberg-editor-page {
 
 	svg {
 		fill: currentColor;
+		outline: none;
 	}
 
 	ul#adminmenu a.wp-has-current-submenu:after,

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -20,30 +20,15 @@
 		margin-bottom: 4px;
 	}
 
-	// unstyle inherited icon button styles
-	&:not(:disabled):hover,
-  	&:not(:disabled):active,
-	&:not(:disabled):focus {
-		box-shadow: none;
-		color: inherit;
-	}
-
-	// apply styles to SVG directly
-	.dashicon {
-		display: block;
-		position: relative; // Fixing the Safari bug for `<button>`s overflow
-		border-radius: 50%;
-	}
-
-	&:not(:disabled):hover .dashicon {
+	&:not(:disabled):hover {
 		@include button-style__hover;
 	}
 
-	&:not(:disabled):active .dashicon {
+	&:not(:disabled):active {
 		@include button-style__active;
 	}
 
-	&:not(:disabled):focus .dashicon {
+	&:not(:disabled):focus {
 		@include button-style__focus-active;
 	}
 }

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -16,11 +16,34 @@
 		pointer-events: none;
 	}
 
-	.dashicon {
-		display: block;
-	}
-
 	&:first-child {
 		margin-bottom: 4px;
+	}
+
+	// unstyle inherited icon button styles
+	&:not(:disabled):hover,
+  	&:not(:disabled):active,
+	&:not(:disabled):focus {
+		box-shadow: none;
+		color: inherit;
+	}
+
+	// apply styles to SVG directly
+	.dashicon {
+		display: block;
+		position: relative; // Fixing the Safari bug for `<button>`s overflow
+		border-radius: 50%;
+	}
+
+	&:not(:disabled):hover .dashicon {
+		@include button-style__hover;
+	}
+
+	&:not(:disabled):active .dashicon {
+		@include button-style__active;
+	}
+
+	&:not(:disabled):focus .dashicon {
+		@include button-style__focus-active;
 	}
 }

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -18,8 +18,11 @@
 .editor-block-settings-menu__toggle {
 	border-radius: 50%;
 	padding: 3px;
-	transform: rotate( 90deg );
 	width: auto;
+
+	.dashicon {
+		transform: rotate( 90deg );
+	}
 }
 
 .editor-block-settings-menu__control {

--- a/editor/edit-post/header/style.scss
+++ b/editor/edit-post/header/style.scss
@@ -55,6 +55,7 @@
 		left: 1px;
 	}
 
+	&.is-toggled:hover,
 	&.is-toggled:focus {
 		outline: none;
 		box-shadow: 0 0 0 1px $dark-gray-500, inset 0 0 0 1px $white;


### PR DESCRIPTION
This takes another stab at improving the button outline and focus styles, making them less distracting. Fixes #3733.

Additionally it adds a hover style, which shows the clickable area of the button, as well as an active state, making it more clear that you're clicking.

Hover:

<img width="92" alt="screen shot 2018-01-16 at 13 16 05" src="https://user-images.githubusercontent.com/1204802/34988704-dde686c0-fabf-11e7-9d53-f6706d3be8e9.png">

Active:

<img width="68" alt="screen shot 2018-01-16 at 13 15 49" src="https://user-images.githubusercontent.com/1204802/34988707-e2b3480a-fabf-11e7-9eaf-8cc5155c188e.png">

Focus:

<img width="67" alt="screen shot 2018-01-16 at 13 15 59" src="https://user-images.githubusercontent.com/1204802/34988709-e6706b80-fabf-11e7-97a9-6c7f83aacf68.png">

The addition of `tabindex="-1"` to the SVG sprite changes the behavior of focus styles on the movers to make them less distracting. Given the SVG sprite already has `aria-hidden` and `focusable="false"`, I don't expect this to cause issues, but worth sanity checking for accessibility regardless. 