### PR TITLE
Block List: Extract copy, scroll-into-view logic to separate non-visual components

### DIFF
--- a/edit-post/components/modes/visual-editor/index.js
+++ b/edit-post/components/modes/visual-editor/index.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
  */
 import {
 	BlockList,
+	CopyHandler,
 	PostTitle,
 	WritingFlow,
 	EditorGlobalKeyboardShortcuts,
@@ -26,6 +27,7 @@ function VisualEditor( props ) {
 	return (
 		<BlockSelectionClearer className="edit-post-visual-editor">
 			<EditorGlobalKeyboardShortcuts />
+			<CopyHandler />
 			<WritingFlow>
 				<PostTitle />
 				<BlockList

--- a/edit-post/components/modes/visual-editor/index.js
+++ b/edit-post/components/modes/visual-editor/index.js
@@ -13,6 +13,7 @@ import {
 	WritingFlow,
 	EditorGlobalKeyboardShortcuts,
 	BlockSelectionClearer,
+	MultiSelectScrollIntoView,
 } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
 
@@ -28,6 +29,7 @@ function VisualEditor( props ) {
 		<BlockSelectionClearer className="edit-post-visual-editor">
 			<EditorGlobalKeyboardShortcuts />
 			<CopyHandler />
+			<MultiSelectScrollIntoView />
 			<WritingFlow>
 				<PostTitle />
 				<BlockList

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -25,6 +25,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { getScrollContainer } from '../../utils/dom';
 import BlockMover from '../block-mover';
 import BlockDropZone from '../block-drop-zone';
 import BlockSettingsMenu from '../block-settings-menu';
@@ -70,31 +71,6 @@ import {
 } from '../../store/selectors';
 
 const { BACKSPACE, ESCAPE, DELETE, ENTER, UP, RIGHT, DOWN, LEFT } = keycodes;
-
-/**
- * Given a DOM node, finds the closest scrollable container node.
- *
- * @param {Element} node Node from which to start.
- *
- * @return {?Element} Scrollable container node, if found.
- */
-function getScrollContainer( node ) {
-	if ( ! node ) {
-		return;
-	}
-
-	// Scrollable if scrollable height exceeds displayed...
-	if ( node.scrollHeight > node.clientHeight ) {
-		// ...except when overflow is defined to be hidden or visible
-		const { overflowY } = window.getComputedStyle( node );
-		if ( /(auto|scroll)/.test( overflowY ) ) {
-			return node;
-		}
-	}
-
-	// Continue traversing
-	return getScrollContainer( node.parentNode );
-}
 
 export class BlockListBlock extends Component {
 	constructor() {

--- a/editor/components/copy-handler/index.js
+++ b/editor/components/copy-handler/index.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { documentHasSelection } from '../../utils/dom';
+import { removeBlocks } from '../../store/actions';
+import {
+	getMultiSelectedBlocks,
+	getMultiSelectedBlockUids,
+	getSelectedBlock,
+} from '../../store/selectors';
+
+class CopyHandler extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onCopy = this.onCopy.bind( this );
+		this.onCut = this.onCut.bind( this );
+	}
+
+	componentDidMount() {
+		document.addEventListener( 'copy', this.onCopy );
+		document.addEventListener( 'cut', this.onCut );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'copy', this.onCopy );
+		document.removeEventListener( 'cut', this.onCut );
+	}
+
+	onCopy( event ) {
+		const { multiSelectedBlocks, selectedBlock } = this.props;
+
+		if ( ! multiSelectedBlocks.length && ! selectedBlock ) {
+			return;
+		}
+
+		// Let native copy behaviour take over in input fields.
+		if ( selectedBlock && documentHasSelection() ) {
+			return;
+		}
+
+		const serialized = serialize( selectedBlock || multiSelectedBlocks );
+
+		event.clipboardData.setData( 'text/plain', serialized );
+		event.clipboardData.setData( 'text/html', serialized );
+
+		event.preventDefault();
+	}
+
+	onCut( event ) {
+		const { multiSelectedBlockUids } = this.props;
+
+		this.onCopy( event );
+
+		if ( multiSelectedBlockUids.length ) {
+			this.props.onRemove( multiSelectedBlockUids );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			multiSelectedBlocks: getMultiSelectedBlocks( state ),
+			multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
+			selectedBlock: getSelectedBlock( state ),
+		};
+	},
+	{ onRemove: removeBlocks },
+)( CopyHandler );

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -64,6 +64,7 @@ export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as Inserter } from './inserter';
 export { default as MultiBlocksSwitcher } from './block-switcher/multi-blocks-switcher';
+export { default as MultiSelectScrollIntoView } from './multi-select-scroll-into-view';
 export { default as NavigableToolbar } from './navigable-toolbar';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -59,6 +59,7 @@ export { default as BlockMover } from './block-mover';
 export { default as BlockSelectionClearer } from './block-selection-clearer';
 export { default as BlockSettingsMenu } from './block-settings-menu';
 export { default as BlockToolbar } from './block-toolbar';
+export { default as CopyHandler } from './copy-handler';
 export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as Inserter } from './inserter';

--- a/editor/components/multi-select-scroll-into-view/index.js
+++ b/editor/components/multi-select-scroll-into-view/index.js
@@ -40,6 +40,12 @@ class MultiSelectScrollIntoView extends Component {
 
 		const scrollContainer = getScrollContainer( extentNode );
 
+		// If there's no scroll container, it follows that there's no scrollbar
+		// and thus there's no need to try to scroll into view.
+		if ( ! scrollContainer ) {
+			return;
+		}
+
 		scrollIntoView( extentNode, scrollContainer, {
 			onlyScrollIfNeeded: true,
 		} );

--- a/editor/components/multi-select-scroll-into-view/index.js
+++ b/editor/components/multi-select-scroll-into-view/index.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import scrollIntoView from 'dom-scroll-into-view';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { query } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getScrollContainer } from '../../utils/dom';
+
+class MultiSelectScrollIntoView extends Component {
+	componentDidUpdate() {
+		// Relies on expectation that `componentDidUpdate` will only be called
+		// if value of `extentUID` changes.
+		this.scrollIntoView();
+	}
+
+	/**
+	 * Ensures that if a multi-selection exists, the extent of the selection is
+	 * visible within the nearest scrollable container.
+	 *
+	 * @return {void}
+	 */
+	scrollIntoView() {
+		const { extentUID } = this.props;
+		if ( ! extentUID ) {
+			return;
+		}
+
+		const extentNode = document.querySelector( '[data-block="' + extentUID + '"]' );
+		if ( ! extentNode ) {
+			return;
+		}
+
+		const scrollContainer = getScrollContainer( extentNode );
+
+		scrollIntoView( extentNode, scrollContainer, {
+			onlyScrollIfNeeded: true,
+		} );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default query( ( select ) => {
+	return {
+		extentUID: select( 'core/editor' ).getLastMultiSelectedBlockUid(),
+	};
+} )( MultiSelectScrollIntoView );

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -10,6 +10,7 @@ import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import {
 	getEditedPostAttribute,
+	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,
 } from './selectors';
 
@@ -26,6 +27,7 @@ loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
 registerSelectors( MODULE_KEY, {
 	getEditedPostAttribute,
+	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,
 } );
 

--- a/editor/utils/dom.js
+++ b/editor/utils/dom.js
@@ -341,3 +341,28 @@ export function documentHasSelection() {
 
 	return range && ! range.collapsed;
 }
+
+/**
+ * Given a DOM node, finds the closest scrollable container node.
+ *
+ * @param {Element} node Node from which to start.
+ *
+ * @return {?Element} Scrollable container node, if found.
+ */
+export function getScrollContainer( node ) {
+	if ( ! node ) {
+		return;
+	}
+
+	// Scrollable if scrollable height exceeds displayed...
+	if ( node.scrollHeight > node.clientHeight ) {
+		// ...except when overflow is defined to be hidden or visible
+		const { overflowY } = window.getComputedStyle( node );
+		if ( /(auto|scroll)/.test( overflowY ) ) {
+			return node;
+		}
+	}
+
+	// Continue traversing
+	return getScrollContainer( node.parentNode );
+}


### PR DESCRIPTION
This pull request seeks to refactor copy and scroll-into-view logic currently contained within `BlockListLayout` to two separate top-level non-visual components `CopyHandler` and `MultiSelectScrollIntoView`. The goal is to optimize rendering of `BlockListLayout`, which currently re-renders when any blocks change because of its dependency on `getMultiSelectedBlocks`. Further, since `CopyHandler` and `MultiSelectScrollIntoView` is neither specific to a list layout rendering nor has any visual effect, it is well-suited as a non-visual component.

__Testing instructions:__

Verify that there are no regressions in the copying, cutting, or scroll-into-view assurance of multi-selection and multi-selection expansions.