### PR TITLE
[WIP] Handle All Asset Registration and Enqueueing For Blocks

### DIFF
--- a/lib/class-wp-block-asset-factory.php
+++ b/lib/class-wp-block-asset-factory.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Class WP_Block_Asset_Factory
+ *
+ * @since 2.x.x
+ *
+ * Responsible for creating objects that handle loading block assets
+ */
+class WP_Block_Asset_Factory{
+
+    /**
+     * Creates objects that register's block assets
+     *
+     * @since 2.x.x
+     *
+     * @param WP_Block_Type $block
+     * @return WP_Registers_Block_Assets
+     */
+    public function registration( WP_Block_Type $block ){
+        /**
+         * Runs before each block's assets are rendered
+         *
+         * @since 2.x.x
+         *
+         * @param null|WP_Registers_Block_Assets $register Return an object
+         *
+         */
+        $register = apply_filters( 'pre_register_block_assets', null, $block, $this );
+
+        if ( ! is_a( $register, WP_Registers_Block_Assets::class )) {
+            $register = new WP_Block_Assets_Registration($block);
+        }
+
+        /**
+         * Runs before each object is instantiated, before hooks are added.
+         *
+         * @since 2.x.x
+         */
+        do_action( 'block_assets_registered', $register, $this );
+        return $register;
+    }
+
+    /**
+     * Creates objects that enqueue block assets
+     *
+     * @since 2.x.x
+     *
+     * @param WP_Block_Type $block Block to enqueue assets for
+     * @return WP_Enqueues_Block_Assets
+     */
+    public function enqueue( WP_Block_Type $block ){
+        /**
+         * Runs before each block's assets are enqueued
+         *
+         * @since 2.x.x
+         *
+         * @param null|WP_Enqueues_Block_Assets $enqueue Return an object
+         *
+         */
+        $enqueue = apply_filters( 'pre_enqueue_block_assets', null, $block, $this );
+
+        if ( ! is_a( $enqueue, WP_Enqueues_Block_Assets::class )) {
+            $enqueue = new WP_Block_Assets_Enqueue($block);
+        }
+
+        /**
+         * Runs after object is instantiated, before hooks are added.
+         *
+         * @since 2.x.x
+         */
+        do_action( 'block_assets_enqueue', $enqueue );
+        return $enqueue;
+    }
+
+}

--- a/lib/class-wp-block-assets-enqueue.php
+++ b/lib/class-wp-block-assets-enqueue.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Default class for enqueuing a block's assets.
+ *
+ * Can be replaced via the "?" filter,
+ *
+ * @since 2.x.x
+ */
+class WP_Block_Assets_Enqueue implements WP_Enqueues_Block_Assets {
+
+    /**
+     * The block
+     *
+     * @since 2.x.x
+     *
+     * @var WP_Block_Type
+     */
+    protected $block;
+
+    /**
+     * WP_Block_Asset_Registration constructor.
+     * @param WP_Block_Type $block A block
+     */
+    public function __construct( WP_Block_Type $block){
+        $this->block = $block;
+    }
+
+    /** @inheritdoc */
+    public function add_hooks(){
+        //?
+    }
+
+    /** @inheritdoc */
+    public function remove_hooks(){
+       //?
+    }
+
+    /** @inheritdoc */
+    public function enqueue_editor_script(){
+        if( $this->block->editor_script ){
+            wp_enqueue_script( $this->block->editor_script );
+        }
+    }
+
+    /** @inheritdoc */
+    public function enqueue_editor_style(){
+        if( $this->block->editor_style ){
+            wp_enqueue_style( $this->block->editor_style );
+        }
+    }
+
+    /** @inheritdoc */
+    public function enqueue_script(){
+        if( $this->block->script ){
+            wp_enqueue_script( $this->block->script );
+        }
+    }
+
+    /** @inheritdoc */
+    public function enqueue_style(){
+        if( $this->block->style ){
+            wp_enqueue_style( $this->block->style );
+        }
+    }
+
+
+}

--- a/lib/class-wp-block-assets-registration.php
+++ b/lib/class-wp-block-assets-registration.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Default class for registering a block's assets.
+ *
+ * Can be replaced via the "?" filter,
+ *
+ * @since 2.x.x
+ */
+class WP_Block_Assets_Registration implements WP_Registers_Block_Assets {
+
+    /**
+     * The block
+     *
+     * @since 2.x.x
+     *
+     * @var WP_Block_Type
+     */
+    protected $block;
+
+    /**
+     * WP_Block_Asset_Registration constructor.
+     * @param WP_Block_Type $block A block
+     */
+    public function __construct( WP_Block_Type $block){
+        $this->block = $block;
+    }
+
+    /** @inheritdoc */
+    public function add_hooks(){
+        add_action( 'enqueue_block_editor_assets', array( $this, 'register_editor_script' ) );
+        add_action( 'enqueue_block_editor_assets', array( $this, 'register_editor_style' ) );
+
+        add_action( 'enqueue_block_assets', array( $this, 'register_script' ) );
+        add_action( 'enqueue_block_assets', array( $this, 'register_style' ) );
+    }
+
+    /** @inheritdoc */
+    public function remove_hooks(){
+        remove_action( 'enqueue_block_editor_assets', array( $this, 'register_editor_script' ) );
+        remove_action( 'enqueue_block_editor_assets', array( $this, 'register_editor_style' ) );
+
+        remove_action( 'enqueue_block_assets', array( $this, 'register_script' ) );
+        remove_action( 'enqueue_block_assets', array( $this, 'register_style' ) );
+    }
+
+    /** @inheritdoc */
+    public function register_editor_script(){
+        if( $this->block->editor_script ){
+            wp_register_script( $this->block->editor_script, $this->get_url_for_asset( 'editor_script' ) );
+        }
+    }
+
+    /** @inheritdoc */
+    public function register_editor_style(){
+        if( $this->block->editor_style ){
+            wp_register_style( $this->block->editor_style, $this->get_url_for_asset( 'editor_style' ) );
+        }
+    }
+
+    /** @inheritdoc */
+    public function register_script(){
+        if( $this->block->script ){
+            wp_register_script( $this->block->script, $this->get_url_for_asset( 'script' ) );
+        }
+    }
+
+    /** @inheritdoc */
+    public function register_style(){
+        if( $this->block->style ){
+            wp_register_style( $this->block->style, $this->get_url_for_asset( 'style' ) );
+        }
+    }
+
+    /**
+     * Get the URL for an asset
+     *
+     * @since 2.x.x
+     *
+     * @param string $asset_type Asset type style|script|editor_script|editor_style
+     * @return string
+     */
+    protected function get_url_for_asset( $asset_type ){
+
+        if ( $this->block->$asset_type ) {
+            //WP_Block_Type doesn't know enough about assets yet for this to be done smartly.
+            $url = ''; //?
+
+            /**
+             * Filter the Url for a block's asset
+             *
+             * @since 2.x.x
+             *
+             * @param string $url Asset url
+             * @param string $asset_type Asset type style|script|editor_script|editor_style
+             * @param WP_Block_Type $block The block whose assets are being registered.
+             */
+            $url = apply_filters( 'block_asset_url', $url, $asset_type, $this->block );
+            return filter_var( $url, FILTER_VALIDATE_URL ) ? $url : '';
+        }
+
+        return '';
+
+    }
+
+}

--- a/lib/class-wp-block-type-registry.php
+++ b/lib/class-wp-block-type-registry.php
@@ -31,7 +31,16 @@ final class WP_Block_Type_Registry {
 	 */
 	private static $instance = null;
 
-	/**
+    /**
+     * Factory for block asset loading
+     *
+     * @since 2.x.x
+     *
+     * @var WP_Block_Asset_Factory
+     */
+    protected $asset_factory;
+
+    /**
 	 * Registers a block type.
 	 *
 	 * @since 0.6.0
@@ -179,4 +188,37 @@ final class WP_Block_Type_Registry {
 
 		return self::$instance;
 	}
+
+    /**
+     * Handles registering and enqueueing block assets
+     *
+     * @since 2.x.x
+     *
+     * @param WP_Block_Type $block
+     */
+	protected function handle_block_assets( WP_Block_Type $block ){
+	    //Register block hooks
+        $register = $this->get_asset_factory()->registration( $block );
+        $register->add_hooks();
+
+        $enqueue = $this->get_asset_factory()->enqueue( $block );
+        $enqueue->add_hooks();
+    }
+
+    /**
+     * Get the asset factory
+     *
+     * @since 2.x.x
+     *
+     * @return WP_Block_Asset_Factory
+     */
+    protected function get_asset_factory(){
+        //Lazy-loader
+        //Hacky, but avoids a singleton, treats this singleton as a container for other types of objects, which is a new concern.
+        if( ! $this->asset_factory ){
+            $this->asset_factory = new WP_Block_Asset_Factory;
+        }
+
+        return $this->asset_factory;
+    }
 }

--- a/lib/interface-wp-adds-asset-hooks.php
+++ b/lib/interface-wp-adds-asset-hooks.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Interface WP_Adds_Asset_Hooks
+ *
+ * @since 2.x.x
+ *
+ * Interface that objects responsible for registering or enqueueing scripts should implement.
+ */
+interface WP_Adds_Asset_Hooks{
+    /**
+     * Add all hooks needed by this object.
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function add_hooks();
+
+    /**
+     * Removes all hooks added by this object's add_hooks method
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function remove_hooks();
+}

--- a/lib/interface-wp-enqueues-block-assets.php
+++ b/lib/interface-wp-enqueues-block-assets.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Interface WP_Enqueues_Block_Assets
+ *
+ * @since 2.x.x
+ *
+ * Objects responsible for enqueuing block assets should implement this.
+ *
+ * @see wp_enqueue_script()
+ * @see wp_enqueue_style()
+ */
+interface WP_Enqueues_Block_Assets extends WP_Adds_Asset_Hooks {
+
+    /**
+     * Enqueue the editor JavaScript
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function enqueue_editor_script();
+
+    /**
+     * Enqueue the editor CSS
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function enqueue_editor_style();
+
+    /**
+     * Enqueue the front-end JavaScript
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function enqueue_script();
+
+    /**
+     * Enqueue the front-end CSS
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function enqueue_style();
+}

--- a/lib/interface-wp-registers-block-assets.php
+++ b/lib/interface-wp-registers-block-assets.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Interface WP_Registers_Block_Assets
+ *
+ * @since 2.x.x
+ *
+ * Objects responsible for registering block assets should implement this.
+ *
+ * @see wp_register_script()
+ * @see wp_register_style()
+ */
+interface WP_Registers_Block_Assets extends WP_Adds_Asset_Hooks {
+
+    /**
+     * Register the editor JavaScript
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function register_editor_script();
+
+    /**
+     * Register the editor CSS
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function register_editor_style();
+
+    /**
+     * Register the front-end JavaScript
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function register_script();
+
+    /**
+     * Register the front-end CSS
+     *
+     * @since 2.x.x
+     *
+     * @return void
+     */
+    public function register_style();
+}


### PR DESCRIPTION
Related: #2751 #4514 #2756 #4841
## Enhancement Overview
After my conversation with @youknowriad  and @davidbhayes I really think that block registration should take the handle and url for assets. The block registration system (not `WP_Block_Type_Registry`, which as several concerns already) should be responsible for registering and enqueuing CSS and JavaScript for blocks.
## Description
This PR, if completed, will allow core or plugins or hosts to take alternative approaches in the future to dealing with problems such as:
* Multiple plugins importing the same library (Vue, Axios, etc) into their wepback bundles.
* Multiple plugins, loading multiple blocks, each block adding 1-4 HTTP requests. Even with HTTP/2 this can become a performance issue. Also, WordPress doesn't require HTTPS, so this is a major problem for many users.
* Async loading of block assets.

I've prepared a quick PR of psuedo-code for what I'd like to propose. This isn't tested, I did not test it at all, or even include the files (sorry so used to autoloaders,) this is just a concept for discussion. I'll happily make it work, and provide unit tests and run PHP_CS on it if there is interest in this PR.

### Proposed Change to register_block_type()
In the [handbook's example](https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/#enqueuing-block-scripts):

```php
    wp_register_script(
        'gutenberg-boilerplate-es5-step01',
        plugins_url('step-01/block.js', __FILE__),
        array('wp-blocks', 'wp-element')
    );
    
    register_block_type('gutenberg-boilerplate-es5/hello-world-step-01', array(
        'editor_script' => 'gutenberg-boilerplate-es5-step01',
    ));

```

Would change to:

```php
    register_block_type('gutenberg-boilerplate-es5/hello-world-step-01', array(
        'editor_script' => array(
            //Handle for block JavaScript that is editor only.
            'handle' => 'gutenberg-boilerplate-es5-step01',
            //URL for block JavaScript that is editor only.
            'url' => plugins_url('step-01/block.js', __FILE__)
        ),
        'editor_style' => array(
            //Handle for block CSS that is editor only.
            'handle' => 'gutenberg-boilerplate-es5-step01',
            'url' => plugins_url('step-01/block.js', __FILE__)
        ),
        'script' => array(
            //Handle for block JavaScript that is for front-end and editor
            'handle' => 'gutenberg-boilerplate-es5-step01-front-end',
            //URL for block JavaScript that is for front-end and editor
            'url' => plugins_url('step-01/front-end.js', __FILE__)
        ),
        'style' => array(
            //Handle for block CSS that is for front-end and editor
            'handle' => 'gutenberg-boilerplate-es5-step01-front-end',
            //URL for block CSS that is for front-end and editor
            'url' => plugins_url('step-01/front-end.js', __FILE__)
        ),
    
    ));
) );

```

### Goals:
* Make core entirely responsible for handling block asset loading for non-core blocks.
    * Less code repetition. 3rd-party developers currently have to write a lot of PHP boilerplate for asset loading. This is inefficient.
    * Can be improved without worrying about backwards-compat. The current documented pattern/ best practice can't change without causing a major disruption for a lot of plugins and themes.
* Make the interaction with `WP_Dependency` automatic by default, and totally extensible.
    * Sensible default by core, using existing APIs.
    * A plugin/ site/ host/ future version of WordPress should be able to provide alternative implementations. For example, a plugin could minfify CSS and JavaScript automatically, or create custom bundles, or integrate with a CDN, or do nothing and let a clever use of webpack solve these problems a totally different way.
    
### What I've Done
* Created a class for registering assets:
    * `WP_Block_Assets_Enqueue` handles registering the block's assets.
    * It implements `WP_Registers_Block_Assets` this interface is important as the factory is written so you can provide own `WP_Registers_Block_Assets`.
    * It's responsibility is  to call `wp_register_script/style` at the right time.
    * A plugin may provide an object that implements `WP_Registers_Block_Assets` on the `pre_register_block_assets` filter if they wish to optimize the process in some way.
* Created a class for registering assets:
    * `WP_Block_Assets_Enqueue` handles registering the block's assets.
    * It implements `WP_Enqueues_Block_Assets` this interface is important as the factory is written so you can provide your own `WP_Enqueues_Block_Assets`.
    * It's responsibility is  to call `wp_enqueue_script/style` at the right time.
    * A plugin may provide an object that implements `WP_Enqueues_Block_Assets` on the `pre_enqueue_block_assets` filter if they wish to optimize the process in some way.
* In `WP_Block_Type_Registry` I've implemented this new system, so that all hooks are added, by default.

### Everything?
This is the current best practice:
```php
    wp_register_script(
        'gutenberg-boilerplate-es5-step01',
        plugins_url('step-01/block.js', __FILE__),
        array('wp-blocks', 'wp-element')
    );
    
    register_block_type('gutenberg-boilerplate-es5/hello-world-step-01', array(
        'editor_script' => 'gutenberg-boilerplate-es5-step01',
    ));

```
With this Gutenberg has everything it needs to call `wp_enqueue_script` at the right time, with the right handle. So, you could argue this is all we really need. So why did I make this new system do everything? I think `WP_Dependency` is deficient for this task. Yes, I'm using it here, but I'd like to have a layer above it, so plugin developers can use a system that includes the following concepts:

 - Treeshacking
 - A tool to scan all blocks package.json to provide the most optimized builds, detect conflicts, and create 1 single entry point for all blocks, custom or not or something, I don't know webpack that well.
- JavaScript modules and imports
- Asynchronous asset loading
- ServiceWorkers

It's probably best not to use `wp_register_script` but instead, create something totally new. By wrapping the current dependency Gutenberg is creating - that it has no way to modify later - in `WP_Dependency` we're not tied long-term to a system that was designed way back when we wrote JavaScript by opening up a file and writing JavaScript and then saving it. And people still do that, and that's fine, `WP_Dependency` is fine for that.

### Discussion Questions
* Is there any interest in this at all?
* We're putting Redux and webpack in core, but we don't have a PHP autoloader?
* Should `WP_Block_Type_Registry` track the factory and objects the factory creates? This is needed for making hooks removable, 

## How Has This Been Tested?
Not at all. This code breaks things as-is, just wanted to discuss.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
