### PR TITLE
Old style for classic block

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -129,12 +129,15 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
     padding-top: 0;
 }
 
-// freeform toolbar
 .freeform-toolbar {
 	width: auto;
 	margin: - $block-padding;
 	margin-bottom: $block-padding;
-	// TinyMCE hides on blur with inline styles.
+}
+
+// TinyMCE hides on blur with inline styles.
+.freeform-toolbar,
+.freeform-toolbar .mce-tinymce-inline {
 	display: block !important;
 }
 

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -116,26 +116,26 @@
 	}
 }
 
-// freeform toolbar
-.freeform-toolbar {
-	position: sticky;
-	width: auto;
-	top: -1px;	// stack borders
-	margin-top: -$block-controls-height - 16px;
-	border: 1px solid $light-gray-500;
-	z-index: z-index( '.freeform-toolbar' );
-	background-color: $white;
-	min-height: $block-controls-height;
-	margin-bottom: 14px;
-
-	@include break-small() {
-		margin-left: - $block-padding - 1px;
-		margin-right: - $block-padding - 1px;
-	}
+.edit-post-visual-editor div[data-type="core/freeform"]:before {
+	outline: 1px solid #e2e4e7;
 }
 
-.freeform-toolbar.has-advanced-toolbar {
-	margin-top: -89px;	// pull upwards the classic block toolbar when enabled, height is manually entered
+div[data-type="core/freeform"] .editor-block-contextual-toolbar {
+	display: none;
+}
+
+div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+// freeform toolbar
+.freeform-toolbar {
+	width: auto;
+	margin: - $block-padding;
+	margin-bottom: $block-padding;
+	// TinyMCE hides on blur with inline styles.
+	display: block !important;
 }
 
 // Overwrite inline styles.
@@ -149,145 +149,19 @@
 	width: 100% !important;
 }
 
-.freeform-toolbar .mce-tinymce-inline .mce-flow-layout {
-    white-space: normal;
-}
-
 .freeform-toolbar .mce-container-body.mce-abs-layout {
 	overflow: visible;
 }
 
-.freeform-toolbar .mce-menubar {
-	position: static;
-}
-
+.freeform-toolbar .mce-menubar,
 .freeform-toolbar div.mce-toolbar-grp {
-	background-color: transparent;
-	border: none;
 	position: static;
-}
-
-.freeform-toolbar div.mce-toolbar-grp > div {
-    padding: 0;
 }
 
 .freeform-toolbar .mce-toolbar-grp .mce-toolbar:not(:first-child) {
 	display: none;
-	border-top: 1px solid $light-gray-500;
 }
 
 .freeform-toolbar.has-advanced-toolbar .mce-toolbar-grp .mce-toolbar {
 	display: block;
-}
-
-.freeform-toolbar div.mce-btn-group {
-	padding: 0;
-	margin: 0;
-	border: 0;
-}
-
-.freeform-toolbar .mce-toolbar-grp .mce-toolbar .mce-btn {
-	margin: 0;
-	padding: 3px;
-	background: none;
-	outline: none;
-	color: $dark-gray-500;
-	cursor: pointer;
-	position: relative;
-	min-width: $icon-button-size;
-	height: $icon-button-size;
-
-	// Overwrite
-	border: none;
-	box-sizing: border-box;
-	box-shadow: none;
-	border-radius: 0;
-
-	&:hover,
-	/* the ":not(:disabled)" is needed to make it specific enough */
-	&:hover:not(:disabled),
-	&:focus,
-	&:focus:active {
-		color: $dark-gray-500;
-		outline: none;
-		box-shadow: none;
-		background: inherit;
-	}
-
-	&.mce-active,
-	&.mce-active:hover {
-		background: none;
-		color: $white;
-	}
-
-	&:disabled {
-		cursor: default;
-	}
-
-	&> button {
-		border: 1px solid transparent;
-		padding: 4px;
-		box-sizing: content-box;
-	}
-
-	&:hover button,
-	&:focus button {
-		color: $dark-gray-500;
-	}
-
-	&:not(:disabled) {
-		&.mce-active button,
-		&:hover button,
-		&:focus button {
-			border: 1px solid $dark-gray-500;
-		}
-	}
-
-	&.mce-active button,
-	&.mce-active:hover button {
-		background-color: $dark-gray-500;
-		color: $white;
-	}
-
-	&.mce-active .mce-ico {
-		color: $white;
-	}
-
-	&.mce-listbox,
-	&.mce-colorbutton {
-		width: auto;
-		border: none;
-		box-shadow: none;
-	}
-
-	&.mce-colorbutton .mce-preview {
-		bottom: 8px;
-		left: 8px;
-	}
-}
-
-.components-toolbar__control .dashicon {
-	display: block;
-}
-
-
-.mce-widget.mce-tooltip {
-	display: block;
-	opacity: initial;
-
-	.mce-tooltip-inner {
-		padding: 4px 12px;
-		background: $dark-gray-400;
-		border-width: 0;
-		color: white;
-		white-space: nowrap;
-		box-shadow: none;
-		font-size: $default-font-size;
-		border-radius: 0;
-	}
-
-	.mce-tooltip-arrow {
-		border-top-color: $dark-gray-400;
-		border-bottom-color: $dark-gray-400;
-	}
 }

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -140,7 +140,7 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 
 .freeform-toolbar {
 	width: auto;
-	margin: - $block-padding;
+	margin: -#{ $block-padding + 1 } -#{ $block-padding } -#{ $block-padding } -#{ $block-padding };
 	margin-bottom: $block-padding;
 }
 

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -125,7 +125,7 @@
 	.editor-block-contextual-toolbar {
 		display: none;
 	}
-	
+
 	// Don't show block type label for classic block
 	&.is-hovered .editor-block-breadcrumb {
 		display: none;
@@ -157,12 +157,6 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 		line-height: 37px;
 		padding: $block-padding;
 	}
-}
-
-// TinyMCE hides on blur with inline styles.
-.freeform-toolbar,
-.freeform-toolbar .mce-tinymce-inline {
-	display: block !important;
 }
 
 // Overwrite inline styles.

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -116,13 +116,22 @@
 	}
 }
 
-.editor-block-list__layout .editor-block-list__block[data-type="core/freeform"] .editor-block-list__block-edit:before {
-	outline: 1px solid #e2e4e7;
+.editor-block-list__layout .editor-block-list__block[data-type="core/freeform"] {
+	.editor-block-list__block-edit:before {
+		outline: 1px solid #e2e4e7;
+	}
+
+	// Don't show normal block toolbar
+	.editor-block-contextual-toolbar {
+		display: none;
+	}
+	
+	// Don't show block type label for classic block
+	&.is-hovered .editor-block-breadcrumb {
+		display: none;
+	}
 }
 
-div[data-type="core/freeform"] .editor-block-contextual-toolbar {
-	display: none;
-}
 
 div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
     margin-top: 0;
@@ -136,11 +145,13 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 }
 
 .freeform-toolbar:empty {
-	height: 37px;
+	height: $block-toolbar-height;
 	background: #f5f5f5;
 	border-bottom: 1px solid #e2e4e7;
 
 	&:before {
+		font-family: $default-font;
+		font-size: $default-font-size;
 		content: attr( data-placeholder );
 		color: #555d66;
 		line-height: 37px;

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -116,7 +116,7 @@
 	}
 }
 
-.edit-post-visual-editor div[data-type="core/freeform"]:before {
+.editor-block-list__layout .editor-block-list__block[data-type="core/freeform"] .editor-block-list__block-edit:before {
 	outline: 1px solid #e2e4e7;
 }
 
@@ -133,6 +133,19 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 	width: auto;
 	margin: - $block-padding;
 	margin-bottom: $block-padding;
+}
+
+.freeform-toolbar:empty {
+	height: 37px;
+	background: #f5f5f5;
+	border-bottom: 1px solid #e2e4e7;
+
+	&:before {
+		content: attr( data-placeholder );
+		color: #555d66;
+		line-height: 37px;
+		padding: $block-padding;
+	}
 }
 
 // TinyMCE hides on blur with inline styles.

--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -140,7 +140,7 @@ div[data-type="core/freeform"] .editor-block-contextual-toolbar + div {
 
 .freeform-toolbar {
 	width: auto;
-	margin: -#{ $block-padding + 1 } -#{ $block-padding } -#{ $block-padding } -#{ $block-padding };
+	margin: -$block-padding;
 	margin-bottom: $block-padding;
 }
 

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -109,6 +109,24 @@ export default class OldEditor extends Component {
 				editor.dom.toggleClass( ref, 'has-advanced-toolbar', active );
 			},
 		} );
+
+		// To do: get TinyMCE to add a setting to the inline theme to always
+		// display toolbars. In the meantime, force display with CSS and force
+		// the creation of toolbars by manually focussing the editor on
+		// initialisation.
+		editor.on( 'init', () => {
+			const { activeElement } = document;
+
+			// Force fire focus, even if the editor already has focus.
+			editor.fire( 'focus' );
+
+			// Set focus back to where it was, unless it was this editor.
+			// This should only be true during page load, where the active
+			// element will be the document.
+			if ( activeElement !== editor.getBody() ) {
+				activeElement.focus();
+			}
+		} );
 	}
 
 	render() {

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -28,6 +28,7 @@ export default class OldEditor extends Component {
 		super( props );
 		this.initialize = this.initialize.bind( this );
 		this.onSetup = this.onSetup.bind( this );
+		this.focus = this.focus.bind( this );
 	}
 
 	componentDidMount() {
@@ -78,6 +79,8 @@ export default class OldEditor extends Component {
 		const { attributes: { content }, setAttributes } = this.props;
 		const { ref } = this;
 
+		this.editor = editor;
+
 		if ( content ) {
 			editor.on( 'loadContent', () => editor.setContent( content ) );
 		}
@@ -110,35 +113,38 @@ export default class OldEditor extends Component {
 			},
 		} );
 
-		// To do: get TinyMCE to add a setting to the inline theme to always
-		// display toolbars. In the meantime, force display with CSS and force
-		// the creation of toolbars by manually focussing the editor on
-		// initialisation.
 		editor.on( 'init', () => {
-			const { activeElement } = document;
+			const rootNode = this.editor.getBody();
 
-			// Force fire focus, even if the editor already has focus.
-			editor.fire( 'focus' );
-
-			// Set focus back to where it was, unless it was this editor.
-			// This should only be true during page load, where the active
-			// element will be the document.
-			if ( activeElement !== editor.getBody() ) {
-				activeElement.focus();
+			// Create the toolbar by refocussing the editor.
+			if ( document.activeElement === rootNode ) {
+				rootNode.blur();
+				this.editor.focus();
 			}
 		} );
+	}
+
+	focus() {
+		if ( this.editor ) {
+			this.editor.focus();
+		}
 	}
 
 	render() {
 		const { isSelected, id } = this.props;
 
 		return [
+			// Disable reason: Clicking on this visual placeholder should create
+			// the toolbar, it can also be created by focussing the field below.
+			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 			<div
 				key="toolbar"
 				id={ `toolbar-${ id }` }
 				ref={ ref => this.ref = ref }
 				className="freeform-toolbar"
 				style={ ! isSelected ? { display: 'none' } : {} }
+				onClick={ this.focus }
+				data-placeholder={ __( 'Classic' ) }
 			/>,
 			<div
 				key="editor"

--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -131,7 +131,7 @@ export default class OldEditor extends Component {
 	}
 
 	render() {
-		const { isSelected, id } = this.props;
+		const { id } = this.props;
 
 		return [
 			// Disable reason: Clicking on this visual placeholder should create
@@ -142,7 +142,6 @@ export default class OldEditor extends Component {
 				id={ `toolbar-${ id }` }
 				ref={ ref => this.ref = ref }
 				className="freeform-toolbar"
-				style={ ! isSelected ? { display: 'none' } : {} }
 				onClick={ this.focus }
 				data-placeholder={ __( 'Classic' ) }
 			/>,

--- a/blocks/library/freeform/test/__snapshots__/index.js.snap
+++ b/blocks/library/freeform/test/__snapshots__/index.js.snap
@@ -6,7 +6,6 @@ Array [
     class="freeform-toolbar"
     data-placeholder="Classic"
     id="toolbar-undefined"
-    style="display:none"
   />,
   <div
     class="wp-block-freeform blocks-rich-text__tinymce"

--- a/blocks/library/freeform/test/__snapshots__/index.js.snap
+++ b/blocks/library/freeform/test/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`core/freeform block edit matches snapshot 1`] = `
 Array [
   <div
     class="freeform-toolbar"
+    data-placeholder="Classic"
     id="toolbar-undefined"
     style="display:none"
   />,


### PR DESCRIPTION
## Description
Fixes #4926. Gives the classic block the old look.

One problem: the toolbar will only start showing on first time focus. :( @spocke, would it be possible at all to add a setting to the modern/inline theme to always show the toolbar? It might also be good to make a separate "theme" for this as we're not using quite a bit of logic in it.

## How Has This Been Tested?
Create a classic block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.