### PR TITLE
Try fixing nav menu scroll

### DIFF
--- a/editor/assets/stylesheets/main.scss
+++ b/editor/assets/stylesheets/main.scss
@@ -1,12 +1,6 @@
 body.gutenberg-editor-page {
 	background: $white;
 
-	// on mobile the main content area has to scroll
-	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
-	@include break-small {
-		overflow: hidden;
-	}
-
 	#update-nag, .update-nag {
 		display: none;
 	}


### PR DESCRIPTION
This fixes #4445. Props @m-e-h to starting the work to address this.

This removes `overflow: hidden;` from the `body` element, which was previously applied at the desktop breakpoint. That means if you have a very tall navigation menu, or your viewport isn't very tall, then you can at least scroll the main container to reveal all menu items.

This is not an ideal fix, as it adds another scrollbar in this edgecase. But given it's an edgecase, and given the benefits of preventing scroll bleed the individually scrolling main content area has, perhaps it's worth it?

We need to test this PR to see that there aren't other side effects.

We also tried letting the nav container itself scroll, but that crops the flyout menu:

<img width="375" alt="before" src="https://user-images.githubusercontent.com/1204802/35211685-d1de6036-ff57-11e7-9dca-58c5962d2b9e.png">

GIF:

![scroll](https://user-images.githubusercontent.com/1204802/35211770-2ae10c2e-ff58-11e7-8e5a-c3371fdba985.gif)
