### PR TITLE
Insert a block on start for some post formats.

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -22,6 +22,7 @@ export {
 	getUnknownTypeHandlerName,
 	setDefaultBlockName,
 	getDefaultBlockName,
+	getDefaultBlockForPostFormat,
 	getBlockType,
 	getBlockTypes,
 	getBlockSupport,

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -64,6 +64,19 @@ let unknownTypeHandlerName;
 let defaultBlockName;
 
 /**
+ * Constant mapping post formats to the expected default block.
+ *
+ * @type {Object}
+ */
+const POST_FORMAT_BLOCK_MAP = {
+	audio: 'core/audio',
+	gallery: 'core/gallery',
+	image: 'core/image',
+	quote: 'core/quote',
+	video: 'core/video',
+};
+
+/**
  * Registers a new block provided a unique name and an object defining its
  * behavior. Once registered, the block is made available as an option to any
  * editor interface where blocks are implemented.
@@ -202,10 +215,24 @@ export function setDefaultBlockName( name ) {
 /**
  * Retrieves the default block name.
  *
- * @return {?string} Blog name.
+ * @return {?string} Block name.
  */
 export function getDefaultBlockName() {
 	return defaultBlockName;
+}
+
+/**
+ * Retrieves the expected default block for the post format.
+ *
+ * @param	{string} postFormat Post format
+ * @return {string}            Block name.
+ */
+export function getDefaultBlockForPostFormat( postFormat ) {
+	const blockName = POST_FORMAT_BLOCK_MAP[ postFormat ];
+	if ( blockName && getBlockType( blockName ) ) {
+		return blockName;
+	}
+	return null;
 }
 
 /**

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -16,6 +16,7 @@ import {
 	createReusableBlock,
 	isReusableBlock,
 	getDefaultBlockName,
+	getDefaultBlockForPostFormat,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
@@ -50,6 +51,7 @@ import {
 	isEditedPostNew,
 	isEditedPostSaveable,
 	getBlock,
+	getBlockCount,
 	getBlocks,
 	getReusableBlock,
 	getMetaBoxes,
@@ -300,6 +302,8 @@ export default {
 				} );
 			};
 			blocks = createBlocksFromTemplate( settings.template );
+		} else if ( getDefaultBlockForPostFormat( post.format ) ) {
+			blocks = [ createBlock( getDefaultBlockForPostFormat( post.format ) ) ];
 		} else {
 			blocks = [];
 		}
@@ -518,5 +522,15 @@ export default {
 		// Save the metaboxes
 		window.fetch( window._wpMetaBoxUrl, fetchOptions )
 			.then( () => store.dispatch( metaBoxUpdatesSuccess() ) );
+	},
+	EDIT_POST( action, { getState } ) {
+		const format = get( action, 'edits.format' );
+		if ( ! format ) {
+			return;
+		}
+		const blockName = getDefaultBlockForPostFormat( format );
+		if ( blockName && getBlockCount( getState() ) === 0 ) {
+			return insertBlock( createBlock( blockName ) );
+		}
 	},
 };


### PR DESCRIPTION
## Description
Addresses part of https://github.com/WordPress/gutenberg/issues/4546
If the post is empty and we select a format e.g: image the corresponding expected block is automatically added.
If a default post format is set when opening the editor the corresponding block for that format is automatically added.


