### PR TITLE
Add a Attempt Fix button for paragraphs blocks that are invalid

### DIFF
--- a/editor/components/block-list/invalid-block-warning.js
+++ b/editor/components/block-list/invalid-block-warning.js
@@ -30,7 +30,7 @@ function InvalidBlockWarning( { block, attemptFixParagraph, ignoreInvalid, switc
 		<Warning>
 			<p>{ defaultBlockType && htmlBlockType && sprintf( __(
 				'This block appears to have been modified externally. ' +
-				'Overwrite the external changes or Convert to %s or %s to keep ' +
+				'Overwrite the changes or Convert to %s or %s to keep ' +
 				'your changes.'
 			), defaultBlockType.title, htmlBlockType.title ) }</p>
 			<p>
@@ -66,7 +66,7 @@ function InvalidBlockWarning( { block, attemptFixParagraph, ignoreInvalid, switc
 						isLarge
 					>
 						{
-							sprintf( __( 'Edit as HTML block' ) )
+							sprintf( __( 'Edit as HTML' ) )
 						}
 					</Button>
 				) }

--- a/editor/components/block-list/invalid-block-warning.js
+++ b/editor/components/block-list/invalid-block-warning.js
@@ -42,12 +42,12 @@ function InvalidBlockWarning( { block, attemptFixParagraph, ignoreInvalid, switc
 						{ sprintf( __( 'Attempt Fix' ) ) }
 					</Button>
 				) }
-				<Button
+				{ block.name !== 'core/paragraph' && ( <Button
 					onClick={ ignoreInvalid }
 					isLarge
 				>
 					{ sprintf( __( 'Overwrite' ) ) }
-				</Button>
+				</Button> ) }
 				{ defaultBlockType && (
 					<Button
 						onClick={ switchTo( defaultBlockType ) }

--- a/editor/components/block-list/invalid-block-warning.js
+++ b/editor/components/block-list/invalid-block-warning.js
@@ -20,7 +20,7 @@ import {
 import { replaceBlock } from '../../store/actions';
 import Warning from '../warning';
 
-function InvalidBlockWarning( { ignoreInvalid, switchToBlockType } ) {
+function InvalidBlockWarning( { block, attemptFixParagraph, ignoreInvalid, switchToBlockType } ) {
 	const htmlBlockName = 'core/html';
 	const defaultBlockType = getBlockType( getUnknownTypeHandlerName() );
 	const htmlBlockType = getBlockType( htmlBlockName );
@@ -34,6 +34,14 @@ function InvalidBlockWarning( { ignoreInvalid, switchToBlockType } ) {
 				'your changes.'
 			), defaultBlockType.title, htmlBlockType.title ) }</p>
 			<p>
+				{ block.name === 'core/paragraph' && (
+					<Button
+						onClick={ attemptFixParagraph }
+						isLarge
+					>
+						{ sprintf( __( 'Attempt Fix' ) ) }
+					</Button>
+				) }
 				<Button
 					onClick={ ignoreInvalid }
 					isLarge
@@ -71,6 +79,13 @@ export default connect(
 	null,
 	( dispatch, ownProps ) => {
 		return {
+			attemptFixParagraph() {
+				const { block } = ownProps;
+				const nextBlock = createBlock( block.name, {
+					content: block.originalContent,
+				} );
+				dispatch( replaceBlock( block.uid, nextBlock ) );
+			},
 			ignoreInvalid() {
 				const { block } = ownProps;
 				const { name, attributes } = block;

--- a/editor/components/warning/index.js
+++ b/editor/components/warning/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { Dashicon } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
 import './style.scss';
@@ -11,7 +6,6 @@ import './style.scss';
 function Warning( { children } ) {
 	return (
 		<div className="editor-warning">
-			<Dashicon icon="warning" />
 			{ children }
 		</div>
 	);

--- a/editor/components/warning/style.scss
+++ b/editor/components/warning/style.scss
@@ -1,4 +1,4 @@
-.editor-warning {
+.edit-post-visual-editor .editor-warning {
 	z-index: z-index( '.editor-warning' );
 	position: absolute;
 	top: 50%;
@@ -10,12 +10,21 @@
 	align-items: center;
 	width: 96%;
 	max-width: 780px;
-	padding: 20px 20px 10px 20px;
+	padding: 20px 20px 0px 20px;
 	background-color: $white;
 	border: 1px solid $light-gray-500;
 	text-align: center;
 	line-height: $default-line-height;
 	box-shadow: $shadow-popover;
+
+	p {
+		font-family: $default-font;
+		font-size: $default-font-size;
+	}
+
+	p:first-child {
+		margin-top: 0;
+	}
 
 	.editor-visual-editor & p {
 		width: 100%;

--- a/editor/components/warning/test/__snapshots__/index.js.snap
+++ b/editor/components/warning/test/__snapshots__/index.js.snap
@@ -4,9 +4,6 @@ exports[`Warning should match snapshot 1`] = `
 <div
   className="editor-warning"
 >
-  <Dashicon
-    icon="warning"
-  />
   error
 </div>
 `;


### PR DESCRIPTION
## Description

The paragraph tags are notorious for getting lost, especially with various editors and markdown formatting that does strange things like autop and removep. This change attempts to recover those lost paragraph tags and return them to their rightful place.

The current option of "Overwrite" seems rather rude to just delete the content.

## How Has This Been Tested?

Create a paragraph block in Gutenberg and then in Code Editor mode, or if you prefer in the Classic Edtior, remove the `<p>` tags but keep the Gutenberg block comments. When you toggle back to Visual mode, you will get the invalid block.  Clicking Overwrite will delete the blocks.

<img src="https://user-images.githubusercontent.com/45363/35695972-dc9631f8-073a-11e8-9d79-85ddc2c9bd7f.gif" width="523">


With this change, an Attempt Fix button would be added when click will maintain the content, making the user much happier than having the content deleted.

<img src="https://user-images.githubusercontent.com/45363/35696017-0091b3ca-073b-11e8-9e03-7b9fbc102b77.gif" width="531">


I hedged my bets by calling the button "Attempt Fix" - if this seems valid, I would probably recommend just naming it "Fix" and remove the Overwrite button. The way the content gets set, I can't really think of a scenario that this fix wouldn't work, open to suggestions and thoughts.
