### PR TITLE
Framework: Support nested templates

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -290,14 +290,16 @@ export default {
 		if ( post.content.raw ) {
 			blocks = parse( post.content.raw );
 		} else if ( settings.template ) {
-			blocks = map( settings.template, ( [ name, attributes ] ) => {
-				const block = createBlock( name );
-				block.attributes = {
-					...block.attributes,
-					...attributes,
-				};
-				return block;
-			} );
+			const createBlocksFromTemplate = ( template ) => {
+				return map( template, ( [ name, attributes, innerBlocksTemplate ] ) => {
+					return createBlock(
+						name,
+						attributes,
+						createBlocksFromTemplate( innerBlocksTemplate )
+					);
+				} );
+			};
+			blocks = createBlocksFromTemplate( settings.template );
 		} else {
 			blocks = [];
 		}


### PR DESCRIPTION
This PR adds support for nested templates. For example, a CPT could use a columns block in its templates and assign a template for this nested block.

This uses the third argument of the array defining a block in a template as a way to define a sub-template.

This doesn't address nested locking yet. This will be worked on separately.

**Testing instructions**

 * Define a block type with nested templates like this:

```php
function register_book_type() {
	$args = array(
		'public' => true,
		'label'  => 'Books',
		'show_in_rest' => true,
		'template' => array(
			array( 'core/image' ),
			array( 'core/paragraph', array(
				'placeholder' => 'Add a book description',
			) ),
			array( 'core/quote' ),
			array( 'core/columns', array(), array(
				array( 'core/image', array( 'layout' => 'column-1' ) ),
				array( 'core/paragraph', array(
					'placeholder' => 'Add a inner paragraph',
					'layout' => 'column-2' 
				) ),
			) )
		),
	);
	register_post_type( 'book', $args );
}
add_action( 'init', 'register_book_type' );
```

 * Check that when inserting a new book, the template is initialized with a prefilled columns block.