### PR TITLE
Pass the block name as a parameter to the dynamic block render callback

### DIFF
--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -118,7 +118,7 @@ class WP_Block_Type {
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return call_user_func( $this->render_callback, $attributes, $content );
+		return call_user_func( $this->render_callback, $attributes, $content, $this->name );
 	}
 
 	/**

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -32,8 +32,11 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$block_type = new WP_Block_Type( 'core/dummy', array(
 			'render_callback' => array( $this, 'render_dummy_block' ),
 		) );
-		$output     = $block_type->render( $attributes );
-		$this->assertEquals( $attributes, json_decode( $output, true ) );
+		$output                 = json_decode( $block_type->render( $attributes ), true );
+
+		$this->assertSame( $attributes, $output['attributes'] );
+		$this->assertNull( $output['content'] );
+		$this->assertSame( 'core/dummy', $output['name'] );
 	}
 
 	function test_render_with_content() {
@@ -46,9 +49,11 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$block_type             = new WP_Block_Type( 'core/dummy', array(
 			'render_callback' => array( $this, 'render_dummy_block_with_content' ),
 		) );
-		$output                 = $block_type->render( $attributes, $content );
-		$attributes['_content'] = $content;
-		$this->assertSame( $attributes, json_decode( $output, true ) );
+		$output                 = json_decode( $block_type->render( $attributes, $content ), true );
+
+		$this->assertSame( $attributes, $output['attributes'] );
+		$this->assertSame( $content, $output['content'] );
+		$this->assertSame( 'core/dummy', $output['name'] );
 	}
 
 	function test_render_without_callback() {
@@ -101,13 +106,19 @@ class Block_Type_Test extends WP_UnitTestCase {
 		), $prepared_attributes );
 	}
 
-	function render_dummy_block( $attributes ) {
-		return json_encode( $attributes );
+	function render_dummy_block( $attributes, $content, $name ) {
+		return json_encode( array(
+			'attributes' => $attributes,
+			'content'    => $content,
+			'name'       => $name,
+		) );
 	}
 
-	function render_dummy_block_with_content( $attributes, $content ) {
-		$attributes['_content'] = $content;
-
-		return json_encode( $attributes );
+	function render_dummy_block_with_content( $attributes, $content, $name ) {
+		return json_encode( array(
+			'attributes' => $attributes,
+			'content'    => $content,
+			'name'       => $name,
+		) );
 	}
 }

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -32,7 +32,7 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$block_type = new WP_Block_Type( 'core/dummy', array(
 			'render_callback' => array( $this, 'render_dummy_block' ),
 		) );
-		$output                 = json_decode( $block_type->render( $attributes ), true );
+		$output     = json_decode( $block_type->render( $attributes ), true );
 
 		$this->assertSame( $attributes, $output['attributes'] );
 		$this->assertNull( $output['content'] );
@@ -46,10 +46,10 @@ class Block_Type_Test extends WP_UnitTestCase {
 		);
 		$content    = '<p>Test content.</p>';
 
-		$block_type             = new WP_Block_Type( 'core/dummy', array(
+		$block_type = new WP_Block_Type( 'core/dummy', array(
 			'render_callback' => array( $this, 'render_dummy_block_with_content' ),
 		) );
-		$output                 = json_decode( $block_type->render( $attributes, $content ), true );
+		$output     = json_decode( $block_type->render( $attributes, $content ), true );
 
 		$this->assertSame( $attributes, $output['attributes'] );
 		$this->assertSame( $content, $output['content'] );


### PR DESCRIPTION
## Description
See #4671. Implements the `$name` parameter for dynamic block callback functions.

## How Has This Been Tested?
* Testing via registering a dynamic block callback.
* Unit tests have been updated to test the parameter is correctly passed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
