### PR TITLE
Gallery BLock: Backspace/delete removes the selected image in a gallery block

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -72,6 +72,7 @@ class GalleryBlock extends Component {
 		return () => {
 			const images = filter( this.props.attributes.images, ( img, i ) => index !== i );
 			const { columns } = this.props.attributes;
+			this.setState( { selectedImage: null } );
 			this.props.setAttributes( {
 				images,
 				columns: columns ? Math.min( images.length, columns ) : columns,
@@ -106,7 +107,9 @@ class GalleryBlock extends Component {
 
 	setImageAttributes( index, attributes ) {
 		const { attributes: { images }, setAttributes } = this.props;
-
+		if ( ! images[ index ] ) {
+			return;
+		}
 		setAttributes( {
 			images: [
 				...images.slice( 0, index ),

--- a/blocks/library/gallery/gallery-image.js
+++ b/blocks/library/gallery/gallery-image.js
@@ -9,11 +9,17 @@ import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { IconButton, withAPIData, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal dependencies
  */
 import RichText from '../../rich-text';
+
+/**
+ * Module constants
+ */
+const { BACKSPACE, DELETE } = keycodes;
 
 class GalleryImage extends Component {
 	constructor() {
@@ -21,10 +27,16 @@ class GalleryImage extends Component {
 
 		this.onImageClick = this.onImageClick.bind( this );
 		this.onSelectCaption = this.onSelectCaption.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
+		this.bindContainer = this.bindContainer.bind( this );
 
 		this.state = {
 			captionSelected: false,
 		};
+	}
+
+	bindContainer( ref ) {
+		this.container = ref;
 	}
 
 	onSelectCaption() {
@@ -48,6 +60,17 @@ class GalleryImage extends Component {
 			this.setState( {
 				captionSelected: false,
 			} );
+		}
+	}
+
+	onKeyDown( event ) {
+		if (
+			this.container === document.activeElement &&
+			this.props.isSelected && [ BACKSPACE, DELETE ].indexOf( event.keyCode ) !== -1
+		) {
+			event.stopPropagation();
+			event.preventDefault();
+			this.props.onRemove();
 		}
 	}
 
@@ -95,7 +118,7 @@ class GalleryImage extends Component {
 		// Disable reason: Each block can be selected by clicking on it and we should keep the same saved markup
 		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
-			<figure className={ className }>
+			<figure className={ className } tabIndex="-1" onKeyDown={ this.onKeyDown } ref={ this.bindContainer }>
 				{ isSelected &&
 					<div className="blocks-gallery-item__inline-menu">
 						<IconButton


### PR DESCRIPTION
Just a small enhancement implementing the backspace/delete shortcut to remove the selected image from a gallery block.

This also fixes a small bug when removing the last item in a gallery.

**Testing instructions**

 - Select an image in a gallery block
 - Hit backspace
 - The image should be removed.