### PR TITLE
Removed non-functional custom taxonomies meta boxes.

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -90,11 +90,24 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 	$core_side_meta_boxes = array(
 		'submitdiv',
 		'formatdiv',
-		'categorydiv',
-		'tagsdiv-post_tag',
 		'pageparentdiv',
 		'postimagediv',
 	);
+
+	$custom_taxonomies = get_taxonomies(
+		array(
+			'show_ui' => true,
+		),
+		'objects'
+	);
+
+	// Following the same logic as meta box generation in:
+	// https://github.com/WordPress/wordpress-develop/blob/c896326/src/wp-admin/edit-form-advanced.php#L288-L292.
+	foreach ( $custom_taxonomies as $custom_taxonomy ) {
+		$core_side_meta_boxes [] = $custom_taxonomy->hierarchical ?
+			$custom_taxonomy->name . 'div' :
+			'tagsdiv-' . $custom_taxonomy->name;
+	}
 
 	$core_normal_meta_boxes = array(
 		'revisionsdiv',


### PR DESCRIPTION
These meta boxes don't work at all, and the new editor already shows panels to allow the use of custom taxonomies. So showing this meta boxes is a bug.

## How Has This Been Tested?
Add a custom taxonomy with a custom slug, verify a meta box with just the taxonomy title appear under Extended settings on the master branch, and does not appear on this branch.
