### PR TITLE
Block List: Restore missing selectionStart props

### DIFF
--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -27,6 +27,7 @@ import BlockListBlock from './block';
 import BlockSelectionClearer from '../block-selection-clearer';
 import DefaultBlockAppender from '../default-block-appender';
 import {
+	getMultiSelectedBlocksEndUid,
 	isSelectionEnabled,
 	isMultiSelecting,
 } from '../../store/selectors';
@@ -128,8 +129,13 @@ class BlockListLayout extends Component {
 		window.addEventListener( 'mouseup', this.onSelectionEnd );
 	}
 
+	/**
+	 * Handles multi-selection changes in response to pointer move.
+	 *
+	 * @param {string} uid Block under cursor in multi-select drag.
+	 */
 	onSelectionChange( uid ) {
-		const { onMultiSelect, selectionStart, selectionEnd } = this.props;
+		const { onMultiSelect, multiSelectionEndUID } = this.props;
 		const { selectionAtStart } = this;
 		const isAtStart = selectionAtStart === uid;
 
@@ -137,11 +143,14 @@ class BlockListLayout extends Component {
 			return;
 		}
 
-		if ( isAtStart && selectionStart ) {
+		// If multi-selecting and cursor extent returns to the start of
+		// selection, cancel multi-select.
+		if ( isAtStart && this.props.isMultiSelecting ) {
 			onMultiSelect( null, null );
 		}
 
-		if ( ! isAtStart && selectionEnd !== uid ) {
+		// Expand multi-selection to block under cursor.
+		if ( ! isAtStart && multiSelectionEndUID !== uid ) {
 			onMultiSelect( selectionAtStart, uid );
 		}
 	}
@@ -237,6 +246,7 @@ export default connect(
 		// assume either multi-selection (getMultiSelectedBlocksStartUid) or
 		// singular-selection (getSelectedBlock) exclusively.
 		selectionStartUID: state.blockSelection.start,
+		multiSelectionEndUID: getMultiSelectedBlocksEndUid( state ),
 		isSelectionEnabled: isSelectionEnabled( state ),
 		isMultiSelecting: isMultiSelecting( state ),
 	} ),


### PR DESCRIPTION
Regression introduced in #5021 (96f809c9fcac27f1d55e9a7813ec2f9b140751a8):

This pull request seeks to restore two props which were removed in #5021, which are still referenced in the `BlockListLayout` component. `selectionStart` and `selectionEnd` are still referenced in `onSelectionChange`, which was not included in the refactoring of #5021 and should therefore still be provided. Since these are string value, it's not expected this should regress much on performance improvements of #5021.

__Testing instructions:__

From what I can tell, the logic of `onSelectionChange` that depends on these props is to discontinue multi-select if click-dragging to multi-select and then, after multi-selection has begun, moving the cursor back to the initiating block. In master, this does not cancel the multi-selection, but should after these changes. Further, expanding the selection by drag had appeared to still work in master (not sure why?) but would be delayed a block behind. In this branch, multi-select should immediately expand under the cursor drag block.