### PR TITLE
Set customClassName support to false on freeform block.

### DIFF
--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -30,6 +30,7 @@ export const settings = {
 
 	supports: {
 		className: false,
+		customClassName: false,
 	},
 
 	edit: OldEditor,


### PR DESCRIPTION
Before className input appear on the classic block but not work because of the nature of the block, we don't have access to the mechanism to save/parse custom attributes.

In the freeform block if wanting custom classNames the user can do so by changing the code. Or using existing TinyMCE functionality.

Props to @phpbits for reporting this problem.

## How Has This Been Tested?
Verify className inputs don't appear in the classic block.
