### PR TITLE
Components: Refactor TableOfContents panel to separate component

### DIFF
--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -1,28 +1,17 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton } from '@wordpress/components';
+import { query } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import WordCount from '../word-count';
-import DocumentOutline from '../document-outline';
-import { getBlocks } from '../../store/selectors';
-import { selectBlock } from '../../store/actions';
+import TableOfContentsPanel from './panel';
 
-function TableOfContents( { blocks } ) {
-	const headings = filter( blocks, ( block ) => block.name === 'core/heading' );
-	const paragraphs = filter( blocks, ( block ) => block.name === 'core/paragraph' );
-
+function TableOfContents( { hasBlocks } ) {
 	return (
 		<Dropdown
 			position="bottom"
@@ -34,49 +23,16 @@ function TableOfContents( { blocks } ) {
 					icon="info-outline"
 					aria-expanded={ isOpen }
 					label={ __( 'Content Structure' ) }
-					disabled={ blocks.length === 0 }
+					disabled={ ! hasBlocks }
 				/>
 			) }
-			renderContent={ () => ( [
-				<div key="counts" className="table-of-contents__counts">
-					<div className="table-of-contents__count">
-						{ __( 'Words' ) }
-						<WordCount />
-					</div>
-					<div className="table-of-contents__count">
-						{ __( 'Headings' ) }
-						<span className="table-of-contents__number">{ headings.length }</span>
-					</div>
-					<div className="table-of-contents__count">
-						{ __( 'Paragraphs' ) }
-						<span className="table-of-contents__number">{ paragraphs.length }</span>
-					</div>
-					<div className="table-of-contents__count">
-						{ __( 'Blocks' ) }
-						<span className="table-of-contents__number">{ blocks.length }</span>
-					</div>
-				</div>,
-				headings.length > 0 && (
-					<div key="headings">
-						<hr />
-						<span className="table-of-contents__title">{ __( 'Document Outline' ) }</span>
-						<DocumentOutline />
-					</div>
-				),
-			] ) }
+			renderContent={ TableOfContentsPanel }
 		/>
 	);
 }
 
-export default connect(
-	( state ) => {
-		return {
-			blocks: getBlocks( state ),
-		};
-	},
-	{
-		onSelect( uid ) {
-			return selectBlock( uid );
-		},
-	}
-)( TableOfContents );
+export default query( ( select ) => {
+	return {
+		hasBlocks: !! select( 'core/editor', 'getBlocks' ),
+	};
+} )( TableOfContents );

--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -33,6 +33,6 @@ function TableOfContents( { hasBlocks } ) {
 
 export default query( ( select ) => {
 	return {
-		hasBlocks: !! select( 'core/editor', 'getBlocks' ),
+		hasBlocks: !! select( 'core/editor', 'getBlockCount' ),
 	};
 } )( TableOfContents );

--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -26,13 +26,13 @@ function TableOfContents( { hasBlocks } ) {
 					disabled={ ! hasBlocks }
 				/>
 			) }
-			renderContent={ TableOfContentsPanel }
+			renderContent={ () => <TableOfContentsPanel /> }
 		/>
 	);
 }
 
 export default query( ( select ) => {
 	return {
-		hasBlocks: !! select( 'core/editor', 'getBlockCount' ),
+		hasBlocks: !! select( 'core/editor' ).getBlockCount(),
 	};
 } )( TableOfContents );

--- a/editor/components/table-of-contents/panel.js
+++ b/editor/components/table-of-contents/panel.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { countBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { query } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import WordCount from '../word-count';
+import DocumentOutline from '../document-outline';
+
+function TableOfContentsPanel( { blocks } ) {
+	const blockCount = countBy( blocks, 'name' );
+
+	return (
+		<Fragment>
+			<div className="table-of-contents__counts">
+				<div className="table-of-contents__count">
+					{ __( 'Words' ) }
+					<WordCount />
+				</div>
+				<div className="table-of-contents__count">
+					{ __( 'Headings' ) }
+					<span className="table-of-contents__number">
+						{ blockCount[ 'core/heading' ] || 0 }
+					</span>
+				</div>
+				<div className="table-of-contents__count">
+					{ __( 'Paragraphs' ) }
+					<span className="table-of-contents__number">
+						{ blockCount[ 'core/paragraph' ] || 0 }
+					</span>
+				</div>
+				<div className="table-of-contents__count">
+					{ __( 'Blocks' ) }
+					<span className="table-of-contents__number">
+						{ blocks.length }
+					</span>
+				</div>
+			</div>
+			{ blockCount[ 'core/heading' ] > 0 && (
+				<Fragment>
+					<hr />
+					<span className="table-of-contents__title">
+						{ __( 'Document Outline' ) }
+					</span>
+					<DocumentOutline />
+				</Fragment>
+			) }
+		</Fragment>
+	);
+}
+
+export default query( ( select ) => {
+	return {
+		blocks: select( 'core/editor', 'getBlocks' ),
+	};
+} )( TableOfContentsPanel );

--- a/editor/components/table-of-contents/panel.js
+++ b/editor/components/table-of-contents/panel.js
@@ -60,6 +60,6 @@ function TableOfContentsPanel( { blocks } ) {
 
 export default query( ( select ) => {
 	return {
-		blocks: select( 'core/editor', 'getBlocks' ),
+		blocks: select( 'core/editor' ).getBlocks(),
 	};
 } )( TableOfContentsPanel );

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -10,6 +10,7 @@ import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import {
 	getBlockCount,
+	getBlocks,
 	getEditedPostAttribute,
 	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,
@@ -28,6 +29,7 @@ loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
 registerSelectors( MODULE_KEY, {
 	getBlockCount,
+	getBlocks,
 	getEditedPostAttribute,
 	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -9,7 +9,7 @@ import { registerReducer, registerSelectors, withRehydratation, loadAndPersist }
 import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import {
-	getBlocks,
+	getBlockCount,
 	getEditedPostAttribute,
 	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,
@@ -27,7 +27,7 @@ const store = applyMiddlewares(
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
 registerSelectors( MODULE_KEY, {
-	getBlocks,
+	getBlockCount,
 	getEditedPostAttribute,
 	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -9,6 +9,7 @@ import { registerReducer, registerSelectors, withRehydratation, loadAndPersist }
 import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import {
+	getBlocks,
 	getEditedPostAttribute,
 	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,
@@ -26,6 +27,7 @@ const store = applyMiddlewares(
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
 registerSelectors( MODULE_KEY, {
+	getBlocks,
 	getEditedPostAttribute,
 	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,


### PR DESCRIPTION
Related: #5015 (current merge target, will revise to master if merged)

This pull request seeks to refactor TableOfContents to separate out the panel component. The goal here is performance-oriented, as any change to any block is currently incurring a re-render of this component, even when not expanded because it observes the `getBlocks` state. ~With this refactoring, the root `TableOfContents` component still observes `getBlocks`, but passes a primitive boolean value which will not cause a re-render to occur unless it changes (when post goes from not having blocks to having blocks).~ This has been further optimized in d7ca67f2f692b406a1a0abd49058e51b6433e2f4.

Generally, we should be cautious using this selector except when component elements are known to be visible.

__Testing instructions:__

Verify that there are no regressions in the behavior of the table of contents.