### PR TITLE
Data: Refactor query HOC usage with withSelect

### DIFF
--- a/edit-post/components/sidebar/featured-image/index.js
+++ b/edit-post/components/sidebar/featured-image/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { PanelBody, withAPIData } from '@wordpress/components';
 import { PostFeaturedImage, PostFeaturedImageCheck } from '@wordpress/editor';
 import { compose } from '@wordpress/element';
-import { query } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ function FeaturedImage( { isOpened, postType, onTogglePanel } ) {
 	);
 }
 
-const applyQuery = query( ( select ) => ( {
+const applyWithSelect = withSelect( ( select ) => ( {
 	postTypeSlug: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
 } ) );
 
@@ -69,7 +69,7 @@ const applyWithAPIData = withAPIData( ( props ) => {
 } );
 
 export default compose(
-	applyQuery,
+	applyWithSelect,
 	applyConnect,
 	applyWithAPIData,
 )( FeaturedImage );

--- a/edit-post/components/sidebar/header.js
+++ b/edit-post/components/sidebar/header.js
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { compose } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
-import { query } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal Dependencies
@@ -47,7 +47,7 @@ const SidebarHeader = ( { panel, onSetPanel, onCloseSidebar, count } ) => {
 };
 
 export default compose(
-	query( ( select ) => ( {
+	withSelect( ( select ) => ( {
 		count: select( 'core/editor' ).getSelectedBlockCount(),
 	} ) ),
 	connect(

--- a/edit-post/components/sidebar/page-attributes/index.js
+++ b/edit-post/components/sidebar/page-attributes/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { PanelBody, PanelRow, withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { PageAttributesCheck, PageAttributesOrder, PageAttributesParent, PageTemplate } from '@wordpress/editor';
-import { query } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -45,7 +45,7 @@ export function PageAttributes( { isOpened, onTogglePanel, postType } ) {
 	);
 }
 
-const applyQuery = query( ( select ) => ( {
+const applyWithSelect = withSelect( ( select ) => ( {
 	postTypeSlug: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
 } ) );
 
@@ -72,7 +72,7 @@ const applyWithAPIData = withAPIData( ( props ) => {
 } );
 
 export default compose(
-	applyQuery,
+	applyWithSelect,
 	applyConnect,
 	applyWithAPIData,
 )( PageAttributes );

--- a/edit-post/hooks/more-menu/copy-content-menu-item/index.js
+++ b/edit-post/hooks/more-menu/copy-content-menu-item/index.js
@@ -3,7 +3,7 @@
  */
 import { ClipboardButton, withState } from '@wordpress/components';
 import { compose } from '@wordpress/element';
-import { query } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 function CopyContentMenuItem( { editedPostContent, hasCopied, setState } ) {
@@ -22,7 +22,7 @@ function CopyContentMenuItem( { editedPostContent, hasCopied, setState } ) {
 }
 
 export default compose(
-	query( ( select ) => ( {
+	withSelect( ( select ) => ( {
 		editedPostContent: select( 'core/editor' ).getEditedPostAttribute( 'content' ),
 	} ) ),
 	withState( { hasCopied: false } )

--- a/editor/components/multi-select-scroll-into-view/index.js
+++ b/editor/components/multi-select-scroll-into-view/index.js
@@ -7,7 +7,7 @@ import scrollIntoView from 'dom-scroll-into-view';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { query } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { getScrollContainer } from '@wordpress/utils';
 
 class MultiSelectScrollIntoView extends Component {
@@ -52,7 +52,7 @@ class MultiSelectScrollIntoView extends Component {
 	}
 }
 
-export default query( ( select ) => {
+export default withSelect( ( select ) => {
 	return {
 		extentUID: select( 'core/editor' ).getLastMultiSelectedBlockUid(),
 	};

--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton } from '@wordpress/components';
-import { query } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ function TableOfContents( { hasBlocks } ) {
 	);
 }
 
-export default query( ( select ) => {
+export default withSelect( ( select ) => {
 	return {
 		hasBlocks: !! select( 'core/editor' ).getBlockCount(),
 	};

--- a/editor/components/table-of-contents/panel.js
+++ b/editor/components/table-of-contents/panel.js
@@ -8,7 +8,7 @@ import { countBy } from 'lodash';
  */
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { query } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -58,7 +58,7 @@ function TableOfContentsPanel( { blocks } ) {
 	);
 }
 
-export default query( ( select ) => {
+export default withSelect( ( select ) => {
 	return {
 		blocks: select( 'core/editor' ).getBlocks(),
 	};


### PR DESCRIPTION
## Description

There are a few deprecations warnings on the JS console coming from `query` HOC. This PR refactors all code occurrences to use new `withSelect` HOC. 


## How Has This Been Tested?
Make sure there are no warnings on the JS console and there are no regressions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
