### PR TITLE
Polish the Classic block, and fix some quote block errors

### DIFF
--- a/blocks/editable/style.scss
+++ b/blocks/editable/style.scss
@@ -14,10 +14,6 @@
 		margin-top: 0;
 	}
 
-	&.mce-content-body > p {	// needs specificity
-		line-height: inherit;
-	}
-
 	&:focus {
 		outline: none;
 	}

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -1,4 +1,8 @@
 .wp-block-freeform.blocks-editable__tinymce {
+	overflow: hidden;
+	margin: -4px;
+	padding: 4px;
+
 	p {
 		line-height: $editor-line-height;
 	}

--- a/blocks/library/quote/editor.scss
+++ b/blocks/library/quote/editor.scss
@@ -1,3 +1,7 @@
+.wp-block-quote {
+	margin: 0;
+}
+
 .wp-block-quote:not(.is-large) {
 	border-left: 4px solid $black;
 	padding-left: 1em;

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -87,6 +87,22 @@ body.gutenberg-editor-page {
 	.components-navigate-regions {
 		height: 100%;
 	}
+
+	.alignright {
+		float: right;
+		margin: 0.5em 0 0.5em 1em;
+	}
+
+	.alignleft {
+		float: left;
+		margin: 0.5em 1em 0.5em 0;
+	}
+
+	.aligncenter {
+		display: block;
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 .editor-post-title,

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -77,6 +77,7 @@ body.gutenberg-editor-page {
 
 	img {
 		max-width: 100%;
+		height: auto;
 	}
 
 	iframe {


### PR DESCRIPTION
This PR fixes a number of little things.

1. It fixes an issue where images in the Classic block would be skewed. Before:

![before](https://user-images.githubusercontent.com/1204802/35557653-0a4fcce4-05a6-11e8-90d2-b7bea3c654c4.png)

After:

![after](https://user-images.githubusercontent.com/1204802/35557659-0e7225f6-05a6-11e8-9c35-c0e5924a95d8.png)

2. It adds missing alignments to the classic block. Floats left, center and right were missing.

3. It fixes an issue where the quote lineheight was off if a classic block was pressent. Before:

![quotebefore](https://user-images.githubusercontent.com/1204802/35557697-22fef530-05a6-11e8-93d4-919990bb9c26.png)

After:

![quoteafter](https://user-images.githubusercontent.com/1204802/35557700-25c0b02e-05a6-11e8-9a1b-f6c97e755e3a.png)

4. It fixes an issue where the quote block had extra margin in the editor, that it didn't need. Before:

![quote2before](https://user-images.githubusercontent.com/1204802/35557713-31c0b978-05a6-11e8-9f6f-0a4e253f386b.png)

After:

![quote2after](https://user-images.githubusercontent.com/1204802/35557718-3509c30e-05a6-11e8-8f2b-f9050674c710.png)
