### PR TITLE
Blocks: Showing a preview of the block immediately after drag and drop

### DIFF
--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -9,6 +9,10 @@
 		outline: 4px solid $blue-medium-500;
 		outline-offset: -4px;
 	}
+
+	&.is-transient img {
+		@include loading_fade;
+	}
 }
 
 .blocks-gallery-item__inline-menu {

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -38,6 +38,7 @@ class GalleryImage extends Component {
 
 		const className = classnames( {
 			'is-selected': isSelected,
+			'is-transient': 0 === url.indexOf( 'blob:' ),
 		} );
 
 		// Disable reason: Each block can be selected by clicking on it and we should keep the same saved markup

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createMediaFromFile } from '@wordpress/utils';
+import { createMediaFromFile, preloadImage } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -88,12 +88,18 @@ registerBlockType( 'core/image', {
 				isMatch( files ) {
 					return files.length === 1 && files[ 0 ].type.indexOf( 'image/' ) === 0;
 				},
-				transform( files ) {
-					return createMediaFromFile( files[ 0 ] )
-						.then( ( media ) => createBlock( 'core/image', {
-							id: media.id,
-							url: media.source_url,
-						} ) );
+				transform( files, onChange ) {
+					const file = files[ 0 ];
+					const block = createBlock( 'core/image', {
+						url: window.URL.createObjectURL( file ),
+					} );
+
+					createMediaFromFile( file )
+						.then( ( media ) => preloadImage( media.source_url ).then(
+							() => onChange( block.uid, { id: media.id, url: media.source_url } )
+						) );
+
+					return block;
 				},
 			},
 			{

--- a/editor/components/block-drop-zone/index.js
+++ b/editor/components/block-drop-zone/index.js
@@ -14,7 +14,7 @@ import { compose } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { insertBlocks } from '../../store/actions';
+import { insertBlocks, updateBlockAttributes } from '../../store/actions';
 
 function BlockDropZone( { index, isLocked, ...props } ) {
 	if ( isLocked ) {
@@ -40,10 +40,8 @@ function BlockDropZone( { index, isLocked, ...props } ) {
 
 		if ( transformation ) {
 			const insertPosition = getInsertPosition( position );
-
-			transformation.transform( files ).then( ( blocks ) => {
-				props.insertBlocks( blocks, insertPosition );
-			} );
+			const blocks = transformation.transform( files, props.updateBlockAttributes );
+			props.insertBlocks( blocks, insertPosition );
 		}
 	};
 
@@ -66,7 +64,7 @@ function BlockDropZone( { index, isLocked, ...props } ) {
 export default compose(
 	connect(
 		undefined,
-		{ insertBlocks }
+		{ insertBlocks, updateBlockAttributes }
 	),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -60,3 +60,19 @@ export function createMediaFromFile( file ) {
 		contentType: false,
 	} );
 }
+
+/**
+ * Utility used to preload an image before displaying it.
+ *
+ * @param   {string}  url Image Url.
+ * @returns {Promise}     Pormise resolved once the image is preloaded.
+ */
+export function preloadImage( url ) {
+	return new Promise( resolve => {
+		const newImg = new window.Image();
+		newImg.onload = function() {
+			resolve( url );
+		};
+		newImg.src = url;
+	} );
+}


### PR DESCRIPTION
closes #3372

This PR adds an immediate feedback when drag/dropping images to the editor. The image/gallery block is immediately appended and the URL is updated once the upload completes.

This matches the behavior we have when uploading the image from the block itself.
There's a flickering happening when the image uploads, this is due to the resizing behavior of the image block, not certain we can do much about it.

**Testing instructions**

 - Drag and drap one (or multiple) images to the editor
 - The blocks should show up immediately.