### PR TITLE
Block Menu: Fix the default render function

### DIFF
--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -21,7 +21,12 @@ import ReusableBlockSettings from './reusable-block-settings';
 import UnknownConverter from './unknown-converter';
 import { selectBlock } from '../../store/actions';
 
-function BlockSettingsMenu( { uids, onSelect, focus, renderBlockMenu = () => null } ) {
+function BlockSettingsMenu( {
+	uids,
+	onSelect,
+	focus,
+	renderBlockMenu = ( { children } ) => children }
+) {
 	const count = uids.length;
 
 	return (


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/4661#discussion_r164296240

This PR fixes the block menu when there's a multi-selection.

**Testing instructions**

 - Select multiple blocks
 - Click the block settings menu (the `...` menu)
 - Notice that the "remove" link show up properly.