### PR TITLE
Effects: Use block API functions in reusable effects

### DIFF
--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -6,7 +6,13 @@ import { noop, reduce, set } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { getBlockTypes, unregisterBlockType, registerBlockType, createBlock } from '@wordpress/blocks';
+import {
+	getBlockTypes,
+	unregisterBlockType,
+	registerBlockType,
+	createBlock,
+	createReusableBlock,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -621,14 +627,9 @@ describe( 'effects', () => {
 					}
 				} );
 
-				const reusableBlock = {
-					id: '69f00b2b-ea09-4d5c-a98f-0b1112d7d400',
-					title: 'My cool block',
-					type: 'core/test-block',
-					attributes: {
-						name: 'Big Bird',
-					},
-				};
+				const reusableBlock = createReusableBlock( 'core/test-block', {
+					name: 'Big Bird',
+				} );
 
 				const initialState = reducer( undefined, {} );
 				const action = updateReusableBlock( reusableBlock.id, reusableBlock );
@@ -640,8 +641,7 @@ describe( 'effects', () => {
 				handler( saveReusableBlock( reusableBlock.id ), store );
 
 				expect( modelAttributes ).toEqual( {
-					id: '69f00b2b-ea09-4d5c-a98f-0b1112d7d400',
-					title: 'My cool block',
+					title: 'Untitled block',
 					content: '<!-- wp:test-block {\"name\":\"Big Bird\"} /-->',
 				} );
 				return promise.then( () => {
@@ -662,14 +662,9 @@ describe( 'effects', () => {
 					}
 				} );
 
-				const reusableBlock = {
-					id: '69f00b2b-ea09-4d5c-a98f-0b1112d7d400',
-					name: 'My cool block',
-					type: 'core/test-block',
-					attributes: {
-						name: 'Big Bird',
-					},
-				};
+				const reusableBlock = createReusableBlock( 'core/test-block', {
+					name: 'Big Bird',
+				} );
 
 				const initialState = reducer( undefined, {} );
 				const action = updateReusableBlock( reusableBlock.id, reusableBlock );
@@ -708,13 +703,9 @@ describe( 'effects', () => {
 
 				const id = 123;
 
-				const associatedBlock = {
-					uid: 'd6b55aa9-16b5-4123-9675-749d75a7f14d',
-					name: 'core/block',
-					attributes: {
-						ref: id,
-					},
-				};
+				const associatedBlock = createBlock( 'core/block', {
+					ref: id,
+				} );
 
 				const actions = [
 					resetBlocks( [ associatedBlock ] ),
@@ -789,21 +780,12 @@ describe( 'effects', () => {
 			const handler = effects.CONVERT_BLOCK_TO_STATIC;
 
 			it( 'should convert a reusable block into a static block', () => {
-				const reusableBlock = {
-					id: '69f00b2b-ea09-4d5c-a98f-0b1112d7d400',
-					name: 'My cool block',
-					type: 'core/test-block',
-					attributes: {
-						name: 'Big Bird',
-					},
-				};
-				const staticBlock = {
-					uid: 'd6b55aa9-16b5-4123-9675-749d75a7f14d',
-					name: 'core/block',
-					attributes: {
-						ref: reusableBlock.id,
-					},
-				};
+				const reusableBlock = createReusableBlock( 'core/test-block', {
+					name: 'Big Bird',
+				} );
+				const staticBlock = createBlock( 'core/block', {
+					ref: reusableBlock.id,
+				} );
 
 				const actions = [
 					resetBlocks( [ staticBlock ] ),
@@ -830,13 +812,9 @@ describe( 'effects', () => {
 			const handler = effects.CONVERT_BLOCK_TO_REUSABLE;
 
 			it( 'should convert a static block into a reusable block', () => {
-				const staticBlock = {
-					uid: 'd6b55aa9-16b5-4123-9675-749d75a7f14d',
-					name: 'core/test-block',
-					attributes: {
-						name: 'Big Bird',
-					},
-				};
+				const staticBlock = createBlock( 'core/test-block', {
+					name: 'Big Bird',
+				} );
 
 				const initialState = reducer( undefined, {} );
 				const state = reducer( initialState, resetBlocks( [ staticBlock ] ) );


### PR DESCRIPTION
Related: #3745
Related: #3017

This pull request seeks to refactor the reusable blocks effects unit tests to use block API `createReusableBlock` and `createBlock` instead of manually creating block objects. This is more durable to changes in the block interface, as in those introduced with #3745.

__Testing instructions:__

Since the proposed changes only impact test files, ensure that tests continue to pass:

```
npm run test-unit
```