### PR TITLE
Add 'Edit: ' to beginning of page title when editing

### DIFF
--- a/editor/components/document-title/index.js
+++ b/editor/components/document-title/index.js
@@ -16,7 +16,7 @@ class DocumentTitle extends Component {
 	}
 
 	setDocumentTitle( title ) {
-		document.title = title + ' | ' + this.originalDocumentTitle;
+		document.title = 'Edit: ' + title + ' | ' + this.originalDocumentTitle;
 	}
 
 	componentDidMount() {


### PR DESCRIPTION
## Description
This is a simple change to the choice for the <title> tag of the editor page, per the request in #3702. This will append an 'Edit: ' string to the beginning of the the editor's <title> tag, to allow for differentiation from posts and pages that are not being edited. According to discussion in that issue, this should also be beneficial for accessibility reasons.

## How Has This Been Tested?
No software tests have been written for this change, but it has been tested for proper in-browser rendering in Firefox.

## Screenshots (jpeg or gifs if applicable):
This is what the tag looked like previously:
![Former-Appearance](https://user-images.githubusercontent.com/4240738/36300160-0e4b098c-12ce-11e8-9b6d-83e9df25842d.png)

This is what the tag looks like with this change:
![New-Appearance](https://user-images.githubusercontent.com/4240738/36300197-36b56048-12ce-11e8-85be-d41b2c66637e.png)

When many tabs are being used, this also allows the user to easily distinguish between the editor and the published/previewed post tab.
![Editor-and-Preview](https://user-images.githubusercontent.com/4240738/36300316-d5402216-12ce-11e8-864f-96335f5ddff2.png)

## Types of changes
This is a single line change in a single file, which should only affect the string of the editor's <title> tag. The edits shouldn't break anything.
