### PR TITLE
State: Return shared array reference in empty multi-selection

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -32,13 +32,15 @@ const MAX_RECENT_BLOCKS = 8;
 export const POST_UPDATE_TRANSACTION_ID = 'post-update';
 
 /**
- * Shared reference to an empty array used as the default block order return
- * value when the state value is not explicitly assigned, since we want to
- * avoid returning a new array reference on every invocation.
+ * Shared reference to an empty array for cases where it is important to avoid
+ * returning a new array reference on every invocation, as in a connected or
+ * other pure component which performs `shouldComponentUpdate` check on props.
+ * This should be used as a last resort, since the normalized data should be
+ * maintained by the reducer result in state.
  *
  * @type {Array}
  */
-const DEFAULT_BLOCK_ORDER = [];
+const EMPTY_ARRAY = [];
 
 /**
  * Returns the state of legacy meta boxes.
@@ -677,7 +679,14 @@ export const getMultiSelectedBlockUids = createSelector(
  * @return {Array} Multi-selected block objects.
  */
 export const getMultiSelectedBlocks = createSelector(
-	( state ) => getMultiSelectedBlockUids( state ).map( ( uid ) => getBlock( state, uid ) ),
+	( state ) => {
+		const multiSelectedBlockUids = getMultiSelectedBlockUids( state );
+		if ( ! multiSelectedBlockUids.length ) {
+			return EMPTY_ARRAY;
+		}
+
+		return multiSelectedBlockUids.map( ( uid ) => getBlock( state, uid ) );
+	},
 	( state ) => [
 		state.editor.present.blockOrder,
 		state.blockSelection.start,
@@ -789,7 +798,7 @@ export function getMultiSelectedBlocksEndUid( state ) {
  * @return {Array} Ordered unique IDs of post blocks.
  */
 export function getBlockOrder( state, rootUID ) {
-	return state.editor.present.blockOrder[ rootUID || '' ] || DEFAULT_BLOCK_ORDER;
+	return state.editor.present.blockOrder[ rootUID || '' ] || EMPTY_ARRAY;
 }
 
 /**

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -43,6 +43,7 @@ const {
 	getBlockRootUID,
 	getEditedPostAttribute,
 	getMultiSelectedBlockUids,
+	getMultiSelectedBlocks,
 	getMultiSelectedBlocksStartUid,
 	getMultiSelectedBlocksEndUid,
 	getBlockOrder,
@@ -1345,6 +1346,26 @@ describe( 'selectors', () => {
 			};
 
 			expect( getMultiSelectedBlockUids( state ) ).toEqual( [ 9, 8, 7 ] );
+		} );
+	} );
+
+	describe( 'getMultiSelectedBlocks', () => {
+		it( 'should return the same reference on subsequent invocations of empty selection', () => {
+			const state = {
+				editor: {
+					present: {
+						blocksByUid: {},
+						blockOrder: {},
+						edits: {},
+					},
+				},
+				blockSelection: { start: null, end: null },
+				currentPost: {},
+			};
+
+			expect(
+				getMultiSelectedBlocks( state )
+			).toBe( getMultiSelectedBlocks( state ) );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request seeks to optimize the `getMultiSelectedBlocks` to return a shared reference to an empty array when there is no selection. This should help avoid re-renders in components which depend on the result of `getMultiSelectedBlocks` when there is no selection, as the `Array#map` used in `getMultiSelectedBlocks` creates a new return result on every invocation.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```

Verify there are no regressions in the behavior of multi-selection.