### PR TITLE
Nesting: Fix broken nested content caused by overly aggressive cache

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -428,8 +428,8 @@ export const getBlock = createSelector(
 			innerBlocks: getBlocks( state, uid ),
 		};
 	},
-	( state ) => [
-		get( state, [ 'editor', 'present', 'blocksByUid' ] ),
+	( state, uid ) => [
+		get( state, [ 'editor', 'present', 'blocksByUid', uid ] ),
 		get( state, [ 'editor', 'present', 'edits', 'meta' ] ),
 		get( state, 'currentPost.meta' ),
 	]

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -428,8 +428,8 @@ export const getBlock = createSelector(
 			innerBlocks: getBlocks( state, uid ),
 		};
 	},
-	( state, uid ) => [
-		get( state, [ 'editor', 'present', 'blocksByUid', uid ] ),
+	( state ) => [
+		get( state, [ 'editor', 'present', 'blocksByUid' ] ),
 		get( state, [ 'editor', 'present', 'edits', 'meta' ] ),
 		get( state, 'currentPost.meta' ),
 	]

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -384,6 +384,27 @@ export function getEditedPostPreviewLink( state ) {
 }
 
 /**
+ * Returns a new reference when the inner blocks of a given block UID change.
+ * This is used exclusively as a memoized selector dependant, relying on this
+ * selector's shared return value and recursively those of its inner blocks
+ * defined as dependencies. This abuses mechanics of the selector memoization
+ * to return from the original selector function only when dependants change.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} uid   Block unique ID.
+ *
+ * @return {*} A value whose reference will change only when inner blocks of
+ *             the given block UID change.
+ */
+export const getBlockDependantsCacheBust = createSelector(
+	() => [],
+	( state, uid ) => map(
+		getBlockOrder( state, uid ),
+		( innerBlockUID ) => getBlock( state, innerBlockUID ),
+	),
+);
+
+/**
  * Returns a block given its unique ID. This is a parsed copy of the block,
  * containing its `blockName`, identifier (`uid`), and current `attributes`
  * state. This is not the block's registration settings, which must be
@@ -430,6 +451,7 @@ export const getBlock = createSelector(
 	},
 	( state, uid ) => [
 		get( state, [ 'editor', 'present', 'blocksByUid', uid ] ),
+		getBlockDependantsCacheBust( state, uid ),
 		get( state, [ 'editor', 'present', 'edits', 'meta' ] ),
 		get( state, 'currentPost.meta' ),
 	]


### PR DESCRIPTION
Regression introduced in #5002 (1ce8079571b298cb9d2d261d95af19548b2364cd)

This pull request seeks to resolve an issue where the content within a nested block is not saved. The issue is that because the selector for `getBlock` was configured to cache with the individual block as a dependant, the cache is incorrectly not bust when any of its inner blocks change.

Since 1ce8079571b298cb9d2d261d95af19548b2364cd was introduced as a performance enhancement, we should separately seek to explore how we tailor the cache to be most specific to the individual block being queried (trigger change on parent when inner blocks change?)

__Testing instructions:__

1. Create a Columns block
2. Insert content in one or both columns
3. Press Save
4. Refresh the post
5. Verify content is saved correctly

__Follow-up Tasks:__

- End-to-end test including nested blocks