### PR TITLE
Fix author select IE11 overflow with max-width

### DIFF
--- a/editor/edit-post/sidebar/post-author/style.scss
+++ b/editor/edit-post/sidebar/post-author/style.scss
@@ -1,3 +1,4 @@
 .editor-post-author__select {
 	margin: -5px 0;
+	max-width: 77%; // For IE11 overflow
 }


### PR DESCRIPTION
## Description
Add `max-width` to author select to prevent overflow on IE11 for long names. Fixes #3432. 

## How Has This Been Tested?
Tested in IE11 using Browserstack, as well as:
Chrome 63.0.3239.132 
FireFox Quantum 57.0.4
Most recent iOS Emulator

## Screenshots (jpeg or gifs if applicable):
<img width="502" alt="screen shot 2018-01-17 at 8 26 27 pm" src="https://user-images.githubusercontent.com/445861/35080905-70e13474-fbc5-11e7-96d9-d3db6bc7c754.png">

## Types of changes
Line of CSS to add max-width to `.editor-post-author__select`. This is nicely scoped to the editor select only, though it is a hardcoded value. Since it is a _max_-width, the worst case would be a little extra space on the right in IE11 (IE11 does not acknowledge `justify-content: space-between`) if the "Author" label was changed to something shorter. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
