### PR TITLE
Fix snapshot tests

### DIFF
--- a/blocks/library/audio/test/__snapshots__/index.js.snap
+++ b/blocks/library/audio/test/__snapshots__/index.js.snap
@@ -26,7 +26,7 @@ exports[`core/audio block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__instructions"
   >
-    Select an audio file from your library, or upload a new one:
+    Select an audio file from your library, or upload a new one
   </div>
   <div
     class="components-placeholder__fieldset"

--- a/blocks/library/video/test/__snapshots__/index.js.snap
+++ b/blocks/library/video/test/__snapshots__/index.js.snap
@@ -26,7 +26,7 @@ exports[`core/video block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__instructions"
   >
-    Select a video file from your library, or upload a new one:
+    Select a video file from your library, or upload a new one
   </div>
   <div
     class="components-placeholder__fieldset"


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/4431 caused the snapshot tests added in https://github.com/WordPress/gutenberg/pull/4399 to fail.