### PR TITLE
Components: Un-skip Tooltip multiple child test

### DIFF
--- a/components/tooltip/test/index.js
+++ b/components/tooltip/test/index.js
@@ -10,14 +10,9 @@ import Tooltip from '../';
 
 describe( 'Tooltip', () => {
 	describe( '#render()', () => {
-		// Disable reason: The Tooltip component leverages array return values
-		// from render, which is not available until React 16.x
-		//
-		// TODO: When on React 16.x, unskip test
-		//
-		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip( 'should render children (abort) if multiple children passed', () => {
-			const wrapper = shallow(
+		it( 'should render children (abort) if multiple children passed', () => {
+			// Mount: Enzyme shallow does not support wrapping multiple nodes
+			const wrapper = mount(
 				<Tooltip><div /><div /></Tooltip>
 			);
 


### PR DESCRIPTION
This pull request seeks to update the unit tests for the Tooltip component to un-skip a test which had previously been skipped only due to inconsistent versioning between the client-loaded React and server-run React for testing. Since we are now running React 16.x in both environments, this test can be unskipped.

__Testing instructions:__

Verify that unit tests pass:

```
npm run test-unit
```