### PR TITLE
Remove "max-width" from PanelRow label to fix the styling of the RangeControl when inside a PanelRow.

### DIFF
--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -123,7 +123,6 @@
 	label {
 		margin-right: 10px;
 		flex-shrink: 0;
-		max-width: 75%;
 	}
 
 	&:empty {


### PR DESCRIPTION
## Description
The change I'm undoing was introduced in https://github.com/WordPress/gutenberg/pull/3786. This change creates an in issue on the rendering of `RangeControl`, as it's described in https://github.com/WordPress/gutenberg/issues/4402.

## Screenshots (jpeg or gifs if applicable):
![before_after](https://user-images.githubusercontent.com/1268089/35086652-f50b0a0c-fc35-11e7-8e3d-d2bffcf405e1.jpg)

![before_after_rc](https://user-images.githubusercontent.com/1268089/35086653-f8006fc2-fc35-11e7-92f3-6f2785016fde.jpg)

As it's seen, my change doesn't affect the selects with long names in sidebar but fixes the styling issue of a `RangeControl` inside a `PanelRow`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
