### PR TITLE
State: Refactor insertion point to include rootUID, layout

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -588,7 +588,6 @@ export class BlockListBlock extends Component {
 					<BlockInsertionPoint
 						uid={ block.uid }
 						rootUID={ rootUID }
-						layout={ layout }
 					/>
 				) }
 				{ showSideInserter && (

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -451,6 +451,7 @@ export class BlockListBlock extends Component {
 			isSelected,
 			isMultiSelected,
 			isFirstMultiSelected,
+			isLastInSelection,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! this.props.isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -471,6 +472,11 @@ export class BlockListBlock extends Component {
 		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error } = this.state;
+
+		// Insertion point can only be made visible when the side inserter is
+		// not present, and either the block is at the extent of a selection or
+		// is the last block in the top-level list rendering.
+		const shouldShowInsertionPoint = ! showSideInserter && ( isLastInSelection || ( isLast && ! rootUID ) );
 
 		// Generate the wrapper class names handling the different states of the block.
 		const wrapperClassName = classnames( 'editor-block-list__block', {
@@ -584,7 +590,7 @@ export class BlockListBlock extends Component {
 					{ shouldShowMobileToolbar && <BlockMobileToolbar uid={ block.uid } renderBlockMenu={ renderBlockMenu } /> }
 				</IgnoreNestedEvents>
 				{ !! error && <BlockCrashWarning /> }
-				{ ! showSideInserter && (
+				{ shouldShowInsertionPoint && (
 					<BlockInsertionPoint
 						uid={ block.uid }
 						rootUID={ rootUID }
@@ -610,6 +616,7 @@ const mapStateToProps = ( state, { uid, rootUID } ) => {
 		isMultiSelected: isBlockMultiSelected( state, uid ),
 		isFirstMultiSelected: isFirstMultiSelectedBlock( state, uid ),
 		isMultiSelecting: isMultiSelecting( state ),
+		isLastInSelection: state.blockSelection.end === uid,
 		// We only care about this prop when the block is selected
 		// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
 		isTyping: isSelected && isTyping( state ),

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -10,6 +10,7 @@ import {
 	getBlockIndex,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
+	getBlockCount,
 } from '../../store/selectors';
 
 function BlockInsertionPoint( { showInsertionPoint } ) {
@@ -23,7 +24,7 @@ function BlockInsertionPoint( { showInsertionPoint } ) {
 export default connect(
 	( state, { uid, rootUID } ) => {
 		const blockIndex = uid ? getBlockIndex( state, uid, rootUID ) : -1;
-		const insertIndex = blockIndex > -1 ? blockIndex + 1 : 0;
+		const insertIndex = blockIndex > -1 ? blockIndex + 1 : getBlockCount( state );
 		const insertionPoint = getBlockInsertionPoint( state );
 
 		return {

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -21,14 +21,16 @@ function BlockInsertionPoint( { showInsertionPoint } ) {
 }
 
 export default connect(
-	( state, { uid, rootUID, layout } ) => {
+	( state, { uid, rootUID } ) => {
 		const blockIndex = uid ? getBlockIndex( state, uid, rootUID ) : -1;
 		const insertIndex = blockIndex > -1 ? blockIndex + 1 : 0;
+		const insertionPoint = getBlockInsertionPoint( state );
 
 		return {
 			showInsertionPoint: (
-				isBlockInsertionPointVisible( state, rootUID, layout ) &&
-				getBlockInsertionPoint( state, rootUID ) === insertIndex
+				isBlockInsertionPointVisible( state ) &&
+				insertionPoint.index === insertIndex &&
+				insertionPoint.rootUID === rootUID
 			),
 		};
 	},

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -51,7 +51,6 @@ class Inserter extends Component {
 			position,
 			children,
 			onInsertBlock,
-			insertionPoint,
 			hasSupportedBlocks,
 			isLocked,
 		} = this.props;
@@ -80,7 +79,7 @@ class Inserter extends Component {
 				) }
 				renderContent={ ( { onClose } ) => {
 					const onSelect = ( item ) => {
-						onInsertBlock( item, insertionPoint );
+						onInsertBlock( item );
 
 						onClose();
 					};
@@ -94,9 +93,9 @@ class Inserter extends Component {
 
 export default compose( [
 	connect(
-		( state, ownProps ) => {
+		( state ) => {
 			return {
-				insertionPoint: getBlockInsertionPoint( state, ownProps.rootUID ),
+				insertionPoint: getBlockInsertionPoint( state ),
 				selectedBlock: getSelectedBlock( state ),
 			};
 		},
@@ -106,12 +105,13 @@ export default compose( [
 			insertBlock,
 			replaceBlocks,
 		},
-		( { selectedBlock, ...stateProps }, dispatchProps, { layout, rootUID, ...ownProps } ) => ( {
+		( { selectedBlock, insertionPoint, ...stateProps }, dispatchProps, { ...ownProps } ) => ( {
 			...stateProps,
 			...ownProps,
 			showInsertionPoint: dispatchProps.showInsertionPoint,
 			hideInsertionPoint: dispatchProps.hideInsertionPoint,
-			onInsertBlock( item, index ) {
+			onInsertBlock( item ) {
+				const { index, rootUID, layout } = insertionPoint;
 				const { name, initialAttributes } = item;
 				const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
 				if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -927,23 +927,24 @@ export function isTyping( state ) {
  * Returns the insertion point, the index at which the new inserted block would
  * be placed. Defaults to the last index.
  *
- * @param {Object}  state   Global application state.
- * @param {?string} rootUID Optional root UID of block list.
+ * @param {Object} state Global application state.
  *
- * @return {?string} Unique ID after which insertion will occur.
+ * @return {Object} Insertion point object with `rootUID`, `layout`, `index`
  */
-export function getBlockInsertionPoint( state, rootUID ) {
-	const lastMultiSelectedBlock = getLastMultiSelectedBlockUid( state );
-	if ( lastMultiSelectedBlock ) {
-		return getBlockIndex( state, lastMultiSelectedBlock, rootUID ) + 1;
+export function getBlockInsertionPoint( state ) {
+	let rootUID, layout, index;
+
+	const { end } = state.blockSelection;
+	if ( end ) {
+		rootUID = getBlockRootUID( state, end ) || undefined;
+
+		layout = get( getBlock( state, end ), [ 'attributes', 'layout' ] );
+		index = getBlockIndex( state, end, rootUID ) + 1;
+	} else {
+		index = getBlockOrder( state ).length;
 	}
 
-	const selectedBlock = getSelectedBlock( state );
-	if ( selectedBlock ) {
-		return getBlockIndex( state, selectedBlock.uid, rootUID ) + 1;
-	}
-
-	return getBlockOrder( state, rootUID ).length;
+	return { rootUID, layout, index };
 }
 
 /**

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2019,21 +2019,22 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getBlockInsertionPoint', () => {
-		it( 'should return the uid of the selected block', () => {
+		it( 'should return an object for the selected block', () => {
 			const state = {
 				currentPost: {},
 				preferences: { mode: 'visual' },
 				blockSelection: {
-					start: 2,
-					end: 2,
+					start: 'uid1',
+					end: 'uid1',
 				},
 				editor: {
 					present: {
 						blocksByUid: {
-							2: { uid: 2 },
+							uid1: { uid: 'uid1' },
 						},
 						blockOrder: {
-							'': [ 1, 2, 3 ],
+							'': [ 'uid1' ],
+							uid1: [],
 						},
 						edits: {},
 					},
@@ -2041,44 +2042,137 @@ describe( 'selectors', () => {
 				isInsertionPointVisible: false,
 			};
 
-			expect( getBlockInsertionPoint( state ) ).toBe( 2 );
+			expect( getBlockInsertionPoint( state ) ).toEqual( {
+				rootUID: undefined,
+				layout: undefined,
+				index: 1,
+			} );
 		} );
 
-		it( 'should return the last multi selected uid', () => {
+		it( 'should return an object for the nested selected block', () => {
 			const state = {
+				currentPost: {},
 				preferences: { mode: 'visual' },
 				blockSelection: {
-					start: 1,
-					end: 2,
+					start: 'uid2',
+					end: 'uid2',
 				},
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 1, 2, 3 ],
+						blocksByUid: {
+							uid1: { uid: 'uid1' },
+							uid2: { uid: 'uid2' },
 						},
+						blockOrder: {
+							'': [ 'uid1' ],
+							uid1: [ 'uid2' ],
+							uid2: [],
+						},
+						edits: {},
 					},
 				},
 				isInsertionPointVisible: false,
 			};
 
-			expect( getBlockInsertionPoint( state ) ).toBe( 2 );
+			expect( getBlockInsertionPoint( state ) ).toEqual( {
+				rootUID: 'uid1',
+				layout: undefined,
+				index: 1,
+			} );
 		} );
 
-		it( 'should return the last block if no selection', () => {
+		it( 'should return an object for the selected block with layout', () => {
 			const state = {
+				currentPost: {},
 				preferences: { mode: 'visual' },
-				blockSelection: { start: null, end: null },
+				blockSelection: {
+					start: 'uid1',
+					end: 'uid1',
+				},
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 1, 2, 3 ],
+						blocksByUid: {
+							uid1: { uid: 'uid1', attributes: { layout: 'wide' } },
 						},
+						blockOrder: {
+							'': [ 'uid1' ],
+							uid1: [],
+						},
+						edits: {},
 					},
 				},
 				isInsertionPointVisible: false,
 			};
 
-			expect( getBlockInsertionPoint( state ) ).toBe( 3 );
+			expect( getBlockInsertionPoint( state ) ).toEqual( {
+				rootUID: undefined,
+				layout: 'wide',
+				index: 1,
+			} );
+		} );
+
+		it( 'should return an object for the last multi selected uid', () => {
+			const state = {
+				currentPost: {},
+				preferences: { mode: 'visual' },
+				blockSelection: {
+					start: 'uid1',
+					end: 'uid2',
+				},
+				editor: {
+					present: {
+						blocksByUid: {
+							uid1: { uid: 'uid1' },
+							uid2: { uid: 'uid2' },
+						},
+						blockOrder: {
+							'': [ 'uid1', 'uid2' ],
+							uid1: [],
+							uid2: [],
+						},
+						edits: {},
+					},
+				},
+				isInsertionPointVisible: false,
+			};
+
+			expect( getBlockInsertionPoint( state ) ).toEqual( {
+				rootUID: undefined,
+				layout: undefined,
+				index: 2,
+			} );
+		} );
+
+		it( 'should return an object for the last block if no selection', () => {
+			const state = {
+				currentPost: {},
+				preferences: { mode: 'visual' },
+				blockSelection: {
+					start: null,
+					end: null,
+				},
+				editor: {
+					present: {
+						blocksByUid: {
+							uid1: { uid: 'uid1' },
+							uid2: { uid: 'uid2' },
+						},
+						blockOrder: {
+							'': [ 'uid1', 'uid2' ],
+							uid1: [],
+							uid2: [],
+						},
+						edits: {},
+					},
+				},
+				isInsertionPointVisible: false,
+			};
+
+			expect( getBlockInsertionPoint( state ) ).toEqual( {
+				rootUID: undefined,
+				layout: undefined,
+				index: 2,
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #5051

This pull request seeks to refactor insertion point to include information about `rootUID` and `layout` at the point where an insertion would take place. Prior to these changes, the header inserter would not be able to insert within a column, and this became more apparent with recent iterations removing the sibling inserter.

__Implementation notes:__

I'm not wholly pleased with this approach, due to:

- `<BlockInsertionPoint />` is rendered after every block, thus every block is calling the now-more-complex `getInsertionPoint` selector on each render
   - ~Could we avoid rendering this element except when we know it's strictly necessary: After the selected block, and at the end of the top-level BlockList~ Added in d77ffc1.
- There's an inconsistency between `defaultLayout` which is applied for `BlockListLayout` only in grouped layouts, but here for any block which has a layout assigned (including ungrouped), since there is no way to distinguish between them from within state

__Testing instructions:__

Verify that the insertion point displays and block inserts at the expected point:

- After a selected block
- After a nested selected block
- After the end of a multi-selection
- At the end of top-level block list if no current selected block