### PR TITLE
Add a link to Hacker One in the GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,6 +7,7 @@ BEFORE POSTING YOUR ISSUE:
 - Search this repository for issues and pull requests and whether it has been fixed or reported already.
 - Ensure you are using the latest code before logging bugs.
 - Disable all plugins to ensure it's not a plugin conflict issue.
+- To report a security issue, please visit the [WordPress HackerOne](http://hackerone.com/wordpress) program.
 -->
 
 ## Issue Overview

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@ BEFORE POSTING YOUR ISSUE:
 - Search this repository for issues and pull requests and whether it has been fixed or reported already.
 - Ensure you are using the latest code before logging bugs.
 - Disable all plugins to ensure it's not a plugin conflict issue.
-- To report a security issue, please visit the [WordPress HackerOne](http://hackerone.com/wordpress) program.
+- To report a security issue, please visit the WordPress HackerOne program: https://hackerone.com/wordpress.
 -->
 
 ## Issue Overview


### PR DESCRIPTION
Fixes #4641

## Description
<!-- Please describe your changes -->
Follow up to #4652

Adds a link to Hacker One in the GitHub issue template

As there are no "clickable" links available in GitGub templates without having the link show on every issue where it doesn't get deleted I added the link directly to Hacker One rather than explaining where to find the `SECURITY.md` file.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Project docs

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
