### PR TITLE
Docs: Document block validation, clarify extensibility validation

### DIFF
--- a/docs/block-edit-save.md
+++ b/docs/block-edit-save.md
@@ -140,3 +140,7 @@ Before starting to debug, be sure to familiarize yourself with the validation st
 If you're using [attribute sources](https://wordpress.org/gutenberg/handbook/block-api/attributes/), be sure that attributes sourced from markup are saved exactly as you expect, and in the correct type (usually a `'string'` or `'number'`).
 
 When a block is detected as invalid, a warning will be logged into your browser's developer tools console. The warning will include specific details about the exact point at which a difference in markup occurred. Be sure to look closely at any differences in the expected and actual markups to see where problems are occurring.
+
+**I've changed my block's `save` behavior and old content now includes invalid blocks. How can I fix this?**
+
+Refer to the guide on [Deprecated Blocks](https://wordpress.org/gutenberg/handbook/block-api/deprecated-blocks/) to learn more about how to accommodate legacy content in intentional markup changes.

--- a/docs/block-edit-save.md
+++ b/docs/block-edit-save.md
@@ -111,3 +111,32 @@ save( { attributes } ) {
 	return <div>{ attributes.content }</div>;
 }
 ```
+
+## Validation
+
+When the editor loads, all blocks within post content are validated to determine their accuracy in order to protect against content loss. This is closely related to the saving implementation of a block, as a user may unintentionally remove or modify their content if the block is unable to restore a block correctly. During editor initialization, the saved markup for each block is regenerated using the attributes that were parsed from the post's content. If the newly-generated markup does not match what was already stored in post content, the block is marked as invalid. This is because we assume that unless the user makes edits, the markup should remain identical to the saved content.
+
+If a block is detected to be invalid, the user will be prompted to choose how to handle the invalidation:
+
+![Invalid block prompt](https://user-images.githubusercontent.com/1779930/35637234-a6a7a18a-0681-11e8-858b-adfc1c6f47da.png)
+
+- **Overwrite**: Ignores the warning and treats the newly generated markup as correct. As noted in the behavior described above, this can result in content loss since it will overwrite the markup saved in post content.
+- **Convert to Classic**: Protects the original markup from the saved post content as correct. Since the block will be converted from its original type to the Classic block type, it will no longer be possible to edit the content using controls available for the original block type.
+- **Edit as HTML block**: Similar to _Convert to Classic_, this will protect the original markup from the saved post content and convert the block from its original type to the HTML block type, enabling the user to modify the HTML markup directly.
+
+### Validation FAQ
+
+**How do blocks become invalid?**
+
+The two most common sources of block invalidations are:
+
+1. A flaw in a block's code would result in unintended content modifications. See the question below on how to debug block invalidation as a plugin author.
+2. You or an external editor changed the HTML markup of the block in such a way that it is no longer considered correct.
+
+**I'm a plugin author. What should I do to debug why my blocks are being marked as invalid?**
+
+Before starting to debug, be sure to familiarize yourself with the validation step described above documenting the process for detecting whether a block is invalid. A block is invalid if its regenerated markup does not match what is saved in post content, so often this can be caused by the attributes of a block being parsed incorrectly from the saved content.
+
+If you're using [attribute sources](https://wordpress.org/gutenberg/handbook/block-api/attributes/), be sure that attributes sourced from markup are saved exactly as you expect, and in the correct type (usually a `'string'` or `'number'`).
+
+When a block is detected as invalid, a warning will be logged into your browser's developer tools console. The warning will include specific details about the exact point at which a difference in markup occurred. Be sure to look closely at any differences in the expected and actual markups to see where problems are occurring.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -105,7 +105,7 @@ Adding a background by default to all blocks.
 ```js
 // Our filter function
 function addBackgroundProp( props ) {
-	return Object.assign( props, { backgroundColor: 'red' } );
+	return Object.assign( props, { style: { backgroundColor: 'red' } } );
 }
 
 // Adding the filter

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -116,6 +116,7 @@ wp.hooks.addFilter(
 );
 ```
 
+_Note:_ This filter must always be run on every page load, and not in your browser's developer tools console. Otherwise, a [block validation](https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/#validation) error will occur the next time the post is edited. This is due to the fact that block validation occurs by verifying that the saved output matches what is stored in the post's content during editor initialization. So, if this filter does not exist when the editor loads, the block will be marked as invalid.
 
 ## Extending the editor's UI (Slot and Fill)
 


### PR DESCRIPTION
Closes #4759 

This pull request seeks to add documentation for block validation, describing the process for determining whether a block is invalid, options presented to the user for resolving the invalidation, and debugging steps for plugin authors. Further, it clarifies a confusion about block extensibility and its relation to validation.

__Testing instructions:__

There are no behavior impact expected with the changes proposed here.