### PR TITLE
JSDoc: prefer `@return` over `@retuns`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -186,7 +186,7 @@
 				"arg": "param",
 				"argument": "param",
 				"extends": "augments",
-				"return": "returns"
+				"returns": "return"
 			},
 			"preferType": {
 				"array": "Array",

--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -23,7 +23,7 @@ const categories = [
 /**
  * Returns all the block categories.
  *
- * @returns {Array} Block categories.
+ * @return {Array} Block categories.
  */
 export function getCategories() {
 	return categories;

--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -33,7 +33,7 @@ import { getBlockType, getBlockTypes } from './registration';
  * @param {string} name            Block name.
  * @param {Object} blockAttributes Block attributes.
  *
- * @returns {Object} Block object.
+ * @return {Object} Block object.
  */
 export function createBlock( name, blockAttributes = {} ) {
 	// Get the type definition associated with a registered block.
@@ -70,7 +70,7 @@ export function createBlock( name, blockAttributes = {} ) {
  * @param {string}  sourceName   Block name.
  * @param {boolean} isMultiBlock Array of possible block transformations.
  *
- * @returns {Function} Predicate that receives a block type.
+ * @return {Function} Predicate that receives a block type.
  */
 const isTransformForBlockSource = ( sourceName, isMultiBlock = false ) => ( transform ) => (
 	transform.type === 'block' &&
@@ -86,7 +86,7 @@ const isTransformForBlockSource = ( sourceName, isMultiBlock = false ) => ( tran
  * @param {string}  sourceName   Block name.
  * @param {boolean} isMultiBlock Array of possible block transformations.
  *
- * @returns {Function} Predicate that receives a block type.
+ * @return {Function} Predicate that receives a block type.
  */
 const createIsTypeTransformableFrom = ( sourceName, isMultiBlock = false ) => ( type ) => (
 	!! find(
@@ -101,7 +101,7 @@ const createIsTypeTransformableFrom = ( sourceName, isMultiBlock = false ) => ( 
  *
  * @param {Array} blocks Blocks array.
  *
- * @returns {Array} Array of possible block transformations.
+ * @return {Array} Array of possible block transformations.
  */
 export function getPossibleBlockTransformations( blocks ) {
 	const sourceBlock = first( blocks );
@@ -149,7 +149,7 @@ export function getPossibleBlockTransformations( blocks ) {
  * @param {Array|Object} blocks Blocks array or block object.
  * @param {string}       name   Block name.
  *
- * @returns {Array} Array of blocks.
+ * @return {Array} Array of blocks.
  */
 export function switchToBlockType( blocks, name ) {
 	const blocksArray = castArray( blocks );
@@ -229,7 +229,7 @@ export function switchToBlockType( blocks, name ) {
  * @param {Object} attributes The attributes of the block referenced by the
  *                            reusable block.
  *
- * @returns {Object} A reusable block object.
+ * @return {Object} A reusable block object.
  */
 export function createReusableBlock( type, attributes ) {
 	return {

--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -27,7 +27,7 @@ import { attr, prop, html, text, query, node, children } from './matchers';
  * @param {*}      value Original value.
  * @param {string} type  Type to coerce.
  *
- * @returns {*} Coerced value.
+ * @return {*} Coerced value.
  */
 export function asType( value, type ) {
 	switch ( type ) {
@@ -63,7 +63,7 @@ export function asType( value, type ) {
  *
  * @param {Object} sourceConfig Attribute Source object.
  *
- * @returns {Function} A hpq Matcher.
+ * @return {Function} A hpq Matcher.
  */
 export function matcherFromSource( sourceConfig ) {
 	switch ( sourceConfig.source ) {
@@ -98,7 +98,7 @@ export function matcherFromSource( sourceConfig ) {
  * @param {string} innerHTML         Block's raw content.
  * @param {Object} commentAttributes Block's comment attributes.
  *
- * @returns {*} Attribute value.
+ * @return {*} Attribute value.
  */
 export function getBlockAttribute( attributeKey, attributeSchema, innerHTML, commentAttributes ) {
 	let value;
@@ -128,7 +128,7 @@ export function getBlockAttribute( attributeKey, attributeSchema, innerHTML, com
  * @param {string}  innerHTML  Raw block content.
  * @param {?Object} attributes Known block attributes (from delimiters).
  *
- * @returns {Object} All block attributes.
+ * @return {Object} All block attributes.
  */
 export function getBlockAttributes( blockType, innerHTML, attributes ) {
 	const blockAttributes = mapValues( blockType.attributes, ( attributeSchema, attributeKey ) => {
@@ -146,7 +146,7 @@ export function getBlockAttributes( blockType, innerHTML, attributes ) {
  * @param {string}  innerHTML  Raw block content.
  * @param {?Object} attributes Known block attributes (from delimiters).
  *
- * @returns {Object} Block attributes.
+ * @return {Object} Block attributes.
  */
 export function getAttributesFromDeprecatedVersion( blockType, innerHTML, attributes ) {
 	if ( ! blockType.deprecated ) {
@@ -182,7 +182,7 @@ export function getAttributesFromDeprecatedVersion( blockType, innerHTML, attrib
  * @param {string}  innerHTML  Raw block content.
  * @param {?Object} attributes Attributes obtained from block delimiters.
  *
- * @returns {?Object} An initialized block object (if possible).
+ * @return {?Object} An initialized block object (if possible).
  */
 export function createBlockWithFallback( name, innerHTML, attributes ) {
 	// Use type from block content, otherwise find unknown handler.
@@ -260,7 +260,7 @@ export function createBlockWithFallback( name, innerHTML, attributes ) {
  *
  * @param {string} content The post content.
  *
- * @returns {Array} Block list.
+ * @return {Array} Block list.
  */
 export function parseWithGrammar( content ) {
 	return grammarParse( content ).reduce( ( memo, blockNode ) => {

--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -37,7 +37,7 @@ import shortcodeConverter from './shortcode-converter';
  * @param {Array}  [options.tagName]   The tag into which content will be
  *                                     inserted.
  *
- * @returns {Array|string} A list of blocks or a string, depending on `handlerMode`.
+ * @return {Array|string} A list of blocks or a string, depending on `handlerMode`.
  */
 export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagName } ) {
 	// First of all, strip any meta tags.

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -85,7 +85,7 @@ export function isAttributeWhitelisted( tag, attribute ) {
  * @param {string} nodeName Node name.
  * @param {string} tagName  Tag name.
  *
- * @returns {boolean} True if nodeName is inline in the context of tagName and
+ * @return {boolean} True if nodeName is inline in the context of tagName and
  *                    false otherwise.
  */
 function isInlineForTag( nodeName, tagName ) {
@@ -222,7 +222,7 @@ export function deepFilterNodeList( nodeList, filters, doc ) {
  * @param {string} HTML    The HTML to filter.
  * @param {Array}  filters An array of functions that can mutate with the provided node.
  *
- * @returns {string} The filtered HTML.
+ * @return {string} The filtered HTML.
  */
 export function deepFilterHTML( HTML, filters = [] ) {
 	const doc = document.implementation.createHTMLDocument( '' );

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -46,7 +46,7 @@ let defaultBlockName;
  * @param {string} name     Block name.
  * @param {Object} settings Block settings.
  *
- * @returns {?WPBlock} The block, if it has been successfully registered;
+ * @return {?WPBlock} The block, if it has been successfully registered;
  *                     otherwise `undefined`.
  */
 export function registerBlockType( name, settings ) {
@@ -130,7 +130,7 @@ export function registerBlockType( name, settings ) {
  *
  * @param {string} name Block name.
  *
- * @returns {?WPBlock} The previous block value, if it has been successfully
+ * @return {?WPBlock} The previous block value, if it has been successfully
  *                     unregistered; otherwise `undefined`.
  */
 export function unregisterBlockType( name ) {
@@ -158,7 +158,7 @@ export function setUnknownTypeHandlerName( name ) {
  * Retrieves name of block handling unknown block types, or undefined if no
  * handler has been defined.
  *
- * @returns {?string} Blog name.
+ * @return {?string} Blog name.
  */
 export function getUnknownTypeHandlerName() {
 	return unknownTypeHandlerName;
@@ -176,7 +176,7 @@ export function setDefaultBlockName( name ) {
 /**
  * Retrieves the default block name.
  *
- * @returns {?string} Blog name.
+ * @return {?string} Blog name.
  */
 export function getDefaultBlockName() {
 	return defaultBlockName;
@@ -187,7 +187,7 @@ export function getDefaultBlockName() {
  *
  * @param {string} name Block name.
  *
- * @returns {?Object} Block type.
+ * @return {?Object} Block type.
  */
 export function getBlockType( name ) {
 	return blocks[ name ];
@@ -196,7 +196,7 @@ export function getBlockType( name ) {
 /**
  * Returns all registered blocks.
  *
- * @returns {Array} Block settings.
+ * @return {Array} Block settings.
  */
 export function getBlockTypes() {
 	return Object.values( blocks );
@@ -210,7 +210,7 @@ export function getBlockTypes() {
  * @param {boolean}         defaultSupports Whether feature is supported by
  *                                          default if not explicitly defined.
  *
- * @returns {boolean} Whether block supports feature.
+ * @return {boolean} Whether block supports feature.
  */
 export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
 	const blockType = 'string' === typeof nameOrType ?
@@ -230,7 +230,7 @@ export function hasBlockSupport( nameOrType, feature, defaultSupports ) {
  *
  * @param {Object} blockOrType Block or Block Type to test.
  *
- * @returns {boolean} Whether the given block is a reusable block.
+ * @return {boolean} Whether the given block is a reusable block.
  */
 export function isReusableBlock( blockOrType ) {
 	return blockOrType.name === 'core/block';

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -20,7 +20,7 @@ import { getBlockType, getUnknownTypeHandlerName } from './registration';
  *
  * @param {string} blockName The block name.
  *
- * @returns {string} The block's default class.
+ * @return {string} The block's default class.
  */
 export function getBlockDefaultClassname( blockName ) {
 	// Drop common prefixes: 'core/' or 'core-' (in 'core-embed/')
@@ -34,7 +34,7 @@ export function getBlockDefaultClassname( blockName ) {
  * @param {Object} blockType  Block type.
  * @param {Object} attributes Block attributes.
  *
- * @returns {Object|string} Save content.
+ * @return {Object|string} Save content.
  */
 export function getSaveElement( blockType, attributes ) {
 	const { save } = blockType;
@@ -73,7 +73,7 @@ export function getSaveElement( blockType, attributes ) {
  * @param {Object} blockType  Block type.
  * @param {Object} attributes Block attributes.
  *
- * @returns {string} Save content.
+ * @return {string} Save content.
  */
 export function getSaveContent( blockType, attributes ) {
 	const saveElement = getSaveElement( blockType, attributes );
@@ -101,7 +101,7 @@ export function getSaveContent( blockType, attributes ) {
  * @param {Object<string,*>} allAttributes Attributes from in-memory block data.
  * @param {Object<string,*>} blockType     Block type.
  *
- * @returns {Object<string,*>} Subset of attributes for comment serialization.
+ * @return {Object<string,*>} Subset of attributes for comment serialization.
  */
 export function getCommentAttributes( allAttributes, blockType ) {
 	const attributes = reduce( blockType.attributes, ( result, attributeSchema, key ) => {
@@ -145,7 +145,7 @@ export function serializeAttributes( attrs ) {
  *
  * @param {string} content Original HTML.
  *
- * @returns {string} Beautiful HTML.
+ * @return {string} Beautiful HTML.
  */
 export function getBeautifulContent( content ) {
 	return beautifyHtml( content, {
@@ -159,7 +159,7 @@ export function getBeautifulContent( content ) {
  *
  * @param {Object} block Block Object.
  *
- * @returns {string} HTML.
+ * @return {string} HTML.
  */
 export function getBlockContent( block ) {
 	const blockType = getBlockType( block.name );
@@ -183,7 +183,7 @@ export function getBlockContent( block ) {
  * @param {Object} attributes   Block attributes.
  * @param {string} content      Block save content.
  *
- * @returns {string} Comment-delimited block content.
+ * @return {string} Comment-delimited block content.
  */
 export function getCommentDelimitedContent( rawBlockName, attributes, content ) {
 	const serializedAttributes = ! isEmpty( attributes ) ?
@@ -212,7 +212,7 @@ export function getCommentDelimitedContent( rawBlockName, attributes, content ) 
  *
  * @param {Object} block Block instance.
  *
- * @returns {string} Serialized block.
+ * @return {string} Serialized block.
  */
 export function serializeBlock( block ) {
 	const blockName = block.name;
@@ -247,7 +247,7 @@ export function serializeBlock( block ) {
  *
  * @param {Array} blocks Block(s) to serialize.
  *
- * @returns {string} The post content.
+ * @return {string} The post content.
  */
 export default function serialize( blocks ) {
 	return castArray( blocks ).map( serializeBlock ).join( '\n\n' );

--- a/blocks/api/validation.js
+++ b/blocks/api/validation.js
@@ -134,7 +134,7 @@ const log = ( () => {
 	 *
 	 * @param {Function} logger Original logger function.
 	 *
-	 * @returns {Function} Augmented logger function.
+	 * @return {Function} Augmented logger function.
 	 */
 	function createLogger( logger ) {
 		// In test environments, pre-process the sprintf message to improve
@@ -162,7 +162,7 @@ const log = ( () => {
  *
  * @param {string} text Original text.
  *
- * @returns {string[]} Text pieces split on whitespace.
+ * @return {string[]} Text pieces split on whitespace.
  */
 export function getTextPiecesSplitOnWhitespace( text ) {
 	return text.trim().split( REGEXP_WHITESPACE );
@@ -174,7 +174,7 @@ export function getTextPiecesSplitOnWhitespace( text ) {
  *
  * @param {string} text Original text.
  *
- * @returns {string} Trimmed text with consecutive whitespace collapsed.
+ * @return {string} Trimmed text with consecutive whitespace collapsed.
  */
 export function getTextWithCollapsedWhitespace( text ) {
 	return getTextPiecesSplitOnWhitespace( text ).join( ' ' );
@@ -189,7 +189,7 @@ export function getTextWithCollapsedWhitespace( text ) {
  *
  * @param {Object} token StartTag token.
  *
- * @returns {Array[]} Attribute pairs.
+ * @return {Array[]} Attribute pairs.
  */
 export function getMeaningfulAttributePairs( token ) {
 	return token.attributes.filter( ( pair ) => {
@@ -209,7 +209,7 @@ export function getMeaningfulAttributePairs( token ) {
  * @param {Object} actual   Actual token.
  * @param {Object} expected Expected token.
  *
- * @returns {boolean} Whether two text tokens are equivalent.
+ * @return {boolean} Whether two text tokens are equivalent.
  */
 export function isEqualTextTokensWithCollapsedWhitespace( actual, expected ) {
 	// This is an overly simplified whitespace comparison. The specification is
@@ -231,7 +231,7 @@ export function isEqualTextTokensWithCollapsedWhitespace( actual, expected ) {
  *
  * @param {string} value Style value.
  *
- * @returns {string} Normalized style value.
+ * @return {string} Normalized style value.
  */
 export function getNormalizedStyleValue( value ) {
 	return value
@@ -244,7 +244,7 @@ export function getNormalizedStyleValue( value ) {
  *
  * @param {string} text Style attribute.
  *
- * @returns {Object} Style properties.
+ * @return {Object} Style properties.
  */
 export function getStyleProperties( text ) {
 	const pairs = text
@@ -290,7 +290,7 @@ export const isEqualAttributesOfName = {
  * @param {Array[]} actual   Actual attributes tuples.
  * @param {Array[]} expected Expected attributes tuples.
  *
- * @returns {boolean} Whether attributes are equivalent.
+ * @return {boolean} Whether attributes are equivalent.
  */
 export function isEqualTagAttributePairs( actual, expected ) {
 	// Attributes is tokenized as tuples. Their lengths should match. This also
@@ -359,7 +359,7 @@ export const isEqualTokensOfType = {
  *
  * @param {Object[]} tokens Set of tokens to search.
  *
- * @returns {Object} Next non-whitespace token.
+ * @return {Object} Next non-whitespace token.
  */
 export function getNextNonWhitespaceToken( tokens ) {
 	let token;
@@ -381,7 +381,7 @@ export function getNextNonWhitespaceToken( tokens ) {
  * @param {string} actual Actual HTML string.
  * @param {string} expected Expected HTML string.
  *
- * @returns {boolean} Whether HTML strings are equivalent.
+ * @return {boolean} Whether HTML strings are equivalent.
  */
 export function isEquivalentHTML( actual, expected ) {
 	// Tokenize input content and reserialized save content
@@ -432,7 +432,7 @@ export function isEquivalentHTML( actual, expected ) {
  * @param {string} blockType  Block type.
  * @param {Object} attributes Parsed block attributes.
  *
- * @returns {boolean} Whether block is valid.
+ * @return {boolean} Whether block is valid.
  */
 export function isValidBlock( innerHTML, blockType, attributes ) {
 	let saveContent;

--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -63,7 +63,7 @@ import BlockIcon from '../block-icon';
  *
  * @param {Function} onReplace  Callback to replace the current block.
  *
- * @returns {Completer} Completer object used by the Autocomplete component.
+ * @return {Completer} Completer object used by the Autocomplete component.
  */
 export function blockAutocompleter( { onReplace } ) {
 	// Prioritize common category in block type options
@@ -104,7 +104,7 @@ export function blockAutocompleter( { onReplace } ) {
  * Returns a "completer" definition for inserting a user mention.
  * The definition can be understood by the Autocomplete component.
  *
- * @returns {Completer} Completer object used by the Autocomplete component.
+ * @return {Completer} Completer object used by the Autocomplete component.
  */
 export function userAutocompleter() {
 	const getOptions = () => {

--- a/blocks/hooks/anchor.js
+++ b/blocks/hooks/anchor.js
@@ -29,7 +29,7 @@ const ANCHOR_REGEX = /[\s#]/g;
  *
  * @param {Object} settings Original block settings.
  *
- * @returns {Object} Filtered block settings.
+ * @return {Object} Filtered block settings.
  */
 export function addAttribute( settings ) {
 	if ( hasBlockSupport( settings, 'anchor' ) ) {
@@ -53,7 +53,7 @@ export function addAttribute( settings ) {
  *
  * @param {function|Component} BlockEdit Original component.
  *
- * @returns {string} Wrapped component.
+ * @return {string} Wrapped component.
  */
 export function withInspectorControl( BlockEdit ) {
 	const WrappedBlockEdit = ( props ) => {
@@ -89,7 +89,7 @@ export function withInspectorControl( BlockEdit ) {
  * @param {Object} blockType  Block type.
  * @param {Object} attributes Current block attributes.
  *
- * @returns {Object} Filtered props applied to save element.
+ * @return {Object} Filtered props applied to save element.
  */
 export function addSaveProps( extraProps, blockType, attributes ) {
 	if ( hasBlockSupport( blockType, 'anchor' ) ) {

--- a/blocks/hooks/custom-class-name.js
+++ b/blocks/hooks/custom-class-name.js
@@ -23,7 +23,7 @@ import InspectorControls from '../inspector-controls';
  *
  * @param {Object} settings Original block settings.
  *
- * @returns {Object} Filtered block settings.
+ * @return {Object} Filtered block settings.
  */
 export function addAttribute( settings ) {
 	if ( hasBlockSupport( settings, 'customClassName', true ) ) {
@@ -44,7 +44,7 @@ export function addAttribute( settings ) {
  *
  * @param {function|Component} BlockEdit Original component.
  *
- * @returns {string} Wrapped component.
+ * @return {string} Wrapped component.
  */
 export function withInspectorControl( BlockEdit ) {
 	const WrappedBlockEdit = ( props ) => {
@@ -79,7 +79,7 @@ export function withInspectorControl( BlockEdit ) {
  * @param {Object} blockType  Block type.
  * @param {Object} attributes Current block attributes.
  *
- * @returns {Object} Filtered props applied to save element.
+ * @return {Object} Filtered props applied to save element.
  */
 export function addSaveProps( extraProps, blockType, attributes ) {
 	if ( hasBlockSupport( blockType, 'customClassName', true ) && attributes.className ) {

--- a/blocks/hooks/generated-class-name.js
+++ b/blocks/hooks/generated-class-name.js
@@ -21,7 +21,7 @@ import { hasBlockSupport, getBlockDefaultClassname } from '../api';
  * @param {Object} extraProps Additional props applied to save element.
  * @param {Object} blockType  Block type.
  *
- * @returns {Object} Filtered props applied to save element.
+ * @return {Object} Filtered props applied to save element.
  */
 export function addGeneratedClassName( extraProps, blockType ) {
 	// Adding the generated className

--- a/blocks/hooks/matchers.js
+++ b/blocks/hooks/matchers.js
@@ -80,7 +80,7 @@ export const node = ( selector ) => () => {
  *
  * @param {Object} settings Original block settings.
  *
- * @returns {Object} Filtered block settings.
+ * @return {Object} Filtered block settings.
  */
 export function resolveAttributes( settings ) {
 	// Resolve deprecated attributes

--- a/blocks/image-placeholder/index.js
+++ b/blocks/image-placeholder/index.js
@@ -21,7 +21,7 @@ import { rawHandler } from '../api';
  *
  * @param   {Object} props  React props passed to the component.
  *
- * @returns {Object} Rendered placeholder.
+ * @return {Object} Rendered placeholder.
  */
 export default function ImagePlaceHolder( { className, icon, label, onSelectImage, multiple = false } ) {
 	const setImage = multiple ? onSelectImage : ( [ image ] ) => onSelectImage( image );

--- a/blocks/media-upload/index.js
+++ b/blocks/media-upload/index.js
@@ -19,7 +19,7 @@ const getGalleryDetailsMediaFrame = () => {
 		/**
 		 * Create the default states.
 		 *
-		 * @returns {void}
+		 * @return {void}
 		 */
 		createStates: function createStates() {
 			this.states.add( [

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -116,7 +116,7 @@ export default class RichText extends Component {
 	 * Allows passing in settings which will be overwritten.
 	 *
 	 * @param {Object} settings The settings to overwrite.
-	 * @returns {Object} The settings for this block.
+	 * @return {Object} The settings for this block.
 	 */
 	getSettings( settings ) {
 		return ( this.props.getSettings || identity )( {
@@ -168,7 +168,7 @@ export default class RichText extends Component {
 	 *
 	 * @param {string} name The name of the event.
 	 *
-	 * @returns {void} Void.
+	 * @return {void} Void.
 	*/
 	proxyPropHandler( name ) {
 		return ( event ) => {
@@ -412,7 +412,7 @@ export default class RichText extends Component {
 	/**
 	 * Determines the DOM rectangle for the selection in the editor.
 	 *
-	 * @returns {DOMRect} The DOMRect based on the selection in the editor.
+	 * @return {DOMRect} The DOMRect based on the selection in the editor.
 	 */
 	getEditorSelectionRect() {
 		let range = this.editor.selection.getRng();
@@ -447,7 +447,7 @@ export default class RichText extends Component {
 	 * absolutely position the toolbar. It does this by finding the closest
 	 * relative element.
 	 *
-	 * @returns {{top: number, left: number}} The desired position of the toolbar.
+	 * @return {{top: number, left: number}} The desired position of the toolbar.
 	 */
 	getFocusPosition() {
 		const position = this.getEditorSelectionRect();
@@ -477,7 +477,7 @@ export default class RichText extends Component {
 	/**
 	 * Determines if the current selection within the editor is at the start.
 	 *
-	 * @returns {boolean} Whether or not the selection is at the start of the editor.
+	 * @return {boolean} Whether or not the selection is at the start of the editor.
 	 */
 	isStartOfEditor() {
 		const range = this.editor.selection.getRng();
@@ -500,7 +500,7 @@ export default class RichText extends Component {
 	/**
 	 * Determines if the current selection within the editor is at the end.
 	 *
-	 * @returns {boolean} Whether or not the selection is at the end of the editor.
+	 * @return {boolean} Whether or not the selection is at the end of the editor.
 	 */
 	isEndOfEditor() {
 		const range = this.editor.selection.getRng();

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -28,7 +28,7 @@ const { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT, SPACE } = keycodes;
  *
  * @param {Node} node The node to find the recursive first child.
  *
- * @returns {Node} The first leaf-node >= node in the ordering.
+ * @return {Node} The first leaf-node >= node in the ordering.
  */
 function descendFirst( node ) {
 	let n = node;
@@ -43,7 +43,7 @@ function descendFirst( node ) {
  *
  * @param {Node} node The node to find the recursive last child.
  *
- * @returns {Node} The first leaf-node <= node in the ordering.
+ * @return {Node} The first leaf-node <= node in the ordering.
  */
 function descendLast( node ) {
 	let n = node;
@@ -58,7 +58,7 @@ function descendLast( node ) {
  *
  * @param {?Node} node The node to check.
  *
- * @returns {boolean} True if the node is a text node.
+ * @return {boolean} True if the node is a text node.
  */
 function isTextNode( node ) {
 	return node !== null && node.nodeType === 3;
@@ -69,7 +69,7 @@ function isTextNode( node ) {
  *
  * @param {?Node} node The node to filter.
  *
- * @returns {?Node} The node or null if it is not a text node.
+ * @return {?Node} The node or null if it is not a text node.
  */
 function onlyTextNode( node ) {
 	return isTextNode( node ) ? node : null;
@@ -80,7 +80,7 @@ function onlyTextNode( node ) {
  *
  * @param {string} text The text to search.
  *
- * @returns {number} The last index of a white space character in the text or -1.
+ * @return {number} The last index of a white space character in the text or -1.
  */
 function lastIndexOfSpace( text ) {
 	for ( let i = text.length - 1; i >= 0; i-- ) {

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -57,7 +57,7 @@ function makeAutocompleter( completers, AutocompleteComponent = Autocomplete ) {
  *
  * @param {string} text Text of text node.
 
- * @returns {Node} A text node.
+ * @return {Node} A text node.
  */
 function tx( text ) {
 	return document.createTextNode( text );
@@ -66,7 +66,7 @@ function tx( text ) {
 /**
  * Create a paragraph node with the arguments as children.
 
- * @returns {Node} A paragraph node.
+ * @return {Node} A paragraph node.
  */
 function par( /* arguments */ ) {
 	const p = document.createElement( 'p' );

--- a/components/higher-order/with-api-data/request.js
+++ b/components/higher-order/with-api-data/request.js
@@ -47,7 +47,7 @@ export const cache = mapKeys(
  *
  * @param {XMLHttpRequest} xhr XMLHttpRequest object.
  *
- * @returns {Array[]} Array of header tuples.
+ * @return {Array[]} Array of header tuples.
  */
 export function getResponseHeaders( xhr ) {
 	// 'date: Tue, 22 Aug 2017 18:45:28 GMT↵server: nginx'
@@ -66,7 +66,7 @@ export function getResponseHeaders( xhr ) {
  *
  * @param {Object} request Request object (path, method).
  *
- * @returns {?Object} Response object (body, headers).
+ * @return {?Object} Response object (body, headers).
  */
 export function getCachedResponse( request ) {
 	if ( isRequestMethod( request, 'GET' ) ) {

--- a/components/higher-order/with-api-data/routes.js
+++ b/components/higher-order/with-api-data/routes.js
@@ -22,7 +22,7 @@ const RE_NAMED_SUBPATTERN = /\(\?P?[<']\w+[>'](.*?)\)/g;
  *
  * @param {string} pattern PCRE regular expression string.
  *
- * @returns {RegExp} Equivalent JavaScript RegExp.
+ * @return {RegExp} Equivalent JavaScript RegExp.
  */
 export function getNormalizedRegExp( pattern ) {
 	pattern = pattern.replace( RE_NAMED_SUBPATTERN, '($1)' );
@@ -36,7 +36,7 @@ export function getNormalizedRegExp( pattern ) {
  * @param {string} pattern PCRE route path pattern.
  * @param {string} path    URL path.
  *
- * @returns {boolean} Whether path is a match.
+ * @return {boolean} Whether path is a match.
  */
 export function isRouteMatch( pattern, path ) {
 	return getNormalizedRegExp( pattern ).test( path );

--- a/components/higher-order/with-filters/index.js
+++ b/components/higher-order/with-filters/index.js
@@ -19,7 +19,7 @@ const ANIMATION_FRAME_PERIOD = 16;
  *
  * @param {string} hookName Hook name exposed to be used by filters.
  *
- * @returns {Function} Higher-order component factory.
+ * @return {Function} Higher-order component factory.
  */
 export default function withFilters( hookName ) {
 	return ( OriginalComponent ) => {

--- a/components/higher-order/with-focus-return/index.js
+++ b/components/higher-order/with-focus-return/index.js
@@ -11,7 +11,7 @@ import { Component } from '@wordpress/element';
  *
  * @param {WPElement} WrappedComponent The disposable component.
  *
- * @returns {Component} Component with the focus restauration behaviour.
+ * @return {Component} Component with the focus restauration behaviour.
  */
 function withFocusReturn( WrappedComponent ) {
 	return class extends Component {

--- a/components/higher-order/with-instance-id/index.js
+++ b/components/higher-order/with-instance-id/index.js
@@ -9,7 +9,7 @@ import { Component } from '@wordpress/element';
  *
  * @param {WPElement} WrappedComponent The wrapped component.
  *
- * @returns {Component} Component with an instanceId prop.
+ * @return {Component} Component with an instanceId prop.
  */
 function withInstanceId( WrappedComponent ) {
 	let instances = 0;

--- a/components/higher-order/with-spoken-messages/index.js
+++ b/components/higher-order/with-spoken-messages/index.js
@@ -15,7 +15,7 @@ import { speak } from '@wordpress/a11y';
  *
  * @param {WPElement} WrappedComponent  The wrapped component.
  *
- * @returns {Component} Component with an instanceId prop.
+ * @return {Component} Component with an instanceId prop.
  */
 function withSpokenMessages( WrappedComponent ) {
 	return class extends Component {

--- a/components/higher-order/with-state/index.js
+++ b/components/higher-order/with-state/index.js
@@ -9,7 +9,7 @@ import { Component, getWrapperDisplayName } from '@wordpress/element';
  *
  * @param {?Object} initialState Optional initial state of the component.
  *
- * @returns {Component} Wrapped component.
+ * @return {Component} Wrapped component.
  */
 function withState( initialState = {} ) {
 	return ( OriginalComponent ) => {

--- a/data/index.js
+++ b/data/index.js
@@ -29,7 +29,7 @@ const store = createStore( initialReducer, {}, flowRight( enhancers ) );
  * @param {string} reducerKey Reducer key.
  * @param {Object} reducer    Reducer function.
  *
- * @returns {Object} Store Object.
+ * @return {Object} Store Object.
  */
 export function registerReducer( reducerKey, reducer ) {
 	reducers[ reducerKey ] = reducer;
@@ -74,7 +74,7 @@ export function registerSelectors( reducerKey, newSelectors ) {
  *                                       to determine the data for the
  *                                       component.
  *
- * @returns {Function} Renders the wrapped component and passes it data.
+ * @return {Function} Renders the wrapped component and passes it data.
  */
 export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
 	const connectWithStore = ( ...args ) => {
@@ -101,7 +101,7 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
  * @param {string} selectorName Selector name.
  * @param {*}      args         Selectors arguments.
  *
- * @returns {*} The selector's returned value.
+ * @return {*} The selector's returned value.
  */
 export const select = ( reducerKey, selectorName, ...args ) => {
 	return selectors[ reducerKey ][ selectorName ]( store.getState()[ reducerKey ], ...args );

--- a/data/persist.js
+++ b/data/persist.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  * @param {string}   reducerKey The reducer key to persist.
  * @param {string}   storageKey The storage key to use.
  *
- * @returns {Function} Enhanced reducer.
+ * @return {Function} Enhanced reducer.
  */
 export function withRehydratation( reducer, reducerKey, storageKey ) {
 	// EnhancedReducer with auto-rehydration

--- a/date/index.js
+++ b/date/index.js
@@ -45,7 +45,7 @@ const formatMap = {
 	 *
 	 * @param {moment} momentDate Moment instance.
 	 *
-	 * @returns {string} Formatted date.
+	 * @return {string} Formatted date.
 	 */
 	S( momentDate ) {
 		// Do - D
@@ -60,7 +60,7 @@ const formatMap = {
 	 *
 	 * @param {moment} momentDate Moment instance.
 	 *
-	 * @returns {string} Formatted date.
+	 * @return {string} Formatted date.
 	 */
 	z( momentDate ) {
 		// DDD - 1
@@ -80,7 +80,7 @@ const formatMap = {
 	 *
 	 * @param {moment} momentDate Moment instance.
 	 *
-	 * @returns {string} Formatted date.
+	 * @return {string} Formatted date.
 	 */
 	t( momentDate ) {
 		return momentDate.daysInMonth();
@@ -92,7 +92,7 @@ const formatMap = {
 	 *
 	 * @param {moment} momentDate Moment instance.
 	 *
-	 * @returns {string} Formatted date.
+	 * @return {string} Formatted date.
 	 */
 	L( momentDate ) {
 		return momentDate.isLeapYear() ? '1' : '0';
@@ -109,7 +109,7 @@ const formatMap = {
 	 *
 	 * @param {moment} momentDate Moment instance.
 	 *
-	 * @returns {string} Formatted date.
+	 * @return {string} Formatted date.
 	 */
 	B( momentDate ) {
 		const timezoned = moment( momentDate ).utcOffset( 60 );
@@ -140,7 +140,7 @@ const formatMap = {
 	 *
 	 * @param {moment} momentDate Moment instance.
 	 *
-	 * @returns {string} Formatted date.
+	 * @return {string} Formatted date.
 	 */
 	I( momentDate ) {
 		return momentDate.isDST() ? '1' : '0';
@@ -153,7 +153,7 @@ const formatMap = {
 	 *
 	 * @param {moment} momentDate Moment instance.
 	 *
-	 * @returns {string} Formatted date.
+	 * @return {string} Formatted date.
 	 */
 	Z( momentDate ) {
 		// Timezone offset in seconds.
@@ -226,7 +226,7 @@ function setupLocale( settings ) {
  * @param {(Date|string|moment|null)} dateValue  Date object or string,
  *                                               parsable by moment.js.
  *
- * @returns {string} Formatted date.
+ * @return {string} Formatted date.
  */
 export function format( dateFormat, dateValue = new Date() ) {
 	let i, char;
@@ -267,7 +267,7 @@ export function format( dateFormat, dateValue = new Date() ) {
  * @param {(Date|string|moment|null)} dateValue  Date object or string,
  *                                               parsable by moment.js.
  *
- * @returns {string} Formatted date.
+ * @return {string} Formatted date.
  */
 export function date( dateFormat, dateValue = new Date() ) {
 	const offset = window._wpDateSettings.timezone.offset * HOUR_IN_MINUTES;
@@ -283,7 +283,7 @@ export function date( dateFormat, dateValue = new Date() ) {
  * @param {(Date|string|moment|null)} dateValue  Date object or string,
  *                                               parsable by moment.js.
  *
- * @returns {string} Formatted date.
+ * @return {string} Formatted date.
  */
 export function gmdate( dateFormat, dateValue = new Date() ) {
 	const dateMoment = moment( dateValue ).utc();
@@ -300,7 +300,7 @@ export function gmdate( dateFormat, dateValue = new Date() ) {
  * @param {boolean}                   gmt        True for GMT/UTC, false for
  *                                               site's timezone.
  *
- * @returns {string} Formatted date.
+ * @return {string} Formatted date.
  */
 export function dateI18n( dateFormat, dateValue = new Date(), gmt = false ) {
 	// Defaults.

--- a/edit-post/index.js
+++ b/edit-post/index.js
@@ -81,7 +81,7 @@ export function reinitializeEditor( target, settings ) {
  * @param {Object}  post     API entity for post to edit.
  * @param {?Object} settings Editor settings object.
  *
- * @returns {Object} Editor interface.
+ * @return {Object} Editor interface.
  */
 export function initializeEditor( id, post, settings ) {
 	const target = document.getElementById( id );

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -7,7 +7,7 @@
  *                               (desktop, mobile or publish).
  * @param {boolean?} forcedValue Force a sidebar state.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function toggleSidebar( sidebar, forcedValue ) {
 	return {
@@ -23,7 +23,7 @@ export function toggleSidebar( sidebar, forcedValue ) {
  *
  * @param {string} panel The panel name.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function setActivePanel( panel ) {
 	return {
@@ -38,7 +38,7 @@ export function setActivePanel( panel ) {
  *
  * @param {string} panel The panel name.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function toggleSidebarPanel( panel ) {
 	return {
@@ -52,7 +52,7 @@ export function toggleSidebarPanel( panel ) {
  *
  * @param {string} feature Featurre name.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function toggleFeature( feature ) {
 	return {

--- a/edit-post/store/middlewares.js
+++ b/edit-post/store/middlewares.js
@@ -13,7 +13,7 @@ import { mobileMiddleware } from '../utils/mobile';
  *
  * @param {Object} store Store Object.
  *
- * @returns {Object} Update Store Object.
+ * @return {Object} Update Store Object.
  */
 function applyMiddlewares( store ) {
 	const middlewares = [

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -18,7 +18,7 @@ import { PREFERENCES_DEFAULTS } from './defaults';
  * @param {Object}  state.panels          The state of the different sidebar panels.
  * @param {Object}  action                Dispatched action.
  *
- * @returns {string} Updated state.
+ * @return {string} Updated state.
  */
 export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 	switch ( action.type ) {

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -3,7 +3,7 @@
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Editing mode.
+ * @return {string} Editing mode.
  */
 export function getEditorMode( state ) {
 	return getPreference( state, 'mode', 'visual' );
@@ -14,7 +14,7 @@ export function getEditorMode( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Active sidebar panel.
+ * @return {string} Active sidebar panel.
  */
 export function getActivePanel( state ) {
 	return state.panel;
@@ -25,7 +25,7 @@ export function getActivePanel( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {Object} Preferences Object.
+ * @return {Object} Preferences Object.
  */
 export function getPreferences( state ) {
 	return state.preferences;
@@ -37,7 +37,7 @@ export function getPreferences( state ) {
  * @param {string} preferenceKey Preference Key.
  * @param {Mixed}  defaultValue  Default Value.
  *
- * @returns {Mixed} Preference Value.
+ * @return {Mixed} Preference Value.
  */
 export function getPreference( state, preferenceKey, defaultValue ) {
 	const preferences = getPreferences( state );
@@ -51,7 +51,7 @@ export function getPreference( state, preferenceKey, defaultValue ) {
  * @param {Object} state   Global application state.
  * @param {string} sidebar Sidebar name (leave undefined for the default sidebar).
  *
- * @returns {boolean} Whether the given sidebar is open.
+ * @return {boolean} Whether the given sidebar is open.
  */
 export function isSidebarOpened( state, sidebar ) {
 	const sidebars = getPreference( state, 'sidebars' );
@@ -67,7 +67,7 @@ export function isSidebarOpened( state, sidebar ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether sidebar is open.
+ * @return {boolean} Whether sidebar is open.
  */
 export function hasOpenSidebar( state ) {
 	const sidebars = getPreference( state, 'sidebars' );
@@ -82,7 +82,7 @@ export function hasOpenSidebar( state ) {
  * @param {Object} state Global application state.
  * @param {string} panel Sidebar panel name.
  *
- * @returns {boolean} Whether sidebar is open.
+ * @return {boolean} Whether sidebar is open.
  */
 export function isEditorSidebarPanelOpened( state, panel ) {
 	const panels = getPreference( state, 'panels' );
@@ -94,7 +94,7 @@ export function isEditorSidebarPanelOpened( state, panel ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether current window size corresponds to
+ * @return {boolean} Whether current window size corresponds to
  *                    mobile resolutions.
  */
 export function isMobile( state ) {
@@ -106,7 +106,7 @@ export function isMobile( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} True if toolbar is fixed.
+ * @return {boolean} True if toolbar is fixed.
  */
 export function hasFixedToolbar( state ) {
 	return ! isMobile( state ) && isFeatureActive( state, 'fixedToolbar' );
@@ -118,7 +118,7 @@ export function hasFixedToolbar( state ) {
  * @param {Object} state   Global application state.
  * @param {string} feature Feature slug.
  *
- * @returns {booleean} Is active.
+ * @return {booleean} Is active.
  */
 export function isFeatureActive( state, feature ) {
 	return !! state.preferences.features[ feature ];

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -73,7 +73,7 @@ const { BACKSPACE, ESCAPE, DELETE, ENTER, UP, RIGHT, DOWN, LEFT } = keycodes;
  *
  * @param {Element} node Node from which to start.
  *
- * @returns {?Element} Scrollable container node, if found.
+ * @return {?Element} Scrollable container node, if found.
  */
 function getScrollContainer( node ) {
 	if ( ! node ) {
@@ -284,7 +284,7 @@ export class BlockListBlock extends Component {
 	 *
 	 * @param {FocusEvent} event A focus event
 	 *
-	 * @returns {void}
+	 * @return {void}
 	 */
 	onFocus( event ) {
 		if ( event.target === this.node && ! this.props.isSelected ) {
@@ -298,7 +298,7 @@ export class BlockListBlock extends Component {
 	 *
 	 * @param {DragEvent} event Drag event.
 	 *
-	 * @returns {void}
+	 * @return {void}
 	 */
 	preventDrag( event ) {
 		event.preventDefault();
@@ -309,7 +309,7 @@ export class BlockListBlock extends Component {
 	 *
 	 * @param {MouseEvent} event A mousedown event.
 	 *
-	 * @returns {void}
+	 * @return {void}
 	 */
 	onPointerDown( event ) {
 		// Not the main button.

--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -108,7 +108,7 @@ class BlockList extends Component {
 	 *
 	 * @param {MouseEvent} event A mousemove event object.
 	 *
-	 * @returns {void}
+	 * @return {void}
 	 */
 	onPointerMove( { clientY } ) {
 		// We don't start multi-selection until the mouse starts moving, so as
@@ -160,7 +160,7 @@ class BlockList extends Component {
 	 *
 	 * @param {string} uid UID of the block where mousedown occurred.
 	 *
-	 * @returns {void}
+	 * @return {void}
 	 */
 	onSelectionStart( uid ) {
 		if ( ! this.props.isSelectionEnabled ) {
@@ -208,7 +208,7 @@ class BlockList extends Component {
 	/**
 	 * Handles a mouseup event to end the current cursor multi-selection.
 	 *
-	 * @returns {void}
+	 * @return {void}
 	 */
 	onSelectionEnd() {
 		// Cancel throttled calls.

--- a/editor/components/block-mover/mover-label.js
+++ b/editor/components/block-mover/mover-label.js
@@ -15,7 +15,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * @param {number}  dir           Direction of movement (> 0 is considered to be going
  *                                 down, < 0 is up).
  *
- * @returns {string} Label for the block movement controls.
+ * @return {string} Label for the block movement controls.
  */
 export function getBlockMoverLabel( selectedCount, type, firstIndex, isFirst, isLast, dir ) {
 	const position = ( firstIndex + 1 );
@@ -76,7 +76,7 @@ export function getBlockMoverLabel( selectedCount, type, firstIndex, isFirst, is
  * @param {number}  dir           Direction of movement (> 0 is considered to be going
  *                                 down, < 0 is up).
  *
- * @returns {string} Label for the block movement controls.
+ * @return {string} Label for the block movement controls.
  */
 export function getMultiBlockMoverLabel( selectedCount, firstIndex, isFirst, isLast, dir ) {
 	const position = ( firstIndex + 1 );

--- a/editor/components/post-saved-state/index.js
+++ b/editor/components/post-saved-state/index.js
@@ -31,7 +31,7 @@ import {
  * Component showing whether the post is saved or not and displaying save links.
  *
  * @param   {Object}    Props Component Props.
- * @returns {WPElement}       WordPress Element.
+ * @return {WPElement}       WordPress Element.
  */
 export function PostSavedState( { hasActiveMetaboxes, isNew, isPublished, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
 	const className = 'editor-post-saved-state';

--- a/editor/components/unsaved-changes-warning/index.js
+++ b/editor/components/unsaved-changes-warning/index.js
@@ -44,7 +44,7 @@ class UnsavedChangesWarning extends Component {
 	 * Warns the user if there are unsaved changes before leaving the editor.
 	 *
 	 * @param   {Event}   event Event Object.
-	 * @returns {string?}       Warning message.
+	 * @return {string?}       Warning message.
 	 */
 	warnIfUnsavedChanges( event ) {
 		const areMetaBoxesDirty = some( this.props.metaBoxes, ( metaBox, location ) => {

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -11,7 +11,7 @@ import { partial, castArray } from 'lodash';
  * @param {Object} post     Post object.
  * @param {Object} settings Editor settings object.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function setupEditor( post, settings ) {
 	return {
@@ -27,7 +27,7 @@ export function setupEditor( post, settings ) {
  *
  * @param {Object} post Post object.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function resetPost( post ) {
 	return {
@@ -42,7 +42,7 @@ export function resetPost( post ) {
  *
  * @param {Object} edits Edited attributes object.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function setupNewPost( edits ) {
 	return {
@@ -58,7 +58,7 @@ export function setupNewPost( edits ) {
  *
  * @param {Array} blocks Array of blocks.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function resetBlocks( blocks ) {
 	return {
@@ -74,7 +74,7 @@ export function resetBlocks( blocks ) {
  * @param {string} uid        Block UID.
  * @param {Object} attributes Block attributes to be merged.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function updateBlockAttributes( uid, attributes ) {
 	return {
@@ -91,7 +91,7 @@ export function updateBlockAttributes( uid, attributes ) {
  * @param {string} uid     Block UID.
  * @param {Object} updates Block attributes to be merged.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function updateBlock( uid, updates ) {
 	return {
@@ -148,7 +148,7 @@ export function clearSelectedBlock() {
  * @param {boolean} [isSelectionEnabled=true] Whether block selection should
  *                                            be enabled.
 
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function toggleSelection( isSelectionEnabled = true ) {
 	return {
@@ -164,7 +164,7 @@ export function toggleSelection( isSelectionEnabled = true ) {
  * @param {(string|string[])} uids   Block UID(s) to replace.
  * @param {(Object|Object[])} blocks Replacement block(s).
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function replaceBlocks( uids, blocks ) {
 	return {
@@ -181,7 +181,7 @@ export function replaceBlocks( uids, blocks ) {
  * @param {(string|string[])} uid   Block UID(s) to replace.
  * @param {(Object|Object[])} block Replacement block(s).
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function replaceBlock( uid, block ) {
 	return replaceBlocks( uid, block );
@@ -203,7 +203,7 @@ export function insertBlocks( blocks, position ) {
  * Returns an action object used in signalling that the insertion point should
  * be shown.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function showInsertionPoint() {
 	return {
@@ -214,7 +214,7 @@ export function showInsertionPoint() {
 /**
  * Returns an action object hiding the insertion point.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function hideInsertionPoint() {
 	return {
@@ -253,7 +253,7 @@ export function mergeBlocks( blockA, blockB ) {
 /**
  * Returns an action object used in signalling that the post should autosave.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function autosave() {
 	return {
@@ -265,7 +265,7 @@ export function autosave() {
  * Returns an action object used in signalling that undo history should
  * restore last popped state.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function redo() {
 	return { type: 'REDO' };
@@ -274,7 +274,7 @@ export function redo() {
 /**
  * Returns an action object used in signalling that undo history should pop.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function undo() {
 	return { type: 'UNDO' };
@@ -286,7 +286,7 @@ export function undo() {
  *
  * @param {string[]} uids Block UIDs.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function removeBlocks( uids ) {
 	return {
@@ -301,7 +301,7 @@ export function removeBlocks( uids ) {
  *
  * @param {string} uid Block UID.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function removeBlock( uid ) {
 	return removeBlocks( [ uid ] );
@@ -312,7 +312,7 @@ export function removeBlock( uid ) {
  *
  * @param {string} uid Block UID.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function toggleBlockMode( uid ) {
 	return {
@@ -324,7 +324,7 @@ export function toggleBlockMode( uid ) {
 /**
  * Returns an action object used in signalling that the user has begun to type.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function startTyping() {
 	return {
@@ -335,7 +335,7 @@ export function startTyping() {
 /**
  * Returns an action object used in signalling that the user has stopped typing.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function stopTyping() {
 	return {
@@ -352,7 +352,7 @@ export function stopTyping() {
  *                              `id` (string; default auto-generated)
  *                              `isDismissible` (boolean; default `true`).
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function createNotice( status, content, options = {} ) {
 	const {
@@ -377,7 +377,7 @@ export function createNotice( status, content, options = {} ) {
  *
  * @param {string} id The notice id.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function removeNotice( id ) {
 	return {
@@ -399,7 +399,7 @@ export function removeNotice( id ) {
  *
  * @param {Object} metaBoxes Whether meta box locations are active.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function initializeMetaBoxState( metaBoxes ) {
 	return {
@@ -411,7 +411,7 @@ export function initializeMetaBoxState( metaBoxes ) {
 /**
  * Returns an action object used to request meta box update.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function requestMetaBoxUpdates() {
 	return {
@@ -422,7 +422,7 @@ export function requestMetaBoxUpdates() {
 /**
  * Returns an action object used signal a successfull meta nox update.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function metaBoxUpdatesSuccess() {
 	return {
@@ -435,7 +435,7 @@ export function metaBoxUpdatesSuccess() {
  * This is used to check if the meta boxes have been touched when leaving the editor.
  *
  * @param   {Object} dataPerLocation Meta Boxes Data per location.
- * @returns {Object}                 Action object.
+ * @return {Object}                 Action object.
  */
 export function setMetaBoxSavedData( dataPerLocation ) {
 	return {
@@ -456,7 +456,7 @@ export const createWarningNotice = partial( createNotice, 'warning' );
  * @param {?string} id If given, only a single reusable block with this ID will
  *                     be fetched.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function fetchReusableBlocks( id ) {
 	return {
@@ -473,7 +473,7 @@ export function fetchReusableBlocks( id ) {
  * @param {Object} reusableBlock The new reusable block object. Any omitted keys
  *                               are not changed.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function updateReusableBlock( id, reusableBlock ) {
 	return {
@@ -489,7 +489,7 @@ export function updateReusableBlock( id, reusableBlock ) {
  *
  * @param {Object} id The ID of the reusable block to save.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function saveReusableBlock( id ) {
 	return {
@@ -503,7 +503,7 @@ export function saveReusableBlock( id ) {
  *
  * @param {number} id The ID of the reusable block to delete.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function deleteReusableBlock( id ) {
 	return {
@@ -518,7 +518,7 @@ export function deleteReusableBlock( id ) {
  *
  * @param {Object} uid The ID of the block to attach.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function convertBlockToStatic( uid ) {
 	return {
@@ -533,7 +533,7 @@ export function convertBlockToStatic( uid ) {
  *
  * @param {Object} uid The ID of the block to detach.
  *
- * @returns {Object} Action object.
+ * @return {Object} Action object.
  */
 export function convertBlockToReusable( uid ) {
 	return {

--- a/editor/store/middlewares.js
+++ b/editor/store/middlewares.js
@@ -15,7 +15,7 @@ import effects from './effects';
  *
  * @param {Object} store Store Object.
  *
- * @returns {Object} Update Store Object.
+ * @return {Object} Update Store Object.
  */
 function applyMiddlewares( store ) {
 	const middlewares = [

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -35,7 +35,7 @@ import { PREFERENCES_DEFAULTS } from './defaults';
  *
  * @param {*} value Original value.
  *
- * @returns {*} Raw value.
+ * @return {*} Raw value.
  */
 export function getPostRawValue( value ) {
 	if ( value && 'object' === typeof value && 'raw' in value ) {
@@ -305,7 +305,7 @@ export const editor = flow( [
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @returns {Object} Updated state.
+ * @return {Object} Updated state.
  */
 export function currentPost( state = {}, action ) {
 	switch ( action.type ) {
@@ -335,7 +335,7 @@ export function currentPost( state = {}, action ) {
  * @param {boolean} state  Current state.
  * @param {Object}  action Dispatched action.
  *
- * @returns {boolean} Updated state.
+ * @return {boolean} Updated state.
  */
 export function isTyping( state = false, action ) {
 	switch ( action.type ) {
@@ -355,7 +355,7 @@ export function isTyping( state = false, action ) {
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @returns {Object} Updated state.
+ * @return {Object} Updated state.
  */
 export function blockSelection( state = {
 	start: null,
@@ -457,7 +457,7 @@ export function blockSelection( state = {
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @returns {Object} Updated state.
+ * @return {Object} Updated state.
  */
 export function hoveredBlock( state = null, action ) {
 	switch ( action.type ) {
@@ -497,7 +497,7 @@ export function blocksMode( state = {}, action ) {
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @returns {Object} Updated state.
+ * @return {Object} Updated state.
  */
 export function isInsertionPointVisible( state = false, action ) {
 	switch ( action.type ) {
@@ -520,7 +520,7 @@ export function isInsertionPointVisible( state = false, action ) {
  * @param {Object}  state.panels          The state of the different sidebar panels.
  * @param {Object}  action                Dispatched action.
  *
- * @returns {string} Updated state.
+ * @return {string} Updated state.
  */
 export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 	switch ( action.type ) {
@@ -559,7 +559,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @returns {Object} Updated state.
+ * @return {Object} Updated state.
  */
 export function saving( state = {}, action ) {
 	switch ( action.type ) {
@@ -633,7 +633,7 @@ const defaultMetaBoxState = locations.reduce( ( result, key ) => {
  *
  * @param {boolean}  state   Previous state.
  * @param {Object}   action  Action Object.
- * @returns {Object}         Updated state.
+ * @return {Object}         Updated state.
  */
 export function isSavingMetaBoxes( state = false, action ) {
 	switch ( action.type ) {
@@ -656,7 +656,7 @@ export function isSavingMetaBoxes( state = false, action ) {
  *
  * @param {boolean}  state   Previous state.
  * @param {Object}   action  Action Object.
- * @returns {Object}         Updated state.
+ * @return {Object}         Updated state.
  */
 export function metaBoxes( state = defaultMetaBoxState, action ) {
 	switch ( action.type ) {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -32,7 +32,7 @@ export const POST_UPDATE_TRANSACTION_ID = 'post-update';
  * Returns the state of legacy meta boxes.
  *
  * @param   {Object} state Global application state.
- * @returns {Object}       State of meta boxes.
+ * @return {Object}       State of meta boxes.
  */
 export function getMetaBoxes( state ) {
 	return state.metaBoxes;
@@ -44,7 +44,7 @@ export function getMetaBoxes( state ) {
  * @param {Object} state    Global application state.
  * @param {string} location Location of the meta box.
  *
- * @returns {Object} State of meta box at specified location.
+ * @return {Object} State of meta box at specified location.
  */
 export function getMetaBox( state, location ) {
 	return getMetaBoxes( state )[ location ];
@@ -69,7 +69,7 @@ export const hasMetaBoxes = createSelector(
  * Returns true if the the Meta Boxes are being saved.
  *
  * @param   {Object}  state Global application state.
- * @returns {boolean}       Whether the metaboxes are being saved.
+ * @return {boolean}       Whether the metaboxes are being saved.
  */
 export function isSavingMetaBoxes( state ) {
 	return state.isSavingMetaBoxes;
@@ -80,7 +80,7 @@ export function isSavingMetaBoxes( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether undo history exists.
+ * @return {boolean} Whether undo history exists.
  */
 export function hasEditorUndo( state ) {
 	return state.editor.past.length > 0;
@@ -92,7 +92,7 @@ export function hasEditorUndo( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether redo history exists.
+ * @return {boolean} Whether redo history exists.
  */
 export function hasEditorRedo( state ) {
 	return state.editor.future.length > 0;
@@ -104,7 +104,7 @@ export function hasEditorRedo( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether the post is new.
+ * @return {boolean} Whether the post is new.
  */
 export function isEditedPostNew( state ) {
 	return getCurrentPost( state ).status === 'auto-draft';
@@ -116,7 +116,7 @@ export function isEditedPostNew( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether unsaved values exist.
+ * @return {boolean} Whether unsaved values exist.
  */
 export function isEditedPostDirty( state ) {
 	return state.editor.isDirty;
@@ -128,7 +128,7 @@ export function isEditedPostDirty( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether new post and unsaved values exist.
+ * @return {boolean} Whether new post and unsaved values exist.
  */
 export function isCleanNewPost( state ) {
 	return ! isEditedPostDirty( state ) && isEditedPostNew( state );
@@ -141,7 +141,7 @@ export function isCleanNewPost( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {Object} Post object.
+ * @return {Object} Post object.
  */
 export function getCurrentPost( state ) {
 	return state.currentPost;
@@ -152,7 +152,7 @@ export function getCurrentPost( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Post type.
+ * @return {string} Post type.
  */
 export function getCurrentPostType( state ) {
 	return state.currentPost.type;
@@ -163,7 +163,7 @@ export function getCurrentPostType( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Slug.
+ * @return {string} Slug.
  */
 export function getCurrentPostSlug( state ) {
 	return getEditedPostAttribute( state, 'slug' );
@@ -175,7 +175,7 @@ export function getCurrentPostSlug( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?number} ID of current post.
+ * @return {?number} ID of current post.
  */
 export function getCurrentPostId( state ) {
 	return getCurrentPost( state ).id || null;
@@ -186,7 +186,7 @@ export function getCurrentPostId( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {number} Number of revisions.
+ * @return {number} Number of revisions.
  */
 export function getCurrentPostRevisionsCount( state ) {
 	return get( getCurrentPost( state ), 'revisions.count', 0 );
@@ -198,7 +198,7 @@ export function getCurrentPostRevisionsCount( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?number} ID of the last revision.
+ * @return {?number} ID of the last revision.
  */
 export function getCurrentPostLastRevisionId( state ) {
 	return get( getCurrentPost( state ), 'revisions.last_id', null );
@@ -210,7 +210,7 @@ export function getCurrentPostLastRevisionId( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {Object} Object of key value pairs comprising unsaved edits.
+ * @return {Object} Object of key value pairs comprising unsaved edits.
  */
 export function getPostEdits( state ) {
 	return get( state, [ 'editor', 'present', 'edits' ], {} );
@@ -224,7 +224,7 @@ export function getPostEdits( state ) {
  * @param {Object} state         Global application state.
  * @param {string} attributeName Post attribute name.
  *
- * @returns {*} Post attribute value.
+ * @return {*} Post attribute value.
  */
 export function getEditedPostAttribute( state, attributeName ) {
 	const edits = getPostEdits( state );
@@ -240,7 +240,7 @@ export function getEditedPostAttribute( state, attributeName ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Post visibility.
+ * @return {string} Post visibility.
  */
 export function getEditedPostVisibility( state ) {
 	const status = getEditedPostAttribute( state, 'status' );
@@ -259,7 +259,7 @@ export function getEditedPostVisibility( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether the post has been published.
+ * @return {boolean} Whether the post has been published.
  */
 export function isCurrentPostPublished( state ) {
 	const post = getCurrentPost( state );
@@ -273,7 +273,7 @@ export function isCurrentPostPublished( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether the post can been published.
+ * @return {boolean} Whether the post can been published.
  */
 export function isEditedPostPublishable( state ) {
 	const post = getCurrentPost( state );
@@ -286,7 +286,7 @@ export function isEditedPostPublishable( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether the post can be saved.
+ * @return {boolean} Whether the post can be saved.
  */
 export function isEditedPostSaveable( state ) {
 	return (
@@ -302,7 +302,7 @@ export function isEditedPostSaveable( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether the post has been published.
+ * @return {boolean} Whether the post has been published.
  */
 export function isEditedPostBeingScheduled( state ) {
 	const date = getEditedPostAttribute( state, 'date' );
@@ -318,7 +318,7 @@ export function isEditedPostBeingScheduled( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Raw post title.
+ * @return {string} Raw post title.
  */
 export function getEditedPostTitle( state ) {
 	const editedTitle = getPostEdits( state ).title;
@@ -337,7 +337,7 @@ export function getEditedPostTitle( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Document title.
+ * @return {string} Document title.
  */
 export function getDocumentTitle( state ) {
 	let title = getEditedPostTitle( state );
@@ -354,7 +354,7 @@ export function getDocumentTitle( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Raw post excerpt.
+ * @return {string} Raw post excerpt.
  */
 export function getEditedPostExcerpt( state ) {
 	return state.editor.present.edits.excerpt === undefined ?
@@ -367,7 +367,7 @@ export function getEditedPostExcerpt( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {string} Preview URL.
+ * @return {string} Preview URL.
  */
 export function getEditedPostPreviewLink( state ) {
 	const link = state.currentPost.link;
@@ -458,7 +458,7 @@ export const getBlocks = createSelector(
  *
  * @param {Object} state Global application state.
  *
- * @returns {number} Number of blocks in the post.
+ * @return {number} Number of blocks in the post.
  */
 export function getBlockCount( state ) {
 	return getBlockUids( state ).length;
@@ -469,7 +469,7 @@ export function getBlockCount( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {number} Number of blocks selected in the post.
+ * @return {number} Number of blocks selected in the post.
  */
 export function getSelectedBlockCount( state ) {
 	const multiSelectedBlockCount = getMultiSelectedBlockUids( state ).length;
@@ -486,7 +486,7 @@ export function getSelectedBlockCount( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?Object} Selected block.
+ * @return {?Object} Selected block.
  */
 export function getSelectedBlock( state ) {
 	const { start, end } = state.blockSelection;
@@ -555,7 +555,7 @@ export const getMultiSelectedBlocks = createSelector(
  *
  * @param {Object} state Global application state.
  *
- * @returns {?string} First unique block ID in the multi-selection set.
+ * @return {?string} First unique block ID in the multi-selection set.
  */
 export function getFirstMultiSelectedBlockUid( state ) {
 	return first( getMultiSelectedBlockUids( state ) ) || null;
@@ -567,7 +567,7 @@ export function getFirstMultiSelectedBlockUid( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?string} Last unique block ID in the multi-selection set.
+ * @return {?string} Last unique block ID in the multi-selection set.
  */
 export function getLastMultiSelectedBlockUid( state ) {
 	return last( getMultiSelectedBlockUids( state ) ) || null;
@@ -581,7 +581,7 @@ export function getLastMultiSelectedBlockUid( state ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {boolean} Whether block is first in mult-selection.
+ * @return {boolean} Whether block is first in mult-selection.
  */
 export function isFirstMultiSelectedBlock( state, uid ) {
 	return getFirstMultiSelectedBlockUid( state ) === uid;
@@ -594,7 +594,7 @@ export function isFirstMultiSelectedBlock( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {boolean} Whether block is in multi-selection set.
+ * @return {boolean} Whether block is in multi-selection set.
  */
 export function isBlockMultiSelected( state, uid ) {
 	return getMultiSelectedBlockUids( state ).indexOf( uid ) !== -1;
@@ -609,7 +609,7 @@ export function isBlockMultiSelected( state, uid ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?string} Unique ID of block beginning multi-selection.
+ * @return {?string} Unique ID of block beginning multi-selection.
  */
 export function getMultiSelectedBlocksStartUid( state ) {
 	const { start, end } = state.blockSelection;
@@ -628,7 +628,7 @@ export function getMultiSelectedBlocksStartUid( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?string} Unique ID of block ending multi-selection.
+ * @return {?string} Unique ID of block ending multi-selection.
  */
 export function getMultiSelectedBlocksEndUid( state ) {
 	const { start, end } = state.blockSelection;
@@ -644,7 +644,7 @@ export function getMultiSelectedBlocksEndUid( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {Array} Ordered unique IDs of post blocks.
+ * @return {Array} Ordered unique IDs of post blocks.
  */
 export function getBlockUids( state ) {
 	return state.editor.present.blockOrder;
@@ -657,7 +657,7 @@ export function getBlockUids( state ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {number} Index at which block exists in order.
+ * @return {number} Index at which block exists in order.
  */
 export function getBlockIndex( state, uid ) {
 	return state.editor.present.blockOrder.indexOf( uid );
@@ -670,7 +670,7 @@ export function getBlockIndex( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {boolean} Whether block is first in post.
+ * @return {boolean} Whether block is first in post.
  */
 export function isFirstBlock( state, uid ) {
 	return first( state.editor.present.blockOrder ) === uid;
@@ -683,7 +683,7 @@ export function isFirstBlock( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {boolean} Whether block is last in post.
+ * @return {boolean} Whether block is last in post.
  */
 export function isLastBlock( state, uid ) {
 	return last( state.editor.present.blockOrder ) === uid;
@@ -696,7 +696,7 @@ export function isLastBlock( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {Object} Block occurring before specified unique ID.
+ * @return {Object} Block occurring before specified unique ID.
  */
 export function getPreviousBlock( state, uid ) {
 	const order = getBlockIndex( state, uid );
@@ -710,7 +710,7 @@ export function getPreviousBlock( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {Object} Block occurring after specified unique ID.
+ * @return {Object} Block occurring after specified unique ID.
  */
 export function getNextBlock( state, uid ) {
 	const order = getBlockIndex( state, uid );
@@ -724,7 +724,7 @@ export function getNextBlock( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {boolean} Whether block is selected and multi-selection exists.
+ * @return {boolean} Whether block is selected and multi-selection exists.
  */
 export function isBlockSelected( state, uid ) {
 	const { start, end } = state.blockSelection;
@@ -745,7 +745,7 @@ export function isBlockSelected( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {boolean} Whether block is selected and not the last in
+ * @return {boolean} Whether block is selected and not the last in
  *                    the selection.
  */
 export function isBlockWithinSelection( state, uid ) {
@@ -765,7 +765,7 @@ export function isBlockWithinSelection( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {boolean} Whether block is hovered.
+ * @return {boolean} Whether block is hovered.
  */
 export function isBlockHovered( state, uid ) {
 	return state.hoveredBlock === uid;
@@ -779,7 +779,7 @@ export function isBlockHovered( state, uid ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {Object} Block focus state.
+ * @return {Object} Block focus state.
  */
 export function getBlockFocus( state, uid ) {
 	// If there is multi-selection, keep returning the focus object for the start block.
@@ -795,7 +795,7 @@ export function getBlockFocus( state, uid ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} True if multi-selecting, false if not.
+ * @return {boolean} True if multi-selecting, false if not.
  */
 export function isMultiSelecting( state ) {
 	return state.blockSelection.isMultiSelecting;
@@ -806,7 +806,7 @@ export function isMultiSelecting( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} True if multi is disable, false if not.
+ * @return {boolean} True if multi is disable, false if not.
  */
 export function isSelectionEnabled( state ) {
 	return state.blockSelection.isEnabled;
@@ -818,7 +818,7 @@ export function isSelectionEnabled( state ) {
  * @param {Object} state Global application state.
  * @param {string} uid   Block unique ID.
  *
- * @returns {Object} Block editing mode.
+ * @return {Object} Block editing mode.
  */
 export function getBlockMode( state, uid ) {
 	return state.blocksMode[ uid ] || 'visual';
@@ -829,7 +829,7 @@ export function getBlockMode( state, uid ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether user is typing.
+ * @return {boolean} Whether user is typing.
  */
 export function isTyping( state ) {
 	return state.isTyping;
@@ -841,7 +841,7 @@ export function isTyping( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?string} Unique ID after which insertion will occur.
+ * @return {?string} Unique ID after which insertion will occur.
  */
 export function getBlockInsertionPoint( state ) {
 	const lastMultiSelectedBlock = getLastMultiSelectedBlockUid( state );
@@ -862,7 +862,7 @@ export function getBlockInsertionPoint( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?boolean} Whether the insertion point is visible or not.
+ * @return {?boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
 	return state.isInsertionPointVisible;
@@ -873,7 +873,7 @@ export function isBlockInsertionPointVisible( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether post is being saved.
+ * @return {boolean} Whether post is being saved.
  */
 export function isSavingPost( state ) {
 	return state.saving.requesting || isSavingMetaBoxes( state );
@@ -885,7 +885,7 @@ export function isSavingPost( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether the post was saved successfully.
+ * @return {boolean} Whether the post was saved successfully.
  */
 export function didPostSaveRequestSucceed( state ) {
 	return state.saving.successful;
@@ -897,7 +897,7 @@ export function didPostSaveRequestSucceed( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether the post save failed.
+ * @return {boolean} Whether the post save failed.
  */
 export function didPostSaveRequestFail( state ) {
 	return !! state.saving.error;
@@ -910,7 +910,7 @@ export function didPostSaveRequestFail( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {?string} Suggested post format.
+ * @return {?string} Suggested post format.
  */
 export function getSuggestedPostFormat( state ) {
 	const blocks = state.editor.present.blockOrder;
@@ -981,7 +981,7 @@ export const getEditedPostContent = createSelector(
  *
  * @param {Object} state Global application state.
  *
- * @returns {Array} List of notices.
+ * @return {Array} List of notices.
  */
 export function getNotices( state ) {
 	return state.notices;
@@ -1009,7 +1009,7 @@ export function getNotices( state ) {
  * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
  * @param {Object}           blockType         Block type, likely from getBlockType().
  *
- * @returns {Editor.InserterItem} Item that appears in inserter.
+ * @return {Editor.InserterItem} Item that appears in inserter.
  */
 function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
 	if ( ! enabledBlockTypes || ! blockType ) {
@@ -1043,7 +1043,7 @@ function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
  * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
  * @param {Object}           reusableBlock     Reusable block, likely from getReusableBlock().
  *
- * @returns {Editor.InserterItem} Item that appears in inserter.
+ * @return {Editor.InserterItem} Item that appears in inserter.
  */
 function buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock ) {
 	if ( ! enabledBlockTypes || ! reusableBlock ) {
@@ -1079,7 +1079,7 @@ function buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock ) 
  * @param {Object}           state             Global application state.
  * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
  *
- * @returns {Editor.InserterItem[]} Items that appear in inserter.
+ * @return {Editor.InserterItem[]} Items that appear in inserter.
  */
 export function getInserterItems( state, enabledBlockTypes = true ) {
 	if ( ! enabledBlockTypes ) {
@@ -1120,7 +1120,7 @@ const getRecentInserts = createSelector(
  * @param {Object}           state             Global application state.
  * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
  *
- * @returns {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
+ * @return {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
  */
 export function getRecentInserterItems( state, enabledBlockTypes = true ) {
 	if ( ! enabledBlockTypes ) {
@@ -1146,7 +1146,7 @@ export function getRecentInserterItems( state, enabledBlockTypes = true ) {
  * @param {Object} state Global application state.
  * @param {string} ref   The reusable block's ID.
  *
- * @returns {Object} The reusable block, or null if none exists.
+ * @return {Object} The reusable block, or null if none exists.
  */
 export function getReusableBlock( state, ref ) {
 	return state.reusableBlocks.data[ ref ] || null;
@@ -1158,7 +1158,7 @@ export function getReusableBlock( state, ref ) {
  * @param {*} state Global application state.
  * @param {*} ref   The reusable block's ID.
  *
- * @returns {boolean} Whether or not the reusable block is being saved.
+ * @return {boolean} Whether or not the reusable block is being saved.
  */
 export function isSavingReusableBlock( state, ref ) {
 	return state.reusableBlocks.isSaving[ ref ] || false;
@@ -1169,7 +1169,7 @@ export function isSavingReusableBlock( state, ref ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {Array} An array of all reusable blocks.
+ * @return {Array} An array of all reusable blocks.
  */
 export function getReusableBlocks( state ) {
 	return Object.values( state.reusableBlocks.data );
@@ -1182,7 +1182,7 @@ export function getReusableBlocks( state ) {
  * @param {Object} state         Current global application state.
  * @param {Object} transactionId Optimist transaction ID.
  *
- * @returns {Object} Global application state prior to transaction.
+ * @return {Object} Global application state prior to transaction.
  */
 export function getStateBeforeOptimisticTransaction( state, transactionId ) {
 	const transaction = find( state.optimist, ( entry ) => (
@@ -1198,7 +1198,7 @@ export function getStateBeforeOptimisticTransaction( state, transactionId ) {
  *
  * @param {Object} state Global application state.
  *
- * @returns {boolean} Whether post is being published.
+ * @return {boolean} Whether post is being published.
  */
 export function isPublishingPost( state ) {
 	if ( ! isSavingPost( state ) ) {

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -16,7 +16,7 @@ const { TEXT_NODE } = window.Node;
  * @param {boolean} isReverse      Set to true to check left, false for right.
  * @param {boolean} collapseRanges Whether or not to collapse the selection range before the check.
  *
- * @returns {boolean} True if at the horizontal edge, false if not.
+ * @return {boolean} True if at the horizontal edge, false if not.
  */
 export function isHorizontalEdge( container, isReverse, collapseRanges = false ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
@@ -82,7 +82,7 @@ export function isHorizontalEdge( container, isReverse, collapseRanges = false )
  * @param {boolean} isReverse      Set to true to check top, false for bottom.
  * @param {boolean} collapseRanges Whether or not to collapse the selection range before the check.
  *
- * @returns {boolean} True if at the edge, false if not.
+ * @return {boolean} True if at the edge, false if not.
  */
 export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
@@ -204,7 +204,7 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
  * @param {number}    x   Horizontal position within the current viewport.
  * @param {number}    y   Vertical position within the current viewport.
  *
- * @returns {?Range} The best range for the given point.
+ * @return {?Range} The best range for the given point.
  */
 function caretRangeFromPoint( doc, x, y ) {
 	if ( doc.caretRangeFromPoint ) {
@@ -234,7 +234,7 @@ function caretRangeFromPoint( doc, x, y ) {
  * @param {number}    y         Vertical position within the current viewport.
  * @param {Element}  container Container in which the range is expected to be found.
  *
- * @returns {?Range} The best range for the given point.
+ * @return {?Range} The best range for the given point.
  */
 function hiddenCaretRangeFromPoint( doc, x, y, container ) {
 	container.style.zIndex = '10000';
@@ -315,7 +315,7 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
  *
  * @param {HTMLElement} element The HTML element.
  *
- * @returns {boolean} True if the element is an input field, false if not.
+ * @return {boolean} True if the element is an input field, false if not.
  */
 export function isInputField( { nodeName, contentEditable } ) {
 	return (
@@ -329,7 +329,7 @@ export function isInputField( { nodeName, contentEditable } ) {
  * Check wether the current document has a selection.
  * This checks both for focus in an input field and general text selection.
  *
- * @returns {boolean} True if there is selection, false if not.
+ * @return {boolean} True if there is selection, false if not.
  */
 export function documentHasSelection() {
 	if ( isInputField( document.activeElement ) ) {

--- a/editor/utils/meta-boxes.js
+++ b/editor/utils/meta-boxes.js
@@ -4,7 +4,7 @@
  * If the MetaBox Area is visible returns it, and returns the original container instead.
  *
  * @param   {string} location Meta Box location.
- * @returns {string}          HTML content.
+ * @return {string}          HTML content.
  */
 export const getMetaBoxContainer = ( location ) => {
 	const area = document.querySelector( `.editor-meta-boxes-area.is-${ location } .metabox-location-${ location }` );

--- a/editor/utils/url.js
+++ b/editor/utils/url.js
@@ -8,7 +8,7 @@ import { addQueryArgs } from '@wordpress/url';
  *
  * @param {number} postId Post ID.
  *
- * @returns {string} Post edit URL.
+ * @return {string} Post edit URL.
  */
 export function getPostEditUrl( postId ) {
 	return getWPAdminURL( 'post.php', { post: postId, action: 'edit' } );
@@ -20,7 +20,7 @@ export function getPostEditUrl( postId ) {
  * @param {string} page  Page to navigate to.
  * @param {Object} query Query Args.
  *
- * @returns {string} WPAdmin URL.
+ * @return {string} WPAdmin URL.
  */
 export function getWPAdminURL( page, query ) {
 	return addQueryArgs( page, query );
@@ -31,7 +31,7 @@ export function getWPAdminURL( page, query ) {
  *
  * @param {string} url Original URL.
  *
- * @returns {string} Displayed URL.
+ * @return {string} Displayed URL.
  */
 export function filterURLForDisplay( url ) {
 	// remove protocol and www prefixes

--- a/editor/utils/with-change-detection/index.js
+++ b/editor/utils/with-change-detection/index.js
@@ -12,7 +12,7 @@ import { includes } from 'lodash';
  * @param {?Object}  options            Optional .
  * @param {?Array}   options.resetTypes Action types upon which to reset dirty.
  *
- * @returns {Function} Enhanced reducer.
+ * @return {Function} Enhanced reducer.
  */
 export default function withChangeDetection( reducer, options = {} ) {
 	return ( state, action ) => {

--- a/editor/utils/with-history/index.js
+++ b/editor/utils/with-history/index.js
@@ -11,7 +11,7 @@ import { includes } from 'lodash';
  * @param {?Object}  options            Optional options.
  * @param {?Array}   options.resetTypes Action types upon which to clear past.
  *
- * @returns {Function} Enhanced reducer.
+ * @return {Function} Enhanced reducer.
  */
 export default function withHistory( reducer, options = {} ) {
 	const initialState = {

--- a/element/index.js
+++ b/element/index.js
@@ -89,7 +89,7 @@ export { renderToStaticMarkup as renderToString };
  *
  * @param {...?Object} childrenArguments Array of children arguments (array of arrays/strings/objects) to concatenate.
  *
- * @returns {Array} The concatenated value.
+ * @return {Array} The concatenated value.
  */
 export function concatChildren( ...childrenArguments ) {
 	return childrenArguments.reduce( ( memo, children, i ) => {
@@ -113,7 +113,7 @@ export function concatChildren( ...childrenArguments ) {
  * @param {?Object} children Children object.
  * @param {string}  nodeName Node name.
  *
- * @returns {?Object} The updated children object.
+ * @return {?Object} The updated children object.
  */
 export function switchChildrenNodeName( children, nodeName ) {
 	return children && Children.map( children, ( elt, index ) => {
@@ -142,7 +142,7 @@ export { flowRight as compose };
  * @param {Function|Component} BaseComponent Used to detect the existing display name.
  * @param {string} wrapperName Wrapper name to prepend to the display name.
  *
- * @returns {string} Wrapped display name.
+ * @return {string} Wrapped display name.
  */
 export function getWrapperDisplayName( BaseComponent, wrapperName ) {
 	const { displayName = BaseComponent.name || 'Component' } = BaseComponent;

--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -88,7 +88,7 @@ const REGEXP_TRANSLATOR_COMMENT = /^\s*translators:\s*([\s\S]+)/im;
  *
  * @param {Object} node AST node.
  *
- * @returns {string} String value.
+ * @return {string} String value.
  */
 function getNodeAsString( node ) {
 	switch ( node.type ) {
@@ -113,7 +113,7 @@ function getNodeAsString( node ) {
  * @param {number} _originalNodeLine Private: In recursion, line number of
  *                                     the original node passed.
  *
- * @returns {?string} Translator comment.
+ * @return {?string} Translator comment.
  */
 function getTranslatorComment( path, _originalNodeLine ) {
 	const { node, parent, parentPath } = path;
@@ -162,7 +162,7 @@ function getTranslatorComment( path, _originalNodeLine ) {
  *
  * @param {string} key Key to test.
  *
- * @returns {boolean} Whether key is valid for assignment.
+ * @return {boolean} Whether key is valid for assignment.
  */
 function isValidTranslationKey( key ) {
 	return -1 !== VALID_TRANSLATION_KEYS.indexOf( key );
@@ -175,7 +175,7 @@ function isValidTranslationKey( key ) {
  * @param {Object} a First translation object.
  * @param {Object} b Second translation object.
  *
- * @returns {boolean} Whether valid translation keys match.
+ * @return {boolean} Whether valid translation keys match.
  */
 function isSameTranslation( a, b ) {
 	return isEqual(

--- a/i18n/index.js
+++ b/i18n/index.js
@@ -20,7 +20,7 @@ export function setLocaleData( data ) {
  * Returns the current Jed instance, initializing with a default configuration
  * if not already assigned.
  *
- * @returns {Jed} Jed instance.
+ * @return {Jed} Jed instance.
  */
 export function getI18n() {
 	if ( ! i18n ) {
@@ -37,7 +37,7 @@ export function getI18n() {
  *
  * @param {string} text Text to translate.
  *
- * @returns {string} Translated text.
+ * @return {string} Translated text.
  */
 export function __( text ) {
 	return getI18n().gettext( text );
@@ -51,7 +51,7 @@ export function __( text ) {
  * @param {string} text    Text to translate.
  * @param {string} context Context information for the translators.
  *
- * @returns {string} Translated context string without pipe.
+ * @return {string} Translated context string without pipe.
  */
 export function _x( text, context ) {
 	return getI18n().pgettext( context, text );
@@ -68,7 +68,7 @@ export function _x( text, context ) {
  * @param {number} number The number to compare against to use either the
  *                         singular or plural form.
  *
- * @returns {string} The translated singular or plural form.
+ * @return {string} The translated singular or plural form.
  */
 export function _n( single, plural, number ) {
 	return getI18n().ngettext( single, plural, number );
@@ -86,7 +86,7 @@ export function _n( single, plural, number ) {
  *                          singular or plural form.
  * @param {string} context Context information for the translators.
  *
- * @returns {string} The translated singular or plural form.
+ * @return {string} The translated singular or plural form.
  */
 export function _nx( single, plural, number, context ) {
 	return getI18n().npgettext( context, single, plural, number );

--- a/utils/focus/focusable.js
+++ b/utils/focus/focusable.js
@@ -42,7 +42,7 @@ const SELECTOR = [
  *
  * @param {Element} element DOM element to test.
  *
- * @returns {boolean} Whether element is visible.
+ * @return {boolean} Whether element is visible.
  */
 function isVisible( element ) {
 	return (
@@ -59,7 +59,7 @@ function isVisible( element ) {
  *
  * @param {Element} element DOM area element to test.
  *
- * @returns {boolean} Whether area element is valid for focus.
+ * @return {boolean} Whether area element is valid for focus.
  */
 function isValidFocusableArea( element ) {
 	const map = element.closest( 'map[name]' );
@@ -76,7 +76,7 @@ function isValidFocusableArea( element ) {
  *
  * @param {Element} context Element in which to search.
  *
- * @returns {Element[]} Focusable elements.
+ * @return {Element[]} Focusable elements.
  */
 export function find( context ) {
 	const elements = context.querySelectorAll( SELECTOR );

--- a/utils/focus/tabbable.js
+++ b/utils/focus/tabbable.js
@@ -13,7 +13,7 @@ import { find as findFocusable } from './focusable';
  *
  * @param {Element} element Element from which to retrieve.
  *
- * @returns {?number} Tab index of element (default 0).
+ * @return {?number} Tab index of element (default 0).
  */
 function getTabIndex( element ) {
 	const tabIndex = element.getAttribute( 'tabindex' );
@@ -25,7 +25,7 @@ function getTabIndex( element ) {
  *
  * @param {Element} element Element to test.
  *
- * @returns {boolean} Whether element is tabbable.
+ * @return {boolean} Whether element is tabbable.
  */
 function isTabbableIndex( element ) {
 	return getTabIndex( element ) !== -1;
@@ -40,7 +40,7 @@ function isTabbableIndex( element ) {
  * @param {Element} element Element.
  * @param {number}  index   Array index of element.
  *
- * @returns {Object} Mapped object with element, index.
+ * @return {Object} Mapped object with element, index.
  */
 function mapElementToObjectTabbable( element, index ) {
 	return { element, index };
@@ -52,7 +52,7 @@ function mapElementToObjectTabbable( element, index ) {
  *
  * @param {Object} object Mapped object with index.
  *
- * @returns {Element} Mapped object element.
+ * @return {Element} Mapped object element.
  */
 function mapObjectTabbableToElement( object ) {
 	return object.element;
@@ -66,7 +66,7 @@ function mapObjectTabbableToElement( object ) {
  * @param {Object} a First object to compare.
  * @param {Object} b Second object to compare.
  *
- * @returns {number} Comparator result.
+ * @return {number} Comparator result.
  */
 function compareObjectTabbables( a, b ) {
 	const aTabIndex = getTabIndex( a.element );

--- a/utils/focus/test/utils/create-element.js
+++ b/utils/focus/test/utils/create-element.js
@@ -4,7 +4,7 @@
  *
  * @param {string} type Element type.
  *
- * @returns {HTMLElement} Layout-emulated element.
+ * @return {HTMLElement} Layout-emulated element.
  */
 export default function createElement( type ) {
 	const element = document.createElement( type );

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -48,7 +48,7 @@ export function mediaUpload( filesList, onImagesChange ) {
 /**
  * @param {File} file Media File to Save.
  *
- * @returns {Promise} Media Object Promise.
+ * @return {Promise} Media Object Promise.
  */
 export function createMediaFromFile( file ) {
 	// Create upload payload
@@ -65,7 +65,7 @@ export function createMediaFromFile( file ) {
  * Utility used to preload an image before displaying it.
  *
  * @param   {string}  url Image Url.
- * @returns {Promise}     Pormise resolved once the image is preloaded.
+ * @return {Promise}     Pormise resolved once the image is preloaded.
  */
 export function preloadImage( url ) {
 	return new Promise( resolve => {

--- a/utils/terms.js
+++ b/utils/terms.js
@@ -8,7 +8,7 @@ import { groupBy } from 'lodash';
  *
  * @param {Array} flatTerms  Array of terms in flat format.
  *
- * @returns {Array} Array of terms in tree format.
+ * @return {Array} Array of terms in tree format.
  */
 export function buildTermsTree( flatTerms ) {
 	const termsByParent = groupBy( flatTerms, 'parent' );


### PR DESCRIPTION
## Description

This pull request is a follow-up and update to #4785, the original pull request still prefer `@returns` over `@return` JSDoc, this PR fixes ESLints `valid-jsdoc` rule to prefer `@return` over `@retuns` per the Gutenberg and Coding Standards documentation

**Testing instructions:**

Verify there are no lint errors:

`npm run lint`