### PR TITLE
Restore firing change before RichText merging

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -508,6 +508,8 @@ export class RichText extends Component {
 
 			const forward = event.keyCode === DELETE;
 
+			this.onChange();
+
 			if ( this.props.onMerge ) {
 				this.props.onMerge( forward );
 			}


### PR DESCRIPTION
## Description
Introduced by #4955. Restores calling `onChange` props right before merging blocks. If this is not called, the content won't be up-to-date. I originally suggested this change, but later on throttling was introduced to the PR.

## How Has This Been Tested?
Select some text at the start of a paragraph, delete it, then backspace to merge with previous paragraph. Content should be correct (not merge previous content).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.