### PR TITLE
Fixed gallery link attribute selector.

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -35,6 +35,7 @@ const blockAttributes = {
 			},
 			link: {
 				source: 'attribute',
+				selector: 'img',
 				attribute: 'data-link',
 			},
 			alt: {


### PR DESCRIPTION
During the addition of captions to the gallery (#4199), a regression was introduced, that make parsing of link attribute invalid.

## How Has This Been Tested?
Add a gallery, add images, save the post and press reload see no invalid block warning appears. See in the code-editor that data-link attributes were correctly loaded.
