### PR TITLE
Made each taxonomy appear on its own panel.

### DIFF
--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -63,7 +63,7 @@
 }
 .components-panel__body.is-opened > .components-panel__body-title {
 	margin: -1 * $panel-padding;
-	margin-bottom: 0;
+	margin-bottom: 5px;
 }
 
 .components-panel__body-toggle.components-button {
@@ -131,7 +131,8 @@
 		max-width: 75%;
 	}
 
-	&:empty {
+	&:empty,
+	&:first-of-type {
 		margin-top: 0;
 	}
 }

--- a/edit-post/components/sidebar/block-inspector-panel/style.scss
+++ b/edit-post/components/sidebar/block-inspector-panel/style.scss
@@ -6,10 +6,6 @@
 		margin: 0 0 1em 0;
 	}
 
-	&.is-opened > .components-panel__body-title {
-		margin-bottom: 5px;
-	}
-
 	.components-panel__body-toggle {
 		color: $dark-gray-500;
 	}

--- a/edit-post/components/sidebar/post-taxonomies/index.js
+++ b/edit-post/components/sidebar/post-taxonomies/index.js
@@ -6,8 +6,6 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
 import { PostTaxonomies as PostTaxonomiesForm, PostTaxonomiesCheck } from '@wordpress/editor';
 
 /**
@@ -15,22 +13,25 @@ import { PostTaxonomies as PostTaxonomiesForm, PostTaxonomiesCheck } from '@word
  */
 import { isEditorSidebarPanelOpened } from '../../../store/selectors';
 import { toggleGeneralSidebarEditorPanel } from '../../../store/actions';
+import TaxonomyPanel from './taxonomy-panel';
 
 /**
  * Module Constants
  */
 const PANEL_NAME = 'post-taxonomies';
 
-function PostTaxonomies( { isOpened, onTogglePanel } ) {
+function PostTaxonomies() {
 	return (
 		<PostTaxonomiesCheck>
-			<PanelBody
-				title={ __( 'Categories & Tags' ) }
-				opened={ isOpened }
-				onToggle={ onTogglePanel }
-			>
-				<PostTaxonomiesForm />
-			</PanelBody>
+			<PostTaxonomiesForm
+				taxonomyWrapper={ ( content, taxonomy ) => {
+					return (
+						<TaxonomyPanel taxonomy={ taxonomy }>
+							{ content }
+						</TaxonomyPanel>
+					);
+				} }
+			/>
 		</PostTaxonomiesCheck>
 	);
 }

--- a/edit-post/components/sidebar/post-taxonomies/taxonomy-panel.js
+++ b/edit-post/components/sidebar/post-taxonomies/taxonomy-panel.js
@@ -1,0 +1,46 @@
+/**
+ * External Dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/element';
+import { PanelBody } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+
+function TaxonomyPanel( { taxonomy, isOpened, onTogglePanel, children } ) {
+	const taxonomyMenuName = get( taxonomy, [ 'labels', 'menu_name' ] );
+	if ( ! taxonomyMenuName ) {
+		return null;
+	}
+	return (
+		<PanelBody
+			title={ taxonomyMenuName }
+			opened={ isOpened }
+			onToggle={ onTogglePanel }
+		>
+			{ children }
+		</PanelBody>
+	);
+}
+
+export default compose(
+	withSelect( ( select, ownProps ) => {
+		const slug = get( ownProps.taxonomy, [ 'slug' ] );
+		const panelName = slug ? `taxonomy-panel-${ slug }` : '';
+		return {
+			panelName,
+			isOpened: slug ?
+				select( 'core/edit-post' ).isEditorSidebarPanelOpened( panelName ) :
+				false,
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => ( {
+		onTogglePanel: () => {
+			dispatch( 'core/edit-post' ).
+				toggleGeneralSidebarEditorPanel( ownProps.panelName );
+		},
+	} ) ),
+)( TaxonomyPanel );

--- a/editor/components/post-taxonomies/flat-term-selector.js
+++ b/editor/components/post-taxonomies/flat-term-selector.js
@@ -160,7 +160,7 @@ class FlatTermSelector extends Component {
 	}
 
 	render() {
-		const { label, slug, taxonomy } = this.props;
+		const { slug, taxonomy } = this.props;
 		const { loading, availableTerms, selectedTerms } = this.state;
 		const termNames = availableTerms.map( ( term ) => term.name );
 		const newTermPlaceholderLabel = get(
@@ -178,24 +178,21 @@ class FlatTermSelector extends Component {
 		const removeTermLabel = sprintf( _x( 'Remove %s: %%s', 'term' ), singularName );
 
 		return (
-			<div className="editor-post-taxonomies__flat-terms-selector">
-				<h3 className="editor-post-taxonomies__flat-terms-selector-title">{ label }</h3>
-				<FormTokenField
-					value={ selectedTerms }
-					displayTransform={ unescapeString }
-					suggestions={ termNames }
-					onChange={ this.onChange }
-					onInputChange={ this.searchTerms }
-					maxSuggestions={ MAX_TERMS_SUGGESTIONS }
-					disabled={ loading }
-					placeholder={ newTermPlaceholderLabel }
-					messages={ {
-						added: termAddedLabel,
-						removed: termRemovedLabel,
-						remove: removeTermLabel,
-					} }
-				/>
-			</div>
+			<FormTokenField
+				value={ selectedTerms }
+				displayTransform={ unescapeString }
+				suggestions={ termNames }
+				onChange={ this.onChange }
+				onInputChange={ this.searchTerms }
+				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
+				disabled={ loading }
+				placeholder={ newTermPlaceholderLabel }
+				messages={ {
+					added: termAddedLabel,
+					removed: termRemovedLabel,
+					remove: removeTermLabel,
+				} }
+			/>
 		);
 	}
 }

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -221,7 +221,7 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	render() {
-		const { label, slug, taxonomy, instanceId } = this.props;
+		const { slug, taxonomy, instanceId } = this.props;
 		const { availableTermsTree, availableTerms, formName, formParent, loading, showForm } = this.state;
 		const labelWithFallback = ( labelProperty, fallbackIsCategory, fallbackIsNotCategory ) => get(
 			taxonomy,
@@ -248,54 +248,52 @@ class HierarchicalTermSelector extends Component {
 		const inputId = `editor-post-taxonomies__hierarchical-terms-input-${ instanceId }`;
 
 		/* eslint-disable jsx-a11y/no-onchange */
-		return (
-			<div className="editor-post-taxonomies__hierarchical-terms-selector">
-				<h3 className="editor-post-taxonomies__hierarchical-terms-selector-title">{ label }</h3>
-				{ this.renderTerms( availableTermsTree ) }
-				{ ! loading &&
-					<button
-						onClick={ this.onToggleForm }
-						className="button-link editor-post-taxonomies__hierarchical-terms-add"
-						aria-expanded={ showForm }
+		return [
+			...this.renderTerms( availableTermsTree ),
+			! loading && (
+				<button
+					key="term-add-button"
+					onClick={ this.onToggleForm }
+					className="button-link editor-post-taxonomies__hierarchical-terms-add"
+					aria-expanded={ showForm }
+				>
+					{ newTermButtonLabel }
+				</button>
+			),
+			showForm && (
+				<form onSubmit={ this.onAddTerm } key="hierarchical-terms-form">
+					<label
+						htmlFor={ inputId }
+						className="editor-post-taxonomies__hierarchical-terms-label"
 					>
-						{ newTermButtonLabel }
-					</button>
-				}
-				{ showForm &&
-					<form onSubmit={ this.onAddTerm }>
-						<label
-							htmlFor={ inputId }
-							className="editor-post-taxonomies__hierarchical-terms-label"
-						>
-							{ newTermLabel }
-						</label>
-						<input
-							type="text"
-							id={ inputId }
-							className="editor-post-taxonomies__hierarchical-terms-input"
-							value={ formName }
-							onChange={ this.onChangeFormName }
-							required
+						{ newTermLabel }
+					</label>
+					<input
+						type="text"
+						id={ inputId }
+						className="editor-post-taxonomies__hierarchical-terms-input"
+						value={ formName }
+						onChange={ this.onChangeFormName }
+						required
+					/>
+					{ !! availableTerms.length &&
+						<TreeSelect
+							label={ parentSelectLabel }
+							noOptionLabel={ noParentOption }
+							onChange={ this.onChangeFormParent }
+							selectedId={ formParent }
+							tree={ availableTermsTree }
 						/>
-						{ !! availableTerms.length &&
-							<TreeSelect
-								label={ parentSelectLabel }
-								noOptionLabel={ noParentOption }
-								onChange={ this.onChangeFormParent }
-								selectedId={ formParent }
-								tree={ availableTermsTree }
-							/>
-						}
-						<button
-							type="submit"
-							className="button editor-post-taxonomies__hierarchical-terms-submit"
-						>
-							{ newTermSubmitLabel }
-						</button>
-					</form>
-				}
-			</div>
-		);
+					}
+					<button
+						type="submit"
+						className="button editor-post-taxonomies__hierarchical-terms-submit"
+					>
+						{ newTermSubmitLabel }
+					</button>
+				</form>
+			),
+		];
 		/* eslint-enable jsx-a11y/no-onchange */
 	}
 }

--- a/editor/components/post-taxonomies/index.js
+++ b/editor/components/post-taxonomies/index.js
@@ -2,13 +2,13 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import { filter, includes } from 'lodash';
+import { filter, identity, includes } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withAPIData } from '@wordpress/components';
-import { compose } from '@wordpress/element';
+import { compose, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,24 +18,24 @@ import HierarchicalTermSelector from './hierarchical-term-selector';
 import FlatTermSelector from './flat-term-selector';
 import { getCurrentPostType } from '../../store/selectors';
 
-export function PostTaxonomies( { postType, taxonomies } ) {
+export function PostTaxonomies( { postType, taxonomies, taxonomyWrapper = identity } ) {
 	const availableTaxonomies = filter( taxonomies.data, ( taxonomy ) => includes( taxonomy.types, postType ) );
-
-	return (
-		<div>
-			{ availableTaxonomies.map( ( taxonomy ) => {
-				const TaxonomyComponent = taxonomy.hierarchical ? HierarchicalTermSelector : FlatTermSelector;
-				return (
-					<TaxonomyComponent
-						key={ taxonomy.slug }
-						label={ taxonomy.name }
-						restBase={ taxonomy.rest_base }
-						slug={ taxonomy.slug }
-					/>
-				);
-			} ) }
-		</div>
-	);
+	return availableTaxonomies.map( ( taxonomy ) => {
+		const TaxonomyComponent = taxonomy.hierarchical ? HierarchicalTermSelector : FlatTermSelector;
+		return (
+			<Fragment key={ `taxonomy-${ taxonomy.slug }` }>
+				{
+					taxonomyWrapper(
+						<TaxonomyComponent
+							restBase={ taxonomy.rest_base }
+							slug={ taxonomy.slug }
+						/>,
+						taxonomy
+					)
+				}
+			</Fragment>
+		);
+	} );
 }
 
 const applyConnect = connect(

--- a/editor/components/post-taxonomies/style.scss
+++ b/editor/components/post-taxonomies/style.scss
@@ -1,14 +1,3 @@
-.editor-post-taxonomies__flat-terms-selector,
-.editor-post-taxonomies__hierarchical-terms-selector {
-	margin-top: $panel-padding;
-}
-
-.editor-sidebar .editor-post-taxonomies__flat-terms-selector-title,
-.editor-sidebar .editor-post-taxonomies__hierarchical-terms-selector-title {
-	display: block;
-	margin-bottom: 10px;
-}
-
 .editor-post-taxonomies__hierarchical-terms-choice {
 	margin-bottom: 5px;
 }

--- a/editor/components/post-taxonomies/test/index.js
+++ b/editor/components/post-taxonomies/test/index.js
@@ -16,38 +16,50 @@ describe( 'PostTaxonomies', () => {
 			<PostTaxonomies postType="page" taxonomies={ taxonomies } />
 		);
 
-		expect( wrapper.children() ).toHaveLength( 0 );
+		expect( wrapper.at( 0 ) ).toHaveLength( 0 );
 	} );
 
 	it( 'should render taxonomy components for taxonomies assigned to post type', () => {
-		const taxonomies = {
-			data: [
-				{
-					name: 'Categories',
-					slug: 'category',
-					types: [ 'post', 'page' ],
-					hierarchical: true,
-					rest_base: 'categories',
-				},
-				{
-					name: 'Genres',
-					slug: 'genre',
-					types: [ 'book' ],
-					hierarchical: true,
-					rest_base: 'genres',
-				},
-			],
+		const genresTaxonomy = {
+			name: 'Genres',
+			slug: 'genre',
+			types: [ 'book' ],
+			hierarchical: true,
+			rest_base: 'genres',
 		};
 
-		const wrapper = shallow(
-			<PostTaxonomies postType="page" taxonomies={ taxonomies } />
+		const categoriesTaxonomy = {
+			name: 'Categories',
+			slug: 'category',
+			types: [ 'post', 'page' ],
+			hierarchical: true,
+			rest_base: 'categories',
+		};
+
+		const wrapperOne = shallow(
+			<PostTaxonomies postType="book"
+				taxonomies={ {
+					data: [ genresTaxonomy, categoriesTaxonomy ],
+				} }
+			/>
 		);
 
-		expect( wrapper.children() ).toHaveLength( 1 );
-		expect( wrapper.childAt( 0 ).props() ).toEqual( {
-			label: 'Categories',
-			slug: 'category',
-			restBase: 'categories',
-		} );
+		expect( wrapperOne.at( 0 ) ).toHaveLength( 1 );
+
+		const wrapperTwo = shallow(
+			<PostTaxonomies postType="book"
+				taxonomies={ {
+					data: [
+						genresTaxonomy,
+						{
+							...categoriesTaxonomy,
+							types: [ 'post', 'page', 'book' ],
+						},
+					],
+				} }
+			/>
+		);
+
+		expect( wrapperTwo.at( 0 ) ).toHaveLength( 2 );
 	} );
 } );


### PR DESCRIPTION
This PR promotes each taxonomy to be a top-level panel (equal to the classic editor).

Closes: https://github.com/WordPress/gutenberg/issues/4599

## How Has This Been Tested?
Open post editor, verify now we don't have panel named "Categories & Tags" but a panel for categories and another one for tabs. Open and close the panels and verify things work as expected.
Change the categories & tags and check the functionality was not affected.
Add a custom taxonomy e.g: Type of Project, verify the taxonomy is rendered with the correct labels and works as expected.


## Screenshots (jpeg or gifs if applicable):
<img width="258" alt="screen shot 2018-02-21 at 18 48 34" src="https://user-images.githubusercontent.com/11271197/36499023-f6821e4e-1737-11e8-84a1-1ecc88318a99.png">

