### PR TITLE
Data Module: Fix multi-store persistence

### DIFF
--- a/data/persist.js
+++ b/data/persist.js
@@ -8,15 +8,16 @@ import { get } from 'lodash';
  *
  * @param {Function} reducer    The reducer to enhance.
  * @param {string}   reducerKey The reducer key to persist.
+ * @param {string}   storageKey The storage key to use.
  *
  * @returns {Function} Enhanced reducer.
  */
-export function withRehydratation( reducer, reducerKey ) {
+export function withRehydratation( reducer, reducerKey, storageKey ) {
 	// EnhancedReducer with auto-rehydration
 	const enhancedReducer = ( state, action ) => {
 		const nextState = reducer( state, action );
 
-		if ( action.type === 'REDUX_REHYDRATE' ) {
+		if ( action.type === 'REDUX_REHYDRATE' && action.storageKey === storageKey ) {
 			return {
 				...nextState,
 				[ reducerKey ]: action.payload,
@@ -51,6 +52,7 @@ export function loadAndPersist( store, reducer, reducerKey, storageKey ) {
 		store.dispatch( {
 			type: 'REDUX_REHYDRATE',
 			payload: persistedState,
+			storageKey,
 		} );
 	}
 

--- a/data/test/persist.js
+++ b/data/test/persist.js
@@ -17,7 +17,7 @@ describe( 'loadAndPersist', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( withRehydratation( reducer, 'preferences' ) );
+		const store = createStore( withRehydratation( reducer, 'preferences', storageKey ) );
 		loadAndPersist(
 			store,
 			reducer,
@@ -25,6 +25,24 @@ describe( 'loadAndPersist', () => {
 			storageKey,
 		);
 		expect( store.getState().preferences ).toEqual( { chicken: true, ribs: true } );
+	} );
+
+	it( 'should not load the initial value from the local storage if the storage key is different.', () => {
+		const storageKey = 'dumbStorageKey';
+		window.localStorage.setItem( storageKey, JSON.stringify( { chicken: true } ) );
+		const reducer = () => {
+			return {
+				preferences: { ribs: true },
+			};
+		};
+		const store = createStore( withRehydratation( reducer, 'preferences', storageKey + 'change' ) );
+		loadAndPersist(
+			store,
+			reducer,
+			'preferences',
+			storageKey,
+		);
+		expect( store.getState().preferences ).toEqual( { ribs: true } );
 	} );
 
 	it( 'should persist to local storage once the state value changes', () => {
@@ -44,7 +62,7 @@ describe( 'loadAndPersist', () => {
 				preferences: { ribs: true },
 			};
 		};
-		const store = createStore( withRehydratation( reducer, 'preferences' ) );
+		const store = createStore( withRehydratation( reducer, 'preferences', storageKey ) );
 		loadAndPersist(
 			store,
 			reducer,
@@ -72,7 +90,7 @@ describe( 'loadAndPersist', () => {
 		// store preferences without the `counter` default
 		window.localStorage.setItem( storageKey, JSON.stringify( {} ) );
 
-		const store = createStore( withRehydratation( reducer, 'preferences' ) );
+		const store = createStore( withRehydratation( reducer, 'preferences', storageKey ) );
 		loadAndPersist(
 			store,
 			reducer,
@@ -102,7 +120,7 @@ describe( 'loadAndPersist', () => {
 
 		window.localStorage.setItem( storageKey, JSON.stringify( { counter: 1 } ) );
 
-		const store = createStore( withRehydratation( reducer, 'preferences' ) );
+		const store = createStore( withRehydratation( reducer, 'preferences', storageKey ) );
 
 		loadAndPersist(
 			store,

--- a/edit-post/store/index.js
+++ b/edit-post/store/index.js
@@ -18,7 +18,7 @@ const STORAGE_KEY = `WP_EDIT_POST_PREFERENCES_${ window.userSettings.uid }`;
 const MODULE_KEY = 'core/edit-post';
 
 const store = applyMiddlewares(
-	registerReducer( MODULE_KEY, withRehydratation( reducer, 'preferences' ) )
+	registerReducer( MODULE_KEY, withRehydratation( reducer, 'preferences', STORAGE_KEY ) )
 );
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 enhanceWithBrowserSize( store, BREAK_MEDIUM );

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -22,7 +22,7 @@ const STORAGE_KEY = `GUTENBERG_PREFERENCES_${ window.userSettings.uid }`;
 const MODULE_KEY = 'core/editor';
 
 const store = applyMiddlewares(
-	registerReducer( MODULE_KEY, withRehydratation( reducer, 'preferences' ) )
+	registerReducer( MODULE_KEY, withRehydratation( reducer, 'preferences', STORAGE_KEY ) )
 );
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 


### PR DESCRIPTION
closes #4695

This PR fixes the persist middleware for multiple-stores. 
The issue was that we were rehydrating both states at the same time with the same value because the reducer was not able to differentiate the actions. The fix adds the storageKey as a parameter to the rehydrate action.

**Testing instructions**

 - Clear localstorage
 - Open the editor
 - It should load