### PR TITLE
Allow copying text in block (non input)

### DIFF
--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -36,7 +36,7 @@ import {
 	isSelectionEnabled,
 } from '../../store/selectors';
 import { startMultiSelect, stopMultiSelect, multiSelect, selectBlock } from '../../store/actions';
-import { isInputField } from '../../utils/dom';
+import { documentHasSelection } from '../../utils/dom';
 
 class BlockList extends Component {
 	constructor( props ) {
@@ -116,7 +116,7 @@ class BlockList extends Component {
 		}
 
 		// Let native copy behaviour take over in input fields.
-		if ( selectedBlock && isInputField( document.activeElement ) ) {
+		if ( selectedBlock && documentHasSelection() ) {
 			return;
 		}
 

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -324,3 +324,20 @@ export function isInputField( { nodeName, contentEditable } ) {
 		contentEditable === 'true'
 	);
 }
+
+/**
+ * Check wether the current document has a selection.
+ * This checks both for focus in an input field and general text selection.
+ *
+ * @returns {Boolean} True if there is selection, false if not.
+ */
+export function documentHasSelection() {
+	if ( isInputField( document.activeElement ) ) {
+		return true;
+	}
+
+	const selection = window.getSelection();
+	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+
+	return range && ! range.collapsed;
+}


### PR DESCRIPTION
## Description
This PR fixes copying text form a block that is not inside an input field.

## How Has This Been Tested?
Create an image block. Select some text from the placeholder and copy it. Copied text should not be the whole block.
