### PR TITLE
Block List: Hide hover effects when typing

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -85,7 +85,7 @@ export class BlockListBlock extends Component {
 		this.bindBlockNode = this.bindBlockNode.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
-		this.onMouseLeave = this.onMouseLeave.bind( this );
+		this.hideHoverEffects = this.hideHoverEffects.bind( this );
 		this.maybeStartTyping = this.maybeStartTyping.bind( this );
 		this.stopTypingOnMouseMove = this.stopTypingOnMouseMove.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
@@ -144,6 +144,10 @@ export class BlockListBlock extends Component {
 			( newProps.isSelected || newProps.isFirstMultiSelected )
 		) {
 			this.previousOffset = this.node.getBoundingClientRect().top;
+		}
+
+		if ( newProps.isTyping ) {
+			this.hideHoverEffects();
 		}
 	}
 
@@ -301,7 +305,7 @@ export class BlockListBlock extends Component {
 	 * where mouseleave may occur but the block is not hovered (multi-select),
 	 * so to avoid unnecesary renders, the state is only set if hovered.
 	 */
-	onMouseLeave() {
+	hideHoverEffects() {
 		if ( this.state.isHovered ) {
 			this.setState( { isHovered: false } );
 		}
@@ -565,7 +569,7 @@ export class BlockListBlock extends Component {
 			<IgnoreNestedEvents
 				ref={ this.setBlockListRef }
 				onMouseOver={ this.maybeHover }
-				onMouseLeave={ this.onMouseLeave }
+				onMouseLeave={ this.hideHoverEffects }
 				className={ wrapperClassName }
 				data-type={ block.name }
 				onTouchStart={ this.onTouchStart }

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -290,10 +290,11 @@ export class BlockListBlock extends Component {
 	 * @see https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
 	 */
 	maybeHover() {
-		const { isMultiSelected } = this.props;
+		const { isMultiSelected, isSelected } = this.props;
 		const { isHovered } = this.state;
 
-		if ( isHovered || isMultiSelected || this.hadTouchStart ) {
+		if ( isHovered || isMultiSelected || isSelected ||
+				this.props.isMultiSelecting || this.hadTouchStart ) {
 			return;
 		}
 

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -146,7 +146,7 @@ export class BlockListBlock extends Component {
 			this.previousOffset = this.node.getBoundingClientRect().top;
 		}
 
-		if ( newProps.isTyping ) {
+		if ( newProps.isTyping || newProps.isSelected ) {
 			this.hideHoverEffects();
 		}
 	}


### PR DESCRIPTION
Regression introduced in #5078

This pull request seeks to resolve an issue where typing in a block does not dismiss hover effects. This behavior existed prior to #5078. Further, it avoids applying hover effects in more cases: when multi-selecting, or the block is selected (since block chrome is shown anyways).

__Testing instructions:__

1. Navigate to Posts > Add New
2. Insert a paragraph block
3. Deselect the block by clicking the title
4. Select the block by clicking it
5. Keeping cursor atop the block, start typing
6. Note that the hover effects are dismissed