### PR TITLE
Fix sidebar tab admin theme regression

### DIFF
--- a/edit-post/assets/stylesheets/_admin-schemes.scss
+++ b/edit-post/assets/stylesheets/_admin-schemes.scss
@@ -30,7 +30,7 @@ $scheme-sunrise__spot-color: #de823f;
 @mixin admin-scheme-color-overrides( $scheme: fresh, $spot-color: $scheme-fresh__spot-color ) {
 	body.admin-color-#{ ( $scheme ) } {
 		// Tab indicators
-		.editor-sidebar__panel-tab.is-active,
+		.edit-post-sidebar__panel-tab.is-active,
 		.editor-inserter__tab.is-active {
 			border-bottom-color: $spot-color;
 		}


### PR DESCRIPTION
In the recent move to the "edit-post" component, there was a regression to the admin theme, which meant sidebar tabs wasn't colored. This PR fixes that.

Before:

<img width="388" alt="before" src="https://user-images.githubusercontent.com/1204802/35672377-aa136ada-073e-11e8-87b6-27d9d532042e.png">

After:

<img width="400" alt="screen shot 2018-02-01 at 10 56 02" src="https://user-images.githubusercontent.com/1204802/35672382-ad15b47c-073e-11e8-837c-168184d7f097.png">
