### PR TITLE
Visual Editor: Refactor VisualEditor to use data query

### DIFF
--- a/edit-post/components/modes/visual-editor/index.js
+++ b/edit-post/components/modes/visual-editor/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -16,15 +11,15 @@ import {
 	MultiSelectScrollIntoView,
 } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import BlockInspectorButton from './block-inspector-button';
-import { hasFixedToolbar } from '../../../store/selectors';
 
-function VisualEditor( props ) {
+function VisualEditor( { hasFixedToolbar } ) {
 	return (
 		<BlockSelectionClearer className="edit-post-visual-editor">
 			<EditorGlobalKeyboardShortcuts />
@@ -33,7 +28,7 @@ function VisualEditor( props ) {
 			<WritingFlow>
 				<PostTitle />
 				<BlockList
-					showContextualToolbar={ ! props.hasFixedToolbar }
+					showContextualToolbar={ ! hasFixedToolbar }
 					renderBlockMenu={ ( { children, onClose } ) => (
 						<Fragment>
 							<BlockInspectorButton onClick={ onClose } />
@@ -46,13 +41,6 @@ function VisualEditor( props ) {
 	);
 }
 
-export default connect(
-	( state ) => {
-		return {
-			hasFixedToolbar: hasFixedToolbar( state ),
-		};
-	},
-	undefined,
-	undefined,
-	{ storeKey: 'edit-post' }
-)( VisualEditor );
+export default withSelect( ( select ) => ( {
+	hasFixedToolbar: select( 'core/edit-post' ).hasFixedToolbar(),
+} ) )( VisualEditor );

--- a/edit-post/store/index.js
+++ b/edit-post/store/index.js
@@ -1,7 +1,12 @@
 /**
  * WordPress Dependencies
  */
-import { registerReducer, withRehydratation, loadAndPersist } from '@wordpress/data';
+import {
+	registerReducer,
+	registerSelectors,
+	withRehydratation,
+	loadAndPersist,
+} from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,6 +15,7 @@ import reducer from './reducer';
 import enhanceWithBrowserSize from './mobile';
 import { BREAK_MEDIUM } from './constants';
 import applyMiddlewares from './middlewares';
+import { hasFixedToolbar } from './selectors';
 
 /**
  * Module Constants
@@ -23,5 +29,9 @@ const store = applyMiddlewares(
 
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 enhanceWithBrowserSize( store, BREAK_MEDIUM );
+
+registerSelectors( MODULE_KEY, {
+	hasFixedToolbar,
+} );
 
 export default store;

--- a/edit-post/store/index.js
+++ b/edit-post/store/index.js
@@ -3,6 +3,7 @@
  */
 import {
 	registerReducer,
+	registerActions,
 	registerSelectors,
 	withRehydratation,
 	loadAndPersist,
@@ -15,7 +16,8 @@ import reducer from './reducer';
 import enhanceWithBrowserSize from './mobile';
 import { BREAK_MEDIUM } from './constants';
 import applyMiddlewares from './middlewares';
-import { hasFixedToolbar } from './selectors';
+import * as actions from './actions';
+import * as selectors from './selectors';
 
 /**
  * Module Constants
@@ -30,8 +32,7 @@ const store = applyMiddlewares(
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 enhanceWithBrowserSize( store, BREAK_MEDIUM );
 
-registerSelectors( MODULE_KEY, {
-	hasFixedToolbar,
-} );
+registerActions( MODULE_KEY, actions );
+registerSelectors( MODULE_KEY, selectors );
 
 export default store;


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/5021#discussion_r167788627

This pull request seeks to refactor the `VisualEditor` component to use the `data` module, largely as a demonstration of the benefits of avoiding:

- [Variable shadowing](https://eslint.org/docs/rules/no-shadow) of selectors
- Importing selectors
- Naming store key in `connect`

__Testing instructions:__

Verify there are no regressions in the behavior of the fixed toolbar.