### PR TITLE
Revert "Meta Boxes: Give #poststuff div a broader scope; remove unused #post-container-2

### DIFF
--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -54,7 +54,7 @@ function Layout( {
 			<UnsavedChangesWarning />
 			<AutosaveMonitor />
 			<Header />
-			<div id="poststuff" className="edit-post-layout__content" role="region" aria-label={ __( 'Editor content' ) } tabIndex="-1">
+			<div className="edit-post-layout__content" role="region" aria-label={ __( 'Editor content' ) } tabIndex="-1">
 				<EditorNotices />
 				<div className="edit-post-layout__editor">
 					<EditorModeKeyboardShortcuts />

--- a/editor/components/meta-boxes/meta-boxes-area/style.scss
+++ b/editor/components/meta-boxes/meta-boxes-area/style.scss
@@ -1,93 +1,93 @@
 
-/* Include #poststuff to override the css rules found in core. */
-#poststuff .editor-meta-boxes-area {
+.editor-meta-boxes-area {
 	position: relative;
 
-	/* Match width and positioning of the meta boxes. Override default styles. */
-	.postbox-container {
+		/* Match width and positioning of the meta boxes. Override default styles. */
+	#poststuff {
 		margin: 0 auto;
 		padding-top: 0;
+		min-width: auto;
+	}
+
+	#post {
+		margin: 0;
+	}
+
+	/* Override Default meta box stylings */
+
+	#poststuff h3.hndle,
+	#poststuff .stuffbox > h3,
+	#poststuff h2.hndle { /* WordPress selectors yolo */
+		border-bottom: 1px solid $light-gray-500;
+		box-sizing: border-box;
+		color: $dark-gray-500;
+		font-weight: 600;
+		outline: none;
+		padding: 15px;
+		position: relative;
 		width: 100%;
+	}
 
-		#post {
-			margin: 0;
-		}
+	.postbox {
+		border: 0;
+		color: $dark-gray-500;
+		margin-bottom: 0;
+	}
 
-		/* Override Default meta box stylings */
+	.postbox > .inside {
+		border-bottom: 1px solid $light-gray-500;
+		color: $dark-gray-500;
+		padding: 15px;
+		margin: 0;
+	}
 
-		.postbox h3.hndle,
-		.postbox .stuffbox > h3,
-		.postbox h2.hndle { /* WordPress selectors yolo */
-			border-bottom: 1px solid $light-gray-500;
-			box-sizing: border-box;
-			color: $dark-gray-500;
-			font-weight: 600;
-			font-size: 14px;
-			line-height: 1.4;
-			margin: 0;
-			outline: none;
-			padding: 15px;
-			position: relative;
-			width: 100%;
-		}
+	input {
+		max-width: 300px;
+	}
 
-		.postbox {
-			border: 0;
-			color: $dark-gray-500;
-			margin-bottom: 0;
-		}
+	input,
+	select,
+	textarea {
+		background: inherit;
+		border: 1px solid $light-gray-500;
+		border-radius: 4px;
+		box-shadow: none;
+		color: $dark-gray-800;
+		display: inline-block;
+		font-family: inherit;
+		font-size: 13px;
+		line-height: 24px;
+		outline: none;
+		padding: 4px;
+	}
 
-		.postbox > .inside {
-			border-bottom: 1px solid $light-gray-500;
-			color: $dark-gray-500;
-			padding: 15px;
-			margin: 0;
-		}
+	input:hover,
+	select:hover,
+	textarea:hover {
+		border: 1px solid $light-gray-700;
+	}
 
-		input,
-		select,
-		textarea {
-			background: inherit;
-			border: 1px solid $light-gray-500;
-			border-radius: 4px;
-			box-shadow: none;
-			color: $dark-gray-800;
-			display: inline-block;
-			font-family: inherit;
-			font-size: 13px;
-			line-height: 24px;
-			outline: none;
-			padding: 4px;
-		}
+	.postbox .handlediv {
+		height: 44px;
+		width: 44px;
+	}
 
-		input:hover,
-		select:hover,
-		textarea:hover {
-			border: 1px solid $light-gray-700;
-		}
+	&.is-loading:before {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		content: '';
+		background: transparent;
+		z-index: z-index( '.editor-meta-boxes-area.is-loading:before');
+	}
 
-		.postbox .handlediv {
-			height: 44px;
-			width: 44px;
-		}
-
-		&.is-loading:before {
-			position: absolute;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			content: '';
-			background: transparent;
-			z-index: z-index( '.editor-meta-boxes-area.is-loading:before');
-		}
-
-		.spinner {
-			position: absolute;
-			top: 10px;
-			right: 20px;
-			z-index: z-index( '.editor-meta-boxes-area .spinner');
-		}
+	.spinner {
+		position: absolute;
+		top: 10px;
+		right: 20px;
+		z-index: z-index( '.editor-meta-boxes-area .spinner');
 	}
 }
 

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -310,23 +310,21 @@ function the_gutenberg_metaboxes() {
 	<form class="metabox-base-form">
 	<?php gutenberg_meta_box_post_form_hidden_fields( $post ); ?>
 	</form>
-	<div class="metabox-location-container">
-		<?php foreach ( $locations as $location ) : ?>
-			<form class="metabox-location-<?php echo esc_attr( $location ); ?>">
-				<div class="sidebar-open">
-					<div class="postbox-container">
-						<?php
-						do_meta_boxes(
-							$current_screen,
-							$location,
-							$post
-						);
-						?>
-					</div>
+	<?php foreach ( $locations as $location ) : ?>
+		<form class="metabox-location-<?php echo esc_attr( $location ); ?>">
+			<div id="poststuff" class="sidebar-open">
+				<div id="postbox-container-2" class="postbox-container">
+					<?php
+					do_meta_boxes(
+						$current_screen,
+						$location,
+						$post
+					);
+					?>
 				</div>
-			</form>
-		<?php endforeach; ?>
-	</div>
+			</div>
+		</form>
+	<?php endforeach; ?>
 	<?php
 
 	// Reset meta box data.


### PR DESCRIPTION
This reverts commit e25a2a5702834635d142ec99663988c097a37683.
This reverts #4697 to give us more time to come up with the best option to use a single id and avoid CSS bleed.