### PR TITLE
Fix loss of focus when navigating from a multi selection

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -28,7 +28,7 @@ import {
 	getMultiSelectedBlocks,
 	getSelectedBlock,
 } from '../../store/selectors';
-import { multiSelect, appendDefaultBlock } from '../../store/actions';
+import { multiSelect, appendDefaultBlock, focusBlock } from '../../store/actions';
 
 /**
  * Module Constants
@@ -140,6 +140,12 @@ class WritingFlow extends Component {
 		this.props.onMultiSelect( currentStartUid, blocks[ nextIndex ] );
 	}
 
+	moveSelection( blocks, currentUid, delta ) {
+		const currentIndex = blocks.indexOf( currentUid );
+		const nextIndex = Math.max( 0, Math.min( blocks.length - 1, currentIndex + delta ) );
+		this.props.onFocusBlock( blocks[ nextIndex ] );
+	}
+
 	isEditableEdge( moveUp, target ) {
 		const editables = this.getEditables( target );
 		const index = editables.indexOf( target );
@@ -177,6 +183,10 @@ class WritingFlow extends Component {
 			// Shift key is down, but no existing block selection
 			event.preventDefault();
 			this.expandSelection( blocks, selectedBlock.uid, selectedBlock.uid, isReverse ? -1 : +1 );
+		} else if ( isNav && hasMultiSelection ) {
+			// Moving from multi block selection to single block selection
+			event.preventDefault();
+			this.moveSelection( blocks, selectionEnd, isReverse ? -1 : +1 );
 		} else if ( isVertical && isVerticalEdge( target, isReverse, isShift ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
@@ -225,5 +235,6 @@ export default connect(
 	{
 		onMultiSelect: multiSelect,
 		onBottomReached: appendDefaultBlock,
+		onFocusBlock: focusBlock,
 	}
 )( WritingFlow );

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import 'element-closest';
-import { find, last, reverse } from 'lodash';
+import { find, last, reverse, clamp } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -136,13 +136,13 @@ class WritingFlow extends Component {
 
 	expandSelection( blocks, currentStartUid, currentEndUid, delta ) {
 		const lastIndex = blocks.indexOf( currentEndUid );
-		const nextIndex = Math.max( 0, Math.min( blocks.length - 1, lastIndex + delta ) );
+		const nextIndex = clamp( lastIndex + delta, 0, blocks.length - 1 );
 		this.props.onMultiSelect( currentStartUid, blocks[ nextIndex ] );
 	}
 
 	moveSelection( blocks, currentUid, delta ) {
 		const currentIndex = blocks.indexOf( currentUid );
-		const nextIndex = Math.max( 0, Math.min( blocks.length - 1, currentIndex + delta ) );
+		const nextIndex = clamp( currentIndex + delta, 0, blocks.length - 1 );
 		this.props.onFocusBlock( blocks[ nextIndex ] );
 	}
 


### PR DESCRIPTION
### ⭐️ What this is

Fixes #4605.

![multi-selection](https://user-images.githubusercontent.com/612155/35661803-b3755136-0768-11e8-8cf7-9a750766f5b0.gif)

When there is a active multi selection and the user navigates with the keyboard (e.g. presses UP or DOWN), the focus should move to the next or previous block. Previously the focus was lost entirely.

### 🤓 How this works

This bug occurred because, when there is a multi selection, the target DOM node (i.e. the node that triggers the key down event) is the block's More Options toggle button. Since this button is not listed in `getVisibleTabbables()`, `getClosestTabbable()` does not correctly return the editable element that is above or before the selection.

I looked at patching `getClosestTabbable()` to accomodate for this case, but it's difficult since the More Options button is not a descendant of an editable element.

Instead, I added code to `WritingFlow` that explicitly handles moving from a multiple block selection to a single block selection . This matches the code that we already have that handles the inverse case.

### ✅ How to test

1. Create a post with 4 paragraph blocks

_Move Down:_

1. Focus the first paragraph block
2. Shift-Down to create a multi-selection
3. Press Down
4. The focus should move to the third block

_Move Up:_

1. Focus the last paragraph block
2. Shift-Up to create a multi-selection
3. Press Up
4. The focus should move to the second block