### PR TITLE
Try Selector Side Effects and withData HoC

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,10 @@ module.exports = {
 				message: 'Use @wordpress/plugins as import path instead.',
 			},
 			{
+				"selector": "ImportDeclaration[source.value=/^core-data$/]",
+				"message": "Use @wordpress/core-data as import path instead."
+			},
+			{
 				selector: 'CallExpression[callee.name="deprecated"] Property[key.name="version"][value.value=/' + majorMinorRegExp + '/]',
 				message: 'Deprecated functions must be removed before releasing this version.',
 			},

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -99,7 +99,7 @@ zip -r gutenberg.zip \
 	blocks/library/*/*.php \
 	post-content.js \
 	$vendor_scripts \
-	{blocks,components,date,editor,element,hooks,i18n,data,utils,edit-post,viewport,plugins}/build/*.{js,map} \
+	{blocks,components,date,editor,element,hooks,i18n,data,utils,edit-post,viewport,plugins,core-data}/build/*.{js,map} \
 	{blocks,components,editor,edit-post}/build/*.css \
 	languages/gutenberg.pot \
 	languages/gutenberg-translations.php \

--- a/blocks/library/categories/block.js
+++ b/blocks/library/categories/block.js
@@ -143,9 +143,8 @@ class CategoriesBlock extends Component {
 	}
 
 	render() {
-		const { attributes, focus, setAttributes } = this.props;
+		const { attributes, focus, setAttributes, isRequesting } = this.props;
 		const { align, displayAsDropdown, showHierarchy, showPostCounts } = attributes;
-		const categories = this.getCategories();
 
 		const inspectorControls = focus && (
 			<InspectorControls key="inspector">
@@ -168,7 +167,7 @@ class CategoriesBlock extends Component {
 			</InspectorControls>
 		);
 
-		if ( ! categories.length ) {
+		if ( isRequesting ) {
 			return [
 				inspectorControls,
 				<Placeholder
@@ -206,7 +205,10 @@ class CategoriesBlock extends Component {
 }
 
 export default withSelect( ( select ) => {
+	const { getCategories, isRequestingCategories } = select( 'core' );
+
 	return {
-		categories: select( 'core' ).getCategories(),
+		categories: getCategories(),
+		isRequesting: isRequestingCategories(),
 	};
 } )( CategoriesBlock );

--- a/blocks/library/categories/block.js
+++ b/blocks/library/categories/block.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Placeholder, Spinner, ToggleControl, withAPIData } from '@wordpress/components';
+import { Placeholder, Spinner, ToggleControl } from '@wordpress/components';
+import { withData } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { times, unescape } from 'lodash';
 
@@ -46,7 +47,7 @@ class CategoriesBlock extends Component {
 	}
 
 	getCategories( parentId = null ) {
-		const categories = this.props.categories.data;
+		const categories = this.props.categories;
 		if ( ! categories || ! categories.length ) {
 			return [];
 		}
@@ -204,8 +205,8 @@ class CategoriesBlock extends Component {
 	}
 }
 
-export default withAPIData( () => {
+export default withData( ( resolve ) => {
 	return {
-		categories: '/wp/v2/categories',
+		categories: resolve( 'core' ).getCategories(),
 	};
 } )( CategoriesBlock );

--- a/blocks/library/categories/block.js
+++ b/blocks/library/categories/block.js
@@ -3,7 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 import { Placeholder, Spinner, ToggleControl } from '@wordpress/components';
-import { withData } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { times, unescape } from 'lodash';
 
@@ -205,8 +205,8 @@ class CategoriesBlock extends Component {
 	}
 }
 
-export default withData( ( resolve ) => {
+export default withSelect( ( select ) => {
 	return {
-		categories: resolve( 'core' ).getCategories(),
+		categories: select( 'core' ).getCategories(),
 	};
 } )( CategoriesBlock );

--- a/core-data/README.md
+++ b/core-data/README.md
@@ -1,0 +1,49 @@
+Core Data
+=========
+
+Core Data is a [data module](../data) intended to simplify access to and manipulation of core WordPress entities. It registers its own store and provides a number of selectors which resolve data from the WordPress REST API automatically, along with dispatching action creators to manipulate data.
+
+Used in combination with features of the data module such as [`subscribe`](https://github.com/WordPress/gutenberg/tree/master/data#subscribe-function) or [higher-order components](https://github.com/WordPress/gutenberg/tree/master/data#higher-order-components), it enables a developer to easily add data into the logic and display of their plugin.
+
+## Example
+
+Below is an example of a component which simply renders a list of categories:
+
+```jsx
+const { withSelect } = wp.data;
+
+function MyCategoriesList( { categories, isRequesting } ) {
+	if ( isRequesting ) {
+		return 'Loading…';
+	}
+
+	return (
+		<ul>
+			{ categories.map( ( category ) => (
+				<li key={ category.id }>{ category.name }</li>
+			) ) }
+		</ul>
+	);
+}
+
+MyCategoriesList = withSelect( ( select ) => {
+	const { getCategories, isRequestingCategories } = select( 'core' );
+
+	return {
+		categories: getCategories(),
+		isRequesting: isRequestingCategories(),
+	};
+} );
+```
+
+## Actions
+
+The following set of dispatching action creators are available on the object returned by `wp.data.dispatch( 'core' )`:
+
+_Refer to `actions.js` for the full set of dispatching action creators. In the future, this documentation will be automatically generated to detail all available dispatching action creators._
+
+## Selectors
+
+The following selectors are available on the object returned by `wp.data.select( 'core' )`:
+
+_Refer to `selectors.js` for the full set of selectors. In the future, this documentation will be automatically generated to detail all available selectors._

--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -1,0 +1,14 @@
+/**
+ * Returns an action object used in signalling that categories have been
+ * received.
+ *
+ * @param {Object[]} categories Categories received.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveCategories( categories ) {
+	return {
+		type: 'RECEIVE_CATEGORIES',
+		categories,
+	};
+}

--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -2,28 +2,32 @@
  * Returns an action object used in signalling that the request for a given
  * data type has been made.
  *
- * @param {string} dataType Data type requested.
+ * @param {string}  dataType Data type requested.
+ * @param {?string} subType  Optional data sub-type.
  *
  * @return {Object} Action object.
  */
-export function setRequested( dataType ) {
+export function setRequested( dataType, subType ) {
 	return {
 		type: 'SET_REQUESTED',
 		dataType,
+		subType,
 	};
 }
 
 /**
- * Returns an action object used in signalling that categories have been
- * received.
+ * Returns an action object used in signalling that terms have been received
+ * for a given taxonomy.
  *
- * @param {Object[]} categories Categories received.
+ * @param {string}   taxonomy Taxonomy name.
+ * @param {Object[]} terms    Terms received.
  *
  * @return {Object} Action object.
  */
-export function receiveCategories( categories ) {
+export function receiveTerms( taxonomy, terms ) {
 	return {
-		type: 'RECEIVE_CATEGORIES',
-		categories,
+		type: 'RECEIVE_TERMS',
+		taxonomy,
+		terms,
 	};
 }

--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -1,4 +1,19 @@
 /**
+ * Returns an action object used in signalling that the request for a given
+ * data type has been made.
+ *
+ * @param {string} dataType Data type requested.
+ *
+ * @return {Object} Action object.
+ */
+export function setRequested( dataType ) {
+	return {
+		type: 'SET_REQUESTED',
+		dataType,
+	};
+}
+
+/**
  * Returns an action object used in signalling that categories have been
  * received.
  *

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -16,17 +16,17 @@ const MODULE_KEY = 'core';
 
 const store = registerStore( MODULE_KEY, {
 	reducer,
-	selectors: { getCategories },
+	selectors: {
+		getCategories,
+	},
 	resolvers: {
-		getCategories: {
-			fulfill() {
-				wp.apiRequest( { path: '/wp/v2/categories' } ).then( categories => {
-					store.dispatch( {
-						type: 'RECEIVE_CATEGORIES',
-						categories,
-					} );
+		getCategories() {
+			wp.apiRequest( { path: '/wp/v2/categories' } ).then( ( categories ) => {
+				store.dispatch( {
+					type: 'RECEIVE_CATEGORIES',
+					categories,
 				} );
-			},
+			} );
 		},
 	},
 } );

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -19,7 +19,7 @@ const store = registerStore( MODULE_KEY, {
 	selectors: { getCategories },
 	resolvers: {
 		getCategories: {
-			fulfill: () => {
+			fulfill() {
 				wp.apiRequest( { path: '/wp/v2/categories' } ).then( categories => {
 					store.dispatch( {
 						type: 'FETCH_CATEGORIES_SUCCESS',

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -22,7 +22,7 @@ const store = registerStore( MODULE_KEY, {
 			fulfill() {
 				wp.apiRequest( { path: '/wp/v2/categories' } ).then( categories => {
 					store.dispatch( {
-						type: 'FETCH_CATEGORIES_SUCCESS',
+						type: 'RECEIVE_CATEGORIES',
 						categories,
 					} );
 				} );

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -4,6 +4,7 @@
 import {
 	registerReducer,
 	registerSelectors,
+	registerResolvers,
 } from '@wordpress/data';
 
 /**
@@ -18,10 +19,12 @@ import { getCategories } from './selectors';
 const MODULE_KEY = 'core';
 
 const store = registerReducer( MODULE_KEY, reducer );
-registerSelectors( MODULE_KEY, {
+
+registerSelectors( MODULE_KEY, { getCategories } );
+registerResolvers( MODULE_KEY, {
 	getCategories: {
-		select: getCategories,
-		effect: () => {
+		isFulfilled: ( state ) => state !== undefined,
+		fulfill: () => {
 			wp.apiRequest( { path: '/wp/v2/categories' } ).then( categories => {
 				store.dispatch( {
 					type: 'FETCH_CATEGORIES_SUCCESS',

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -23,7 +23,6 @@ const store = registerReducer( MODULE_KEY, reducer );
 registerSelectors( MODULE_KEY, { getCategories } );
 registerResolvers( MODULE_KEY, {
 	getCategories: {
-		isFulfilled: ( state ) => state !== undefined,
 		fulfill: () => {
 			wp.apiRequest( { path: '/wp/v2/categories' } ).then( categories => {
 				store.dispatch( {

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -1,11 +1,7 @@
 /**
  * WordPress Dependencies
  */
-import {
-	registerReducer,
-	registerSelectors,
-	registerResolvers,
-} from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,18 +14,19 @@ import { getCategories } from './selectors';
  */
 const MODULE_KEY = 'core';
 
-const store = registerReducer( MODULE_KEY, reducer );
-
-registerSelectors( MODULE_KEY, { getCategories } );
-registerResolvers( MODULE_KEY, {
-	getCategories: {
-		fulfill: () => {
-			wp.apiRequest( { path: '/wp/v2/categories' } ).then( categories => {
-				store.dispatch( {
-					type: 'FETCH_CATEGORIES_SUCCESS',
-					categories,
+const store = registerStore( MODULE_KEY, {
+	reducer,
+	selectors: { getCategories },
+	resolvers: {
+		getCategories: {
+			fulfill: () => {
+				wp.apiRequest( { path: '/wp/v2/categories' } ).then( categories => {
+					store.dispatch( {
+						type: 'FETCH_CATEGORIES_SUCCESS',
+						categories,
+					} );
 				} );
-			} );
+			},
 		},
 	},
 } );

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress Dependencies
+ */
+import {
+	registerReducer,
+	registerSelectors,
+} from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import { getCategories } from './selectors';
+
+/**
+ * Module Constants
+ */
+const MODULE_KEY = 'core';
+
+const store = registerReducer( MODULE_KEY, reducer );
+registerSelectors( MODULE_KEY, {
+	getCategories: {
+		select: getCategories,
+		effect: () => {
+			wp.apiRequest( { path: '/wp/v2/categories' } ).then( categories => {
+				store.dispatch( {
+					type: 'FETCH_CATEGORIES_SUCCESS',
+					categories,
+				} );
+			} );
+		},
+	},
+} );
+
+export default store;

--- a/core-data/index.js
+++ b/core-data/index.js
@@ -7,28 +7,15 @@ import { registerStore } from '@wordpress/data';
  * Internal dependencies
  */
 import reducer from './reducer';
-import { getCategories } from './selectors';
+import * as selectors from './selectors';
+import * as actions from './actions';
+import * as resolvers from './resolvers';
 
-/**
- * Module Constants
- */
-const MODULE_KEY = 'core';
-
-const store = registerStore( MODULE_KEY, {
+const store = registerStore( 'core', {
 	reducer,
-	selectors: {
-		getCategories,
-	},
-	resolvers: {
-		getCategories() {
-			wp.apiRequest( { path: '/wp/v2/categories' } ).then( ( categories ) => {
-				store.dispatch( {
-					type: 'RECEIVE_CATEGORIES',
-					categories,
-				} );
-			} );
-		},
-	},
+	actions,
+	selectors,
+	resolvers,
 } );
 
 export default store;

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -1,13 +1,30 @@
-const reducer = ( state, action ) => {
+/**
+ * External dependencies
+ */
+import { uniqBy } from 'lodash';
+import { combineReducers } from 'redux';
+
+/**
+ * Reducer returning the categories list.
+ *
+ * @param {Object}  state                 Current state.
+ * @param {Object}  action                Dispatched action.
+ *
+ * @return {string} Updated state.
+ */
+function categories( state = [], action ) {
 	switch ( action.type ) {
-		case 'FETCH_CATEGORIES_SUCCESS':
-			return action.categories.reduce( ( memo, category ) => ( {
-				...memo,
-				[ category.id ]: category,
-			} ), {} );
+		case 'RECEIVE_CATEGORIES':
+			return uniqBy(
+				[
+					...action.categories,
+					...state,
+				],
+				( category ) => category.id
+			);
 	}
 
 	return state;
-};
+}
 
-export default reducer;
+export default combineReducers( { categories } );

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -4,37 +4,33 @@
 import { combineReducers } from 'redux';
 
 /**
- * Reducer returning the categories list.
+ * Reducer managing terms state. Keyed by taxonomy slug, the value is either
+ * undefined (if no request has been made for given taxonomy), null (if a
+ * request is in-flight for given taxonomy), or the array of terms for the
+ * taxonomy.
  *
- * @param {Object}  state  Current state.
- * @param {Object}  action Dispatched action.
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
  *
  * @return {string} Updated state.
  */
-function categories( state = null, action ) {
+export function terms( state = {}, action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_CATEGORIES':
-			return [ ...action.categories ];
-	}
-
-	return state;
-}
-
-/**
- * Reducer returning requested state, tracking whether requests have been
- * issued for a given data type.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Action object.
- *
- * @return {Object} Next state.
- */
-function requested( state = {}, action ) {
-	switch ( action.type ) {
-		case 'SET_REQUESTED':
+		case 'RECEIVE_TERMS':
 			return {
 				...state,
-				[ action.dataType ]: true,
+				[ action.taxonomy ]: action.terms,
+			};
+
+		case 'SET_REQUESTED':
+			const { dataType, subType: taxonomy } = action;
+			if ( dataType !== 'terms' || state.hasOwnProperty( taxonomy ) ) {
+				return state;
+			}
+
+			return {
+				...state,
+				[ taxonomy ]: null,
 			};
 	}
 
@@ -42,6 +38,5 @@ function requested( state = {}, action ) {
 }
 
 export default combineReducers( {
-	categories,
-	requested,
+	terms,
 } );

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -1,30 +1,47 @@
 /**
  * External dependencies
  */
-import { uniqBy } from 'lodash';
 import { combineReducers } from 'redux';
 
 /**
  * Reducer returning the categories list.
  *
- * @param {Object}  state                 Current state.
- * @param {Object}  action                Dispatched action.
+ * @param {Object}  state  Current state.
+ * @param {Object}  action Dispatched action.
  *
  * @return {string} Updated state.
  */
-function categories( state = [], action ) {
+function categories( state = null, action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_CATEGORIES':
-			return uniqBy(
-				[
-					...action.categories,
-					...state,
-				],
-				( category ) => category.id
-			);
+			return [ ...action.categories ];
 	}
 
 	return state;
 }
 
-export default combineReducers( { categories } );
+/**
+ * Reducer returning requested state, tracking whether requests have been
+ * issued for a given data type.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Action object.
+ *
+ * @return {Object} Next state.
+ */
+function requested( state = {}, action ) {
+	switch ( action.type ) {
+		case 'SET_REQUESTED':
+			return {
+				...state,
+				[ action.dataType ]: true,
+			};
+	}
+
+	return state;
+}
+
+export default combineReducers( {
+	categories,
+	requested,
+} );

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -1,0 +1,13 @@
+const reducer = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case 'FETCH_CATEGORIES_SUCCESS':
+			return action.categories.reduce( ( memo, category ) => ( {
+				...memo,
+				[ category.id ]: category,
+			} ), {} );
+	}
+
+	return state;
+};
+
+export default reducer;

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -1,4 +1,4 @@
-const reducer = ( state = {}, action ) => {
+const reducer = ( state, action ) => {
 	switch ( action.type ) {
 		case 'FETCH_CATEGORIES_SUCCESS':
 			return action.categories.reduce( ( memo, category ) => ( {

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import apiRequest from '@wordpress/api-request';
+
+/**
  * Internal dependencies
  */
 import { setRequested, receiveTerms } from './actions';
@@ -8,7 +13,7 @@ import { setRequested, receiveTerms } from './actions';
  * progress.
  */
 export async function* getCategories() {
-	const categories = await wp.apiRequest( { path: '/wp/v2/categories' } );
 	yield setRequested( 'terms', 'categories' );
+	const categories = await apiRequest( { path: '/wp/v2/categories' } );
 	yield receiveTerms( 'categories', categories );
 }

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { receiveCategories } from './actions';
+
+/**
+ * Requests categories from the REST API, returning a promise resolving to an
+ * action object for receiving categories.
+ *
+ * @return {Promise<Object>} Categories request promise.
+ */
+export async function getCategories() {
+	const categories = await wp.apiRequest( { path: '/wp/v2/categories' } );
+	return receiveCategories( categories );
+}

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -1,14 +1,14 @@
 /**
  * Internal dependencies
  */
-import { setRequested, receiveCategories } from './actions';
+import { setRequested, receiveTerms } from './actions';
 
 /**
  * Requests categories from the REST API, yielding action objects on request
  * progress.
  */
 export async function* getCategories() {
-	yield setRequested( 'categories' );
 	const categories = await wp.apiRequest( { path: '/wp/v2/categories' } );
-	yield receiveCategories( categories );
+	yield setRequested( 'terms', 'categories' );
+	yield receiveTerms( 'categories', categories );
 }

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -1,15 +1,14 @@
 /**
  * Internal dependencies
  */
-import { receiveCategories } from './actions';
+import { setRequested, receiveCategories } from './actions';
 
 /**
- * Requests categories from the REST API, returning a promise resolving to an
- * action object for receiving categories.
- *
- * @return {Promise<Object>} Categories request promise.
+ * Requests categories from the REST API, yielding action objects on request
+ * progress.
  */
-export async function getCategories() {
+export async function* getCategories() {
+	yield setRequested( 'categories' );
 	const categories = await wp.apiRequest( { path: '/wp/v2/categories' } );
-	return receiveCategories( categories );
+	yield receiveCategories( categories );
 }

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -1,5 +1,11 @@
-import { values } from 'lodash';
 
+/**
+ * Returns all the available categories.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Array} Categories List
+ */
 export function getCategories( state ) {
-	return values( state );
+	return state.categories;
 }

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -1,0 +1,5 @@
+import { values } from 'lodash';
+
+export function getCategories( state ) {
+	return values( state );
+}

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -1,11 +1,38 @@
-
 /**
  * Returns all the available categories.
  *
- * @param {Object} state Global application state.
+ * @param {Object} state Data state.
  *
- * @return {Array} Categories List
+ * @return {Array} Categories list.
  */
 export function getCategories( state ) {
 	return state.categories;
+}
+
+/**
+ * Returns true if a request has been issued for the given data type, or false
+ * otherwise.
+ *
+ * @param {Object} state    Data state.
+ * @param {string} dataType Data type to test.
+ *
+ * @return {boolean} Whether data type has been requested.
+ */
+export function hasRequested( state, dataType ) {
+	return !! state.requested[ dataType ];
+}
+
+/**
+ * Returns true if a request is in progress for categories data, or false
+ * otherwise.
+ *
+ * @param {Object} state    Data state.
+ *
+ * @return {boolean} Whether a request is in progress for categories.
+ */
+export function isRequestingCategories( state ) {
+	return (
+		hasRequested( state, 'categories' ) &&
+		getCategories( state ) === null
+	);
 }

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -1,4 +1,16 @@
 /**
+ * Returns all the available terms for the given taxonomy.
+ *
+ * @param {Object} state    Data state.
+ * @param {string} taxonomy Taxonomy name.
+ *
+ * @return {Array} Categories list.
+ */
+export function getTerms( state, taxonomy ) {
+	return state.terms[ taxonomy ];
+}
+
+/**
  * Returns all the available categories.
  *
  * @param {Object} state Data state.
@@ -6,33 +18,30 @@
  * @return {Array} Categories list.
  */
 export function getCategories( state ) {
-	return state.categories;
+	return getTerms( state, 'categories' );
 }
 
 /**
- * Returns true if a request has been issued for the given data type, or false
- * otherwise.
+ * Returns true if a request is in progress for terms data of a given taxonomy,
+ * or false otherwise.
  *
  * @param {Object} state    Data state.
- * @param {string} dataType Data type to test.
+ * @param {string} taxonomy Taxonomy name.
  *
- * @return {boolean} Whether data type has been requested.
+ * @return {boolean} Whether a request is in progress for taxonomy's terms.
  */
-export function hasRequested( state, dataType ) {
-	return !! state.requested[ dataType ];
+export function isRequestingTerms( state, taxonomy ) {
+	return state.terms[ taxonomy ] === null;
 }
 
 /**
  * Returns true if a request is in progress for categories data, or false
  * otherwise.
  *
- * @param {Object} state    Data state.
+ * @param {Object} state Data state.
  *
  * @return {boolean} Whether a request is in progress for categories.
  */
 export function isRequestingCategories( state ) {
-	return (
-		hasRequested( state, 'categories' ) &&
-		getCategories( state ) === null
-	);
+	return isRequestingTerms( state, 'categories' );
 }

--- a/core-data/test/__mocks__/@wordpress/api-request.js
+++ b/core-data/test/__mocks__/@wordpress/api-request.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn();

--- a/core-data/test/reducer.js
+++ b/core-data/test/reducer.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { terms } from '../reducer';
+
+describe( 'terms()', () => {
+	it( 'returns an empty object by default', () => {
+		const state = terms( undefined, {} );
+
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns with received terms', () => {
+		const originalState = deepFreeze( {} );
+		const state = terms( originalState, {
+			type: 'RECEIVE_TERMS',
+			taxonomy: 'categories',
+			terms: [ { id: 1 } ],
+		} );
+
+		expect( state ).toEqual( {
+			categories: [ { id: 1 } ],
+		} );
+	} );
+
+	it( 'assigns requested taxonomy to null', () => {
+		const originalState = deepFreeze( {} );
+		const state = terms( originalState, {
+			type: 'SET_REQUESTED',
+			dataType: 'terms',
+			subType: 'categories',
+		} );
+
+		expect( state ).toEqual( {
+			categories: null,
+		} );
+	} );
+
+	it( 'does not assign requested taxonomy to null if received', () => {
+		const originalState = deepFreeze( {
+			categories: [ { id: 1 } ],
+		} );
+		const state = terms( originalState, {
+			type: 'SET_REQUESTED',
+			dataType: 'terms',
+			subType: 'categories',
+		} );
+
+		expect( state ).toEqual( {
+			categories: [ { id: 1 } ],
+		} );
+	} );
+
+	it( 'does not assign requested taxonomy if not terms data type', () => {
+		const originalState = deepFreeze( {} );
+		const state = terms( originalState, {
+			type: 'SET_REQUESTED',
+			dataType: 'foo',
+			subType: 'categories',
+		} );
+
+		expect( state ).toEqual( {} );
+	} );
+} );

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import apiRequest from '@wordpress/api-request';
+
+/**
+ * Internal dependencies
+ */
+import { getCategories } from '../resolvers';
+import { setRequested, receiveTerms } from '../actions';
+
+jest.mock( '@wordpress/api-request' );
+
+describe( 'getCategories', () => {
+	const CATEGORIES = [ { id: 1 } ];
+
+	beforeAll( () => {
+		apiRequest.mockImplementation( ( options ) => {
+			if ( options.path === '/wp/v2/categories' ) {
+				return Promise.resolve( CATEGORIES );
+			}
+		} );
+	} );
+
+	it( 'yields with requested terms', async () => {
+		const fulfillment = getCategories();
+		const requested = ( await fulfillment.next() ).value;
+		expect( requested.type ).toBe( setRequested().type );
+		const received = ( await fulfillment.next() ).value;
+		expect( received ).toEqual( receiveTerms( 'categories', CATEGORIES ) );
+	} );
+} );

--- a/core-data/test/selectors.js
+++ b/core-data/test/selectors.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { getTerms, isRequestingTerms } from '../selectors';
+
+describe( 'getTerms()', () => {
+	it( 'returns value of terms by taxonomy', () => {
+		let state = deepFreeze( {
+			terms: {},
+		} );
+		expect( getTerms( state, 'categories' ) ).toBe( undefined );
+
+		state = deepFreeze( {
+			terms: {
+				categories: [ { id: 1 } ],
+			},
+		} );
+		expect( getTerms( state, 'categories' ) ).toEqual( [ { id: 1 } ] );
+	} );
+} );
+
+describe( 'isRequestingTerms()', () => {
+	it( 'returns false if never requested', () => {
+		const state = deepFreeze( {
+			terms: {},
+		} );
+
+		const result = isRequestingTerms( state, 'categories' );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns false if terms received', () => {
+		const state = deepFreeze( {
+			terms: {
+				categories: [ { id: 1 } ],
+			},
+		} );
+
+		const result = isRequestingTerms( state, 'categories' );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if requesting', () => {
+		const state = deepFreeze( {
+			terms: {
+				categories: null,
+			},
+		} );
+
+		const result = isRequestingTerms( state, 'categories' );
+		expect( result ).toBe( true );
+	} );
+} );

--- a/data/README.md
+++ b/data/README.md
@@ -9,7 +9,8 @@ The data module is built upon and shares many of the same core principles of [Re
 Use the `registerStore` function to add your own store to the centralized data registry. This function accepts two arguments: a name to identify the module, and an object with values describing how your state is represented, modified, and accessed. At a minimum, you must provide a reducer function describing the shape of your state and how it changes in response to actions dispatched to the store.
 
 ```js
-const { registerStore } = wp.data;
+const { data, apiRequest } = wp;
+const { registerStore, dispatch } = data;
 
 const DEFAULT_STATE = {
 	prices: {},
@@ -60,6 +61,13 @@ registerStore( 'my-shop', {
 			const price = prices[ item ];
 
 			return price * ( 1 - ( 0.01 * discountPercent ) );
+		},
+	},
+
+	resolvers: {
+		async getPrice( state, item ) {
+			const price = await apiRequest( { path: '/wp/v2/prices/' + item } );
+			dispatch( 'my-shop' ).setPrice( item, price );
 		},
 	},
 } );

--- a/data/README.md
+++ b/data/README.md
@@ -55,7 +55,7 @@ registerStore( 'my-shop', {
 	},
 
 	selectors: {
-		getPrice( item ) {
+		getPrice( state, item ) {
 			const { prices, discountPercent } = state;
 			const price = prices[ item ];
 

--- a/data/index.js
+++ b/data/index.js
@@ -3,7 +3,7 @@
  */
 import isShallowEqual from 'shallowequal';
 import { combineReducers, createStore } from 'redux';
-import { flowRight, without, mapValues } from 'lodash';
+import { flowRight, without, mapValues, isFunction, omitBy, forEach } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -113,7 +113,12 @@ export { combineReducers };
 export function registerSelectors( reducerKey, newSelectors ) {
 	const store = stores[ reducerKey ];
 	const createStateSelector = ( selector ) => ( ...args ) => selector( store.getState(), ...args );
-	selectors[ reducerKey ] = mapValues( newSelectors, createStateSelector );
+	selectors[ reducerKey ] = mapValues( newSelectors, ( selector ) => {
+		return {
+			...( isFunction( selector ) ? {} : selector ),
+			select: createStateSelector( isFunction( selector ) ? selector : selector.select ),
+		};
+	} );
 }
 
 /**
@@ -153,7 +158,7 @@ export const subscribe = ( listener ) => {
  * @return {*} The selector's returned value.
  */
 export function select( reducerKey ) {
-	return selectors[ reducerKey ];
+	return mapValues( selectors[ reducerKey ], ( selector ) => selector.select );
 }
 
 /**
@@ -297,6 +302,105 @@ export const withDispatch = ( mapDispatchToProps ) => ( WrappedComponent ) => {
 	ComponentWithDispatch.displayName = getWrapperDisplayName( WrappedComponent, 'dispatch' );
 
 	return ComponentWithDispatch;
+};
+
+/**
+ * Higher-order component used to inject state-derived props using registered
+ * selectors and trigger the necessary actions to fetch the selected data.
+ *
+ * @param {Function} mapStateToProps Function called on every state change,
+ *                                   expected to return object of resolvers to
+ *                                   run and provide prop for resolver.
+ *
+ * @return {Component} Enhanced component with merged state data props.
+ */
+export const withData = ( mapStateToProps ) => ( WrappedComponent ) => {
+	class ComponentWithData extends Component {
+		constructor() {
+			super( ...arguments );
+
+			this.runSelection = this.runSelection.bind( this );
+
+			this.state = {};
+			this.resolvers = {};
+		}
+
+		componentWillMount() {
+			this.subscribe();
+
+			// Populate initial state.
+			this.runResolvers();
+		}
+
+		componentWillReceiveProps( nextProps ) {
+			if ( ! isShallowEqual( nextProps, this.props ) ) {
+				this.runResolvers( nextProps );
+			}
+		}
+
+		componentWillUnmount() {
+			this.unsubscribe();
+		}
+
+		subscribe() {
+			this.unsubscribe = subscribe( this.runSelection );
+		}
+
+		resolve( props ) {
+			const resolve = ( reducerKey ) => {
+				return mapValues( selectors[ reducerKey ], ( selector, key ) => {
+					return ( ...args ) => ( {
+						args,
+						key,
+						reducerKey,
+					} );
+				} );
+			};
+			return mapStateToProps( resolve, props );
+		}
+
+		runResolvers( props = this.props ) {
+			const resolvers = this.resolve( props );
+			const newResolvers = omitBy( resolvers, ( resolver, key ) => {
+				const previousResolver = this.resolvers[ key ];
+				return (
+					!! previousResolver &&
+					previousResolver.key === resolver.key &&
+					isShallowEqual( previousResolver.args, resolver.args )
+				);
+			} );
+			this.resolvers = resolvers;
+			this.runSideEffects( newResolvers );
+			this.runSelection();
+		}
+
+		runSideEffects( resolvers ) {
+			forEach( resolvers, ( { key, reducerKey, args } ) => {
+				const selector = selectors[ reducerKey ][ key ];
+				if ( selector.effect ) {
+					selector.effect( ...args );
+				}
+			} );
+		}
+
+		runSelection() {
+			const newState = mapValues( this.resolvers, ( { key, reducerKey, args } ) => {
+				const selector = selectors[ reducerKey ][ key ];
+				return selector.select( ...args );
+			} );
+			if ( ! isShallowEqual( newState, this.state ) ) {
+				this.setState( newState );
+			}
+		}
+
+		render() {
+			return <WrappedComponent { ...this.props } { ...this.state } />;
+		}
+	}
+
+	ComponentWithData.displayName = getWrapperDisplayName( WrappedComponent, 'data' );
+
+	return ComponentWithData;
 };
 
 export const query = ( mapSelectToProps ) => {

--- a/data/index.js
+++ b/data/index.js
@@ -22,7 +22,6 @@ export { loadAndPersist, withRehydratation } from './persist';
  */
 const stores = {};
 const selectors = {};
-const resolvers = {};
 const actions = {};
 let listeners = [];
 
@@ -130,10 +129,21 @@ export function registerSelectors( reducerKey, newSelectors ) {
  * @param {Object} newResolvers Resolvers to register.
  */
 export function registerResolvers( reducerKey, newResolvers ) {
-	resolvers[ reducerKey ] = mapValues(
-		newResolvers,
-		( resolver ) => ( { fulfill: memize( resolver.fulfill ) } )
-	);
+	const createResolver = ( selector, key ) => {
+		let resolver = get( newResolvers, [ key, 'fulfill' ] );
+		if ( resolver ) {
+			resolver = memize( resolver );
+		}
+		return ( ...args ) => {
+			if ( resolver ) {
+				resolver( ...args );
+			}
+
+			return selector( ...args );
+		};
+	};
+
+	selectors[ reducerKey ] = mapValues( selectors[ reducerKey ], createResolver );
 }
 
 /**
@@ -173,16 +183,7 @@ export const subscribe = ( listener ) => {
  * @return {*} The selector's returned value.
  */
 export function select( reducerKey ) {
-	const createResolver = ( selector, key ) => ( ...args ) => {
-		const resolver = get( resolvers, [ reducerKey, key ] );
-		if ( resolver ) {
-			resolver.fulfill( ...args );
-		}
-
-		return selector( ...args );
-	};
-
-	return mapValues( selectors[ reducerKey ], createResolver );
+	return selectors[ reducerKey ];
 }
 
 /**

--- a/data/index.js
+++ b/data/index.js
@@ -130,15 +130,17 @@ export function registerSelectors( reducerKey, newSelectors ) {
  */
 export function registerResolvers( reducerKey, newResolvers ) {
 	const createResolver = ( selector, key ) => {
-		let resolver = get( newResolvers, [ key, 'fulfill' ] );
-		if ( resolver ) {
-			resolver = memize( resolver );
+		// Don't modify selector behavior if no resolver exists.
+		let fulfill = get( newResolvers, [ key, 'fulfill' ] );
+		if ( typeof fulfill !== 'function' ) {
+			return selector;
 		}
-		return ( ...args ) => {
-			if ( resolver ) {
-				resolver( ...args );
-			}
 
+		// Ensure single invocation per argument set via memoization.
+		fulfill = memize( fulfill );
+
+		return ( ...args ) => {
+			fulfill( ...args );
 			return selector( ...args );
 		};
 	};

--- a/data/index.js
+++ b/data/index.js
@@ -3,7 +3,7 @@
  */
 import isShallowEqual from 'shallowequal';
 import { combineReducers, createStore } from 'redux';
-import { flowRight, without, mapValues } from 'lodash';
+import { flowRight, without, mapValues, get } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -132,7 +132,7 @@ export function registerSelectors( reducerKey, newSelectors ) {
 export function registerResolvers( reducerKey, newResolvers ) {
 	resolvers[ reducerKey ] = mapValues(
 		newResolvers,
-		( resolver ) => ( { ...resolver, fulfill: memize( resolver.fulfill ) } )
+		( resolver ) => ( { fulfill: memize( resolver.fulfill ) } )
 	);
 }
 
@@ -174,14 +174,12 @@ export const subscribe = ( listener ) => {
  */
 export function select( reducerKey ) {
 	const createResolver = ( selector, key ) => ( ...args ) => {
-		const result = selector( ...args );
-		const resolver = resolvers[ reducerKey ] && resolvers[ reducerKey ][ key ];
-		if ( ! resolver ) {
-			return result;
+		const resolver = get( resolvers, [ reducerKey, key ] );
+		if ( resolver ) {
+			resolver.fulfill( ...args );
 		}
-		resolver.fulfill( ...args );
 
-		return result;
+		return selector( ...args );
 	};
 
 	return mapValues( selectors[ reducerKey ], createResolver );

--- a/data/index.js
+++ b/data/index.js
@@ -3,7 +3,7 @@
  */
 import isShallowEqual from 'shallowequal';
 import { combineReducers, createStore } from 'redux';
-import { flowRight, without, mapValues, get } from 'lodash';
+import { flowRight, without, mapValues } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -131,13 +131,12 @@ export function registerSelectors( reducerKey, newSelectors ) {
 export function registerResolvers( reducerKey, newResolvers ) {
 	const createResolver = ( selector, key ) => {
 		// Don't modify selector behavior if no resolver exists.
-		let fulfill = get( newResolvers, [ key, 'fulfill' ] );
-		if ( typeof fulfill !== 'function' ) {
+		if ( ! newResolvers.hasOwnProperty( key ) ) {
 			return selector;
 		}
 
 		// Ensure single invocation per argument set via memoization.
-		fulfill = memize( fulfill );
+		const fulfill = memize( newResolvers[ key ] );
 
 		return ( ...args ) => {
 			fulfill( ...args );

--- a/data/index.js
+++ b/data/index.js
@@ -175,12 +175,7 @@ export function select( reducerKey ) {
 		if ( ! resolver ) {
 			return result;
 		}
-		const isFulfilled = resolver.isFulfilled( stores[ reducerKey ].getState(), ...args );
-		if ( isFulfilled ) {
-			// TODO: clear memize cache for these sepecific args
-		} else {
-			resolver.fulfill( ...args );
-		}
+		resolver.fulfill( ...args );
 
 		return result;
 	};

--- a/data/index.js
+++ b/data/index.js
@@ -25,13 +25,6 @@ const selectors = {};
 const actions = {};
 let listeners = [];
 
-// Babel transform doesn't provide its own `asyncIterator` symbol, but it does
-// test for its presence at runtime, so define a shim value if not otherwise
-// defined by the browser.
-if ( typeof Symbol.asyncIterator !== 'symbol' ) {
-	Symbol.asyncIterator = Symbol( 'Symbol.asyncIterator' );
-}
-
 /**
  * Global listener called for each store's update.
  */

--- a/data/index.js
+++ b/data/index.js
@@ -37,7 +37,7 @@ export function globalListener() {
  * Convenience for registering reducer with actions and selectors.
  *
  * @param {string} reducerKey Reducer key.
- * @param {Object} options    Store description (reducer, actions, selectors).
+ * @param {Object} options    Store description (reducer, actions, selectors, resolvers).
  *
  * @return {Object} Registered store object.
  */
@@ -54,6 +54,10 @@ export function registerStore( reducerKey, options ) {
 
 	if ( options.selectors ) {
 		registerSelectors( reducerKey, options.selectors );
+	}
+
+	if ( options.resolvers ) {
+		registerResolvers( reducerKey, options.resolvers );
 	}
 
 	return store;

--- a/data/index.js
+++ b/data/index.js
@@ -3,7 +3,8 @@
  */
 import isShallowEqual from 'shallowequal';
 import { combineReducers, createStore } from 'redux';
-import { flowRight, without, mapValues, isFunction, omitBy, forEach } from 'lodash';
+import { flowRight, without, mapValues } from 'lodash';
+import memize from 'memize';
 
 /**
  * WordPress dependencies
@@ -21,6 +22,7 @@ export { loadAndPersist, withRehydratation } from './persist';
  */
 const stores = {};
 const selectors = {};
+const resolvers = {};
 const actions = {};
 let listeners = [];
 
@@ -113,12 +115,21 @@ export { combineReducers };
 export function registerSelectors( reducerKey, newSelectors ) {
 	const store = stores[ reducerKey ];
 	const createStateSelector = ( selector ) => ( ...args ) => selector( store.getState(), ...args );
-	selectors[ reducerKey ] = mapValues( newSelectors, ( selector ) => {
-		return {
-			...( isFunction( selector ) ? {} : selector ),
-			select: createStateSelector( isFunction( selector ) ? selector : selector.select ),
-		};
-	} );
+	selectors[ reducerKey ] = mapValues( newSelectors, createStateSelector );
+}
+
+/**
+ * Registers resolvers.
+ *
+ * @param {string} reducerKey   Part of the state shape to register the
+ *                              resolvers for.
+ * @param {Object} newResolvers Resolvers to register.
+ */
+export function registerResolvers( reducerKey, newResolvers ) {
+	resolvers[ reducerKey ] = mapValues(
+		newResolvers,
+		( resolver ) => ( { ...resolver, fulfill: memize( resolver.fulfill ) } )
+	);
 }
 
 /**
@@ -158,7 +169,23 @@ export const subscribe = ( listener ) => {
  * @return {*} The selector's returned value.
  */
 export function select( reducerKey ) {
-	return mapValues( selectors[ reducerKey ], ( selector ) => selector.select );
+	const createResolver = ( selector, key ) => ( ...args ) => {
+		const result = selector( ...args );
+		const resolver = resolvers[ reducerKey ] && resolvers[ reducerKey ][ key ];
+		if ( ! resolver ) {
+			return result;
+		}
+		const isFulfilled = resolver.isFulfilled( stores[ reducerKey ].getState(), ...args );
+		if ( isFulfilled ) {
+			// TODO: clear memize cache for these sepecific args
+		} else {
+			resolver.fulfill( ...args );
+		}
+
+		return result;
+	};
+
+	return mapValues( selectors[ reducerKey ], createResolver );
 }
 
 /**
@@ -302,105 +329,6 @@ export const withDispatch = ( mapDispatchToProps ) => ( WrappedComponent ) => {
 	ComponentWithDispatch.displayName = getWrapperDisplayName( WrappedComponent, 'dispatch' );
 
 	return ComponentWithDispatch;
-};
-
-/**
- * Higher-order component used to inject state-derived props using registered
- * selectors and trigger the necessary actions to fetch the selected data.
- *
- * @param {Function} mapStateToProps Function called on every state change,
- *                                   expected to return object of resolvers to
- *                                   run and provide prop for resolver.
- *
- * @return {Component} Enhanced component with merged state data props.
- */
-export const withData = ( mapStateToProps ) => ( WrappedComponent ) => {
-	class ComponentWithData extends Component {
-		constructor() {
-			super( ...arguments );
-
-			this.runSelection = this.runSelection.bind( this );
-
-			this.state = {};
-			this.resolvers = {};
-		}
-
-		componentWillMount() {
-			this.subscribe();
-
-			// Populate initial state.
-			this.runResolvers();
-		}
-
-		componentWillReceiveProps( nextProps ) {
-			if ( ! isShallowEqual( nextProps, this.props ) ) {
-				this.runResolvers( nextProps );
-			}
-		}
-
-		componentWillUnmount() {
-			this.unsubscribe();
-		}
-
-		subscribe() {
-			this.unsubscribe = subscribe( this.runSelection );
-		}
-
-		resolve( props ) {
-			const resolve = ( reducerKey ) => {
-				return mapValues( selectors[ reducerKey ], ( selector, key ) => {
-					return ( ...args ) => ( {
-						args,
-						key,
-						reducerKey,
-					} );
-				} );
-			};
-			return mapStateToProps( resolve, props );
-		}
-
-		runResolvers( props = this.props ) {
-			const resolvers = this.resolve( props );
-			const newResolvers = omitBy( resolvers, ( resolver, key ) => {
-				const previousResolver = this.resolvers[ key ];
-				return (
-					!! previousResolver &&
-					previousResolver.key === resolver.key &&
-					isShallowEqual( previousResolver.args, resolver.args )
-				);
-			} );
-			this.resolvers = resolvers;
-			this.runSideEffects( newResolvers );
-			this.runSelection();
-		}
-
-		runSideEffects( resolvers ) {
-			forEach( resolvers, ( { key, reducerKey, args } ) => {
-				const selector = selectors[ reducerKey ][ key ];
-				if ( selector.effect ) {
-					selector.effect( ...args );
-				}
-			} );
-		}
-
-		runSelection() {
-			const newState = mapValues( this.resolvers, ( { key, reducerKey, args } ) => {
-				const selector = selectors[ reducerKey ][ key ];
-				return selector.select( ...args );
-			} );
-			if ( ! isShallowEqual( newState, this.state ) ) {
-				this.setState( newState );
-			}
-		}
-
-		render() {
-			return <WrappedComponent { ...this.props } { ...this.state } />;
-		}
-	}
-
-	ComponentWithData.displayName = getWrapperDisplayName( WrappedComponent, 'data' );
-
-	return ComponentWithData;
 };
 
 export const query = ( mapSelectToProps ) => {

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -97,8 +97,12 @@ describe( 'registerResolvers', () => {
 		} );
 
 		const value = select( 'demo' ).getValue( 'arg1', 'arg2' );
-		expect( resolver ).toHaveBeenCalledWith( 'arg1', 'arg2' );
 		expect( value ).toBe( 'OK' );
+		expect( resolver ).toHaveBeenCalledWith( 'OK', 'arg1', 'arg2' );
+		select( 'demo' ).getValue( 'arg1', 'arg2' );
+		expect( resolver ).toHaveBeenCalledTimes( 1 );
+		select( 'demo' ).getValue( 'arg3', 'arg4' );
+		expect( resolver ).toHaveBeenCalledTimes( 2 );
 	} );
 } );
 

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -15,6 +15,7 @@ import {
 	registerStore,
 	registerReducer,
 	registerSelectors,
+	registerResolvers,
 	registerActions,
 	dispatch,
 	select,
@@ -70,6 +71,48 @@ describe( 'registerReducer', () => {
 
 		const store2 = registerReducer( 'red2', reducer2 );
 		expect( store2.getState() ).toEqual( 'ribs' );
+	} );
+} );
+
+describe( 'registerResolvers', () => {
+	it( 'should not do anything for selectors which do not have resolvers', () => {
+		registerReducer( 'demo', ( state = 'OK' ) => state );
+		registerSelectors( 'demo', {
+			getValue: ( state ) => state,
+		} );
+		registerResolvers( 'demo', {} );
+
+		expect( select( 'demo' ).getValue() ).toBe( 'OK' );
+	} );
+
+	it( 'should not do anything if registered without fulfill', () => {
+		registerReducer( 'demo', ( state = 'OK' ) => state );
+		registerSelectors( 'demo', {
+			getValue: ( state ) => state,
+		} );
+		registerResolvers( 'demo', {
+			getValue: {},
+		} );
+
+		expect( select( 'demo' ).getValue() ).toBe( 'OK' );
+	} );
+
+	it( 'should behave as a side effect for the given selector, with arguments', () => {
+		const resolver = jest.fn();
+
+		registerReducer( 'demo', ( state = 'OK' ) => state );
+		registerSelectors( 'demo', {
+			getValue: ( state ) => state,
+		} );
+		registerResolvers( 'demo', {
+			getValue: {
+				fulfill: resolver,
+			},
+		} );
+
+		const value = select( 'demo' ).getValue( 'arg1', 'arg2' );
+		expect( resolver ).toHaveBeenCalledWith( 'arg1', 'arg2' );
+		expect( value ).toBe( 'OK' );
 	} );
 } );
 

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -85,18 +85,6 @@ describe( 'registerResolvers', () => {
 		expect( select( 'demo' ).getValue() ).toBe( 'OK' );
 	} );
 
-	it( 'should not do anything if registered without fulfill', () => {
-		registerReducer( 'demo', ( state = 'OK' ) => state );
-		registerSelectors( 'demo', {
-			getValue: ( state ) => state,
-		} );
-		registerResolvers( 'demo', {
-			getValue: {},
-		} );
-
-		expect( select( 'demo' ).getValue() ).toBe( 'OK' );
-	} );
-
 	it( 'should behave as a side effect for the given selector, with arguments', () => {
 		const resolver = jest.fn();
 
@@ -105,9 +93,7 @@ describe( 'registerResolvers', () => {
 			getValue: ( state ) => state,
 		} );
 		registerResolvers( 'demo', {
-			getValue: {
-				fulfill: resolver,
-			},
+			getValue: resolver,
 		} );
 
 		const value = select( 'demo' ).getValue( 'arg1', 'arg2' );

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -62,7 +62,7 @@ import TinyMCE from 'tinymce';
 
 #### WordPress Dependencies
 
-To encourage reusability between features, our JavaScript is split into domain-specific modules which [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) one or more functions or objects. In the Gutenberg project, we've distinguished these modules under top-level directories `blocks`, `components`, `editor`, `edit-post`, `element`, `data`, `core-data` and `i18n`. These each serve an independent purpose, and often code is shared between them. For example, in order to localize its text, editor code will need to include functions from the `i18n` module.
+To encourage reusability between features, our JavaScript is split into domain-specific modules which [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) one or more functions or objects. In the Gutenberg project, we've distinguished these modules under top-level directories. Each module serve an independent purpose, and often code is shared between them. For example, in order to localize its text, editor code will need to include functions from the `i18n` module.
 
 Example:
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -62,7 +62,7 @@ import TinyMCE from 'tinymce';
 
 #### WordPress Dependencies
 
-To encourage reusability between features, our JavaScript is split into domain-specific modules which [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) one or more functions or objects. In the Gutenberg project, we've distinguished these modules under top-level directories `blocks`, `components`, `editor`, `edit-post`, `element`, `data` and `i18n`. These each serve an independent purpose, and often code is shared between them. For example, in order to localize its text, editor code will need to include functions from the `i18n` module.
+To encourage reusability between features, our JavaScript is split into domain-specific modules which [`export`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) one or more functions or objects. In the Gutenberg project, we've distinguished these modules under top-level directories `blocks`, `components`, `editor`, `edit-post`, `element`, `data`, `core-data` and `i18n`. These each serve an independent purpose, and often code is shared between them. For example, in order to localize its text, editor code will need to include functions from the `i18n` module.
 
 Example:
 

--- a/eslint/config.js
+++ b/eslint/config.js
@@ -126,12 +126,17 @@ module.exports = {
 		semi: 'error',
 		'semi-spacing': 'error',
 		'space-before-blocks': [ 'error', 'always' ],
-		'space-before-function-paren': [ 'error', 'never' ],
+		'space-before-function-paren': [ 'error', {
+			anonymous: 'never',
+			named: 'never',
+			asyncArrow: 'always',
+		} ],
 		'space-in-parens': [ 'error', 'always' ],
 		'space-infix-ops': [ 'error', { int32Hint: false } ],
 		'space-unary-ops': [ 'error', {
 			overrides: {
 				'!': true,
+				yield: true,
 			},
 		} ],
 		'template-curly-spacing': [ 'error', 'always' ],

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -83,6 +83,12 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'data/build/index.js' )
 	);
 	wp_register_script(
+		'wp-core-data',
+		gutenberg_url( 'core-data/build/index.js' ),
+		array( 'wp-data', 'wp-api-request' ),
+		filemtime( gutenberg_dir_path() . 'core-data/build/index.js' )
+	);
+	wp_register_script(
 		'wp-utils',
 		gutenberg_url( 'utils/build/index.js' ),
 		array( 'tinymce-latest' ),
@@ -147,7 +153,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-blocks',
 		gutenberg_url( 'blocks/build/index.js' ),
-		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-hooks', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models', 'shortcode', 'editor' ),
+		array( 'wp-element', 'wp-components', 'wp-utils', 'wp-hooks', 'wp-i18n', 'tinymce-latest', 'tinymce-latest-lists', 'tinymce-latest-paste', 'tinymce-latest-table', 'media-views', 'media-models', 'shortcode', 'editor', 'wp-core-data' ),
 		filemtime( gutenberg_dir_path() . 'blocks/build/index.js' )
 	);
 	wp_add_inline_script(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1271,6 +1271,12 @@
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
 			"dev": true
 		},
+		"babel-plugin-syntax-async-generators": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
+		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
@@ -1294,6 +1300,17 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
 			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
 			"dev": true
+		},
+		"babel-plugin-transform-async-generator-functions": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-generators": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2792,9 +2792,10 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -4469,6 +4470,13 @@
 				"promise": "7.3.1",
 				"setimmediate": "1.0.5",
 				"ua-parser-js": "0.7.17"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
 		},
 		"fd-slicer": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 		"check-node-version": "3.1.1",
 		"codecov": "3.0.0",
 		"concurrently": "3.5.0",
+		"core-js": "2.5.3",
 		"cross-env": "3.2.4",
 		"cypress": "1.4.1",
 		"deep-freeze": "0.0.1",
@@ -125,9 +126,9 @@
 		},
 		"preset": "@wordpress/jest-preset-default",
 		"setupFiles": [
+			"core-js/fn/symbol/async-iterator",
 			"<rootDir>/test/unit/setup-blocks.js",
-			"<rootDir>/test/unit/setup-wp-aliases.js",
-			"<rootDir>/test/unit/shim-async-iterator-symbol.js"
+			"<rootDir>/test/unit/setup-wp-aliases.js"
 		],
 		"transform": {
 			"\\.pegjs$": "<rootDir>/test/unit/pegjs-transform.js"

--- a/package.json
+++ b/package.json
@@ -113,10 +113,10 @@
 	},
 	"jest": {
 		"collectCoverageFrom": [
-			"(blocks|components|date|editor|element|i18n|data|utils|edit-post|viewport|plugins)/**/*.js"
+			"(blocks|components|date|editor|element|i18n|data|utils|edit-post|viewport|plugins|core-data)/**/*.js"
 		],
 		"moduleNameMapper": {
-			"@wordpress\\/(blocks|components|date|editor|element|i18n|data|utils|edit-post|viewport|plugins)": "$1"
+			"@wordpress\\/(blocks|components|date|editor|element|i18n|data|utils|edit-post|viewport|plugins|core-data)": "$1"
 		},
 		"preset": "@wordpress/jest-preset-default",
 		"setupFiles": [

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"babel-core": "6.26.0",
 		"babel-eslint": "8.0.3",
 		"babel-loader": "7.1.2",
+		"babel-plugin-transform-async-generator-functions": "6.24.1",
 		"babel-traverse": "6.26.0",
 		"check-node-version": "3.1.1",
 		"codecov": "3.0.0",
@@ -98,6 +99,9 @@
 		"presets": [
 			"@wordpress/default"
 		],
+		"plugins": [
+			"transform-async-generator-functions"
+		],
 		"env": {
 			"production": {
 				"plugins": [
@@ -106,7 +110,8 @@
 						{
 							"output": "languages/gutenberg.pot"
 						}
-					]
+					],
+					"transform-async-generator-functions"
 				]
 			}
 		}
@@ -121,7 +126,8 @@
 		"preset": "@wordpress/jest-preset-default",
 		"setupFiles": [
 			"<rootDir>/test/unit/setup-blocks.js",
-			"<rootDir>/test/unit/setup-wp-aliases.js"
+			"<rootDir>/test/unit/setup-wp-aliases.js",
+			"<rootDir>/test/unit/shim-async-iterator-symbol.js"
 		],
 		"transform": {
 			"\\.pegjs$": "<rootDir>/test/unit/pegjs-transform.js"

--- a/test/unit/setup-wp-aliases.js
+++ b/test/unit/setup-wp-aliases.js
@@ -14,6 +14,7 @@ global.wp = {
 	'date',
 	'editor',
 	'data',
+	'core-data',
 	'edit-post',
 	'viewport',
 	'plugins',

--- a/test/unit/shim-async-iterator-symbol.js
+++ b/test/unit/shim-async-iterator-symbol.js
@@ -1,3 +1,0 @@
-if ( typeof Symbol.asyncIterator !== 'symbol' ) {
-	Symbol.asyncIterator = Symbol( 'Symbol.asyncIterator' );
-}

--- a/test/unit/shim-async-iterator-symbol.js
+++ b/test/unit/shim-async-iterator-symbol.js
@@ -1,0 +1,3 @@
+if ( typeof Symbol.asyncIterator !== 'symbol' ) {
+	Symbol.asyncIterator = Symbol( 'Symbol.asyncIterator' );
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,7 @@ const entryPointNames = [
 	'utils',
 	'data',
 	'viewport',
+	[ 'coreData', 'core-data' ],
 	[ 'editPost', 'edit-post' ],
 	'plugins',
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@
 const webpack = require( 'webpack' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
-const { reduce, escapeRegExp, castArray, get } = require( 'lodash' );
+const { reduce, escapeRegExp, get } = require( 'lodash' );
 const { basename } = require( 'path' );
 
 // Main CSS loader for everything but blocks..
@@ -46,6 +46,23 @@ const extractConfig = {
 	],
 };
 
+/**
+ * Given a string, returns a new string with dash separators converedd to
+ * camel-case equivalent. This is not as aggressive as `_.camelCase` in
+ * converting to uppercase, where Lodash will convert letters following
+ * numbers.
+ *
+ * @param {string} string Input dash-delimited string.
+ *
+ * @return {string} Camel-cased string.
+ */
+function camelCaseDash( string ) {
+	return string.replace(
+		/-([a-z])/,
+		( match, letter ) => letter.toUpperCase()
+	);
+}
+
 const entryPointNames = [
 	'blocks',
 	'components',
@@ -56,13 +73,17 @@ const entryPointNames = [
 	'utils',
 	'data',
 	'viewport',
-	[ 'coreData', 'core-data' ],
-	[ 'editPost', 'edit-post' ],
+	'core-data',
 	'plugins',
+	'edit-post',
 ];
 
 const packageNames = [
 	'hooks',
+];
+
+const coreGlobals = [
+	'api-request',
 ];
 
 const externals = {
@@ -74,9 +95,13 @@ const externals = {
 	jquery: 'jQuery',
 };
 
-[ ...entryPointNames, ...packageNames ].forEach( name => {
+[
+	...entryPointNames,
+	...packageNames,
+	...coreGlobals,
+].forEach( ( name ) => {
 	externals[ `@wordpress/${ name }` ] = {
-		this: [ 'wp', name ],
+		this: [ 'wp', camelCaseDash( name ) ],
 	};
 } );
 
@@ -130,14 +155,9 @@ class CustomTemplatedPathPlugin {
 
 const config = {
 	entry: Object.assign(
-		entryPointNames.reduce( ( memo, entryPoint ) => {
-			// Normalized entry point as an array of [ name, path ]. If a path
-			// is not explicitly defined, use the name.
-			entryPoint = castArray( entryPoint );
-			const [ name, path = name ] = entryPoint;
-
+		entryPointNames.reduce( ( memo, path ) => {
+			const name = camelCaseDash( path );
 			memo[ name ] = `./${ path }`;
-
 			return memo;
 		}, {} ),
 		packageNames.reduce( ( memo, packageName ) => {


### PR DESCRIPTION
This PR is not polished yet as it's just an exploration at the moment. 
It introduces two new APIs:

 - When registering selectors we can attach side effects to each selector like this:

```js
wp.data.registerSelectors( { 
  mySelector: {
    select: ( state, ...args ) => state.something // the real selector
    effect: ( ...args ) => { // do something with the args }
  }
} );
```

 - a new Higher Order Component you can use to resolve data (run selectors and their side effects)

```js
wp.data.withData( ( resolve ) => ( {
  categories: resolve( 'core' ).getCategories()
} ) );
```

the `withData` behaves closely to the `withSelect` HoC but also runs the side effects attached to each selector. The other difference is that the `select` function passed as arg to the `withSelect` HoC returns the real result of the selector when called while the `resolve` function passed as arg to the `withData` returns just a descriptor (or resolver) used to select the data an trigger the side effect when needed.

---
An example implementation has been tried in the newly introduced `core-data` module. This module register a selector to fetch categories and is being used in the `categories` bloc to test it.