### PR TITLE
Blocks: The movers and the block settings menu visible for selected empty default block

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -451,8 +451,9 @@ export class BlockListBlock extends Component {
 		// Empty paragraph blocks should always show up as unselected.
 		const isEmptyDefaultBlock = isUnmodifiedDefaultBlock( block );
 		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
-		const shouldAppearSelected = ! showSideInserter && isSelected && ( ! this.props.isTyping || ! this.state.isSelectionCollapsed );
-		const shouldShowMovers = shouldAppearSelected || isHovered;
+		const isSelectedNotTyping = isSelected && ( ! this.props.isTyping || ! this.state.isSelectionCollapsed );
+		const shouldAppearSelected = ! showSideInserter && isSelectedNotTyping;
+		const shouldShowMovers = shouldAppearSelected || isHovered || ( isEmptyDefaultBlock && isSelectedNotTyping );
 		const shouldShowSettingsMenu = shouldShowMovers;
 		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
 		const shouldShowMobileToolbar = shouldAppearSelected;


### PR DESCRIPTION
closes #5047

This does not revert dbad796 entirely but it ensure the block settings menu and the block movers are shown when the default block is selected and we're not typing. The only difference with other blocks is that the "border" around the block is not shown.

**Testing instructions**

 - Add an empty paragraph
 - Open the block settings menu (dots on the right of the block)
 - The menu should show up properly