### PR TITLE
Blocks: Disable Convert to Reusable for nested blocks

### DIFF
--- a/editor/components/block-settings-menu/reusable-block-settings.js
+++ b/editor/components/block-settings-menu/reusable-block-settings.js
@@ -15,10 +15,20 @@ import { isReusableBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { getBlock, getReusableBlock } from '../../store/selectors';
+import {
+	getBlock,
+	getBlockOrder,
+	getReusableBlock,
+} from '../../store/selectors';
 import { convertBlockToStatic, convertBlockToReusable, deleteReusableBlock } from '../../store/actions';
 
-export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onConvertToReusable, onDelete } ) {
+export function ReusableBlockSettings( {
+	reusableBlock,
+	isValidForConvert,
+	onConvertToStatic,
+	onConvertToReusable,
+	onDelete,
+} ) {
 	return (
 		<Fragment>
 			{ ! reusableBlock && (
@@ -26,6 +36,7 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 					className="editor-block-settings-menu__control"
 					icon="controls-repeat"
 					onClick={ onConvertToReusable }
+					disabled={ ! isValidForConvert }
 				>
 					{ __( 'Convert to Reusable Block' ) }
 				</IconButton>
@@ -56,7 +67,9 @@ export function ReusableBlockSettings( { reusableBlock, onConvertToStatic, onCon
 export default connect(
 	( state, { uid } ) => {
 		const block = getBlock( state, uid );
+
 		return {
+			isValidForConvert: ! getBlockOrder( state, block.uid ).length,
 			reusableBlock: isReusableBlock( block ) ? getReusableBlock( state, block.attributes.ref ) : null,
 		};
 	},


### PR DESCRIPTION
Related: #5010

This pull request seeks to temporarily disable the "Convert to Reusable Block" for nested blocks, until after supported is added through #5010. With these changes, it may still be technically possible for a nesting block to be saved as reusable, since it uses presence of inner blocks as condition for disabling the button, but this is both difficult to achieve in practice and would have the same effect as attempting to save a nesting block as exists currently.

__Testing instructions:__

Verify that you cannot save a nesting block as reusable.