### PR TITLE
Keep mobile keyboard on ENTER: delay focus until MCE init

### DIFF
--- a/blocks/rich-text/tinymce.js
+++ b/blocks/rich-text/tinymce.js
@@ -18,6 +18,10 @@ import { diffAriaProps, pickAriaProps } from './aria';
 const IS_PLACEHOLDER_VISIBLE_ATTR_NAME = 'data-is-placeholder-visible';
 export default class TinyMCE extends Component {
 	componentDidMount() {
+		if ( this.props.onMount ) {
+			this.props.onMount( this.editorNode );
+		}
+
 		this.initialize();
 	}
 

--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -70,6 +70,8 @@
 
 .edit-post-layout__content {
 	position: relative;
+	// Pad the scroll box so content on the bottom can be scrolled up.
+	padding-bottom: 100vh;
 
 	// on mobile the main content area has to scroll
 	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -231,7 +231,10 @@ export class BlockListBlock extends Component {
 			return;
 		}
 
-		target.focus();
+		// If there is a contenteditable element, it will move focus by itself.
+		if ( ! target.querySelector( '[contenteditable="true"]' ) ) {
+			target.focus();
+		}
 
 		// In reverse case, need to explicitly place caret position.
 		if ( isReverse ) {


### PR DESCRIPTION
## Description

This PR fixes #2601 and part of #4731. It delays moving the focus an editable that is still initialising, which fixes the keyboard hiding on ENTER.

## How Has This Been Tested?
Open Gutenberg in iOS with an on screen keyboard. Keyboard should not hide on ENTER.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.