### PR TITLE
Add hook to validate `useOnce` blocks

### DIFF
--- a/edit-post/hooks/index.js
+++ b/edit-post/hooks/index.js
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 import './more-menu';
+import './validate-use-once';

--- a/edit-post/hooks/validate-use-once/index.js
+++ b/edit-post/hooks/validate-use-once/index.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock, getBlockType } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { Warning } from '@wordpress/editor';
+import { compose, getWrapperDisplayName } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+const enhance = compose(
+	/*
+	 * For blocks whose block type defines `useOnce`, provides the wrapped
+	 * component with `originalBlockUid` -- a reference to the first block of
+	 * the same type in the content -- if and only if that "original" block is
+	 * not the current one. Thus, an inexisting `originalBlockUid` prop signals
+	 * that the block is valid.
+	 *
+	 * @param {Component} WrappedBlockEdit A filtered BlockEdit instance.
+	 * @return {Component}                 Enhanced component with merged state
+	 *                                     data props.
+	 */
+	withSelect( ( select, block ) => {
+		const blocks = select( 'core/editor' ).getBlocks();
+		const { useOnce } = getBlockType( block.name );
+
+		// For block types with no `useOnce` restriction, there is no "original
+		// block" to be found in the content, as the block itself is valid.
+		if ( ! useOnce ) {
+			return {};
+		}
+
+		// Otherwise, only pass `originalBlockUid` if it refers to a different
+		// block from the current one.
+		const firstOfSameType = find( blocks, ( { name } ) => block.name === name );
+		const isInvalid = firstOfSameType && firstOfSameType.uid !== block.id;
+		return {
+			originalBlockUid: isInvalid && firstOfSameType.uid,
+		};
+	} ),
+	withDispatch( ( dispatch, { originalBlockUid } ) => ( {
+		selectFirst: () => dispatch( 'core/editor' ).selectBlock( originalBlockUid ),
+	} ) ),
+);
+
+function withUseOnceValidation( BlockEdit ) {
+	const WrappedBlockEdit = ( {
+		originalBlockUid,
+		selectFirst,
+		...props
+	} ) => {
+		if ( ! originalBlockUid ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const blockType = getBlockType( props.name );
+		const outboundType = getOutboundType( blockType );
+
+		return [
+			<div key="invalid-preview" style={ { minHeight: '100px' } }>
+				<BlockEdit key="block-edit" { ...props } />
+			</div>,
+			<Warning key="use-once-warning">
+				<p>
+					<strong>{ blockType.title }: </strong>
+					{ __( 'This block may not be used more than once.' ) }</p>
+				<p>
+					<Button isLarge onClick={
+						selectFirst
+					}>{ __( 'Find original' ) }</Button>
+					<Button isLarge onClick={
+						() => props.onReplace( [] )
+					}>{ __( 'Remove' ) }</Button>
+					{ outboundType &&
+						<Button isLarge onClick={ () => props.onReplace(
+							createBlock( outboundType.name, props.attributes )
+						) }>
+							{ __( 'Transform into:' ) }{ ' ' }
+							{ outboundType.title }
+						</Button>
+					}
+				</p>
+			</Warning>,
+		];
+	};
+
+	WrappedBlockEdit.displayName = getWrapperDisplayName( BlockEdit, 'useOnceValidation' );
+
+	return enhance( WrappedBlockEdit );
+}
+
+/**
+ * Given a base block type, returns the default block type to which to offer
+ * transforms.
+ *
+ * @param {Object} blockType Base block type.
+ * @return {?Object}         The chosen default block type.
+ */
+function getOutboundType( blockType ) {
+	// Grab the first outbound transform
+	const { to = [] } = blockType.transforms || {};
+	const transform = find( to, ( { type, blocks } ) =>
+		type === 'block' && blocks.length === 1 // What about when .length > 1?
+	);
+
+	if ( ! transform ) {
+		return null;
+	}
+
+	return getBlockType( transform.blocks[ 0 ] );
+}
+
+addFilter(
+	'blocks.BlockEdit',
+	'core/validation/useOnce',
+	withUseOnceValidation
+);


### PR DESCRIPTION
## Description
Fixes #4932.

This pull request is one answer to handling scenarios in which multiple instances of a block are found in a post even though the block's type specifies it should only be used once ([`useOnce`](https://github.com/WordPress/gutenberg/blob/6c574c332caf8fa95bfa8077efe231f646434358/docs/block-api.md#useonce-optional)). The following example should be useful:

**Edit:** The _Edit as HTML_ button has been removed for now, and the More block doesn't offer any transformation (offering "Next Page" was merely conceptual). Instead, a _Find original_ button was added that selects (and moves into view) the one block in the content that is valid for the same block type.

Source | Result
--|--
<img width="632" alt="screen shot 2018-02-13 at 14 22 26" src="https://user-images.githubusercontent.com/150562/36154440-5f2ebcba-10c9-11e8-8682-7305493d0375.png"> | <img width="609" alt="screen shot 2018-02-13 at 14 22 05" src="https://user-images.githubusercontent.com/150562/36154446-65fde836-10c9-11e8-895c-e3dac2090809.png">

### Caveat

- The inspector controls aren't disabled for invalid blocks. This is a limitation stemming from the chosen hook (`blocks.BlockEdit`) and can be revisited.
- The suggestion to convert More to a Next Page block came out of my own liberty. We do not provide such a block yet, but it seemed like it would be a very timely suggestion: a lot of users may not even know of `<!--nextpage-->` and may be stitching together a post and realize they have multiple break points that they were representing with `<!--more-->`. Creating `blocks/library/next-page` and adding a transform from More would solve this. _Edit: more on Pagination [below](https://github.com/WordPress/gutenberg/pull/5031#issuecomment-365345920)._

## How Has This Been Tested?
- [Source](https://pastebin.com/raw/CpKjvnSr) of a post with multiple Subhead and More blocks.
- Very rough, needs testing, UX and design feedback.
- Needs a couple of unit tests.

## Screenshots (jpeg or gifs if applicable):

![gutenberg-use-once](https://user-images.githubusercontent.com/150562/36154708-378ec5a0-10ca-11e8-855f-ba51c2acf72d.gif)

## Types of changes
Enhancement; extension.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
