### PR TITLE
Block: Move drag handling to instance-bound handler

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -104,6 +104,7 @@ export class BlockListBlock extends Component {
 		this.stopTypingOnMouseMove = this.stopTypingOnMouseMove.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
 		this.onFocus = this.onFocus.bind( this );
+		this.preventDrag = this.preventDrag.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onBlockError = this.onBlockError.bind( this );
@@ -280,6 +281,18 @@ export class BlockListBlock extends Component {
 		}
 	}
 
+	/**
+	 * Prevents default dragging behavior within a block to allow for multi-
+	 * selection to take effect unhampered.
+	 *
+	 * @param {DragEvent} event Drag event.
+	 *
+	 * @returns {void}
+	 */
+	preventDrag( event ) {
+		event.preventDefault();
+	}
+
 	onPointerDown( event ) {
 		// Not the main button.
 		// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
@@ -407,7 +420,7 @@ export class BlockListBlock extends Component {
 				<div
 					ref={ this.bindBlockNode }
 					onKeyPress={ this.maybeStartTyping }
-					onDragStart={ ( event ) => event.preventDefault() }
+					onDragStart={ this.preventDrag }
 					onMouseDown={ this.onPointerDown }
 					onKeyDown={ this.onKeyDown }
 					onFocus={ this.onFocus }


### PR DESCRIPTION
Related: #1014

This pull request seeks to refactor the `BlockListBlock` component to create an `onDragStart` handler which is consistent during the lifecycle of the component. This prevents unnecessary reconciliation which can occur when assigning an event handler as an arrow function ([related resource](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md)), and provides an opportunity to explain the rationale behind preventing the default event behavior through documentation of the created function.

__Testing instructions:__

Repeat testing instructions from #1014