### PR TITLE
State: Replace global hover state with local component state

### DIFF
--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -540,33 +540,6 @@ export function blockSelection( state = {
 	return state;
 }
 
-/**
- * Reducer returning hovered block state.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function hoveredBlock( state = null, action ) {
-	switch ( action.type ) {
-		case 'TOGGLE_BLOCK_HOVERED':
-			return action.hovered ? action.uid : null;
-		case 'SELECT_BLOCK':
-		case 'START_TYPING':
-		case 'MULTI_SELECT':
-			return null;
-		case 'REPLACE_BLOCKS':
-			if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state ) === -1 ) {
-				return state;
-			}
-
-			return action.blocks[ 0 ].uid;
-	}
-
-	return state;
-}
-
 export function blocksMode( state = {}, action ) {
 	if ( action.type === 'TOGGLE_BLOCK_MODE' ) {
 		const { uid } = action;
@@ -880,7 +853,6 @@ export default optimist( combineReducers( {
 	currentPost,
 	isTyping,
 	blockSelection,
-	hoveredBlock,
 	blocksMode,
 	isInsertionPointVisible,
 	preferences,

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -879,19 +879,6 @@ export function isBlockWithinSelection( state, uid ) {
 }
 
 /**
- * Returns true if the cursor is hovering the block corresponding to the
- * specified unique ID, or false otherwise.
- *
- * @param {Object} state Global application state.
- * @param {string} uid   Block unique ID.
- *
- * @return {boolean} Whether block is hovered.
- */
-export function isBlockHovered( state, uid ) {
-	return state.hoveredBlock === uid;
-}
-
-/**
  * Whether in the process of multi-selecting or not.
  *
  * @param {Object} state Global application state.

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -21,7 +21,6 @@ import {
 	getPostRawValue,
 	editor,
 	currentPost,
-	hoveredBlock,
 	isTyping,
 	blockSelection,
 	preferences,
@@ -851,55 +850,6 @@ describe( 'state', () => {
 				title: 'updated post object from server',
 				status: 'publish',
 			} );
-		} );
-	} );
-
-	describe( 'hoveredBlock()', () => {
-		it( 'should return with block uid as hovered', () => {
-			const state = hoveredBlock( null, {
-				type: 'TOGGLE_BLOCK_HOVERED',
-				uid: 'kumquat',
-				hovered: true,
-			} );
-
-			expect( state ).toBe( 'kumquat' );
-		} );
-
-		it( 'should return null when a block is selected', () => {
-			const state = hoveredBlock( 'kumquat', {
-				type: 'SELECT_BLOCK',
-				uid: 'kumquat',
-			} );
-
-			expect( state ).toBeNull();
-		} );
-
-		it( 'should replace the hovered block', () => {
-			const state = hoveredBlock( 'chicken', {
-				type: 'REPLACE_BLOCKS',
-				uids: [ 'chicken' ],
-				blocks: [ {
-					uid: 'wings',
-					name: 'core/freeform',
-					innerBlocks: [],
-				} ],
-			} );
-
-			expect( state ).toBe( 'wings' );
-		} );
-
-		it( 'should keep the hovered block', () => {
-			const state = hoveredBlock( 'chicken', {
-				type: 'REPLACE_BLOCKS',
-				uids: [ 'ribs' ],
-				blocks: [ {
-					uid: 'wings',
-					name: 'core/freeform',
-					innerBlocks: [],
-				} ],
-			} );
-
-			expect( state ).toBe( 'chicken' );
 		} );
 	} );
 

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -55,7 +55,6 @@ const {
 	isBlockWithinSelection,
 	isBlockMultiSelected,
 	isFirstMultiSelectedBlock,
-	isBlockHovered,
 	getBlockMode,
 	isTyping,
 	getBlockInsertionPoint,
@@ -1942,24 +1941,6 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is not first in multi selection', () => {
 			expect( isFirstMultiSelectedBlock( state, 3 ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'isBlockHovered', () => {
-		it( 'should return true if the block is hovered', () => {
-			const state = {
-				hoveredBlock: 123,
-			};
-
-			expect( isBlockHovered( state, 123 ) ).toBe( true );
-		} );
-
-		it( 'should return false if the block is not hovered', () => {
-			const state = {
-				hoveredBlock: 123,
-			};
-
-			expect( isBlockHovered( state, 23 ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request seeks to remove block hover state from the global Redux store. It was only ever used locally within the `BlockListBlock` component, and handling it as local component state avoids excessive dispatching on mouse events and simplifies global state handling.

__Testing instructions:__

Verify that there are no regressions with hover behavior:

- Hover and unhover a block
- Hovering UI shouldn't be visible when multi-selecting
- Hovering UI should disappear on typing and reappear on mouse move
