### PR TITLE
State: Access state paths directly in selector dependants

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -450,10 +450,10 @@ export const getBlock = createSelector(
 		};
 	},
 	( state, uid ) => [
-		get( state, [ 'editor', 'present', 'blocksByUid', uid ] ),
+		state.editor.present.blocksByUid[ uid ],
 		getBlockDependantsCacheBust( state, uid ),
-		get( state, [ 'editor', 'present', 'edits', 'meta' ] ),
-		get( state, 'currentPost.meta' ),
+		state.editor.present.edits.meta,
+		state.currentPost.meta,
 	]
 );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -1448,6 +1448,11 @@ describe( 'selectors', () => {
 							23: { uid: 23, name: 'core/heading', attributes: {} },
 							123: { uid: 123, name: 'core/paragraph', attributes: {} },
 						},
+						blockOrder: {
+							'': [ 23, 123 ],
+							23: [],
+							123: [],
+						},
 						edits: {},
 					},
 				},
@@ -1459,22 +1464,7 @@ describe( 'selectors', () => {
 
 		it( 'should return null if there is multi selection', () => {
 			const state = {
-				editor: {
-					present: {
-						blocksByUid: {
-							23: { uid: 23, name: 'core/heading', attributes: {} },
-							123: { uid: 123, name: 'core/paragraph', attributes: {} },
-						},
-					},
-				},
-				blockSelection: { start: 23, end: 123 },
-			};
-
-			expect( getSelectedBlock( state ) ).toBe( null );
-		} );
-
-		it( 'should return the selected block', () => {
-			const state = {
+				currentPost: {},
 				editor: {
 					present: {
 						blocksByUid: {
@@ -1486,6 +1476,30 @@ describe( 'selectors', () => {
 							23: [],
 							123: [],
 						},
+						edits: {},
+					},
+				},
+				blockSelection: { start: 23, end: 123 },
+			};
+
+			expect( getSelectedBlock( state ) ).toBe( null );
+		} );
+
+		it( 'should return the selected block', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocksByUid: {
+							23: { uid: 23, name: 'core/heading', attributes: {} },
+							123: { uid: 123, name: 'core/paragraph', attributes: {} },
+						},
+						blockOrder: {
+							'': [ 23, 123 ],
+							23: [],
+							123: [],
+						},
+						edits: {},
 					},
 				},
 				blockSelection: { start: 23, end: 23 },
@@ -2183,8 +2197,10 @@ describe( 'selectors', () => {
 					present: {
 						blockOrder: {},
 						blocksByUid: {},
+						edits: {},
 					},
 				},
+				currentPost: {},
 			};
 
 			expect( getSuggestedPostFormat( state ) ).toBeNull();
@@ -2201,8 +2217,10 @@ describe( 'selectors', () => {
 							123: { uid: 123, name: 'core/image', attributes: {} },
 							456: { uid: 456, name: 'core/quote', attributes: {} },
 						},
+						edits: {},
 					},
 				},
+				currentPost: {},
 			};
 
 			expect( getSuggestedPostFormat( state ) ).toBeNull();
@@ -2218,8 +2236,10 @@ describe( 'selectors', () => {
 						blocksByUid: {
 							123: { uid: 123, name: 'core/image', attributes: {} },
 						},
+						edits: {},
 					},
 				},
+				currentPost: {},
 			};
 
 			expect( getSuggestedPostFormat( state ) ).toBe( 'image' );
@@ -2235,8 +2255,10 @@ describe( 'selectors', () => {
 						blocksByUid: {
 							456: { uid: 456, name: 'core/quote', attributes: {} },
 						},
+						edits: {},
 					},
 				},
+				currentPost: {},
 			};
 
 			expect( getSuggestedPostFormat( state ) ).toBe( 'quote' );
@@ -2252,8 +2274,10 @@ describe( 'selectors', () => {
 						blocksByUid: {
 							567: { uid: 567, name: 'core-embed/youtube', attributes: {} },
 						},
+						edits: {},
 					},
 				},
+				currentPost: {},
 			};
 
 			expect( getSuggestedPostFormat( state ) ).toBe( 'video' );
@@ -2270,8 +2294,10 @@ describe( 'selectors', () => {
 							456: { uid: 456, name: 'core/quote', attributes: {} },
 							789: { uid: 789, name: 'core/paragraph', attributes: {} },
 						},
+						edits: {},
 					},
 				},
+				currentPost: {},
 			};
 
 			expect( getSuggestedPostFormat( state ) ).toBe( 'quote' );
@@ -2298,8 +2324,10 @@ describe( 'selectors', () => {
 					present: {
 						blocksByUid: {},
 						blockOrder: {},
+						edits: {},
 					},
 				},
+				currentPost: {},
 				reusableBlocks: {
 					data: {},
 				},
@@ -2315,8 +2343,10 @@ describe( 'selectors', () => {
 					present: {
 						blocksByUid: {},
 						blockOrder: {},
+						edits: {},
 					},
 				},
+				currentPost: {},
 				reusableBlocks: {
 					data: {},
 				},
@@ -2346,8 +2376,10 @@ describe( 'selectors', () => {
 						blockOrder: {
 							'': [ 1 ],
 						},
+						edits: {},
 					},
 				},
+				currentPost: {},
 				reusableBlocks: {
 					data: {},
 				},
@@ -2363,8 +2395,10 @@ describe( 'selectors', () => {
 					present: {
 						blocksByUid: {},
 						blockOrder: {},
+						edits: {},
 					},
 				},
+				currentPost: {},
 				reusableBlocks: {
 					data: {
 						123: {


### PR DESCRIPTION
This pull request seeks to replace the dependants getters for the `getBlock` selector with equivalent path access, avoiding [Lodash `_.get`](https://lodash.com/docs/4.17.5#get). By the shape of our reducer, we are guaranteed that these paths will always be accessible in a state object, so `_.get` is not necessary. To my knowledge, it was implemented this way for convenience in writing unit tests to avoid providing the entire object shape touched by the selectors invoked.

To illustrate why `_.get` can be unadvisable whenever possible, here's an animated GIF stepping into all parts of the process of evaluating a single call to `get( obj, 'a.b.c.d' )`:

![get](https://user-images.githubusercontent.com/1779930/36221898-918e096c-118d-11e8-8aa0-82a2dfb26f2b.gif)

Via: 

```
node --inspect-brk -e "require( 'lodash' ).get( { a: { b: { c: { d: 5 } } } } , 'a.b.c.d' );"
```

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```

Verify there are no regressions in the behavior of interacting with the editor, notably block manipulation.