### PR TITLE
Fix prioritization during shortcode conversion

### DIFF
--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -7,7 +7,7 @@ import { castArray, find, get, dropRight, last, mapValues, pickBy } from 'lodash
  * Internal dependencies
  */
 import { createBlock } from '../factory';
-import { getBlockTypes } from '../registration';
+import { getBlockType, getBlockTypes } from '../registration';
 import { getBlockAttributes } from '../parser';
 
 /**
@@ -16,8 +16,12 @@ import { getBlockAttributes } from '../parser';
 const { shortcode } = window.wp;
 
 export default function( HTML ) {
+	// Move Shortcode block to beginning of block types array to ensure it processes first.
+	let blockTypes = getBlockTypes().filter( ( block ) => block.name !== 'core/shortcode' );
+	blockTypes = [ getBlockType( 'core/shortcode' ), ...blockTypes ];
+
 	// Get all matches. These are *not* ordered.
-	const matches = getBlockTypes().reduce( ( acc, blockType ) => {
+	const matches = blockTypes.reduce( ( acc, blockType ) => {
 		const transformsFrom = get( blockType, 'transforms.from', [] );
 		const transform = find( transformsFrom, ( { type } ) => type === 'shortcode' );
 

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -36,26 +36,6 @@ import * as video from './video';
 
 export const registerCoreBlocks = () => {
 	[
-		// FIXME: Temporary fix.
-		//
-		// The Shortcode block declares a catch-all shortcode transform,
-		// meaning it will attempt to intercept pastes and block conversions of
-		// any valid shortcode-like content. Other blocks (e.g. Gallery) may
-		// declare specific shortcode transforms (e.g. `[gallery]`), with which
-		// this block would conflict. Thus, the Shortcode block needs to be
-		// registered as early as possible, so that any other block types'
-		// shortcode transforms can be honoured.
-		//
-		// This isn't a proper solution, as it is at odds with the
-		// specification of shortcode conversion, in the sense that conversion
-		// is explicitly independent of block order. Thus, concurrent parse
-		// rules (i.e. a same text input can yield two different transforms,
-		// like `[gallery] -> { Gallery, Shortcode }`) are unsupported,
-		// yielding non-deterministic results. A proper solution could be to
-		// let the editor (or site owners) determine a default block handler of
-		// unknown shortcodes — see `setUnknownTypeHandlerName`.
-		shortcode,
-
 		audio,
 		button,
 		categories,
@@ -79,6 +59,7 @@ export const registerCoreBlocks = () => {
 		quote,
 		reusableBlock,
 		separator,
+		shortcode,
 		subhead,
 		table,
 		textColumns,


### PR DESCRIPTION
## Description
The Shortcode block uses a catch-all shortcode transform to convert any pasted in shortcodes. This block needs to be registered as early as possible, so that other block types that have shortcode transforms defined are processed instead.

The Shortcode block is currently defined first in the list of core blocks, but if a third party block calls `registerBlockType()` directly, it can be processed and added to the list before any of the core blocks are, preventing the third party block shortcode transform from being processed.

This pull request gets the list of block types and moves the Shortcode block to the beginning of the array before processing available shortcode transforms to ensure other blocks with defined shortcode transforms are processed instead.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.