### PR TITLE
updated the style.scss to solve issue (#3945)

### DIFF
--- a/edit-post/components/modes/visual-editor/style.scss
+++ b/edit-post/components/modes/visual-editor/style.scss
@@ -88,3 +88,4 @@
 		}
 	}
 }
+.edit-post-visual-editor .editor-default-block-appender .editor-default-block-appender__content{padding:0 14px}


### PR DESCRIPTION
## Description
I have changed the style.scss to solve the issue. I have added css property to right align the image when the image-block is on right-aligned.

## How Has This Been Tested?
I have tested in my local copy.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [Yes] My code is tested.
- [Yes] My code follows the WordPress code style.
- [Yes] My code has proper inline documentation.
