### PR TITLE
Framework: Assign preferred JSDoc tags and types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -181,7 +181,30 @@
 			}
 		} ],
 		"template-curly-spacing": [ "error", "always" ],
-		"valid-jsdoc": [ "error", { "requireReturn": false } ],
+		"valid-jsdoc": [ "error", {
+			"prefer": {
+				"arg": "param",
+				"argument": "param",
+				"extends": "augments",
+				"return": "returns"
+			},
+			"preferType": {
+				"array": "Array",
+				"bool": "boolean",
+				"Boolean": "boolean",
+				"float": "number",
+				"Float": "number",
+				"int": "number",
+				"integer": "number",
+				"Integer": "number",
+				"Number": "number",
+				"object": "Object",
+				"String": "string",
+				"Void": "void"
+			},
+			"requireParamDescription": false,
+			"requireReturn": false
+		} ],
 		"valid-typeof": "error",
 		"yoda": "off"
 	}

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -178,7 +178,7 @@ export function getAttributesFromDeprecatedVersion( blockType, innerHTML, attrib
 /**
  * Creates a block with fallback to the unknown type handler.
  *
- * @param {?String} name       Block type name.
+ * @param {?string} name       Block type name.
  * @param {string}  innerHTML  Raw block content.
  * @param {?Object} attributes Attributes obtained from block delimiters.
  *

--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -37,7 +37,7 @@ import shortcodeConverter from './shortcode-converter';
  * @param {Array}  [options.tagName]   The tag into which content will be
  *                                     inserted.
  *
- * @returns {Array|String} A list of blocks or a string, depending on `handlerMode`.
+ * @returns {Array|string} A list of blocks or a string, depending on `handlerMode`.
  */
 export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagName } ) {
 	// First of all, strip any meta tags.

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -162,7 +162,7 @@ const log = ( () => {
  *
  * @param {string} text Original text.
  *
- * @returns {String[]} Text pieces split on whitespace.
+ * @returns {string[]} Text pieces split on whitespace.
  */
 export function getTextPiecesSplitOnWhitespace( text ) {
 	return text.trim().split( REGEXP_WHITESPACE );

--- a/components/higher-order/with-filters/index.js
+++ b/components/higher-order/with-filters/index.js
@@ -14,7 +14,7 @@ const ANIMATION_FRAME_PERIOD = 16;
 /**
  * Creates a higher-order component which adds filtering capability to the
  * wrapped component. Filters get applied when the original component is about
- * to be mounted. When a filter is added or removed that matches the hook name, 
+ * to be mounted. When a filter is added or removed that matches the hook name,
  * the wrapped component re-renders.
  *
  * @param {string} hookName Hook name exposed to be used by filters.

--- a/docs/testing-overview.md
+++ b/docs/testing-overview.md
@@ -12,7 +12,7 @@ Assuming you've followed the instructions above to install Node and project depe
 npm test
 ```
 
-Code style in JavaScript is enforced using [ESLint](http://eslint.org/). The above `npm test` will execute both unit tests and code linting. Code linting can be verified independently by running `npm run lint`. ESLint can also fix not all, but many issues automatically by running `npm run lint:fix`.
+Code style in JavaScript is enforced using [ESLint](http://eslint.org/). The above `npm test` will execute both unit tests and code linting. Code linting can be verified independently by running `npm run lint`. ESLint can also fix not all, but many issues automatically by running `npm run lint:fix`. To reduce the likelihood of unexpected build failures caused by code styling issues, you're encouraged to [install an ESLint integration for your editor](https://eslint.org/docs/user-guide/integrations) and/or create a [git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) containing the `npm run lint:fix` command.
 
 To run unit tests only, without the linter, use `npm run test-unit` instead.
 

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -162,7 +162,7 @@ export function getCurrentPostType( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?Number} ID of current post.
+ * @returns {?number} ID of current post.
  */
 export function getCurrentPostId( state ) {
 	return getCurrentPost( state ).id || null;
@@ -185,7 +185,7 @@ export function getCurrentPostRevisionsCount( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?Number} ID of the last revision.
+ * @returns {?number} ID of the last revision.
  */
 export function getCurrentPostLastRevisionId( state ) {
 	return get( getCurrentPost( state ), 'revisions.last_id', null );
@@ -541,7 +541,7 @@ export const getMultiSelectedBlocks = createSelector(
  *
  * @param {Object} state Global application state.
  *
- * @returns {?String} First unique block ID in the multi-selection set.
+ * @returns {?string} First unique block ID in the multi-selection set.
  */
 export function getFirstMultiSelectedBlockUid( state ) {
 	return first( getMultiSelectedBlockUids( state ) ) || null;
@@ -553,7 +553,7 @@ export function getFirstMultiSelectedBlockUid( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?String} Last unique block ID in the multi-selection set.
+ * @returns {?string} Last unique block ID in the multi-selection set.
  */
 export function getLastMultiSelectedBlockUid( state ) {
 	return last( getMultiSelectedBlockUids( state ) ) || null;
@@ -595,7 +595,7 @@ export function isBlockMultiSelected( state, uid ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?String} Unique ID of block beginning multi-selection.
+ * @returns {?string} Unique ID of block beginning multi-selection.
  */
 export function getMultiSelectedBlocksStartUid( state ) {
 	const { start, end } = state.blockSelection;
@@ -614,7 +614,7 @@ export function getMultiSelectedBlocksStartUid( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?String} Unique ID of block ending multi-selection.
+ * @returns {?string} Unique ID of block ending multi-selection.
  */
 export function getMultiSelectedBlocksEndUid( state ) {
 	const { start, end } = state.blockSelection;
@@ -827,7 +827,7 @@ export function isTyping( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?String} Unique ID after which insertion will occur.
+ * @returns {?string} Unique ID after which insertion will occur.
  */
 export function getBlockInsertionPoint( state ) {
 	const lastMultiSelectedBlock = getLastMultiSelectedBlockUid( state );
@@ -848,7 +848,7 @@ export function getBlockInsertionPoint( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?Boolean} Whether the insertion point is visible or not.
+ * @returns {?boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
 	return state.isInsertionPointVisible;
@@ -896,7 +896,7 @@ export function didPostSaveRequestFail( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?String} Suggested post format.
+ * @returns {?string} Suggested post format.
  */
 export function getSuggestedPostFormat( state ) {
 	const blocks = state.editor.present.blockOrder;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3299,9 +3299,9 @@
       }
     },
     "eslint": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
-      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
+      "integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -3310,22 +3310,22 @@
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.2",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.2",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.3.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
-        "is-resolvable": "1.0.1",
+        "is-resolvable": "1.1.0",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -3391,13 +3391,19 @@
           }
         },
         "doctrine": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-          "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
             "esutils": "2.0.2"
           }
+        },
+        "globals": {
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+          "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
@@ -3613,6 +3619,12 @@
         "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
       }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
     },
     "espree": {
       "version": "3.5.2",
@@ -5825,9 +5837,9 @@
       }
     },
     "is-resolvable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
@@ -7157,6 +7169,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"deep-freeze": "0.0.1",
 		"enzyme": "3.2.0",
 		"enzyme-adapter-react-16": "1.1.0",
-		"eslint": "4.9.0",
+		"eslint": "4.16.0",
 		"eslint-config-wordpress": "2.0.0",
 		"eslint-plugin-jest": "21.5.0",
 		"eslint-plugin-jsx-a11y": "6.0.2",

--- a/utils/focus/tabbable.js
+++ b/utils/focus/tabbable.js
@@ -13,7 +13,7 @@ import { find as findFocusable } from './focusable';
  *
  * @param {Element} element Element from which to retrieve.
  *
- * @returns {?Number} Tab index of element (default 0).
+ * @returns {?number} Tab index of element (default 0).
  */
 function getTabIndex( element ) {
 	const tabIndex = element.getAttribute( 'tabindex' );


### PR DESCRIPTION
This pull request seeks to assign preferred JSDoc tags and types as prescribed by the [WordPress JavaScript Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/), and [as discussed in the 2018-01-30 JS Core Chat](https://wordpress.slack.com/archives/C5UNMSU4R/p1517321893000333). The following preferences have been assigned:

**Tags:**

Discouraged|Replacement
---|---
`@arg`|`@param`
`@argument`|`@param`
`@extends`|`@augments`
`@return`|`@returns`

**Types:**

Discouraged|Replacement
---|---
`array`|`Array`
`bool`|`boolean`
`Boolean`|`boolean`
`float`|`number`
`Float`|`number`
`int`|`number`
`integer`|`number`
`Integer`|`number`
`Number`|`number`
`object`|`Object`
`String`|`string`
`Void`|`void`

Unlike my original proposition, I have decided to keep the distinction between upper- and lower- cased types, which are in-fact different. They have been kept because (a) with the options assigned, they are now correctly flagged as errors and (b) can easily be resolved with `npm run lint:fix`.

Documentation has been updated to encourage the installation of an ESLint integration and/or pre-commit hook to try to reduce friction of code styling issues.

While it has since been decided that we will encourage `@return` over `@returns`, I did not want to make this change as part of the pull request here, as I expect it will impact many files and introduce merge conflicts. A follow-up pull request is planned.

__Testing instructions:__

Verify there are no lint errors:

```
npm run lint
```