### PR TITLE
Collapse the publish sidebar when making edits to a published post

### DIFF
--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -46,10 +46,12 @@ class PostPublishPanel extends Component {
 				loading: false,
 			} );
 		}
+	}
 
-		// Automatically collapse the publish sidebar when
-		// a post is published and the user makes an edit.
-		if ( this.props.isPublished && newProps.isDirty ) {
+	componentDidUpdate( prevProps ) {
+		// Automatically collapse the publish sidebar when a post
+		// is published and the user makes an edit.
+		if ( prevProps.isPublished && this.props.isDirty ) {
 			this.props.onClose();
 		}
 	}

--- a/editor/components/post-publish-panel/index.js
+++ b/editor/components/post-publish-panel/index.js
@@ -18,7 +18,12 @@ import './style.scss';
 import PostPublishButton from '../post-publish-button';
 import PostPublishPanelPrepublish from './prepublish';
 import PostPublishPanelPostpublish from './postpublish';
-import { getCurrentPostType, isCurrentPostPublished, isSavingPost } from '../../store/selectors';
+import {
+	getCurrentPostType,
+	isCurrentPostPublished,
+	isSavingPost,
+	isEditedPostDirty,
+} from '../../store/selectors';
 
 class PostPublishPanel extends Component {
 	constructor() {
@@ -40,6 +45,12 @@ class PostPublishPanel extends Component {
 				published: true,
 				loading: false,
 			} );
+		}
+
+		// Automatically collapse the publish sidebar when
+		// a post is published and the user makes an edit.
+		if ( this.props.isPublished && newProps.isDirty ) {
+			this.props.onClose();
 		}
 	}
 
@@ -85,6 +96,7 @@ const applyConnect = connect(
 			postType: getCurrentPostType( state ),
 			isPublished: isCurrentPostPublished( state ),
 			isSaving: isSavingPost( state ),
+			isDirty: isEditedPostDirty( state ),
 		};
 	},
 );


### PR DESCRIPTION
Closes #4976.

As described in the issue, this seeks to close the post-publish sidebar if the user makes edits to a post they just published.

It will benefit from work being done in https://github.com/WordPress/gutenberg/pull/4955.