### PR TITLE
Change "Edit Link" to "Insert/edit link" on Image Block

### DIFF
--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -43,7 +43,7 @@ class UrlInputButton extends Component {
 			<div className="blocks-url-input__button">
 				<IconButton
 					icon="admin-links"
-					label={ __( 'Edit Link' ) }
+					label={ __( 'Insert/edit link' ) }
 					onClick={ this.toggle }
 					className={ classnames( 'components-toolbar__control', {
 						'is-active': url,


### PR DESCRIPTION
## Description
PR is a copy change from "Edit Link" to "Insert/edit link" - within the toolbar for the Image Block.

> 2
When I insert an image, by default it has no link. However, the link button says "Edit link". In the classic editor, the link button always says "Insert/edit link" to avoid this issue.

This was one of two changes recommended by @afercia in #4325

## Screenshot Examples of Changes
<img width="746" alt="screen shot 2018-01-17 at 10 30 06 pm" src="https://user-images.githubusercontent.com/7691812/35082346-726ce3c2-fbd6-11e7-9b7b-790ec0e7d0f5.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
