### PR TITLE
Element / Block API: Add RawHTML component, drop support for HTML string block save

### DIFF
--- a/blocks/README.md
+++ b/blocks/README.md
@@ -231,7 +231,7 @@ editor interface where blocks are implemented.
 
 - `title: string` - A human-readable
   [localized](https://codex.wordpress.org/I18n_for_WordPress_Developers#Handling_JavaScript_files)
-  label for the block. Shown in the block picker.
+  label for the block. Shown in the block inserter.
 - `icon: string | WPElement | Function` - Slug of the
   [Dashicon](https://developer.wordpress.org/resource/dashicons/#awards)
   to be shown in the control's button, or an element (or function returning an

--- a/blocks/README.md
+++ b/blocks/README.md
@@ -250,9 +250,9 @@ editor interface where blocks are implemented.
   editor. A block can update its own state in response to events using the
   `setAttributes` function, passing an object of properties to be applied as a
   partial update.
-- `save( { attributes: Object } ): WPElement | String` - Returns an element
-  describing the markup of a block to be saved in the published content. This
-  function is called before save and when switching to an editor's HTML view.
+- `save( { attributes: Object } ): WPElement` - Returns an element describing
+  the markup of a block to be saved in the published content. This function is
+  called before save and when switching to an editor's HTML view.
 - `keywords` - An optional array of keywords used to filter the block list.
 
 ### `wp.blocks.getBlockType( name: string )`

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -16,9 +16,34 @@ import { applyFilters } from '@wordpress/hooks';
 import { getCategories } from './categories';
 
 /**
- * Block settings keyed by block name.
+ * Defined behavior of a block type.
  *
- * @type {Object}
+ * @typedef {WPBlockType}
+ *
+ * @property {string}             name       Block's namespaced name.
+ * @property {string}             title      Human-readable label for a block.
+ *                                           Shown in the block inserter.
+ * @property {string}             category   Category classification of block,
+ *                                           impacting where block is shown in
+ *                                           inserter results.
+ * @property {(string|WPElement)} icon       Slug of the Dashicon to be shown
+ *                                           as the icon for the block in the
+ *                                           inserter, or element.
+ * @property {?string[]}          keywords   Additional keywords to produce
+ *                                           block as inserter search result.
+ * @property {?Object}            attributes Block attributes.
+ * @property {Function}           save       Serialize behavior of a block,
+ *                                           returning an element describing
+ *                                           structure of the block's post
+ *                                           content markup.
+ * @property {WPComponent}        edit       Component rendering element to be
+ *                                           interacted with in an editor.
+ */
+
+/**
+ * Block type definitions keyed by block name.
+ *
+ * @type {Object.<string,WPBlockType>}
  */
 const blocks = {};
 

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -45,11 +45,6 @@ export function getSaveElement( blockType, attributes ) {
 		saveElement = createElement( save, { attributes } );
 	} else {
 		saveElement = save( { attributes } );
-
-		// Special-case function render implementation to allow raw HTML return
-		if ( 'string' === typeof saveElement ) {
-			return saveElement;
-		}
 	}
 
 	const addExtraContainerProps = ( element ) => {
@@ -76,15 +71,7 @@ export function getSaveElement( blockType, attributes ) {
  * @return {string} Save content.
  */
 export function getSaveContent( blockType, attributes ) {
-	const saveElement = getSaveElement( blockType, attributes );
-
-	// Special-case function render implementation to allow raw HTML return
-	if ( 'string' === typeof saveElement ) {
-		return saveElement;
-	}
-
-	// Otherwise, infer as element
-	return renderToString( saveElement );
+	return renderToString( getSaveElement( blockType, attributes ) );
 }
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -47,6 +47,15 @@ export function getSaveElement( blockType, attributes ) {
 		saveElement = save( { attributes } );
 	}
 
+	/**
+	 * Filters the save result of a block during serialization.
+	 *
+	 * @param {WPElement}   saveElement Block save result.
+	 * @param {WPBlockType} blockType   Block type definition.
+	 * @param {Object}      attributes  Block attributes.
+	 */
+	saveElement = applyFilters( 'blocks.getSaveContent.saveElement', saveElement, blockType, attributes );
+
 	const addExtraContainerProps = ( element ) => {
 		if ( ! element || ! isObject( element ) ) {
 			return element;

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -257,7 +257,7 @@ describe( 'block serializer', () => {
 						},
 					},
 
-					save: ( { attributes } ) => attributes.customText,
+					save: () => null,
 				} );
 			} );
 

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -117,7 +117,7 @@ describe( 'block serializer', () => {
 					{ fruit: 'Bananas' }
 				);
 
-				expect( saved ).toBe( '<div>Bananas</div>' );
+				expect( saved ).toBe( '<div class="wp-block-fruit">Bananas</div>' );
 			} );
 		} );
 	} );

--- a/blocks/api/test/serializer.js
+++ b/blocks/api/test/serializer.js
@@ -46,18 +46,6 @@ describe( 'block serializer', () => {
 
 	describe( 'getSaveContent()', () => {
 		describe( 'function save', () => {
-			it( 'should return string verbatim', () => {
-				const saved = getSaveContent(
-					{
-						save: ( { attributes } ) => attributes.fruit,
-						name: 'core/fruit',
-					},
-					{ fruit: 'Bananas' }
-				);
-
-				expect( saved ).toBe( 'Bananas' );
-			} );
-
 			it( 'should return element as string if save returns element', () => {
 				const saved = getSaveContent(
 					{
@@ -411,11 +399,11 @@ describe( 'block serializer', () => {
 			const block =	{
 				name: 'core/chicken',
 				attributes: {
-					content: '<p>chicken   </p>',
+					content: 'chicken',
 				},
 				isValid: true,
 			};
-			expect( getBlockContent( block ) ).toBe( '<p>chicken </p>' );
+			expect( getBlockContent( block ) ).toBe( 'chicken' );
 		} );
 	} );
 } );

--- a/blocks/hooks/deprecated.js
+++ b/blocks/hooks/deprecated.js
@@ -56,7 +56,7 @@ export function shimRawHTML( element ) {
 }
 
 addFilter(
-	'blocks.getSaveContent.saveElement',
+	'blocks.getSaveElement',
 	'core/deprecated/shim-dangerous-html',
 	shimRawHTML
 );

--- a/blocks/hooks/deprecated.js
+++ b/blocks/hooks/deprecated.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, RawHTML } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Wrapper component for RawHTML, logging a warning about unsupported raw
+ * markup return values from a block's `save` implementation.
+ */
+export class RawHTMLWithWarning extends Component {
+	constructor() {
+		super( ...arguments );
+
+		// Disable reason: We're intentionally logging a console warning
+		// advising the developer to upgrade usage.
+
+		// eslint-disable-next-line no-console
+		console.warn(
+			'Deprecated: Returning raw HTML from block `save` is not supported. ' +
+			'Use `wp.element.RawHTML` component instead.\n\n' +
+			'See: https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/#save'
+		);
+	}
+
+	render() {
+		const { children } = this.props;
+
+		return <RawHTML>{ children }</RawHTML>;
+	}
+}
+
+/**
+ * Override save element for a block, providing support for deprecated HTML
+ * return value, logging a warning advising the developer to use the preferred
+ * RawHTML component instead.
+ *
+ * @param {WPElement} element Original block save return.
+ *
+ * @return {WPElement} Dangerously shimmed block save.
+ */
+export function shimRawHTML( element ) {
+	// Still support string return from save, but in the same way any component
+	// could render a string, it should be escaped. Therefore, only shim usage
+	// which had included some HTML expected to be unescaped.
+	if ( typeof element === 'string' && ( includes( element, '<' ) || /^\[.+\]$/.test( element ) ) ) {
+		element = <RawHTMLWithWarning children={ element } />;
+	}
+
+	return element;
+}
+
+addFilter(
+	'blocks.getSaveContent.saveElement',
+	'core/deprecated/shim-dangerous-html',
+	shimRawHTML
+);

--- a/blocks/hooks/index.js
+++ b/blocks/hooks/index.js
@@ -3,5 +3,6 @@
  */
 import './anchor';
 import './custom-class-name';
+import './deprecated';
 import './generated-class-name';
 import './matchers';

--- a/blocks/hooks/test/deprecated.js
+++ b/blocks/hooks/test/deprecated.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	RawHTMLWithWarning,
+	shimRawHTML,
+} from '../deprecated';
+
+describe( 'deprecated', () => {
+	describe( 'RawHTMLWithWarning', () => {
+		it( 'warns on mount', () => {
+			shallow( <RawHTMLWithWarning /> );
+
+			expect( console ).toHaveWarned();
+		} );
+
+		it( 'renders RawHTML', () => {
+			const wrapper = shallow(
+				<RawHTMLWithWarning>
+					Scary!
+				</RawHTMLWithWarning>
+			);
+
+			expect( console ).toHaveWarned();
+			expect( wrapper.name() ).toBe( 'RawHTML' );
+			expect( wrapper.find( 'RawHTML' ).prop( 'children' ) ).toBe( 'Scary!' );
+		} );
+	} );
+
+	describe( 'shimRawHTML()', () => {
+		it( 'should do nothing to elements', () => {
+			const original = createElement( 'div' );
+			const result = shimRawHTML( original );
+
+			expect( result ).toBe( original );
+		} );
+
+		it( 'should do nothing to non-HTML strings', () => {
+			const original = 'Not so scary';
+			const result = shimRawHTML( original );
+
+			expect( result ).toBe( original );
+		} );
+
+		it( 'replace HTML strings with RawHTMLWithWarning', () => {
+			const original = '<p>So scary!</p>';
+			const result = shimRawHTML( original );
+
+			expect( result.type ).toBe( RawHTMLWithWarning );
+			expect( result.props.children ).toBe( original );
+		} );
+
+		it( 'replace shortcode strings with RawHTMLWithWarning', () => {
+			const original = '[myshortcode]Hello[/myshortcode]';
+			const result = shimRawHTML( original );
+
+			expect( result.type ).toBe( RawHTMLWithWarning );
+			expect( result.props.children ).toBe( original );
+		} );
+	} );
+} );

--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,10 +28,15 @@ export const settings = {
 		},
 	},
 
+	supports: {
+		className: false,
+	},
+
 	edit: OldEditor,
 
 	save( { attributes } ) {
 		const { content } = attributes;
-		return content;
+
+		return <RawHTML>{ content }</RawHTML>;
 	},
 };

--- a/blocks/library/freeform/test/__snapshots__/index.js.snap
+++ b/blocks/library/freeform/test/__snapshots__/index.js.snap
@@ -8,7 +8,7 @@ Array [
     style="display:none"
   />,
   <div
-    class="wp-block-freeform blocks-rich-text__tinymce"
+    class="blocks-rich-text__tinymce"
   />,
 ]
 `;

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withState } from '@wordpress/components';
 
@@ -70,6 +71,6 @@ export const settings = {
 	] ),
 
 	save( { attributes } ) {
-		return attributes.content;
+		return <RawHTML>{ attributes.content }</RawHTML>;
 	},
 };

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withInstanceId, Dashicon } from '@wordpress/components';
 
@@ -80,6 +81,6 @@ export const settings = {
 	),
 
 	save( { attributes } ) {
-		return attributes.text;
+		return <RawHTML>{ attributes.text }</RawHTML>;
 	},
 };

--- a/docs/block-edit-save.md
+++ b/docs/block-edit-save.md
@@ -90,27 +90,49 @@ edit( { attributes, setAttributes, className, focus } ) {
 
 The `save` function defines the way in which the different attributes should be combined into the final markup, which is then serialized by Gutenberg into `post_content`.
 
+{% codetabs %}
+{% ES5 %}
 ```js
-// Defining the save interface
+save() {
+	return wp.element.createElement( 'hr' );
+}
+```
+{% ESNext %}
+```jsx
 save() {
 	return <hr />;
 }
 ```
+{% end %}
 
-This function can return a `null` value, in which case the block is considered to be _dynamic_—that means that only an HTML comment with attributes is serialized and the server has to provide the render function. (This is the equivalent to purely dynamic shortcodes, with the advantage that the grammar parsing it is assertive and they can remain invisible in contexts that are unable to compute them on the server, instead of showing gibberish as text.)
+For most blocks, the return value of `save` should be an [instance of WordPress Element](https://github.com/WordPress/gutenberg/blob/master/element/README.md) representing how the block is to appear on the front of the site.
 
-`save` can also receive properties.
+_Note:_ While it is possible to return a string value from `save`, it _will be escaped_. If the string includes HTML markup, the markup will be shown on the front of the site verbatim, not as the equivalent HTML node content. If you must return raw HTML from `save`, use `wp.element.RawHTML`. As the name implies, this is prone to [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) and therefore is discouraged in favor of a WordPress Element hierarchy whenever possible.
+
+For [dynamic blocks](https://wordpress.org/gutenberg/handbook/blocks/creating-dynamic-blocks/), the return value of `save` could either represent a cached copy of the block's content to be shown only in case the plugin implementing the block is ever disabled. Alternatively, return a `null` (empty) value to save no markup in post content for the dynamic block, instead deferring this to always be calculated when the block is shown on the front of the site.
 
 ### attributes
 
-It operates the same way as it does on `edit` and allows to save certain attributes directly to the markup, so they don't have to be computed on the server. This is how most _static_ blocks are expected to work.
+As with `edit`, the `save` function also receives an object argument including attributes which can be inserted into the markup.
 
+{% codetabs %}
+{% ES5 %}
 ```js
-// Defining the edit interface
+save( props ) {
+	return wp.element.createElement(
+		'div',
+		null,
+		props.attributes.content
+	);
+}
+```
+{% ESNext %}
+```jsx
 save( { attributes } ) {
 	return <div>{ attributes.content }</div>;
 }
 ```
+{% end %}
 
 ## Validation
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -94,6 +94,8 @@ To modify the behaviour of existing blocks, Gutenberg exposes a list of filters:
 
 - `blocks.registerBlockType`: Used to filter the block settings. It receives the block settings and the name of the block the registered block as arguments.
 
+- `blocks.getSaveElement`: A filter that applies to the result of a block's `save` function. This filter is used to replace or extend the element, for example using `wp.element.cloneElement` to modify the element's props or replace its children, or returning an entirely new element.
+
 - `blocks.getSaveContent.extraProps`: A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block Type and the block attributes as arguments.
 
 - `blocks.BlockEdit`: Used to modify the block's `edit` component. It receives the original block `edit` component and returns a new wrapped component.

--- a/element/index.js
+++ b/element/index.js
@@ -16,7 +16,7 @@ import { camelCase, flowRight, isString, upperFirst } from 'lodash';
  *                                       pass through to element creator
  * @param {...WPElement}       children Descendant elements
  *
- * @returns {WPElement} Element.
+ * @return {WPElement} Element.
  */
 export { createElement };
 
@@ -46,7 +46,7 @@ export { Component };
  * @param {WPElement} element Element
  * @param {?Object}   props   Props to apply to cloned element
  *
- * @returns {WPElement} Cloned element.
+ * @return {WPElement} Cloned element.
  */
 export { cloneElement };
 
@@ -80,9 +80,16 @@ export { createPortal };
  *
  * @param {WPElement} element Element to render
  *
- * @returns {String} HTML.
+ * @return {string} HTML.
  */
-export { renderToStaticMarkup as renderToString };
+export function renderToString( element ) {
+	let rendered = renderToStaticMarkup( element );
+
+	// Drop raw HTML wrappers (support dangerous inner HTML without wrapper)
+	rendered = rendered.replace( /<\/?wp-raw-html>/g, '' );
+
+	return rendered;
+}
 
 /**
  * Concatenate two or more React children objects.
@@ -131,7 +138,7 @@ export function switchChildrenNodeName( children, nodeName ) {
  *
  * @param {...Function} hocs The HOC functions to invoke.
  *
- * @returns {Function} Returns the new composite function.
+ * @return {Function} Returns the new composite function.
  */
 export { flowRight as compose };
 
@@ -148,4 +155,19 @@ export function getWrapperDisplayName( BaseComponent, wrapperName ) {
 	const { displayName = BaseComponent.name || 'Component' } = BaseComponent;
 
 	return `${ upperFirst( camelCase( wrapperName ) ) }(${ displayName })`;
+}
+
+/**
+ * Component used as equivalent of Fragment with unescaped HTML, in cases where
+ * it is desirable to render dangerous HTML without needing a wrapper element.
+ *
+ * @param {string} props.children HTML to render.
+ *
+ * @return {WPElement} Dangerously-rendering element.
+ */
+export function RawHTML( { children } ) {
+	return (
+		<wp-raw-html
+			dangerouslySetInnerHTML={ { __html: children } } />
+	);
 }

--- a/element/index.js
+++ b/element/index.js
@@ -4,7 +4,13 @@
 import { createElement, Component, cloneElement, Children, Fragment } from 'react';
 import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { camelCase, flowRight, isString, upperFirst } from 'lodash';
+import {
+	camelCase,
+	flowRight,
+	isString,
+	upperFirst,
+	isEmpty,
+} from 'lodash';
 
 /**
  * Returns a new element of given type. Type can be either a string tag name or
@@ -160,14 +166,22 @@ export function getWrapperDisplayName( BaseComponent, wrapperName ) {
 /**
  * Component used as equivalent of Fragment with unescaped HTML, in cases where
  * it is desirable to render dangerous HTML without needing a wrapper element.
+ * To preserve additional props, a `div` wrapper _will_ be created if any props
+ * aside from `children` are passed.
  *
  * @param {string} props.children HTML to render.
  *
  * @return {WPElement} Dangerously-rendering element.
  */
-export function RawHTML( { children } ) {
-	return (
-		<wp-raw-html
-			dangerouslySetInnerHTML={ { __html: children } } />
-	);
+export function RawHTML( { children, ...props } ) {
+	// Render wrapper only if props are non-empty.
+	const tagName = isEmpty( props ) ? 'wp-raw-html' : 'div';
+
+	// Merge HTML into assigned props.
+	props = {
+		dangerouslySetInnerHTML: { __html: children },
+		...props,
+	};
+
+	return createElement( tagName, props );
 }

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -160,5 +160,19 @@ describe( 'element', () => {
 			expect( element.prop( 'dangerouslySetInnerHTML' ).__html ).toBe( html );
 			expect( element.prop( 'children' ) ).toBe( undefined );
 		} );
+
+		it( 'creates wrapper if assigned other props', () => {
+			const html = '<p>So scary!</p>';
+			const element = shallow(
+				<RawHTML className="foo">
+					{ html }
+				</RawHTML>
+			);
+
+			expect( element.type() ).toBe( 'div' );
+			expect( element.prop( 'className' ) ).toBe( 'foo' );
+			expect( element.prop( 'dangerouslySetInnerHTML' ).__html ).toBe( html );
+			expect( element.prop( 'children' ) ).toBe( undefined );
+		} );
 	} );
 } );

--- a/element/test/index.js
+++ b/element/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
  * Internal dependencies
  */
 import {
@@ -8,6 +13,7 @@ import {
 	renderToString,
 	switchChildrenNodeName,
 	getWrapperDisplayName,
+	RawHTML,
 } from '../';
 
 describe( 'element', () => {
@@ -43,6 +49,14 @@ describe( 'element', () => {
 			expect( renderToString(
 				createElement( 'strong', null, 'Courgette' )
 			) ).toBe( '<strong>Courgette</strong>' );
+		} );
+
+		it( 'strips raw html wrapper', () => {
+			const html = '<p>So scary!</p>';
+
+			expect( renderToString(
+				<RawHTML>{ html }</RawHTML>,
+			) ).toBe( html );
 		} );
 	} );
 
@@ -130,6 +144,21 @@ describe( 'element', () => {
 			SomeComponent.displayName = 'CustomDisplayName';
 
 			expect( getWrapperDisplayName( SomeComponent, 'test' ) ).toBe( 'Test(CustomDisplayName)' );
+		} );
+	} );
+
+	describe( 'RawHTML', () => {
+		it( 'is dangerous', () => {
+			const html = '<p>So scary!</p>';
+			const element = shallow(
+				<RawHTML>
+					{ html }
+				</RawHTML>
+			);
+
+			expect( element.type() ).toBe( 'wp-raw-html' );
+			expect( element.prop( 'dangerouslySetInnerHTML' ).__html ).toBe( html );
+			expect( element.prop( 'children' ) ).toBe( undefined );
 		} );
 	} );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5682,7 +5682,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
       "requires": {
         "is-primitive": "2.0.0"
       }
@@ -5812,8 +5811,7 @@
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-promise": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"escape-string-regexp": "1.0.5",
 		"eslint-plugin-wordpress": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#327b6bdec434177a6e841bd3210e87627ccfcecb",
 		"hpq": "1.2.0",
+		"is-equal-shallow": "0.1.3",
 		"jed": "1.1.1",
 		"jquery": "3.2.1",
 		"js-beautify": "1.6.14",


### PR DESCRIPTION
Related: #3745 (cherry-picks 57978ebebf2d7f7d57a29ccb5bc958a3a946aa42)

This pull request seeks to migrate away from string return from block `save` implementation toward a new `RawHTML` component, which serves an identical purpose while also providing additional utility for nesting (#3745) and Editable value (#2750). Further, it reduces the number of code paths to maintain and improves consistency of hook behaviors (e.g. hooks injecting props via `blocks.getSaveContent.extraProps` are now respected). You can see this demonstrated here in the change introducing `supports.className = false` to the Classic block, as otherwise a wrapper with the auto-generated class name is applied (a bug resolved by these changes).

__Breaking Change__: (_Deprecation_) All existing block `save` implementations returning raw HTML will continue to work, but a warning will be logged to the browser console recommending the `RawHTML` component instead. We may want to seek to remove this deprecated code in the future.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```

Verify that there are no regressions in the behavior of blocks expecting to save raw HTML, notably the Classic, HTML, and Shortcode blocks. These blocks should also not render any wrapper elements, except in the case that a custom class name is assigned.