### PR TITLE
Register Core Blocks on Init

### DIFF
--- a/blocks/library/categories/index.php
+++ b/blocks/library/categories/index.php
@@ -12,7 +12,7 @@
  *
  * @return string Returns the categories list/dropdown markup.
  */
-function gutenberg_render_block_core_categories( $attributes ) {
+function render_block_core_categories( $attributes ) {
 	static $block_id = 0;
 	$block_id++;
 
@@ -38,7 +38,7 @@ function gutenberg_render_block_core_categories( $attributes ) {
 		$type                     = 'dropdown';
 
 		if ( ! is_admin() ) {
-			$wrapper_markup .= gutenberg_build_dropdown_script_block_core_categories( $id );
+			$wrapper_markup .= build_dropdown_script_block_core_categories( $id );
 		}
 	} else {
 		$wrapper_markup = '<div class="%1$s"><ul>%2$s</ul></div>';
@@ -64,7 +64,7 @@ function gutenberg_render_block_core_categories( $attributes ) {
  *
  * @return string Returns the dropdown onChange redirection script.
  */
-function gutenberg_build_dropdown_script_block_core_categories( $dropdown_id ) {
+function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	ob_start();
 	?>
 	<script type='text/javascript'>
@@ -84,6 +84,13 @@ function gutenberg_build_dropdown_script_block_core_categories( $dropdown_id ) {
 	return ob_get_clean();
 }
 
-register_block_type( 'core/categories', array(
-	'render_callback' => 'gutenberg_render_block_core_categories',
-) );
+/**
+ * Registers the `core/categories` block on server.
+ */
+function register_block_core_categories() {
+	register_block_type( 'core/categories', array(
+		'render_callback' => 'render_block_core_categories',
+	) );
+}
+
+add_action( 'init', 'register_block_core_categories' );

--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -12,7 +12,7 @@
  *
  * @return string Returns the post content with latest posts added.
  */
-function gutenberg_render_block_core_latest_posts( $attributes ) {
+function render_block_core_latest_posts( $attributes ) {
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => $attributes['postsToShow'],
 		'post_status' => 'publish',
@@ -65,39 +65,46 @@ function gutenberg_render_block_core_latest_posts( $attributes ) {
 	return $block_content;
 }
 
-register_block_type( 'core/latest-posts', array(
-	'attributes'      => array(
-		'categories'      => array(
-			'type' => 'string',
+/**
+ * Registers the `core/latest-posts` block on server.
+ */
+function register_block_core_latest_posts() {
+	register_block_type( 'core/latest-posts', array(
+		'attributes'      => array(
+			'categories'      => array(
+				'type' => 'string',
+			),
+			'postsToShow'     => array(
+				'type'    => 'number',
+				'default' => 5,
+			),
+			'displayPostDate' => array(
+				'type'    => 'boolean',
+				'default' => false,
+			),
+			'postLayout'      => array(
+				'type'    => 'string',
+				'default' => 'list',
+			),
+			'columns'         => array(
+				'type'    => 'number',
+				'default' => 3,
+			),
+			'align'           => array(
+				'type'    => 'string',
+				'default' => 'center',
+			),
+			'order'           => array(
+				'type'    => 'string',
+				'default' => 'desc',
+			),
+			'orderBy'         => array(
+				'type'    => 'string',
+				'default' => 'date',
+			),
 		),
-		'postsToShow'     => array(
-			'type'    => 'number',
-			'default' => 5,
-		),
-		'displayPostDate' => array(
-			'type'    => 'boolean',
-			'default' => false,
-		),
-		'postLayout'      => array(
-			'type'    => 'string',
-			'default' => 'list',
-		),
-		'columns'         => array(
-			'type'    => 'number',
-			'default' => 3,
-		),
-		'align'           => array(
-			'type'    => 'string',
-			'default' => 'center',
-		),
-		'order'           => array(
-			'type'    => 'string',
-			'default' => 'desc',
-		),
-		'orderBy'         => array(
-			'type'    => 'string',
-			'default' => 'date',
-		),
-	),
-	'render_callback' => 'gutenberg_render_block_core_latest_posts',
-) );
+		'render_callback' => 'render_block_core_latest_posts',
+	) );
+}
+
+add_action( 'init', 'register_block_core_latest_posts' );


### PR DESCRIPTION
closes #1097

Initially, I wanted to match the recommendations of the handbook (https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/) for registering the Core Blocks server-side but at the moment the blocks don't have separate scripts so I just 
updated the registration to move it to the `init` function instead.

**Testing instructions**

 - Try the categories and recent posts blocks.