### PR TITLE
Fix scrollbars on preview intermezzo

### DIFF
--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -80,6 +80,9 @@ export class PostPreviewButton extends Component {
 				<p>Generating preview.</p>
 			</div>
 			<style>
+				body {
+					margin: 0;
+				}
 				div {
 					display: flex;
 					flex-direction: column;


### PR DESCRIPTION
There are horizontal and vertical scrollbars on the small preview loading inicator.

This PR fixes it.

Before:

<img width="1304" alt="screen shot 2018-02-05 at 08 54 35" src="https://user-images.githubusercontent.com/1204802/35793618-a996d454-0a52-11e8-8410-d1dc5def7fc1.png">

After:

<img width="1186" alt="screen shot 2018-02-05 at 08 56 19" src="https://user-images.githubusercontent.com/1204802/35793627-aee57226-0a52-11e8-968e-61458e04b19f.png">

