### PR TITLE
Fix the lingering dropzone placeholder at the end of the editor

### DIFF
--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -57,6 +57,9 @@ class DropZoneProvider extends Component {
 	}
 
 	resetDragState() {
+		// Avoid throttled drag over handler calls
+		this.toggleDraggingOverDocument.cancel();
+
 		const { isDraggingOverDocument, hoveredDropZone } = this.state;
 		if ( ! isDraggingOverDocument && hoveredDropZone === -1 ) {
 			return;

--- a/edit-post/components/modes/visual-editor/style.scss
+++ b/edit-post/components/modes/visual-editor/style.scss
@@ -78,6 +78,11 @@
 	@include break-small() {
 		padding: 0 $block-mover-padding-visible;	// don't subtract 1px border because it's a border not an outline
 
+		.components-drop-zone {
+			left: $block-mover-padding-visible;
+			right: $block-mover-padding-visible;
+		}
+
 		.editor-default-block-appender__content {
 			padding: 0 $block-padding;
 		}

--- a/editor/components/block-list/index.js
+++ b/editor/components/block-list/index.js
@@ -25,7 +25,6 @@ import { serialize } from '@wordpress/blocks';
  */
 import './style.scss';
 import BlockListBlock from './block';
-import BlockInsertionPoint from './insertion-point';
 import BlockSelectionClearer from '../block-selection-clearer';
 import {
 	getBlockUids,
@@ -250,7 +249,6 @@ class BlockList extends Component {
 
 		return (
 			<BlockSelectionClearer>
-				{ !! blocks.length && <BlockInsertionPoint /> }
 				{ map( blocks, ( uid ) => (
 					<BlockListBlock
 						key={ 'block-' + uid }

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -27,7 +27,7 @@ export class DefaultBlockAppender extends Component {
 
 		return (
 			<div className="editor-default-block-appender">
-				<BlockDropZone />
+				{ ( count === 0 || showAppender ) && <BlockDropZone /> }
 				{ count === 0 &&
 					<input
 						className="editor-default-block-appender__content"

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -3,9 +3,7 @@
 exports[`DefaultBlockAppender blocks present should match snapshot 1`] = `
 <div
   className="editor-default-block-appender"
->
-  <Connect(WrappedComponent) />
-</div>
+/>
 `;
 
 exports[`DefaultBlockAppender no block present should match snapshot 1`] = `


### PR DESCRIPTION
closes #4810 

Since the DragOver event handler is debounced, it's called even after the onDrop event handler happens which causes the placeholder to show up after the mouse has been released.
This PR fixes this behavior by canceling the debounced calls.
It also includes some small fixes to the dropzone size of the default block appender.

**Testing instructions**

 - Drag and drop files into the document
 - You should not see any lingering placeholder after releasing the mouse.