### PR TITLE
Data: Expose registered selectors as functions

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -39,14 +39,14 @@ Let's say the state of our plugin (registered with the key `myPlugin`) has the f
 wp.data.registerSelectors( 'myPlugin', { getTitle: ( state ) => state.title } );
 ```
 
-### `wp.data.select( key: string, selectorName: string, ...args )`
+### `wp.data.select( key: string )`
 
-This function allows calling any registered selector. Given a module's key, a selector's name and extra arguments passed to the selector, this function calls the selector passing it the current state and the extra arguments provided.
+This function allows calling any registered selector. Given a module's key, this function returns an object of all selector functions registered for the module.
 
 #### Example:
 
 ```js
-wp.data.select( 'myPlugin', 'getTitle' ); // Returns "My post title"
+wp.data.select( 'myPlugin' ).getTitle(); // Returns "My post title"
 ```
 
 ### `wp.data.query( mapSelectorsToProps: function )( WrappedComponent: Component )`
@@ -58,7 +58,7 @@ const Component = ( { title } ) => <div>{ title }</div>;
 
 wp.data.query( select => {
 	return {
-		title: select( 'myPlugin', 'getTitle' ),
+		title: select( 'myPlugin' ).getTitle(),
 	};
 } )( Component );
 ```
@@ -71,7 +71,7 @@ Function used to subscribe to data changes. The listener function is called each
 // Subscribe.
 const unsubscribe = wp.data.subscribe( () => {
 	const data = {
-		slug: wp.data.select( 'core/editor', 'getEditedPostSlug' ),
+		slug: wp.data.select( 'core/editor' ).getEditedPostSlug(),
 	};
 
 	console.log( 'data changed', data );

--- a/data/index.js
+++ b/data/index.js
@@ -69,8 +69,20 @@ export function registerReducer( reducerKey, reducer ) {
  *                              state as first argument.
  */
 export function registerSelectors( reducerKey, newSelectors ) {
-	selectors[ reducerKey ] = newSelectors;
+	const store = stores[ reducerKey ];
+	const createStateSelector = ( selector ) => ( ...args ) => selector( store.getState(), ...args );
+	selectors[ reducerKey ] = mapValues( newSelectors, createStateSelector );
 }
+
+/**
+ * Calls a selector given the current state and extra arguments.
+ *
+ * @param {string} reducerKey Part of the state shape to register the
+ *                            selectors for.
+ *
+ * @return {*} The selector's returned value.
+ */
+export const select = ( reducerKey ) => selectors[ reducerKey ];
 
 /**
  * Higher Order Component used to inject data using the registered selectors.
@@ -100,24 +112,6 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
 	};
 
 	return connectWithStore( ( state, ownProps ) => {
-		const select = ( key, selectorName, ...args ) => {
-			return selectors[ key ][ selectorName ]( state[ key ], ...args );
-		};
-
 		return mapSelectorsToProps( select, ownProps );
 	} );
-};
-
-/**
- * Calls a selector given the current state and extra arguments.
- *
- * @param {string} reducerKey   Part of the state shape to register the
- *                              selectors for.
- * @param {string} selectorName Selector name.
- * @param {*}      args         Selectors arguments.
- *
- * @return {*} The selector's returned value.
- */
-export const select = ( reducerKey, selectorName, ...args ) => {
-	return selectors[ reducerKey ][ selectorName ]( stores[ reducerKey ].getState(), ...args );
 };

--- a/data/index.js
+++ b/data/index.js
@@ -82,7 +82,20 @@ export function registerSelectors( reducerKey, newSelectors ) {
  *
  * @return {*} The selector's returned value.
  */
-export const select = ( reducerKey ) => selectors[ reducerKey ];
+export function select( reducerKey ) {
+	if ( arguments.length > 1 ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'Deprecated: `select` now accepts only a single argument: the reducer key. ' +
+			'The return value is an object of selector functions.'
+		);
+
+		const [ , selectorKey, ...args ] = arguments;
+		return select( reducerKey )[ selectorKey ]( ...args );
+	}
+
+	return selectors[ reducerKey ];
+}
 
 /**
  * Higher Order Component used to inject data using the registered selectors.

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -38,6 +38,17 @@ describe( 'select', () => {
 		expect( select( 'reducer1' ).selector2() ).toEqual( 'result2' );
 		expect( selector2 ).toBeCalledWith( store.getState() );
 	} );
+
+	it( 'provides upgrade path for deprecated usage', () => {
+		const store = registerReducer( 'reducer', () => 'state' );
+		const selector = jest.fn( () => 'result' );
+
+		registerSelectors( 'reducer', { selector } );
+
+		expect( select( 'reducer', 'selector', 'arg' ) ).toEqual( 'result' );
+		expect( selector ).toBeCalledWith( store.getState(), 'arg' );
+		expect( console ).toHaveWarned();
+	} );
 } );
 
 describe( 'query', () => {

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -32,10 +32,10 @@ describe( 'select', () => {
 			selector2,
 		} );
 
-		expect( select( 'reducer1', 'selector1' ) ).toEqual( 'result1' );
+		expect( select( 'reducer1' ).selector1() ).toEqual( 'result1' );
 		expect( selector1 ).toBeCalledWith( store.getState() );
 
-		expect( select( 'reducer1', 'selector2' ) ).toEqual( 'result2' );
+		expect( select( 'reducer1' ).selector2() ).toEqual( 'result2' );
 		expect( selector2 ).toBeCalledWith( store.getState() );
 	} );
 } );
@@ -48,7 +48,7 @@ describe( 'query', () => {
 		} );
 		const Component = query( ( selectFunc, ownProps ) => {
 			return {
-				data: selectFunc( 'reactReducer', 'reactSelector', ownProps.keyName ),
+				data: selectFunc( 'reactReducer' ).reactSelector( ownProps.keyName ),
 			};
 		} )( ( props ) => {
 			return <div>{ props.data }</div>;
@@ -68,7 +68,7 @@ describe( 'subscribe', () => {
 			globalSelector: ( state ) => state,
 		} );
 		const unsubscribe = subscribe( () => {
-			incrementedValue = select( 'myAwesomeReducer', 'globalSelector' );
+			incrementedValue = select( 'myAwesomeReducer' ).globalSelector();
 		} );
 		const action = { type: 'dummy' };
 

--- a/edit-post/components/sidebar/featured-image/index.js
+++ b/edit-post/components/sidebar/featured-image/index.js
@@ -43,7 +43,7 @@ function FeaturedImage( { isOpened, postType, onTogglePanel } ) {
 }
 
 const applyQuery = query( ( select ) => ( {
-	postTypeSlug: select( 'core/editor', 'getEditedPostAttribute', 'type' ),
+	postTypeSlug: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
 } ) );
 
 const applyConnect = connect(

--- a/edit-post/components/sidebar/header.js
+++ b/edit-post/components/sidebar/header.js
@@ -49,7 +49,7 @@ const SidebarHeader = ( { panel, onSetPanel, onToggleSidebar, count } ) => {
 
 export default compose(
 	query( ( select ) => ( {
-		count: select( 'core/editor', 'getSelectedBlockCount' ),
+		count: select( 'core/editor' ).getSelectedBlockCount(),
 	} ) ),
 	connect(
 		( state ) => ( {

--- a/edit-post/components/sidebar/page-attributes/index.js
+++ b/edit-post/components/sidebar/page-attributes/index.js
@@ -46,7 +46,7 @@ export function PageAttributes( { isOpened, onTogglePanel, postType } ) {
 }
 
 const applyQuery = query( ( select ) => ( {
-	postTypeSlug: select( 'core/editor', 'getEditedPostAttribute', 'type' ),
+	postTypeSlug: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
 } ) );
 
 const applyConnect = connect(

--- a/editor/hooks/copy-content/index.js
+++ b/editor/hooks/copy-content/index.js
@@ -24,7 +24,7 @@ function CopyContentButton( { editedPostContent, hasCopied, setState } ) {
 
 const Enhanced = compose(
 	query( ( select ) => ( {
-		editedPostContent: select( 'core/editor', 'getEditedPostAttribute', 'content' ),
+		editedPostContent: select( 'core/editor' ).getEditedPostAttribute( 'content' ),
 	} ) ),
 	withState( { hasCopied: false } )
 )( CopyContentButton );


### PR DESCRIPTION
Related: #4105

This pull request seeks to update the data module selector pattern to expose selectors as functions directly, not invoke via named string arguments.

*Before:*

```js
select( 'core/editor', 'getEditedPostAttribute', 'title' );
```

*After:*

```js
select( 'core/editor' ).getEditedPostAttribute( 'title' );
```

__Implementation notes:__

~Since this was included in 2.1.0 of the plugin, do we need to include a deprecation upgrade path?~ Added in 338e5a8.

__Testing instructions:__

Ensure unit tests pass:

```
npm test
```

Verify there are no regressions in the current usage of data module `select`.