### PR TITLE
Framework: Remove invalid reference to WeakMap polyfill

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -155,7 +155,6 @@ function gutenberg_register_scripts_and_styles() {
 		gutenberg_get_script_polyfill( array(
 			'\'Promise\' in window' => 'promise',
 			'\'fetch\' in window'   => 'fetch',
-			'\'WeakMap\' in window' => 'WeakMap',
 		) ),
 		'before'
 	);


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/5002#discussion_r167532619

This pull request seeks to remove a reference to a WeakMap polyfill which is both invalid and unnecessary. Earlier iterations of what resulted in the [rememo 2.4.0 release](https://github.com/aduth/rememo/blob/master/CHANGELOG.md#v240-2018-02-11) required WeakMap, so a polyfill was added to our script enqueueing. This was later turned into a soft dependency, leveraging WeakMap if present as an optimization.

Further, this polyfill does not work, because it expects a script handle matching the value in the tests array, but this was never registered.

__Testing instructions:__

Verify there are no regressions in editor usage, particularly around memoized selectors (block manipulation).

For extra credit, test in a browser which doesn't support WeakMap (IE11).