### PR TITLE
MetaBoxes: Saving meta boxes don't reset the comment/ping status

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -425,14 +425,11 @@ export function initializeMetaBoxState( metaBoxes ) {
 /**
  * Returns an action object used to request meta box update.
  *
- * @param   {Object} post Post object.
- *
  * @return {Object}      Action object.
  */
-export function requestMetaBoxUpdates( post ) {
+export function requestMetaBoxUpdates() {
 	return {
 		type: 'REQUEST_META_BOX_UPDATES',
-		post,
 	};
 }
 

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -425,11 +425,14 @@ export function initializeMetaBoxState( metaBoxes ) {
 /**
  * Returns an action object used to request meta box update.
  *
- * @return {Object} Action object.
+ * @param   {Object} post Post object.
+ *
+ * @return {Object}      Action object.
  */
-export function requestMetaBoxUpdates() {
+export function requestMetaBoxUpdates( post ) {
 	return {
 		type: 'REQUEST_META_BOX_UPDATES',
+		post,
 	};
 }
 

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -153,7 +153,7 @@ export default {
 
 		// Update dirty meta boxes.
 		if ( hasMetaBoxes( store.getState() ) ) {
-			dispatch( requestMetaBoxUpdates( post ) );
+			dispatch( requestMetaBoxUpdates() );
 		}
 
 		if ( get( window.history.state, 'id' ) !== post.id ) {
@@ -492,8 +492,9 @@ export default {
 		}, {} );
 		store.dispatch( setMetaBoxSavedData( dataPerLocation ) );
 	},
-	REQUEST_META_BOX_UPDATES( { post }, store ) {
-		const dataPerLocation = reduce( getMetaBoxes( store.getState() ), ( memo, metabox, location ) => {
+	REQUEST_META_BOX_UPDATES( action, store ) {
+		const state = store.getState();
+		const dataPerLocation = reduce( getMetaBoxes( state ), ( memo, metabox, location ) => {
 			if ( metabox.isActive ) {
 				memo[ location ] = jQuery( getMetaBoxContainer( location ) ).serialize();
 			}
@@ -503,6 +504,7 @@ export default {
 
 		// Additional data needed for backwards compatibility.
 		// If we do not provide this data the post will be overriden with the default values.
+		const post = getCurrentPost( state );
 		const additionalData = [
 			post.comment_status && `comment_status=${ post.comment_status }`,
 			post.ping_status && `ping_status=${ post.ping_status }`,

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -55,6 +55,7 @@ import {
 	getBlocks,
 	getReusableBlock,
 	getMetaBoxes,
+	hasMetaBoxes,
 	POST_UPDATE_TRANSACTION_ID,
 } from './selectors';
 import { getMetaBoxContainer } from '../utils/meta-boxes';
@@ -151,7 +152,9 @@ export default {
 		}
 
 		// Update dirty meta boxes.
-		dispatch( requestMetaBoxUpdates() );
+		if ( hasMetaBoxes( store.getState() ) ) {
+			dispatch( requestMetaBoxUpdates( post ) );
+		}
 
 		if ( get( window.history.state, 'id' ) !== post.id ) {
 			window.history.replaceState(
@@ -489,7 +492,7 @@ export default {
 		}, {} );
 		store.dispatch( setMetaBoxSavedData( dataPerLocation ) );
 	},
-	REQUEST_META_BOX_UPDATES( action, store ) {
+	REQUEST_META_BOX_UPDATES( { post }, store ) {
 		const dataPerLocation = reduce( getMetaBoxes( store.getState() ), ( memo, metabox, location ) => {
 			if ( metabox.isActive ) {
 				memo[ location ] = jQuery( getMetaBoxContainer( location ) ).serialize();
@@ -498,11 +501,18 @@ export default {
 		}, {} );
 		store.dispatch( setMetaBoxSavedData( dataPerLocation ) );
 
+		// Additional data needed for backwards compatibility.
+		// If we do not provide this data the post will be overriden with the default values.
+		const additionData = []
+			.concat( post[ 'comment_status' ] ? [ `comment_status=${ post[ 'comment_status' ] }` ] : [] )
+			.concat( post[ 'ping_status' ] ? [ `ping_status=${ post[ 'ping_status' ] }` ] : [] );
+
 		// To save the metaboxes, we serialize each one of the location forms and combine them
 		// We also add the "common" hidden fields from the base .metabox-base-form
-		const formData = values( dataPerLocation ).concat(
-			jQuery( '.metabox-base-form' ).serialize()
-		).join( '&' );
+		const formData = values( dataPerLocation )
+			.concat( jQuery( '.metabox-base-form' ).serialize() )
+			.concat( additionData )
+			.join( '&' );
 		const fetchOptions = {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -503,15 +503,16 @@ export default {
 
 		// Additional data needed for backwards compatibility.
 		// If we do not provide this data the post will be overriden with the default values.
-		const additionData = []
-			.concat( post[ 'comment_status' ] ? [ `comment_status=${ post[ 'comment_status' ] }` ] : [] )
-			.concat( post[ 'ping_status' ] ? [ `ping_status=${ post[ 'ping_status' ] }` ] : [] );
+		const additionalData = [
+			post.comment_status && `comment_status=${ post.comment_status }`,
+			post.ping_status && `ping_status=${ post.ping_status }`,
+		].filter( Boolean );
 
 		// To save the metaboxes, we serialize each one of the location forms and combine them
 		// We also add the "common" hidden fields from the base .metabox-base-form
 		const formData = values( dataPerLocation )
 			.concat( jQuery( '.metabox-base-form' ).serialize() )
-			.concat( additionData )
+			.concat( additionalData )
 			.join( '&' );
 		const fetchOptions = {
 			method: 'POST',

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -323,19 +323,23 @@ describe( 'effects', () => {
 
 		it( 'should dispatch meta box updates on success for dirty meta boxes', () => {
 			const dispatch = jest.fn();
-			const store = { getState: () => {}, dispatch };
+			const store = { getState: () => ( {
+				metaBoxes: { side: { isActive: true } },
+			} ), dispatch };
 
 			const post = getDraftPost();
 
 			handler( { post: post, previousPost: post }, store );
 
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( requestMetaBoxUpdates() );
+			expect( dispatch ).toHaveBeenCalledWith( requestMetaBoxUpdates( post ) );
 		} );
 
 		it( 'should dispatch notices when publishing or scheduling a post', () => {
 			const dispatch = jest.fn();
-			const store = { getState: () => {}, dispatch };
+			const store = { getState: () => ( {
+				metaBoxes: { side: { isActive: true } },
+			} ), dispatch };
 
 			const previousPost = getDraftPost();
 			const post = getPublishedPost();
@@ -357,7 +361,9 @@ describe( 'effects', () => {
 
 		it( 'should dispatch notices when reverting a published post to a draft', () => {
 			const dispatch = jest.fn();
-			const store = { getState: () => {}, dispatch };
+			const store = { getState: () => ( {
+				metaBoxes: { side: { isActive: true } },
+			} ), dispatch };
 
 			const previousPost = getPublishedPost();
 			const post = getDraftPost();
@@ -383,7 +389,9 @@ describe( 'effects', () => {
 
 		it( 'should dispatch notices when just updating a published post again', () => {
 			const dispatch = jest.fn();
-			const store = { getState: () => {}, dispatch };
+			const store = { getState: () => ( {
+				metaBoxes: { side: { isActive: true } },
+			} ), dispatch };
 
 			const previousPost = getPublishedPost();
 			const post = getPublishedPost();


### PR DESCRIPTION
closes #4843 and closes #4663 

This PR fixes two related issues:

 - The meta boxes save was being triggered even if we didn't have any meta box enabled
 - The meta boxes save was resetting the ping/comments status due to legacy code on the backend. I ensured the post status and ping status are passed to the meta box request to avoid this.

**Testing instructions**

 - Add some metaboxes
 - Save your post
 - Refresh the page
 - The ping and comment status should stay enabled unless you disable them explicitely.