### PR TITLE
Components: Ensure isLoading set to false after request error

### DIFF
--- a/components/higher-order/with-api-data/index.js
+++ b/components/higher-order/with-api-data/index.js
@@ -139,16 +139,24 @@ export default ( mapPropsToData ) => ( WrappedComponent ) => {
 				[ this.getPendingKey( method ) ]: true,
 			} );
 
-			request( { path, method } ).then( ( response ) => {
-				this.setIntoDataProp( propName, {
-					[ this.getPendingKey( method ) ]: false,
+			request( { path, method } )
+				// [Success] Set the data prop:
+				.then( ( response ) => ( {
 					[ this.getResponseDataKey( method ) ]: response.body,
-				} );
-			} ).catch( ( error ) => {
-				this.setIntoDataProp( propName, {
+				} ) )
+
+				// [Failure] Set the error prop:
+				.catch( ( error ) => ( {
 					[ this.getErrorResponseKey( method ) ]: error,
+				} ) )
+
+				// Always reset loading prop:
+				.then( ( nextDataProp ) => {
+					this.setIntoDataProp( propName, {
+						[ this.getPendingKey( method ) ]: false,
+						...nextDataProp,
+					} );
 				} );
-			} );
 		}
 
 		applyMapping( props ) {


### PR DESCRIPTION
This pull request seeks to resolve an issue where the `withAPIData` higher-order component does not set the data prop's `isLoading` to `false` if an error response is returned from the REST API. In practice, this did not appear to impact any part of the editor application, but was a logic error in the implementation.

__Review notes:__

The "Unified" diff in GitHub is fairly difficult to read with these changes. I'd suggest the "Split" view.

__Testing instructions:__

Verify that the unit tests pass:

```
npm run test-unit components/higher-order/with-api-data/index.js
```