### PR TITLE
Data Module: Support multiple stores for the redux dev tools

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -15,11 +15,7 @@ export { loadAndPersist, withRehydratation } from './persist';
  */
 const stores = {};
 const selectors = {};
-const enhancers = [];
 let listeners = [];
-if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
-	enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__() );
-}
 
 /**
  * Global listener called for each store's update.
@@ -52,6 +48,10 @@ export const subscribe = ( listener ) => {
  * @return {Object} Store Object.
  */
 export function registerReducer( reducerKey, reducer ) {
+	const enhancers = [];
+	if ( window.__REDUX_DEVTOOLS_EXTENSION__ ) {
+		enhancers.push( window.__REDUX_DEVTOOLS_EXTENSION__( { name: reducerKey, instanceId: reducerKey } ) );
+	}
 	const store = createStore( reducer, flowRight( enhancers ) );
 	stores[ reducerKey ] = store;
 	store.subscribe( globalListener );


### PR DESCRIPTION
Redux Dev Tools supports multiple redux stores. This PR gives a distinct name to each one of our internal stores to ease debugging.

**Testing instructions**

 - Install Redux Dev Tools
 - Open Gutenberg
 - Notice that you can switch store instance in the Redux Dev Tools tab