### PR TITLE
Nested blocks: Show the side inserter on empty paragraphs

### DIFF
--- a/blocks/api/utils.js
+++ b/blocks/api/utils.js
@@ -4,6 +4,11 @@
 import { every, keys, isEqual } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import { getDefaultBlockName } from './registration';
@@ -25,10 +30,11 @@ export function isUnmodifiedDefaultBlock( block ) {
 	}
 
 	const newDefaultBlock = createBlock( defaultBlockName );
-	const attributeKeys = [
+
+	const attributeKeys = applyFilters( 'blocks.isUnmodifiedDefaultBlock.attributes', [
 		...keys( newDefaultBlock.attributes ),
 		...keys( block.attributes ),
-	];
+	] );
 
 	return every( attributeKeys, key =>
 		isEqual( newDefaultBlock.attributes[ key ], block.attributes[ key ] )

--- a/blocks/hooks/layout.js
+++ b/blocks/hooks/layout.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, compact, get } from 'lodash';
+import { assign, compact, get, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -70,6 +70,19 @@ function preserveLayoutAttribute( transformedBlock, blocks ) {
 	return transformedBlock;
 }
 
+/**
+ * Excludes the layout from the list of attributes to check
+ * when determining if a block is unmodified or not.
+ *
+ * @param  {Object} attributeKeys  Attribute keys to check
+ *
+ * @return {Object}                Modified list of attribute keys
+ */
+function excludeLayoutFromUnmodifiedBlockCheck( attributeKeys ) {
+	return without( attributeKeys, 'layout' );
+}
+
 addFilter( 'blocks.registerBlockType', 'core/layout/attribute', addAttribute );
 addFilter( 'blocks.getSaveContent.extraProps', 'core/layout/save-props', addSaveProps );
 addFilter( 'blocks.switchToBlockType.transformedBlock', 'core/layout/preserve-layout', preserveLayoutAttribute );
+addFilter( 'blocks.isUnmodifiedDefaultBlock.attributes', 'core/layout/exclude-layout-attribute-check', excludeLayoutFromUnmodifiedBlockCheck );

--- a/blocks/hooks/test/layout.js
+++ b/blocks/hooks/test/layout.js
@@ -53,4 +53,14 @@ describe( 'layout', () => {
 			expect( transformedBlock.attributes.layout ).toBe( 'wide' );
 		} );
 	} );
+
+	describe( 'excludeLayoutFromUnmodifiedBlockCheck', () => {
+		const excludeLayoutAttribute = applyFilters.bind( null, 'blocks.isUnmodifiedDefaultBlock.attributes' );
+
+		it( 'should exclude the layout attribute', () => {
+			const attributeKeys = excludeLayoutAttribute( [ 'align', 'content', 'layout' ] );
+
+			expect( attributeKeys ).toEqual( [ 'align', 'content' ] );
+		} );
+	} );
 } );


### PR DESCRIPTION
When checking if a block is empty or not, we should ignore the "layout" attribute as it's not really a block attribute but more something related to the position of the block inside the parent block. (which makes me think it should be best stored separately cc @aduth )

While this PR fix the issue where we needed at least one paragraph block inside the columns block to be able to insert another type of block type, it surfaces the styling issues in the columns block where there's not enough room for the side-inserter.

A workaround could be to hide this inserter in the columns block, you'd still be able to use the global inserter to replace the first block instead of appending a new block.

**Testing instructions**

 - Add a columns block
 - Select the first block in a column
 - Use the inserter 
 - It should replace the block and not insert a new one.

closes #5134