### PR TITLE
Post Editor: Fix lingering visual editor classes

### DIFF
--- a/blocks/library/subhead/editor.scss
+++ b/blocks/library/subhead/editor.scss
@@ -1,5 +1,4 @@
-// Overwrite .editor-visual-editor p
-.editor-visual-editor p.wp-block-subhead {
+.edit-post-visual-editor p.wp-block-subhead {
 	color: $dark-gray-300;
 	font-size: 1.1em;
 	font-style: italic;

--- a/editor/components/warning/style.scss
+++ b/editor/components/warning/style.scss
@@ -1,4 +1,4 @@
-.edit-post-visual-editor .editor-warning {
+.editor-warning {
 	z-index: z-index( '.editor-warning' );
 	position: absolute;
 	top: 50%;
@@ -17,16 +17,11 @@
 	line-height: $default-line-height;
 	box-shadow: $shadow-popover;
 
-	p {
-		font-family: $default-font;
-		font-size: $default-font-size;
-	}
-
 	p:first-child {
 		margin-top: 0;
 	}
 
-	.editor-visual-editor & p {
+	.edit-post-visual-editor & p {
 		width: 100%;
 		font-family: $default-font;
 		font-size: $default-font-size;


### PR DESCRIPTION
Regression introduced in #4661

This pull request seeks to resolve an issue where a few styles remained which had been applied to the `.editor-visual-editor` class scope, which was renamed `.edit-post-visual-editor` in #4661. This affects both the Subhead block and EditorWarning components.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/35637251-b3a8628e-0681-11e8-8ed7-a0eb7805de40.png)|![After](https://user-images.githubusercontent.com/1779930/35637234-a6a7a18a-0681-11e8-858b-adfc1c6f47da.png)

__Testing instructions:__

Verify that the invalid block warning is styled as expected (per "After" screenshot above). For example, try modifying attributes of a block in `post-content.js` demo content to cause the block to become invalid.