### PR TITLE
State: Assign default for all allowed blockTypes

### DIFF
--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -36,6 +36,9 @@ const DEFAULT_SETTINGS = {
 	// This is current max width of the block inner area
 	// It's used to constraint image resizing and this value could be overriden later by themes
 	maxWidth: 608,
+
+	// Allowed block types for the editor, defaulting to true (all supported).
+	blockTypes: true,
 };
 
 class EditorProvider extends Component {


### PR DESCRIPTION
Related: #3745

This pull request seeks to define a default value for the `EditorProvider` `blockTypes` setting. As implemented, this is only respected if explicitly provided. This is true for the top-level editor, passed from the [server-side `client-assets.php` script enqueuing](https://github.com/WordPress/gutenberg/blob/0f6dd64e1e5f33d274659eeecf06f150330be8a7/lib/client-assets.php#L905-L911), but as discovered in the original implementation of #3745 with nested editor providers, would result in an error if not provided. The changes here provide this default which, while not currently used, reduces fragility of the provider usage.

__Testing instructions:__

There should be no changes in behavior, specifically note lack of regressions in behavior of allowed block types.