### PR TITLE
WIP - OpenGraph and link embed fallbacks

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -163,6 +163,9 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 					</BlockControls>
 				);
 
+				// If the user just pasted a URL into a paragraph, we display a paragraph with the
+				// URL in it while we do the fetch. This is so the user doesn't see the big grey
+				// "Embedding..." UI unexpectedly, and makes the experience a bit smoother.
 				if ( fetching && fromPaste ) {
 					return [
 						controls,

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -125,7 +125,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 							return;
 						}
 						response.json().then( ( obj ) => {
-							const { html, type, title: urlTitle, provider_name: providerName } = obj;
+							const { html, type, provider_name: providerName, code } = obj;
 							const providerNameSlug = kebabCase( toLower( providerName ) );
 
 							// invalid url, and this didn't come from submitting the form
@@ -165,7 +165,8 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 
 				if ( fetching && fromPaste ) {
 					return [
-						<p>{ url }</p>
+						controls,
+						<p key="loading">{ url }</p>,
 					];
 				}
 

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -134,6 +134,7 @@ export default class Sandbox extends Component {
 				document.body.style.position = 'absolute';
 				document.body.style.width = '100%';
 				document.body.setAttribute( 'data-resizable-iframe-connected', '' );
+
 				sendResize();
 		} )();`;
 

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -140,7 +140,6 @@ export default class Sandbox extends Component {
 		const style = `
 			body {
 				margin: 0;
-				font: 13px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 			}
 			body.video,
 			body.video > div,
@@ -151,32 +150,6 @@ export default class Sandbox extends Component {
 			body > div > * {
 				margin-top: 0 !important;	/* has to have !important to override inline styles */
 				margin-bottom: 0 !important;
-			}
-			/* OpenGraph styles */
-			.opengraph blockquote {
-				margin: 0;
-				border: 1px solid #e1e3e6;
-				border-radius: 4px;
-				padding: 8px;
-				overflow: hidden;
-				height: 96px;
-			}
-			.opengraph img {
-				width: 96px;
-				height: 96px;
-				object-fit: cover;
-				float: left;
-				margin-right: 1em;
-			}
-			.opengraph h1 {
-				font-size: 13px;
-				margin: 0;
-			}
-			.opengraph p {
-				margin: 0;
-			}
-			.opengraph a {
-				color: #007daa;
 			}
 		`;
 

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -134,13 +134,13 @@ export default class Sandbox extends Component {
 				document.body.style.position = 'absolute';
 				document.body.style.width = '100%';
 				document.body.setAttribute( 'data-resizable-iframe-connected', '' );
-
 				sendResize();
 		} )();`;
 
 		const style = `
 			body {
 				margin: 0;
+				font: 13px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 			}
 			body.video,
 			body.video > div,
@@ -151,6 +151,32 @@ export default class Sandbox extends Component {
 			body > div > * {
 				margin-top: 0 !important;	/* has to have !important to override inline styles */
 				margin-bottom: 0 !important;
+			}
+			/* OpenGraph styles */
+			.opengraph blockquote {
+				margin: 0;
+				border: 1px solid #e1e3e6;
+				border-radius: 4px;
+				padding: 8px;
+				overflow: hidden;
+				height: 96px;
+			}
+			.opengraph img {
+				width: 96px;
+				height: 96px;
+				object-fit: cover;
+				float: left;
+				margin-right: 1em;
+			}
+			.opengraph h1 {
+				font-size: 13px;
+				margin: 0;
+			}
+			.opengraph p {
+				margin: 0;
+			}
+			.opengraph a {
+				color: #007daa;
 			}
 		`;
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -618,6 +618,9 @@ function gutenberg_oembed_opengraph( $url ) {
 		body.opengraph h1,
 		.is-type-opengraph p,
 		.is-type-opengraph h1 {
+			clear: none;
+			line-height: inherit;
+			padding: 0;
 			font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 			font-size: 13px;
 			margin: 0;

--- a/lib/register.php
+++ b/lib/register.php
@@ -565,15 +565,48 @@ function gutenberg_oembed_opengraph( $url ) {
 	if ( ! $image && ! $desc ) {
 		$html = '';
 	} else {
-		$html = '<blockquote style="margin: 0; border: 1px solid #e1e3e6; border-radius: 4px; padding: 8px; overflow: hidden; height: 96px">';
+		$html = '<blockquote>';
 		if ( $image ) {
-			$html .= "<img src=\"$image\" style=\"width: 96px; height: 96px; object-fit: cover; float: left; margin-right: 1em\" />";
+			$html .= "<img src=\"$image\" />";
 		}
-		$html .= "<h1 style=\"font-size: 13px; margin: 0\"><a href=\"$url\" style=\"color: #007daa;\">$title</a></h1>";
+		$html .= "<h1><a href=\"$url\">$title</a></h1>";
 		if ( $desc ) {
-			$html .= "<p style=\"margin: 0\">$desc</p>";
+			$html .= "<p>$desc</p>";
 		}
 		$html .= '</blockquote>';
+		$html .= '<style type="text/css">
+		body.opengraph blockquote,
+		.is-type-opengraph blockquote {
+			margin: 0;
+			border: 1px solid #e1e3e6;
+			border-radius: 4px;
+			padding: 8px;
+			overflow: hidden;
+			height: 96px;
+			box-sizing: content-box;
+			-moz-box-sizing: content-box;
+			-webkit-box-sizing: content-box;
+		}
+		body.opengraph img,
+		.is-type-opengraph img {
+			width: 96px;
+			height: 96px;
+			object-fit: cover;
+			float: left;
+			margin-right: 1em;
+		}
+		body.opengraph p,
+		body.opengraph h1,
+		.is-type-opengraph p,
+		.is-type-opengraph h1 {
+			font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+			font-size: 13px;
+			margin: 0;
+		}
+		body.opengraph a {
+			color: #007daa;
+		}
+		</style>';
 	}
 
 	$ttl = apply_filters( 'gutenberg_opengraph_ttl', DAY_IN_SECONDS, $url );

--- a/lib/register.php
+++ b/lib/register.php
@@ -526,17 +526,20 @@ add_filter( 'wp_prepare_revision_for_js', 'gutenberg_revisions_restore' );
  */
 function gutenberg_get_opengraph_metadata( $html ) {
 	$matches = array();
-	$data = array();
+	$data    = array();
 	preg_match_all( '/<meta[^>]+property="og:([^"]+)"[^>]+content="([^"]+)"[^>]+>/i', $html, $matches );
-	foreach( $matches[1] as $key => $value ) {
+
+	foreach ( $matches[1] as $key => $value ) {
 		$data[ $value ] = $matches[2][ $key ];
 	}
+
 	if ( ! isset( $data['title'] ) ) {
 		preg_match( '/<title>([^<]+)<\/title>/i', $html, $matches );
 		if ( isset( $matches[1] ) ) {
 			$data['title'] = $matches[1];
 		}
 	}
+
 	return $data;
 }
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -526,9 +526,9 @@ add_filter( 'wp_prepare_revision_for_js', 'gutenberg_revisions_restore' );
  */
 function gutenberg_oembed_opengraph( $url ) {
 	$cache_key = 'gutenberg_opengraph_' . md5( $url );
-	$html = get_transient( $cache_key );
+	$html      = get_transient( $cache_key );
 
-	// empty string means we tried to get OpenGraph information for this url, but it had none
+	// Empty string means we tried to get OpenGraph information for this url, but it had none.
 	if ( '' === $html ) {
 		return false;
 	}
@@ -541,8 +541,7 @@ function gutenberg_oembed_opengraph( $url ) {
 		$url,
 		array(
 			'limit_response_size' => 250000,
-			// set a user agent, or else some sites block the request
-			'user-agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:20.0) Gecko/20100101 Firefox/20.0'
+			'user-agent'          => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:20.0) Gecko/20100101 Firefox/20.0',
 		)
 	);
 
@@ -601,17 +600,17 @@ function gutenberg_oembed_fallback( $response, $handler, $request ) {
 		}
 
 		return  array(
-			'url'   => $url,
-			'html'  => $html,
-			'type'  => 'opengraph',
+			'url'  => $url,
+			'html' => $html,
+			'type' => 'opengraph',
 		);
 	}
 
 	return $response;
 }
 
-// potentially return an OpenGraph response if the embed proxy API cannot embed
+// Potentially return an OpenGraph response if the embed proxy API cannot embed.
 add_filter( 'rest_request_after_callbacks', 'gutenberg_oembed_fallback', 10, 3 );
 
-// fires if there are no providers for a URL, so do the OpenGraph stuff here
+// Fires if there are no providers for a URL, so do the OpenGraph stuff here.
 add_filter( 'embed_maybe_make_link', 'gutenberg_oembed_opengraph' );

--- a/lib/register.php
+++ b/lib/register.php
@@ -518,6 +518,12 @@ function gutenberg_revisions_restore( $revisions_data ) {
 }
 add_filter( 'wp_prepare_revision_for_js', 'gutenberg_revisions_restore' );
 
+/**
+ * Generates and caches HTML for a URL that contains OpenGraph metadata.
+ *
+ * @param string $url The URL to generate HTML for.
+ * @return mixed OpenGraph HTML, or false if there was no OpenGraph data.
+ */
 function gutenberg_oembed_opengraph( $url ) {
 	$cache_key = 'gutenberg_opengraph_' . md5( $url );
 	$html = get_transient( $cache_key );

--- a/lib/register.php
+++ b/lib/register.php
@@ -565,13 +565,13 @@ function gutenberg_oembed_opengraph( $url ) {
 	if ( ! $image && ! $desc ) {
 		$html = '';
 	} else {
-		$html = '<blockquote>';
+		$html = '<blockquote style="margin: 0; border: 1px solid #e1e3e6; border-radius: 4px; padding: 8px; overflow: hidden; height: 96px">';
 		if ( $image ) {
-			$html .= "<img src=\"$image\" />";
+			$html .= "<img src=\"$image\" style=\"width: 96px; height: 96px; object-fit: cover; float: left; margin-right: 1em\" />";
 		}
-		$html .= "<h1><a href=\"$url\">$title</a></h1>";
+		$html .= "<h1 style=\"font-size: 13px; margin: 0\"><a href=\"$url\" style=\"color: #007daa;\">$title</a></h1>";
 		if ( $desc ) {
-			$html .= "<p>$desc</p>";
+			$html .= "<p style=\"margin: 0\">$desc</p>";
 		}
 		$html .= '</blockquote>';
 	}


### PR DESCRIPTION
## Description

Adds OpenGraph and plain link fallbacks to oEmbed rendering.

I'd like feedback on what we render for OpenGraph, and the user experience, especially around pasting links that have no embed or OG data.

## Screenshots
Embedding a youtube video, https://www.youtube.com/watch?v=PfKUdmTq2MI

![embed-paste-youtube](https://user-images.githubusercontent.com/3314354/36255572-78577f54-1247-11e8-9492-491e7078b794.gif)

Embedding with OpenGraph, https://reactjs.org/docs/rendering-elements.html

![embed-paste-opengraph](https://user-images.githubusercontent.com/3314354/36255622-a9d22d86-1247-11e8-86de-b88e2c0a8083.gif)

Embedding a site with no embed support and no OpenGraph data, http://notnownikki.com/sameties/

![embed-paste-url](https://user-images.githubusercontent.com/3314354/36255649-be2a51aa-1247-11e8-9313-35518d3d2204.gif)

