### PR TITLE
Blocks: Support reusable nested blocks

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -261,19 +261,21 @@ export function switchToBlockType( blocks, name ) {
 /**
  * Creates a new reusable block.
  *
- * @param {string} type       The type of the block referenced by the reusable
- *                            block.
- * @param {Object} attributes The attributes of the block referenced by the
- *                            reusable block.
+ * @param {string} type        The type of the block referenced by the reusable
+ *                             block.
+ * @param {Object} attributes  The attributes of the block referenced by the
+ *                             reusable block.
+ * @param {?Array} innerBlocks Nested blocks.
  *
  * @return {Object} A reusable block object.
  */
-export function createReusableBlock( type, attributes ) {
+export function createReusableBlock( type, attributes = {}, innerBlocks = [] ) {
 	return {
 		id: -uniqueId(), // Temorary id replaced when the block is saved server side
 		isTemporary: true,
 		title: __( 'Untitled block' ),
 		type,
 		attributes,
+		innerBlocks,
 	};
 }

--- a/blocks/api/test/factory.js
+++ b/blocks/api/test/factory.js
@@ -706,9 +706,11 @@ describe( 'block factory', () => {
 			const type = 'core/test-block';
 			const attributes = { name: 'Big Bird' };
 
-			expect( createReusableBlock( type, attributes ) ).toMatchObject( {
+			expect( createReusableBlock( type, attributes ) ).toEqual( {
 				id: expect.any( Number ),
+				isTemporary: true,
 				title: 'Untitled block',
+				innerBlocks: [],
 				type,
 				attributes,
 			} );

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -2,51 +2,90 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
+import { noop, get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { withFilters } from '@wordpress/components';
+import { query } from '@wordpress/data';
+import { Component, compose } from '@wordpress/element';
+import { withFilters, withAPIData } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import { createInnerBlockList } from './utils';
 import {
 	getBlockType,
 	getBlockDefaultClassname,
 	hasBlockSupport,
 } from '../api';
 
-export function BlockEdit( props ) {
-	const { name, attributes = {} } = props;
-	const blockType = getBlockType( name );
+export class BlockEdit extends Component {
+	getChildContext() {
+		const {
+			id: uid,
+			renderBlockMenu,
+			showContextualToolbar,
+			user,
+		} = this.props;
 
-	if ( ! blockType ) {
-		return null;
+		return {
+			BlockList: createInnerBlockList(
+				uid,
+				renderBlockMenu,
+				showContextualToolbar
+			),
+			canUserUseUnfilteredHTML: get( user.data, [
+				'capabilities',
+				'unfiltered_html',
+			], false ),
+		};
 	}
 
-	// Generate a class name for the block's editable form
-	const generatedClassName = hasBlockSupport( blockType, 'className', true ) ?
-		getBlockDefaultClassname( name ) :
-		null;
-	const className = classnames( generatedClassName, attributes.className );
+	render() {
+		const { name, attributes = {}, isSelected } = this.props;
+		const blockType = getBlockType( name );
 
-	// `edit` and `save` are functions or components describing the markup
-	// with which a block is displayed. If `blockType` is valid, assign
-	// them preferencially as the render value for the block.
-	const Edit = blockType.edit || blockType.save;
+		if ( ! blockType ) {
+			return null;
+		}
 
-	// For backwards compatibility concerns adds a focus and setFocus prop
-	// These should be removed after some time (maybe when merging to Core)
-	return (
-		<Edit
-			{ ...props }
-			className={ className }
-			focus={ props.isSelected ? {} : false }
-			setFocus={ noop }
-		/>
-	);
+		// Generate a class name for the block's editable form
+		const generatedClassName = hasBlockSupport( blockType, 'className', true ) ?
+			getBlockDefaultClassname( name ) :
+			null;
+		const className = classnames( generatedClassName, attributes.className );
+
+		// `edit` and `save` are functions or components describing the markup
+		// with which a block is displayed. If `blockType` is valid, assign
+		// them preferencially as the render value for the block.
+		const Edit = blockType.edit || blockType.save;
+
+		// For backwards compatibility concerns adds a focus and setFocus prop
+		// These should be removed after some time (maybe when merging to Core)
+		return (
+			<Edit
+				{ ...this.props }
+				className={ className }
+				focus={ isSelected ? {} : false }
+				setFocus={ noop }
+			/>
+		);
+	}
 }
 
-export default withFilters( 'blocks.BlockEdit' )( BlockEdit );
+BlockEdit.childContextTypes = {
+	BlockList: noop,
+	canUserUseUnfilteredHTML: noop,
+};
+
+export default compose( [
+	withFilters( 'blocks.BlockEdit' ),
+	query( ( select ) => ( {
+		postType: select( 'core/editor', 'getCurrentPostType' ),
+	} ) ),
+	withAPIData( ( { postType } ) => ( {
+		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
+	} ) ),
+] )( BlockEdit );

--- a/blocks/block-edit/utils.js
+++ b/blocks/block-edit/utils.js
@@ -4,11 +4,6 @@
 import { Component } from '@wordpress/element';
 
 /**
- * Internal dependencies
- */
-import BlockList from './';
-
-/**
  * An object of cached BlockList components
  *
  * @type {Object}
@@ -48,8 +43,12 @@ export function createInnerBlockList( uid, renderBlockMenu, showContextualToolba
 				}
 
 				render() {
+					// TODO: We shouldn't access BlockList via the global. Need
+					// to explore better merging of overlapping editor / blocks
+					// modules pieces.
 					return (
-						<BlockList
+						// eslint-disable-next-line react/jsx-no-undef
+						<wp.editor.BlockList
 							rootUID={ uid }
 							renderBlockMenu={ renderBlockMenu }
 							showContextualToolbar={ showContextualToolbar }

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -40,15 +40,6 @@ class ReusableBlockEdit extends Component {
 		}
 	}
 
-	/**
-	 * @inheritdoc
-	 */
-	componentWillReceiveProps( nextProps ) {
-		if ( this.props.focus && ! nextProps.focus ) {
-			this.stopEditing();
-		}
-	}
-
 	startEditing() {
 		this.setState( { isEditing: true } );
 	}
@@ -110,7 +101,7 @@ class ReusableBlockEdit extends Component {
 					setAttributes={ isEditing ? this.setAttributes : noop }
 				/>
 			</div>,
-			isSelected && (
+			( isSelected || isEditing ) && (
 				<ReusableBlockEditPanel
 					key="panel"
 					isEditing={ isEditing }

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -95,6 +95,7 @@ class ReusableBlockEdit extends Component {
 			<div key="edit" style={ { pointerEvents: isEditing ? 'auto' : 'none' } }>
 				<BlockEdit
 					{ ...this.props }
+					id={ reusableBlock.uid }
 					name={ reusableBlock.type }
 					isSelected={ isEditing && isSelected }
 					attributes={ reusableBlockAttributes }

--- a/blocks/test/helpers/index.js
+++ b/blocks/test/helpers/index.js
@@ -11,8 +11,8 @@ import {
 	createBlock,
 	getBlockType,
 	registerBlockType,
-	BlockEdit,
 } from '../..';
+import { BlockEdit } from '../../block-edit';
 
 export const blockEditRender = ( name, settings ) => {
 	if ( ! getBlockType( name ) ) {
@@ -26,6 +26,7 @@ export const blockEditRender = ( name, settings ) => {
 			isSelected={ false }
 			attributes={ block.attributes }
 			setAttributes={ noop }
+			user={ {} }
 		/>
 	);
 };

--- a/data/index.js
+++ b/data/index.js
@@ -92,20 +92,21 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
 			console.warn( 'Dispatch is not supported.' );
 		},
 	};
-	const connectWithStore = ( ...args ) => {
-		const ConnectedWrappedComponent = connect( ...args )( WrappedComponent );
-		return ( props ) => {
-			return <ConnectedWrappedComponent { ...props } store={ store } />;
-		};
-	};
 
-	return connectWithStore( ( state, ownProps ) => {
-		const select = ( key, selectorName, ...args ) => {
-			return selectors[ key ][ selectorName ]( state[ key ], ...args );
-		};
+	const ConnectedWrappedComponent = connect(
+		( state, ownProps ) => {
+			const select = ( key, selectorName, ...args ) => {
+				return selectors[ key ][ selectorName ]( state[ key ], ...args );
+			};
 
-		return mapSelectorsToProps( select, ownProps );
-	} );
+			return mapSelectorsToProps( select, ownProps );
+		},
+		null,
+		null,
+		{ storeKey: 'wpDataStore' }
+	)( WrappedComponent );
+
+	return ( props ) => <ConnectedWrappedComponent { ...props } wpDataStore={ store } />;
 };
 
 /**

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import { get, reduce, size, castArray, noop } from 'lodash';
+import { get, reduce, size, castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,7 +18,7 @@ import {
 	getSaveElement,
 	isReusableBlock,
 } from '@wordpress/blocks';
-import { withFilters, withContext, withAPIData } from '@wordpress/components';
+import { withFilters, withContext } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -37,7 +37,6 @@ import BlockMultiControls from './multi-controls';
 import BlockMobileToolbar from './block-mobile-toolbar';
 import BlockInsertionPoint from './insertion-point';
 import IgnoreNestedEvents from './ignore-nested-events';
-import { createInnerBlockList } from './utils';
 import {
 	clearSelectedBlock,
 	editPost,
@@ -65,7 +64,6 @@ import {
 	isSelectionEnabled,
 	isTyping,
 	getBlockMode,
-	getCurrentPostType,
 } from '../../store/selectors';
 
 const { BACKSPACE, ESCAPE, DELETE, ENTER, UP, RIGHT, DOWN, LEFT } = keycodes;
@@ -123,23 +121,6 @@ export class BlockListBlock extends Component {
 		this.state = {
 			error: null,
 			isSelectionCollapsed: true,
-		};
-	}
-
-	getChildContext() {
-		const {
-			uid,
-			renderBlockMenu,
-			showContextualToolbar,
-		} = this.props;
-
-		return {
-			BlockList: createInnerBlockList(
-				uid,
-				renderBlockMenu,
-				showContextualToolbar
-			),
-			canUserUseUnfilteredHTML: get( this.props.user, [ 'data', 'capabilities', 'unfiltered_html' ], false ),
 		};
 	}
 
@@ -612,7 +593,6 @@ const mapStateToProps = ( state, { uid, rootUID } ) => ( {
 	meta: getEditedPostAttribute( state, 'meta' ),
 	mode: getBlockMode( state, uid ),
 	isSelectionEnabled: isSelectionEnabled( state ),
-	postType: getCurrentPostType( state ),
 } );
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
@@ -688,11 +668,6 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 
 BlockListBlock.className = 'editor-block-list__block-edit';
 
-BlockListBlock.childContextTypes = {
-	BlockList: noop,
-	canUserUseUnfilteredHTML: noop,
-};
-
 export default compose(
 	connect( mapStateToProps, mapDispatchToProps ),
 	withContext( 'editor' )( ( settings ) => {
@@ -703,7 +678,4 @@ export default compose(
 		};
 	} ),
 	withFilters( 'editor.BlockListBlock' ),
-	withAPIData( ( { postType } ) => ( {
-		user: `/wp/v2/users/me?post_type=${ postType }&context=edit`,
-	} ) ),
 )( BlockListBlock );

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -340,8 +340,8 @@ export default {
 					type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
 					id,
 					reusableBlocks: castArray( reusableBlockOrBlocks ).map( ( { id: itemId, title, content } ) => {
-						const [ { name: type, attributes } ] = parse( content );
-						return { id: itemId, title, type, attributes };
+						const [ { uid, name: type, attributes, innerBlocks } ] = parse( content );
+						return { uid, id: itemId, title, type, attributes, innerBlocks };
 					} ),
 				} );
 			},
@@ -367,8 +367,8 @@ export default {
 		const { id } = action;
 		const { getState, dispatch } = store;
 
-		const { title, type, attributes, isTemporary } = getReusableBlock( getState(), id );
-		const content = serialize( createBlock( type, attributes ) );
+		const { title, type, attributes, isTemporary, innerBlocks } = getReusableBlock( getState(), id );
+		const content = serialize( createBlock( type, attributes, innerBlocks ) );
 		const requestData = isTemporary ? { title, content } : { id, title, content };
 
 		new wp.api.models.Blocks( requestData ).save().then(
@@ -457,14 +457,15 @@ export default {
 		const { getState, dispatch } = store;
 
 		const oldBlock = getBlock( getState(), action.uid );
-		const reusableBlock = createReusableBlock( oldBlock.name, oldBlock.attributes );
+		const { uid, name, attributes, innerBlocks } = oldBlock;
+		const reusableBlock = createReusableBlock( name, attributes, innerBlocks );
 		const newBlock = createBlock( 'core/block', {
 			ref: reusableBlock.id,
-			layout: oldBlock.attributes.layout,
+			layout: attributes.layout,
 		} );
 		dispatch( updateReusableBlock( reusableBlock.id, reusableBlock ) );
 		dispatch( saveReusableBlock( reusableBlock.id ) );
-		dispatch( replaceBlocks( [ oldBlock.uid ], [ newBlock ] ) );
+		dispatch( replaceBlocks( [ uid ], [ newBlock ] ) );
 	},
 	APPEND_DEFAULT_BLOCK( action ) {
 		const { attributes, rootUID } = action;

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -169,6 +169,12 @@ export const editor = flow( [
 			case 'RESET_BLOCKS':
 				return getFlattenedBlocks( action.blocks );
 
+			case 'FETCH_REUSABLE_BLOCKS_SUCCESS':
+				return {
+					...state,
+					...getFlattenedBlocks( action.reusableBlocks ),
+				};
+
 			case 'UPDATE_BLOCK_ATTRIBUTES':
 				// Ignore updates if block isn't known
 				if ( ! state[ action.uid ] ) {
@@ -271,6 +277,14 @@ export const editor = flow( [
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
 				return mapBlockOrder( action.blocks );
+
+			case 'FETCH_REUSABLE_BLOCKS_SUCCESS':
+				return {
+					...state,
+					...reduce( action.reusableBlocks, ( result, block ) => (
+						Object.assign( result, mapBlockOrder( block.innerBlocks, block.uid ) )
+					), {} ),
+				};
 
 			case 'INSERT_BLOCKS': {
 				const { rootUID = '', blocks } = action;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1228,7 +1228,15 @@ export function getRecentInserterItems( state, enabledBlockTypes = true ) {
  * @return {Object} The reusable block, or null if none exists.
  */
 export function getReusableBlock( state, ref ) {
-	return state.reusableBlocks.data[ ref ] || null;
+	const reusableBlock = state.reusableBlocks.data[ ref ];
+	if ( ! reusableBlock ) {
+		return null;
+	}
+
+	return {
+		...state.reusableBlocks.data[ ref ],
+		...getBlock( state, reusableBlock.uid ),
+	};
 }
 
 /**

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -506,7 +506,7 @@ describe( 'effects', () => {
 			it( 'should fetch multiple reusable blocks', () => {
 				const promise = Promise.resolve( [
 					{
-						id: 'a9691cf9-ecaa-42bd-a9ca-49587e817647',
+						id: 1,
 						title: 'My cool block',
 						content: '<!-- wp:core/test-block {"name":"Big Bird"} /-->',
 					},
@@ -528,12 +528,14 @@ describe( 'effects', () => {
 						type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
 						reusableBlocks: [
 							{
-								id: 'a9691cf9-ecaa-42bd-a9ca-49587e817647',
+								id: 1,
+								uid: expect.any( String ),
 								title: 'My cool block',
 								type: 'core/test-block',
 								attributes: {
 									name: 'Big Bird',
 								},
+								innerBlocks: [],
 							},
 						],
 					} );
@@ -573,11 +575,13 @@ describe( 'effects', () => {
 						reusableBlocks: [
 							{
 								id,
+								uid: expect.any( String ),
 								title: 'My cool block',
 								type: 'core/test-block',
 								attributes: {
 									name: 'Big Bird',
 								},
+								innerBlocks: [],
 							},
 						],
 					} );
@@ -831,6 +835,7 @@ describe( 'effects', () => {
 						title: 'Untitled block',
 						type: staticBlock.name,
 						attributes: staticBlock.attributes,
+						innerBlocks: [],
 					} )
 				);
 				expect( dispatch ).toHaveBeenCalledWith(

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2217,6 +2217,12 @@ describe( 'selectors', () => {
 						[ id ]: expectedReusableBlock,
 					},
 				},
+				editor: {
+					present: {
+						blocksByUid: {},
+						blockOrder: [],
+					},
+				},
 			};
 
 			const actualReusableBlock = getReusableBlock( state, id );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2156,6 +2156,7 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
+						blocksByUid: {},
 						blockOrder: [],
 					},
 				},


### PR DESCRIPTION
_In-Progress:_ Generally complete and working, but needs a close audit of revisions to reusable blocks APIs, as it is possible / likely that redundant data is being tracked.

This pull request seeks to resolves issues with saving a nested block as reusable.

This includes a number of revisions to...

1. Support `innerBlocks` in reusable-specific block factory methods, store effects, and reducers
2. Move context assignment of inner block list from `BlockListBlock` to `BlockEdit`, as the latter is the component used in rendering from `core/block`'s `edit`
   - Downside is a circular dependency from `blocks` to `editor`, as `BlockEdit` requires access to the `BlockList` component
3. Update reusable block UI behaviors to not abort editing when the block becomes deselected, as this is incompatible with nested blocks where selection changes to the inner block
4. Assign custom store key for components connected via the data module's `query` higher-order component, as this can otherwise conflict with other store-dependant wrappers.
   - The Reusable Block components depend on editor store directly, and while this is generally unadvisable and worth refactoring, we maybe shouldn't assume that multiple stores would not be present in plugin-implemented blocks.

__Future Tasks:__

We arguably ought to consolidate the block and reusable block object types, as there's a fair bit of redundancy between the two, evidenced by copying of behaviors from the original nested blocks implementation.

__Testing instructions:__

Verify there are no regressions in the behavior of reusable blocks.

Ensure that you can save a Columns block, including content, as a reusable block.

Ensure unit tests pass:

```
npm test
```