### PR TITLE
Video block: Gracefully auto-transform into Embed if embeddable resource provided

### DIFF
--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -6,8 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Placeholder, Toolbar, IconButton, Button } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Placeholder, Toolbar, IconButton, Button, withState } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -18,6 +17,12 @@ import MediaUpload from '../../media-upload';
 import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+
+const enhance = withState( ( props ) => ( {
+	editing: ! props.attributes.src,
+	src: props.attributes.src,
+	className: props.className,
+} ) );
 
 export const name = 'core/video';
 
@@ -57,116 +62,111 @@ export const settings = {
 		}
 	},
 
-	edit: class extends Component {
-		constructor( { className } ) {
-			super( ...arguments );
-			// edit component has its own src in the state so it can be edited
-			// without setting the actual value outside of the edit UI
-			this.state = {
-				editing: ! this.props.attributes.src,
-				src: this.props.attributes.src,
-				className,
-			};
-		}
-
-		render() {
-			const { align, caption, id } = this.props.attributes;
-			const { setAttributes, isSelected } = this.props;
-			const { editing, className, src } = this.state;
-			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
-			const switchToEditing = () => {
-				this.setState( { editing: true } );
-			};
-			const onSelectVideo = ( media ) => {
-				if ( media && media.url ) {
-					// sets the block's attribute and updates the edit component from the
-					// selected media, then switches off the editing UI
-					setAttributes( { src: media.url, id: media.id } );
-					this.setState( { src: media.url, editing: false } );
-				}
-			};
-			const onSelectUrl = ( event ) => {
-				event.preventDefault();
-				if ( src ) {
-					// set the block's src from the edit component's state, and switch off the editing UI
-					setAttributes( { src } );
-					this.setState( { editing: false } );
-				}
-				return false;
-			};
-			const controls = isSelected && (
-				<BlockControls key="controls">
-					<BlockAlignmentToolbar
-						value={ align }
-						onChange={ updateAlignment }
-					/>
-					<Toolbar>
-						<IconButton
-							className="components-icon-button components-toolbar__control"
-							label={ __( 'Edit video' ) }
-							onClick={ switchToEditing }
-							icon="edit"
-						/>
-					</Toolbar>
-				</BlockControls>
-			);
-
-			if ( editing ) {
-				return [
-					controls,
-					<Placeholder
-						key="placeholder"
-						icon="media-video"
-						label={ __( 'Video' ) }
-						instructions={ __( 'Select a video file from your library, or upload a new one' ) }
-						className={ className }>
-						<form onSubmit={ onSelectUrl }>
-							<input
-								type="url"
-								className="components-placeholder__input"
-								placeholder={ __( 'Enter URL of video file here…' ) }
-								onChange={ event => this.setState( { src: event.target.value } ) }
-								value={ src || '' } />
-							<Button
-								isLarge
-								type="submit">
-								{ __( 'Use URL' ) }
-							</Button>
-						</form>
-						<MediaUpload
-							onSelect={ onSelectVideo }
-							type="video"
-							id={ id }
-							render={ ( { open } ) => (
-								<Button isLarge onClick={ open } >
-									{ __( 'Add from Media Library' ) }
-								</Button>
-							) }
-						/>
-					</Placeholder>,
-				];
+	edit: enhance( ( {
+		// Provided by `withState`:
+		editing,
+		src,
+		className,
+		setState,
+		// Provided by parent:
+		...props
+	} ) => {
+		const { align, caption, id } = props.attributes;
+		const { setAttributes, isSelected } = props;
+		const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
+		const switchToEditing = () => {
+			setState( { editing: true } );
+		};
+		const onSelectVideo = ( media ) => {
+			if ( media && media.url ) {
+				// sets the block's attribute and updates the edit component from the
+				// selected media, then switches off the editing UI
+				setAttributes( { src: media.url, id: media.id } );
+				setState( { src: media.url, editing: false } );
 			}
+		};
+		const onSelectUrl = ( event ) => {
+			event.preventDefault();
+			if ( src ) {
+				// set the block's src from the edit component's state, and switch off the editing UI
+				setAttributes( { src } );
+				setState( { editing: false } );
+			}
+			return false;
+		};
 
-			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		const controls = isSelected && (
+			<BlockControls key="controls">
+				<BlockAlignmentToolbar
+					value={ align }
+					onChange={ updateAlignment }
+				/>
+				<Toolbar>
+					<IconButton
+						className="components-icon-button components-toolbar__control"
+						label={ __( 'Edit video' ) }
+						onClick={ switchToEditing }
+						icon="edit"
+					/>
+				</Toolbar>
+			</BlockControls>
+		);
+
+		if ( editing ) {
 			return [
 				controls,
-				<figure key="video" className={ className }>
-					<video controls src={ src } />
-					{ ( ( caption && caption.length ) || isSelected ) && (
-						<RichText
-							tagName="figcaption"
-							placeholder={ __( 'Write caption…' ) }
-							value={ caption }
-							onChange={ ( value ) => setAttributes( { caption: value } ) }
-							isSelected={ isSelected }
-							inlineToolbar
-						/>
-					) }
-				</figure>,
+				<Placeholder
+					key="placeholder"
+					icon="media-video"
+					label={ __( 'Video' ) }
+					instructions={ __( 'Select a video file from your library, or upload a new one' ) }
+					className={ className }>
+					<form onSubmit={ onSelectUrl }>
+						<input
+							type="url"
+							className="components-placeholder__input"
+							placeholder={ __( 'Enter URL of video file here…' ) }
+							onChange={ event => setState( { src: event.target.value } ) }
+							value={ src || '' } />
+						<Button
+							isLarge
+							type="submit">
+							{ __( 'Use URL' ) }
+						</Button>
+					</form>
+					<MediaUpload
+						onSelect={ onSelectVideo }
+						type="video"
+						id={ id }
+						render={ ( { open } ) => (
+							<Button isLarge onClick={ open } >
+								{ __( 'Add from Media Library' ) }
+							</Button>
+						) }
+					/>
+				</Placeholder>,
 			];
-			/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		}
-	},
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		return [
+			controls,
+			<figure key="video" className={ className }>
+				<video controls src={ src } />
+				{ ( ( caption && caption.length ) || isSelected ) && (
+					<RichText
+						tagName="figcaption"
+						placeholder={ __( 'Write caption…' ) }
+						value={ caption }
+						onChange={ ( value ) => setAttributes( { caption: value } ) }
+						isSelected={ isSelected }
+						inlineToolbar
+					/>
+				) }
+			</figure>,
+		];
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+	} ),
 
 	save( { attributes } ) {
 		const { src, caption, align } = attributes;

--- a/components/higher-order/with-state/README.md
+++ b/components/higher-order/with-state/README.md
@@ -29,4 +29,14 @@ export default withState( {
 } )( MyCounter );
 ```
 
-`withState` optionally accepts an object argument to define the initial state. It returns a function which can then be used in composing your component.
+`withState` optionally accepts an object argument to define the initial state. Instead of an object, it also accept a function which will be called with parent props; its return value will be used as the initial state. It returns a function which can then be used in composing your component.
+
+An alternative example with a function as the initial state resolver:
+
+```js
+const applyWithState = withState( ( props ) => ( {
+	count: props.initialCount,
+} ) );
+
+export default applyWithState( MyCounter );
+```

--- a/components/higher-order/with-state/index.js
+++ b/components/higher-order/with-state/index.js
@@ -14,10 +14,16 @@ import { Component, getWrapperDisplayName } from '@wordpress/element';
 function withState( initialState = {} ) {
 	return ( OriginalComponent ) => {
 		class WrappedComponent extends Component {
-			constructor() {
+			constructor( props ) {
 				super( ...arguments );
 
 				this.setState = this.setState.bind( this );
+
+				// If passed a function, call it with component props to
+				// compute initial state object.
+				if ( 'function' === typeof initialState ) {
+					initialState = initialState( props );
+				}
 
 				this.state = initialState;
 			}


### PR DESCRIPTION
Partly fixes #4922. This is an experimental take on the parent issue which eschews the display of failure information. More than anything else, it needs feedback on whether it's a feature worth having, and—if so—it needs design feedback. Moreover, adding this automated correction behavior doesn't exclude displaying failure information if we can't handle the video automatically.

## Description

When adding a new Video block, if the URL provided doesn't correspond to a usable video file (or if its loading otherwise fails) _and_ the URL corresponds to an embeddable resource, then automatically transform the block into a proper Embed block.

![gutenberg-video-to-embed](https://user-images.githubusercontent.com/150562/36065699-4246e3aa-0e96-11e8-9eb1-a57ea72a0b0d.gif)

## How Has This Been Tested?

Try adding a Video block with the following kinds of values:
- A valid video URL (e.g. `https://upload.wikimedia.org/wikipedia/commons/9/96/Curiosity%27s_Seven_Minutes_of_Terror.ogv`)
- A valid video URL while the network is down
- An invalid video URL (e.g. a mis-copied link like `https://upload.wikimedia.org/wikipedia/commons/9/96/Curiosity%27s_Seven_Minutes_of_Terror.og`)
- A valid embeddable URL (e.g. `https://youtube.com/watch?v=lNHhmz-smlE`)
- An invalid embeddable URL (e.g. `https://youtube.com/watch?v=lNHhmz-sml`)

Verify that the block is only converted to Embed when provided a valid embeddable URL.

## Types of changes
Tentative UX enhancement

## A technical aside

This pull request refactors the Video block's `edit` method into a functional component. For this, it extended `withState` in order to accommodate its use case, allowing prop-dependent state initializations. If this is a desirable addition, I can spawn a new PR for it.

Because of the refactor, the [Commits](https://github.com/WordPress/gutenberg/pull/4990/commits) view may provide diffs that are easier to review.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
