### PR TITLE
Fix for drop-down "New Post" button to remove hacky code - Fixes #4682

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -389,38 +389,6 @@ function gutenberg_add_edit_link( $actions, $post ) {
 }
 
 /**
- * Sets the default behaviour for the "Add New" button to go to the classic editor.
- * If JavaScript is enabled, this will be replaced by a button that goes to Gutenberg.
- *
- * @since 1.5.0
- *
- * @param string $url  The URL to modify.
- * @param string $path The path part of $url.
- *
- * @return string The URL with the classic-editor parameter added.
- */
-function gutenberg_modify_add_new_button_url( $url, $path ) {
-	global $pagenow;
-
-	if ( 'edit.php' !== $pagenow ) {
-		return $url;
-	}
-
-	if ( ! preg_match( '/^post-new.php(\?post_type=[^&]*)?$/', $path ) ) {
-		return $url;
-	}
-
-	// The Add New button should be the only thing calling admin_url() from global scope.
-	$stack = wp_debug_backtrace_summary( null, 0, false );
-	if ( 'admin_url' !== end( $stack ) ) {
-		return $url;
-	}
-
-	return add_query_arg( 'classic-editor', '', $url );
-}
-add_filter( 'admin_url', 'gutenberg_modify_add_new_button_url', 10, 2 );
-
-/**
  * Prints the JavaScript to replace the default "Add New" button.$_COOKIE
  *
  * @since 1.5.0
@@ -517,13 +485,14 @@ function gutenberg_replace_default_add_new_button() {
 			}
 
 			var url = button.href;
-			var newUrl = url.replace( /[&\?]?classic-editor/, '' );
+			var urlHasParams = ( -1 !== url.indexOf( '?' ) ); 
+			var classicUrl = url + ( urlHasParams ? '&' : '?' ) + 'classic-editor';
 
 			var newbutton = '<span id="split-page-title-action" class="split-page-title-action">';
-			newbutton += '<a href="' + newUrl + '">' + button.innerText + '</a>';
+			newbutton += '<a href="' + url + '">' + button.innerText + '</a>';
 			newbutton += '<span class="expander" tabindex="0" role="button" aria-haspopup="true" aria-label="<?php echo esc_js( __( 'Toggle editor selection menu', 'gutenberg' ) ); ?>"></span>';
-			newbutton += '<span class="dropdown"><a href="' + newUrl + '">Gutenberg</a>';
-			newbutton += '<a href="' + url + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span><span class="page-title-action" style="display:none;"></span>';
+			newbutton += '<span class="dropdown"><a href="' + url + '">Gutenberg</a>';
+			newbutton += '<a href="' + classicUrl + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span><span class="page-title-action" style="display:none;"></span>';
 
 			button.insertAdjacentHTML( 'afterend', newbutton );
 			button.remove();


### PR DESCRIPTION
This makes the button work in environments that run WordPress in non-global scope, such as Laravel Valet. It's an alternative solution to #4683 that attempts to fix #4682

## Description
Removed hacky code that sets default URL for New Post button.
Modify JS that "fixed" this URL for the classic editor.

## How Has This Been Tested?

Manually on my local Laravel Valet environment. You may want to test it in other environments.

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected):

Arguably if you have JS turned off then then New Post button no longer works. But then, none of the other new post links around the place work either, so this seems OK.

## Checklist:
- [X] My code is tested.
- [?] My code follows the WordPress code style.
- [X] My code has proper inline documentation.
