### PR TITLE
Block List: Allow clicking behind block next to toolbar

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -489,6 +489,10 @@
 	pointer-events: none;
 	height: $block-toolbar-height;
 
+	// Table shares same characteristics of inline-block (collapsing width to
+	// minimum of child content) while supporting negative margins.
+	display: table;
+
 	// Position the contextual toolbar above the block, add 1px to each to stack borders
 	margin-top: -$block-toolbar-height - 1px;
 	margin-bottom: $block-padding + 1px;

--- a/editor/components/block-toolbar/style.scss
+++ b/editor/components/block-toolbar/style.scss
@@ -1,5 +1,5 @@
 .editor-block-toolbar {
-	display: inline-flex;
+	display: flex;
 	overflow: auto; // allow horizontal scrolling on mobile
 	flex-grow: 1;
 	width: 100%;


### PR DESCRIPTION
__Edit:__ This pull request has been updated to not include any changes to clickable area for a block, since it's expected this would conflict with upcoming changes to introduce drag-and-drop (#4115). Instead, this only includes the changes noted for toolbar effective width:

>Further, improvements have been made to not consider the area to the right of toolbar actions as part of the toolbar, so it is possible to select a preceding block even when a contextual toolbar is visible.

-----

_Original Text:_

This pull request seeks to improve block deselection behavior when clicking "outside" of a block. The issue is that because the block container encompasses more than just the visible editable area of a block, while the user might often think they're clicking outside the block, they're merely clicking on its container.

Visualization:

![image](https://user-images.githubusercontent.com/1779930/36485896-41ca1020-16eb-11e8-915e-0b4c9dd5fa90.png)

Clicking within the green highlighted regions would previously not deselect a block.

The solution proposed here is one I've been reluctant to introduce, largely because I believed `*` CSS selectors were non-performant ([related](https://cssguidelin.es/#selector-performance)). Based on some relevant readings ([[1]](http://www.stevesouders.com/blog/2009/03/10/performance-impact-of-css-selectors/), [[2]](https://www.telerik.com/blogs/css-tip-star-selector-not-that-bad), [[3]](https://stackoverflow.com/questions/2951997/what-is-the-performance-impact-of-the-universal-selector)), I'm led to believe these concerns are overstated and, all the same, the user impact cost/benefit is more largely in favor of optimizing selection behaviors.

Further, improvements have been made to not consider the area to the right of toolbar actions as part of the toolbar, so it is possible to select a preceding block even when a contextual toolbar is visible.

__Testing instructions:__

Verify that it's easy to deselect a block, and that there are no regressions in using controls of a block.