### PR TITLE
State: Cascade inner blocks removal

### DIFF
--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -557,6 +557,29 @@ describe( 'state', () => {
 			} );
 		} );
 
+		it( 'should cascade remove to include inner blocks', () => {
+			const block = createBlock( 'core/test-block', {}, [
+				createBlock( 'core/test-block', {}, [
+					createBlock( 'core/test-block' ),
+				] ),
+			] );
+
+			const original = editor( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [ block ],
+			} );
+
+			const state = editor( original, {
+				type: 'REMOVE_BLOCKS',
+				uids: [ block.uid ],
+			} );
+
+			expect( state.present.blocksByUid ).toEqual( {} );
+			expect( state.present.blockOrder ).toEqual( {
+				'': [],
+			} );
+		} );
+
 		it( 'should insert at the specified index', () => {
 			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',


### PR DESCRIPTION
This pull request seeks to resolve an issue where removing a block which had contained inner blocks would not clear those inner blocks from state, thereby causing them to linger in perpetuity as zombie blocks.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```

Verify that there are no regressions in removing blocks, those with nesting or otherwise.

Extra Credit: Confirm via [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en) that adding a Columns block with an inner paragraph block, then removing said Columns block, will result in an initial `state.editor`.