### PR TITLE
Improved gallery caption CSS.

### DIFF
--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -18,10 +18,7 @@
 		width: 100%;
 	}
 
-	// last-of-type is used because RichText creates to figcations when placeholders are visible,
-	// and in that case only the second one should be targeted.
-	// Using data-is-placeholder-visible caused blinks because the attributes are not immediately added to the dom.
-	.blocks-rich-text figcaption:last-of-type {
+	.blocks-rich-text figcaption:not( [data-is-placeholder-visible="true"] ) {
 		position: relative;
 	}
 


### PR DESCRIPTION
With the latest changes, we can use attribute data-is-placeholder-visible without blinks because the attribute is present from the start. The use of  data-is-placeholder-visible  is more reliable for our use case then :last-of-type.
This PR just updates an existing CSS selected to make use of data-is-placeholder-visible instead of relying on last-of-type.

## How Has This Been Tested?
Add a gallery, add images to it, verify you can write captions without problems.

