### PR TITLE
Improve interception functions.

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -181,12 +181,14 @@ function gutenberg_intercept_edit_post() {
 		return;
 	}
 
-	if ( isset( $_GET['post'] ) ) {
-		$post_ID = (int) $_GET['post'];
-		$post_id = $post_ID;
+	if ( empty( $_GET['post'] ) ) {
+		return;
 	}
 
-	if ( empty( $post_id ) ) {
+	$post_ID = (int) $_GET['post'];
+	$post_id = $post_ID;
+
+	if ( ! $post_id ) {
 		return;
 	}
 
@@ -204,7 +206,7 @@ function gutenberg_intercept_edit_post() {
 		return;
 	}
 
-	if ( ! in_array( $typenow, get_post_types( array( 'show_ui' => true ) ) ) ) {
+	if ( ! in_array( $typenow, get_post_types( array( 'show_ui' => true ) ), true ) ) {
 		return;
 	}
 
@@ -212,7 +214,7 @@ function gutenberg_intercept_edit_post() {
 		return;
 	}
 
-	if ( 'trash' == $post->post_status ) {
+	if ( 'trash' === $post->post_status ) {
 		return;
 	}
 
@@ -226,12 +228,11 @@ function gutenberg_intercept_edit_post() {
 	$editing = true;
 	$title   = $post_type_object->labels->edit_item;
 
-	$post_type = $post->post_type;
-	if ( 'post' == $post_type ) {
+	if ( 'post' === $post_type ) {
 		$parent_file   = 'edit.php';
 		$submenu_file  = 'edit.php';
 		$post_new_file = 'post-new.php';
-	} elseif ( 'attachment' == $post_type ) {
+	} elseif ( 'attachment' === $post_type ) {
 		$parent_file   = 'upload.php';
 		$submenu_file  = 'upload.php';
 		$post_new_file = 'media-new.php';
@@ -261,17 +262,17 @@ function gutenberg_intercept_post_new() {
 
 	if ( ! isset( $_GET['post_type'] ) ) {
 		$post_type = 'post';
-	} elseif ( in_array( $_GET['post_type'], get_post_types( array( 'show_ui' => true ) ) ) ) {
+	} elseif ( in_array( $_GET['post_type'], get_post_types( array( 'show_ui' => true ) ), true ) ) {
 		$post_type = $_GET['post_type'];
 	} else {
 		return;
 	}
 	$post_type_object = get_post_type_object( $post_type );
 
-	if ( 'post' == $post_type ) {
+	if ( 'post' === $post_type ) {
 		$parent_file  = 'edit.php';
 		$submenu_file = 'post-new.php';
-	} elseif ( 'attachment' == $post_type ) {
+	} elseif ( 'attachment' === $post_type ) {
 		if ( wp_redirect( admin_url( 'media-new.php' ) ) ) {
 			exit;
 		}

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -181,16 +181,12 @@ function gutenberg_intercept_edit_post() {
 		return;
 	}
 
-	if ( empty( $_GET['post'] ) ) {
+	if ( empty( $_GET['post'] ) || ! is_numeric( $_GET['post'] ) ) {
 		return;
 	}
 
 	$post_ID = (int) $_GET['post'];
 	$post_id = $post_ID;
-
-	if ( ! $post_id ) {
-		return;
-	}
 
 	$post = get_post( $post_id );
 


### PR DESCRIPTION
## Description
Overall improved version of the `gutenberg_intercept_*` functions.

## Types of changes
* Strict checking (also for `in_array`).
* Switch early return logic in case of missing post for edit.
* Deleted redundant definition of `$post_type`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.