### PR TITLE
Writing Flow: Guard against falsey block container

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -259,7 +259,7 @@ class WritingFlow extends Component {
 			( ! prevProps.selectedBlock || this.props.selectedBlock.uid !== prevProps.selectedBlock.uid )
 		) {
 			const blockContainer = this.container.querySelector( `[data-block="${ this.props.selectedBlock.uid }"]` );
-			if ( ! blockContainer.contains( document.activeElement ) ) {
+			if ( blockContainer && ! blockContainer.contains( document.activeElement ) ) {
 				const target = this.getInnerTabbable( blockContainer, this.props.initialPosition === -1 );
 				target.focus();
 				if ( this.props.initialPosition === -1 ) {


### PR DESCRIPTION
This pull request seeks to resolve an application error which can occur when pasting some content into a Columns block.

__Implementation notes:__

It seems our `WritingFlow` behaviors assumes that all other block rendering has flushed by the time `componentDidUpdate` is called. While I'm yet unclear what it is about nested blocks that breaks this expectation (i.e. error'ing only in Columns), I don't think that we should not be relying on this behavior unless it's explicitly documented somewhere to occur this way (renders occurring upward from children through to ancestors).

__Testing instructions:__

Copy content from the following Google Doc:

https://docs.google.com/document/d/1z4B4WT3KI11AhQS29iKDBNeoqrjmDpFCNYzZLKr_Oy4/edit?usp=sharing

Paste into a column of the Columns block.

Verify that no errors occur.