### PR TITLE
Change instances of FormToggle to use ToggleControl component

### DIFF
--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -129,6 +129,15 @@
 	&:empty {
 		margin-top: 0;
 	}
+	
+	.blocks-base-control {
+		width: 100%;
+	}
+	
+	.blocks-base-control:last-child,
+	.blocks-toggle-control > .blocks-base-control__label {
+		margin-bottom: 0;
+	}
 }
 
 .components-panel .circle-picker {

--- a/components/toggle-control/README.md
+++ b/components/toggle-control/README.md
@@ -48,3 +48,9 @@ A function that receives the checked state (boolean) as input.
 - Type: `function`
 - Required: Yes
 
+### showHint
+
+If set to false the On/Off hint text will not appear alongside the toggle control. Default is true.
+
+- Type: `Boolean`
+- Required: No

--- a/components/toggle-control/index.js
+++ b/components/toggle-control/index.js
@@ -25,7 +25,7 @@ class ToggleControl extends Component {
 	}
 
 	render() {
-		const { label, checked, help, instanceId } = this.props;
+		const { label, checked, help, instanceId, showHint } = this.props;
 		const id = `inspector-toggle-control-${ instanceId }`;
 
 		let describedBy;
@@ -45,6 +45,7 @@ class ToggleControl extends Component {
 					checked={ checked }
 					onChange={ this.onChange }
 					aria-describedby={ describedBy }
+					showHint={ showHint }
 				/>
 			</BaseControl>
 		);

--- a/editor/components/post-comments/index.js
+++ b/editor/components/post-comments/index.js
@@ -20,6 +20,7 @@ function PostComments( { commentStatus = 'open', ...props } ) {
 
 	return (
 		<ToggleControl
+			key="toggle"
 			label={ __( 'Allow Comments' ) }
 			checked={ commentStatus === 'open' }
 			onChange={ onToggleComments }

--- a/editor/components/post-comments/index.js
+++ b/editor/components/post-comments/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { FormToggle, withInstanceId } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -15,21 +15,17 @@ import { FormToggle, withInstanceId } from '@wordpress/components';
 import { getEditedPostAttribute } from '../../store/selectors';
 import { editPost } from '../../store/actions';
 
-function PostComments( { commentStatus = 'open', instanceId, ...props } ) {
+function PostComments( { commentStatus = 'open', ...props } ) {
 	const onToggleComments = () => props.editPost( { comment_status: commentStatus === 'open' ? 'closed' : 'open' } );
 
-	const commentsToggleId = 'allow-comments-toggle-' + instanceId;
-
-	return [
-		<label key="label" htmlFor={ commentsToggleId }>{ __( 'Allow Comments' ) }</label>,
-		<FormToggle
-			key="toggle"
+	return (
+		<ToggleControl
+			label={ __( 'Allow Comments' ) }
 			checked={ commentStatus === 'open' }
 			onChange={ onToggleComments }
 			showHint={ false }
-			id={ commentsToggleId }
-		/>,
-	];
+		/>
+	);
 }
 
 export default connect(
@@ -41,5 +37,5 @@ export default connect(
 	{
 		editPost,
 	}
-)( withInstanceId( PostComments ) );
+)( PostComments );
 

--- a/editor/components/post-comments/index.js
+++ b/editor/components/post-comments/index.js
@@ -20,7 +20,6 @@ function PostComments( { commentStatus = 'open', ...props } ) {
 
 	return (
 		<ToggleControl
-			key="toggle"
 			label={ __( 'Allow Comments' ) }
 			checked={ commentStatus === 'open' }
 			onChange={ onToggleComments }

--- a/editor/components/post-pending-status/index.js
+++ b/editor/components/post-pending-status/index.js
@@ -26,6 +26,7 @@ export function PostPendingStatus( { status, onUpdateStatus } ) {
 	return (
 		<PostPendingStatusCheck>
 			<ToggleControl
+				key="toggle"
 				label={ __( 'Pending Review' ) }
 				checked={ status === 'pending' }
 				onChange={ togglePendingStatus }

--- a/editor/components/post-pending-status/index.js
+++ b/editor/components/post-pending-status/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { FormToggle, withInstanceId } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 
 /**
@@ -17,8 +17,7 @@ import PostPendingStatusCheck from './check';
 import { getEditedPostAttribute } from '../../store/selectors';
 import { editPost } from '../../store/actions';
 
-export function PostPendingStatus( { instanceId, status, onUpdateStatus } ) {
-	const pendingId = 'pending-toggle-' + instanceId;
+export function PostPendingStatus( { status, onUpdateStatus } ) {
 	const togglePendingStatus = () => {
 		const updatedStatus = status === 'pending' ? 'draft' : 'pending';
 		onUpdateStatus( updatedStatus );
@@ -26,9 +25,8 @@ export function PostPendingStatus( { instanceId, status, onUpdateStatus } ) {
 
 	return (
 		<PostPendingStatusCheck>
-			<label htmlFor={ pendingId }>{ __( 'Pending Review' ) }</label>
-			<FormToggle
-				id={ pendingId }
+			<ToggleControl
+				label={ __( 'Pending Review' ) }
 				checked={ status === 'pending' }
 				onChange={ togglePendingStatus }
 				showHint={ false }
@@ -50,5 +48,4 @@ const applyConnect = connect(
 
 export default compose(
 	applyConnect,
-	withInstanceId
 )( PostPendingStatus );

--- a/editor/components/post-pending-status/index.js
+++ b/editor/components/post-pending-status/index.js
@@ -26,7 +26,6 @@ export function PostPendingStatus( { status, onUpdateStatus } ) {
 	return (
 		<PostPendingStatusCheck>
 			<ToggleControl
-				key="toggle"
 				label={ __( 'Pending Review' ) }
 				checked={ status === 'pending' }
 				onChange={ togglePendingStatus }

--- a/editor/components/post-pingbacks/index.js
+++ b/editor/components/post-pingbacks/index.js
@@ -18,15 +18,14 @@ import { editPost } from '../../store/actions';
 function PostPingbacks( { pingStatus = 'open', ...props } ) {
 	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
 
-	return [
+	return (
 		<ToggleControl
-			key="toggle"
 			label={ __( 'Allow Pingbacks & Trackbacks' ) }
 			checked={ pingStatus === 'open' }
 			onChange={ onTogglePingback }
 			showHint={ false }
-		/>,
-	];
+		/>
+	);
 }
 
 export default connect(

--- a/editor/components/post-pingbacks/index.js
+++ b/editor/components/post-pingbacks/index.js
@@ -20,6 +20,7 @@ function PostPingbacks( { pingStatus = 'open', ...props } ) {
 
 	return [
 		<ToggleControl
+			key="toggle"
 			label={ __( 'Allow Pingbacks & Trackbacks' ) }
 			checked={ pingStatus === 'open' }
 			onChange={ onTogglePingback }

--- a/editor/components/post-pingbacks/index.js
+++ b/editor/components/post-pingbacks/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { FormToggle, withInstanceId } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -15,19 +15,15 @@ import { FormToggle, withInstanceId } from '@wordpress/components';
 import { getEditedPostAttribute } from '../../store/selectors';
 import { editPost } from '../../store/actions';
 
-function PostPingbacks( { pingStatus = 'open', instanceId, ...props } ) {
+function PostPingbacks( { pingStatus = 'open', ...props } ) {
 	const onTogglePingback = () => props.editPost( { ping_status: pingStatus === 'open' ? 'closed' : 'open' } );
 
-	const pingbacksToggleId = 'allow-pingbacks-toggle-' + instanceId;
-
 	return [
-		<label key="label" htmlFor={ pingbacksToggleId }>{ __( 'Allow Pingbacks & Trackbacks' ) }</label>,
-		<FormToggle
-			key="toggle"
+		<ToggleControl
+			label={ __( 'Allow Pingbacks & Trackbacks' ) }
 			checked={ pingStatus === 'open' }
 			onChange={ onTogglePingback }
 			showHint={ false }
-			id={ pingbacksToggleId }
 		/>,
 	];
 }
@@ -41,5 +37,4 @@ export default connect(
 	{
 		editPost,
 	}
-)( withInstanceId( PostPingbacks ) );
-
+)( PostPingbacks );

--- a/editor/components/post-sticky/index.js
+++ b/editor/components/post-sticky/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { FormToggle, withInstanceId } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 
 /**
@@ -17,18 +17,14 @@ import { getEditedPostAttribute } from '../../store/selectors';
 import { editPost } from '../../store/actions';
 import PostStickyCheck from './check';
 
-export function PostSticky( { onUpdateSticky, postSticky = false, instanceId } ) {
-	const stickyToggleId = 'post-sticky-toggle-' + instanceId;
-
+export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 	return (
 		<PostStickyCheck>
-			<label htmlFor={ stickyToggleId }>{ __( 'Stick to the Front Page' ) }</label>
-			<FormToggle
-				key="toggle"
+			<ToggleControl
+				label={ __( 'Stick to the Front Page' ) }
 				checked={ postSticky }
 				onChange={ () => onUpdateSticky( ! postSticky ) }
 				showHint={ false }
-				id={ stickyToggleId }
 			/>
 		</PostStickyCheck>
 	);
@@ -51,5 +47,4 @@ const applyConnect = connect(
 
 export default compose( [
 	applyConnect,
-	withInstanceId,
 ] )( PostSticky );

--- a/editor/components/post-sticky/index.js
+++ b/editor/components/post-sticky/index.js
@@ -21,7 +21,6 @@ export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 	return (
 		<PostStickyCheck>
 			<ToggleControl
-				key="toggle"
 				label={ __( 'Stick to the Front Page' ) }
 				checked={ postSticky }
 				onChange={ () => onUpdateSticky( ! postSticky ) }

--- a/editor/components/post-sticky/index.js
+++ b/editor/components/post-sticky/index.js
@@ -21,6 +21,7 @@ export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 	return (
 		<PostStickyCheck>
 			<ToggleControl
+				key="toggle"
 				label={ __( 'Stick to the Front Page' ) }
 				checked={ postSticky }
 				onChange={ () => onUpdateSticky( ! postSticky ) }


### PR DESCRIPTION
Inspired by #4817, this moves all instances of the FormToggle component to use the ToggleControl component. It also adds a showHint prop to the ToggleControl.