### PR TITLE
Fix Admin_Test, use `wpSetUpBeforeClass()`

### DIFF
--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -34,8 +34,7 @@ class Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Set up before class.
 	 */
-	public static function setUpBeforeClass() {
-
+	public static function wpSetUpBeforeClass() {
 		self::$editor_user_id      = self::factory()->user->create( array(
 			'role' => 'editor',
 		) );
@@ -47,7 +46,6 @@ class Admin_Test extends WP_UnitTestCase {
 			'post_title'   => 'Example',
 			'post_content' => 'Tester',
 		) );
-		return parent::setUpBeforeClass();
 	}
 
 	/**


### PR DESCRIPTION
## Description

Take advantage of [`wpSetUpBeforeClass()`](https://github.com/WordPress/wordpress-develop/blob/afb4f45e62520397b147e560e051d3940797121e/tests/phpunit/includes/testcase.php#L80) offered by `WP_UnitTestCase`.

### Solves a Problem

In addition to overriding `setUpBeforeClass()`, this method was also inserting data into the database before `parent::setUpBeforeClass()` was called upon. The `parent::setUpBeforeClass()` method does some important things to prepare for a test case. It's better to insert fake data either in `wpSetUpBeforeClass()` or within individual test functions.

Referencing: https://github.com/WordPress/gutenberg/pull/4685#issuecomment-361219754

> The existing Admin_Test was broken when running alongside those for annotations. The wpSetUpBeforeClass method should be used instead of setUpBeforeClass. I fixed it in this branch so tests will run properly, but I'm going to open a separate PR.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
