### PR TITLE
Framework: Strip comment demarcations in content filtering

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -199,6 +199,9 @@ function do_blocks( $content ) {
 	// Append remaining unmatched content.
 	$rendered_content .= $content;
 
+	// Strip remaining block comment demarcations.
+	$rendered_content = preg_replace( '/<!--\s+\/?wp:.*?-->\r?\n?/m', '', $rendered_content );
+
 	return $rendered_content;
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode().

--- a/phpunit/class-do-blocks-test.php
+++ b/phpunit/class-do-blocks-test.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * `do_blocks` rendering test
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Test do_blocks
+ */
+class Do_Blocks_Test extends WP_UnitTestCase {
+	/**
+	 * Test do_blocks removes comment demarcations.
+	 *
+	 * @covers ::do_blocks
+	 */
+	function test_do_blocks_removes_comments() {
+		$original_html = file_get_contents( dirname( __FILE__ ) . '/fixtures/do-blocks-original.html' );
+		$expected_html = file_get_contents( dirname( __FILE__ ) . '/fixtures/do-blocks-expected.html' );
+
+		$actual_html = do_blocks( $original_html );
+
+		$this->assertEquals( $expected_html, $actual_html );
+	}
+}

--- a/phpunit/fixtures/do-blocks-expected.html
+++ b/phpunit/fixtures/do-blocks-expected.html
@@ -1,0 +1,12 @@
+<p>First Auto Paragraph</p>
+
+<!--more-->
+
+<p>First Gutenberg Paragraph</p>
+
+<p>Second Auto Paragraph</p>
+
+
+<p>Third Gutenberg Paragraph</p>
+
+<p>Third Auto Paragraph</p>

--- a/phpunit/fixtures/do-blocks-original.html
+++ b/phpunit/fixtures/do-blocks-original.html
@@ -1,0 +1,17 @@
+<p>First Auto Paragraph</p>
+
+<!--more-->
+
+<!-- wp:core/paragraph -->
+<p>First Gutenberg Paragraph</p>
+<!-- /wp:core/paragraph -->
+
+<p>Second Auto Paragraph</p>
+
+<!-- wp:core/test-self-closing /-->
+
+<!-- wp:core/paragraph -->
+<p>Third Gutenberg Paragraph</p>
+<!-- /wp:core/paragraph -->
+
+<p>Third Auto Paragraph</p>


### PR DESCRIPTION
Related: #4591

This pull request seeks to naively search and replace static block comment demarcations after server-side replacement has been completed. #4591 had the effect of only omitting comment demarcations for dynamic blocks from front-end content display. After these changes, all block comments should be omitted.

__Testing instructions:__

Verify that when viewing a block post on the front-end, no comment demarcations are shown.