### PR TITLE
A way to register custom blocks translations

### DIFF
--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -40,7 +40,7 @@ function gutenberg_get_jed_locale_data( $domain ) {
 	foreach ( $translations->entries as $msgid => $entry ) {
 		$locale['locale_data'][ $domain ][ $msgid ] = $entry->translations;
 	}
-	
+
 	$third_party_translation_domains = apply_filters( 'gutenberg_get_third_party_translation_domains', array() );
 	if ( ! empty( $third_party_translation_domains ) ) {
 		foreach ( $third_party_translation_domains as $third_party_domain ) {

--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -40,6 +40,20 @@ function gutenberg_get_jed_locale_data( $domain ) {
 	foreach ( $translations->entries as $msgid => $entry ) {
 		$locale['locale_data'][ $domain ][ $msgid ] = $entry->translations;
 	}
+	
+	$third_party_translation_domains = apply_filters( 'gutenberg_get_third_party_translation_domains', array() );
+	if ( ! empty( $third_party_translation_domains ) ) {
+		foreach ( $third_party_translation_domains as $third_party_domain ) {
+			$translations = get_translations_for_domain( $third_party_domain );
+			if ( ! $translations ) {
+				continue;
+			}
+			foreach ( $translations->entries as $msgid => $entry ) {
+				$locale['locale_data'][ $domain ][ $msgid ] = $entry->translations;
+				$locale['locale_data'][ $domain ]['domain'] = $third_party_domain;
+			}
+		}
+	}
 
 	return $locale;
 }

--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -41,6 +41,9 @@ function gutenberg_get_jed_locale_data( $domain ) {
 		$locale['locale_data'][ $domain ][ $msgid ] = $entry->translations;
 	}
 
+	/*
+	 * Get Third Party textdomains to add custom translation to Jed local data
+	 */
 	$third_party_translation_domains = apply_filters( 'gutenberg_get_third_party_translation_domains', array() );
 	if ( ! empty( $third_party_translation_domains ) ) {
 		foreach ( $third_party_translation_domains as $third_party_domain ) {


### PR DESCRIPTION
## Description
The purpose of this update is to provide a way (for a plugin) to push its translations into Jed's data (at the same time as that of Gutenberg, because Jed can't switch between two localData).

It have to be used this way :

```
add_filter( 'gutenberg_get_third_party_translation_domains', 'add_my_plugin_blocks_textdomain' );
function add_my_plugin_blocks_textdomain( $domains ) {
	$domains[] = 'my-plugin-textdomain';
	return $domains;
}
```

I hesitated to propose a method like `load_plugin_textdomain`, but I think it's not a good idea to use another global ;-)

## How Has This Been Tested?
I installed Gutenberg on a local WP instance, aside another plugin containing a block (and translated strings). Then I added the described add_filter into my plugin file and I verified that my translated strings appeared.

## Types of changes
Just after getting Gutenberg text translations, and before set Jed Local Data, we request custom domains translations (using a filter hook), and add it to the data array.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
