### PR TITLE
MetaBoxes: Fix initialization after extracting the edit-post module

### DIFF
--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -100,6 +100,6 @@ export function initializeEditor( id, post, settings ) {
 	);
 
 	return {
-		initializeMetaBoxState: provider.initializeMetaBoxState,
+		initializeMetaBoxes: provider.initializeMetaBoxes,
 	};
 }

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -46,6 +46,7 @@ class EditorProvider extends Component {
 		super( ...arguments );
 
 		this.store = store;
+		this.initializeMetaBoxes = this.initializeMetaBoxes.bind( this );
 
 		this.settings = {
 			...DEFAULT_SETTINGS,

--- a/lib/register.php
+++ b/lib/register.php
@@ -267,7 +267,7 @@ function gutenberg_collect_meta_box_data() {
 	 * this, and try to get this data to load directly into the editor settings.
 	 */
 	wp_add_inline_script(
-		'wp-editor',
+		'wp-edit-post',
 		'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
 	);
 


### PR DESCRIPTION
Since we extracted the `edit-post` module, the meta boxes were not initializing properly. This PR should fix it.

We need some integration tests using meta boxes, might not be easy to setup though. I'll take a look later.