### PR TITLE
Increase maximum recent blocks to 9

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -27,7 +27,7 @@ import { addQueryArgs } from '@wordpress/url';
 /***
  * Module constants
  */
-const MAX_RECENT_BLOCKS = 8;
+const MAX_RECENT_BLOCKS = 9;
 export const POST_UPDATE_TRANSACTION_ID = 'post-update';
 
 /**

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2136,7 +2136,7 @@ describe( 'selectors', () => {
 			registerCoreBlocks();
 		} );
 
-		it( 'should return the 8 most recently used blocks', () => {
+		it( 'should return the 9 most recently used blocks', () => {
 			const state = {
 				preferences: {
 					recentInserts: [
@@ -2175,6 +2175,7 @@ describe( 'selectors', () => {
 				{ name: 'core/heading', initialAttributes: {} },
 				{ name: 'core/list', initialAttributes: {} },
 				{ name: 'core/video', initialAttributes: {} },
+				{ name: 'core/audio', initialAttributes: {} },
 			] );
 		} );
 
@@ -2195,7 +2196,7 @@ describe( 'selectors', () => {
 			// We should get back 8 items with no duplicates
 			const items = getRecentInserterItems( state );
 			const blockNames = items.map( item => item.name );
-			expect( union( blockNames ) ).toHaveLength( 8 );
+			expect( union( blockNames ) ).toHaveLength( 9 );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
Previously, when the inserter was limited to two columns, the recent blocks tab was capped at eight blocks to ensure even rows. Now that the inserter is three columns, there's space for an additional recent block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.