### PR TITLE
Block List: Pass selection start as UID

### DIFF
--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -28,7 +28,6 @@ import BlockListBlock from './block';
 import BlockSelectionClearer from '../block-selection-clearer';
 import DefaultBlockAppender from '../default-block-appender';
 import {
-	getSelectedBlock,
 	isSelectionEnabled,
 	isMultiSelecting,
 } from '../../store/selectors';
@@ -177,12 +176,10 @@ class BlockListLayout extends Component {
 			return;
 		}
 
-		const { selectedBlock, selectionStart, onMultiSelect, onSelect } = this.props;
+		const { selectionStartUID, onMultiSelect, onSelect } = this.props;
 
-		if ( selectedBlock ) {
-			onMultiSelect( selectedBlock.uid, uid );
-		} else if ( selectionStart ) {
-			onMultiSelect( selectionStart, uid );
+		if ( selectionStartUID ) {
+			onMultiSelect( selectionStartUID, uid );
 		} else {
 			onSelect( uid );
 		}
@@ -237,7 +234,10 @@ class BlockListLayout extends Component {
 
 export default connect(
 	( state ) => ( {
-		selectedBlock: getSelectedBlock( state ),
+		// Reference block selection value directly, since current selectors
+		// assume either multi-selection (getMultiSelectedBlocksStartUid) or
+		// singular-selection (getSelectedBlock) exclusively.
+		selectionStartUID: state.blockSelection.start,
 		isSelectionEnabled: isSelectionEnabled( state ),
 		isMultiSelecting: isMultiSelecting( state ),
 	} ),


### PR DESCRIPTION
This pull request seeks to update the `BlockListLayout` component to pass selection start as a UID string. This is an optimization to avoid changes in blocks state from incurring unnecessary re-renders to the component, since `getSelectedBlock` will return a new reference object on such changes. The proposed revisions here instead consolidate handling of multi-select and singular-select to a single value: the `state.blockSelection.start` (which is referenced directly, since there are no other applicable selectors, as explained in included inline documentation).

__Testing instructions:__

Verify there are no regressions in the behavior of shift expansion of block multi-selection.