### PR TITLE
Add/gallery reordering

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -74,14 +74,23 @@ class GalleryBlock extends Component {
 	}
 
 	onReorderImage( index, direction ) {
-		console.log(index);
-		console.log(direction);
-		return () => {
-			// const images = filter( this.props.attributes.images, ( img, i ) => index !== i );
-			// this.props.setAttributes( {
-			// 	images
-			// } );
-		};
+		const { attributes: { images }, setAttributes } = this.props;
+		let to = 0;
+		switch(direction) {
+			case 'left':
+				to = index - 1;
+				break;
+			case 'right':
+				to = index + 1;
+				break;
+			default:
+				return false;
+		}
+		
+		images.splice(to, 0, images.splice(index, 1)[0]);
+
+		setAttributes( { images: images } );
+		
 	}
 
 	onSelectImages( imgs ) {

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -73,8 +73,9 @@ class GalleryBlock extends Component {
 		};
 	}
 
-	onReorder( index ) {
-		console.log('reordering');
+	onReorderImage( index, direction ) {
+		console.log(index);
+		console.log(direction);
 		return () => {
 			// const images = filter( this.props.attributes.images, ( img, i ) => index !== i );
 			// this.props.setAttributes( {
@@ -256,7 +257,7 @@ class GalleryBlock extends Component {
 							isSelected={ this.state.selectedImage === index }
 							onRemove={ this.onRemoveImage( index ) }
 							onClick={ this.onSelectImage( index ) }
-							onReorder={this.onReorder( index )}
+							onReorder={(direction) => this.onReorderImage( index, direction )}
 							setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
 						/>
 					</li>

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -46,7 +46,6 @@ class GalleryBlock extends Component {
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
 		this.uploadFromFiles = this.uploadFromFiles.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
-		this.onReorderImage = this.onReorderImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.dropFiles = this.dropFiles.bind( this );
 
@@ -57,7 +56,6 @@ class GalleryBlock extends Component {
 
 	onSelectImage( index ) {
 		return () => {
-			console.log(index);
 			this.setState( ( state ) => ( {
 				selectedImage: index === state.selectedImage ? null : index,
 			} ) );

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -73,6 +73,16 @@ class GalleryBlock extends Component {
 		};
 	}
 
+	onReorder( index ) {
+		console.log('reordering');
+		return () => {
+			// const images = filter( this.props.attributes.images, ( img, i ) => index !== i );
+			// this.props.setAttributes( {
+			// 	images
+			// } );
+		};
+	}
+
 	onSelectImages( imgs ) {
 		this.props.setAttributes( { images: imgs } );
 	}
@@ -246,6 +256,7 @@ class GalleryBlock extends Component {
 							isSelected={ this.state.selectedImage === index }
 							onRemove={ this.onRemoveImage( index ) }
 							onClick={ this.onSelectImage( index ) }
+							onReorder={this.onReorder( index )}
 							setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
 						/>
 					</li>

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -46,6 +46,7 @@ class GalleryBlock extends Component {
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
 		this.uploadFromFiles = this.uploadFromFiles.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
+		this.onReorderImage = this.onReorderImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.dropFiles = this.dropFiles.bind( this );
 
@@ -56,6 +57,7 @@ class GalleryBlock extends Component {
 
 	onSelectImage( index ) {
 		return () => {
+			console.log(index);
 			this.setState( ( state ) => ( {
 				selectedImage: index === state.selectedImage ? null : index,
 			} ) );
@@ -73,7 +75,8 @@ class GalleryBlock extends Component {
 		};
 	}
 
-	onReorderImage( index, direction ) {
+	onReorderImage( event, index, direction ) {
+		event.stopPropagation();
 		const { attributes: { images }, setAttributes } = this.props;
 		let to = 0;
 		switch(direction) {
@@ -86,10 +89,13 @@ class GalleryBlock extends Component {
 			default:
 				return false;
 		}
-		
-		images.splice(to, 0, images.splice(index, 1)[0]);
 
-		setAttributes( { images: images } );
+		const newImages = Array.from(images);
+		
+		newImages.splice(to, 0, newImages.splice(index, 1)[0]);
+
+		this.setState({selectedImage: to});
+		setAttributes( { images: newImages } );
 		
 	}
 
@@ -266,7 +272,7 @@ class GalleryBlock extends Component {
 							isSelected={ this.state.selectedImage === index }
 							onRemove={ this.onRemoveImage( index ) }
 							onClick={ this.onSelectImage( index ) }
-							onReorder={(direction) => this.onReorderImage( index, direction )}
+							onReorder={(event, direction) => this.onReorderImage( event, index, direction )}
 							isFirst={index === 0}
 							isLast={index === images.length - 1}
 							setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -267,6 +267,8 @@ class GalleryBlock extends Component {
 							onRemove={ this.onRemoveImage( index ) }
 							onClick={ this.onSelectImage( index ) }
 							onReorder={(direction) => this.onReorderImage( index, direction )}
+							isFirst={index === 0}
+							isLast={index === images.length - 1}
 							setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
 						/>
 					</li>

--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -31,6 +31,11 @@
 			color: $white;
 		}
 	}
+
+	&.lower {
+		top: initial;
+		bottom: 0;
+	}
 }
 
 .blocks-gallery-item__remove {

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -44,7 +44,7 @@ class GalleryImage extends Component {
 		// Disable reason: Each block can be selected by clicking on it and we should keep the same saved markup
 		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
-			<figure className={ className } onClick={ onClick }>
+			<figure className={ className } onClick={ onClick } tabindex={0} onKeyPress={ onClick }>
 				{ isSelected &&
 					<div>
 						<div className="blocks-gallery-item__inline-menu">

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -21,7 +21,7 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { url, alt, id, linkTo, link, isSelected, onClick, onRemove, onReorder } = this.props;
+		const { url, alt, id, linkTo, link, isSelected, onClick, onRemove, onReorder, isFirst, isLast } = this.props;
 
 		let href;
 
@@ -56,18 +56,28 @@ class GalleryImage extends Component {
 							/>
 						</div>
 						<div className="blocks-gallery-item__inline-menu lower">
-							<IconButton
-								icon="arrow-left-alt"
-								onClick={ () => onReorder('left') }
-								className="blocks-gallery-item__arrow-left"
-								label={ __( 'Reorder Image Left' ) }
-							/>
-							<IconButton
-								icon="arrow-right-alt"
-								onClick={ () => onReorder('right') }
-								className="blocks-gallery-item__arrow-right"
-								label={ __( 'Reorder Image Right' ) }
-							/>
+							{!isFirst
+								?
+									<IconButton
+										icon="arrow-left-alt"
+										onClick={ () => onReorder('left') }
+										className="blocks-gallery-item__arrow-left"
+										label={ __( 'Reorder Image Left' ) }
+									/>
+								:
+									null
+							}
+							{!isLast
+								?
+									<IconButton
+										icon="arrow-right-alt"
+										onClick={ () => onReorder('right') }
+										className="blocks-gallery-item__arrow-right"
+										label={ __( 'Reorder Image Right' ) }
+									/>
+								:
+									null
+							}
 						</div>
 					</div>
 				}

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -60,7 +60,7 @@ class GalleryImage extends Component {
 								?
 									<IconButton
 										icon="arrow-left-alt"
-										onClick={ () => onReorder('left') }
+										onClick={ (event) => onReorder(event, 'left') }
 										className="blocks-gallery-item__arrow-left"
 										label={ __( 'Reorder Image Left' ) }
 									/>
@@ -71,7 +71,7 @@ class GalleryImage extends Component {
 								?
 									<IconButton
 										icon="arrow-right-alt"
-										onClick={ () => onReorder('right') }
+										onClick={ (event) => onReorder(event, 'right') }
 										className="blocks-gallery-item__arrow-right"
 										label={ __( 'Reorder Image Right' ) }
 									/>

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -61,6 +61,7 @@ class GalleryImage extends Component {
 									<IconButton
 										icon="arrow-left-alt"
 										onClick={ (event) => onReorder(event, 'left') }
+										onKeyPress={ (event) => onReorder(event, 'left') }
 										className="blocks-gallery-item__arrow-left"
 										label={ __( 'Reorder Image Left' ) }
 									/>
@@ -72,6 +73,7 @@ class GalleryImage extends Component {
 									<IconButton
 										icon="arrow-right-alt"
 										onClick={ (event) => onReorder(event, 'right') }
+										onKeyPress={ (event) => onReorder(event, 'right') }
 										className="blocks-gallery-item__arrow-right"
 										label={ __( 'Reorder Image Right' ) }
 									/>

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -21,7 +21,7 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { url, alt, id, linkTo, link, isSelected, onClick, onRemove } = this.props;
+		const { url, alt, id, linkTo, link, isSelected, onClick, onRemove, onReorder } = this.props;
 
 		let href;
 
@@ -46,13 +46,29 @@ class GalleryImage extends Component {
 		return (
 			<figure className={ className } onClick={ onClick }>
 				{ isSelected &&
-					<div className="blocks-gallery-item__inline-menu">
-						<IconButton
-							icon="no-alt"
-							onClick={ onRemove }
-							className="blocks-gallery-item__remove"
-							label={ __( 'Remove Image' ) }
-						/>
+					<div>
+						<div className="blocks-gallery-item__inline-menu">
+							<IconButton
+								icon="no-alt"
+								onClick={ onRemove }
+								className="blocks-gallery-item__remove"
+								label={ __( 'Remove Image' ) }
+							/>
+						</div>
+						<div className="blocks-gallery-item__inline-menu lower">
+							<IconButton
+								icon="arrow-left-alt"
+								onClick={ onReorder }
+								className="blocks-gallery-item__arrow-left"
+								label={ __( 'Reorder Image Left' ) }
+							/>
+							<IconButton
+								icon="arrow-right-alt"
+								onClick={ onReorder }
+								className="blocks-gallery-item__arrow-right"
+								label={ __( 'Reorder Image Right' ) }
+							/>
+						</div>
 					</div>
 				}
 				{ href ? <a href={ href }>{ img }</a> : img }

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -58,13 +58,13 @@ class GalleryImage extends Component {
 						<div className="blocks-gallery-item__inline-menu lower">
 							<IconButton
 								icon="arrow-left-alt"
-								onClick={ onReorder }
+								onClick={ () => onReorder('left') }
 								className="blocks-gallery-item__arrow-left"
 								label={ __( 'Reorder Image Left' ) }
 							/>
 							<IconButton
 								icon="arrow-right-alt"
-								onClick={ onReorder }
+								onClick={ () => onReorder('right') }
 								className="blocks-gallery-item__arrow-right"
 								label={ __( 'Reorder Image Right' ) }
 							/>


### PR DESCRIPTION
## Description
Added a click event to reorder the images in a gallery image block. This was from Contributor Day - WordCamp ABQ 2018

## How Has This Been Tested?
Created a gallery in the editor, added up to 10 images, saved post. Edited the post, reordered the gallery images, saved post and checked in both editor and front end to confirm changes were made.
This was tested across Chrome, Safari, and Firefox on a Macbook Pro running Sierra 10.12.3

## Screenshots (jpeg or gifs if applicable):
![gallery-reorder](https://user-images.githubusercontent.com/8893429/35235953-ec6f36fe-ff62-11e7-9c97-577b06197978.gif)


## Types of changes
New Feature to allow reordering of images in gallery block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

Edit: fixed task list markdown