### PR TITLE
Display reusable blocks in the inserter's 'Recent' tab

### DIFF
--- a/editor/store/defaults.js
+++ b/editor/store/defaults.js
@@ -1,3 +1,3 @@
 export const PREFERENCES_DEFAULTS = {
-	recentlyUsedBlocks: [],
+	recentInserts: [],
 };

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -525,11 +525,9 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 	switch ( action.type ) {
 		case 'INSERT_BLOCKS':
 			return action.blocks.reduce( ( prevState, block ) => {
-				let insert;
+				const insert = { name: block.name };
 				if ( isReusableBlock( block ) ) {
-					insert = { name: block.name, ref: block.attributes.ref };
-				} else {
-					insert = { name: block.name };
+					insert.ref = block.attributes.ref;
 				}
 
 				const isSameAsInsert = ( { name, ref } ) => name === insert.name && ref === insert.ref;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -11,6 +11,7 @@ import {
 	compact,
 	find,
 	some,
+	unionWith,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -24,6 +25,7 @@ import { addQueryArgs } from '@wordpress/url';
 /***
  * Module constants
  */
+const MAX_RECENT_BLOCKS = 8;
 export const POST_UPDATE_TRANSACTION_ID = 'post-update';
 
 /**
@@ -1106,6 +1108,22 @@ export function getInserterItems( state, enabledBlockTypes = true ) {
 	return compact( items );
 }
 
+const getRecentInserts = createSelector(
+	state => {
+		// Filter out any inserts that are associated with a block type that isn't registered
+		const inserts = state.preferences.recentInserts.filter( insert => getBlockType( insert.name ) );
+
+		// Common blocks that we'll use to pad out our list
+		const commonInserts = getBlockTypes()
+			.filter( blockType => blockType.category === 'common' )
+			.map( blockType => ( { name: blockType.name } ) );
+
+		const areInsertsEqual = ( a, b ) => a.name === b.name && a.ref === b.ref;
+		return unionWith( inserts, commonInserts, areInsertsEqual );
+	},
+	state => state.preferences.recentInserts
+);
+
 /**
  * Determines the items that appear in the 'Recent' tab of the inserter.
  *
@@ -1119,13 +1137,17 @@ export function getRecentInserterItems( state, enabledBlockTypes = true ) {
 		return [];
 	}
 
-	const items = state.preferences.recentlyUsedBlocks.map( name =>
-		buildInserterItemFromBlockType( state, enabledBlockTypes, getBlockType( name ) )
-	);
+	const items = getRecentInserts( state ).map( insert => {
+		if ( insert.ref ) {
+			const reusableBlock = getReusableBlock( state, insert.ref );
+			return buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock );
+		}
 
-	// TODO: Merge in recently used reusable blocks
+		const blockType = getBlockType( insert.name );
+		return buildInserterItemFromBlockType( state, enabledBlockTypes, blockType );
+	} );
 
-	return compact( items );
+	return compact( items ).slice( 0, MAX_RECENT_BLOCKS );
 }
 
 /**

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -11,7 +11,6 @@ import {
 	registerCoreBlocks,
 	registerBlockType,
 	unregisterBlockType,
-	getBlockType,
 } from '@wordpress/blocks';
 
 /**
@@ -970,12 +969,12 @@ describe( 'state', () => {
 			const state = preferences( undefined, {} );
 
 			expect( state ).toEqual( {
-				recentlyUsedBlocks: [],
+				recentInserts: [],
 			} );
 		} );
 
 		it( 'should record recently used blocks', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [] } ), {
+			const state = preferences( deepFreeze( { recentInserts: [] } ), {
 				type: 'INSERT_BLOCKS',
 				blocks: [ {
 					uid: 'bacon',
@@ -983,42 +982,52 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
+			expect( state ).toEqual( {
+				recentInserts: [
+					{ name: 'core-embed/twitter' },
+				],
+			} );
 
-			const twoRecentBlocks = preferences( deepFreeze( { recentlyUsedBlocks: [] } ), {
+			const twoRecentBlocks = preferences( deepFreeze( { recentInserts: [] } ), {
 				type: 'INSERT_BLOCKS',
 				blocks: [ {
 					uid: 'eggs',
 					name: 'core-embed/twitter',
 				}, {
 					uid: 'bacon',
-					name: 'core-embed/youtube',
+					name: 'core/block',
+					attributes: { ref: 123 },
 				} ],
 			} );
 
-			expect( twoRecentBlocks.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
-			expect( twoRecentBlocks.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/twitter' );
+			expect( twoRecentBlocks ).toEqual( {
+				recentInserts: [
+					{ name: 'core/block', ref: 123 },
+					{ name: 'core-embed/twitter' },
+				],
+			} );
 		} );
 
-		it( 'should populate recentlyUsedBlocks, filling up with common blocks, on editor setup', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [ 'core-embed/twitter', 'core-embed/youtube' ] } ), {
-				type: 'SETUP_EDITOR',
+		it( 'should remove recorded reusable blocks that are deleted', () => {
+			const initialState = {
+				recentInserts: [
+					{ name: 'core-embed/twitter' },
+					{ name: 'core/block', ref: 123 },
+					{ name: 'core/block', ref: 456 },
+				],
+			};
+
+			const state = preferences( deepFreeze( initialState ), {
+				type: 'REMOVE_REUSABLE_BLOCK',
+				id: 123,
 			} );
 
-			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/twitter' );
-			expect( state.recentlyUsedBlocks[ 1 ] ).toEqual( 'core-embed/youtube' );
-
-			state.recentlyUsedBlocks.slice( 2 ).forEach(
-				block => expect( getBlockType( block ).category ).toEqual( 'common' )
-			);
-			expect( state.recentlyUsedBlocks ).toHaveLength( 8 );
-		} );
-
-		it( 'should remove unregistered blocks from persisted recent usage', () => {
-			const state = preferences( deepFreeze( { recentlyUsedBlocks: [ 'core-embed/i-do-not-exist', 'core-embed/youtube' ] } ), {
-				type: 'SETUP_EDITOR',
+			expect( state ).toEqual( {
+				recentInserts: [
+					{ name: 'core-embed/twitter' },
+					{ name: 'core/block', ref: 456 },
+				],
 			} );
-			expect( state.recentlyUsedBlocks[ 0 ] ).toEqual( 'core-embed/youtube' );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
+import { union } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -1961,18 +1962,70 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getRecentInserterItems', () => {
-		beforeEach( () => {
+		beforeAll( () => {
 			registerCoreBlocks();
 		} );
-		it( 'should return the most recently used blocks', () => {
+
+		it( 'should return the 8 most recently used blocks', () => {
 			const state = {
 				preferences: {
-					recentlyUsedBlocks: [ 'core/deleted-block', 'core/paragraph', 'core/image' ],
+					recentInserts: [
+						{ name: 'core/deleted-block' }, // Deleted blocks should be filtered out
+						{ name: 'core/block', ref: 456 }, // Deleted reusable blocks should be filtered out
+						{ name: 'core/paragraph' },
+						{ name: 'core/block', ref: 123 },
+						{ name: 'core/image' },
+						{ name: 'core/quote' },
+						{ name: 'core/gallery' },
+						{ name: 'core/heading' },
+						{ name: 'core/list' },
+						{ name: 'core/video' },
+						{ name: 'core/audio' },
+						{ name: 'core/code' },
+					],
+				},
+				editor: {
+					present: {
+						blockOrder: [],
+					},
+				},
+				reusableBlocks: {
+					data: {
+						123: { id: 123, type: 'core/test-block' },
+					},
 				},
 			};
 
-			expect( getRecentInserterItems( state ).map( ( item ) => item.name ) )
-				.toEqual( [ 'core/paragraph', 'core/image' ] );
+			expect( getRecentInserterItems( state ) ).toMatchObject( [
+				{ name: 'core/paragraph', initialAttributes: {} },
+				{ name: 'core/block', initialAttributes: { ref: 123 } },
+				{ name: 'core/image', initialAttributes: {} },
+				{ name: 'core/quote', initialAttributes: {} },
+				{ name: 'core/gallery', initialAttributes: {} },
+				{ name: 'core/heading', initialAttributes: {} },
+				{ name: 'core/list', initialAttributes: {} },
+				{ name: 'core/video', initialAttributes: {} },
+			] );
+		} );
+
+		it( 'should pad list out with blocks from the common category', () => {
+			const state = {
+				preferences: {
+					recentInserts: [
+						{ name: 'core/paragraph' },
+					],
+				},
+				editor: {
+					present: {
+						blockOrder: [],
+					},
+				},
+			};
+
+			// We should get back 8 items with no duplicates
+			const items = getRecentInserterItems( state );
+			const blockNames = items.map( item => item.name );
+			expect( union( blockNames ) ).toHaveLength( 8 );
 		} );
 	} );
 


### PR DESCRIPTION
### 🐶 What this is

Closes #4653.

<img width="371" alt="screen shot 2018-01-31 at 11 01 22" src="https://user-images.githubusercontent.com/612155/35598216-1ba95d72-0676-11e8-940a-88d8e52c30db.png">

Shows reusable blocks in the 'Recent' tab of the inserter.

### 🤔 How this works

Before, our reducer would build out a `state.preferences.recentlyUsedBlocks` that looks like this:

```js
recentlyUsedBlocks: [ 'core/paragraph', 'core/image' ],
```

This PR changes the shape of this data to look like this:

```js
recentInserts: [
    { name: 'core/paragraph' },
    { name: 'core/image' },
    { name: 'core/block', ref: 123 }
],
```

It's then just a simple matter of patching `selectors.getRecentInserterItems` to look up reusable blocks by the `ref` that is stored.

I've renamed `recentlyUsedBlocks` to `recentInserts` so that we don't need to worry about parsing old data which is in a different shape. This means that, when a user upgrades to the next version of Gutenberg, the blocks that appear in their 'Recent' tab will be reset. I think this is an acceptable trade-off since this data isn't all that important and will be quickly re-populated.

### 📋 How to test

1. Insert a regular block
2. Insert a reusable block
3. Open the inserter and see that both blocks appear in the 'Recent' tab
4. Check that clicking on the block in the inserter inserts that block