### PR TITLE
Edit post: Make sure that styles do not contain duplicates in dev mode

### DIFF
--- a/edit-post/assets/stylesheets/_admin-schemes.scss
+++ b/edit-post/assets/stylesheets/_admin-schemes.scss
@@ -66,11 +66,3 @@ $scheme-sunrise__spot-color: #de823f;
 		}
 	}
 }
-
-// Output overrides for each scheme
-@include admin-scheme-color-overrides( 'blue', $scheme-blue__spot-color );
-@include admin-scheme-color-overrides( 'coffee', $scheme-coffee__spot-color );
-@include admin-scheme-color-overrides( 'ectoplasm', $scheme-ectoplasm__spot-color );
-@include admin-scheme-color-overrides( 'midnight', $scheme-midnight__spot-color );
-@include admin-scheme-color-overrides( 'ocean', $scheme-ocean__spot-color );
-@include admin-scheme-color-overrides( 'sunrise', $scheme-sunrise__spot-color );

--- a/edit-post/assets/stylesheets/_animations.scss
+++ b/edit-post/assets/stylesheets/_animations.scss
@@ -3,48 +3,18 @@
 	animation-fill-mode: forwards;
 }
 
-@keyframes animate_fade {
-	from {
-		opacity: 0;
-		transform: translateY( 4px );
-	}
-	to {
-		opacity: 1;
-		transform: translateY( 0px );
-	}
-}
-
-
 @mixin move_background {
 	background-size: 28px 28px;
 	animation: move_background .5s linear infinite;
-}
-
-@keyframes move_background {
-	from {
-		background-position: 0 0;
-	}
-	to {
-		background-position: 28px 0;
-	}
 }
 
 @mixin loading_fade {
 	animation: loading_fade 1.6s ease-in-out infinite;
 }
 
-@keyframes loading_fade {
-	0% { opacity: .5; }
-	50% { opacity: 1; }
-	100% { opacity: .5; }
-}
-
-
 @mixin slide_in_right {
 	transform: translateX(+100%);
 	animation: slide_in_right 0.1s forwards;
 }
 
-@keyframes slide_in_right {
-	100% { transform: translateX(0%); }
-}
+

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -1,3 +1,49 @@
+// Output overrides for each scheme
+@include admin-scheme-color-overrides( 'blue', $scheme-blue__spot-color );
+@include admin-scheme-color-overrides( 'coffee', $scheme-coffee__spot-color );
+@include admin-scheme-color-overrides( 'ectoplasm', $scheme-ectoplasm__spot-color );
+@include admin-scheme-color-overrides( 'midnight', $scheme-midnight__spot-color );
+@include admin-scheme-color-overrides( 'ocean', $scheme-ocean__spot-color );
+@include admin-scheme-color-overrides( 'sunrise', $scheme-sunrise__spot-color );
+
+@keyframes animate_fade {
+	from {
+		opacity: 0;
+		transform: translateY( 4px );
+	}
+	to {
+		opacity: 1;
+		transform: translateY( 0px );
+	}
+}
+
+@keyframes move_background {
+	from {
+		background-position: 0 0;
+	}
+	to {
+		background-position: 28px 0;
+	}
+}
+
+@keyframes loading_fade {
+	0% {
+		opacity: .5;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: .5;
+	}
+}
+
+@keyframes slide_in_right {
+	100% {
+		transform: translateX( 0% );
+	}
+}
+
 body.gutenberg-editor-page {
 	background: $white;
 


### PR DESCRIPTION
## Description
@jasmussen discovered that admin scheme styles are duplicated for `edit-post` module. It turned out it happens only when in development mode (`npm run dev`). It doesn't seem to be a big issue, but this fix might help to decrease the size of the CSS file when developing this module.

I moved all SCSS code that output code to the `main.scss` file to make sure it is executed only once instead of for every `.scss` file as it happens at the moment.

## How Has This Been Tested?
Manually.

## Screenshots (jpeg or gifs if applicable):

![screen shot 2018-02-05 at 11 30 53](https://user-images.githubusercontent.com/699132/35800057-15312f1a-0a68-11e8-9b53-d08d3959c781.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
