### PR TITLE
Writing Flow: Fix merging blocks after nested blocks refactoring

### DIFF
--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -58,7 +58,7 @@ function mapBlockOrder( blocks, rootUID = '' ) {
 	const result = { [ rootUID ]: [] };
 
 	blocks.forEach( ( block ) => {
-		const { uid, innerBlocks } = block;
+		const { uid, innerBlocks = [] } = block;
 
 		result[ rootUID ].push( uid );
 
@@ -84,7 +84,7 @@ function getFlattenedBlocks( blocks ) {
 	while ( stack.length ) {
 		// `innerBlocks` is redundant data which can fall out of sync, since
 		// this is reflected in `blockOrder`, so exclude from appended block.
-		const { innerBlocks, ...block } = stack.shift();
+		const { innerBlocks = [], ...block } = stack.shift();
 
 		stack.push( ...innerBlocks );
 

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -58,7 +58,7 @@ function mapBlockOrder( blocks, rootUID = '' ) {
 	const result = { [ rootUID ]: [] };
 
 	blocks.forEach( ( block ) => {
-		const { uid, innerBlocks = [] } = block;
+		const { uid, innerBlocks } = block;
 
 		result[ rootUID ].push( uid );
 
@@ -84,7 +84,7 @@ function getFlattenedBlocks( blocks ) {
 	while ( stack.length ) {
 		// `innerBlocks` is redundant data which can fall out of sync, since
 		// this is reflected in `blockOrder`, so exclude from appended block.
-		const { innerBlocks = [], ...block } = stack.shift();
+		const { innerBlocks, ...block } = stack.shift();
 
 		stack.push( ...innerBlocks );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -959,14 +959,23 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							123: { uid: 123, name: 'core/paragraph' },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
+						},
+						blockOrder: {
+							'': [ 123 ],
+							123: [],
 						},
 						edits: {},
 					},
 				},
 			};
 
-			expect( getBlock( state, 123 ) ).toEqual( { uid: 123, name: 'core/paragraph' } );
+			expect( getBlock( state, 123 ) ).toEqual( {
+				uid: 123,
+				name: 'core/paragraph',
+				attributes: {},
+				innerBlocks: [],
+			} );
 		} );
 
 		it( 'should return null if the block is not present in state', () => {
@@ -975,12 +984,45 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {},
+						borderOrder: {},
 						edits: {},
 					},
 				},
 			};
 
 			expect( getBlock( state, 123 ) ).toBe( null );
+		} );
+
+		it( 'should include inner blocks', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocksByUid: {
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
+							456: { uid: 456, name: 'core/paragraph', attributes: {} },
+						},
+						blockOrder: {
+							'': [ 123 ],
+							123: [ 456 ],
+							456: [],
+						},
+						edits: {},
+					},
+				},
+			};
+
+			expect( getBlock( state, 123 ) ).toEqual( {
+				uid: 123,
+				name: 'core/paragraph',
+				attributes: {},
+				innerBlocks: [ {
+					uid: 456,
+					name: 'core/paragraph',
+					attributes: {},
+					innerBlocks: [],
+				} ],
+			} );
 		} );
 
 		it( 'should merge meta attributes for the block', () => {
@@ -1006,7 +1048,11 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							123: { uid: 123, name: 'core/meta-block' },
+							123: { uid: 123, name: 'core/meta-block', attributes: {} },
+						},
+						blockOrder: {
+							'': [ 123 ],
+							123: [],
 						},
 						edits: {},
 					},
@@ -1019,6 +1065,7 @@ describe( 'selectors', () => {
 				attributes: {
 					foo: 'bar',
 				},
+				innerBlocks: [],
 			} );
 		} );
 	} );
@@ -1030,8 +1077,8 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1042,8 +1089,8 @@ describe( 'selectors', () => {
 			};
 
 			expect( getBlocks( state ) ).toEqual( [
-				{ uid: 123, name: 'core/paragraph', innerBlocks: [] },
-				{ uid: 23, name: 'core/heading', innerBlocks: [] },
+				{ uid: 123, name: 'core/paragraph', attributes: {}, innerBlocks: [] },
+				{ uid: 23, name: 'core/heading', attributes: {}, innerBlocks: [] },
 			] );
 		} );
 	} );
@@ -1054,8 +1101,8 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1072,9 +1119,9 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							123: { uid: 123, name: 'core/columns' },
-							456: { uid: 456, name: 'core/paragraph' },
-							789: { uid: 789, name: 'core/paragraph' },
+							123: { uid: 123, name: 'core/columns', attributes: {} },
+							456: { uid: 456, name: 'core/paragraph', attributes: {} },
+							789: { uid: 789, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123 ],
@@ -1095,8 +1142,8 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
 						edits: {},
 					},
@@ -1112,8 +1159,8 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
 					},
 				},
@@ -1128,15 +1175,25 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
+						},
+						blockOrder: {
+							'': [ 23, 123 ],
+							23: [],
+							123: [],
 						},
 					},
 				},
 				blockSelection: { start: 23, end: 23 },
 			};
 
-			expect( getSelectedBlock( state ) ).toBe( state.editor.present.blocksByUid[ 23 ] );
+			expect( getSelectedBlock( state ) ).toEqual( {
+				uid: 23,
+				name: 'core/heading',
+				attributes: {},
+				innerBlocks: [],
+			} );
 		} );
 	} );
 
@@ -1321,8 +1378,8 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1331,7 +1388,12 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getPreviousBlock( state, 23 ) ).toEqual( { uid: 123, name: 'core/paragraph' } );
+			expect( getPreviousBlock( state, 23 ) ).toEqual( {
+				uid: 123,
+				name: 'core/paragraph',
+				attributes: {},
+				innerBlocks: [],
+			} );
 		} );
 
 		it( 'should return the previous block (nested context)', () => {
@@ -1339,10 +1401,10 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
-							56: { uid: 56, name: 'core/heading' },
-							456: { uid: 456, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
+							56: { uid: 56, name: 'core/heading', attributes: {} },
+							456: { uid: 456, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1352,7 +1414,12 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getPreviousBlock( state, 56, '123' ) ).toEqual( { uid: 456, name: 'core/paragraph' } );
+			expect( getPreviousBlock( state, 56, '123' ) ).toEqual( {
+				uid: 456,
+				name: 'core/paragraph',
+				attributes: {},
+				innerBlocks: [],
+			} );
 		} );
 
 		it( 'should return null for the first block', () => {
@@ -1360,8 +1427,8 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1378,10 +1445,10 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
-							56: { uid: 56, name: 'core/heading' },
-							456: { uid: 456, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
+							56: { uid: 56, name: 'core/heading', attributes: {} },
+							456: { uid: 456, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1401,8 +1468,8 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1411,7 +1478,12 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getNextBlock( state, 123 ) ).toEqual( { uid: 23, name: 'core/heading' } );
+			expect( getNextBlock( state, 123 ) ).toEqual( {
+				uid: 23,
+				name: 'core/heading',
+				attributes: {},
+				innerBlocks: [],
+			} );
 		} );
 
 		it( 'should return the following block (nested context)', () => {
@@ -1419,10 +1491,10 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
-							56: { uid: 56, name: 'core/heading' },
-							456: { uid: 456, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
+							56: { uid: 56, name: 'core/heading', attributes: {} },
+							456: { uid: 456, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1432,7 +1504,12 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getNextBlock( state, 456, '123' ) ).toEqual( { uid: 56, name: 'core/heading' } );
+			expect( getNextBlock( state, 456, '123' ) ).toEqual( {
+				uid: 56,
+				name: 'core/heading',
+				attributes: {},
+				innerBlocks: [],
+			} );
 		} );
 
 		it( 'should return null for the last block', () => {
@@ -1440,8 +1517,8 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1458,10 +1535,10 @@ describe( 'selectors', () => {
 				editor: {
 					present: {
 						blocksByUid: {
-							23: { uid: 23, name: 'core/heading' },
-							123: { uid: 123, name: 'core/paragraph' },
-							56: { uid: 56, name: 'core/heading' },
-							456: { uid: 456, name: 'core/paragraph' },
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
+							56: { uid: 56, name: 'core/heading', attributes: {} },
+							456: { uid: 456, name: 'core/paragraph', attributes: {} },
 						},
 						blockOrder: {
 							'': [ 123, 23 ],
@@ -1908,8 +1985,8 @@ describe( 'selectors', () => {
 							'': [ 123, 456 ],
 						},
 						blocksByUid: {
-							123: { uid: 123, name: 'core/image' },
-							456: { uid: 456, name: 'core/quote' },
+							123: { uid: 123, name: 'core/image', attributes: {} },
+							456: { uid: 456, name: 'core/quote', attributes: {} },
 						},
 					},
 				},
@@ -1926,7 +2003,7 @@ describe( 'selectors', () => {
 							'': [ 123 ],
 						},
 						blocksByUid: {
-							123: { uid: 123, name: 'core/image' },
+							123: { uid: 123, name: 'core/image', attributes: {} },
 						},
 					},
 				},
@@ -1943,7 +2020,7 @@ describe( 'selectors', () => {
 							'': [ 456 ],
 						},
 						blocksByUid: {
-							456: { uid: 456, name: 'core/quote' },
+							456: { uid: 456, name: 'core/quote', attributes: {} },
 						},
 					},
 				},
@@ -1960,7 +2037,7 @@ describe( 'selectors', () => {
 							'': [ 567 ],
 						},
 						blocksByUid: {
-							567: { uid: 567, name: 'core-embed/youtube' },
+							567: { uid: 567, name: 'core-embed/youtube', attributes: {} },
 						},
 					},
 				},
@@ -1977,8 +2054,8 @@ describe( 'selectors', () => {
 							'': [ 456, 789 ],
 						},
 						blocksByUid: {
-							456: { uid: 456, name: 'core/quote' },
-							789: { uid: 789, name: 'core/paragraph' },
+							456: { uid: 456, name: 'core/quote', attributes: {} },
+							789: { uid: 789, name: 'core/paragraph', attributes: {} },
 						},
 					},
 				},


### PR DESCRIPTION
After the nested blocks refactoring, merging blocks is producing a JS error because of undefined `innerBlocks` in several places. I was not certain if this property is optional or not cc @aduth 

The fix here just adds a default value to the property when needed.

**Testing instructions**

- Create two paragraphs
- Press Backspace when the caret is at the beginning of the second paragraph
- The paragraphs should merge properly.