### PR TITLE
Release: Adding the i18n messages to the built plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cypress
 /hooks
 node_modules
 gutenberg.zip
+languages/gutenberg.pot
 
 # Directories/files that may appear in your environment
 .DS_Store

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -79,6 +79,8 @@ status "Installing dependencies..."
 npm install
 status "Generating build..."
 npm run build
+status "Generating translation messages..."
+npm run gettext-strings
 
 # Remove any existing zip file
 rm -f gutenberg.zip
@@ -110,6 +112,7 @@ zip -r gutenberg.zip \
 	blocks/build/*.css \
 	components/build/*.css \
 	editor/build/*.css \
+	languages/gutenberg.pot \
 	README.md
 
 # Reset `gutenberg.php`


### PR DESCRIPTION
On each release, we generate a new i18n messages file to submit with the plugin. This would allow translating the plugin into other languages.