### PR TITLE
Remove image float max-width

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -170,8 +170,6 @@ export const settings = {
 
 		if ( width ) {
 			figureStyle = { width };
-		} else if ( align === 'left' || align === 'right' ) {
-			figureStyle = { maxWidth: '50%' };
 		}
 
 		return (


### PR DESCRIPTION
In the editor, we apply a max-width to images that are floated and not resized. We do this because otherwise on big images you probably wouldn't see the image float at all.

The line of code that is removed in this PR, prevents this from also happening on the frontend.

The reason is — in WordPress, the `.alignleft` and `.alignright` classes have traditionally been handled by the WordPress theme. By adding an inline style, not only are we overriding that, but we are also making it even harder for a theme to override. Inline styles take precendence over any other CSS style that is not !important.