### PR TITLE
Used labels provided by the rest API on taxonomies.

### DIFF
--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { unescape as unescapeString, without, map, repeat, find, some } from 'lodash';
+import { get, unescape as unescapeString, without, map, repeat, find, some } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
-import { withInstanceId, withSpokenMessages } from '@wordpress/components';
+import { withAPIData, withInstanceId, withSpokenMessages } from '@wordpress/components';
 import { buildTermsTree } from '@wordpress/utils';
 
 /**
@@ -128,7 +128,14 @@ class HierarchicalTermSelector extends Component {
 			.then( ( term ) => {
 				const hasTerm = !! find( this.state.availableTerms, ( availableTerm ) => availableTerm.id === term.id );
 				const newAvailableTerms = hasTerm ? this.state.availableTerms : [ term, ...this.state.availableTerms ];
-				const termAddedMessage = slug === 'category' ? __( 'Category added' ) : __( 'Term added' );
+				const termAddedMessage = sprintf(
+					_x( '%s added', 'term' ),
+					get(
+						this.props.taxonomy,
+						[ 'data', 'labels', 'singular_name' ],
+						slug === 'category' ? __( 'Category' ) : __( 'Term' )
+					)
+				);
 				this.props.speak( termAddedMessage, 'assertive' );
 				this.setState( {
 					adding: false,
@@ -216,14 +223,30 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	render() {
+		const { label, slug, taxonomy, instanceId } = this.props;
 		const { availableTermsTree, availableTerms, formName, formParent, loading, showForm } = this.state;
-		const { label, slug, instanceId } = this.props;
-
-		const newTermButtonLabel = slug === 'category' ? __( 'Add new category' ) : __( 'Add new term' );
-		const newTermLabel = slug === 'category' ? __( 'Category Name' ) : __( 'Term Name' );
-		const parentSelectLabel = slug === 'category' ? __( 'Parent Category' ) : __( 'Parent Term' );
-		const noParentOption = slug === 'category' ? _x( 'None', 'category' ) : _x( 'None', 'term' );
-		const newTermSubmitLabel = slug === 'category' ? __( 'Add Category' ) : __( 'Add Term' );
+		const labelWithFallback = ( labelProperty, fallbackIsCategory, fallbackIsNotCategory ) => get(
+			taxonomy,
+			[ 'data', 'labels', labelProperty ],
+			slug === 'category' ? fallbackIsCategory : fallbackIsNotCategory
+		);
+		const newTermButtonLabel = labelWithFallback(
+			'add_new_item',
+			__( 'Add new category' ),
+			__( 'Add new term' )
+		);
+		const newTermLabel = labelWithFallback(
+			'new_item_name',
+			__( 'Add new category' ),
+			__( 'Add new term' )
+		);
+		const parentSelectLabel = labelWithFallback(
+			'parent_item',
+			__( 'Parent Category' ),
+			__( 'Parent Term' )
+		);
+		const noParentOption = `— ${ parentSelectLabel } —`;
+		const newTermSubmitLabel = newTermButtonLabel;
 		const inputId = `editor-post-taxonomies__hierarchical-terms-input-${ instanceId }`;
 		const selectId = `editor-post-taxonomies__hierarchical-terms-select-${ instanceId }`;
 
@@ -290,6 +313,13 @@ class HierarchicalTermSelector extends Component {
 	}
 }
 
+const applyWithAPIData = withAPIData( ( props ) => {
+	const { slug } = props;
+	return {
+		taxonomy: `/wp/v2/taxonomies/${ slug }?context=edit`,
+	};
+} );
+
 const applyConnect = connect(
 	( state, onwProps ) => {
 		return {
@@ -304,6 +334,7 @@ const applyConnect = connect(
 );
 
 export default compose(
+	applyWithAPIData,
 	applyConnect,
 	withSpokenMessages,
 	withInstanceId


### PR DESCRIPTION
This uses labels provided by the rest API on taxonomies. Until now we were using hardcoded values.
This made labels like "Add new gender" on custom taxonomies useless and instead "Add new term" was used.

## How Has This Been Tested?
Verify categories and tags work as expected.
Add a new taxonomy with custom labels and verify correct labels are used. (easily done with a plugin like Custom Post Type UI)