### PR TITLE
fix: PHPUnit `@covers` ::function

### DIFF
--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -51,7 +51,7 @@ class Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Tests gutenberg_can_edit_post().
 	 *
-	 * @covers gutenberg_can_edit_post
+	 * @covers ::gutenberg_can_edit_post
 	 */
 	function test_gutenberg_can_edit_post() {
 		$this->assertFalse( gutenberg_can_edit_post( -1 ) );
@@ -80,7 +80,7 @@ class Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Tests gutenberg_post_has_blocks().
 	 *
-	 * @covers gutenberg_post_has_blocks
+	 * @covers ::gutenberg_post_has_blocks
 	 */
 	function test_gutenberg_post_has_blocks() {
 		$this->assertTrue( gutenberg_post_has_blocks( self::$post_with_blocks ) );
@@ -90,7 +90,7 @@ class Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Tests gutenberg_content_has_blocks().
 	 *
-	 * @covers gutenberg_content_has_blocks
+	 * @covers ::gutenberg_content_has_blocks
 	 */
 	function test_gutenberg_content_has_blocks() {
 		$content_with_blocks    = get_post_field( 'post_content', self::$post_with_blocks );
@@ -103,7 +103,7 @@ class Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Tests gutenberg_add_gutenberg_post_state().
 	 *
-	 * @covers gutenberg_add_gutenberg_post_state
+	 * @covers ::gutenberg_add_gutenberg_post_state
 	 */
 	function test_add_gutenberg_post_state() {
 		// With blocks.
@@ -118,7 +118,7 @@ class Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Test that the revisions 'return to editor' links are set correctly for Classic & Gutenberg editors.
 	 *
-	 * @covers gutenberg_revisions_link_to_editor
+	 * @covers ::gutenberg_revisions_link_to_editor
 	 */
 	function test_gutenberg_revisions_link_to_editor() {
 		global $pagenow;

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -44,7 +44,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	/**
 	 * Test dynamic blocks that lack content, including void blocks.
 	 *
-	 * @covers do_blocks
+	 * @covers ::do_blocks
 	 */
 	function test_dynamic_block_rendering() {
 		$settings = array(


### PR DESCRIPTION
## Description
Corrects the issue described in https://github.com/WordPress/gutenberg/issues/4788. PHPUnit expects `@covers` to prefix a global function with `::`. Otherwise it throws warnings when you run a code coverage analysis.

## Next Actions

- [x] Review all occurrences of `@covers` in PHP files.
- [x] Change `@covers function` to `@covers ::function` as [outlined here](https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.annotations.covers).

## How can this be tested?

Run the following to get a code coverage analysis and confirm there are no warnings.

```sh
$ npm run test-unit-php -- --coverage-text --whitelist=./lib
```

*You'll need the Gutenberg [local environment](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md#local-environment) for this to work.*