### PR TITLE
Effects: Restore new post setup as non-dirtying change

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,6 @@
 		"browser": false,
 		"es6": true,
 		"node": true,
-		"mocha": true,
 		"jest/globals": true
 	},
 	"parserOptions": {

--- a/editor/components/editor-history/redo.js
+++ b/editor/components/editor-history/redo.js
@@ -21,6 +21,7 @@ function EditorHistoryRedo( { hasRedo, redo } ) {
 			label={ __( 'Redo' ) }
 			disabled={ ! hasRedo }
 			onClick={ redo }
+			className="editor-history__undo"
 		/>
 	);
 }

--- a/editor/components/editor-history/undo.js
+++ b/editor/components/editor-history/undo.js
@@ -21,6 +21,7 @@ function EditorHistoryUndo( { hasUndo, undo } ) {
 			label={ __( 'Undo' ) }
 			disabled={ ! hasUndo }
 			onClick={ undo }
+			className="editor-history__undo"
 		/>
 	);
 }

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -305,16 +305,16 @@ export default {
 			effects.push( resetBlocks( blocks ) );
 		}
 
+		// Resetting post should occur after blocks have been reset, since it's
+		// the post reset that restarts history (used in dirty detection).
+		effects.push( resetPost( post ) );
+
 		// Include auto draft title in edits while not flagging post as dirty
 		if ( post.status === 'auto-draft' ) {
 			effects.push( setupNewPost( {
 				title: post.title.raw,
 			} ) );
 		}
-
-		// Resetting post should occur after blocks have been reset, since it's
-		// the post reset that restarts history (used in dirty detection).
-		effects.push( resetPost( post ) );
 
 		return effects;
 	},

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -114,7 +114,7 @@ export const editor = flow( [
 	combineReducers,
 
 	// Track undo history, starting at editor initialization.
-	partialRight( withHistory, { resetTypes: [ 'SETUP_EDITOR' ] } ),
+	partialRight( withHistory, { resetTypes: [ 'SETUP_NEW_POST', 'SETUP_EDITOR' ] } ),
 
 	// Track whether changes exist, resetting at each post save. Relies on
 	// editor initialization firing post reset as an effect.

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -118,7 +118,7 @@ export const editor = flow( [
 
 	// Track whether changes exist, resetting at each post save. Relies on
 	// editor initialization firing post reset as an effect.
-	partialRight( withChangeDetection, { resetTypes: [ 'RESET_POST' ] } ),
+	partialRight( withChangeDetection, { resetTypes: [ 'SETUP_NEW_POST', 'RESET_POST' ] } ),
 ] )( {
 	edits( state = {}, action ) {
 		switch ( action.type ) {

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -469,8 +469,8 @@ describe( 'effects', () => {
 			const result = handler( { post, settings: {} } );
 
 			expect( result ).toEqual( [
-				setupNewPost( { title: 'A History of Pork' } ),
 				resetPost( post ),
+				setupNewPost( { title: 'A History of Pork' } ),
 			] );
 		} );
 	} );

--- a/test/e2e/.eslintrc.js
+++ b/test/e2e/.eslintrc.js
@@ -1,4 +1,10 @@
-{
+// For the most part, this file mirrors the same configuration from the root
+// `.eslintrc.json`, the exceptions being that since Cypress is preconfigured
+// with Mocha & Chai, we need to broadly disable the Jest rules, which is
+// otherwise difficult to do. This file could be made more minimal once all of
+// the Gutenberg-specific rules are migrated to a common WordPress config.
+
+module.exports = {
 	"root": true,
 	"parser": "babel-eslint",
 	"extends": [
@@ -172,4 +178,4 @@
 		"valid-typeof": "error",
 		"yoda": "off"
 	}
-}
+};

--- a/test/e2e/.eslintrc.json
+++ b/test/e2e/.eslintrc.json
@@ -1,6 +1,175 @@
 {
+	"root": true,
+	"parser": "babel-eslint",
+	"extends": [
+		"wordpress"
+	],
+	"env": {
+		"browser": false,
+		"es6": true,
+		"node": true,
+		"mocha": true
+	},
+	"parserOptions": {
+		"sourceType": "module"
+	},
 	"globals": {
 		"cy": true,
-		"Cypress": true
+		"Cypress": true,
+		"expect": true
+	},
+	"plugins": [
+		"wordpress"
+	],
+	"rules": {
+		"array-bracket-spacing": [ "error", "always" ],
+		"brace-style": [ "error", "1tbs" ],
+		"camelcase": [ "error", { "properties": "never" } ],
+		"comma-dangle": [ "error", "always-multiline" ],
+		"comma-spacing": "error",
+		"comma-style": "error",
+		"computed-property-spacing": [ "error", "always" ],
+		"constructor-super": "error",
+		"dot-notation": "error",
+		"eol-last": "error",
+		"eqeqeq": "error",
+		"func-call-spacing": "error",
+		"indent": [ "error", "tab", { "SwitchCase": 1 } ],
+		"key-spacing": "error",
+		"keyword-spacing": "error",
+		"lines-around-comment": "off",
+		"no-alert": "error",
+		"no-bitwise": "error",
+		"no-caller": "error",
+		"no-console": "error",
+		"no-const-assign": "error",
+		"no-debugger": "error",
+		"no-dupe-args": "error",
+		"no-dupe-class-members": "error",
+		"no-dupe-keys": "error",
+		"no-duplicate-case": "error",
+		"no-duplicate-imports": "error",
+		"no-else-return": "error",
+		"no-eval": "error",
+		"no-extra-semi": "error",
+		"no-fallthrough": "error",
+		"no-lonely-if": "error",
+		"no-mixed-operators": "error",
+		"no-mixed-spaces-and-tabs": "error",
+		"no-multiple-empty-lines": [ "error", { "max": 1 } ],
+		"no-multi-spaces": "error",
+		"no-multi-str": "off",
+		"no-negated-in-lhs": "error",
+		"no-nested-ternary": "error",
+		"no-redeclare": "error",
+		"no-restricted-syntax": [
+			"error",
+			{
+				"selector": "ImportDeclaration[source.value=/^@wordpress\\u002F.+\\u002F/]",
+				"message": "Path access on WordPress dependencies is not allowed."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^blocks$/]",
+				"message": "Use @wordpress/blocks as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^components$/]",
+				"message": "Use @wordpress/components as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^date$/]",
+				"message": "Use @wordpress/date as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^editor$/]",
+				"message": "Use @wordpress/editor as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^element$/]",
+				"message": "Use @wordpress/element as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^i18n$/]",
+				"message": "Use @wordpress/i18n as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^data$/]",
+				"message": "Use @wordpress/data as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^utils$/]",
+				"message": "Use @wordpress/utils as import path instead."
+			},
+			{
+				"selector": "ImportDeclaration[source.value=/^edit-poost$/]",
+				"message": "Use @wordpress/edit-post as import path instead."
+			},
+			{
+				"selector": "CallExpression[callee.name=/^__|_n|_x$/]:not([arguments.0.type=/^Literal|BinaryExpression$/])",
+				"message": "Translate function arguments must be string literals."
+			},
+			{
+				"selector": "CallExpression[callee.name=/^_n|_x$/]:not([arguments.1.type=/^Literal|BinaryExpression$/])",
+				"message": "Translate function arguments must be string literals."
+			},
+			{
+				"selector": "CallExpression[callee.name=_nx]:not([arguments.2.type=/^Literal|BinaryExpression$/])",
+				"message": "Translate function arguments must be string literals."
+			}
+		],
+		"no-shadow": "error",
+		"no-undef": "error",
+		"no-undef-init": "error",
+		"no-unreachable": "error",
+		"no-unsafe-negation": "error",
+		"no-unused-expressions": "error",
+		"no-unused-vars": "error",
+		"no-useless-computed-key": "error",
+		"no-useless-constructor": "error",
+		"no-useless-return": "error",
+		"no-var": "error",
+		"no-whitespace-before-property": "error",
+		"object-curly-spacing": [ "error", "always" ],
+		"padded-blocks": [ "error", "never" ],
+		"prefer-const": "error",
+		"quote-props": [ "error", "as-needed" ],
+		"semi": "error",
+		"semi-spacing": "error",
+		"space-before-blocks": [ "error", "always" ],
+		"space-before-function-paren": [ "error", "never" ],
+		"space-in-parens": [ "error", "always" ],
+		"space-infix-ops": [ "error", { "int32Hint": false } ],
+		"space-unary-ops": [ "error", {
+			"overrides": {
+				"!": true
+			}
+		} ],
+		"template-curly-spacing": [ "error", "always" ],
+		"valid-jsdoc": [ "error", {
+			"prefer": {
+				"arg": "param",
+				"argument": "param",
+				"extends": "augments",
+				"returns": "return"
+			},
+			"preferType": {
+				"array": "Array",
+				"bool": "boolean",
+				"Boolean": "boolean",
+				"float": "number",
+				"Float": "number",
+				"int": "number",
+				"integer": "number",
+				"Integer": "number",
+				"Number": "number",
+				"object": "Object",
+				"String": "string",
+				"Void": "void"
+			},
+			"requireParamDescription": false,
+			"requireReturn": false
+		} ],
+		"valid-typeof": "error",
+		"yoda": "off"
 	}
 }

--- a/test/e2e/integration/001-hello-gutenberg.js
+++ b/test/e2e/integration/001-hello-gutenberg.js
@@ -8,4 +8,30 @@ describe( 'Hello Gutenberg', () => {
 		cy.url().should( 'include', 'post-new.php' );
 		cy.get( '[placeholder="Add title"]' ).should( 'exist' );
 	} );
+
+	it( 'Should have no history', () => {
+		cy.get( '.editor-history__undo:not( :disabled )' ).should( 'not.exist' );
+		cy.get( '.editor-history__redo:not( :disabled )' ).should( 'not.exist' );
+	} );
+
+	it( 'Should not prompt to confirm unsaved changes', ( done ) => {
+		const timeout = setTimeout( () => {
+			done( new Error( 'Expected page reload' ) );
+		}, 5000 );
+
+		cy.window().then( ( window ) => {
+			function verify( event ) {
+				expect( event.returnValue ).to.equal( '' );
+
+				window.removeEventListener( 'beforeunload', verify );
+				clearTimeout( timeout );
+
+				done();
+			}
+
+			window.addEventListener( 'beforeunload', verify );
+
+			cy.reload();
+		} );
+	} );
 } );


### PR DESCRIPTION
Regression introduced in #3983

This pull request seeks to resolve an issue where saving a new post which has an empty title will set the title as "Auto Draft".

When starting a new post, a temporary post is created with "Auto Draft" as the assigned title. Obviously, we do not want to display this title to the user, so we artificially set the title to an empty string during editor initialization.

In the case that the user never sets a title of their own, we must also include the empty string value in the save request. This relies on a complex exchange whereby:

- The empty title is considered a change, so as to be included in the save payload
- But the change is not dirtying so that the user is not prompted about changes when navigating away from an untouched editor

To resolve this, we can add additional reset types to the `withChangeDetection` higher-order reducer applied for `state.editor`. The `RESET_POST` action must occur _before_ `SETUP_NEW_POST` so the post setup is considered a change, but `SETUP_NEW_POST` must also reset change detection.

In the course of implementing this, I also discovered that `SETUP_NEW_POST` should also be a reset type for change history, as prior to this change, "Undo" would be offered as an option for a new post.

__Next steps:__

I'd encourage exploring two tasks in the future, as this flow is rather fragile:

- We should not have to artificially make changes on behalf of the user when the editor initializes. Can we avoid "Auto Draft" ever being a title for the auto-draft post?
- ~Add integration tests for editor initialization, e.g. "After the editor finishes loading, there should be a title change, but not dirty, and with no history". I was going to add these here, but given how the editor store is shared, it wasn't clear how we isolate/reset/tear down this in unit tests (cc @youknowriad @gziolo).~
   - ~__Edit:__ I guess these could be e2e tests?~ Added in 7dce790.

__Testing instructions:__

1. Navigate to Posts > Add New
2. Refresh the page
3. Note that there is no prompt about unsaved changes
4. Note that the Undo button is disabled
5. Add some content
6. Save the post
7. Note that the title is still empty after save