### PR TITLE
Writing Flow: Clicking the default appender, triggers the isTyping mode

### DIFF
--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -15,7 +15,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
  */
 import './style.scss';
 import BlockDropZone from '../block-drop-zone';
-import { appendDefaultBlock } from '../../store/actions';
+import { appendDefaultBlock, startTyping } from '../../store/actions';
 import { getBlock, getBlockCount } from '../../store/selectors';
 
 export function DefaultBlockAppender( { isVisible, onAppend, showPrompt } ) {
@@ -60,6 +60,7 @@ export default connect(
 			}
 
 			dispatch( appendDefaultBlock( attributes, rootUID ) );
+			dispatch( startTyping() );
 		},
 	} ),
 )( DefaultBlockAppender );


### PR DESCRIPTION
related #4492

**Testing instructions**

 - Click "write story" on an empty post
 - The block toolbar shouldn't show up, you're automatically in the `isTyping` mode