### PR TITLE
Writing Flow: Avoid auto-focus on nested blocks

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -261,6 +261,14 @@ class WritingFlow extends Component {
 			const blockContainer = this.container.querySelector( `[data-block="${ this.props.selectedBlockUID }"]` );
 			if ( blockContainer && ! blockContainer.contains( document.activeElement ) ) {
 				const target = this.getInnerTabbable( blockContainer, this.props.initialPosition === -1 );
+
+				// Avoid selecting the target if it's:
+				//  - The default block appender (or generally uneditable)
+				//  - Within a nested block
+				if ( target.readOnly || target.closest( '[data-block]' ) !== blockContainer ) {
+					return;
+				}
+
 				target.focus();
 				if ( this.props.initialPosition === -1 ) {
 					// Special casing RichText components because the two functions at the bottom are not working as expected.


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/4872#discussion_r167594565

This pull request seeks to resolve an issue where it is difficult to use the ellipsis More Options menu for the Column block due to focus transitioning into the block. The changes here revise the logic for focusing the newly-selected block to ensure that the selected block is not within a nested block, since if it is, the selected block will change and the menu will become dismissed.

__Testing instructions:__

Verify that you can open the More Options ellipsis menu, both for the Columns block and a non-nesting block. In the latter case, ensure that focus is still transitioned within the block.

Verify there are no regressions in the behavior where this auto-focus behavior is necessary:

- Block splitting
- Block merging
- Block replacement (paste)