### PR TITLE
Blocks: Update ToggleControl to pass boolean onChange

### DIFF
--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -27,6 +27,11 @@ class ToggleControl extends Component {
 		const { label, checked, help, instanceId } = this.props;
 		const id = 'inspector-toggle-control-' + instanceId;
 
+		let describedBy;
+		if ( help ) {
+			describedBy = id + '__help';
+		}
+
 		return (
 			<BaseControl
 				label={ label }
@@ -38,7 +43,7 @@ class ToggleControl extends Component {
 					id={ id }
 					checked={ checked }
 					onChange={ this.onChange }
-					aria-describedby={ !! help ? id + '__help' : undefined }
+					aria-describedby={ describedBy }
 				/>
 			</BaseControl>
 		);

--- a/blocks/inspector-controls/toggle-control/index.js
+++ b/blocks/inspector-controls/toggle-control/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { withInstanceId, FormToggle } from '@wordpress/components';
 
 /**
@@ -9,19 +10,39 @@ import { withInstanceId, FormToggle } from '@wordpress/components';
 import BaseControl from './../base-control';
 import './style.scss';
 
-function ToggleControl( { label, checked, help, instanceId, onChange } ) {
-	const id = 'inspector-toggle-control-' + instanceId;
+class ToggleControl extends Component {
+	constructor() {
+		super( ...arguments );
 
-	return (
-		<BaseControl label={ label } id={ id } help={ help } className="blocks-toggle-control">
-			<FormToggle
+		this.onChange = this.onChange.bind( this );
+	}
+
+	onChange( event ) {
+		if ( this.props.onChange ) {
+			this.props.onChange( event.target.checked );
+		}
+	}
+
+	render() {
+		const { label, checked, help, instanceId } = this.props;
+		const id = 'inspector-toggle-control-' + instanceId;
+
+		return (
+			<BaseControl
+				label={ label }
 				id={ id }
-				checked={ checked }
-				onChange={ onChange }
-				aria-describedby={ !! help ? id + '__help' : undefined }
-			/>
-		</BaseControl>
-	);
+				help={ help }
+				className="blocks-toggle-control"
+			>
+				<FormToggle
+					id={ id }
+					checked={ checked }
+					onChange={ this.onChange }
+					aria-describedby={ !! help ? id + '__help' : undefined }
+				/>
+			</BaseControl>
+		);
+	}
 }
 
 export default withInstanceId( ToggleControl );

--- a/blocks/inspector-controls/toggle-control/test/index.js
+++ b/blocks/inspector-controls/toggle-control/test/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import ToggleControl from '../';
+
+describe( 'ToggleControl', () => {
+	it( 'triggers change callback with numeric value', () => {
+		// Mount: With shallow, cannot find input child of BaseControl
+		const onChange = jest.fn();
+		const wrapper = mount( <ToggleControl onChange={ onChange } /> );
+
+		wrapper.find( 'input' ).simulate( 'change', { target: { checked: true } } );
+
+		expect( onChange ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/blocks/inspector-controls/toggle-control/test/index.js
+++ b/blocks/inspector-controls/toggle-control/test/index.js
@@ -18,4 +18,26 @@ describe( 'ToggleControl', () => {
 
 		expect( onChange ).toHaveBeenCalledWith( true );
 	} );
+
+	describe( 'help', () => {
+		it( 'does not render input with describedby if no help prop', () => {
+			// Mount: With shallow, cannot find input child of BaseControl
+			const onChange = jest.fn();
+			const wrapper = mount( <ToggleControl onChange={ onChange } /> );
+
+			const input = wrapper.find( 'input' );
+
+			expect( input.prop( 'aria-describedby' ) ).toBeUndefined();
+		} );
+
+		it( 'renders input with describedby if help prop', () => {
+			// Mount: With shallow, cannot find input child of BaseControl
+			const onChange = jest.fn();
+			const wrapper = mount( <ToggleControl help onChange={ onChange } /> );
+
+			const input = wrapper.find( 'input' );
+
+			expect( input.prop( 'aria-describedby' ) ).toMatch( /^inspector-toggle-control-.*__help$/ );
+		} );
+	} );
 } );


### PR DESCRIPTION
Closes #4613 

This pull request seeks to change the argument signature of the `onChange` callback of `InspectorControls.ToggleControl`, passing a boolean value instead of the event object, for consistency with other inspector controls.

Existing core blocks tend to ignore this argument altogether, instead opting to infer the change as toggle of the current value (i.e. `setAttributes( { checked: ! checked } );` ).

__Testing instructions:__

Verify there are no regressions in behavior of any block using the `InspectorControls.ToggleControl` block helper component:

https://github.com/WordPress/gutenberg/search?utf8=%E2%9C%93&q=togglecontrol&type=