### PR TITLE
Performance: Use isTypingInBlock to avoid unnecessary block rerenders

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -599,21 +599,26 @@ export class BlockListBlock extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { uid, rootUID } ) => ( {
-	previousBlock: getPreviousBlock( state, uid ),
-	nextBlock: getNextBlock( state, uid ),
-	block: getBlock( state, uid ),
-	isSelected: isBlockSelected( state, uid ),
-	isMultiSelected: isBlockMultiSelected( state, uid ),
-	isFirstMultiSelected: isFirstMultiSelectedBlock( state, uid ),
-	isHovered: isBlockHovered( state, uid ) && ! isMultiSelecting( state ),
-	isTyping: isTyping( state ),
-	order: getBlockIndex( state, uid, rootUID ),
-	meta: getEditedPostAttribute( state, 'meta' ),
-	mode: getBlockMode( state, uid ),
-	isSelectionEnabled: isSelectionEnabled( state ),
-	postType: getCurrentPostType( state ),
-} );
+const mapStateToProps = ( state, { uid, rootUID } ) => {
+	const isSelected = isBlockSelected( state, uid );
+	return {
+		previousBlock: getPreviousBlock( state, uid ),
+		nextBlock: getNextBlock( state, uid ),
+		block: getBlock( state, uid ),
+		isMultiSelected: isBlockMultiSelected( state, uid ),
+		isFirstMultiSelected: isFirstMultiSelectedBlock( state, uid ),
+		isHovered: isBlockHovered( state, uid ) && ! isMultiSelecting( state ),
+		// We only care about this prop when the block is selected
+		// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
+		isTyping: isSelected && isTyping( state ),
+		order: getBlockIndex( state, uid, rootUID ),
+		meta: getEditedPostAttribute( state, 'meta' ),
+		mode: getBlockMode( state, uid ),
+		isSelectionEnabled: isSelectionEnabled( state ),
+		postType: getCurrentPostType( state ),
+		isSelected,
+	};
+};
 
 const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	onChange( uid, attributes ) {


### PR DESCRIPTION
The `isTyping` prop changes a lot when we move the mouse and write on the keyboard. The idea of this PR is that we only care about this prop when the block is selected so to avoid unnecessary rerenders in the Block component I'm injecting `isTypingInBlock` prop instead of the more generic `isTyping`.

**Testing instructions**

 - Test that writing hides the toolbar
 - Test that moving the mouse reshows the toolbar
 - Using the React dev tools, you can check that the unselected BlockListBlock components don't rerender when the isTyping action is dispatched.