### PR TITLE
Fix image alignment

### DIFF
--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -87,3 +87,9 @@
 		margin-right: auto;
 	}
 }
+
+.editor-block-list__block[data-type="core/image"][data-align="right"] {
+	.wp-block-image {
+		float: right;
+	}
+}

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -177,8 +177,6 @@ export const settings = {
 
 		if ( width ) {
 			figureStyle = { width };
-		} else if ( align === 'left' || align === 'right' ) {
-			figureStyle = { maxWidth: '50%' };
 		}
 
 		return (

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -1,3 +1,7 @@
+.wp-block-image {
+	width: fit-content;
+}
+
 .wp-block-image figcaption {
 	margin-top: 0.5em;
 	color: $dark-gray-300;


### PR DESCRIPTION
## Description

After #4898, there are some bugs in image alignment, because the `<figure>` element defaults to `width: 100%`, so WordPress' `align*` classes have no effect on it.

## How Has This Been Tested?

Upload an image smaller than the post width, and change its alignment. View the results on the front end.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
