### PR TITLE
Ensure editor still exists after timeout

### DIFF
--- a/blocks/editable/patterns.js
+++ b/blocks/editable/patterns.js
@@ -21,9 +21,15 @@ const { setTimeout } = window;
 
 const { ESCAPE, ENTER, SPACE, BACKSPACE } = keycodes;
 
-const setSafeTimeout = ( editor, callback ) => {
-	return setTimeout( () => ! editor.removed && callback() );
-};
+/**
+ * Sets a timeout and checks if the given editor still exists.
+ *
+ * @param {Editor}   editor   TinyMCE editor instance.
+ * @param {Function} callback The function to call.
+ */
+function setSafeTimeout( editor, callback ) {
+	setTimeout( () => ! editor.removed && callback() );
+}
 
 export default function( editor ) {
 	const getContent = this.getContent.bind( this );

--- a/blocks/editable/patterns.js
+++ b/blocks/editable/patterns.js
@@ -21,6 +21,10 @@ const { setTimeout } = window;
 
 const { ESCAPE, ENTER, SPACE, BACKSPACE } = keycodes;
 
+const setSafeTimeout = ( editor, callback ) => {
+	return setTimeout( () => ! editor.removed && callback() );
+};
+
 export default function( editor ) {
 	const getContent = this.getContent.bind( this );
 	const { onReplace } = this.props;
@@ -64,9 +68,9 @@ export default function( editor ) {
 			enter();
 		// Wait for the browser to insert the character.
 		} else if ( keyCode === SPACE ) {
-			setTimeout( () => searchFirstText( spacePatterns ) );
+			setSafeTimeout( editor, () => searchFirstText( spacePatterns ) );
 		} else if ( keyCode > 47 && ! ( keyCode >= 91 && keyCode <= 93 ) ) {
-			setTimeout( inline );
+			setSafeTimeout( editor, inline );
 		}
 	}, true );
 


### PR DESCRIPTION
## Description
This change makes sure that the editor still exists after a timeout in the patterns plugin. An error occurs when a previous keydown callback removes the editor and still satisfies the conditions in the patterns plugin callback.

Fixes https://github.com/WordPress/gutenberg/pull/2192#pullrequestreview-88911833.
