### PR TITLE
Initial adding checks for Blocks model

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -322,15 +322,15 @@ export default {
 		return effects;
 	},
 	FETCH_REUSABLE_BLOCKS( action, store ) {
-		const { id } = action;
-		const { dispatch } = store;
-
-		let result;
 		// TODO: these are potentially undefined, this fix is in place
 		// until there is a filter to not use reusable blocks if undefined
 		if ( ! has( wp, 'api.models.Blocks' ) && ! has( wp, 'api.collections.Blocks' ) ) {
 			return;
 		}
+		const { id } = action;
+		const { dispatch } = store;
+
+		let result;
 		if ( id ) {
 			result = new wp.api.models.Blocks( { id } ).fetch();
 		} else {
@@ -395,6 +395,12 @@ export default {
 		);
 	},
 	DELETE_REUSABLE_BLOCK( action, store ) {
+		// TODO: these are potentially undefined, this fix is in place
+		// until there is a filter to not use reusable blocks if undefined
+		if ( ! has( wp, 'api.models.Blocks' ) ) {
+			return;
+		}
+
 		const { id } = action;
 		const { getState, dispatch } = store;
 
@@ -418,11 +424,6 @@ export default {
 			optimist: { type: BEGIN, id: transactionId },
 		} );
 
-		// TODO: these are potentially undefined, this fix is in place
-		// until there is a filter to not use reusable blocks if undefined
-		if ( ! has( wp, 'api.models.Blocks' ) ) {
-			return;
-		}
 		new wp.api.models.Blocks( { id } ).destroy().then(
 			() => {
 				dispatch( {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, includes, map, castArray, uniqueId, reduce, values, some } from 'lodash';
+import { get, has, includes, map, castArray, uniqueId, reduce, values, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -328,7 +328,7 @@ export default {
 		let result;
 		// TODO: these are potentially undefined, this fix is in place
 		// until there is a filter to not use reusable blocks if undefined
-		if ( ! wp.api.models.Blocks && ! wp.api.collections.Blocks ) {
+		if ( ! has( wp, 'api.models.Blocks' ) && ! has( wp, 'api.collections.Blocks' ) ) {
 			return;
 		}
 		if ( id ) {
@@ -363,7 +363,7 @@ export default {
 	SAVE_REUSABLE_BLOCK( action, store ) {
 		// TODO: these are potentially undefined, this fix is in place
 		// until there is a filter to not use reusable blocks if undefined
-		if ( ! wp.api.models.Blocks ) {
+		if ( ! has( wp, 'api.models.Blocks' ) ) {
 			return;
 		}
 
@@ -420,7 +420,7 @@ export default {
 
 		// TODO: these are potentially undefined, this fix is in place
 		// until there is a filter to not use reusable blocks if undefined
-		if ( ! wp.api.models.Blocks ) {
+		if ( ! has( wp, 'api.models.Blocks' ) ) {
 			return;
 		}
 		new wp.api.models.Blocks( { id } ).destroy().then(


### PR DESCRIPTION
Adds checks for blocks model, however I'm not if it is an error if not defined, so not sure if that should be the proper dispatch if wp.api.models.Blocks does not exist.

On our install we are working on API to get the Blocks model in place, however in the interim without the models data Gutenberg will crash without these checks.

I think the proper solution might be to have a config of sorts to enable/disable ReusableBlocks, which would then bypass these actions ever being called.


## How Has This Been Tested?

Verify that ReusableBlocks still can be used (fetched, saved, and deleted)
