### PR TITLE
Introduce allowCustom attribute to ColorPalette component.

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -42,32 +42,32 @@ export function ColorPalette( { defaultColors, colors, value, onChange, allowCus
 					</div>
 				);
 			} ) }
-            
-            { allowCustom &&
-    			<Dropdown
-    				className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"
-    				contentClassName="blocks-color-palette__picker "
-    				renderToggle={ ( { isOpen, onToggle } ) => (
-    					<button
-    						type="button"
-    						aria-expanded={ isOpen }
-    						className="blocks-color-palette__item"
-    						onClick={ onToggle }
-    						aria-label={ __( 'Custom color picker' ) }
-    					>
-    						<span className="blocks-color-palette__custom-color-gradient" />
-    					</button>
-    				) }
-    				renderContent={ () => (
-    					<ChromePicker
-    						color={ value }
-    						onChangeComplete={ ( color ) => onChange( color.hex ) }
-    						style={ { width: '100%' } }
-    						disableAlpha
-    					/>
-    				) }
-    			/>
-            }
+			
+			{ allowCustom &&
+				<Dropdown
+					className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"
+					contentClassName="blocks-color-palette__picker "
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<button
+							type="button"
+							aria-expanded={ isOpen }
+							className="blocks-color-palette__item"
+							onClick={ onToggle }
+							aria-label={ __( 'Custom color picker' ) }
+						>
+							<span className="blocks-color-palette__custom-color-gradient" />
+						</button>
+					) }
+					renderContent={ () => (
+						<ChromePicker
+							color={ value }
+							onChangeComplete={ ( color ) => onChange( color.hex ) }
+							style={ { width: '100%' } }
+							disableAlpha
+						/>
+					) }
+				/>
+			}
 
 			<button
 				className="button-link blocks-color-palette__clear"

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -16,7 +16,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import './style.scss';
 
-export function ColorPalette( { defaultColors, colors, value, onChange } ) {
+export function ColorPalette( { defaultColors, colors, value, onChange, allowCustom } ) {
 	const usedColors = colors || defaultColors;
 
 	function applyOrUnset( color ) {
@@ -42,30 +42,32 @@ export function ColorPalette( { defaultColors, colors, value, onChange } ) {
 					</div>
 				);
 			} ) }
-
-			<Dropdown
-				className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"
-				contentClassName="blocks-color-palette__picker "
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<button
-						type="button"
-						aria-expanded={ isOpen }
-						className="blocks-color-palette__item"
-						onClick={ onToggle }
-						aria-label={ __( 'Custom color picker' ) }
-					>
-						<span className="blocks-color-palette__custom-color-gradient" />
-					</button>
-				) }
-				renderContent={ () => (
-					<ChromePicker
-						color={ value }
-						onChangeComplete={ ( color ) => onChange( color.hex ) }
-						style={ { width: '100%' } }
-						disableAlpha
-					/>
-				) }
-			/>
+            
+            { allowCustom &&
+    			<Dropdown
+    				className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"
+    				contentClassName="blocks-color-palette__picker "
+    				renderToggle={ ( { isOpen, onToggle } ) => (
+    					<button
+    						type="button"
+    						aria-expanded={ isOpen }
+    						className="blocks-color-palette__item"
+    						onClick={ onToggle }
+    						aria-label={ __( 'Custom color picker' ) }
+    					>
+    						<span className="blocks-color-palette__custom-color-gradient" />
+    					</button>
+    				) }
+    				renderContent={ () => (
+    					<ChromePicker
+    						color={ value }
+    						onChangeComplete={ ( color ) => onChange( color.hex ) }
+    						style={ { width: '100%' } }
+    						disableAlpha
+    					/>
+    				) }
+    			/>
+            }
 
 			<button
 				className="button-link blocks-color-palette__clear"

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -108,14 +108,14 @@ class ButtonBlock extends Component {
 							<ColorPalette
 								value={ color }
 								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
-                                allowCustom
+								allowCustom
 							/>
 						</PanelColor>
 						<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } >
 							<ColorPalette
 								value={ textColor }
 								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
-                                allowCustom
+								allowCustom
 							/>
 						</PanelColor>
 						{ this.nodeRef && <ContrastCheckerWithFallbackStyles

--- a/blocks/library/button/index.js
+++ b/blocks/library/button/index.js
@@ -108,12 +108,14 @@ class ButtonBlock extends Component {
 							<ColorPalette
 								value={ color }
 								onChange={ ( colorValue ) => setAttributes( { color: colorValue } ) }
+                                allowCustom
 							/>
 						</PanelColor>
 						<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } >
 							<ColorPalette
 								value={ textColor }
 								onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
+                                allowCustom
 							/>
 						</PanelColor>
 						{ this.nodeRef && <ContrastCheckerWithFallbackStyles

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -118,14 +118,14 @@ class ParagraphBlock extends Component {
 						<ColorPalette
 							value={ backgroundColor }
 							onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
-                            allowCustom
+							allowCustom
 						/>
 					</PanelColor>
 					<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } initialOpen={ false }>
 						<ColorPalette
 							value={ textColor }
 							onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
-                            allowCustom
+							allowCustom
 						/>
 					</PanelColor>
 					{ this.nodeRef && <ContrastCheckerWithFallbackStyles

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -118,12 +118,14 @@ class ParagraphBlock extends Component {
 						<ColorPalette
 							value={ backgroundColor }
 							onChange={ ( colorValue ) => setAttributes( { backgroundColor: colorValue } ) }
+                            allowCustom
 						/>
 					</PanelColor>
 					<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } initialOpen={ false }>
 						<ColorPalette
 							value={ textColor }
 							onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
+                            allowCustom
 						/>
 					</PanelColor>
 					{ this.nodeRef && <ContrastCheckerWithFallbackStyles


### PR DESCRIPTION
Introduces an optional attribute which enables the custom colour selection.

I've set it to be opt-in rather than opt-out, as I believe allowing any this by default allows users to create blog posts full of rainbow text. 

I've added the attribute to those blocks already using the component as to not break backwards compatibility.

Fixes #4834.