### PR TITLE
Try/3992 filtrable inserter tabs

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -37,6 +37,7 @@ import './style.scss';
 import { getInserterItems, getRecentInserterItems } from '../../store/selectors';
 import { fetchReusableBlocks } from '../../store/actions';
 import { default as InserterGroup } from './group';
+import {applyFilters, addFilter} from "@wordpress/hooks/build/index";
 
 export const searchItems = ( items, searchTerm ) => {
 	const normalizedSearchTerm = searchTerm.toLowerCase().trim();
@@ -281,28 +282,7 @@ export class InserterMenu extends Component {
 				{ ! isSearching &&
 					<TabPanel className="editor-inserter__tabs" activeClass="is-active"
 						onSelect={ this.switchTab }
-						tabs={ [
-							{
-								name: 'recent',
-								title: __( 'Recent' ),
-								className: 'editor-inserter__tab',
-							},
-							{
-								name: 'blocks',
-								title: __( 'Blocks' ),
-								className: 'editor-inserter__tab',
-							},
-							{
-								name: 'embeds',
-								title: __( 'Embeds' ),
-								className: 'editor-inserter__tab',
-							},
-							{
-								name: 'saved',
-								title: __( 'Saved' ),
-								className: 'editor-inserter__tab',
-							},
-						] }
+						tabs={ this.props.tabs }
 					>
 						{ ( tabKey ) => (
 							<div ref={ ( ref ) => this.tabContainer = ref }>
@@ -320,6 +300,70 @@ export class InserterMenu extends Component {
 		);
 	}
 }
+
+/**
+ * I'm not sure where I should move this filter @TODO
+ */
+addFilter( 'editor.inserterMenu.tabs', 'core/editor/inserterMenu', ( tabs, items ) => {
+	let embeds = _.filter(items, function(o) {
+		return o.category === 'embed';
+	});
+
+	if ( embeds.length > 0 ) {
+		tabs.push({
+			name: 'embeds',
+			title: __( 'Embeds' ),
+			className: 'editor-inserter__tab',
+		});
+	}
+
+	return tabs;
+});
+
+/**
+ * I'm not sure where I should move this filter @TODO
+ */
+addFilter( 'editor.inserterMenu.tabs', 'core/editor/inserterMenu', ( tabs, items ) => {
+	let reusableBlocks = _.filter(items, function(o) {
+		return o.category === 'reusable-blocks';
+	});
+
+	if ( reusableBlocks.length > 0 ) {
+		tabs.push({
+			name: 'saved',
+			title: __( 'Saved' ),
+			className: 'editor-inserter__tab',
+		});
+	}
+
+	return tabs;
+});
+
+/**
+ * I'm not sure where I should move this function @TODO
+ */
+const filterTabs = (InserterMenu) => (props) => {
+	// init the default tabs;
+	let newProps = {
+		tabs: [
+			{
+				name: 'recent',
+				title: __( 'Recent' ),
+				className: 'editor-inserter__tab',
+			},
+			{
+				name: 'blocks',
+				title: __( 'Blocks' ),
+				className: 'editor-inserter__tab',
+			},
+		],
+		...props
+	};
+
+	newProps.tabs = applyFilters( 'editor.inserterMenu.tabs', newProps.tabs, newProps.items);
+
+	return <InserterMenu {...newProps} />
+};
 
 export default compose(
 	withContext( 'editor' )( ( settings ) => {
@@ -339,5 +383,6 @@ export default compose(
 		{ fetchReusableBlocks }
 	),
 	withSpokenMessages,
-	withInstanceId
+	withInstanceId,
+	filterTabs
 )( InserterMenu );


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
As a theme/plugin developer, I would love to have control on the inserterMenu tabs, so I'm proposing a filter on this prop(yeah, I've also made tabs as props in order to be passed through HOCs)

This PR is more like a question, would you guys take this approach for filtering things in UI?

I know that the filters aren't in their place and that tests fail. But if this conceptually makes sense I'll move on to fix these issues. 

This should also fix #3992
 
## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):
![saved-blocks-tab](https://user-images.githubusercontent.com/1893980/35484926-5b06a83e-0460-11e8-885d-4e56d1605317.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
