### PR TITLE
Compat: Support unwrapped paragraph text via deprecation

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -192,6 +192,40 @@ class ParagraphBlock extends Component {
 	}
 }
 
+const supports = {
+	className: false,
+};
+
+const schema = {
+	content: {
+		type: 'array',
+		source: 'children',
+		selector: 'p',
+	},
+	align: {
+		type: 'string',
+	},
+	dropCap: {
+		type: 'boolean',
+		default: false,
+	},
+	placeholder: {
+		type: 'string',
+	},
+	width: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	backgroundColor: {
+		type: 'string',
+	},
+	fontSize: {
+		type: 'number',
+	},
+};
+
 export const name = 'core/paragraph';
 
 export const settings = {
@@ -205,39 +239,9 @@ export const settings = {
 
 	keywords: [ __( 'text' ) ],
 
-	supports: {
-		className: false,
-	},
+	supports,
 
-	attributes: {
-		content: {
-			type: 'array',
-			source: 'children',
-			selector: 'p',
-		},
-		align: {
-			type: 'string',
-		},
-		dropCap: {
-			type: 'boolean',
-			default: false,
-		},
-		placeholder: {
-			type: 'string',
-		},
-		width: {
-			type: 'string',
-		},
-		textColor: {
-			type: 'string',
-		},
-		backgroundColor: {
-			type: 'string',
-		},
-		fontSize: {
-			type: 'number',
-		},
-	},
+	attributes: schema,
 
 	transforms: {
 		from: [
@@ -251,6 +255,28 @@ export const settings = {
 			},
 		],
 	},
+
+	deprecated: [
+		{
+			supports,
+			attributes: {
+				...schema,
+				content: {
+					type: 'string',
+					source: 'html',
+				},
+			},
+			save( { attributes } ) {
+				return attributes.content;
+			},
+			migrate( attributes ) {
+				return {
+					...attributes,
+					content: [ attributes.content ],
+				};
+			},
+		},
+	],
 
 	merge( attributes, attributesToMerge ) {
 		return {

--- a/blocks/test/fixtures/core__paragraph__deprecated.html
+++ b/blocks/test/fixtures/core__paragraph__deprecated.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph -->
+Unwrapped is still valid.
+<!-- /wp:paragraph -->

--- a/blocks/test/fixtures/core__paragraph__deprecated.json
+++ b/blocks/test/fixtures/core__paragraph__deprecated.json
@@ -1,0 +1,14 @@
+[
+    {
+        "uid": "_uid_0",
+        "name": "core/paragraph",
+        "isValid": true,
+        "attributes": {
+            "content": [
+                "Unwrapped is still valid."
+            ],
+            "dropCap": false
+        },
+        "originalContent": "Unwrapped is still valid."
+    }
+]

--- a/blocks/test/fixtures/core__paragraph__deprecated.parsed.json
+++ b/blocks/test/fixtures/core__paragraph__deprecated.parsed.json
@@ -1,0 +1,12 @@
+[
+    {
+        "blockName": "core/paragraph",
+        "attrs": null,
+        "innerBlocks": [],
+        "innerHTML": "\nUnwrapped is still valid.\n"
+    },
+    {
+        "attrs": {},
+        "innerHTML": "\n"
+    }
+]

--- a/blocks/test/fixtures/core__paragraph__deprecated.serialized.html
+++ b/blocks/test/fixtures/core__paragraph__deprecated.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph -->
+<p>Unwrapped is still valid.</p>
+<!-- /wp:paragraph -->

--- a/blocks/test/full-content.js
+++ b/blocks/test/full-content.js
@@ -138,6 +138,16 @@ describe( 'full post content fixture', () => {
 			}
 
 			const blocksActual = parse( content );
+
+			// Block validation logs during deprecation migration. Since this
+			// is expected for deprecated blocks, match on filename and allow.
+			const isDeprecated = /__deprecated([-_]|$)/.test( f );
+			if ( isDeprecated ) {
+				// eslint-disable-next-line no-console
+				console.warn.mockReset();
+				expect( console ).toHaveErrored();
+			}
+
 			const blocksActualNormalized = normalizeParsedBlocks( blocksActual );
 			let blocksExpectedString = readFixtureFile( f + '.json' );
 

--- a/editor/components/block-list/invalid-block-warning.js
+++ b/editor/components/block-list/invalid-block-warning.js
@@ -20,7 +20,7 @@ import {
 import { replaceBlock } from '../../store/actions';
 import Warning from '../warning';
 
-function InvalidBlockWarning( { block, attemptFixParagraph, ignoreInvalid, switchToBlockType } ) {
+function InvalidBlockWarning( { ignoreInvalid, switchToBlockType } ) {
 	const htmlBlockName = 'core/html';
 	const defaultBlockType = getBlockType( getUnknownTypeHandlerName() );
 	const htmlBlockType = getBlockType( htmlBlockName );
@@ -34,20 +34,12 @@ function InvalidBlockWarning( { block, attemptFixParagraph, ignoreInvalid, switc
 				'your changes.'
 			), defaultBlockType.title, htmlBlockType.title ) }</p>
 			<p>
-				{ block.name === 'core/paragraph' && (
-					<Button
-						onClick={ attemptFixParagraph }
-						isLarge
-					>
-						{ sprintf( __( 'Attempt Fix' ) ) }
-					</Button>
-				) }
-				{ block.name !== 'core/paragraph' && ( <Button
+				<Button
 					onClick={ ignoreInvalid }
 					isLarge
 				>
 					{ sprintf( __( 'Overwrite' ) ) }
-				</Button> ) }
+				</Button>
 				{ defaultBlockType && (
 					<Button
 						onClick={ switchTo( defaultBlockType ) }
@@ -79,13 +71,6 @@ export default connect(
 	null,
 	( dispatch, ownProps ) => {
 		return {
-			attemptFixParagraph() {
-				const { block } = ownProps;
-				const nextBlock = createBlock( block.name, {
-					content: block.originalContent,
-				} );
-				dispatch( replaceBlock( block.uid, nextBlock ) );
-			},
 			ignoreInvalid() {
 				const { block } = ownProps;
 				const { name, attributes } = block;


### PR DESCRIPTION
Closes #589
Related: #589, #3922

This pull request seeks to enhance the paragraph block to accommodate technically-broken-but-common markup of text without a paragraph tag wrapper.

Specifically, this can assist in cases where:

- A third-party editor emulates legacy `removep` behavior and strips paragraph tags from the inner contents of `<!-- wp:paragraph -->` blocks
- The user pastes unwrapped content into the block's "Edit as HTML" mode

__Implementation notes:__

The approach here ~abuses~ uses the block deprecation pattern to consider an unwrapped paragraph as deprecated, even though it was never truly a supported implementation. The idea is that we anticipate the block invalidation and repair it to its supported equivalent.

__Testing instructions:__

1. Navigate to Posts > Add New
2. Add a new paragraph block with some text
3. Cmd/Ctrl+A to select all text of the paragraph block, then copy it
4. Switch block to Edit as HTML mode via its "More Options" menu
5. Paste the contents copied in step 3
6. Switch back to Edit as Visual mode
7. Note that the block is still valid and appears with the same text entered in step 2