### PR TITLE
Fix issue with floated block toolbar on adjecent floats

### DIFF
--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -18,7 +18,7 @@ $z-layers: (
 	'.edit-post-meta-boxes-area.is-loading:before': 1,
 	'.edit-post-meta-boxes-area .spinner': 2,
 	'.blocks-format-toolbar__link-modal': 2,
-	'.editor-block-contextual-toolbar': 2,
+	'.editor-block-contextual-toolbar': 21,
 	'.editor-block-switcher__menu': 2,
 	'.components-popover__close': 2,
 	'.editor-block-mover': 1,

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -461,6 +461,9 @@
 		border: 1px solid $light-gray-500;
 		width: 100%;
 
+		// this prevents floats from messing up the position
+		position: absolute;
+
 		// remove stacked borders in inline toolbar
 		> div:first-child {
 			margin-left: -1px;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -463,6 +463,12 @@
 
 		// this prevents floats from messing up the position
 		position: absolute;
+		left: 0;
+
+		.editor-block-list__block[data-align="right"] & {
+			left: auto;
+			right: 0;
+		}
 
 		// remove stacked borders in inline toolbar
 		> div:first-child {


### PR DESCRIPTION
Fixes #3870

When you have multiple small blocks floated left, each blocks get a more and more indented block toolbar. At some point the block toolbar will be cropped by the viewport itself.

This PR adresses that by making it always leftalign. There appear to be no side-effects, but it would be good to test.

Before:

![before](https://user-images.githubusercontent.com/1204802/36586398-ec4ada06-1881-11e8-956f-dfa2e8e7eab9.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/36586403-eed161d2-1881-11e8-94f2-e926cd6e1277.gif)
