### PR TITLE
Fix Grammarly conflict by disabling Grammarly

### DIFF
--- a/blocks/editable/tinymce.js
+++ b/blocks/editable/tinymce.js
@@ -117,6 +117,7 @@ export default class TinyMCE extends Component {
 			className: classnames( className, 'blocks-editable__tinymce' ),
 			style,
 			...ariaProps,
+			'data-enable-grammarly': false,
 		}, children );
 	}
 }

--- a/blocks/library/button/test/__snapshots__/index.js.snap
+++ b/blocks/library/button/test/__snapshots__/index.js.snap
@@ -11,6 +11,7 @@ exports[`core/button block edit matches snapshot 1`] = `
       aria-label="Add text…"
       class="wp-block-button__link blocks-editable__tinymce"
       contenteditable="true"
+      data-enable-grammarly="false"
     />
     <span
       class="blocks-editable__tinymce wp-block-button__link"

--- a/blocks/library/heading/test/__snapshots__/index.js.snap
+++ b/blocks/library/heading/test/__snapshots__/index.js.snap
@@ -8,6 +8,7 @@ exports[`core/heading block edit matches snapshot 1`] = `
     aria-label="Write heading…"
     class="blocks-editable__tinymce"
     contenteditable="true"
+    data-enable-grammarly="false"
   />
   <h2
     class="blocks-editable__tinymce"

--- a/blocks/library/list/test/__snapshots__/index.js.snap
+++ b/blocks/library/list/test/__snapshots__/index.js.snap
@@ -8,6 +8,7 @@ exports[`core/list block edit matches snapshot 1`] = `
     aria-label="Write list…"
     class="blocks-editable__tinymce"
     contenteditable="true"
+    data-enable-grammarly="false"
   />
   <ul
     class="blocks-editable__tinymce"

--- a/blocks/library/paragraph/test/__snapshots__/index.js.snap
+++ b/blocks/library/paragraph/test/__snapshots__/index.js.snap
@@ -15,6 +15,7 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
           aria-label="Add text or type / to add content"
           class="wp-block-paragraph blocks-editable__tinymce"
           contenteditable="true"
+          data-enable-grammarly="false"
         />
         <p
           class="blocks-editable__tinymce wp-block-paragraph"

--- a/blocks/library/preformatted/test/__snapshots__/index.js.snap
+++ b/blocks/library/preformatted/test/__snapshots__/index.js.snap
@@ -8,6 +8,7 @@ exports[`core/preformatted block edit matches snapshot 1`] = `
     aria-label="Write preformatted text…"
     class="blocks-editable__tinymce"
     contenteditable="true"
+    data-enable-grammarly="false"
   />
   <pre
     class="blocks-editable__tinymce"

--- a/blocks/library/pullquote/test/__snapshots__/index.js.snap
+++ b/blocks/library/pullquote/test/__snapshots__/index.js.snap
@@ -11,6 +11,7 @@ exports[`core/pullquote block edit matches snapshot 1`] = `
       aria-label="Write quote…"
       class="blocks-editable__tinymce"
       contenteditable="true"
+      data-enable-grammarly="false"
     />
     <div
       class="blocks-editable__tinymce"

--- a/blocks/library/quote/test/__snapshots__/index.js.snap
+++ b/blocks/library/quote/test/__snapshots__/index.js.snap
@@ -11,6 +11,7 @@ exports[`core/quote block edit matches snapshot 1`] = `
       aria-label="Write quote…"
       class="blocks-editable__tinymce"
       contenteditable="true"
+      data-enable-grammarly="false"
     />
     <div
       class="blocks-editable__tinymce"

--- a/blocks/library/table/test/__snapshots__/index.js.snap
+++ b/blocks/library/table/test/__snapshots__/index.js.snap
@@ -7,6 +7,7 @@ exports[`core/embed block edit matches snapshot 1`] = `
   <table
     class="blocks-editable__tinymce"
     contenteditable="true"
+    data-enable-grammarly="false"
   >
     <tbody>
       <tr>

--- a/blocks/library/text-columns/test/__snapshots__/index.js.snap
+++ b/blocks/library/text-columns/test/__snapshots__/index.js.snap
@@ -14,6 +14,7 @@ exports[`core/text-columns block edit matches snapshot 1`] = `
         aria-label="New Column"
         class="blocks-editable__tinymce"
         contenteditable="true"
+        data-enable-grammarly="false"
       />
       <p
         class="blocks-editable__tinymce"
@@ -32,6 +33,7 @@ exports[`core/text-columns block edit matches snapshot 1`] = `
         aria-label="New Column"
         class="blocks-editable__tinymce"
         contenteditable="true"
+        data-enable-grammarly="false"
       />
       <p
         class="blocks-editable__tinymce"

--- a/blocks/library/verse/test/__snapshots__/index.js.snap
+++ b/blocks/library/verse/test/__snapshots__/index.js.snap
@@ -8,6 +8,7 @@ exports[`core/verse block edit matches snapshot 1`] = `
     aria-label="Write…"
     class="blocks-editable__tinymce"
     contenteditable="true"
+    data-enable-grammarly="false"
   />
   <pre
     class="blocks-editable__tinymce"

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -121,6 +121,7 @@ class PostTitle extends Component {
 						onClick={ this.onSelect }
 						onKeyDown={ this.onKeyDown }
 						onKeyPress={ this.onUnselect }
+						data-enable-grammarly="false"
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
## Description
See: https://github.com/WordPress/gutenberg/issues/1698

This is one way to resolve Grammarly conflicts, at least in the short term.

*Regarding `data-enable-grammarly="false"`, see: https://github.com/facebook/draft-js/issues/616#issuecomment-343596615*

## How Has This Been Tested?
Tested in latest Chrome on macOS with [Grammarly extension](https://chrome.google.com/webstore/detail/grammarly-for-chrome/kbfnbcaeplbcioakkpcpgfkobkghlhen?hl=en) installed. Confirmed that Grammarly has been disabled in the post title textarea, and also in block contentEditables.

## Types of changes
- Added `data-enable-grammarly="false"`
- Ran `npm run test-unit -- --updateSnapshot` to update snapshots.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- ~~[ ] My code has proper inline documentation.~~
