### PR TITLE
Prioritize specific blocks (e.g. Gallery) over Shortcode block during conversion

### DIFF
--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -35,6 +35,26 @@ import * as video from './video';
 
 export const registerCoreBlocks = () => {
 	[
+		// FIXME: Temporary fix.
+		//
+		// The Shortcode block declares a catch-all shortcode transform,
+		// meaning it will attempt to intercept pastes and block conversions of
+		// any valid shortcode-like content. Other blocks (e.g. Gallery) may
+		// declare specific shortcode transforms (e.g. `[gallery]`), with which
+		// this block would conflict. Thus, the Shortcode block needs to be
+		// registered as early as possible, so that any other block types'
+		// shortcode transforms can be honoured.
+		//
+		// This isn't a proper solution, as it is at odds with the
+		// specification of shortcode conversion, in the sense that conversion
+		// is explicitly independent of block order. Thus, concurrent parse
+		// rules (i.e. a same text input can yield two different transforms,
+		// like `[gallery] -> { Gallery, Shortcode }`) are unsupported,
+		// yielding non-deterministic results. A proper solution could be to
+		// let the editor (or site owners) determine a default block handler of
+		// unknown shortcodes — see `setUnknownTypeHandlerName`.
+		shortcode,
+
 		audio,
 		button,
 		categories,
@@ -57,7 +77,6 @@ export const registerCoreBlocks = () => {
 		quote,
 		reusableBlock,
 		separator,
-		shortcode,
 		subhead,
 		table,
 		textColumns,


### PR DESCRIPTION
Fixes regression identified in https://github.com/WordPress/gutenberg/pull/4514#issuecomment-360873293 whereby freeform-to-block conversion and pasting of known shortcodes, such as `[gallery]` was intercepted by the generic Shortcode block.

## Description
Read comment in diff for details. The gist is that shortcode conversion doesn't support concurrent shortcode transforms, in that there is no explicit prioritization mechanism to handle conflicting matches. A proper solution is underway, but until then this quick fix restores registration order to its state before #4514.

## How Has This Been Tested?
1. Open Gutenberg.
2. Paste `[gallery]` or some custom transform-enabled shortcode.
3. Make sure that the specific block (e.g. Shortcode) is inserted.
4. Paste an unknown shortcode (`[sfoihergv]`).
5. Make sure that a Shortcode block is inserted.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
