### PR TITLE
Build: Assign `edit-post` global as `wp.editPost`

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -895,7 +895,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$script .= <<<JS
 		window._wpLoadGutenbergEditor = wp.api.init().then( function() {
 			wp.blocks.registerCoreBlocks();
-			return wp[ 'edit-post' ].initializeEditor( 'editor', window._wpGutenbergPost, editorSettings );
+			return wp.editPost.initializeEditor( 'editor', window._wpGutenbergPost, editorSettings );
 		} );
 JS;
 	$script .= '} )();';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@
 const webpack = require( 'webpack' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
-const { reduce, escapeRegExp, get } = require( 'lodash' );
+const { reduce, escapeRegExp, castArray, get } = require( 'lodash' );
 const { basename, dirname } = require( 'path' );
 
 // Main CSS loader for everything but blocks..
@@ -55,7 +55,7 @@ const entryPointNames = [
 	'i18n',
 	'utils',
 	'data',
-	'edit-post',
+	[ 'editPost', 'edit-post' ],
 ];
 
 const packageNames = [
@@ -127,8 +127,10 @@ class CustomTemplatedPathPlugin {
 
 const config = {
 	entry: Object.assign(
-		entryPointNames.reduce( ( memo, entryPointName ) => {
-			memo[ entryPointName ] = `./${ entryPointName }/index.js`;
+		entryPointNames.reduce( ( memo, entryPoint ) => {
+			entryPoint = castArray( entryPoint );
+			const [ name, path = name ] = entryPoint;
+			memo[ name ] = `./${ path }/index.js`;
 			return memo;
 		}, {} ),
 		packageNames.reduce( ( memo, packageName ) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,9 +128,13 @@ class CustomTemplatedPathPlugin {
 const config = {
 	entry: Object.assign(
 		entryPointNames.reduce( ( memo, entryPoint ) => {
+			// Normalized entry point as an array of [ name, path ]. If a path
+			// is not explicitly defined, use the name.
 			entryPoint = castArray( entryPoint );
 			const [ name, path = name ] = entryPoint;
+
 			memo[ name ] = `./${ path }`;
+
 			return memo;
 		}, {} ),
 		packageNames.reduce( ( memo, packageName ) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,11 +5,11 @@ const webpack = require( 'webpack' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 const { reduce, escapeRegExp, castArray, get } = require( 'lodash' );
-const { basename, dirname } = require( 'path' );
+const { basename } = require( 'path' );
 
 // Main CSS loader for everything but blocks..
 const mainCSSExtractTextPlugin = new ExtractTextPlugin( {
-	filename: './[dir]/build/style.css',
+	filename: './[basename]/build/style.css',
 } );
 
 // CSS loader for styles specific to block editing.
@@ -130,7 +130,7 @@ const config = {
 		entryPointNames.reduce( ( memo, entryPoint ) => {
 			entryPoint = castArray( entryPoint );
 			const [ name, path = name ] = entryPoint;
-			memo[ name ] = `./${ path }/index.js`;
+			memo[ name ] = `./${ path }`;
 			return memo;
 		}, {} ),
 		packageNames.reduce( ( memo, packageName ) => {
@@ -139,7 +139,7 @@ const config = {
 		}, {} )
 	),
 	output: {
-		filename: '[dir]/build/index.js',
+		filename: '[basename]/build/index.js',
 		path: __dirname,
 		library: [ 'wp', '[name]' ],
 		libraryTarget: 'this',
@@ -202,10 +202,10 @@ const config = {
 			debug: process.env.NODE_ENV !== 'production',
 		} ),
 		new CustomTemplatedPathPlugin( {
-			dir( path, data ) {
-				const request = get( data, [ 'chunk', 'entryModule', 'request' ] );
-				if ( request ) {
-					return basename( dirname( request ) );
+			basename( path, data ) {
+				const rawRequest = get( data, [ 'chunk', 'entryModule', 'rawRequest' ] );
+				if ( rawRequest ) {
+					return basename( rawRequest );
 				}
 
 				return path;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,10 +4,12 @@
 const webpack = require( 'webpack' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
+const { reduce, escapeRegExp, get } = require( 'lodash' );
+const { basename, dirname } = require( 'path' );
 
 // Main CSS loader for everything but blocks..
 const mainCSSExtractTextPlugin = new ExtractTextPlugin( {
-	filename: './[name]/build/style.css',
+	filename: './[dir]/build/style.css',
 } );
 
 // CSS loader for styles specific to block editing.
@@ -75,6 +77,54 @@ const externals = {
 	};
 } );
 
+/**
+ * Webpack plugin for handling specific template tags in Webpack configuration
+ * values like those supported in the base Webpack functionality (e.g. `name`).
+ *
+ * @see webpack.TemplatedPathPlugin
+ */
+class CustomTemplatedPathPlugin {
+	/**
+	 * CustomTemplatedPathPlugin constructor. Initializes handlers as a tuple
+	 * set of RegExp, handler, where the regular expression is used in matching
+	 * a Webpack asset path.
+	 *
+	 * @param {Object.<string,Function>} handlers Object keyed by tag to match,
+	 *                                            with function value returning
+	 *                                            replacement string.
+	 *
+	 * @return {void}
+	 */
+	constructor( handlers ) {
+		this.handlers = reduce( handlers, ( result, handler, key ) => {
+			const regexp = new RegExp( `\\[${ escapeRegExp( key ) }\\]`, 'gi' );
+			return [ ...result, [ regexp, handler ] ];
+		}, [] );
+	}
+
+	/**
+	 * Webpack plugin application logic.
+	 *
+	 * @param {Object} compiler Webpack compiler
+	 *
+	 * @return {void}
+	 */
+	apply( compiler ) {
+		compiler.plugin( 'compilation', ( compilation ) => {
+			compilation.mainTemplate.plugin( 'asset-path', ( path, data ) => {
+				for ( let i = 0; i < this.handlers.length; i++ ) {
+					const [ regexp, handler ] = this.handlers[ i ];
+					if ( regexp.test( path ) ) {
+						return path.replace( regexp, handler( path, data ) );
+					}
+				}
+
+				return path;
+			} );
+		} );
+	}
+}
+
 const config = {
 	entry: Object.assign(
 		entryPointNames.reduce( ( memo, entryPointName ) => {
@@ -87,7 +137,7 @@ const config = {
 		}, {} )
 	),
 	output: {
-		filename: '[name]/build/index.js',
+		filename: '[dir]/build/index.js',
 		path: __dirname,
 		library: [ 'wp', '[name]' ],
 		libraryTarget: 'this',
@@ -148,6 +198,16 @@ const config = {
 		new webpack.LoaderOptionsPlugin( {
 			minimize: process.env.NODE_ENV === 'production',
 			debug: process.env.NODE_ENV !== 'production',
+		} ),
+		new CustomTemplatedPathPlugin( {
+			dir( path, data ) {
+				const request = get( data, [ 'chunk', 'entryModule', 'request' ] );
+				if ( request ) {
+					return basename( dirname( request ) );
+				}
+
+				return path;
+			},
 		} ),
 	],
 	stats: {


### PR DESCRIPTION
Related: #4661

This pull request seeks to ensure module assignment into the `wp` global is camel-cased, specifically the `edit-post` module introduced in #4661 (as `wp.editPost`, currently `wp[ 'edit-post' ]`). As our build process is generalized, this required some customization of our Webpack build configuration, including the introduction of a custom Webpack plugin for enhancing tags to include custom keys (e.g. add `[dir]` in addition to `[name]`, `[id]`, etc). This plugin could be easily externalized to a separate module, likely under the WordPress namespace.

__Testing instructions:__

Verify that the build outputs file as expected and that the editor loads without errors.