### PR TITLE
Update datepicker styling to inherit font-family/colour scheme

### DIFF
--- a/components/date-time/style.scss
+++ b/components/date-time/style.scss
@@ -1,4 +1,44 @@
-@import '~react-datepicker/dist/react-datepicker';
+$datepicker__background-color: $light-gray-300;
+$datepicker__border-color: $light-gray-500;
+$datepicker__highlighted-color: $blue-wordpress;
+$datepicker__muted-color: #ccc;
+$datepicker__selected-color: $blue-wordpress;
+$datepicker__text-color: $dark-gray-500;
+$datepicker__header-color: $black;
+$datepicker__navigation-disabled-color: lighten($datepicker__muted-color, 10%);
+
+$datepicker__border-radius: 0;
+$datepicker__day-margin: 0.166rem;
+$datepicker__font-size: 13px;
+$datepicker__font-family: inherit;
+$datepicker__item-size: 28px;
+$datepicker__margin: 0.4rem;
+$datepicker__navigation-size: 6px;
+$datepicker__triangle-size: 6px;
+
+@import '~react-datepicker/src/stylesheets/datepicker';
+
+.react-datepicker__month-container {
+    float: none;
+}
+
+.react-datepicker-time__header,
+.react-datepicker__current-month {
+    font-size: $datepicker__font-size;
+}
+
+.react-datepicker__navigation {
+    top: 12px;
+    
+    &--previous,
+    &--previous:hover {
+        border-right-color: $black;
+    }
+    &--next,
+    &--next:hover {
+        border-left-color: $black;
+    }
+}
 
 .components-time-picker {
 	display: flex;

--- a/components/date-time/style.scss
+++ b/components/date-time/style.scss
@@ -19,25 +19,25 @@ $datepicker__triangle-size: 6px;
 @import '~react-datepicker/src/stylesheets/datepicker';
 
 .react-datepicker__month-container {
-    float: none;
+	float: none;
 }
 
 .react-datepicker-time__header,
 .react-datepicker__current-month {
-    font-size: $datepicker__font-size;
+	font-size: $datepicker__font-size;
 }
 
 .react-datepicker__navigation {
-    top: 12px;
-    
-    &--previous,
-    &--previous:hover {
-        border-right-color: $black;
-    }
-    &--next,
-    &--next:hover {
-        border-left-color: $black;
-    }
+	top: 12px;
+	
+	&--previous,
+	&--previous:hover {
+		border-right-color: $black;
+	}
+	&--next,
+	&--next:hover {
+		border-left-color: $black;
+	}
 }
 
 .components-time-picker {

--- a/edit-post/assets/stylesheets/_admin-schemes.scss
+++ b/edit-post/assets/stylesheets/_admin-schemes.scss
@@ -64,11 +64,11 @@ $scheme-sunrise__spot-color: #de823f;
 				background-image: repeating-linear-gradient( -45deg, darken( $spot-color, 20 ), darken( $spot-color, 20 ) 11px, darken( $spot-color, 10 ) 10px, darken( $spot-color, 10 ) 20px );
 			}
 		}
-        
-        // Datepicker
-        .react-datepicker__day--selected {
-            background-color: $spot-color;
-        }
+		
+		// Datepicker
+		.react-datepicker__day--selected {
+			background-color: $spot-color;
+		}
 	}
 }
 

--- a/edit-post/assets/stylesheets/_admin-schemes.scss
+++ b/edit-post/assets/stylesheets/_admin-schemes.scss
@@ -64,6 +64,11 @@ $scheme-sunrise__spot-color: #de823f;
 				background-image: repeating-linear-gradient( -45deg, darken( $spot-color, 20 ), darken( $spot-color, 20 ) 11px, darken( $spot-color, 10 ) 10px, darken( $spot-color, 10 ) 20px );
 			}
 		}
+        
+        // Datepicker
+        .react-datepicker__day--selected {
+            background-color: $spot-color;
+        }
 	}
 }
 


### PR DESCRIPTION
Updates the datepicker style so its more consistent with the overall Gutenberg UI.

![datepickers](https://user-images.githubusercontent.com/704594/35701404-ceaf24e8-078d-11e8-97dd-91267d3baa3f.png)