### PR TITLE
Switch get_locale() to get_user_locale()

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -103,7 +103,7 @@ function gutenberg_register_scripts_and_styles() {
 	global $wp_locale;
 	wp_add_inline_script( 'wp-date', 'window._wpDateSettings = ' . wp_json_encode( array(
 		'l10n'     => array(
-			'locale'        => get_locale(),
+			'locale'        => get_user_locale(),
 			'months'        => array_values( $wp_locale->month ),
 			'monthsShort'   => array_values( $wp_locale->month_abbrev ),
 			'weekdays'      => array_values( $wp_locale->weekday ),


### PR DESCRIPTION
## Description

For setting locale, we should use the user locale's first and then fall back to blog locale. This can be achieved by switching to `get_user_locale()` If the user locale is not set, the `get_user_locale()` function will default to `get_locale()`

## How Has This Been Tested?

Confirmed that Gutenberg locale settings are working as expected, specifically confirmed displayed dates and time work as expected.

## Checklist:
- [x ] My code is tested.
- [ x] My code follows the WordPress code style.

