### PR TITLE
Used menu order to order pages in the parent page dropdown.

### DIFF
--- a/editor/components/page-attributes/parent.js
+++ b/editor/components/page-attributes/parent.js
@@ -75,6 +75,8 @@ const applyWithAPIDataItems = withAPIData( ( props, { type } ) => {
 		exclude: postId,
 		parent_exclude: postId,
 		_fields: [ 'id', 'parent', 'title' ],
+		orderby: 'menu_order',
+		order: 'asc',
 	} );
 	return isHierarchical ? { items: `/wp/v2/${ type( postTypeSlug ) }?${ queryString }` } : {};
 } );


### PR DESCRIPTION
## Description
This PR adds ordering by menu_order in the parent page drop-down.
In core besides menu_order title is also used, but the rest API, for now, does not allow multiple order criteria.
Fixes: https://github.com/WordPress/gutenberg/issues/4614

## How Has This Been Tested?
Create a page "A" and give it an order of 1.
Create another page "B" and give it an order of 2
Create a new page and verify that in the parent page drop-down "A" appears before "B".
