### PR TITLE
Fix float issues

### DIFF
--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -84,6 +84,7 @@
 	}
 	&[data-resized="true"] {
 		width: auto;
+		max-width: none;
 	}
 }
 

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -78,9 +78,12 @@
 
 .editor-block-list__block[data-type="core/image"][data-align="right"],
 .editor-block-list__block[data-type="core/image"][data-align="left"] {
-	max-width: none !important;
+	max-width: none;
 	&[data-resized="false"] {
-		max-width: 370px !important;
+		max-width: 370px;
+	}
+	&[data-resized="true"] {
+		width: auto;
 	}
 }
 

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -127,7 +127,7 @@
 		// Without z-index, won't be clickable as "above" adjacent content
 		z-index: z-index( '.editor-block-list__block {core/image aligned left or right}' );
 		width: 100%;
-		max-width: 370px;
+		max-width: 370px;	// Needed for blocks with no intrinsic width, like Cover Image or Gallery
 	}
 
 	&[data-align="left"] {


### PR DESCRIPTION
There were some niggling issues with resized floats, as a result of https://github.com/WordPress/gutenberg/pull/4806. This fixes it.

<img width="560" alt="screen shot 2018-02-01 at 13 16 06" src="https://user-images.githubusercontent.com/1204802/35678122-72be36dc-0752-11e8-90a4-b252cbaaae22.png">
