### PR TITLE
Editor HTML: Give #poststuff div a broader scope; remove unused #postbox-container-2

### DIFF
--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -54,7 +54,7 @@ function Layout( {
 			<UnsavedChangesWarning />
 			<AutosaveMonitor />
 			<Header />
-			<div className="edit-post-layout__content" role="region" aria-label={ __( 'Editor content' ) } tabIndex="-1">
+			<div id="poststuff" className="edit-post-layout__content" role="region" aria-label={ __( 'Editor content' ) } tabIndex="-1">
 				<EditorNotices />
 				<div className="edit-post-layout__editor">
 					<EditorModeKeyboardShortcuts />

--- a/editor/components/meta-boxes/meta-boxes-area/style.scss
+++ b/editor/components/meta-boxes/meta-boxes-area/style.scss
@@ -44,10 +44,6 @@
 			margin: 0;
 		}
 
-		input {
-			max-width: 300px;
-		}
-
 		input,
 		select,
 		textarea {

--- a/editor/components/meta-boxes/meta-boxes-area/style.scss
+++ b/editor/components/meta-boxes/meta-boxes-area/style.scss
@@ -22,6 +22,9 @@
 		box-sizing: border-box;
 		color: $dark-gray-500;
 		font-weight: 600;
+		font-size: 14px;
+		line-height: 1.4;
+		margin: 0;
 		outline: none;
 		padding: 15px;
 		position: relative;

--- a/editor/components/meta-boxes/meta-boxes-area/style.scss
+++ b/editor/components/meta-boxes/meta-boxes-area/style.scss
@@ -1,96 +1,97 @@
 
-.editor-meta-boxes-area {
+/* Include #poststuff to override the css rules found in core. */
+#poststuff .editor-meta-boxes-area {
 	position: relative;
 
-		/* Match width and positioning of the meta boxes. Override default styles. */
+	/* Match width and positioning of the meta boxes. Override default styles. */
 	.postbox-container {
 		margin: 0 auto;
 		padding-top: 0;
-		width: 100%
-	}
-
-	#post {
-		margin: 0;
-	}
-
-	/* Override Default meta box stylings */
-
-	.postbox h3.hndle,
-	.postbox .stuffbox > h3,
-	.postbox h2.hndle { /* WordPress selectors yolo */
-		border-bottom: 1px solid $light-gray-500;
-		box-sizing: border-box;
-		color: $dark-gray-500;
-		font-weight: 600;
-		font-size: 14px;
-		line-height: 1.4;
-		margin: 0;
-		outline: none;
-		padding: 15px;
-		position: relative;
 		width: 100%;
-	}
 
-	.postbox {
-		border: 0;
-		color: $dark-gray-500;
-		margin-bottom: 0;
-	}
+		#post {
+			margin: 0;
+		}
 
-	.postbox > .inside {
-		border-bottom: 1px solid $light-gray-500;
-		color: $dark-gray-500;
-		padding: 15px;
-		margin: 0;
-	}
+		/* Override Default meta box stylings */
 
-	input {
-		max-width: 300px;
-	}
+		.postbox h3.hndle,
+		.postbox .stuffbox > h3,
+		.postbox h2.hndle { /* WordPress selectors yolo */
+			border-bottom: 1px solid $light-gray-500;
+			box-sizing: border-box;
+			color: $dark-gray-500;
+			font-weight: 600;
+			font-size: 14px;
+			line-height: 1.4;
+			margin: 0;
+			outline: none;
+			padding: 15px;
+			position: relative;
+			width: 100%;
+		}
 
-	input,
-	select,
-	textarea {
-		background: inherit;
-		border: 1px solid $light-gray-500;
-		border-radius: 4px;
-		box-shadow: none;
-		color: $dark-gray-800;
-		display: inline-block;
-		font-family: inherit;
-		font-size: 13px;
-		line-height: 24px;
-		outline: none;
-		padding: 4px;
-	}
+		.postbox {
+			border: 0;
+			color: $dark-gray-500;
+			margin-bottom: 0;
+		}
 
-	input:hover,
-	select:hover,
-	textarea:hover {
-		border: 1px solid $light-gray-700;
-	}
+		.postbox > .inside {
+			border-bottom: 1px solid $light-gray-500;
+			color: $dark-gray-500;
+			padding: 15px;
+			margin: 0;
+		}
 
-	.postbox .handlediv {
-		height: 44px;
-		width: 44px;
-	}
+		input {
+			max-width: 300px;
+		}
 
-	&.is-loading:before {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		content: '';
-		background: transparent;
-		z-index: z-index( '.editor-meta-boxes-area.is-loading:before');
-	}
+		input,
+		select,
+		textarea {
+			background: inherit;
+			border: 1px solid $light-gray-500;
+			border-radius: 4px;
+			box-shadow: none;
+			color: $dark-gray-800;
+			display: inline-block;
+			font-family: inherit;
+			font-size: 13px;
+			line-height: 24px;
+			outline: none;
+			padding: 4px;
+		}
 
-	.spinner {
-		position: absolute;
-		top: 10px;
-		right: 20px;
-		z-index: z-index( '.editor-meta-boxes-area .spinner');
+		input:hover,
+		select:hover,
+		textarea:hover {
+			border: 1px solid $light-gray-700;
+		}
+
+		.postbox .handlediv {
+			height: 44px;
+			width: 44px;
+		}
+
+		&.is-loading:before {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			content: '';
+			background: transparent;
+			z-index: z-index( '.editor-meta-boxes-area.is-loading:before');
+		}
+
+		.spinner {
+			position: absolute;
+			top: 10px;
+			right: 20px;
+			z-index: z-index( '.editor-meta-boxes-area .spinner');
+		}
 	}
 }
 

--- a/editor/components/meta-boxes/meta-boxes-area/style.scss
+++ b/editor/components/meta-boxes/meta-boxes-area/style.scss
@@ -3,10 +3,10 @@
 	position: relative;
 
 		/* Match width and positioning of the meta boxes. Override default styles. */
-	#poststuff {
+	.postbox-container {
 		margin: 0 auto;
 		padding-top: 0;
-		min-width: auto;
+		width: 100%
 	}
 
 	#post {
@@ -15,9 +15,9 @@
 
 	/* Override Default meta box stylings */
 
-	#poststuff h3.hndle,
-	#poststuff .stuffbox > h3,
-	#poststuff h2.hndle { /* WordPress selectors yolo */
+	.postbox h3.hndle,
+	.postbox .stuffbox > h3,
+	.postbox h2.hndle { /* WordPress selectors yolo */
 		border-bottom: 1px solid $light-gray-500;
 		box-sizing: border-box;
 		color: $dark-gray-500;

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -314,7 +314,7 @@ function the_gutenberg_metaboxes() {
 		<?php foreach ( $locations as $location ) : ?>
 			<form class="metabox-location-<?php echo esc_attr( $location ); ?>">
 				<div class="sidebar-open">
-					<div id="postbox-container-2" class="postbox-container">
+					<div class="postbox-container">
 						<?php
 						do_meta_boxes(
 							$current_screen,

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -310,7 +310,7 @@ function the_gutenberg_metaboxes() {
 	<form class="metabox-base-form">
 	<?php gutenberg_meta_box_post_form_hidden_fields( $post ); ?>
 	</form>
-	<div id="poststuff">
+	<div class="metabox-location-container">
 		<?php foreach ( $locations as $location ) : ?>
 			<form class="metabox-location-<?php echo esc_attr( $location ); ?>">
 				<div class="sidebar-open">

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -310,21 +310,23 @@ function the_gutenberg_metaboxes() {
 	<form class="metabox-base-form">
 	<?php gutenberg_meta_box_post_form_hidden_fields( $post ); ?>
 	</form>
-	<?php foreach ( $locations as $location ) : ?>
-		<form class="metabox-location-<?php echo esc_attr( $location ); ?>">
-			<div id="poststuff" class="sidebar-open">
-				<div id="postbox-container-2" class="postbox-container">
-					<?php
-					do_meta_boxes(
-						$current_screen,
-						$location,
-						$post
-					);
-					?>
+	<div id="poststuff">
+		<?php foreach ( $locations as $location ) : ?>
+			<form class="metabox-location-<?php echo esc_attr( $location ); ?>">
+				<div class="sidebar-open">
+					<div id="postbox-container-2" class="postbox-container">
+						<?php
+						do_meta_boxes(
+							$current_screen,
+							$location,
+							$post
+						);
+						?>
+					</div>
 				</div>
-			</div>
-		</form>
-	<?php endforeach; ?>
+			</form>
+		<?php endforeach; ?>
+	</div>
 	<?php
 
 	// Reset meta box data.


### PR DESCRIPTION
## Description
Removed some duplicate IDs which are printed in the metabox area.
This is somewhat in reference to https://github.com/WordPress/gutenberg/issues/2375

## How Has This Been Tested?
`npm test`

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Gave `#poststuff` a broader scope as it wraps the entire editor in classic.
Removed `#postbox-container-2` as it is not being used at all.

## Checklist:
I believe I am all set with these items, but I'd appreciate some outside help 
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
