### PR TITLE
Fix typo in unit test case -> "Reusable"

### DIFF
--- a/phpunit/class-reusable-blocks-render-test.php
+++ b/phpunit/class-reusable-blocks-render-test.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Reusuable block rendering tests.
+ * Reusable block rendering tests.
  *
  * @package Gutenberg
  */
 
 /**
- * Tests reusuable block rendering.
+ * Tests reusable block rendering.
  */
-class Reusuable_Blocks_Render_Test extends WP_UnitTestCase {
+class Reusable_Blocks_Render_Test extends WP_UnitTestCase {
 	/**
 	 * Fake user ID.
 	 *


### PR DESCRIPTION
see: https://github.com/WordPress/gutenberg/pull/4608#pullrequestreview-92128558 "Reusuable" -> "Reusable"
