### PR TITLE
Fixed image caption select behaviour.

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -47,9 +47,15 @@ class ImageBlock extends Component {
 		super( ...arguments );
 		this.updateAlt = this.updateAlt.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
+		this.onFocusCaption = this.onFocusCaption.bind( this );
+		this.onImageClick = this.onImageClick.bind( this );
 		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSetHref = this.onSetHref.bind( this );
 		this.updateImageURL = this.updateImageURL.bind( this );
+
+		this.state = {
+			captionFocused: false,
+		};
 	}
 
 	componentDidMount() {
@@ -77,6 +83,14 @@ class ImageBlock extends Component {
 		}
 	}
 
+	componentWillReceiveProps( { isSelected } ) {
+		if ( ! isSelected && this.props.isSelected && this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: false,
+			} );
+		}
+	}
+
 	onSelectImage( media ) {
 		const attributes = { url: media.url, alt: media.alt, id: media.id };
 		if ( media.caption ) {
@@ -87,6 +101,22 @@ class ImageBlock extends Component {
 
 	onSetHref( value ) {
 		this.props.setAttributes( { href: value } );
+	}
+
+	onFocusCaption() {
+		if ( ! this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: true,
+			} );
+		}
+	}
+
+	onImageClick() {
+		if ( this.state.captionFocused ) {
+			this.setState( {
+				captionFocused: false,
+			} );
+		}
 	}
 
 	updateAlt( newAlt ) {
@@ -198,7 +228,7 @@ class ImageBlock extends Component {
 						// Disable reason: Image itself is not meant to be
 						// interactive, but should direct focus to block
 						// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-						const img = <img src={ url } alt={ alt } />;
+						const img = <img src={ url } alt={ alt } onClick={ this.onImageClick } />;
 
 						if ( ! isResizable || ! imageWidthWithinContainer ) {
 							return img;
@@ -250,8 +280,9 @@ class ImageBlock extends Component {
 						tagName="figcaption"
 						placeholder={ __( 'Write caption…' ) }
 						value={ caption }
+						onFocus={ this.onFocusCaption }
 						onChange={ ( value ) => setAttributes( { caption: value } ) }
-						isSelected={ isSelected }
+						isSelected={ this.state.captionFocused }
 						inlineToolbar
 					/>
 				) : null }


### PR DESCRIPTION
A regression happened and now the caption of the image is automatically selected and the placeholder is never shown.
This is not intuitive for the user because the caption is focused but the cursor does not appear.

## How Has This Been Tested?
Add an image block with an image, click the image, verify you see the caption placeholder.
Write a caption click the image and see that the caption field lost the focus

## Screenshots (jpeg or gifs if applicable):
![feb-12-2018 22-20-29](https://user-images.githubusercontent.com/11271197/36123145-b5574fe8-1043-11e8-96d3-3984843f72c1.gif)
![feb-12-2018 22-16-19](https://user-images.githubusercontent.com/11271197/36123163-bfa361c6-1043-11e8-81c5-824458fc85b5.gif)

