### PR TITLE
Gallery Block: Persist link attribute to fix invalid galleries

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -32,6 +32,10 @@ const blockAttributes = {
 				source: 'attribute',
 				attribute: 'src',
 			},
+			link: {
+				source: 'attribute',
+				attribute: 'data-link',
+			},
 			alt: {
 				source: 'attribute',
 				attribute: 'alt',
@@ -131,6 +135,7 @@ export const settings = {
 						images: medias.map( media => ( {
 							id: media.id,
 							url: media.source_url,
+							link: media.link,
 						} ) ),
 					} ) );
 
@@ -177,7 +182,7 @@ export const settings = {
 							break;
 					}
 
-					const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } />;
+					const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } />;
 
 					return (
 						<li key={ image.id || image.url } className="blocks-gallery-item">

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -34,7 +34,7 @@ export function mediaUpload( filesList, onImagesChange ) {
 
 		return createMediaFromFile( mediaFile ).then(
 			( savedMedia ) => {
-				setAndUpdateImages( idx, { id: savedMedia.id, url: savedMedia.source_url } );
+				setAndUpdateImages( idx, { id: savedMedia.id, url: savedMedia.source_url, link: savedMedia.link } );
 			},
 			() => {
 				// Reset to empty on failure.


### PR DESCRIPTION
When creating galleries with links to attachments pages, the link of each image was not persisted which created invalid blocks.

**Testing instructions**

 - Open the editor
 - Create a gallery block
 - Add images to the block
 - Set the link to "attachment page"
 - Save and refresh
- The block should not show up as invalid.