### PR TITLE
Use docker-compose for all Docker commands

### DIFF
--- a/bin/install-docker.sh
+++ b/bin/install-docker.sh
@@ -18,16 +18,19 @@ if ! docker info >/dev/null 2>&1; then
 	exit 1
 fi
 
-# Launch the containers
-echo -e $(status_message "Updating and starting Docker containers...")
-if ! docker-compose up -d; then
-	# Launching may fail due to the docker config file directory having changed.
-	# Remove the old wordpress-dev container, and try again.
-	docker container rm -fv wordpress-dev
-	docker-compose up -d
-fi
+# Stop existing containers
+echo -e $(status_message "Stopping Docker containers...")
+docker-compose down --remove-orphans >/dev/null 2>&1
 
-HOST_PORT=$(docker inspect --format '{{(index (index .HostConfig.PortBindings "80/tcp") 0).HostPort}}' wordpress-dev)
+# Download image updates
+echo -e $(status_message "Downlading Docker image updates...")
+docker-compose pull --parallel
+
+# Launch the containers
+echo -e $(status_message "Starting Docker containers...")
+docker-compose up -d >/dev/null
+
+HOST_PORT=$(docker-compose port wordpress 80 | awk -F : '{printf $2}')
 
 # Wait until the docker containers are setup properely
 echo -en $(status_message "Attempting to connect to wordpress...")
@@ -35,28 +38,28 @@ until $(curl -L http://localhost:$HOST_PORT -so - 2>&1 | grep -q "WordPress"); d
     echo -n '.'
     sleep 5
 done
-echo ' done!'
+echo ''
 
 # Install WordPress
-echo -en $(status_message "Installing WordPress...")
-docker run -it --rm --volumes-from wordpress-dev --network container:wordpress-dev wordpress:cli core install --url=localhost:$HOST_PORT --title=Gutenberg --admin_user=admin --admin_password=password --admin_email=test@test.com >/dev/null
+echo -e $(status_message "Installing WordPress...")
+docker-compose run --rm cli core install --url=localhost:$HOST_PORT --title=Gutenberg --admin_user=admin --admin_password=password --admin_email=test@test.com >/dev/null
+# Check for WordPress updates, just in case the WordPress image isn't up to date.
+docker-compose run --rm cli core update >/dev/null
 
-CURRENT_URL=$(docker run -it --rm --volumes-from wordpress-dev --network container:wordpress-dev wordpress:cli option get siteurl)
+# If the 'wordpress' volume wasn't during the down/up earlier, but the post port has changed, we need to update it.
+CURRENT_URL=$(docker-compose run -T --rm cli option get siteurl)
 if [ "$CURRENT_URL" != "http://localhost:$HOST_PORT" ]; then
-	docker run -it --rm --volumes-from wordpress-dev --network container:wordpress-dev wordpress:cli option update home "http://localhost:$HOST_PORT"
-	docker run -it --rm --volumes-from wordpress-dev --network container:wordpress-dev wordpress:cli option update siteurl "http://localhost:$HOST_PORT"
+	docker-compose run --rm cli option update home "http://localhost:$HOST_PORT" >/dev/null
+	docker-compose run --rm cli option update siteurl "http://localhost:$HOST_PORT" >/dev/null
 fi
-echo ' done!'
 
 # Activate Gutenberg
-echo -en $(status_message "Activating Gutenberg...")
-docker run -it --rm --volumes-from wordpress-dev --network container:wordpress-dev wordpress:cli plugin activate gutenberg >/dev/null
-echo ' done!'
+echo -e $(status_message "Activating Gutenberg...")
+docker-compose run --rm cli plugin activate gutenberg >/dev/null
 
 # Install the PHPUnit test scaffolding
-echo -en $(status_message "Installing PHPUnit test scaffolding...")
+echo -e $(status_message "Installing PHPUnit test scaffolding...")
 docker-compose run --rm wordpress_phpunit /app/bin/install-wp-tests.sh wordpress_test root example mysql latest false >/dev/null
-echo ' done!'
 
 # Install Composer
 echo -e $(status_message "Installing and updating Composer modules...")

--- a/bin/install-docker.sh
+++ b/bin/install-docker.sh
@@ -23,7 +23,7 @@ echo -e $(status_message "Stopping Docker containers...")
 docker-compose down --remove-orphans >/dev/null 2>&1
 
 # Download image updates
-echo -e $(status_message "Downlading Docker image updates...")
+echo -e $(status_message "Downloading Docker image updates...")
 docker-compose pull --parallel
 
 # Launch the containers

--- a/bin/setup-local-env.sh
+++ b/bin/setup-local-env.sh
@@ -23,8 +23,7 @@ cd "$(dirname "$0")/.."
                                                 `---'
 EOT
 
-CURRENT_URL=$(docker run -it --rm --volumes-from wordpress-dev --network container:wordpress-dev wordpress:cli option get siteurl)
-CURRENT_URL="${CURRENT_URL//[[:space:]]/}"
+CURRENT_URL=$(docker-compose run -T --rm cli option get siteurl)
 
 echo -e "\nWelcome to...\n"
 echo -e "\033[95m$GUTENBERG\033[0m"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,14 @@ services:
       WORDPRESS_DB_PASSWORD: example
       ABSPATH: /usr/src/wordpress/
     volumes:
+      - wordpress:/var/www/html
       - .:/var/www/html/wp-content/plugins/gutenberg
-    container_name: wordpress-dev
+
+  cli:
+    image: wordpress:cli
+    volumes:
+      - wordpress:/var/www/html
+      - .:/var/www/html/wp-content/plugins/gutenberg
 
   mysql:
     image: mysql:5.7
@@ -33,4 +39,5 @@ services:
       - .:/app
 
 volumes:
-  testsuite: {}
+  testsuite:
+  wordpress:

--- a/test/e2e/plugins/index.js
+++ b/test/e2e/plugins/index.js
@@ -3,14 +3,9 @@ const exec = promisify( require( 'child_process' ).exec );
 
 module.exports = ( on, config ) => {
 	// Retrieve the port that the docker container is running on
-	return exec( 'docker inspect --format \'{{(index (index .HostConfig.PortBindings "80/tcp") 0).HostPort}}\' wordpress-dev' )
+	return exec( 'docker-compose run -T --rm cli option get siteurl' )
 		.then( ( stdout ) => {
-			const port = parseInt( stdout );
-			const url = 'http://localhost:' + port;
-			if ( stdout && config.baseUrl !== url ) {
-				config.baseUrl = url;
-			}
-
+			config.baseUrl = stdout.trim();
 			return config;
 		} )
 		.catch( () => {


### PR DESCRIPTION
We use a mixture of `docker` and `docker-compose` across our various scripts, there are a couple of benefits to standardising on `docker-compose`:

- We no longer have to name the `wordpress-dev` container, so there's no risk of name collisions.
- `docker-compose` commands are significantly shorter by default, as many of the options we'd usually have to define at the command line are read from `docker-compose.yml`.

This PR also tidies up some of the setup script messages, and makes a couple of commands a little less convoluted.