### PR TITLE
Error checking in select API

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -100,10 +100,6 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
 	};
 
 	return connectWithStore( ( state, ownProps ) => {
-		const select = ( key, selectorName, ...args ) => {
-			return selectors[ key ][ selectorName ]( state[ key ], ...args );
-		};
-
 		return mapSelectorsToProps( select, ownProps );
 	} );
 };

--- a/data/index.js
+++ b/data/index.js
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { createStore } from 'redux';
-import { flowRight, without, mapValues } from 'lodash';
+import { flowRight, without, mapValues, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -119,5 +119,12 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
  * @return {*} The selector's returned value.
  */
 export const select = ( reducerKey, selectorName, ...args ) => {
+	const selector = get( selectors, [ reducerKey, selectorName ] );
+	if ( typeof selector !== 'function' ) {
+		// eslint-disable-next-line no-console
+		console.error( `Invalid selector called, with name "${ selectorName }" for reducer "${ reducerKey }".` +
+			' Make sure the reducerName and selectorName are correct!' );
+		return undefined;
+	}
 	return selectors[ reducerKey ][ selectorName ]( stores[ reducerKey ].getState(), ...args );
 };

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -58,28 +58,20 @@ describe( 'select', () => {
 
 	it( 'prints an error when a selector is called on a non-existing reducer', () => {
 		/* eslint-disable no-console */
-		const originalConsoleError = console.error;
-		console.error = jest.fn( () => {} );
-
 		expect( select( 'reducer1', 'selector1' ) ).toBeUndefined();
-		expect( console.error ).toHaveBeenCalled();
-
-		console.error = originalConsoleError;
+		expect( console ).toHaveErroredWith( 'Invalid selector called, with name "selector1" for reducer "reducer1".' +
+			' Make sure the reducerName and selectorName are correct!' );
 		/* eslint-enable no-console */
 	} );
 
 	it( 'prints an error when a non-existing selector is called', () => {
 		/* eslint-disable no-console */
-		const originalConsoleError = console.error;
-		console.error = jest.fn( () => {} );
-
 		// Call register reducer to make sure the store is created.
-		registerReducer( 'reducer1', () => 'state1' );
+		registerReducer( 'reducer2', () => 'state1' );
 
-		expect( select( 'reducer1', 'selector1' ) ).toBeUndefined();
-		expect( console.error ).toHaveBeenCalled();
-
-		console.error = originalConsoleError;
+		expect( select( 'reducer2', 'selector2' ) ).toBeUndefined();
+		expect( console ).toHaveErroredWith( 'Invalid selector called, with name "selector2" for reducer "reducer2".' +
+			' Make sure the reducerName and selectorName are correct!' );
 		/* eslint-enable no-console */
 	} );
 } );

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -6,7 +6,24 @@ import { render } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { registerReducer, registerSelectors, select, query, subscribe } from '../';
+let registerReducer, registerSelectors, select, query, subscribe;
+
+const loadModule = () => {
+	const module = require( '../' );
+	registerReducer = module.registerReducer;
+	registerSelectors = module.registerSelectors;
+	select = module.select;
+	query = module.query;
+	subscribe = module.subscribe;
+};
+
+/**
+ * Make sure every test is ran with a fresh data/index.js module.
+ */
+beforeEach( () => {
+	jest.resetModules();
+	loadModule();
+} );
 
 describe( 'store', () => {
 	it( 'Should append reducers to the state', () => {
@@ -37,6 +54,33 @@ describe( 'select', () => {
 
 		expect( select( 'reducer1', 'selector2' ) ).toEqual( 'result2' );
 		expect( selector2 ).toBeCalledWith( store.getState() );
+	} );
+
+	it( 'prints an error when a selector is called on a non-existing reducer', () => {
+		/* eslint-disable no-console */
+		const originalConsoleError = console.error;
+		console.error = jest.fn( () => {} );
+
+		expect( select( 'reducer1', 'selector1' ) ).toBeUndefined();
+		expect( console.error ).toHaveBeenCalled();
+
+		console.error = originalConsoleError;
+		/* eslint-enable no-console */
+	} );
+
+	it( 'prints an error when a non-existing selector is called', () => {
+		/* eslint-disable no-console */
+		const originalConsoleError = console.error;
+		console.error = jest.fn( () => {} );
+
+		// Call register reducer to make sure the store is created.
+		registerReducer( 'reducer1', () => 'state1' );
+
+		expect( select( 'reducer1', 'selector1' ) ).toBeUndefined();
+		expect( console.error ).toHaveBeenCalled();
+
+		console.error = originalConsoleError;
+		/* eslint-enable no-console */
 	} );
 } );
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Updated select function to print an error when the called selector does not exist.

The reason I created this PR is because I want to make sure that plugins using the Gutenberg API will not interupt the javascript execution as much as possible. I also believe all other public APIs should have some error checking.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Created unit tests and tested the select API in the browser.
Also improved unit tests to reload the `data/index.js` module for each test, so all module globals are reset, ensuring a clean test environement.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Improvement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
