### PR TITLE
Request "Next Actions" in issue template (GTD)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,16 +30,17 @@ BEFORE POSTING YOUR ISSUE:
 <!-- If describing a bug, tell us what happens instead of the expected behavior -->
 <!-- If suggesting a change/improvement, explain the difference from current behavior -->
 
-## Possible Solution
-<!-- Not obligatory, but suggest a fix/reason for the bug, -->
-<!-- or ideas how to implement the addition or change -->
-
 ## Screenshots / Video
 <!-- Visual records are oxygen for others to understand what you are sharing -->
 
 ## Related Issues and/or PRs
 <!-- List related issues or PRs against other branches -->
 
-## Todos
-- [ ] Tests
-- [ ] Documentation
+## Next Actions
+<!-- Not obligatory, but suggest next actions required for closure, -->
+<!-- or ideas about how to implement the addition or change. -->
+<!-- See also: http://bit.ly/gettings-things-done -->
+- [ ] Change a specific line or file.
+- [ ] Add or update unit tests.
+- [ ] Add or update documentation.
+- [ ] Determine next actions.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -39,8 +39,8 @@ BEFORE POSTING YOUR ISSUE:
 ## Next Actions
 <!-- Not obligatory, but suggest next actions required for closure, -->
 <!-- or ideas about how to implement the addition or change. -->
-<!-- See also: http://bit.ly/gettings-things-done -->
+<!-- See also: http://bit.ly/importance-of-next-actions -->
+- [ ] Determine next actions, such as...
 - [ ] Change a specific line or file.
 - [ ] Add or update unit tests.
 - [ ] Add or update documentation.
-- [ ] Determine next actions.


### PR DESCRIPTION
## Description

see [GTD: The Importance of Next Actions](https://facilethings.com/blog/en/the-importance-of-next-actions)
> **“Things rarely get stuck because of lack of time. They get stuck because the doing of them has not been defined.” ~ David Allen**
> According to David Allen, the _next action_ is the most immediate physical, visible activity that would be required to move the situation toward closure.

## Types of changes
- Remove "Possible Solution" and "Todo" sections from issue template.
- Replace those with a new "Next Actions" section.

Discussed in my comments on [repository management document](https://github.com/WordPress/gutenberg/issues/4664) by @danielbachhuber