### PR TITLE
New block: Custom Navigation Menu

### DIFF
--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -23,6 +23,7 @@ import * as html from './html';
 import * as latestPosts from './latest-posts';
 import * as list from './list';
 import * as more from './more';
+import * as navigationMenu from './navigation-menu';
 import * as preformatted from './preformatted';
 import * as pullquote from './pullquote';
 import * as reusableBlock from './block';
@@ -79,6 +80,7 @@ export const registerCoreBlocks = () => {
 		html,
 		latestPosts,
 		more,
+		navigationMenu,
 		preformatted,
 		pullquote,
 		reusableBlock,

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { filter, forEach, isEmpty, isUndefined } from 'lodash';
+import { filter, forEach, isEmpty, isUndefined, sortBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -43,12 +43,11 @@ function getMenuChildren( list, data ) {
 		list[ i ].children = filter( data, { menu_item_parent: item.id } );
 		list[ i ].children = getMenuChildren( list[ i ].children, data );
 	} );
-	// return sortBy( list, 'menu_order' );
-	return list;
+	return sortBy( list, 'menu_order' );
 }
 
 function getMenuWithChildren( data ) {
-	const sorted = filter( data, { menu_item_parent: 0 } );
+	const sorted = sortBy( filter( data, { menu_item_parent: 0 } ), 'menu_order' );
 	getMenuChildren( sorted, data );
 	return sorted;
 }

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -48,6 +53,7 @@ class NavigationMenuBlock extends Component {
 	}
 
 	renderMenu() {
+		const { layout } = this.props.attributes;
 		const { data, isLoading } = this.props.items;
 		if ( ! data || isLoading ) {
 			return (
@@ -65,7 +71,12 @@ class NavigationMenuBlock extends Component {
 		}
 
 		return (
-			<ul key="navigation-menu">
+			<ul
+				key="navigation-menu"
+				className={ classnames( this.props.className, {
+					'is-horizontal': layout === 'horizontal',
+				} ) }
+			>
 				{ data.map( ( item, i ) => {
 					return (
 						<li key={ i }>

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { filter, forEach, isEmpty, isUndefined, sortBy } from 'lodash';
+import { filter, forEach, isEmpty, isUndefined } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -44,18 +44,24 @@ function getOptionsFromMenu( menus, selected ) {
 	return options;
 }
 
+function sortMenuItems( items ) {
+	return [ ...items ].sort( ( a, b ) => {
+		return a.menu_order - b.menu_order;
+	} );
+}
+
 function getMenuChildren( list, data ) {
 	forEach( list, function( item, i ) {
 		const children = filter( data, { menu_item_parent: item.id } );
 		list[ i ].children = getMenuChildren( children, data );
 	} );
-	return sortBy( list, 'menu_order' );
+	return sortMenuItems( list );
 }
 
 function getMenuWithChildren( data ) {
-	const sorted = sortBy( filter( data, { menu_item_parent: 0 } ), 'menu_order' );
-	getMenuChildren( sorted, data );
-	return sorted;
+	const items = filter( data, { menu_item_parent: 0 } );
+	const sorted = sortMenuItems( items );
+	return getMenuChildren( sorted, data );
 }
 
 class NavigationMenuBlock extends Component {

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -40,8 +40,8 @@ function getOptionsFromMenu( menus, selected ) {
 
 function getMenuChildren( list, data ) {
 	forEach( list, function( item, i ) {
-		list[ i ].children = filter( data, { menu_item_parent: item.id } );
-		list[ i ].children = getMenuChildren( list[ i ].children, data );
+		const children = filter( data, { menu_item_parent: item.id } );
+		list[ i ].children = getMenuChildren( children, data );
 	} );
 	return sortBy( list, 'menu_order' );
 }
@@ -75,14 +75,15 @@ class NavigationMenuBlock extends Component {
 
 		const { layout } = this.props.attributes;
 		const isTopLevel = items[ 0 ].menu_item_parent === 0;
+		const isHorizontal = layout === 'horizontal';
 		const className = classnames( this.props.className, {
-			'is-horizontal': layout === 'horizontal',
+			'is-horizontal': isHorizontal,
 		} );
 
 		return (
 			<ul
 				key="navigation-menu"
-				className={ isTopLevel ? className : '' }
+				className={ isTopLevel || ! isHorizontal ? className : '' }
 			>
 				{ items.map( ( item, i ) => {
 					return (
@@ -96,7 +97,6 @@ class NavigationMenuBlock extends Component {
 	}
 
 	renderMenu() {
-		const { layout } = this.props.attributes;
 		const { data, isLoading } = this.props.items;
 		const customizerUrl = '';
 
@@ -117,12 +117,8 @@ class NavigationMenuBlock extends Component {
 			);
 		}
 
-		if ( 'horizontal' === layout ) {
-			const nestedData = getMenuWithChildren( data );
-			return this.renderMenuLevel( nestedData );
-		}
-
-		return this.renderMenuLevel( data );
+		const nestedData = getMenuWithChildren( data );
+		return this.renderMenuLevel( nestedData );
 	}
 
 	render() {

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -11,10 +11,26 @@ import { decodeEntities } from '@wordpress/utils';
  */
 import './editor.scss';
 import './style.scss';
-import InspectorControls from '../../inspector-controls';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+import InspectorControls from '../../inspector-controls';
 import MenuPlaceholder from './placeholder';
+import SelectControl from '../../inspector-controls/select-control';
+
+function getOptionsFromMenu( menus, selected ) {
+	if ( ! menus ) {
+		return [];
+	}
+
+	const options = menus.map( item => ( {
+		value: item.id,
+		label: item.name,
+	} ) );
+	if ( ! selected ) {
+		options.unshift( { value: '', label: __( 'Select' ) } );
+	}
+	return options;
+}
 
 class NavigationMenuBlock extends Component {
 	constructor() {
@@ -26,7 +42,9 @@ class NavigationMenuBlock extends Component {
 
 	setMenu( value ) {
 		const { setAttributes } = this.props;
-		setAttributes( { selected: value } );
+		if ( value ) {
+			setAttributes( { selected: value } );
+		}
 	}
 
 	renderMenu() {
@@ -62,11 +80,21 @@ class NavigationMenuBlock extends Component {
 	render() {
 		const { attributes, focus, setAttributes } = this.props;
 		const { align, layout, selected } = attributes;
-		const menus = this.props.menus.data;
+		const { data: menus, isLoading } = this.props.menus;
+
+		const menuSelectControl = (
+			<SelectControl
+				label={ __( 'Select an existing menu' ) }
+				value={ selected }
+				onChange={ this.setMenu }
+				options={ getOptionsFromMenu( menus, selected ) }
+			/>
+		);
 
 		const inspectorControls = focus && (
 			<InspectorControls key="inspector">
 				<h3>{ __( 'Menu Settings' ) }</h3>
+				{ ! isLoading && menuSelectControl }
 			</InspectorControls>
 		);
 
@@ -90,8 +118,9 @@ class NavigationMenuBlock extends Component {
 				key="navigation-menu"
 				menus={ menus }
 				selected={ false }
-				setMenu={ this.setMenu }
-			/>
+				setMenu={ this.setMenu } >
+				{ menuSelectControl }
+			</MenuPlaceholder>
 		);
 
 		if ( !! selected ) {

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -10,7 +10,7 @@ import { stringify } from 'querystringify';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Placeholder, Toolbar, Spinner, withAPIData } from '@wordpress/components';
+import { Toolbar, withAPIData } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/utils';
 
@@ -19,32 +19,26 @@ import { decodeEntities } from '@wordpress/utils';
  */
 import './editor.scss';
 import './style.scss';
-import QueryPanel from '../../query-panel';
 import InspectorControls from '../../inspector-controls';
-import ToggleControl from '../../inspector-controls/toggle-control';
-import RangeControl from '../../inspector-controls/range-control';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
-
-const MAX_POSTS_COLUMNS = 6;
+import MenuPlaceholder from './placeholder';
 
 class NavigationMenuBlock extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.toggleDisplayPostDate = this.toggleDisplayPostDate.bind( this );
+		this.setMenu = this.setMenu.bind( this );
 	}
 
-	toggleDisplayPostDate() {
-		const { displayPostDate } = this.props.attributes;
+	setMenu( value ) {
 		const { setAttributes } = this.props;
-
-		setAttributes( { displayPostDate: ! displayPostDate } );
+		setAttributes( { selected: value } );
 	}
 
 	render() {
 		const { attributes, focus, setAttributes } = this.props;
-		const { align, layout } = attributes;
+		const { align, layout, selected } = attributes;
 		const menus = this.props.menus.data;
 
 		const inspectorControls = focus && (
@@ -52,22 +46,6 @@ class NavigationMenuBlock extends Component {
 				<h3>{ __( 'Menu Settings' ) }</h3>
 			</InspectorControls>
 		);
-
-		const hasPosts = Array.isArray( menus ) && menus.length;
-		if ( ! hasPosts ) {
-			return [
-				inspectorControls,
-				<Placeholder key="placeholder"
-					icon="admin-post"
-					label={ __( 'Navigation Menu' ) }
-				>
-					{ ! Array.isArray( menus ) ?
-						<Spinner /> :
-						__( 'No posts found.' )
-					}
-				</Placeholder>,
-			];
-		}
 
 		const layoutControls = [
 			{
@@ -84,6 +62,19 @@ class NavigationMenuBlock extends Component {
 			},
 		];
 
+		let displayBlock = (
+			<MenuPlaceholder
+				key="navigation-menu"
+				menus={ menus }
+				selected={ false }
+				setMenu={ this.setMenu }
+			/>
+		);
+
+		if ( !! selected ) {
+			displayBlock = selected;
+		}
+
 		return [
 			inspectorControls,
 			focus && (
@@ -98,13 +89,7 @@ class NavigationMenuBlock extends Component {
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
 			),
-			<Placeholder
-				key="block-placeholder"
-				instructions={ __( 'Select an existing menu' ) }
-				icon={ 'menu' }
-				label={ __( 'Navigation Menu' ) } >
-				Test child
-			</Placeholder>,
+			displayBlock,
 		];
 	}
 }

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -112,7 +112,6 @@ class NavigationMenuBlock extends Component {
 
 	renderMenu() {
 		const { data, isLoading } = this.props.items;
-		const customizerUrl = '';
 
 		if ( isUndefined( data ) || isEmpty( data ) || isLoading ) {
 			return (
@@ -123,7 +122,7 @@ class NavigationMenuBlock extends Component {
 				>
 					{ ! Array.isArray( data ) ?
 						<Spinner /> :
-						<Button href={ `${ customizerUrl }?autofocus%5Bpanel%5D=nav_menus` }>
+						<Button href="customize.php?autofocus[panel]=nav_menus" target="_blank">
 							{ __( 'No items found in this menu.' ) }
 						</Button>
 					}

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { isEmpty, isUndefined } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Placeholder, Toolbar, Spinner, withAPIData } from '@wordpress/components';
+import { Button, Placeholder, Toolbar, Spinner, withAPIData } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/utils';
 
@@ -55,7 +56,9 @@ class NavigationMenuBlock extends Component {
 	renderMenu() {
 		const { layout } = this.props.attributes;
 		const { data, isLoading } = this.props.items;
-		if ( ! data || isLoading ) {
+		const customizerUrl = '';
+
+		if ( isUndefined( data ) || isEmpty( data ) || isLoading ) {
 			return (
 				<Placeholder
 					key="navigation-menu"
@@ -64,7 +67,9 @@ class NavigationMenuBlock extends Component {
 				>
 					{ ! Array.isArray( data ) ?
 						<Spinner /> :
-						__( 'No items found in this menu.' )
+						<Button href={ `${ customizerUrl }?autofocus%5Bpanel%5D=nav_menus` }>
+							{ __( 'No items found in this menu.' ) }
+						</Button>
 					}
 				</Placeholder>
 			);

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -76,14 +76,16 @@ class NavigationMenuBlock extends Component {
 		const { layout } = this.props.attributes;
 		const isTopLevel = items[ 0 ].menu_item_parent === 0;
 		const isHorizontal = layout === 'horizontal';
-		const className = classnames( this.props.className, {
+		const className = classnames( {
+			[ this.props.className ]: isTopLevel,
 			'is-horizontal': isHorizontal,
+			'is-vertical': ! isHorizontal,
 		} );
 
 		return (
 			<ul
 				key="navigation-menu"
-				className={ isTopLevel || ! isHorizontal ? className : '' }
+				className={ className }
 			>
 				{ items.map( ( item, i ) => {
 					return (

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -8,7 +8,14 @@ import { filter, forEach, isEmpty, isUndefined, sortBy } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Button, Placeholder, Toolbar, Spinner, withAPIData } from '@wordpress/components';
+import {
+	Button,
+	Placeholder,
+	Toolbar,
+	SelectControl,
+	Spinner,
+	withAPIData,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -21,7 +28,6 @@ import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import InspectorControls from '../../inspector-controls';
 import MenuItem from './item';
 import MenuPlaceholder from './placeholder';
-import SelectControl from '../../inspector-controls/select-control';
 
 function getOptionsFromMenu( menus, selected ) {
 	if ( ! menus ) {

--- a/blocks/library/navigation-menu/block.js
+++ b/blocks/library/navigation-menu/block.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { isUndefined, pickBy } from 'lodash';
+import moment from 'moment';
+import classnames from 'classnames';
+import { stringify } from 'querystringify';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { Placeholder, Toolbar, Spinner, withAPIData } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/utils';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import './style.scss';
+import QueryPanel from '../../query-panel';
+import InspectorControls from '../../inspector-controls';
+import ToggleControl from '../../inspector-controls/toggle-control';
+import RangeControl from '../../inspector-controls/range-control';
+import BlockControls from '../../block-controls';
+import BlockAlignmentToolbar from '../../block-alignment-toolbar';
+
+const MAX_POSTS_COLUMNS = 6;
+
+class NavigationMenuBlock extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.toggleDisplayPostDate = this.toggleDisplayPostDate.bind( this );
+	}
+
+	toggleDisplayPostDate() {
+		const { displayPostDate } = this.props.attributes;
+		const { setAttributes } = this.props;
+
+		setAttributes( { displayPostDate: ! displayPostDate } );
+	}
+
+	render() {
+		const { attributes, focus, setAttributes } = this.props;
+		const { align, layout } = attributes;
+		const menus = this.props.menus.data;
+
+		const inspectorControls = focus && (
+			<InspectorControls key="inspector">
+				<h3>{ __( 'Menu Settings' ) }</h3>
+			</InspectorControls>
+		);
+
+		const hasPosts = Array.isArray( menus ) && menus.length;
+		if ( ! hasPosts ) {
+			return [
+				inspectorControls,
+				<Placeholder key="placeholder"
+					icon="admin-post"
+					label={ __( 'Navigation Menu' ) }
+				>
+					{ ! Array.isArray( menus ) ?
+						<Spinner /> :
+						__( 'No posts found.' )
+					}
+				</Placeholder>,
+			];
+		}
+
+		const layoutControls = [
+			{
+				icon: 'list-view',
+				title: __( 'Vertical View' ),
+				onClick: () => setAttributes( { layout: 'vertical' } ),
+				isActive: layout === 'vertical',
+			},
+			{
+				icon: 'grid-view',
+				title: __( 'Horizontal View' ),
+				onClick: () => setAttributes( { layout: 'horizontal' } ),
+				isActive: layout === 'horizontal',
+			},
+		];
+
+		return [
+			inspectorControls,
+			focus && (
+				<BlockControls key="controls">
+					<BlockAlignmentToolbar
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
+						controls={ [ 'center', 'wide', 'full' ] }
+					/>
+					<Toolbar controls={ layoutControls } />
+				</BlockControls>
+			),
+			<Placeholder
+				key="block-placeholder"
+				instructions={ __( 'Select an existing menu' ) }
+				icon={ 'menu' }
+				label={ __( 'Navigation Menu' ) } >
+				Test child
+			</Placeholder>,
+		];
+	}
+}
+
+export default withAPIData( () => ( {
+	menus: '/wp/v2/menus',
+} ) )( NavigationMenuBlock );

--- a/blocks/library/navigation-menu/editor.scss
+++ b/blocks/library/navigation-menu/editor.scss
@@ -1,5 +1,8 @@
 .gutenberg .wp-block-navigation-menu {
 	padding-left: 2.5em;
+	&.is-vertical ul {
+		padding-left: 2.5em;
+	}
 	&.is-horizontal {
 		padding-left: 0;
 	}

--- a/blocks/library/navigation-menu/editor.scss
+++ b/blocks/library/navigation-menu/editor.scss
@@ -4,6 +4,7 @@
 		padding-left: 2.5em;
 	}
 	&.is-horizontal {
+		padding-left: 0;
 		ul {
 			border: 1px solid $light-gray-500;
 			border-top: none;
@@ -15,4 +16,9 @@
 
 		}
 	}
+}
+
+.gutenberg [data-align="full"] .wp-block-navigation-menu {
+	padding-left: 2em;
+	padding-right: 2em;
 }

--- a/blocks/library/navigation-menu/editor.scss
+++ b/blocks/library/navigation-menu/editor.scss
@@ -4,6 +4,15 @@
 		padding-left: 2.5em;
 	}
 	&.is-horizontal {
-		padding-left: 0;
+		ul {
+			border: 1px solid $light-gray-500;
+			border-top: none;
+			background: white;
+
+			ul {
+				border: none;
+			}
+
+		}
 	}
 }

--- a/blocks/library/navigation-menu/editor.scss
+++ b/blocks/library/navigation-menu/editor.scss
@@ -1,0 +1,6 @@
+.gutenberg .wp-block-navigation-menu {
+	padding-left: 2.5em;
+	&.is-horizontal {
+		padding-left: 0;
+	}
+}

--- a/blocks/library/navigation-menu/index.js
+++ b/blocks/library/navigation-menu/index.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import './style.scss';
+import NavMenuBlock from './block';
+
+export const name = 'core/navigation-menu';
+
+export const settings = {
+	title: __( 'Navigation Menu' ),
+
+	description: __( 'Display your site pages.' ),
+
+	icon: 'menu',
+
+	category: 'widgets',
+
+	keywords: [ __( 'navigation menu' ) ],
+
+	supports: {
+		html: false,
+	},
+
+	getEditWrapperProps( attributes ) {
+		const { align } = attributes;
+		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
+			return { 'data-align': align };
+		}
+	},
+
+	edit: NavMenuBlock,
+
+	save() {
+		return null;
+	},
+};

--- a/blocks/library/navigation-menu/index.js
+++ b/blocks/library/navigation-menu/index.js
@@ -15,7 +15,7 @@ export const name = 'core/navigation-menu';
 export const settings = {
 	title: __( 'Navigation Menu' ),
 
-	description: __( 'Display your site pages.' ),
+	description: __( 'Show a list of menu items.' ),
 
 	icon: 'menu',
 

--- a/blocks/library/navigation-menu/index.php
+++ b/blocks/library/navigation-menu/index.php
@@ -13,19 +13,30 @@
  * @return string Returns the post content with navigtion menu added.
  */
 function gutenberg_render_block_core_navigation_menu( $attributes ) {
-	// get menu.
+
+	$menu_id = (int) $attributes['selected'];
+
+	if ( ! $menu_id ) {
+		return '';
+	}
+
+	$menu = wp_get_nav_menu_object( $menu_id );
+
+	if ( ! $menu ) {
+		return '';
+	}
+
 	$class = "wp-block-navigation-menu align{$attributes['align']}";
 	if ( isset( $attributes['layout'] ) && 'horizontal' === $attributes['layout'] ) {
 		$class .= ' is-horizontal';
 	}
 
-	$block_content = sprintf(
-		'<ul class="%1$s">%2$s</ul>',
-		esc_attr( $class ),
-		''
-	);
-
-	return $block_content;
+	return wp_nav_menu( array(
+		'menu' => $menu,
+		'menu_class' => $class,
+		'fallback_cb' => false,
+		'echo' => false,
+	) );
 }
 
 register_block_type( 'core/navigation-menu', array(

--- a/blocks/library/navigation-menu/index.php
+++ b/blocks/library/navigation-menu/index.php
@@ -40,15 +40,15 @@ function gutenberg_render_block_core_navigation_menu( $attributes ) {
 }
 
 register_block_type( 'core/navigation-menu', array(
-	'attributes'      => array(
-		'selected'        => array(
-			'type' => 'string',
+	'attributes' => array(
+		'selected' => array(
+			'type' => 'int',
 		),
-		'layout'          => array(
+		'layout'   => array(
 			'type'    => 'string',
 			'default' => 'vertical',
 		),
-		'align'           => array(
+		'align'    => array(
 			'type'    => 'string',
 			'default' => 'center',
 		),

--- a/blocks/library/navigation-menu/index.php
+++ b/blocks/library/navigation-menu/index.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Server-side rendering of the `core/navigation-menu` block.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Renders the `core/navigation-menu` block on server.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string Returns the post content with navigtion menu added.
+ */
+function gutenberg_render_block_core_navigation_menu( $attributes ) {
+	// get menu.
+	$class = "wp-block-navigation-menu align{$attributes['align']}";
+	if ( isset( $attributes['layout'] ) && 'horizontal' === $attributes['layout'] ) {
+		$class .= ' is-horizontal';
+	}
+
+	$block_content = sprintf(
+		'<ul class="%1$s">%2$s</ul>',
+		esc_attr( $class ),
+		''
+	);
+
+	return $block_content;
+}
+
+register_block_type( 'core/navigation-menu', array(
+	'attributes'      => array(
+		'selected'        => array(
+			'type' => 'string',
+		),
+		'layout'          => array(
+			'type'    => 'string',
+			'default' => 'vertical',
+		),
+		'align'           => array(
+			'type'    => 'string',
+			'default' => 'center',
+		),
+	),
+	'render_callback' => 'gutenberg_render_block_core_navigation_menu',
+) );

--- a/blocks/library/navigation-menu/item.js
+++ b/blocks/library/navigation-menu/item.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -10,8 +15,8 @@ class MenuItem extends Component {
 		const { children, item } = this.props;
 
 		return (
-			<li>
-				<a href={ item.url } target="_blank">
+			<li className={ classnames( item.classes ) }>
+				<a title={ item.title } rel={ item.xfn } href={ item.url } target="_blank">
 					{ decodeEntities( item.title.trim() ) || __( '(Untitled)' ) }
 				</a>
 				{ children }

--- a/blocks/library/navigation-menu/item.js
+++ b/blocks/library/navigation-menu/item.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/utils';
+
+class MenuItem extends Component {
+	render() {
+		const { children, item } = this.props;
+
+		return (
+			<li>
+				<a href={ item.url } target="_blank">
+					{ decodeEntities( item.title.trim() ) || __( '(Untitled)' ) }
+				</a>
+				{ children }
+			</li>
+		);
+	}
+}
+
+export default MenuItem;

--- a/blocks/library/navigation-menu/item.js
+++ b/blocks/library/navigation-menu/item.js
@@ -13,9 +13,12 @@ import { decodeEntities } from '@wordpress/utils';
 class MenuItem extends Component {
 	render() {
 		const { children, item } = this.props;
+		const classes = classnames( item.classes, {
+			'menu-item-has-children': !! children,
+		} );
 
 		return (
-			<li className={ classnames( item.classes ) }>
+			<li className={ classes }>
 				<a title={ item.title } rel={ item.xfn } href={ item.url } target="_blank">
 					{ decodeEntities( item.title.trim() ) || __( '(Untitled)' ) }
 				</a>

--- a/blocks/library/navigation-menu/placeholder.js
+++ b/blocks/library/navigation-menu/placeholder.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button, Placeholder, Spinner } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { Placeholder, Spinner } from '@wordpress/components';
 
 class MenuPlaceholder extends Component {
 	render() {
@@ -12,14 +12,23 @@ class MenuPlaceholder extends Component {
 
 		if ( ! hasMenus ) {
 			return (
-				<Placeholder key="placeholder"
+				<Placeholder
+					key="placeholder"
 					icon="menu"
-					label={ __( 'Navigation Menu' ) }
-				>
-					{ ! Array.isArray( menus ) ?
-						<Spinner /> :
-						__( 'No menus found.' )
-					}
+					label={ __( 'Navigation Menu' ) }>
+					{ ! Array.isArray( menus ) ? (
+						<Spinner />
+					) : (
+						<div>
+							<span>{ __( 'No menus found.' ) }</span>
+							{ ' ' }
+							<Button
+								href="customize.php?autofocus[panel]=nav_menus"
+								target="_blank">
+								{ __( 'Create a menu.' ) }
+							</Button>
+						</div>
+					) }
 				</Placeholder>
 			);
 		}
@@ -28,7 +37,7 @@ class MenuPlaceholder extends Component {
 			<Placeholder
 				key="block-placeholder"
 				icon={ 'menu' }
-				label={ __( 'Navigation Menu' ) } >
+				label={ __( 'Navigation Menu' ) }>
 				{ children }
 			</Placeholder>
 		);

--- a/blocks/library/navigation-menu/placeholder.js
+++ b/blocks/library/navigation-menu/placeholder.js
@@ -21,7 +21,7 @@ class MenuPlaceholder extends Component {
 		if ( ! hasMenus ) {
 			return (
 				<Placeholder key="placeholder"
-					icon="admin-post"
+					icon="menu"
 					label={ __( 'Navigation Menu' ) }
 				>
 					{ ! Array.isArray( menus ) ?

--- a/blocks/library/navigation-menu/placeholder.js
+++ b/blocks/library/navigation-menu/placeholder.js
@@ -4,18 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
-import SelectControl from '../../inspector-controls/select-control';
 
 class MenuPlaceholder extends Component {
-	getOptionsFromMenu( menu ) {
-		return {
-			value: menu.id,
-			label: menu.name,
-		};
-	}
-
 	render() {
-		const { menus, selected, setMenu } = this.props;
+		const { children, menus } = this.props;
 		const hasMenus = Array.isArray( menus ) && menus.length;
 
 		if ( ! hasMenus ) {
@@ -37,12 +29,7 @@ class MenuPlaceholder extends Component {
 				key="block-placeholder"
 				icon={ 'menu' }
 				label={ __( 'Navigation Menu' ) } >
-				<SelectControl
-					label={ __( 'Select an existing menu' ) }
-					value={ selected }
-					onChange={ setMenu }
-					options={ menus.map( this.getOptionsFromMenu ) }
-				/>
+				{ children }
 			</Placeholder>
 		);
 	}

--- a/blocks/library/navigation-menu/placeholder.js
+++ b/blocks/library/navigation-menu/placeholder.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Placeholder, Spinner } from '@wordpress/components';
+import SelectControl from '../../inspector-controls/select-control';
+
+class MenuPlaceholder extends Component {
+	getOptionsFromMenu( menu ) {
+		return {
+			value: menu.id,
+			label: menu.name,
+		};
+	}
+
+	render() {
+		const { menus, selected, setMenu } = this.props;
+		const hasMenus = Array.isArray( menus ) && menus.length;
+
+		if ( ! hasMenus ) {
+			return (
+				<Placeholder key="placeholder"
+					icon="admin-post"
+					label={ __( 'Navigation Menu' ) }
+				>
+					{ ! Array.isArray( menus ) ?
+						<Spinner /> :
+						__( 'No menus found.' )
+					}
+				</Placeholder>
+			);
+		}
+
+		return (
+			<Placeholder
+				key="block-placeholder"
+				icon={ 'menu' }
+				label={ __( 'Navigation Menu' ) } >
+				<SelectControl
+					label={ __( 'Select an existing menu' ) }
+					value={ selected }
+					onChange={ setMenu }
+					options={ menus.map( this.getOptionsFromMenu ) }
+				/>
+			</Placeholder>
+		);
+	}
+}
+
+export default MenuPlaceholder;

--- a/blocks/library/navigation-menu/style.scss
+++ b/blocks/library/navigation-menu/style.scss
@@ -62,7 +62,6 @@
 		}
 	}
 
-	[data-align="full"] &,
 	&.alignfull {
 		padding-left: 2em;
 		padding-right: 2em;

--- a/blocks/library/navigation-menu/style.scss
+++ b/blocks/library/navigation-menu/style.scss
@@ -2,7 +2,6 @@
 	&.is-horizontal {
 		display: flex;
 		flex-wrap: wrap;
-		padding: 0;
 
 		ul {
 			float: left;
@@ -10,21 +9,22 @@
 			top: 100%;
 			left: -999em;
 			z-index: 99999;
+			margin: 0;
+			padding: 0 10px 10px;
 
 			ul {
-				left: -999em;
+				position: static;
+				left: 0;
 				top: 0;
+				padding: 0 0 0 10px;
 			}
 
 			li {
-				&:hover > ul,
-				&.focus > ul {
-					left: 100%;
-				}
+				margin: 0;
 			}
 
 			a {
-				width: 200px;
+				width: 160px;
 			}
 		}
 
@@ -42,9 +42,29 @@
 			}
 		}
 
+		.menu-item-has-children > a:after {
+			content: "\f347";
+			display: inline-block;
+			width: 10px;
+			height: 10px;
+			font-size: 10px;
+			line-height: 1;
+			font-family: dashicons;
+			text-decoration: inherit;
+			vertical-align: baseline;
+			text-align: center;
+			padding-left: 6px;
+		}
+
 		a {
 			display: block;
 			text-decoration: none;
 		}
+	}
+
+	[data-align="full"] &,
+	&.alignfull {
+		padding-left: 2em;
+		padding-right: 2em;
 	}
 }

--- a/blocks/library/navigation-menu/style.scss
+++ b/blocks/library/navigation-menu/style.scss
@@ -1,0 +1,50 @@
+.wp-block-navigation-menu {
+	&.is-horizontal {
+		display: flex;
+		flex-wrap: wrap;
+		padding: 0;
+
+		ul {
+			float: left;
+			position: absolute;
+			top: 100%;
+			left: -999em;
+			z-index: 99999;
+
+			ul {
+				left: -999em;
+				top: 0;
+			}
+
+			li {
+				&:hover > ul,
+				&.focus > ul {
+					left: 100%;
+				}
+			}
+
+			a {
+				width: 200px;
+			}
+		}
+
+		li {
+			float: left;
+			position: relative;
+			margin: 0 16px 16px 0;
+			list-style: none;
+			width: auto;
+
+			&:hover > ul,
+			&.focus > ul {
+				left: auto;
+				display: block;
+			}
+		}
+
+		a {
+			display: block;
+			text-decoration: none;
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new block, "Navigation Menu". This is the basic version mocked up in this issue: https://github.com/WordPress/gutenberg/issues/1466#issuecomment-356667674. The block itself is mostly done, only some questions (marked ⚠️in this issue) & tests remain. This also requires [the patch on 40878](https://core.trac.wordpress.org/ticket/40878#comment:15) applied to your WP install (if this PR gets a 👍, perhaps we could patch these API changes into gutenberg for now).

This creates a dynamic block for the front end of the site, so that items added to the selected menus are updated automatically.

## Screenshots

When first added, the block inserts a placeholder with a menu dropdown:

<img width="739" alt="initial" src="https://user-images.githubusercontent.com/541093/36131821-d9dfb30c-1041-11e8-8e4b-ead2cfcb0c55.png">

After selecting a menu, it populates the block with the items, in a vertical list or horizontal nav-bar style.

<img width="765" alt="vertical" src="https://user-images.githubusercontent.com/541093/36131836-e76da664-1041-11e8-9de0-2f14d6b85a8d.png">
<img width="758" alt="horizontal" src="https://user-images.githubusercontent.com/541093/36131835-e7600dce-1041-11e8-8a85-a283bf5412f0.png">

⚠️We need different icons for vertical & horizontal (currently using the list/grid pair from latest posts).

If the list is empty, it says so in the editor, but doesn't display anything on the front end. 

<img width="751" alt="empty" src="https://user-images.githubusercontent.com/541093/36131844-f6c9b5ee-1041-11e8-8d31-dab989ed5db9.png">

⚠️The link in this placeholder should go to the site's customizer, but I'm not sure how to get that.

The menu select is also added to the inspector controls area, so that the menu can be updated once the block is added.

<img width="292" alt="controls" src="https://user-images.githubusercontent.com/541093/36131847-faefd1ee-1041-11e8-8d01-096c1c9b7950.png">

On the front end of the site, the menu is displayed in the post using minimal styling.

<img width="515" alt="front-end-vertical" src="https://user-images.githubusercontent.com/541093/36131856-01f45e60-1042-11e8-887e-7146b6cd0643.png">
<img width="493" alt="front-end-horizontal" src="https://user-images.githubusercontent.com/541093/36131857-020870bc-1042-11e8-9889-3de3c72a0bbf.png">

## Testing

As I mentioned, no tests are written for this yet. To manually test, you can add a Navigation block to your posts with different menus: a nested menu, empty menu, long menu, add a menu then delete it, etc.

## Other notes

⚠️We should add some JS to the front end when this block is present to enable the keyboard navigation. This should also be added to the editor, perhaps to the react item component itself.

⚠️Not done in this version, but could be later -- a toggle for showing the item description.
