### PR TITLE
Add widget_posts_args filter from Recent Posts widget to also apply in Latest Posts block

### DIFF
--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -13,13 +13,18 @@
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
-	$recent_posts = wp_get_recent_posts( array(
-		'numberposts' => $attributes['postsToShow'],
-		'post_status' => 'publish',
-		'order'       => $attributes['order'],
-		'orderby'     => $attributes['orderBy'],
-		'category'    => $attributes['categories'],
-	) );
+	$recent_posts = wp_get_recent_posts(
+		apply_filters(
+			'widget_posts_args',
+			array(
+				'numberposts' => $attributes['postsToShow'],
+				'post_status' => 'publish',
+				'order'       => $attributes['order'],
+				'orderby'     => $attributes['orderBy'],
+				'category'    => $attributes['categories'],
+			)
+		)
+	);
 
 	$list_items_markup = '';
 

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -13,17 +13,22 @@
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
+	$args     = array(
+		'numberposts' => $attributes['postsToShow'],
+		'post_status' => 'publish',
+		'order'       => $attributes['order'],
+		'orderby'     => $attributes['orderBy'],
+		'category'    => $attributes['categories'],
+	);
+	$instance = array(
+		'title'     => '',
+		'number'    => $attributes['postsToShow'],
+		'show_date' => $attributes['displayPostDate'],
+	);
+
 	$recent_posts = wp_get_recent_posts(
-		apply_filters(
-			'widget_posts_args',
-			array(
-				'numberposts' => $attributes['postsToShow'],
-				'post_status' => 'publish',
-				'order'       => $attributes['order'],
-				'orderby'     => $attributes['orderBy'],
-				'category'    => $attributes['categories'],
-			)
-		)
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-recent-posts.php of WordPress core codebase */
+		apply_filters( 'widget_posts_args', $args, $instance )
 	);
 
 	$list_items_markup = '';


### PR DESCRIPTION
## Description

Fixes #4733

Brings `WPQuery` hook in-line with recent posts widget

## How Has This Been Tested?

Manually tested against PHP7.2 on Dreamhost shared hosting

## Screenshots (jpeg or gifs if applicable):

## Types of changes

Hook `widget_posts_args` for `latest posts` widget. Shouldn't break anything

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
