### PR TITLE
Fixed bug when pasting in a paragraph block with custom styles.

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -51,7 +51,22 @@ class ParagraphBlock extends Component {
 		super( ...arguments );
 		this.nodeRef = null;
 		this.bindRef = this.bindRef.bind( this );
+		this.onReplace = this.onReplace.bind( this );
 		this.toggleDropCap = this.toggleDropCap.bind( this );
+	}
+
+	onReplace( blocks ) {
+		const { attributes, onReplace } = this.props;
+		onReplace( blocks.map( ( block, index ) => (
+			index === 0 && block.name === name ?
+				{ ...block,
+					attributes: {
+						...attributes,
+						...block.attributes,
+					},
+				} :
+				block
+		) ) );
 	}
 
 	toggleDropCap() {
@@ -179,7 +194,7 @@ class ParagraphBlock extends Component {
 								undefined
 							}
 							onMerge={ mergeBlocks }
-							onReplace={ onReplace }
+							onReplace={ this.onReplace }
 							onRemove={ () => onReplace( [] ) }
 							placeholder={ placeholder || __( 'Add text or type / to add content' ) }
 							aria-autocomplete="list"


### PR DESCRIPTION
Before when pasting text in a paragraph, we totally replaced the block with a new block containing just the content attribute. This deleted all other attribute changes e.g: colors, drop cap, etc... Now when replacing a paragraph we check if the first new block is also paragraph and if yes we change the block to use the existing attributes besides content.

Fixes: https://github.com/WordPress/gutenberg/issues/4850

## How Has This Been Tested?
Create a new paragraph block, change some attributes e.g: background and text color, without writing any text. Paste simple text from Gutenberg or an external source in the paragraph. Verify the text got pasted as expected and the formats are the same as before. Without this PR all custom formats would be lost.

