### PR TITLE
Blocks: Defer registration of all core blocks until editor loads

### DIFF
--- a/blocks/api/raw-handling/test/integration/index.js
+++ b/blocks/api/raw-handling/test/integration/index.js
@@ -8,6 +8,7 @@ import path from 'path';
 /**
  * Internal dependencies
  */
+import { registerCoreBlocks } from '../../../../library';
 import rawHandler from '../../index';
 import serialize from '../../../serializer';
 
@@ -23,8 +24,7 @@ describe( 'raw handling: integration', () => {
 	beforeAll( () => {
 		// Load all hooks that modify blocks
 		require( 'blocks/hooks' );
-		// Load all blocks
-		require( 'blocks/library' );
+		registerCoreBlocks();
 	} );
 
 	types.forEach( ( type ) => {

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import './hooks';
-import './library';
 
 // A "block" is the abstract term used to describe units of markup that,
 // when composed together, form the content or layout of a page.
@@ -14,6 +13,7 @@ import './library';
 // Blocks are inferred from the HTML source of a post through a parsing mechanism
 // and then stored as objects in state, from which it is then rendered for editing.
 export * from './api';
+export { registerCoreBlocks } from './library';
 export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockControls } from './block-controls';

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -14,13 +14,14 @@ import { Component } from '@wordpress/element';
  */
 import './style.scss';
 import './editor.scss';
-import { registerBlockType } from '../../api';
 import MediaUpload from '../../media-upload';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-export const registerAudioBlock = () => registerBlockType( 'core/audio', {
+export const name = 'core/audio';
+
+export const settings = {
 	title: __( 'Audio' ),
 
 	description: __( 'The Audio block allows you to embed audio files and play them back using a simple player.' ),
@@ -178,4 +179,4 @@ export const registerAudioBlock = () => registerBlockType( 'core/audio', {
 			</figure>
 		);
 	},
-} );
+};

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -20,7 +20,7 @@ import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-registerBlockType( 'core/audio', {
+export const registerAudioBlock = () => registerBlockType( 'core/audio', {
 	title: __( 'Audio' ),
 
 	description: __( 'The Audio block allows you to embed audio files and play them back using a simple player.' ),

--- a/blocks/library/audio/test/index.js
+++ b/blocks/library/audio/test/index.js
@@ -1,18 +1,14 @@
 /**
  * Internal dependencies
  */
-import { registerAudioBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
 
 describe( 'core/audio', () => {
-	beforeAll( () => {
-		registerAudioBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/audio' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/audio/test/index.js
+++ b/blocks/library/audio/test/index.js
@@ -1,12 +1,16 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerAudioBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
 
 describe( 'core/audio', () => {
+	beforeAll( () => {
+		registerAudioBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/audio' );
 

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -156,7 +156,7 @@ const ConnectedReusableBlockEdit = connect(
 	} )
 )( ReusableBlockEdit );
 
-registerBlockType( 'core/block', {
+export const registerReusableBlock = () => registerBlockType( 'core/block', {
 	title: __( 'Reusable Block' ),
 	category: 'reusable-blocks',
 	isPrivate: true,

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -15,7 +15,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockEdit from '../../block-edit';
-import { registerBlockType } from '../../api';
 import ReusableBlockEditPanel from './edit-panel';
 
 class ReusableBlockEdit extends Component {
@@ -156,7 +155,9 @@ const ConnectedReusableBlockEdit = connect(
 	} )
 )( ReusableBlockEdit );
 
-export const registerReusableBlock = () => registerBlockType( 'core/block', {
+export const name = 'core/block';
+
+export const settings = {
 	title: __( 'Reusable Block' ),
 	category: 'reusable-blocks',
 	isPrivate: true,
@@ -174,4 +175,4 @@ export const registerReusableBlock = () => registerBlockType( 'core/block', {
 
 	edit: ConnectedReusableBlockEdit,
 	save: () => null,
-} );
+};

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -10,7 +10,6 @@ import { Dashicon, IconButton, PanelColor, withFallbackStyles } from '@wordpress
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType } from '../../api';
 import Editable from '../../editable';
 import UrlInput from '../../url-input';
 import BlockControls from '../../block-controls';
@@ -173,7 +172,9 @@ const blockAttributes = {
 	},
 };
 
-export const registerButtonBlock = () => registerBlockType( 'core/button', {
+export const name = 'core/button';
+
+export const settings = {
 	title: __( 'Button' ),
 
 	description: __( 'A nice little button. Call something out with it.' ),
@@ -235,4 +236,4 @@ export const registerButtonBlock = () => registerBlockType( 'core/button', {
 			);
 		},
 	} ],
-} );
+};

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -173,7 +173,7 @@ const blockAttributes = {
 	},
 };
 
-registerBlockType( 'core/button', {
+export const registerButtonBlock = () => registerBlockType( 'core/button', {
 	title: __( 'Button' ),
 
 	description: __( 'A nice little button. Call something out with it.' ),

--- a/blocks/library/button/test/index.js
+++ b/blocks/library/button/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerButtonBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/button', () => {
-	beforeAll( () => {
-		registerButtonBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/button' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/button/test/index.js
+++ b/blocks/library/button/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerButtonBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/button', () => {
+	beforeAll( () => {
+		registerButtonBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/button' );
 

--- a/blocks/library/categories/index.js
+++ b/blocks/library/categories/index.js
@@ -8,10 +8,11 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType } from '../../api';
 import CategoriesBlock from './block';
 
-export const registerCategoriesBlock = () => registerBlockType( 'core/categories', {
+export const name = 'core/categories';
+
+export const settings = {
 	title: __( 'Categories' ),
 
 	description: __( 'Shows a list of your site\'s categories.' ),
@@ -54,4 +55,4 @@ export const registerCategoriesBlock = () => registerBlockType( 'core/categories
 	save() {
 		return null;
 	},
-} );
+};

--- a/blocks/library/categories/index.js
+++ b/blocks/library/categories/index.js
@@ -11,7 +11,7 @@ import './style.scss';
 import { registerBlockType } from '../../api';
 import CategoriesBlock from './block';
 
-registerBlockType( 'core/categories', {
+export const registerCategoriesBlock = () => registerBlockType( 'core/categories', {
 	title: __( 'Categories' ),
 
 	description: __( 'Shows a list of your site\'s categories.' ),

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import { registerBlockType, createBlock } from '../../api';
 
-registerBlockType( 'core/code', {
+export const registerCodeBlock = () => registerBlockType( 'core/code', {
 	title: __( 'Code' ),
 
 	description: __( 'The code block maintains spaces and tabs, great for showing code snippets.' ),

--- a/blocks/library/code/index.js
+++ b/blocks/library/code/index.js
@@ -12,9 +12,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 
-export const registerCodeBlock = () => registerBlockType( 'core/code', {
+export const name = 'core/code';
+
+export const settings = {
 	title: __( 'Code' ),
 
 	description: __( 'The code block maintains spaces and tabs, great for showing code snippets.' ),
@@ -71,4 +73,4 @@ export const registerCodeBlock = () => registerBlockType( 'core/code', {
 	save( { attributes } ) {
 		return <pre><code>{ attributes.content }</code></pre>;
 	},
-} );
+};

--- a/blocks/library/code/test/index.js
+++ b/blocks/library/code/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerCodeBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/code', () => {
+	beforeAll( () => {
+		registerCodeBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/code' );
 

--- a/blocks/library/code/test/index.js
+++ b/blocks/library/code/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerCodeBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/code', () => {
-	beforeAll( () => {
-		registerCodeBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/code' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -28,7 +28,7 @@ import RangeControl from '../../inspector-controls/range-control';
 
 const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
 
-registerBlockType( 'core/cover-image', {
+export const registerCoverImageBlock = () => registerBlockType( 'core/cover-image', {
 	title: __( 'Cover Image' ),
 
 	description: __( 'Cover Image is a bold image block with an optional title.' ),

--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -15,7 +15,7 @@ import classnames from 'classnames';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import Editable from '../../editable';
 import AlignmentToolbar from '../../alignment-toolbar';
 import MediaUpload from '../../media-upload';
@@ -28,7 +28,9 @@ import RangeControl from '../../inspector-controls/range-control';
 
 const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
 
-export const registerCoverImageBlock = () => registerBlockType( 'core/cover-image', {
+export const name = 'core/cover-image';
+
+export const settings = {
 	title: __( 'Cover Image' ),
 
 	description: __( 'Cover Image is a bold image block with an optional title.' ),
@@ -234,7 +236,7 @@ export const registerCoverImageBlock = () => registerBlockType( 'core/cover-imag
 			</section>
 		);
 	},
-} );
+};
 
 function dimRatioToClass( ratio ) {
 	return ( ratio === 0 || ratio === 50 ) ?

--- a/blocks/library/cover-image/test/index.js
+++ b/blocks/library/cover-image/test/index.js
@@ -1,18 +1,14 @@
 /**
  * Internal dependencies
  */
-import { registerCoverImageBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
 
 describe( 'core/cover-image', () => {
-	beforeAll( () => {
-		registerCoverImageBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/cover-image' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/cover-image/test/index.js
+++ b/blocks/library/cover-image/test/index.js
@@ -1,12 +1,16 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerCoverImageBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
 
 describe( 'core/cover-image', () => {
+	beforeAll( () => {
+		registerCoverImageBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/cover-image' );
 

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -237,7 +237,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 	};
 }
 
-registerBlockType(
+export const registerEmbedBlock = () => registerBlockType(
 	'core/embed',
 	getEmbedBlockSettings( {
 		title: __( 'Embed' ),
@@ -258,246 +258,248 @@ registerBlockType(
 	} )
 );
 
-// Common
-registerBlockType(
-	'core-embed/twitter',
-	getEmbedBlockSettings( {
-		title: 'Twitter',
-		icon: 'embed-post',
-		keywords: [ __( 'tweet' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/youtube',
-	getEmbedBlockSettings( {
-		title: 'YouTube',
-		icon: 'embed-video',
-		keywords: [ __( 'music' ), __( 'video' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/facebook',
-	getEmbedBlockSettings( {
-		title: 'Facebook',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/instagram',
-	getEmbedBlockSettings( {
-		title: 'Instagram',
-		icon: 'embed-photo',
-		keywords: [ __( 'image' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/wordpress',
-	getEmbedBlockSettings( {
-		title: 'WordPress',
-		icon: 'embed-post',
-		keywords: [ __( 'post' ), __( 'blog' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/soundcloud',
-	getEmbedBlockSettings( {
-		title: 'SoundCloud',
-		icon: 'embed-audio',
-		keywords: [ __( 'music' ), __( 'audio' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/spotify',
-	getEmbedBlockSettings( {
-		title: 'Spotify',
-		icon: 'embed-audio',
-		keywords: [ __( 'music' ), __( 'audio' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/flickr',
-	getEmbedBlockSettings( {
-		title: 'Flickr',
-		icon: 'embed-photo',
-		keywords: [ __( 'image' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/vimeo',
-	getEmbedBlockSettings( {
-		title: 'Vimeo',
-		icon: 'embed-video',
-		keywords: [ __( 'video' ) ],
-	} )
-);
+export const registerCommonEmbedBlocks = () => {
+	registerBlockType(
+		'core-embed/twitter',
+		getEmbedBlockSettings( {
+			title: 'Twitter',
+			icon: 'embed-post',
+			keywords: [ __( 'tweet' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/youtube',
+		getEmbedBlockSettings( {
+			title: 'YouTube',
+			icon: 'embed-video',
+			keywords: [ __( 'music' ), __( 'video' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/facebook',
+		getEmbedBlockSettings( {
+			title: 'Facebook',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/instagram',
+		getEmbedBlockSettings( {
+			title: 'Instagram',
+			icon: 'embed-photo',
+			keywords: [ __( 'image' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/wordpress',
+		getEmbedBlockSettings( {
+			title: 'WordPress',
+			icon: 'embed-post',
+			keywords: [ __( 'post' ), __( 'blog' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/soundcloud',
+		getEmbedBlockSettings( {
+			title: 'SoundCloud',
+			icon: 'embed-audio',
+			keywords: [ __( 'music' ), __( 'audio' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/spotify',
+		getEmbedBlockSettings( {
+			title: 'Spotify',
+			icon: 'embed-audio',
+			keywords: [ __( 'music' ), __( 'audio' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/flickr',
+		getEmbedBlockSettings( {
+			title: 'Flickr',
+			icon: 'embed-photo',
+			keywords: [ __( 'image' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/vimeo',
+		getEmbedBlockSettings( {
+			title: 'Vimeo',
+			icon: 'embed-video',
+			keywords: [ __( 'video' ) ],
+		} )
+	);
+};
 
-// Others
-registerBlockType(
-	'core-embed/animoto',
-	getEmbedBlockSettings( {
-		title: 'Animoto',
-		icon: 'embed-video',
-	} )
-);
-registerBlockType(
-	'core-embed/cloudup',
-	getEmbedBlockSettings( {
-		title: 'Cloudup',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/collegehumor',
-	getEmbedBlockSettings( {
-		title: 'CollegeHumor',
-		icon: 'embed-video',
-	} )
-);
-registerBlockType(
-	'core-embed/dailymotion',
-	getEmbedBlockSettings( {
-		title: 'Dailymotion',
-		icon: 'embed-video',
-	} )
-);
-registerBlockType(
-	'core-embed/funnyordie',
-	getEmbedBlockSettings( {
-		title: 'Funny or Die',
-		icon: 'embed-video',
-	} ) );
-registerBlockType(
-	'core-embed/hulu',
-	getEmbedBlockSettings( {
-		title: 'Hulu',
-		icon: 'embed-video',
-	} )
-);
-registerBlockType(
-	'core-embed/imgur',
-	getEmbedBlockSettings( {
-		title: 'Imgur',
-		icon: 'embed-photo',
-	} )
-);
-registerBlockType(
-	'core-embed/issuu',
-	getEmbedBlockSettings( {
-		title: 'Issuu',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/kickstarter',
-	getEmbedBlockSettings( {
-		title: 'Kickstarter',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/meetup-com',
-	getEmbedBlockSettings( {
-		title: 'Meetup.com',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/mixcloud',
-	getEmbedBlockSettings( {
-		title: 'Mixcloud',
-		icon: 'embed-audio',
-		keywords: [ __( 'music' ), __( 'audio' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/photobucket',
-	getEmbedBlockSettings( {
-		title: 'Photobucket',
-		icon: 'embed-photo',
-	} )
-);
-registerBlockType(
-	'core-embed/polldaddy',
-	getEmbedBlockSettings( {
-		title: 'Polldaddy',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/reddit',
-	getEmbedBlockSettings( {
-		title: 'Reddit',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/reverbnation',
-	getEmbedBlockSettings( {
-		title: 'ReverbNation',
-		icon: 'embed-audio',
-	} )
-);
-registerBlockType(
-	'core-embed/screencast',
-	getEmbedBlockSettings( {
-		title: 'Screencast',
-		icon: 'embed-video',
-	} )
-);
-registerBlockType(
-	'core-embed/scribd',
-	getEmbedBlockSettings( {
-		title: 'Scribd',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/slideshare',
-	getEmbedBlockSettings( {
-		title: 'Slideshare',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/smugmug',
-	getEmbedBlockSettings( {
-		title: 'SmugMug',
-		icon: 'embed-photo',
-	} )
-);
-registerBlockType(
-	'core-embed/speaker',
-	getEmbedBlockSettings( {
-		title: 'Speaker',
-		icon: 'embed-audio',
-	} )
-);
-registerBlockType(
-	'core-embed/ted',
-	getEmbedBlockSettings( {
-		title: 'TED',
-		icon: 'embed-video',
-	} )
-);
-registerBlockType(
-	'core-embed/tumblr',
-	getEmbedBlockSettings( {
-		title: 'Tumblr',
-		icon: 'embed-post',
-	} )
-);
-registerBlockType(
-	'core-embed/videopress',
-	getEmbedBlockSettings( {
-		title: 'VideoPress',
-		icon: 'embed-video',
-		keywords: [ __( 'video' ) ],
-	} )
-);
-registerBlockType(
-	'core-embed/wordpress-tv',
-	getEmbedBlockSettings( {
-		title: 'WordPress.tv',
-		icon: 'embed-video',
-	} )
-);
+export const registerOtherEmbedBlocks = () => {
+	registerBlockType(
+		'core-embed/animoto',
+		getEmbedBlockSettings( {
+			title: 'Animoto',
+			icon: 'embed-video',
+		} )
+	);
+	registerBlockType(
+		'core-embed/cloudup',
+		getEmbedBlockSettings( {
+			title: 'Cloudup',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/collegehumor',
+		getEmbedBlockSettings( {
+			title: 'CollegeHumor',
+			icon: 'embed-video',
+		} )
+	);
+	registerBlockType(
+		'core-embed/dailymotion',
+		getEmbedBlockSettings( {
+			title: 'Dailymotion',
+			icon: 'embed-video',
+		} )
+	);
+	registerBlockType(
+		'core-embed/funnyordie',
+		getEmbedBlockSettings( {
+			title: 'Funny or Die',
+			icon: 'embed-video',
+		} ) );
+	registerBlockType(
+		'core-embed/hulu',
+		getEmbedBlockSettings( {
+			title: 'Hulu',
+			icon: 'embed-video',
+		} )
+	);
+	registerBlockType(
+		'core-embed/imgur',
+		getEmbedBlockSettings( {
+			title: 'Imgur',
+			icon: 'embed-photo',
+		} )
+	);
+	registerBlockType(
+		'core-embed/issuu',
+		getEmbedBlockSettings( {
+			title: 'Issuu',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/kickstarter',
+		getEmbedBlockSettings( {
+			title: 'Kickstarter',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/meetup-com',
+		getEmbedBlockSettings( {
+			title: 'Meetup.com',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/mixcloud',
+		getEmbedBlockSettings( {
+			title: 'Mixcloud',
+			icon: 'embed-audio',
+			keywords: [ __( 'music' ), __( 'audio' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/photobucket',
+		getEmbedBlockSettings( {
+			title: 'Photobucket',
+			icon: 'embed-photo',
+		} )
+	);
+	registerBlockType(
+		'core-embed/polldaddy',
+		getEmbedBlockSettings( {
+			title: 'Polldaddy',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/reddit',
+		getEmbedBlockSettings( {
+			title: 'Reddit',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/reverbnation',
+		getEmbedBlockSettings( {
+			title: 'ReverbNation',
+			icon: 'embed-audio',
+		} )
+	);
+	registerBlockType(
+		'core-embed/screencast',
+		getEmbedBlockSettings( {
+			title: 'Screencast',
+			icon: 'embed-video',
+		} )
+	);
+	registerBlockType(
+		'core-embed/scribd',
+		getEmbedBlockSettings( {
+			title: 'Scribd',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/slideshare',
+		getEmbedBlockSettings( {
+			title: 'Slideshare',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/smugmug',
+		getEmbedBlockSettings( {
+			title: 'SmugMug',
+			icon: 'embed-photo',
+		} )
+	);
+	registerBlockType(
+		'core-embed/speaker',
+		getEmbedBlockSettings( {
+			title: 'Speaker',
+			icon: 'embed-audio',
+		} )
+	);
+	registerBlockType(
+		'core-embed/ted',
+		getEmbedBlockSettings( {
+			title: 'TED',
+			icon: 'embed-video',
+		} )
+	);
+	registerBlockType(
+		'core-embed/tumblr',
+		getEmbedBlockSettings( {
+			title: 'Tumblr',
+			icon: 'embed-post',
+		} )
+	);
+	registerBlockType(
+		'core-embed/videopress',
+		getEmbedBlockSettings( {
+			title: 'VideoPress',
+			icon: 'embed-video',
+			keywords: [ __( 'video' ) ],
+		} )
+	);
+	registerBlockType(
+		'core-embed/wordpress-tv',
+		getEmbedBlockSettings( {
+			title: 'WordPress.tv',
+			icon: 'embed-video',
+		} )
+	);
+};

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -239,7 +239,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 
 export const name = 'core/embed';
 
-export const settings =	getEmbedBlockSettings( {
+export const settings = getEmbedBlockSettings( {
 	title: __( 'Embed' ),
 	icon: 'embed-generic',
 	transforms: {

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -17,7 +17,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import './style.scss';
 import './editor.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
@@ -237,269 +237,269 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 	};
 }
 
-export const registerEmbedBlock = () => registerBlockType(
-	'core/embed',
-	getEmbedBlockSettings( {
-		title: __( 'Embed' ),
-		icon: 'embed-generic',
-		transforms: {
-			from: [
-				{
-					type: 'raw',
-					isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*/i.test( node.textContent ),
-					transform: ( node ) => {
-						return createBlock( 'core/embed', {
-							url: node.textContent.trim(),
-						} );
-					},
-				},
-			],
-		},
-	} )
-);
+export const name = 'core/embed';
 
-export const registerCommonEmbedBlocks = () => {
-	registerBlockType(
-		'core-embed/twitter',
-		getEmbedBlockSettings( {
+export const settings =	getEmbedBlockSettings( {
+	title: __( 'Embed' ),
+	icon: 'embed-generic',
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*/i.test( node.textContent ),
+				transform: ( node ) => {
+					return createBlock( 'core/embed', {
+						url: node.textContent.trim(),
+					} );
+				},
+			},
+		],
+	},
+} );
+
+export const common = [
+	{
+		name: 'core-embed/twitter',
+		settings: getEmbedBlockSettings( {
 			title: 'Twitter',
 			icon: 'embed-post',
 			keywords: [ __( 'tweet' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/youtube',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/youtube',
+		settings: getEmbedBlockSettings( {
 			title: 'YouTube',
 			icon: 'embed-video',
 			keywords: [ __( 'music' ), __( 'video' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/facebook',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/facebook',
+		settings: getEmbedBlockSettings( {
 			title: 'Facebook',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/instagram',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/instagram',
+		settings: getEmbedBlockSettings( {
 			title: 'Instagram',
 			icon: 'embed-photo',
 			keywords: [ __( 'image' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/wordpress',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/wordpress',
+		settings: getEmbedBlockSettings( {
 			title: 'WordPress',
 			icon: 'embed-post',
 			keywords: [ __( 'post' ), __( 'blog' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/soundcloud',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/soundcloud',
+		settings: getEmbedBlockSettings( {
 			title: 'SoundCloud',
 			icon: 'embed-audio',
 			keywords: [ __( 'music' ), __( 'audio' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/spotify',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/spotify',
+		settings: getEmbedBlockSettings( {
 			title: 'Spotify',
 			icon: 'embed-audio',
 			keywords: [ __( 'music' ), __( 'audio' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/flickr',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/flickr',
+		settings: getEmbedBlockSettings( {
 			title: 'Flickr',
 			icon: 'embed-photo',
 			keywords: [ __( 'image' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/vimeo',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/vimeo',
+		settings: getEmbedBlockSettings( {
 			title: 'Vimeo',
 			icon: 'embed-video',
 			keywords: [ __( 'video' ) ],
-		} )
-	);
-};
+		} ),
+	},
+];
 
-export const registerOtherEmbedBlocks = () => {
-	registerBlockType(
-		'core-embed/animoto',
-		getEmbedBlockSettings( {
+export const others = [
+	{
+		name: 'core-embed/animoto',
+		settings: getEmbedBlockSettings( {
 			title: 'Animoto',
 			icon: 'embed-video',
-		} )
-	);
-	registerBlockType(
-		'core-embed/cloudup',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/cloudup',
+		settings: getEmbedBlockSettings( {
 			title: 'Cloudup',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/collegehumor',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/collegehumor',
+		settings: getEmbedBlockSettings( {
 			title: 'CollegeHumor',
 			icon: 'embed-video',
-		} )
-	);
-	registerBlockType(
-		'core-embed/dailymotion',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/dailymotion',
+		settings: getEmbedBlockSettings( {
 			title: 'Dailymotion',
 			icon: 'embed-video',
-		} )
-	);
-	registerBlockType(
-		'core-embed/funnyordie',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/funnyordie',
+		settings: getEmbedBlockSettings( {
 			title: 'Funny or Die',
 			icon: 'embed-video',
-		} ) );
-	registerBlockType(
-		'core-embed/hulu',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/hulu',
+		settings: getEmbedBlockSettings( {
 			title: 'Hulu',
 			icon: 'embed-video',
-		} )
-	);
-	registerBlockType(
-		'core-embed/imgur',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/imgur',
+		settings: getEmbedBlockSettings( {
 			title: 'Imgur',
 			icon: 'embed-photo',
-		} )
-	);
-	registerBlockType(
-		'core-embed/issuu',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/issuu',
+		settings: getEmbedBlockSettings( {
 			title: 'Issuu',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/kickstarter',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/kickstarter',
+		settings: getEmbedBlockSettings( {
 			title: 'Kickstarter',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/meetup-com',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/meetup-com',
+		settings: getEmbedBlockSettings( {
 			title: 'Meetup.com',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/mixcloud',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/mixcloud',
+		settings: getEmbedBlockSettings( {
 			title: 'Mixcloud',
 			icon: 'embed-audio',
 			keywords: [ __( 'music' ), __( 'audio' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/photobucket',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/photobucket',
+		settings: getEmbedBlockSettings( {
 			title: 'Photobucket',
 			icon: 'embed-photo',
-		} )
-	);
-	registerBlockType(
-		'core-embed/polldaddy',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/polldaddy',
+		settings: getEmbedBlockSettings( {
 			title: 'Polldaddy',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/reddit',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/reddit',
+		settings: getEmbedBlockSettings( {
 			title: 'Reddit',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/reverbnation',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/reverbnation',
+		settings: getEmbedBlockSettings( {
 			title: 'ReverbNation',
 			icon: 'embed-audio',
-		} )
-	);
-	registerBlockType(
-		'core-embed/screencast',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/screencast',
+		settings: getEmbedBlockSettings( {
 			title: 'Screencast',
 			icon: 'embed-video',
-		} )
-	);
-	registerBlockType(
-		'core-embed/scribd',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/scribd',
+		settings: getEmbedBlockSettings( {
 			title: 'Scribd',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/slideshare',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/slideshare',
+		settings: getEmbedBlockSettings( {
 			title: 'Slideshare',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/smugmug',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/smugmug',
+		settings: getEmbedBlockSettings( {
 			title: 'SmugMug',
 			icon: 'embed-photo',
-		} )
-	);
-	registerBlockType(
-		'core-embed/speaker',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/speaker',
+		settings: getEmbedBlockSettings( {
 			title: 'Speaker',
 			icon: 'embed-audio',
-		} )
-	);
-	registerBlockType(
-		'core-embed/ted',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/ted',
+		settings: getEmbedBlockSettings( {
 			title: 'TED',
 			icon: 'embed-video',
-		} )
-	);
-	registerBlockType(
-		'core-embed/tumblr',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/tumblr',
+		settings: getEmbedBlockSettings( {
 			title: 'Tumblr',
 			icon: 'embed-post',
-		} )
-	);
-	registerBlockType(
-		'core-embed/videopress',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/videopress',
+		settings: getEmbedBlockSettings( {
 			title: 'VideoPress',
 			icon: 'embed-video',
 			keywords: [ __( 'video' ) ],
-		} )
-	);
-	registerBlockType(
-		'core-embed/wordpress-tv',
-		getEmbedBlockSettings( {
+		} ),
+	},
+	{
+		name: 'core-embed/wordpress-tv',
+		settings: getEmbedBlockSettings( {
 			title: 'WordPress.tv',
 			icon: 'embed-video',
-		} )
-	);
-};
+		} ),
+	},
+];

--- a/blocks/library/embed/test/index.js
+++ b/blocks/library/embed/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerEmbedBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/embed', () => {
-	beforeAll( () => {
-		registerEmbedBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/embed' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/embed/test/index.js
+++ b/blocks/library/embed/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerEmbedBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/embed', () => {
+	beforeAll( () => {
+		registerEmbedBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/embed' );
 

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -7,33 +7,30 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType, setUnknownTypeHandlerName } from '../../api';
 import OldEditor from './old-editor';
 
-export const registerFreeformBlock = () => {
-	registerBlockType( 'core/freeform', {
-		title: __( 'Classic' ),
+export const name = 'core/freeform';
 
-		desription: __( 'The classic editor, in block form.' ),
+export const settings = {
+	title: __( 'Classic' ),
 
-		icon: 'editor-kitchensink',
+	desription: __( 'The classic editor, in block form.' ),
 
-		category: 'formatting',
+	icon: 'editor-kitchensink',
 
-		attributes: {
-			content: {
-				type: 'string',
-				source: 'html',
-			},
+	category: 'formatting',
+
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
 		},
+	},
 
-		edit: OldEditor,
+	edit: OldEditor,
 
-		save( { attributes } ) {
-			const { content } = attributes;
-			return content;
-		},
-	} );
-
-	setUnknownTypeHandlerName( 'core/freeform' );
+	save( { attributes } ) {
+		const { content } = attributes;
+		return content;
+	},
 };

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -10,28 +10,30 @@ import './editor.scss';
 import { registerBlockType, setUnknownTypeHandlerName } from '../../api';
 import OldEditor from './old-editor';
 
-registerBlockType( 'core/freeform', {
-	title: __( 'Classic' ),
+export const registerFreeformBlock = () => {
+	registerBlockType( 'core/freeform', {
+		title: __( 'Classic' ),
 
-	desription: __( 'The classic editor, in block form.' ),
+		desription: __( 'The classic editor, in block form.' ),
 
-	icon: 'editor-kitchensink',
+		icon: 'editor-kitchensink',
 
-	category: 'formatting',
+		category: 'formatting',
 
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
+		attributes: {
+			content: {
+				type: 'string',
+				source: 'html',
+			},
 		},
-	},
 
-	edit: OldEditor,
+		edit: OldEditor,
 
-	save( { attributes } ) {
-		const { content } = attributes;
-		return content;
-	},
-} );
+		save( { attributes } ) {
+			const { content } = attributes;
+			return content;
+		},
+	} );
 
-setUnknownTypeHandlerName( 'core/freeform' );
+	setUnknownTypeHandlerName( 'core/freeform' );
+};

--- a/blocks/library/freeform/test/index.js
+++ b/blocks/library/freeform/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerFreeformBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/freeform', () => {
-	beforeAll( () => {
-		registerFreeformBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/freeform' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/freeform/test/index.js
+++ b/blocks/library/freeform/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerFreeformBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/freeform', () => {
+	beforeAll( () => {
+		registerFreeformBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/freeform' );
 

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -14,7 +14,7 @@ import { createMediaFromFile, preloadImage } from '@wordpress/utils';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import { default as GalleryBlock, defaultColumnsNumber } from './block';
 
 const blockAttributes = {
@@ -56,7 +56,9 @@ const blockAttributes = {
 	},
 };
 
-export const registerGalleryBlock = () => registerBlockType( 'core/gallery', {
+export const name = 'core/gallery';
+
+export const settings = {
 	title: __( 'Gallery' ),
 	description: __( 'Image galleries are a great way to share groups of pictures on your site.' ),
 	icon: 'format-gallery',
@@ -228,5 +230,4 @@ export const registerGalleryBlock = () => registerBlockType( 'core/gallery', {
 			},
 		},
 	],
-
-} );
+};

--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -56,7 +56,7 @@ const blockAttributes = {
 	},
 };
 
-registerBlockType( 'core/gallery', {
+export const registerGalleryBlock = () => registerBlockType( 'core/gallery', {
 	title: __( 'Gallery' ),
 	description: __( 'Image galleries are a great way to share groups of pictures on your site.' ),
 	icon: 'format-gallery',

--- a/blocks/library/gallery/test/index.js
+++ b/blocks/library/gallery/test/index.js
@@ -1,18 +1,14 @@
 /**
  * Internal dependencies
  */
-import { registerGalleryBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
 
 describe( 'core/gallery', () => {
-	beforeAll( () => {
-		registerGalleryBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/gallery' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/gallery/test/index.js
+++ b/blocks/library/gallery/test/index.js
@@ -1,12 +1,16 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerGalleryBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
 
 describe( 'core/gallery', () => {
+	beforeAll( () => {
+		registerGalleryBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/gallery' );
 

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -9,13 +9,15 @@ import { Toolbar } from '@wordpress/components';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import InspectorControls from '../../inspector-controls';
 import AlignmentToolbar from '../../alignment-toolbar';
 
-export const registerHeadingBlock = () => registerBlockType( 'core/heading', {
+export const name = 'core/heading';
+
+export const settings = {
 	title: __( 'Heading' ),
 
 	description: __( 'Search engines use the headings to index the structure and content of your web pages.' ),
@@ -178,4 +180,4 @@ export const registerHeadingBlock = () => registerBlockType( 'core/heading', {
 			</Tag>
 		);
 	},
-} );
+};

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -15,7 +15,7 @@ import BlockControls from '../../block-controls';
 import InspectorControls from '../../inspector-controls';
 import AlignmentToolbar from '../../alignment-toolbar';
 
-registerBlockType( 'core/heading', {
+export const registerHeadingBlock = () => registerBlockType( 'core/heading', {
 	title: __( 'Heading' ),
 
 	description: __( 'Search engines use the headings to index the structure and content of your web pages.' ),

--- a/blocks/library/heading/test/index.js
+++ b/blocks/library/heading/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerHeadingBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/heading', () => {
+	beforeAll( () => {
+		registerHeadingBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/heading' );
 

--- a/blocks/library/heading/test/index.js
+++ b/blocks/library/heading/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerHeadingBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/heading', () => {
-	beforeAll( () => {
-		registerHeadingBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/heading' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -16,7 +16,7 @@ import './editor.scss';
 import { registerBlockType } from '../../api';
 import BlockControls from '../../block-controls';
 
-registerBlockType( 'core/html', {
+export const registerHtmlBlock = () => registerBlockType( 'core/html', {
 	title: __( 'Custom HTML' ),
 
 	description: __( 'Add custom HTML code and preview it right here in the editor.' ),

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -13,10 +13,11 @@ import { withState } from '@wordpress/components';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType } from '../../api';
 import BlockControls from '../../block-controls';
 
-export const registerHtmlBlock = () => registerBlockType( 'core/html', {
+export const name = 'core/html';
+
+export const settings = {
 	title: __( 'Custom HTML' ),
 
 	description: __( 'Add custom HTML code and preview it right here in the editor.' ),
@@ -75,4 +76,4 @@ export const registerHtmlBlock = () => registerBlockType( 'core/html', {
 	save( { attributes } ) {
 		return attributes.content;
 	},
-} );
+};

--- a/blocks/library/html/test/index.js
+++ b/blocks/library/html/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerHtmlBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/html', () => {
-	beforeAll( () => {
-		registerHtmlBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/html' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/html/test/index.js
+++ b/blocks/library/html/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerHtmlBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/html', () => {
+	beforeAll( () => {
+		registerHtmlBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/html' );
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -9,10 +9,12 @@ import { createMediaFromFile, preloadImage } from '@wordpress/utils';
  */
 import './style.scss';
 import './editor.scss';
-import { registerBlockType, createBlock, getBlockAttributes, getBlockType } from '../../api';
+import { createBlock, getBlockAttributes, getBlockType } from '../../api';
 import ImageBlock from './block';
 
-export const registerImageBlock = () => registerBlockType( 'core/image', {
+export const name = 'core/image';
+
+export const settings = {
 	title: __( 'Image' ),
 
 	description: __( 'Worth a thousand words.' ),
@@ -179,4 +181,4 @@ export const registerImageBlock = () => registerBlockType( 'core/image', {
 			</figure>
 		);
 	},
-} );
+};

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -12,7 +12,7 @@ import './editor.scss';
 import { registerBlockType, createBlock, getBlockAttributes, getBlockType } from '../../api';
 import ImageBlock from './block';
 
-registerBlockType( 'core/image', {
+export const registerImageBlock = () => registerBlockType( 'core/image', {
 	title: __( 'Image' ),
 
 	description: __( 'Worth a thousand words.' ),

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -1,26 +1,63 @@
-import './shortcode';
-import './image';
-import './gallery';
-import './heading';
-import './quote';
-import './embed';
-import './list';
-import './separator';
-import './more';
-import './button';
-import './pullquote';
-import './table';
-import './preformatted';
-import './code';
-import './html';
-import './freeform';
-import './latest-posts';
-import './categories';
-import './cover-image';
-import './text-columns';
-import './verse';
-import './video';
-import './audio';
-import './block';
-import './paragraph';
+/**
+ * Internal dependencies
+ */
+import { registerShortcodeBlock } from './shortcode';
+import { registerImageBlock } from './image';
+import { registerGalleryBlock } from './gallery';
+import { registerHeadingBlock } from './heading';
+import { registerQuoteBlock } from './quote';
+import {
+	registerEmbedBlock,
+	registerCommonEmbedBlocks,
+	registerOtherEmbedBlocks,
+} from './embed';
+import { registerListBlock } from './list';
+import { registerSeparatorBlock } from './separator';
+import { registerMoreBlock } from './more';
+import { registerButtonBlock } from './button';
+import { registerPullquoteBlock } from './pullquote';
+import { registerTableBlock } from './table';
+import { registerPreformattedBlock } from './preformatted';
+import { registerCodeBlock } from './code';
+import { registerHtmlBlock } from './html';
+import { registerFreeformBlock } from './freeform';
+import { registerLatestPostsBlock } from './latest-posts';
+import { registerCategoriesBlock } from './categories';
+import { registerCoverImageBlock } from './cover-image';
+import { registerTextColumnsBlock } from './text-columns';
+import { registerVerseBlock } from './verse';
+import { registerVideoBlock } from './video';
+import { registerAudioBlock } from './audio';
+import { registerReusableBlock } from './block';
+import { registerParagraphBlock } from './paragraph';
 import './subhead';
+
+export const registerCoreBlocks = () => {
+	registerShortcodeBlock();
+	registerImageBlock();
+	registerGalleryBlock();
+	registerHeadingBlock();
+	registerQuoteBlock();
+	registerEmbedBlock();
+	registerCommonEmbedBlocks();
+	registerOtherEmbedBlocks();
+	registerListBlock();
+	registerSeparatorBlock();
+	registerMoreBlock();
+	registerButtonBlock();
+	registerPullquoteBlock();
+	registerTableBlock();
+	registerPreformattedBlock();
+	registerCodeBlock();
+	registerHtmlBlock();
+	registerFreeformBlock();
+	registerLatestPostsBlock();
+	registerCategoriesBlock();
+	registerCoverImageBlock();
+	registerTextColumnsBlock();
+	registerVerseBlock();
+	registerVideoBlock();
+	registerAudioBlock();
+	registerReusableBlock();
+	registerParagraphBlock();
+};

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -3,7 +3,8 @@
  */
 import * as audio from './audio';
 import * as embed from './embed';
-import { registerBlockType } from '../api';
+import * as paragraph from './paragraph';
+import { registerBlockType, setDefaultBlockName } from '../api';
 import { registerShortcodeBlock } from './shortcode';
 import { registerImageBlock } from './image';
 import { registerGalleryBlock } from './gallery';
@@ -26,7 +27,6 @@ import { registerTextColumnsBlock } from './text-columns';
 import { registerVerseBlock } from './verse';
 import { registerVideoBlock } from './video';
 import { registerReusableBlock } from './block';
-import { registerParagraphBlock } from './paragraph';
 import './subhead';
 
 export const registerCoreBlocks = () => {
@@ -35,6 +35,7 @@ export const registerCoreBlocks = () => {
 		embed,
 		...embed.common,
 		...embed.others,
+		paragraph,
 	].forEach( ( { name, settings } ) => {
 		registerBlockType( name, settings );
 	} );
@@ -60,5 +61,6 @@ export const registerCoreBlocks = () => {
 	registerVerseBlock();
 	registerVideoBlock();
 	registerReusableBlock();
-	registerParagraphBlock();
+
+	setDefaultBlockName( paragraph.name );
 };

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { registerBlockType } from '../api';
 import { registerShortcodeBlock } from './shortcode';
 import { registerImageBlock } from './image';
 import { registerGalleryBlock } from './gallery';
@@ -27,7 +28,7 @@ import { registerCoverImageBlock } from './cover-image';
 import { registerTextColumnsBlock } from './text-columns';
 import { registerVerseBlock } from './verse';
 import { registerVideoBlock } from './video';
-import { registerAudioBlock } from './audio';
+import * as audio from './audio';
 import { registerReusableBlock } from './block';
 import { registerParagraphBlock } from './paragraph';
 import './subhead';
@@ -57,7 +58,7 @@ export const registerCoreBlocks = () => {
 	registerTextColumnsBlock();
 	registerVerseBlock();
 	registerVideoBlock();
-	registerAudioBlock();
+	registerBlockType( audio.name, audio.settings );
 	registerReusableBlock();
 	registerParagraphBlock();
 };

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -1,66 +1,71 @@
 /**
  * Internal dependencies
  */
+import {
+	registerBlockType,
+	setDefaultBlockName,
+	setUnknownTypeHandlerName,
+} from '../api';
 import * as audio from './audio';
+import * as button from './button';
+import * as categories from './categories';
+import * as code from './code';
+import * as coverImage from './cover-image';
 import * as embed from './embed';
+import * as freeform from './freeform';
+import * as gallery from './gallery';
+import * as heading from './heading';
+import * as html from './html';
+import * as image from './image';
+import * as latestPosts from './latest-posts';
+import * as list from './list';
+import * as more from './more';
 import * as paragraph from './paragraph';
-import { registerBlockType, setDefaultBlockName } from '../api';
-import { registerShortcodeBlock } from './shortcode';
-import { registerImageBlock } from './image';
-import { registerGalleryBlock } from './gallery';
-import { registerHeadingBlock } from './heading';
-import { registerQuoteBlock } from './quote';
-import { registerListBlock } from './list';
-import { registerSeparatorBlock } from './separator';
-import { registerMoreBlock } from './more';
-import { registerButtonBlock } from './button';
-import { registerPullquoteBlock } from './pullquote';
-import { registerTableBlock } from './table';
-import { registerPreformattedBlock } from './preformatted';
-import { registerCodeBlock } from './code';
-import { registerHtmlBlock } from './html';
-import { registerFreeformBlock } from './freeform';
-import { registerLatestPostsBlock } from './latest-posts';
-import { registerCategoriesBlock } from './categories';
-import { registerCoverImageBlock } from './cover-image';
-import { registerTextColumnsBlock } from './text-columns';
-import { registerVerseBlock } from './verse';
-import { registerVideoBlock } from './video';
-import { registerReusableBlock } from './block';
+import * as preformatted from './preformatted';
+import * as pullquote from './pullquote';
+import * as quote from './quote';
+import * as reusableBlock from './block';
+import * as separator from './separator';
+import * as shortcode from './shortcode';
 import './subhead';
+import * as table from './table';
+import * as textColumns from './text-columns';
+import * as verse from './verse';
+import * as video from './video';
 
 export const registerCoreBlocks = () => {
 	[
 		audio,
+		button,
+		categories,
+		code,
+		coverImage,
 		embed,
 		...embed.common,
 		...embed.others,
+		freeform,
+		gallery,
+		heading,
+		html,
+		image,
+		list,
+		latestPosts,
+		more,
 		paragraph,
+		preformatted,
+		pullquote,
+		quote,
+		reusableBlock,
+		separator,
+		shortcode,
+		table,
+		textColumns,
+		verse,
+		video,
 	].forEach( ( { name, settings } ) => {
 		registerBlockType( name, settings );
 	} );
-	registerShortcodeBlock();
-	registerImageBlock();
-	registerGalleryBlock();
-	registerHeadingBlock();
-	registerQuoteBlock();
-	registerListBlock();
-	registerSeparatorBlock();
-	registerMoreBlock();
-	registerButtonBlock();
-	registerPullquoteBlock();
-	registerTableBlock();
-	registerPreformattedBlock();
-	registerCodeBlock();
-	registerHtmlBlock();
-	registerFreeformBlock();
-	registerLatestPostsBlock();
-	registerCategoriesBlock();
-	registerCoverImageBlock();
-	registerTextColumnsBlock();
-	registerVerseBlock();
-	registerVideoBlock();
-	registerReusableBlock();
 
 	setDefaultBlockName( paragraph.name );
+	setUnknownTypeHandlerName( freeform.name );
 };

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -27,7 +27,7 @@ import * as quote from './quote';
 import * as reusableBlock from './block';
 import * as separator from './separator';
 import * as shortcode from './shortcode';
-import './subhead';
+import * as subhead from './subhead';
 import * as table from './table';
 import * as textColumns from './text-columns';
 import * as verse from './verse';
@@ -58,6 +58,7 @@ export const registerCoreBlocks = () => {
 		reusableBlock,
 		separator,
 		shortcode,
+		subhead,
 		table,
 		textColumns,
 		verse,

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -1,17 +1,14 @@
 /**
  * Internal dependencies
  */
+import * as audio from './audio';
+import * as embed from './embed';
 import { registerBlockType } from '../api';
 import { registerShortcodeBlock } from './shortcode';
 import { registerImageBlock } from './image';
 import { registerGalleryBlock } from './gallery';
 import { registerHeadingBlock } from './heading';
 import { registerQuoteBlock } from './quote';
-import {
-	registerEmbedBlock,
-	registerCommonEmbedBlocks,
-	registerOtherEmbedBlocks,
-} from './embed';
 import { registerListBlock } from './list';
 import { registerSeparatorBlock } from './separator';
 import { registerMoreBlock } from './more';
@@ -28,20 +25,24 @@ import { registerCoverImageBlock } from './cover-image';
 import { registerTextColumnsBlock } from './text-columns';
 import { registerVerseBlock } from './verse';
 import { registerVideoBlock } from './video';
-import * as audio from './audio';
 import { registerReusableBlock } from './block';
 import { registerParagraphBlock } from './paragraph';
 import './subhead';
 
 export const registerCoreBlocks = () => {
+	[
+		audio,
+		embed,
+		...embed.common,
+		...embed.others,
+	].forEach( ( { name, settings } ) => {
+		registerBlockType( name, settings );
+	} );
 	registerShortcodeBlock();
 	registerImageBlock();
 	registerGalleryBlock();
 	registerHeadingBlock();
 	registerQuoteBlock();
-	registerEmbedBlock();
-	registerCommonEmbedBlocks();
-	registerOtherEmbedBlocks();
 	registerListBlock();
 	registerSeparatorBlock();
 	registerMoreBlock();
@@ -58,7 +59,6 @@ export const registerCoreBlocks = () => {
 	registerTextColumnsBlock();
 	registerVerseBlock();
 	registerVideoBlock();
-	registerBlockType( audio.name, audio.settings );
 	registerReusableBlock();
 	registerParagraphBlock();
 };

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -11,7 +11,7 @@ import './style.scss';
 import { registerBlockType } from '../../api';
 import LatestPostsBlock from './block';
 
-registerBlockType( 'core/latest-posts', {
+export const registerLatestPostsBlock = () => registerBlockType( 'core/latest-posts', {
 	title: __( 'Latest Posts' ),
 
 	description: __( 'Shows a list of your site\'s most recent posts.' ),

--- a/blocks/library/latest-posts/index.js
+++ b/blocks/library/latest-posts/index.js
@@ -8,10 +8,11 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType } from '../../api';
 import LatestPostsBlock from './block';
 
-export const registerLatestPostsBlock = () => registerBlockType( 'core/latest-posts', {
+export const name = 'core/latest-posts';
+
+export const settings = {
 	title: __( 'Latest Posts' ),
 
 	description: __( 'Shows a list of your site\'s most recent posts.' ),
@@ -38,4 +39,4 @@ export const registerLatestPostsBlock = () => registerBlockType( 'core/latest-po
 	save() {
 		return null;
 	},
-} );
+};

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -13,11 +13,13 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 
-export const registerListBlock = () => registerBlockType( 'core/list', {
+export const name = 'core/list';
+
+export const settings = {
 	title: __( 'List' ),
 	description: __( 'List. Numbered or bulleted.' ),
 	icon: 'editor-ul',
@@ -212,10 +214,10 @@ export const registerListBlock = () => registerBlockType( 'core/list', {
 			};
 		}
 
-		getEditorSettings( settings ) {
+		getEditorSettings( editorSettings ) {
 			return {
-				...settings,
-				plugins: ( settings.plugins || [] ).concat( 'lists' ),
+				...editorSettings,
+				plugins: ( editorSettings.plugins || [] ).concat( 'lists' ),
 				lists_indent_on_tab: false,
 			};
 		}
@@ -313,4 +315,4 @@ export const registerListBlock = () => registerBlockType( 'core/list', {
 			values
 		);
 	},
-} );
+};

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -17,7 +17,7 @@ import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 
-registerBlockType( 'core/list', {
+export const registerListBlock = () => registerBlockType( 'core/list', {
 	title: __( 'List' ),
 	description: __( 'List. Numbered or bulleted.' ),
 	icon: 'editor-ul',

--- a/blocks/library/list/test/index.js
+++ b/blocks/library/list/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerListBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/list', () => {
+	beforeAll( () => {
+		registerListBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/list' );
 

--- a/blocks/library/list/test/index.js
+++ b/blocks/library/list/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerListBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/list', () => {
-	beforeAll( () => {
-		registerListBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/list' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -7,11 +7,12 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType } from '../../api';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 
-export const registerMoreBlock = () => registerBlockType( 'core/more', {
+export const name = 'core/more';
+
+export const settings = {
 	title: __( 'More' ),
 
 	description: __( '"More" allows you to break your post into a part shown on index pages, and the subsequent after clicking a "Read More" link.' ),
@@ -71,4 +72,4 @@ export const registerMoreBlock = () => registerBlockType( 'core/more', {
 	save() {
 		return null;
 	},
-} );
+};

--- a/blocks/library/more/index.js
+++ b/blocks/library/more/index.js
@@ -11,7 +11,7 @@ import { registerBlockType } from '../../api';
 import InspectorControls from '../../inspector-controls';
 import ToggleControl from '../../inspector-controls/toggle-control';
 
-registerBlockType( 'core/more', {
+export const registerMoreBlock = () => registerBlockType( 'core/more', {
 	title: __( 'More' ),
 
 	description: __( '"More" allows you to break your post into a part shown on index pages, and the subsequent after clicking a "Read More" link.' ),

--- a/blocks/library/more/test/index.js
+++ b/blocks/library/more/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerMoreBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/more', () => {
+	beforeAll( () => {
+		registerMoreBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/more' );
 

--- a/blocks/library/more/test/index.js
+++ b/blocks/library/more/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerMoreBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/more', () => {
-	beforeAll( () => {
-		registerMoreBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/more' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -192,95 +192,97 @@ class ParagraphBlock extends Component {
 	}
 }
 
-registerBlockType( 'core/paragraph', {
-	title: __( 'Paragraph' ),
+export const registerParagraphBlock = () => {
+	registerBlockType( 'core/paragraph', {
+		title: __( 'Paragraph' ),
 
-	description: __( 'This is a simple text only block for adding a single paragraph of content.' ),
+		description: __( 'This is a simple text only block for adding a single paragraph of content.' ),
 
-	icon: 'editor-paragraph',
+		icon: 'editor-paragraph',
 
-	category: 'common',
+		category: 'common',
 
-	keywords: [ __( 'text' ) ],
+		keywords: [ __( 'text' ) ],
 
-	supports: {
-		className: false,
-	},
+		supports: {
+			className: false,
+		},
 
-	attributes: {
-		content: {
-			type: 'array',
-			source: 'children',
-			selector: 'p',
-		},
-		align: {
-			type: 'string',
-		},
-		dropCap: {
-			type: 'boolean',
-			default: false,
-		},
-		placeholder: {
-			type: 'string',
-		},
-		width: {
-			type: 'string',
-		},
-		textColor: {
-			type: 'string',
-		},
-		backgroundColor: {
-			type: 'string',
-		},
-		fontSize: {
-			type: 'number',
-		},
-	},
-
-	transforms: {
-		from: [
-			{
-				type: 'raw',
-				isMatch: ( node ) => (
-					node.nodeName === 'P' &&
-					// Do not allow embedded content.
-					! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
-				),
+		attributes: {
+			content: {
+				type: 'array',
+				source: 'children',
+				selector: 'p',
 			},
-		],
-	},
+			align: {
+				type: 'string',
+			},
+			dropCap: {
+				type: 'boolean',
+				default: false,
+			},
+			placeholder: {
+				type: 'string',
+			},
+			width: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+			backgroundColor: {
+				type: 'string',
+			},
+			fontSize: {
+				type: 'number',
+			},
+		},
 
-	merge( attributes, attributesToMerge ) {
-		return {
-			content: concatChildren( attributes.content, attributesToMerge.content ),
-		};
-	},
+		transforms: {
+			from: [
+				{
+					type: 'raw',
+					isMatch: ( node ) => (
+						node.nodeName === 'P' &&
+						// Do not allow embedded content.
+						! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
+					),
+				},
+			],
+		},
 
-	getEditWrapperProps( attributes ) {
-		const { width } = attributes;
-		if ( [ 'wide', 'full', 'left', 'right' ].indexOf( width ) !== -1 ) {
-			return { 'data-align': width };
-		}
-	},
+		merge( attributes, attributesToMerge ) {
+			return {
+				content: concatChildren( attributes.content, attributesToMerge.content ),
+			};
+		},
 
-	edit: ParagraphBlock,
+		getEditWrapperProps( attributes ) {
+			const { width } = attributes;
+			if ( [ 'wide', 'full', 'left', 'right' ].indexOf( width ) !== -1 ) {
+				return { 'data-align': width };
+			}
+		},
 
-	save( { attributes } ) {
-		const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
-		const className = classnames( {
-			[ `align${ width }` ]: width,
-			'has-background': backgroundColor,
-			'has-drop-cap': dropCap,
-		} );
-		const styles = {
-			backgroundColor: backgroundColor,
-			color: textColor,
-			fontSize: fontSize,
-			textAlign: align,
-		};
+		edit: ParagraphBlock,
 
-		return <p style={ styles } className={ className ? className : undefined }>{ content }</p>;
-	},
-} );
+		save( { attributes } ) {
+			const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
+			const className = classnames( {
+				[ `align${ width }` ]: width,
+				'has-background': backgroundColor,
+				'has-drop-cap': dropCap,
+			} );
+			const styles = {
+				backgroundColor: backgroundColor,
+				color: textColor,
+				fontSize: fontSize,
+				textAlign: align,
+			};
 
-setDefaultBlockName( 'core/paragraph' );
+			return <p style={ styles } className={ className ? className : undefined }>{ content }</p>;
+		},
+	} );
+
+	setDefaultBlockName( 'core/paragraph' );
+};

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -15,7 +15,7 @@ import { Autocomplete, PanelBody, PanelColor, withFallbackStyles } from '@wordpr
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType, createBlock, setDefaultBlockName } from '../../api';
+import { createBlock } from '../../api';
 import { blockAutocompleter, userAutocompleter } from '../../autocompleters';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
@@ -192,97 +192,95 @@ class ParagraphBlock extends Component {
 	}
 }
 
-export const registerParagraphBlock = () => {
-	registerBlockType( 'core/paragraph', {
-		title: __( 'Paragraph' ),
+export const name = 'core/paragraph';
 
-		description: __( 'This is a simple text only block for adding a single paragraph of content.' ),
+export const settings = {
+	title: __( 'Paragraph' ),
 
-		icon: 'editor-paragraph',
+	description: __( 'This is a simple text only block for adding a single paragraph of content.' ),
 
-		category: 'common',
+	icon: 'editor-paragraph',
 
-		keywords: [ __( 'text' ) ],
+	category: 'common',
 
-		supports: {
-			className: false,
+	keywords: [ __( 'text' ) ],
+
+	supports: {
+		className: false,
+	},
+
+	attributes: {
+		content: {
+			type: 'array',
+			source: 'children',
+			selector: 'p',
 		},
-
-		attributes: {
-			content: {
-				type: 'array',
-				source: 'children',
-				selector: 'p',
-			},
-			align: {
-				type: 'string',
-			},
-			dropCap: {
-				type: 'boolean',
-				default: false,
-			},
-			placeholder: {
-				type: 'string',
-			},
-			width: {
-				type: 'string',
-			},
-			textColor: {
-				type: 'string',
-			},
-			backgroundColor: {
-				type: 'string',
-			},
-			fontSize: {
-				type: 'number',
-			},
+		align: {
+			type: 'string',
 		},
-
-		transforms: {
-			from: [
-				{
-					type: 'raw',
-					isMatch: ( node ) => (
-						node.nodeName === 'P' &&
-						// Do not allow embedded content.
-						! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
-					),
-				},
-			],
+		dropCap: {
+			type: 'boolean',
+			default: false,
 		},
-
-		merge( attributes, attributesToMerge ) {
-			return {
-				content: concatChildren( attributes.content, attributesToMerge.content ),
-			};
+		placeholder: {
+			type: 'string',
 		},
-
-		getEditWrapperProps( attributes ) {
-			const { width } = attributes;
-			if ( [ 'wide', 'full', 'left', 'right' ].indexOf( width ) !== -1 ) {
-				return { 'data-align': width };
-			}
+		width: {
+			type: 'string',
 		},
-
-		edit: ParagraphBlock,
-
-		save( { attributes } ) {
-			const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
-			const className = classnames( {
-				[ `align${ width }` ]: width,
-				'has-background': backgroundColor,
-				'has-drop-cap': dropCap,
-			} );
-			const styles = {
-				backgroundColor: backgroundColor,
-				color: textColor,
-				fontSize: fontSize,
-				textAlign: align,
-			};
-
-			return <p style={ styles } className={ className ? className : undefined }>{ content }</p>;
+		textColor: {
+			type: 'string',
 		},
-	} );
+		backgroundColor: {
+			type: 'string',
+		},
+		fontSize: {
+			type: 'number',
+		},
+	},
 
-	setDefaultBlockName( 'core/paragraph' );
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				isMatch: ( node ) => (
+					node.nodeName === 'P' &&
+					// Do not allow embedded content.
+					! node.querySelector( 'audio, canvas, embed, iframe, img, math, object, svg, video' )
+				),
+			},
+		],
+	},
+
+	merge( attributes, attributesToMerge ) {
+		return {
+			content: concatChildren( attributes.content, attributesToMerge.content ),
+		};
+	},
+
+	getEditWrapperProps( attributes ) {
+		const { width } = attributes;
+		if ( [ 'wide', 'full', 'left', 'right' ].indexOf( width ) !== -1 ) {
+			return { 'data-align': width };
+		}
+	},
+
+	edit: ParagraphBlock,
+
+	save( { attributes } ) {
+		const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
+		const className = classnames( {
+			[ `align${ width }` ]: width,
+			'has-background': backgroundColor,
+			'has-drop-cap': dropCap,
+		} );
+		const styles = {
+			backgroundColor: backgroundColor,
+			color: textColor,
+			fontSize: fontSize,
+			textAlign: align,
+		};
+
+		return <p style={ styles } className={ className ? className : undefined }>{ content }</p>;
+	},
 };

--- a/blocks/library/paragraph/test/index.js
+++ b/blocks/library/paragraph/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerParagraphBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/paragraph', () => {
+	beforeAll( () => {
+		registerParagraphBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/paragraph' );
 

--- a/blocks/library/paragraph/test/index.js
+++ b/blocks/library/paragraph/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerParagraphBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/paragraph', () => {
-	beforeAll( () => {
-		registerParagraphBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/paragraph' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -10,7 +10,7 @@ import './editor.scss';
 import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
 
-registerBlockType( 'core/preformatted', {
+export const registerPreformattedBlock = () => registerBlockType( 'core/preformatted', {
 	title: __( 'Preformatted' ),
 
 	description: __( 'Preformatted text keeps your spaces, tabs and linebreaks as they are.' ),

--- a/blocks/library/preformatted/index.js
+++ b/blocks/library/preformatted/index.js
@@ -7,10 +7,12 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import Editable from '../../editable';
 
-export const registerPreformattedBlock = () => registerBlockType( 'core/preformatted', {
+export const name = 'core/preformatted';
+
+export const settings = {
 	title: __( 'Preformatted' ),
 
 	description: __( 'Preformatted text keeps your spaces, tabs and linebreaks as they are.' ),
@@ -82,4 +84,4 @@ export const registerPreformattedBlock = () => registerBlockType( 'core/preforma
 
 		return <pre>{ content }</pre>;
 	},
-} );
+};

--- a/blocks/library/preformatted/test/index.js
+++ b/blocks/library/preformatted/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerPreformattedBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/preformatted', () => {
+	beforeAll( () => {
+		registerPreformattedBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/preformatted' );
 

--- a/blocks/library/preformatted/test/index.js
+++ b/blocks/library/preformatted/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerPreformattedBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/preformatted', () => {
-	beforeAll( () => {
-		registerPreformattedBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/preformatted' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -13,7 +13,6 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType } from '../../api';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
@@ -44,7 +43,9 @@ const blockAttributes = {
 	},
 };
 
-export const registerPullquoteBlock = () => registerBlockType( 'core/pullquote', {
+export const name = 'core/pullquote';
+
+export const settings = {
 
 	title: __( 'Pullquote' ),
 
@@ -148,4 +149,4 @@ export const registerPullquoteBlock = () => registerBlockType( 'core/pullquote',
 			);
 		},
 	} ],
-} );
+};

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -44,7 +44,7 @@ const blockAttributes = {
 	},
 };
 
-registerBlockType( 'core/pullquote', {
+export const registerPullquoteBlock = () => registerBlockType( 'core/pullquote', {
 
 	title: __( 'Pullquote' ),
 

--- a/blocks/library/pullquote/test/index.js
+++ b/blocks/library/pullquote/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerPullquoteBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/pullquote', () => {
+	beforeAll( () => {
+		registerPullquoteBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/pullquote' );
 

--- a/blocks/library/pullquote/test/index.js
+++ b/blocks/library/pullquote/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerPullquoteBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/pullquote', () => {
-	beforeAll( () => {
-		registerPullquoteBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/pullquote' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -51,7 +51,7 @@ const blockAttributes = {
 	},
 };
 
-registerBlockType( 'core/quote', {
+export const registerQuoteBlock = () => registerBlockType( 'core/quote', {
 	title: __( 'Quote' ),
 	description: __( 'Quote. In quoting others, we cite ourselves. (Julio Cortázar)' ),
 	icon: 'format-quote',

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -15,7 +15,7 @@ import { Toolbar } from '@wordpress/components';
  */
 import './style.scss';
 import './editor.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import Editable from '../../editable';
@@ -51,7 +51,9 @@ const blockAttributes = {
 	},
 };
 
-export const registerQuoteBlock = () => registerBlockType( 'core/quote', {
+export const name = 'core/quote';
+
+export const settings = {
 	title: __( 'Quote' ),
 	description: __( 'Quote. In quoting others, we cite ourselves. (Julio Cortázar)' ),
 	icon: 'format-quote',
@@ -270,4 +272,4 @@ export const registerQuoteBlock = () => registerBlockType( 'core/quote', {
 			},
 		},
 	],
-} );
+};

--- a/blocks/library/quote/test/index.js
+++ b/blocks/library/quote/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerQuoteBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/quote', () => {
+	beforeAll( () => {
+		registerQuoteBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/quote' );
 

--- a/blocks/library/quote/test/index.js
+++ b/blocks/library/quote/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerQuoteBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/quote', () => {
-	beforeAll( () => {
-		registerQuoteBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/quote' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import { registerBlockType, createBlock } from '../../api';
 
-registerBlockType( 'core/separator', {
+export const registerSeparatorBlock = () => registerBlockType( 'core/separator', {
 	title: __( 'Separator' ),
 
 	description: __( 'Use the separator to indicate a thematic change in the content.' ),

--- a/blocks/library/separator/index.js
+++ b/blocks/library/separator/index.js
@@ -7,9 +7,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './style.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 
-export const registerSeparatorBlock = () => registerBlockType( 'core/separator', {
+export const name = 'core/separator';
+
+export const settings = {
 	title: __( 'Separator' ),
 
 	description: __( 'Use the separator to indicate a thematic change in the content.' ),
@@ -42,4 +44,4 @@ export const registerSeparatorBlock = () => registerBlockType( 'core/separator',
 	save() {
 		return <hr />;
 	},
-} );
+};

--- a/blocks/library/separator/test/index.js
+++ b/blocks/library/separator/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerSeparatorBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/separator', () => {
-	beforeAll( () => {
-		registerSeparatorBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/separator' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/separator/test/index.js
+++ b/blocks/library/separator/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerSeparatorBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/separator', () => {
+	beforeAll( () => {
+		registerSeparatorBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/separator' );
 

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -13,9 +13,10 @@ import { withInstanceId, Dashicon } from '@wordpress/components';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType } from '../../api';
 
-export const registerShortcodeBlock = () => registerBlockType( 'core/shortcode', {
+export const name = 'core/shortcode';
+
+export const settings = {
 	title: __( 'Shortcode' ),
 
 	description: __( 'A shortcode is a WordPress-specific code snippet that is written between square brackets as [shortcode]. ' ),
@@ -88,4 +89,4 @@ export const registerShortcodeBlock = () => registerBlockType( 'core/shortcode',
 	save( { attributes } ) {
 		return attributes.text;
 	},
-} );
+};

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -15,7 +15,7 @@ import { withInstanceId, Dashicon } from '@wordpress/components';
 import './editor.scss';
 import { registerBlockType } from '../../api';
 
-registerBlockType( 'core/shortcode', {
+export const registerShortcodeBlock = () => registerBlockType( 'core/shortcode', {
 	title: __( 'Shortcode' ),
 
 	description: __( 'A shortcode is a WordPress-specific code snippet that is written between square brackets as [shortcode]. ' ),

--- a/blocks/library/shortcode/test/index.js
+++ b/blocks/library/shortcode/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerShortcodeBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/shortcode', () => {
-	beforeAll( () => {
-		registerShortcodeBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/shortcode' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/shortcode/test/index.js
+++ b/blocks/library/shortcode/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerShortcodeBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/shortcode', () => {
+	beforeAll( () => {
+		registerShortcodeBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/shortcode' );
 

--- a/blocks/library/subhead/index.js
+++ b/blocks/library/subhead/index.js
@@ -8,12 +8,14 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
 import BlockDescription from '../../block-description';
 
-registerBlockType( 'core/subhead', {
+export const name = 'core/subhead';
+
+export const settings = {
 	title: __( 'Subhead' ),
 
 	icon: 'text',
@@ -88,4 +90,4 @@ registerBlockType( 'core/subhead', {
 
 		return <p className={ className }>{ content }</p>;
 	},
-} );
+};

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -8,12 +8,13 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 import './style.scss';
-import { registerBlockType } from '../../api';
 import TableBlock from './table-block';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-export const registerTableBlock = () => registerBlockType( 'core/table', {
+export const name = 'core/table';
+
+export const settings = {
 	title: __( 'Table' ),
 	description: __( 'Tables. Best used for tabular data.' ),
 	icon: 'editor-table',
@@ -85,4 +86,4 @@ export const registerTableBlock = () => registerBlockType( 'core/table', {
 			</table>
 		);
 	},
-} );
+};

--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -13,7 +13,7 @@ import TableBlock from './table-block';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-registerBlockType( 'core/table', {
+export const registerTableBlock = () => registerBlockType( 'core/table', {
 	title: __( 'Table' ),
 	description: __( 'Tables. Best used for tabular data.' ),
 	icon: 'editor-table',

--- a/blocks/library/table/test/index.js
+++ b/blocks/library/table/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerTableBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/embed', () => {
+	beforeAll( () => {
+		registerTableBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/table' );
 

--- a/blocks/library/table/test/index.js
+++ b/blocks/library/table/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerTableBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/embed', () => {
-	beforeAll( () => {
-		registerTableBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/table' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -13,14 +13,15 @@ import { __ } from '@wordpress/i18n';
  */
 import './style.scss';
 import './editor.scss';
-import { registerBlockType } from '../../api';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import RangeControl from '../../inspector-controls/range-control';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
 
-export const registerTextColumnsBlock = () => registerBlockType( 'core/text-columns', {
+export const name = 'core/text-columns';
+
+export const settings = {
 	title: __( 'Text Columns' ),
 
 	description: __( 'Add text across columns. This block is experimental' ),
@@ -118,4 +119,4 @@ export const registerTextColumnsBlock = () => registerBlockType( 'core/text-colu
 			</div>
 		);
 	},
-} );
+};

--- a/blocks/library/text-columns/index.js
+++ b/blocks/library/text-columns/index.js
@@ -20,7 +20,7 @@ import RangeControl from '../../inspector-controls/range-control';
 import Editable from '../../editable';
 import InspectorControls from '../../inspector-controls';
 
-registerBlockType( 'core/text-columns', {
+export const registerTextColumnsBlock = () => registerBlockType( 'core/text-columns', {
 	title: __( 'Text Columns' ),
 
 	description: __( 'Add text across columns. This block is experimental' ),

--- a/blocks/library/text-columns/test/index.js
+++ b/blocks/library/text-columns/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerTextColumnsBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/text-columns', () => {
+	beforeAll( () => {
+		registerTextColumnsBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/text-columns' );
 

--- a/blocks/library/text-columns/test/index.js
+++ b/blocks/library/text-columns/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerTextColumnsBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/text-columns', () => {
-	beforeAll( () => {
-		registerTextColumnsBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/text-columns' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -10,7 +10,7 @@ import './editor.scss';
 import { registerBlockType, createBlock } from '../../api';
 import Editable from '../../editable';
 
-registerBlockType( 'core/verse', {
+export const registerVerseBlock = () => registerBlockType( 'core/verse', {
 	title: __( 'Verse' ),
 
 	description: __( 'Write poetry and other literary expressions honoring all spaces and line-breaks.' ),

--- a/blocks/library/verse/index.js
+++ b/blocks/library/verse/index.js
@@ -7,10 +7,12 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './editor.scss';
-import { registerBlockType, createBlock } from '../../api';
+import { createBlock } from '../../api';
 import Editable from '../../editable';
 
-export const registerVerseBlock = () => registerBlockType( 'core/verse', {
+export const name = 'core/verse';
+
+export const settings = {
 	title: __( 'Verse' ),
 
 	description: __( 'Write poetry and other literary expressions honoring all spaces and line-breaks.' ),
@@ -72,4 +74,4 @@ export const registerVerseBlock = () => registerBlockType( 'core/verse', {
 	save( { attributes, className } ) {
 		return <pre className={ className }>{ attributes.content }</pre>;
 	},
-} );
+};

--- a/blocks/library/verse/test/index.js
+++ b/blocks/library/verse/test/index.js
@@ -1,10 +1,14 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerVerseBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/verse', () => {
+	beforeAll( () => {
+		registerVerseBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/verse' );
 

--- a/blocks/library/verse/test/index.js
+++ b/blocks/library/verse/test/index.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import { registerVerseBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 describe( 'core/verse', () => {
-	beforeAll( () => {
-		registerVerseBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/verse' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -20,7 +20,7 @@ import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-registerBlockType( 'core/video', {
+export const registerVideoBlock = () => registerBlockType( 'core/video', {
 	title: __( 'Video' ),
 
 	description: __( 'The Video block allows you to embed video files and play them back using a simple player.' ),

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -14,13 +14,14 @@ import { Component } from '@wordpress/element';
  */
 import './style.scss';
 import './editor.scss';
-import { registerBlockType } from '../../api';
 import MediaUpload from '../../media-upload';
 import Editable from '../../editable';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-export const registerVideoBlock = () => registerBlockType( 'core/video', {
+export const name = 'core/video';
+
+export const settings = {
 	title: __( 'Video' ),
 
 	description: __( 'The Video block allows you to embed video files and play them back using a simple player.' ),
@@ -180,4 +181,4 @@ export const registerVideoBlock = () => registerBlockType( 'core/video', {
 			</figure>
 		);
 	},
-} );
+};

--- a/blocks/library/video/test/index.js
+++ b/blocks/library/video/test/index.js
@@ -1,12 +1,16 @@
 /**
  * Internal dependencies
  */
-import '../';
+import { registerVideoBlock } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
 
 describe( 'core/video', () => {
+	beforeAll( () => {
+		registerVideoBlock();
+	} );
+
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( 'core/video' );
 

--- a/blocks/library/video/test/index.js
+++ b/blocks/library/video/test/index.js
@@ -1,18 +1,14 @@
 /**
  * Internal dependencies
  */
-import { registerVideoBlock } from '../';
+import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
 
 describe( 'core/video', () => {
-	beforeAll( () => {
-		registerVideoBlock();
-	} );
-
 	test( 'block edit matches snapshot', () => {
-		const wrapper = blockEditRender( 'core/video' );
+		const wrapper = blockEditRender( name, settings );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/blocks/test/full-content.js
+++ b/blocks/test/full-content.js
@@ -9,6 +9,7 @@ import { format } from 'util';
 /**
  * Internal dependencies
  */
+import { registerCoreBlocks } from '../library';
 import parse from '../api/parser';
 import { parse as grammarParse } from '../api/post.pegjs';
 import serialize from '../api/serializer';
@@ -91,8 +92,9 @@ describe( 'full post content fixture', () => {
 	beforeAll( () => {
 		window._wpBlocks = require( './server-registered.json' );
 
-		// Register all blocks.
-		require( 'blocks' );
+		// Load all hooks that modify blocks
+		require( 'blocks/hooks' );
+		registerCoreBlocks();
 	} );
 
 	fileBasenames.forEach( f => {

--- a/blocks/test/helpers/index.js
+++ b/blocks/test/helpers/index.js
@@ -7,10 +7,18 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createBlock, BlockEdit } from '../..';
+import {
+	createBlock,
+	getBlockType,
+	registerBlockType,
+	BlockEdit,
+} from '../..';
 
-export const blockEditRender = ( name, initialAttributes = {} ) => {
-	const block = createBlock( name, initialAttributes );
+export const blockEditRender = ( name, settings ) => {
+	if ( ! getBlockType( name ) ) {
+		registerBlockType( name, settings );
+	}
+	const block = createBlock( name );
 
 	return render(
 		<BlockEdit

--- a/editor/components/document-outline/test/index.js
+++ b/editor/components/document-outline/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, registerCoreBlocks } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,6 +14,8 @@ import { createBlock } from '@wordpress/blocks';
 import { DocumentOutline } from '../';
 
 describe( 'DocumentOutline', () => {
+	registerCoreBlocks();
+
 	const paragraph = createBlock( 'core/paragraph' );
 	const headingH1 = createBlock( 'core/heading', {
 		content: 'Heading 1',

--- a/editor/edit-post/modes/visual-editor/test/inserter.js
+++ b/editor/edit-post/modes/visual-editor/test/inserter.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * WordPress dependencies
  */
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, registerCoreBlocks } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,6 +14,10 @@ import { getBlockType } from '@wordpress/blocks';
 import { VisualEditorInserter } from '../inserter';
 
 describe( 'VisualEditorInserter', () => {
+	beforeAll( () => {
+		registerCoreBlocks();
+	} );
+
 	it( 'should show controls when receiving focus', () => {
 		const clearSelectedBlock = jest.fn();
 		const wrapper = shallow( <VisualEditorInserter clearSelectedBlock={ clearSelectedBlock } /> );

--- a/editor/index.js
+++ b/editor/index.js
@@ -7,7 +7,6 @@ import 'moment-timezone/moment-timezone-utils';
 /**
  * WordPress dependencies
  */
-import { registerCoreBlocks } from '@wordpress/blocks';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { settings as dateSettings } from '@wordpress/date';
 
@@ -22,8 +21,6 @@ import { initializeMetaBoxState } from './store/actions';
 
 export * from './components';
 import store from './store'; // Registers the state tree
-
-registerCoreBlocks();
 
 // Configure moment globally
 moment.locale( dateSettings.l10n.locale );

--- a/editor/index.js
+++ b/editor/index.js
@@ -7,6 +7,7 @@ import 'moment-timezone/moment-timezone-utils';
 /**
  * WordPress dependencies
  */
+import { registerCoreBlocks } from '@wordpress/blocks';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { settings as dateSettings } from '@wordpress/date';
 
@@ -21,6 +22,8 @@ import { initializeMetaBoxState } from './store/actions';
 
 export * from './components';
 import store from './store'; // Registers the state tree
+
+registerCoreBlocks();
 
 // Configure moment globally
 moment.locale( dateSettings.l10n.locale );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -7,7 +7,12 @@ import deepFreeze from 'deep-freeze';
 /**
  * WordPress dependencies
  */
-import { registerBlockType, unregisterBlockType, getBlockType } from '@wordpress/blocks';
+import {
+	registerCoreBlocks,
+	registerBlockType,
+	unregisterBlockType,
+	getBlockType,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -957,6 +962,10 @@ describe( 'state', () => {
 	} );
 
 	describe( 'preferences()', () => {
+		beforeAll( () => {
+			registerCoreBlocks();
+		} );
+
 		it( 'should apply all defaults', () => {
 			const state = preferences( undefined, {} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -7,7 +7,7 @@ import moment from 'moment';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType, unregisterBlockType, getBlockTypes } from '@wordpress/blocks';
+import { getBlockTypes, registerBlockType, registerCoreBlocks, unregisterBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -2119,6 +2119,10 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getMostFrequentlyUsedBlocks', () => {
+		beforeAll( () => {
+			registerCoreBlocks();
+		} );
+
 		it( 'should have paragraph and image to bring frequently used blocks up to three blocks', () => {
 			const noUsage = { preferences: { blockUsage: {} } };
 			const someUsage = { preferences: { blockUsage: { 'core/paragraph': 1 } } };
@@ -2250,6 +2254,10 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getRecentInserterItems', () => {
+		beforeAll( () => {
+			registerCoreBlocks();
+		} );
+
 		it( 'should return the most recently used blocks', () => {
 			const state = {
 				preferences: {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -890,6 +890,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$script .= sprintf( 'var editorSettings = %s;', wp_json_encode( $editor_settings ) );
 	$script .= <<<JS
 		window._wpLoadGutenbergEditor = wp.api.init().then( function() {
+			wp.blocks.registerCoreBlocks();
 			return wp.editor.createEditorInstance( 'editor', window._wpGutenbergPost, editorSettings );
 		} );
 JS;


### PR DESCRIPTION
## Description

My first attempt to resolve one of the issues raised in #3800 by @andreiglingeanu:

> ```javascript
> let settings = wp.blocks.getBlockType('core/button')
> wp.blocks.unregisterBlockType('core/button')
> wp.blocks.registerBlockType('core/button', {
> 	...oldSettings,
> 	attributes: {
> 		...settings.attributes,
> 		heya: {
> 			type: 'string',
> 			default: '#cf2e2e',
> 		},
> 	},
> })
> ```
> 
> The reason for that hack was this: `wp-blocks` script does two things:
> 
> 1. Registers the hooks (in `wp.hooks.*`) to be received
> 2. Calls each `wp.blocks.registerBlockType` method of core's blocks _immediately_, in a _sync_ way
> 
> This in itself is not a problem. The problem arise when third-party plugins try to hook into `registerBlockType`. They literally have no time to do their transformations because action `1)` and `2)` happen one after another, with no way to interfere between them.

This PR refactors the library of blocks to expose the function `registerCoreBlocks` that registers all core block rather than doing it as a side effect at the time of declaration. This simple change allows us to have a much better control over when we want to register blocks. My initial proposal is to register all core blocks at the same time when Store instance for the editor is created. I'm open for discussion here and happy to hear how we can tackle it differently.

I like this refactoring because it revealed that some code assumes that blocks are globally available. I had to modify a few failing tests where importing from `@wordpress/blocks` magically bootstraps core blocks.

_Sidenote: It's much easier to review this code using diff without unnecessary whitespace changes:_
* https://github.com/WordPress/gutenberg/pull/4514/files?w=1

## How Has This Been Tested?
Manually and `npm run test-unit`. There should be no visual changes introduced.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.