### PR TITLE
Gallery Block: Center spinner when the images are loading

### DIFF
--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -54,3 +54,10 @@
 .blocks-gallery-item__remove {
 	padding: 0;
 }
+
+.blocks-gallery-item .spinner {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+}


### PR DESCRIPTION
Tiny CSS fix. A bit hard to recreate since the images can load quickly.

**Testing instructions**

 Ensure that when uploading images to galleries the spinner is centered for each image being uploaded.

closes #4973