### PR TITLE
Components: Refactor insertIndex from Inserter component

### DIFF
--- a/editor/components/block-list/sibling-inserter.js
+++ b/editor/components/block-list/sibling-inserter.js
@@ -21,24 +21,36 @@ import {
 } from '../../store/selectors';
 import {
 	clearSelectedBlock,
+	setInsertionPointIndex,
 } from '../../store/actions';
 
 class BlockListSiblingInserter extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.forceVisibleWhileInserting = this.forceVisibleWhileInserting.bind( this );
+		this.onToggle = this.onToggle.bind( this );
 
 		this.state = {
 			isForcedVisible: false,
 		};
 	}
 
-	forceVisibleWhileInserting( isOpen ) {
+	/**
+	 * Handles sibling inserter behaviors to occur when the inserter is opened
+	 * or closed.
+	 *
+	 * @param {Boolean} isOpen Whether inserter is open.
+	 */
+	onToggle( isOpen ) {
+		// Set index at which insertion point should display
+		const { setInsertionPoint, insertIndex } = this.props;
+		setInsertionPoint( isOpen ? insertIndex : null );
+
 		// Prevent mouseout and blur while navigating the open inserter menu
 		// from causing the inserter to be unmounted.
 		this.setState( { isForcedVisible: isOpen } );
 
+		// Clear block selection when opening
 		if ( isOpen ) {
 			this.props.clearSelectedBlock();
 		}
@@ -68,7 +80,7 @@ class BlockListSiblingInserter extends Component {
 					key="inserter"
 					position="bottom"
 					insertIndex={ insertIndex }
-					onToggle={ this.forceVisibleWhileInserting }
+					onToggle={ this.onToggle }
 				/>
 			</div>
 		);
@@ -91,5 +103,6 @@ export default connect(
 	},
 	{
 		clearSelectedBlock,
+		setInsertionPoint: setInsertionPointIndex,
 	}
 )( BlockListSiblingInserter );

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -199,27 +199,32 @@ export function insertBlocks( blocks, position ) {
 }
 
 /**
- * Returns an action object showing the insertion point at a given index
+ * Returns an action object used in signalling that the visibility of the
+ * insertion point is to be toggled.
  *
- * @param  {Number?} index  Index of the insertion point
+ * @param {Boolean} isVisible Whether the insertion point is visible.
  *
  * @returns {Object} Action object.
  */
-export function showInsertionPoint( index ) {
+export function toggleInsertionPointVisible( isVisible ) {
 	return {
-		type: 'SHOW_INSERTION_POINT',
-		index,
+		type: 'TOGGLE_INSERTION_POINT_VISIBLE',
+		isVisible,
 	};
 }
 
 /**
- * Returns an action object hiding the insertion point
+ * Returns an action object used in signalling that the insertion point is to
+ * be shown at a given index.
+ *
+ * @param {Number?} index Index of the insertion point, or null to unset.
  *
  * @returns {Object} Action object.
  */
-export function hideInsertionPoint() {
+export function setInsertionPointIndex( index ) {
 	return {
-		type: 'HIDE_INSERTION_POINT',
+		type: 'SET_INSERTION_POINT_INDEX',
+		index,
 	};
 }
 

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -495,11 +495,13 @@ export function blocksMode( state = {}, action ) {
  */
 export function blockInsertionPoint( state = {}, action ) {
 	switch ( action.type ) {
-		case 'SHOW_INSERTION_POINT':
-			return { ...state, visible: true, position: action.index };
+		case 'TOGGLE_INSERTION_POINT_VISIBLE':
+			const { isVisible } = action;
+			return { ...state, isVisible };
 
-		case 'HIDE_INSERTION_POINT':
-			return { ...state, visible: false, position: null };
+		case 'SET_INSERTION_POINT_INDEX':
+			const { index } = action;
+			return { ...state, index };
 	}
 
 	return state;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -945,9 +945,9 @@ export function getBlockInsertionPoint( state ) {
 		return state.editor.present.blockOrder.length;
 	}
 
-	const position = getBlockSiblingInserterPosition( state );
-	if ( null !== position ) {
-		return position;
+	const { index } = state.blockInsertionPoint;
+	if ( Number.isInteger( index ) ) {
+		return index;
 	}
 
 	const lastMultiSelectedBlock = getLastMultiSelectedBlockUid( state );
@@ -964,23 +964,6 @@ export function getBlockInsertionPoint( state ) {
 }
 
 /**
- * Returns the position at which the block inserter will insert a new adjacent
- * sibling block, or null if the inserter is not actively visible.
- *
- * @param  {Object}  state Global application state
- *
- * @returns {?Number} Whether the inserter is currently visible.
- */
-export function getBlockSiblingInserterPosition( state ) {
-	const { position } = state.blockInsertionPoint;
-	if ( ! Number.isInteger( position ) ) {
-		return null;
-	}
-
-	return position;
-}
-
-/**
  * Returns true if we should show the block insertion point
  *
  * @param  {Object}  state Global application state
@@ -988,7 +971,7 @@ export function getBlockSiblingInserterPosition( state ) {
  * @returns {?Boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
-	return !! state.blockInsertionPoint.visible;
+	return !! state.blockInsertionPoint.isVisible;
 }
 
 /**

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -31,8 +31,8 @@ import {
 	replaceBlock,
 	insertBlock,
 	insertBlocks,
-	showInsertionPoint,
-	hideInsertionPoint,
+	toggleInsertionPointVisible,
+	setInsertionPointIndex,
 	editPost,
 	savePost,
 	trashPost,
@@ -245,19 +245,20 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'showInsertionPoint', () => {
-		it( 'should return the SHOW_INSERTION_POINT action', () => {
-			expect( showInsertionPoint( 1 ) ).toEqual( {
-				type: 'SHOW_INSERTION_POINT',
-				index: 1,
+	describe( 'toggleInsertionPointVisible', () => {
+		it( 'should return the TOGGLE_INSERTION_POINT_VISIBLE action', () => {
+			expect( toggleInsertionPointVisible( true ) ).toEqual( {
+				type: 'TOGGLE_INSERTION_POINT_VISIBLE',
+				isVisible: true,
 			} );
 		} );
 	} );
 
-	describe( 'hideInsertionPoint', () => {
-		it( 'should return the HIDE_INSERTION_POINT action', () => {
-			expect( hideInsertionPoint() ).toEqual( {
-				type: 'HIDE_INSERTION_POINT',
+	describe( 'setInsertionPointIndex', () => {
+		it( 'should return the SET_INSERTION_POINT_INDEX action', () => {
+			expect( setInsertionPointIndex( 1 ) ).toEqual( {
+				type: 'SET_INSERTION_POINT_INDEX',
+				index: 1,
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -716,24 +716,30 @@ describe( 'state', () => {
 			expect( state ).toEqual( {} );
 		} );
 
-		it( 'should set insertion point position', () => {
+		it( 'should set insertion point index', () => {
 			const state = blockInsertionPoint( undefined, {
-				type: 'SHOW_INSERTION_POINT',
+				type: 'SET_INSERTION_POINT_INDEX',
 				index: 5,
 			} );
 
 			expect( state ).toEqual( {
-				position: 5,
-				visible: true,
+				index: 5,
 			} );
 		} );
 
-		it( 'should clear the insertion point', () => {
-			const state = blockInsertionPoint( deepFreeze( {} ), {
-				type: 'HIDE_INSERTION_POINT',
+		it( 'should toggle insertion point visibility', () => {
+			const originalState = deepFreeze( {
+				index: 5,
+			} );
+			const state = blockInsertionPoint( originalState, {
+				type: 'TOGGLE_INSERTION_POINT_VISIBLE',
+				isVisible: true,
 			} );
 
-			expect( state ).toEqual( { visible: false, position: null } );
+			expect( state ).toEqual( {
+				index: 5,
+				isVisible: true,
+			} );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -63,7 +63,6 @@ import {
 	getBlockMode,
 	isTyping,
 	getBlockInsertionPoint,
-	getBlockSiblingInserterPosition,
 	isBlockInsertionPointVisible,
 	isSavingPost,
 	didPostSaveRequestSucceed,
@@ -1960,7 +1959,7 @@ describe( 'selectors', () => {
 					},
 				},
 				blockInsertionPoint: {
-					position: 2,
+					index: 2,
 				},
 			};
 
@@ -2000,6 +1999,23 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toBe( 3 );
 		} );
 
+		it( 'should return the last block if insertion point is explicitly null', () => {
+			const state = {
+				preferences: { mode: 'visual' },
+				blockSelection: { start: null, end: null },
+				editor: {
+					present: {
+						blockOrder: [ 1, 2, 3 ],
+					},
+				},
+				blockInsertionPoint: {
+					index: null,
+				},
+			};
+
+			expect( getBlockInsertionPoint( state ) ).toBe( 3 );
+		} );
+
 		it( 'should return the last block for the text mode', () => {
 			const state = {
 				preferences: { mode: 'text' },
@@ -2016,31 +2032,19 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getBlockSiblingInserterPosition', () => {
-		it( 'should return null if no sibling insertion point', () => {
+	describe( 'isBlockInsertionPointVisible', () => {
+		it( 'should return false by default', () => {
 			const state = {
 				blockInsertionPoint: {},
 			};
 
-			expect( getBlockSiblingInserterPosition( state ) ).toBe( null );
+			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
 		} );
 
-		it( 'should return sibling insertion point', () => {
-			const state = {
-				blockInsertionPoint: {
-					position: 5,
-				},
-			};
-
-			expect( getBlockSiblingInserterPosition( state ) ).toBe( 5 );
-		} );
-	} );
-
-	describe( 'isBlockInsertionPointVisible', () => {
 		it( 'should return the value in state', () => {
 			const state = {
 				blockInsertionPoint: {
-					visible: true,
+					isVisible: true,
 				},
 			};
 


### PR DESCRIPTION
This pull request seeks to refactor the `Inserter` component to separate handling of insertion point and visibility. Previously the Inserter component was responsible for: setting the insertion point, showing the insertion point, and inserting a block at the current insertion point. To achieve this, it received two props `insertIndex` and `insertionPoint` which often -- but not always -- held the same value.

The changes here distinguish setting an insertion point to be the responsibility of where it is relevant; namely, the sibling inserter component. `showInsertionPoint( index )` and `hideInsertionPoint()` have been replaced with `toggleInsertionPointVisible( isVisible )` and `setInsertionPointIndex( index )`.

A hope here is to try to clarify a difference between an explicit insertion point (reflected in `state.blockInsertionPoint`) and the implicit insertion point (the logic contained within the `getBlockInsertionPoint` selector, inserting after content or the current block selection).

The main downside is that since there are now two separate actions for setting the insertion point index and its visibility, there may be separate renders which occur. This can be seen when, while a block is selected, you use the header inserter and then cancel both insertion and block selection by clicking on the editor background. The insertion point shows briefly at the bottom of the post content.

__Testing instructions:__

Verify that there are no regressions in the behavior of the insertion point, notably around selection (including multi-selection), sibling block insertion, and the header inserter (with and without selected block, in Visual and Text modes).

Ensure that unit tests pass:

```
npm test
```