### PR TITLE
State: Set new post status to draft in initialization

### DIFF
--- a/editor/components/post-saved-state/index.js
+++ b/editor/components/post-saved-state/index.js
@@ -15,7 +15,7 @@ import { Dashicon, Button } from '@wordpress/components';
  */
 import './style.scss';
 import PostSwitchToDraftButton from '../post-switch-to-draft-button';
-import { editPost, savePost } from '../../store/actions';
+import { savePost } from '../../store/actions';
 import {
 	isEditedPostNew,
 	isCurrentPostPublished,
@@ -23,7 +23,6 @@ import {
 	isSavingPost,
 	isEditedPostSaveable,
 	getCurrentPost,
-	getEditedPostAttribute,
 	hasMetaBoxes,
 } from '../../store/selectors';
 
@@ -33,7 +32,7 @@ import {
  * @param   {Object}    Props Component Props.
  * @return {WPElement}       WordPress Element.
  */
-export function PostSavedState( { hasActiveMetaboxes, isNew, isPublished, isDirty, isSaving, isSaveable, status, onStatusChange, onSave } ) {
+export function PostSavedState( { hasActiveMetaboxes, isNew, isPublished, isDirty, isSaving, isSaveable, onSave } ) {
 	const className = 'editor-post-saved-state';
 
 	if ( isSaving ) {
@@ -61,16 +60,8 @@ export function PostSavedState( { hasActiveMetaboxes, isNew, isPublished, isDirt
 		);
 	}
 
-	const onClick = () => {
-		if ( 'auto-draft' === status ) {
-			onStatusChange( 'draft' );
-		}
-
-		onSave();
-	};
-
 	return (
-		<Button className={ classnames( className, 'button-link' ) } onClick={ onClick }>
+		<Button className={ classnames( className, 'button-link' ) } onClick={ onSave }>
 			<span className="editor-post-saved-state__mobile">{ __( 'Save' ) }</span>
 			<span className="editor-post-saved-state__desktop">{ __( 'Save Draft' ) }</span>
 		</Button>
@@ -85,11 +76,9 @@ export default connect(
 		isDirty: isEditedPostDirty( state ),
 		isSaving: isSavingPost( state ),
 		isSaveable: isEditedPostSaveable( state ),
-		status: getEditedPostAttribute( state, 'status' ),
 		hasActiveMetaboxes: hasMetaBoxes( state ),
 	} ),
 	{
-		onStatusChange: ( status ) => editPost( { status } ),
 		onSave: savePost,
 	}
 )( PostSavedState );

--- a/editor/components/post-saved-state/test/index.js
+++ b/editor/components/post-saved-state/test/index.js
@@ -52,29 +52,7 @@ describe( 'PostSavedState', () => {
 		expect( wrapper.childAt( 1 ).text() ).toBe( 'Saved' );
 	} );
 
-	it( 'should edit auto-draft post to draft before save', () => {
-		const statusSpy = jest.fn();
-		const saveSpy = jest.fn();
-		const wrapper = shallow(
-			<PostSavedState
-				isNew={ false }
-				isDirty={ true }
-				isSaving={ false }
-				isSaveable={ true }
-				onStatusChange={ statusSpy }
-				onSave={ saveSpy }
-				status="auto-draft" />
-		);
-
-		expect( wrapper.name() ).toBe( 'Button' );
-		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save' );
-		wrapper.simulate( 'click' );
-		expect( statusSpy ).toHaveBeenCalledWith( 'draft' );
-		expect( saveSpy ).toHaveBeenCalled();
-	} );
-
 	it( 'should return Save button if edits to be saved', () => {
-		const statusSpy = jest.fn();
 		const saveSpy = jest.fn();
 		const wrapper = shallow(
 			<PostSavedState
@@ -82,14 +60,12 @@ describe( 'PostSavedState', () => {
 				isDirty={ true }
 				isSaving={ false }
 				isSaveable={ true }
-				onStatusChange={ statusSpy }
 				onSave={ saveSpy } />
 		);
 
 		expect( wrapper.name() ).toBe( 'Button' );
 		expect( wrapper.childAt( 0 ).text() ).toBe( 'Save' );
 		wrapper.simulate( 'click' );
-		expect( statusSpy ).not.toHaveBeenCalled();
 		expect( saveSpy ).toHaveBeenCalled();
 	} );
 } );

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -33,7 +33,6 @@ import {
 	createErrorNotice,
 	removeNotice,
 	savePost,
-	editPost,
 	requestMetaBoxUpdates,
 	metaBoxUpdatesSuccess,
 	updateReusableBlock,
@@ -285,11 +284,6 @@ export default {
 			return;
 		}
 
-		// Change status from auto-draft to draft
-		if ( isEditedPostNew( state ) ) {
-			dispatch( editPost( { status: 'draft' } ) );
-		}
-
 		dispatch( savePost() );
 	},
 	SETUP_EDITOR( action ) {
@@ -319,6 +313,7 @@ export default {
 		if ( post.status === 'auto-draft' ) {
 			effects.push( setupNewPost( {
 				title: post.title.raw,
+				status: 'draft',
 			} ) );
 		}
 

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -23,7 +23,6 @@ import {
 	resetBlocks,
 	mergeBlocks,
 	replaceBlocks,
-	editPost,
 	savePost,
 	requestMetaBoxUpdates,
 	updateReusableBlock,
@@ -265,8 +264,7 @@ describe( 'effects', () => {
 
 			handler( {}, store );
 
-			expect( dispatch ).toHaveBeenCalledTimes( 2 );
-			expect( dispatch ).toHaveBeenCalledWith( editPost( { status: 'draft' } ) );
+			expect( dispatch ).toHaveBeenCalledTimes( 1 );
 			expect( dispatch ).toHaveBeenCalledWith( savePost() );
 		} );
 
@@ -278,19 +276,6 @@ describe( 'effects', () => {
 
 			// TODO: Publish autosave
 			expect( dispatch ).not.toHaveBeenCalled();
-		} );
-
-		it( 'should set auto-draft to draft before save', () => {
-			selectors.isEditedPostSaveable.mockReturnValue( true );
-			selectors.isEditedPostDirty.mockReturnValue( true );
-			selectors.isCurrentPostPublished.mockReturnValue( false );
-			selectors.isEditedPostNew.mockReturnValue( true );
-
-			handler( {}, store );
-
-			expect( dispatch ).toHaveBeenCalledTimes( 2 );
-			expect( dispatch ).toHaveBeenCalledWith( editPost( { status: 'draft' } ) );
-			expect( dispatch ).toHaveBeenCalledWith( savePost() );
 		} );
 
 		it( 'should return update action for saveable, dirty draft', () => {
@@ -497,7 +482,10 @@ describe( 'effects', () => {
 
 			expect( result ).toEqual( [
 				resetPost( post ),
-				setupNewPost( { title: 'A History of Pork' } ),
+				setupNewPost( {
+					title: 'A History of Pork',
+					status: 'draft',
+				} ),
 			] );
 		} );
 	} );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -254,7 +254,9 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
-						edits: {},
+						edits: {
+							status: 'draft',
+						},
 					},
 				},
 			};
@@ -269,7 +271,9 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
-						edits: {},
+						edits: {
+							status: 'draft',
+						},
 					},
 				},
 			};


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/4956#pullrequestreview-97041289

This pull request seeks to simplify the behavior for setting a new post's status to draft, taking advantage of existing mechanisms put in place for setting the "Auto Draft" title to an empty string. This has the advantage of removing several ad-hoc checks, and avoids both the dispatch itself, but more importantly the creation of an undo level during the first save (since the `EDIT_POST` action is considered a change to undo).

We can still rely on the behavior of `isEditedPostNew` to check the `currentPost.status`, which will reflect the saved value prior to the initialization action setting `edits` values. This has been reflected in updated unit tests simulating a real-world scenario.

__Testing instructions:__

Verify that there are no regressions in the behavior of saving a new post. Notably:

- Saving a new post should save it as draft status (can verify in the posts list or in the network response)
- Elements not shown for new posts are still not shown (e.g. permalink)