### PR TITLE
Framework: Adding a deprecation helper

### DIFF
--- a/blocks/block-description/index.js
+++ b/blocks/block-description/index.js
@@ -11,7 +11,11 @@ import './style.scss';
 class BlockDescription extends Component {
 	constructor() {
 		super( ...arguments );
-		deprecated( 'The wp.blocks.BlockDescription component', '2.4', 'the "description" block property', 'Gutenberg' );
+		deprecated( 'The wp.blocks.BlockDescription component', {
+			version: '2.4',
+			alternative: 'the "description" block property',
+			plugin: 'Gutenberg',
+		} );
 	}
 
 	render() {

--- a/blocks/block-description/index.js
+++ b/blocks/block-description/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { deprecated } from '@wordpress/utils';
 /**
  * Internal dependencies
  */
@@ -10,8 +11,7 @@ import './style.scss';
 class BlockDescription extends Component {
 	constructor() {
 		super( ...arguments );
-		// eslint-disable-next-line no-console
-		console.warn( 'The wp.blocks.BlockDescription component is deprecated. Use the "description" block property instead.' );
+		deprecated( 'The wp.blocks.BlockDescription component', '2.4', 'the "description" block property', 'Gutenberg' );
 	}
 
 	render() {

--- a/blocks/block-description/test/index.js
+++ b/blocks/block-description/test/index.js
@@ -16,7 +16,7 @@ describe( 'BlockDescription', () => {
 			expect( blockDescription.type() ).toBe( 'div' );
 			expect( blockDescription.text() ).toBe( 'Hello World' );
 			expect( console ).toHaveWarnedWith(
-				'The wp.blocks.BlockDescription component is deprecated. Use the "description" block property instead.'
+				'The wp.blocks.BlockDescription component is deprecated and will be removed from Gutenberg in 2.4. Please use the \"description\" block property instead.'
 			);
 		} );
 	} );

--- a/blocks/hooks/deprecated.js
+++ b/blocks/hooks/deprecated.js
@@ -20,7 +20,12 @@ export class RawHTMLWithWarning extends Component {
 
 		// Disable reason: We're intentionally logging a console warning
 		// advising the developer to upgrade usage.
-		deprecated( 'Returning raw HTML from block `save`', '2.5', '`wp.element.RawHTML` component', 'Gutenberg', 'https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/#save' );
+		deprecated( 'Returning raw HTML from block `save`', {
+			version: '2.5',
+			alternative: '`wp.element.RawHTML` component',
+			plugin: 'Gutenberg',
+			link: 'https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/#save',
+		} );
 	}
 
 	render() {

--- a/blocks/hooks/deprecated.js
+++ b/blocks/hooks/deprecated.js
@@ -8,6 +8,7 @@ import { includes } from 'lodash';
  */
 import { Component, RawHTML } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
+import { deprecated } from '@wordpress/utils';
 
 /**
  * Wrapper component for RawHTML, logging a warning about unsupported raw
@@ -19,13 +20,7 @@ export class RawHTMLWithWarning extends Component {
 
 		// Disable reason: We're intentionally logging a console warning
 		// advising the developer to upgrade usage.
-
-		// eslint-disable-next-line no-console
-		console.warn(
-			'Deprecated: Returning raw HTML from block `save` is not supported. ' +
-			'Use `wp.element.RawHTML` component instead.\n\n' +
-			'See: https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/#save'
-		);
+		deprecated( 'Returning raw HTML from block `save`', '2.5', '`wp.element.RawHTML` component', 'Gutenberg', 'https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/#save' );
 	}
 
 	render() {

--- a/blocks/hooks/matchers.js
+++ b/blocks/hooks/matchers.js
@@ -6,14 +6,11 @@ import { isFunction, mapValues } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { deprecated } from '@wordpress/utils';
 import { addFilter } from '@wordpress/hooks';
 
 function warnAboutDeprecatedMatcher() {
-	// eslint-disable-next-line no-console
-	console.warn(
-		'Attributes matchers are deprecated and they will be removed in a future version of Gutenberg. ' +
-		'Please update your attributes definition https://wordpress.org/gutenberg/handbook/block-api/attributes/'
-	);
+	deprecated( 'Attributes matching using functions', '2.3', 'the declarative attributes', 'Gutenberg', 'https://wordpress.org/gutenberg/handbook/block-api/attributes/' );
 }
 
 export const attr = ( selector, attribute ) => () => {

--- a/blocks/hooks/matchers.js
+++ b/blocks/hooks/matchers.js
@@ -10,7 +10,12 @@ import { deprecated } from '@wordpress/utils';
 import { addFilter } from '@wordpress/hooks';
 
 function warnAboutDeprecatedMatcher() {
-	deprecated( 'Attributes matching using functions', '2.3', 'the declarative attributes', 'Gutenberg', 'https://wordpress.org/gutenberg/handbook/block-api/attributes/' );
+	deprecated( 'Attributes matching using functions', {
+		version: '2.4',
+		alternative: 'the declarative attributes',
+		plugin: 'Gutenberg',
+		link: 'https://wordpress.org/gutenberg/handbook/block-api/attributes/',
+	} );
 }
 
 export const attr = ( selector, attribute ) => () => {

--- a/blocks/inspector-controls/index.js
+++ b/blocks/inspector-controls/index.js
@@ -31,7 +31,11 @@ export default function InspectorControls( { children } ) {
 const withDeprecation = ( componentName ) => ( OriginalComponent ) => {
 	class WrappedComponent extends Component {
 		componentDidMount() {
-			deprecated( `wp.blocks.InspectorControls.${ componentName }`, '2.4', `wp.components.${ componentName }`, 'Gutenberg' );
+			deprecated( `wp.blocks.InspectorControls.${ componentName }`, {
+				version: '2.4',
+				alternative: `wp.components.${ componentName }`,
+				plugin: 'Gutenberg',
+			} );
 		}
 
 		render() {

--- a/blocks/inspector-controls/index.js
+++ b/blocks/inspector-controls/index.js
@@ -18,6 +18,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
+import { deprecated } from '@wordpress/utils';
 
 export default function InspectorControls( { children } ) {
 	return (
@@ -30,8 +31,7 @@ export default function InspectorControls( { children } ) {
 const withDeprecation = ( componentName ) => ( OriginalComponent ) => {
 	class WrappedComponent extends Component {
 		componentDidMount() {
-			// eslint-disable-next-line no-console
-			console.warn( `wp.blocks.InspectorControls.${ componentName } is deprecated, use wp.components.${ componentName }.` );
+			deprecated( `wp.blocks.InspectorControls.${ componentName }`, '2.4', `wp.components.${ componentName }`, 'Gutenberg' );
 		}
 
 		render() {

--- a/blocks/media-upload/button.js
+++ b/blocks/media-upload/button.js
@@ -12,7 +12,11 @@ import MediaUpload from './';
 
 class MediaUploadButton extends Component {
 	componentDidMount() {
-		deprecated( 'MediaUploadButton', '2.4', 'wp.blocks.MediaUpload', 'Gutenberg' );
+		deprecated( 'MediaUploadButton', {
+			version: '2.4',
+			alternative: 'wp.blocks.MediaUpload',
+			plugin: 'Gutenberg',
+		} );
 	}
 
 	render() {

--- a/blocks/media-upload/button.js
+++ b/blocks/media-upload/button.js
@@ -3,6 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 import { Button, Tooltip } from '@wordpress/components';
+import { deprecated } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -11,8 +12,7 @@ import MediaUpload from './';
 
 class MediaUploadButton extends Component {
 	componentDidMount() {
-		// eslint-disable-next-line no-console
-		console.warn( 'MediaUploadButton is deprecated use wp.blocks.MediaUpload instead' );
+		deprecated( 'MediaUploadButton', '2.4', 'wp.blocks.MediaUpload', 'Gutenberg' );
 	}
 
 	render() {

--- a/blocks/rich-text/editable.js
+++ b/blocks/rich-text/editable.js
@@ -11,7 +11,11 @@ import RichText from './';
 class Editable extends RichText {
 	constructor() {
 		super( ...arguments );
-		deprecated( 'Editable', '2.5', 'wp.blocks.RichText', 'Gutenberg' );
+		deprecated( 'Editable', {
+			version: '2.5',
+			alternative: 'wp.blocks.RichText',
+			plugin: 'Gutenberg',
+		} );
 	}
 }
 

--- a/blocks/rich-text/editable.js
+++ b/blocks/rich-text/editable.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { deprecated } from '@wordpress/utils';
+
+/**
  * Internal dependencies
  */
 import RichText from './';
@@ -6,8 +11,7 @@ import RichText from './';
 class Editable extends RichText {
 	constructor() {
 		super( ...arguments );
-		// eslint-disable-next-line no-console
-		console.warn( 'Editable is deprecated, use wp.blocks.RichText instead.' );
+		deprecated( 'Editable', '2.5', 'wp.blocks.RichText', 'Gutenberg' );
 	}
 }
 

--- a/data/index.js
+++ b/data/index.js
@@ -89,7 +89,10 @@ export function registerSelectors( reducerKey, newSelectors ) {
  */
 export function select( reducerKey ) {
 	if ( arguments.length > 1 ) {
-		deprecated( 'Calling select with multiple arguments', '2.4', undefined, 'Gutenberg' );
+		deprecated( 'Calling select with multiple arguments', {
+			version: '2.4',
+			plugin: 'Gutenberg',
+		} );
 
 		const [ , selectorKey, ...args ] = arguments;
 		return select( reducerKey )[ selectorKey ]( ...args );

--- a/data/index.js
+++ b/data/index.js
@@ -6,6 +6,11 @@ import { createStore } from 'redux';
 import { flowRight, without, mapValues } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { deprecated } from '@wordpress/utils';
+
+/**
  * Internal dependencies
  */
 export { loadAndPersist, withRehydratation } from './persist';
@@ -84,11 +89,7 @@ export function registerSelectors( reducerKey, newSelectors ) {
  */
 export function select( reducerKey ) {
 	if ( arguments.length > 1 ) {
-		// eslint-disable-next-line no-console
-		console.warn(
-			'Deprecated: `select` now accepts only a single argument: the reducer key. ' +
-			'The return value is an object of selector functions.'
-		);
+		deprecated( 'Calling select with multiple arguments', '2.4', undefined, 'Gutenberg' );
 
 		const [ , selectorKey, ...args ] = arguments;
 		return select( reducerKey )[ selectorKey ]( ...args );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -79,7 +79,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-data',
 		gutenberg_url( 'data/build/index.js' ),
-		array( 'wp-element' ),
+		array( 'wp-element', 'wp-utils' ),
 		filemtime( gutenberg_dir_path() . 'data/build/index.js' )
 	);
 	wp_register_script(

--- a/utils/deprecation.js
+++ b/utils/deprecation.js
@@ -1,16 +1,17 @@
 /**
  * Logs a message to notify developpers about a deprecated feature.
  *
- * @param {string}  feature     Name of the deprecated feature.
- * @param {?string} version     Version in which the feature will be removed.
- * @param {?string}  useInstead Feature to use instead
- * @param {?string}  plugin     Plugin name if it's a plugin feature
- * @param {?string}  link       Link to documentation
+ * @param {string}  feature             Name of the deprecated feature.
+ * @param {?Object} options             Personalisation options
+ * @param {?string} options.version     Version in which the feature will be removed.
+ * @param {?string} options.alternative Feature to use instead
+ * @param {?string} options.plugin      Plugin name if it's a plugin feature
+ * @param {?string} options.link        Link to documentation
  */
-export function deprecated( feature, version, useInstead, plugin, link ) {
+export function deprecated( feature, { version, alternative, plugin, link } = {} ) {
 	const pluginMessage = plugin ? ` from ${ plugin }` : '';
 	const versionMessage = version ? `${ pluginMessage } in ${ version }` : '';
-	const useInsteadMessage = useInstead ? ` Please use ${ useInstead } instead.` : '';
+	const useInsteadMessage = alternative ? ` Please use ${ alternative } instead.` : '';
 	const linkMessage = link ? ` See: ${ link }` : '';
 	const message = `${ feature } is deprecated and will be removed${ versionMessage }.${ useInsteadMessage }${ linkMessage }`;
 

--- a/utils/deprecation.js
+++ b/utils/deprecation.js
@@ -1,0 +1,19 @@
+/**
+ * Logs a message to notify developpers about a deprecated feature.
+ *
+ * @param {string}  feature     Name of the deprecated feature.
+ * @param {?string} version     Version in which the feature will be removed.
+ * @param {?string}  useInstead Feature to use instead
+ * @param {?string}  plugin     Plugin name if it's a plugin feature
+ * @param {?string}  link       Link to documentation
+ */
+export function deprecated( feature, version, useInstead, plugin, link ) {
+	const pluginMessage = plugin ? ` from ${ plugin }` : '';
+	const versionMessage = version ? `${ pluginMessage } in ${ version }` : '';
+	const useInsteadMessage = useInstead ? ` Please use ${ useInstead } instead.` : '';
+	const linkMessage = link ? ` See: ${ link }` : '';
+	const message = `${ feature } is deprecated and will be removed${ versionMessage }.${ useInsteadMessage }${ linkMessage }`;
+
+	// eslint-disable-next-line no-console
+	console.warn( message );
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -10,5 +10,6 @@ export { decodeEntities };
 export * from './blob-cache';
 export * from './mediaupload';
 export * from './terms';
+export * from './deprecation';
 
 export { viewPort };

--- a/utils/test/deprecation.js
+++ b/utils/test/deprecation.js
@@ -13,7 +13,7 @@ describe( 'deprecated', () => {
 	} );
 
 	it( 'should show a deprecation warning with a version', () => {
-		deprecated( 'Eating meat', 'the future' );
+		deprecated( 'Eating meat', { version: 'the future' } );
 
 		expect( console ).toHaveWarnedWith(
 			'Eating meat is deprecated and will be removed in the future.'
@@ -21,7 +21,7 @@ describe( 'deprecated', () => {
 	} );
 
 	it( 'should show a deprecation warning with an alternative', () => {
-		deprecated( 'Eating meat', 'the future', 'vegetables' );
+		deprecated( 'Eating meat', { version: 'the future', alternative: 'vegetables' } );
 
 		expect( console ).toHaveWarnedWith(
 			'Eating meat is deprecated and will be removed in the future. Please use vegetables instead.'
@@ -29,7 +29,11 @@ describe( 'deprecated', () => {
 	} );
 
 	it( 'should show a deprecation warning with an alternative specific to a plugin', () => {
-		deprecated( 'Eating meat', 'the future', 'vegetables', 'the earth' );
+		deprecated( 'Eating meat', {
+			version: 'the future',
+			alternative: 'vegetables',
+			plugin: 'the earth',
+		} );
 
 		expect( console ).toHaveWarnedWith(
 			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead.'
@@ -37,7 +41,12 @@ describe( 'deprecated', () => {
 	} );
 
 	it( 'should show a deprecation warning with a link', () => {
-		deprecated( 'Eating meat', 'the future', 'vegetables', 'the earth', 'https://en.wikipedia.org/wiki/Vegetarianism' );
+		deprecated( 'Eating meat', {
+			version: 'the future',
+			alternative: 'vegetables',
+			plugin: 'the earth',
+			link: 'https://en.wikipedia.org/wiki/Vegetarianism',
+		} );
 
 		expect( console ).toHaveWarnedWith(
 			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead. See: https://en.wikipedia.org/wiki/Vegetarianism'

--- a/utils/test/deprecation.js
+++ b/utils/test/deprecation.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import { deprecated } from '../deprecation';
+
+describe( 'deprecated', () => {
+	it( 'should show a deprecation warning', () => {
+		deprecated( 'Eating meat' );
+
+		expect( console ).toHaveWarnedWith(
+			'Eating meat is deprecated and will be removed.'
+		);
+	} );
+
+	it( 'should show a deprecation warning with a version', () => {
+		deprecated( 'Eating meat', 'the future' );
+
+		expect( console ).toHaveWarnedWith(
+			'Eating meat is deprecated and will be removed in the future.'
+		);
+	} );
+
+	it( 'should show a deprecation warning with an alternative', () => {
+		deprecated( 'Eating meat', 'the future', 'vegetables' );
+
+		expect( console ).toHaveWarnedWith(
+			'Eating meat is deprecated and will be removed in the future. Please use vegetables instead.'
+		);
+	} );
+
+	it( 'should show a deprecation warning with an alternative specific to a plugin', () => {
+		deprecated( 'Eating meat', 'the future', 'vegetables', 'the earth' );
+
+		expect( console ).toHaveWarnedWith(
+			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead.'
+		);
+	} );
+
+	it( 'should show a deprecation warning with a link', () => {
+		deprecated( 'Eating meat', 'the future', 'vegetables', 'the earth', 'https://en.wikipedia.org/wiki/Vegetarianism' );
+
+		expect( console ).toHaveWarnedWith(
+			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead. See: https://en.wikipedia.org/wiki/Vegetarianism'
+		);
+	} );
+} );


### PR DESCRIPTION
This PR adds a `deprecated` function to produce a consistent warning message when deprecating features in WordPress and WordPress plugin. 

You can provide: 

 - A feature name (the only mandatory parameter),
 - A version in which the feature will be deprecated,
 - An alternative feature to use instead,
 - A plugin name (default to WordPress Core)
 - A link for more details

