### PR TITLE
Framework: Upgrade Rememo dependency to 2.4.0

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -434,8 +434,8 @@ export const getBlock = createSelector(
 			innerBlocks: getBlocks( state, uid ),
 		};
 	},
-	( state ) => [
-		get( state, [ 'editor', 'present', 'blocksByUid' ] ),
+	( state, uid ) => [
+		get( state, [ 'editor', 'present', 'blocksByUid', uid ] ),
 		get( state, [ 'editor', 'present', 'edits', 'meta' ] ),
 		get( state, 'currentPost.meta' ),
 	]

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -155,6 +155,7 @@ function gutenberg_register_scripts_and_styles() {
 		gutenberg_get_script_polyfill( array(
 			'\'Promise\' in window' => 'promise',
 			'\'fetch\' in window'   => 'fetch',
+			'\'WeakMap\' in window' => 'WeakMap',
 		) ),
 		'before'
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10252,9 +10252,9 @@
       }
     },
     "rememo": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-2.3.4.tgz",
-      "integrity": "sha512-pg3DcYhBAVbOdd6IPY6NOnI9M7lqTQU/g/BDrjNgzt1/G/meU6pWJFos3DHsY7HBTwC+oOFvpf3nLSuZg7+awA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-2.4.0.tgz",
+      "integrity": "sha512-4rqlLATPcha9lfdvylUWqSbceiTlYiBJvEJAyUiT/68cYPlNG1zXf7ABeve7s4YPrT6o3Q6zfN6n38ecAL71lw==",
       "requires": {
         "shallow-equal": "1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"redux-multi": "0.1.12",
 		"redux-optimist": "0.0.2",
 		"refx": "3.0.0",
-		"rememo": "2.3.4",
+		"rememo": "2.4.0",
 		"showdown": "1.7.4",
 		"simple-html-tokenizer": "0.4.1",
 		"tinycolor2": "1.4.1",


### PR DESCRIPTION
Related: https://github.com/aduth/rememo/pull/1
Related: #4939
Related: #4955

This pull request seeks to upgrade the `rememo` dependency from 2.3.4 to 2.4.0 .

[View Changelog](https://github.com/aduth/rememo/blob/master/CHANGELOG.md)

Notably, the new version improves support for nested dependants, which is important for the `getBlock` selector which otherwise has its cache busted much more frequently than desired, having performance impact on frequent block changes (such as those proposed in #4955).

__Testing instructions:__

Verify that there are no regressions in the behavior of block changes.

Note that block changes should only incur rerenders to the relevant block†, e.g. using [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) Highlight Updates feature.

Ensure unit tests pass:

```
npm run test-unit
```

_† There are still some unnecessary rerenders, though not nearly as bad as original in #4955 where every block would re-render._