### PR TITLE
Framework: Support registering and invoking actions in the data module

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -39,6 +39,25 @@ Let's say the state of our plugin (registered with the key `myPlugin`) has the f
 wp.data.registerSelectors( 'myPlugin', { getTitle: ( state ) => state.title } );
 ```
 
+### `wp.data.registerActions( reducerKey: string, newActions: object )`
+
+If your module or plugin needs to expose its actions to other modules and plugins, you'll have to register action creators.
+
+An action creator is a function that takes arguments and returns an action object dispatch to the registered reducer to update the state.
+
+#### Example:
+
+```js
+wp.data.registerActions( 'myPlugin', {
+	setTitle( newTitle ) {
+		return {
+			type: 'SET_TITLE',
+			title: newTitle,
+		};
+	},
+} );
+```
+
 ### `wp.data.select( key: string )`
 
 This function allows calling any registered selector. Given a module's key, this function returns an object of all selector functions registered for the module.
@@ -49,7 +68,17 @@ This function allows calling any registered selector. Given a module's key, this
 wp.data.select( 'myPlugin' ).getTitle(); // Returns "My post title"
 ```
 
-### `wp.data.query( mapSelectorsToProps: function )( WrappedComponent: Component )`
+### `wp.data.dispatch( key: string )`
+
+This function allows calling any registered action. Given a module's key, this function returns an object of all action creators functions registered for the module.
+
+#### Example:
+
+```js
+wp.data.dispatch( 'myPlugin' ).setTitle( 'new Title' ); // Dispatches the setTitle action to the reducer
+```
+
+### `wp.data.query( mapSelectorsToProps: function, mapDispatchToProps: function )( WrappedComponent: Component )`
 
 If you use a React or WordPress Element, a Higher Order Component is made available to inject data into your components like so:
 
@@ -61,6 +90,25 @@ wp.data.query( select => {
 		title: select( 'myPlugin' ).getTitle(),
 	};
 } )( Component );
+```
+
+You can also use this Higher Order Component to provide action handlers to your components
+
+```js
+const Component = ( { title, updateTitle } ) => <input value={ title } onChange={ updateTitle } />;
+
+wp.data.query(
+	select => {
+		return {
+			title: select( 'myPlugin' ).getTitle(),
+		};
+	} ,
+	dispatch => ( {
+		updateTitle( event ) {
+			dispatch( 'myPlugin' ).setTitle( event.target.value )
+		}
+	} )
+)( Component );
 ```
 
 ### `wp.data.subscribe( listener: function )`

--- a/data/README.md
+++ b/data/README.md
@@ -96,15 +96,17 @@ const unsubscribe = wp.data.subscribe( () => {
 unsubscribe();
 ```
 
-### `wp.data.withData( mapStateToProps: Object|Function )( WrappedComponent: Component )`
+### `wp.data.withSelect( mapStateToProps: Object|Function )( WrappedComponent: Component )`
 
-To inject state-derived props into a WordPress Element Component, use the `withData` higher-order component:
+To inject state-derived props into a WordPress Element Component, use the `withSelect` higher-order component:
 
 ```jsx
 const Component = ( { title } ) => <div>{ title }</div>;
 
-const EnhancedComponent = wp.data.withData( {
-	title: wp.data.select( 'myPlugin' ).getTitle,
+const EnhancedComponent = wp.data.withSelect( ( select ) => {
+	return {
+		title: select( 'myPlugin' ).getTitle,		
+	};
 } )( Component );
 ```
 
@@ -116,11 +118,15 @@ To manipulate store data, you can pass dispatching actions into your component a
 const Component = ( { title, updateTitle } ) => <input value={ title } onChange={ updateTitle } />;
 
 const EnhancedComponent = wp.element.compose( [
-	wp.data.withData( {
-		title: select( 'myPlugin' ).getTitle,
+	wp.data.withSelect( ( select ) => {
+		return {
+			title: select( 'myPlugin' ).getTitle(),
+		};
 	} ),
-	wp.data.withDispatch( {
-		updateTitle: dispatch( 'myPlugin' ).setTitle,
+	wp.data.withDispatch( ( dispatch ) => {
+		return {
+			updateTitle: dispatch( 'myPlugin' ).setTitle,			
+		};
 	} ),
 ] )( Component );
 ```

--- a/data/README.md
+++ b/data/README.md
@@ -96,29 +96,31 @@ const unsubscribe = wp.data.subscribe( () => {
 unsubscribe();
 ```
 
-### `wp.data.onSubscribe( mapDataToProps: function )( WrappedComponent: Component )`
+### `wp.data.withData( mapStateToProps: Object|Function )( WrappedComponent: Component )`
 
-If you use a React or WordPress Element, a Higher Order Component is made available to inject data into your components like so:
+To inject state-derived props into a WordPress Element Component, use the `withData` higher-order component:
 
-```js
+```jsx
 const Component = ( { title } ) => <div>{ title }</div>;
 
-wp.data.onSubscribe( () => {
-	return {
-		title: wp.data.select( 'myPlugin' ).getTitle(),
-	};
+const EnhancedComponent = wp.data.withData( {
+	title: wp.data.select( 'myPlugin' ).getTitle,
 } )( Component );
 ```
 
-You can also use this Higher Order Component to provide action handlers to your components
+### `wp.data.withDispatch( propsToDispatchers: Object )( WrappedComponent: Component )`
 
-```js
+To manipulate store data, you can pass dispatching actions into your component as props using the `withDispatch` higher-order component:
+
+```jsx
 const Component = ( { title, updateTitle } ) => <input value={ title } onChange={ updateTitle } />;
 
-wp.data.onSubscribe( () => {
-	return {
-		title: select( 'myPlugin' ).getTitle(),
+const EnhancedComponent = wp.element.compose( [
+	wp.data.withData( {
+		title: select( 'myPlugin' ).getTitle,
+	} ),
+	wp.data.withDispatch( {
 		updateTitle: dispatch( 'myPlugin' ).setTitle,
-	};
-} )( Component );
+	} ),
+] )( Component );
 ```

--- a/data/README.md
+++ b/data/README.md
@@ -78,39 +78,6 @@ This function allows calling any registered action. Given a module's key, this f
 wp.data.dispatch( 'myPlugin' ).setTitle( 'new Title' ); // Dispatches the setTitle action to the reducer
 ```
 
-### `wp.data.query( mapSelectorsToProps: function, mapDispatchToProps: function )( WrappedComponent: Component )`
-
-If you use a React or WordPress Element, a Higher Order Component is made available to inject data into your components like so:
-
-```js
-const Component = ( { title } ) => <div>{ title }</div>;
-
-wp.data.query( select => {
-	return {
-		title: select( 'myPlugin' ).getTitle(),
-	};
-} )( Component );
-```
-
-You can also use this Higher Order Component to provide action handlers to your components
-
-```js
-const Component = ( { title, updateTitle } ) => <input value={ title } onChange={ updateTitle } />;
-
-wp.data.query(
-	select => {
-		return {
-			title: select( 'myPlugin' ).getTitle(),
-		};
-	} ,
-	dispatch => ( {
-		updateTitle( event ) {
-			dispatch( 'myPlugin' ).setTitle( event.target.value )
-		}
-	} )
-)( Component );
-```
-
 ### `wp.data.subscribe( listener: function )`
 
 Function used to subscribe to data changes. The listener function is called each time a change is made to any of the registered reducers. This function returns a `unsubscribe` function used to abort the subscription.
@@ -127,4 +94,31 @@ const unsubscribe = wp.data.subscribe( () => {
 
 // Unsubcribe.
 unsubscribe();
+```
+
+### `wp.data.onSubscribe( mapDataToProps: function )( WrappedComponent: Component )`
+
+If you use a React or WordPress Element, a Higher Order Component is made available to inject data into your components like so:
+
+```js
+const Component = ( { title } ) => <div>{ title }</div>;
+
+wp.data.onSubscribe( () => {
+	return {
+		title: wp.data.select( 'myPlugin' ).getTitle(),
+	};
+} )( Component );
+```
+
+You can also use this Higher Order Component to provide action handlers to your components
+
+```js
+const Component = ( { title, updateTitle } ) => <input value={ title } onChange={ updateTitle } />;
+
+wp.data.onSubscribe( () => {
+	return {
+		title: select( 'myPlugin' ).getTitle(),
+		updateTitle: dispatch( 'myPlugin' ).setTitle,
+	};
+} )( Component );
 ```

--- a/data/index.js
+++ b/data/index.js
@@ -155,6 +155,12 @@ export const withSelect = ( mapStateToProps ) => ( WrappedComponent ) => {
 			this.runSelection();
 		}
 
+		componentWillReceiveProps( nextProps ) {
+			if ( ! isEqualShallow( nextProps, this.props ) ) {
+				this.runSelection( nextProps );
+			}
+		}
+
 		componentWillUnmount() {
 			this.unsubscribe();
 		}
@@ -163,8 +169,8 @@ export const withSelect = ( mapStateToProps ) => ( WrappedComponent ) => {
 			this.unsubscribe = subscribe( this.runSelection );
 		}
 
-		runSelection() {
-			const newState = mapStateToProps( select, this.props );
+		runSelection( props = this.props ) {
+			const newState = mapStateToProps( select, props );
 			if ( ! isEqualShallow( newState, this.state ) ) {
 				this.setState( newState );
 			}

--- a/data/index.js
+++ b/data/index.js
@@ -20,6 +20,7 @@ export { loadAndPersist, withRehydratation } from './persist';
  */
 const stores = {};
 const selectors = {};
+const actions = {};
 let listeners = [];
 
 /**
@@ -28,21 +29,6 @@ let listeners = [];
 export function globalListener() {
 	listeners.forEach( listener => listener() );
 }
-
-/**
- * Subscribe to changes to any data.
- *
- * @param {Function}   listener Listener function.
- *
- * @return {Function}           Unsubscribe function.
- */
-export const subscribe = ( listener ) => {
-	listeners.push( listener );
-
-	return () => {
-		listeners = without( listeners, listener );
-	};
-};
 
 /**
  * Registers a new sub-reducer to the global state and returns a Redux-like store object.
@@ -80,6 +66,34 @@ export function registerSelectors( reducerKey, newSelectors ) {
 }
 
 /**
+ * Registers actions for external usage.
+ *
+ * @param {string} reducerKey   Part of the state shape to register the
+ *                              selectors for.
+ * @param {Object} newActions   Actions to register.
+ */
+export function registerActions( reducerKey, newActions ) {
+	const store = stores[ reducerKey ];
+	const createBoundAction = ( action ) => ( ...args ) => store.dispatch( action( ...args ) );
+	actions[ reducerKey ] = mapValues( newActions, createBoundAction );
+}
+
+/**
+ * Subscribe to changes to any data.
+ *
+ * @param {Function}   listener Listener function.
+ *
+ * @return {Function}           Unsubscribe function.
+ */
+export const subscribe = ( listener ) => {
+	listeners.push( listener );
+
+	return () => {
+		listeners = without( listeners, listener );
+	};
+};
+
+/**
  * Calls a selector given the current state and extra arguments.
  *
  * @param {string} reducerKey Part of the state shape to register the
@@ -102,15 +116,30 @@ export function select( reducerKey ) {
 }
 
 /**
+ * Returns the available actions for a part of the state.
+ *
+ * @param {string} reducerKey Part of the state shape to dispatch the
+ *                            action for.
+ *
+ * @return {*} The action's returned value.
+ */
+export function dispatch( reducerKey ) {
+	return actions[ reducerKey ];
+}
+
+/**
  * Higher Order Component used to inject data using the registered selectors.
  *
  * @param {Function} mapSelectorsToProps Gets called with the selectors object
  *                                       to determine the data for the
  *                                       component.
+ * @param {Function} mapDispatchToProps  Gets called with the wp.data.dispatch function
+ *                                       to create action handlers.
+ *
  *
  * @return {Function} Renders the wrapped component and passes it data.
  */
-export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
+export const query = ( mapSelectorsToProps, mapDispatchToProps ) => ( WrappedComponent ) => {
 	const store = {
 		getState() {
 			return mapValues( stores, subStore => subStore.getState() );
@@ -128,7 +157,14 @@ export const query = ( mapSelectorsToProps ) => ( WrappedComponent ) => {
 		};
 	};
 
-	return connectWithStore( ( state, ownProps ) => {
-		return mapSelectorsToProps( select, ownProps );
-	} );
+	return connectWithStore(
+		mapSelectorsToProps ?
+			( state, ownProps ) => {
+				return mapSelectorsToProps( select, ownProps );
+			} : undefined,
+		mapDispatchToProps ?
+			( unusedDispatch, ownProps ) => {
+				return mapDispatchToProps( dispatch, ownProps );
+			} : undefined
+	);
 };

--- a/data/index.js
+++ b/data/index.js
@@ -3,13 +3,13 @@
  */
 import isEqualShallow from 'is-equal-shallow';
 import { createStore } from 'redux';
-import { flowRight, without, mapValues } from 'lodash';
+import { flowRight, without, mapValues, isPlainObject } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { deprecated } from '@wordpress/utils';
-import { Component } from '@wordpress/element';
+import { Component, getWrapperDisplayName } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -129,25 +129,36 @@ export function dispatch( reducerKey ) {
 }
 
 /**
- * Higher Order Component used to inject data and actions using the registered selectors/actions.
+ * Higher-order component used to inject state-derived props using registered
+ * selectors.
  *
- * @param {Function} mapDataToProps Gets called with the props object
- *                                  to determine the data for the
- *                                  component.
+ * @param {Object|Function} mapStateToProps Object of prop names where value is
+ *                                          a state selector to populate every
+ *                                          state change. Passed as function,
+ *                                          it is called with the component's
+ *                                          own original props.
  *
- * @return {Function} Renders the wrapped component and passes it data.
+ * @return {Component} Enhanced component with merged state data props.
  */
-export const onSubscribe = ( mapDataToProps ) => ( WrappedComponent ) => {
-	const usePropsArgument = mapDataToProps.length !== 0;
+export const withData = ( mapStateToProps ) => ( WrappedComponent ) => {
+	// Normalize object form to function.
+	if ( isPlainObject( mapStateToProps ) ) {
+		// Object form is pairs of prop names to selectors.
+		const propsToSelectors = mapStateToProps;
+		mapStateToProps = () => mapValues( propsToSelectors, ( selector ) => selector() );
+	}
 
 	class ComponentWithData extends Component {
 		constructor() {
 			super( ...arguments );
+
 			this.state = {};
 		}
 
 		componentWillMount() {
 			this.subscribe();
+
+			// Populate initial state.
 			this.runSelection( this.props );
 		}
 
@@ -155,45 +166,83 @@ export const onSubscribe = ( mapDataToProps ) => ( WrappedComponent ) => {
 			this.unsubscribe();
 		}
 
-		componentWillReceiveProps( newProps ) {
-			if ( usePropsArgument ) {
-				this.runSelection( newProps );
-			}
-		}
-
 		subscribe() {
 			this.unsubscribe = subscribe( () => this.runSelection( this.props ) );
 		}
 
 		runSelection( props ) {
-			const newState = mapDataToProps( props );
+			const newState = mapStateToProps( props );
 			if ( ! isEqualShallow( newState, this.state ) ) {
 				this.setState( newState );
 			}
 		}
 
-		shouldComponentUpdate( nextProps, nextState ) {
-			return nextState !== this.state || ! isEqualShallow( nextProps, this.props );
-		}
-
 		render() {
-			return (
-				<WrappedComponent { ...this.props } { ...this.state } />
-			);
+			return <WrappedComponent { ...this.props } { ...this.state } />;
 		}
 	}
 
+	ComponentWithData.displayName = getWrapperDisplayName( ComponentWithData, 'data' );
+
 	return ComponentWithData;
+};
+
+/**
+ * Higher-order component used to add dispatch props using registered action
+ * creators.
+ *
+ * @param {Object} propsToDispatchers Object of prop names where value is a
+ *                                    dispatch-bound action creator, or a
+ *                                    function to be called with with the
+ *                                    component's props and returning an
+ *                                    action creator.
+ *
+ * @return {Component} Enhanced component with merged dispatcher props.
+ */
+export const withDispatch = ( propsToDispatchers ) => ( WrappedComponent ) => {
+	class ComponentWithDispatch extends Component {
+		constructor() {
+			super( ...arguments );
+
+			// Assign as instance property so that in reconciling subsequent
+			// renders, the assigned prop values are referentially equal.
+			this.proxyProps = mapValues( propsToDispatchers, ( dispatcher, propName ) => {
+				// Prebind with prop name so we have reference to the original
+				// dispatcher to invoke.
+				return this.proxyDispatch.bind( this, propName );
+			} );
+		}
+
+		proxyDispatch( propName, ...args ) {
+			// Original dispatcher is a pre-bound (dispatching) action creator.
+			const result = propsToDispatchers[ propName ]( ...args );
+
+			// ...or, in more complex cases, it can leverage component props to
+			// generate dispatch arguments. We assume that if the result is not
+			// an object (return value of dispatch), not yet dispatched.
+			if ( typeof result === 'function' ) {
+				result( this.props );
+			}
+		}
+
+		render() {
+			return <WrappedComponent { ...this.props } { ...this.proxyProps } />;
+		}
+	}
+
+	ComponentWithDispatch.displayName = getWrapperDisplayName( ComponentWithDispatch, 'dispatch' );
+
+	return ComponentWithDispatch;
 };
 
 export const query = ( mapSelectToProps ) => {
 	deprecated( 'wp.data.query', {
 		version: '2.5',
-		alternative: 'wp.data.onSubscribe',
+		alternative: 'wp.data.withData',
 		plugin: 'Gutenberg',
 	} );
 
-	return onSubscribe( ( props ) => {
+	return withData( ( props ) => {
 		return mapSelectToProps( select, props );
 	} );
 };

--- a/data/test/__snapshots__/index.js.snap
+++ b/data/test/__snapshots__/index.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`onSubscribe passes the relevant data to the component 1`] = `
-<div>
-  reactState
-</div>
-`;

--- a/data/test/__snapshots__/index.js.snap
+++ b/data/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`query passes the relevant data to the component 1`] = `
+exports[`onSubscribe passes the relevant data to the component 1`] = `
 <div>
   reactState
 </div>

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, mount } from 'enzyme';
+import { render } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import {
 	registerActions,
 	dispatch,
 	select,
-	query,
+	onSubscribe,
 	subscribe,
 } from '../';
 
@@ -59,15 +59,15 @@ describe( 'select', () => {
 	} );
 } );
 
-describe( 'query', () => {
+describe( 'onSubscribe', () => {
 	it( 'passes the relevant data to the component', () => {
 		registerReducer( 'reactReducer', () => ( { reactKey: 'reactState' } ) );
 		registerSelectors( 'reactReducer', {
 			reactSelector: ( state, key ) => state[ key ],
 		} );
-		const Component = query( ( selectFunc, ownProps ) => {
+		const Component = onSubscribe( ( ownProps ) => {
 			return {
-				data: selectFunc( 'reactReducer' ).reactSelector( ownProps.keyName ),
+				data: select( 'reactReducer' ).reactSelector( ownProps.keyName ),
 			};
 		} )( ( props ) => {
 			return <div>{ props.data }</div>;
@@ -76,32 +76,6 @@ describe( 'query', () => {
 		const tree = render( <Component keyName="reactKey" /> );
 
 		expect( tree ).toMatchSnapshot();
-	} );
-
-	it( 'passes the relevant actions to the component', () => {
-		const store = registerReducer( 'reactCounter', ( state = 0, action ) => {
-			if ( action.type === 'increment' ) {
-				return state + 1;
-			}
-			return state;
-		} );
-		const increment = () => ( { type: 'increment' } );
-		registerActions( 'reactCounter', {
-			increment,
-		} );
-		const Component = query( undefined, ( dispatchAction ) => ( {
-			onClick: () => dispatchAction( 'reactCounter' ).increment(),
-		} ) )( ( props ) => {
-			return <button onClick={ props.onClick }>Increment</button>;
-		} );
-
-		const tree = mount( <Component keyName="reactKey" /> );
-		const button = tree.find( 'button' );
-
-		button.simulate( 'click' ); // state = 1
-		button.simulate( 'click' ); // state = 2
-
-		expect( store.getState() ).toBe( 2 );
 	} );
 } );
 

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton, withContext } from '@wordpress/components';
 import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
-import { withData, withDispatch, dispatch, select } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -85,15 +85,15 @@ class Inserter extends Component {
 }
 
 export default compose( [
-	withData( {
+	withSelect( ( select ) => ( {
 		insertionPoint: select( 'core/editor' ).getBlockInsertionPoint,
 		selectedBlock: select( 'core/editor' ).getSelectedBlock,
-	} ),
-	withDispatch( {
+	} ) ),
+	withDispatch( ( dispatch, ownProps ) => ( {
 		showInsertionPoint: dispatch( 'core/editor' ).showInsertionPoint,
 		hideInsertionPoint: dispatch( 'core/editor' ).hideInsertionPoint,
-		onInsertBlock: ( item ) => ( props ) => {
-			const { insertionPoint, selectedBlock } = props;
+		onInsertBlock: ( item ) => {
+			const { insertionPoint, selectedBlock } = ownProps;
 			const { index, rootUID, layout } = insertionPoint;
 			const { name, initialAttributes } = item;
 			const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
@@ -102,7 +102,7 @@ export default compose( [
 			}
 			return dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootUID );
 		},
-	} ),
+	} ) ),
 	withContext( 'editor' )( ( settings ) => {
 		const { blockTypes, templateLock } = settings;
 

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 
 /**
@@ -11,18 +10,12 @@ import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton, withContext } from '@wordpress/components';
 import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component, compose } from '@wordpress/element';
+import { withData, withDispatch, dispatch, select } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import InserterMenu from './menu';
-import { getBlockInsertionPoint, getSelectedBlock } from '../../store/selectors';
-import {
-	insertBlock,
-	hideInsertionPoint,
-	showInsertionPoint,
-	replaceBlocks,
-} from '../../store/actions';
 
 class Inserter extends Component {
 	constructor() {
@@ -92,36 +85,24 @@ class Inserter extends Component {
 }
 
 export default compose( [
-	connect(
-		( state ) => {
-			return {
-				insertionPoint: getBlockInsertionPoint( state ),
-				selectedBlock: getSelectedBlock( state ),
-			};
+	withData( {
+		insertionPoint: select( 'core/editor' ).getBlockInsertionPoint,
+		selectedBlock: select( 'core/editor' ).getSelectedBlock,
+	} ),
+	withDispatch( {
+		showInsertionPoint: dispatch( 'core/editor' ).showInsertionPoint,
+		hideInsertionPoint: dispatch( 'core/editor' ).hideInsertionPoint,
+		onInsertBlock: ( item ) => ( props ) => {
+			const { insertionPoint, selectedBlock } = props;
+			const { index, rootUID, layout } = insertionPoint;
+			const { name, initialAttributes } = item;
+			const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
+			if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
+				return dispatch( 'core/editor' ).replaceBlocks( selectedBlock.uid, insertedBlock );
+			}
+			return dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootUID );
 		},
-		{
-			showInsertionPoint,
-			hideInsertionPoint,
-			insertBlock,
-			replaceBlocks,
-		},
-		( { selectedBlock, insertionPoint, ...stateProps }, dispatchProps, { ...ownProps } ) => ( {
-			...stateProps,
-			...ownProps,
-			showInsertionPoint: dispatchProps.showInsertionPoint,
-			hideInsertionPoint: dispatchProps.hideInsertionPoint,
-			onInsertBlock( item ) {
-				const { index, rootUID, layout } = insertionPoint;
-				const { name, initialAttributes } = item;
-				const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
-				if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
-					dispatchProps.replaceBlocks( selectedBlock.uid, insertedBlock );
-					return;
-				}
-				dispatchProps.insertBlock( insertedBlock, index, rootUID );
-			},
-		} )
-	),
+	} ),
 	withContext( 'editor' )( ( settings ) => {
 		const { blockTypes, templateLock } = settings;
 

--- a/editor/index.js
+++ b/editor/index.js
@@ -1,4 +1,6 @@
 /**
  * Internal dependencies
  */
+import './store';
+
 export * from './components';

--- a/editor/index.js
+++ b/editor/index.js
@@ -1,6 +1,1 @@
-/**
- * Internal dependencies
- */
-import './store';
-
 export * from './components';

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -1,7 +1,13 @@
 /**
  * WordPress Dependencies
  */
-import { registerReducer, registerSelectors, withRehydratation, loadAndPersist } from '@wordpress/data';
+import {
+	registerReducer,
+	registerSelectors,
+	registerActions,
+	withRehydratation,
+	loadAndPersist,
+} from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,6 +21,9 @@ import {
 	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,
 } from './selectors';
+import {
+	insertBlocks,
+} from './actions';
 
 /**
  * Module Constants
@@ -34,5 +43,7 @@ registerSelectors( MODULE_KEY, {
 	getLastMultiSelectedBlockUid,
 	getSelectedBlockCount,
 } );
+
+registerActions( MODULE_KEY, { insertBlocks } );
 
 export default store;

--- a/editor/store/index.js
+++ b/editor/store/index.js
@@ -14,16 +14,8 @@ import {
  */
 import reducer from './reducer';
 import applyMiddlewares from './middlewares';
-import {
-	getBlockCount,
-	getBlocks,
-	getEditedPostAttribute,
-	getLastMultiSelectedBlockUid,
-	getSelectedBlockCount,
-} from './selectors';
-import {
-	insertBlocks,
-} from './actions';
+import * as selectors from './selectors';
+import * as actions from './actions';
 
 /**
  * Module Constants
@@ -36,14 +28,7 @@ const store = applyMiddlewares(
 );
 loadAndPersist( store, reducer, 'preferences', STORAGE_KEY );
 
-registerSelectors( MODULE_KEY, {
-	getBlockCount,
-	getBlocks,
-	getEditedPostAttribute,
-	getLastMultiSelectedBlockUid,
-	getSelectedBlockCount,
-} );
-
-registerActions( MODULE_KEY, { insertBlocks } );
+registerSelectors( MODULE_KEY, selectors );
+registerActions( MODULE_KEY, actions );
 
 export default store;


### PR DESCRIPTION
The same way we support registering and calling selectors, this PR adds support for registering and calling actions to the data module.

 - We now have a `wp.data.dispatch` function taking a key and an action (similar to select)
 - We have a `wp.data.registerActions` to register the exposed actions.
 - We also have support for `mapDispatchToProps` in the `query` HoC.

I implemented inserting a block as an exposed action in this PR.

As a follow-up, we could provide a `registerState` helper function to register everything at once: `reducer, actions and selectors`.

**Testing instructions**

 - Open the console of your browser
 - Type `wp.data.dispatch( 'core/editor' ).insertBlocks( wp.blocks.createBlock( 'core/image' ) );` in your browser.
 - A new image block should be created.