### PR TITLE
Persistence: Improved serialize persistence action name; Used correct redux initialisation type.

### DIFF
--- a/data/persist.js
+++ b/data/persist.js
@@ -45,7 +45,7 @@ export function loadAndPersist( store, reducer, reducerKey, storageKey ) {
 	const persistedString = window.localStorage.getItem( storageKey );
 	if ( persistedString ) {
 		const persistedState = {
-			...get( reducer( undefined, { type: 'DEFAULTS' } ), reducerKey ),
+			...get( reducer( undefined, { type: '@@gutenberg/init' } ), reducerKey ),
 			...JSON.parse( persistedString ),
 		};
 
@@ -62,7 +62,7 @@ export function loadAndPersist( store, reducer, reducerKey, storageKey ) {
 		const newStateValue = get( store.getState(), reducerKey );
 		if ( newStateValue !== currentStateValue ) {
 			currentStateValue = newStateValue;
-			const stateToSave = get( reducer( store.getState(), { type: 'REDUX_SERIALIZE' } ), reducerKey );
+			const stateToSave = get( reducer( store.getState(), { type: 'SERIALIZE' } ), reducerKey );
 			window.localStorage.setItem( storageKey, JSON.stringify( stateToSave ) );
 		}
 	} );

--- a/data/test/persist.js
+++ b/data/test/persist.js
@@ -48,7 +48,7 @@ describe( 'loadAndPersist', () => {
 	it( 'should persist to local storage once the state value changes', () => {
 		const storageKey = 'dumbStorageKey2';
 		const reducer = ( state, action ) => {
-			if ( action.type === 'REDUX_SERIALIZE' ) {
+			if ( action.type === 'SERIALIZE' ) {
 				return state;
 			}
 

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -51,7 +51,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					[ action.feature ]: ! state.features[ action.feature ],
 				},
 			};
-		case 'REDUX_SERIALIZE':
+		case 'SERIALIZE':
 			return omit( state, [ 'sidebars.mobile', 'sidebars.publish' ] );
 	}
 


### PR DESCRIPTION
This PR applies two improvements to changes made on https://github.com/WordPress/gutenberg/pull/4529. Props to  @aduth for suggesting these improvements.

The serialize action is not redux prefix, so the prefix does not add value here.
We were using action type DEFAULTS to compute default value of a reducer and redux initialization is '@@INIT' so we can use that type instead.

## How Has This Been Tested?
Executing our automatic tests.
Check that desktop sidebar open state is persisted on reload, while on mobile it is always closed on reloading.