### PR TITLE
Data Module: Add a subscribe function to the data module

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -66,13 +66,13 @@ wp.data.query( select => {
 
 ### `wp.data.subscribe( listener: func )`
 
-Function used to subscribe to changes to data changes. The listener function is called each time a change is made to any of the registered reducers. This function returns a `unsubscribe` function used to abort the subscription.
+Function used to subscribe to data changes. The listener function is called each time a change is made to any of the registered reducers. This function returns a `unsubscribe` function used to abort the subscription.
 
 ```js
 // Subscribe.
-let unsubscribe = wp.data.subscribe( () => {
-  const data = {
-    slug: wp.data.select( "core/editor", "getEditedPostSlug" ),
+const unsubscribe = wp.data.subscribe( () => {
+	const data = {
+		slug: wp.data.select( "core/editor", "getEditedPostSlug" ),
 	};
 
 	console.log( 'data changed', data );

--- a/data/README.md
+++ b/data/README.md
@@ -62,3 +62,22 @@ wp.data.query( select => {
 	};
 } )( Component );
 ```
+
+
+### `wp.data.subscribe( listener: func )`
+
+Function used to subscribe to changes to data changes. The listener function is called each time a change is made to any of the registered reducers. This function returns a `unsubscribe` function used to abort the subscription.
+
+```js
+// Subscribe.
+let unsubscribe = wp.data.subscribe( () => {
+  const data = {
+    slug: wp.data.select( "core/editor", "getEditedPostSlug" ),
+	};
+
+	console.log( 'data changed', data );
+} );
+
+// Unsubcribe.
+unsubscribe();
+```

--- a/data/index.js
+++ b/data/index.js
@@ -33,7 +33,7 @@ export function globalListener() {
  *
  * @param {Function}   listener Listener function.
  *
- * @returns {Function}          Unsubscribe function.
+ * @return {Function}           Unsubscribe function.
  */
 export const subscribe = ( listener ) => {
 	listeners.push( listener );

--- a/data/index.js
+++ b/data/index.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { createStore, combineReducers } from 'redux';
-import { flowRight } from 'lodash';
+import { createStore } from 'redux';
+import { flowRight, without, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,15 +13,35 @@ export { loadAndPersist, withRehydratation } from './persist';
 /**
  * Module constants
  */
-const reducers = {};
+const stores = {};
 const selectors = {};
 const enhancers = [];
+let listeners = [];
 if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
 	enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
 }
 
-const initialReducer = () => ( {} );
-const store = createStore( initialReducer, {}, flowRight( enhancers ) );
+/**
+ * Global listener called for each store's update.
+ */
+export function globalListener() {
+	listeners.forEach( listener => listener() );
+}
+
+/**
+ * Subscribe to changes to any data.
+ *
+ * @param {Function}   listener Listener function.
+ *
+ * @returns {Function}          Unsubscribe function.
+ */
+export const subscribe = ( listener ) => {
+	listeners.push( listener );
+
+	return () => {
+		listeners = without( listeners, listener );
+	};
+};
 
 /**
  * Registers a new sub-reducer to the global state and returns a Redux-like store object.
@@ -32,26 +52,11 @@ const store = createStore( initialReducer, {}, flowRight( enhancers ) );
  * @return {Object} Store Object.
  */
 export function registerReducer( reducerKey, reducer ) {
-	reducers[ reducerKey ] = reducer;
-	store.replaceReducer( combineReducers( reducers ) );
-	const getState = () => store.getState()[ reducerKey ];
+	const store = createStore( reducer, flowRight( enhancers ) );
+	stores[ reducerKey ] = store;
+	store.subscribe( globalListener );
 
-	return {
-		dispatch: store.dispatch,
-		subscribe( listener ) {
-			let previousState = getState();
-			const unsubscribe = store.subscribe( () => {
-				const newState = getState();
-				if ( newState !== previousState ) {
-					listener();
-					previousState = newState;
-				}
-			} );
-
-			return unsubscribe;
-		},
-		getState,
-	};
+	return store;
 }
 
 /**
@@ -77,6 +82,16 @@ export function registerSelectors( reducerKey, newSelectors ) {
  * @return {Function} Renders the wrapped component and passes it data.
  */
 export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
+	const store = {
+		getState() {
+			return mapValues( stores, subStore => subStore.getState() );
+		},
+		subscribe,
+		dispatch() {
+			// eslint-disable-next-line no-console
+			console.warn( 'Dispatch is not supported.' );
+		},
+	};
 	const connectWithStore = ( ...args ) => {
 		const ConnectedWrappedComponent = connect( ...args )( WrappedComponent );
 		return ( props ) => {
@@ -104,5 +119,5 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
  * @return {*} The selector's returned value.
  */
 export const select = ( reducerKey, selectorName, ...args ) => {
-	return selectors[ reducerKey ][ selectorName ]( store.getState()[ reducerKey ], ...args );
+	return selectors[ reducerKey ][ selectorName ]( stores[ reducerKey ].getState(), ...args );
 };

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -6,7 +6,7 @@ import { render } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { registerReducer, registerSelectors, select, query } from '../';
+import { registerReducer, registerSelectors, select, query, subscribe } from '../';
 
 describe( 'store', () => {
 	it( 'Should append reducers to the state', () => {
@@ -57,5 +57,32 @@ describe( 'query', () => {
 		const tree = render( <Component keyName="reactKey" /> );
 
 		expect( tree ).toMatchSnapshot();
+	} );
+} );
+
+describe( 'subscribe', () => {
+	it( 'registers multiple selectors to the public API', () => {
+		let inrecementedValue = null;
+		const store = registerReducer( 'myAwesomeReducer', ( state = 0 ) => state + 1 );
+		registerSelectors( 'myAwesomeReducer', {
+			globalSelector: ( state ) => state,
+		} );
+		const unsubscribe = subscribe( () => {
+			inrecementedValue = select( 'myAwesomeReducer', 'globalSelector' );
+		} );
+		const action = { type: 'dummy' };
+
+		store.dispatch( action ); // increment the data by => data = 2
+		expect( inrecementedValue ).toBe( 2 );
+
+		store.dispatch( action ); // increment the data by => data = 3
+		expect( inrecementedValue ).toBe( 3 );
+
+		unsubscribe(); // Store subscribe to changes, the data variable stops upgrading.
+
+		store.dispatch( action );
+		store.dispatch( action );
+
+		expect( inrecementedValue ).toBe( 3 );
 	} );
 } );

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -62,27 +62,27 @@ describe( 'query', () => {
 
 describe( 'subscribe', () => {
 	it( 'registers multiple selectors to the public API', () => {
-		let inrecementedValue = null;
+		let incrementedValue = null;
 		const store = registerReducer( 'myAwesomeReducer', ( state = 0 ) => state + 1 );
 		registerSelectors( 'myAwesomeReducer', {
 			globalSelector: ( state ) => state,
 		} );
 		const unsubscribe = subscribe( () => {
-			inrecementedValue = select( 'myAwesomeReducer', 'globalSelector' );
+			incrementedValue = select( 'myAwesomeReducer', 'globalSelector' );
 		} );
 		const action = { type: 'dummy' };
 
 		store.dispatch( action ); // increment the data by => data = 2
-		expect( inrecementedValue ).toBe( 2 );
+		expect( incrementedValue ).toBe( 2 );
 
 		store.dispatch( action ); // increment the data by => data = 3
-		expect( inrecementedValue ).toBe( 3 );
+		expect( incrementedValue ).toBe( 3 );
 
 		unsubscribe(); // Store subscribe to changes, the data variable stops upgrading.
 
 		store.dispatch( action );
 		store.dispatch( action );
 
-		expect( inrecementedValue ).toBe( 3 );
+		expect( incrementedValue ).toBe( 3 );
 	} );
 } );


### PR DESCRIPTION
Also, separate reducers into multiple stores to avoid unallowed access to the actions.

closes #4809 

**Testing instructions**

 - Check that the UI still shows up as expected.


**EDIT (by @atimmer):**
To give additional context about why to add multiple stores, see this Slack conversation: https://wordpress.slack.com/archives/C02QB2JS7/p1516266922000279.