### PR TITLE
Utils: Fix focusable matching contenteditable=false

### DIFF
--- a/utils/focus/focusable.js
+++ b/utils/focus/focusable.js
@@ -33,7 +33,7 @@ const SELECTOR = [
 	'object',
 	'embed',
 	'area[href]',
-	'[contenteditable]',
+	'[contenteditable]:not([contenteditable=false])',
 ].join( ',' );
 
 /**

--- a/utils/focus/test/focusable.js
+++ b/utils/focus/test/focusable.js
@@ -85,6 +85,27 @@ describe( 'focusable', () => {
 			expect( find( map ) ).toEqual( [] );
 		} );
 
+		it( 'finds contenteditable', () => {
+			const node = createElement( 'div' );
+			const div = createElement( 'div' );
+			node.appendChild( div );
+
+			div.setAttribute( 'contenteditable', '' );
+			expect( find( node ) ).toEqual( [ div ] );
+
+			div.setAttribute( 'contenteditable', 'true' );
+			expect( find( node ) ).toEqual( [ div ] );
+		} );
+
+		it( 'ignores contenteditable=false', () => {
+			const node = createElement( 'div' );
+			const div = createElement( 'div' );
+			node.appendChild( div );
+
+			div.setAttribute( 'contenteditable', 'false' );
+			expect( find( node ) ).toEqual( [] );
+		} );
+
 		it( 'ignores invisible inputs', () => {
 			const node = createElement( 'div' );
 			const input = createElement( 'input' );


### PR DESCRIPTION
This pull request seeks to resolve an issue where `wp.utils.focus.focusable.find` will return elements which are assigned `contenteditable="false"`.

References:

- https://codepen.io/aduth/pen/GQBLov
- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```

Verify there are no regressions in focusable contenteditable detection, e.g. keyboard navigating between paragraph blocks.