### PR TITLE
Fix: Used correct label on Featured Image Panel.

### DIFF
--- a/edit-post/components/sidebar/featured-image/index.js
+++ b/edit-post/components/sidebar/featured-image/index.js
@@ -2,13 +2,16 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, withAPIData } from '@wordpress/components';
 import { PostFeaturedImage, PostFeaturedImageCheck } from '@wordpress/editor';
+import { compose } from '@wordpress/element';
+import { query } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,17 +24,29 @@ import { toggleSidebarPanel } from '../../../store/actions';
  */
 const PANEL_NAME = 'featured-image';
 
-function FeaturedImage( { isOpened, onTogglePanel } ) {
+function FeaturedImage( { isOpened, postType, onTogglePanel } ) {
 	return (
 		<PostFeaturedImageCheck>
-			<PanelBody title={ __( 'Featured Image' ) } opened={ isOpened } onToggle={ onTogglePanel }>
+			<PanelBody
+				title={ get(
+					postType,
+					[ 'data', 'labels', 'featured_image' ],
+					__( 'Featured Image' )
+				) }
+				opened={ isOpened }
+				onToggle={ onTogglePanel }
+			>
 				<PostFeaturedImage />
 			</PanelBody>
 		</PostFeaturedImageCheck>
 	);
 }
 
-export default connect(
+const applyQuery = query( ( select ) => ( {
+	postTypeSlug: select( 'core/editor', 'getCurrentPostType' ),
+} ) );
+
+const applyConnect = connect(
 	( state ) => {
 		return {
 			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
@@ -44,4 +59,17 @@ export default connect(
 	},
 	undefined,
 	{ storeKey: 'edit-post' }
+);
+
+const applyWithAPIData = withAPIData( ( props ) => {
+	const { postTypeSlug } = props;
+	return {
+		postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+	};
+} );
+
+export default compose(
+	applyQuery,
+	applyConnect,
+	applyWithAPIData,
 )( FeaturedImage );


### PR DESCRIPTION
Before a static label was used, this PR changes to use the label provided for the post type.

## How Has This Been Tested?
Add a post type with a custom featured image label, verify the label is used in the featured image panel. (Can easily be done with a plugin like Custom Post Type UI)

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/11271197/35528303-5da238cc-0525-11e8-82a8-d460bbd1a136.png)
