### PR TITLE
Block List: Select block only if not already selected

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -275,8 +275,17 @@ export class BlockListBlock extends Component {
 		this.props.onInsertBlocks( blocks, this.props.order + 1 );
 	}
 
+	/**
+	 * Marks the block as selected when focused and not already selected. This
+	 * specifically handles the case where block does not set focus on its own
+	 * (via `setFocus`), typically if there is no focusable input in the block.
+	 *
+	 * @param {FocusEvent} event A focus event
+	 *
+	 * @returns {void}
+	 */
 	onFocus( event ) {
-		if ( event.target === this.node ) {
+		if ( event.target === this.node && ! this.props.isSelected ) {
 			this.props.onSelect();
 		}
 	}
@@ -293,6 +302,13 @@ export class BlockListBlock extends Component {
 		event.preventDefault();
 	}
 
+	/**
+	 * Begins tracking cursor multi-selection when clicking down within block.
+	 *
+	 * @param {MouseEvent} event A mousedown event.
+	 *
+	 * @returns {void}
+	 */
 	onPointerDown( event ) {
 		// Not the main button.
 		// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
@@ -307,7 +323,10 @@ export class BlockListBlock extends Component {
 			}
 		} else {
 			this.props.onSelectionStart( this.props.uid );
-			this.props.onSelect();
+
+			if ( ! this.props.isSelected ) {
+				this.props.onSelect();
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request seeks to refactor the `BlockListBlock` component to avoid dispatching the `SELECT_BLOCK` action needlessly when it is already selected. It merely adds conditions to check whether the block is currently selected before calling its `onSelect` prop callback. This is a trivial performance improvement by avoiding a number of `mapStateToProps` calls which would otherwise occur by the dispatches.

__Testing instructions:__

Verify that there are no regressions in the behavior of selecting blocks by click or tab focus, including but not limited to blocks which have no focusable inputs (e.g. Latest Posts).