### PR TITLE
Fix Cypress path checks to allow sub-directory

### DIFF
--- a/test/e2e/support/gutenberg-commands.js
+++ b/test/e2e/support/gutenberg-commands.js
@@ -4,7 +4,7 @@ Cypress.Commands.add( 'newPost', () => {
 
 Cypress.Commands.add( 'visitAdmin', ( adminPath ) => {
 	cy.visit( '/wp-admin/' + adminPath ).location( 'pathname' ).then( ( path ) => {
-		if ( /\/wp-login\.php$/.test( path ) ) {
+		if ( path.endsWith( '/wp-login.php' ) ) {
 			cy.login();
 		}
 	} );

--- a/test/e2e/support/gutenberg-commands.js
+++ b/test/e2e/support/gutenberg-commands.js
@@ -4,7 +4,7 @@ Cypress.Commands.add( 'newPost', () => {
 
 Cypress.Commands.add( 'visitAdmin', ( adminPath ) => {
 	cy.visit( '/wp-admin/' + adminPath ).location( 'pathname' ).then( ( path ) => {
-		if ( path === '/wp-login.php' ) {
+		if ( /\/wp-login\.php$/.test( path ) ) {
 			cy.login();
 		}
 	} );

--- a/test/e2e/support/user-commands.js
+++ b/test/e2e/support/user-commands.js
@@ -4,7 +4,7 @@ Cypress.Commands.add( 'login', ( username = Cypress.env( 'username' ), password 
 	// (not sure this is possible in WP)
 
 	cy.location( 'pathname' ).then( ( path ) => {
-		if ( ! /\/wp-login\.php$/.test( path ) ) {
+		if ( ! path.endsWith( '/wp-login.php' ) ) {
 			cy.visit( '/wp-login.php' );
 		}
 	} );

--- a/test/e2e/support/user-commands.js
+++ b/test/e2e/support/user-commands.js
@@ -4,7 +4,7 @@ Cypress.Commands.add( 'login', ( username = Cypress.env( 'username' ), password 
 	// (not sure this is possible in WP)
 
 	cy.location( 'pathname' ).then( ( path ) => {
-		if ( path !== '/wp-login.php' ) {
+		if ( ! /\/wp-login\.php$/.test( path ) ) {
 			cy.visit( '/wp-login.php' );
 		}
 	} );


### PR DESCRIPTION
## Description
Subtle changes in this PR allow a developer to set a custom base URL for Cypress using an environment variable, where the custom base URL includes a subdirectory. For example, note the `/wp` subdirectory in this command:

```bash
cypress_base_url=http://localhost:8888/wp npm run test-e2e
```

This wasn't working before. We were running tests against URL paths without considering the possibility of a leading subdirectory in each path. Fixed in this PR.

## How Has This Been Tested?
@iseulde and I tested this by running E2E tests in a subdirectory, with help from @youknowriad.

## Types of changes
Use regex to test location instead of `===`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
