### PR TITLE
Inserter: Try showing a "line" between two blocks on hover to insert a new empty block

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -20,7 +20,7 @@ $z-layers: (
 	'.editor-block-contextual-toolbar': 21,
 	'.editor-block-switcher__menu': 2,
 	'.components-popover__close': 2,
-	'.editor-block-list__block > .editor-block-list__insertion-point':2,
+	'.editor-block-list__block > .editor-block-list__insertion-point': 2,
 	'.blocks-format-toolbar__link-modal': 3,
 	'.editor-block-mover': 1,
 	'.blocks-gallery-item__inline-menu': 20,

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -17,11 +17,11 @@ $z-layers: (
 	'.components-panel__header': 1,
 	'.edit-post-meta-boxes-area.is-loading:before': 1,
 	'.edit-post-meta-boxes-area .spinner': 2,
-	'.blocks-format-toolbar__link-modal': 2,
 	'.editor-block-contextual-toolbar': 21,
 	'.editor-block-switcher__menu': 2,
 	'.components-popover__close': 2,
 	'.editor-block-list__block > .editor-block-list__insertion-point':2,
+	'.blocks-format-toolbar__link-modal': 3,
 	'.editor-block-mover': 1,
 	'.blocks-gallery-item__inline-menu': 20,
 	'.editor-block-settings-menu__popover': 20, // Below the header

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -20,7 +20,7 @@ $z-layers: (
 	'.editor-block-contextual-toolbar': 21,
 	'.editor-block-switcher__menu': 2,
 	'.components-popover__close': 2,
-	'.editor-block-list__block > .editor-block-list__insertion-point': 2,
+	'.editor-block-list__insertion-point': 2,
 	'.blocks-format-toolbar__link-modal': 3,
 	'.editor-block-mover': 1,
 	'.blocks-gallery-item__inline-menu': 20,

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -21,6 +21,7 @@ $z-layers: (
 	'.editor-block-contextual-toolbar': 21,
 	'.editor-block-switcher__menu': 2,
 	'.components-popover__close': 2,
+	'.editor-block-list__block > .editor-block-list__insertion-point':2,
 	'.editor-block-mover': 1,
 	'.blocks-gallery-item__inline-menu': 20,
 	'.editor-block-settings-menu__popover': 20, // Below the header

--- a/edit-post/components/modes/visual-editor/style.scss
+++ b/edit-post/components/modes/visual-editor/style.scss
@@ -88,3 +88,7 @@
 		}
 	}
 }
+
+.edit-post-visual-editor .editor-block-list__layout > .editor-block-list__insertion-point {
+	max-width: $visual-editor-max-width + ( 2 * $block-mover-padding-visible );
+}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -545,7 +545,11 @@ export class BlockListBlock extends Component {
 		// Insertion point can only be made visible when the side inserter is
 		// not present, and either the block is at the extent of a selection or
 		// is the last block in the top-level list rendering.
-		const shouldShowInsertionPoint = ! showSideInserter && ( isLastInSelection || ( isLast && ! rootUID ) );
+		const shouldShowInsertionPoint = (
+			( ! isMultiSelected && ! isLast ) ||
+			( isMultiSelected && isLastInSelection ) ||
+			( isLast && ! rootUID )
+		);
 
 		// Generate the wrapper class names handling the different states of the block.
 		const wrapperClassName = classnames( 'editor-block-list__block', {

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -548,7 +548,7 @@ export class BlockListBlock extends Component {
 		const shouldShowInsertionPoint = (
 			( ! isMultiSelected && ! isLast ) ||
 			( isMultiSelected && isLastInSelection ) ||
-			( isLast && ! rootUID )
+			( isLast && ! rootUID && ! isEmptyDefaultBlock )
 		);
 
 		// Generate the wrapper class names handling the different states of the block.

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -17,7 +17,6 @@ import {
 	getBlockIndex,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
-	getBlockCount,
 	getBlock,
 	isTyping,
 } from '../../store/selectors';
@@ -58,7 +57,7 @@ class BlockInsertionPoint extends Component {
 export default connect(
 	( state, { uid, rootUID } ) => {
 		const blockIndex = uid ? getBlockIndex( state, uid, rootUID ) : -1;
-		const insertIndex = blockIndex > -1 ? blockIndex + 1 : getBlockCount( state );
+		const insertIndex = blockIndex + 1;
 		const insertionPoint = getBlockInsertionPoint( state );
 		const block = uid ? getBlock( state, uid ) : null;
 

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -36,7 +36,6 @@ function BlockInsertionPoint( { showInsertionPoint, showInserter, index, layout,
 			{ showInsertionPoint && <div className="editor-block-list__insertion-point-indicator" /> }
 			{ showInserter && (
 				<button
-					tabIndex="-1"
 					className="editor-block-list__insertion-point-inserter"
 					onClick={ onClick }
 					aria-label={ __( 'Insert block' ) }

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
  */
 import { __ } from '@wordpress/i18n';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,24 +26,33 @@ import {
 	startTyping,
 } from '../../store/actions';
 
-function BlockInsertionPoint( { showInsertionPoint, showInserter, index, layout, rootUID, ...props } ) {
-	const onClick = () => {
+class BlockInsertionPoint extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onClick = this.onClick.bind( this );
+	}
+	onClick() {
+		const { layout, rootUID, index, ...props } = this.props;
 		props.insertDefaultBlock( { layout }, rootUID, index );
 		props.startTyping();
-	};
+	}
 
-	return (
-		<div className="editor-block-list__insertion-point">
-			{ showInsertionPoint && <div className="editor-block-list__insertion-point-indicator" /> }
-			{ showInserter && (
-				<button
-					className="editor-block-list__insertion-point-inserter"
-					onClick={ onClick }
-					aria-label={ __( 'Insert block' ) }
-				/>
-			) }
-		</div>
-	);
+	render() {
+		const { showInsertionPoint, showInserter } = this.props;
+
+		return (
+			<div className="editor-block-list__insertion-point">
+				{ showInsertionPoint && <div className="editor-block-list__insertion-point-indicator" /> }
+				{ showInserter && (
+					<button
+						className="editor-block-list__insertion-point-inserter"
+						onClick={ this.onClick }
+						aria-label={ __( 'Insert block' ) }
+					/>
+				) }
+			</div>
+		);
+	}
 }
 
 export default connect(

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -24,6 +24,7 @@ import { Component } from '@wordpress/element';
  */
 import './style.scss';
 import BlockListBlock from './block';
+import BlockInsertionPoint from './insertion-point';
 import BlockSelectionClearer from '../block-selection-clearer';
 import DefaultBlockAppender from '../default-block-appender';
 import {
@@ -215,6 +216,7 @@ class BlockListLayout extends Component {
 
 		return (
 			<BlockSelectionClearer className={ classes }>
+				{ !! blockUIDs.length && <BlockInsertionPoint /> }
 				{ map( blockUIDs, ( uid, blockIndex ) => (
 					<BlockListBlock
 						key={ 'block-' + uid }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -371,24 +371,51 @@
 
 .editor-block-list__insertion-point {
 	position: relative;
+}
+
+.editor-block-list__insertion-point-indicator {
+	position: absolute;
+	top: 9px;
+	height: 2px;
+	left: 0;
+	right: 0;
+	background: $blue-medium-500;
+}
+
+.editor-block-list__insertion-point-inserter {
+	background: none;
+	border: none;
+	display: block;
+	width: 100%;
+	height: 100%;
+	cursor: pointer;
 
 	&:before {
 		position: absolute;
-		top: -1px;
+		top: 9px;
 		height: 2px;
 		left: 0;
 		right: 0;
-		background: $blue-medium-500;
+		background: $dark-gray-100;
 		content: '';
+		opacity: 0;
+		transition: opacity 0.1s linear 0.1s;
+	}
+
+	&:hover:before {
+		opacity: 1;
+		transition: opacity 0.8s linear 0.5s;
 	}
 }
 
 .editor-block-list__block > .editor-block-list__insertion-point {
 	position: absolute;
 	bottom: -10px;
+	height: 20px;
 	top: auto;
 	left: 0;
 	right: 0;
+	z-index: z-index( '.editor-block-list__block > .editor-block-list__insertion-point' );
 
 	@include break-small {
 		left: $block-mover-padding-visible;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -371,6 +371,7 @@
 
 .editor-block-list__insertion-point {
 	position: relative;
+	z-index: z-index( '.editor-block-list__insertion-point' );
 }
 
 .editor-block-list__insertion-point-indicator {
@@ -383,11 +384,13 @@
 }
 
 .editor-block-list__insertion-point-inserter {
+	position: absolute;
 	background: none;
 	border: none;
 	display: block;
+	top: 0;
+	height: 34px; // Matches the whole empty space between two blocks
 	width: 100%;
-	height: 100%;
 	cursor: pointer;
 
 	&:before {
@@ -420,7 +423,21 @@
 	top: auto;
 	left: 0;
 	right: 0;
-	z-index: z-index( '.editor-block-list__block > .editor-block-list__insertion-point' );
+
+	@include break-small {
+		left: $block-mover-padding-visible;
+		right: $block-mover-padding-visible;
+	}
+}
+
+.editor-block-list__layout > .editor-block-list__insertion-point {
+	position: relative;
+	margin-top: -15px;
+	margin-left: auto;
+	margin-right: auto;
+	top: -19px;
+	left: 0;
+	right: 0;
 
 	@include break-small {
 		left: $block-mover-padding-visible;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -406,6 +406,11 @@
 		opacity: 1;
 		transition: opacity 0.2s linear 0.5s;
 	}
+
+	&:focus:before {
+		opacity: 1;
+		transition: opacity 0.2s linear;
+	}
 }
 
 .editor-block-list__block > .editor-block-list__insertion-point {

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -404,7 +404,7 @@
 
 	&:hover:before {
 		opacity: 1;
-		transition: opacity 0.8s linear 0.5s;
+		transition: opacity 0.2s linear 0.5s;
 	}
 }
 

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -375,7 +375,7 @@
 
 .editor-block-list__insertion-point-indicator {
 	position: absolute;
-	top: 9px;
+	top: 16px;
 	height: 2px;
 	left: 0;
 	right: 0;
@@ -392,10 +392,10 @@
 
 	&:before {
 		position: absolute;
-		top: 9px;
+		top: 16px;
 		height: 2px;
-		left: 0;
-		right: 0;
+		left: $block-padding;
+		right: $block-padding;
 		background: $dark-gray-100;
 		content: '';
 		opacity: 0;
@@ -410,8 +410,8 @@
 
 .editor-block-list__block > .editor-block-list__insertion-point {
 	position: absolute;
-	bottom: -10px;
-	height: 20px;
+	bottom: -19px;
+	height: 34px; // Matches the whole empty space between two blocks
 	top: auto;
 	left: 0;
 	right: 0;

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -16,7 +16,7 @@ import { withContext } from '@wordpress/components';
  */
 import './style.scss';
 import BlockDropZone from '../block-drop-zone';
-import { appendDefaultBlock, startTyping } from '../../store/actions';
+import { insertDefaultBlock, startTyping } from '../../store/actions';
 import { getBlock, getBlockCount } from '../../store/selectors';
 
 export function DefaultBlockAppender( { isLocked, isVisible, onAppend, showPrompt } ) {
@@ -60,7 +60,7 @@ export default compose(
 					attributes = { layout };
 				}
 
-				dispatch( appendDefaultBlock( attributes, rootUID ) );
+				dispatch( insertDefaultBlock( attributes, rootUID ) );
 				dispatch( startTyping() );
 			},
 		} )

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -32,7 +32,7 @@ import {
 } from '../../store/selectors';
 import {
 	multiSelect,
-	appendDefaultBlock,
+	insertDefaultBlock,
 	selectBlock,
 } from '../../store/actions';
 
@@ -267,7 +267,7 @@ export default connect(
 	} ),
 	{
 		onMultiSelect: multiSelect,
-		onBottomReached: appendDefaultBlock,
+		onBottomReached: insertDefaultBlock,
 		onSelectBlock: selectBlock,
 	}
 )( WritingFlow );

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -520,17 +520,19 @@ export function convertBlockToReusable( uid ) {
 }
 /**
  * Returns an action object used in signalling that a new block of the default
- * type should be appended to the block list.
+ * type should be added to the block list.
  *
  * @param {?Object} attributes Optional attributes of the block to assign.
  * @param {?string} rootUID    Optional root UID of block list to append.
+ * @param {?number} index      Optional index where to insert the default block
  *
  * @return {Object} Action object
  */
-export function appendDefaultBlock( attributes, rootUID ) {
+export function insertDefaultBlock( attributes, rootUID, index ) {
 	return {
-		type: 'APPEND_DEFAULT_BLOCK',
+		type: 'INSERT_DEFAULT_BLOCK',
 		attributes,
 		rootUID,
+		index,
 	};
 }

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -454,11 +454,11 @@ export default {
 		dispatch( saveReusableBlock( reusableBlock.id ) );
 		dispatch( replaceBlocks( [ oldBlock.uid ], [ newBlock ] ) );
 	},
-	APPEND_DEFAULT_BLOCK( action ) {
-		const { attributes, rootUID } = action;
+	INSERT_DEFAULT_BLOCK( action ) {
+		const { attributes, rootUID, index } = action;
 		const block = createBlock( getDefaultBlockName(), attributes );
 
-		return insertBlock( block, undefined, rootUID );
+		return insertBlock( block, index, rootUID );
 	},
 	CREATE_NOTICE( { notice: { content, spokenMessage } } ) {
 		const message = spokenMessage || content;


### PR DESCRIPTION
Feedback suggests that people care about the in-between blocks inserter. 
This inserter had some issues: being too distractive, some issues related to the big click area.
This PR explores an alternative showing a gray line between two blocks on hover and when you click it, you add a new empty block at that position. At that moment you'll be able to insert any other block there.

![kapture 2018-02-22 at 11 21 58](https://user-images.githubusercontent.com/272444/36533022-a6d0ea52-17c2-11e8-826a-9c206c4a7e55.gif)
