### PR TITLE
Update RangeControl to render number optionally

### DIFF
--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -10,9 +10,24 @@ import { __ } from '@wordpress/i18n';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIcon, help, allowReset, ...props } ) {
+function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIcon, help, allowReset, showNumber=true, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
+
+  function renderNumber() {
+    if(!showNumber) {
+      return null
+    }
+    return (
+      <input
+        className="blocks-range-control__number"
+        type="number"
+        onChange={ onChangeValue }
+        value={ value }
+        { ...props }
+      />
+    )
+  }
 
 	return (
 		<BaseControl label={ label } id={ id } help={ help } className="blocks-range-control">
@@ -26,13 +41,7 @@ function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIc
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props } />
 			{ afterIcon && <Dashicon icon={ afterIcon } /> }
-			<input
-				className="blocks-range-control__number"
-				type="number"
-				onChange={ onChangeValue }
-				value={ value }
-				{ ...props }
-			/>
+			{renderNumber()}
 			{ allowReset &&
 				<Button onClick={ () => onChange() } disabled={ value === undefined }>
 					{ __( 'Reset' ) }

--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -10,24 +10,24 @@ import { __ } from '@wordpress/i18n';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIcon, help, allowReset, showNumber=true, ...props } ) {
+function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIcon, help, allowReset, showNumber = true, ...props } ) {
 	const id = 'inspector-range-control-' + instanceId;
 	const onChangeValue = ( event ) => onChange( Number( event.target.value ) );
 
-  function renderNumber() {
-    if(!showNumber) {
-      return null
-    }
-    return (
-      <input
-        className="blocks-range-control__number"
-        type="number"
-        onChange={ onChangeValue }
-        value={ value }
-        { ...props }
-      />
-    )
-  }
+	function renderNumber() {
+		if ( ! showNumber ) {
+			return null;
+		}
+		return (
+			<input
+				className="blocks-range-control__number"
+				type="number"
+				onChange={ onChangeValue }
+				value={ value }
+				{ ...props }
+			/>
+		);
+	}
 
 	return (
 		<BaseControl label={ label } id={ id } help={ help } className="blocks-range-control">
@@ -41,7 +41,7 @@ function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIc
 				aria-describedby={ !! help ? id + '__help' : undefined }
 				{ ...props } />
 			{ afterIcon && <Dashicon icon={ afterIcon } /> }
-			{renderNumber()}
+			{ renderNumber() }
 			{ allowReset &&
 				<Button onClick={ () => onChange() } disabled={ value === undefined }>
 					{ __( 'Reset' ) }


### PR DESCRIPTION
## Description
Here is my suggestion to make RangeControl number input field optional. It may be cases where showing it may lead to confusion to why it's there. Number is shown by default to ensure backwards compatibility. 

Feel free to ignore this PR if it makes sense to leave it as non-optional.

## How Has This Been Tested?
The code has been linted.

Created a test block using range control. Tested the block by using `showNumber={false}` and `showNumber={true}` and not specify the property at all.

## Screenshots (jpeg or gifs if applicable):
<img width="724" alt="screen shot 2018-01-16 at 19 26 05" src="https://user-images.githubusercontent.com/7047431/35005287-361602ac-faf3-11e7-9512-7133bb6c4729.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.