### PR TITLE
Components: Remove Popover isOpen prop, render by presence

### DIFF
--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -472,35 +472,36 @@ export class Autocomplete extends Component {
 				className="components-autocomplete"
 			>
 				{ children( { isExpanded, listBoxId, activeId } ) }
-				<Popover
-					isOpen={ isExpanded }
-					focusOnOpen={ false }
-					onClose={ this.reset }
-					position="top right"
-					className="components-autocomplete__popover"
-					getAnchorRect={ this.getWordRect }
-				>
-					<div
-						id={ listBoxId }
-						role="listbox"
-						className="components-autocomplete__results"
+				{ isExpanded && (
+					<Popover
+						focusOnMount={ false }
+						onClose={ this.reset }
+						position="top right"
+						className="components-autocomplete__popover"
+						getAnchorRect={ this.getWordRect }
 					>
-						{ isExpanded && map( filteredOptions, ( option, index ) => (
-							<Button
-								key={ option.key }
-								id={ `components-autocomplete-item-${ instanceId }-${ option.key }` }
-								role="option"
-								aria-selected={ index === selectedIndex }
-								className={ classnames( 'components-autocomplete__result', className, {
-									'is-selected': index === selectedIndex,
-								} ) }
-								onClick={ () => this.select( option ) }
-							>
-								{ option.label }
-							</Button>
-						) ) }
-					</div>
-				</Popover>
+						<div
+							id={ listBoxId }
+							role="listbox"
+							className="components-autocomplete__results"
+						>
+							{ isExpanded && map( filteredOptions, ( option, index ) => (
+								<Button
+									key={ option.key }
+									id={ `components-autocomplete-item-${ instanceId }-${ option.key }` }
+									role="option"
+									aria-selected={ index === selectedIndex }
+									className={ classnames( 'components-autocomplete__result', className, {
+										'is-selected': index === selectedIndex,
+									} ) }
+									onClick={ () => this.select( option ) }
+								>
+									{ option.label }
+								</Button>
+							) ) }
+						</div>
+					</Popover>
+				) }
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */

--- a/components/autocomplete/test/index.js
+++ b/components/autocomplete/test/index.js
@@ -127,7 +127,7 @@ function expectInitialState( wrapper ) {
 	expect( wrapper.state( 'query' ) ).toBeUndefined();
 	expect( wrapper.state( 'search' ) ).toEqual( /./ );
 	expect( wrapper.state( 'filteredOptions' ) ).toEqual( [] );
-	expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( false );
+	expect( wrapper.find( 'Popover' ) ).toHaveLength( 0 );
 	expect( wrapper.find( '.components-autocomplete__result' ) ).toHaveLength( 0 );
 }
 
@@ -206,7 +206,6 @@ describe( 'Autocomplete', () => {
 		it( 'renders children', () => {
 			const wrapper = makeAutocompleter( [] );
 			expect( wrapper.state().open ).toBeUndefined();
-			expect( wrapper.find( 'Popover' ).prop( 'focusOnOpen' ) ).toBe( false );
 			expect( wrapper.childAt( 0 ).hasClass( 'components-autocomplete' ) ).toBe( true );
 			expect( wrapper.find( '.fake-editor' ) ).toHaveLength( 1 );
 		} );
@@ -226,7 +225,8 @@ describe( 'Autocomplete', () => {
 				expect( wrapper.state( 'filteredOptions' ) ).toEqual( [
 					{ key: '0-0', value: 1, label: 'Bananas', keywords: [ 'fruit' ] },
 				] );
-				expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( true );
+				expect( wrapper.find( 'Popover' ) ).toHaveLength( 1 );
+				expect( wrapper.find( 'Popover' ).prop( 'focusOnMount' ) ).toBe( false );
 				expect( wrapper.find( 'button.components-autocomplete__result' ) ).toHaveLength( 1 );
 				done();
 			} );
@@ -245,7 +245,7 @@ describe( 'Autocomplete', () => {
 				expect( wrapper.state( 'query' ) ).toEqual( 'zzz' );
 				expect( wrapper.state( 'search' ) ).toEqual( /(?:\b|\s|^)zzz/i );
 				expect( wrapper.state( 'filteredOptions' ) ).toEqual( [] );
-				expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( false );
+				expect( wrapper.find( 'Popover' ) ).toHaveLength( 0 );
 				expect( wrapper.find( 'button.components-autocomplete__result' ) ).toHaveLength( 0 );
 				done();
 			} );
@@ -283,7 +283,7 @@ describe( 'Autocomplete', () => {
 					{ key: '0-1', value: 2, label: 'Apple', keywords: [ 'fruit' ] },
 					{ key: '0-2', value: 3, label: 'Avocado', keywords: [ 'fruit' ] },
 				] );
-				expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( true );
+				expect( wrapper.find( 'Popover' ) ).toHaveLength( 1 );
 				expect( wrapper.find( 'button.components-autocomplete__result' ) ).toHaveLength( 3 );
 				done();
 			} );
@@ -307,7 +307,7 @@ describe( 'Autocomplete', () => {
 					{ key: '0-1', value: 2, label: 'Apple', keywords: [ 'fruit' ] },
 					{ key: '0-2', value: 3, label: 'Avocado', keywords: [ 'fruit' ] },
 				] );
-				expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( true );
+				expect( wrapper.find( 'Popover' ) ).toHaveLength( 1 );
 				expect( wrapper.find( 'button.components-autocomplete__result' ) ).toHaveLength( 3 );
 				done();
 			} );
@@ -330,7 +330,7 @@ describe( 'Autocomplete', () => {
 					{ key: '0-1', value: 2, label: 'Apple', keywords: [ 'fruit' ] },
 					{ key: '0-2', value: 3, label: 'Avocado', keywords: [ 'fruit' ] },
 				] );
-				expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( true );
+				expect( wrapper.find( 'Popover' ) ).toHaveLength( 1 );
 				expect( wrapper.find( 'button.components-autocomplete__result' ) ).toHaveLength( 2 );
 				// simulate typing 'p'
 				simulateInput( wrapper, [ tx( 'ap' ) ] );
@@ -342,7 +342,7 @@ describe( 'Autocomplete', () => {
 				expect( wrapper.state( 'filteredOptions' ) ).toEqual( [
 					{ key: '0-1', value: 2, label: 'Apple', keywords: [ 'fruit' ] },
 				] );
-				expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( true );
+				expect( wrapper.find( 'Popover' ) ).toHaveLength( 1 );
 				expect( wrapper.find( 'button.components-autocomplete__result' ) ).toHaveLength( 1 );
 				// simulate typing ' '
 				simulateInput( wrapper, [ tx( 'ap ' ) ] );
@@ -445,7 +445,7 @@ describe( 'Autocomplete', () => {
 					{ key: '0-1', value: 2, label: 'Apple', keywords: [ 'fruit' ] },
 					{ key: '0-2', value: 3, label: 'Avocado', keywords: [ 'fruit' ] },
 				] );
-				expect( wrapper.find( 'Popover' ).prop( 'isOpen' ) ).toBe( false );
+				expect( wrapper.find( 'Popover' ) ).toHaveLength( 0 );
 				// the editor should not have gotten the event
 				expect( editorKeydown ).not.toHaveBeenCalled();
 				done();

--- a/components/dropdown-menu/test/index.js
+++ b/components/dropdown-menu/test/index.js
@@ -65,9 +65,7 @@ describe( 'DropdownMenu', () => {
 				keyCode: DOWN,
 			} );
 
-			const popover = wrapper.find( 'Popover' );
-
-			expect( popover.prop( 'isOpen' ) ).toBe( true );
+			expect( wrapper.find( 'Popover' ) ).toHaveLength( 1 );
 		} );
 	} );
 } );

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -80,18 +80,19 @@ class Dropdown extends Component {
 				   */ }
 				<div>
 					{ renderToggle( args ) }
-					<Popover
-						className={ contentClassName }
-						isOpen={ isOpen }
-						position={ position }
-						onClose={ this.close }
-						onClickOutside={ this.clickOutside }
-						expandOnMobile={ expandOnMobile }
-					>
-						<FocusManaged>
-							{ renderContent( args ) }
-						</FocusManaged>
-					</Popover>
+					{ isOpen && (
+						<Popover
+							className={ contentClassName }
+							position={ position }
+							onClose={ this.close }
+							onClickOutside={ this.clickOutside }
+							expandOnMobile={ expandOnMobile }
+						>
+							<FocusManaged>
+								{ renderContent( args ) }
+							</FocusManaged>
+						</Popover>
+					) }
 				</div>
 			</div>
 		);

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -6,10 +6,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal Dependencies
  */
-import withFocusReturn from '../higher-order/with-focus-return';
 import Popover from '../popover';
-
-const FocusManaged = withFocusReturn( ( { children } ) => children );
 
 class Dropdown extends Component {
 	constructor() {

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -88,9 +88,7 @@ class Dropdown extends Component {
 							onClickOutside={ this.clickOutside }
 							expandOnMobile={ expandOnMobile }
 						>
-							<FocusManaged>
-								{ renderContent( args ) }
-							</FocusManaged>
+							{ renderContent( args ) }
 						</Popover>
 					) }
 				</div>

--- a/components/dropdown/test/index.js
+++ b/components/dropdown/test/index.js
@@ -9,7 +9,7 @@ import { mount } from 'enzyme';
 import Dropdown from '../';
 
 describe( 'Dropdown', () => {
-	const expectPopoverOpened = ( wrapper, opened ) => expect( wrapper.find( 'Popover' ) ).toHaveProp( 'isOpen', opened );
+	const expectPopoverVisible = ( wrapper, visible ) => expect( wrapper.find( 'Popover' ) ).toHaveLength( visible ? 1 : 0 );
 
 	it( 'should toggle the dropdown properly', () => {
 		const expectButtonExpanded = ( wrapper, expanded ) => {
@@ -26,13 +26,13 @@ describe( 'Dropdown', () => {
 		/> );
 
 		expectButtonExpanded( wrapper, false );
-		expectPopoverOpened( wrapper, false );
+		expectPopoverVisible( wrapper, false );
 
 		wrapper.find( 'button' ).simulate( 'click' );
 		wrapper.update();
 
 		expectButtonExpanded( wrapper, true );
-		expectPopoverOpened( wrapper, true );
+		expectPopoverVisible( wrapper, true );
 	} );
 
 	it( 'should close the dropdown when calling onClose', () => {
@@ -46,16 +46,16 @@ describe( 'Dropdown', () => {
 			renderContent={ () => null }
 		/> );
 
-		expectPopoverOpened( wrapper, false );
+		expectPopoverVisible( wrapper, false );
 
 		wrapper.find( '.open' ).simulate( 'click' );
 		wrapper.update();
 
-		expectPopoverOpened( wrapper, true );
+		expectPopoverVisible( wrapper, true );
 
 		wrapper.find( '.close' ).simulate( 'click' );
 		wrapper.update();
 
-		expectPopoverOpened( wrapper, false );
+		expectPopoverVisible( wrapper, false );
 	} );
 } );

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -14,17 +14,20 @@ function ToggleButton( { isVisible, toggleVisible } ) {
 	return (
 		<button onClick={ toggleVisible }>
 			Toggle Popover!
-			<Popover
-				isOpen={ isVisible }
-				onClose={ toggleVisible }
-				onClick={ ( event ) => event.stopPropagation() }
-			>
-				Popover is toggled!
-			</Popover>
+			{ isVisible && (
+				<Popover
+					onClose={ toggleVisible }
+					onClick={ ( event ) => event.stopPropagation() }
+				>
+					Popover is toggled!
+				</Popover>
+			) }
 		</button>
 	);
 }
 ```
+
+If a Popover is returned by your component, it will be shown. To hide the popover, simply omit it from your component's render value.
 
 If you want Popover elementss to render to a specific location on the page to allow style cascade to take effect, you must render a `Popover.Slot` further up the element tree:
 
@@ -48,17 +51,9 @@ render(
 
 The component accepts the following props. Props not included in this set will be applied to the element wrapping Popover content.
 
-### isOpen
+### focusOnMount
 
-As a controlled component, it is expected that you will pass `isOpen` to control whether the popover is visible. Refer to the `onClose` documentation for the complementary behavior for determining when this value should be toggled in your parent component state.
-
-- Type: `Boolean`
-- Required: No
-- Default: `false`
-
-### focusOnOpen
-
-By default, the popover will receive focus when it transitions from closed to open. To suppress this behavior, assign `focusOnOpen` to `true`. This should only be assigned when an appropriately accessible substitute behavior exists.
+By default, the popover will receive focus when it mounts. To suppress this behavior, assign `focusOnMount` to `false`. This should only be assigned when an appropriately accessible substitute behavior exists.
 
 - Type: `Boolean`
 - Required: No

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -52,11 +52,10 @@ class Popover extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.isOpen ) {
-			this.setOffset();
-			this.setForcedPositions();
-			this.toggleWindowEvents( true );
-		}
+		this.setOffset();
+		this.setForcedPositions();
+		this.toggleWindowEvents( true );
+		this.focus();
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -69,21 +68,10 @@ class Popover extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { isOpen, position } = this.props;
-		const { isOpen: prevIsOpen, position: prevPosition } = prevProps;
-		if ( isOpen !== prevIsOpen ) {
-			this.toggleWindowEvents( isOpen );
+		const { position } = this.props;
+		const { position: prevPosition } = prevProps;
 
-			if ( isOpen ) {
-				this.focus();
-			}
-		}
-
-		if ( ! isOpen ) {
-			return;
-		}
-
-		if ( isOpen !== prevIsOpen || position !== prevPosition ) {
+		if ( position !== prevPosition ) {
 			this.setOffset();
 			this.setForcedPositions();
 		} else if ( ! isEqual( this.state, prevState ) ) {
@@ -105,8 +93,8 @@ class Popover extends Component {
 	}
 
 	focus() {
-		const { focusOnOpen = true } = this.props;
-		if ( ! focusOnOpen ) {
+		const { focusOnMount = true } = this.props;
+		if ( ! focusOnMount ) {
 			return;
 		}
 
@@ -129,7 +117,7 @@ class Popover extends Component {
 		this.rafHandle = window.requestAnimationFrame( this.setOffset );
 	}
 
-	getAnchorRect( ) {
+	getAnchorRect() {
 		const { anchor } = this.nodes;
 		if ( ! anchor || ! anchor.parentNode ) {
 			return;
@@ -251,7 +239,6 @@ class Popover extends Component {
 
 	render() {
 		const {
-			isOpen,
 			onClose,
 			children,
 			className,
@@ -261,17 +248,13 @@ class Popover extends Component {
 			/* eslint-disable no-unused-vars */
 			position,
 			range,
-			focusOnOpen,
+			focusOnMount,
 			getAnchorRect,
 			expandOnMobile,
 			/* eslint-enable no-unused-vars */
 			...contentProps
 		} = this.props;
 		const [ yAxis, xAxis ] = this.getPositions();
-
-		if ( ! isOpen ) {
-			return null;
-		}
 
 		const classes = classnames(
 			'components-popover',
@@ -314,7 +297,7 @@ class Popover extends Component {
 
 		// Apply focus return behavior except when default focus on open
 		// behavior is disabled.
-		if ( false !== focusOnOpen ) {
+		if ( false !== focusOnMount ) {
 			content = <FocusManaged>{ content }</FocusManaged>;
 		}
 

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -171,15 +171,16 @@ class Tooltip extends Component {
 			onBlur: this.createToggleIsOver( 'onBlur' ),
 			children: concatChildren(
 				child.props.children,
-				<Popover
-					isOpen={ isOver }
-					focusOnOpen={ false }
-					position={ position }
-					className="components-tooltip"
-					aria-hidden="true"
-				>
-					{ upperFirst( toLower( text ) ) }
-				</Popover>,
+				isOver && (
+					<Popover
+						focusOnMount={ false }
+						position={ position }
+						className="components-tooltip"
+						aria-hidden="true"
+					>
+						{ upperFirst( toLower( text ) ) }
+					</Popover>
+				),
 			),
 		} );
 	}

--- a/components/tooltip/test/index.js
+++ b/components/tooltip/test/index.js
@@ -19,7 +19,7 @@ describe( 'Tooltip', () => {
 			expect( wrapper.children() ).toHaveLength( 2 );
 		} );
 
-		it( 'should render children with additional popover', () => {
+		it( 'should render children', () => {
 			const wrapper = shallow(
 				<Tooltip position="bottom right" text="Help Text">
 					<button>Hover Me!</button>
@@ -27,13 +27,27 @@ describe( 'Tooltip', () => {
 			);
 
 			const button = wrapper.find( 'button' );
+			expect( wrapper.type() ).toBe( 'button' );
+			expect( button.children() ).toHaveLength( 1 );
+			expect( button.childAt( 0 ).text() ).toBe( 'Hover Me!' );
+		} );
+
+		it( 'should render children with additional popover when over', () => {
+			const wrapper = shallow(
+				<Tooltip position="bottom right" text="Help Text">
+					<button>Hover Me!</button>
+				</Tooltip>
+			);
+
+			wrapper.setState( { isOver: true } );
+
+			const button = wrapper.find( 'button' );
 			const popover = wrapper.find( 'Popover' );
 			expect( wrapper.type() ).toBe( 'button' );
 			expect( button.children() ).toHaveLength( 2 );
 			expect( button.childAt( 0 ).text() ).toBe( 'Hover Me!' );
 			expect( button.childAt( 1 ).name() ).toBe( 'Popover' );
-			expect( popover.prop( 'isOpen' ) ).toBe( false );
-			expect( popover.prop( 'focusOnOpen' ) ).toBe( false );
+			expect( popover.prop( 'focusOnMount' ) ).toBe( false );
 			expect( popover.prop( 'position' ) ).toBe( 'bottom right' );
 			expect( popover.children().text() ).toBe( 'Help text' );
 		} );
@@ -58,11 +72,11 @@ describe( 'Tooltip', () => {
 			const popover = wrapper.find( 'Popover' );
 			expect( originalFocus ).toHaveBeenCalledWith( event );
 			expect( wrapper.state( 'isOver' ) ).toBe( true );
-			expect( popover.prop( 'isOpen' ) ).toBe( true );
+			expect( popover ).toHaveLength( 1 );
 		} );
 
 		it( 'should show popover on delayed mouseenter', () => {
-			const expectPopoverOpened = ( wrapper, opened ) => expect( wrapper.find( 'Popover' ) ).toHaveProp( 'isOpen', opened );
+			const expectPopoverVisible = ( wrapper, visible ) => expect( wrapper.find( 'Popover' ) ).toHaveLength( visible ? 1 : 0 );
 
 			// Mount: Issues with using `setState` asynchronously with shallow-
 			// rendered components: https://github.com/airbnb/enzyme/issues/450
@@ -88,12 +102,12 @@ describe( 'Tooltip', () => {
 			expect( originalMouseEnter ).toHaveBeenCalled();
 
 			expect( wrapper.state( 'isOver' ) ).toBe( false );
-			expectPopoverOpened( wrapper, false );
+			expectPopoverVisible( wrapper, false );
 			wrapper.instance().delayedSetIsOver.flush();
 			wrapper.update();
 
 			expect( wrapper.state( 'isOver' ) ).toBe( true );
-			expectPopoverOpened( wrapper, true );
+			expectPopoverVisible( wrapper, true );
 		} );
 
 		it( 'should ignore mouseenter on disabled elements', () => {
@@ -124,7 +138,7 @@ describe( 'Tooltip', () => {
 			const popover = wrapper.find( 'Popover' );
 			wrapper.instance().delayedSetIsOver.flush();
 			expect( wrapper.state( 'isOver' ) ).toBe( false );
-			expect( popover.prop( 'isOpen' ) ).toBe( false );
+			expect( popover ).toHaveLength( 0 );
 		} );
 
 		it( 'should cancel pending setIsOver on mouseleave', () => {
@@ -150,7 +164,7 @@ describe( 'Tooltip', () => {
 
 			const popover = wrapper.find( 'Popover' );
 			expect( wrapper.state( 'isOver' ) ).toBe( false );
-			expect( popover.prop( 'isOpen' ) ).toBe( false );
+			expect( popover ).toHaveLength( 0 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to refactor the Popover component to remove the `isOpen` prop and instead infer openness by its presence.

The goal with this change is that it avoids render logic of rendered children from being executed except when the Popover is in-fact visible, thus avoiding wasted render reconciliation.

*Before:*

```jsx
<Popover isOpen={ isOpen }>Content</Popover>
```

*After:*

```jsx
{ isOpen && <Popover>Content</Popover> }
```

__Testing instructions:__

Verify that there are no regressions in the behavior of any popovers, dropdown menus, and tooltips, including focus management (focus return, close on blur).

Ensure unit tests pass:

```
npm run test-unit
```