### PR TITLE
Add a confirmation message before reverting to draft

### DIFF
--- a/editor/components/post-switch-to-draft-button/index.js
+++ b/editor/components/post-switch-to-draft-button/index.js
@@ -23,11 +23,18 @@ function PostSwitchToDraftButton( { className, isSaving, isPublished, onClick } 
 		return null;
 	}
 
+	const onSwitch = () => {
+		// eslint-disable-next-line no-alert
+		if ( window.confirm( __( 'Are you sure you want to unpublish this post?' ) ) ) {
+			onClick();
+		}
+	};
+
 	return (
 		<Button
 			className={ className }
 			isLarge
-			onClick={ onClick }
+			onClick={ onSwitch }
 			disabled={ isSaving }
 		>
 			{ __( 'Switch to Draft' ) }


### PR DESCRIPTION
Fixes #4964

To avoid switching to drafts inadvertently, This PR adds a confirmation message.

**Testing instructions**

 - Publish a post
 - Click "switch to draft" link
 - A confirmation message will show up and the switch will happen only if you confirm.