### PR TITLE
Remove margin styles from blockquote to avoid overwriting themes.

### DIFF
--- a/blocks/library/quote/style.scss
+++ b/blocks/library/quote/style.scss
@@ -1,6 +1,4 @@
 .wp-block-quote {
-	margin: 0 0 16px;
-
 	cite,
 	footer {
 		color: $dark-gray-300;
@@ -11,6 +9,7 @@
 	}
 
 	&.is-large {
+		margin: 0 0 16px;
 		padding: 0 1em;
 
 		p {


### PR DESCRIPTION
Only apply them to the "large" variation, not the default. Considering we already removed the border, we don't need the margin reset anymore.