### PR TITLE
Add capabilities for reusable blocks

### DIFF
--- a/lib/class-wp-rest-blocks-controller.php
+++ b/lib/class-wp-rest-blocks-controller.php
@@ -17,54 +17,21 @@
  */
 class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	/**
-	 * Given an update or create request, build the post object that is saved to
-	 * the database.
+	 * Checks if a block can be read.
 	 *
-	 * @since 1.10.0
+	 * @since 2.1.0
 	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return stdClass|WP_Error Post object or WP_Error.
+	 * @param object $post Post object that backs the block.
+	 * @return bool Whether the block can be read.
 	 */
-	protected function prepare_item_for_database( $request ) {
-		$prepared_post = new stdClass;
-
-		if ( isset( $request['id'] ) ) {
-			$existing_post = $this->get_post( $request['id'] );
-			if ( is_wp_error( $existing_post ) ) {
-				return $existing_post;
-			}
-
-			$prepared_post->ID = $existing_post->ID;
+	public function check_read_permission( $post ) {
+		// Ensure that the user is logged in and has the read_blocks capability.
+		$post_type = get_post_type_object( $post->post_type );
+		if ( ! current_user_can( $post_type->cap->read_post, $post->ID ) ) {
+			return false;
 		}
 
-		$prepared_post->post_title   = $request['title'];
-		$prepared_post->post_content = $request['content'];
-		$prepared_post->post_type    = $this->post_type;
-		$prepared_post->post_status  = 'publish';
-
-		return apply_filters( "rest_pre_insert_{$this->post_type}", $prepared_post, $request );
-	}
-
-	/**
-	 * Given a post from the database, build the array that is returned from an
-	 * API response.
-	 *
-	 * @since 1.10.0
-	 *
-	 * @param WP_Post         $post    Post object.
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response object.
-	 */
-	public function prepare_item_for_response( $post, $request ) {
-		$data = array(
-			'id'      => $post->ID,
-			'title'   => $post->post_title,
-			'content' => $post->post_content,
-		);
-
-		$response = rest_ensure_response( $data );
-
-		return apply_filters( "rest_prepare_{$this->post_type}", $response, $post, $request );
+		return parent::check_read_permission( $post );
 	}
 
 	/**
@@ -80,6 +47,46 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		$request->set_param( 'force', true );
 
 		return parent::delete_item( $request );
+	}
+
+	/**
+	 * Given an update or create request, build the post object that is saved to
+	 * the database.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return stdClass|WP_Error Post object or WP_Error.
+	 */
+	public function prepare_item_for_database( $request ) {
+		$prepared_post = parent::prepare_item_for_database( $request );
+
+		// Force blocks to always be published.
+		$prepared_post->post_status = 'publish';
+
+		return $prepared_post;
+	}
+
+	/**
+	 * Given a block from the database, build the array that is returned from an
+	 * API response.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param WP_Post         $post    Post object that backs the block.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $post, $request ) {
+		$data = array(
+			'id'      => $post->ID,
+			'title'   => $post->post_title,
+			'content' => $post->post_content,
+		);
+
+		$response = rest_ensure_response( $data );
+
+		return apply_filters( "rest_prepare_{$this->post_type}", $response, $post, $request );
 	}
 
 	/**

--- a/lib/register.php
+++ b/lib/register.php
@@ -401,11 +401,48 @@ function gutenberg_register_post_types() {
 			'singular_name' => 'Block',
 		),
 		'public'                => false,
-		'capability_type'       => 'post',
 		'show_in_rest'          => true,
 		'rest_base'             => 'blocks',
 		'rest_controller_class' => 'WP_REST_Blocks_Controller',
+		'capability_type'       => 'block',
+		'capabilities'          => array(
+			'read'         => 'read_blocks',
+			'create_posts' => 'create_blocks',
+		),
+		'map_meta_cap'          => true,
 	) );
+
+	foreach ( array( 'administrator', 'editor' ) as $role_name ) {
+		$editor = get_role( $role_name );
+		$editor->add_cap( 'edit_blocks' );
+		$editor->add_cap( 'edit_others_blocks' );
+		$editor->add_cap( 'publish_blocks' );
+		$editor->add_cap( 'read_private_blocks' );
+		$editor->add_cap( 'read_blocks' );
+		$editor->add_cap( 'delete_blocks' );
+		$editor->add_cap( 'delete_private_blocks' );
+		$editor->add_cap( 'delete_published_blocks' );
+		$editor->add_cap( 'delete_others_blocks' );
+		$editor->add_cap( 'edit_private_blocks' );
+		$editor->add_cap( 'edit_published_blocks' );
+		$editor->add_cap( 'create_blocks' );
+	}
+
+	$author = get_role( 'author' );
+	$author->add_cap( 'edit_blocks' );
+	$author->add_cap( 'publish_blocks' );
+	$author->add_cap( 'read_blocks' );
+	$author->add_cap( 'delete_blocks' );
+	$author->add_cap( 'delete_published_blocks' );
+	$author->add_cap( 'edit_published_blocks' );
+	$author->add_cap( 'create_blocks' );
+
+	$contributor = get_role( 'contributor' );
+	$contributor->add_cap( 'edit_blocks' );
+	$contributor->add_cap( 'read_blocks' );
+	$contributor->add_cap( 'delete_blocks' );
+	$contributor->add_cap( 'delete_published_blocks' );
+	$contributor->add_cap( 'edit_published_blocks' );
 }
 add_action( 'init', 'gutenberg_register_post_types' );
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -440,11 +440,7 @@ function gutenberg_register_post_types() {
 			'create_blocks',
 		),
 		'contributor'   => array(
-			'edit_blocks',
 			'read_blocks',
-			'delete_blocks',
-			'delete_published_blocks',
-			'edit_published_blocks',
 		),
 	);
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -412,37 +412,50 @@ function gutenberg_register_post_types() {
 		'map_meta_cap'          => true,
 	) );
 
-	foreach ( array( 'administrator', 'editor' ) as $role_name ) {
-		$editor = get_role( $role_name );
-		$editor->add_cap( 'edit_blocks' );
-		$editor->add_cap( 'edit_others_blocks' );
-		$editor->add_cap( 'publish_blocks' );
-		$editor->add_cap( 'read_private_blocks' );
-		$editor->add_cap( 'read_blocks' );
-		$editor->add_cap( 'delete_blocks' );
-		$editor->add_cap( 'delete_private_blocks' );
-		$editor->add_cap( 'delete_published_blocks' );
-		$editor->add_cap( 'delete_others_blocks' );
-		$editor->add_cap( 'edit_private_blocks' );
-		$editor->add_cap( 'edit_published_blocks' );
-		$editor->add_cap( 'create_blocks' );
+	$editor_caps = array(
+		'edit_blocks',
+		'edit_others_blocks',
+		'publish_blocks',
+		'read_private_blocks',
+		'read_blocks',
+		'delete_blocks',
+		'delete_private_blocks',
+		'delete_published_blocks',
+		'delete_others_blocks',
+		'edit_private_blocks',
+		'edit_published_blocks',
+		'create_blocks',
+	);
+
+	$caps_map = array(
+		'administrator' => $editor_caps,
+		'editor'        => $editor_caps,
+		'author'        => array(
+			'edit_blocks',
+			'publish_blocks',
+			'read_blocks',
+			'delete_blocks',
+			'delete_published_blocks',
+			'edit_published_blocks',
+			'create_blocks',
+		),
+		'contributor'   => array(
+			'edit_blocks',
+			'read_blocks',
+			'delete_blocks',
+			'delete_published_blocks',
+			'edit_published_blocks',
+		),
+	);
+
+	foreach ( $caps_map as $role_name => $caps ) {
+		$role = get_role( $role_name );
+		foreach ( $caps as $cap ) {
+			if ( ! $role->has_cap( $cap ) ) {
+				$role->add_cap( $cap );
+			}
+		}
 	}
-
-	$author = get_role( 'author' );
-	$author->add_cap( 'edit_blocks' );
-	$author->add_cap( 'publish_blocks' );
-	$author->add_cap( 'read_blocks' );
-	$author->add_cap( 'delete_blocks' );
-	$author->add_cap( 'delete_published_blocks' );
-	$author->add_cap( 'edit_published_blocks' );
-	$author->add_cap( 'create_blocks' );
-
-	$contributor = get_role( 'contributor' );
-	$contributor->add_cap( 'edit_blocks' );
-	$contributor->add_cap( 'read_blocks' );
-	$contributor->add_cap( 'delete_blocks' );
-	$contributor->add_cap( 'delete_published_blocks' );
-	$contributor->add_cap( 'edit_published_blocks' );
 }
 add_action( 'init', 'gutenberg_register_post_types' );
 

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -197,6 +197,128 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'content', $properties );
 	}
 
+	/**
+	 * Test cases for test_capabilities().
+	 */
+	public function data_capabilities() {
+		return array(
+			array( 'create', 'editor', 201 ),
+			array( 'create', 'author', 201 ),
+			array( 'create', 'contributor', 403 ),
+			array( 'create', null, 401 ),
+
+			array( 'read', 'editor', 200 ),
+			array( 'read', 'author', 200 ),
+			array( 'read', 'contributor', 200 ),
+			array( 'read', null, 401 ),
+
+			array( 'update_delete_own', 'editor', 200 ),
+			array( 'update_delete_own', 'author', 200 ),
+			array( 'update_delete_own', 'contributor', 200 ),
+
+			array( 'update_delete_others', 'editor', 200 ),
+			array( 'update_delete_others', 'author', 403 ),
+			array( 'update_delete_others', 'contributor', 403 ),
+			array( 'update_delete_others', null, 401 ),
+		);
+	}
+
+	/**
+	 * Exhaustively check that each role either can or cannot create, edit,
+	 * update, and delete reusable blocks.
+	 *
+	 * @dataProvider data_capabilities
+	 */
+	public function test_capabilities( $action, $role, $expected_status ) {
+		if ( $role ) {
+			$user_id = $this->factory->user->create( array( 'role' => $role ) );
+			wp_set_current_user( $user_id );
+		} else {
+			wp_set_current_user( 0 );
+		}
+
+		switch ( $action ) {
+			case 'create':
+				$request = new WP_REST_Request( 'POST', '/wp/v2/blocks' );
+				$request->set_body_params(
+					array(
+						'title'   => 'Test',
+						'content' => '<!-- wp:core/paragraph --><p>Test</p><!-- /wp:core/paragraph -->',
+					)
+				);
+
+				$response = $this->server->dispatch( $request );
+				$this->assertEquals( $expected_status, $response->get_status() );
+
+				break;
+
+			case 'read':
+				$request = new WP_REST_Request( 'GET', '/wp/v2/blocks/' . self::$post_id );
+
+				$response = $this->server->dispatch( $request );
+				$this->assertEquals( $expected_status, $response->get_status() );
+
+				break;
+
+			case 'update_delete_own':
+				$post_id = wp_insert_post(
+					array(
+						'post_type'    => 'wp_block',
+						'post_status'  => 'publish',
+						'post_title'   => 'My cool block',
+						'post_content' => '<!-- wp:core/paragraph --><p>Hello!</p><!-- /wp:core/paragraph -->',
+						'post_author'  => $user_id,
+					)
+				);
+
+				$request = new WP_REST_Request( 'PUT', '/wp/v2/blocks/' . $post_id );
+				$request->set_body_params(
+					array(
+						'title'   => 'Test',
+						'content' => '<!-- wp:core/paragraph --><p>Test</p><!-- /wp:core/paragraph -->',
+					)
+				);
+
+				$response = $this->server->dispatch( $request );
+				$this->assertEquals( $expected_status, $response->get_status() );
+
+				$request = new WP_REST_Request( 'DELETE', '/wp/v2/blocks/' . $post_id );
+
+				$response = $this->server->dispatch( $request );
+				$this->assertEquals( $expected_status, $response->get_status() );
+
+				wp_delete_post( $post_id );
+
+				break;
+
+			case 'update_delete_others':
+				$request = new WP_REST_Request( 'PUT', '/wp/v2/blocks/' . self::$post_id );
+				$request->set_body_params(
+					array(
+						'title'   => 'Test',
+						'content' => '<!-- wp:core/paragraph --><p>Test</p><!-- /wp:core/paragraph -->',
+					)
+				);
+
+				$response = $this->server->dispatch( $request );
+				$this->assertEquals( $expected_status, $response->get_status() );
+
+				$request = new WP_REST_Request( 'DELETE', '/wp/v2/blocks/' . self::$post_id );
+
+				$response = $this->server->dispatch( $request );
+				$this->assertEquals( $expected_status, $response->get_status() );
+
+				break;
+
+			default:
+				$this->fail( "'$action' is not a valid action." );
+		}
+
+		if ( isset( $user_id ) ) {
+			self::delete_user( $user_id );
+		}
+	}
+
 	public function test_context_param() {
 		$this->markTestSkipped( 'Controller doesn\'t implement get_context_param().' );
 	}

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -214,7 +214,7 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 
 			array( 'update_delete_own', 'editor', 200 ),
 			array( 'update_delete_own', 'author', 200 ),
-			array( 'update_delete_own', 'contributor', 200 ),
+			array( 'update_delete_own', 'contributor', 403 ),
 
 			array( 'update_delete_others', 'editor', 200 ),
 			array( 'update_delete_others', 'author', 403 ),


### PR DESCRIPTION
### 🔒 What this does

Fixes #3936.

Adds capabilities for the reusable block custom post type and maps them to the default WordPress roles. The capabilities are mapped as per https://github.com/WordPress/gutenberg/issues/3936#issuecomment-353251845:

> * Contributors can see and use existing blocks. The can edit/delete blocks for which they're the `post_author`. There's no draft reusable blocks, so no equivalent for them to be able to create blocks.
> * Authors can create blocks, and edit/delete blocks for which they're the `post_author`.
> * Editors and above can create/edit/delete all blocks. They can change the `post_author` for all blocks.

Here's a table to help illustrate:

|        | Admins/Editors | Authors | Contributors | Subscribers/Visitors |
| ------ | -------- | ------- | ------------ | ------------ |
| **Create** | Yes      | Yes     | No           | No           |
| **Read**   | Yes      | Yes     | Yes          | No           |
| **Update/Delete** | Yes      | Own     | Own          | No           |

### ✅ How I tested this (and how you could too)

I've added unit tests which run through the cases described by the table above.

You could also test this manually. First, I used WP-CLI to make sure I was working with a clean slate:

```
$ wp site empty
$ wp role reset --all
```

Then I created a bunch of users with different roles:

```
$ wp user create editor editor@local.test --role=editor --user_pass=password
$ wp user create author1 author1@local.test --role=author --user_pass=password
$ wp user create author2 author2@local.test --role=author --user_pass=password
$ wp user create contributor contributor@local.test --role=contributor --user_pass=password
$ wp user create subscriber subscriber@local.test --role=subscriber --user_pass=password
```

Then I tested various reusable block API operations while authenticated as different users. Here I'm using [HTTPie](https://httpie.org), but any API client would work. Make sure your WordPress has the [basic-auth plugin](https://github.com/WP-API/Basic-Auth) installed.

```
$ http -a editor:password POST local.wordpress.test/wp-json/wp/v2/blocks title='Editor block' content=Test
```