### PR TITLE
Link UI improvements

### DIFF
--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -11,15 +11,10 @@ import { keycodes } from '@wordpress/utils';
  */
 import './style.scss';
 import UrlInput from '../../url-input';
+import { LINK_PLACEHOLDER_VALUE } from '../';
 import { filterURLForDisplay } from '../../../editor/utils/url';
 
 const { ESCAPE } = keycodes;
-
-/**
- * When inserting a new link, we insert an <a> tag with this placeholder href
- * so that there is a visual indication of which text will be made into a link.
- */
-const NEW_LINK_PLACEHOLDER_VALUE = '_wp_link_placeholder';
 
 const FORMATTING_CONTROLS = [
 	{
@@ -71,7 +66,7 @@ class FormatToolbar extends Component {
 		if ( event.keyCode === ESCAPE ) {
 			this.setState( { isEditingLink: false, newLinkValue: '' } );
 
-			if ( this.props.formats.link.value === NEW_LINK_PLACEHOLDER_VALUE ) {
+			if ( this.props.formats.link.value === LINK_PLACEHOLDER_VALUE ) {
 				this.dropLink();
 			}
 		}
@@ -99,7 +94,7 @@ class FormatToolbar extends Component {
 	}
 
 	addLink() {
-		this.props.onChange( { link: { value: NEW_LINK_PLACEHOLDER_VALUE } } );
+		this.props.onChange( { link: { value: LINK_PLACEHOLDER_VALUE } } );
 	}
 
 	dropLink() {
@@ -116,7 +111,7 @@ class FormatToolbar extends Component {
 
 		this.setState( { isEditingLink: false, newLinkValue: '' } );
 
-		if ( this.props.formats.link.value === NEW_LINK_PLACEHOLDER_VALUE ) {
+		if ( this.props.formats.link.value === LINK_PLACEHOLDER_VALUE ) {
 			this.props.speak( __( 'Link added.' ), 'assertive' );
 		}
 
@@ -154,8 +149,8 @@ class FormatToolbar extends Component {
 			} );
 
 		const hasLinkUI = !! formats.link;
-		const hasEditLinkUI = hasLinkUI && ( isEditingLink || formats.link.value === NEW_LINK_PLACEHOLDER_VALUE );
-		const hasViewLinkUI = hasLinkUI && ! isEditingLink && formats.link.value !== NEW_LINK_PLACEHOLDER_VALUE;
+		const hasEditLinkUI = hasLinkUI && ( isEditingLink || formats.link.value === LINK_PLACEHOLDER_VALUE );
+		const hasViewLinkUI = hasLinkUI && ! isEditingLink && formats.link.value !== LINK_PLACEHOLDER_VALUE;
 
 		return (
 			<div className="blocks-format-toolbar">

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -38,8 +38,6 @@ const FORMATTING_CONTROLS = [
 		format: 'strikethrough',
 	},
 	{
-		icon: 'admin-links',
-		title: __( 'Link' ),
 		format: 'link',
 	},
 ];
@@ -133,13 +131,24 @@ class FormatToolbar extends Component {
 		const { isEditingLink, newLinkValue } = this.state;
 
 		const toolbarControls = FORMATTING_CONTROLS.concat( customControls )
-			.filter( control => enabledControls.indexOf( control.format ) !== -1 )
+			.filter( control => enabledControls.includes( control.format ) )
 			.map( ( control ) => {
-				const isLink = control.format === 'link';
+				const isActive = this.isFormatActive( control.format );
+
+				if ( control.format === 'link' ) {
+					return {
+						...control,
+						icon: isActive ? 'editor-unlink' : 'admin-links', // TODO: proper unlink icon
+						title: isActive ? __( 'Unlink' ) : __( 'Link' ),
+						isActive,
+						onClick: isActive ? this.dropLink : this.addLink,
+					};
+				}
+
 				return {
 					...control,
-					onClick: isLink ? this.addLink : this.toggleFormat( control.format ),
-					isActive: this.isFormatActive( control.format ),
+					isActive,
+					onClick: this.toggleFormat( control.format ),
 				};
 			} );
 
@@ -165,7 +174,6 @@ class FormatToolbar extends Component {
 							<div className="blocks-format-toolbar__link-modal-line">
 								<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
 								<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-								<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
 							</div>
 						</form>
 					</Fill>
@@ -190,7 +198,6 @@ class FormatToolbar extends Component {
 									{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
 								</a>
 								<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
-								<IconButton icon="editor-unlink" label={ __( 'Remove link' ) } onClick={ this.dropLink } />
 							</div>
 						</div>
 					</Fill>

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -13,7 +13,7 @@ import './style.scss';
 import UrlInput from '../../url-input';
 import { filterURLForDisplay } from '../../../editor/utils/url';
 
-const { ESCAPE, LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } = keycodes;
+const { ESCAPE } = keycodes;
 
 /**
  * When inserting a new link, we insert an <a> tag with this placeholder href
@@ -66,14 +66,14 @@ class FormatToolbar extends Component {
 	}
 
 	onKeyDown( event ) {
+		event.stopPropagation();
+
 		if ( event.keyCode === ESCAPE ) {
-			if ( this.state.isEditingLink ) {
-				event.stopPropagation();
+			this.setState( { isEditingLink: false, newLinkValue: '' } );
+
+			if ( this.props.formats.link.value === NEW_LINK_PLACEHOLDER_VALUE ) {
 				this.dropLink();
 			}
-		}
-		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-			stopKeyPropagation( event );
 		}
 	}
 
@@ -113,6 +113,7 @@ class FormatToolbar extends Component {
 
 	submitLink( event ) {
 		event.preventDefault();
+
 		this.setState( { isEditingLink: false, newLinkValue: '' } );
 
 		if ( this.props.formats.link.value === NEW_LINK_PLACEHOLDER_VALUE ) {

--- a/blocks/rich-text/format-toolbar/index.js
+++ b/blocks/rich-text/format-toolbar/index.js
@@ -153,56 +153,55 @@ class FormatToolbar extends Component {
 				};
 			} );
 
-		const hasEditLinkUI = formats.link && ( isEditingLink || formats.link.value === NEW_LINK_PLACEHOLDER_VALUE );
-		const hasViewLinkUI = formats.link && ! isEditingLink && formats.link.value !== NEW_LINK_PLACEHOLDER_VALUE;
-
-		const linkStyle = focusPosition ? { position: 'absolute', ...focusPosition } : null;
+		const hasLinkUI = !! formats.link;
+		const hasEditLinkUI = hasLinkUI && ( isEditingLink || formats.link.value === NEW_LINK_PLACEHOLDER_VALUE );
+		const hasViewLinkUI = hasLinkUI && ! isEditingLink && formats.link.value !== NEW_LINK_PLACEHOLDER_VALUE;
 
 		return (
 			<div className="blocks-format-toolbar">
 				<Toolbar controls={ toolbarControls } />
 
-				{ hasEditLinkUI &&
-					// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-					/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+				{ hasLinkUI &&
 					<Fill name="RichText.Siblings">
-						<form
-							className="blocks-format-toolbar__link-modal"
-							style={ linkStyle }
-							onKeyPress={ stopKeyPropagation }
-							onKeyDown={ this.onKeyDown }
-							onSubmit={ this.submitLink }>
-							<div className="blocks-format-toolbar__link-modal-line">
-								<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
-								<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
-							</div>
-						</form>
-					</Fill>
-					/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
-				}
+						<div style={ focusPosition && { position: 'absolute', ...focusPosition } }>
+							{ hasEditLinkUI &&
+								// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+								<form
+									className="blocks-format-toolbar__link-modal"
+									onKeyPress={ stopKeyPropagation }
+									onKeyDown={ this.onKeyDown }
+									onSubmit={ this.submitLink }>
+									<div className="blocks-format-toolbar__link-modal-line">
+										<UrlInput value={ newLinkValue } onChange={ this.onChangeLinkValue } />
+										<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
+									</div>
+								</form>
+								/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+							}
 
-				{ hasViewLinkUI &&
-					// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
-					/* eslint-disable jsx-a11y/no-static-element-interactions */
-					<Fill name="RichText.Siblings">
-						<div
-							className="blocks-format-toolbar__link-modal"
-							style={ linkStyle }
-							onKeyPress={ stopKeyPropagation }
-						>
-							<div className="blocks-format-toolbar__link-modal-line">
-								<a
-									className="blocks-format-toolbar__link-value"
-									href={ formats.link.value }
-									target="_blank"
+							{ hasViewLinkUI &&
+								// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
+								/* eslint-disable jsx-a11y/no-static-element-interactions */
+								<div
+									className="blocks-format-toolbar__link-modal"
+									onKeyPress={ stopKeyPropagation }
 								>
-									{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
-								</a>
-								<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
-							</div>
+									<div className="blocks-format-toolbar__link-modal-line">
+										<a
+											className="blocks-format-toolbar__link-value"
+											href={ formats.link.value }
+											target="_blank"
+										>
+											{ formats.link.value && filterURLForDisplay( decodeURI( formats.link.value ) ) }
+										</a>
+										<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ this.editLink } />
+									</div>
+								</div>
+								/* eslint-enable jsx-a11y/no-static-element-interactions */
+							}
 						</div>
 					</Fill>
-					/* eslint-enable jsx-a11y/no-static-element-interactions */
 				}
 			</div>
 		);

--- a/blocks/rich-text/format-toolbar/style.scss
+++ b/blocks/rich-text/format-toolbar/style.scss
@@ -3,11 +3,11 @@
 }
 
 .blocks-format-toolbar__link-modal {
-	position: absolute;
+	position: relative;
+	left: -50%;
 	box-shadow: 0px 3px 20px rgba( 18, 24, 30, .1 ), 0px 1px 3px rgba( 18, 24, 30, .1 );
 	border: 1px solid #e0e5e9;
 	background: #fff;
-	width: 300px;
 	display: flex;
 	flex-direction: column;
 	font-family: $default-font;
@@ -37,8 +37,4 @@
 	position: relative;
 	white-space: nowrap;
 	min-width: 0;
-
-	&:after {
-		@include long-content-fade( $size: 40% );
-	}
 }

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -72,6 +72,12 @@ export function getFormatProperties( formatName, parents ) {
 
 const DEFAULT_FORMATS = [ 'bold', 'italic', 'strikethrough', 'link' ];
 
+/**
+ * When inserting a new link, we insert an <a> tag with this placeholder href
+ * so that there is a visual indication of which text will be made into a link.
+ */
+export const LINK_PLACEHOLDER_VALUE = '_wp_link_placeholder';
+
 export default class RichText extends Component {
 	constructor( props ) {
 		super( ...arguments );
@@ -655,22 +661,41 @@ export default class RichText extends Component {
 		);
 	}
 
-	onNodeChange( { parents } ) {
+	removePlaceholderLinks() {
+		this.editor.$( 'a' ).each( ( index, element ) => {
+			if ( element.getAttribute( 'href' ) === LINK_PLACEHOLDER_VALUE ) {
+				this.editor.dom.remove( element, true );
+			}
+		} );
+	}
+
+	getFormats( parents ) {
+		return this.editor.formatter.matchAll( this.props.formattingControls ).reduce( ( formats, format ) => {
+			formats[ format ] = {
+				isActive: true,
+				...getFormatProperties( format, parents ),
+			};
+			return formats;
+		}, {} );
+	}
+
+	onNodeChange( event ) {
 		if ( document.activeElement !== this.editor.getBody() ) {
 			return;
 		}
-		const formatNames = this.props.formattingControls;
-		const formats = this.editor.formatter.matchAll( formatNames ).reduce( ( accFormats, activeFormat ) => {
-			accFormats[ activeFormat ] = {
-				isActive: true,
-				...getFormatProperties( activeFormat, parents ),
-			};
 
-			return accFormats;
-		}, {} );
+		const formats = this.getFormats( event.parents );
 
-		const focusPosition = this.getFocusPosition();
-		this.setState( { formats, focusPosition, selectedNodeId: this.state.selectedNodeId + 1 } );
+		// Remove all placeholder links if selection moves away from a placeholder link
+		if ( ! formats.link || formats.link.value !== LINK_PLACEHOLDER_VALUE ) {
+			this.removePlaceholderLinks();
+		}
+
+		this.setState( {
+			formats,
+			focusPosition: this.getFocusPosition(),
+			selectedNodeId: this.state.selectedNodeId + 1,
+		} );
 	}
 
 	updateContent() {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -428,11 +428,10 @@ export default class RichText extends Component {
 		const container = findRelativeParent( this.editor.getBody() );
 		const containerPosition = container.getBoundingClientRect();
 		const toolbarOffset = { top: 10, left: 0 };
-		const linkModalWidth = 298;
 
 		return {
 			top: position.top - containerPosition.top + ( position.height ) + toolbarOffset.top,
-			left: position.left - containerPosition.left - ( linkModalWidth / 2 ) + ( position.width / 2 ) + toolbarOffset.left,
+			left: position.left - containerPosition.left + ( position.width / 2 ) + toolbarOffset.left,
 		};
 	}
 

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -177,11 +177,9 @@ class UrlInput extends Component {
 	render() {
 		const { value, instanceId } = this.props;
 		const { showSuggestions, posts, selectedSuggestion, loading } = this.state;
-		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<div className="blocks-url-input">
 				<input
-					autoFocus
 					type="text"
 					aria-label={ __( 'URL' ) }
 					required
@@ -227,7 +225,6 @@ class UrlInput extends Component {
 				}
 			</div>
 		);
-		/* eslint-enable jsx-a11y/no-autofocus */
 	}
 }
 


### PR DESCRIPTION
**🚧 Work in progress! 🚧**

Fixes #4572.

![link](https://user-images.githubusercontent.com/612155/35901612-49bebe84-0c23-11e8-8f3d-638282dff697.gif)

**Still to do:**

- [ ] Padding and margin tweaks—get things looking like they're described in #4572
- [ ] Remove 'edit link' button in lieu of just displaying a text field
- [x] Remove placeholder links when selection changes