### PR TITLE
Block List: Include consistent block margin for default appender

### DIFF
--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -199,7 +199,7 @@ class BlockListLayout extends Component {
 			defaultLayout = layout;
 		}
 
-		const classes = classnames( {
+		const classes = classnames( 'editor-block-list__layout', {
 			[ `layout-${ layout }` ]: layout,
 		} );
 

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -1,5 +1,9 @@
-.edit-post-visual-editor .editor-block-list__block {
+.editor-block-list__layout .editor-default-block-appender,
+.editor-block-list__layout .editor-block-list__block {
 	margin-bottom: $block-spacing;
+}
+
+.editor-block-list__layout .editor-block-list__block {
 	position: relative;
 	padding: $block-padding;
 

--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -1,8 +1,6 @@
 $empty-paragraph-height: $text-editor-font-size * 4;
 
 .editor-default-block-appender {
-	margin-bottom: $block-spacing;
-
 	.editor-default-block-appender__content {
 		height: $empty-paragraph-height;
 		color: $dark-gray-300;

--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -1,6 +1,8 @@
 $empty-paragraph-height: $text-editor-font-size * 4;
 
 .editor-default-block-appender {
+	margin-bottom: $block-spacing;
+
 	.editor-default-block-appender__content {
 		height: $empty-paragraph-height;
 		color: $dark-gray-300;


### PR DESCRIPTION
This pull request seeks to resolve a minor design issue where the default block appender does not include the same margins applied to blocks, which can result in a change in editor height when clicking the prompt. This is most noticeable when meta boxes are present, as they will be pushed down.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/36273241-e3b62dae-1251-11e8-840a-1f8bed428501.gif)|![after](https://user-images.githubusercontent.com/1779930/36273240-e3a5d152-1251-11e8-9d69-3bc2a6d53be7.gif)

__Testing instructions:__

With meta boxes present, ensure that clicking the default block appender causes no shift in editor content height.