### PR TITLE
Fixes #4772 - don't change $current_screen

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -38,16 +38,7 @@ add_action(
  * @since 1.5.0
  */
 function gutenberg_collect_meta_box_data() {
-	global $_gutenberg_restore_globals_after_meta_boxes, $current_screen, $wp_meta_boxes, $post, $typenow;
-
-	// Depending on whether we are creating a post or editing one this may need to be different.
-	$potential_hookname = 'post';
-
-	// Set original screen to return to.
-	$GLOBALS['_gutenberg_restore_globals_after_meta_boxes']['current_screen'] = $current_screen;
-
-	// Override screen as though we are on post.php We have access to WP_Screen etc. by this point.
-	WP_Screen::get( $potential_hookname )->set_current_screen();
+	global $current_screen, $wp_meta_boxes, $post, $typenow;
 
 	$screen = $current_screen;
 
@@ -270,11 +261,6 @@ function gutenberg_collect_meta_box_data() {
 		'wp-edit-post',
 		'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
 	);
-
-	// Restore any global variables that we temporarily modified above.
-	foreach ( $_gutenberg_restore_globals_after_meta_boxes as $name => $value ) {
-		$GLOBALS[ $name ] = $value;
-	}
 }
 
 /**


### PR DESCRIPTION
## Description
When Gutenberg is determining which meta boxes to display it first needs to determine which are being provided by the plugins/theme. The logic set the $current_screen to `post`, overriding the present value. For any post type other than 'post', meta boxes registered with a `null` value for the `$screen` parameter would fail to be detected. So they did not appear in the editor window. 

This is what I was getting for my custom meta box in the oik-clone plugin.

I removed the logic that overrode the value of $current_screen, allowing the plugins to remain unchanged. 
<!-- Please describe your changes -->

## How Has This Been Tested?
Using the custom meta box in my oik-clone plugin. 
First I had to detect the problem with multiple meta boxes
```
// Workaround for Gutenberg issue #4772 - Set the post type explicitely
// Note: Values for context are: advanced ( default ), normal and side
// Values for priority are: default, high, low
//add_meta_box( 'oik_clone_NSD', __( "Clone on update - NSD", 'oik-clone' ), 'oik_clone_box', null, 'side', 'default'  );
//add_meta_box( 'oik_clone_NSH', __( "Clone on update - NSH", 'oik-clone' ), 'oik_clone_box', null, 'side', 'high'  );
//add_meta_box( 'oik_clone_NND', __( "Clone on update - NND", 'oik-clone' ), 'oik_clone_box', null, 'normal', 'default'  );
//add_meta_box( 'oik_clone_NNH', __( "Clone on update - NNH", 'oik-clone' ), 'oik_clone_box', null, 'normal', 'high'  );
//add_meta_box( 'oik_clone_PSD', __( "Clone on update - PSD", 'oik-clone' ), 'oik_clone_box', $post_type, 'side', 'default'  );
//add_meta_box( 'oik_clone_PSH', __( "Clone on update - PSH", 'oik-clone' ), 'oik_clone_box', $post_type, 'side', 'high'  );
 add_meta_box( 'oik_clone', __( "Clone on update", 'oik-clone' ), 'oik_clone_box', $post_type, 'normal', 'default' );
 //add_meta_box( 'oik_clone_PNH', __( "Clone on update - PNH", 'oik-clone' ), 'oik_clone_box', $post_type, 'normal', 'high' );
```
For `post`s all 8 boxes appeared. For `page` and my CPT `block` the only ones to appear were passing $post_type; 4 of them.

Then I had to track down where `$current_screen` was being changed. 
Commenting out the offending line
```
WP_Screen::get( $potential_hookname )->set_current_screen();
```
enabled all 8 of my meta boxes to appear.
I then reduced the number of my meta boxes back to 1, implementing the workaround at the same time.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I have not run the PHPUnit tests.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
Fixes #4772 
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested. - Manually
- [x] My code follows the WordPress code style. - I deleted code
- [x] My code has proper inline documentation - and the comments too
