### PR TITLE
Polish the list block.

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -3,11 +3,13 @@
 	margin: -4px;
 	padding: 4px;
 
-	p {
+	p,
+	li {
 		line-height: $editor-line-height;
 	}
 
-	ul, ol {
+	ul,
+	ol {
 		padding-left: 2.5em;
 		margin-left: 0;
 	}

--- a/blocks/rich-text/style.scss
+++ b/blocks/rich-text/style.scss
@@ -70,6 +70,10 @@
 		opacity: 0.5;
 		pointer-events: none;
 	}
+
+	&.mce-content-body {
+		line-height: $editor-line-height;
+	}
 }
 
 .has-drop-cap .blocks-rich-text__tinymce:not( :focus )  {


### PR DESCRIPTION
The line-height bled from the classic block into adjecent list blocks.

To elaborate, list items in TinyMCE have a pretty tight line-height. This PR both overrides that to make it the same line-height, and it also ensures that it doesn't bleed into the Gutenberg list block when a classic block is present next to it. 