### PR TITLE
Replace the side inserter by an inserter with shortcuts on empty paragraphs

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -509,6 +509,8 @@ export class RichText extends Component {
 				return;
 			}
 
+			this.onChange( false );
+
 			const forward = event.keyCode === DELETE;
 
 			if ( this.props.onMerge ) {
@@ -721,6 +723,7 @@ export class RichText extends Component {
 			this.updateContent();
 		}
 	}
+
 	componentWillReceiveProps( nextProps ) {
 		if ( 'development' === process.env.NODE_ENV ) {
 			if ( ! isEqual( this.props.formatters, nextProps.formatters ) ) {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -93,7 +93,7 @@ export class RichText extends Component {
 		this.getSettings = this.getSettings.bind( this );
 		this.onSetup = this.onSetup.bind( this );
 		this.onChange = this.onChange.bind( this );
-		this.throttledOnChange = throttle( this.onChange.bind( this ), 500 );
+		this.throttledOnChange = throttle( this.onChange.bind( this, false ), 500, { leading: true } );
 		this.onNewBlock = this.onNewBlock.bind( this );
 		this.onNodeChange = this.onNodeChange.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
@@ -371,12 +371,15 @@ export class RichText extends Component {
 
 	/**
 	 * Handles any case where the content of the tinyMCE instance has changed.
+	 *
+	 * @param {boolean} checkIfDirty Check whether the editor is dirty before calling onChange.
 	 */
-	onChange() {
-		if ( ! this.editor.isDirty() ) {
+	onChange( checkIfDirty = true ) {
+		if ( checkIfDirty && ! this.editor.isDirty() ) {
 			return;
 		}
-		this.savedContent = this.state.empty ? [] : this.getContent();
+		const isEmpty = tinymce.DOM.isEmpty( this.editor.getBody() );
+		this.savedContent = isEmpty ? [] : this.getContent();
 		this.props.onChange( this.savedContent );
 		this.editor.save();
 	}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -17,6 +17,7 @@ import {
 	getBlockType,
 	getSaveElement,
 	isReusableBlock,
+	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
 import { withFilters, withContext, withAPIData } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -25,7 +26,6 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import BlockMover from '../block-mover';
-import VisualEditorInserter from '../inserter';
 import BlockDropZone from '../block-drop-zone';
 import BlockSettingsMenu from '../block-settings-menu';
 import InvalidBlockWarning from './invalid-block-warning';
@@ -37,6 +37,7 @@ import BlockMultiControls from './multi-controls';
 import BlockMobileToolbar from './block-mobile-toolbar';
 import BlockInsertionPoint from './insertion-point';
 import IgnoreNestedEvents from './ignore-nested-events';
+import InserterWithShortcuts from '../inserter-with-shortcuts';
 import { createInnerBlockList } from './utils';
 import {
 	clearSelectedBlock,
@@ -522,13 +523,6 @@ export class BlockListBlock extends Component {
 					layout={ layout }
 				/>
 				{ ( showUI || isHovered ) && (
-					<VisualEditorInserter
-						onToggle={ this.selectOnOpen }
-						rootUID={ rootUID }
-						layout={ layout }
-					/>
-				) }
-				{ ( showUI || isHovered ) && (
 					<BlockMover
 						uids={ [ block.uid ] }
 						rootUID={ rootUID }
@@ -593,6 +587,11 @@ export class BlockListBlock extends Component {
 					rootUID={ rootUID }
 					layout={ layout }
 				/>
+				{ ( showUI || isHovered ) && isUnmodifiedDefaultBlock( block ) && (
+					<div className="editor-block-list__side-inserter">
+						<InserterWithShortcuts uid={ block.uid } layout={ layout } onToggle={ this.selectOnOpen } />
+					</div>
+				) }
 			</IgnoreNestedEvents>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -586,11 +586,13 @@ export class BlockListBlock extends Component {
 					{ showUI && <BlockMobileToolbar uid={ block.uid } renderBlockMenu={ renderBlockMenu } /> }
 				</IgnoreNestedEvents>
 				{ !! error && <BlockCrashWarning /> }
-				<BlockInsertionPoint
-					uid={ block.uid }
-					rootUID={ rootUID }
-					layout={ layout }
-				/>
+				{ ! showSideInserter && (
+					<BlockInsertionPoint
+						uid={ block.uid }
+						rootUID={ rootUID }
+						layout={ layout }
+					/>
+				) }
 				{ showSideInserter && (
 					<div className="editor-block-list__side-inserter">
 						<InserterWithShortcuts uid={ block.uid } layout={ layout } onToggle={ this.selectOnOpen } />

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -459,6 +459,10 @@ export class BlockListBlock extends Component {
 			rootUID,
 			layout,
 			renderBlockMenu,
+			isHovered,
+			isSelected,
+			isMultiSelected,
+			isFirstMultiSelected,
 		} = this.props;
 		const { name: blockName, isValid } = block;
 		const blockType = getBlockType( blockName );
@@ -467,13 +471,13 @@ export class BlockListBlock extends Component {
 		// The block as rendered in the editor is composed of general block UI
 		// (mover, toolbar, wrapper) and the display of the block content.
 
-		// Generate the wrapper class names handling the different states of the block.
-		const { isHovered, isSelected, isMultiSelected, isFirstMultiSelected } = this.props;
-
 		// If the block is selected and we're typing we hide the sidebar
 		// unless the selection is not collapsed.
+		const showSideInserter = ( isSelected || isHovered ) && isUnmodifiedDefaultBlock( block );
 		const showUI = isSelected && ( ! this.props.isTyping || ! this.state.isSelectionCollapsed );
 		const { error } = this.state;
+
+		// Generate the wrapper class names handling the different states of the block.
 		const wrapperClassName = classnames( 'editor-block-list__block', {
 			'has-warning': ! isValid || !! error,
 			'is-selected': showUI,
@@ -587,7 +591,7 @@ export class BlockListBlock extends Component {
 					rootUID={ rootUID }
 					layout={ layout }
 				/>
-				{ ( showUI || isHovered ) && isUnmodifiedDefaultBlock( block ) && (
+				{ showSideInserter && (
 					<div className="editor-block-list__side-inserter">
 						<InserterWithShortcuts uid={ block.uid } layout={ layout } onToggle={ this.selectOnOpen } />
 					</div>

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -275,41 +275,6 @@
 		}
 	}
 
-	// Left side inserter
-	> .editor-inserter {
-		position: absolute;
-		left: 2px;
-		top: 16px;
-
-		// Mobile
-		display: none;
-		@include break-small {
-			display: block;
-		}
-
-		.editor-inserter__toggle {
-			width: $icon-button-size-small;
-			padding: 2px;
-
-			// Adjust inserter design
-			box-shadow: inset 0 0 0 1px $light-gray-500;
-			border-radius: 50%;
-
-			// Hide the outer ring on the inserter, to visually lighten it
-			&:before {
-				content: '';
-				position: absolute;
-				top: 2px;
-				right: 2px;
-				bottom: 2px;
-				left: 2px;
-				display: block;
-				border: 4px solid $white;
-				border-radius: 50%;
-			}
-		}
-	}
-
 	// Left and right side UI
 	> .editor-block-settings-menu,
 	> .editor-block-mover {
@@ -508,4 +473,14 @@ $sticky-bottom-offset: 20px;
 	// prevent collapsing margins between block and toolbar, matches the 20px bottom offset		 +		display: flex;
 	margin-top: - $sticky-bottom-offset - 1px;
 	padding-top: 2px;
+}
+
+.editor-block-list__side-inserter {
+	position: absolute;
+	top: 10px;
+	right: 10px;
+
+	@include break-small {
+		right: $block-mover-padding-visible + 10px;
+	}
 }

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { filter } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { BlockIcon, createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { compose } from '@wordpress/element';
+import { IconButton, withContext } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import Inserter from '../inserter';
+import { getRecentInserterItems } from '../../store/selectors';
+import { replaceBlocks } from '../../store/actions';
+
+function InserterWithShortcuts( { items, isLocked, onToggle, onInsert } ) {
+	if ( isLocked ) {
+		return null;
+	}
+
+	const itemsWithTheDefaultBlock =
+		filter( items, ( item ) => item.name !== getDefaultBlockName() || ! item.initialAttributes )
+			.slice( 0, 2 );
+
+	return (
+		<div className="editor-inserter-with-shortcuts">
+			<Inserter
+				position="top left"
+				onToggle={ onToggle }
+			/>
+
+			{ itemsWithTheDefaultBlock.map( ( item ) => (
+				<IconButton
+					key={ item.id }
+					className="editor-inserter-with-shortcuts__block"
+					onClick={ () => onInsert( item ) }
+					label={ sprintf( __( 'Add %s' ), item.title ) }
+					icon={ (
+						<span className="editor-inserter-with-shortcuts__block-icon">
+							<BlockIcon icon={ item.icon } />
+						</span>
+					) }
+				/>
+			) ) }
+		</div>
+	);
+}
+
+export default compose(
+	connect(
+		( state ) => ( {
+			items: getRecentInserterItems( state, true, 3 ),
+		} ),
+		( dispatch, { uid, layout } ) => ( {
+			onInsert( { name, initialAttributes } ) {
+				const block = createBlock( name, { ...initialAttributes, layout } );
+				return dispatch( replaceBlocks( uid, block ) );
+			},
+		} )
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
+
+		return {
+			isLocked: !! templateLock,
+		};
+	} ),
+)( InserterWithShortcuts );

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -17,7 +17,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import './style.scss';
 import Inserter from '../inserter';
-import { getRecentInserterItems } from '../../store/selectors';
+import { getMostFrequentlyUsedBlocks } from '../../store/selectors';
 import { replaceBlocks } from '../../store/actions';
 
 function InserterWithShortcuts( { items, isLocked, onToggle, onInsert } ) {
@@ -56,7 +56,7 @@ function InserterWithShortcuts( { items, isLocked, onToggle, onInsert } ) {
 export default compose(
 	connect(
 		( state ) => ( {
-			items: getRecentInserterItems( state, true, 3 ),
+			items: getMostFrequentlyUsedBlocks( state, true, 3 ),
 		} ),
 		( dispatch, { uid, layout } ) => ( {
 			onInsert( { name, initialAttributes } ) {

--- a/editor/components/inserter-with-shortcuts/style.scss
+++ b/editor/components/inserter-with-shortcuts/style.scss
@@ -1,0 +1,13 @@
+.editor-inserter-with-shortcuts {
+	display: flex;
+	align-items: center;
+	flex-direction: row-reverse;
+}
+
+.editor-inserter-with-shortcuts__block {
+	margin-right: 5px;
+	width: 36px;
+	height: 36px;
+	border-radius: 0;
+	padding-top: 8px;
+}

--- a/editor/components/inserter-with-shortcuts/style.scss
+++ b/editor/components/inserter-with-shortcuts/style.scss
@@ -2,12 +2,15 @@
 	display: flex;
 	align-items: center;
 	flex-direction: row-reverse;
+
+	.components-icon-button {
+		border-radius: $button-style__radius-roundrect;
+	}
 }
 
 .editor-inserter-with-shortcuts__block {
 	margin-right: 5px;
 	width: 36px;
 	height: 36px;
-	border-radius: 0;
 	padding-top: 8px;
 }

--- a/editor/store/defaults.js
+++ b/editor/store/defaults.js
@@ -1,3 +1,4 @@
 export const PREFERENCES_DEFAULTS = {
 	recentInserts: [],
+	insertUsage: {},
 };

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -621,10 +621,6 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					insert.ref = block.attributes.ref;
 					id += '/' + block.attributes.ref;
 				}
-				const usage = prevState.insertUsage[ id ] ?
-					{ ...prevState.insertUsage[ id ] } :
-					{ count: 0, insert };
-				usage.count = usage.count + 1;
 
 				const isSameAsInsert = ( { name, ref } ) => name === insert.name && ref === insert.ref;
 
@@ -636,7 +632,10 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					],
 					insertUsage: {
 						...prevState.insertUsage,
-						[ id ]: usage,
+						[ id ]: {
+							count: prevState.insertUsage[ id ] ? prevState.insertUsage[ id ].count + 1 : 1,
+							insert,
+						},
 					},
 				};
 			}, state );

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1198,10 +1198,11 @@ const getRecentInserts = createSelector(
  *
  * @param {Object}           state             Global application state.
  * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
+ * @param {number}           maximum           Number of items to return.
  *
  * @return {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
  */
-export function getRecentInserterItems( state, enabledBlockTypes = true ) {
+export function getRecentInserterItems( state, enabledBlockTypes = true, maximum = MAX_RECENT_BLOCKS ) {
 	if ( ! enabledBlockTypes ) {
 		return [];
 	}
@@ -1216,7 +1217,7 @@ export function getRecentInserterItems( state, enabledBlockTypes = true ) {
 		return buildInserterItemFromBlockType( state, enabledBlockTypes, blockType );
 	} );
 
-	return compact( items ).slice( 0, MAX_RECENT_BLOCKS );
+	return compact( items ).slice( 0, maximum );
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1223,7 +1223,7 @@ export function getRecentInserterItems( state, enabledBlockTypes = true, maximum
 }
 
 /**
- * Determines the items that appear in the inserter with shortcodes based on the block usage
+ * Determines the items that appear in the inserter with shortcuts based on the block usage
  *
  * @param {Object}           state             Global application state.
  * @param {string[]|boolean} enabledBlockTypes Enabled block types, or true/false to enable/disable all types.
@@ -1231,7 +1231,7 @@ export function getRecentInserterItems( state, enabledBlockTypes = true, maximum
  *
  * @return {Editor.InserterItem[]} Items that appear in the 'Recent' tab.
  */
-export function getMostFrequentlyUsedBlocks( state, enabledBlockTypes = true, maximum = MAX_RECENT_BLOCKS ) {
+export function getFrequentInserterItems( state, enabledBlockTypes = true, maximum = MAX_RECENT_BLOCKS ) {
 	const sortedInserts = values( state.preferences.insertUsage )
 		.sort( ( a, b ) => b.count - a.count )
 		.map( ( { insert } ) => insert );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1163,11 +1163,12 @@ describe( 'state', () => {
 
 			expect( state ).toEqual( {
 				recentInserts: [],
+				insertUsage: {},
 			} );
 		} );
 
 		it( 'should record recently used blocks', () => {
-			const state = preferences( deepFreeze( { recentInserts: [] } ), {
+			const state = preferences( deepFreeze( { recentInserts: [], insertUsage: {} } ), {
 				type: 'INSERT_BLOCKS',
 				blocks: [ {
 					uid: 'bacon',
@@ -1179,9 +1180,23 @@ describe( 'state', () => {
 				recentInserts: [
 					{ name: 'core-embed/twitter' },
 				],
+				insertUsage: {
+					'core-embed/twitter': {
+						count: 1,
+						insert: { name: 'core-embed/twitter' },
+					},
+				},
 			} );
 
-			const twoRecentBlocks = preferences( deepFreeze( { recentInserts: [] } ), {
+			const twoRecentBlocks = preferences( deepFreeze( {
+				recentInserts: [],
+				insertUsage: {
+					'core-embed/twitter': {
+						count: 1,
+						insert: { name: 'core-embed/twitter' },
+					},
+				},
+			} ), {
 				type: 'INSERT_BLOCKS',
 				blocks: [ {
 					uid: 'eggs',
@@ -1198,6 +1213,16 @@ describe( 'state', () => {
 					{ name: 'core/block', ref: 123 },
 					{ name: 'core-embed/twitter' },
 				],
+				insertUsage: {
+					'core-embed/twitter': {
+						count: 2,
+						insert: { name: 'core-embed/twitter' },
+					},
+					'core/block/123': {
+						count: 1,
+						insert: { name: 'core/block', ref: 123 },
+					},
+				},
 			} );
 		} );
 
@@ -1208,6 +1233,12 @@ describe( 'state', () => {
 					{ name: 'core/block', ref: 123 },
 					{ name: 'core/block', ref: 456 },
 				],
+				insertUsage: {
+					'core/block/123': {
+						count: 1,
+						insert: { name: 'core/block', ref: 123 },
+					},
+				},
 			};
 
 			const state = preferences( deepFreeze( initialState ), {
@@ -1220,6 +1251,7 @@ describe( 'state', () => {
 					{ name: 'core-embed/twitter' },
 					{ name: 'core/block', ref: 456 },
 				],
+				insertUsage: {},
 			} );
 		} );
 	} );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -75,7 +75,7 @@ const {
 	isPublishingPost,
 	getInserterItems,
 	getRecentInserterItems,
-	getMostFrequentlyUsedBlocks,
+	getFrequentInserterItems,
 	POST_UPDATE_TRANSACTION_ID,
 } = selectors;
 
@@ -2200,7 +2200,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getMostFrequentlyUsedBlocks', () => {
+	describe( 'getFrequentInserterItems', () => {
 		beforeAll( () => {
 			registerCoreBlocks();
 		} );
@@ -2228,7 +2228,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getMostFrequentlyUsedBlocks( state, true, 3 ) ).toMatchObject( [
+			expect( getFrequentInserterItems( state, true, 3 ) ).toMatchObject( [
 				{ name: 'core/block', initialAttributes: { ref: 123 } },
 				{ name: 'core/image', initialAttributes: {} },
 				{ name: 'core/paragraph', initialAttributes: {} },
@@ -2249,8 +2249,8 @@ describe( 'selectors', () => {
 				},
 			};
 
-			// We should get back 8 items with no duplicates
-			const items = getMostFrequentlyUsedBlocks( state, true, 4 );
+			// We should get back 4 items with no duplicates
+			const items = getFrequentInserterItems( state, true, 4 );
 			const blockNames = items.map( item => item.name );
 			expect( union( blockNames ) ).toHaveLength( 4 );
 		} );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -75,6 +75,7 @@ const {
 	isPublishingPost,
 	getInserterItems,
 	getRecentInserterItems,
+	getMostFrequentlyUsedBlocks,
 	POST_UPDATE_TRANSACTION_ID,
 } = selectors;
 
@@ -2196,6 +2197,62 @@ describe( 'selectors', () => {
 			const items = getRecentInserterItems( state );
 			const blockNames = items.map( item => item.name );
 			expect( union( blockNames ) ).toHaveLength( 8 );
+		} );
+	} );
+
+	describe( 'getMostFrequentlyUsedBlocks', () => {
+		beforeAll( () => {
+			registerCoreBlocks();
+		} );
+
+		it( 'should return the 8 most recently used blocks', () => {
+			const state = {
+				preferences: {
+					insertUsage: {
+						'core/deleted-block': { count: 10, insert: { name: 'core/deleted-block' } }, // Deleted blocks should be filtered out
+						'core/block/456': { count: 4, insert: { name: 'core/block', ref: 456 } }, // Deleted reusable blocks should be filtered out
+						'core/image': { count: 3, insert: { name: 'core/image' } },
+						'core/block/123': { count: 5, insert: { name: 'core/block', ref: 123 } },
+						'core/paragraph': { count: 2, insert: { name: 'core/paragraph' } },
+					},
+				},
+				editor: {
+					present: {
+						blockOrder: [],
+					},
+				},
+				reusableBlocks: {
+					data: {
+						123: { id: 123, type: 'core/test-block' },
+					},
+				},
+			};
+
+			expect( getMostFrequentlyUsedBlocks( state, true, 3 ) ).toMatchObject( [
+				{ name: 'core/block', initialAttributes: { ref: 123 } },
+				{ name: 'core/image', initialAttributes: {} },
+				{ name: 'core/paragraph', initialAttributes: {} },
+			] );
+		} );
+
+		it( 'should pad list out with blocks from the common category', () => {
+			const state = {
+				preferences: {
+					insertUsage: {
+						'core/image': { count: 2, insert: { name: 'core/paragraph' } },
+					},
+				},
+				editor: {
+					present: {
+						blockOrder: [],
+					},
+				},
+			};
+
+			// We should get back 8 items with no duplicates
+			const items = getMostFrequentlyUsedBlocks( state, true, 4 );
+			const blockNames = items.map( item => item.name );
+			expect( union( blockNames ) ).toHaveLength( 4 );
 		} );
 	} );
 

--- a/test/e2e/integration/004-managing-links.js
+++ b/test/e2e/integration/004-managing-links.js
@@ -45,11 +45,16 @@ describe( 'Managing links', () => {
 		const lastBlockSelector = '.editor-block-list__block-edit:last [contenteditable="true"]:first';
 
 		cy.get( lastBlockSelector ).click();
+		cy.focused().type( 'test' );
+
+		// we need to trigger isTyping = false
+		cy.get( lastBlockSelector ).trigger( 'mousemove', { clientX: 200, clientY: 300 } );
+		cy.get( lastBlockSelector ).trigger( 'mousemove', { clientX: 250, clientY: 350 } );
 
 		cy.get( 'button[aria-label="Link"]' ).click();
 
 		// Typing "left" should not close the dialog
-		cy.focused().type( '{leftarrow}' );
+		cy.get( '.blocks-url-input input' ).type( '{leftarrow}' );
 		cy.get( '.blocks-format-toolbar__link-modal' ).should( 'be.visible' );
 
 		// Escape should close the dialog still.


### PR DESCRIPTION
closes #4951 

This PR updates the side inserter. Instead of having a side inserter at the right of each block we show a quick inserter with shortcuts for the most frequently used blocks on empty paragraphs.

Combined with the default block appender, this allows a nice writing flow, where you click the empty area at the bottom of a post to create a new empty paragraph which will trigger this side inserter.

