### PR TITLE
Correct Slack Markdown code block variant

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -24,6 +24,7 @@ import tableNormaliser from './table-normaliser';
 import inlineContentConverter from './inline-content-converter';
 import { deepFilterHTML, isInvalidInline, isNotWhitelisted, isPlain, isInline } from './utils';
 import shortcodeConverter from './shortcode-converter';
+import slackMarkdownVariantCorrector from './slack-markdown-variant-corrector';
 
 /**
  * Converts an HTML string to known blocks. Strips everything else.
@@ -56,6 +57,9 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 
 		converter.setOption( 'noHeaderId', true );
 		converter.setOption( 'tables', true );
+		converter.setOption( 'omitExtraWLInCodeBlocks', true );
+
+		plainText = slackMarkdownVariantCorrector( plainText );
 
 		HTML = converter.makeHtml( plainText );
 

--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -58,6 +58,7 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 		converter.setOption( 'noHeaderId', true );
 		converter.setOption( 'tables', true );
 		converter.setOption( 'omitExtraWLInCodeBlocks', true );
+		converter.setOption( 'simpleLineBreaks', true );
 
 		plainText = slackMarkdownVariantCorrector( plainText );
 

--- a/blocks/api/raw-handling/slack-markdown-variant-corrector.js
+++ b/blocks/api/raw-handling/slack-markdown-variant-corrector.js
@@ -1,0 +1,16 @@
+/**
+ * Corrects the Slack Markdown variant of the code block.
+ * If uncorrected, it will be converted to inline code.
+ *
+ * @see https://get.slack.help/hc/en-us/articles/202288908-how-can-i-add-formatting-to-my-messages-#code-blocks
+ *
+ * @param {string} text The potential Markdown text to correct.
+ *
+ * @returns {string} The corrected Markdown.
+ */
+export default function( text ) {
+	return text.replace(
+		/((?:^|\n)```)([^\n`]+)(```(?:$|\n))/,
+		( match, p1, p2, p3 ) => `${ p1 }\n${ p2 }\n${ p3 }`
+	);
+}

--- a/blocks/api/raw-handling/test/slack-markdown-variant-corrector.js
+++ b/blocks/api/raw-handling/test/slack-markdown-variant-corrector.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { equal } from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import slackMarkdownVariantCorrector from '../slack-markdown-variant-corrector';
+
+describe( 'slackMarkdownVariantCorrector', () => {
+	it( 'should correct Slack variant', () => {
+		equal( slackMarkdownVariantCorrector( '```test```' ), '```\ntest\n```' );
+	} );
+
+	it( 'should correct Slack variant on own line', () => {
+		equal( slackMarkdownVariantCorrector( 'test\n```test```\ntest' ), 'test\n```\ntest\n```\ntest' );
+	} );
+
+	it( 'should not correct inline code', () => {
+		const text = 'test ```test``` test';
+		equal( slackMarkdownVariantCorrector( text ), text );
+	} );
+
+	it( 'should not correct code with line breaks', () => {
+		const text = '```js\ntest\n```';
+		equal( slackMarkdownVariantCorrector( text ), text );
+	} );
+} );


### PR DESCRIPTION
## Description

This corrects pasting code blocks from Slack. Unfortunately they insist on another Markdown variant, so I see no other way of fixing the code block right before we call showdown.

```md
This is `inline code`.
```This is a code block.```
```

Adds tests.

Also adds showdown option to not add extra line break to code blocks.

## How Has This Been Tested?

Copy some text with a code block from Slack. Before it would put the code inline. Now it should create a code block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.