### PR TITLE
Store: Mutate editor store reference in middlewares application

### DIFF
--- a/edit-post/store/middlewares.js
+++ b/edit-post/store/middlewares.js
@@ -36,10 +36,8 @@ function applyMiddlewares( store ) {
 	chain = middlewares.map( middleware => middleware( middlewareAPI ) );
 	enhancedDispatch = flowRight( ...chain )( store.dispatch );
 
-	return {
-		...store,
-		dispatch: enhancedDispatch,
-	};
+	store.dispatch = enhancedDispatch;
+	return store;
 }
 
 export default applyMiddlewares;

--- a/editor/store/middlewares.js
+++ b/editor/store/middlewares.js
@@ -38,10 +38,8 @@ function applyMiddlewares( store ) {
 	chain = middlewares.map( middleware => middleware( middlewareAPI ) );
 	enhancedDispatch = flowRight( ...chain )( store.dispatch );
 
-	return {
-		...store,
-		dispatch: enhancedDispatch,
-	};
+	store.dispatch = enhancedDispatch;
+	return store;
 }
 
 export default applyMiddlewares;


### PR DESCRIPTION
Extracted from #5228

This pull request seeks to resolve an issue where side effects are ignored when dispatching to the registered editor store. Because middlewares are applied to the editor store in a non-mutative fashion, the editor module itself uses a different `dispatch` reference from external modules. Therefore, if an external module attempts to dispatch an action on the `core/editor` namespace which has a side-effect attach, the effect will not be triggered.

__Testing instructions:__

This was observed in #5228 where, after updating to use `withDispatch`, it was observed that triggering `fetchReusableBlocks` would not actually fetch the blocks because [the effect behavior](https://github.com/WordPress/gutenberg/blob/aa1df371e2e85f4ac06a40cbe37643e2c63a9601/editor/store/effects.js#L309-L347) was not triggered.