### PR TITLE
Insert Link Label and Edit Link Label

### DIFF
--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -38,13 +38,13 @@ class UrlInputButton extends Component {
 	render() {
 		const { url, onChange } = this.props;
 		const { expanded } = this.state;
-		const buttonLabel = url ? "Edit Link" : "Insert Link";
+		const buttonLabel = url ? __( 'Edit Link' ) : __( 'Insert Link' );
 
 		return (
 			<div className="blocks-url-input__button">
 				<IconButton
 					icon="admin-links"
-					label={ __( buttonLabel ) }
+					label={ buttonLabel }
 					onClick={ this.toggle }
 					className={ classnames( 'components-toolbar__control', {
 						'is-active': url,

--- a/blocks/url-input/button.js
+++ b/blocks/url-input/button.js
@@ -38,12 +38,13 @@ class UrlInputButton extends Component {
 	render() {
 		const { url, onChange } = this.props;
 		const { expanded } = this.state;
+		const buttonLabel = url ? "Edit Link" : "Insert Link";
 
 		return (
 			<div className="blocks-url-input__button">
 				<IconButton
 					icon="admin-links"
-					label={ __( 'Insert/edit link' ) }
+					label={ __( buttonLabel ) }
 					onClick={ this.toggle }
 					className={ classnames( 'components-toolbar__control', {
 						'is-active': url,


### PR DESCRIPTION
Fixes #4745 

### Description
PR is for the `url-input_button` label that reads: "Insert/edit link" - to make it a little more dynamic.
- If the link field does not contain any characters, the label reads: "Insert Link" 
- If the link field does contain any characters (`'is-active'`) the label reads: "Edit Link"

### Screenshot Examples of Changes
**Before**
<img width="621" alt="screen shot 2018-02-01 at 6 01 39 pm" src="https://user-images.githubusercontent.com/7691812/35714092-20b60280-0788-11e8-8d1f-3d0cb894e37d.png">

**After**
<img width="732" alt="screen shot 2018-02-01 at 6 36 48 pm" src="https://user-images.githubusercontent.com/7691812/35714093-21adc128-0788-11e8-90ef-1db618ac2237.png">
<img width="723" alt="screen shot 2018-02-01 at 7 45 00 pm" src="https://user-images.githubusercontent.com/7691812/35714189-753c6baa-0788-11e8-9ae9-0cbf92231d86.png">
<img width="738" alt="screen shot 2018-02-01 at 6 37 06 pm" src="https://user-images.githubusercontent.com/7691812/35714094-21dc37b0-0788-11e8-8c28-10342a656fd8.png">
