### PR TITLE
Testing: Automate memoized selector setup clear

### DIFF
--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import { union } from 'lodash';
+import { filter, property, union } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,7 +13,9 @@ import { registerBlockType, unregisterBlockType, registerCoreBlocks, getBlockTyp
 /**
  * Internal dependencies
  */
-import {
+import * as selectors from '../selectors';
+
+const {
 	hasEditorUndo,
 	hasEditorRedo,
 	isEditedPostNew,
@@ -40,9 +42,7 @@ import {
 	getBlockCount,
 	getSelectedBlock,
 	getBlockRootUID,
-	getEditedPostContent,
 	getMultiSelectedBlockUids,
-	getMultiSelectedBlocks,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
 	getBlockOrder,
@@ -76,9 +76,11 @@ import {
 	getInserterItems,
 	getRecentInserterItems,
 	POST_UPDATE_TRANSACTION_ID,
-} from '../selectors';
+} = selectors;
 
 describe( 'selectors', () => {
+	let cachedSelectors;
+
 	beforeAll( () => {
 		registerBlockType( 'core/test-block', {
 			save: ( props ) => props.attributes.text,
@@ -88,14 +90,12 @@ describe( 'selectors', () => {
 			keywords: [ 'testing' ],
 			useOnce: true,
 		} );
+
+		cachedSelectors = filter( selectors, property( 'clear' ) );
 	} );
 
 	beforeEach( () => {
-		getBlock.clear();
-		getBlocks.clear();
-		getEditedPostContent.clear();
-		getMultiSelectedBlockUids.clear();
-		getMultiSelectedBlocks.clear();
+		cachedSelectors.forEach( ( { clear } ) => clear() );
 	} );
 
 	afterAll( () => {


### PR DESCRIPTION
This pull request seeks to improve selector tests to automate memoized selector cache clearing. Gutenberg includes memoized selectors via [rememo](https://github.com/aduth/rememo) whose cache can taint the result of subsequent tests if not cleared during test lifecycle. Previously, this relied on the developer implementing caching to a selector to include their selector's `clear` call in the selector tests' `beforeEach` method. With these changes, this has been automated to remove manual developer intervention, detecting which selectors are cached, and automatically clearing them.

__Testing instructions:__

Verify that unit tests pass:

```
npm run test-unit
```