### PR TITLE
Update CONTRIBUTING.md local setting section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To test the plugin, or to contribute to it, you can clone this repository and bu
 
 ### Local Environment
 
-First, you need a WordPress Environment to run the plugin on. The quickest way to get up and running is to use the provided docker setup. Just install [docker](https://www.docker.com/) on your machine and run `./bin/setup-local-env.sh`.
+First, you need a WordPress Environment to run the plugin on. The quickest way to get up and running is to use the provided docker setup. Just install [docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/) on your machine and run `./bin/setup-local-env.sh`.
 
 The WordPress installation should be available at `http://localhost:8888` (username: `admin`, password: `password`).
 Inside the "docker" directory, you can use any docker command to interact with your containers. If this port is in use, you can override it in your `docker-compose.override.yml` file. If you're running [e2e tests](https://wordpress.org/gutenberg/handbook/reference/testing-overview/#end-to-end-testing), this change will be used correctly.


### PR DESCRIPTION
## Description
I update setting local environment section in CONTRIBUTING.md because docker-compose needs to be installed to run setup-local-env.sh. Docker doesn't install docker-compose automatically. If you don't install docker-compose, setup-local-env.sh fails without any comment of docker-compose. I followed the instruction; CONTRIBUTING.md, and met this issue.

## Types of changes
Updating setting local environment section in CONTRIBUTING.md
