### PR TITLE
Fix codepen embeds width

### DIFF
--- a/components/sandbox/README.md
+++ b/components/sandbox/README.md
@@ -1,0 +1,14 @@
+This component is used to embed embeds!
+
+#### To test
+
+Embed the following:
+
+- Short tweet: https://twitter.com/notnownikki/status/876229494465581056
+- Long tweet with media: https://twitter.com/PattyJenks/status/874034832430424065
+- Video: https://www.youtube.com/watch?v=PfKUdmTq2MI
+- Photo: https://cloudup.com/cQFlxqtY4ob
+- Long tumblr post: http://doctorwho.tumblr.com/post/162052108791
+- Create a custom html block with the following content: <img src="https://cldup.com/G3fFjtKEKe-3000x3000.jpeg">
+
+This tests that HTML is written into the sandbox correctly in all cases, and that sites that do responsive resizes (e.g. tumblr) don't mess up when put into a small iframe that is also trying to resize.

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -132,6 +132,7 @@ export default class Sandbox extends Component {
 				} );
 
 				document.body.style.position = 'absolute';
+				document.body.style.width = '100%';
 				document.body.setAttribute( 'data-resizable-iframe-connected', '' );
 
 				sendResize();


### PR DESCRIPTION
If you paste in a codepen URL into the editor, it embeds, but is not full width. This PR fixes that.

Before:

![screen shot 2018-02-07 at 10 41 52](https://user-images.githubusercontent.com/1204802/35909397-c42a8b56-0bf3-11e8-8484-98319584f397.png)

After:

![screen shot 2018-02-07 at 10 42 27](https://user-images.githubusercontent.com/1204802/35909401-c690f89e-0bf3-11e8-8ef7-99d63a4df226.png)
