### PR TITLE
Build: Consolidate module build JS, CSS, map inclusion

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -99,19 +99,8 @@ zip -r gutenberg.zip \
 	blocks/library/*/*.php \
 	post-content.js \
 	$vendor_scripts \
-	blocks/build/*.{js,map} \
-	components/build/*.{js,map} \
-	date/build/*.{js,map} \
-	editor/build/*.{js,map} \
-	element/build/*.{js,map} \
-	hooks/build/*.{js,map} \
-	i18n/build/*.{js,map} \
-	data/build/*.{js,map} \
-	utils/build/*.{js,map} \
-	edit-post/build/*.{js,map} \
-	blocks/build/*.css \
-	components/build/*.css \
-	editor/build/*.css \
+	{blocks,components,date,editor,element,hooks,i18n,data,utils,edit-post}/build/*.{js,map} \
+	{blocks,components,editor,edit-post}/build/*.css \
 	languages/gutenberg.pot \
 	README.md
 


### PR DESCRIPTION
Fixes #4891 
Related: #4661 

Props @phpbits for observation at https://github.com/WordPress/gutenberg/issues/4891#issuecomment-364066472

This pull request seeks to resolve an issue where the `edit-post` stylesheet is not included in the packaged plugin. It consolidates our file listing patterns in hopes of facilitating future updates.

__Testing instructions:__

Verify that on a test site, the packaged version of the Gutenberg plugin works as expected, generated via:

```
npm run package-plugin
```