### PR TITLE
RichText: Ensure that hitting enter at the end of a paragraph creates an empty paragraph

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -612,8 +612,9 @@ export class RichText extends Component {
 			const afterFragment = afterRange.extractContents();
 
 			const beforeElement = nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
-			const afterElement = isLinkBoundary( afterFragment ) ? [] : nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
-
+			const afterElement = isLinkBoundary( afterFragment ) || tinymce.DOM.isEmpty( afterFragment ) ?
+				[] :
+				nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
 			this.setContent( beforeElement );
 			this.props.onSplit( beforeElement, afterElement, ...blocks );
 		} else {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -14,6 +14,7 @@ import {
 	defer,
 	noop,
 	throttle,
+	get,
 } from 'lodash';
 import { nodeListToReact } from 'dom-react';
 import 'element-closest';
@@ -54,10 +55,37 @@ export function createTinyMCEElement( type, props, ...children ) {
 	);
 }
 
-export function isLinkBoundary( fragment ) {
-	return fragment.childNodes && fragment.childNodes.length === 1 &&
-		fragment.childNodes[ 0 ].nodeName === 'A' && fragment.childNodes[ 0 ].text.length === 1 &&
-		fragment.childNodes[ 0 ].text[ 0 ] === '\uFEFF';
+/**
+ * Returns true if the fragment is the inline node boundary. This is used in
+ * fragment emptiness check to prevent the inline boundary from being included
+ * in the split which occurs while within but at the end of an inline node,
+ * since TinyMCE includes a placeholder caret character at the end.
+ *
+ * @param {DocumentFragment} fragment Fragment to test.
+ *
+ * @return {boolean} Whether fragment is inline boundary.
+ */
+export function isInlineBoundary( fragment ) {
+	return get( fragment.childNodes, [ 0, 'text' ] ) === '\uFEFF';
+}
+
+/**
+ * Returns true if the fragment is empty, meaning it contains only the
+ * placeholder caret character or has no text content of its own.
+ *
+ * @param {DocumentFragment} fragment Fragment to test.
+ *
+ * @return {boolean} Whether fragment is empty.
+ */
+export function isEmptyFragment( fragment ) {
+	return (
+		// Use strict equality because this value can be null in the case of a
+		// document value (`null === document.textContent`)
+		//
+		// See: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
+		'' === fragment.textContent ||
+		isInlineBoundary( fragment )
+	);
 }
 
 export function getFormatProperties( formatName, parents ) {
@@ -612,9 +640,7 @@ export class RichText extends Component {
 			const afterFragment = afterRange.extractContents();
 
 			const beforeElement = nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
-			const afterElement = isLinkBoundary( afterFragment ) || tinymce.DOM.isEmpty( afterFragment ) ?
-				[] :
-				nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
+			const afterElement = isEmptyFragment( afterFragment ) ? [] : nodeListToReact( afterFragment.childNodes, createTinyMCEElement );
 			this.setContent( beforeElement );
 			this.props.onSplit( beforeElement, afterElement, ...blocks );
 		} else {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -74,7 +74,7 @@ export function isEmptyInlineBoundary( node ) {
 
 /**
  * Returns true if the node is empty, meaning it contains only the placeholder
- * caret character or has no text content of its own.
+ * caret character or is an empty text node.
  *
  * @param {Node} node Node to test.
  *
@@ -82,18 +82,14 @@ export function isEmptyInlineBoundary( node ) {
  */
 export function isEmptyNode( node ) {
 	return (
-		// Use strict equality because this value can be null in the case of a
-		// document value (`null === document.textContent`)
-		//
-		// See: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
-		'' === node.textContent ||
+		'' === node.nodeValue ||
 		isEmptyInlineBoundary( node )
 	);
 }
 
 /**
  * Given a set of Nodes, filters to set to exclude any empty nodes: those with
- * either no text of their own or only including the inline boundary caret.
+ * either empty text nodes or only including the inline boundary caret.
  *
  * @param {Node[]} childNodes Nodes to filter.
  *

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -61,6 +61,8 @@ export function createTinyMCEElement( type, props, ...children ) {
  * occurs while within but at the end of an inline node, since TinyMCE includes
  * a placeholder caret character at the end.
  *
+ * @see https://github.com/tinymce/tinymce/blob/master/src/plugins/link/main/ts/core/Utils.ts
+ *
  * @param {Node} node Node to test.
  *
  * @return {boolean} Whether node is inline boundary.

--- a/blocks/rich-text/test/index.js
+++ b/blocks/rich-text/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { RichText, createTinyMCEElement, isLinkBoundary, getFormatProperties } from '../';
+import { RichText, createTinyMCEElement, isEmptyInlineBoundary, isEmptyNode, getFormatProperties } from '../';
 import { diffAriaProps, pickAriaProps } from '../aria';
 
 describe( 'createTinyMCEElement', () => {
@@ -40,24 +40,66 @@ describe( 'createTinyMCEElement', () => {
 	} );
 } );
 
-describe( 'isLinkBoundary', () => {
-	const fragment = {
-		childNodes: [
-			{
-				nodeName: 'A',
-				text: '\uFEFF',
+describe( 'isEmptyInlineBoundary', () => {
+	describe( 'link', () => {
+		const node = document.createElement( 'a' );
+		node.innerText = '\uFEFF';
 
-			},
-		],
-	};
+		test( 'should return true for a valid link boundary', () => {
+			expect( isEmptyInlineBoundary( node ) ).toBe( true );
+		} );
 
-	test( 'should return true for a valid link boundary', () => {
-		expect( isLinkBoundary( fragment ) ).toBe( true );
+		test( 'should return false for an invalid link boundary', () => {
+			const invalid = { ...node, childNodes: [] };
+			expect( isEmptyInlineBoundary( invalid ) ).toBe( false );
+		} );
 	} );
 
-	test( 'should return false for an invalid link boundary', () => {
-		const invalid = { ...fragment, childNodes: [] };
-		expect( isLinkBoundary( invalid ) ).toBe( false );
+	describe( 'code', () => {
+		const node = document.createElement( 'code' );
+		node.textContent = '\uFEFF';
+
+		test( 'should return true for a valid link boundary', () => {
+			expect( isEmptyInlineBoundary( node ) ).toBe( true );
+		} );
+
+		test( 'should return false for an invalid link boundary', () => {
+			const invalid = { ...node, childNodes: [] };
+			expect( isEmptyInlineBoundary( invalid ) ).toBe( false );
+		} );
+	} );
+} );
+
+describe( 'isEmptyNode', () => {
+	it( 'returns false for document', () => {
+		const node = document;
+
+		expect( isEmptyNode( node ) ).toBe( false );
+	} );
+
+	it( 'returns true for empty text node', () => {
+		const node = document.createTextNode( '' );
+
+		expect( isEmptyNode( node ) ).toBe( true );
+	} );
+
+	it( 'returns false for non-empty text node', () => {
+		const node = document.createTextNode( 'rabbit' );
+
+		expect( isEmptyNode( node ) ).toBe( false );
+	} );
+
+	it( 'returns true for empty element node', () => {
+		const node = document.createElement( 'div' );
+
+		expect( isEmptyNode( node ) ).toBe( true );
+	} );
+
+	it( 'returns false for non-empty element node', () => {
+		const node = document.createElement( 'div' );
+		node.textContent = 'rabbit';
+
+		expect( isEmptyNode( node ) ).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
**Testing instructions**

 - Hit enter at the end of a paragraph
 - The side inserter should show up in the newly created paragraph