### PR TITLE
State: Avoid parameters in memoized selectors getDependants

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -432,8 +432,8 @@ export const getBlock = createSelector(
 			},
 		};
 	},
-	( state, uid ) => [
-		get( state, [ 'editor', 'present', 'blocksByUid', uid ] ),
+	( state ) => [
+		get( state, [ 'editor', 'present', 'blocksByUid' ] ),
 		get( state, [ 'editor', 'present', 'edits', 'meta' ] ),
 		get( state, 'currentPost.meta' ),
 	]


### PR DESCRIPTION
This pull request seeks to resolve an issue where memoized selector cache clearing occurs more frequently than anticipated, due to the internal behavior of the underlying [rememo](https://github.com/aduth/rememo) library.

Given the following scenario, the cache for `getBlock` would be cleared on every single invocation:

```js
for ( i = 0; i < 100; i++ ) {
	getBlock( state, i % 2 ? aBlockUID : bBlockUID );
}
```

This is because memoization compares the result of the dependents between invocations, and in the above case, `blocksByUid[ uid ]` will produce different results:

https://github.com/aduth/rememo/blob/11644c10d5bb6fa041c387c9ce9e6c26604d3556/es/index.js#L86-L90

As the maintainer of `rememo`, unless compelling arguments are made otherwise, I plan to release a subsequent major release dropping support for all but the `state` argument in `getDependants` (the second argument of `createSelector`).

__Testing instructions:__

Verify that unit tests pass:

```
npm run test-unit
```