### PR TITLE
Edit Post: Refactor class names in More Menu component

### DIFF
--- a/components/menu-items/menu-items-group.js
+++ b/components/menu-items/menu-items-group.js
@@ -33,12 +33,12 @@ export function MenuItemsGroup( {
 	}
 
 	const labelId = `components-menu-items-group-label-${ instanceId }`;
-	const classNames = classnames( className, 'components-menu-items-group' );
+	const classNames = classnames( className, 'components-menu-items__group' );
 
 	return (
 		<div className={ classNames }>
 			{ label &&
-				<div className="components-menu-items-group__label" id={ labelId }>{ label }</div>
+				<div className="components-menu-items__group-label" id={ labelId }>{ label }</div>
 			}
 			<NavigableMenu orientation="vertical" aria-labelledby={ labelId }>
 				{ menuItems }

--- a/components/menu-items/style.scss
+++ b/components/menu-items/style.scss
@@ -1,9 +1,9 @@
-.components-menu-items-group {
+.components-menu-items__group {
 	width: 100%;
 	padding: 10px;
 }
 
-.components-menu-items-group__label {
+.components-menu-items__group-label {
 	margin-bottom: 10px;
 	color: $dark-gray-300;
 }

--- a/components/menu-items/test/__snapshots__/menu-items-group.js.snap
+++ b/components/menu-items/test/__snapshots__/menu-items-group.js.snap
@@ -2,10 +2,10 @@
 
 exports[`MenuItemsGroup should match snapshot 1`] = `
 <div
-  className="components-menu-items-group"
+  className="components-menu-items__group"
 >
   <div
-    className="components-menu-items-group__label"
+    className="components-menu-items__group-label"
     id="components-menu-items-group-label-1"
   >
     My group

--- a/edit-post/components/header/more-menu/style.scss
+++ b/edit-post/components/header/more-menu/style.scss
@@ -15,7 +15,7 @@
 }
 
 .edit-post-more-menu__content {
-	.components-menu-items-group:not(:last-child) {
+	.components-menu-items__group:not(:last-child) {
   		border-bottom: 1px solid $light-gray-500;
 	}
 }


### PR DESCRIPTION
## Description
Related comment from @aduth https://github.com/WordPress/gutenberg/pull/5161#discussion_r170167862:

> This should be .components-menu-items__group
>
> https://github.com/WordPress/gutenberg/blob/master/docs/coding-guidelines.md#css

This PR addresses it.

## Types of changes
Refactoring

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
