### PR TITLE
Classic block: Make <!--more--> visible

### DIFF
--- a/blocks/library/freeform/editor.scss
+++ b/blocks/library/freeform/editor.scss
@@ -104,6 +104,16 @@
 		margin-left: auto;
 		margin-right: auto;
 	}
+
+	.wp-more-tag {
+		width: 96%;
+		height: 0;
+		display: block;
+		margin: 15px auto;
+		outline: 0;
+		cursor: default;
+		border: 2px dashed rgb( 186, 186, 186 );
+	}
 }
 
 // freeform toolbar


### PR DESCRIPTION
## Description
Fixes #4958 

Adds a visual reminiscent of that found in the classic editor, but doesn't resort to an actual image for the dashed effect. Furthermore, that [classic image](https://github.com/WordPress/WordPress/blob/master/wp-includes/js/tinymce/skins/wordpress/images/more-2x.png) contained an English-only string ("read more"), whereas this change contains no strings.

## How Has This Been Tested?
1. Open the classic editor, start a new post
2. Paste the text that follows these instructions
3. Save the draft
4. Open in Gutenberg

```
Lorem ipsum dolor sit amet, ferri vidisse nam eu, ad nec copiosae mnesarchum vituperatoribus. Te brute dicunt sea, ut vis omnium menandri, ut sumo aliquam has. Eum aperiam interpretaris at, sea et recusabo expetenda, omnis tibique mea no. Pri suas partem ea, ius sonet numquam offendit cu, ad simul admodum pri. Eum cu unum choro albucius.

<!--more-->

Prima ridens denique his te, ferri illum volumus an his. Eu vel dicat homero qualisque, vitae regione deserunt vis ei. Graeci incorrupte liberavisse no mea, saepe voluptaria usu ex, vis dicant euismod id. At dolor reprimique eos, quo altera detraxit moderatius id. Quo iudico utinam eu, ad alia munere mel.
```

## Screenshots (jpeg or gifs if applicable):
<img width="648" alt="screen shot 2018-02-22 at 00 36 32" src="https://user-images.githubusercontent.com/150562/36513742-01cc8cea-1769-11e8-9b10-37b6671d898f.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
