### PR TITLE
Compat: Remove unnecessary api-request shim

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -391,15 +391,6 @@ function gutenberg_register_vendor_scripts() {
 		'promise',
 		'https://unpkg.com/promise-polyfill@7.0.0/dist/promise' . $suffix . '.js'
 	);
-
-	// TODO: This is only necessary so long as WordPress 4.9 is not yet stable,
-	// since we depend on the newly-introduced wp-api-request script handle.
-	//
-	// See: gutenberg_ensure_wp_api_request (compat.php).
-	gutenberg_register_vendor_script(
-		'wp-api-request-shim',
-		'https://rawgit.com/WordPress/wordpress-develop/master/src/wp-includes/js/api-request.js'
-	);
 }
 
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -70,41 +70,6 @@ function _gutenberg_utf8_split( $str ) {
 }
 
 /**
- * Shims wp-api-request for WordPress installations not running 4.9-alpha or
- * newer.
- *
- * @see https://core.trac.wordpress.org/ticket/40919
- *
- * @since 0.10.0
- */
-function gutenberg_ensure_wp_api_request() {
-	if ( wp_script_is( 'wp-api-request', 'registered' ) ||
-			! wp_script_is( 'wp-api-request-shim', 'registered' ) ) {
-		return;
-	}
-
-	global $wp_scripts;
-
-	// Define script using existing shim. We do this because we must define the
-	// vendor script in client-assets.php, but want to use consistent handle.
-	$shim = $wp_scripts->registered['wp-api-request-shim'];
-	wp_register_script(
-		'wp-api-request',
-		$shim->src,
-		$shim->deps,
-		$shim->ver
-	);
-
-	// Localize wp-api-request using wp-api handle data (swapped in 4.9-alpha).
-	$wp_api_localized_data = $wp_scripts->get_data( 'wp-api', 'data' );
-	if ( false !== $wp_api_localized_data ) {
-		wp_add_inline_script( 'wp-api-request', $wp_api_localized_data, 'before' );
-	}
-}
-add_action( 'wp_enqueue_scripts', 'gutenberg_ensure_wp_api_request', 20 );
-add_action( 'admin_enqueue_scripts', 'gutenberg_ensure_wp_api_request', 20 );
-
-/**
  * Disables wpautop behavior in classic editor when post contains blocks, to
  * prevent removep from invalidating paragraph blocks.
  *


### PR DESCRIPTION
Previously: #4762
Related: #4950 (WordPress support explicitly updated)

This pull request seeks to remove the api-request JavaScript shim which had existed while WordPress 4.9 was in pre-release, in order to support the 4.8 stable release at the time. Since WordPress 4.9.x is now stable, this shim can now be removed. This effectively increases the minimum WordPress version supported by the Gutenberg plugin to 4.9.0.

__Testing instructions:__

Verify that the editor loads as expected, particularly that the api-request file is loaded correctly from the WordPress installation.

