### PR TITLE
Replaced focus with isSelected verification on hooks.

### DIFF
--- a/blocks/hooks/anchor.js
+++ b/blocks/hooks/anchor.js
@@ -58,8 +58,7 @@ export function addAttribute( settings ) {
  */
 export function withInspectorControl( BlockEdit ) {
 	const WrappedBlockEdit = ( props ) => {
-		const hasAnchor = hasBlockSupport( props.name, 'anchor' ) && props.focus;
-
+		const hasAnchor = hasBlockSupport( props.name, 'anchor' ) && props.isSelected;
 		return [
 			<BlockEdit key="block-edit-anchor" { ...props } />,
 			hasAnchor && <InspectorControls key="inspector-anchor">

--- a/blocks/hooks/custom-class-name.js
+++ b/blocks/hooks/custom-class-name.js
@@ -49,7 +49,7 @@ export function addAttribute( settings ) {
  */
 export function withInspectorControl( BlockEdit ) {
 	const WrappedBlockEdit = ( props ) => {
-		const hasCustomClassName = hasBlockSupport( props.name, 'customClassName', true ) && props.focus;
+		const hasCustomClassName = hasBlockSupport( props.name, 'customClassName', true ) && props.isSelected;
 
 		return [
 			<BlockEdit key="block-edit-custom-class-name" { ...props } />,


### PR DESCRIPTION
This fixes a bug where classes and anchor inputs are not being shown.
 
The focus property has been removed, and now isSelected should be used. During this change, hooks were not updated causing our checks condition to fail.

Props to @phpbits for reporting this problem.


## How Has This Been Tested?
Verify custom anchor input appears e.g: in the heading block.
Verify custom class input appears e.g: in the image block.

