### PR TITLE
Add scroll on admin-menu.

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -5,6 +5,16 @@ body.gutenberg-editor-page {
 	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
 	@include break-small {
 		overflow: hidden;
+
+		#adminmenuwrap {
+			height: 100%;
+			max-height: 100%;
+			position: absolute;
+			top: 0;
+			left: 0;
+			overflow-y: auto;
+			overflow-x: hidden;
+		}
 	}
 
 	#update-nag, .update-nag {


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Allows the admin menu to scroll when it's taller than the viewport.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Visual tests in Chrome and Firefox. Tested with a clean/empty WP install and a site with many admin menu sidebar items (cpts).

## Screenshots (jpeg or gifs if applicable):
![admin-scroll](https://user-images.githubusercontent.com/3585901/35121967-3ff4512e-fc6b-11e7-903d-a96f2f177abf.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Layout tweak.

<!-- Bug fix (non-breaking change which fixes an issue) -->
Fixes https://github.com/WordPress/gutenberg/issues/4445

<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
