### PR TITLE
Refactor Default Colors and the ColorPalette component

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { ChromePicker } from 'react-color';
+import { map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,7 +25,7 @@ export function ColorPalette( { defaultColors, colors, value, onChange } ) {
 
 	return (
 		<div className="blocks-color-palette">
-			{ usedColors.map( ( color ) => {
+			{ map( usedColors, ( color ) => {
 				const style = { color: color };
 				const className = classnames( 'blocks-color-palette__item', { 'is-active': value === color } );
 

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -32,6 +32,19 @@ import store from '../../store';
  */
 const DEFAULT_SETTINGS = {
 	alignWide: false,
+	colors: [
+		'#f78da7',
+		'#cf2e2e',
+		'#ff6900',
+		'#fcb900',
+		'#7bdcb5',
+		'#00d084',
+		'#8ed1fc',
+		'#0693e3',
+		'#eee',
+		'#abb8c3',
+		'#313131',
+	],
 
 	// This is current max width of the block inner area
 	// It's used to constraint image resizing and this value could be overriden later by themes

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -681,29 +681,6 @@ add_action( 'enqueue_block_assets', 'gutenberg_enqueue_registered_block_scripts_
 add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_registered_block_scripts_and_styles' );
 
 /**
- * Returns a default color palette.
- *
- * @return array Color strings in hex format.
- *
- * @since 0.7.0
- */
-function gutenberg_color_palette() {
-	return array(
-		'#f78da7',
-		'#cf2e2e',
-		'#ff6900',
-		'#fcb900',
-		'#7bdcb5',
-		'#00d084',
-		'#8ed1fc',
-		'#0693e3',
-		'#eee',
-		'#abb8c3',
-		'#313131',
-	);
-}
-
-/**
  * Scripts & Styles.
  *
  * Enqueues the needed scripts and styles when visiting the top-level page of
@@ -870,12 +847,8 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$color_palette           = get_theme_support( 'editor-color-palette' );
 
 	// Backcompat for Color Palette set through `gutenberg` array.
-	if ( empty( $color_palette ) ) {
-		if ( ! empty( $gutenberg_theme_support[0]['colors'] ) ) {
-			$color_palette = $gutenberg_theme_support[0]['colors'];
-		} else {
-			$color_palette = gutenberg_color_palette();
-		}
+	if ( empty( $color_palette ) && ! empty( $gutenberg_theme_support[0]['colors'] ) ) {
+		$color_palette = $gutenberg_theme_support[0]['colors'];
 	}
 
 	if ( ! empty( $gutenberg_theme_support ) ) {
@@ -899,10 +872,13 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$editor_settings = array(
 		'alignWide'          => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
 		'availableTemplates' => wp_get_theme()->get_page_templates( get_post( $post_to_edit['id'] ) ),
-		'colors'             => $color_palette,
 		'blockTypes'         => $allowed_block_types,
 		'titlePlaceholder'   => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
 	);
+
+	if ( ! empty( $color_palette ) ) {
+		$editor_settings['colors'] = $color_palette;
+	}
 
 	$post_type_object = get_post_type_object( $post_to_edit['type'] );
 	if ( ! empty( $post_type_object->template ) ) {


### PR DESCRIPTION
Tiny PR that does two things related to colors:

 - Moves the default colors to the frontend making the Editor script more reusable without the need of the server-side bootstraping.

 - Small fix the ColorPalette component to accommodate the empty colors use-case. (Avoid JS errors)

**Testing instructions**

 - Open Gutenberg
 - Create a paragraph
 - Assign colors