### PR TITLE
Add HTML handler to dropzone

### DIFF
--- a/blocks/image-placeholder/index.js
+++ b/blocks/image-placeholder/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { DropZone, FormFileUpload, Placeholder, Button } from '@wordpress/components';
@@ -9,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import MediaUpload from '../media-upload';
+import { rawHandler } from '../api';
 
 /**
  *  ImagePlaceHolder is a react component used by blocks containing user configurable images e.g: image and cover image.
@@ -19,7 +25,12 @@ import MediaUpload from '../media-upload';
  */
 export default function ImagePlaceHolder( { className, icon, label, onSelectImage } ) {
 	const setImage = ( [ image ] ) => onSelectImage( image );
-	const dropFiles = ( files ) => mediaUpload( files, setImage );
+	const onFilesDrop = ( files ) => mediaUpload( files, setImage );
+	const onHTMLDrop = ( HTML ) => setImage( map(
+		rawHandler( { HTML, mode: 'BLOCKS' } )
+			.filter( ( { name } ) => name === 'core/image' ),
+		'attributes'
+	) );
 	const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setImage );
 	return (
 		<Placeholder
@@ -28,7 +39,8 @@ export default function ImagePlaceHolder( { className, icon, label, onSelectImag
 			icon={ icon }
 			label={ label } >
 			<DropZone
-				onFilesDrop={ dropFiles }
+				onFilesDrop={ onFilesDrop }
+				onHTMLDrop={ onHTMLDrop }
 			/>
 			<FormFileUpload
 				isLarge

--- a/components/drop-zone/index.js
+++ b/components/drop-zone/index.js
@@ -23,6 +23,7 @@ class DropZone extends Component {
 		this.setZoneNode = this.setZoneNode.bind( this );
 		this.onDrop = this.onDrop.bind( this );
 		this.onFilesDrop = this.onFilesDrop.bind( this );
+		this.onHTMLDrop = this.onHTMLDrop.bind( this );
 
 		this.state = {
 			isDraggingOverDocument: false,
@@ -37,6 +38,7 @@ class DropZone extends Component {
 			updateState: this.setState.bind( this ),
 			onDrop: this.onDrop,
 			onFilesDrop: this.onFilesDrop,
+			onHTMLDrop: this.onHTMLDrop,
 		} );
 	}
 
@@ -53,6 +55,12 @@ class DropZone extends Component {
 	onFilesDrop() {
 		if ( this.props.onFilesDrop ) {
 			this.props.onFilesDrop( ...arguments );
+		}
+	}
+
+	onHTMLDrop() {
+		if ( this.props.onHTMLDrop ) {
+			this.props.onHTMLDrop( ...arguments );
 		}
 	}
 

--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -179,9 +179,13 @@ class DropZoneProvider extends Component {
 			const HTML = event.dataTransfer.getData( 'text/html' );
 
 			if ( files.length ) {
-				dropzone.onFilesDrop && dropzone.onFilesDrop( [ ...event.dataTransfer.files ], position );
+				if ( dropzone.onFilesDrop ) {
+					dropzone.onFilesDrop( [ ...event.dataTransfer.files ], position );
+				}
 			} else if ( HTML ) {
-				dropzone.onHTMLDrop && dropzone.onHTMLDrop( HTML, position );
+				if ( dropzone.onHTMLDrop ) {
+					dropzone.onHTMLDrop( HTML, position );
+				}
 			}
 		}
 

--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -29,8 +29,8 @@ class DropZoneProvider extends Component {
 	getChildContext() {
 		return {
 			dropzones: {
-				add: ( { element, updateState, onDrop, onFilesDrop } ) => {
-					this.dropzones.push( { element, updateState, onDrop, onFilesDrop } );
+				add: ( { element, updateState, onDrop, onFilesDrop, onHTMLDrop } ) => {
+					this.dropzones.push( { element, updateState, onDrop, onFilesDrop, onHTMLDrop } );
 				},
 				remove: ( element ) => {
 					this.dropzones = filter( this.dropzones, ( dropzone ) => dropzone.element !== element );
@@ -174,8 +174,15 @@ class DropZoneProvider extends Component {
 			return;
 		}
 
-		if ( event.dataTransfer && !! dropzone && !! dropzone.onFilesDrop ) {
-			dropzone.onFilesDrop( Array.prototype.slice.call( event.dataTransfer.files ), position );
+		if ( event.dataTransfer && !! dropzone ) {
+			const files = event.dataTransfer.files;
+			const HTML = event.dataTransfer.getData( 'text/html' );
+
+			if ( files.length ) {
+				dropzone.onFilesDrop && dropzone.onFilesDrop( [ ...event.dataTransfer.files ], position );
+			} else if ( HTML ) {
+				dropzone.onHTMLDrop && dropzone.onHTMLDrop( HTML, position );
+			}
 		}
 
 		event.stopPropagation();

--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -178,14 +178,10 @@ class DropZoneProvider extends Component {
 			const files = event.dataTransfer.files;
 			const HTML = event.dataTransfer.getData( 'text/html' );
 
-			if ( files.length ) {
-				if ( dropzone.onFilesDrop ) {
-					dropzone.onFilesDrop( [ ...event.dataTransfer.files ], position );
-				}
-			} else if ( HTML ) {
-				if ( dropzone.onHTMLDrop ) {
-					dropzone.onHTMLDrop( HTML, position );
-				}
+			if ( files.length && dropzone.onFilesDrop ) {
+				dropzone.onFilesDrop( [ ...event.dataTransfer.files ], position );
+			} else if ( HTML && dropzone.onHTMLDrop ) {
+				dropzone.onHTMLDrop( HTML, position );
 			}
 		}
 


### PR DESCRIPTION
## Description

Fixes #3744. This PR adds an HTML handler to drops zones, and handles it for the block drop zone with the `rawHandler`.

## How Has This Been Tested?
Drag and drop an image from the web into Gutenberg. The HTML will be dropped, sent through the raw handler, and an image block should appear.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.