### PR TITLE
Blocks: Fix the black border appearing too often in blocks

### DIFF
--- a/edit-post/components/modes/visual-editor/style.scss
+++ b/edit-post/components/modes/visual-editor/style.scss
@@ -37,17 +37,6 @@
 	}
 }
 
-// This is a focus style shown for blocks that need an indicator even when in an isEditing state
-// like for example an image block that receives arrowkey focus.
-.edit-post-visual-editor .editor-block-list__block:not( .is-selected ) .editor-block-list__block-edit  {
-	box-shadow: 0 0 0 0 $white, 0 0 0 0 $dark-gray-900;
-	transition: .1s box-shadow .05s;
-
-	&:focus {
-		box-shadow: 0 0 0 1px $white, 0 0 0 3px $dark-gray-900;
-	}
-}
-
 .edit-post-visual-editor .editor-post-title {
 	margin-left: auto;
 	margin-right: auto;

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -101,6 +101,7 @@ export class BlockListBlock extends Component {
 		this.onClick = this.onClick.bind( this );
 		this.selectOnOpen = this.selectOnOpen.bind( this );
 		this.onSelectionChange = this.onSelectionChange.bind( this );
+		this.updateHasEditableContent = this.updateHasEditableContent.bind( this );
 
 		this.previousOffset = null;
 		this.hadTouchStart = false;
@@ -140,6 +141,9 @@ export class BlockListBlock extends Component {
 			this.focusTabbable();
 		}
 
+		this.contentObserver = new window.MutationObserver( this.updateHasEditableContent );
+		this.contentObserver.observe( this.node, { childList: true, subtree: true } );
+
 		this.updateHasEditableContent();
 	}
 
@@ -169,8 +173,6 @@ export class BlockListBlock extends Component {
 			this.previousOffset = null;
 		}
 
-		this.updateHasEditableContent();
-
 		// Bind or unbind mousemove from page when user starts or stops typing
 		if ( this.props.isTyping !== prevProps.isTyping ) {
 			if ( this.props.isTyping ) {
@@ -188,6 +190,7 @@ export class BlockListBlock extends Component {
 	componentWillUnmount() {
 		this.removeStopTypingListener();
 		document.removeEventListener( 'selectionchange', this.onSelectionChange );
+		this.contentObserver.disconnect();
 	}
 
 	removeStopTypingListener() {

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -360,6 +360,12 @@
 	}
 }
 
+// This is a focus style shown for blocks that need an indicator even when in an isEditing state
+// like for example an image block that receives arrowkey focus.
+.editor-block-list__block:not(.has-editable-content):not( .is-selected ) > .editor-block-list__block-edit:focus {
+	box-shadow: 0 0 0 1px $white, 0 0 0 3px $dark-gray-900;
+}
+
 .editor-block-list .editor-inserter {
 	margin: $item-spacing;
 

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -17,6 +17,7 @@ import {
 	isVerticalEdge,
 	placeCaretAtHorizontalEdge,
 	placeCaretAtVerticalEdge,
+	isEditableNode,
 } from '@wordpress/utils';
 
 /**
@@ -76,12 +77,9 @@ class WritingFlow extends Component {
 	getVisibleTabbables() {
 		return focus.tabbable
 			.find( this.container )
-			.filter( ( node ) => (
-				node.nodeName === 'INPUT' ||
-				node.nodeName === 'TEXTAREA' ||
-				node.contentEditable === 'true' ||
-				node.classList.contains( 'editor-block-list__block-edit' )
-			) );
+			.filter( ( node ) =>
+				isEditableNode( node ) || node.classList.contains( 'editor-block-list__block-edit' )
+			);
 	}
 
 	getClosestTabbable( target, isReverse ) {

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -366,3 +366,18 @@ export function getScrollContainer( node ) {
 	// Continue traversing
 	return getScrollContainer( node.parentNode );
 }
+
+/**
+ * Given a DOM node, returns whether the node is editable or not.
+ *
+ * @param {Element} node Node to check
+ *
+ * @return {boolean}     Whether the node is editable or not
+ */
+export function isEditableNode( node ) {
+	return (
+		node.nodeName === 'INPUT' ||
+		node.nodeName === 'TEXTAREA' ||
+		node.contentEditable === 'true'
+	);
+}


### PR DESCRIPTION
Sometimes when a block is selected by clicking on its surroundings (paragraph), a black border appears. This black border is only meant for blocks without any textual content (like image blocks, etc..) when they receive focus and isTyping is true (for example when navigating using arrows).

This PR adds a `has-textual-content` className for these blocks to avoid seeing this black border when we don't need it.

Nested blocks made this border appear too often.

**Testing instructions**

 - Try clicking and typing in paragraph blocks
 - Clicking on the margin/padding of the block
 - The block border should not appear.
 - It should only appear when navigating using arrows to these non-textual blocks.