### PR TITLE
Disable post format input if the theme does not support post formats.

### DIFF
--- a/editor/components/post-format/check.js
+++ b/editor/components/post-format/check.js
@@ -1,10 +1,19 @@
 /**
+ * WordPress dependencies
+ */
+import { withContext } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
 
-function PostFormatCheck( props ) {
-	return <PostTypeSupportCheck { ...props } supportKeys="post-formats" />;
+function PostFormatCheck( { disablePostFormats, ...props } ) {
+	return ! disablePostFormats &&
+		<PostTypeSupportCheck { ...props } supportKeys="post-formats" />;
 }
 
-export default PostFormatCheck;
+export default withContext( 'editor' )(
+	( { disablePostFormats } ) => ( { disablePostFormats } )
+)( PostFormatCheck );
+

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -910,6 +910,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'availableTemplates'  => wp_get_theme()->get_page_templates( get_post( $post_to_edit['id'] ) ),
 		'blockTypes'          => $allowed_block_types,
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
+		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
 	);
 


### PR DESCRIPTION
This is the same behaviour we have currently on the classic. Showing the post format input also has another non-desirable side effect, when the theme does not support post formats, posts are created with standard post format and not the default post format setting. As the setting is not respected, leaving the input there confuses the user.

## How Has This Been Tested?
Verify that in themes that support post formats e.g:Twenty Seventeen, we have the post format input with the value equal to the default post format setting.
Verify that in themes that do not support post formats e.g: Gutenberg theme the post format input does not appear.