### PR TITLE
Fixed a series of z-index sidebar related issues

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -23,6 +23,7 @@ $z-layers: (
 	'.editor-block-mover': 1,
 	'.blocks-gallery-item__inline-menu': 20,
 	'.editor-block-settings-menu__popover': 20, // Below the header
+	'.blocks-url-input__suggestions': 30,
 	'.edit-post-header': 30,
 	'.wp-block-image__resize-handlers': 1, // Resize handlers above sibling inserter
 
@@ -35,6 +36,10 @@ $z-layers: (
 	'.edit-post-sidebar': 100000,
 	'.edit-post-layout .edit-post-post-publish-panel': 100001,
 
+	// Show sidebar in greater than small viewports above editor related elements
+	// but bellow #adminmenuback { z-index: 100 }
+	'.edit-post-sidebar {greater than small}': 50,
+
 	// Show notices below expanded wp-admin submenus:
 	// #adminmenuwrap { z-index: 9990 }
 	'.components-notice-list': 9989,
@@ -43,7 +48,6 @@ $z-layers: (
 	// #adminmenuwrap { z-index: 9990 }
 	'.components-popover': 1000000,
 	'.components-autocomplete__results': 1000000,
-	'.blocks-url-input__suggestions': 9999,
 );
 
 @function z-index( $key ) {

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -13,7 +13,7 @@
 
 	@include break-small() {
 		top: $admin-bar-height-big + $header-height;
-		z-index: auto;
+		z-index: z-index( '.edit-post-sidebar {greater than small}' );
 		height: auto;
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
This PR fixes a series of issues where editor elements appear above the sidebar in resolutions between 600 and 782px.

## How Has This Been Tested?
Most tests should be executed on a resolution between 600 and 782. The test describes the problem happening on master right now. 

Go to the target resolution, open the sidebar, make the window big (> 782 px).  Add a block, press the block settings menu, resize to the target resolution again, see the block setting menu is not above the sidebar.

Add a galley in the target resolution, select an image, open the sidebar and verify the remove image icon is not above the sidebar.

Add a button in the target resolution, go to the URL input see some suggestions, open the sidebar verify the suggestions and the formatting toolbar is not above the sidebar.

Add an invalid block in the target resolution, e.g: add a paragraph and in the code view change the code to <ps></p>. Open the sidebar, see the invalid block warning is not above the sidebar.

## Screenshots (jpeg or gifs if applicable):
<img width="635" alt="screen shot 2018-02-20 at 14 14 54" src="https://user-images.githubusercontent.com/11271197/36429933-d3b37120-164b-11e8-9fc4-0462c89e0bbc.png">
<img width="550" alt="screen shot 2018-02-20 at 14 14 20" src="https://user-images.githubusercontent.com/11271197/36429953-e2d440ee-164b-11e8-82cb-a8c0b0fb0d4f.png">
<img width="626" alt="screen shot 2018-02-20 at 14 15 28" src="https://user-images.githubusercontent.com/11271197/36429970-ee668084-164b-11e8-9ddf-75e889579389.png">
