### PR TITLE
Scripts: Simplify scripts registration and remove useless jetpack fix

### DIFF
--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -52,13 +47,13 @@ export default class OldEditor extends Component {
 
 	componentWillUnmount() {
 		window.addEventListener( 'DOMContentLoaded', this.initialize );
-		wp.oldEditor.remove( this.props.id );
+		wp.oldEditor.remove( `editor-${ this.props.id }` );
 	}
 
 	componentDidUpdate( prevProps ) {
 		const { id, attributes: { content } } = this.props;
 
-		const editor = window.tinymce.get( id );
+		const editor = window.tinymce.get( `editor-${ id }` );
 
 		if ( prevProps.attributes.content !== content ) {
 			editor.setContent( content || '' );
@@ -68,13 +63,12 @@ export default class OldEditor extends Component {
 	initialize() {
 		const { id } = this.props;
 		const { settings } = window.wpEditorL10n.tinymce;
-
-		wp.oldEditor.initialize( id, {
+		wp.oldEditor.initialize( `editor-${ id }`, {
 			tinymce: {
 				...settings,
 				inline: true,
 				content_css: false,
-				fixed_toolbar_container: '#' + id + '-toolbar',
+				fixed_toolbar_container: `#toolbar-${ id }`,
 				setup: this.onSetup,
 			},
 		} );
@@ -168,20 +162,20 @@ export default class OldEditor extends Component {
 	}
 
 	render() {
-		const { isSelected, id, className } = this.props;
+		const { isSelected, id } = this.props;
 
 		return [
 			<div
 				key="toolbar"
-				id={ id + '-toolbar' }
+				id={ `toolbar-${ id }` }
 				ref={ ref => this.ref = ref }
 				className="freeform-toolbar"
 				style={ ! isSelected ? { display: 'none' } : {} }
 			/>,
 			<div
 				key="editor"
-				id={ id }
-				className={ classnames( className, 'blocks-rich-text__tinymce' ) }
+				id={ `editor-${ id }` }
+				className="wp-block-freeform blocks-rich-text__tinymce"
 			/>,
 		];
 	}

--- a/blocks/library/freeform/test/__snapshots__/index.js.snap
+++ b/blocks/library/freeform/test/__snapshots__/index.js.snap
@@ -4,11 +4,12 @@ exports[`core/freeform block edit matches snapshot 1`] = `
 Array [
   <div
     class="freeform-toolbar"
-    id="undefined-toolbar"
+    id="toolbar-undefined"
     style="display:none"
   />,
   <div
-    class="blocks-rich-text__tinymce"
+    class="wp-block-freeform blocks-rich-text__tinymce"
+    id="editor-undefined"
   />,
 ]
 `;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -147,7 +147,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-hooks', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models', 'shortcode' ),
+		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-hooks', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models', 'shortcode', 'editor' ),
 		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 	wp_add_inline_script(
@@ -158,6 +158,74 @@ function gutenberg_register_scripts_and_styles() {
 		) ),
 		'before'
 	);
+	// Loading the old editor and its config to ensure the classic block works as expected.
+	wp_add_inline_script(
+		'wp-blocks', 'window.wp.oldEditor = window.wp.editor;', 'before'
+	);
+	$tinymce_settings = apply_filters( 'tiny_mce_before_init', array(
+		'plugins'          => implode( ',', array_unique( apply_filters( 'tiny_mce_plugins', array(
+			'charmap',
+			'colorpicker',
+			'hr',
+			'lists',
+			'media',
+			'paste',
+			'tabfocus',
+			'textcolor',
+			'fullscreen',
+			'wordpress',
+			'wpautoresize',
+			'wpeditimage',
+			'wpemoji',
+			'wpgallery',
+			'wplink',
+			'wpdialogs',
+			'wptextpattern',
+			'wpview',
+		) ) ) ),
+		'toolbar1'         => implode( ',', array_merge( apply_filters( 'mce_buttons', array(
+			'formatselect',
+			'bold',
+			'italic',
+			'bullist',
+			'numlist',
+			'blockquote',
+			'alignleft',
+			'aligncenter',
+			'alignright',
+			'link',
+			'unlink',
+			'wp_more',
+			'spellchecker',
+		), 'editor' ), array( 'kitchensink' ) ) ),
+		'toolbar2'         => implode( ',', apply_filters( 'mce_buttons_2', array(
+			'strikethrough',
+			'hr',
+			'forecolor',
+			'pastetext',
+			'removeformat',
+			'charmap',
+			'outdent',
+			'indent',
+			'undo',
+			'redo',
+			'wp_help',
+		), 'editor' ) ),
+		'toolbar3'         => implode( ',', apply_filters( 'mce_buttons_3', array(), 'editor' ) ),
+		'toolbar4'         => implode( ',', apply_filters( 'mce_buttons_4', array(), 'editor' ) ),
+		'external_plugins' => apply_filters( 'mce_external_plugins', array() ),
+	), 'editor' );
+	if ( isset( $tinymce_settings['style_formats'] ) && is_string( $tinymce_settings['style_formats'] ) ) {
+		// Decode the options as we used to recommende json_encoding the TinyMCE settings.
+		$tinymce_settings['style_formats'] = json_decode( $tinymce_settings['style_formats'] );
+	}
+	wp_localize_script( 'wp-blocks', 'wpEditorL10n', array(
+		'tinymce' => array(
+			'baseURL'  => includes_url( 'js/tinymce' ),
+			'suffix'   => SCRIPT_DEBUG ? '' : '.min',
+			'settings' => $tinymce_settings,
+		),
+	) );
 
 	wp_register_script(
 		'wp-editor',
@@ -693,79 +761,7 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_registered_block_s
 function gutenberg_editor_scripts_and_styles( $hook ) {
 	$is_demo = isset( $_GET['gutenberg-demo'] );
 
-	wp_add_inline_script(
-		'editor', 'window.wp.oldEditor = window.wp.editor;', 'after'
-	);
-
 	gutenberg_extend_wp_api_backbone_client();
-
-	gutenberg_fix_jetpack_freeform_block_conflict();
-
-	$tinymce_settings = apply_filters( 'tiny_mce_before_init', array(
-		'plugins'          => implode( ',', array_unique( apply_filters( 'tiny_mce_plugins', array(
-			'charmap',
-			'colorpicker',
-			'hr',
-			'lists',
-			'media',
-			'paste',
-			'tabfocus',
-			'textcolor',
-			'fullscreen',
-			'wordpress',
-			'wpautoresize',
-			'wpeditimage',
-			'wpemoji',
-			'wpgallery',
-			'wplink',
-			'wpdialogs',
-			'wptextpattern',
-			'wpview',
-		) ) ) ),
-		'toolbar1'         => implode( ',', array_merge( apply_filters( 'mce_buttons', array(
-			'formatselect',
-			'bold',
-			'italic',
-			'bullist',
-			'numlist',
-			'blockquote',
-			'alignleft',
-			'aligncenter',
-			'alignright',
-			'link',
-			'unlink',
-			'wp_more',
-			'spellchecker',
-		), 'editor' ), array( 'kitchensink' ) ) ),
-		'toolbar2'         => implode( ',', apply_filters( 'mce_buttons_2', array(
-			'strikethrough',
-			'hr',
-			'forecolor',
-			'pastetext',
-			'removeformat',
-			'charmap',
-			'outdent',
-			'indent',
-			'undo',
-			'redo',
-			'wp_help',
-		), 'editor' ) ),
-		'toolbar3'         => implode( ',', apply_filters( 'mce_buttons_3', array(), 'editor' ) ),
-		'toolbar4'         => implode( ',', apply_filters( 'mce_buttons_4', array(), 'editor' ) ),
-		'external_plugins' => apply_filters( 'mce_external_plugins', array() ),
-	), 'editor' );
-	if ( isset( $tinymce_settings['style_formats'] ) && is_string( $tinymce_settings['style_formats'] ) ) {
-		// Decode the options as we used to recommende json_encoding the TinyMCE settings.
-		$tinymce_settings['style_formats'] = json_decode( $tinymce_settings['style_formats'] );
-	}
-
-	wp_localize_script( 'wp-editor', 'wpEditorL10n', array(
-		'tinymce' => array(
-			'baseURL'  => includes_url( 'js/tinymce' ),
-			'suffix'   => SCRIPT_DEBUG ? '' : '.min',
-			'settings' => $tinymce_settings,
-		),
-	) );
 
 	wp_enqueue_script( 'wp-edit-post' );
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -70,25 +70,6 @@ function _gutenberg_utf8_split( $str ) {
 }
 
 /**
- * Fixes a conflict with the Jetpack plugin trying to read an undefined global
- * variable `grunionEditorView` during the initialization of the
- * `core/freeform` block.
- *
- * @since 0.7.1
- */
-function gutenberg_fix_jetpack_freeform_block_conflict() {
-	if (
-		defined( 'JETPACK__VERSION' ) &&
-		version_compare( JETPACK__VERSION, '5.2.2', '<' )
-	) {
-		remove_filter(
-			'mce_external_plugins',
-			array( 'Grunion_Editor_View', 'mce_external_plugins' )
-		);
-	}
-}
-
-/**
  * Shims wp-api-request for WordPress installations not running 4.9-alpha or
  * newer.
  *


### PR DESCRIPTION
This PR refactors a little bit the way we enqueue Gutenberg scripts to clarify the dependency we have between the "blocks" module and the classic "editor" script.

It also fixes the classic editor where we were using an `id` starting with a numeric character (this is not valid).

It also removes a useless jetpack fix. The right fix has been included in Jetpack in 5.2.2 see https://github.com/WordPress/gutenberg/pull/2229

**Testing instructions**

- Open Gutenberg
- Add a classic block
- It should work