### PR TITLE
Blocks: Avoid autofocus behavior for blocks without focusable elements

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -218,7 +218,8 @@ export class BlockListBlock extends Component {
 		}
 
 		// Find all tabbables within node.
-		const tabbables = focus.tabbable.find( this.node );
+		const tabbables = focus.tabbable.find( this.node )
+			.filter( ( node ) => node !== this.node );
 
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -29,6 +29,8 @@ import DefaultBlockAppender from '../default-block-appender';
 import {
 	isSelectionEnabled,
 	isMultiSelecting,
+	getMultiSelectedBlocksStartUid,
+	getMultiSelectedBlocksEndUid,
 } from '../../store/selectors';
 import { startMultiSelect, stopMultiSelect, multiSelect, selectBlock } from '../../store/actions';
 
@@ -236,6 +238,8 @@ export default connect(
 		// Reference block selection value directly, since current selectors
 		// assume either multi-selection (getMultiSelectedBlocksStartUid) or
 		// singular-selection (getSelectedBlock) exclusively.
+		selectionStart: getMultiSelectedBlocksStartUid( state ),
+		selectionEnd: getMultiSelectedBlocksEndUid( state ),
 		selectionStartUID: state.blockSelection.start,
 		isSelectionEnabled: isSelectionEnabled( state ),
 		isMultiSelecting: isMultiSelecting( state ),

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -130,6 +130,11 @@ class BlockListLayout extends Component {
 		window.addEventListener( 'mouseup', this.onSelectionEnd );
 	}
 
+	/**
+	 * Handles multi-selection changes in response to pointer move.
+	 *
+	 * @param {string} uid Block under cursor in multi-select drag.
+	 */
 	onSelectionChange( uid ) {
 		const { onMultiSelect, selectionStart, selectionEnd } = this.props;
 		const { selectionAtStart } = this;
@@ -139,10 +144,13 @@ class BlockListLayout extends Component {
 			return;
 		}
 
+		// If multi-selecting and cursor extent returns to the start of
+		// selection, cancel multi-select.
 		if ( isAtStart && selectionStart ) {
 			onMultiSelect( null, null );
 		}
 
+		// Expand multi-selection to block under cursor.
 		if ( ! isAtStart && selectionEnd !== uid ) {
 			onMultiSelect( selectionAtStart, uid );
 		}

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -27,7 +27,6 @@ import BlockListBlock from './block';
 import BlockSelectionClearer from '../block-selection-clearer';
 import DefaultBlockAppender from '../default-block-appender';
 import {
-	getMultiSelectedBlocksEndUid,
 	isSelectionEnabled,
 	isMultiSelecting,
 } from '../../store/selectors';
@@ -129,13 +128,8 @@ class BlockListLayout extends Component {
 		window.addEventListener( 'mouseup', this.onSelectionEnd );
 	}
 
-	/**
-	 * Handles multi-selection changes in response to pointer move.
-	 *
-	 * @param {string} uid Block under cursor in multi-select drag.
-	 */
 	onSelectionChange( uid ) {
-		const { onMultiSelect, multiSelectionEndUID } = this.props;
+		const { onMultiSelect, selectionStart, selectionEnd } = this.props;
 		const { selectionAtStart } = this;
 		const isAtStart = selectionAtStart === uid;
 
@@ -143,14 +137,11 @@ class BlockListLayout extends Component {
 			return;
 		}
 
-		// If multi-selecting and cursor extent returns to the start of
-		// selection, cancel multi-select.
-		if ( isAtStart && this.props.isMultiSelecting ) {
+		if ( isAtStart && selectionStart ) {
 			onMultiSelect( null, null );
 		}
 
-		// Expand multi-selection to block under cursor.
-		if ( ! isAtStart && multiSelectionEndUID !== uid ) {
+		if ( ! isAtStart && selectionEnd !== uid ) {
 			onMultiSelect( selectionAtStart, uid );
 		}
 	}
@@ -246,7 +237,6 @@ export default connect(
 		// assume either multi-selection (getMultiSelectedBlocksStartUid) or
 		// singular-selection (getSelectedBlock) exclusively.
 		selectionStartUID: state.blockSelection.start,
-		multiSelectionEndUID: getMultiSelectedBlocksEndUid( state ),
 		isSelectionEnabled: isSelectionEnabled( state ),
 		isMultiSelecting: isMultiSelecting( state ),
 	} ),


### PR DESCRIPTION
Avoid auto-focusing blocks without any tabbable element.
