### PR TITLE
Use `cheap-module-eval-source-map`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,7 +160,7 @@ switch ( process.env.NODE_ENV ) {
 		break;
 
 	default:
-		config.devtool = 'source-map';
+		config.devtool = 'cheap-module-eval-source-map';
 }
 
 module.exports = config;


### PR DESCRIPTION
By sacrificing a small amount of source map accuracy, we make incremental development builds about 20% faster.

Learn about the different modes here: https://webpack.js.org/configuration/devtool/#devtool

### About the trade-off

Say you have code like this:

```js
const { foo, bar, baz } = coolObject;
```

With `source-maps`, DevTools will allow you to step through each operation within that line: first, the `foo` assignment, then the `bar` assignment, then the `baz` assignment.

With `cheap-module-eval-source-map`, DevTools will only allow you to break at that entire line.

In my experience, it’s not worth the performance penalty.

And besides, if one needs to step through things more granularly, they can temporarily change their Webpack settings and rebuild.
