### PR TITLE
Add "convert to blocks" to invalid block message

### DIFF
--- a/editor/components/block-list/invalid-block-warning.js
+++ b/editor/components/block-list/invalid-block-warning.js
@@ -20,21 +20,8 @@ import {
 import { replaceBlock } from '../../store/actions';
 import Warning from '../warning';
 
-function InvalidBlockWarning( { block, onReplace } ) {
+function InvalidBlockWarning( { convertToHTML, convertToBlocks } ) {
 	const hasHTMLBlock = !! getBlockType( 'core/html' );
-
-	const convertToHTML = () => {
-		onReplace( block.uid, createBlock( 'core/html', {
-			content: block.originalContent,
-		} ) );
-	};
-
-	const convertToBlocks = () => {
-		onReplace( block.uid, rawHandler( {
-			HTML: block.originalContent,
-			mode: 'BLOCKS',
-		} ) );
-	};
 
 	return (
 		<Warning>
@@ -55,7 +42,17 @@ function InvalidBlockWarning( { block, onReplace } ) {
 
 export default connect(
 	null,
-	{
-		onReplace: replaceBlock,
-	}
+	( dispatch, { block } ) => ( {
+		convertToHTML() {
+			dispatch( replaceBlock( block.uid, createBlock( 'core/html', {
+				content: block.originalContent,
+			} ) ) );
+		},
+		convertToBlocks() {
+			dispatch( replaceBlock( block.uid, rawHandler( {
+				HTML: block.originalContent,
+				mode: 'BLOCKS',
+			} ) ) );
+		},
+	} )
 )( InvalidBlockWarning );

--- a/editor/components/block-list/invalid-block-warning.js
+++ b/editor/components/block-list/invalid-block-warning.js
@@ -6,12 +6,12 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import {
 	getBlockType,
-	getUnknownTypeHandlerName,
 	createBlock,
+	rawHandler,
 } from '@wordpress/blocks';
 
 /**
@@ -20,46 +20,32 @@ import {
 import { replaceBlock } from '../../store/actions';
 import Warning from '../warning';
 
-function InvalidBlockWarning( { ignoreInvalid, switchToBlockType } ) {
-	const htmlBlockName = 'core/html';
-	const defaultBlockType = getBlockType( getUnknownTypeHandlerName() );
-	const htmlBlockType = getBlockType( htmlBlockName );
-	const switchTo = ( blockType ) => () => switchToBlockType( blockType );
+function InvalidBlockWarning( { block, onReplace } ) {
+	const hasHTMLBlock = !! getBlockType( 'core/html' );
+
+	const convertToHTML = () => {
+		onReplace( block.uid, createBlock( 'core/html', {
+			content: block.originalContent,
+		} ) );
+	};
+
+	const convertToBlocks = () => {
+		onReplace( block.uid, rawHandler( {
+			HTML: block.originalContent,
+			mode: 'BLOCKS',
+		} ) );
+	};
 
 	return (
 		<Warning>
-			<p>{ defaultBlockType && htmlBlockType && sprintf( __(
-				'This block appears to have been modified externally. ' +
-				'Overwrite the changes or Convert to %s or %s to keep ' +
-				'your changes.'
-			), defaultBlockType.title, htmlBlockType.title ) }</p>
+			<p>{ __( 'This block appears to have been modified externally.' ) }</p>
 			<p>
-				<Button
-					onClick={ ignoreInvalid }
-					isLarge
-				>
-					{ sprintf( __( 'Overwrite' ) ) }
+				<Button onClick={ convertToBlocks } isLarge isPrimary={ ! hasHTMLBlock }>
+					{ __( 'Convert to Blocks' ) }
 				</Button>
-				{ defaultBlockType && (
-					<Button
-						onClick={ switchTo( defaultBlockType ) }
-						isLarge
-					>
-						{
-							/* translators: Revert invalid block to another block type */
-							sprintf( __( 'Convert to %s' ), defaultBlockType.title )
-						}
-					</Button>
-				) }
-
-				{ htmlBlockType && (
-					<Button
-						onClick={ switchTo( htmlBlockType ) }
-						isLarge
-					>
-						{
-							sprintf( __( 'Edit as HTML' ) )
-						}
+				{ hasHTMLBlock && (
+					<Button onClick={ convertToHTML } isLarge isPrimary>
+						{ __( 'Edit as HTML' ) }
 					</Button>
 				) }
 			</p>
@@ -69,24 +55,7 @@ function InvalidBlockWarning( { ignoreInvalid, switchToBlockType } ) {
 
 export default connect(
 	null,
-	( dispatch, ownProps ) => {
-		return {
-			ignoreInvalid() {
-				const { block } = ownProps;
-				const { name, attributes } = block;
-				const nextBlock = createBlock( name, attributes );
-				dispatch( replaceBlock( block.uid, nextBlock ) );
-			},
-			switchToBlockType( blockType ) {
-				const { block } = ownProps;
-				if ( blockType && block ) {
-					const nextBlock = createBlock( blockType.name, {
-						content: block.originalContent,
-					} );
-
-					dispatch( replaceBlock( block.uid, nextBlock ) );
-				}
-			},
-		};
+	{
+		onReplace: replaceBlock,
 	}
 )( InvalidBlockWarning );


### PR DESCRIPTION
## Description

See: https://github.com/WordPress/gutenberg/pull/4813#discussion_r166346534

This PR aims to improve the invalid block warning, a.k.a. the "This block appears to have been modified externally" error.

1. Add the "convert to blocks" option. We have pretty good raw handling, so chances are we can convert the user or external input to something good.
2. Remove "convert to classic". We should avoid pointing people in this direction. It's hard to get back out of. It's an inferior experience. We already have enough options.
3. Remove the paragraph fix. Not needed after #4874. #4874 will improve this.
4. Remove overwrite. This option is unclear and there are better alternatives.
5. Make a button primary (as recommendation). I chose "edit as HTML", but this can easily be changed.

## How Has This Been Tested?
Create e.g. a heading block. Edit the HTML. Add some text after the tag. Select another block. Observe the "warning". Try both options.

## Screenshots (jpeg or gifs if applicable):

https://cloudup.com/cH9E_akVgGy

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.