### PR TITLE
Fix error when pasting image in caption

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -13,7 +13,6 @@ import {
 	find,
 	defer,
 	noop,
-	pull,
 } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 import 'element-closest';
@@ -35,11 +34,6 @@ import TinyMCE from './tinymce';
 import { pickAriaProps } from './aria';
 import patterns from './patterns';
 import { EVENTS } from './constants';
-
-/**
- * Browser dependencies
- */
-const { setTimeout, clearTimeout } = window;
 
 const { BACKSPACE, DELETE, ENTER } = keycodes;
 
@@ -107,15 +101,12 @@ export default class RichText extends Component {
 		this.maybePropagateUndo = this.maybePropagateUndo.bind( this );
 		this.onPastePreProcess = this.onPastePreProcess.bind( this );
 		this.onPaste = this.onPaste.bind( this );
-		this.setSafeTimeout = this.setSafeTimeout.bind( this );
 
 		this.state = {
 			formats: {},
 			empty: ! value || ! value.length,
 			selectedNodeId: 0,
 		};
-
-		this.timeouts = [];
 	}
 
 	/**
@@ -276,11 +267,11 @@ export default class RichText extends Component {
 
 			if ( isEmpty && this.props.onReplace ) {
 				// Necessary to allow the paste bin to be removed without errors.
-				this.setSafeTimeout( () => this.props.onReplace( content ) );
+				setTimeout( () => this.props.onReplace( content ) );
 			} else if ( this.props.onSplit ) {
 				// Necessary to get the right range.
 				// Also done in the TinyMCE paste plugin.
-				this.setSafeTimeout( () => this.splitContent( content ) );
+				setTimeout( () => this.splitContent( content ) );
 			}
 
 			event.preventDefault();
@@ -590,10 +581,6 @@ export default class RichText extends Component {
 	 * @param {Array} blocks The blocks to add after the split point.
 	 */
 	splitContent( blocks = [] ) {
-		if ( ! this.props.onSplit ) {
-			return;
-		}
-
 		const { dom } = this.editor;
 		const rootNode = this.editor.getBody();
 		const beforeRange = dom.createRng();
@@ -713,26 +700,6 @@ export default class RichText extends Component {
 
 	componentWillUnmount() {
 		this.onChange();
-		this.timeouts.forEach( clearTimeout );
-		this.timeouts = [];
-	}
-
-	/**
-	 * Sets a timeout, stores reference in `this.timeouts`, and checks if the
-	 * editor still exists when calling the callback.
-	 *
-	 * @param {Function} callback The function to call.
-	 */
-	setSafeTimeout( callback ) {
-		const timeout = setTimeout( () => {
-			pull( this.timeouts, timeout );
-
-			if ( ! this.editor.removed ) {
-				callback();
-			}
-		} );
-
-		this.timeouts.push( timeout );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -581,6 +581,10 @@ export default class RichText extends Component {
 	 * @param {Array} blocks The blocks to add after the split point.
 	 */
 	splitContent( blocks = [] ) {
+		if ( ! this.props.onSplit ) {
+			return;
+		}
+
 		const { dom } = this.editor;
 		const rootNode = this.editor.getBody();
 		const beforeRange = dom.createRng();

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -268,7 +268,7 @@ export default class RichText extends Component {
 			if ( isEmpty && this.props.onReplace ) {
 				// Necessary to allow the paste bin to be removed without errors.
 				setTimeout( () => this.props.onReplace( content ) );
-			} else {
+			} else if ( this.props.onSplit ) {
 				// Necessary to get the right range.
 				// Also done in the TinyMCE paste plugin.
 				setTimeout( () => this.splitContent( content ) );

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -13,6 +13,7 @@ import {
 	find,
 	defer,
 	noop,
+	pull,
 } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 import 'element-closest';
@@ -34,6 +35,11 @@ import TinyMCE from './tinymce';
 import { pickAriaProps } from './aria';
 import patterns from './patterns';
 import { EVENTS } from './constants';
+
+/**
+ * Browser dependencies
+ */
+const { setTimeout, clearTimeout } = window;
 
 const { BACKSPACE, DELETE, ENTER } = keycodes;
 
@@ -101,12 +107,15 @@ export default class RichText extends Component {
 		this.maybePropagateUndo = this.maybePropagateUndo.bind( this );
 		this.onPastePreProcess = this.onPastePreProcess.bind( this );
 		this.onPaste = this.onPaste.bind( this );
+		this.setSafeTimeout = this.setSafeTimeout.bind( this );
 
 		this.state = {
 			formats: {},
 			empty: ! value || ! value.length,
 			selectedNodeId: 0,
 		};
+
+		this.timeouts = [];
 	}
 
 	/**
@@ -267,11 +276,11 @@ export default class RichText extends Component {
 
 			if ( isEmpty && this.props.onReplace ) {
 				// Necessary to allow the paste bin to be removed without errors.
-				setTimeout( () => this.props.onReplace( content ) );
+				this.setSafeTimeout( () => this.props.onReplace( content ) );
 			} else if ( this.props.onSplit ) {
 				// Necessary to get the right range.
 				// Also done in the TinyMCE paste plugin.
-				setTimeout( () => this.splitContent( content ) );
+				this.setSafeTimeout( () => this.splitContent( content ) );
 			}
 
 			event.preventDefault();
@@ -581,6 +590,10 @@ export default class RichText extends Component {
 	 * @param {Array} blocks The blocks to add after the split point.
 	 */
 	splitContent( blocks = [] ) {
+		if ( ! this.props.onSplit ) {
+			return;
+		}
+
 		const { dom } = this.editor;
 		const rootNode = this.editor.getBody();
 		const beforeRange = dom.createRng();
@@ -700,6 +713,26 @@ export default class RichText extends Component {
 
 	componentWillUnmount() {
 		this.onChange();
+		this.timeouts.forEach( clearTimeout );
+		this.timeouts = [];
+	}
+
+	/**
+	 * Sets a timeout, stores reference in `this.timeouts`, and checks if the
+	 * editor still exists when calling the callback.
+	 *
+	 * @param {Function} callback The function to call.
+	 */
+	setSafeTimeout( callback ) {
+		const timeout = setTimeout( () => {
+			pull( this.timeouts, timeout );
+
+			if ( ! this.editor.removed ) {
+				callback();
+			}
+		} );
+
+		this.timeouts.push( timeout );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/blocks/rich-text/patterns.js
+++ b/blocks/rich-text/patterns.js
@@ -14,25 +14,11 @@ import { keycodes } from '@wordpress/utils';
  */
 import { getBlockTypes } from '../api/registration';
 
-/**
- * Browser dependencies
- */
-const { setTimeout } = window;
-
 const { ESCAPE, ENTER, SPACE, BACKSPACE } = keycodes;
-
-/**
- * Sets a timeout and checks if the given editor still exists.
- *
- * @param {Editor}   editor   TinyMCE editor instance.
- * @param {Function} callback The function to call.
- */
-function setSafeTimeout( editor, callback ) {
-	setTimeout( () => ! editor.removed && callback() );
-}
 
 export default function( editor ) {
 	const getContent = this.getContent.bind( this );
+	const setSafeTimeout = this.setSafeTimeout.bind( this );
 	const { onReplace } = this.props;
 
 	const VK = tinymce.util.VK;
@@ -74,9 +60,9 @@ export default function( editor ) {
 			enter();
 		// Wait for the browser to insert the character.
 		} else if ( keyCode === SPACE ) {
-			setSafeTimeout( editor, () => searchFirstText( spacePatterns ) );
+			setSafeTimeout( () => searchFirstText( spacePatterns ) );
 		} else if ( keyCode > 47 && ! ( keyCode >= 91 && keyCode <= 93 ) ) {
-			setSafeTimeout( editor, inline );
+			setSafeTimeout( inline );
 		}
 	}, true );
 

--- a/blocks/rich-text/patterns.js
+++ b/blocks/rich-text/patterns.js
@@ -14,11 +14,25 @@ import { keycodes } from '@wordpress/utils';
  */
 import { getBlockTypes } from '../api/registration';
 
+/**
+ * Browser dependencies
+ */
+const { setTimeout } = window;
+
 const { ESCAPE, ENTER, SPACE, BACKSPACE } = keycodes;
+
+/**
+ * Sets a timeout and checks if the given editor still exists.
+ *
+ * @param {Editor}   editor   TinyMCE editor instance.
+ * @param {Function} callback The function to call.
+ */
+function setSafeTimeout( editor, callback ) {
+	setTimeout( () => ! editor.removed && callback() );
+}
 
 export default function( editor ) {
 	const getContent = this.getContent.bind( this );
-	const setSafeTimeout = this.setSafeTimeout.bind( this );
 	const { onReplace } = this.props;
 
 	const VK = tinymce.util.VK;
@@ -60,9 +74,9 @@ export default function( editor ) {
 			enter();
 		// Wait for the browser to insert the character.
 		} else if ( keyCode === SPACE ) {
-			setSafeTimeout( () => searchFirstText( spacePatterns ) );
+			setSafeTimeout( editor, () => searchFirstText( spacePatterns ) );
 		} else if ( keyCode > 47 && ! ( keyCode >= 91 && keyCode <= 93 ) ) {
-			setSafeTimeout( inline );
+			setSafeTimeout( editor, inline );
 		}
 	}, true );
 


### PR DESCRIPTION
## Description

Caused by #4298. An error occurs if you paste a single image (right click, copy image) inside an editable field that does not support the splitting of content, e.g. an image caption.

## How Has This Been Tested?
See above.