### PR TITLE
Removed DefaultBlockAppender when a template Lock exits.

### DIFF
--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -8,7 +8,9 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/element';
 import { getDefaultBlockName } from '@wordpress/blocks';
+import { withContext } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -18,8 +20,8 @@ import BlockDropZone from '../block-drop-zone';
 import { appendDefaultBlock, startTyping } from '../../store/actions';
 import { getBlock, getBlockCount } from '../../store/selectors';
 
-export function DefaultBlockAppender( { isVisible, onAppend, showPrompt } ) {
-	if ( ! isVisible ) {
+export function DefaultBlockAppender( { isLocked, isVisible, onAppend, showPrompt } ) {
+	if ( isLocked || ! isVisible ) {
 		return null;
 	}
 
@@ -38,29 +40,37 @@ export function DefaultBlockAppender( { isVisible, onAppend, showPrompt } ) {
 		</div>
 	);
 }
+export default compose(
+	connect(
+		( state, ownProps ) => {
+			const isEmpty = ! getBlockCount( state, ownProps.rootUID );
+			const lastBlock = getBlock( state, ownProps.lastBlockUID );
+			const isLastBlockDefault = get( lastBlock, 'name' ) === getDefaultBlockName();
 
-export default connect(
-	( state, ownProps ) => {
-		const isEmpty = ! getBlockCount( state, ownProps.rootUID );
-		const lastBlock = getBlock( state, ownProps.lastBlockUID );
-		const isLastBlockDefault = get( lastBlock, 'name' ) === getDefaultBlockName();
+			return {
+				isVisible: isEmpty || ! isLastBlockDefault,
+				showPrompt: isEmpty,
+			};
+		},
+		( dispatch, ownProps ) => ( {
+			onAppend() {
+				const { layout, rootUID } = ownProps;
+
+				let attributes;
+				if ( layout ) {
+					attributes = { layout };
+				}
+
+				dispatch( appendDefaultBlock( attributes, rootUID ) );
+				dispatch( startTyping() );
+			},
+		} )
+	),
+	withContext( 'editor' )( ( settings ) => {
+		const { templateLock } = settings;
 
 		return {
-			isVisible: isEmpty || ! isLastBlockDefault,
-			showPrompt: isEmpty,
+			isLocked: !! templateLock,
 		};
-	},
-	( dispatch, ownProps ) => ( {
-		onAppend() {
-			const { layout, rootUID } = ownProps;
-
-			let attributes;
-			if ( layout ) {
-				attributes = { layout };
-			}
-
-			dispatch( appendDefaultBlock( attributes, rootUID ) );
-			dispatch( startTyping() );
-		},
 	} ),
 )( DefaultBlockAppender );


### PR DESCRIPTION
Before even if template locking was enabled, DefaultBlockAppender was rendered, allowing the user to insert a new block.


## How Has This Been Tested?
Enable a custom post with template locking and precreted non default block e.g:
```
function register_book_post_type() {
    $args = array(
        'public' => true,
        'label'  => 'Books',
        'show_in_rest' => true,
        'template_lock' => 'all',
        'template' => array(
            array( 'core/image', array(
                'align' => 'center',
            ) ),
        ),
    );
    register_post_type( 'book', $args );
}
add_action( 'init', 'register_book_post_type' );
```
Verify it is not possible to insert a new block using the default block appender, before it was possible.