### PR TITLE
Disable link suggestions when value is URL

### DIFF
--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -122,10 +122,10 @@ class UrlInput extends Component {
 	}
 
 	onKeyDown( event ) {
-		const { selectedSuggestion, posts } = this.state;
+		const { showSuggestions, selectedSuggestion, posts, loading } = this.state;
 		// If the suggestions are not shown or loading, we shouldn't handle the arrow keys
 		// We shouldn't preventDefault to allow block arrow keys navigation
-		if ( ! this.state.showSuggestions || ! this.state.posts.length || this.suggestionsRequest ) {
+		if ( ! showSuggestions || ! posts.length || loading ) {
 			return;
 		}
 

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -52,18 +52,8 @@ class UrlInput extends Component {
 		}
 
 		// Show the suggestions after typing at least 2 characters
-		if ( value.length < 2 ) {
-			this.setState( {
-				showSuggestions: false,
-				selectedSuggestion: null,
-				loading: false,
-			} );
-
-			return;
-		}
-
-		// Disable suggestions for URLs
-		if ( /^https?:/.test( value ) ) {
+		// and also for URLs
+		if ( value.length < 2 || /^https?:/.test( value ) ) {
 			this.setState( {
 				showSuggestions: false,
 				selectedSuggestion: null,

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -63,7 +63,7 @@ class UrlInput extends Component {
 		}
 
 		// Disable suggestions for URLs
-		if ( 0 === value.indexOf( 'http://' ) || 0 === value.indexOf( 'https://' ) ) {
+		if ( /^https?:/.test( value )  ) {
 			this.setState( {
 				showSuggestions: false,
 				selectedSuggestion: null,

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -63,7 +63,7 @@ class UrlInput extends Component {
 		}
 
 		// Disable suggestions for URLs
-		if ( /^https?:/.test( value )  ) {
+		if ( /^https?:/.test( value ) ) {
 			this.setState( {
 				showSuggestions: false,
 				selectedSuggestion: null,

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -51,7 +51,7 @@ class UrlInput extends Component {
 			this.suggestionsRequest.abort();
 		}
 
-		// Show the suggestions after typing at least 3 characters
+		// Show the suggestions after typing at least 2 characters
 		if ( value.length < 2 ) {
 			this.setState( {
 				showSuggestions: false,

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -62,6 +62,17 @@ class UrlInput extends Component {
 			return;
 		}
 
+		// Disable suggestions for URLs
+		if ( 0 === value.indexOf( 'http://' ) || 0 === value.indexOf( 'https://' ) ) {
+			this.setState( {
+				showSuggestions: false,
+				selectedSuggestion: null,
+				loading: false,
+			} );
+
+			return;
+		}
+
 		this.setState( {
 			showSuggestions: true,
 			selectedSuggestion: null,
@@ -112,9 +123,9 @@ class UrlInput extends Component {
 
 	onKeyDown( event ) {
 		const { selectedSuggestion, posts } = this.state;
-		// If the suggestions are not shown, we shouldn't handle the arrow keys
+		// If the suggestions are not shown or loading, we shouldn't handle the arrow keys
 		// We shouldn't preventDefault to allow block arrow keys navigation
-		if ( ! this.state.showSuggestions || ! this.state.posts.length ) {
+		if ( ! this.state.showSuggestions || ! this.state.posts.length || this.suggestionsRequest ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

1. Disables link suggestions when `value` looks like a URL.
2. Disables `onKeyDown` handling when link suggestions are loading.

## How Has This Been Tested?

I've manually tested this locally.

## Screenshots (jpeg or gifs if applicable):

![urlsuggestions](https://user-images.githubusercontent.com/36432/35305727-40e9d166-004f-11e8-8167-ad94854099a3.gif)

See #4053