### PR TITLE
Store: Remove redundant handling of inserter position

### DIFF
--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -32,13 +32,10 @@ class Inserter extends Component {
 	}
 
 	onToggle( isOpen ) {
-		const {
-			insertIndex,
-			onToggle,
-		} = this.props;
+		const { onToggle } = this.props;
 
 		if ( isOpen ) {
-			this.props.showInsertionPoint( insertIndex );
+			this.props.showInsertionPoint();
 		} else {
 			this.props.hideInsertionPoint();
 		}

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -200,16 +200,14 @@ export function insertBlocks( blocks, position ) {
 }
 
 /**
- * Returns an action object showing the insertion point at a given index.
- *
- * @param {Number?} index Index of the insertion point.
+ * Returns an action object used in signalling that the insertion point should
+ * be shown.
  *
  * @returns {Object} Action object.
  */
-export function showInsertionPoint( index ) {
+export function showInsertionPoint() {
 	return {
 		type: 'SHOW_INSERTION_POINT',
-		index,
 	};
 }
 

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -497,20 +497,21 @@ export function blocksMode( state = {}, action ) {
 }
 
 /**
- * Reducer returning the block insertion point.
+ * Reducer returning the block insertion point visibility, a boolean value
+ * reflecting whether the insertion point should be shown.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
  * @returns {Object} Updated state.
  */
-export function blockInsertionPoint( state = {}, action ) {
+export function isInsertionPointVisible( state = false, action ) {
 	switch ( action.type ) {
 		case 'SHOW_INSERTION_POINT':
-			return { ...state, visible: true };
+			return true;
 
 		case 'HIDE_INSERTION_POINT':
-			return { ...state, visible: false };
+			return false;
 	}
 
 	return state;
@@ -789,7 +790,7 @@ export default optimist( combineReducers( {
 	blockSelection,
 	hoveredBlock,
 	blocksMode,
-	blockInsertionPoint,
+	isInsertionPointVisible,
 	preferences,
 	saving,
 	notices,

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -507,10 +507,10 @@ export function blocksMode( state = {}, action ) {
 export function blockInsertionPoint( state = {}, action ) {
 	switch ( action.type ) {
 		case 'SHOW_INSERTION_POINT':
-			return { ...state, visible: true, position: action.index };
+			return { ...state, visible: true };
 
 		case 'HIDE_INSERTION_POINT':
-			return { ...state, visible: false, position: null };
+			return { ...state, visible: false };
 	}
 
 	return state;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -830,11 +830,6 @@ export function isTyping( state ) {
  * @returns {?String} Unique ID after which insertion will occur.
  */
 export function getBlockInsertionPoint( state ) {
-	const position = getBlockSiblingInserterPosition( state );
-	if ( null !== position ) {
-		return position;
-	}
-
 	const lastMultiSelectedBlock = getLastMultiSelectedBlockUid( state );
 	if ( lastMultiSelectedBlock ) {
 		return getBlockIndex( state, lastMultiSelectedBlock ) + 1;
@@ -846,23 +841,6 @@ export function getBlockInsertionPoint( state ) {
 	}
 
 	return state.editor.present.blockOrder.length;
-}
-
-/**
- * Returns the position at which the block inserter will insert a new adjacent
- * sibling block, or null if the inserter is not actively visible.
- *
- * @param {Object} state Global application state.
- *
- * @returns {?Number} Whether the inserter is currently visible.
- */
-export function getBlockSiblingInserterPosition( state ) {
-	const { position } = state.blockInsertionPoint;
-	if ( ! Number.isInteger( position ) ) {
-		return null;
-	}
-
-	return position;
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -851,7 +851,7 @@ export function getBlockInsertionPoint( state ) {
  * @returns {?Boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
-	return !! state.blockInsertionPoint.visible;
+	return state.isInsertionPointVisible;
 }
 
 /**

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -240,9 +240,8 @@ describe( 'actions', () => {
 
 	describe( 'showInsertionPoint', () => {
 		it( 'should return the SHOW_INSERTION_POINT action', () => {
-			expect( showInsertionPoint( 1 ) ).toEqual( {
+			expect( showInsertionPoint() ).toEqual( {
 				type: 'SHOW_INSERTION_POINT',
-				index: 1,
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -728,14 +728,12 @@ describe( 'state', () => {
 			expect( state ).toEqual( {} );
 		} );
 
-		it( 'should set insertion point position', () => {
+		it( 'should set insertion point visible', () => {
 			const state = blockInsertionPoint( undefined, {
 				type: 'SHOW_INSERTION_POINT',
-				index: 5,
 			} );
 
 			expect( state ).toEqual( {
-				position: 5,
 				visible: true,
 			} );
 		} );
@@ -745,7 +743,7 @@ describe( 'state', () => {
 				type: 'HIDE_INSERTION_POINT',
 			} );
 
-			expect( state ).toEqual( { visible: false, position: null } );
+			expect( state ).toEqual( { visible: false } );
 		} );
 	} );
 

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -28,7 +28,7 @@ import {
 	saving,
 	notices,
 	blocksMode,
-	blockInsertionPoint,
+	isInsertionPointVisible,
 	isSavingMetaBoxes,
 	metaBoxes,
 	reusableBlocks,
@@ -721,29 +721,27 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'blockInsertionPoint', () => {
-		it( 'should default to an empty object', () => {
-			const state = blockInsertionPoint( undefined, {} );
+	describe( 'isInsertionPointVisible', () => {
+		it( 'should default to false', () => {
+			const state = isInsertionPointVisible( undefined, {} );
 
-			expect( state ).toEqual( {} );
+			expect( state ).toBe( false );
 		} );
 
 		it( 'should set insertion point visible', () => {
-			const state = blockInsertionPoint( undefined, {
+			const state = isInsertionPointVisible( false, {
 				type: 'SHOW_INSERTION_POINT',
 			} );
 
-			expect( state ).toEqual( {
-				visible: true,
-			} );
+			expect( state ).toBe( true );
 		} );
 
 		it( 'should clear the insertion point', () => {
-			const state = blockInsertionPoint( deepFreeze( {} ), {
+			const state = isInsertionPointVisible( true, {
 				type: 'HIDE_INSERTION_POINT',
 			} );
 
-			expect( state ).toEqual( { visible: false } );
+			expect( state ).toBe( false );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -57,7 +57,6 @@ import {
 	getBlockMode,
 	isTyping,
 	getBlockInsertionPoint,
-	getBlockSiblingInserterPosition,
 	isBlockInsertionPointVisible,
 	isSavingPost,
 	didPostSaveRequestSucceed,
@@ -1591,23 +1590,6 @@ describe( 'selectors', () => {
 			expect( getBlockInsertionPoint( state ) ).toBe( 2 );
 		} );
 
-		it( 'should return the assigned insertion point', () => {
-			const state = {
-				preferences: { mode: 'visual' },
-				blockSelection: {},
-				editor: {
-					present: {
-						blockOrder: [ 1, 2, 3 ],
-					},
-				},
-				blockInsertionPoint: {
-					position: 2,
-				},
-			};
-
-			expect( getBlockInsertionPoint( state ) ).toBe( 2 );
-		} );
-
 		it( 'should return the last multi selected uid', () => {
 			const state = {
 				preferences: { mode: 'visual' },
@@ -1639,26 +1621,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toBe( 3 );
-		} );
-	} );
-
-	describe( 'getBlockSiblingInserterPosition', () => {
-		it( 'should return null if no sibling insertion point', () => {
-			const state = {
-				blockInsertionPoint: {},
-			};
-
-			expect( getBlockSiblingInserterPosition( state ) ).toBe( null );
-		} );
-
-		it( 'should return sibling insertion point', () => {
-			const state = {
-				blockInsertionPoint: {
-					position: 5,
-				},
-			};
-
-			expect( getBlockSiblingInserterPosition( state ) ).toBe( 5 );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -1584,7 +1584,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				blockInsertionPoint: {},
+				isInsertionPointVisible: false,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toBe( 2 );
@@ -1602,7 +1602,7 @@ describe( 'selectors', () => {
 						blockOrder: [ 1, 2, 3 ],
 					},
 				},
-				blockInsertionPoint: {},
+				isInsertionPointVisible: false,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toBe( 2 );
@@ -1617,7 +1617,7 @@ describe( 'selectors', () => {
 						blockOrder: [ 1, 2, 3 ],
 					},
 				},
-				blockInsertionPoint: {},
+				isInsertionPointVisible: false,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toBe( 3 );
@@ -1627,9 +1627,7 @@ describe( 'selectors', () => {
 	describe( 'isBlockInsertionPointVisible', () => {
 		it( 'should return the value in state', () => {
 			const state = {
-				blockInsertionPoint: {
-					visible: true,
-				},
+				isInsertionPointVisible: true,
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( true );


### PR DESCRIPTION
Blocker for #3745
Related: #4539, #3745

See: https://github.com/WordPress/gutenberg/pull/4539#issuecomment-361669816

This pull request seeks to remove redundant handling of inserter position, relevant only for the sibling inserter which was removed in #4539. It also consequently reshapes the reducer state for insertion point, which now only needs to reflect a single value reflecting whether or not the insertion point is visible.

__Testing instructions:__

Repeat testing instructions from #4539.