### PR TITLE
Simplify Editor State initialization using a single action to fix undo/redo initialization

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -37,16 +37,19 @@ export function resetPost( post ) {
 }
 
 /**
- * Returns an action object used in signalling that editor has initialized as a
- * new post with specified edits which should be considered non-dirtying.
+ * Returns an action object used to setup the editor state when first opening an editor.
  *
- * @param {Object} edits Edited attributes object.
+ * @param {Object} post   Post object.
+ * @param {Array}  blocks Array of blocks.
+ * @param {Object} edits  Initial edited attributes object.
  *
  * @return {Object} Action object.
  */
-export function setupNewPost( edits ) {
+export function setupEditorState( post, blocks, edits ) {
 	return {
-		type: 'SETUP_NEW_POST',
+		type: 'SETUP_EDITOR_STATE',
+		post,
+		blocks,
 		edits,
 	};
 }

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -25,9 +25,8 @@ import { speak } from '@wordpress/a11y';
  */
 import { getPostEditUrl, getWPAdminURL } from '../utils/url';
 import {
+	setupEditorState,
 	resetPost,
-	setupNewPost,
-	resetBlocks,
 	replaceBlocks,
 	createSuccessNotice,
 	createErrorNotice,
@@ -86,10 +85,7 @@ export default {
 		dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
 		const Model = wp.api.getPostTypeModel( getCurrentPostType( state ) );
 		new Model( toSend ).save().done( ( newPost ) => {
-			dispatch( {
-				type: 'RESET_POST',
-				post: newPost,
-			} );
+			dispatch( resetPost( newPost ) );
 			dispatch( {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				previousPost: post,
@@ -288,13 +284,13 @@ export default {
 	},
 	SETUP_EDITOR( action ) {
 		const { post, settings } = action;
-		const effects = [];
 
 		// Parse content as blocks
+		let blocks;
 		if ( post.content.raw ) {
-			effects.push( resetBlocks( parse( post.content.raw ) ) );
+			blocks = parse( post.content.raw );
 		} else if ( settings.template ) {
-			const blocks = map( settings.template, ( [ name, attributes ] ) => {
+			blocks = map( settings.template, ( [ name, attributes ] ) => {
 				const block = createBlock( name );
 				block.attributes = {
 					...block.attributes,
@@ -302,22 +298,18 @@ export default {
 				};
 				return block;
 			} );
-			effects.push( resetBlocks( blocks ) );
+		} else {
+			blocks = [];
 		}
-
-		// Resetting post should occur after blocks have been reset, since it's
-		// the post reset that restarts history (used in dirty detection).
-		effects.push( resetPost( post ) );
 
 		// Include auto draft title in edits while not flagging post as dirty
+		const edits = {};
 		if ( post.status === 'auto-draft' ) {
-			effects.push( setupNewPost( {
-				title: post.title.raw,
-				status: 'draft',
-			} ) );
+			edits.title = post.title.raw;
+			edits.status = 'draft';
 		}
 
-		return effects;
+		return setupEditorState( post, blocks, edits );
 	},
 	FETCH_REUSABLE_BLOCKS( action, store ) {
 		// TODO: these are potentially undefined, this fix is in place

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -143,18 +143,18 @@ export const editor = flow( [
 
 	// Track undo history, starting at editor initialization.
 	partialRight( withHistory, {
-		resetTypes: [ 'SETUP_NEW_POST', 'SETUP_EDITOR' ],
+		resetTypes: [ 'SETUP_EDITOR_STATE' ],
 		shouldOverwriteState,
 	} ),
 
 	// Track whether changes exist, resetting at each post save. Relies on
 	// editor initialization firing post reset as an effect.
-	partialRight( withChangeDetection, { resetTypes: [ 'SETUP_NEW_POST', 'RESET_POST' ] } ),
+	partialRight( withChangeDetection, { resetTypes: [ 'SETUP_EDITOR_STATE', 'RESET_POST' ] } ),
 ] )( {
 	edits( state = {}, action ) {
 		switch ( action.type ) {
 			case 'EDIT_POST':
-			case 'SETUP_NEW_POST':
+			case 'SETUP_EDITOR_STATE':
 				return reduce( action.edits, ( result, value, key ) => {
 					// Only assign into result if not already same value
 					if ( value !== state[ key ] ) {
@@ -198,6 +198,7 @@ export const editor = flow( [
 	blocksByUid( state = {}, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
+			case 'SETUP_EDITOR_STATE':
 				return getFlattenedBlocks( action.blocks );
 
 			case 'UPDATE_BLOCK_ATTRIBUTES':
@@ -301,6 +302,7 @@ export const editor = flow( [
 	blockOrder( state = {}, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':
+			case 'SETUP_EDITOR_STATE':
 				return mapBlockOrder( action.blocks );
 
 			case 'INSERT_BLOCKS': {
@@ -436,6 +438,7 @@ export const editor = flow( [
  */
 export function currentPost( state = {}, action ) {
 	switch ( action.type ) {
+		case 'SETUP_EDITOR_STATE':
 		case 'RESET_POST':
 		case 'UPDATE_POST':
 			let post;

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -16,7 +16,6 @@ import {
 	toggleSelection,
 	setupEditor,
 	resetPost,
-	setupNewPost,
 	resetBlocks,
 	updateBlockAttributes,
 	updateBlock,
@@ -72,18 +71,6 @@ describe( 'actions', () => {
 			} );
 		} );
 	} );
-
-	describe( 'setupNewPost', () => {
-		it( 'should return the SETUP_NEW_POST action', () => {
-			const edits = {};
-			const result = setupNewPost( edits );
-			expect( result ).toEqual( {
-				type: 'SETUP_NEW_POST',
-				edits,
-			} );
-		} );
-	} );
-
 	describe( 'resetBlocks', () => {
 		it( 'should return the RESET_BLOCKS actions', () => {
 			const blocks = [];

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -18,8 +18,7 @@ import {
  * Internal dependencies
  */
 import {
-	resetPost,
-	setupNewPost,
+	setupEditorState,
 	resetBlocks,
 	mergeBlocks,
 	replaceBlocks,
@@ -439,9 +438,7 @@ describe( 'effects', () => {
 
 			const result = handler( { post, settings: {} } );
 
-			expect( result ).toEqual( [
-				resetPost( post ),
-			] );
+			expect( result ).toEqual( setupEditorState( post, [], {} ) );
 		} );
 
 		it( 'should return block reset with non-empty content', () => {
@@ -459,11 +456,8 @@ describe( 'effects', () => {
 
 			const result = handler( { post, settings: {} } );
 
-			expect( result ).toHaveLength( 2 );
-			expect( result ).toContainEqual( resetPost( post ) );
-			expect( result.some( ( { blocks } ) => {
-				return blocks && blocks[ 0 ].name === 'core/test-block';
-			} ) ).toBe( true );
+			expect( result.blocks ).toHaveLength( 1 );
+			expect( result ).toEqual( setupEditorState( post, result.blocks, {} ) );
 		} );
 
 		it( 'should return post setup action only if auto-draft', () => {
@@ -480,13 +474,7 @@ describe( 'effects', () => {
 
 			const result = handler( { post, settings: {} } );
 
-			expect( result ).toEqual( [
-				resetPost( post ),
-				setupNewPost( {
-					title: 'A History of Pork',
-					status: 'draft',
-				} ),
-			] );
+			expect( result ).toEqual( setupEditorState( post, [], { title: 'A History of Pork', status: 'draft' } ) );
 		} );
 	} );
 

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -688,11 +688,12 @@ describe( 'state', () => {
 
 			it( 'should save initial post state', () => {
 				const state = editor( undefined, {
-					type: 'SETUP_NEW_POST',
+					type: 'SETUP_EDITOR_STATE',
 					edits: {
 						status: 'draft',
 						title: 'post title',
 					},
+					blocks: [],
 				} );
 
 				expect( state.present.edits ).toEqual( {


### PR DESCRIPTION
The idea of this PR is to simplify all the necessary initialization when loading the editor to use a single action. This allow us to add this action to the resetActions of both `dirtyDetection` and `withHistory` fixing a bug where loading a saved post will result in an already filled undo state.

I think we can even remove `setupEditorState` and rely on just `SETUP_EDITOR` without any effect handler, the only reason I avoided this for now is to avoid calling `parse` in the reducer as it's not pure.

**Testing instructions**

 - Load the editor for a new post 
 - No undo state and post not dirty

 - Load the editor with an existing post
 - No undo state and post not dirty