### PR TITLE
Add label to range control

### DIFF
--- a/blocks/inspector-controls/range-control/index.js
+++ b/blocks/inspector-controls/range-control/index.js
@@ -30,6 +30,7 @@ function RangeControl( { label, value, instanceId, onChange, beforeIcon, afterIc
 				className="blocks-range-control__number"
 				type="number"
 				onChange={ onChangeValue }
+				aria-label={ label }
 				value={ value }
 				{ ...props }
 			/>


### PR DESCRIPTION
Fixes #4826. This adds an aria-label to the input field associated with the range control.

Example markup:

```
<div class="blocks-base-control blocks-range-control">
  <label class="blocks-base-control__label" for="inspector-range-control-3">Background Dimness</label>
control">
  <input type="range" step="10" min="0" max="100" class="blocks-range-control__slider" id="inspector-range-control-3" value="50">
control">
  <input type="number" step="10" min="0" max="100" class="blocks-range-control__number" aria-label="Background Dimness" value="50">
</div>
```

@afercia does this address the issue? It uses the same label as the explicitly output text label that sits before the range control. Or would you like a different label for the input field? Would appreciate your advice, thanks.