### PR TITLE
Block: Ignore focus if explicitOriginalTarget is not node (Firefox)

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -373,6 +373,14 @@ export class BlockListBlock extends Component {
 	 * @return {void}
 	 */
 	onFocus( event ) {
+		// Firefox-specific: Firefox will redirect focus of an already-focused
+		// node to its parent, but assign a property before doing so. If that
+		// property exists, ensure that it is the node, or abort.
+		const { explicitOriginalTarget } = event.nativeEvent;
+		if ( explicitOriginalTarget && explicitOriginalTarget !== this.node ) {
+			return;
+		}
+
 		if ( event.target === this.node && ! this.props.isSelected ) {
 			this.props.onSelect();
 		}


### PR DESCRIPTION
This pull request seeks to resolve an issue where it is not possible to use the block toolbar for a nested block in Firefox. From what I've surmised, this is related to differing treatment of focus events and focus bubbling between Firefox and other browsers, and in its treatment of retargeting said events. My understanding is that `IgnoreNestedEvents` is not effective for preventing the focus event from surfacing to the ancestor block because it is already focused and is instead retargeted.

https://developer.mozilla.org/en-US/docs/Web/API/Event/explicitOriginalTarget

These changes detect the presence of this property and ensure that, if present, it is equal to the block node.

__Testing instructions:__

Verify that you can use the block toolbar, in Firefox and your preferred browser, for nested and non-nested blocks.

Verify that there are no regressions in the behavior of block selection via direct focus. Typically this can be done by tab navigating from one block to the next (e.g. a paragraph to a image placeholder block).