### PR TITLE
Expand selection on consecutive Meta+A presses

### DIFF
--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { first, last } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component, Fragment, compose } from '@wordpress/element';
@@ -12,10 +17,17 @@ class EditorGlobalKeyboardShortcuts extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.selectAll = this.selectAll.bind( this );
 		this.undoOrRedo = this.undoOrRedo.bind( this );
 		this.save = this.save.bind( this );
 		this.deleteSelectedBlocks = this.deleteSelectedBlocks.bind( this );
 		this.clearMultiSelection = this.clearMultiSelection.bind( this );
+	}
+
+	selectAll( event ) {
+		const { uids, onMultiSelect } = this.props;
+		event.preventDefault();
+		onMultiSelect( first( uids ), last( uids ) );
 	}
 
 	undoOrRedo( event ) {
@@ -52,6 +64,7 @@ class EditorGlobalKeyboardShortcuts extends Component {
 		const { hasMultiSelection, clearSelectedBlock } = this.props;
 		if ( hasMultiSelection ) {
 			clearSelectedBlock();
+			window.getSelection().removeAllRanges();
 		}
 	}
 
@@ -60,6 +73,7 @@ class EditorGlobalKeyboardShortcuts extends Component {
 			<Fragment>
 				<KeyboardShortcuts
 					shortcuts={ {
+						[ rawShortcut.primary( 'a' ) ]: this.selectAll,
 						[ rawShortcut.primary( 'z' ) ]: this.undoOrRedo,
 						[ rawShortcut.primaryShift( 'z' ) ]: this.undoOrRedo,
 						backspace: this.deleteSelectedBlocks,
@@ -98,6 +112,7 @@ export default compose( [
 	withDispatch( ( dispatch ) => {
 		const {
 			clearSelectedBlock,
+			multiSelect,
 			redo,
 			undo,
 			removeBlocks,
@@ -106,6 +121,7 @@ export default compose( [
 
 		return {
 			clearSelectedBlock,
+			onMultiSelect: multiSelect,
 			onRedo: redo,
 			onUndo: undo,
 			onRemove: removeBlocks,

--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { first, last } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Component, Fragment, compose } from '@wordpress/element';
@@ -17,17 +12,10 @@ class EditorGlobalKeyboardShortcuts extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.selectAll = this.selectAll.bind( this );
 		this.undoOrRedo = this.undoOrRedo.bind( this );
 		this.save = this.save.bind( this );
 		this.deleteSelectedBlocks = this.deleteSelectedBlocks.bind( this );
 		this.clearMultiSelection = this.clearMultiSelection.bind( this );
-	}
-
-	selectAll( event ) {
-		const { uids, onMultiSelect } = this.props;
-		event.preventDefault();
-		onMultiSelect( first( uids ), last( uids ) );
 	}
 
 	undoOrRedo( event ) {
@@ -72,7 +60,6 @@ class EditorGlobalKeyboardShortcuts extends Component {
 			<Fragment>
 				<KeyboardShortcuts
 					shortcuts={ {
-						[ rawShortcut.primary( 'a' ) ]: this.selectAll,
 						[ rawShortcut.primary( 'z' ) ]: this.undoOrRedo,
 						[ rawShortcut.primaryShift( 'z' ) ]: this.undoOrRedo,
 						backspace: this.deleteSelectedBlocks,
@@ -111,7 +98,6 @@ export default compose( [
 	withDispatch( ( dispatch ) => {
 		const {
 			clearSelectedBlock,
-			multiSelect,
 			redo,
 			undo,
 			removeBlocks,
@@ -120,7 +106,6 @@ export default compose( [
 
 		return {
 			clearSelectedBlock,
-			onMultiSelect: multiSelect,
 			onRedo: redo,
 			onUndo: undo,
 			onRemove: removeBlocks,

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -33,7 +33,7 @@ import {
  * Module Constants
  */
 
-const { UP, DOWN, LEFT, RIGHT, is } = keycodes;
+const { UP, DOWN, LEFT, RIGHT, isKeyboardEvent } = keycodes;
 
 /**
  * Given an element, returns true if the element is a tabbable text field, or
@@ -203,11 +203,11 @@ class WritingFlow extends Component {
 
 		if ( ! isNav ) {
 			// Set immediately before the meta+a combination can be pressed.
-			if ( is.primary( event ) ) {
+			if ( isKeyboardEvent.primary( event ) ) {
 				this.isEntirelySelected = isEntirelySelected( target );
 			}
 
-			if ( is.primary( event, 'a' ) ) {
+			if ( isKeyboardEvent.primary( event, 'a' ) ) {
 				// When the target is contentEditable, selection will already
 				// have been set by TinyMCE earlier in this call stack. We need
 				// check the previous result, otherwise all blocks will be

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -15,7 +15,7 @@ import {
 	isVerticalEdge,
 	placeCaretAtHorizontalEdge,
 	placeCaretAtVerticalEdge,
-	isFullySelected,
+	isEntirelySelected,
 } from '@wordpress/dom';
 import { keycodes } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -202,23 +202,23 @@ class WritingFlow extends Component {
 		}
 
 		if ( ! isNav ) {
-			const activeElement = document.activeElement;
-
-			// Set right before the meta+a combination can be pressed.
+			// Set immediately before the meta+a combination can be pressed.
 			if ( is.primary( event ) ) {
-				this.isFullySelected = isFullySelected( activeElement );
+				this.isEntirelySelected = isEntirelySelected( target );
 			}
 
 			if ( is.primary( event, 'a' ) ) {
-				// In the case of contentEditable, we want to know the earlier value
-				// because the selection will have already been set by TinyMCE.
-				if ( activeElement.isContentEditable ? this.isFullySelected : isFullySelected( activeElement ) ) {
+				// When the target is contentEditable, selection will already
+				// have been set by TinyMCE earlier in this call stack. We need
+				// check the previous result, otherwise all blocks will be
+				// selected right away.
+				if ( target.isContentEditable ? this.isEntirelySelected : isEntirelySelected( target ) ) {
 					onMultiSelect( first( blocks ), last( blocks ) );
 					event.preventDefault();
 				}
 
 				// Set in case the meta key doesn't get released.
-				this.isFullySelected = isFullySelected( activeElement );
+				this.isEntirelySelected = isEntirelySelected( target );
 			}
 
 			return;

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -401,7 +401,7 @@ export function documentHasSelection() {
  *
  * @param {Element} element The element to check.
  *
- * @return {boolean} True if fully selected, false if not.
+ * @return {boolean} True if entirely selected, false if not.
  */
 export function isEntirelySelected( element ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], element.nodeName ) ) {

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -396,6 +396,40 @@ export function documentHasSelection() {
 }
 
 /**
+ * Check wether the contents of the element have been fully selected.
+ * Returns true if there is no possibility of full selection.
+ *
+ * @param {Element} element The element to check.
+ *
+ * @return {boolean} True if fully selected, false if not.
+ */
+export function isFullySelected( element ) {
+	if ( includes( [ 'INPUT', 'TEXTAREA' ], element.nodeName ) ) {
+		return element.selectionStart === 0 && element.value.length === element.selectionEnd;
+	}
+
+	if ( ! element.isContentEditable ) {
+		return true;
+	}
+
+	const selection = window.getSelection();
+	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+
+	if ( ! range ) {
+		return true;
+	}
+
+	const { startContainer, endContainer, startOffset, endOffset } = range;
+
+	return (
+		startContainer === element &&
+		endContainer === element &&
+		startOffset === 0 &&
+		endOffset === element.childNodes.length
+	);
+}
+
+/**
  * Given a DOM node, finds the closest scrollable container node.
  *
  * @param {Element} node Node from which to start.

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -396,14 +396,14 @@ export function documentHasSelection() {
 }
 
 /**
- * Check wether the contents of the element have been fully selected.
- * Returns true if there is no possibility of full selection.
+ * Check whether the contents of the element have been entirely selected.
+ * Returns true if there is no possibility of selection.
  *
  * @param {Element} element The element to check.
  *
  * @return {boolean} True if fully selected, false if not.
  */
-export function isFullySelected( element ) {
+export function isEntirelySelected( element ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], element.nodeName ) ) {
 		return element.selectionStart === 0 && element.value.length === element.selectionEnd;
 	}

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -12,7 +12,7 @@
 /**
  * External dependencies
  */
-import { get, mapValues } from 'lodash';
+import { get, mapValues, includes } from 'lodash';
 
 export const BACKSPACE = 8;
 export const TAB = 9;
@@ -88,5 +88,21 @@ export const displayShortcut = mapValues( modifiers, ( modifier ) => {
 		// the key join character ("+") between it and the final character if that
 		// final character is alphanumeric. ⌘S looks nicer than ⌘+S.
 		return shortcut.replace( /⌘\+([A-Z0-9])$/g, '⌘$1' );
+	};
+} );
+
+export const is = mapValues( modifiers, ( getModifiers ) => {
+	return ( event, character, _isMac = isMacOS ) => {
+		const mods = getModifiers( _isMac );
+
+		if ( ! mods.every( ( key ) => event[ `${ key }Key` ] ) ) {
+			return false;
+		}
+
+		if ( ! character ) {
+			return includes( mods, event.key.toLowerCase() );
+		}
+
+		return event.key === character;
 	};
 } );

--- a/utils/keycodes.js
+++ b/utils/keycodes.js
@@ -91,7 +91,15 @@ export const displayShortcut = mapValues( modifiers, ( modifier ) => {
 	};
 } );
 
-export const is = mapValues( modifiers, ( getModifiers ) => {
+/**
+ * An object that contains functions to check if a keyboard event matches a
+ * predefined shortcut combination.
+ * E.g. isKeyboardEvent.primary( event, 'm' ) will return true if the event
+ * signals pressing ⌘M.
+ *
+ * @type {Object} Keyed map of functions to match events.
+ */
+export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 	return ( event, character, _isMac = isMacOS ) => {
 		const mods = getModifiers( _isMac );
 


### PR DESCRIPTION
## Description
See #4369. This PR only adds going straight to selecting all blocks, just like it does now block selection without input focus.

## How Has This Been Tested?
Focus an Editable. `meta+a` should select all contents. Press `meta+a` once more to select all blocks. Try one by releasing the `meta` key, and once by holding it. Both ways should work.

Annoying thing here is that `Editable` and other input fields behave slightly different. For `Editable` selection happens before the `keyDown` event (because of TinyMCE intercepting), for the rest it happens after.
