### PR TITLE
Issue #4455 - filter out custom taxonomies that have been overridden …

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -126,6 +126,9 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 					if ( isset( $data['callback'] ) && in_array( $data['callback'], $taxonomy_callbacks_to_unset ) ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
+					if ( isset( $data['args']['__original_callback'] )  && in_array( $data['args']['__original_callback'], $taxonomy_callbacks_to_unset ) ) {
+						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
+					}
 					// Filter out meta boxes that are just registered for back compat.
 					if ( isset( $data['args']['__back_compat_meta_box'] ) && $data['args']['__back_compat_meta_box'] ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -176,11 +176,17 @@ add_filter( 'filter_gutenberg_meta_boxes', 'gutenberg_filter_meta_boxes' );
  */
 function gutenberg_intercept_meta_box_render() {
 	global $wp_meta_boxes;
+	/** This filter is documented in lib/meta-box-partial-page.php */
+	$filtered_meta_boxes = apply_filters( 'filter_gutenberg_meta_boxes', $wp_meta_boxes );
 
 	foreach ( $wp_meta_boxes as $post_type => $contexts ) {
 		foreach ( $contexts as $context => $priorities ) {
 			foreach ( $priorities as $priority => $boxes ) {
 				foreach ( $boxes as $id => $box ) {
+					// Don't override meta boxes that Gutenberg handles itself.
+					if ( ! isset( $filtered_meta_boxes[ $post_type ][ $context ][ $priority ][ $id ] ) ) {
+						continue;
+					}
 					if ( ! is_array( $box ) ) {
 						continue;
 					}

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -126,9 +126,6 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 					if ( isset( $data['callback'] ) && in_array( $data['callback'], $taxonomy_callbacks_to_unset ) ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
-					if ( isset( $data['args']['__original_callback'] ) && in_array( $data['args']['__original_callback'], $taxonomy_callbacks_to_unset ) ) {
-						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
-					}
 					// Filter out meta boxes that are just registered for back compat.
 					if ( isset( $data['args']['__back_compat_meta_box'] ) && $data['args']['__back_compat_meta_box'] ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -126,7 +126,7 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 					if ( isset( $data['callback'] ) && in_array( $data['callback'], $taxonomy_callbacks_to_unset ) ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
-					if ( isset( $data['args']['__original_callback'] )  && in_array( $data['args']['__original_callback'], $taxonomy_callbacks_to_unset ) ) {
+					if ( isset( $data['args']['__original_callback'] ) && in_array( $data['args']['__original_callback'], $taxonomy_callbacks_to_unset ) ) {
 						unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
 					}
 					// Filter out meta boxes that are just registered for back compat.


### PR DESCRIPTION
…by gutenberg_override_meta_box_callback

## Description
Adds another test to see if a meta box for a custom taxonomy should be filtered out of the list of taxonomies destined for the Extended setting area.

The change is described in https://github.com/bobbingwide/oik-a2z/issues/8

I did not remove the test that failed to find the custom taxonomy by comparing directly against callback.
This is belt and braces; I don't know all the cases where the filter function is invoked. 
<!-- Please describe your changes -->

## How Has This Been Tested?
Tested manually using a custom letter taxonomy attached to posts.  
Screen captures show before and after.
Note: In the screenshots the custom taxonomy was manually marked as `show_in_rest`, so it appeared in the Categories & Tags block.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/2474435/35435783-e3b741e0-0283-11e8-9385-0f548e24f2a9.png)
![image](https://user-images.githubusercontent.com/2474435/35436205-6f6f1806-0285-11e8-8301-b05015466472.png)

## Types of changes
Fixes #4455.

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
