### PR TITLE
Gallery Block: Try masonry layout option

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -45,6 +45,7 @@ class GalleryBlock extends Component {
 		this.setColumnsNumber = this.setColumnsNumber.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
+		this.toggleMasonryLayout = this.toggleMasonryLayout.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.dropFiles = this.dropFiles.bind( this );
@@ -93,6 +94,10 @@ class GalleryBlock extends Component {
 		this.props.setAttributes( { imageCrop: ! this.props.attributes.imageCrop } );
 	}
 
+	toggleMasonryLayout() {
+		this.props.setAttributes( { masonryLayout: ! this.props.attributes.masonryLayout } );
+	}
+
 	setImageAttributes( index, attributes ) {
 		const { attributes: { images }, setAttributes } = this.props;
 
@@ -132,7 +137,7 @@ class GalleryBlock extends Component {
 
 	render() {
 		const { attributes, focus, className } = this.props;
-		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
+		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, masonryLayout, linkTo } = attributes;
 
 		const dropZone = (
 			<DropZone
@@ -200,6 +205,11 @@ class GalleryBlock extends Component {
 						checked={ !! imageCrop }
 						onChange={ this.toggleImageCrop }
 					/>
+					<ToggleControl
+						label={ __( 'Masonry Layout' ) }
+						checked={ !! masonryLayout }
+						onChange={ this.toggleMasonryLayout }
+					/>
 					<SelectControl
 						label={ __( 'Link to' ) }
 						value={ linkTo }
@@ -208,7 +218,7 @@ class GalleryBlock extends Component {
 					/>
 				</InspectorControls>
 			),
-			<ul key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
+			<ul key="gallery" className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' } ${ masonryLayout ? 'is-masonry-layout' : '' }` }>
 				{ dropZone }
 				{ images.map( ( img, index ) => (
 					<li className="blocks-gallery-item" key={ img.id || img.url }>

--- a/blocks/library/gallery/style.scss
+++ b/blocks/library/gallery/style.scss
@@ -1,7 +1,7 @@
-.wp-block-gallery,
-.wp-block-gallery.alignleft,
-.wp-block-gallery.alignright,
-.wp-block-gallery.aligncenter {
+.wp-block-gallery:not( .is-masonry-layout ),
+.wp-block-gallery.alignleft:not( .is-masonry-layout ),
+.wp-block-gallery.alignright:not( .is-masonry-layout ),
+.wp-block-gallery.aligncenter:not( .is-masonry-layout ) {
 	display: flex;
 	flex-wrap: wrap;
 	list-style-type: none;
@@ -62,5 +62,39 @@
 				width: calc(100% / #{ $i } - 16px );
 			}
 		}
+	}
+}
+
+.wp-block-gallery.is-masonry-layout,
+.wp-block-gallery.alignleft.is-masonry-layout,
+.wp-block-gallery.alignright.is-masonry-layout,
+.wp-block-gallery.aligncenter.is-masonry-layout {
+	column-gap: 0;
+	margin: 0;
+	padding: 0;
+	display: block;
+
+	// Responsive fallback value, 2 columns
+	column-count: 2;
+
+	&.columns-1 {
+		column-count: 1;
+	}
+
+	@include break-small {
+		@for $i from 3 through 8 {
+			&.columns-#{ $i } {
+				column-count: #{ $i };
+			}
+		}
+	}
+
+	li,
+	figure {
+		margin: 0;
+	}
+
+	img {
+		display: block;
 	}
 }


### PR DESCRIPTION
This PR adds a "masonry layout" option to the gallery block inspector. Toggling this will let you show your gallery in a masonry style layout instead of the default one. "Masonry" refers to having either the width or the height vary, yet laying out items so items fit snugly edge to edge.

GIF:

![masonry](https://user-images.githubusercontent.com/1204802/35509294-e90f37e8-04f3-11e8-98de-4710dae548cf.gif)

This PR is unfinished. The masonry option isn't saved yet, and as a result the frontend styles don't output. Also, the crop feature is tied to the default style of the gallery, so we'd probably want to "gray" the crop option if you choose the masonry option. But it works in the editor, so you can try it. 

Before I do any work to polish this any more, the question is: do we want this feature as part of the stock gallery, or should this be left to plugins to build?
