### PR TITLE
Add `my_` prefix to callback function for registering post type

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -34,7 +34,7 @@ const template = [
 A custom post type can register its own template during registration:
 
 ```php
-function register_post_type() {
+function my_register_post_type() {
 	$args = array(
 		'public' => true,
 		'label'  => 'Books',
@@ -53,7 +53,7 @@ function register_post_type() {
 	);
 	register_post_type( 'book', $args );
 }
-add_action( 'init', 'register_post_type' );
+add_action( 'init', 'my_register_post_type' );
 ```
 
 ### Locking

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -34,7 +34,7 @@ const template = [
 A custom post type can register its own template during registration:
 
 ```php
-function my_register_post_type() {
+function myplugin_register_book_post_type() {
 	$args = array(
 		'public' => true,
 		'label'  => 'Books',
@@ -53,7 +53,7 @@ function my_register_post_type() {
 	);
 	register_post_type( 'book', $args );
 }
-add_action( 'init', 'my_register_post_type' );
+add_action( 'init', 'myplugin_register_book_post_type' );
 ```
 
 ### Locking


### PR DESCRIPTION
Simple doc fix for #5149



## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style.
- [x ] My code has proper inline documentation.
