### PR TITLE
Blocks: Shortcode: Support multi-line shortcodes

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -27,6 +27,8 @@ export {
 	getUnknownTypeHandlerName,
 	setDefaultBlockName,
 	getDefaultBlockName,
+	addRawContentBlockName,
+	isRawContentBlockName,
 	getDefaultBlockForPostFormat,
 	getBlockType,
 	getBlockTypes,

--- a/blocks/api/registration.js
+++ b/blocks/api/registration.js
@@ -64,6 +64,14 @@ let unknownTypeHandlerName;
 let defaultBlockName;
 
 /**
+ * A set of block names representing block types whose content the serializer
+ * should never attempt to beautify.
+ *
+ * @type {?string}
+ */
+const rawContentBlockNames = new Set();
+
+/**
  * Constant mapping post formats to the expected default block.
  *
  * @type {Object}
@@ -219,6 +227,18 @@ export function setDefaultBlockName( name ) {
  */
 export function getDefaultBlockName() {
 	return defaultBlockName;
+}
+
+export function addRawContentBlockName( name ) {
+	rawContentBlockNames.add( name );
+}
+
+export function isRawContentBlockName( name ) {
+	return rawContentBlockNames.has( name );
+}
+
+export function clearRawContentBlockNames() {
+	rawContentBlockNames.clear();
 }
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -14,7 +14,7 @@ import { hasFilter, applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { getBlockType, getUnknownTypeHandlerName } from './registration';
+import { getBlockType, getUnknownTypeHandlerName, hasBlockSupport } from './registration';
 import BlockContentProvider from '../block-content-provider';
 
 /**
@@ -196,7 +196,11 @@ export function getBlockContent( block ) {
 		} catch ( error ) {}
 	}
 
-	return getUnknownTypeHandlerName() === block.name || ! saveContent ? saveContent : getBeautifulContent( saveContent );
+	return (
+		getUnknownTypeHandlerName() === block.name ||
+		hasBlockSupport( blockType, 'rawContent' ) ||
+		! saveContent
+	) ? saveContent : getBeautifulContent( saveContent );
 }
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -14,7 +14,7 @@ import { hasFilter, applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { getBlockType, getUnknownTypeHandlerName, hasBlockSupport } from './registration';
+import { getBlockType, getUnknownTypeHandlerName, isRawContentBlockName } from './registration';
 import BlockContentProvider from '../block-content-provider';
 
 /**
@@ -198,7 +198,7 @@ export function getBlockContent( block ) {
 
 	return (
 		getUnknownTypeHandlerName() === block.name ||
-		hasBlockSupport( blockType, 'rawContent' ) ||
+		isRawContentBlockName( block.name ) ||
 		! saveContent
 	) ? saveContent : getBeautifulContent( saveContent );
 }

--- a/blocks/api/test/registration.js
+++ b/blocks/api/test/registration.js
@@ -18,6 +18,9 @@ import {
 	getUnknownTypeHandlerName,
 	setDefaultBlockName,
 	getDefaultBlockName,
+	addRawContentBlockName,
+	isRawContentBlockName,
+	clearRawContentBlockNames,
 	getBlockType,
 	getBlockTypes,
 	getBlockSupport,
@@ -39,6 +42,7 @@ describe( 'blocks', () => {
 		} );
 		setUnknownTypeHandlerName( undefined );
 		setDefaultBlockName( undefined );
+		clearRawContentBlockNames();
 		window._wpBlocks = {};
 	} );
 
@@ -303,6 +307,17 @@ describe( 'blocks', () => {
 	describe( 'getDefaultBlockName()', () => {
 		it( 'defaults to undefined', () => {
 			expect( getDefaultBlockName() ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'isRawContentBlockName', () => {
+		it( 'adds block names to a set', () => {
+			addRawContentBlockName( 'core/test-block-1' );
+			addRawContentBlockName( 'core/test-block-2' );
+			addRawContentBlockName( 'core/test-block-1' );
+			expect( isRawContentBlockName( 'core/test-block-1' ) ).toBe( true );
+			expect( isRawContentBlockName( 'core/test-block-2' ) ).toBe( true );
+			expect( isRawContentBlockName( 'core/test-block-3' ) ).toBe( false );
 		} );
 	} );
 

--- a/core-blocks/index.js
+++ b/core-blocks/index.js
@@ -5,6 +5,7 @@ import {
 	registerBlockType,
 	setDefaultBlockName,
 	setUnknownTypeHandlerName,
+	addRawContentBlockName,
 } from '@wordpress/blocks';
 import { deprecated } from '@wordpress/utils';
 
@@ -83,6 +84,7 @@ export const registerCoreBlocks = () => {
 
 	setDefaultBlockName( paragraph.name );
 	setUnknownTypeHandlerName( freeform.name );
+	addRawContentBlockName( shortcode.name );
 };
 
 // Backwards compatibility

--- a/core-blocks/shortcode/index.js
+++ b/core-blocks/shortcode/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withInstanceId, Dashicon } from '@wordpress/components';
 import { PlainText } from '@wordpress/blocks';
@@ -45,7 +44,7 @@ export const settings = {
 					text: {
 						type: 'string',
 						shortcode: ( attrs, { content } ) => {
-							return content;
+							return content.replace( /<br \/>/g, '' );
 						},
 					},
 				},
@@ -58,6 +57,7 @@ export const settings = {
 		customClassName: false,
 		className: false,
 		html: false,
+		rawContent: true,
 	},
 
 	edit: withInstanceId(
@@ -83,6 +83,6 @@ export const settings = {
 	),
 
 	save( { attributes } ) {
-		return <RawHTML>{ attributes.text }</RawHTML>;
+		return attributes.text;
 	},
 };

--- a/core-blocks/shortcode/index.js
+++ b/core-blocks/shortcode/index.js
@@ -45,7 +45,10 @@ export const settings = {
 					text: {
 						type: 'string',
 						shortcode: ( attrs, { content } ) => {
-							return content;
+							return content.replace(
+								/<br \/>/g,
+								'\n'
+							);
 						},
 					},
 				},

--- a/core-blocks/shortcode/index.js
+++ b/core-blocks/shortcode/index.js
@@ -57,7 +57,6 @@ export const settings = {
 		customClassName: false,
 		className: false,
 		html: false,
-		rawContent: true,
 	},
 
 	edit: withInstanceId(

--- a/core-blocks/shortcode/index.js
+++ b/core-blocks/shortcode/index.js
@@ -45,10 +45,7 @@ export const settings = {
 					text: {
 						type: 'string',
 						shortcode: ( attrs, { content } ) => {
-							return content.replace(
-								/<br \/>/g,
-								'\n'
-							);
+							return content;
 						},
 					},
 				},


### PR DESCRIPTION
## Description
Partly fixes #4456 

~_In progress: this doesn't yet preserve newlines within a Shortcode block if reloading the block (when switching between Visual and Code modes or by reloading Gutenberg)._~

When converting content to blocks (either explicitly via the _Convert to blocks_ action or by pasting content), content fragments that are recognized as shortcodes (but don't have a specific block to handle it) are then sent through the generic Shortcode block's `'shortcode'` transform. Since raw content is canonically treated as HTML, the Shortcode transform receives any newline as `<br />`. This PR converts these into `\n` inside the shortcode transform.

This was an issue because the Shortcode block _intentionally_ treats its contents literally. This is because it is meant to be a place where HTML entities are not decoded, so as to better support the extent of WordPress shortcode usage. See #3609 for history.

## How Has This Been Tested?
1. Attempt to repeat the reported bug by following the steps in #4456. In a nutshell, try to _convert from classic to blocks_ or try to _paste_ content with a multi-line shortcode such as:

```
[bwcsv]One,Two,Three
A,B,C
D,E,F
[/bwcsv]
```

and make sure the process creates a Shortcode block that respects the original line breaks.

Caveat: this is a remaining issue to be solved concerning pasting for shortcodes containing underscores. In other words, the issue author's `[bw_csv]` shortcode will not be correctly parsed upon pasting. It will, however, be handled correctly when converting from classic.

2. Make sure that one-line shortcodes are still supported.
3. Make sure that a fragment of *text* that reads `<br />` will not be treated as a newline.

## Screenshots (jpeg or gifs if applicable):

Before | After
--|--
![Before](https://user-images.githubusercontent.com/150562/35946315-2c15a432-0c5b-11e8-8ce7-f777b493b005.gif) | ![After](https://user-images.githubusercontent.com/150562/35946956-b4fd44b0-0c5d-11e8-892a-0efa95f5450d.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
