### PR TITLE
Added target and rel to the inlineWhiteList of the "a" element.

### DIFF
--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -23,7 +23,7 @@ const inlineWhitelist = {
 	em: {},
 	del: {},
 	ins: {},
-	a: { attributes: [ 'href' ] },
+	a: { attributes: [ 'href', 'target', 'rel' ] },
 	code: {},
 	abbr: { attributes: [ 'title' ] },
 	sub: {},


### PR DESCRIPTION
Allows target and rel to attributes of anchors to be kept during copy & paste and convert to blocks operation.
Fixes: https://github.com/WordPress/gutenberg/issues/4498

## How Has This Been Tested?

1. Create a post in the classic editor or Gutenberg code editor with rel and target attributes in an anchor e.g:`<p>test <a href="http://example.com" target="_blank" rel="nofollow noopener">link</a> test</p> ` ( can be copy pasted to the code editor).
2. Open the post in the Gutenberg visual editor and use the convert to blocks option, verify in the code editor or code view that both rel and target attributes of anchor were kept.
3. Copy an paste an HTML anchor with rel and target attributes in a paragraph block e.g: `<a href="http://example.com" target="_blank" rel="nofollow noopener">link</a>` verify both target and rel attributes were kept.