### PR TITLE
Remove wrapper from image raw transform; Added test cases;

### DIFF
--- a/blocks/api/raw-handling/test/integration/index.js
+++ b/blocks/api/raw-handling/test/integration/index.js
@@ -20,6 +20,8 @@ const types = [
 	'ms-word-online',
 	'evernote',
 	'iframe-embed',
+	'one-image',
+	'two-images',
 ];
 
 describe( 'raw handling: integration', () => {

--- a/blocks/api/raw-handling/test/integration/one-image-in.html
+++ b/blocks/api/raw-handling/test/integration/one-image-in.html
@@ -1,0 +1,1 @@
+<img class="alignnone wp-image-5114 size-medium" src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" width="300" height="137" />

--- a/blocks/api/raw-handling/test/integration/one-image-out.html
+++ b/blocks/api/raw-handling/test/integration/one-image-out.html
@@ -1,0 +1,3 @@
+<!-- wp:image -->
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" /></figure>
+<!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/two-images-in.html
+++ b/blocks/api/raw-handling/test/integration/two-images-in.html
@@ -1,0 +1,4 @@
+<img class="alignnone wp-image-5114 size-medium" src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" width="300" height="137" />
+
+
+<img class="alignnone wp-image-5109 size-medium" src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" width="300" height="248" />

--- a/blocks/api/raw-handling/test/integration/two-images-out.html
+++ b/blocks/api/raw-handling/test/integration/two-images-out.html
@@ -1,0 +1,7 @@
+<!-- wp:image -->
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" /></figure>
+<!-- /wp:image -->
+
+<!-- wp:image -->
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" /></figure>
+<!-- /wp:image -->

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -77,12 +77,10 @@ export const settings = {
 					return tag === 'img' || ( hasImage && tag === 'figure' );
 				},
 				transform( node ) {
-					const targetNode = node.parentNode.querySelector( 'figure,img' );
-					const matches = /align(left|center|right)/.exec( targetNode.className );
+					const matches = /align(left|center|right)/.exec( node.className );
 					const align = matches ? matches[ 1 ] : undefined;
 					const blockType = getBlockType( 'core/image' );
-					const attributes = getBlockAttributes( blockType, targetNode.outerHTML, { align } );
-
+					const attributes = getBlockAttributes( blockType, node.outerHTML, { align } );
 					return createBlock( 'core/image', attributes );
 				},
 			},


### PR DESCRIPTION
With the latest code changes the wrapper in the image raw transform is no longer required. Added integration tests cases to make sure we don't regress on image raw handling and existing bugs don't come back. Previous bugs affecting the functionality: https://github.com/WordPress/gutenberg/issues/4694, https://github.com/WordPress/gutenberg/issues/4449

## How Has This Been Tested?
Past multiple images in a post, verify the correct URLs are used.
Create a block with multiple images in the classic editor, use the convert to blocks option work as expected.
