### PR TITLE
Block Settings Menu: Adding a duplicate block button

### DIFF
--- a/editor/components/block-list/block-mobile-toolbar.js
+++ b/editor/components/block-list/block-mobile-toolbar.js
@@ -6,13 +6,13 @@ import BlockRemoveButton from '../block-settings-menu/block-remove-button';
 import BlockSettingsMenu from '../block-settings-menu';
 import VisualEditorInserter from '../inserter';
 
-function BlockMobileToolbar( { uid, renderBlockMenu } ) {
+function BlockMobileToolbar( { rootUID, uid, renderBlockMenu } ) {
 	return (
 		<div className="editor-block-list__block-mobile-toolbar">
 			<VisualEditorInserter />
 			<BlockMover uids={ [ uid ] } />
 			<BlockRemoveButton uids={ [ uid ] } small />
-			<BlockSettingsMenu uids={ [ uid ] } renderBlockMenu={ renderBlockMenu } />
+			<BlockSettingsMenu rootUID={ rootUID } uids={ [ uid ] } renderBlockMenu={ renderBlockMenu } />
 		</div>
 	);
 }

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -611,6 +611,7 @@ export class BlockListBlock extends Component {
 				{ shouldShowSettingsMenu && (
 					<BlockSettingsMenu
 						uids={ [ block.uid ] }
+						rootUID={ rootUID }
 						renderBlockMenu={ renderBlockMenu }
 					/>
 				) }
@@ -656,7 +657,13 @@ export class BlockListBlock extends Component {
 							/>,
 						] }
 					</BlockCrashBoundary>
-					{ shouldShowMobileToolbar && <BlockMobileToolbar uid={ block.uid } renderBlockMenu={ renderBlockMenu } /> }
+					{ shouldShowMobileToolbar && (
+						<BlockMobileToolbar
+							rootUID={ rootUID }
+							uid={ block.uid }
+							renderBlockMenu={ renderBlockMenu }
+						/>
+					) }
 				</IgnoreNestedEvents>
 				{ !! error && <BlockCrashWarning /> }
 				{ shouldShowInsertionPoint && (

--- a/editor/components/block-list/multi-controls.js
+++ b/editor/components/block-list/multi-controls.js
@@ -26,6 +26,7 @@ function BlockListMultiControls( { multiSelectedBlockUids, rootUID, isSelecting 
 		/>,
 		<BlockSettingsMenu
 			key="menu"
+			rootUID={ rootUID }
 			uids={ multiSelectedBlockUids }
 			focus
 		/>,

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, noop, last, every } from 'lodash';
+import { flow, noop, last, every, first } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -42,11 +42,15 @@ export default compose(
 	} ) ),
 	withDispatch( ( dispatch, { blocks, index, rootUID } ) => ( {
 		onDuplicate() {
+			const clonedBlocks = blocks.map( block => cloneBlock( block ) );
 			dispatch( 'core/editor' ).insertBlocks(
-				blocks.map( block => cloneBlock( block ) ),
+				clonedBlocks,
 				index + 1,
 				rootUID
 			);
+			if ( clonedBlocks.length > 1 ) {
+				dispatch( 'core/editor' ).multiSelect( first( clonedBlocks ).uid, last( clonedBlocks ).uid );
+			}
 		},
 	} ) ),
 	withContext( 'editor' )( ( settings ) => {

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { flow, noop, last } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { IconButton, withContext } from '@wordpress/components';
+import { compose } from '@wordpress/element';
+import { cloneBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { getBlocksByUid, getBlockIndex } from '../../store/selectors';
+import { insertBlocks } from '../../store/actions';
+
+export function BlockDuplicateButton( { onDuplicate, onClick = noop, isLocked, small = false } ) {
+	if ( isLocked ) {
+		return null;
+	}
+
+	const label = __( 'Duplicate' );
+
+	return (
+		<IconButton
+			className="editor-block-settings-menu__control"
+			onClick={ flow( onDuplicate, onClick ) }
+			icon="admin-page"
+			label={ small ? label : undefined }
+		>
+			{ ! small && label }
+		</IconButton>
+	);
+}
+
+export default compose(
+	connect(
+		( state, ownProps ) => ( {
+			blocks: getBlocksByUid( state, ownProps.uids ),
+			index: getBlockIndex( state, last( ownProps.uids ), ownProps.rootUID ),
+		} ),
+		{ insertBlocks },
+		( { blocks, index }, dispatchProps, { rootUID } ) => ( {
+			onDuplicate() {
+				dispatchProps.insertBlocks(
+					blocks.map( block => cloneBlock( block ) ),
+					index + 1,
+					rootUID
+				);
+			},
+		} )
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
+
+		return {
+			isLocked: !! templateLock,
+		};
+	} ),
+)( BlockDuplicateButton );

--- a/editor/components/block-settings-menu/block-duplicate-button.js
+++ b/editor/components/block-settings-menu/block-duplicate-button.js
@@ -37,7 +37,7 @@ export function BlockDuplicateButton( { blocks, onDuplicate, onClick = noop, isL
 
 export default compose(
 	withSelect( ( select, { uids, rootUID } ) => ( {
-		blocks: select( 'core/editor' ).getBlocksByUid( uids ),
+		blocks: select( 'core/editor' ).getBlocksByUID( uids ),
 		index: select( 'core/editor' ).getBlockIndex( last( uids ), rootUID ),
 	} ) ),
 	withDispatch( ( dispatch, { blocks, index, rootUID } ) => ( {

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -16,6 +16,7 @@ import { IconButton, Dropdown, NavigableMenu } from '@wordpress/components';
 import './style.scss';
 import BlockModeToggle from './block-mode-toggle';
 import BlockRemoveButton from './block-remove-button';
+import BlockDuplicateButton from './block-duplicate-button';
 import BlockTransformations from './block-transformations';
 import ReusableBlockSettings from './reusable-block-settings';
 import UnknownConverter from './unknown-converter';
@@ -25,6 +26,7 @@ function BlockSettingsMenu( {
 	uids,
 	onSelect,
 	focus,
+	rootUID,
 	renderBlockMenu = ( { children } ) => children }
 ) {
 	const count = uids.length;
@@ -62,6 +64,7 @@ function BlockSettingsMenu( {
 						count === 1 && <BlockModeToggle key="mode-toggle" uid={ uids[ 0 ] } onToggle={ onClose } />,
 						count === 1 && <UnknownConverter key="unknown-converter" uid={ uids[ 0 ] } />,
 						<BlockRemoveButton key="remove" uids={ uids } />,
+						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } />,
 						count === 1 && <ReusableBlockSettings key="reusable-block" uid={ uids[ 0 ] } onToggle={ onClose } />,
 						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } />,
 					] } ) }

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -439,6 +439,16 @@ export const getBlocks = createSelector(
 	]
 );
 
+export const getBlocksByUid = createSelector(
+	( state, uids ) => {
+		return map( uids, ( uid ) => getBlock( state, uid ) );
+	},
+	( state ) => [
+		state.editor.present.blockOrder,
+		state.editor.present.blocksByUid,
+	]
+);
+
 /**
  * Returns the number of blocks currently present in the post.
  *

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -439,12 +439,15 @@ export const getBlocks = createSelector(
 	]
 );
 
-export const getBlocksByUid = createSelector(
+export const getBlocksByUID = createSelector(
 	( state, uids ) => {
 		return map( uids, ( uid ) => getBlock( state, uid ) );
 	},
 	( state ) => [
+		state.editor.present.blocksByUid,
 		state.editor.present.blockOrder,
+		state.editor.present.edits.meta,
+		state.currentPost.meta,
 		state.editor.present.blocksByUid,
 	]
 );


### PR DESCRIPTION
closes #2231

**Testing instructions**

 - Add any block
 - Open the block settings menu
 - Click "Duplicate"
 - A new block should be created right after the current block

It should also work for multiselection