### PR TITLE
RichText Trigger onChange on input

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -13,6 +13,7 @@ import {
 	find,
 	defer,
 	noop,
+	throttle,
 } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 import 'element-closest';
@@ -92,6 +93,7 @@ export class RichText extends Component {
 		this.getSettings = this.getSettings.bind( this );
 		this.onSetup = this.onSetup.bind( this );
 		this.onChange = this.onChange.bind( this );
+		this.throttledOnChange = throttle( this.onChange.bind( this ), 500 );
 		this.onNewBlock = this.onNewBlock.bind( this );
 		this.onNodeChange = this.onNodeChange.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
@@ -149,7 +151,7 @@ export class RichText extends Component {
 		editor.on( 'BeforeExecCommand', this.maybePropagateUndo );
 		editor.on( 'PastePreProcess', this.onPastePreProcess, true /* Add before core handlers */ );
 		editor.on( 'paste', this.onPaste, true /* Add before core handlers */ );
-		editor.on( 'input', this.onChange );
+		editor.on( 'input', this.throttledOnChange );
 
 		patterns.apply( this, [ editor ] );
 

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -149,6 +149,7 @@ export class RichText extends Component {
 		editor.on( 'BeforeExecCommand', this.maybePropagateUndo );
 		editor.on( 'PastePreProcess', this.onPastePreProcess, true /* Add before core handlers */ );
 		editor.on( 'paste', this.onPaste, true /* Add before core handlers */ );
+		editor.on( 'input', this.onChange );
 
 		patterns.apply( this, [ editor ] );
 
@@ -366,21 +367,12 @@ export class RichText extends Component {
 		}
 	}
 
-	fireChange() {
-		this.savedContent = this.getContent();
-		this.editor.save();
-		this.props.onChange( this.state.empty ? [] : this.savedContent );
-	}
-
 	/**
 	 * Handles any case where the content of the tinyMCE instance has changed.
 	 */
 	onChange() {
-		// Note that due to efficiency, speed and low cost requirements isDirty may
-		// not reflect reality for a brief period immediately after a change.
-		if ( this.editor.isDirty() ) {
-			this.fireChange();
-		}
+		this.savedContent = this.state.empty ? [] : this.getContent();
+		this.props.onChange( this.savedContent );
 	}
 
 	/**
@@ -507,8 +499,6 @@ export class RichText extends Component {
 			if ( ! this.props.onMerge && ! this.props.onRemove ) {
 				return;
 			}
-
-			this.fireChange();
 
 			const forward = event.keyCode === DELETE;
 
@@ -692,19 +682,10 @@ export class RichText extends Component {
 		this.savedContent = this.props.value;
 		this.setContent( this.savedContent );
 		this.editor.selection.moveToBookmark( bookmark );
-
-		// Saving the editor on updates avoid unecessary onChanges calls
-		// These calls can make the focus jump
-		this.editor.save();
 	}
 
-	setContent( content ) {
-		if ( ! content ) {
-			content = '';
-		}
-
-		content = renderToString( content );
-		this.editor.setContent( content );
+	setContent( content = '' ) {
+		this.editor.setContent( renderToString( content ) );
 	}
 
 	getContent() {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -373,8 +373,12 @@ export class RichText extends Component {
 	 * Handles any case where the content of the tinyMCE instance has changed.
 	 */
 	onChange() {
+		if ( ! this.editor.isDirty() ) {
+			return;
+		}
 		this.savedContent = this.state.empty ? [] : this.getContent();
 		this.props.onChange( this.savedContent );
+		this.editor.save();
 	}
 
 	/**
@@ -684,6 +688,10 @@ export class RichText extends Component {
 		this.savedContent = this.props.value;
 		this.setContent( this.savedContent );
 		this.editor.selection.moveToBookmark( bookmark );
+
+		// Saving the editor on updates avoid unecessary onChanges calls
+		// These calls can make the focus jump
+		this.editor.save();
 	}
 
 	setContent( content = '' ) {
@@ -727,6 +735,7 @@ export class RichText extends Component {
 		this.editor.focus();
 		this.editor.formatter.remove( format );
 	}
+
 	applyFormat( format, args, node ) {
 		this.editor.focus();
 		this.editor.formatter.apply( format, args, node );

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -703,14 +703,11 @@ export class RichText extends Component {
 		if (
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
-			this.props.value !== this.savedContent &&
-			! isEqual( this.props.value, prevProps.value ) &&
-			! isEqual( this.props.value, this.savedContent )
+			this.props.value !== this.savedContent
 		) {
 			this.updateContent();
 		}
 	}
-
 	componentWillReceiveProps( nextProps ) {
 		if ( 'development' === process.env.NODE_ENV ) {
 			if ( ! isEqual( this.props.formatters, nextProps.formatters ) ) {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -701,6 +701,7 @@ export class RichText extends Component {
 	componentDidUpdate( prevProps ) {
 		// The `savedContent` var allows us to avoid updating the content right after an `onChange` call
 		if (
+			!! this.editor &&
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
 			this.props.value !== this.savedContent

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -696,6 +696,7 @@ export class RichText extends Component {
 
 	componentWillUnmount() {
 		this.onChange();
+		this.throttledOnChange.cancel();
 	}
 
 	componentDidUpdate( prevProps ) {


### PR DESCRIPTION
This will be necessary to achieve #4951 

It also fixes some issues while the save draft link doesn't show up until we focus out of the component.
It may introduce a difference in a way undo/redo works but I believe we should handle those consistently (it's not the case right now, RichText triggers and undo state per word while PlainText it's per character). I'm thinking we could use the `withHistory` a Reducer enhancer to group similar changes into one undo level.

**Testing instructions**

 - Test several writing flow interactions