### PR TITLE
Refactor WP_Block_Type::render() logic.

### DIFF
--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -108,17 +108,13 @@ class WP_Block_Type {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = null ) {
-		if ( ! is_callable( $this->render_callback ) ) {
-			if ( ! $content ) {
-				return '';
-			}
+		if ( is_callable( $this->render_callback ) ) {
+			$attributes = $this->prepare_attributes_for_render( $attributes );
 
-			return $content;
+			return (string) call_user_func( $this->render_callback, $attributes, $content );
 		}
 
-		$attributes = $this->prepare_attributes_for_render( $attributes );
-
-		return call_user_func( $this->render_callback, $attributes, $content );
+		return (string) $content;
 	}
 
 	/**

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -36,6 +36,8 @@ function _manually_load_plugin() {
 
 	// Require dummy block type class for testing.
 	require_once dirname( __FILE__ ) . '/class-wp-dummy-block-type.php';
+	// Require string type class for testing.
+	require_once dirname( __FILE__ ) . '/class-wp-string-type.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -52,15 +52,37 @@ class Block_Type_Test extends WP_UnitTestCase {
 	}
 
 	function test_render_without_callback() {
-		$attributes = array(
-			'foo' => 'bar',
-			'bar' => 'foo',
-		);
+		$attributes = array();
 		$content    = '<p>Test content.</p>';
 
 		$block_type = new WP_Block_Type( 'core/dummy' );
 		$output     = $block_type->render( $attributes, $content );
 		$this->assertSame( $content, $output );
+	}
+
+	function test_render_without_arguments() {
+		$block_type = new WP_Block_Type( 'core/dummy' );
+		$output     = $block_type->render();
+		$this->assertSame( '', $output );
+	}
+
+	function test_render_without_callback_for_string_zero() {
+		$attributes = array();
+		$content    = '0';
+
+		$block_type = new WP_Block_Type( 'core/dummy' );
+		$output     = $block_type->render( $attributes, $content );
+		$this->assertSame( $content, $output );
+	}
+
+	function test_render_without_callback_for_object_with_toString() {
+		$attributes = array();
+		$value      = '0';
+		$content    = new WP_String_Type( $value );
+
+		$block_type = new WP_Block_Type( 'core/dummy' );
+		$output     = $block_type->render( $attributes, $content );
+		$this->assertSame( $value, $output );
 	}
 
 	function test_prepare_attributes() {

--- a/phpunit/class-wp-string-type.php
+++ b/phpunit/class-wp-string-type.php
@@ -18,7 +18,7 @@ class WP_String_Type {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $value
+	 * @param string $value Value for string representation.
 	 */
 	public function __construct( $value ) {
 

--- a/phpunit/class-wp-string-type.php
+++ b/phpunit/class-wp-string-type.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * WP_String_Type for testing
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Test class implementing __toString()
+ */
+class WP_String_Type {
+
+	/**
+	 * @var string
+	 */
+	private $value;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $value
+	 */
+	public function __construct( $value ) {
+
+		$this->value = (string) $value;
+	}
+
+	public function __toString() {
+		return $this->value;
+	}
+}


### PR DESCRIPTION
## Description
In case of no render callback, the function always returned `''` (empty string) for faulty (i.e., `== false`) `$content`. Firstly, the code for doing this was overly complicated, secondly, it didn't make sure there was actually a string being returned, and thirdly, in case of the string `'0'` there was also the empty string being returned.

The proposed code is straightforward, type-safe, and does not include the `'0'` error.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.