### PR TITLE
Add focus styles for Windows High Contrast mode

### DIFF
--- a/components/menu-items/style.scss
+++ b/components/menu-items/style.scss
@@ -25,10 +25,10 @@
 	}
 
 	&:hover {
-		@include menu-style__neutral()
+		@include menu-style__neutral;
 	}
 
 	&:focus {
-		@include menu-style__focus()
+		@include menu-style__focus;
 	}
 }

--- a/components/menu-items/style.scss
+++ b/components/menu-items/style.scss
@@ -25,6 +25,10 @@
 	}
 
 	&:hover {
-		color: $black;
+		@include menu-style__neutral()
+	}
+
+	&:focus {
+		@include menu-style__focus()
 	}
 }

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -73,6 +73,11 @@
 	width: 100%;
 	font-weight: 600;
 	text-align: left;
+	@include menu-style__neutral();
+
+	&:focus {
+		@include menu-style__focus();
+	}
 
 	.dashicon {
 		position: absolute;

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -73,10 +73,10 @@
 	width: 100%;
 	font-weight: 600;
 	text-align: left;
-	@include menu-style__neutral();
+	@include menu-style__neutral;
 
 	&:focus {
-		@include menu-style__focus();
+		@include menu-style__focus;
 	}
 
 	.dashicon {

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -45,6 +45,17 @@ div.components-toolbar {
 	width: $icon-button-size;
 	height: $icon-button-size;
 
+	// unset icon button styles
+	&:active,
+	&:hover,
+	&:focus {
+		outline: none;
+		box-shadow: none;
+		background: none;
+		border: none;
+	}
+
+	// disabled
 	&:disabled {
 		cursor: default;
 	}
@@ -70,42 +81,20 @@ div.components-toolbar {
 		bottom: 8px;
 	}
 
-	// special hover style
-	&:not(:disabled) {
-		&.is-active > svg,
-		&:hover > svg {
-			box-shadow: inset 0 0 0 1px $dark-gray-500;
-		}
+	// hover style
+	&:not( :disabled ).is-active > svg,
+	&:not( :disabled ):hover > svg {
+		@include formatting-button-style__hover;
 	}
 
-	// special active style
-	&.is-active {
-		color: $white;
-		> svg {
-			background: $dark-gray-500;
-		}
+	// active & toggled style
+	&:not(:disabled).is-active > svg {
+		@include formatting-button-style__active;
 	}
 
 	// focus style
-	&:hover,
-	&:focus {
-		outline: none;
-		box-shadow: none;
-		background: none;
-	}
-
-	&:focus > svg {
-		@include button-style__focus-active;
-	}
-	&:focus:hover > svg {
-		@include button-style__focus-active;
-	}
-
-	// active focus style
-	&.is-active:focus > svg {
-		background: $dark-gray-500;
-		color: $white;
-		box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
+	&:not(:disabled):focus > svg {
+		@include formatting-button-style__focus;
 	}
 }
 

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -144,8 +144,7 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 // Formatting Buttons
 @mixin formatting-button-style__hover {
 	color: $dark-gray-500;
-	border: 1px solid $dark-gray-500;
-	box-shadow: inset 0 0 0 1px $white;
+	box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
 }
 
 @mixin formatting-button-style__active() {
@@ -156,9 +155,11 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 }
 
 @mixin formatting-button-style__focus() {
-	outline: none;
-	border: 1px solid $dark-gray-500;
-	box-shadow: inset 0 0 0 1px $white;
+	box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow
+	outline: 2px solid transparent;
+	outline-offset: -2px;
 }
 
 // Tabs, Inputs, Square buttons

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -174,12 +174,12 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 
 // Menu items
 @mixin menu-style__neutral() {
-	color: $black;
 	border: none;
 	box-shadow: none;
 }
 
 @mixin menu-style__focus() {
+	color: $black;
 	border: none;
 	box-shadow: none;
 	outline-offset: -2px;

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -174,15 +174,17 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 
 // Menu items
 @mixin menu-style__neutral() {
+	color: $black;
 	border: none;
 	box-shadow: none;
 }
 
 @mixin menu-style__focus() {
 	border: none;
-	outline-offset: -1px;
+	box-shadow: none;
+	outline-offset: -2px;
 	color: $dark-gray-900;
-	outline: 1px dotted $dark-gray-300;
+	outline: 1px dotted $dark-gray-500;
 }
 
 // Old

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -115,6 +115,7 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
  * Button states and focus styles
  */
 
+// Buttons with rounded corners
 @mixin button-style__disabled {
 	opacity: 0.6;
 	cursor: default;
@@ -132,11 +133,58 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 }
 
 @mixin button-style__focus-active() {
-	outline: none;
 	color: $dark-gray-900;
 	box-shadow: inset 0 0 0 1px $dark-gray-300, inset 0 0 0 2px $white;
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow
+	outline: 2px solid transparent;
+	outline-offset: -2px;
 }
 
+// Formatting Buttons
+@mixin formatting-button-style__hover {
+	color: $dark-gray-500;
+	border: 1px solid $dark-gray-500;
+	box-shadow: inset 0 0 0 1px $white;
+}
+
+@mixin formatting-button-style__active() {
+	outline: none;
+	color: $white;
+	box-shadow: none;
+	background: $dark-gray-500;
+}
+
+@mixin formatting-button-style__focus() {
+	outline: none;
+	border: 1px solid $dark-gray-500;
+	box-shadow: inset 0 0 0 1px $white;
+}
+
+// Tabs, Inputs, Square buttons
+@mixin square-style__neutral() {
+	outline-offset: -1px;
+}
+
+@mixin square-style__focus-active() {
+	color: $dark-gray-900;
+	outline: 1px solid $dark-gray-300;
+}
+
+// Menu items
+@mixin menu-style__neutral() {
+	border: none;
+	box-shadow: none;
+}
+
+@mixin menu-style__focus() {
+	border: none;
+	outline-offset: -1px;
+	color: $dark-gray-900;
+	outline: 1px dotted $dark-gray-300;
+}
+
+// Old
 @mixin tab-style__focus-active() {
 	outline: none;
 	color: $dark-gray-900;

--- a/edit-post/components/sidebar/last-revision/style.scss
+++ b/edit-post/components/sidebar/last-revision/style.scss
@@ -1,5 +1,8 @@
-.edit-post-last-revision__panel .edit-post-post-last-revision__title {
-	box-sizing: content-box;
-	margin: #{ -1 * $panel-padding };
-	padding: $panel-padding;
+// Needs specificity, because this panel is just a button
+.components-panel__body.is-opened.edit-post-last-revision__panel {
+	padding: 0;
+}
+
+.editor-post-last-revision__title {
+	padding: #{ $panel-padding - 3px } $panel-padding;	// subtract extra height of dashicon
 }

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -123,6 +123,7 @@
 	padding: 0 20px;
 	margin-left: 0;
 	font-weight: 400;
+	@include square-style__neutral;
 
 	&.is-active {
 		border-bottom-color: $blue-medium-500;
@@ -130,6 +131,6 @@
 	}
 
 	&:focus {
-		@include button-style__focus-active;
+		@include square-style__focus-active;
 	}
 }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -362,10 +362,6 @@
 		color: $dark-gray-300;
 		margin: 4px 0 0 -4px;	// align better with text blocks
 	}
-
-	.editor-inserter__toggle.components-icon-button:not(:disabled):hover {
-		@include button-style__hover;
-	}
 }
 
 .editor-block-list__insertion-point {

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -30,7 +30,10 @@
 
 .editor-block-settings-menu__section {
 	margin-top: $item-spacing;
-	padding-top: $item-spacing;
+	margin-left: -$item-spacing;
+	margin-right: -$item-spacing;
+	margin-bottom: -$item-spacing;
+	padding: $item-spacing;
 	border-top: 1px solid $light-gray-500;
 }
 
@@ -44,14 +47,12 @@
 	border-radius: 0;
 	color: $dark-gray-500;
 	cursor: pointer;
-	border: 1px solid transparent;
+	@include menu-style__neutral;
 
 	&:hover,
 	&:focus,
 	&:not(:disabled):hover {
-		box-shadow: none;
-		color: $dark-gray-500;
-		border: 1px solid $dark-gray-500;
+		@include menu-style__focus;
 	}
 
 	.dashicon {

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -30,10 +30,8 @@
 
 .editor-block-settings-menu__section {
 	margin-top: $item-spacing;
-	margin-left: -$item-spacing;
-	margin-right: -$item-spacing;
 	margin-bottom: -$item-spacing;
-	padding: $item-spacing;
+	padding: $item-spacing 0;
 	border-top: 1px solid $light-gray-500;
 }
 

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -35,6 +35,7 @@ input[type="search"].editor-inserter__search {
 	z-index: 1;
 	border: none;
 	box-shadow: 0 1px 0 0 $light-gray-500;
+	@include square-style__neutral;
 
 	// fonts smaller than 16px causes mobile safari to zoom
 	font-size: $mobile-text-min-font-size;
@@ -43,7 +44,7 @@ input[type="search"].editor-inserter__search {
 	}
 
 	&:focus {
-		@include input-style__focus-active;
+		@include square-style__focus-active;
 	}
 }
 
@@ -164,6 +165,7 @@ input[type="search"].editor-inserter__search {
 		border-bottom: 1px solid $light-gray-500;
 		flex-shrink: 0;
 		margin-top: 1px;
+		@include square-style__neutral;
 	}
 
 	.editor-inserter__no-tab-content-message {

--- a/editor/components/post-last-revision/style.scss
+++ b/editor/components/post-last-revision/style.scss
@@ -1,9 +1,21 @@
 .editor-post-last-revision__title {
-	padding: 0;
 	width: 100%;
 	font-weight: 600;
 
 	.dashicon {
 		margin-right: 5px;
+	}
+}
+
+// Needs specificity
+.components-icon-button:not(:disabled).editor-post-last-revision__title {
+
+	&:hover,
+	&:active {
+		@include menu-style__neutral();
+	}
+
+	&:focus {
+		@include menu-style__focus();
 	}
 }

--- a/editor/components/post-last-revision/style.scss
+++ b/editor/components/post-last-revision/style.scss
@@ -12,10 +12,10 @@
 
 	&:hover,
 	&:active {
-		@include menu-style__neutral();
+		@include menu-style__neutral;
 	}
 
 	&:focus {
-		@include menu-style__focus();
+		@include menu-style__focus;
 	}
 }


### PR DESCRIPTION
Fixes #4297, replaces #4833. 

This is a new PR that addresses the same issue as before. It adds focus styles for Windows high contrast mode (Edge, IE, Firefox, Chrome doesn't support it at all). It also refactors the focus styles in the process, making some enhancements to focus styles for panels and menu items.

The chief change from the previous PR is that this PR doesn't use CSS borders, which lets us rely still on drop shadows for the normal visual styles of buttons. This means we don't have to do crazy padding math to ensure buttons don't change sizes in between the visual states of hover active and focus, which makes the CSS more flexible.

It relies on the fact that Windows High Contrast mode _omits_ box shadows entirely, but it _shows_ any border or outline, even if they are `transparent`. We leverage that to show thick and visually helpful focus outlines in this high contrast mode — `2px solid transparent`. They will show up in high contrast mode, not in normal mode. See also [this codepen](https://codepen.io/joen/pen/mXXbOR).

Screenshots

![screen shot 2018-02-19 at 10 36 48](https://user-images.githubusercontent.com/1204802/36371123-78d19056-1561-11e8-87f0-ab93eb65eac4.png)

![screen shot 2018-02-19 at 10 36 53](https://user-images.githubusercontent.com/1204802/36371124-7a1ac2ac-1561-11e8-89e6-6a47870c2d3e.png)

![screen shot 2018-02-19 at 10 36 58](https://user-images.githubusercontent.com/1204802/36371128-7b824dae-1561-11e8-9b91-f3e4d034af24.png)

![36366512-cad05724-154e-11e8-804a-c5ccea5ea49c](https://user-images.githubusercontent.com/1204802/36371332-1401a016-1562-11e8-83a6-61c64896b886.PNG)


Things to test for:

Does this work as intended both in Windows high contrast mode (test in IE, Edge or Firefox), and does it work as intended without high contrast mode enabled.

