### PR TITLE
Implemented mechanism to allow themes to disable custom colors

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -16,16 +16,14 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import './style.scss';
 
-export function ColorPalette( { defaultColors, colors, value, onChange } ) {
-	const usedColors = colors || defaultColors;
-
+export function ColorPalette( { colors, disableCustomColors = false, value, onChange } ) {
 	function applyOrUnset( color ) {
 		return () => onChange( value === color ? undefined : color );
 	}
 
 	return (
 		<div className="blocks-color-palette">
-			{ map( usedColors, ( color ) => {
+			{ map( colors, ( color ) => {
 				const style = { color: color };
 				const className = classnames( 'blocks-color-palette__item', { 'is-active': value === color } );
 
@@ -43,29 +41,31 @@ export function ColorPalette( { defaultColors, colors, value, onChange } ) {
 				);
 			} ) }
 
-			<Dropdown
-				className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"
-				contentClassName="blocks-color-palette__picker "
-				renderToggle={ ( { isOpen, onToggle } ) => (
-					<button
-						type="button"
-						aria-expanded={ isOpen }
-						className="blocks-color-palette__item"
-						onClick={ onToggle }
-						aria-label={ __( 'Custom color picker' ) }
-					>
-						<span className="blocks-color-palette__custom-color-gradient" />
-					</button>
-				) }
-				renderContent={ () => (
-					<ChromePicker
-						color={ value }
-						onChangeComplete={ ( color ) => onChange( color.hex ) }
-						style={ { width: '100%' } }
-						disableAlpha
-					/>
-				) }
-			/>
+			{ ! disableCustomColors &&
+				<Dropdown
+					className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"
+					contentClassName="blocks-color-palette__picker "
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<button
+							type="button"
+							aria-expanded={ isOpen }
+							className="blocks-color-palette__item"
+							onClick={ onToggle }
+							aria-label={ __( 'Custom color picker' ) }
+						>
+							<span className="blocks-color-palette__custom-color-gradient" />
+						</button>
+					) }
+					renderContent={ () => (
+						<ChromePicker
+							color={ value }
+							onChangeComplete={ ( color ) => onChange( color.hex ) }
+							style={ { width: '100%' } }
+							disableAlpha
+						/>
+					) }
+				/>
+			}
 
 			<button
 				className="button-link blocks-color-palette__clear"
@@ -79,7 +79,10 @@ export function ColorPalette( { defaultColors, colors, value, onChange } ) {
 }
 
 export default withContext( 'editor' )(
-	( settings ) => ( {
-		defaultColors: settings.colors,
+	( settings, props ) => ( {
+		colors: props.colors || settings.colors,
+		disableCustomColors: props.disableCustomColors !== undefined ?
+			props.disableCustomColors :
+			settings.disableCustomColors,
 	} )
 )( ColorPalette );

--- a/blocks/color-palette/test/__snapshots__/index.js.snap
+++ b/blocks/color-palette/test/__snapshots__/index.js.snap
@@ -63,7 +63,7 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
 />
 `;
 
-exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
+exports[`ColorPalette should allow disabling custom color picker 1`] = `
 <div
   className="blocks-color-palette"
 >
@@ -118,12 +118,6 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
       type="button"
     />
   </div>
-  <Dropdown
-    className="blocks-color-palette__item-wrapper blocks-color-palette__custom-color"
-    contentClassName="blocks-color-palette__picker "
-    renderContent={[Function]}
-    renderToggle={[Function]}
-  />
   <button
     className="button-link blocks-color-palette__clear"
     onClick={[Function]}
@@ -134,22 +128,56 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
 </div>
 `;
 
-exports[`ColorPalette should render a dynamic toolbar with default colors, when colors are not present 1`] = `
+exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
 <div
   className="blocks-color-palette"
 >
   <div
     className="blocks-color-palette__item-wrapper"
-    key="green"
+    key="red"
   >
     <button
-      aria-label="Color: green"
+      aria-label="Color: red"
+      aria-pressed={true}
+      className="blocks-color-palette__item is-active"
+      onClick={[Function]}
+      style={
+        Object {
+          "color": "red",
+        }
+      }
+      type="button"
+    />
+  </div>
+  <div
+    className="blocks-color-palette__item-wrapper"
+    key="white"
+  >
+    <button
+      aria-label="Color: white"
       aria-pressed={false}
       className="blocks-color-palette__item"
       onClick={[Function]}
       style={
         Object {
-          "color": "green",
+          "color": "white",
+        }
+      }
+      type="button"
+    />
+  </div>
+  <div
+    className="blocks-color-palette__item-wrapper"
+    key="blue"
+  >
+    <button
+      aria-label="Color: blue"
+      aria-pressed={false}
+      className="blocks-color-palette__item"
+      onClick={[Function]}
+      style={
+        Object {
+          "color": "blue",
         }
       }
       type="button"

--- a/blocks/color-palette/test/index.js
+++ b/blocks/color-palette/test/index.js
@@ -9,7 +9,6 @@ import { shallow } from 'enzyme';
 import { ColorPalette } from '../';
 
 describe( 'ColorPalette', () => {
-	const defaultColors = [ 'green' ];
 	const colors = [ 'red', 'white', 'blue' ];
 	const currentColor = 'red';
 	const onChange = jest.fn();
@@ -23,10 +22,6 @@ describe( 'ColorPalette', () => {
 
 	test( 'should render a dynamic toolbar of colors', () => {
 		expect( wrapper ).toMatchSnapshot();
-	} );
-
-	test( 'should render a dynamic toolbar with default colors, when colors are not present', () => {
-		expect( shallow( <ColorPalette defaultColors={ defaultColors } value={ currentColor } onChange={ onChange } /> ) ).toMatchSnapshot();
 	} );
 
 	test( 'should render three color button options', () => {
@@ -57,6 +52,10 @@ describe( 'ColorPalette', () => {
 
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 		expect( onChange ).toHaveBeenCalledWith( undefined );
+	} );
+
+	test( 'should allow disabling custom color picker', () => {
+		expect( shallow( <ColorPalette colors={ colors } disableCustomColors={ true } value={ currentColor } onChange={ onChange } /> ) ).toMatchSnapshot();
 	} );
 
 	describe( 'Dropdown', () => {

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -43,3 +43,13 @@ add_theme_support( 'editor-color-palette',
 ```
 
 The colors will be shown in order on the palette, and there's no limit to how many can be specified.
+
+### Disabling custom colors in block Color Palettes
+
+By default, the color palette offered to blocks, allows the user to select a custom color different from the editor or theme default colors.
+Themes can disable this feature using:
+```php
+add_theme_support( 'disable-custom-colors' );
+```
+
+This flag will make sure users are only able to choose colors from the `editor-color-palette` the theme provided or from the editor default colors if the theme did not provide one.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -874,10 +874,11 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$allowed_block_types = apply_filters( 'allowed_block_types', true );
 
 	$editor_settings = array(
-		'alignWide'          => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
-		'availableTemplates' => wp_get_theme()->get_page_templates( get_post( $post_to_edit['id'] ) ),
-		'blockTypes'         => $allowed_block_types,
-		'titlePlaceholder'   => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
+		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
+		'availableTemplates'  => wp_get_theme()->get_page_templates( get_post( $post_to_edit['id'] ) ),
+		'blockTypes'          => $allowed_block_types,
+		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
+		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
 	);
 
 	if ( ! empty( $color_palette ) ) {


### PR DESCRIPTION
When configuring theme support for Gutenberg themes can disable custom colors by setting allow-custom-colors to false.
Custom colors can also be configured in a per-use-case basis by changing allowCustomColors  prop when using ColorPalette component.

Sample theme code for disabling custom colors:
add_theme_support( '`disable-custom-colors`' );

## How Has This Been Tested?
Execute unit tests.
In a theme add the sample code and verify in a paragraph and/or button custom colors get disabled.
Go to one of ColorPalette uses and temporarily set an allowCustomColors prop in a ColorPalette use case, verify that if the prop is explicitly passed the component always respects it.
