### PR TITLE
State: Refactor reducer enhancers as higher-order reducer creators

### DIFF
--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -5,7 +5,6 @@ import optimist from 'redux-optimist';
 import { combineReducers } from 'redux';
 import {
 	flow,
-	partialRight,
 	reduce,
 	first,
 	last,
@@ -142,14 +141,16 @@ export const editor = flow( [
 	combineReducers,
 
 	// Track undo history, starting at editor initialization.
-	partialRight( withHistory, {
+	withHistory( {
 		resetTypes: [ 'SETUP_EDITOR_STATE' ],
 		shouldOverwriteState,
 	} ),
 
 	// Track whether changes exist, resetting at each post save. Relies on
 	// editor initialization firing post reset as an effect.
-	partialRight( withChangeDetection, { resetTypes: [ 'SETUP_EDITOR_STATE', 'RESET_POST' ] } ),
+	withChangeDetection( {
+		resetTypes: [ 'SETUP_EDITOR_STATE', 'RESET_POST' ],
+	} ),
 ] )( {
 	edits( state = {}, action ) {
 		switch ( action.type ) {

--- a/editor/utils/with-change-detection/index.js
+++ b/editor/utils/with-change-detection/index.js
@@ -4,17 +4,16 @@
 import { includes } from 'lodash';
 
 /**
- * Reducer enhancer for tracking changes to reducer state over time. The
- * returned reducer will include a new `isDirty` property on the object
- * reflecting whether the original reference of the reducer has changed.
+ * Higher-order reducer creator for tracking changes to state over time. The
+ * returned reducer will include a `isDirty` property on the object reflecting
+ * whether the original reference of the reducer has changed.
  *
- * @param {Function} reducer            Original reducer.
- * @param {?Object}  options            Optional .
- * @param {?Array}   options.resetTypes Action types upon which to reset dirty.
+ * @param {?Object} options            Optional options.
+ * @param {?Array}  options.resetTypes Action types upon which to reset dirty.
  *
- * @return {Function} Enhanced reducer.
+ * @return {Function} Higher-order reducer.
  */
-export default function withChangeDetection( reducer, options = {} ) {
+const withChangeDetection = ( options = {} ) => ( reducer ) => {
 	return ( state, action ) => {
 		const nextState = reducer( state, action );
 
@@ -41,4 +40,6 @@ export default function withChangeDetection( reducer, options = {} ) {
 
 		return nextState;
 	};
-}
+};
+
+export default withChangeDetection;

--- a/editor/utils/with-change-detection/test/index.js
+++ b/editor/utils/with-change-detection/test/index.js
@@ -24,7 +24,7 @@ describe( 'withChangeDetection()', () => {
 	}
 
 	it( 'should respect original reducer behavior', () => {
-		const reducer = withChangeDetection( originalReducer );
+		const reducer = withChangeDetection()( originalReducer );
 
 		const state = reducer( undefined, {} );
 		expect( state ).toEqual( { count: 0, isDirty: false } );
@@ -35,7 +35,7 @@ describe( 'withChangeDetection()', () => {
 	} );
 
 	it( 'should allow reset types as option', () => {
-		const reducer = withChangeDetection( originalReducer, { resetTypes: [ 'RESET' ] } );
+		const reducer = withChangeDetection( { resetTypes: [ 'RESET' ] } )( originalReducer );
 
 		let state;
 
@@ -50,7 +50,7 @@ describe( 'withChangeDetection()', () => {
 	} );
 
 	it( 'should preserve isDirty into non-resetting non-reference-changing types', () => {
-		const reducer = withChangeDetection( originalReducer, { resetTypes: [ 'RESET' ] } );
+		const reducer = withChangeDetection( { resetTypes: [ 'RESET' ] } )( originalReducer );
 
 		let state;
 
@@ -65,7 +65,7 @@ describe( 'withChangeDetection()', () => {
 	} );
 
 	it( 'should maintain separate states', () => {
-		const reducer = withChangeDetection( originalReducer );
+		const reducer = withChangeDetection()( originalReducer );
 
 		let firstState;
 
@@ -80,7 +80,7 @@ describe( 'withChangeDetection()', () => {
 	} );
 
 	it( 'should flag as not dirty even if reset type causes reference change', () => {
-		const reducer = withChangeDetection( originalReducer, { resetTypes: [ 'RESET_AND_CHANGE_REFERENCE' ] } );
+		const reducer = withChangeDetection( { resetTypes: [ 'RESET_AND_CHANGE_REFERENCE' ] } )( originalReducer );
 
 		let state;
 

--- a/editor/utils/with-history/index.js
+++ b/editor/utils/with-history/index.js
@@ -4,16 +4,15 @@
 import { includes, first, last, drop, dropRight } from 'lodash';
 
 /**
- * Reducer enhancer which transforms the result of the original reducer into an
- * object tracking its own history (past, present, future).
+ * Higher-order reducer creator which transforms the result of the original
+ * reducer into an object tracking its own history (past, present, future).
  *
- * @param {Function} reducer            Original reducer.
- * @param {?Object}  options            Optional options.
- * @param {?Array}   options.resetTypes Action types upon which to clear past.
+ * @param {?Object} options            Optional options.
+ * @param {?Array}  options.resetTypes Action types upon which to clear past.
  *
- * @return {Function} Enhanced reducer.
+ * @return {Function} Higher-order reducer.
  */
-export default function withHistory( reducer, options = {} ) {
+const withHistory = ( options = {} ) => ( reducer ) => {
 	const initialState = {
 		past: [],
 		present: reducer( undefined, {} ),
@@ -93,4 +92,6 @@ export default function withHistory( reducer, options = {} ) {
 			future: [],
 		};
 	};
-}
+};
+
+export default withHistory;

--- a/editor/utils/with-history/test/index.js
+++ b/editor/utils/with-history/test/index.js
@@ -9,7 +9,7 @@ describe( 'withHistory', () => {
 	);
 
 	it( 'should return a new reducer', () => {
-		const reducer = withHistory( counter );
+		const reducer = withHistory()( counter );
 
 		expect( typeof reducer ).toBe( 'function' );
 		expect( reducer( undefined, {} ) ).toEqual( {
@@ -20,7 +20,7 @@ describe( 'withHistory', () => {
 	} );
 
 	it( 'should track history', () => {
-		const reducer = withHistory( counter );
+		const reducer = withHistory()( counter );
 
 		let state;
 		state = reducer( undefined, {} );
@@ -42,7 +42,7 @@ describe( 'withHistory', () => {
 	} );
 
 	it( 'should perform undo', () => {
-		const reducer = withHistory( counter );
+		const reducer = withHistory()( counter );
 
 		let state;
 		state = reducer( undefined, {} );
@@ -57,14 +57,14 @@ describe( 'withHistory', () => {
 	} );
 
 	it( 'should not perform undo on empty past', () => {
-		const reducer = withHistory( counter );
+		const reducer = withHistory()( counter );
 		const state = reducer( undefined, {} );
 
 		expect( state ).toBe( reducer( state, { type: 'UNDO' } ) );
 	} );
 
 	it( 'should perform redo', () => {
-		const reducer = withHistory( counter );
+		const reducer = withHistory()( counter );
 
 		let state;
 		state = reducer( undefined, {} );
@@ -80,14 +80,14 @@ describe( 'withHistory', () => {
 	} );
 
 	it( 'should not perform redo on empty future', () => {
-		const reducer = withHistory( counter );
+		const reducer = withHistory()( counter );
 		const state = reducer( undefined, {} );
 
 		expect( state ).toBe( reducer( state, { type: 'REDO' } ) );
 	} );
 
 	it( 'should reset history by options.resetTypes', () => {
-		const reducer = withHistory( counter, { resetTypes: [ 'RESET_HISTORY' ] } );
+		const reducer = withHistory( { resetTypes: [ 'RESET_HISTORY' ] } )( counter );
 
 		let state;
 		state = reducer( undefined, {} );
@@ -102,7 +102,7 @@ describe( 'withHistory', () => {
 	} );
 
 	it( 'should return same reference if state has not changed', () => {
-		const reducer = withHistory( counter );
+		const reducer = withHistory()( counter );
 		const original = reducer( undefined, {} );
 		const state = reducer( original, {} );
 
@@ -110,9 +110,9 @@ describe( 'withHistory', () => {
 	} );
 
 	it( 'should overwrite present state with option.shouldOverwriteState', () => {
-		const reducer = withHistory( counter, {
+		const reducer = withHistory( {
 			shouldOverwriteState: ( { type } ) => type === 'INCREMENT',
-		} );
+		} )( counter );
 
 		let state;
 		state = reducer( undefined, {} );
@@ -134,9 +134,9 @@ describe( 'withHistory', () => {
 	} );
 
 	it( 'should create undo level with option.shouldOverwriteState and CREATE_UNDO_LEVEL', () => {
-		const reducer = withHistory( counter, {
+		const reducer = withHistory( {
 			shouldOverwriteState: ( { type } ) => type === 'INCREMENT',
-		} );
+		} )( counter );
 
 		let state;
 		state = reducer( undefined, {} );


### PR DESCRIPTION
This pull request seeks to refactor our custom "reducer enhancers" `withHistory` and `withChangeDetection` to a more conventional higher-order reducer pattern to avoid dependence on the awkward partial application via [`partialRight`](https://lodash.com/docs/4.17.5#partialRight).

__Testing instructions:__

Verify that unit tests pass:

```
npm run test-unit
```