### PR TITLE
Fix crash in PostAuthor component if we can't list users

### DIFF
--- a/editor/components/post-author/check.js
+++ b/editor/components/post-author/check.js
@@ -17,7 +17,7 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import { getCurrentPostType } from '../../store/selectors';
 
 export function PostAuthorCheck( { user, users, children } ) {
-	const authors = filter( users.data, ( { capabilities } ) => capabilities.level_1 );
+	const authors = filter( users.data, ( { capabilities } ) => undefined !== capabilities && capabilities.level_1 );
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
 
 	if ( ! userCanPublishPosts || authors.length < 2 ) {

--- a/editor/components/post-author/index.js
+++ b/editor/components/post-author/index.js
@@ -39,7 +39,7 @@ export class PostAuthor extends Component {
 		// See: https://codex.wordpress.org/Roles_and_Capabilities#User_Levels
 		const { users } = this.props;
 		return filter( users.data, ( user ) => {
-			return user.capabilities.level_1;
+			return undefined !== user.capabilities && user.capabilities.level_1;
 		} );
 	}
 


### PR DESCRIPTION
## Description

There are situations where a user can post to a blog, but
is not allowed to list the users on the blog. This is a
very strange and specific case, but it happens in the wild,
even though I couldn't tell you exactly how to recreate it,
short of "log in as me."

In this situation, Gutenberg crashes when it starts up, because
the data structures coming back from the API are not what
it expects.

This change checks that the data structures we need to
create a list of potential authors are present, before
trying to check for the required user level.

## How Has This Been Tested?

I applied this fix on a gutenberg install on a blog where
this happens to me, and the editor no longer crashed on startup.

## Types of changes
Bug fix (non-breaking change which fixes an issue)
