### PR TITLE
Try smaller up/down arrows, and focus management

### DIFF
--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -34,7 +34,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ isFirst ? null : onMoveUp }
-				icon="arrow-up-alt2"
+				icon={ <svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg"><path d="M12.293 12.207L9 8.914l-3.293 3.293-1.414-1.414L9 6.086l4.707 4.707z" /></svg> }
 				tooltip={ __( 'Move Up' ) }
 				label={ getBlockMoverLabel(
 					uids.length,
@@ -49,7 +49,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ isLast ? null : onMoveDown }
-				icon="arrow-down-alt2"
+				icon={ <svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg"><path d="M12.293 6.086L9 9.379 5.707 6.086 4.293 7.5 9 12.207 13.707 7.5z" /></svg> }
 				tooltip={ __( 'Move Down' ) }
 				label={ getBlockMoverLabel(
 					uids.length,

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -20,15 +20,30 @@
 		margin-bottom: 4px;
 	}
 
-	&:not(:disabled):hover {
+	// unstyle inherited icon button styles
+	&:not(:disabled):hover,
+	&:not(:disabled):active,
+	&:not(:disabled):focus {
+		box-shadow: none;
+		color: inherit;
+	}
+
+	// apply styles to SVG directly
+	svg {
+		display: block;
+		position: relative; // Fixing the Safari bug for `<button>`s overflow
+		border-radius: 50%;
+	}
+
+	&:not(:disabled):hover svg {
 		@include button-style__hover;
 	}
 
-	&:not(:disabled):active {
+	&:not(:disabled):active svg {
 		@include button-style__active;
 	}
 
-	&:not(:disabled):focus {
+	&:not(:disabled):focus svg {
 		@include button-style__focus-active;
 	}
 }

--- a/editor/components/block-mover/test/index.js
+++ b/editor/components/block-mover/test/index.js
@@ -32,14 +32,12 @@ describe( 'BlockMover', () => {
 			expect( moveUp.props() ).toMatchObject( {
 				className: 'editor-block-mover__control',
 				onClick: undefined,
-				icon: 'arrow-up-alt2',
 				label: 'Move 2 blocks from position 1 up by one place',
 				'aria-disabled': undefined,
 			} );
 			expect( moveDown.props() ).toMatchObject( {
 				className: 'editor-block-mover__control',
 				onClick: undefined,
-				icon: 'arrow-down-alt2',
 				label: 'Move 2 blocks from position 1 down by one place',
 				'aria-disabled': undefined,
 			} );


### PR DESCRIPTION
This PR proposes to reduce the visual and cognitive weight of the up/down movers. It is part of an ongoing effort to improve the writing flow by refining the UI. Additional efforts include a recent visual change to the hover/active/focus states of buttons, and in #4539 those efforts include unifying where the contextual inserter sits and how it behaves.

Screenshots:

<img width="299" alt="hover" src="https://user-images.githubusercontent.com/1204802/35217709-86a42dca-ff6c-11e7-8dd1-48cca346be36.png">

<img width="217" alt="active" src="https://user-images.githubusercontent.com/1204802/35217716-89d6b238-ff6c-11e7-986f-363d9b329c2b.png">

<img width="206" alt="keyboard" src="https://user-images.githubusercontent.com/1204802/35217719-8cbcbf92-ff6c-11e7-9781-5f13dad45b7d.png">

GIF:

![in-action](https://user-images.githubusercontent.com/1204802/35217721-8f701c34-ff6c-11e7-99c1-5f4654d2894a.gif)

It reduces the visual weight by making the icons smaller (note that the hit-area size is unchanged), and by handling the focusring so it's there for keyboard interactions but not for mouse interactions (<a href="https://www.youtube.com/watch?v=ilj2P5-5CjI">see also</a>).

Note that:

- the focusring is present for keyboard users
- the focusring change should not apply to other buttons in the UI, only the up/down arrows
- there will be direct keyboard shortcuts for moving blocks up/down (see #71)
- drag & drop is in development to further expand the ways blocks can be rearranged

## Why this change?

Gutenberg has received a lot of fair feedback around the UI feeling distracting and impacting the writing flow. While we have done many things to address this, including fading out UI when writing, simplifying toolbars and hover styles, we are approaching the phase where we refine the subtle details. In this case, I'm proposing that the value the up/down buttons add to the writing and editing flow is well-balanced with the smaller icons and lack of mousefocus ring.

## Tests

This has been tested for mouse and keyboard interactions in:

- Mac/Chrome
- Mac/Safari
- Mac/Firefox
- Windows/Chrome
- Windows/Edge
- Windows/IE11

Penny for your thoughts.