### PR TITLE
Fix description setting typo in core/freeform block

### DIFF
--- a/blocks/library/freeform/index.js
+++ b/blocks/library/freeform/index.js
@@ -15,7 +15,7 @@ export const name = 'core/freeform';
 export const settings = {
 	title: __( 'Classic' ),
 
-	desription: __( 'The classic editor, in block form.' ),
+	description: __( 'The classic editor, in block form.' ),
 
 	icon: 'editor-kitchensink',
 


### PR DESCRIPTION
The description setting for the core/freeform block had a typo in it causing it not to be displayed in the advanced panel.