### PR TITLE
Add more context to Templates sample code

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -74,7 +74,7 @@ Sometimes the intention might be to lock the template on the UI so that the bloc
 It is also possible to assign a template to an existing post type like "posts" and "pages":
 
 ```php
-function my_post_template() {
+function my_add_template_to_posts() {
 	$post_type_object = get_post_type_object( 'post' );
 	$post_type_object->template = array(
 		array( 'core/paragraph', array(
@@ -83,5 +83,5 @@ function my_post_template() {
 	);
 	$post_type_object->template_lock = 'all';
 }
-add_action( 'init', 'my_post_template' );
+add_action( 'init', 'my_add_template_to_posts' );
 ```

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -74,11 +74,14 @@ Sometimes the intention might be to lock the template on the UI so that the bloc
 It is also possible to assign a template to an existing post type like "posts" and "pages":
 
 ```php
-$post_type_object = get_post_type_object( 'post' );
-$post_type_object->template = array(
-	array( 'core/paragraph', array(
-		'placeholder' => 'Add Description...',
-	) ),
-);
-$post_type_object->template_lock = 'all';
+function my_post_template() {
+	$post_type_object = get_post_type_object( 'post' );
+	$post_type_object->template = array(
+		array( 'core/paragraph', array(
+			'placeholder' => 'Add Description...',
+		) ),
+	);
+	$post_type_object->template_lock = 'all';
+}
+add_action( 'init', 'my_post_template' );
 ```


### PR DESCRIPTION
## Description
Added to the documentation for [Templates](https://wordpress.org/gutenberg/handbook/templates/). I put a wrapper function and `add_action` call into the PHP code for adding a template to a post type. This makes the code copy/pastable and gives readers more context.

## How Has This Been Tested?
Yes, I tested the code in a plugin.

## Types of changes
Added to the demo code in the markdown file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
