### PR TITLE
Blocks: Fix Reusable Blocks keyboard navigable (Introduce Disabled component)

### DIFF
--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -118,7 +118,6 @@ class ReusableBlockEdit extends Component {
 				{ element }
 				{ isSelected && (
 					<ReusableBlockEditPanel
-						key="panel"
 						isEditing={ isEditing }
 						title={ title !== null ? title : reusableBlock.title }
 						isSaving={ isSaving && ! reusableBlock.isTemporary }

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -7,8 +7,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { Placeholder, Spinner } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -99,30 +99,37 @@ class ReusableBlockEdit extends Component {
 
 		const reusableBlockAttributes = { ...reusableBlock.attributes, ...attributes };
 
-		return [
-			// We fake the block being read-only by wrapping it with an element that has pointer-events: none
-			<div key="edit" style={ { pointerEvents: isEditing ? 'auto' : 'none' } }>
-				<BlockEdit
-					{ ...this.props }
-					name={ reusableBlock.type }
-					isSelected={ isEditing && isSelected }
-					attributes={ reusableBlockAttributes }
-					setAttributes={ isEditing ? this.setAttributes : noop }
-				/>
-			</div>,
-			isSelected && (
-				<ReusableBlockEditPanel
-					key="panel"
-					isEditing={ isEditing }
-					title={ title !== null ? title : reusableBlock.title }
-					isSaving={ isSaving && ! reusableBlock.isTemporary }
-					onEdit={ this.startEditing }
-					onChangeTitle={ this.setTitle }
-					onSave={ this.updateReusableBlock }
-					onCancel={ this.stopEditing }
-				/>
-			),
-		];
+		let element = (
+			<BlockEdit
+				{ ...this.props }
+				name={ reusableBlock.type }
+				isSelected={ isEditing && isSelected }
+				attributes={ reusableBlockAttributes }
+				setAttributes={ isEditing ? this.setAttributes : noop }
+			/>
+		);
+
+		if ( ! isEditing ) {
+			element = <Disabled>{ element }</Disabled>;
+		}
+
+		return (
+			<Fragment>
+				{ element }
+				{ isSelected && (
+					<ReusableBlockEditPanel
+						key="panel"
+						isEditing={ isEditing }
+						title={ title !== null ? title : reusableBlock.title }
+						isSaving={ isSaving && ! reusableBlock.isTemporary }
+						onEdit={ this.startEditing }
+						onChangeTitle={ this.setTitle }
+						onSave={ this.updateReusableBlock }
+						onCancel={ this.stopEditing }
+					/>
+				) }
+			</Fragment>
+		);
 	}
 }
 

--- a/components/disabled/README.md
+++ b/components/disabled/README.md
@@ -1,0 +1,33 @@
+Disabled
+========
+
+Disabled is a component which disables descendant tabbable elements and prevents pointer interaction.
+
+## Usage
+
+Assuming you have a form component, you can disable all form inputs by wrapping the form with `<Disabled>`.
+
+```jsx
+const DisableToggleForm = withState( {
+	isDisabled: true,
+} )( ( { isDisabled, setState } ) => {
+	let form = <form><input /></form>;
+
+	if ( isDisabled ) {
+		form = <Disabled>{ form }</Disabled>;
+	}
+
+	const toggleDisabled = setState( ( state ) => ( {
+		isDisabled: ! state.isDisabled,
+	} ) );
+
+	return (
+		<div>
+			{ form }
+			<button onClick={ toggleDisabled }>
+				Toggle Disabled
+			</button>
+		</div>
+	);
+} )
+```

--- a/components/disabled/index.js
+++ b/components/disabled/index.js
@@ -21,7 +21,7 @@ class Disabled extends Component {
 		this.bindNode = this.bindNode.bind( this );
 		this.disable = this.disable.bind( this );
 
-		// Disable re-disable since disabling process itself will incur
+		// Debounce re-disable since disabling process itself will incur
 		// additional mutations which should be ignored.
 		this.debouncedDisable = debounce( this.disable, { leading: true } );
 	}

--- a/components/disabled/index.js
+++ b/components/disabled/index.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { focus } from '@wordpress/utils';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+class Disabled extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.bindNode = this.bindNode.bind( this );
+		this.disable = this.disable.bind( this );
+
+		// Disable re-disable since disabling process itself will incur
+		// additional mutations which should be ignored.
+		this.debouncedDisable = debounce( this.disable, { leading: true } );
+	}
+
+	componentDidMount() {
+		this.disable();
+
+		this.observer = new window.MutationObserver( this.debouncedDisable );
+		this.observer.observe( this.node, {
+			childList: true,
+			attributes: true,
+			subtree: true,
+		} );
+	}
+
+	componentWillUnmount() {
+		this.observer.disconnect();
+		this.debouncedDisable.cancel();
+	}
+
+	bindNode( node ) {
+		this.node = node;
+	}
+
+	disable() {
+		focus.focusable.find( this.node ).forEach( ( focusable ) => {
+			if ( ! focusable.hasAttribute( 'disabled' ) ) {
+				focusable.setAttribute( 'disabled', '' );
+			}
+
+			if ( focusable.hasAttribute( 'contenteditable' ) ) {
+				focusable.setAttribute( 'contenteditable', 'false' );
+			}
+		} );
+	}
+
+	render() {
+		return (
+			<div ref={ this.bindNode } className="components-disabled">
+				{ this.props.children }
+			</div>
+		);
+	}
+}
+
+export default Disabled;

--- a/components/disabled/style.scss
+++ b/components/disabled/style.scss
@@ -1,0 +1,12 @@
+.components-disabled {
+	position: relative;
+
+	&:after {
+		content: '';
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	}
+}

--- a/components/disabled/test/index.js
+++ b/components/disabled/test/index.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Disabled from '../';
+
+jest.mock( '@wordpress/utils', () => {
+	const focus = require.requireActual( '@wordpress/utils' ).focus;
+
+	return {
+		focus: {
+			...focus,
+			focusable: {
+				...focus.focusable,
+				find( context ) {
+					// In JSDOM, all elements have zero'd widths and height.
+					// This is a metric for focusable's `isVisible`, so find
+					// and apply an arbitrary non-zero width.
+					[ ...context.querySelectorAll( '*' ) ].forEach( ( element ) => {
+						Object.defineProperties( element, {
+							offsetWidth: {
+								get: () => 1,
+							},
+						} );
+					} );
+
+					return focus.focusable.find( ...arguments );
+				},
+			},
+		},
+	};
+} );
+
+describe( 'Disabled', () => {
+	let MutationObserver;
+
+	beforeAll( () => {
+		MutationObserver = window.MutationObserver;
+		window.MutationObserver = function() {};
+		window.MutationObserver.prototype = {
+			observe() {},
+			disconnect() {},
+		};
+	} );
+
+	afterAll( () => {
+		window.MutationObserver = MutationObserver;
+	} );
+
+	const Form = () => <form><input /><div contentEditable /></form>;
+
+	it( 'will disable all fields', () => {
+		const wrapper = mount( <Disabled><Form /></Disabled> );
+
+		expect( wrapper.find( 'input' ).getDOMNode().hasAttribute( 'disabled' ) ).toBe( true );
+		expect( wrapper.find( '[contentEditable]' ).getDOMNode().getAttribute( 'contenteditable' ) ).toBe( 'false' );
+	} );
+
+	it( 'should cleanly un-disable via reconciliation', () => {
+		// If this test suddenly starts failing, it means React has become
+		// smarter about reusing children into grandfather element when the
+		// parent is dropped, so we'd need to find another way to restore
+		// original form state.
+		function MaybeDisable( { isDisabled = true } ) {
+			const element = <Form />;
+			return isDisabled ? <Disabled>{ element }</Disabled> : element;
+		}
+
+		const wrapper = mount( <MaybeDisable /> );
+		wrapper.setProps( { isDisabled: false } );
+
+		expect( wrapper.find( 'input' ).getDOMNode().hasAttribute( 'disabled' ) ).toBe( false );
+		expect( wrapper.find( '[contentEditable]' ).getDOMNode().getAttribute( 'contenteditable' ) ).toBe( 'true' );
+	} );
+
+	// Ideally, we'd have two more test cases here:
+	//
+	//  - it( 'will disable all fields on component render change' )
+	//  - it( 'will disable all fields on sneaky DOM manipulation' )
+	//
+	// Alas, JSDOM does not support MutationObserver:
+	//
+	//  https://github.com/jsdom/jsdom/issues/639
+} );

--- a/components/index.js
+++ b/components/index.js
@@ -7,6 +7,7 @@ export { default as CheckboxControl } from './checkbox-control';
 export { default as ClipboardButton } from './clipboard-button';
 export { default as Dashicon } from './dashicon';
 export { DateTimePicker, DatePicker, TimePicker } from './date-time';
+export { default as Disabled } from './disabled';
 export { default as DropZone } from './drop-zone';
 export { default as DropZoneProvider } from './drop-zone/provider';
 export { default as Dropdown } from './dropdown';


### PR DESCRIPTION
This pull request seeks to resolve an issue where reusable blocks are keyboard navigable when not intended to be editable. The previous implementation used a `pointer-events: none` style to prevent a user from interacting with the reusable block, but it was easy to navigate into with keyboard thanks to `WritingFlow` behaviors.

The implementation here introduces a new reusable `Disabled` component which intends to manage all field disabling automatically.

[Refer to included README](https://github.com/WordPress/gutenberg/blob/80e03deba7d7737099eed1cdd02e6cc352792c25/components/disabled/README.md)

__Testing instructions:__

Verify that you cannot edit a Reusable Block until selecting the parent block and choosing Edit, including when navigating between blocks using the keyboard.