### PR TITLE
Remove danger warning from plugin header

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
- * Description: Printing since 1440. This is the development plugin for the new block editor in core. <strong>Meant for development, do not run on real sites.</strong>
+ * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Version: 2.0.0
  * Author: Gutenberg Team
  *


### PR DESCRIPTION
## Description

See: https://github.com/WordPress/gutenberg/issues/4185 This is a simple change to the plugin header description.