### PR TITLE
Gallery: Fix regression in conversion from shortcode

### DIFF
--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -38,7 +38,7 @@ class GalleryImage extends Component {
 
 		const className = classnames( {
 			'is-selected': isSelected,
-			'is-transient': 0 === url.indexOf( 'blob:' ),
+			'is-transient': url && 0 === url.indexOf( 'blob:' ),
 		} );
 
 		// Disable reason: Each block can be selected by clicking on it and we should keep the same saved markup


### PR DESCRIPTION
## Description
Fixes a regression, introduced in #4567, whereby pasting a gallery shortcode (`[gallery ids="1,2,3"]`) would throw a `TypeError` and break the paste action.

A gallery's `images` attribute may contain images missing a `url`. Notably, when creating a block from the pasting of a gallery shortcode (`[gallery ids="1,2,3"]`), the editor needs to work with media IDs to retrieve the corresponding URLs. Provisions are made in order to support optional `url` data in `GalleryImage`:

https://github.com/WordPress/gutenberg/blob/a5ca7919ef202d5b022dea7663896fbb43d08144/blocks/library/gallery/gallery-image.js#L14-L18

https://github.com/WordPress/gutenberg/blob/a5ca7919ef202d5b022dea7663896fbb43d08144/blocks/library/gallery/gallery-image.js#L37

This PR applies the same to the new logic that handles transient media objects.

## How Has This Been Tested?
- Make sure pasting is fully restored.
- Make sure mid-upload image previewing is kept (#4567).
- Make sure basic usage of gallery blocks is unchanged (create a block, manually add images, change attributes via `InspectorControls`).

## Screenshots (jpeg or gifs if applicable):

## Types of changes
- Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
