### PR TITLE
Remove unused code after WP 4.9

### DIFF
--- a/blocks/library/freeform/old-editor.js
+++ b/blocks/library/freeform/old-editor.js
@@ -109,56 +109,6 @@ export default class OldEditor extends Component {
 				editor.dom.toggleClass( ref, 'has-advanced-toolbar', active );
 			},
 		} );
-
-		/* eslint-disable */
-
-		// Re-register WP_More as it doesn't work with inline mode.
-		// This should be fixed in core.
-		// See wp-includes/js/tinymce/plugins/wordpress/plugin.js
-		// Swaps node.nodeName === 'BODY' to node === editor.getBody()
-		editor.on( 'init', () => {
-			editor.addCommand( 'WP_More', function( tag ) {
-				var parent, html, title,
-					classname = 'wp-more-tag',
-					dom = editor.dom,
-					node = editor.selection.getNode(),
-					rootNode = editor.getBody();
-
-				tag = tag || 'more';
-				classname += ' mce-wp-' + tag;
-				title = tag === 'more' ? 'Read more...' : 'Next page';
-				title = editor.editorManager.i18n.translate( title );
-				html = '<img src="' + tinymce.Env.transparentSrc + '" alt="" title="' + title + '" class="' + classname + '" ' +
-					'data-wp-more="' + tag + '" data-mce-resize="false" data-mce-placeholder="1" />';
-
-				// Most common case
-				if ( node === rootNode || ( node.nodeName === 'P' && node.parentNode == rootNode ) ) {
-					editor.insertContent( html );
-					return;
-				}
-
-				// Get the top level parent node
-				parent = dom.getParent( node, function( found ) {
-					if ( found.parentNode && found.parentNode === rootNode ) {
-						return true;
-					}
-
-					return false;
-				}, editor.getBody() );
-
-				if ( parent ) {
-					if ( parent.nodeName === 'P' ) {
-						parent.appendChild( dom.create( 'p', null, html ).firstChild );
-					} else {
-						dom.insertAfter( dom.create( 'p', null, html ), parent );
-					}
-
-					editor.nodeChanged();
-				}
-			} );
-		} );
-
-		/* eslint-enable */
 	}
 
 	render() {

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -86,7 +86,7 @@ add_action( 'admin_menu', 'gutenberg_menu' );
  */
 function gutenberg_wordpress_version_notice() {
 	echo '<div class="error"><p>';
-	echo __( 'Gutenberg requires WordPress 4.8 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
+	echo __( 'Gutenberg requires WordPress 4.9 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
 	echo '</p></div>';
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );
@@ -120,7 +120,7 @@ function gutenberg_pre_init() {
 	// Strip '-src' from the version string. Messes up version_compare().
 	$version = str_replace( '-src', '', $wp_version );
 
-	if ( version_compare( $version, '4.8', '<' ) ) {
+	if ( version_compare( $version, '4.9', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
 		return;
 	}


### PR DESCRIPTION
## Description
This branch removes code adjusted core code for the TinyMCE inline mode to function properly in the classic block. It was fixed as part of WordPress 4.9, so this code is no longer needed.

https://github.com/WordPress/wordpress-develop/commit/9b5781fef96582b8c2f3da0a13a05ad790b02c66#diff-ae1914402704971fe55f9d47f55d4bee

When testing this, I saw that the more tag does not display, but it doesn't seem like this ever worked properly.

## How Has This Been Tested?
Insert a more tag in the classic block. There should be no errors.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.