### PR TITLE
Add withSafeTimeout higher-order component

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -22,7 +22,7 @@ import 'element-closest';
  */
 import { createElement, Component, renderToString } from '@wordpress/element';
 import { keycodes, createBlobURL } from '@wordpress/utils';
-import { Slot, Fill } from '@wordpress/components';
+import { withSafeTimeout, Slot, Fill } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -72,7 +72,7 @@ export function getFormatProperties( formatName, parents ) {
 
 const DEFAULT_FORMATS = [ 'bold', 'italic', 'strikethrough', 'link' ];
 
-export default class RichText extends Component {
+export class RichText extends Component {
 	constructor( props ) {
 		super( ...arguments );
 
@@ -267,11 +267,11 @@ export default class RichText extends Component {
 
 			if ( isEmpty && this.props.onReplace ) {
 				// Necessary to allow the paste bin to be removed without errors.
-				setTimeout( () => this.props.onReplace( content ) );
+				this.props.setTimeout( () => this.props.onReplace( content ) );
 			} else if ( this.props.onSplit ) {
 				// Necessary to get the right range.
 				// Also done in the TinyMCE paste plugin.
-				setTimeout( () => this.splitContent( content ) );
+				this.props.setTimeout( () => this.splitContent( content ) );
 			}
 
 			event.preventDefault();
@@ -855,3 +855,5 @@ RichText.defaultProps = {
 	formattingControls: DEFAULT_FORMATS,
 	formatters: [],
 };
+
+export default withSafeTimeout( RichText );

--- a/blocks/rich-text/patterns.js
+++ b/blocks/rich-text/patterns.js
@@ -14,26 +14,11 @@ import { keycodes } from '@wordpress/utils';
  */
 import { getBlockTypes } from '../api/registration';
 
-/**
- * Browser dependencies
- */
-const { setTimeout } = window;
-
 const { ESCAPE, ENTER, SPACE, BACKSPACE } = keycodes;
-
-/**
- * Sets a timeout and checks if the given editor still exists.
- *
- * @param {Editor}   editor   TinyMCE editor instance.
- * @param {Function} callback The function to call.
- */
-function setSafeTimeout( editor, callback ) {
-	setTimeout( () => ! editor.removed && callback() );
-}
 
 export default function( editor ) {
 	const getContent = this.getContent.bind( this );
-	const { onReplace } = this.props;
+	const { setTimeout, onReplace } = this.props;
 
 	const VK = tinymce.util.VK;
 	const settings = editor.settings.wptextpattern || {};
@@ -74,9 +59,9 @@ export default function( editor ) {
 			enter();
 		// Wait for the browser to insert the character.
 		} else if ( keyCode === SPACE ) {
-			setSafeTimeout( editor, () => searchFirstText( spacePatterns ) );
+			setTimeout( () => searchFirstText( spacePatterns ) );
 		} else if ( keyCode > 47 && ! ( keyCode >= 91 && keyCode <= 93 ) ) {
-			setSafeTimeout( editor, inline );
+			setTimeout( inline );
 		}
 	}, true );
 

--- a/blocks/rich-text/test/index.js
+++ b/blocks/rich-text/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import RichText, { createTinyMCEElement, isLinkBoundary, getFormatProperties } from '../';
+import { RichText, createTinyMCEElement, isLinkBoundary, getFormatProperties } from '../';
 import { diffAriaProps, pickAriaProps } from '../aria';
 
 describe( 'createTinyMCEElement', () => {

--- a/components/higher-order/with-safe-timeout/README.md
+++ b/components/higher-order/with-safe-timeout/README.md
@@ -1,0 +1,25 @@
+withSafeTimeout
+===============
+
+`withSafeTimeout` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) which provides a special version of `window.setTimeout` which respects the original component's lifecycle. Simply put, a function set to be called in the future via `setSafeTimeout` will never be called if the original component instance ceases to exist in the meantime.
+
+## Usage
+
+```jsx
+/**
+ * WordPress dependencies
+ */
+import { withSafeTimeout } from '@wordpress/components';
+
+function MyEffectfulComponent( { setSafeTimeout } ) {
+	return (
+		<TextField
+			onBlur={ () => {
+				setSafeTimeout( delayedAction, 0 );
+			} }
+		/>
+	);
+}
+
+export default withSafeTimeout( MyEffectfulComponent );
+```

--- a/components/higher-order/with-safe-timeout/index.js
+++ b/components/higher-order/with-safe-timeout/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { without } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Browser dependencies
+ */
+const { clearTimeout, setTimeout } = window;
+
+/**
+ * A higher-order component used to provide and manage delayed function calls
+ * that ought to be bound to a component's lifecycle.
+ *
+ * @param {Component} OriginalComponent   Component requiring setTimeout
+ *
+ * @return {Component}                   Wrapped component.
+ */
+function withSafeTimeout( OriginalComponent ) {
+	return class WrappedComponent extends Component {
+		constructor() {
+			super( ...arguments );
+			this.timeouts = [];
+			this.setTimeout = this.setTimeout.bind( this );
+			this.clearTimeout = this.clearTimeout.bind( this );
+		}
+
+		componentWillUnmount() {
+			this.timeouts.forEach( clearTimeout );
+		}
+
+		setTimeout( fn, delay ) {
+			const id = setTimeout( () => {
+				fn();
+				this.clearTimeout( id );
+			}, delay );
+			this.timeouts.push( id );
+			return id;
+		}
+
+		clearTimeout( id ) {
+			clearTimeout( id );
+			this.timeouts = without( this.timeouts, id );
+		}
+
+		render() {
+			return (
+				<OriginalComponent
+					{ ...this.props }
+					setTimeout={ this.setTimeout }
+					clearTimeout={ this.clearTimeout }
+				/>
+			);
+		}
+	};
+}
+
+export default withSafeTimeout;

--- a/components/index.js
+++ b/components/index.js
@@ -44,5 +44,6 @@ export { default as withFilters } from './higher-order/with-filters';
 export { default as withFocusOutside } from './higher-order/with-focus-outside';
 export { default as withFocusReturn } from './higher-order/with-focus-return';
 export { default as withInstanceId } from './higher-order/with-instance-id';
+export { default as withSafeTimeout } from './higher-order/with-safe-timeout';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';
 export { default as withState } from './higher-order/with-state';


### PR DESCRIPTION
## Description

Sparked by recent _in situ_ conversations and by #4603, here's an attempt to make asynchronous function calling safer using a lifecycle-bound `setTimeout` equivalent.

Depending on use cases, I could also see this accommodating more functions (`setInterval`, perhaps even `debounce`), whether via HoC arguments or separate HoCs.

## How Has This Been Tested?

1. Apply [this patch](https://gist.github.com/mcsf/1cb6c61d7bf392372f9189cb36c2813f) to tweak `CopyContentButton`'s behavior.
2. Go to the editor, open the console.
3. Open the global ellipsis menu. Click _Copy All Content_.
4. Leave the menu open. Make sure that, after a second, the console logs `copied`.
5. Open the ellipsis menu again. Click _Copy All Content_ and immediately close the menu.
6. Make sure that the console _doesn't_ log `copied` after that.
7. In `editor/hooks/copy-content/index.js`, replace the `setSafeTimeout( … )` call with the standard `window.setTimeout`. Repeat step 5 and make sure that the message gets logged even though the menu was previously closed.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
