### PR TITLE
Components: Persist withFocusOutside event for async usage

### DIFF
--- a/components/higher-order/with-focus-outside/index.js
+++ b/components/higher-order/with-focus-outside/index.js
@@ -27,7 +27,10 @@ function withFocusOutside( WrappedComponent ) {
 		}
 
 		queueBlurCheck( event ) {
-			this.isBlurring = true;
+			// React does not allow using an event reference asynchronously
+			// due to recycling behavior, except when explicitly persisted.
+			event.persist();
+
 			this.blurCheckTimeout = setTimeout( () => {
 				if ( 'function' === typeof this.node.handleFocusOutside ) {
 					this.node.handleFocusOutside( event );
@@ -36,7 +39,6 @@ function withFocusOutside( WrappedComponent ) {
 		}
 
 		cancelBlurCheck() {
-			delete this.isBlurring;
 			clearTimeout( this.blurCheckTimeout );
 		}
 


### PR DESCRIPTION
Related: #3745

This pull request seeks to refactor the `withFocusOutside` behavior to...

1. Properly persist event to be used asynchronously, since it is passed as an argument after a timeout
2. Remove an unused `isBlurring` instance variable in the generated component class

See: https://reactjs.org/docs/events.html#event-pooling

__Testing instructions:__

Verify there are no regressions in the behavior of `withFocusOutside` (currently used in dismissing the autocomplete component).