### PR TITLE
Framework: Skip server grammar parse, seek and replace dynamic blocks

### DIFF
--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -98,27 +98,32 @@ class WP_Block_Type {
 	}
 
 	/**
-	 * Renders the block type output for given attributes and content.
+	 * Renders the block type output for given attributes.
 	 *
 	 * @since 0.6.0
 	 * @access public
 	 *
-	 * @param array       $attributes Optional. Block attributes. Default empty array.
-	 * @param string|null $content    Optional. Raw block content, or null if none set. Default null.
+	 * @param array $attributes Optional. Block attributes. Default empty array.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = null ) {
-		if ( ! is_callable( $this->render_callback ) ) {
-			if ( ! $content ) {
-				return '';
-			}
-
-			return $content;
+	public function render( $attributes = array() ) {
+		if ( ! $this->is_dynamic() ) {
+			return '';
 		}
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return call_user_func( $this->render_callback, $attributes, $content );
+		return call_user_func( $this->render_callback, $attributes );
+	}
+
+	/**
+	 * Returns true if the block type is dynamic, or false otherwise. A dynamic
+	 * block is one which defers its rendering to occur on-demand at runtime.
+	 *
+	 * @returns boolean Whether block type is dynamic.
+	 */
+	public function is_dynamic() {
+		return is_callable( $this->render_callback );
 	}
 
 	/**

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -36,31 +36,25 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$this->assertEquals( $attributes, json_decode( $output, true ) );
 	}
 
-	function test_render_with_content() {
-		$attributes = array(
-			'foo' => 'bar',
-			'bar' => 'foo',
-		);
-		$content    = '<p>Test content.</p>';
+	function test_render_for_static_block() {
+		$block_type = new WP_Block_Type( 'core/dummy', array() );
+		$output     = $block_type->render();
 
-		$block_type             = new WP_Block_Type( 'core/dummy', array(
-			'render_callback' => array( $this, 'render_dummy_block_with_content' ),
-		) );
-		$output                 = $block_type->render( $attributes, $content );
-		$attributes['_content'] = $content;
-		$this->assertSame( $attributes, json_decode( $output, true ) );
+		$this->assertEquals( '', $output );
 	}
 
-	function test_render_without_callback() {
-		$attributes = array(
-			'foo' => 'bar',
-			'bar' => 'foo',
-		);
-		$content    = '<p>Test content.</p>';
+	function test_is_dynamic_for_static_block() {
+		$block_type = new WP_Block_Type( 'core/dummy', array() );
 
-		$block_type = new WP_Block_Type( 'core/dummy' );
-		$output     = $block_type->render( $attributes, $content );
-		$this->assertSame( $content, $output );
+		$this->assertFalse( $block_type->is_dynamic() );
+	}
+
+	function test_is_dynamic_for_dynamic_block() {
+		$block_type = new WP_Block_Type( 'core/dummy', array(
+			'render_callback' => array( $this, 'render_dummy_block' ),
+		) );
+
+		$this->assertTrue( $block_type->is_dynamic() );
 	}
 
 	function test_prepare_attributes() {

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -21,13 +21,12 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	 * Dummy block rendering function.
 	 *
 	 * @param  array $attributes Block attributes.
-	 * @param  array $content    Content.
 	 *
 	 * @return string             Block output.
 	 */
-	function render_dummy_block( $attributes, $content ) {
+	function render_dummy_block( $attributes ) {
 		$this->dummy_block_instance_number += 1;
-		return $this->dummy_block_instance_number . ':' . $attributes['value'] . ":$content";
+		return $this->dummy_block_instance_number . ':' . $attributes['value'];
 	}
 
 	/**
@@ -69,41 +68,11 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$updated_post_content = do_blocks( $post_content );
 		$this->assertEquals( $updated_post_content,
 			'before' .
-			'1:b1:' .
-			'2:b1:' .
+			'1:b1' .
+			'2:b1' .
 			'between' .
-			'3:b2:' .
-			'4:b2:' .
-			'after'
-		);
-	}
-
-	/**
-	 * Test dynamic blocks that contain content.
-	 *
-	 * @covers do_blocks
-	 */
-	function test_dynamic_block_rendering_with_content() {
-		$settings = array(
-			'render_callback' => array(
-				$this,
-				'render_dummy_block',
-			),
-		);
-		register_block_type( 'core/dummy', $settings );
-		$post_content =
-			'before' .
-			"<!-- wp:core/dummy {\"value\":\"b1\"} -->this\ncontent\n\nshould\nbe\npassed<!-- /wp:core/dummy -->" .
-			'between' .
-			'<!-- wp:core/dummy {"value":"b2"} -->content2<!-- /wp:core/dummy -->' .
-			'after';
-
-		$updated_post_content = do_blocks( $post_content );
-		$this->assertEquals( $updated_post_content,
-			'before' .
-			"1:b1:this\ncontent\n\nshould\nbe\npassed" .
-			'between' .
-			'2:b2:content2' .
+			'3:b2' .
+			'4:b2' .
 			'after'
 		);
 	}

--- a/phpunit/class-registration-test.php
+++ b/phpunit/class-registration-test.php
@@ -6,17 +6,23 @@
  */
 
 /**
- * Test register_block_type() and unregister_block_type()
+ * Test register_block_type(), unregister_block_type(), get_dynamic_block_names()
  */
 class Registration_Test extends WP_UnitTestCase {
+
+	function render_stub() {}
 
 	function tearDown() {
 		parent::tearDown();
 
 		$registry = WP_Block_Type_Registry::get_instance();
 
-		if ( $registry->is_registered( 'core/dummy' ) ) {
-			$registry->unregister( 'core/dummy' );
+		foreach ( array( 'dummy', 'dynamic' ) as $block_name ) {
+			$block_name = 'core/' . $block_name;
+
+			if ( $registry->is_registered( $block_name ) ) {
+				$registry->unregister( $block_name );
+			}
 		}
 	}
 
@@ -43,5 +49,15 @@ class Registration_Test extends WP_UnitTestCase {
 
 		$registry = WP_Block_Type_Registry::get_instance();
 		$this->assertFalse( $registry->is_registered( $name ) );
+	}
+
+	function test_get_dynamic_block_names() {
+		register_block_type( 'core/dummy', array() );
+		register_block_type( 'core/dynamic', array( 'render_callback' => array( $this, 'render_stub' ) ) );
+
+		$dynamic_block_names = get_dynamic_block_names();
+
+		$this->assertContains( 'core/dynamic', $dynamic_block_names );
+		$this->assertNotContains( 'core/dummy', $dynamic_block_names );
 	}
 }

--- a/phpunit/class-reusable-blocks-render-test.php
+++ b/phpunit/class-reusable-blocks-render-test.php
@@ -81,7 +81,7 @@ class Reusable_Blocks_Render_Test extends WP_UnitTestCase {
 	 */
 	public function test_ref_empty() {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/block' );
-		$output     = $block_type->render( array(), 'foo' );
+		$output     = $block_type->render( array() );
 		$this->assertSame( '', $output );
 	}
 
@@ -91,7 +91,7 @@ class Reusable_Blocks_Render_Test extends WP_UnitTestCase {
 	 */
 	public function test_ref_wrong_post_type() {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/block' );
-		$output     = $block_type->render( array( 'ref' => self::$post_id ), 'foo' );
+		$output     = $block_type->render( array( 'ref' => self::$post_id ) );
 		$this->assertSame( '', $output );
 	}
 }


### PR DESCRIPTION
Blocker for #3745 
Related: #3545
Possible resolution for #3799 ?

This pull request seeks to refactor Gutenberg's `the_content` filtering of dynamic blocks to bypass the grammar parser altogether and explicitly seek and replace dynamic block fragments via regular expressions.

The reasons for this change include:

- Parsing all of content into a data shape during the front-end display of a post is heavy-handed when the only operation necessary is to replace dynamic blocks.
   - It is quite likely for the majority of users' posts that there are no dynamic blocks at all, and this is wasted effort.
- It supports nested block content, which is non-supportable with the current implementation because static blocks render with `innerHTML`, which does not include the parsed inner blocks (see also #3545).

The downsides of this change include:

- Relying on regular expressions to match block fragments, including the attributes JSON string which is passed through `json_decode`.
   - The latter note is not a requirement, and it's possible that we could still leverage the grammar parser to extract the attributes array.
   - Related to this is the maintenance cost of keeping syntax identification in sync.
- We no longer strip the comment demarcations for static blocks
   - They are stripped for dynamic blocks, though not necessarily so

__To Do:__ (Non-blocking)

- [ ] Run a performance benchmark comparison, as I suspect the changes proposed here perform significantly better than the grammar-based parser.

__Testing instructions:__

Verify PHPUnit tests pass:

```
phpunit
```

Try manually creating a post (via Text mode or Classic Editor) including both dynamic blocks and blocks with nested content, ensuring that when viewing source on the front-end, both the dynamic block rendered content and nested content is rendered as expected:

```
<!-- wp:latest-posts /-->

<!-- wp:columns -->
<div class="wp-block-columns has-2-columns">
    <!-- wp:paragraph {"layout":"column-1"} -->
    <p class="layout-column-1">col 1</p>
    <!-- /wp:paragraph -->

    <!-- wp:paragraph {"layout":"column-2"} -->
    <p class="layout-column-2">col 2</p>
    <!-- /wp:paragraph -->
</div>
<!-- /wp:columns -->

<!-- wp:paragraph -->
<p>end text</p>
<!-- /wp:paragraph -->
```