### PR TITLE
 Fixed a bug in paragraph affecting content writing when block is left/right aligned.

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -168,7 +168,6 @@ class ParagraphBlock extends Component {
 						<RichText
 							tagName="p"
 							className={ classnames( 'wp-block-paragraph', className, {
-								[ `align${ width }` ]: width,
 								'has-background': backgroundColor,
 							} ) }
 							style={ {


### PR DESCRIPTION
Classes alignright and alignleft were being passed to paragraph RichText, these classes contain CSS that makes the cursor invisible when the paragraph is empty making content writing impossible.

## Before
Add a post with an empty paragraph, use Block Alignment setting in inspector controls and choose left or right alignments. See it is impossible to write any content in the paragraph when it is left/right aligned and the cursor is never visible.

## How Has This Been Tested?
Verify the behavior described above is fixed and paragraph works as expected.