### PR TITLE
Fix type error when merging blocks

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -550,6 +550,11 @@ export default class RichText extends Component {
 			}
 
 			event.preventDefault();
+
+			// Calling onMerge() or onRemove() will destroy the editor, so it's important
+			// that we stop other handlers (e.g. ones registered by TinyMCE) from
+			// also handling this event.
+			event.stopImmediatePropagation();
 		}
 
 		// If we click shift+Enter on inline RichTexts, we avoid creating two contenteditables


### PR DESCRIPTION
### What this is 

Fixes #4580. This was a regression introduced by https://github.com/WordPress/gutenberg/pull/4395. 

When we merge two blocks by pressing the BACKSPACE KEY, the TinyMCE instance belonging to the second block is destroyed. This results in a type error raised by a TinyMCE event handler that is listening to the *same* event.
    
By *immediately* preventing propagation, we can stop TinyMCE's handler from ever running.

### How to test

Check that the bug is fixed:

1. Navigate to Posts > New Post
2. Create two paragraph blocks
3. Place cursor at beginning of second paragraph block
4. Press Backspace
5. There should be no errors in the console

Check that we didn't break https://github.com/WordPress/gutenberg/pull/4395:

1. Place your cursor in the middle of some text
2. Press ENTER
3. The block controls should go away
4. Move your mouse so that the block controls come back
5. Press BACKSPACE
6. The block controls should go away