### PR TITLE
Tests: Improve string cast render test

### DIFF
--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -105,6 +105,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 
 		$rendered = $block_type->render();
 
-		$this->assertEquals( '10', $rendered );
+		$this->assertSame( '10', $rendered );
+		$this->assertInternalType( 'string', $rendered );
 	}
 }


### PR DESCRIPTION
Raised at: https://github.com/WordPress/gutenberg/pull/4879#issuecomment-366804496 (props @johnbillion)

This pull request seeks to improve dynamic block rendering tests which verify the string output of a `render` call. While the behavior itself is working as expected, the tests will wrongly pass even if the string cast was not implemented.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit-php
```

Extra credit: Ensure unit tests fail when removing `(string)` cast:

https://github.com/WordPress/gutenberg/blob/967d0100e78f06bd4d76e2cb6d6f1640b2b770f1/lib/class-wp-block-type.php#L116