### PR TITLE
Fix unset variable

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -351,6 +351,9 @@ function gutenberg_meta_box_post_form_hidden_fields( $post ) {
 	$referer      = wp_get_referer();
 	$current_user = wp_get_current_user();
 	$user_id      = $current_user->ID;
+	if ( ! wp_check_post_lock( $post->ID ) ) {
+		$active_post_lock = wp_set_post_lock( $post->ID );
+	}
 	wp_nonce_field( $nonce_action );
 	?>
 	<input type="hidden" id="user-id" name="user_ID" value="<?php echo (int) $user_id; ?>" />

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -351,9 +351,6 @@ function gutenberg_meta_box_post_form_hidden_fields( $post ) {
 	$referer      = wp_get_referer();
 	$current_user = wp_get_current_user();
 	$user_id      = $current_user->ID;
-	if ( ! wp_check_post_lock( $post->ID ) ) {
-		$active_post_lock = wp_set_post_lock( $post->ID );
-	}
 	wp_nonce_field( $nonce_action );
 	?>
 	<input type="hidden" id="user-id" name="user_ID" value="<?php echo (int) $user_id; ?>" />
@@ -365,9 +362,6 @@ function gutenberg_meta_box_post_form_hidden_fields( $post ) {
 	<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>" />
 	<!-- These fields are not part of the standard post form. Used to redirect back to this page on save. -->
 	<input type="hidden" name="gutenberg_meta_boxes" value="gutenberg_meta_boxes" />
-	<?php if ( ! empty( $active_post_lock ) ) : ?>
-	<input type="hidden" id="active_post_lock" value="<?php echo esc_attr( implode( ':', $active_post_lock ) ); ?>" />
-	<?php endif; ?>
 
 	<?php
 	if ( 'draft' !== get_post_status( $post ) ) {


### PR DESCRIPTION
## Description
In the `gutenberg_meta_box_post_form_hidden_fields` function the `active_post_lock` variable never was defined. This function was added in https://github.com/WordPress/gutenberg/pull/2804 by @BE-Webdesign. 

Closes #4714 

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.