### PR TITLE
Flow for adding in images in the gallery without going through the media library

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -12,6 +12,7 @@ import { mediaUpload } from '@wordpress/utils';
 import {
 	IconButton,
 	DropZone,
+	FormFileUpload,
 	RangeControl,
 	SelectControl,
 	ToggleControl,
@@ -51,7 +52,8 @@ class GalleryBlock extends Component {
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
-		this.dropFiles = this.dropFiles.bind( this );
+		this.addFiles = this.addFiles.bind( this );
+		this.uploadFromFiles = this.uploadFromFiles.bind( this );
 
 		this.state = {
 			selectedImage: null,
@@ -122,7 +124,11 @@ class GalleryBlock extends Component {
 		} );
 	}
 
-	dropFiles( files ) {
+	uploadFromFiles( event ) {
+		this.addFiles( event.target.files );
+	}
+
+	addFiles( files ) {
 		const currentImages = this.props.attributes.images || [];
 		const { setAttributes } = this.props;
 		mediaUpload(
@@ -151,7 +157,7 @@ class GalleryBlock extends Component {
 
 		const dropZone = (
 			<DropZone
-				onFilesDrop={ this.dropFiles }
+				onFilesDrop={ this.addFiles }
 			/>
 		);
 
@@ -239,6 +245,18 @@ class GalleryBlock extends Component {
 						/>
 					</li>
 				) ) }
+				{ isSelected &&
+					<li className="blocks-gallery-item">
+						<FormFileUpload
+							multiple
+							isLarge
+							className="blocks-gallery-add-item-button"
+							onChange={ this.uploadFromFiles }
+							accept="image/*"
+							icon="insert"
+						/>
+					</li>
+				}
 			</ul>,
 		];
 	}

--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -28,6 +28,28 @@
 		margin-top: -4px;
 	}
 
+	.components-form-file-upload,
+	.button.blocks-gallery-add-item-button {
+		width: 100%;
+		height: 100%;
+	}
+
+	.button.blocks-gallery-add-item-button {
+		box-shadow: none;
+		border: none;
+		border-radius: 0;
+		min-height: 100px;
+
+		& .dashicon {
+			margin-top: 10px;
+		}
+
+
+		&:hover,
+		&:focus {
+			border: 1px solid #999;
+		}
+	}
 }
 
 .blocks-gallery-item__inline-menu {

--- a/components/form-file-upload/index.js
+++ b/components/form-file-upload/index.js
@@ -25,12 +25,12 @@ class FormFileUpload extends Component {
 	}
 
 	render() {
-		const { children, multiple = false, accept, onChange, ...props } = this.props;
+		const { children, multiple = false, accept, onChange, icon = 'upload', ...props } = this.props;
 
 		return (
 			<div className="components-form-file-upload">
 				<IconButton
-					icon="upload"
+					icon={ icon }
 					onClick={ this.openFileDialog }
 					{ ...props }
 				>


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/1704

This PR implements a button that appears when the gallery is selected and allows the user to upload new images without going through the media library.


## How Has This Been Tested?
Add a gallery block add some images. Select the block to see a plus button is present in the position a new image will appear if it is added.
Try to use the button to upload one or more images.
Unselect the block and see the button disappears.

## Screenshots (jpeg or gifs if applicable):
<img width="789" alt="screen shot 2018-02-20 at 17 39 36" src="https://user-images.githubusercontent.com/11271197/36439776-c8e5d476-1665-11e8-8f81-fa59d9e28a80.png">
<img width="784" alt="screen shot 2018-02-20 at 17 39 45" src="https://user-images.githubusercontent.com/11271197/36439778-c90b8ad6-1665-11e8-8a80-152de1286be1.png">
<img width="761" alt="screen shot 2018-02-20 at 17 39 52" src="https://user-images.githubusercontent.com/11271197/36439779-c92c3146-1665-11e8-8d13-f722c8de40e5.png">
