### PR TITLE
Try/windows high contrast support

### DIFF
--- a/components/autocomplete/style.scss
+++ b/components/autocomplete/style.scss
@@ -25,6 +25,7 @@
 	align-items: center;
 	padding: 6px;
 	text-align: left;
+	@include button-style__neutral;
 
 	&.is-selected {
 		@include button-style__focus-active;

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -1,7 +1,6 @@
 .components-icon-button {
 	display: flex;
 	align-items: center;
-	padding: 8px;
 	margin: 0;
 	border: none;
 	background: none;
@@ -9,6 +8,9 @@
 	position: relative;
 	width: $icon-button-size;	// show only icon on small breakpoints
 	overflow: hidden;
+
+	padding: 7px;				// should be 8px, subtract 1px to account for a transparent border
+	@include button-style__neutral;
 
 	.dashicon {
 		display: inline-block;

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -9,7 +9,7 @@
 	width: $icon-button-size;	// show only icon on small breakpoints
 	overflow: hidden;
 
-	padding: 7px;				// should be 8px, subtract 1px to account for a transparent border
+	padding: 8px;
 	@include button-style__neutral;
 
 	.dashicon {
@@ -19,6 +19,12 @@
 
 	@include break-medium() {
 		width: auto;
+	}
+
+	&:not( :disabled ):hover,
+	&:not( :disabled ):active,
+	&:not( :disabled ):focus {
+		padding: 7px;				// subtract 1px to account for a transparent border
 	}
 
 	&:not( :disabled ):hover {

--- a/components/icon-button/style.scss
+++ b/components/icon-button/style.scss
@@ -12,6 +12,13 @@
 	padding: 8px;
 	@include button-style__neutral;
 
+	// subtract 1px to account for a transparent border
+	&:not( :disabled ):hover,
+	&:not( :disabled ):active,
+	&:not( :disabled ):focus {
+		padding: 7px;
+	}
+
 	.dashicon {
 		display: inline-block;
 		flex: 0 0 auto;
@@ -19,12 +26,6 @@
 
 	@include break-medium() {
 		width: auto;
-	}
-
-	&:not( :disabled ):hover,
-	&:not( :disabled ):active,
-	&:not( :disabled ):focus {
-		padding: 7px;				// subtract 1px to account for a transparent border
 	}
 
 	&:not( :disabled ):hover {

--- a/components/menu-items/style.scss
+++ b/components/menu-items/style.scss
@@ -15,6 +15,7 @@
 	text-align: left;
 	padding-left: 25px;
 	color: $dark-gray-500;
+	@include menu-style__neutral()
 
 	.dashicon {
 		margin-right: 5px;
@@ -27,4 +28,9 @@
 	&:hover {
 		color: $black;
 	}
+
+	&:focus {
+		@include menu-style__focus()
+	}
+
 }

--- a/components/menu-items/style.scss
+++ b/components/menu-items/style.scss
@@ -26,6 +26,7 @@
 	}
 
 	&:hover {
+		@include menu-style__neutral()
 		color: $black;
 	}
 

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -73,10 +73,10 @@
 	font-weight: 600;
 	text-align: left;
 	padding: 14px;
-	@include button-style__neutral;
+	@include menu-style__neutral;
 
 	&:focus {
-		@include button-style__focus-active;
+		@include menu-style__focus;
 	}
 
 	.dashicon {

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -68,11 +68,16 @@
 
 .components-panel__body-toggle.components-button {
 	position: relative;
-	padding: 15px;
 	outline: none;
 	width: 100%;
 	font-weight: 600;
 	text-align: left;
+	padding: 14px;
+	@include button-style__neutral;
+
+	&:focus {
+		@include button-style__focus-active;
+	}
 
 	.dashicon {
 		position: absolute;

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -38,19 +38,39 @@ div.components-toolbar {
 	display: inline-flex;
 	align-items: flex-end;
 	margin: 0;
-	padding: 3px;
 	outline: none;
 	cursor: pointer;
 	position: relative;
 	width: $icon-button-size;
 	height: $icon-button-size;
 
+	padding: 3px;
+
+	// subtract 1px to account for a transparent border
+	&:not( :disabled ):hover,
+	&:not( :disabled ):active,
+	&:not( :disabled ):focus,
+	&.is-active {
+		padding: 2px;
+	}
+
+	// unset icon button styles
+	&:active,
+	&:hover,
+	&:focus {
+		outline: none;
+		box-shadow: none;
+		background: none;
+		border: none;
+	}
+
+	// disabled
 	&:disabled {
 		cursor: default;
 	}
 
 	& > svg {
-		padding: 5px;
+		padding: 4px;
 		box-sizing: content-box;
 		border-radius: $button-style__radius-roundrect;
 	}
@@ -70,42 +90,20 @@ div.components-toolbar {
 		bottom: 8px;
 	}
 
-	// special hover style
-	&:not(:disabled) {
-		&.is-active > svg,
-		&:hover > svg {
-			box-shadow: inset 0 0 0 1px $dark-gray-500;
-		}
+	// hover style
+	&:not(:disabled).is-active > svg,
+	&:not(:disabled):hover > svg {
+		@include formatting-button-style__hover;
 	}
 
-	// special active style
-	&.is-active {
-		color: $white;
-		> svg {
-			background: $dark-gray-500;
-		}
+	// active & toggled style
+	&:not(:disabled).is-active > svg {
+		@include formatting-button-style__active;
 	}
 
 	// focus style
-	&:hover,
-	&:focus {
-		outline: none;
-		box-shadow: none;
-		background: none;
-	}
-
-	&:focus > svg {
-		@include button-style__focus-active;
-	}
-	&:focus:hover > svg {
-		@include button-style__focus-active;
-	}
-
-	// active focus style
-	&.is-active:focus > svg {
-		background: $dark-gray-500;
-		color: $white;
-		box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
+	&:not(:disabled):focus > svg {
+		@include formatting-button-style__focus;
 	}
 }
 

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -119,11 +119,10 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 @mixin button-style__disabled {
 	opacity: 0.6;
 	cursor: default;
-	border: 1px solid transparent;
 }
 
 @mixin button-style__neutral {
-	border: 1px solid transparent;
+	transition: unset;
 }
 
 @mixin button-style__hover {
@@ -148,7 +147,6 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 
 // Tabs
 @mixin tab-style__neutral() {
-	outline: 1px solid transparent;
 	outline-offset: -1px;
 }
 
@@ -159,24 +157,25 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 
 // Inputs
 @mixin input-style__neutral() {
-	border: 1px solid transparent;
+	outline-offset: -1px;
 }
 
 @mixin input-style__focus-active() {
-	outline: none;
 	color: $dark-gray-900;
-	border: 1px solid $dark-gray-300;
+	outline: 1px solid $dark-gray-300;
 }
 
 // Inputs
 @mixin menu-style__neutral() {
-	border: 1px solid transparent;
+	border: none;
+	box-shadow: none;
 }
 
 @mixin menu-style__focus() {
-	outline: none;
+	border: none;
+	outline-offset: -1px;
 	color: $dark-gray-900;
-	border: 1px dotted $dark-gray-300;
+	outline: 1px dotted $dark-gray-300;
 }
 
 

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -168,6 +168,17 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 	border: 1px solid $dark-gray-300;
 }
 
+// Inputs
+@mixin menu-style__neutral() {
+	border: 1px solid transparent;
+}
+
+@mixin menu-style__focus() {
+	outline: none;
+	color: $dark-gray-900;
+	border: 1px dotted $dark-gray-300;
+}
+
 
 /**
  * Applies editor left position to the selector passed as argument

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -115,39 +115,51 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
  * Button states and focus styles
  */
 
+// Buttons
 @mixin button-style__disabled {
 	opacity: 0.6;
 	cursor: default;
+	border: 1px solid transparent;
+}
+
+@mixin button-style__neutral {
+	border: 1px solid transparent;
 }
 
 @mixin button-style__hover {
 	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $light-gray-500, inset 0 0 0 2px $white, 0 1px 1px rgba( $dark-gray-900, .2 );
+	border: 1px solid $light-gray-500;
+	box-shadow: inset 0 0 0 2px $white, 0 1px 1px rgba( $dark-gray-900, .2 );
 }
 
 @mixin button-style__active() {
 	outline: none;
 	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $light-gray-700, inset 0 0 0 2px $white;
+	border: 1px solid $light-gray-700;
+	box-shadow: inset 0 0 0 2px $white;
 }
 
 @mixin button-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $dark-gray-300, inset 0 0 0 2px $white;
+	border: 1px solid $dark-gray-300;
+	box-shadow: inset 0 0 0 2px $white;
 }
 
+// Tabs
 @mixin tab-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;
 	box-shadow: inset 0 0 0 1px $dark-gray-300;
 }
 
+// Inputs
 @mixin input-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;
 	box-shadow: 0 0 0 1px $dark-gray-300;
 }
+
 
 /**
  * Applies editor left position to the selector passed as argument

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -147,17 +147,25 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 }
 
 // Tabs
+@mixin tab-style__neutral() {
+	outline: 1px solid transparent;
+	outline-offset: -1px;
+}
+
 @mixin tab-style__focus-active() {
-	outline: none;
 	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $dark-gray-300;
+	outline: 1px solid $dark-gray-300;
 }
 
 // Inputs
+@mixin input-style__neutral() {
+	border: 1px solid transparent;
+}
+
 @mixin input-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;
-	box-shadow: 0 0 0 1px $dark-gray-300;
+	border: 1px solid $dark-gray-300;
 }
 
 

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -115,7 +115,7 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
  * Button states and focus styles
  */
 
-// Buttons
+// Buttons with rounded corners
 @mixin button-style__disabled {
 	opacity: 0.6;
 	cursor: default;
@@ -145,27 +145,37 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 	box-shadow: inset 0 0 0 2px $white;
 }
 
-// Tabs
-@mixin tab-style__neutral() {
+// Formatting Buttons
+@mixin formatting-button-style__hover {
+	color: $dark-gray-500;
+	border: 1px solid $dark-gray-500;
+	box-shadow: inset 0 0 0 1px $white;
+}
+
+@mixin formatting-button-style__active() {
+	outline: none;
+	color: $white;
+	box-shadow: none;
+	background: $dark-gray-500;
+}
+
+@mixin formatting-button-style__focus() {
+	outline: none;
+	border: 1px solid $dark-gray-500;
+	box-shadow: inset 0 0 0 1px $white;
+}
+
+// Tabs, Inputs, Square buttons
+@mixin square-style__neutral() {
 	outline-offset: -1px;
 }
 
-@mixin tab-style__focus-active() {
+@mixin square-style__focus-active() {
 	color: $dark-gray-900;
 	outline: 1px solid $dark-gray-300;
 }
 
-// Inputs
-@mixin input-style__neutral() {
-	outline-offset: -1px;
-}
-
-@mixin input-style__focus-active() {
-	color: $dark-gray-900;
-	outline: 1px solid $dark-gray-300;
-}
-
-// Inputs
+// Menu items
 @mixin menu-style__neutral() {
 	border: none;
 	box-shadow: none;

--- a/edit-post/components/header/ellipsis-menu/style.scss
+++ b/edit-post/components/header/ellipsis-menu/style.scss
@@ -5,8 +5,14 @@
 	}
 
 	.components-icon-button {
-		padding: 7px 3px;	// should be 8px 4px but subtract 1px to account for a transparent border
+		padding: 8px 4px;
 		width: auto;
+
+		&:hover,
+		&:active,
+		&:focus {
+			padding: 7px 3px;	// subtract 1px to account for a transparent border
+		}
 	}
 
 	.components-button svg {

--- a/edit-post/components/header/ellipsis-menu/style.scss
+++ b/edit-post/components/header/ellipsis-menu/style.scss
@@ -5,7 +5,7 @@
 	}
 
 	.components-icon-button {
-		padding: 8px 4px;
+		padding: 7px 3px;	// should be 8px 4px but subtract 1px to account for a transparent border
 		width: auto;
 	}
 

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -49,10 +49,10 @@
 		position: absolute;
 		z-index: -1;
 		background: $dark-gray-500;
-		top: 0px;
-		right: 0px;
-		bottom: 0px;
-		left: 0px;
+		top: 1px;
+		right: 1px;
+		bottom: 1px;
+		left: 1px;
 	}
 
 	&.is-toggled:hover,

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -49,16 +49,17 @@
 		position: absolute;
 		z-index: -1;
 		background: $dark-gray-500;
-		top: 1px;
-		right: 1px;
-		bottom: 1px;
-		left: 1px;
+		top: 0px;
+		right: 0px;
+		bottom: 0px;
+		left: 0px;
 	}
 
 	&.is-toggled:hover,
 	&.is-toggled:focus {
 		outline: none;
-		box-shadow: 0 0 0 1px $dark-gray-500, inset 0 0 0 1px $white;
+		border: 1px solid $dark-gray-500;
+		box-shadow: inset 0 0 0 1px $white;
 		color: $white;
 		background: $dark-gray-500;
 	}

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -123,6 +123,7 @@
 	padding: 0 20px;
 	margin-left: 0;
 	font-weight: 400;
+	@include tab-style__neutral;
 
 	&.is-active {
 		border-bottom-color: $blue-medium-500;
@@ -130,6 +131,6 @@
 	}
 
 	&:focus {
-		@include button-style__focus-active;
+		@include tab-style__focus-active;
 	}
 }

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -123,7 +123,7 @@
 	padding: 0 20px;
 	margin-left: 0;
 	font-weight: 400;
-	@include tab-style__neutral;
+	@include square-style__neutral;
 
 	&.is-active {
 		border-bottom-color: $blue-medium-500;
@@ -131,6 +131,6 @@
 	}
 
 	&:focus {
-		@include tab-style__focus-active;
+		@include square-style__focus-active;
 	}
 }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -58,7 +58,7 @@
 	&.is-selected > .editor-block-mover:before,
 	&.is-hovered > .editor-block-mover:before {
 		border-right: 1px solid $light-gray-500;
-		right: 8px;
+		right: 6px;
 	}
 
 	&.is-reusable.is-selected > .editor-block-mover:before {
@@ -68,7 +68,7 @@
 	&.is-selected > .editor-block-settings-menu:before,
 	&.is-hovered > .editor-block-settings-menu:before {
 		border-left: 1px solid $light-gray-500;
-		left: 6px;
+		left: 4px;
 	}
 
 	&.is-reusable.is-selected > .editor-block-settings-menu:before {
@@ -321,7 +321,7 @@
 	// Right side UI
 	> .editor-block-settings-menu {
 		right: $block-mover-margin;
-		padding-top: 2px;
+		padding-top: 3px;
 
 		// Mobile
 		display: none;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -58,7 +58,7 @@
 	&.is-selected > .editor-block-mover:before,
 	&.is-hovered > .editor-block-mover:before {
 		border-right: 1px solid $light-gray-500;
-		right: 6px;
+		right: 8px;
 	}
 
 	&.is-reusable.is-selected > .editor-block-mover:before {
@@ -288,21 +288,21 @@
 		}
 
 		.editor-inserter__toggle {
-			width: $icon-button-size-small;
-			padding: 2px;
+			padding: 1px;	// subtract 1px to account for a transparent border
 
 			// Adjust inserter design
-			box-shadow: inset 0 0 0 1px $light-gray-500;
+			border: 1px solid $light-gray-500;
+			//box-shadow: inset 0 0 0 1px $light-gray-500;
 			border-radius: 50%;
 
 			// Hide the outer ring on the inserter, to visually lighten it
 			&:before {
 				content: '';
 				position: absolute;
-				top: 2px;
-				right: 2px;
-				bottom: 2px;
-				left: 2px;
+				top: 1px;
+				right: 1px;
+				bottom: 1px;
+				left: 1px;
 				display: block;
 				border: 4px solid $white;
 				border-radius: 50%;
@@ -334,7 +334,7 @@
 	// Left side UI
 	> .editor-block-mover {
 		left: $block-mover-margin + 2px;
-		padding-top: 6px;
+		padding-top: 4px;
 		z-index: z-index( '.editor-block-mover' );
 
 		// Mobile
@@ -392,6 +392,7 @@
 
 .editor-block-list .editor-inserter {
 	margin: $item-spacing;
+	@include button-style__neutral;
 
 	.editor-inserter__toggle {
 		color: $dark-gray-300;

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -1,7 +1,6 @@
 // Mover icon buttons$
 .editor-block-mover__control {
 	display: block;
-	padding: 2px;
 	margin: 0 6px 0 4px;
 	border: none;
 	outline: none;
@@ -9,7 +8,18 @@
 	color: $dark-gray-300;
 	cursor: pointer;
 	border-radius: 50%;
-	width: $icon-button-size-small + 2px;
+	width: $icon-button-size-small;
+	height: $icon-button-size-small;
+	padding: 0;
+
+	padding: 3px;
+
+	// subtract 1px to account for a transparent border
+	&:not( :disabled ):hover,
+	&:not( :disabled ):active,
+	&:not( :disabled ):focus {
+		padding: 2px;
+	}
 
 	&[aria-disabled="true"] {
 		cursor: default;
@@ -32,12 +42,12 @@
 			display: block;
 			position: relative; // Fixing the Safari bug for `<button>`s overflow
 			border-radius: 50%;
-			width: 20px;
-			height: 20px;
 			@include button-style__neutral;
 		}
 
 		&:not(:disabled):hover svg {
+			width: 20px;
+			height: 20px;
 			@include button-style__hover;
 		}
 
@@ -47,6 +57,15 @@
 
 		&:not(:disabled):focus svg {
 			@include button-style__focus-active;
+		}
+
+
+
+		&:not(:disabled):hover svg,
+		&:not(:disabled):active svg,
+		&:not(:disabled):focus svg {
+			width: 20px;
+			height: 20px;
 		}
 	}
 }

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -9,7 +9,7 @@
 	color: $dark-gray-300;
 	cursor: pointer;
 	border-radius: 50%;
-	width: $icon-button-size-small;
+	width: $icon-button-size-small + 2px;
 
 	&[aria-disabled="true"] {
 		cursor: default;
@@ -25,18 +25,20 @@
 		&:not(:disabled):focus {
 			box-shadow: none;
 			color: inherit;
+			border: none;
 		}
 
 		svg {
 			display: block;
 			position: relative; // Fixing the Safari bug for `<button>`s overflow
 			border-radius: 50%;
-			margin: auto;
-
+			width: 20px;
+			height: 20px;
+			@include button-style__neutral;
 		}
 
 		&:not(:disabled):hover svg {
-			box-shadow: inset 0 0 0 1px $light-gray-500;
+			@include button-style__hover;
 		}
 
 		&:not(:disabled):active svg {

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -18,10 +18,9 @@
 // The ellipsis icon button
 .editor-block-settings-menu__toggle {
 	border-radius: 50%;
-	width: auto;
+	margin: 13px 2px 13px 8px;
 	padding: 2px;
-	margin: 14px 4px 14px 8px;
-	width: $icon-button-size-small;
+	width: $icon-button-size-small + 2px;	 // add 2px to account for a transparent border
 
 	.dashicon {
 		transform: rotate( 90deg );

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -8,6 +8,7 @@
 
 	.components-popover__content {
 		width: 182px;
+		padding: $item-spacing;
 	}
 }
 
@@ -30,6 +31,10 @@
 .editor-block-settings-menu__section {
 	margin-top: $item-spacing;
 	padding-top: $item-spacing;
+	margin-left: -$item-spacing;
+	margin-right: -$item-spacing;
+	margin-bottom: -$item-spacing;
+	padding: $item-spacing;
 	border-top: 1px solid $light-gray-500;
 }
 
@@ -43,14 +48,12 @@
 	border-radius: 0;
 	color: $dark-gray-500;
 	cursor: pointer;
-	border: 1px solid transparent;
+	@include menu-style__neutral();
 
 	&:hover,
 	&:focus,
 	&:not(:disabled):hover {
-		box-shadow: none;
-		color: $dark-gray-500;
-		border: 1px solid $dark-gray-500;
+		@include menu-style__focus();
 	}
 
 	.dashicon {

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -19,9 +19,17 @@
 // The ellipsis icon button
 .editor-block-settings-menu__toggle {
 	border-radius: 50%;
-	margin: 13px 2px 13px 8px;
+	margin: 13px 3px 13px 7px;
+	width: $icon-button-size-small;
+
 	padding: 2px;
-	width: $icon-button-size-small + 2px;	 // add 2px to account for a transparent border
+
+	// subtract 1px to account for a transparent border
+	&:not( :disabled ):hover,
+	&:not( :disabled ):active,
+	&:not( :disabled ):focus {
+		padding: 1px;
+	}
 
 	.dashicon {
 		transform: rotate( 90deg );

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -31,6 +31,7 @@ input[type="search"].editor-inserter__search {
 	z-index: 1;
 	border: none;
 	box-shadow: 0 1px 0 0 $light-gray-500;
+	@include input-style__neutral;
 
 	// fonts smaller than 16px causes mobile safari to zoom
 	font-size: $mobile-text-min-font-size;
@@ -164,6 +165,7 @@ input[type="search"].editor-inserter__search {
 	margin: 0;
 	color: $dark-gray-500;
 	cursor: pointer;
+	@include tab-style__neutral;
 
 	&.is-active {
 		font-weight: 600;

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -31,7 +31,7 @@ input[type="search"].editor-inserter__search {
 	z-index: 1;
 	border: none;
 	box-shadow: 0 1px 0 0 $light-gray-500;
-	@include input-style__neutral;
+	@include square-style__neutral;
 
 	// fonts smaller than 16px causes mobile safari to zoom
 	font-size: $mobile-text-min-font-size;
@@ -40,7 +40,7 @@ input[type="search"].editor-inserter__search {
 	}
 
 	&:focus {
-		@include input-style__focus-active;
+		@include square-style__focus-active;
 	}
 }
 
@@ -80,6 +80,13 @@ input[type="search"].editor-inserter__search {
 	line-height: 20px;
 	background: transparent;
 	@include button-style__neutral;
+
+	// subtract 1px to account for a transparent border
+	&:not( :disabled ):hover,
+	&:not( :disabled ):active,
+	&:not( :disabled ):focus {
+		padding: 11px 5px 5px 5px;
+	}
 
 	&:disabled {
 		@include button-style__disabled;
@@ -165,7 +172,7 @@ input[type="search"].editor-inserter__search {
 	margin: 0;
 	color: $dark-gray-500;
 	cursor: pointer;
-	@include tab-style__neutral;
+	@include square-style__neutral;
 
 	&.is-active {
 		font-weight: 600;
@@ -177,6 +184,6 @@ input[type="search"].editor-inserter__search {
 	&:active,
 	&:focus {
 		z-index: z-index( '.editor-inserter__tab.is-active' );
-		@include tab-style__focus-active;
+		@include square-style__focus-active;
 	}
 }

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -18,7 +18,6 @@
 	color: $dark-gray-500;
 	background: none;
 	cursor: pointer;
-	border: none;
 	outline: none;
 	transition: color .2s ease;
 }
@@ -79,6 +78,7 @@ input[type="search"].editor-inserter__search {
 	border: none;
 	line-height: 20px;
 	background: transparent;
+	@include button-style__neutral;
 
 	&:disabled {
 		@include button-style__disabled;

--- a/editor/components/post-featured-image/style.scss
+++ b/editor/components/post-featured-image/style.scss
@@ -13,6 +13,7 @@
 	&:focus {
 		box-shadow: none;
 		outline: none;
+		border: none;	// remove this when core moves to border styles for focus
 	}
 
 	&:hover {


### PR DESCRIPTION
Add support for Windows High Contrast Mode, by changing focus styles from using box-shadow to using borders and outlines. Fixes #4297. 

Visually there _shouldn't_ be any difference between this branch and master. But because borders take up space and change metrics, a lot of gymnastics had to be done so buttons kept their same footprint as before. As such, it is not unlikely I missed some buttons/styles in the process of doing this. As such, this PR needs a fair bit of testing. 

Things to look for include buttons or elements that are suddenly smaller than before, or indeed _bigger_ than before. 

Some screenshots:

<img width="378" alt="screen shot 2018-02-02 at 13 43 12" src="https://user-images.githubusercontent.com/1204802/35733916-8088569e-081f-11e8-9811-cf8759a74b56.png">

<img width="122" alt="screen shot 2018-02-02 at 13 43 17" src="https://user-images.githubusercontent.com/1204802/35733918-81a01cf6-081f-11e8-897f-2c0f5fc1c4cf.png">

<img width="210" alt="screen shot 2018-02-02 at 13 43 27" src="https://user-images.githubusercontent.com/1204802/35733920-830450c6-081f-11e8-914c-ccb7682da38d.png">

<img width="320" alt="screen shot 2018-02-02 at 13 43 31" src="https://user-images.githubusercontent.com/1204802/35733922-843a88d4-081f-11e8-985b-b03322b9f888.png">

<img width="184" alt="screen shot 2018-02-02 at 13 43 39" src="https://user-images.githubusercontent.com/1204802/35733923-8597de2a-081f-11e8-9818-0ff50881fd5a.png">
