### PR TITLE
REST API for annotations (back-end comments, take 2)

### DIFF
--- a/lib/annotations.php
+++ b/lib/annotations.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Annotations API: Functions
+ *
+ * @package gutenberg
+ * @since [version]
+ */
+
+// Dependencies.
+require dirname( __FILE__ ) . '/class-wp-annotation-utils.php';
+require dirname( __FILE__ ) . '/class-wp-annotation-caps.php';
+require dirname( __FILE__ ) . '/class-wp-annotation.php';
+require dirname( __FILE__ ) . '/class-wp-annotation-selector.php';
+
+/**
+ * Gets an annotation.
+ *
+ * @since [version]
+ *
+ * @param WP_Annotation|WP_Comment|string|int $comment Annotation, comment, or ID.
+ * @param string                              $output  The required return type.
+ *  One of `OBJECT`, `ARRAY_A`, or `ARRAY_N`, which correspond to an object,
+ *  an associative array, or a numeric array, respectively.
+ *
+ * @return WP_Annotation|array|null                    Depends on `$output` value.
+ */
+function get_annotation( $comment = null, $output = OBJECT ) {
+	if ( null === $comment && isset( $GLOBALS['comment'] ) ) {
+		$comment = $GLOBALS['comment'];
+	}
+
+	if ( $comment instanceof WP_Annotation ) {
+		$annotation = $comment;
+	} else {
+		$annotation = WP_Annotation::get_instance( $comment );
+	}
+
+	if ( ! $annotation ) {
+		return null;
+	}
+
+	/**
+	 * Fires after an annotation is retrieved.
+	 *
+	 * @since [version]
+	 *
+	 * @param WP_Annotation $annotation Annotation.
+	 */
+	$annotation = apply_filters( 'get_annotation', $annotation );
+
+	if ( OBJECT === $output ) {
+		return $annotation;
+	} elseif ( ARRAY_A === $output ) {
+		return $annotation->to_array();
+	} elseif ( ARRAY_N === $output ) {
+		return array_values( $annotation->to_array() );
+	}
+
+	return $annotation;
+}
+
+/**
+ * Gets annotation comment types.
+ *
+ * @since [version]
+ *
+ * @return string[] Annotation comment types.
+ */
+function get_annotation_types() {
+	$types = array( get_default_annotation_type() );
+
+	/**
+	 * Filters annotation comment types.
+	 *
+	 * @since [version]
+	 *
+	 * @param string[] $types Annotation comment types.
+	 */
+	$types = apply_filters( 'get_annotation_types', $types );
+
+	return $types;
+}
+
+/**
+ * Gets default annotation comment type.
+ *
+ * @since [version]
+ *
+ * @return string Default annotation comment type.
+ */
+function get_default_annotation_type() {
+	$type = 'annotation';
+
+	/**
+	 * Filters default annotation comment type.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $type Default annotation comment type.
+	 */
+	$type = apply_filters( 'get_default_annotation_type', $type );
+
+	return $type;
+}
+
+/**
+ * Gets annotation comment statuses.
+ *
+ * @since [version]
+ *
+ * @param  bool $filter One of `built_in`, `custom`.
+ *                      Default is `''` (all statuses).
+ *
+ * @return string[]     Annotation comment statuses.
+ */
+function get_annotation_statuses( $filter = '' ) {
+	$built_in = array(
+		'approved',
+		'approve',
+		'1',
+		'hold',
+		'0',
+		'spam',
+		'trash',
+	);
+
+	if ( 'built_in' === $filter ) {
+		return $built_in;
+	}
+
+	$custom   = array(
+		'resolve', // Archived as resolved.
+		'reject',  // Archived as rejected.
+		'archive', // Archived for another reason.
+	);
+	$statuses = array_merge( $built_in, $custom );
+
+	/**
+	 * Filters annotation comment statuses.
+	 *
+	 * @since [version]
+	 *
+	 * @param string[] $statuses Annotation comment statuses.
+	 */
+	$statuses = apply_filters( 'get_annotation_statuses', $statuses );
+
+	if ( 'custom' === $filter ) {
+		$statuses = array_diff( $statuses, $built_in );
+	}
+
+	return $statuses;
+}
+
+/**
+ * Gets default annotation comment status.
+ *
+ * @since [version]
+ *
+ * @return string Default annotation comment status.
+ */
+function get_default_annotation_status() {
+	$status = 'approve';
+
+	/**
+	 * Filters default annotation comment status.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $type Default annotation comment status.
+	 */
+	$status = apply_filters( 'get_default_annotation_status', $status );
+
+	return $status;
+}

--- a/lib/class-wp-annotation-caps.php
+++ b/lib/class-wp-annotation-caps.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * Annotations API: WP_Annotation_Caps class
+ *
+ * @package gutenberg
+ * @since [version]
+ */
+
+/**
+ * Annotation capabilities.
+ *
+ * @since [version]
+ */
+final class WP_Annotation_Caps {
+	/**
+	 * Maps annotation caps.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $caps    Required capabilities.
+	 * @param string $cap     Capability to check/map.
+	 * @param int    $user_id User ID (empty if not logged in).
+	 * @param array  $args    Arguments to {@see map_meta_cap()}.
+	 *
+	 * @return array          Array of required capabilities.
+	 */
+	public static function on_map_meta_cap( $caps, $cap, $user_id, $args ) {
+		switch ( $cap ) {
+			case 'create_annotation':
+			case 'read_annotation':
+			case 'read_annotations':
+			case 'edit_annotation':
+			case 'delete_annotation':
+				$map = __CLASS__ . '::map_' . $cap;
+				return call_user_func( $map, $caps, $cap, $user_id, $args );
+
+			case 'create_annotations':
+			case 'delete_annotations':
+			case 'delete_others_annotations':
+			case 'delete_private_annotations':
+			case 'delete_published_annotations':
+			case 'edit_annotations':
+			case 'edit_others_annotations':
+			case 'edit_private_annotations':
+			case 'edit_published_annotations':
+			case 'publish_annotations':
+			case 'read_private_annotations':
+				return self::map_others( $caps, $cap, $user_id, $args );
+		}
+
+		return $caps;
+	}
+
+	/**
+	 * Maps the 'create_annotation' meta-cap.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $caps    Required capabilities.
+	 * @param string $cap     Capability to check/map.
+	 * @param int    $user_id User ID (empty if not logged in).
+	 *
+	 * @param array  $args {
+	 *     Arguments that were passed to {@see map_meta_cap()}.
+	 *
+	 *     @type int    $post_id Required post ID at index `[0]`.
+	 *     @type string $type    Optional annotation type at index `[1]`.
+	 *                           If not set, defaults to 'annotation'.
+	 * }
+	 * @return array          Array of required capabilities.
+	 */
+	protected static function map_create_annotation( $caps, $cap, $user_id, $args ) {
+		$user_id = absint( $user_id );
+		$caps    = array_diff( $caps, array( $cap ) );
+
+		if ( ! isset( $args[0] ) ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		if ( isset( $args[1] ) && ! WP_Annotation_Utils::is_valid_type( $args[1] ) ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		$post_id     = absint( $args[0] );
+		$post        = $post_id ? get_post( $post_id ) : null;
+		$post_type   = $post ? get_post_type_object( $post->post_type ) : null;
+		$post_status = $post ? get_post_status_object( get_post_status( $post ) ) : null;
+
+		if ( ! $post || ! $post_type || ! $post_status ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		if ( 'trash' === $post_status->name ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		/*
+		 * For example, a contributor can annotate a post they authored, even if they can no
+		 * longer edit the post itself; e.g., after it's approved/published.
+		 */
+		if ( $user_id && (int) $post->post_author === $user_id ) {
+			return array_merge( $caps, map_meta_cap( $post_type->cap->edit_posts, $user_id ) );
+		}
+
+		return array_merge( $caps, map_meta_cap( $post_type->cap->edit_post, $user_id, $post->ID ) );
+	}
+
+	/**
+	 * Maps the 'read_annotation' meta-cap.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $caps    Required capabilities.
+	 * @param string $cap     Capability to check/map.
+	 * @param int    $user_id User ID (empty if not logged in).
+	 *
+	 * @param array  $args {
+	 *     Arguments that were passed to {@see map_meta_cap()}.
+	 *
+	 *     @type int $id Required annotation ID at index `[0]`.
+	 * }
+	 * @return array          Array of required capabilities.
+	 */
+	protected static function map_read_annotation( $caps, $cap, $user_id, $args ) {
+		$user_id = absint( $user_id );
+		$caps    = array_diff( $caps, array( $cap ) );
+
+		if ( ! isset( $args[0] ) ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		$annotation  = get_annotation( absint( $args[0] ) );
+		$post        = $annotation ? $annotation->get_post() : null;
+		$post_type   = $annotation ? $annotation->get_post_type() : null;
+		$post_status = $annotation ? $annotation->get_post_status() : null;
+
+		if ( ! $annotation || ! $post || ! $post_type || ! $post_status ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		if ( 'trash' === $post_status->name ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		/*
+		 * If it's in the trash and they're not the author, or if it's spam, or it's been held
+		 * for moderation, then access requires the ability to edit others posts.
+		 */
+		if ( ( 'trash' === $annotation->status && ( ! $user_id || (int) $annotation->user_id !== $user_id ) )
+				|| in_array( $annotation->status, array( 'unapproved', 'spam' ), true )
+				|| in_array( $annotation->meta_status, array( 'unapproved', 'spam' ), true ) ) {
+			$caps = array_merge( $caps, map_meta_cap( $post_type->cap->edit_others_posts, $user_id, $post->ID ) );
+		}
+
+		/*
+		 * For example, a contributor can read annotations in a post they authored, even if
+		 * they can no longer edit the post itself; e.g., after it's approved/published.
+		 */
+		if ( $user_id && (int) $post->post_author === $user_id ) {
+			return array_merge( $caps, map_meta_cap( $post_type->cap->edit_posts, $user_id ) );
+		}
+
+		return array_merge( $caps, map_meta_cap( $post_type->cap->edit_post, $user_id, $post->ID ) );
+	}
+
+	/**
+	 * Maps the 'read_annotations' pseudo-cap.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $caps    Required capabilities.
+	 * @param string $cap     Capability to check/map.
+	 * @param int    $user_id User ID (empty if not logged in).
+	 *
+	 * @param array  $args {
+	 *     Arguments that were passed to {@see map_meta_cap()}.
+	 *
+	 *     @type int    $post_id Optional post ID at index `[0]`.
+	 *                           If not set, simply maps to 'edit_posts'.
+	 *     @type string $type    Optional annotation type at index `[1]`.
+	 *                           If not set, defaults to 'annotation'.
+	 * }
+	 * @return array          Array of required capabilities.
+	 */
+	protected static function map_read_annotations( $caps, $cap, $user_id, $args ) {
+		$user_id = absint( $user_id );
+		$caps    = array_diff( $caps, array( $cap ) );
+
+		if ( ! isset( $args[0] ) ) {
+			$caps[] = 'edit_posts';
+			return $caps;
+		}
+
+		if ( isset( $args[1] ) && ! WP_Annotation_Utils::is_valid_type( $args[1] ) ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		$post_id     = absint( $args[0] );
+		$post        = $post_id ? get_post( $post_id ) : null;
+		$post_type   = $post ? get_post_type_object( $post->post_type ) : null;
+		$post_status = $post ? get_post_status_object( get_post_status( $post ) ) : null;
+
+		if ( ! $post || ! $post_type || ! $post_status ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		if ( 'trash' === $post_status->name ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		/*
+		 * For example, a contributor can read annotations in a post they authored, even if
+		 * they can no longer edit the post itself; e.g., after it's approved/published.
+		 */
+		if ( $user_id && (int) $post->post_author === $user_id ) {
+			return array_merge( $caps, map_meta_cap( $post_type->cap->edit_posts, $user_id ) );
+		}
+
+		return array_merge( $caps, map_meta_cap( $post_type->cap->edit_post, $user_id, $post->ID ) );
+	}
+
+	/**
+	 * Maps the 'edit_annotation' meta-cap.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $caps    Required capabilities.
+	 * @param string $cap     Capability to check/map.
+	 * @param int    $user_id User ID (empty if not logged in).
+	 *
+	 * @param array  $args {
+	 *     Arguments that were passed to {@see map_meta_cap()}.
+	 *
+	 *     @type int $id Required annotation ID at index `[0]`.
+	 * }
+	 * @param string $action  'edit' or 'delete'. Default is 'edit'.
+	 *
+	 * @return array          Array of required capabilities.
+	 */
+	protected static function map_edit_annotation( $caps, $cap, $user_id, $args, $action = 'edit' ) {
+		$user_id = absint( $user_id );
+		$caps    = array_diff( $caps, array( $cap ) );
+
+		if ( ! isset( $args[0] ) ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		$annotation  = get_annotation( absint( $args[0] ) );
+		$post        = $annotation ? $annotation->get_post() : null;
+		$post_type   = $annotation ? $annotation->get_post_type() : null;
+		$post_status = $annotation ? $annotation->get_post_status() : null;
+
+		if ( ! $annotation || ! $post || ! $post_type || ! $post_status ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		if ( 'trash' === $post_status->name ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		if ( $user_id && (int) $annotation->user_id === $user_id ) {
+			/*
+			 * If it's spam, or held, require ability to edit others posts.
+			 */
+			if ( in_array( $annotation->status, array( 'unapproved', 'spam' ), true )
+					|| in_array( $annotation->meta_status, array( 'unapproved', 'spam' ), true ) ) {
+				$caps = array_merge( $caps, map_meta_cap( $post_type->cap->{ $action . '_others_posts' }, $user_id, $post->ID ) );
+			}
+
+			/*
+			 * For example, a contributor can edit their own annotation in a post they authored, even
+			 * if they can no longer edit the post itself; e.g., after it's approved/published.
+			 */
+			if ( $user_id && (int) $post->post_author === $user_id ) {
+				return array_merge( $caps, map_meta_cap( $post_type->cap->{ $action . '_posts' }, $user_id ) );
+			}
+
+			return array_merge( $caps, map_meta_cap( $post_type->cap->{ $action . '_post' }, $user_id, $post->ID ) );
+		}
+
+		return array_merge( $caps,
+			map_meta_cap( $post_type->cap->{ $action . '_post' }, $user_id, $post->ID ),
+			map_meta_cap( $post_type->cap->{ $action . '_others_posts' }, $user_id )
+		);
+	}
+
+	/**
+	 * Maps the 'delete_annotation' meta-cap.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $caps    Required capabilities.
+	 * @param string $cap     Capability to check/map.
+	 * @param int    $user_id User ID (empty if not logged in).
+	 * @param array  $args    Arguments that were passed to {@see map_meta_cap()}.
+	 *
+	 * @return array          Array of required capabilities.
+	 */
+	protected static function map_delete_annotation( $caps, $cap, $user_id, $args ) {
+		return self::map_edit_annotation( $caps, $cap, $user_id, $args, 'delete' );
+	}
+
+	/**
+	 * Maps other annotation caps.
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $caps    Required capabilities.
+	 * @param string $cap     Capability to check/map.
+	 * @param int    $user_id User ID (empty if not logged in).
+	 *
+	 * @param array  $args {
+	 *     Arguments that were passed to {@see map_meta_cap()}.
+	 *
+	 *     @type string $type Optional annotation type at index `[0]`.
+	 *                        If not set, defaults to 'annotation'.
+	 * }
+	 * @return array          Array of required capabilities.
+	 */
+	protected static function map_others( $caps, $cap, $user_id, $args ) {
+		$caps = array_diff( $caps, array( $cap ) );
+
+		if ( isset( $args[0] ) && ! WP_Annotation_Utils::is_valid_type( $args[0] ) ) {
+			$caps[] = 'do_not_allow';
+			return $caps;
+		}
+
+		if ( 'create_annotations' === $cap ) {
+			$caps[] = 'edit_posts';
+		} else {
+			$caps[] = str_replace( 'annotations', 'posts', $cap );
+		}
+
+		return $caps;
+	}
+}

--- a/lib/class-wp-annotation-selector.php
+++ b/lib/class-wp-annotation-selector.php
@@ -1,0 +1,450 @@
+<?php
+/**
+ * Annotations API: WP_Annotation_Selector class
+ *
+ * @package gutenberg
+ * @since [version]
+ */
+
+/*
+ * https://www.w3.org/TR/annotation-model/#selectors
+ *
+ * @codingStandardsIgnoreStart - Intentionally following W3C camelCase naming convention.
+ * Note: The codingStandardsIgnoreStart line can be removed once PHPCS is upgraded to v3.2+.
+ *
+ * PHPCS v3.2+: Intentionally following W3C camelCase naming convention.
+ * phpcs:disable WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+ */
+
+/**
+ * Annotation selector (W3C object model).
+ *
+ * @since [version]
+ *
+ * @link https://www.w3.org/TR/annotation-model/#selectors
+ */
+final class WP_Annotation_Selector {
+	/**
+	 * Gets a {@see WP_Annotation_Selector} instance.
+	 *
+	 * @since [version]
+	 *
+	 * @param  object|array $selector        Selector object or array.
+	 *
+	 * @return WP_Annotation_Selector|false  Selector object. False on failure.
+	 */
+	public static function get_instance( $selector ) {
+		try {
+			return new WP_Annotation_Selector( $selector );
+		} catch ( Exception $exception ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Contructor.
+	 *
+	 * @since [version]
+	 *
+	 * @param  object|array $selector Selector object or array.
+	 *
+	 * @throws Exception              On invalid selector.
+	 */
+	public function __construct( $selector ) {
+		if ( ! is_object( $selector ) && ! is_array( $selector ) ) {
+			throw new Exception( 'Invalid data type for annotation selector.' );
+		}
+
+		foreach ( $selector as $key => $value ) {
+			$this->{ $key } = $value;
+		}
+
+		if ( ! $this->parse() ) {
+			throw new Exception( 'Invalid annotation selector.' );
+		}
+	}
+
+	/**
+	 * Converts object to array.
+	 *
+	 * @since [version]
+	 *
+	 * @return array Object as array.
+	 */
+	public function to_array() {
+		$array = get_object_vars( $this );
+
+		foreach ( $array as $key => $value ) {
+			$array[ $key ] = $value instanceof self ? $value->to_array() : $value;
+		}
+
+		return $array;
+	}
+
+	/**
+	 * Parses selector deeply.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if valid.
+	 */
+	protected function parse() {
+		if ( empty( $this->type ) ) {
+			return false;
+		} elseif ( ! $this->is_allowed() ) {
+			return false;
+		} elseif ( $this->is_too_large() ) {
+			return false;
+		}
+
+		switch ( $this->type ) {
+			case 'FragmentSelector':
+				return $this->parse_fragment_selector();
+
+			case 'CssSelector':
+			case 'XPathSelector':
+				return $this->parse_css_xpath_selectors();
+
+			case 'TextQuoteSelector':
+				return $this->parse_text_quote_selector();
+
+			case 'TextPositionSelector':
+			case 'DataPositionSelector':
+				return $this->parse_text_data_position_selectors();
+
+			case 'SvgSelector':
+				return $this->parse_svg_selector();
+
+			case 'RangeSelector':
+				return $this->parse_range_selector();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if selector is allowed.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if allowed.
+	 *
+	 * @internal As a security precaution, SVG selectors are disabled for now. If SVG is
+	 * enabled, please enhance {@see WP_Annotation_Selector::parse_svg_selector()}.
+	 */
+	protected function is_allowed() {
+		$types = array(
+			'FragmentSelector',
+			'CssSelector',
+			'XPathSelector',
+			'TextQuoteSelector',
+			'TextPositionSelector',
+			'DataPositionSelector',
+			// 'SvgSelector', Disabled for now.
+			'RangeSelector',
+		);
+		$is_allowed = in_array( $this->type, $types, true );
+
+		/**
+		 * Checks if annotation selector is allowed.
+		 *
+		 * @since [version]
+		 *
+		 * @param bool                   $is_allowed True if allowed.
+		 * @param WP_Annotation_Selector $this       Selector object instance.
+		 */
+		$is_allowed = apply_filters( 'annotation_selector_is_allowed', $is_allowed, $this );
+
+		return $is_allowed;
+	}
+
+	/**
+	 * Checks if selector is too large.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if too large.
+	 */
+	protected function is_too_large() {
+		if ( 'RangeSelector' === $this->type ) {
+			return false;
+		}
+
+		if ( 'SvgSelector' === $this->type ) {
+			$max_size = 131072; // 128kb.
+		} else {
+			$max_size = 16384; // 16kb.
+		}
+
+		$minus_refinements = $this->to_array();
+		unset( $minus_refinements['refinedBy'] );
+
+		$size         = strlen( json_encode( $minus_refinements ) );
+		$is_too_large = $size > $max_size;
+
+		/**
+		 * Filters max annotation selector size (in bytes).
+		 *
+		 * @since [version]
+		 *
+		 * @param bool                   $is_too_large True if too large.
+		 * @param WP_Annotation_Selector $this         Selector object instance.
+		 */
+		$is_too_large = apply_filters( 'annotation_selector_is_too_large', $is_too_large, $this );
+
+		return $is_too_large;
+	}
+
+	/**
+	 * Parses a FragmentSelector.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if valid.
+	 *
+	 * @link https://www.w3.org/TR/annotation-model/#fragment-selector
+	 */
+	protected function parse_fragment_selector() {
+		$array = $this->to_array();
+
+		$allow_keys = array_fill_keys( array(
+			'type',
+			'value',
+			'conformsTo',
+			'refinedBy',
+		), 0 );
+		if ( array_diff_key( $array, $allow_keys ) ) {
+			return false;
+		}
+
+		if ( empty( $this->value ) ) {
+			return false;
+		} elseif ( ! is_string( $this->value ) ) {
+			return false;
+		}
+
+		if ( isset( $this->conformsTo ) ) {
+			if ( ! is_string( $this->conformsTo ) ) {
+				return false;
+			} elseif ( ! wp_parse_url( $this->conformsTo ) ) {
+				return false;
+			}
+		}
+
+		if ( isset( $this->refinedBy ) ) {
+			$this->refinedBy = self::get_instance( $this->refinedBy );
+
+			if ( ! $this->refinedBy ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Parses a CssSelector or XPathSelector.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if valid.
+	 *
+	 * @link https://www.w3.org/TR/annotation-model/#css-selector
+	 * @link https://www.w3.org/TR/annotation-model/#xpath-selector
+	 */
+	protected function parse_css_xpath_selectors() {
+		$array = $this->to_array();
+
+		$allow_keys = array_fill_keys( array(
+			'type',
+			'value',
+			'refinedBy',
+		), 0 );
+		if ( array_diff_key( $array, $allow_keys ) ) {
+			return false;
+		}
+
+		if ( empty( $this->value ) ) {
+			return false;
+		} elseif ( ! is_string( $this->value ) ) {
+			return false;
+		}
+
+		if ( isset( $this->refinedBy ) ) {
+			$this->refinedBy = self::get_instance( $this->refinedBy );
+
+			if ( ! $this->refinedBy ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Parses a TextQuoteSelector.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if valid.
+	 *
+	 * @link https://www.w3.org/TR/annotation-model/#text-quote-selector
+	 */
+	protected function parse_text_quote_selector() {
+		$array = $this->to_array();
+
+		$allow_keys = array_fill_keys( array(
+			'type',
+			'exact',
+			'prefix',
+			'suffix',
+		), 0 );
+		if ( array_diff_key( $array, $allow_keys ) ) {
+			return false;
+		}
+
+		if ( ! isset( $this->exact ) ) {
+			return false;
+		} elseif ( ! is_string( $this->exact ) ) {
+			return false;
+		} elseif ( '' === $this->exact ) {
+			return false;
+		}
+
+		if ( isset( $this->prefix ) ) {
+			if ( ! is_string( $this->prefix ) ) {
+				return false;
+			}
+		}
+
+		if ( isset( $this->suffix ) ) {
+			if ( ! is_string( $this->suffix ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Parses a TextPositionSelector or DataPositionSelector.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if valid.
+	 *
+	 * @link https://www.w3.org/TR/annotation-model/#text-position-selector
+	 * @link https://www.w3.org/TR/annotation-model/#data-position-selector
+	 */
+	protected function parse_text_data_position_selectors() {
+		$array = $this->to_array();
+
+		$allow_keys = array_fill_keys( array(
+			'type',
+			'start',
+			'end',
+		), 0 );
+		if ( array_diff_key( $array, $allow_keys ) ) {
+			return false;
+		}
+
+		if ( ! isset( $this->start ) ) {
+			return false;
+		} elseif ( ! is_int( $this->start ) ) {
+			return false;
+		} elseif ( 0 > $this->start ) {
+			return false;
+		}
+
+		if ( ! isset( $this->end ) ) {
+			return false;
+		} elseif ( ! is_int( $this->end ) ) {
+			return false;
+		} elseif ( 0 > $this->end ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Parses an SvgSelector.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if valid.
+	 *
+	 * @link https://www.w3.org/TR/annotation-model/#svg-selector
+	 */
+	protected function parse_svg_selector() {
+		$array = $this->to_array();
+
+		$allow_keys = array_fill_keys( array(
+			'type',
+			'id',    // URL leading to an SVG file.
+			'value', // Inline SVG markup.
+		), 0 );
+		if ( array_diff_key( $array, $allow_keys ) ) {
+			return false;
+		}
+
+		if ( empty( $this->id ) && empty( $this->value ) ) {
+			return false;
+		}
+
+		if ( ! empty( $this->id ) ) {
+			if ( ! is_string( $this->id ) ) {
+				return false;
+			} elseif ( ! wp_parse_url( $this->id ) ) {
+				return false;
+			}
+		}
+
+		if ( ! empty( $this->value ) ) {
+			if ( ! is_string( $this->value ) ) {
+				return false;
+			} elseif ( false === stripos( $this->value, '</svg>' ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Parses an RangeSelector.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if valid.
+	 *
+	 * @link https://www.w3.org/TR/annotation-model/#range-selector
+	 */
+	protected function parse_range_selector() {
+		$array = $this->to_array();
+
+		$allow_keys = array_fill_keys( array(
+			'type',
+			'startSelector',
+			'endSelector',
+		), 0 );
+		if ( array_diff_key( $array, $allow_keys ) ) {
+			return false;
+		}
+
+		if ( empty( $this->startSelector ) ) {
+			return false;
+		} elseif ( empty( $this->endSelector ) ) {
+			return false;
+		}
+
+		$this->startSelector = self::get_instance( $this->startSelector );
+		$this->endSelector   = self::get_instance( $this->endSelector );
+
+		if ( ! $this->startSelector || ! $this->endSelector ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/lib/class-wp-annotation-utils.php
+++ b/lib/class-wp-annotation-utils.php
@@ -1,0 +1,487 @@
+<?php
+/**
+ * Annotations API: WP_Annotation_Utils class
+ *
+ * @package gutenberg
+ * @since [version]
+ */
+
+/**
+ * Annotation utilities.
+ *
+ * @since [version]
+ */
+final class WP_Annotation_Utils {
+	/**
+	 * Translates/normalizes a comment's status.
+	 *
+	 * Matches normalized statuses returned by {@see wp_get_comment_status()}.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $status Comment status.
+	 *
+	 * @return string         'approved', 'unapproved', 'spam', 'trash', or a custom
+	 *                        status. Returns an empty string on failure.
+	 *
+	 * @see wp_get_comment_status()
+	 */
+	public static function translate_comment_status( $status ) {
+		$status = (string) $status;
+
+		switch ( $status ) {
+			case 'approved':
+			case 'approve':
+			case '1':
+				return 'approved';
+
+			case 'hold':
+			case '0':
+				return 'unapproved';
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Gets comment status (supports custom statuses).
+	 *
+	 * Unlike {@see wp_get_comment_status()}, this supports custom statuses. Otherwise,
+	 * it closely resembles {@see wp_get_comment_status()}.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment|string|int $comment    Comment object or ID.
+	 * @param  bool                  $check_meta Optional. Default is false. If true,
+	 *                                           return would-be status if restored
+	 *                                           from spam or trash.
+	 *
+	 * @return string|bool                       'approved', 'unapproved', 'spam',
+	 *                                           'trash', or a custom status.
+	 *                                           False on failure.
+	 *
+	 * @see wp_get_comment_status()
+	 */
+	public static function get_comment_status( $comment, $check_meta = false ) {
+		if ( ! $comment ) {
+			return false;
+		}
+
+		$comment = get_comment( $comment );
+
+		if ( ! $comment ) {
+			return false;
+		}
+
+		$status = $comment->comment_approved;
+		$status = self::translate_comment_status( $status );
+
+		if ( $check_meta && in_array( $status, array( 'spam', 'trash' ), true ) ) {
+			$meta_status = get_comment_meta( $comment->comment_ID, '_wp_trash_meta_status', true );
+			$status      = self::translate_comment_status( $meta_status ? $meta_status : '0' );
+		}
+
+		return $status ? $status : false;
+	}
+
+	/**
+	 * Sets comment status (supports custom statuses).
+	 *
+	 * Unlike {@see wp_set_comment_status()}, this supports custom statuses. Otherwise,
+	 * it closely resembles {@see wp_set_comment_status()}.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment|string|int $comment    Comment object or ID.
+	 * @param  string                $new_status New status. Supports custom statuses.
+	 *
+	 * @return bool|WP_Error                     True on comment status success.
+	 *                                           False (or a {@see WP_Error}) on failure.
+	 *
+	 * @see wp_set_comment_status()
+	 */
+	public static function set_comment_status( $comment, $new_status ) {
+		global $wpdb;
+
+		if ( ! $comment ) {
+			return false;
+		}
+
+		$old_comment = get_comment( $comment );
+		$old_comment = $old_comment ? clone $old_comment : null;
+
+		if ( ! $old_comment ) {
+			return false;
+		}
+
+		$new_status     = (string) $new_status;
+		$new_raw_status = $new_status; // Before normalizing.
+		$old_raw_status = $old_comment->comment_approved;
+
+		switch ( $new_status ) {
+			case 'approved':
+			case 'approve':
+			case '1':
+				$new_status = '1';
+				add_action( 'wp_set_comment_status', 'wp_new_comment_notify_postauthor' );
+				break;
+
+			case 'hold':
+			case '0':
+				$new_status = '0';
+				break;
+		}
+
+		if ( ! $wpdb->update(
+			$wpdb->comments,
+			array( 'comment_approved' => $new_status ),
+			array( 'comment_ID' => $old_comment->comment_ID )
+		) ) {
+			return false;
+		}
+
+		clean_comment_cache( $old_comment->comment_ID );
+		$new_comment = get_comment( $old_comment->comment_ID );
+
+		/** This filter is documented in wp-includes/comment.php */
+		do_action( 'wp_set_comment_status', $new_comment->comment_ID, $new_raw_status );
+
+		wp_transition_comment_status( $new_raw_status, $old_raw_status, $new_comment );
+		wp_update_comment_count( $new_comment->comment_post_ID );
+
+		return true;
+	}
+
+	/**
+	 * Removes a comment from spam (supports custom restoration statuses).
+	 *
+	 * Unlike {@see wp_unspam_comment()}, this supports custom restoration statuses.
+	 * Otherwise, it closely resembles {@see wp_unspam_comment()}.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment|string|int $comment Comment object or ID.
+	 *
+	 * @return bool                           True on success. False on failure.
+	 *
+	 * @see wp_unspam_comment()
+	 */
+	public static function unspam_comment( $comment ) {
+		if ( ! $comment ) {
+			return false;
+		}
+
+		$comment = get_comment( $comment );
+
+		if ( ! $comment ) {
+			return false;
+		}
+
+		/** This action is documented in wp-includes/comment.php */
+		do_action( 'unspam_comment', $comment->comment_ID, $comment );
+
+		$status = (string) get_comment_meta( $comment->comment_ID, '_wp_trash_meta_status', true );
+		$status = $status ? $status : '0';
+
+		if ( self::set_comment_status( $comment, $status ) ) {
+			delete_comment_meta( $comment->comment_ID, '_wp_trash_meta_status' );
+			delete_comment_meta( $comment->comment_ID, '_wp_trash_meta_time' );
+
+			/** This action is documented in wp-includes/comment.php */
+			do_action( 'unspammed_comment', $comment->comment_ID, $comment );
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Removes a comment from trash (supports custom restoration statuses).
+	 *
+	 * Unlike {@see wp_untrash_comment()}, this supports custom restoration statuses.
+	 * Otherwise, it closely resembles {@see wp_untrash_comment()}.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment|string|int $comment Comment object or ID.
+	 *
+	 * @return bool                           True on success. False on failure.
+	 *
+	 * @see wp_untrash_comment()
+	 */
+	public static function untrash_comment( $comment ) {
+		if ( ! $comment ) {
+			return false;
+		}
+
+		$comment = get_comment( $comment );
+
+		if ( ! $comment ) {
+			return false;
+		}
+
+		/** This action is documented in wp-includes/comment.php */
+		do_action( 'untrash_comment', $comment->comment_ID, $comment );
+
+		$status = (string) get_comment_meta( $comment->comment_ID, '_wp_trash_meta_status', true );
+		$status = $status ? $status : '0';
+
+		if ( self::set_comment_status( $comment, $status ) ) {
+			delete_comment_meta( $comment->comment_ID, '_wp_trash_meta_time' );
+			delete_comment_meta( $comment->comment_ID, '_wp_trash_meta_status' );
+
+			/** This action is documented in wp-includes/comment.php */
+			do_action( 'untrashed_comment', $comment->comment_ID, $comment );
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Queries additional REST API collection parameters.
+	 *
+	 * @since [version]
+	 *
+	 * @param array           $query_vars {@see WP_Query} vars.
+	 * @param WP_REST_Request $request    REST API request.
+	 *
+	 * @return array                      Filtered query args.
+	 *
+	 * @see WP_Annotation_Utils::on_comments_clauses()
+	 * @see WP_REST_Comments_Controller::get_items()
+	 */
+	public static function on_rest_comment_query( $query_vars, $request ) {
+		if ( ! preg_match( '/\/annotations$/', $request->get_route() ) ) {
+			return $query_vars;
+		}
+
+		// This allows annotations in comment query.
+		// see: WP_Annotation_Utils::on_comments_clauses().
+		$query_vars['cache_domain'] = 'annotations';
+
+		if ( isset( $request['hierarchical'] ) ) {
+			$query_vars['hierarchical'] = $request['hierarchical'];
+		}
+
+		$meta_queries = array();
+
+		$vias = $request['via'];
+		$vias = $vias ? (array) $vias : array();
+		$vias = array_map( 'strval', $vias );
+
+		if ( $vias ) {
+			$meta_queries[] = array(
+				'key'     => '_via',
+				'value'   => $vias,
+				'compare' => 'IN',
+			);
+		}
+
+		if ( $meta_queries ) {
+			if ( ! empty( $query_vars['meta_query'] ) ) {
+				$query_vars['meta_query'] = array(
+					'relation' => 'AND',
+					$query_vars['meta_query'],
+					array(
+						'relation' => 'AND',
+						$meta_queries,
+					),
+				);
+			} else {
+				$query_vars['meta_query'] = array(
+					'relation' => 'AND',
+					$meta_queries,
+				);
+			}
+		}
+
+		return $query_vars;
+	}
+
+	/**
+	 * Filters WP_Comment_Query clauses.
+	 *
+	 * @since [version]
+	 *
+	 * @param  array            $pieces Array of comment query clauses.
+	 * @param  WP_Comment_Query $query  Current {@see WP_Comment_Query} instance.
+	 *
+	 * @return array                    Array of comment query clauses.
+	 *
+	 * @see WP_Annotation_Utils::on_rest_comment_query()
+	 * @see WP_Comment_Query::get_comment_ids()
+	 */
+	public static function on_comments_clauses( $pieces, $query ) {
+		global $wpdb;
+
+		/*
+		 * Annotations can only be returned when 'cache_domain=annotations'. This keeps
+		 * annotations out of any normal comment query. If a plugin wants to query annotations,
+		 * it can set 'cache_domain=annotations' also.
+		 */
+		if ( 'annotations' !== $query->query_vars['cache_domain'] ) {
+			$annotation_types = get_annotation_types();
+
+			foreach ( $annotation_types as $key => $type ) {
+				$annotation_types[ $key ] = $wpdb->prepare( '%s', $type );
+			}
+
+			$pieces['where'] .= $pieces['where'] ? ' AND ' : '';
+			$pieces['where'] .= 'comment_type NOT IN (' . implode( ', ', $annotation_types ) . ')';
+		}
+
+		/*
+		 * Work around a bug in WP_Comment_Query. If 'hierarchical' is given, WP_Comment_Query
+		 * forces 'parent' to '0', even if 'parent__in' is defined. That's a problem because
+		 * the REST API uses 'parent__in'. See: <https://git.io/vNc8j>
+		 */
+		if ( 'annotations' === $query->query_vars['cache_domain'] && $query->query_vars['hierarchical'] ) {
+			// If performing a hierarchical comment query, WP_Comment_Query will set the 'parent' query var
+			// to a value of 0 by default; i.e., if it wasn't defined already. That conflicts with 'parent__in'.
+			if ( $query->query_vars['parent__in'] && ! $query->query_vars['parent'] ) {
+
+				// So 'parent__in' is not empty, and 'parent' is empty (e.g., 0 or otherwise).
+				// Now, if the clause itself contains 'comment_parent IN' as a result of 'parent__in'.
+				if ( preg_match( '/\bcomment_parent\s+IN\b/i', $pieces['where'] ) ) {
+					// Then remove the conflicting 'comment_parent =' SQL that is brought about by 'parent'.
+					// In other words, we want to do away with 'parent' and let 'parent__in' work as expected.
+					$pieces['where'] = preg_replace( '/\s+AND\s+comment_parent\s*\=\s*[0-9]+/', '', $pieces['where'] );
+				}
+			}
+		}
+
+		return $pieces;
+	}
+
+	/**
+	 * Checks an annotation comment type.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $type Comment type.
+	 *
+	 * @return bool         True if comment is valid.
+	 */
+	public static function is_valid_type( $type ) {
+		return in_array( $type, get_annotation_types(), true );
+	}
+
+	/**
+	 * Checks an annotation comment status (or status action).
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $status Comment status.
+	 *
+	 * @return bool           True if status is valid.
+	 */
+	public static function is_valid_status_or_action( $status ) {
+		return self::is_valid_status( $status, true );
+	}
+
+	/**
+	 * Checks an annotation comment status.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $status        Comment status.
+	 * @param  bool   $allow_actions Allow actions? Default false.
+	 *
+	 * @return bool                  True if status is valid.
+	 */
+	public static function is_valid_status( $status, $allow_actions = false ) {
+		$allow = get_annotation_statuses();
+
+		if ( $allow_actions ) {
+			$allow = array_merge( $allow, array( 'unspam', 'untrash' ) );
+		}
+
+		return in_array( $status, $allow, true );
+	}
+
+	/**
+	 * Validates a W3C annotation client identifier.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $client The annotation client to check.
+	 *
+	 * @return bool           True if client is valid.
+	 *
+	 * @link https://www.w3.org/TR/annotation-model/#rendering-software
+	 */
+	public static function is_valid_client( $client ) {
+		if ( '' === $client ) {
+			return true; // Empty is OK.
+		}
+
+		if ( ! is_string( $client ) ) {
+			return false;
+		}
+		$raw_client = $client;
+		$client     = preg_replace( '/[^a-z0-9:_\-]/i', '', $client );
+		$client     = substr( trim( $client, ':_-' ), 0, 250 );
+
+		if ( ! $client || $client !== $raw_client ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates a selector deeply.
+	 *
+	 * @since [version]
+	 *
+	 * @param  array $selector Selector to check.
+	 *
+	 * @return bool            True if selector is valid.
+	 */
+	public static function is_valid_selector( $selector ) {
+		if ( array() === $selector ) {
+			return true; // Empty is OK.
+		}
+
+		return (bool) WP_Annotation_Selector::get_instance( $selector );
+	}
+
+	/**
+	 * Checks if comment content is empty.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $content Content to check.
+	 *
+	 * @return bool           True if empty, if it's not a string, or the blog's charset
+	 *                        is UTF-8 and it's invalid UTF-8.
+	 */
+	public static function is_content_empty( $content ) {
+		if ( ! is_string( $content ) ) {
+			return true;
+		}
+
+		$content = wp_check_invalid_utf8( $content );
+
+		if ( false !== strpos( $content, '<' ) ) {
+			// If it contains anything audible or visual it's not empty.
+			if ( preg_match( '/\<(img|svg|audio|video|embed|object)[^<>]*\>/i', $content ) ) {
+				return false;
+			}
+			// Else remove tags and require text.
+			$content = wp_strip_all_tags( $content );
+		}
+
+		if ( empty( $content ) ) {
+			return true;
+		}
+
+		// Strip whitespace including `&nbsp;` and everything that trim() handles too.
+		$content = preg_replace( '/(?:' . wp_spaces_regexp() . '|[\0\x0B])/', '', $content );
+
+		return empty( $content );
+	}
+}

--- a/lib/class-wp-annotation.php
+++ b/lib/class-wp-annotation.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Annotations API: WP_Annotation class
+ *
+ * @package gutenberg
+ * @since [version]
+ */
+
+/**
+ * Annotation.
+ *
+ * @since [version]
+ */
+final class WP_Annotation {
+	/**
+	 * Comment object.
+	 *
+	 * @since [version]
+	 *
+	 * @var WP_Comment
+	 */
+	public $comment;
+
+	/**
+	 * Annotation status.
+	 *
+	 * @since [version]
+	 *
+	 * @var string
+	 */
+	public $status;
+
+	/**
+	 * Annotation meta-status.
+	 *
+	 * @since [version]
+	 *
+	 * @var string
+	 */
+	public $meta_status;
+
+	/**
+	 * Gets a {@see WP_Annotation} instance.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment|int|string $comment Comment object or ID.
+	 *
+	 * @return WP_Annotation|false            Annotation object. False on failure.
+	 */
+	public static function get_instance( $comment ) {
+		try {
+			return new WP_Annotation( $comment );
+		} catch ( Exception $exception ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Contructor.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment|int|string $comment Comment object or ID.
+	 *
+	 * @throws Exception                      On invalid comment type.
+	 */
+	public function __construct( $comment ) {
+		$this->comment = $comment ? get_comment( $comment ) : null;
+
+		if ( ! ( $this->comment instanceof WP_Comment ) ) {
+			throw new Exception( 'Missing annotation comment.' );
+		} elseif ( ! in_array( $this->comment_type, get_annotation_types(), true ) ) {
+			throw new Exception( 'Invalid annotation comment type.' );
+		}
+
+		$this->status      = WP_Annotation_Utils::get_comment_status( $this->comment );
+		$this->meta_status = WP_Annotation_Utils::get_comment_status( $this->comment, true );
+	}
+
+	/**
+	 * Checks for an ID.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool True if exists.
+	 */
+	public function exists() {
+		return ! empty( $this->comment_ID );
+	}
+
+	/**
+	 * Magic isset.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $property Property name.
+	 *
+	 * @return bool             True if set.
+	 */
+	public function __isset( $property ) {
+		return isset( $this->comment->{ $property } );
+	}
+
+	/**
+	 * Magic getter.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $property Property name.
+	 *
+	 * @return mixed            Property value.
+	 */
+	public function __get( $property ) {
+		return $this->comment->{ $property };
+	}
+
+	/**
+	 * Magic caller.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $method Method name.
+	 * @param  array  $args   Method arguments.
+	 *
+	 * @return mixed          Method return value.
+	 */
+	public function __call( $method, $args ) {
+		return call_user_func_array( array( $this->comment, $method ), $args );
+	}
+
+	/**
+	 * Converts object to array.
+	 *
+	 * @since [version]
+	 *
+	 * @return array Object as array.
+	 */
+	public function to_array() {
+		$vars = get_object_vars( $this );
+		unset( $vars['comment'] );
+
+		return array_merge( $this->comment->to_array(), $vars );
+	}
+
+	/**
+	 * Gets selector.
+	 *
+	 * @since [version]
+	 *
+	 * @return WP_Annotation_Selector|null Selector. Null on failure.
+	 */
+	public function get_selector() {
+		$selector = $this->get_meta( '_selector' );
+
+		if ( $selector ) {
+			$selector = WP_Annotation_Selector::get_instance( $selector );
+		}
+
+		return $selector ? $selector : null;
+	}
+
+	/**
+	 * Gets meta.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key    Meta key.
+	 * @param bool   $single Whether to return a single value. Default is true.
+	 *
+	 * @return mixed         Array if `$single` is false. Value if `$single` is true.
+	 */
+	public function get_meta( $key, $single = true ) {
+		return get_comment_meta( $this->comment_ID, $key, $single );
+	}
+
+	/**
+	 * Updates meta.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key        Meta key.
+	 * @param mixed  $value      Meta value.
+	 * @param mixed  $prev_value Previous value to check. Default is `''`.
+	 *
+	 * @return int|bool          Meta ID if key didn't exist, true on success, false on failure.
+	 */
+	public function update_meta( $key, $value, $prev_value = '' ) {
+		return update_comment_meta( $this->comment_ID, $key, $value, $prev_value );
+	}
+
+	/**
+	 * Gets parent post.
+	 *
+	 * @since [version]
+	 *
+	 * @return WP_Post|null Post object. Null on failure.
+	 */
+	public function get_post() {
+		if ( ! $this->comment_post_ID ) {
+			return null;
+		}
+
+		return get_post( $this->comment_post_ID );
+	}
+
+	/**
+	 * Gets parent post type object.
+	 *
+	 * @since [version]
+	 *
+	 * @return WP_Post_Type|null Post type object. Null on failure.
+	 */
+	public function get_post_type() {
+		$post = $this->get_post();
+
+		if ( ! $post ) {
+			return null;
+		}
+
+		return get_post_type_object( $post->post_type );
+	}
+
+	/**
+	 * Gets parent post status object.
+	 *
+	 * @since [version]
+	 *
+	 * @return object|null Post status object. Null on failure.
+	 */
+	public function get_post_status() {
+		$post = $this->get_post();
+
+		if ( ! $post ) {
+			return null;
+		}
+
+		return get_post_status_object( get_post_status( $post ) );
+	}
+}

--- a/lib/class-wp-rest-annotations-controller.php
+++ b/lib/class-wp-rest-annotations-controller.php
@@ -1,0 +1,1054 @@
+<?php
+/**
+ * Annotations REST API: WP_REST_Annotations_Controller class
+ *
+ * @package gutenberg
+ * @since [version]
+ */
+
+/**
+ * Controller providing a REST API endpoint for annotations.
+ *
+ * Annotations are stored as comments with a custom comment type.
+ *
+ * @since [version]
+ *
+ * @see WP_REST_Controller
+ * @see WP_REST_Comments_Controller
+ */
+class WP_REST_Annotations_Controller extends WP_REST_Comments_Controller {
+	/**
+	 * Constructor.
+	 *
+	 * Overrides parent method and sets a custom REST base.
+	 *
+	 * @since [version]
+	 *
+	 * @see WP_REST_Comments_Controller::__construct()
+	 */
+	public function __construct() {
+		// phpcs:ignore PHPCompatibility.PHP.NewKeywords.t_namespaceFound — mistaken as 'namespace' keyword.
+		$this->namespace = 'wp/v2'; // @codingStandardsIgnoreLine
+		$this->rest_base = 'annotations';
+
+		$this->meta = new WP_REST_Comment_Meta_Fields();
+	}
+
+	/**
+	 * Retrieves annotation schema.
+	 *
+	 * Overrides parent method and makes 'type' writable. Also adds default values &
+	 * validators for the 'type' and 'status' fields.
+	 *
+	 * @since [version]
+	 *
+	 * @return array Annotation schema.
+	 *
+	 * @see WP_REST_Comments_Controller::get_item_schema()
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		$schema['properties']['type']     = array(
+			'type'        => 'string',
+			'arg_options' => array(
+				'validate_callback' => 'WP_Annotation_Utils::is_valid_type',
+			),
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'description' => __( 'Annotation comment type.', 'gutenberg' ),
+			'default'     => get_default_annotation_type(),
+		);
+		$schema['properties']['status']   = array(
+			'type'        => 'string',
+			'arg_options' => array(
+				'validate_callback' => 'WP_Annotation_Utils::is_valid_status_or_action',
+			),
+			'context'     => array( 'view', 'edit' ),
+			'description' => __( 'Annotation status.', 'gutenberg' ),
+			'default'     => get_default_annotation_status(),
+		);
+		$schema['properties']['children'] = array(
+			'readonly'    => true,
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'object',
+			),
+			'context'     => array( 'view', 'edit' ),
+			'description' => __( 'Hierarchical children in threaded format.', 'gutenberg' ),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Retrieves additional fields.
+	 *
+	 * Overrides parent method and adds additional fields specific to annotation comment
+	 * types. Note: Intentionally *not* using {@see register_rest_field()} because that
+	 * would affect all comment types.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $object_type Optional object type.
+	 *
+	 * @return array               Additional fields.
+	 *
+	 * @see WP_REST_Controller::get_collection_params()
+	 */
+	protected function get_additional_fields( $object_type = null ) {
+		$fields = parent::get_additional_fields( $object_type );
+
+		$fields['via'] = array(
+			'get_callback'    => array( $this, 'on_get_additional_field' ),
+			'update_callback' => array( $this, 'on_update_additional_field' ),
+			'schema'          => array(
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'description' => __( 'W3C annotation client identifier.', 'gutenberg' ),
+				'default'     => '',
+			),
+		);
+
+		$fields['selector'] = array(
+			'get_callback'    => array( $this, 'on_get_additional_field' ),
+			'update_callback' => array( $this, 'on_update_additional_field' ),
+			'schema'          => array(
+				'type'        => 'object',
+				'context'     => array( 'view', 'edit' ),
+				'description' => __( 'W3C annotation selector.', 'gutenberg' ),
+
+				'properties'  => array(
+					'type'                 => array(
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'enum'        => array(
+							'FragmentSelector',
+							'CssSelector',
+							'XPathSelector',
+							'TextQuoteSelector',
+							'TextPositionSelector',
+							'DataPositionSelector',
+							'SvgSelector',
+							'RangeSelector',
+						),
+						'description' => __( 'Type of selector.', 'gutenberg' ),
+					),
+					'additionalProperties' => true,
+				),
+				'default'     => array(),
+			),
+		);
+
+		return $fields;
+	}
+
+	/**
+	 * Retrieves collection parameters.
+	 *
+	 * Overrides parent method and adds additional params specific to annotation comment
+	 * types. Note: Intentionally *not* using REST API filters because that would affect
+	 * all comment types.
+	 *
+	 * @since [version]
+	 *
+	 * @return array Collection parameters.
+	 *
+	 * @see WP_REST_Comments_Controller::get_collection_params()
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+
+		$params['post'] = array(
+			'type'              => 'array',
+			'description'       => __( 'Post ID(s).', 'gutenberg' ),
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'required'          => true,
+			'validate_callback' => array( $this, 'validate_post_collection_param' ),
+		);
+
+		$params['type'] = array(
+			'type'              => 'array',
+			'description'       => __( 'Annotation type(s).', 'gutenberg' ),
+			'items'             => array(
+				'type' => 'string',
+				'enum' => get_annotation_types(),
+			),
+			'default'           => array( get_default_annotation_type() ),
+			'validate_callback' => array( $this, 'validate_type_collection_param' ),
+		);
+
+		$params['status'] = array(
+			'type'              => 'array',
+			'description'       => __( 'Annotation status(es).', 'gutenberg' ),
+			'items'             => array(
+				'type' => 'string',
+			),
+			'default'           => array( 'approve' ),
+			'validate_callback' => array( $this, 'validate_status_collection_param' ),
+		);
+
+		$params['via'] = array(
+			'type'              => 'array',
+			'description'       => __( 'W3C annotation client identifier(s).', 'gutenberg' ),
+			'items'             => array(
+				'type' => 'string',
+			),
+			'validate_callback' => array( $this, 'validate_via_collection_param' ),
+		);
+
+		$params['hierarchical'] = array(
+			'type'        => 'string',
+			'description' => __( 'Results in hierarchical format?', 'gutenberg' ),
+			'enum'        => array( '', 'flat', 'threaded' ),
+		);
+
+		return $params;
+	}
+
+	/**
+	 * Validates 'post' collection parameter.
+	 *
+	 * @since [version]
+	 *
+	 * @param  int|array $posts Post IDs.
+	 *
+	 * @return WP_Error|bool    True if valid, {@see WP_Error} otherwise.
+	 */
+	public function validate_post_collection_param( $posts ) {
+		if ( ! is_array( $posts ) ) {
+			$posts = preg_split( '/[\s,]+/', (string) $posts );
+		}
+
+		if ( ! $posts || ! wp_is_numeric_array( $posts ) ) {
+			return new WP_Error( 'rest_annotation_invalid_array_param_post', __( 'Invalid post(s).', 'gutenberg' ) );
+		}
+
+		foreach ( $posts as $post ) {
+			if ( (string) absint( $post ) !== (string) $post || 0 >= $post ) {
+				return new WP_Error( 'rest_annotation_invalid_param_post', __( 'Invalid post.', 'gutenberg' ) );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates 'type' collection parameter.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string|array $types Annotation comment types.
+	 *
+	 * @return WP_Error|bool       True if valid, {@see WP_Error} otherwise.
+	 */
+	public function validate_type_collection_param( $types ) {
+		if ( ! is_array( $types ) ) {
+			$types = preg_split( '/[\s,]+/', (string) $types );
+		}
+
+		if ( ! $types || ! wp_is_numeric_array( $types ) ) {
+			return new WP_Error( 'rest_annotation_invalid_array_param_type', __( 'Invalid type(s).', 'gutenberg' ) );
+		}
+
+		foreach ( $types as $type ) {
+			if ( ! WP_Annotation_Utils::is_valid_type( $type ) ) {
+				return new WP_Error( 'rest_annotation_invalid_param_type', __( 'Invalid type.', 'gutenberg' ) );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates 'status' collection parameter.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string|array $statuses Annotation comment statuses.
+	 *
+	 * @return WP_Error|bool          True if valid, {@see WP_Error} otherwise.
+	 */
+	public function validate_status_collection_param( $statuses ) {
+		if ( ! is_array( $statuses ) ) {
+			$statuses = preg_split( '/[\s,]+/', (string) $statuses );
+		}
+
+		if ( ! $statuses || ! wp_is_numeric_array( $statuses ) ) {
+			return new WP_Error( 'rest_annotation_invalid_array_param_status', __( 'Invalid status(es).', 'gutenberg' ) );
+		}
+
+		foreach ( $statuses as $status ) {
+			if ( ! WP_Annotation_Utils::is_valid_status( $status ) ) {
+				return new WP_Error( 'rest_annotation_invalid_param_status', __( 'Invalid status.', 'gutenberg' ) );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates the 'via' collection parameter.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string|array $vias W3C annotation client identifier(s).
+	 *
+	 * @return WP_Error|bool      True if valid, {@see WP_Error} otherwise.
+	 */
+	public function validate_via_collection_param( $vias ) {
+		if ( ! is_array( $vias ) ) {
+			$vias = preg_split( '/[\s,]+/', (string) $vias );
+		}
+
+		if ( ! $vias || ! wp_is_numeric_array( $vias ) ) {
+			return new WP_Error( 'rest_annotation_invalid_array_param_via', __( 'Invalid client identifier(s).', 'gutenberg' ) );
+		}
+
+		foreach ( $vias as $via ) {
+			if ( ! WP_Annotation_Utils::is_valid_client( $via ) ) {
+				return new WP_Error( 'rest_annotation_invalid_param_via', __( 'Invalid client identifier.', 'gutenberg' ) );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets an additional field value.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment|array $comment Comment data.
+	 * @param  string           $field   Name of the field to get.
+	 * @param  WP_Rest_Request  $request Full REST API request details.
+	 *
+	 * @return mixed|null                Current value, null otherwise.
+	 *
+	 * @see WP_REST_Annotations_Controller::get_additional_fields()
+	 */
+	public function on_get_additional_field( $comment, $field, $request ) {
+		if ( $comment instanceof WP_Comment ) {
+			$comment_id = $comment->comment_ID;
+		} elseif ( ! empty( $comment['id'] ) ) {
+			$comment_id = $comment['id'];
+		}
+
+		if ( empty( $comment_id ) ) {
+			return null;
+		}
+
+		$value = get_comment_meta( $comment_id, '_' . $field, true );
+
+		switch ( $field ) {
+			case 'via':
+				return is_string( $value ) ? $value : '';
+
+			case 'selector':
+				return is_array( $value ) ? $value : array();
+		}
+
+		return null;
+	}
+
+	/**
+	 * Updates an additional field value.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string           $value   New field value.
+	 * @param  WP_Comment|array $comment Comment data.
+	 * @param  string           $field   Name of the field to update.
+	 * @param  WP_Rest_Request  $request Full REST API request details.
+	 *
+	 * @return bool|WP_Error             {@see WP_Error} on failure, null otherwise.
+	 *
+	 * @see WP_REST_Annotations_Controller::get_additional_fields()
+	 */
+	public function on_update_additional_field( $value, $comment, $field, $request ) {
+		// translators: %s is a REST API field name associated with failure.
+		$error = __( 'Validation failure. Failed to update: %s.', 'gutenberg' );
+		$error = new WP_Error( 'rest_annotation_field_validation_update_failure', sprintf( $error, $field ), array( 'status' => 400 ) );
+
+		if ( $comment instanceof WP_Comment ) {
+			$comment_id = $comment->comment_ID;
+		} elseif ( ! empty( $comment['id'] ) ) {
+			$comment_id = $comment['id'];
+		}
+
+		if ( empty( $comment_id ) ) {
+			return $error;
+		}
+
+		switch ( $field ) {
+			case 'via':
+				if ( ! WP_Annotation_Utils::is_valid_client( $value ) ) {
+					return $error;
+				}
+				return update_comment_meta( $comment_id, '_' . $field, $value );
+
+			case 'selector':
+				if ( ! WP_Annotation_Utils::is_valid_selector( $value ) ) {
+					return $error;
+				}
+				return update_comment_meta( $comment_id, '_' . $field, $value );
+		}
+
+		return $error;
+	}
+
+	/**
+	 * Prepares a comment for DB insertion.
+	 *
+	 * Overrides parent method and handles 'comment_type'.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full REST API request details.
+	 *
+	 * @return array|WP_Error           Prepared comment, {@see WP_Error} otherwise.
+	 *
+	 * @see WP_REST_Comments_Controller::prepare_item_for_database()
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$prepared_comment = parent::prepare_item_for_database( $request );
+
+		if ( is_wp_error( $prepared_comment ) ) {
+			return $prepared_comment;
+		}
+
+		if ( isset( $request['type'] ) ) {
+			$prepared_comment['comment_type'] = $request['type'];
+		}
+
+		if ( isset( $prepared_comment['comment_content'] ) ) {
+			/** This filter is documented in wp-includes/comment.php */
+			$filtered_content = wp_slash( $prepared_comment['comment_content'] );
+			$filtered_content = apply_filters( 'pre_comment_content', $filtered_content );
+			$filtered_content = wp_unslash( $filtered_content );
+
+			if ( WP_Annotation_Utils::is_content_empty( $prepared_comment['comment_content'] )
+					|| WP_Annotation_Utils::is_content_empty( $filtered_content ) ) {
+				return new WP_Error( 'rest_missing_annotation_content', __( 'Content empty.', 'gutenberg' ), array( 'status' => 400 ) );
+			}
+		}
+
+		return $prepared_comment;
+	}
+
+	/**
+	 * Prepares an annotation response.
+	 *
+	 * Overrides parent method and handles 'children'.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment      $comment Comment object.
+	 * @param  WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response         Response object.
+	 */
+	public function prepare_item_for_response( $comment, $request ) {
+		$response = parent::prepare_item_for_response( $comment, $request );
+
+		if ( 'threaded' === $request['hierarchical'] ) {
+			$data             = $response->get_data();
+			$data['children'] = array();
+
+			foreach ( $comment->get_children() as $child_comment ) {
+				$child_response       = $this->prepare_item_for_response( $child_comment, $request );
+				$child_data           = $child_response->get_data();
+				$child_data['_links'] = $child_response->get_links();
+				$data['children'][]   = $child_data;
+			}
+
+			$response->set_data( $data );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Sets a comment's status.
+	 *
+	 * Overrides parent method and handles custom statuses.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string|int $new_status New status.
+	 * @param  int        $comment_id Comment ID.
+	 *
+	 * @return bool                   True if status changed.
+	 *
+	 * @see WP_REST_Comments_Controller::handle_status_param()
+	 */
+	protected function handle_status_param( $new_status, $comment_id ) {
+		$old_status = WP_Annotation_Utils::get_comment_status( $comment_id );
+
+		if ( $new_status === $old_status ) {
+			return false;
+		}
+
+		switch ( $new_status ) {
+			case 'approved':
+			case 'approve':
+			case '1':
+				return wp_set_comment_status( $comment_id, 'approve' );
+
+			case 'hold':
+			case '0':
+				return wp_set_comment_status( $comment_id, 'hold' );
+
+			case 'spam':
+				return wp_spam_comment( $comment_id );
+
+			case 'unspam': // Supports custom restoration statuses.
+				return WP_Annotation_Utils::unspam_comment( $comment_id );
+
+			case 'trash':
+				return wp_trash_comment( $comment_id );
+
+			case 'untrash': // Supports custom restoration statuses.
+				return WP_Annotation_Utils::untrash_comment( $comment_id );
+
+			default: // Supports custom statuses.
+				return WP_Annotation_Utils::set_comment_status( $comment_id, $new_status );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Creates a comment; i.e., an annotation.
+	 *
+	 * Overrides parent method and allows comment 'type'. Excludes the front-end {@see
+	 * wp_allow_comment()} check paranoia. Handles response 'context' differently by
+	 * checking annotation permissions.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request  Full REST API request details.
+	 *
+	 * @return WP_Error|WP_REST_Response Response object, {@see WP_Error} otherwise.
+	 *
+	 * @see WP_REST_Comments_Controller::create_item()
+	 */
+	public function create_item( $request ) {
+		if ( $request['id'] ) {
+			return new WP_Error( 'rest_readonly_annotation_param_id', __( 'ID is read-only.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+
+		$prepared_comment = $this->prepare_item_for_database( $request );
+
+		if ( is_wp_error( $prepared_comment ) ) {
+			return $prepared_comment;
+		}
+
+		if ( empty( $prepared_comment['comment_content'] ) ) {
+			return new WP_Error( 'rest_missing_annotation_content', __( 'Content empty.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+
+		if ( ! isset( $prepared_comment['comment_date_gmt'] ) ) {
+			$prepared_comment['comment_date_gmt'] = current_time( 'mysql', true );
+		}
+
+		$missing_author = empty( $prepared_comment['user_id'] )
+			&& empty( $prepared_comment['comment_author'] )
+			&& empty( $prepared_comment['comment_author_email'] )
+			&& empty( $prepared_comment['comment_author_url'] );
+
+		if ( $missing_author && is_user_logged_in() ) {
+			$user = wp_get_current_user();
+
+			$prepared_comment['user_id']              = $user->ID;
+			$prepared_comment['comment_author']       = $user->display_name;
+			$prepared_comment['comment_author_email'] = $user->user_email;
+			$prepared_comment['comment_author_url']   = $user->user_url;
+		}
+
+		if ( empty( $prepared_comment['comment_author'] ) || empty( $prepared_comment['comment_author_email'] ) ) {
+			if ( get_option( 'require_name_email' ) ) {
+				return new WP_Error( 'rest_missing_annotation_author_data', __( 'Missing author data.', 'gutenberg' ), array( 'status' => 400 ) );
+			}
+		}
+
+		if ( ! isset( $prepared_comment['comment_author_email'] ) ) {
+			$prepared_comment['comment_author_email'] = '';
+		}
+
+		if ( ! isset( $prepared_comment['comment_author_url'] ) ) {
+			$prepared_comment['comment_author_url'] = '';
+		}
+
+		if ( ! isset( $prepared_comment['comment_agent'] ) ) {
+			$prepared_comment['comment_agent'] = '';
+		}
+
+		$check_comment_lengths = wp_check_comment_data_max_lengths( $prepared_comment );
+
+		if ( is_wp_error( $check_comment_lengths ) ) {
+			return new WP_Error( $check_comment_lengths->get_error_code(), __( 'Comment field exceeds maximum length allowed.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+
+		/** This filter is documented in wp-includes/rest-api/class-wp-rest-comments-controller.php */
+		$prepared_comment = apply_filters( 'rest_pre_insert_comment', $prepared_comment, $request );
+
+		if ( is_wp_error( $prepared_comment ) ) {
+			return $prepared_comment;
+		}
+
+		$comment_id = wp_insert_comment( wp_filter_comment( wp_slash( (array) $prepared_comment ) ) );
+
+		if ( ! $comment_id ) {
+			return new WP_Error( 'rest_annotation_insert_failure', __( 'Annotation insertion failure.', 'gutenberg' ), array( 'status' => 500 ) );
+		}
+
+		if ( isset( $request['status'] ) ) {
+			$this->handle_status_param( $request['status'], $comment_id );
+		}
+
+		$comment = get_comment( $comment_id );
+
+		if ( ! $comment ) {
+			return new WP_Error( 'rest_annotation_insert_retrieve_failure', __( 'Annotation insert/retrieve failure.', 'gutenberg' ), array( 'status' => 500 ) );
+		}
+
+		/** This action is documented in wp-includes/rest-api/class-wp-rest-comments-controller.php */
+		do_action( 'rest_insert_comment', $comment, $request, true );
+
+		$schema = $this->get_item_schema();
+
+		if ( ! empty( $schema['properties']['meta'] ) && isset( $request['meta'] ) ) {
+			$meta_update = $this->meta->update_value( $request['meta'], $comment_id );
+
+			if ( is_wp_error( $meta_update ) ) {
+				return $meta_update;
+			}
+		}
+
+		$fields_update = $this->update_additional_fields_for_object( $comment, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
+		$request->set_param( 'context', current_user_can( 'edit_annotation', $comment->comment_ID ) ? 'edit' : 'view' );
+
+		$response = $this->prepare_item_for_response( $comment, $request );
+		$response = rest_ensure_response( $response );
+
+		$response->set_status( 201 );
+
+		// phpcs:ignore PHPCompatibility.PHP.NewKeywords.t_namespaceFound — mistaken as 'namespace' keyword.
+		$response->header( 'Location', rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $comment_id ) ) ); // @codingStandardsIgnoreLine
+
+		return $response;
+	}
+
+	/**
+	 * Checks if request has access to create an item.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full REST API request details.
+	 *
+	 * @return bool|WP_Error            True if request has access to create,
+	 *                                  {@see WP_Error} otherwise.
+	 *
+	 * @see WP_REST_Comments_Controller::create_item_permissions_check()
+	 */
+	public function create_item_permissions_check( $request ) {
+		$post_id        = (int) $request['post'];
+		$type           = (string) $request['type'];
+		$status         = (string) $request['status'];
+		$parent_id      = (int) $request['parent'];
+		$default_params = $request->get_default_params();
+
+		/*
+		 * Check request method in case of {@see rest_send_allow_header()}.
+		 */
+		if ( 'POST' !== $request->get_method() ) {
+			return new WP_Error( 'rest_annotation_unexpected_request', __( 'Unexpected request.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+
+		/*
+		 * Check basic permissions.
+		 */
+		if ( ! $post_id || ! $this->check_read_post_permission( $post_id, $request ) ) {
+			return new WP_Error( 'rest_cannot_read_annotation_post', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		if ( ! $type || ! current_user_can( 'create_annotation', $post_id, $type ) ) {
+			return new WP_Error( 'rest_cannot_create_annotation', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		if ( $parent_id && ! current_user_can( 'read_annotation', $parent_id ) ) {
+			return new WP_Error( 'rest_cannot_read_annotation_parent', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		/*
+		 * These fields are readonly.
+		 */
+		foreach ( array(
+			'id',
+		) as $param ) {
+			if ( isset( $request[ $param ] ) && ( ! isset( $default_params[ $param ] ) || $request[ $param ] !== $default_params[ $param ] ) ) {
+				return new WP_Error( 'rest_readonly_annotation_param_' . $param, __( 'Read-only param.', 'gutenberg' ), array( 'status' => 400 ) );
+			}
+		}
+
+		/*
+		 * In case of a plugin altering permissions in such a way that annotations can be
+		 * created but not edited. If you can't edit annotations, we don't allow the date to be
+		 * set when creating an annotation.
+		 */
+		if ( ! current_user_can( 'edit_annotations', $type ) ) {
+			foreach ( array(
+				'date',
+				'date_gmt',
+			) as $param ) {
+				if ( isset( $request[ $param ] ) && ( ! isset( $default_params[ $param ] ) || $request[ $param ] !== $default_params[ $param ] ) ) {
+					return new WP_Error( 'rest_forbidden_annotation_param_' . $param, __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+				}
+			}
+		}
+
+		/*
+		 * Impersonating a user requires the ability to edit the annotations of others. Note
+		 * that it's still possible to set `author_name`, `author_email`, `author_url` though.
+		 */
+		if ( ! current_user_can( 'edit_others_annotations', $type ) ) {
+			foreach ( array(
+				'author',
+				'author_ip',
+				'author_user_agent',
+			) as $param ) {
+				if ( isset( $request[ $param ] ) && ( ! isset( $default_params[ $param ] ) || $request[ $param ] !== $default_params[ $param ] ) ) {
+					return new WP_Error( 'rest_forbidden_annotation_param_' . $param, __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+				}
+			}
+
+			$allow_statuses = array( 'approved', 'approve', '1' );
+			$allow_statuses = array_merge( $allow_statuses, get_annotation_statuses( 'custom' ) );
+
+			if ( ! in_array( $status, $allow_statuses, true ) ) {
+				return new WP_Error( 'rest_forbidden_annotation_param_status', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if request has access to read items.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full REST API request details.
+	 *
+	 * @return bool|WP_Error            True if request has access to read,
+	 *                                  {@see WP_Error} otherwise.
+	 *
+	 * @see WP_REST_Comments_Controller::get_items_permissions_check()
+	 */
+	public function get_items_permissions_check( $request ) {
+		$post_ids       = (array) $request['post'];
+		$types          = (array) $request['type'];
+		$statuses       = (array) $request['status'];
+		$default_params = $request->get_default_params();
+
+		/*
+		 * Check request method in case of {@see rest_send_allow_header()}.
+		 */
+		if ( 'GET' !== $request->get_method() ) {
+			return new WP_Error( 'rest_annotation_unexpected_request', __( 'Unexpected request.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+
+		/*
+		 * Collection params required to check permissions. These should not be empty given
+		 * schema validations, but it's good to do a sanity check before going any further.
+		 */
+		if ( ! $post_ids || ! $types || ! $statuses ) {
+			return new WP_Error( 'rest_missing_annotation_params', __( 'Unexpected request.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+
+		/*
+		 * Check all post and annotation type combinations.
+		 */
+		foreach ( $post_ids as $post_id ) {
+			if ( ! $post_id || ! $this->check_read_post_permission( $post_id, $request ) ) {
+				return new WP_Error( 'rest_cannot_read_annotations_post', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+
+			foreach ( $types as $type ) {
+				if ( ! $type || ! current_user_can( 'read_annotations', $post_id, $type ) ) {
+					return new WP_Error( 'rest_cannot_read_annotations', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+				}
+			}
+		}
+
+		/*
+		 * Check permissions against all annotation types.
+		 */
+		foreach ( $types as $type ) {
+			/*
+			 * Guards `context` and some restricted statuses.
+			 */
+			if ( ! current_user_can( 'edit_annotations', $type ) ) {
+				if ( 'edit' === $request['context'] ) {
+					return new WP_Error( 'rest_forbidden_annotations_context', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+				}
+
+				$allow_statuses = array( 'approved', 'approve', '1' );
+				$allow_statuses = array_merge( $allow_statuses, get_annotation_statuses( 'custom' ) );
+
+				if ( array_diff( $statuses, $allow_statuses ) ) {
+					return new WP_Error( 'rest_forbidden_annotation_param_status', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+				}
+			}
+
+			/*
+			 * The goal here is to prevent non-administrative users from looking at another user's
+			 * history. The `author`, `author_exclude`, and `author_email` parameters are also
+			 * guarded in core, in a similar way for comments. A useful exception to this rule is
+			 * that any user who can edit, can list their own annotations. Note the
+			 * `$is_current_user_query` variable below.
+			 *
+			 * In addition, some statuses are restricted too.
+			 */
+			if ( ! current_user_can( 'edit_others_annotations', $type ) ) {
+				$current_user_id       = get_current_user_id();
+				$current_user_can_edit = current_user_can( 'edit_annotations', $type );
+				$is_current_user_query = $current_user_id && array( $current_user_id ) === $request['author'];
+
+				foreach ( array(
+					'author',
+					'author_exclude',
+					'author_email',
+				) as $param ) {
+					if ( ! isset( $request[ $param ] ) ) {
+						continue;
+					} elseif ( isset( $default_params[ $param ] )
+							&& $request[ $param ] === $default_params[ $param ] ) {
+						continue;
+					}
+					if ( 'author' === $param ) {
+						if ( ! $is_current_user_query || ! $current_user_can_edit ) {
+							return new WP_Error( 'rest_forbidden_annotations_param_' . $param, __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+						}
+					} else {
+						return new WP_Error( 'rest_forbidden_annotations_param_' . $param, __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+					}
+				}
+
+				$allow_statuses = array( 'approved', 'approve', '1' );
+				$allow_statuses = array_merge( $allow_statuses, get_annotation_statuses( 'custom' ) );
+
+				if ( $is_current_user_query && $current_user_can_edit ) {
+					$allow_statuses[] = 'trash'; // A user can view their own trash.
+				}
+
+				if ( array_diff( $statuses, $allow_statuses ) ) {
+					return new WP_Error( 'rest_forbidden_annotations_param_status', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if request has access to read an item.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full REST API request details.
+	 *
+	 * @return bool|WP_Error            True if request has read access,
+	 *                                  {@see WP_Error} otherwise.
+	 *
+	 * @see WP_REST_Comments_Controller::get_item_permissions_check()
+	 */
+	public function get_item_permissions_check( $request ) {
+		$id      = $request['id'];
+		$comment = $id ? get_comment( $id ) : null;
+		$post_id = $comment ? absint( $comment->comment_post_ID ) : 0;
+
+		/*
+		 * Check basic permissions.
+		 */
+		if ( ! $post_id || ! $this->check_read_post_permission( $post_id, $request ) ) {
+			return new WP_Error( 'rest_cannot_read_annotation_post', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		if ( ! $comment || ! current_user_can( 'read_annotation', $comment->comment_ID ) ) {
+			return new WP_Error( 'rest_cannot_read_annotation', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		if ( 'edit' === $request['context'] && ! current_user_can( 'edit_annotation', $comment->comment_ID ) ) {
+			return new WP_Error( 'rest_forbidden_annotation_context', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if request has access to update an item.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full REST API request details.
+	 *
+	 * @return bool|WP_Error            True if request has access to update,
+	 *                                  {@see WP_Error} otherwise.
+	 *
+	 * @see WP_REST_Comments_Controller::update_item_permissions_check()
+	 */
+	public function update_item_permissions_check( $request ) {
+		$id      = $request['id'];
+		$comment = $id ? get_comment( $id ) : null;
+		$post_id = $comment ? absint( $comment->comment_post_ID ) : 0;
+
+		/*
+		 * Check basic permissions.
+		 */
+		if ( ! $post_id || ! $this->check_read_post_permission( $post_id, $request ) ) {
+			return new WP_Error( 'rest_cannot_read_annotation_post', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		if ( ! $comment || ! current_user_can( 'edit_annotation', $comment->comment_ID ) ) {
+			return new WP_Error( 'rest_cannot_update_annotation', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		/*
+		 * These fields are readonly.
+		 */
+		foreach ( array(
+			'id'     => 'comment_ID',
+			'post'   => 'comment_post_ID',
+			'type'   => 'comment_type',
+			'parent' => 'comment_parent',
+		) as $param => $prop ) {
+			if ( in_array( $param, array( 'id', 'post', 'parent' ), true ) ) {
+				if ( isset( $request[ $param ] ) && $request[ $param ] !== (int) $comment->{$prop} ) {
+					return new WP_Error( 'rest_cannot_update_annotation_param_' . $param, __( 'Read-only param.', 'gutenberg' ), array( 'status' => 400 ) );
+				}
+			} elseif ( isset( $request[ $param ] ) && $request[ $param ] !== $comment->{$prop} ) {
+				return new WP_Error( 'rest_cannot_update_annotation_param_' . $param, __( 'Read-only param.', 'gutenberg' ), array( 'status' => 400 ) );
+			}
+		}
+
+		/*
+		 * These fields are restricted to admins/editors only
+		 */
+		if ( ! current_user_can( 'edit_others_annotations', $comment->comment_type ) ) {
+			foreach ( array(
+				'author'            => 'user_id',
+				'author_name'       => 'comment_author',
+				'author_email'      => 'comment_author_email',
+				'author_ip'         => 'comment_author_IP',
+				'author_user_agent' => 'comment_agent',
+				'author_url'        => 'comment_author_url',
+			) as $param => $prop ) {
+				if ( isset( $request[ $param ] ) && $request[ $param ] !== $comment->{$prop} ) {
+					return new WP_Error( 'rest_forbidden_annotation_param_' . $param, __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+				}
+			}
+
+			if ( isset( $request['status'] ) ) {
+				$allow_statuses = array( 'approved', 'approve', '1' );
+				$allow_statuses = array_merge( $allow_statuses, get_annotation_statuses( 'custom' ) );
+
+				if ( current_user_can( 'delete_annotation', $comment->comment_ID ) ) {
+					$allow_statuses[] = 'trash'; // The user can trash also.
+				}
+
+				if ( ! in_array( $request['status'], $allow_statuses, true ) ) {
+					return new WP_Error( 'rest_forbidden_annotation_param_status', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if request has access to delete an item.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full REST API request details.
+	 *
+	 * @return bool|WP_Error            True if request has access to delete,
+	 *                                  {@see WP_Error} otherwise.
+	 *
+	 * @see WP_REST_Comments_Controller::delete_item_permissions_check()
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$id      = $request['id'];
+		$comment = $id ? get_comment( $id ) : null;
+		$post_id = $comment ? absint( $comment->comment_post_ID ) : 0;
+
+		/*
+		 * Check basic permissions.
+		 */
+		if ( ! $post_id || ! $this->check_read_post_permission( $post_id, $request ) ) {
+			return new WP_Error( 'rest_cannot_read_annotation_post', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		if ( ! $comment || ! current_user_can( 'delete_annotation', $comment->comment_ID ) ) {
+			return new WP_Error( 'rest_cannot_delete_annotation', __( 'Sorry, you are not allowed as this user.', 'gutenberg' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if the post can be read.
+	 *
+	 * Overrides parent method and supports post object or ID.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Post|int     $post    Post object or ID.
+	 * @param  WP_REST_Request $request Request data to check.
+	 *
+	 * @return bool                     True if post can be read.
+	 */
+	protected function check_read_post_permission( $post, $request ) {
+		$post = $post ? get_post( $post ) : null;
+		return $post ? parent::check_read_post_permission( $post, $request ) : false;
+	}
+
+	/**
+	 * Checks if a comment can be read.
+	 *
+	 * @since [version]
+	 *
+	 * @param WP_Comment      $comment Comment object.
+	 * @param WP_REST_Request $request Full REST API request details.
+	 *
+	 * @return bool                    True if comment can be read.
+	 *
+	 * @see WP_REST_Comments_Controller::check_read_permission()
+	 */
+	protected function check_read_permission( $comment, $request ) {
+		return current_user_can( 'read_annotation', $comment->comment_ID );
+	}
+
+	/**
+	 * Checks if a comment can be edited.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_Comment $comment Comment object.
+	 *
+	 * @return bool                True if comment can be edited.
+	 *
+	 * @see WP_REST_Comments_Controller::check_edit_permission()
+	 */
+	protected function check_edit_permission( $comment ) {
+		return current_user_can( 'edit_annotation', $comment->comment_ID );
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -18,6 +18,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require dirname( __FILE__ ) . '/class-wp-rest-search-controller.php';
 	require dirname( __FILE__ ) . '/class-wp-rest-search-handler.php';
 	require dirname( __FILE__ ) . '/class-wp-rest-post-search-handler.php';
+	require dirname( __FILE__ ) . '/class-wp-rest-annotations-controller.php';
 	require dirname( __FILE__ ) . '/rest-api.php';
 }
 
@@ -25,6 +26,7 @@ require dirname( __FILE__ ) . '/meta-box-partial-page.php';
 require dirname( __FILE__ ) . '/class-wp-block-type.php';
 require dirname( __FILE__ ) . '/class-wp-block-type-registry.php';
 require dirname( __FILE__ ) . '/blocks.php';
+require dirname( __FILE__ ) . '/annotations.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/plugin-compat.php';

--- a/lib/register.php
+++ b/lib/register.php
@@ -532,6 +532,17 @@ function gutenberg_register_post_types() {
 add_action( 'init', 'gutenberg_register_post_types' );
 
 /**
+ * Initializes annotations.
+ *
+ * @since [version]
+ */
+function gutenberg_init_annotations() {
+	add_filter( 'map_meta_cap', 'WP_Annotation_Caps::on_map_meta_cap', 10, 4 );
+	add_filter( 'comments_clauses', 'WP_Annotation_Utils::on_comments_clauses', 1000, 2 );
+}
+add_action( 'init', 'gutenberg_init_annotations' );
+
+/**
  * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
  *
  * @since 1.5.2

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -45,6 +45,14 @@ function gutenberg_register_rest_routes() {
 		$autosaves_controller = new WP_REST_Autosaves_Controller( $post_type->name );
 		$autosaves_controller->register_routes();
 	}
+
+	/*
+	 * REST API for Annotations.
+	 */
+	$annotations_controller = new WP_REST_Annotations_Controller();
+	$annotations_controller->register_routes();
+
+	add_filter( 'rest_comment_query', 'WP_Annotation_Utils::on_rest_comment_query', 10, 2 );
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
 

--- a/phpunit/annotations/class-annotation-caps-test.php
+++ b/phpunit/annotations/class-annotation-caps-test.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * WP_Annotation_Caps Tests
+ *
+ * @package gutenberg
+ */
+
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-objects.php';
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-utils.php';
+
+/**
+ * Tests annotation capabilities.
+ */
+class Annotation_Caps_Test extends WP_UnitTestCase {
+	/**
+	 * Magic first-access properties.
+	 *
+	 * @param  string $property Property name.
+	 * @return mixed            Property value.
+	 */
+	public function __get( $property ) {
+		if ( 'objects' === $property ) {
+			$this->objects = new Annotation_Test_Objects( $this );
+			return $this->objects;
+		} elseif ( 'utils' === $property ) {
+			$this->utils = new Annotation_Test_Utils( $this );
+			return $this->utils;
+		}
+		return parent::__get( $property );
+	}
+
+	/**
+	 * Check that we have necessary hooks.
+	 */
+	public function test_has_hooks() {
+		$this->assertNotEmpty( has_filter( 'map_meta_cap', 'WP_Annotation_Caps::on_map_meta_cap' ) );
+	}
+
+	/**
+	 * Test standard meta-caps.
+	 */
+	public function test_standard_meta_caps() {
+		foreach ( $this->generate_standard_meta_cap_tests() as $key => $test ) {
+			list ( $expecting, $user, $cap, $annotation ) = $test;
+			$this->assertSame( $expecting, $user->has_cap( $cap, $annotation ? $annotation->comment_ID : null ), $key );
+		}
+	}
+
+	/**
+	 * Test meta-caps that check a post ID.
+	 */
+	public function test_post_check_meta_caps() {
+		foreach ( $this->generate_post_check_meta_cap_tests() as $key => $test ) {
+			list ( $expecting, $user, $cap, $post, $type ) = $test;
+			$this->assertSame( $expecting, $user->has_cap( $cap, $post ? $post->ID : null, $type ), $key );
+		}
+	}
+
+	/**
+	 * Test other pseudo-caps.
+	 */
+	public function test_other_pseudo_caps() {
+		foreach ( $this->generate_other_pseudo_cap_tests() as $key => $test ) {
+			list ( $expecting, $user, $cap, $type ) = $test;
+			$this->assertSame( $expecting, $user->has_cap( $cap, $type ), $key );
+		}
+	}
+
+	/*
+	 * --- Test generators -------------------------------------------------------
+	 */
+
+	/**
+	 * Generates tests for {@see test_standard_meta_caps()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_standard_meta_cap_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		$users                  = $this->objects->create_users();
+		$posts                  = $this->objects->create_posts( $users, array( 'publish', 'trash' ) );
+		$annotations            = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => $users,
+			'with_statuses' => array( '1', 'trash' ),
+		) );
+		$nonexistent_annotation = new WP_Annotation( (object) array(
+			'comment_ID'   => 0,
+			'comment_type' => get_default_annotation_type(),
+		) );
+		$comment                = $this->factory->comment->create_and_get(
+			array( 'comment_post_ID' => $posts[ $users['editor']->ID ]['publish']->ID )
+		);
+
+		foreach ( $users as $user ) {
+			$user_role = $this->utils->get_user_role( $user );
+
+			// Test all comments.
+			foreach ( $annotations as $in_post_id => $by_author_ids ) {
+				foreach ( $by_author_ids as $by_author_id => $with_statuses ) {
+					$in_post             = get_post( $in_post_id );
+					$in_post_with_status = $in_post->post_status;
+
+					$in_post_by_author      = new WP_User( $in_post->post_author );
+					$in_post_by_author_role = $this->utils->get_user_role( $in_post_by_author );
+
+					$by_author      = new WP_User( $by_author_id );
+					$by_author_role = $this->utils->get_user_role( $by_author );
+
+					foreach ( $with_statuses as $with_status => $annotation ) {
+						foreach ( $this->utils->standard_meta_caps as $cap ) {
+							$key  = "{$user_role} can {$cap},";
+							$key .= " in post by {$in_post_by_author_role} with status={$in_post_with_status},";
+							$key .= " annotated by {$by_author_role} with status={$with_status}";
+
+							switch ( $user_role ) {
+								case 'administrator':
+								case 'editor':
+									$can           = 'trash' !== $in_post_with_status;
+									$tests[ $key ] = array( $can, $user, $cap, $annotation );
+									break;
+
+								case 'author':
+								case 'contributor':
+									$can = 'trash' !== $in_post_with_status
+										&& $user->ID === $in_post_by_author->ID
+										&& ( ! in_array( $with_status, array( 0, 'spam', 'trash' ), true )
+											|| ( 'trash' === $with_status && $user->ID === $by_author->ID ) );
+
+									if ( 'read_annotation' !== $cap ) {
+										$can = $can && $user->ID === $by_author->ID;
+									}
+
+									$tests[ $key ] = array( $can, $user, $cap, $annotation );
+									break;
+
+								case 'subscriber':
+								case 'anonymous':
+								default:
+									$can           = false;
+									$tests[ $key ] = array( $can, $user, $cap, $annotation );
+									break;
+							}
+							$counter++;
+						}
+					}
+				}
+			}
+
+			// Test additional scenarios to expand coverage.
+			foreach ( $this->utils->standard_meta_caps as $cap ) {
+				// Test missing comment ID arg.
+				$key           = "{$user_role} can {$cap} with missing comment ID arg";
+				$tests[ $key ] = array( false, $user, $cap, null );
+				$counter++;
+
+				// Test empty comment ID arg.
+				$key           = "{$user_role} can {$cap} with empty comment ID arg";
+				$tests[ $key ] = array( false, $user, $cap, $nonexistent_annotation );
+				$counter++;
+
+				// Test a normal comment type.
+				$key           = "{$user_role} can {$cap} with normal comment type";
+				$tests[ $key ] = array( false, $user, $cap, $comment );
+				$counter++;
+			}
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+
+	/**
+	 * Generates tests for {@see test_post_check_meta_caps()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_post_check_meta_cap_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		$users      = $this->objects->create_users();
+		$posts      = $this->objects->create_posts( $users, array( 'publish', 'trash' ) );
+		$post_no_id = new WP_Post( (object) array( 'ID' => 0 ) );
+
+		foreach ( $users as $user ) {
+			$user_role = $this->utils->get_user_role( $user );
+
+			// Test all posts.
+			foreach ( $posts as $by_author_id => $with_statuses ) {
+				$by_author      = new WP_User( $by_author_id );
+				$by_author_role = $this->utils->get_user_role( $by_author );
+
+				foreach ( $with_statuses as $with_status => $post ) {
+					foreach ( $this->utils->post_check_meta_caps as $cap ) {
+						$key  = "{$user_role} can {$cap},";
+						$key .= " in post by {$by_author_role} with status={$with_status}";
+
+						switch ( $user_role ) {
+							case 'administrator':
+							case 'editor':
+								$can           = 'trash' !== $with_status;
+								$tests[ $key ] = array( $can, $user, $cap, $post, null );
+								break;
+
+							case 'author':
+							case 'contributor':
+								$can           = 'trash' !== $with_status && $user->ID === $by_author->ID;
+								$tests[ $key ] = array( $can, $user, $cap, $post, null );
+								break;
+
+							case 'subscriber':
+							case 'anonymous':
+							default:
+								$can           = false;
+								$tests[ $key ] = array( $can, $user, $cap, $post, null );
+								break;
+						}
+						$counter++;
+					}
+				}
+			}
+
+			// Test additional scenarios to expand coverage.
+			foreach ( $this->utils->post_check_meta_caps as $cap ) {
+				// Test missing post ID arg.
+				$key           = "{$user_role} can {$cap} with missing post ID arg";
+				$can           = 'read_annotations' === $cap;
+				$can           = $can && ! in_array( $user_role, array( 'subscriber', 'anonymous' ), true );
+				$tests[ $key ] = array( $can, $user, $cap, null, null );
+				$counter++;
+
+				// Test empty post ID arg.
+				$key           = "{$user_role} can {$cap} with empty post ID arg";
+				$tests[ $key ] = array( false, $user, $cap, $post_no_id, null );
+				$counter++;
+
+				// Test empty post ID arg.
+				$key           = "{$user_role} can {$cap} with normal comment type";
+				$tests[ $key ] = array( false, $user, $cap, $posts[ $users['editor']->ID ]['publish'], 'comment' );
+				$counter++;
+			}
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+
+	/**
+	 * Generates tests for {@see test_other_pseudo_caps()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_other_pseudo_cap_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		$users = $this->objects->create_users();
+
+		foreach ( $users as $user ) {
+			$user_role = $this->utils->get_user_role( $user );
+
+			// Test all pseudo-caps.
+			foreach ( $this->utils->other_pseudo_caps as $cap ) {
+				$key = "{$user_role} can {$cap}";
+
+				switch ( $user_role ) {
+					case 'administrator':
+					case 'editor':
+						$can           = true;
+						$tests[ $key ] = array( $can, $user, $cap, null );
+						break;
+
+					case 'author':
+						$has_caps      = array(
+							'read_annotations',
+							'create_annotations',
+							'edit_annotations',
+							'publish_annotations',
+							'edit_published_annotations',
+							'delete_annotations',
+							'delete_published_annotations',
+						);
+						$can           = in_array( $cap, $has_caps, true );
+						$tests[ $key ] = array( $can, $user, $cap, null );
+						break;
+
+					case 'contributor':
+						$has_caps      = array(
+							'read_annotations',
+							'create_annotations',
+							'edit_annotations',
+							'delete_annotations',
+						);
+						$can           = in_array( $cap, $has_caps, true );
+						$tests[ $key ] = array( $can, $user, $cap, null );
+						break;
+
+					case 'subscriber':
+					case 'anonymous':
+					default:
+						$can           = false;
+						$tests[ $key ] = array( $can, $user, $cap, null );
+						break;
+				}
+				$counter++;
+			}
+
+			// Test additional scenarios to expand coverage.
+			foreach ( $this->utils->other_pseudo_caps as $cap ) {
+				// Test normal comment type.
+				$key           = "{$user_role} can {$cap} with invalid comment type";
+				$tests[ $key ] = array( false, $user, $cap, 'comment' );
+				$counter++;
+			}
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+}

--- a/phpunit/annotations/class-annotation-queries-test.php
+++ b/phpunit/annotations/class-annotation-queries-test.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Annotation Query Tests
+ *
+ * @package gutenberg
+ */
+
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-objects.php';
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-utils.php';
+
+/**
+ * Tests annotation queries.
+ */
+class Annotation_Queries_Test extends WP_UnitTestCase {
+	/**
+	 * Magic first-access properties.
+	 *
+	 * @param  string $property Property name.
+	 * @return mixed            Property value.
+	 */
+	public function __get( $property ) {
+		if ( 'objects' === $property ) {
+			$this->objects = new Annotation_Test_Objects( $this );
+			return $this->objects;
+		} elseif ( 'utils' === $property ) {
+			$this->utils = new Annotation_Test_Utils( $this );
+			return $this->utils;
+		}
+		return parent::__get( $property );
+	}
+
+	/**
+	 * Check that we have necessary hooks.
+	 */
+	public function test_has_hooks() {
+		$this->assertNotEmpty( has_filter( 'comments_clauses', 'WP_Annotation_Utils::on_comments_clauses' ) );
+	}
+
+	/**
+	 * Test getting annotations.
+	 */
+	public function test_get_annotations() {
+		$users       = $this->objects->create_users();
+		$posts       = $this->objects->create_posts( $users, array( 'publish' ) );
+		$annotations = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => $users,
+			'with_statuses' => array( '1' ),
+		) );
+
+		$query          = new WP_Comment_Query();
+		$annotation_ids = $query->query( array(
+			'fields'       => 'ids',
+			'type'         => get_annotation_types(),
+			'cache_domain' => 'annotations',
+			'status'       => 'any',
+			'number'       => 0,
+		) );
+		$this->assertSame( 16, count( $annotation_ids ) );
+	}
+
+	/**
+	 * Test getting non-annotation comments.
+	 */
+	public function test_get_non_annotation_comments() {
+		$users       = $this->objects->create_users();
+		$posts       = $this->objects->create_posts( $users, array( 'publish', 'trash' ) );
+		$annotations = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => $users,
+			'with_statuses' => array( '0', '1', 'archive', 'spam', 'trash' ),
+		) );
+
+		$query       = new WP_Comment_Query();
+		$comment_ids = $query->query( array(
+			'fields' => 'ids',
+			'status' => 'any',
+			'number' => 0,
+		) );
+		$this->assertEmpty( $comment_ids, 'no type' );
+
+		$query       = new WP_Comment_Query();
+		$comment_ids = $query->query( array(
+			'fields' => 'ids',
+			'type'   => 'all',
+			'status' => 'any',
+			'number' => 0,
+		) );
+		$this->assertEmpty( $comment_ids, 'all types' );
+	}
+
+	/**
+	 * Test that permanently deleting a post erases its annotations.
+	 */
+	public function test_delete_post_annotations() {
+		$user = $this->objects->create_user( 'editor' );
+		$post = $this->objects->create_post( $user->ID );
+
+		$this->objects->create_annotation( $post->ID, $user->ID, 0, '0' );
+		$this->objects->create_annotation( $post->ID, $user->ID, 0, '1' );
+
+		wp_delete_post( $post->ID, true );
+
+		$query          = new WP_Comment_Query();
+		$annotation_ids = $query->query( array(
+			'fields'       => 'ids',
+			'post_id'      => $post->ID,
+			'cache_domain' => 'annotations',
+			'type'         => get_annotation_types(),
+			'status'       => 'any',
+			'number'       => 0,
+		) );
+
+		$this->assertEmpty( $annotation_ids );
+	}
+}

--- a/phpunit/annotations/class-annotation-test.php
+++ b/phpunit/annotations/class-annotation-test.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Annotation Tests
+ *
+ * @package gutenberg
+ */
+
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-objects.php';
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-utils.php';
+
+/**
+ * Tests annotation class.
+ */
+class Annotation_Test extends WP_UnitTestCase {
+	/**
+	 * Magic first-access properties.
+	 *
+	 * @param  string $property Property name.
+	 * @return mixed            Property value.
+	 */
+	public function __get( $property ) {
+		if ( 'objects' === $property ) {
+			$this->objects = new Annotation_Test_Objects( $this );
+			return $this->objects;
+		} elseif ( 'utils' === $property ) {
+			$this->utils = new Annotation_Test_Utils( $this );
+			return $this->utils;
+		}
+		return parent::__get( $property );
+	}
+
+	/**
+	 * Test an annotation.
+	 */
+	public function test_annotation() {
+		$user       = $this->objects->create_user( 'editor' );
+		$post       = $this->objects->create_post( $user->ID );
+		$annotation = $this->objects->create_annotation( array(
+			'in_post_id' => $post->ID,
+			'by_user_id' => $user->ID,
+		) );
+
+		$this->assertInstanceOf( 'WP_Annotation', $annotation, 'instanceof' );
+		$this->assertInstanceOf( 'WP_Annotation_Selector', $annotation->get_selector(), 'get_selector' );
+		$this->assertSame( true, $annotation->exists(), 'exists' );
+
+		$this->assertSame( 'gutenberg', $annotation->get_meta( '_via' ), 'get_meta_via' );
+		$this->assertSame( true, $annotation->update_meta( '_via', 'foo' ), 'update_meta_via::foo' );
+		$this->assertSame( 'foo', $annotation->get_meta( '_via' ), 'get_meta_via::foo' );
+
+		$this->assertSame( true, isset( $annotation->comment_ID ), '__isset' );
+		$this->assertSame( array(), $annotation->get_children(), '__call' );
+		$this->assertArrayHasKey( 'comment_ID', $annotation->to_array(), 'to_array' );
+	}
+
+	/**
+	 * Test getting an annotation.
+	 */
+	public function test_get_annotation() {
+		$user       = $this->objects->create_user( 'editor' );
+		$post       = $this->objects->create_post( $user->ID );
+		$annotation = $this->objects->create_annotation( array(
+			'in_post_id' => $post->ID,
+			'by_user_id' => $user->ID,
+		) );
+
+		$this->assertInstanceOf( 'WP_Annotation', $annotation, 'instanceof' );
+		$this->assertInstanceOf( 'WP_Annotation', get_annotation( $annotation ), 'get' );
+		$this->assertInstanceOf( 'WP_Annotation', get_annotation( $annotation->comment_ID ), 'object' );
+
+		$this->assertArrayHasKey( 'comment_ID', get_annotation( $annotation->comment_ID, ARRAY_A ), 'array_a' );
+		$this->assertArrayHasKey( 0, get_annotation( $annotation->comment_ID, ARRAY_N ), 'array_n' );
+	}
+}

--- a/phpunit/annotations/class-annotation-utils-test.php
+++ b/phpunit/annotations/class-annotation-utils-test.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * WP_Annotation_Utils Tests
+ *
+ * @package gutenberg
+ */
+
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-objects.php';
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-utils.php';
+
+/**
+ * Tests annotation utilities.
+ */
+class Annotation_Utils_Test extends WP_UnitTestCase {
+	/**
+	 * Magic first-access properties.
+	 *
+	 * @param  string $property Property name.
+	 * @return mixed            Property value.
+	 */
+	public function __get( $property ) {
+		if ( 'objects' === $property ) {
+			$this->objects = new Annotation_Test_Objects( $this );
+			return $this->objects;
+		} elseif ( 'utils' === $property ) {
+			$this->utils = new Annotation_Test_Utils( $this );
+			return $this->utils;
+		}
+		return parent::__get( $property );
+	}
+
+	/**
+	 * Tests comment status.
+	 */
+	public function test_comment_status() {
+		$user       = $this->objects->create_user( 'editor' );
+		$post       = $this->objects->create_post( $user->ID );
+		$annotation = $this->objects->create_annotation( array(
+			'in_post_id' => $post->ID,
+			'by_user_id' => $user->ID,
+		) );
+
+		$this->assertEmpty( WP_Annotation_Utils::get_comment_status( null ), 'get:nonexistent' );
+		$this->assertEmpty( WP_Annotation_Utils::get_comment_status( 999999 ), 'get:unknown' );
+		$this->assertNotEmpty( WP_Annotation_Utils::get_comment_status( $annotation->comment ), 'get:status' );
+
+		$this->assertFalse( WP_Annotation_Utils::set_comment_status( null, 'archive' ), 'set:nonexistent' );
+		$this->assertFalse( WP_Annotation_Utils::set_comment_status( 999999, 'archive' ), 'set:unknown' );
+		$this->assertTrue( WP_Annotation_Utils::set_comment_status( $annotation->comment, 'archive' ), 'set:archive' );
+		$this->assertTrue( WP_Annotation_Utils::set_comment_status( $annotation->comment, 'approve' ), 'set:approve' );
+
+		$this->assertTrue( wp_spam_comment( $annotation->comment ), 'wp_spam_comment' );
+		$this->assertEmpty( WP_Annotation_Utils::unspam_comment( null ), 'unspam:nonexistent' );
+		$this->assertEmpty( WP_Annotation_Utils::unspam_comment( 999999 ), 'unspam:unknown' );
+		$this->assertNotEmpty( WP_Annotation_Utils::unspam_comment( $annotation->comment ), 'unspam' );
+
+		$this->assertTrue( wp_trash_comment( $annotation->comment ), 'wp_trash_comment' );
+		$this->assertEmpty( WP_Annotation_Utils::untrash_comment( null ), 'untrash:nonexistent' );
+		$this->assertEmpty( WP_Annotation_Utils::untrash_comment( 999999 ), 'untrash:unknown' );
+		$this->assertNotEmpty( WP_Annotation_Utils::untrash_comment( $annotation->comment ), 'untrash' );
+	}
+
+	/**
+	 * Tests client validation.
+	 */
+	public function test_is_valid_client() {
+		$this->assertFalse( WP_Annotation_Utils::is_valid_client( array( 'foo' ) ), 'array(foo)' );
+		$this->assertFalse( WP_Annotation_Utils::is_valid_client( '^foo' ), '^foo' );
+		$this->assertTrue( WP_Annotation_Utils::is_valid_client( 'foo' ), 'foo' );
+	}
+
+	/**
+	 * Tests selector validation.
+	 */
+	public function test_is_valid_selector() {
+		$this->assertFalse( WP_Annotation_Utils::is_valid_selector( 'foo' ), 'foo' );
+		$this->assertFalse( WP_Annotation_Utils::is_valid_selector( array( 'foo' ) ), 'array(foo)' );
+		$this->assertFalse( WP_Annotation_Utils::is_valid_selector( array( 'type' => 'foo' ) ), '1 key' );
+
+		$this->assertFalse(
+			WP_Annotation_Utils::is_valid_selector(
+				array(
+					'type'  => 'foo',
+					'value' => 'foo',
+				)
+			),
+			'CssSelector'
+		);
+
+		$this->assertTrue(
+			WP_Annotation_Utils::is_valid_selector(
+				array(
+					'type'  => 'CssSelector',
+					'value' => '#foo > .bar',
+				)
+			),
+			'CssSelector'
+		);
+	}
+
+	/**
+	 * Tests content empty checks.
+	 */
+	public function test_is_content_empty() {
+		$this->assertTrue( WP_Annotation_Utils::is_content_empty( null ), 'null' );
+		$this->assertTrue( WP_Annotation_Utils::is_content_empty( '' ), 'empty string' );
+		$this->assertFalse( WP_Annotation_Utils::is_content_empty( 'foo' ), 'foo' );
+	}
+}

--- a/phpunit/annotations/class-rest-annotations-controller-test.php
+++ b/phpunit/annotations/class-rest-annotations-controller-test.php
@@ -1,0 +1,2302 @@
+<?php
+/**
+ * WP_REST_Annotations_Controller Tests
+ *
+ * @package gutenberg
+ */
+
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-objects.php';
+require_once dirname( __FILE__ ) . '/includes/class-annotation-test-utils.php';
+
+/**
+ * Tests WP_REST_Annotations_Controller.
+ */
+class REST_Annotations_Controller_Test extends WP_Test_REST_Controller_Testcase {
+	/**
+	 * REST namespace/base.
+	 *
+	 * @var string
+	 */
+	public $rest_ns_base = '/wp/v2/annotations';
+
+	/**
+	 * Magic first-access properties.
+	 *
+	 * @param  string $property Property name.
+	 * @return mixed            Property value.
+	 */
+	public function __get( $property ) {
+		if ( 'objects' === $property ) {
+			$this->objects = new Annotation_Test_Objects( $this );
+			return $this->objects;
+		} elseif ( 'utils' === $property ) {
+			$this->utils = new Annotation_Test_Utils( $this );
+			return $this->utils;
+		}
+		return parent::__get( $property );
+	}
+
+	/**
+	 * Test registered routes.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->rest_ns_base, $routes );
+		$this->assertCount( 2, $routes[ $this->rest_ns_base ] );
+
+		$this->assertArrayHasKey( $this->rest_ns_base . '/(?P<id>[\d]+)', $routes );
+		$this->assertCount( 3, $routes[ $this->rest_ns_base . '/(?P<id>[\d]+)' ] );
+	}
+
+	/**
+	 * Test JSON schema.
+	 */
+	public function test_get_item_schema() {
+		$request = new WP_REST_Request( 'OPTIONS', $this->rest_ns_base );
+
+		$response   = $this->server->dispatch( $request );
+		$status     = $response->get_status();
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'author', $properties );
+		$this->assertArrayHasKey( 'author_avatar_urls', $properties );
+		$this->assertArrayHasKey( 'author_email', $properties );
+		$this->assertArrayHasKey( 'author_ip', $properties );
+		$this->assertArrayHasKey( 'author_name', $properties );
+		$this->assertArrayHasKey( 'author_url', $properties );
+		$this->assertArrayHasKey( 'author_user_agent', $properties );
+		$this->assertArrayHasKey( 'content', $properties );
+		$this->assertArrayHasKey( 'date', $properties );
+		$this->assertArrayHasKey( 'date_gmt', $properties );
+		$this->assertArrayHasKey( 'link', $properties );
+		$this->assertArrayHasKey( 'meta', $properties );
+		$this->assertArrayHasKey( 'parent', $properties );
+		$this->assertArrayHasKey( 'post', $properties );
+		$this->assertArrayHasKey( 'status', $properties );
+		$this->assertArrayHasKey( 'type', $properties );
+
+		$this->assertArrayHasKey( 'via', $properties );
+		$this->assertArrayHasKey( 'selector', $properties );
+		$this->assertArrayHasKey( 'children', $properties );
+
+		$this->assertSame( 17 + 3, count( $properties ) );
+	}
+
+	/**
+	 * Test context.
+	 */
+	public function test_context_param() {
+		$this->utils->set_current_user( 'editor' );
+
+		$request  = new WP_REST_Request( 'OPTIONS', $this->rest_ns_base );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'status' );
+		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'], 'default' );
+		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'], 'enum' );
+	}
+
+	/**
+	 * Test ID-specific context.
+	 */
+	public function test_single_context_param() {
+		$user       = $this->utils->set_current_user( 'editor' );
+		$post       = $this->objects->create_post( $user->ID );
+		$annotation = $this->objects->create_annotation( $post->ID, $user->ID );
+
+		$request  = new WP_REST_Request( 'OPTIONS', $this->rest_ns_base . '/' . $annotation->comment_ID );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'status' );
+		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'], 'default' );
+		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'], 'enum' );
+	}
+
+	/**
+	 * Test GET items.
+	 */
+	public function test_get_items() {
+		foreach ( $this->generate_get_items_tests() as $key => $test ) {
+			list( $user, $params, $status, $count, $code, $assertions ) = $test;
+			$this->utils->set_current_user( $user );
+
+			$request            = new WP_REST_Request( 'GET', $this->rest_ns_base );
+			$params['per_page'] = isset( $params['per_page'] ) ? $params['per_page'] : 100;
+
+			foreach ( $params as $_key => $_value ) {
+				$request->set_param( $_key, $_value );
+			}
+
+			$response        = $this->server->dispatch( $request );
+			$response_status = $response->get_status();
+			$response_data   = $response->get_data();
+			$is_error        = $response->is_error();
+
+			if ( $code || $is_error ) {
+				$response_code = isset( $response_data['code'] ) ? $response_data['code'] : '';
+				$this->assertSame( $code, $response_code, $key . '::error' );
+			}
+			$this->assertSame( $status, $response_status, $key . '::status' );
+			$this->assertSame( $count, $is_error ? 0 : count( $response_data ), $key . '::count' );
+
+			if ( ! $is_error ) {
+				$context      = isset( $params['context'] ) ? $params['context'] : 'view';
+				$hierarchical = isset( $params['hierarchical'] ) ? $params['hierarchical'] : '';
+				$this->check_collection( $response, $context, 'threaded' === $hierarchical, $assertions );
+			}
+		}
+	}
+
+	/**
+	 * Test GET item.
+	 */
+	public function test_get_item() {
+		foreach ( $this->generate_get_item_tests() as $key => $test ) {
+			list( $user, $id, $params, $status, $code, $assertions ) = $test;
+			$this->utils->set_current_user( $user );
+
+			$request = new WP_REST_Request( 'GET', $this->rest_ns_base . '/' . $id );
+
+			foreach ( $params as $_key => $_value ) {
+				$request->set_param( $_key, $_value );
+			}
+
+			$response        = $this->server->dispatch( $request );
+			$response_status = $response->get_status();
+			$response_data   = $response->get_data();
+			$is_error        = $response->is_error();
+
+			if ( $code || $is_error ) {
+				$response_code = isset( $response_data['code'] ) ? $response_data['code'] : '';
+				$this->assertSame( $code, $response_code, $key . '::error' );
+			}
+			$this->assertSame( $status, $response_status, $key . '::status' );
+
+			if ( ! $is_error ) {
+				$context = isset( $params['context'] ) ? $params['context'] : 'view';
+				$this->check_data( $response_data, $context, $response->get_links(), false, $assertions );
+			}
+		}
+	}
+
+	/**
+	 * Test GET item w/ edit context.
+	 */
+	public function test_prepare_item() {
+		$this->markTestSkipped( 'Tested already via test_get_item().' );
+	}
+
+	/**
+	 * Test POST item.
+	 */
+	public function test_create_item() {
+		foreach ( $this->generate_create_item_tests() as $key => $test ) {
+			list( $user, $params, $status, $code, $assertions ) = $test;
+			$this->utils->set_current_user( $user );
+
+			$request = new WP_REST_Request( 'POST', $this->rest_ns_base );
+
+			foreach ( $params as $_key => $_value ) {
+				$request->set_param( $_key, $_value );
+			}
+
+			$response        = $this->server->dispatch( $request );
+			$response_status = $response->get_status();
+			$response_data   = $response->get_data();
+			$is_error        = $response->is_error();
+
+			if ( $code || $is_error ) {
+				$response_code = isset( $response_data['code'] ) ? $response_data['code'] : '';
+				$this->assertSame( $code, $response_code, $key . '::error' );
+			}
+			$this->assertSame( $status, $response_status, $key . '::status' );
+
+			if ( ! $is_error ) {
+				$context = $user->has_cap( 'edit_annotation', $response_data['id'] ) ? 'edit' : 'view';
+				$this->check_data( $response_data, $context, $response->get_links(), false, $assertions );
+			}
+		}
+	}
+
+	/**
+	 * Test PUT item.
+	 */
+	public function test_update_item() {
+		foreach ( $this->generate_update_item_tests() as $key => $test ) {
+			list( $user, $id, $params, $status, $code, $assertions ) = $test;
+			$this->utils->set_current_user( $user );
+
+			$request = new WP_REST_Request( 'PUT', $this->rest_ns_base . '/' . $id );
+
+			foreach ( $params as $_key => $_value ) {
+				$request->set_param( $_key, $_value );
+			}
+
+			$response        = $this->server->dispatch( $request );
+			$response_status = $response->get_status();
+			$response_data   = $response->get_data();
+			$is_error        = $response->is_error();
+
+			if ( $code || $is_error ) {
+				$response_code = isset( $response_data['code'] ) ? $response_data['code'] : '';
+				$this->assertSame( $code, $response_code, $key . '::error' );
+			}
+			$this->assertSame( $status, $response_status, $key . '::status' );
+
+			if ( ! $is_error ) {
+				$this->check_data( $response_data, 'edit', $response->get_links(), false, $assertions );
+			}
+		}
+	}
+
+	/**
+	 * Test DELETE item.
+	 */
+	public function test_delete_item() {
+		foreach ( $this->generate_delete_item_tests() as $key => $test ) {
+			list( $user, $id, $params, $status, $code ) = $test;
+			$this->utils->set_current_user( $user );
+
+			$request = new WP_REST_Request( 'DELETE', $this->rest_ns_base . '/' . $id );
+
+			foreach ( $params as $_key => $_value ) {
+				$request->set_param( $_key, $_value );
+			}
+
+			$response        = $this->server->dispatch( $request );
+			$response_status = $response->get_status();
+			$response_data   = $response->get_data();
+			$is_error        = $response->is_error();
+
+			if ( $code || $is_error ) {
+				$response_code = isset( $response_data['code'] ) ? $response_data['code'] : '';
+				$this->assertSame( $code, $response_code, $key . '::error' );
+			}
+			$this->assertSame( $status, $response_status, $key . '::status' );
+		}
+	}
+
+	/**
+	 * Test function calls.
+	 */
+	public function test_function_calls() {
+		foreach ( $this->generate_function_tests() as $key => $test ) {
+			list( $user, $function, $args, $assertions ) = $test;
+
+			$this->utils->set_current_user( $user );
+			$value = call_user_func_array( $function, $args );
+
+			foreach ( $assertions as $_key => $assertion ) {
+				$this->{ 'assert' . $assertion['assert'] }(
+					$assertion['value'],
+					$value,
+					is_string( $_key ) ? $_key : $key
+				);
+			}
+		}
+	}
+
+	/*
+	 * --- Test generators -------------------------------------------------------
+	 */
+
+	/**
+	 * Generates tests for {@see test_get_items()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_get_items_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		$users                   = $this->objects->create_users();
+		$posts                   = $this->objects->create_posts( $users, array( 'publish' ) );
+		$trashed_posts           = $this->objects->create_posts( $users, array( 'trash' ) );
+		$password_protected_post = $this->objects->create_post( $users['editor']->ID );
+		wp_update_post( array(
+			'ID'       => $password_protected_post->ID,
+			'password' => 'foo',
+		) );
+		$annotations                     = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => $users,
+			'with_statuses' => array( '1', 'trash' ),
+		) );
+		$replies                         = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => $users,
+			'in_reply_to'   => $annotations,
+			'with_statuses' => array( '1', 'trash' ),
+		) );
+		$annotations_in_trashed_posts    = $this->objects->create_annotations( array(
+			'in_posts'      => $trashed_posts,
+			'by_users'      => $users,
+			'with_statuses' => array( '1' ),
+		) );
+		$password_protected_annotation   = $this->objects->create_annotation( array(
+			'in_post_id' => $password_protected_post->ID,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$post_ids                        = $this->utils->extract_ids( $posts );
+		$trashed_post_ids                = $this->utils->extract_ids( $trashed_posts );
+		$annotation_ids                  = $this->utils->extract_ids( $annotations );
+		$annotation_ids_in_trashed_posts = $this->utils->extract_ids( $annotations_in_trashed_posts );
+
+		// Admins and editors.
+		foreach ( array( $users['administrator'], $users['editor'] ) as $user ) {
+			foreach ( array( 'view', 'edit' ) as $context ) {
+
+				// Test valid params.
+				foreach ( array(
+					array(
+						'post' => $post_ids[0],
+						8,
+					),
+					array(
+						'post' => $post_ids,
+						32,
+					),
+					array(
+						'post'   => $post_ids,
+						'parent' => $annotation_ids,
+						16,
+					),
+					array(
+						'post'         => $post_ids,
+						'hierarchical' => 'flat',
+						32,
+					),
+					array(
+						'post'         => $post_ids,
+						'hierarchical' => 'flat',
+						'status'       => '1,trash',
+						64,
+					),
+					array(
+						'post'         => $post_ids,
+						'hierarchical' => 'threaded',
+						16,
+					),
+				) as $_params ) {
+					list( $_count ) = $_params;
+					unset( $_params[0] );
+
+					$tests += $this->generate_collection_test( $user, $_params + array( 'context' => $context ), 200, $_count, '' );
+					$counter++;
+				}
+
+				// Test no access in trashed posts.
+				foreach ( $trashed_post_ids as $_trashed_post_id ) {
+					$tests += $this->generate_collection_test(
+						$user,
+						array(
+							'context' => $context,
+							'post'    => $_trashed_post_id,
+						),
+						403,
+						0,
+						'rest_cannot_read_annotations'
+					);
+					$counter++;
+				}
+			}
+		}
+
+		// Authors and contributors.
+		foreach ( array( $users['author'], $users['contributor'] ) as $user ) {
+			$own_post_ids            = $this->utils->extract_ids( $posts[ $user->ID ] );
+			$own_trashed_post_ids    = $this->utils->extract_ids( $trashed_posts[ $user->ID ] );
+			$own_post_annotation_ids = array();
+
+			foreach ( $annotations as $in_post_id => $annotations_by_users ) {
+				if ( in_array( $in_post_id, $own_post_ids, true ) ) {
+					$_extracted_ids          = $this->utils->extract_ids( $annotations_by_users );
+					$own_post_annotation_ids = array_merge( $own_post_annotation_ids, $_extracted_ids );
+				}
+			}
+			foreach ( array( 'view', 'edit' ) as $context ) {
+
+				// Test valid params.
+				foreach ( array(
+					array(
+						'post' => $own_post_ids[0],
+						8,
+					),
+					array(
+						'post' => $own_post_ids,
+						8,
+					),
+					array(
+						'post'   => $own_post_ids,
+						'parent' => $own_post_annotation_ids,
+						4,
+					),
+					array(
+						'post'         => $own_post_ids,
+						'hierarchical' => 'flat',
+						8,
+					),
+					array(
+						'post'         => $own_post_ids,
+						'author'       => $user->ID,
+						'hierarchical' => 'flat',
+						'status'       => '1,trash',
+						4,
+					),
+					array(
+						'post'         => $own_post_ids,
+						'hierarchical' => 'threaded',
+						4,
+					),
+				) as $_params ) {
+					list( $_count ) = $_params;
+					unset( $_params[0] );
+
+					$tests += $this->generate_collection_test( $user, $_params + array( 'context' => $context ), 200, $_count, '' );
+					$counter++;
+				}
+
+				// Test no access in others' posts.
+				foreach ( array_diff( $post_ids, $own_post_ids ) as $_others_post_id ) {
+					$tests += $this->generate_collection_test(
+						$user,
+						array(
+							'context' => $context,
+							'post'    => $_others_post_id,
+						),
+						403,
+						0,
+						'rest_cannot_read_annotations'
+					);
+					$counter++;
+				}
+
+				// Test no access in others' trashed posts.
+				foreach ( array_diff( $trashed_post_ids, $own_trashed_post_ids ) as $_trashed_post_id ) {
+					$tests += $this->generate_collection_test(
+						$user,
+						array(
+							'context' => $context,
+							'post'    => $_trashed_post_id,
+						),
+						403,
+						0,
+						'rest_cannot_read_annotations_post'
+					);
+					$counter++;
+				}
+
+				// Test no access in own trashed posts.
+				foreach ( $own_trashed_post_ids as $_own_trashed_post_id ) {
+					$tests += $this->generate_collection_test(
+						$user,
+						array(
+							'context' => $context,
+							'post'    => $_own_trashed_post_id,
+						),
+						403,
+						0,
+						'rest_cannot_read_annotations'
+					);
+					$counter++;
+				}
+
+				// Test forbidden params.
+				foreach ( array(
+					'status'         => 'trash',
+					'author'         => $users['editor']->ID,
+					'author_exclude' => $users['editor']->ID,
+					'author_email'   => $users['editor']->user_email,
+				) as $_key => $_value ) {
+					$tests += $this->generate_collection_test(
+						$user,
+						array( $_key => $_value ) + array(
+							'context' => $context,
+							'post'    => $own_post_ids[0],
+						),
+						403,
+						0,
+						'rest_forbidden_annotations_param_' . $_key
+					);
+					$counter++;
+				}
+			}
+		}
+
+		// Subscriber and anonymous users.
+		foreach ( array( $users['subscriber'], $users['anonymous'] ) as $user ) {
+			foreach ( array( 'view', 'edit' ) as $context ) {
+
+				// Test no access to any.
+				foreach ( array(
+					array( 'post' => $post_ids ),
+					array( 'post' => $post_ids[0] ),
+				) as $_params ) {
+					$tests += $this->generate_collection_test(
+						$user,
+						$_params + array(
+							'context' => $context,
+							'post'    => $post_ids[0],
+						),
+						$user->ID ? 403 : 401,
+						0,
+						'rest_cannot_read_annotations'
+					);
+					$counter++;
+				}
+
+				// Test no access to any in trashed posts.
+				foreach ( array(
+					array( 'post' => $trashed_post_ids ),
+					array( 'post' => $trashed_post_ids[0] ),
+				) as $_params ) {
+					$tests += $this->generate_collection_test(
+						$user,
+						$_params + array(
+							'context' => $context,
+							'post'    => $trashed_post_ids[0],
+						),
+						$user->ID ? 403 : 401,
+						0,
+						'rest_cannot_read_annotations_post'
+					);
+					$counter++;
+				}
+			}
+		}
+
+		// Other tests with 'editor' user.
+		foreach ( array( $users['editor'] ) as $user ) {
+			foreach ( array( 'edit' ) as $context ) {
+
+				// Test valid params.
+				foreach ( array(
+					array(
+						'post' => $post_ids,
+						'type' => get_default_annotation_type(),
+						32,
+					),
+					array(
+						'post' => $post_ids,
+						'type' => array(
+							get_default_annotation_type(),
+							get_default_annotation_type(),
+						),
+						32,
+					),
+					array(
+						'post'   => $post_ids[0],
+						'author' => $user->ID,
+						2,
+					),
+					array(
+						'post'   => $post_ids[0],
+						'author' => $user->ID,
+						'status' => '1,trash',
+						4,
+					),
+					array(
+						'post'   => $post_ids,
+						'author' => $user->ID,
+						'status' => '1,trash',
+						16,
+					),
+					array(
+						'post'           => $post_ids,
+						'author'         => $user->ID,
+						'author_exclude' => $user->ID,
+						0,
+					),
+					array(
+						'post'           => $post_ids,
+						'author_exclude' => $user->ID,
+						24,
+					),
+					array(
+						'post' => $post_ids,
+						'via'  => 'gutenberg,other',
+						32,
+					),
+					array(
+						'post' => $post_ids,
+						'via'  => 'other',
+						0,
+					),
+					array(
+						'post' => $password_protected_post->ID,
+						1,
+					),
+					array(
+						'post'         => $post_ids,
+						'parent'       => 0,
+						'hierarchical' => 'flat',
+						32,
+					),
+				) as $_params ) {
+					list( $_count ) = $_params;
+					unset( $_params[0] );
+
+					$tests += $this->generate_collection_test( $user, $_params + array( 'context' => $context ), 200, $_count, '' );
+					$counter++;
+				}
+
+				// Test invalid params.
+				foreach ( array(
+					array( 'context' => 'foo' ),
+					array( 'type' => 'foo' ),
+					array(
+						'type' => array(),
+						'rest_invalid_param',
+					),
+					array( 'type' => array( '' ) ),
+					array( 'type' => array( 'foo' => 'bar' ) ),
+					array( 'type' => array( 'annotation', 'foo' ) ),
+					array(
+						'post' => null,
+						'rest_missing_callback_param',
+					),
+					array(
+						'post' => array(),
+						'rest_invalid_param',
+					),
+					array(
+						'post' => array( 0 ),
+						'rest_invalid_param',
+					),
+					array(
+						'post' => array( 999999 ),
+						'rest_cannot_read_annotations_post',
+						403,
+					),
+					array( 'post' => 'foo' ),
+					array( 'password' => 0 ),
+					array( 'parent' => 'foo' ),
+					array( 'parent_exclude' => 'foo' ),
+					array(
+						'status' => array(),
+						'rest_invalid_param',
+					),
+					array( 'status' => 'foo' ),
+					array( 'status' => array( 'foo' => 'bar' ) ),
+					array( 'status' => array( '1', 'foo' ) ),
+					array( 'include' => 'foo' ),
+					array( 'exclude' => 'foo' ),
+					array( 'search' => 0 ),
+					array( 'before' => 'foo' ),
+					array( 'after' => 'foo' ),
+					array( 'author' => 'foo' ),
+					array( 'author_email' => 'foo' ),
+					array( 'author_exclude' => 'foo' ),
+					array( 'via' => '[foo]' ),
+					array( 'via' => array( 'foo' => 'bar' ) ),
+					array( 'via' => array( 'foo', '^bar' ) ),
+					array( 'hierarchical' => 'foo' ),
+					array( 'page' => 'foo' ),
+					array( 'offset' => 'foo' ),
+					array( 'per_page' => 'foo' ),
+					array( 'order' => 'foo' ),
+					array( 'orderby' => 'foo' ),
+				) as $_params ) {
+					$_params                += array( 'rest_invalid_param', 400 );
+					list( $_code, $_status ) = $_params;
+					unset( $_params[0], $_params[1] );
+
+					$tests += $this->generate_collection_test(
+						$user,
+						$_params + array(
+							'context' => $context,
+							'post'    => $post_ids[0],
+						),
+						$_status,
+						0,
+						$_code
+					);
+					$counter++;
+				}
+			}
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+
+	/**
+	 * Generates tests for {@see test_get_item()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_get_item_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		$users                   = $this->objects->create_users();
+		$posts                   = $this->objects->create_posts( $users, array( 'publish' ) );
+		$password_protected_post = $this->objects->create_post( $users['editor']->ID );
+		wp_update_post( array(
+			'ID'       => $password_protected_post->ID,
+			'password' => 'foo',
+		) );
+		$annotations                   = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => $users,
+			'with_statuses' => array( '1', 'trash' ),
+		) );
+		$orphan_annotation             = $this->objects->create_annotation( array(
+			'in_post_id' => 0,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$unknown_post_annotation       = $this->objects->create_annotation( array(
+			'in_post_id' => 999999,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$password_protected_annotation = $this->objects->create_annotation( array(
+			'in_post_id' => $password_protected_post->ID,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$post_ids                      = $this->utils->extract_ids( $posts );
+		$annotation_ids                = $this->utils->extract_ids( $annotations );
+
+		// Admins and editors.
+		foreach ( array( $users['administrator'], $users['editor'] ) as $user ) {
+			foreach ( array( 'edit' ) as $context ) {
+
+				// Test permissions.
+				foreach ( $annotation_ids as $_id ) {
+					$tests += $this->generate_id_test( $user, $_id, array( 'context' => $context ), 200, '' );
+					$counter++;
+				}
+			}
+		}
+
+		// Authors and contributors.
+		foreach ( array( $users['author'], $users['contributor'] ) as $user ) {
+			$own_post_ids = $this->utils->extract_ids( $posts[ $user->ID ] );
+
+			foreach ( array( 'view', 'edit' ) as $context ) {
+				foreach ( $annotations as $_in_post_id => $_by_users ) {
+					foreach ( $_by_users as $_by_user_id => $_with_statuses ) {
+						foreach ( $_with_statuses as $_with_status => $_annotation ) {
+							$_id                = (int) $_annotation->comment_ID;
+							$_is_own_post       = in_array( $_in_post_id, $own_post_ids, true );
+							$_is_own_annotation = $_by_user_id === $user->ID;
+
+							// Test permissions.
+							if ( ( $_is_own_post && $_is_own_annotation )
+									|| ( $_is_own_post && 'view' === $context && 'trash' !== $_with_status ) ) {
+								$tests += $this->generate_id_test( $user, $_id, array( 'context' => $context ), 200, '' );
+							} elseif ( $_is_own_post && 'view' !== $context && 'trash' !== $_with_status ) {
+								$tests += $this->generate_id_test( $user, $_id, array( 'context' => $context ), 403, 'rest_forbidden_annotation_context' );
+							} else {
+								$tests += $this->generate_id_test( $user, $_id, array( 'context' => $context ), 403, 'rest_cannot_read_annotation' );
+							}
+							$counter++;
+						}
+					}
+				}
+			}
+		}
+
+		// Subscriber and anonymous users.
+		foreach ( array( $users['subscriber'], $users['anonymous'] ) as $user ) {
+			foreach ( array( 'view', 'edit' ) as $context ) {
+
+				// Test permissions.
+				foreach ( $annotation_ids as $_id ) {
+					$tests += $this->generate_id_test( $user, $_id, array( 'context' => $context ), $user->ID ? 403 : 401, 'rest_cannot_read_annotation' );
+					$counter++;
+				}
+			}
+		}
+
+		// Other tests with 'editor' user.
+		foreach ( array( $users['editor'] ) as $user ) {
+			foreach ( array( 'edit' ) as $context ) {
+
+				// Test valid params.
+				foreach ( array(
+					array( $password_protected_annotation->comment_ID ),
+				) as $_params ) {
+					$_params    += array( $annotation_ids[0] );
+					list( $_id ) = $_params;
+					unset( $_params[0] );
+
+					$tests += $this->generate_id_test( $user, $_id, $_params + array( 'context' => $context ), 200, '' );
+					$counter++;
+				}
+
+				// Test invalid params.
+				foreach ( array(
+					array( 'rest_no_route', 404, null ),
+					array( 'rest_cannot_read_annotation_post', 403, 0 ),
+					array( 'rest_cannot_read_annotation_post', 403, 999999 ),
+					array( 'rest_no_route', 404, '0/' . $annotation_ids[0] ),
+					array( 'rest_cannot_read_annotation_post', 403, $orphan_annotation->comment_ID ),
+					array( 'rest_cannot_read_annotation_post', 403, $unknown_post_annotation->comment_ID ),
+					array(
+						'context' => 'foo',
+						'rest_invalid_param',
+					),
+				) as $_params ) {
+					$_params                      += array( 'rest_invalid_param', 400, $annotation_ids[0] );
+					list( $_code, $_status, $_id ) = $_params;
+					unset( $_params[0], $_params[1], $_params[2] );
+
+					$tests += $this->generate_id_test(
+						$user,
+						$_id,
+						$_params + array(
+							'context' => $context,
+							'post'    => $post_ids[0],
+						),
+						$_status,
+						$_code
+					);
+					$counter++;
+				}
+			}
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+
+	/**
+	 * Generates tests for {@see test_create_item()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_create_item_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		update_option( 'require_name_email', '1' );
+		add_filter( 'annotation_selector_is_allowed', '__return_true' );
+
+		$users         = $this->objects->create_users();
+		$no_email_user = $this->objects->create_user( 'editor' );
+		wp_update_user( array(
+			'ID'         => $no_email_user->ID,
+			'user_email' => '',
+		) );
+		$posts                   = $this->objects->create_posts( $users, array( 'publish' ) );
+		$password_protected_post = $this->objects->create_post( $users['editor']->ID );
+		wp_update_post( array(
+			'ID'       => $password_protected_post->ID,
+			'password' => 'foo',
+		) );
+		$post_ids    = $this->utils->extract_ids( $posts );
+		$max_lengths = wp_get_comment_fields_max_lengths();
+
+		// Admins and editors.
+		foreach ( array( $users['administrator'], $users['editor'] ) as $user ) {
+
+			// Test permissions.
+			foreach ( $users as $_user ) {
+				if ( $_user->ID ) {
+					foreach ( $post_ids as $_post_id ) {
+						$tests += $this->generate_test(
+							$user,
+							array(
+								'post'    => $_post_id,
+								'author'  => $_user->ID,
+								'content' => 'foo',
+							),
+							201,
+							''
+						);
+						$counter++;
+					}
+				}
+			}
+		}
+
+		// Authors and contributors.
+		foreach ( array( $users['author'], $users['contributor'] ) as $user ) {
+			$own_post_ids = $this->utils->extract_ids( $posts[ $user->ID ] );
+
+			foreach ( $posts as $_by_user_id => $_with_statuses ) {
+				foreach ( $_with_statuses as $_with_status => $_post ) {
+					$_is_own_post = in_array( $_post->ID, $own_post_ids, true );
+
+					// Test permissions.
+					if ( $_is_own_post ) {
+						$tests += $this->generate_test(
+							$user,
+							array(
+								'post'    => $_post->ID,
+								'content' => 'foo',
+							),
+							201,
+							''
+						);
+						$counter++;
+					} else {
+						$tests += $this->generate_test(
+							$user,
+							array(
+								'post'    => $_post->ID,
+								'content' => 'foo',
+							),
+							403,
+							'rest_cannot_create_annotation'
+						);
+						$counter++;
+					}
+				}
+			}
+
+			// Test inability to create as another user.
+			foreach ( $users as $_user ) {
+				if ( $_user->ID && $_user->ID !== $user->ID ) {
+					$tests += $this->generate_test(
+						$user,
+						array(
+							'post'    => $own_post_ids[0],
+							'author'  => $_user->ID,
+							'content' => 'foo',
+						),
+						403,
+						'rest_forbidden_annotation_param_author'
+					);
+					$counter++;
+				}
+			}
+
+			// Test filtered HTML.
+			$tests += $this->generate_test(
+				$user,
+				array(
+					'post'    => $own_post_ids[0],
+					'content' => '<foo><code>bar</code></foo>',
+				),
+				201,
+				'',
+				array(
+					'only allowed tags should remain' => array(
+						'key'    => 'content.raw',
+						'assert' => 'same',
+						'value'  => '<code>bar</code>',
+					),
+				)
+			);
+			$counter++;
+
+			// Test filtered HTML w/ empty content check.
+			$tests += $this->generate_test(
+				$user,
+				array(
+					'post'    => $own_post_ids[0],
+					'content' => '<svg><p>0 <foo /></p></svg>',
+				),
+				400,
+				'rest_missing_annotation_content'
+			);
+			$counter++;
+
+			// Test restricted statuses.
+			foreach ( array( '0', 'hold', 'spam' ) as $status ) {
+				$tests += $this->generate_test(
+					$user,
+					array(
+						'post'    => $own_post_ids[0],
+						'content' => 'foo',
+						'status'  => $status,
+					),
+					403,
+					'rest_forbidden_annotation_param_status'
+				);
+				$counter++;
+			}
+		}
+
+		// Subscriber and anonymous users.
+		foreach ( array( $users['subscriber'], $users['anonymous'] ) as $user ) {
+
+			// Test permissions.
+			foreach ( $post_ids as $_post_id ) {
+				$tests += $this->generate_test(
+					$user,
+					array(
+						'post'    => $_post_id,
+						'author'  => $user->ID,
+						'content' => 'foo',
+					),
+					$user->ID ? 403 : 401,
+					'rest_cannot_create_annotation'
+				);
+				$counter++;
+			}
+		}
+
+		// Other tests with 'editor' user.
+		foreach ( array( $users['editor'] ) as $user ) {
+
+			// Test valid params.
+			foreach ( array(
+				array( 'status' => 'hold' ),
+				array( 'status' => 'approve' ),
+				array( 'status' => 'spam' ),
+				array( 'status' => 'unspam' ),
+				array( 'status' => 'trash' ),
+				array( 'status' => 'untrash' ),
+				array( 'status' => 'resolve' ),
+				array( 'status' => 'reject' ),
+				array( 'status' => 'archive' ),
+				array(
+					'via'      => 'foo',
+					'selector' => array(),
+				),
+				array(
+					'selector' => array(
+						'type'       => 'FragmentSelector',
+						'conformsTo' => 'https://foo.com',
+						'value'      => 'foo',
+						'refinedBy'  => array(
+							'type'  => 'TextPositionSelector',
+							'start' => 0,
+							'end'   => 0,
+						),
+					),
+				),
+				array(
+					'selector' => array(
+						'type'      => 'CssSelector',
+						'value'     => '#foo > .bar',
+						'refinedBy' => array(
+							'type'  => 'DataPositionSelector',
+							'start' => 0,
+							'end'   => 0,
+						),
+					),
+				),
+				array(
+					'selector' => array(
+						'type'   => 'TextQuoteSelector',
+						'exact'  => 'foo bar',
+						'prefix' => 'foo',
+						'suffix' => 'bar',
+					),
+				),
+				array(
+					'selector' => array(
+						'type'          => 'RangeSelector',
+						'startSelector' => array(
+							'type'      => 'XPathSelector',
+							'value'     => '//*[@id="c9xi4jhi"]/text()[1]',
+							'refinedBy' => array(
+								'type'  => 'TextPositionSelector',
+								'start' => 0,
+								'end'   => 0,
+							),
+						),
+						'endSelector'   => array(
+							'type'      => 'XPathSelector',
+							'value'     => '//*[@id="c9xi4jhi"]/text()[1]',
+							'refinedBy' => array(
+								'type'  => 'TextPositionSelector',
+								'start' => 1,
+								'end'   => 1,
+							),
+						),
+					),
+				),
+				array(
+					'selector' => array(
+						'type' => 'SvgSelector',
+						'id'   => 'https://foo.com/foo.svg',
+					),
+				),
+				array(
+					'selector' => array(
+						'type'  => 'SvgSelector',
+						'value' => '<svg></svg>',
+					),
+				),
+				array(
+					'content' => 'Iñtërnâtiônàlizætiøn 🤪',
+					array(
+						'valid UTF-8 chars' => array(
+							'key'    => 'content.raw',
+							'assert' => 'same',
+							'value'  => 'Iñtërnâtiônàlizætiøn 🤪',
+						),
+					),
+				),
+				array(
+					'content' => "\xc3\xb1",
+					array(
+						'valid 2-byte UTF-8 sequence' => array(
+							'key'    => 'content.raw',
+							'assert' => 'same',
+							'value'  => "\xc3\xb1",
+						),
+					),
+				),
+				array(
+					'content' => "\xe2\x82\xa1",
+					array(
+						'valid 3-byte UTF-8 sequence' => array(
+							'key'    => 'content.raw',
+							'assert' => 'same',
+							'value'  => "\xe2\x82\xa1",
+						),
+					),
+				),
+				array(
+					'content' => "\xf0\x90\x8c\xbc",
+					array(
+						'valid 4-byte UTF-8 sequence' => array(
+							'key'    => 'content.raw',
+							'assert' => 'same',
+							'value'  => "\xf0\x90\x8c\xbc",
+						),
+					),
+				),
+				array( 'meta' => array( 'foo' => 'bar' ) ),
+				array( 'post' => $password_protected_post->ID ),
+			) as $_params ) {
+				$_params    += array( array() );
+				$_assertions = $_params[0];
+				unset( $_params[0] );
+
+				$tests += $this->generate_test(
+					$user,
+					$_params + array(
+						'post'    => $post_ids[0],
+						'author'  => $user->ID,
+						'content' => 'foo',
+					),
+					201,
+					'',
+					$_assertions
+				);
+				$counter++;
+			}
+
+			// Test invalid params.
+			foreach ( array(
+				array(
+					'id' => 1,
+					'rest_readonly_annotation_param_id',
+				),
+				array(
+					'post' => null,
+					'rest_cannot_read_annotation_post',
+					403,
+				),
+				array(
+					'post' => 0,
+					'rest_cannot_read_annotation_post',
+					403,
+				),
+				array(
+					'post' => 999999,
+					'rest_cannot_read_annotation_post',
+					403,
+				),
+				array( 'post' => 'foo' ),
+				array( 'type' => '' ),
+				array( 'type' => 'foo' ),
+				array( 'type' => 'comment' ),
+				array( 'parent' => 'foo' ),
+				array(
+					'parent' => 999999,
+					'rest_cannot_read_annotation_parent',
+					403,
+				),
+				array( 'date' => 'foo' ),
+				array( 'date_gmt' => 'foo' ),
+				array( 'author' => 'foo' ),
+				array(
+					'author' => '123',
+					'rest_comment_author_invalid',
+				),
+				array( 'author_name' => 0 ),
+				array(
+					'author' => $no_email_user->ID,
+					'rest_missing_annotation_author_data',
+				),
+				array(
+					'author_name' => str_repeat( 'x', $max_lengths['comment_author'] + 1 ),
+					'comment_author_column_length',
+				),
+				array( 'author_email' => 'foo' ),
+				array(
+					'author_email' => str_repeat( 'x', $max_lengths['comment_author_email'] + 1 ) . '@foo.com',
+					'comment_author_email_column_length',
+				),
+				array( 'author_url' => 0 ),
+				array( 'author_ip' => 0 ),
+				array( 'author_user_agent' => 0 ),
+				array(
+					'content' => 0,
+					'rest_missing_annotation_content',
+				),
+				array(
+					'content' => null,
+					'rest_missing_annotation_content',
+				),
+				array( // A lonely first byte of a 2-byte sequence.
+					'content' => "\xc0",
+					'rest_missing_annotation_content',
+				),
+				array( // A lonely first byte of a 3-byte sequence.
+					'content' => "\xe0",
+					'rest_missing_annotation_content',
+				),
+				array( // A lonely first byte of a 4-byte sequence.
+					'content' => "\xf0",
+					'rest_missing_annotation_content',
+				),
+				array( // A valid 5-byte sequence is not valid UTF-8.
+					'content' => "\xf8\xa1\xa1\xa1\xa1",
+					'rest_missing_annotation_content',
+				),
+				array( // A valid 6-byte sequence is not valid UTF-8.
+					'content' => "\xfc\xa1\xa1\xa1\xa1\xa1",
+					'rest_missing_annotation_content',
+				),
+				array(
+					'content' => " 0 \t \n \r \0 \x0B" .
+						' <script src="#">foo</script> <style href="#">foo</style>' .
+						' &nbsp; <div>&nbsp;</div> <p></p> <br/><br> <hr/><hr> </><>',
+					'rest_missing_annotation_content',
+				),
+				array(
+					'content' => str_repeat( 'x', $max_lengths['comment_content'] + 1 ),
+					'comment_content_column_length',
+				),
+				array( 'via' => 0 ),
+				array(
+					'via' => '[foo]',
+					'rest_annotation_field_validation_update_failure',
+				),
+				array( 'selector' => 'foo' ),
+				array( 'selector' => array( 'type' => '' ) ),
+				array( 'selector' => array( 'type' => 'foo' ) ),
+				array(
+					'selector' => array(
+						'type'  => 'CssSelector',
+						'value' => str_repeat( 'x', 16385 ),
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				// FragmentSelector type.
+				array(
+					'selector' => array(
+						'type' => 'FragmentSelector',
+						'foo'  => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'  => 'FragmentSelector',
+						'value' => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'       => 'FragmentSelector',
+						'value'      => 'foo',
+						'conformsTo' => ':',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'      => 'FragmentSelector',
+						'value'     => 'foo',
+						'refinedBy' => array(),
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				// CssSelector type.
+				array(
+					'selector' => array(
+						'type' => 'CssSelector',
+						'foo'  => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'  => 'CssSelector',
+						'value' => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'      => 'CssSelector',
+						'value'     => 'foo',
+						'refinedBy' => array(),
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				// TextQuoteSelector type.
+				array(
+					'selector' => array(
+						'type' => 'TextQuoteSelector',
+						'foo'  => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'  => 'TextQuoteSelector',
+						'exact' => 0,
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'  => 'TextQuoteSelector',
+						'exact' => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'   => 'TextQuoteSelector',
+						'exact'  => 'foo',
+						'prefix' => 0,
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'   => 'TextQuoteSelector',
+						'exact'  => 'foo',
+						'suffix' => 0,
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				// TextPositionSelector type.
+				array(
+					'selector' => array(
+						'type' => 'TextPositionSelector',
+						'foo'  => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'  => 'TextPositionSelector',
+						'start' => null,
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'  => 'TextPositionSelector',
+						'start' => 0,
+						'end'   => null,
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				// SvgSelector type.
+				array(
+					'selector' => array(
+						'type' => 'SvgSelector',
+						'foo'  => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'  => 'SvgSelector',
+						'id'    => '',
+						'value' => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type' => 'SvgSelector',
+						'id'   => ':',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'  => 'SvgSelector',
+						'value' => 'foo',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				// RangeSelector type.
+				array(
+					'selector' => array(
+						'type' => 'RangeSelector',
+						'foo'  => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'          => 'RangeSelector',
+						'startSelector' => array(),
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'          => 'RangeSelector',
+						'startSelector' => array( 'foo' ),
+						'endSelector'   => array( 'foo' ),
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array(
+					'selector' => array(
+						'type'          => 'RangeSelector',
+						'startSelector' => array(
+							'type'  => 'CssSelector',
+							'value' => '#foo',
+						),
+						'endSelector'   => array( 'foo' ),
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array( 'status' => '' ),
+				array( 'status' => 'foo' ),
+				array( 'meta' => 'foo' ),
+				array(
+					'author_url' => 'https://foo.com/' . str_repeat( 'x', $max_lengths['comment_author_url'] + 1 ),
+					'comment_author_url_column_length',
+				),
+			) as $_params ) {
+				$_params                              += array( 'rest_invalid_param', 400, array() );
+				list( $_code, $_status, $_assertions ) = $_params;
+				unset( $_params[0], $_params[1], $_params[2] );
+
+				$tests += $this->generate_test(
+					$user,
+					$_params + array(
+						'post'    => $post_ids[0],
+						'author'  => $user->ID,
+						'content' => 'foo',
+					),
+					$_status,
+					$_code,
+					$_assertions
+				);
+				$counter++;
+			}
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+
+	/**
+	 * Generates tests for {@see test_update_item()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_update_item_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		update_option( 'require_name_email', '1' );
+		add_filter( 'annotation_selector_is_allowed', '__return_true' );
+
+		$users                   = $this->objects->create_users();
+		$posts                   = $this->objects->create_posts( $users, array( 'publish' ) );
+		$password_protected_post = $this->objects->create_post( $users['editor']->ID );
+		wp_update_post( array(
+			'ID'       => $password_protected_post->ID,
+			'password' => 'foo',
+		) );
+		$annotations                   = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => $users,
+			'with_statuses' => array( '1', 'trash' ),
+		) );
+		$orphan_annotation             = $this->objects->create_annotation( array(
+			'in_post_id' => 0,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$unknown_post_annotation       = $this->objects->create_annotation( array(
+			'in_post_id' => 999999,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$password_protected_annotation = $this->objects->create_annotation( array(
+			'in_post_id' => $password_protected_post->ID,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$post_ids                      = $this->utils->extract_ids( $posts );
+		$annotation_ids                = $this->utils->extract_ids( $annotations );
+		$max_lengths                   = wp_get_comment_fields_max_lengths();
+
+		// Admins and editors.
+		foreach ( array( $users['administrator'], $users['editor'] ) as $user ) {
+
+			// Test permissions.
+			foreach ( $annotation_ids as $_id ) {
+				$tests += $this->generate_id_test(
+					$user,
+					$_id,
+					array(
+						'author_name'       => 'foo',
+						'author_email'      => 'foo@bar.com',
+						'author_ip'         => '127.0.0.1',
+						'author_user_agent' => 'foo',
+						'author_url'        => 'https://foo.com',
+						'content'           => 'foo',
+					),
+					200,
+					''
+				);
+				$counter++;
+			}
+		}
+
+		// Authors and contributors.
+		foreach ( array( $users['author'], $users['contributor'] ) as $user ) {
+			$own_post_ids = $this->utils->extract_ids( $posts[ $user->ID ] );
+
+			foreach ( $annotations as $_in_post_id => $_by_users ) {
+				foreach ( $_by_users as $_by_user_id => $_with_statuses ) {
+					foreach ( $_with_statuses as $_with_status => $_annotation ) {
+						$_id                = (int) $_annotation->comment_ID;
+						$_is_own_post       = in_array( $_in_post_id, $own_post_ids, true );
+						$_is_own_annotation = $_by_user_id === $user->ID;
+
+						// Test permissions.
+						if ( $_is_own_post && $_is_own_annotation ) {
+							$tests += $this->generate_id_test(
+								$user,
+								$_id,
+								array(
+									'content' => 'foo',
+									'status'  => $_annotation->comment_approved,
+								),
+								200,
+								''
+							);
+							$counter++;
+
+							// Test restricted params.
+							$_0_255  = mt_rand( 0, 255 );
+							$_uniqid = str_replace( '.', '', uniqid( '', true ) );
+
+							foreach ( array(
+								'author'            => $users['editor']->ID,
+								'author_name'       => $_uniqid . '-foo',
+								'author_email'      => $_uniqid . '@foo.com',
+								'author_ip'         => $_0_255 . str_repeat( '.' . $_0_255, 3 ),
+								'author_user_agent' => $_uniqid . '-foo',
+								'author_url'        => 'https://' . $_uniqid . '-foo.com',
+								'status'            => 'spam',
+							) as $_key => $_value ) {
+								$tests += $this->generate_id_test( $user, $_id, array( $_key => $_value ), 403, 'rest_forbidden_annotation_param_' . $_key );
+								$counter++;
+							}
+						} else {
+							$tests += $this->generate_id_test( $user, $_id, array( 'content' => 'foo' ), 403, 'rest_cannot_update_annotation' );
+							$counter++;
+						}
+					}
+				}
+			}
+		}
+
+		// Subscriber and anonymous users.
+		foreach ( array( $users['subscriber'], $users['anonymous'] ) as $user ) {
+
+			// Test permissions.
+			foreach ( $annotation_ids as $_id ) {
+				$tests += $this->generate_id_test( $user, $_id, array( 'content' => 'foo' ), $user->ID ? 403 : 401, 'rest_cannot_update_annotation' );
+				$counter++;
+			}
+		}
+
+		// Other tests with 'editor' user.
+		foreach ( array( $users['editor'] ) as $user ) {
+
+			// Test valid params.
+			foreach ( array(
+				array(
+					'via'      => 'foo',
+					'selector' => array(),
+				),
+				array(
+					'via'      => 'foo',
+					'selector' => array(
+						'type'  => 'CssSelector',
+						'value' => '#foo > .bar',
+					),
+				),
+				array(
+					'content' => 'Iñtërnâtiônàlizætiøn 🤪',
+					array(
+						'valid UTF-8 chars' => array(
+							'key'    => 'content.raw',
+							'assert' => 'same',
+							'value'  => 'Iñtërnâtiônàlizætiøn 🤪',
+						),
+					),
+				),
+				array(
+					'content' => "\xc3\xb1",
+					array(
+						'valid 2-byte UTF-8 sequence' => array(
+							'key'    => 'content.raw',
+							'assert' => 'same',
+							'value'  => "\xc3\xb1",
+						),
+					),
+				),
+				array(
+					'content' => "\xe2\x82\xa1",
+					array(
+						'valid 3-byte UTF-8 sequence' => array(
+							'key'    => 'content.raw',
+							'assert' => 'same',
+							'value'  => "\xe2\x82\xa1",
+						),
+					),
+				),
+				array(
+					'content' => "\xf0\x90\x8c\xbc",
+					array(
+						'valid 4-byte UTF-8 sequence' => array(
+							'key'    => 'content.raw',
+							'assert' => 'same',
+							'value'  => "\xf0\x90\x8c\xbc",
+						),
+					),
+				),
+				array( array(), $password_protected_annotation->comment_ID ),
+			) as $_params ) {
+				$_params                  += array( array(), $annotation_ids[0] );
+				list( $_assertions, $_id ) = $_params;
+				unset( $_params[0], $_params[1] );
+
+				$tests += $this->generate_id_test( $user, $_id, $_params + array( 'content' => 'foo' ), 200, '', $_assertions );
+				$counter++;
+			}
+
+			// Test invalid params.
+			foreach ( array(
+				array(
+					'post' => 999999,
+					'rest_cannot_update_annotation_param_post',
+				),
+				array(
+					'type' => 'comment',
+					'rest_invalid_param',
+				),
+				array(
+					'parent' => 999999,
+					'rest_cannot_update_annotation_param_parent',
+				),
+				array(
+					'rest_cannot_read_annotation_post',
+					403,
+					3 => 999999,
+				),
+				array(
+					'rest_cannot_read_annotation_post',
+					403,
+					3 => $orphan_annotation->comment_ID,
+				),
+				array(
+					'rest_cannot_read_annotation_post',
+					403,
+					3 => $unknown_post_annotation->comment_ID,
+				),
+				array( 'date' => 'foo' ),
+				array( 'date_gmt' => 'foo' ),
+				array( 'author' => 'foo' ),
+				array( 'author_name' => 0 ),
+				array(
+					'author_name' => str_repeat( 'x', $max_lengths['comment_author'] + 1 ),
+					'comment_author_column_length',
+				),
+				array( 'author_email' => 'foo' ),
+				array(
+					'author_email' => str_repeat( 'x', $max_lengths['comment_author_email'] + 1 ) . '@foo.com',
+					'comment_author_email_column_length',
+				),
+				array( 'author_url' => 0 ),
+				array( 'author_ip' => 0 ),
+				array( 'author_user_agent' => 0 ),
+				array( // A lonely first byte of a 2-byte sequence.
+					'content' => "\xc0",
+					'rest_missing_annotation_content',
+				),
+				array( // A lonely first byte of a 3-byte sequence.
+					'content' => "\xe0",
+					'rest_missing_annotation_content',
+				),
+				array( // A lonely first byte of a 4-byte sequence.
+					'content' => "\xf0",
+					'rest_missing_annotation_content',
+				),
+				array( // A valid 5-byte sequence is not valid UTF-8.
+					'content' => "\xf8\xa1\xa1\xa1\xa1",
+					'rest_missing_annotation_content',
+				),
+				array( // A valid 6-byte sequence is not valid UTF-8.
+					'content' => "\xfc\xa1\xa1\xa1\xa1\xa1",
+					'rest_missing_annotation_content',
+				),
+				array(
+					'content' => " 0 \t \n \r \0 \x0B" .
+						' <script src="#">foo</script> <style href="#">foo</style>' .
+						' &nbsp; <div>&nbsp;</div> <p></p> <br/><br> <hr/><hr> </><>',
+					'rest_missing_annotation_content',
+				),
+				array(
+					'content' => str_repeat( 'x', $max_lengths['comment_content'] + 1 ),
+					'comment_content_column_length',
+				),
+				array( 'via' => 0 ),
+				array(
+					'via' => '[foo]',
+					'rest_annotation_field_validation_update_failure',
+				),
+				array( 'selector' => 'foo' ),
+				array( 'selector' => array( 'type' => 'foo' ) ),
+				array(
+					'selector' => array(
+						'type'  => 'CssSelector',
+						'value' => '',
+					),
+					'rest_annotation_field_validation_update_failure',
+				),
+				array( 'status' => 'foo' ),
+				array( 'meta' => 'foo' ),
+				array(
+					'author_url' => 'https://foo.com/' . str_repeat( 'x', $max_lengths['comment_author_url'] + 1 ),
+					'comment_author_url_column_length',
+				),
+			) as $_params ) {
+				$_params                                    += array( 'rest_invalid_param', 400, array(), $annotation_ids[0] );
+				list( $_code, $_status, $_assertions, $_id ) = $_params;
+				unset( $_params[0], $_params[1], $_params[2], $_params[3] );
+
+				$tests += $this->generate_id_test( $user, $_id, $_params + array( 'content' => 'foo' ), $_status, $_code, $_assertions );
+				$counter++;
+			}
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+
+	/**
+	 * Generates tests for {@see test_delete_item()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_delete_item_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		$users                   = $this->objects->create_users();
+		$posts                   = $this->objects->create_posts( $users, array( 'publish' ) );
+		$password_protected_post = $this->objects->create_post( $users['editor']->ID );
+		wp_update_post( array(
+			'ID'       => $password_protected_post->ID,
+			'password' => 'foo',
+		) );
+		$password_protected_annotation = $this->objects->create_annotation( array(
+			'in_post_id' => $password_protected_post->ID,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$orphan_annotation             = $this->objects->create_annotation( array(
+			'in_post_id' => 0,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$unknown_post_annotation       = $this->objects->create_annotation( array(
+			'in_post_id' => 999999,
+			'by_user_id' => $users['editor']->ID,
+		) );
+		$post_ids                      = $this->utils->extract_ids( $posts );
+
+		// Admins and editors.
+		foreach ( array( $users['administrator'], $users['editor'] ) as $user ) {
+			$annotations = $this->objects->create_annotations( array(
+				'in_posts'      => $posts,
+				'by_users'      => $users,
+				'with_statuses' => array( '1' ),
+			) );
+
+			// Test permissions.
+			foreach ( $this->utils->extract_ids( $annotations ) as $_id ) {
+				$tests += $this->generate_id_test( $user, $_id, array( 'force' => true ), 200, '' );
+				$counter++;
+			}
+		}
+
+		// Authors and contributors.
+		foreach ( array( $users['author'], $users['contributor'] ) as $user ) {
+			$own_post_ids = $this->utils->extract_ids( $posts[ $user->ID ] );
+			$annotations  = $this->objects->create_annotations( array(
+				'in_posts'      => $posts,
+				'by_users'      => $users,
+				'with_statuses' => array( '1' ),
+			) );
+
+			foreach ( $annotations as $_in_post_id => $_by_users ) {
+				foreach ( $_by_users as $_by_user_id => $_with_statuses ) {
+					foreach ( $_with_statuses as $_with_status => $_annotation ) {
+						$_id                = (int) $_annotation->comment_ID;
+						$_is_own_post       = in_array( $_in_post_id, $own_post_ids, true );
+						$_is_own_annotation = $_by_user_id === $user->ID;
+
+						// Test permissions.
+						if ( $_is_own_post && $_is_own_annotation ) {
+							$tests += $this->generate_id_test( $user, $_id, array( 'force' => true ), 200, '' );
+						} else {
+							$tests += $this->generate_id_test( $user, $_id, array(), 403, 'rest_cannot_delete_annotation' );
+						}
+						$counter++;
+					}
+				}
+			}
+		}
+
+		// Subscriber and anonymous users.
+		$annotations = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => $users,
+			'with_statuses' => array( '1' ),
+		) );
+		foreach ( array( $users['subscriber'], $users['anonymous'] ) as $user ) {
+			// Test permissions.
+			foreach ( $this->utils->extract_ids( $annotations ) as $_id ) {
+				$tests += $this->generate_id_test( $user, $_id, array(), $user->ID ? 403 : 401, 'rest_cannot_delete_annotation' );
+				$counter++;
+			}
+		}
+
+		// Other tests with 'editor' user.
+		$annotations    = $this->objects->create_annotations( array(
+			'in_posts'      => $posts,
+			'by_users'      => array( $users['editor'] ),
+			'with_statuses' => array( '1' ),
+		) );
+		$annotation_ids = $this->utils->extract_ids( $annotations );
+
+		foreach ( array( $users['editor'] ) as $user ) {
+			// Test valid params.
+			foreach ( array(
+				array( array(), $password_protected_annotation->comment_ID ),
+			) as $_params ) {
+				$_params                  += array( array(), $annotation_ids[0] );
+				list( $_assertions, $_id ) = $_params;
+				unset( $_params[0], $_params[1] );
+
+				$tests += $this->generate_id_test( $user, $_id, array(), 200, '', $_assertions );
+				$counter++;
+			}
+
+			// Test invalid params.
+			foreach ( array(
+				array(
+					'rest_cannot_read_annotation_post',
+					403,
+					3 => 999999,
+				),
+				array(
+					'rest_cannot_read_annotation_post',
+					403,
+					3 => $orphan_annotation->comment_ID,
+				),
+				array(
+					'rest_cannot_read_annotation_post',
+					403,
+					3 => $unknown_post_annotation->comment_ID,
+				),
+			) as $_params ) {
+				$_params                                    += array( 'rest_invalid_param', 400, array(), $annotation_ids[0] );
+				list( $_code, $_status, $_assertions, $_id ) = $_params;
+				unset( $_params[0], $_params[1], $_params[2], $_params[3] );
+
+				$tests += $this->generate_id_test( $user, $_id, array(), $_status, $_code, $_assertions );
+				$counter++;
+			}
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+
+	/**
+	 * Generates tests for {@see test_function_calls()}.
+	 *
+	 * @return array Test arrays.
+	 */
+	protected function generate_function_tests() {
+		$tests   = array();
+		$counter = 0;
+
+		$user       = $this->objects->create_user( 'editor' );
+		$controller = new WP_REST_Annotations_Controller();
+		$request    = new WP_REST_Request( 'GET', $this->rest_ns_base );
+
+		$post                   = $this->objects->create_post( $user->ID );
+		$nonexistent_annotation = new WP_Annotation( (object) array(
+			'comment_ID'   => 0,
+			'comment_type' => get_default_annotation_type(),
+		) );
+		$orphan_annotation      = $this->objects->create_annotation( array(
+			'in_post_id' => 0,
+			'by_user_id' => $user->ID,
+		) );
+
+		foreach ( array(
+			'create w/ ID' => array(
+				'id' => 999999,
+			),
+		) as $_key => $_params ) {
+			$_request = new WP_REST_Request( 'POST', $this->rest_ns_base );
+
+			foreach ( $_params as $__key => $_value ) {
+				$_request->set_param( $__key, $_value );
+			}
+
+			$_function = array( $controller, 'create_item' );
+			$tests    += $this->generate_function_test(
+				$user,
+				$_function,
+				array( $_request ),
+				array(
+					$_key => array(
+						'assert' => 'instanceof',
+						'value'  => 'WP_Error',
+					),
+				)
+			);
+			$counter++;
+		}
+
+		foreach ( array(
+			'empty type'   => array(
+				'post'   => $post->ID,
+				'type'   => '',
+				'status' => 'foo',
+			),
+			'empty status' => array(
+				'post'   => $post->ID,
+				'type'   => 'foo',
+				'status' => '',
+			),
+		) as $_key => $_params ) {
+			$_request = new WP_REST_Request( 'POST', $this->rest_ns_base );
+
+			foreach ( $_params as $__key => $_value ) {
+				$_request->set_param( $__key, $_value );
+			}
+
+			$_function = array( $controller, 'create_item_permissions_check' );
+			$tests    += $this->generate_function_test(
+				$user,
+				$_function,
+				array( $_request ),
+				array(
+					$_key => array(
+						'assert' => 'instanceof',
+						'value'  => 'WP_Error',
+					),
+				)
+			);
+			$counter++;
+		}
+
+		foreach ( array(
+			'unknown field'          => array( $orphan_annotation->comment, 'foo', $request ),
+			'nonexistent annotation' => array( $nonexistent_annotation->comment, 'foo', $request ),
+			'annotation array ID'    => array( array( 'id' => -1 ), 'foo', $request ),
+		) as $_key => $_args ) {
+			$_function = array( $controller, 'on_get_additional_field' );
+			$tests    += $this->generate_function_test(
+				$user,
+				$_function,
+				$_args,
+				array(
+					$_key => array(
+						'assert' => 'same',
+						'value'  => null,
+					),
+				)
+			);
+			$counter++;
+		}
+
+		foreach ( array(
+			'unknown field'          => array( null, $orphan_annotation->comment, 'foo', $request ),
+			'nonexistent annotation' => array( null, $nonexistent_annotation->comment, 'foo', $request ),
+			'annotation array ID'    => array( null, array( 'id' => -1 ), 'foo', $request ),
+		) as $_key => $_args ) {
+			$_function = array( $controller, 'on_update_additional_field' );
+			$tests    += $this->generate_function_test(
+				$user,
+				$_function,
+				$_args,
+				array(
+					$_key => array(
+						'assert' => 'instanceof',
+						'value'  => 'WP_Error',
+					),
+				)
+			);
+			$counter++;
+		}
+
+		$this->assertSame( $counter, count( $tests ) );
+
+		return $tests;
+	}
+
+	/*
+	 * --- REST API utilities ----------------------------------------------------
+	 */
+
+	/**
+	 * Generates a test array.
+	 *
+	 * @param WP_User $user   User.
+	 * @param array   $params Request params.
+	 * @param int     $status Expected status.
+	 * @param int     $code   Expected error code.
+	 * @param array   $assertions {
+	 *    Optional. An array of assertion arrays with descriptive keys.
+	 *
+	 *    @type array $assertion {
+	 *        @type string $key    Response data array key; e.g., 'selector'.
+	 *        @type string $assert PHPUnit assert method w/o prefix; e.g., 'same'.
+	 *        @type mixed  $value  Expected value for this assertion.
+	 *    }
+	 * }
+	 * @return array Test array.
+	 */
+	protected function generate_test( $user, $params, $status, $code, $assertions = array() ) {
+		$json                  = json_encode( $params );
+		$serialized_params     = serialize( $params );
+		$serialized_assertions = serialize( $assertions );
+
+		$key = md5( $json . $serialized_params . $status . $code . $serialized_assertions );
+
+		$role   = $this->utils->get_user_role( $user );
+		$params = $this->utils->remove_nulls( $params );
+
+		return array( "{$role}:{$json}:{$key}" => array( $user, $params, $status, $code, $assertions ) );
+	}
+
+	/**
+	 * Generates a ID-specific test array.
+	 *
+	 * @param WP_User $user   User.
+	 * @param int     $id     Annotation ID.
+	 * @param array   $params Request params.
+	 * @param int     $status Expected status.
+	 * @param int     $code   Expected error code.
+	 * @param array   $assertions {
+	 *    Optional. An array of assertion arrays with descriptive keys.
+	 *
+	 *    @type array $assertion {
+	 *        @type string $key    Response data array key; e.g., 'selector'.
+	 *        @type string $assert PHPUnit assert method w/o prefix; e.g., 'same'.
+	 *        @type mixed  $value  Expected value for this assertion.
+	 *    }
+	 * }
+	 * @return array Test array.
+	 */
+	protected function generate_id_test( $user, $id, $params, $status, $code, $assertions = array() ) {
+		$json                  = json_encode( array_merge( compact( 'id' ), $params ) );
+		$serialized_params     = serialize( $params );
+		$serialized_assertions = serialize( $assertions );
+
+		$key = md5( $json . $serialized_params . $status . $code . $serialized_assertions );
+
+		$role   = $this->utils->get_user_role( $user );
+		$params = $this->utils->remove_nulls( $params );
+
+		return array( "{$role}:{$json}:{$key}" => array( $user, $id, $params, $status, $code, $assertions ) );
+	}
+
+	/**
+	 * Generates a collection test array.
+	 *
+	 * @param WP_User $user   User.
+	 * @param array   $params Request params.
+	 * @param int     $status Expected status.
+	 * @param int     $count  Expected total items.
+	 * @param int     $code   Expected error code.
+	 * @param array   $assertions {
+	 *    Optional. An array of assertion arrays with descriptive keys.
+	 *
+	 *    @type array $assertion {
+	 *        @type string $key    Response data array key; e.g., 'selector'.
+	 *        @type string $assert PHPUnit assert method w/o prefix; e.g., 'same'.
+	 *        @type mixed  $value  Expected value for this assertion.
+	 *    }
+	 * }
+	 * @return array Test array.
+	 */
+	protected function generate_collection_test( $user, $params, $status, $count, $code, $assertions = array() ) {
+		$json                  = json_encode( $params );
+		$serialized_params     = serialize( $params );
+		$serialized_assertions = serialize( $assertions );
+
+		$key = md5( $json . $serialized_params . $status . $code . $serialized_assertions );
+
+		$role   = $this->utils->get_user_role( $user );
+		$params = $this->utils->remove_nulls( $params );
+
+		return array( "{$role}:{$json}:{$key}" => array( $user, $params, $status, $count, $code, $assertions ) );
+	}
+
+	/**
+	 * Generates a function test array.
+	 *
+	 * @param WP_User  $user     User.
+	 * @param callable $function Callable.
+	 * @param array    $args     Arguments.
+	 * @param array    $assertions {
+	 *    Assertion arrays with descriptive keys.
+	 *
+	 *    @type array $assertion {
+	 *        @type string $assert PHPUnit assert method w/o prefix; e.g., 'same'.
+	 *        @type mixed  $value  Expected value for this assertion.
+	 *    }
+	 * }
+	 * @return array Test array.
+	 */
+	protected function generate_function_test( $user, $function, $args, $assertions ) {
+		$function_id           = _test_filter_build_unique_id( '', $function, 0 );
+		$serialized_args       = serialize( $args );
+		$serialized_assertions = serialize( $assertions );
+
+		$key  = md5( $function_id . $serialized_args . $serialized_assertions );
+		$role = $this->utils->get_user_role( $user );
+
+		return array( "{$role}:{$function_id}:{$key}" => array( $user, $function, $args, $assertions ) );
+	}
+
+	/**
+	 * Tests an annotation collection.
+	 *
+	 * @param WP_REST_Response $response REST API response.
+	 * @param string           $context  Exepcted response context.
+	 * @param bool             $threaded True if it's a threaded response.
+	 * @param array            $assertions {
+	 *    Optional. An array of assertion arrays with descriptive keys.
+	 *
+	 *    @type array $assertion {
+	 *        @type string $key    Response data array key; e.g., 'selector'.
+	 *        @type string $assert PHPUnit assert method w/o prefix; e.g., 'same'.
+	 *        @type mixed  $value  Expected value for this assertion.
+	 *    }
+	 * }
+	 */
+	protected function check_collection( $response, $context, $threaded, $assertions = array() ) {
+		$this->assertNotInstanceOf( 'WP_Error', $response );
+
+		$response = rest_ensure_response( $response );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'X-WP-Total', $headers );
+		$this->assertArrayHasKey( 'X-WP-TotalPages', $headers );
+
+		foreach ( $response->get_data() as $data ) {
+			$this->check_data( $data, $context, $data['_links'], $threaded, $assertions );
+		}
+	}
+
+	/**
+	 * Tests annotation data.
+	 *
+	 * @param array  $data     Response data.
+	 * @param string $context  Response context.
+	 * @param array  $links    Response links.
+	 * @param bool   $threaded True if threaded data.
+	 * @param array  $assertions {
+	 *    Optional. An array of assertion arrays with descriptive keys.
+	 *
+	 *    @type array $assertion {
+	 *        @type string $key    Response data array key; e.g., 'selector'.
+	 *        @type string $assert PHPUnit assert method w/o prefix; e.g., 'same'.
+	 *        @type mixed  $value  Expected value for this assertion.
+	 *    }
+	 * }
+	 */
+	protected function check_data( $data, $context, $links, $threaded, $assertions = array() ) {
+		$this->assertSame( true, ! empty( $data['id'] ), '!empty(id)' );
+		$annotation = get_annotation( $data['id'] );
+
+		$this->assertSame( (int) $annotation->comment_ID, $data['id'], 'id' );
+		$this->assertSame( (int) $annotation->comment_post_ID, $data['post'], 'post' );
+		$this->assertSame( (int) $annotation->comment_parent, $data['parent'], 'parent' );
+		$this->assertSame( (int) $annotation->user_id, $data['author'], 'author' );
+		$this->assertSame( $annotation->comment_author, $data['author_name'], 'author_name' );
+		$this->assertSame( $annotation->comment_author_url, $data['author_url'], 'author_url' );
+		$this->assertSame( wpautop( $annotation->comment_content ), $data['content']['rendered'], 'content[rendered]' );
+
+		// phpcs:ignore PHPCompatibility.PHP.RemovedExtensions.mysql_DeprecatedRemoved — function provided by core.
+		$this->assertSame( mysql_to_rfc3339( $annotation->comment_date ), $data['date'], 'date' ); // @codingStandardsIgnoreLine
+		$this->assertSame( mysql_to_rfc3339( $annotation->comment_date_gmt ), $data['date_gmt'], 'date_gmt' ); // @codingStandardsIgnoreLine
+
+		$this->assertSame( get_comment_link( $annotation->comment ), $data['link'], 'link' );
+		$this->assertArrayHasKey( 'author_avatar_urls', $data, 'author_avatar_urls' );
+
+		$this->assertSame( $annotation->get_meta( '_via' ), $data['via'], 'via' );
+		$this->assertSame( $annotation->get_meta( '_selector' ), $data['selector'], 'selector' );
+
+		$this->assertSame( rest_url( '/wp/v2/posts/' . $data['post'] ), $links['up'][0]['href'], 'links[up]' );
+		$this->assertSame( rest_url( '/wp/v2/users/' . $data['author'] ), $links['author'][0]['href'], 'links[author]' );
+		$this->assertSame( rest_url( $this->rest_ns_base . '/' . $data['id'] ), $links['self'][0]['href'], 'links[self]' );
+		$this->assertSame( rest_url( $this->rest_ns_base ), $links['collection'][0]['href'], 'links[collection]' );
+
+		if ( 'edit' === $context ) {
+			$this->assertSame( $annotation->comment_author_email, $data['author_email'], 'author_email' );
+			$this->assertSame( $annotation->comment_author_IP, $data['author_ip'], 'author_ip' );
+			$this->assertSame( $annotation->comment_agent, $data['author_user_agent'], 'author_user_agent' );
+			$this->assertSame( $annotation->comment_content, $data['content']['raw'], 'content[raw]' );
+		}
+
+		if ( 'edit' !== $context ) {
+			$this->assertArrayNotHasKey( 'author_email', $data, '!author_email' );
+			$this->assertArrayNotHasKey( 'author_ip', $data, '!author_ip' );
+			$this->assertArrayNotHasKey( 'author_user_agent', $data, '!author_user_agent' );
+			$this->assertArrayNotHasKey( 'raw', $data['content'], '!content[raw]' );
+		}
+
+		if ( $threaded ) {
+			$this->assertArrayHasKey( 'children', $data, 'children' );
+
+			foreach ( $data['children'] as $child ) {
+				$this->assertArrayHasKey( '_links', $child, 'child[_links]' );
+				$this->check_data( $child, $context, $child['_links'], $threaded );
+			}
+		} else {
+			$this->assertArrayNotHasKey( 'children', $data, '!children' );
+		}
+
+		foreach ( $assertions as $key => $assertion ) {
+			$this->{ 'assert' . $assertion['assert'] }(
+				$assertion['value'],
+				$this->utils->get_path( $data, $assertion['key'] ),
+				is_string( $key ) ? $key : $assertion['key']
+			);
+		}
+	}
+}

--- a/phpunit/annotations/includes/class-annotation-test-objects.php
+++ b/phpunit/annotations/includes/class-annotation-test-objects.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Annotation Test Object Factory
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Annotation test object factory.
+ */
+class Annotation_Test_Objects {
+	/**
+	 * Test case.
+	 *
+	 * @var WP_UnitTestCase
+	 */
+	protected $case;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WP_UnitTestCase $case Test case.
+	 */
+	public function __construct( $case ) {
+		$this->case = $case;
+	}
+
+	/**
+	 * Creates a user.
+	 *
+	 * @param  string $with_role With role.
+	 *
+	 * @return WP_User           New user.
+	 */
+	public function create_user( $with_role ) {
+		$user = $this->case->factory->user->create_and_get( array( 'role' => $with_role ) );
+
+		$this->case->assertTrue( $user instanceof WP_User && $user->ID );
+
+		return $user;
+	}
+
+	/**
+	 * Creates a post.
+	 *
+	 * @param  int    $by_user_id  By user ID.
+	 * @param  string $with_status With status.
+	 *
+	 * @return WP_Post             New post.
+	 */
+	public function create_post( $by_user_id, $with_status = 'publish' ) {
+		$post = $this->case->factory->post->create_and_get( array(
+			'post_type'   => 'post',
+			'post_author' => $by_user_id,
+			'post_status' => $with_status,
+		) );
+
+		$this->case->assertTrue( $post instanceof WP_Post && $post->ID );
+
+		return $post;
+	}
+
+	/**
+	 * Creates an annotation.
+	 *
+	 * @param  array $args {
+	 *     How to create annotation.
+	 *
+	 *     @type int    $in_post_id  In post ID.
+	 *     @type int    $by_user_id  By user ID.
+	 *     @type int    $in_reply_to Optional parent ID. Defaults to `0`.
+	 *     @type string $with_status Optional status. Defaults to `1`.
+	 * }
+	 * @return WP_Annotation         New annotation.
+	 */
+	public function create_annotation( $args ) {
+		$default_args = array(
+			'in_post_id'  => 0,
+			'by_user_id'  => 0,
+			'in_reply_to' => 0,
+			'with_status' => '1',
+		);
+		$args         = wp_parse_args( $args, $default_args );
+
+		$comment    = $this->case->factory->comment->create_and_get( array(
+			'comment_type'     => get_default_annotation_type(),
+			'comment_post_ID'  => $args['in_post_id'],
+			'user_id'          => $args['by_user_id'],
+			'comment_parent'   => $args['in_reply_to'],
+			'comment_approved' => $args['with_status'],
+			'comment_content'  => 'hello world',
+			'comment_meta'     => array(
+				'_via'      => 'gutenberg',
+				'_selector' => array(
+					'type'  => 'CssSelector',
+					'value' => '#foo > .bar',
+				),
+			),
+		) );
+		$annotation = get_annotation( $comment );
+
+		$this->case->assertTrue( $annotation instanceof WP_Annotation && $annotation->comment_ID );
+
+		return $annotation;
+	}
+
+	/**
+	 * Creates an associative array of users.
+	 *
+	 * @param  array|null $with_roles Optional array of role names. Default is all roles.
+	 *
+	 * @return array                  Associative array of {@see WP_User} objects.
+	 */
+	public function create_users( $with_roles = null ) {
+		$users = array();
+
+		if ( ! isset( $with_roles ) ) {
+			$with_roles = $this->case->utils->roles;
+		}
+
+		foreach ( $with_roles as $with_role ) {
+			if ( 'anonymous' === $with_role ) {
+				$users[ $with_role ] = new WP_User( 0 );
+			} else {
+				$users[ $with_role ] = $this->create_user( $with_role );
+			}
+		}
+
+		$this->case->assertNotEmpty( $users );
+
+		return $users;
+	}
+
+	/**
+	 * Creates an associative array of posts.
+	 *
+	 * @param  WP_User[] $by_users      An array of post authors.
+	 * @param  string[]  $with_statuses An array of post statuses.
+	 *
+	 * @return array                    Associative array {@see WP_Post} objects.
+	 */
+	public function create_posts( $by_users, $with_statuses = array( 'publish' ) ) {
+		$posts = array();
+
+		foreach ( $by_users as $by_user ) {
+			$by_user_role = $this->case->utils->get_user_role( $by_user );
+
+			if ( 'subscriber' === $by_user_role || 'anonymous' === $by_user_role ) {
+				continue; // Not an author user.
+			}
+
+			foreach ( $with_statuses as $with_status ) {
+				$posts[ $by_user->ID ][ $with_status ] = $this->create_post( $by_user->ID, $with_status );
+
+				if ( 'trash' === $with_status ) {
+					$id = $posts[ $by_user->ID ][ $with_status ]->ID;
+					update_post_meta( $id, '_wp_trash_meta_status', 'publish' );
+				}
+			}
+		}
+
+		$this->case->assertNotEmpty( $posts );
+
+		return $posts;
+	}
+
+	/**
+	 * Creates an associative array of annotations.
+	 *
+	 * @param  array $args {
+	 *     How to create annotations.
+	 *
+	 *     @type array     $in_posts      Collection of posts to annotate.
+	 *     @type WP_User[] $by_users      An array of annotation authors.
+	 *     @type int       $in_reply_to   Collection of parent annotations.
+	 *     @type string[]  $with_statuses An array of annotation statuses.
+	 * }
+	 * @return array Associative array of {@see WP_Annotation} objects.
+	 */
+	public function create_annotations( $args ) {
+		$default_args = array(
+			'in_posts'      => array(),
+			'by_users'      => array(),
+			'in_reply_to'   => array(),
+			'with_statuses' => array( '1' ),
+		);
+		$args         = wp_parse_args( $args, $default_args );
+		$annotations  = array();
+
+		foreach ( $args['in_posts'] as $in_post_by_author_id => $in_posts_with_statuses ) {
+			foreach ( $in_posts_with_statuses as $in_post_with_status => $in_post ) {
+				foreach ( $args['by_users'] as $by_user ) {
+
+					$by_user_role = $this->case->utils->get_user_role( $by_user );
+
+					if ( 'subscriber' === $by_user_role || 'anonymous' === $by_user_role ) {
+						continue; // Not an author user.
+					}
+
+					foreach ( $args['with_statuses'] as $with_status ) {
+
+						if ( ! empty( $args['in_reply_to'][ $in_post->ID ][ $by_user->ID ][ $with_status ] ) ) {
+							$in_reply_to_id = $args['in_reply_to'][ $in_post->ID ][ $by_user->ID ][ $with_status ]->comment_ID;
+						} else {
+							$in_reply_to_id = 0; // Top-level annotation.
+						}
+
+						$annotations[ $in_post->ID ][ $by_user->ID ][ $with_status ]
+							= $this->create_annotation( array(
+								'in_post_id'  => $in_post->ID,
+								'by_user_id'  => $by_user->ID,
+								'in_reply_to' => $in_reply_to_id,
+								'with_status' => $with_status,
+							) );
+
+						if ( 'trash' === $with_status ) {
+							$id = $annotations[ $in_post->ID ][ $by_user->ID ][ $with_status ]->comment_ID;
+							update_comment_meta( $id, '_wp_trash_meta_status', '1' );
+						}
+					}
+				}
+			}
+		}
+
+		$this->case->assertNotEmpty( $annotations );
+
+		return $annotations;
+	}
+}

--- a/phpunit/annotations/includes/class-annotation-test-utils.php
+++ b/phpunit/annotations/includes/class-annotation-test-utils.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Annotation Test Utilities
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Annotation test utilities.
+ */
+class Annotation_Test_Utils {
+	/**
+	 * Test case.
+	 *
+	 * @var WP_UnitTestCase
+	 */
+	protected $case;
+
+	/**
+	 * Roles + anonymous.
+	 *
+	 * @var string[]
+	 */
+	public $roles = array(
+		'administrator',
+		'editor',
+		'author',
+		'contributor',
+		'subscriber',
+		'anonymous',
+	);
+
+	/**
+	 * Standard meta-caps.
+	 *
+	 * @var string[]
+	 */
+	public $standard_meta_caps = array(
+		'read_annotation',
+		'edit_annotation',
+		'delete_annotation',
+	);
+
+	/**
+	 * Meta-caps that check post IDs.
+	 *
+	 * @var string[]
+	 */
+	public $post_check_meta_caps = array(
+		'create_annotation',
+		'read_annotations',
+	);
+
+	/**
+	 * Other pseudo-caps.
+	 *
+	 * @var string[]
+	 */
+	public $other_pseudo_caps = array(
+		'create_annotations',
+		'delete_annotations',
+		'delete_others_annotations',
+		'delete_private_annotations',
+		'delete_published_annotations',
+		'edit_annotations',
+		'edit_others_annotations',
+		'edit_private_annotations',
+		'edit_published_annotations',
+		'publish_annotations',
+		'read_annotations',
+		'read_private_annotations',
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WP_UnitTestCase $case Test case.
+	 */
+	public function __construct( $case ) {
+		$this->case = $case;
+	}
+
+	/**
+	 * Get a user's role.
+	 *
+	 * @param  WP_User $user User.
+	 *
+	 * @return string        Role name.
+	 */
+	public function get_user_role( $user ) {
+		return isset( $user->roles[0] ) ? $user->roles[0] : 'anonymous';
+	}
+
+	/**
+	 * Sets and returns current user.
+	 *
+	 * @param WP_User|string $user User object or role name.
+	 *
+	 * @return WP_User             Existing user, or a new user.
+	 */
+	public function set_current_user( $user ) {
+		if ( ! ( $user instanceof WP_User ) ) {
+			$role = (string) $user;
+			$user = $this->case->objects->create_user( $role );
+		}
+		wp_set_current_user( $user->ID );
+
+		return $user;
+	}
+
+	/**
+	 * Extracts IDs from a collection.
+	 *
+	 * @param  array $collection Collection.
+	 *
+	 * @return int[]             An array of IDs.
+	 */
+	public function extract_ids( $collection ) {
+		$ids = array();
+
+		foreach ( $collection as $value ) {
+			if ( is_array( $value ) ) {
+				$ids = array_merge( $ids, $this->extract_ids( $value ) );
+			} elseif ( $value instanceof WP_User || $value instanceof WP_Post ) {
+				$ids[] = (int) $value->ID;
+			} elseif ( $value instanceof WP_Annotation ) {
+				$ids[] = (int) $value->comment_ID;
+			}
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Removes null values from array or object.
+	 *
+	 * @param  array|object $collection An array or object.
+	 *
+	 * @return array|object             New array or object.
+	 */
+	public function remove_nulls( $collection ) {
+		foreach ( $collection as $key => $value ) {
+			if ( null === $value ) {
+				unset( $collection[ $key ], $collection->{ $key } );
+			}
+		}
+
+		return $collection;
+	}
+
+	/**
+	 * Gets value from an array or object by path.
+	 *
+	 * @param array|object $value   An array or object to search.
+	 * @param string       $path    A dot.path.leading.to.desired.key[0].
+	 * @param mixed        $default Default value if not found.
+	 *
+	 * @return mixed|null           The desired value, else `$default` value.
+	 */
+	public function get_path( $value, $path, $default = null ) {
+		if ( ! $value || ! $path ) {
+			return $default;
+		}
+
+		foreach ( preg_split( '/\.|\[([0-9]+)\]/', $path, -1, PREG_SPLIT_DELIM_CAPTURE ) as $key ) {
+			if ( is_array( $value ) && array_key_exists( $key, $value ) ) {
+				$value = $value[ $key ];
+			} elseif ( is_object( $value ) && property_exists( $value, $key ) ) {
+				$value = $value->{ $key };
+			} else {
+				return $default;
+			}
+		}
+
+		return $value;
+	}
+}


### PR DESCRIPTION
## Description

Alternative approaches explored: #4385 and #4386.

A WP REST API endpoint for annotations (back-end comments). Implemented as a custom comment type. The API uses the W3C annotation data model for [annotation selectors](https://www.w3.org/TR/annotation-model/#selectors) and maintains some parity with the W3C annotation object model and protocol — while still doing things the WordPress way, which maximizes compatibility with WP REST API utilities, including those in JavaScript.

### Overview of Changes

#### Introduces:

- `lib/class-wp-annotation-caps.php` to deal with annotation capabilities.
- `lib/class-wp-rest-annotations-controller.php` is the REST API controller.
- `lib/class-wp-annotation-utils.php` are a few annotation utilities.

#### Modifies:

- `lib/load.php`
- `lib/register.php`

#### Near 100% coverage by unit tests

- see: `phpunit/annotations/*`

## API Documentation

**See:** 📄  [https://speca.io/jaswrks/wp-annotations](https://speca.io/jaswrks/wp-annotations)

## How can you test the WP REST API for Annotations?

- Install the [Basic Auth](https://github.com/WP-API/Basic-Auth) plugin for the WP REST API. This allows you to run tests with only a username/password via Postman.

  - Or, simply create this directory and file, which forces the current user to `1` while testing. If you go this route, be sure to delete the file after testing.
  `wp-content/mu-plugins/rest-api-auth-bypass.php`
    ```php
      <?php
      add_action( 'rest_api_init', function() {
          wp_set_current_user( 1 ); // Assuming admin is user ID 1.
          // It's worth testing other roles too; e.g., editor, author, contributor, subscriber.
      } );
    ```

- Now, visit [this page](https://documenter.getpostman.com/view/2613712/collection/7TNeqaX) and click "[Run in Postman](https://documenter.getpostman.com/view/2613712/collection/7TNeqaX)". You can then run your own tests locally in [Postman](https://www.getpostman.com/). Either that, or follow along with the [Annotation API docs](https://speca.io/jaswrks/wp-annotations) and run your own tests over HTTP in any other way you'd like.

  [![2018-01-25_16-17-27](https://user-images.githubusercontent.com/1563559/35420660-4573f34a-01eb-11e8-8505-ea52bd6d16e3.png)](https://documenter.getpostman.com/view/2613712/collection/7TNeqaX)


## How Has This Been Tested?
- Postman (as described above)
- Several unit tests are included with this PR.

## Types of changes
- This approach uses a custom comment type instead of a custom post type.
- This PR strips away support for front-end annotations. Front-end annotations [were explored in a prior PR for the REST API](https://github.com/WordPress/gutenberg/pull/4386), but not a concern at this time.

---

This approach requires a comment query filter to keep annotations out of the comments admin area, and away from plugins that might mistake them as being a more typical comment type. In this PR, the following alters `comments_clauses` in core.

```php
/**
 * Filters WP_Comment_Query clauses.
 *
 * @param  array            $pieces Array of comment query clauses.
 * @param  WP_Comment_Query $query  Current WP_Comment_Query instance.
 *
 * @return array                    Array of comment query clauses.
 */
public static function on_comments_clauses( $pieces, $query ) {
	global $wpdb;

	/*
	 * When cache_domain is 'annotations', only then will annotations be returned by WP_Comment_Query.
	 * Otherwise, if cache_domain is not 'annotations', annotation comment types cannot be returned whatsoever.
	 *
	 * The point being that we want to keep annotations out of any normal comment query performed by core,
	 * and also keep them away from comment-related plugins; i.e., annotations will be unexpected by most plugins.
	 * If a plugin *does* want to query annotations, they should set cache_domain to 'annotations'.
	 */
	if ( 'annotations' !== $query->query_vars['cache_domain'] ) {
		$annotation_types = self::$types;

		foreach ( $annotation_types as &$_type ) {
			$_type = $wpdb->prepare( '%s', $_type );
		}
		$pieces['where'] .= $pieces['where'] ? ' AND ' : '';
		$pieces['where'] .= 'comment_type NOT IN (' . implode( ', ', $annotation_types ) . ')';
	}

	return $pieces;
}
```

## Back-End Annotation Permissions

### Simplified Explanation

- If you can `edit_posts`, and you can `edit_post` (this post). Or, _if you're the post author_. Then you can read all, and create, edit, delete your own back-end annotations in this post.

- Administrators and Editors can edit and delete any post, so they can read, edit, and delete any annotation without restriction.

- Subscribers and the public have no access to back-end annotations whatsoever.

![back-end-permissions](https://user-images.githubusercontent.com/1563559/35069028-6765811a-fb85-11e7-9a58-fa90b676ccb0.png)


## TODO

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [x] Expand unit test coverage.
- [x] Fix bugs found by @chriskmnds. Noted in comments.

## Non-Blocking TODOs

- [x] Refactor `WP_Annotation_Utils::on_map_meta_cap()` — move logic in each 'case' to a separate function, making a somewhat complex routine easier to follow along with.
- [x] Polish unit tests; e.g., use test generators.
- [x] Move capability-related methods to their own class.
- [x] Remove useless comments in caps class.
- [x] Cleanup comments in utils class.
- [x] Add tests that check valid/invalid UTF-8 sequences.
- [x] Add tests that consider unfiltered HTML.
- [x] fix: Check empty content before & after filters.
- [x] Add tests for annotations in trashed posts.
- [x] Add tests against WP_Comment_Query filters.
- [x] Test setting all comment statuses.
- [x] Cover all selector types in unit tests.
- [x] Test cap checks with missing/invalid args.
- [x] Add tests that expand coverage in REST controller.
- [x] Add tests that expand coverage in utils.
- [x] Fill in any remaining test coverage gaps.
- [x] Document code coverage.
  ```text
  @WP.Annotation::WP_Annotation_Caps
    Methods:  71.43% ( 5/ 7)   Lines:  96.58% (113/117)
  @WP.Annotation::WP_Annotation_Utils
    Methods:  66.67% (10/15)   Lines:  97.71% (256/262)
  @WP.REST.Annotations::WP_REST_Annotations_Controller
    Methods:  85.00% (17/20)   Lines:  98.64% (364/369)
  ```
- [x] Try simplifying cap handlers, https://github.com/WordPress/gutenberg/pull/4685#discussion_r165098655
- [x] Document args to cap handlers, https://github.com/WordPress/gutenberg/pull/4685#discussion_r165092469
- [x] Comment on status considerations in cap handlers, https://github.com/WordPress/gutenberg/pull/4685#discussion_r165096973
- [ ] ~~Consider typehinting WP_REST_Request, https://github.com/WordPress/gutenberg/pull/4685#discussion_r165101602~~
- [ ] Replace `@since [version]` with version in docBlocks.

## Client Side Exploration of Selectors

**jsFiddle:** Building and highlighting a W3C Annotation Selector using XPath.
https://jsfiddle.net/jaswrks/1cLaeyfd/