### PR TITLE
Blocks: Ensure string return value from render_callback

### DIFF
--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -113,7 +113,7 @@ class WP_Block_Type {
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return call_user_func( $this->render_callback, $attributes );
+		return (string) call_user_func( $this->render_callback, $attributes );
 	}
 
 	/**

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Test do_blocks
+ * Test do_blocks, WP_Block_Type::render
  */
 class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 
@@ -27,6 +27,15 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	function render_dummy_block( $attributes ) {
 		$this->dummy_block_instance_number += 1;
 		return $this->dummy_block_instance_number . ':' . $attributes['value'];
+	}
+
+	/**
+	 * Dummy block rendering function, returning numeric value.
+	 *
+	 * @return number Block output.
+	 */
+	function render_dummy_block_numeric() {
+		return 10;
 	}
 
 	/**
@@ -75,5 +84,27 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			'4:b2' .
 			'after'
 		);
+	}
+
+	/**
+	 * Test dynamic blocks return string value from render, even if render
+	 * callback does not.
+	 *
+	 * @covers WP_Block_Type::render
+	 */
+	function test_dynamic_block_renders_string() {
+		$settings = array(
+			'render_callback' => array(
+				$this,
+				'render_dummy_block_numeric',
+			),
+		);
+
+		register_block_type( 'core/dummy', $settings );
+		$block_type = new WP_Block_Type( 'core/dummy', $settings );
+
+		$rendered = $block_type->render();
+
+		$this->assertEquals( '10', $rendered );
 	}
 }


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/pull/4716#issuecomment-361940993

This pull request seeks to update and verify the behavior of `WP_Block_Type` to ensure a string return value from its `render` function, as documented in inline code docs.

__Testing instructions:__

Verify PHPUnit tests pass:

```
phpunit
```

cc @tfrommen 