### PR TITLE
Add reusable block render tests

### DIFF
--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -38,8 +38,12 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 
 		$this->dummy_block_instance_number = 0;
 
-		foreach ( WP_Block_Type_Registry::get_instance()->get_all_registered() as $name => $block_type ) {
-			WP_Block_Type_Registry::get_instance()->unregister( $name );
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		foreach ( array( 'core/dummy' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
 		}
 	}
 

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -39,12 +39,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$this->dummy_block_instance_number = 0;
 
 		$registry = WP_Block_Type_Registry::get_instance();
-
-		foreach ( array( 'core/dummy' ) as $name ) {
-			if ( $registry->is_registered( $name ) ) {
-				$registry->unregister( $name );
-			}
-		}
+		$registry->unregister( 'core/dummy' );
 	}
 
 	/**

--- a/phpunit/class-prepare-for-js-test.php
+++ b/phpunit/class-prepare-for-js-test.php
@@ -14,12 +14,7 @@ class Prepare_For_JS_Test extends WP_UnitTestCase {
 		parent::tearDown();
 
 		$registry = WP_Block_Type_Registry::get_instance();
-
-		foreach ( array( 'core/dummy' ) as $name ) {
-			if ( $registry->is_registered( $name ) ) {
-				$registry->unregister( $name );
-			}
-		}
+		$registry->unregister( 'core/dummy' );
 	}
 
 	function test_gutenberg_prepare_blocks_for_js() {

--- a/phpunit/class-prepare-for-js-test.php
+++ b/phpunit/class-prepare-for-js-test.php
@@ -10,26 +10,20 @@
  */
 class Prepare_For_JS_Test extends WP_UnitTestCase {
 
-	function setUp() {
-		parent::setUp();
-
-		$this->reset();
-	}
-
 	function tearDown() {
 		parent::tearDown();
 
-		$this->reset();
-	}
+		$registry = WP_Block_Type_Registry::get_instance();
 
-	function reset() {
-		foreach ( WP_Block_Type_Registry::get_instance()->get_all_registered() as $name => $block_type ) {
-			WP_Block_Type_Registry::get_instance()->unregister( $name );
+		foreach ( array( 'core/dummy' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
 		}
 	}
 
 	function test_gutenberg_prepare_blocks_for_js() {
-		$name     = 'core/paragraph';
+		$name     = 'core/dummy';
 		$settings = array(
 			'icon'            => 'text',
 			'render_callback' => 'foo',
@@ -39,10 +33,7 @@ class Prepare_For_JS_Test extends WP_UnitTestCase {
 
 		$blocks = gutenberg_prepare_blocks_for_js();
 
-		$this->assertEquals( array(
-			'core/paragraph' => array(
-				'icon' => 'text',
-			),
-		), $blocks );
+		$this->assertArrayHasKey( $name, $blocks );
+		$this->assertSame( array( 'icon' => 'text' ), $blocks[ $name ] );
 	}
 }

--- a/phpunit/class-registration-test.php
+++ b/phpunit/class-registration-test.php
@@ -15,10 +15,8 @@ class Registration_Test extends WP_UnitTestCase {
 
 		$registry = WP_Block_Type_Registry::get_instance();
 
-		foreach ( array( 'core/dummy' ) as $name ) {
-			if ( $registry->is_registered( $name ) ) {
-				$registry->unregister( $name );
-			}
+		if ( $registry->is_registered( 'core/dummy' ) ) {
+			$registry->unregister( 'core/dummy' );
 		}
 	}
 

--- a/phpunit/class-registration-test.php
+++ b/phpunit/class-registration-test.php
@@ -13,24 +13,29 @@ class Registration_Test extends WP_UnitTestCase {
 	function tearDown() {
 		parent::tearDown();
 
-		foreach ( WP_Block_Type_Registry::get_instance()->get_all_registered() as $name => $block_type ) {
-			WP_Block_Type_Registry::get_instance()->unregister( $name );
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		foreach ( array( 'core/dummy' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
 		}
 	}
 
 	function test_register_affects_main_registry() {
-		$name     = 'core/paragraph';
+		$name     = 'core/dummy';
 		$settings = array(
 			'icon' => 'text',
 		);
 
 		register_block_type( $name, $settings );
 
-		$this->assertTrue( WP_Block_Type_Registry::get_instance()->is_registered( $name ) );
+		$registry = WP_Block_Type_Registry::get_instance();
+		$this->assertTrue( $registry->is_registered( $name ) );
 	}
 
 	function test_unregister_affects_main_registry() {
-		$name     = 'core/paragraph';
+		$name     = 'core/dummy';
 		$settings = array(
 			'icon' => 'text',
 		);
@@ -38,6 +43,7 @@ class Registration_Test extends WP_UnitTestCase {
 		register_block_type( $name, $settings );
 		unregister_block_type( $name );
 
-		$this->assertFalse( WP_Block_Type_Registry::get_instance()->is_registered( $name ) );
+		$registry = WP_Block_Type_Registry::get_instance();
+		$this->assertFalse( $registry->is_registered( $name ) );
 	}
 }

--- a/phpunit/class-reusable-blocks-render-test.php
+++ b/phpunit/class-reusable-blocks-render-test.php
@@ -67,33 +67,11 @@ class Reusuable_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Set up.
-	 */
-	public function setUp() {
-		parent::setUp();
-
-		$this->registry = new WP_Block_Type_Registry();
-		$main_registry  = WP_Block_Type_Registry::get_instance();
-
-		$this->registry->register( 'core/block', $main_registry->get_registered( 'core/block' ) );
-	}
-
-	/**
-	 * Tear down.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		$this->registry = null;
-	}
-
-	/**
 	 * Test rendering of a reusable block.
 	 */
 	public function test_render() {
-		$block_type = $this->registry->get_registered( 'core/block' );
-
-		$output = $block_type->render( array( 'ref' => self::$block_id ) );
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/block' );
+		$output     = $block_type->render( array( 'ref' => self::$block_id ) );
 		$this->assertSame( '<p>Hello world!</p>', $output );
 	}
 
@@ -102,9 +80,8 @@ class Reusuable_Blocks_Render_Test extends WP_UnitTestCase {
 	 * rendering an empty string.
 	 */
 	public function test_ref_empty() {
-		$block_type = $this->registry->get_registered( 'core/block' );
-
-		$output = $block_type->render( array(), 'foo' );
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/block' );
+		$output     = $block_type->render( array(), 'foo' );
 		$this->assertSame( '', $output );
 	}
 
@@ -113,9 +90,8 @@ class Reusuable_Blocks_Render_Test extends WP_UnitTestCase {
 	 * should fail by rendering an empty string.
 	 */
 	public function test_ref_wrong_post_type() {
-		$block_type = $this->registry->get_registered( 'core/block' );
-
-		$output = $block_type->render( array( 'ref' => self::$post_id ), 'foo' );
+		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'core/block' );
+		$output     = $block_type->render( array( 'ref' => self::$post_id ), 'foo' );
 		$this->assertSame( '', $output );
 	}
 }

--- a/phpunit/class-reusable-blocks-render-test.php
+++ b/phpunit/class-reusable-blocks-render-test.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Reusuable block rendering tests.
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Tests reusuable block rendering.
+ */
+class Reusuable_Blocks_Render_Test extends WP_UnitTestCase {
+	/**
+	 * Fake user ID.
+	 *
+	 * @var int
+	 */
+	protected static $user_id;
+
+	/**
+	 * Fake block ID.
+	 *
+	 * @var int
+	 */
+	protected static $block_id;
+
+	/**
+	 * Fake post ID.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Create fake data before tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that creates fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id = $factory->user->create( array(
+			'role' => 'editor',
+		) );
+
+		self::$post_id = $factory->post->create( array(
+			'post_author'  => self::$user_id,
+			'post_type'    => 'post',
+			'post_status'  => 'publish',
+			'post_title'   => 'Test Post',
+			'post_content' => '<p>Hello world!</p>',
+		) );
+
+		self::$block_id = $factory->post->create( array(
+			'post_author'  => self::$user_id,
+			'post_type'    => 'wp_block',
+			'post_status'  => 'publish',
+			'post_title'   => 'Test Block',
+			'post_content' => '<!-- wp:core/paragraph --><p>Hello world!</p><!-- /wp:core/paragraph -->',
+		) );
+	}
+
+	/**
+	 * Delete fake data after tests run.
+	 */
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$block_id, true );
+		wp_delete_post( self::$post_id, true );
+		self::delete_user( self::$user_id );
+	}
+
+	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->registry = new WP_Block_Type_Registry();
+
+		$this->registry->register( 'core/block', array(
+			'attributes'      => array(
+				'ref' => array(
+					'type' => 'number',
+				),
+			),
+			'render_callback' => 'gutenberg_render_block_core_reusable_block',
+		) );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->registry = null;
+	}
+
+	/**
+	 * Test rendering of a reusable block.
+	 */
+	public function test_render() {
+		$block_type = $this->registry->get_registered( 'core/block' );
+
+		$output = $block_type->render( array( 'ref' => self::$block_id ) );
+		$this->assertSame( '<p>Hello world!</p>', $output );
+	}
+
+	/**
+	 * Test rendering of a reusable block when 'ref' is missing, which should fail by
+	 * rendering an empty string.
+	 */
+	public function test_ref_empty() {
+		$block_type = $this->registry->get_registered( 'core/block' );
+
+		$output = $block_type->render( array(), 'foo' );
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Test rendering of a reusable block when 'ref' points to wrong post type, which
+	 * should fail by rendering an empty string.
+	 */
+	public function test_ref_wrong_post_type() {
+		$block_type = $this->registry->get_registered( 'core/block' );
+
+		$output = $block_type->render( array( 'ref' => self::$post_id ), 'foo' );
+		$this->assertSame( '', $output );
+	}
+}

--- a/phpunit/class-reusable-blocks-render-test.php
+++ b/phpunit/class-reusable-blocks-render-test.php
@@ -73,15 +73,9 @@ class Reusuable_Blocks_Render_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->registry = new WP_Block_Type_Registry();
+		$main_registry  = WP_Block_Type_Registry::get_instance();
 
-		$this->registry->register( 'core/block', array(
-			'attributes'      => array(
-				'ref' => array(
-					'type' => 'number',
-				),
-			),
-			'render_callback' => 'gutenberg_render_block_core_reusable_block',
-		) );
+		$this->registry->register( 'core/block', $main_registry->get_registered( 'core/block' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Requested by @aduth in https://github.com/WordPress/gutenberg/pull/3882#issuecomment-350824562

## Types of changes
- Added tests for reusable block rendering.
  Includes tests for two special conditions validated by changes in https://github.com/WordPress/gutenberg/pull/3882

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
