### PR TITLE
Expose getEditedPostAttribute selector

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -100,10 +100,6 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
 	};
 
 	return connectWithStore( ( state, ownProps ) => {
-		const select = ( key, selectorName, ...args ) => {
-			return selectors[ key ][ selectorName ]( state[ key ], ...args );
-		};
-
 		return mapSelectorsToProps( select, ownProps );
 	} );
 };

--- a/data/index.js
+++ b/data/index.js
@@ -100,6 +100,10 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
 	};
 
 	return connectWithStore( ( state, ownProps ) => {
+		const select = ( key, selectorName, ...args ) => {
+			return selectors[ key ][ selectorName ]( state[ key ], ...args );
+		};
+
 		return mapSelectorsToProps( select, ownProps );
 	} );
 };

--- a/edit-post/components/sidebar/featured-image/index.js
+++ b/edit-post/components/sidebar/featured-image/index.js
@@ -43,7 +43,7 @@ function FeaturedImage( { isOpened, postType, onTogglePanel } ) {
 }
 
 const applyQuery = query( ( select ) => ( {
-	postTypeSlug: select( 'core/editor', 'getCurrentPostType' ),
+	postTypeSlug: select( 'core/editor', 'getEditedPostAttribute' ),
 } ) );
 
 const applyConnect = connect(

--- a/edit-post/components/sidebar/featured-image/index.js
+++ b/edit-post/components/sidebar/featured-image/index.js
@@ -43,7 +43,7 @@ function FeaturedImage( { isOpened, postType, onTogglePanel } ) {
 }
 
 const applyQuery = query( ( select ) => ( {
-	postTypeSlug: select( 'core/editor', 'getEditedPostAttribute' ),
+	postTypeSlug: select( 'core/editor', 'getEditedPostAttribute', 'type' ),
 } ) );
 
 const applyConnect = connect(

--- a/edit-post/components/sidebar/page-attributes/index.js
+++ b/edit-post/components/sidebar/page-attributes/index.js
@@ -46,7 +46,7 @@ export function PageAttributes( { isOpened, onTogglePanel, postType } ) {
 }
 
 const applyQuery = query( ( select ) => ( {
-	postTypeSlug: select( 'core/editor', 'getCurrentPostType' ),
+	postTypeSlug: select( 'core/editor', 'getEditedPostAttribute', 'type' ),
 } ) );
 
 const applyConnect = connect(

--- a/editor/components/document-outline/index.js
+++ b/editor/components/document-outline/index.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import './style.scss';
 import DocumentOutlineItem from './item';
-import { getBlocks, getEditedPostTitle } from '../../store/selectors';
+import { getBlocks, getEditedPostAttribute } from '../../store/selectors';
 import { selectBlock } from '../../store/actions';
 
 /**
@@ -134,7 +134,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect } ) => {
 export default connect(
 	( state ) => {
 		return {
-			title: getEditedPostTitle( state ),
+			title: getEditedPostAttribute( state, 'title' ),
 			blocks: getBlocks( state ),
 		};
 	},

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -19,7 +19,7 @@ import { withContext } from '@wordpress/components';
  */
 import './style.scss';
 import PostPermalink from '../post-permalink';
-import { getEditedPostTitle } from '../../store/selectors';
+import { getEditedPostAttribute } from '../../store/selectors';
 import { insertBlock, editPost, clearSelectedBlock } from '../../store/actions';
 
 /**
@@ -130,7 +130,7 @@ class PostTitle extends Component {
 
 const applyConnect = connect(
 	( state ) => ( {
-		title: getEditedPostTitle( state ),
+		title: getEditedPostAttribute( state, 'title' ),
 	} ),
 	{
 		onEnterPress() {

--- a/editor/hooks/copy-content/index.js
+++ b/editor/hooks/copy-content/index.js
@@ -24,7 +24,7 @@ function CopyContentButton( { editedPostContent, hasCopied, setState } ) {
 
 const Enhanced = compose(
 	query( ( select ) => ( {
-		editedPostContent: select( 'core/editor', 'getEditedPostContent' ),
+		editedPostContent: select( 'core/editor', 'getEditedPostAttribute', 'content' ),
 	} ) ),
 	withState( { hasCopied: false } )
 )( CopyContentButton );

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -10,7 +10,6 @@ import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import {
 	getEditedPostAttribute,
-	getEditedPostContent,
 	getSelectedBlockCount,
 } from './selectors';
 
@@ -27,7 +26,6 @@ loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
 registerSelectors( MODULE_KEY, {
 	getEditedPostAttribute,
-	getEditedPostContent,
 	getSelectedBlockCount,
 } );
 

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -10,6 +10,7 @@ import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import {
 	getEditedPostAttribute,
+	getEditedPostAttributes,
 	getSelectedBlockCount,
 } from './selectors';
 
@@ -26,6 +27,7 @@ loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
 registerSelectors( MODULE_KEY, {
 	getEditedPostAttribute,
+	getEditedPostAttributes,
 	getSelectedBlockCount,
 } );
 

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -10,7 +10,6 @@ import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import {
 	getEditedPostAttribute,
-	getEditedPostAttributes,
 	getSelectedBlockCount,
 } from './selectors';
 
@@ -27,7 +26,6 @@ loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
 registerSelectors( MODULE_KEY, {
 	getEditedPostAttribute,
-	getEditedPostAttributes,
 	getSelectedBlockCount,
 } );
 

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -9,11 +9,9 @@ import { registerReducer, registerSelectors, withRehydratation, loadAndPersist }
 import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import {
-	getCurrentPostType,
+	getEditedPostAttribute,
 	getEditedPostContent,
-	getEditedPostTitle,
 	getSelectedBlockCount,
-	getCurrentPostSlug,
 } from './selectors';
 
 /**
@@ -28,11 +26,9 @@ const store = applyMiddlewares(
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
 registerSelectors( MODULE_KEY, {
-	getCurrentPostType,
+	getEditedPostAttribute,
 	getEditedPostContent,
-	getEditedPostTitle,
 	getSelectedBlockCount,
-	getCurrentPostSlug,
 } );
 
 export default store;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -232,7 +232,7 @@ export function getEditedPostAttribute( state, attributeName ) {
 	// Special cases
 	switch ( attributeName ) {
 		case 'content':
-			return getEditedPostContent();
+			return getEditedPostContent( state );
 	}
 
 	return edits[ attributeName ] === undefined ?

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -252,8 +252,11 @@ export function getEditedPostAttribute( state, attributeName ) {
  */
 export function getEditedPostAttributes( state, attributeNames ) {
 	const attributes = {};
-	attributeNames.map( attributeName => {
-		attributes[ attributeName ] = getEditedPostAttribute( state, attributeName );
+	map( attributeNames, attributeName => {
+		const value = getEditedPostAttribute( state, attributeName );
+		if ( value ) {
+			attributes[ attributeName ] = getEditedPostAttribute( state, attributeName );
+		}
 	} );
 	return attributes;
 }

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -292,7 +292,7 @@ export function isEditedPostSaveable( state ) {
 	return (
 		!! getEditedPostAttribute( state, 'title' ) ||
 		!! getEditedPostExcerpt( state ) ||
-		!! getEditedPostAttribute( state, 'content' )
+		!! getEditedPostContent( state )
 	);
 }
 

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -228,6 +228,13 @@ export function getPostEdits( state ) {
  */
 export function getEditedPostAttribute( state, attributeName ) {
 	const edits = getPostEdits( state );
+
+	// Special cases
+	switch ( attributeName ) {
+		case 'content':
+			return getEditedPostContent();
+	}
+
 	return edits[ attributeName ] === undefined ?
 		state.currentPost[ attributeName ] :
 		edits[ attributeName ];

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -241,27 +241,6 @@ export function getEditedPostAttribute( state, attributeName ) {
 }
 
 /**
- * Returns a single attribute of the post being edited, preferring the unsaved
- * edit if one exists, but falling back to the attribute for the last known
- * saved state of the post.
- *
- * @param {Object}   state          Global application state.
- * @param {string[]} attributeNames Post attribute name.
- *
- * @return {Object}  Post attributes mapped to object by name.
- */
-export function getEditedPostAttributes( state, attributeNames ) {
-	const attributes = {};
-	map( attributeNames, attributeName => {
-		const value = getEditedPostAttribute( state, attributeName );
-		if ( value ) {
-			attributes[ attributeName ] = getEditedPostAttribute( state, attributeName );
-		}
-	} );
-	return attributes;
-}
-
-/**
  * Returns the current visibility of the post being edited, preferring the
  * unsaved value if different than the saved post. The return value is one of
  * "private", "password", or "public".

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -241,6 +241,24 @@ export function getEditedPostAttribute( state, attributeName ) {
 }
 
 /**
+ * Returns a single attribute of the post being edited, preferring the unsaved
+ * edit if one exists, but falling back to the attribute for the last known
+ * saved state of the post.
+ *
+ * @param {Object}   state          Global application state.
+ * @param {string[]} attributeNames Post attribute name.
+ *
+ * @return {Object}  Post attributes mapped to object by name.
+ */
+export function getEditedPostAttributes( state, attributeNames ) {
+	const attributes = {};
+	attributeNames.map( attributeName => {
+		attributes[ attributeName ] = getEditedPostAttribute( state, attributeName );
+	} );
+	return attributes;
+}
+
+/**
  * Returns the current visibility of the post being edited, preferring the
  * unsaved value if different than the saved post. The return value is one of
  * "private", "password", or "public".

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -170,17 +170,6 @@ export function getCurrentPostType( state ) {
 }
 
 /**
- * Returns the slug of the post currently being edited.
- *
- * @param {Object} state Global application state.
- *
- * @return {string} Slug.
- */
-export function getCurrentPostSlug( state ) {
-	return getEditedPostAttribute( state, 'slug' );
-}
-
-/**
  * Returns the ID of the post currently being edited, or null if the post has
  * not yet been saved.
  *
@@ -301,9 +290,9 @@ export function isEditedPostPublishable( state ) {
  */
 export function isEditedPostSaveable( state ) {
 	return (
-		!! getEditedPostTitle( state ) ||
+		!! getEditedPostAttribute( state, 'title' ) ||
 		!! getEditedPostExcerpt( state ) ||
-		!! getEditedPostContent( state )
+		!! getEditedPostAttribute( state, 'content' )
 	);
 }
 
@@ -324,26 +313,6 @@ export function isEditedPostBeingScheduled( state ) {
 }
 
 /**
- * Returns the raw title of the post being edited, preferring the unsaved value
- * if different than the saved post.
- *
- * @param {Object} state Global application state.
- *
- * @return {string} Raw post title.
- */
-export function getEditedPostTitle( state ) {
-	const editedTitle = getPostEdits( state ).title;
-	if ( editedTitle !== undefined ) {
-		return editedTitle;
-	}
-	const currentPost = getCurrentPost( state );
-	if ( currentPost.title && currentPost.title ) {
-		return currentPost.title;
-	}
-	return '';
-}
-
-/**
  * Gets the document title to be used.
  *
  * @param {Object} state Global application state.
@@ -351,7 +320,7 @@ export function getEditedPostTitle( state ) {
  * @return {string} Document title.
  */
 export function getDocumentTitle( state ) {
-	let title = getEditedPostTitle( state );
+	let title = getEditedPostAttribute( state, 'title' );
 
 	if ( ! title.trim() ) {
 		title = isCleanNewPost( state ) ? __( 'New post' ) : __( '(Untitled)' );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -41,6 +41,7 @@ const {
 	getSelectedBlock,
 	getBlockRootUID,
 	getEditedPostAttribute,
+	getEditedPostAttributes,
 	getMultiSelectedBlockUids,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
@@ -425,6 +426,47 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'youcha' );
+		} );
+	} );
+
+	describe( 'getEditedPostAttributes', () => {
+		it( 'should return the current post\'s slug and type if no edits have been made', () => {
+			const state = {
+				currentPost: {
+					slug: 'post slug',
+					type: 'post',
+				},
+			};
+
+			const expected = {
+				slug: 'post slug',
+				type: 'post',
+			};
+
+			expect( getEditedPostAttributes( state, [ 'slug', 'type' ] ) ).toEqual( expected );
+		} );
+
+		it( 'should return the current post\'s slug and type if only the slug is edited', () => {
+			const state = {
+				currentPost: {
+					slug: 'old slug',
+					type: 'post',
+				},
+				editor: {
+					present: {
+						edits: {
+							slug: 'new slug',
+						},
+					},
+				},
+			};
+
+			const expected = {
+				slug: 'new slug',
+				type: 'post',
+			};
+
+			expect( getEditedPostAttributes( state, [ 'slug', 'type' ] ) ).toEqual( expected );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -26,9 +26,7 @@ const {
 	getCurrentPostLastRevisionId,
 	getCurrentPostRevisionsCount,
 	getCurrentPostType,
-	getCurrentPostSlug,
 	getPostEdits,
-	getEditedPostTitle,
 	getDocumentTitle,
 	getEditedPostExcerpt,
 	getEditedPostVisibility,
@@ -42,6 +40,7 @@ const {
 	getBlockCount,
 	getSelectedBlock,
 	getBlockRootUID,
+	getEditedPostAttribute,
 	getMultiSelectedBlockUids,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
@@ -374,13 +373,13 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getCurrentPostSlug', () => {
+	describe( 'getEditedPostAttribute', () => {
 		it( 'should return the current post\'s slug if no edits have been made', () => {
 			const state = {
 				currentPost: { slug: 'post slug' },
 			};
 
-			expect( getCurrentPostSlug( state ) ).toBe( 'post slug' );
+			expect( getEditedPostAttribute( state, 'slug' ) ).toBe( 'post slug' );
 		} );
 
 		it( 'should return the latest slug if edits have been made to the post', () => {
@@ -395,7 +394,37 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getCurrentPostSlug( state ) ).toBe( 'new slug' );
+			expect( getEditedPostAttribute( state, 'slug' ) ).toBe( 'new slug' );
+		} );
+
+		it( 'should return the post saved title if the title is not edited', () => {
+			const state = {
+				currentPost: {
+					title: 'sassel',
+				},
+				editor: {
+					present: {
+						edits: { status: 'private' },
+					},
+				},
+			};
+
+			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'sassel' );
+		} );
+
+		it( 'should return the edited title', () => {
+			const state = {
+				currentPost: {
+					title: 'sassel',
+				},
+				editor: {
+					present: {
+						edits: { title: 'youcha' },
+					},
+				},
+			};
+
+			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'youcha' );
 		} );
 	} );
 
@@ -466,38 +495,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPostEdits( state ) ).toEqual( { title: 'terga' } );
-		} );
-	} );
-
-	describe( 'getEditedPostTitle', () => {
-		it( 'should return the post saved title if the title is not edited', () => {
-			const state = {
-				currentPost: {
-					title: 'sassel',
-				},
-				editor: {
-					present: {
-						edits: { status: 'private' },
-					},
-				},
-			};
-
-			expect( getEditedPostTitle( state ) ).toBe( 'sassel' );
-		} );
-
-		it( 'should return the edited title', () => {
-			const state = {
-				currentPost: {
-					title: 'sassel',
-				},
-				editor: {
-					present: {
-						edits: { title: 'youcha' },
-					},
-				},
-			};
-
-			expect( getEditedPostTitle( state ) ).toBe( 'youcha' );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -41,7 +41,6 @@ const {
 	getSelectedBlock,
 	getBlockRootUID,
 	getEditedPostAttribute,
-	getEditedPostAttributes,
 	getMultiSelectedBlockUids,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
@@ -426,47 +425,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'youcha' );
-		} );
-	} );
-
-	describe( 'getEditedPostAttributes', () => {
-		it( 'should return the current post\'s slug and type if no edits have been made', () => {
-			const state = {
-				currentPost: {
-					slug: 'post slug',
-					type: 'post',
-				},
-			};
-
-			const expected = {
-				slug: 'post slug',
-				type: 'post',
-			};
-
-			expect( getEditedPostAttributes( state, [ 'slug', 'type' ] ) ).toEqual( expected );
-		} );
-
-		it( 'should return the current post\'s slug and type if only the slug is edited', () => {
-			const state = {
-				currentPost: {
-					slug: 'old slug',
-					type: 'post',
-				},
-				editor: {
-					present: {
-						edits: {
-							slug: 'new slug',
-						},
-					},
-				},
-			};
-
-			const expected = {
-				slug: 'new slug',
-				type: 'post',
-			};
-
-			expect( getEditedPostAttributes( state, [ 'slug', 'type' ] ) ).toEqual( expected );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
In https://github.com/WordPress/gutenberg/pull/4802 @aduth voiced some concerns if attributes should have dedicated selectors for the `select` API. This PR removes the `getEditedPostSlug` and `getEditedPostTitle` selectors and exposes the `getEditedPostAttribute` selector.

I have removed the `getEditedPostContent` selector from the public API but not the selector itself, because it contains additional logic. I added a switch statement to `getEditedPostAttribute` to call `getEditedPostContent` when the attribute name passed is `content`.

Initially also added `getEditedPostAttributes` selector this PR, but moved it to a separate branch. `add/get-edited-post-attributes-selector`.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Rewritten existing unit tests.
Console tested.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Breaking change, if someone has already used the `getEditedPostSlug` or `getEditedPostTitle` selector.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
