### PR TITLE
Quote Block: Fixing focus transfer between citation and content

### DIFF
--- a/blocks/library/pullquote/editor.scss
+++ b/blocks/library/pullquote/editor.scss
@@ -11,6 +11,10 @@
 }
 
 .wp-block-pullquote {
+	cite {
+		display: block;
+	}
+
 	cite .blocks-rich-text__tinymce[data-is-empty="true"]:before {
 		font-size: 14px;
 		font-family: $default-font;

--- a/blocks/library/quote/editor.scss
+++ b/blocks/library/quote/editor.scss
@@ -1,5 +1,9 @@
 .wp-block-quote {
 	margin: 0;
+
+	cite {
+		display: block;
+	}
 }
 
 .wp-block-quote:not(.is-large) {

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -158,7 +158,9 @@ export const settings = {
 	} )( ( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className, editable, setState } ) => {
 		const { align, value, citation, style } = attributes;
 		const containerClassname = classnames( className, style === 2 ? 'is-large' : '' );
-		const onSetActiveEditable = ( newEditable ) => () => setState( { editable: newEditable } );
+		const onSetActiveEditable = ( newEditable ) => () => {
+			setState( { editable: newEditable } );
+		};
 
 		return [
 			isSelected && (

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -740,7 +740,9 @@ export class RichText extends Component {
 			!! this.editor &&
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
-			this.props.value !== this.savedContent
+			this.props.value !== this.savedContent &&
+			! isEqual( this.props.value, prevProps.value ) &&
+			! isEqual( this.props.value, this.savedContent )
 		) {
 			this.updateContent();
 		}

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -579,7 +579,7 @@ export class RichText extends Component {
 				const beforeElement = nodeListToReact( beforeNodes, createTinyMCEElement );
 				const afterElement = nodeListToReact( afterNodes, createTinyMCEElement );
 
-				this.props.onSplit( beforeElement, afterElement );
+				this.restoreContentAndSplit( beforeElement, afterElement );
 			} else {
 				event.preventDefault();
 				this.onCreateUndoLevel();
@@ -638,9 +638,10 @@ export class RichText extends Component {
 
 			const beforeElement = nodeListToReact( beforeFragment.childNodes, createTinyMCEElement );
 			const afterElement = nodeListToReact( filterEmptyNodes( afterFragment.childNodes ), createTinyMCEElement );
-			this.props.onSplit( beforeElement, afterElement, ...blocks );
+
+			this.restoreContentAndSplit( beforeElement, afterElement, blocks );
 		} else {
-			this.props.onSplit( [], [], ...blocks );
+			this.restoreContentAndSplit( [], [], blocks );
 		}
 	}
 
@@ -686,7 +687,7 @@ export class RichText extends Component {
 		// Splitting into two blocks
 		this.setContent( this.props.value );
 
-		this.props.onSplit(
+		this.restoreContentAndSplit(
 			nodeListToReact( before, createTinyMCEElement ),
 			nodeListToReact( after, createTinyMCEElement )
 		);
@@ -796,6 +797,19 @@ export class RichText extends Component {
 		this.setState( ( state ) => ( {
 			formats: merge( {}, state.formats, formats ),
 		} ) );
+	}
+
+	/**
+	 * Calling onSplit means we need to abort the change done by TinyMCE.
+	 * we need to call updateContent to restore the initial content before calling onSplit.
+	 *
+	 * @param {Array}  before content before the split position
+	 * @param {Array}  after  content after the split position
+	 * @param {?Array} blocks blocks to insert at the split position
+	 */
+	restoreContentAndSplit( before, after, blocks ) {
+		this.updateContent();
+		this.props.onSplit( before, after, ...blocks );
 	}
 
 	render() {


### PR DESCRIPTION
closes #5081

This PR fixes moving focus between citation and content in quote blocks.

**Testing instructions**

 - Add a quote block
 - type content
 - type citation
 - click to switch focus between quote and citation