### PR TITLE
Fix centering

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -88,6 +88,22 @@
 	&:focus code[data-mce-selected] {
 		background: $light-gray-400;
 	}
+
+	.alignright {
+		float: right;
+		margin: 0.5em 0 0.5em 1em;
+	}
+
+	.alignleft {
+		float: left;
+		margin: 0.5em 1em 0.5em 0;
+	}
+
+	.aligncenter {
+		display: block;
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 // freeform toolbar

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -88,7 +88,14 @@
 	}
 }
 
-.editor-block-list__block[data-type="core/image"][data-align="center"] .wp-block-image {
-	margin-left: auto;
-	margin-right: auto;
+.editor-block-list__block[data-type="core/image"][data-align="center"] {
+	.wp-block-image {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	&[data-resized="false"] .wp-block-image div {
+		margin-left: auto;
+		margin-right: auto;
+	}
 }

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -133,22 +133,6 @@ body.gutenberg-editor-page {
 	.components-navigate-regions {
 		height: 100%;
 	}
-
-	.alignright {
-		float: right;
-		margin: 0.5em 0 0.5em 1em;
-	}
-
-	.alignleft {
-		float: left;
-		margin: 0.5em 1em 0.5em 0;
-	}
-
-	.aligncenter {
-		display: block;
-		margin-left: auto;
-		margin-right: auto;
-	}
 }
 
 .editor-post-title,


### PR DESCRIPTION
This fixes an issue where an un-resized but still not full-width image wouldn't center in the editor.

It also removes some CSS bleed for some alignment styles that were specific to the Classic block, but weren't necessary for Gutenblocks. This fixes #4968.

Editor centered images, before:

![screen shot 2018-02-09 at 07 45 04](https://user-images.githubusercontent.com/1204802/36015662-b8db6022-0d6f-11e8-851e-faff61f8dc8f.png)

After:

![screen shot 2018-02-09 at 07 51 15](https://user-images.githubusercontent.com/1204802/36015668-bc3436d6-0d6f-11e8-8175-cbb65c3b4bd9.png)

Alignment styles scoped to classic block:

![screen shot 2018-02-09 at 08 00 55](https://user-images.githubusercontent.com/1204802/36015677-c4528b2e-0d6f-11e8-92bb-9042da766a01.png)
