### PR TITLE
Block List: Refactor to use minimal block UIDs array

### DIFF
--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -9,16 +9,15 @@ import {
 	mapValues,
 	sortBy,
 	throttle,
-	get,
 	last,
 } from 'lodash';
+import classnames from 'classnames';
 import 'element-closest';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { getDefaultBlockName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -190,7 +189,7 @@ class BlockListLayout extends Component {
 
 	render() {
 		const {
-			blocks,
+			blockUIDs,
 			showContextualToolbar,
 			layout,
 			isGroupedByLayout,
@@ -203,15 +202,17 @@ class BlockListLayout extends Component {
 			defaultLayout = layout;
 		}
 
-		const isLastBlockDefault = get( last( blocks ), 'name' ) === getDefaultBlockName();
+		const classes = classnames( {
+			[ `layout-${ layout }` ]: layout,
+		} );
 
 		return (
-			<BlockSelectionClearer className={ 'layout-' + layout }>
-				{ map( blocks, ( block, blockIndex ) => (
+			<BlockSelectionClearer className={ classes }>
+				{ map( blockUIDs, ( uid, blockIndex ) => (
 					<BlockListBlock
-						key={ 'block-' + block.uid }
+						key={ 'block-' + uid }
 						index={ blockIndex }
-						uid={ block.uid }
+						uid={ uid }
 						blockRef={ this.setBlockRef }
 						onSelectionStart={ this.onSelectionStart }
 						onShiftSelection={ this.onShiftSelection }
@@ -219,17 +220,15 @@ class BlockListLayout extends Component {
 						rootUID={ rootUID }
 						layout={ defaultLayout }
 						isFirst={ blockIndex === 0 }
-						isLast={ blockIndex === blocks.length - 1 }
+						isLast={ blockIndex === blockUIDs.length - 1 }
 						renderBlockMenu={ renderBlockMenu }
 					/>
 				) ) }
-				{ ( ! blocks.length || ! isLastBlockDefault ) && (
-					<DefaultBlockAppender
-						rootUID={ rootUID }
-						layout={ defaultLayout }
-						showPrompt={ ! blocks.length }
-					/>
-				) }
+				<DefaultBlockAppender
+					rootUID={ rootUID }
+					lastBlockUID={ last( blockUIDs ) }
+					layout={ defaultLayout }
+				/>
 			</BlockSelectionClearer>
 		);
 	}

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { getDefaultBlockName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,8 +16,13 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import BlockDropZone from '../block-drop-zone';
 import { appendDefaultBlock } from '../../store/actions';
+import { getBlock, getBlockCount } from '../../store/selectors';
 
-export function DefaultBlockAppender( { onAppend, showPrompt = true } ) {
+export function DefaultBlockAppender( { isVisible, onAppend, showPrompt } ) {
+	if ( ! isVisible ) {
+		return null;
+	}
+
 	return (
 		<div className="editor-default-block-appender">
 			<BlockDropZone />
@@ -33,7 +40,16 @@ export function DefaultBlockAppender( { onAppend, showPrompt = true } ) {
 }
 
 export default connect(
-	null,
+	( state, ownProps ) => {
+		const isEmpty = ! getBlockCount( state, ownProps.rootUID );
+		const lastBlock = getBlock( state, ownProps.lastBlockUID );
+		const isLastBlockDefault = get( lastBlock, 'name' ) === getDefaultBlockName();
+
+		return {
+			isVisible: isEmpty || ! isLastBlockDefault,
+			showPrompt: isEmpty,
+		};
+	},
 	( dispatch, ownProps ) => ( {
 		onAppend() {
 			const { layout, rootUID } = ownProps;

--- a/editor/components/default-block-appender/test/index.js
+++ b/editor/components/default-block-appender/test/index.js
@@ -14,16 +14,22 @@ describe( 'DefaultBlockAppender', () => {
 		expect( onAppend ).toHaveBeenCalledWith();
 	};
 
+	it( 'should render nothing if not visible', () => {
+		const wrapper = shallow( <DefaultBlockAppender /> );
+
+		expect( wrapper.type() ).toBe( null );
+	} );
+
 	it( 'should match snapshot', () => {
 		const onAppend = jest.fn();
-		const wrapper = shallow( <DefaultBlockAppender onAppend={ onAppend } /> );
+		const wrapper = shallow( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
 
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	it( 'should append a default block when input clicked', () => {
 		const onAppend = jest.fn();
-		const wrapper = shallow( <DefaultBlockAppender onAppend={ onAppend } /> );
+		const wrapper = shallow( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
 		const input = wrapper.find( 'input.editor-default-block-appender__content' );
 
 		expect( input.prop( 'value' ) ).toEqual( 'Write your story' );
@@ -34,7 +40,7 @@ describe( 'DefaultBlockAppender', () => {
 
 	it( 'should append a default block when input focused', () => {
 		const onAppend = jest.fn();
-		const wrapper = shallow( <DefaultBlockAppender onAppend={ onAppend } /> );
+		const wrapper = shallow( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt /> );
 
 		wrapper.find( 'input.editor-default-block-appender__content' ).simulate( 'focus' );
 
@@ -45,7 +51,7 @@ describe( 'DefaultBlockAppender', () => {
 
 	it( 'should optionally show without prompt', () => {
 		const onAppend = jest.fn();
-		const wrapper = shallow( <DefaultBlockAppender onAppend={ onAppend } showPrompt={ false } /> );
+		const wrapper = shallow( <DefaultBlockAppender isVisible onAppend={ onAppend } showPrompt={ false } /> );
 		const input = wrapper.find( 'input.editor-default-block-appender__content' );
 
 		expect( input.prop( 'value' ) ).toEqual( '' );


### PR DESCRIPTION
This pull request seeks to refactor the BlockListLayout component to accept an array of block UIDs, and updates the VisualEditor to bypass default BlockList rendering for optimized skipping of layout filtering which do not apply at the top-level. The intent here is to avoid `getBlocks` selecting which can incur a re-render on any change to any block. After these changes, the top-level block list will render only when block order changes.

__Testing instructions:__

Verify that there are no regressions in the rendering of blocks, particularly adding new blocks, and the default block appender (present when no content exists with prompt, or when last block is not of the default type).