### PR TITLE
Try showing plugin notices above the editor

### DIFF
--- a/components/notice/README.md
+++ b/components/notice/README.md
@@ -1,0 +1,10 @@
+This component is used to implement notices in editor.
+
+#### Props
+
+The following props are used to control the display of the component.
+
+* `status`: (string) can be `warning` (red), `success` (green), `error` (red), `info` (yellow)
+* `content`: (string) the text of the notice
+* `onRemove`: function called when dismissing the notice
+* `isDismissible`: (bool) defaults to true, whether the notice should be dismissible or not

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -1,16 +1,23 @@
 body.gutenberg-editor-page {
 	background: $white;
 
-	#update-nag, .update-nag {
-		display: none;
-	}
-
 	#wpcontent {
 		padding-left: 0;
 	}
 
 	#wpbody-content {
 		padding-bottom: 0;
+	}
+
+	// Show all notice above
+	#wpbody-content > div:not( .gutenberg ):not( #screen-meta ) {
+		position: relative;
+		z-index: z-index( '.components-notice-list' );
+		box-shadow: $shadow-popover;
+		display: inline-block;
+		margin: 10px;
+		float: left;
+		clear: both;
 	}
 
 	#wpfooter {

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -9,15 +9,10 @@ body.gutenberg-editor-page {
 		padding-bottom: 0;
 	}
 
-	// Show all notice above
+	/* We hide legacy notices in Gutenberg, because they were not designed in a way that scaled well.
+	   Plugins can use Gutenberg notices if they need to pass on information to the user when they are editing. */
 	#wpbody-content > div:not( .gutenberg ):not( #screen-meta ) {
-		position: relative;
-		z-index: z-index( '.components-notice-list' );
-		box-shadow: $shadow-popover;
-		display: inline-block;
-		margin: 10px;
-		float: left;
-		clear: both;
+		display: none;
 	}
 
 	#wpfooter {


### PR DESCRIPTION
These notices aren't pretty. But now they're visible, so you kind of have to deal with them before you can edit. This is one approach we can take — the other being _hide them_ and let the user deal with them on another screen in the wp-admin than the editor screen. 

Thoughts? What's the best approach? Are there other approaches?

Screenshot:

![screen shot 2018-02-01 at 18 57 39](https://user-images.githubusercontent.com/1204802/35694585-0ffe76bc-0782-11e8-918b-a7e88e8e4cfb.png)
