### PR TITLE
Avoid the deprecated (from 5.0 to 5.2) `is_a()` function

### DIFF
--- a/lib/class-wp-block-type-registry.php
+++ b/lib/class-wp-block-type-registry.php
@@ -51,7 +51,7 @@ final class WP_Block_Type_Registry {
 	 */
 	public function register( $name, $args = array() ) {
 		$block_type = null;
-		if ( is_a( $name, 'WP_Block_Type' ) ) {
+		if ( $name instanceof WP_Block_Type ) {
 			$block_type = $name;
 			$name       = $block_type->name;
 		}
@@ -102,7 +102,7 @@ final class WP_Block_Type_Registry {
 	 * @return WP_Block_Type|false The unregistered block type on success, or false on failure.
 	 */
 	public function unregister( $name ) {
-		if ( is_a( $name, 'WP_Block_Type' ) ) {
+		if ( $name instanceof WP_Block_Type ) {
 			$name = $name->name;
 		}
 


### PR DESCRIPTION
The `is_a()` has been deprecated in PHP 5.0 in favor of the `instanceof` operator, and it throws notices under PHP 5.2 with the `E_STRICT` setting.

It has been undeprecated with PHP 5.3 (upon popular request), but that doesn't mean there's any valid reason to use it in new code.

See http://php.net/manual/en/function.is-a.php