### PR TITLE
Code error in blocks-control.md

### DIFF
--- a/docs/blocks-controls.md
+++ b/docs/blocks-controls.md
@@ -150,7 +150,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 	save( { attributes, className } ) {
 		const { content, alignment } = attributes;
 
-		return <p className={ className } style={ textAlign: alignment }>{ content }</p>;
+		return <p className={ className } style={ { textAlign: alignment } }>{ content }</p>;
 	},
 } );
 ```


### PR DESCRIPTION
JSX style attributes require an extra pair of {{}} since it is an object.

## Description
The attribute style tag was written incorrectly.

## How Has This Been Tested?
Yes, I using the provided code caused errors in my local code base, I fixed it and it solved the errors.

## Screenshots (jpeg or gifs if applicable):

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
