### PR TITLE
Made gallery images unselect when clicking outside the block or selecting other image.

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -39,7 +39,7 @@ class GalleryBlock extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.onUnselectImage = this.onUnselectImage.bind( this );
+		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSelectImages = this.onSelectImages.bind( this );
 		this.setLinkTo = this.setLinkTo.bind( this );
 		this.setColumnsNumber = this.setColumnsNumber.bind( this );
@@ -55,29 +55,13 @@ class GalleryBlock extends Component {
 	}
 
 	onSelectImage( index ) {
-		return ( event ) => {
-			// ignore clicks in the editable caption.
-			// Without this logic, text operations like selection, select / unselects the images.
-			if ( event.target.tagName === 'FIGCAPTION' ) {
-				return;
+		return () => {
+			if ( this.state.selectedImage !== index ) {
+				this.setState( {
+					selectedImage: index,
+				} );
 			}
-
-			this.setState( {
-				selectedImage: index,
-			} );
 		};
-	}
-
-	onUnselectImage( event ) {
-		// ignore clicks in the editable caption.
-		// Without this logic, text operations like selection, select / unselects the images.
-		if ( event.target.tagName === 'FIGCAPTION' ) {
-			return;
-		}
-
-		this.setState( {
-			selectedImage: null,
-		} );
 	}
 
 	onRemoveImage( index ) {
@@ -149,6 +133,7 @@ class GalleryBlock extends Component {
 		if ( ! nextProps.isSelected && this.props.isSelected ) {
 			this.setState( {
 				selectedImage: null,
+				captionSelected: false,
 			} );
 		}
 	}
@@ -242,7 +227,6 @@ class GalleryBlock extends Component {
 							isSelected={ isSelected && this.state.selectedImage === index }
 							onRemove={ this.onRemoveImage( index ) }
 							onSelect={ this.onSelectImage( index ) }
-							onUnselect={ this.onUnselectImage }
 							setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
 							caption={ img.caption }
 						/>


### PR DESCRIPTION
Currently, gallery images, are unselected when clicking on images already selected. This change makes the block more consistent with other blocks.

This PR comes from a suggestion of @iseulde in PR https://github.com/WordPress/gutenberg/pull/4199. A different PR was created so https://github.com/WordPress/gutenberg/pull/4199 does not introduce behavior changes to the gallery just adds the captions.

## How Has This Been Tested?
Add a gallery with images.
Select an image click again on the image, verify it does not unselect while clicking.
Click on other image verify the selected image changes.
Click outside the block verify images get unselected.
Focus a caption verify the edition toolbar appears, click on the image outside the caption verify the image is still selected but the toolbar disappears.


