### PR TITLE
Proposal: history "buffer"/overwrite, sync RichText history records

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -146,7 +146,7 @@ export class RichText extends Component {
 			selectedNodeId: 0,
 		};
 
-		this.isEmpty = ! value || ! value.length || ( value.length === 1 && ! value[ 0 ] );
+		this.isEmpty = ! value || ! value.length;
 	}
 
 	/**

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -609,7 +609,8 @@ export class RichText extends Component {
 	 * @param {number} keyCode The key code that has been pressed on the keyboard.
 	 */
 	onKeyUp( { keyCode } ) {
-		// See https://bugs.chromium.org/p/chromium/issues/detail?id=725890
+		// The input event does not fire when the whole field is selected and
+		// BACKSPACE is pressed.
 		if ( keyCode === BACKSPACE ) {
 			this.onChange();
 		}

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -710,6 +710,18 @@ export class RichText extends Component {
 		this.setState( { formats, focusPosition, selectedNodeId: this.state.selectedNodeId + 1 } );
 	}
 
+	updateContent() {
+		// Do not trigger a change event coming from the TinyMCE undo manager.
+		// Our global state is already up-to-date.
+		this.editor.undoManager.ignore( () => {
+			const bookmark = this.editor.selection.getBookmark( 2, true );
+
+			this.savedContent = this.props.value;
+			this.setContent( this.savedContent );
+			this.editor.selection.moveToBookmark( bookmark );
+		} );
+	}
+
 	setContent( content = '' ) {
 		this.editor.setContent( renderToString( content ) );
 	}
@@ -730,14 +742,7 @@ export class RichText extends Component {
 			this.props.value !== prevProps.value &&
 			this.props.value !== this.savedContent
 		) {
-			// Do not trigger a `addUndo` event.
-			this.editor.undoManager.ignore( () => {
-				const bookmark = this.editor.selection.getBookmark( 2, true );
-
-				this.savedContent = this.props.value;
-				this.setContent( this.savedContent );
-				this.editor.selection.moveToBookmark( bookmark );
-			} );
+			this.updateContent();
 		}
 	}
 

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -138,7 +138,6 @@ export class RichText extends Component {
 		this.onPropagateUndo = this.onPropagateUndo.bind( this );
 		this.onPastePreProcess = this.onPastePreProcess.bind( this );
 		this.onPaste = this.onPaste.bind( this );
-		this.onAddUndo = this.onAddUndo.bind( this );
 		this.onCreateUndoLevel = this.onCreateUndoLevel.bind( this );
 
 		this.state = {
@@ -191,7 +190,8 @@ export class RichText extends Component {
 		editor.on( 'PastePreProcess', this.onPastePreProcess, true /* Add before core handlers */ );
 		editor.on( 'paste', this.onPaste, true /* Add before core handlers */ );
 		editor.on( 'input', this.onChange );
-		editor.on( 'addundo', this.onAddUndo );
+		// The change event in TinyMCE fires every time an undo level is added.
+		editor.on( 'change', this.onCreateUndoLevel );
 
 		patterns.apply( this, [ editor ] );
 
@@ -400,14 +400,6 @@ export class RichText extends Component {
 		this.isEmpty = this.editor.dom.isEmpty( this.editor.getBody() );
 		this.savedContent = this.isEmpty ? [] : this.getContent();
 		this.props.onChange( this.savedContent );
-	}
-
-	onAddUndo( { lastLevel } ) {
-		if ( ! lastLevel ) {
-			return;
-		}
-
-		this.onCreateUndoLevel();
 	}
 
 	onCreateUndoLevel() {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -143,7 +143,6 @@ export class RichText extends Component {
 
 		this.state = {
 			formats: {},
-			empty: ! value || ! value.length,
 			selectedNodeId: 0,
 		};
 
@@ -251,11 +250,16 @@ export class RichText extends Component {
 	 * @param {UndoEvent} event The undo event as triggered by TinyMCE.
 	 */
 	onPropagateUndo( event ) {
-		const { onUndo } = this.context;
+		const { onUndo, onRedo } = this.context;
 		const { command } = event;
 
-		if ( onUndo && ( command === 'Undo' || command === 'Redo' ) ) {
+		if ( command === 'Undo' && onUndo ) {
 			defer( onUndo );
+			event.preventDefault();
+		}
+
+		if ( command === 'Redo' && onRedo ) {
+			defer( onRedo );
 			event.preventDefault();
 		}
 	}
@@ -874,6 +878,7 @@ export class RichText extends Component {
 
 RichText.contextTypes = {
 	onUndo: noop,
+	onRedo: noop,
 	canUserUseUnfilteredHTML: noop,
 	onCreateUndoLevel: noop,
 };

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -735,11 +735,14 @@ export class RichText extends Component {
 			this.props.value !== prevProps.value &&
 			this.props.value !== this.savedContent
 		) {
-			const bookmark = this.editor.selection.getBookmark( 2, true );
+			// Do not trigger a `addUndo` event.
+			this.editor.undoManager.ignore( () => {
+				const bookmark = this.editor.selection.getBookmark( 2, true );
 
-			this.savedContent = this.props.value;
-			this.setContent( this.savedContent );
-			this.editor.selection.moveToBookmark( bookmark );
+				this.savedContent = this.props.value;
+				this.setContent( this.savedContent );
+				this.editor.selection.moveToBookmark( bookmark );
+			} );
 		}
 	}
 

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -392,8 +392,6 @@ export class RichText extends Component {
 
 	/**
 	 * Handles any case where the content of the tinyMCE instance has changed.
-	 *
-	 * @param {boolean} checkIfDirty Check whether the editor is dirty before calling onChange.
 	 */
 
 	onChange() {
@@ -791,8 +789,6 @@ export class RichText extends Component {
 		this.setState( ( state ) => ( {
 			formats: merge( {}, state.formats, formats ),
 		} ) );
-
-		this.editor.setDirty( true );
 	}
 
 	render() {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -162,6 +162,9 @@ export class RichText extends Component {
 		return ( this.props.getSettings || identity )( {
 			...settings,
 			forced_root_block: this.props.multiline || false,
+			// Allow TinyMCE to keep one undo level for comparing changes.
+			// Prevent it otherwise from accumulating any history.
+			custom_undo_redo_levels: 1,
 		} );
 	}
 

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -585,7 +585,6 @@ export class RichText extends Component {
 				const beforeElement = nodeListToReact( beforeNodes, createTinyMCEElement );
 				const afterElement = nodeListToReact( afterNodes, createTinyMCEElement );
 
-				this.setContent( beforeElement );
 				this.props.onSplit( beforeElement, afterElement );
 			} else {
 				event.preventDefault();
@@ -644,10 +643,8 @@ export class RichText extends Component {
 
 			const beforeElement = nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
 			const afterElement = nodeListToReact( filterEmptyNodes( afterFragment.childNodes ), createTinyMCEElement );
-			this.setContent( beforeElement );
 			this.props.onSplit( beforeElement, afterElement, ...blocks );
 		} else {
-			this.setContent( [] );
 			this.props.onSplit( [], [], ...blocks );
 		}
 	}

--- a/blocks/rich-text/provider.js
+++ b/blocks/rich-text/provider.js
@@ -29,6 +29,7 @@ class RichTextProvider extends Component {
 
 RichTextProvider.childContextTypes = {
 	onUndo: noop,
+	onRedo: noop,
 	onCreateUndoLevel: noop,
 };
 

--- a/blocks/rich-text/provider.js
+++ b/blocks/rich-text/provider.js
@@ -29,6 +29,7 @@ class RichTextProvider extends Component {
 
 RichTextProvider.childContextTypes = {
 	onUndo: noop,
+	onCreateUndoLevel: noop,
 };
 
 export default RichTextProvider;

--- a/blocks/rich-text/test/index.js
+++ b/blocks/rich-text/test/index.js
@@ -219,6 +219,7 @@ describe( 'RichText', () => {
 				expect( wrapper.instance().getSettings( settings ) ).toEqual( {
 					setting: 'hi',
 					forced_root_block: false,
+					custom_undo_redo_levels: 1,
 				} );
 			} );
 

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -19,7 +19,7 @@ import {
 /**
  * Internal Dependencies
  */
-import { setupEditor, undo, initializeMetaBoxState } from '../../store/actions';
+import { setupEditor, undo, createUndoLevel, initializeMetaBoxState } from '../../store/actions';
 import store from '../../store';
 
 /**
@@ -105,10 +105,12 @@ class EditorProvider extends Component {
 			// RichText provider:
 			//
 			//  - context.onUndo
+			//  - context.onCreateUndoLevel
 			[
 				RichTextProvider,
 				bindActionCreators( {
 					onUndo: undo,
+					onCreateUndoLevel: createUndoLevel,
 				}, this.store.dispatch ),
 			],
 

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -19,7 +19,7 @@ import {
 /**
  * Internal Dependencies
  */
-import { setupEditor, undo, createUndoLevel, initializeMetaBoxState } from '../../store/actions';
+import { setupEditor, undo, redo, createUndoLevel, initializeMetaBoxState } from '../../store/actions';
 import store from '../../store';
 
 /**
@@ -105,11 +105,13 @@ class EditorProvider extends Component {
 			// RichText provider:
 			//
 			//  - context.onUndo
+			//  - context.onRedo
 			//  - context.onCreateUndoLevel
 			[
 				RichTextProvider,
 				bindActionCreators( {
 					onUndo: undo,
+					onRedo: redo,
 					onCreateUndoLevel: createUndoLevel,
 				}, this.store.dispatch ),
 			],

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -302,6 +302,12 @@ export function undo() {
 	return { type: 'UNDO' };
 }
 
+/**
+ * Returns an action object used in signalling that undo history record should
+ * be created.
+ *
+ * @return {Object} Action object.
+ */
 export function createUndoLevel() {
 	return { type: 'CREATE_UNDO_LEVEL' };
 }

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -302,6 +302,10 @@ export function undo() {
 	return { type: 'UNDO' };
 }
 
+export function createUndoLevel() {
+	return { type: 'CREATE_UNDO_LEVEL' };
+}
+
 /**
  * Returns an action object used in signalling that the blocks
  * corresponding to the specified UID set are to be removed.

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -15,7 +15,6 @@ import {
 	findIndex,
 	reject,
 	omitBy,
-	includes,
 	keys,
 	isEqual,
 } from 'lodash';
@@ -99,6 +98,31 @@ function getFlattenedBlocks( blocks ) {
 }
 
 /**
+ * Option for the history reducer. When the block ID and updated attirbute keys
+ * are the same as previously, the history reducer should overwrite its present
+ * state.
+ *
+ * @param {Object} action         The currently dispatched action.
+ * @param {Object} previousAction The previously dispatched action.
+ *
+ * @return {boolean} Whether or not to overwrite present state.
+ */
+function shouldOverwriteState( action, previousAction ) {
+	if (
+		previousAction &&
+		action.type === 'UPDATE_BLOCK_ATTRIBUTES' &&
+		action.type === previousAction.type
+	) {
+		const attributes = keys( action.attributes );
+		const previousAttributes = keys( previousAction.attributes );
+
+		return action.uid === previousAction.uid && isEqual( attributes, previousAttributes );
+	}
+
+	return false;
+}
+
+/**
  * Undoable reducer returning the editor post state, including blocks parsed
  * from current HTML markup.
  *
@@ -120,24 +144,7 @@ export const editor = flow( [
 	// Track undo history, starting at editor initialization.
 	partialRight( withHistory, {
 		resetTypes: [ 'SETUP_NEW_POST', 'SETUP_EDITOR' ],
-		shouldOverwriteState( action, previousAction ) {
-			if ( ! includes( [ 'UPDATE_BLOCK_ATTRIBUTES', 'EDIT_POST', 'RESET_POST' ], action.type ) ) {
-				return false;
-			}
-
-			if (
-				previousAction &&
-				action.type === 'UPDATE_BLOCK_ATTRIBUTES' &&
-				action.type === previousAction.type
-			) {
-				const attributes = keys( action.attributes );
-				const previousAttributes = keys( previousAction.attributes );
-
-				return action.uid === previousAction.uid && isEqual( attributes, previousAttributes );
-			}
-
-			return true;
-		},
+		shouldOverwriteState,
 	} ),
 
 	// Track whether changes exist, resetting at each post save. Relies on

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -97,8 +97,7 @@ export function isSavingMetaBoxes( state ) {
  * @return {boolean} Whether undo history exists.
  */
 export function hasEditorUndo( state ) {
-	const { past, present } = state.editor;
-	return past.length > 1 || last( past ) !== present;
+	return state.editor.past.length > 0;
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -97,7 +97,8 @@ export function isSavingMetaBoxes( state ) {
  * @return {boolean} Whether undo history exists.
  */
 export function hasEditorUndo( state ) {
-	return state.editor.past.length > 0;
+	const { past, present } = state.editor;
+	return past.length > 1 || last( past ) !== present;
 }
 
 /**

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -72,7 +72,7 @@ describe( 'state', () => {
 		it( 'should return history (empty edits, blocksByUid, blockOrder), dirty flag by default', () => {
 			const state = editor( undefined, {} );
 
-			expect( state.past ).toEqual( [] );
+			expect( state.past ).toEqual( [ state.present ] );
 			expect( state.future ).toEqual( [] );
 			expect( state.present.edits ).toEqual( {} );
 			expect( state.present.blocksByUid ).toEqual( {} );
@@ -817,6 +817,70 @@ describe( 'state', () => {
 				} );
 
 				expect( state.present.blocksByUid ).toBe( state.present.blocksByUid );
+			} );
+		} );
+
+		describe( 'withHistory', () => {
+			it( 'should overwrite present history if updating same attributes', () => {
+				let state;
+
+				state = editor( state, {
+					type: 'RESET_BLOCKS',
+					blocks: [ {
+						uid: 'kumquat',
+						attributes: {},
+						innerBlocks: [],
+					} ],
+				} );
+
+				state = editor( state, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					uid: 'kumquat',
+					attributes: {
+						test: 1,
+					},
+				} );
+
+				state = editor( state, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					uid: 'kumquat',
+					attributes: {
+						test: 2,
+					},
+				} );
+
+				expect( state.past ).toHaveLength( 2 );
+			} );
+
+			it( 'should not overwrite present history if updating same attributes', () => {
+				let state;
+
+				state = editor( state, {
+					type: 'RESET_BLOCKS',
+					blocks: [ {
+						uid: 'kumquat',
+						attributes: {},
+						innerBlocks: [],
+					} ],
+				} );
+
+				state = editor( state, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					uid: 'kumquat',
+					attributes: {
+						test: 1,
+					},
+				} );
+
+				state = editor( state, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					uid: 'kumquat',
+					attributes: {
+						other: 1,
+					},
+				} );
+
+				expect( state.past ).toHaveLength( 3 );
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -72,7 +72,7 @@ describe( 'state', () => {
 		it( 'should return history (empty edits, blocksByUid, blockOrder), dirty flag by default', () => {
 			const state = editor( undefined, {} );
 
-			expect( state.past ).toEqual( [ state.present ] );
+			expect( state.past ).toEqual( [] );
 			expect( state.future ).toEqual( [] );
 			expect( state.present.edits ).toEqual( {} );
 			expect( state.present.blocksByUid ).toEqual( {} );
@@ -849,7 +849,7 @@ describe( 'state', () => {
 					},
 				} );
 
-				expect( state.past ).toHaveLength( 2 );
+				expect( state.past ).toHaveLength( 1 );
 			} );
 
 			it( 'should not overwrite present history if updating same attributes', () => {
@@ -880,7 +880,7 @@ describe( 'state', () => {
 					},
 				} );
 
-				expect( state.past ).toHaveLength( 3 );
+				expect( state.past ).toHaveLength( 2 );
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -833,6 +833,8 @@ describe( 'state', () => {
 					} ],
 				} );
 
+				expect( state.past ).toHaveLength( 1 );
+
 				state = editor( state, {
 					type: 'UPDATE_BLOCK_ATTRIBUTES',
 					uid: 'kumquat',
@@ -849,7 +851,7 @@ describe( 'state', () => {
 					},
 				} );
 
-				expect( state.past ).toHaveLength( 1 );
+				expect( state.past ).toHaveLength( 2 );
 			} );
 
 			it( 'should not overwrite present history if updating same attributes', () => {
@@ -863,6 +865,8 @@ describe( 'state', () => {
 						innerBlocks: [],
 					} ],
 				} );
+
+				expect( state.past ).toHaveLength( 1 );
 
 				state = editor( state, {
 					type: 'UPDATE_BLOCK_ATTRIBUTES',
@@ -880,7 +884,7 @@ describe( 'state', () => {
 					},
 				} );
 
-				expect( state.past ).toHaveLength( 2 );
+				expect( state.past ).toHaveLength( 3 );
 			} );
 		} );
 	} );

--- a/editor/utils/with-history/index.js
+++ b/editor/utils/with-history/index.js
@@ -77,12 +77,12 @@ export default function withHistory( reducer, options = {} ) {
 			return state;
 		}
 
-		let nextPast = [ ...past, present ];
+		let nextPast = past;
 
 		shouldCreateUndoLevel = ! past.length || shouldCreateUndoLevel;
 
-		if ( ! shouldCreateUndoLevel && shouldOverwriteState( action, previousAction ) ) {
-			nextPast = past;
+		if ( shouldCreateUndoLevel || ! shouldOverwriteState( action, previousAction ) ) {
+			nextPast = [ ...past, present ];
 		}
 
 		shouldCreateUndoLevel = false;

--- a/editor/utils/with-history/index.js
+++ b/editor/utils/with-history/index.js
@@ -20,7 +20,7 @@ export default function withHistory( reducer, options = {} ) {
 		future: [],
 	};
 
-	let lastAction = null;
+	let lastAction;
 	let shouldCreateUndoLevel = false;
 
 	const {

--- a/editor/utils/with-history/test/index.js
+++ b/editor/utils/with-history/test/index.js
@@ -4,22 +4,22 @@
 import withHistory from '../';
 
 describe( 'withHistory', () => {
-	const counter = ( state = { count: 0 }, { type } ) => {
-		return type === 'INCREMENT' ? { count: state.count + 1 } : state;
-	};
+	const counter = ( state = 0, { type } ) => (
+		type === 'INCREMENT' ? state + 1 : state
+	);
 
 	it( 'should return a new reducer', () => {
 		const reducer = withHistory( counter );
-		const state = reducer( undefined, {} );
 
-		expect( state ).toEqual( {
+		expect( typeof reducer ).toBe( 'function' );
+		expect( reducer( undefined, {} ) ).toEqual( {
 			past: [],
-			present: { count: 0 },
+			present: 0,
 			future: [],
 		} );
 	} );
 
-	it( 'should track changes in present', () => {
+	it( 'should track history', () => {
 		const reducer = withHistory( counter );
 
 		let state;
@@ -27,31 +27,16 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
-			present: { count: 1 },
-			future: [],
-		} );
-	} );
-
-	it( 'should create undo level', () => {
-		const reducer = withHistory( counter );
-
-		let state;
-		state = reducer( undefined, {} );
-		state = reducer( state, { type: 'INCREMENT' } );
-		// state = reducer( state, { type: 'CREATE_UNDO_LEVEL' } );
-
-		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
-			present: { count: 1 },
+			past: [ 0 ],
+			present: 1,
 			future: [],
 		} );
 
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 }, { count: 1 } ],
-			present: { count: 2 },
+			past: [ 0, 1 ],
+			present: 2,
 			future: [],
 		} );
 	} );
@@ -66,9 +51,14 @@ describe( 'withHistory', () => {
 
 		expect( state ).toEqual( {
 			past: [],
-			present: { count: 0 },
-			future: [ { count: 1 } ],
+			present: 0,
+			future: [ 1 ],
 		} );
+	} );
+
+	it( 'should not perform undo on empty past', () => {
+		const reducer = withHistory( counter );
+		const state = reducer( undefined, {} );
 
 		expect( state ).toBe( reducer( state, { type: 'UNDO' } ) );
 	} );
@@ -83,10 +73,15 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'REDO' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
-			present: { count: 1 },
+			past: [ 0 ],
+			present: 1,
 			future: [],
 		} );
+	} );
+
+	it( 'should not perform redo on empty future', () => {
+		const reducer = withHistory( counter );
+		const state = reducer( undefined, {} );
 
 		expect( state ).toBe( reducer( state, { type: 'REDO' } ) );
 	} );
@@ -101,9 +96,17 @@ describe( 'withHistory', () => {
 
 		expect( state ).toEqual( {
 			past: [],
-			present: { count: 1 },
+			present: 1,
 			future: [],
 		} );
+	} );
+
+	it( 'should return same reference if state has not changed', () => {
+		const reducer = withHistory( counter );
+		const original = reducer( undefined, {} );
+		const state = reducer( original, {} );
+
+		expect( state ).toBe( original );
 	} );
 
 	it( 'should overwrite present state with option.shouldOverwriteState', () => {
@@ -116,16 +119,16 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
-			present: { count: 1 },
+			past: [ 0 ],
+			present: 1,
 			future: [],
 		} );
 
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
-			present: { count: 2 },
+			past: [ 0 ],
+			present: 2,
 			future: [],
 		} );
 	} );
@@ -141,16 +144,16 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'CREATE_UNDO_LEVEL' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
-			present: { count: 1 },
+			past: [ 0 ],
+			present: 1,
 			future: [],
 		} );
 
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 }, { count: 1 } ],
-			present: { count: 2 },
+			past: [ 0, 1 ],
+			present: 2,
 			future: [],
 		} );
 	} );

--- a/editor/utils/with-history/test/index.js
+++ b/editor/utils/with-history/test/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { last } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import withHistory from '../';
@@ -30,12 +25,10 @@ describe( 'withHistory', () => {
 		const state = reducer( undefined, {} );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
+			past: [],
 			present: { count: 0 },
 			future: [],
 		} );
-
-		expect( last( state.past ) ).toBe( state.present );
 	} );
 
 	it( 'should track changes in present', () => {
@@ -50,19 +43,25 @@ describe( 'withHistory', () => {
 		} );
 	} );
 
-	it( 'should create undo level if buffer is available', () => {
+	it( 'should create undo level', () => {
 		let state;
 		state = reducer( undefined, {} );
 		state = reducer( state, { type: 'INCREMENT' } );
 		state = reducer( state, { type: 'CREATE_UNDO_LEVEL' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 }, { count: 1 } ],
+			past: [ { count: 0 } ],
 			present: { count: 1 },
 			future: [],
 		} );
 
-		expect( state ).toBe( reducer( state, { type: 'CREATE_UNDO_LEVEL' } ) );
+		state = reducer( state, { type: 'INCREMENT' } );
+
+		expect( state ).toEqual( {
+			past: [ { count: 0 }, { count: 1 } ],
+			present: { count: 2 },
+			future: [],
+		} );
 	} );
 
 	it( 'should perform undo of buffer', () => {
@@ -72,12 +71,11 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'UNDO' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
+			past: [],
 			present: { count: 0 },
 			future: [ { count: 1 } ],
 		} );
 
-		expect( last( state.past ) ).toBe( state.present );
 		expect( state ).toBe( reducer( state, { type: 'UNDO' } ) );
 	} );
 
@@ -89,12 +87,11 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'UNDO' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 } ],
+			past: [],
 			present: { count: 0 },
 			future: [ { count: 1 } ],
 		} );
 
-		expect( last( state.past ) ).toBe( state.present );
 		expect( state ).toBe( reducer( state, { type: 'UNDO' } ) );
 	} );
 
@@ -107,12 +104,11 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'REDO' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 0 }, { count: 1 } ],
+			past: [ { count: 0 } ],
 			present: { count: 1 },
 			future: [],
 		} );
 
-		expect( last( state.past ) ).toBe( state.present );
 		expect( state ).toBe( reducer( state, { type: 'REDO' } ) );
 	} );
 
@@ -124,7 +120,7 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'RESET_HISTORY' } );
 
 		expect( state ).toEqual( {
-			past: [ { count: 1 } ],
+			past: [],
 			present: { count: 1 },
 			future: [],
 		} );


### PR DESCRIPTION
## Description

This PR proposes:

* Overwriting/buffering changes in the history reducer when block attributes are updated and the block id and updated attribute keys are the same. This will fix the cases where history records are added for every single character change.
* With this change it is OK for editable to sync continuously.
* In addition, we'd like changes `RichText` instances to create additional history records such as a formatting change, on moving the caret, etc. For this we can use the `AddUndo` event TinyMCE fires.
* Completely propagate undo/redo command from `RichText`. This is necessary to actually undo the changes in the global state as well, not just `RichText` and pile up changes in the global state.

## How Has This Been Tested?
Try undoing changes in the editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.