### PR TITLE
Added button (call to action) to cover image using nesting

### DIFF
--- a/blocks/library/cover-image/editor.scss
+++ b/blocks/library/cover-image/editor.scss
@@ -1,4 +1,8 @@
 .wp-block-cover-image {
+	.blocks-rich-text, .wp-block-button{
+		width: 100%;
+	}
+
 	.blocks-rich-text__tinymce[data-is-empty="true"]:before {
 		position: inherit;
 	}
@@ -30,4 +34,24 @@
 	&.has-right-content .block-rich-text__inline-toolbar{
 		justify-content: flex-end;
 	}
+
+	.editor-block-list__layout {
+		margin-top: 20px;
+		width: 100%;
+	}
+
+	.editor-block-list__block[data-type="core/button"] {
+		&[data-align="center"] .editor-block-toolbar {
+			left: calc(50% - 100px);
+		}
+
+		&:not([data-align]) .blocks-button__inline-link {
+			margin-left: 0px;
+		}
+	}
+
+	.editor-block-list__block-edit .wp-block-button {
+		width: auto;
+	}
+
 }

--- a/blocks/library/cover-image/style.scss
+++ b/blocks/library/cover-image/style.scss
@@ -1,30 +1,28 @@
-.wp-block-cover-image {
+section.wp-block-cover-image {
 	position: relative;
 	background-size: cover;
 	height: 430px;
 	width: 100%;
 	margin: 0;
 	display: flex;
+	flex-direction: column;
 	justify-content: center;
 	align-items: center;
 
 	&.has-left-content {
-		justify-content: flex-start;
 		h2 {
-			margin-left: 0;
 			text-align: left;
 		}
 	}
 
 	&.has-right-content {
-		justify-content: flex-end;
 		h2 {
-			margin-right: 0;
 			text-align: right;
 		}
 	}
 
 	h2 {
+		width: 100%;
 		color: white;
 		font-size: 24pt;
 		line-height: 1em;
@@ -56,6 +54,10 @@
 
 	&.components-placeholder {
 		height: inherit;
+	}
+
+	.wp-block-button {
+		width: calc( 100% - 40px );
 	}
 
 }

--- a/blocks/library/cover-image/test/index.js
+++ b/blocks/library/cover-image/test/index.js
@@ -5,7 +5,14 @@ import { name, settings } from '../';
 import { blockEditRender } from 'blocks/test/helpers';
 
 jest.mock( 'blocks/media-upload', () => () => '*** Mock(Media upload button) ***' );
-
+jest.mock(
+	'@wordpress/data',
+	() => ( {
+		withSelect() {
+			return ( BlockEdit ) => ( props ) => <BlockEdit hasCallAction={ false } { ...props } />;
+		},
+	} ),
+);
 describe( 'core/cover-image', () => {
 	test( 'block edit matches snapshot', () => {
 		const wrapper = blockEditRender( name, settings );

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -23,6 +23,7 @@ import {
 	cloneBlock,
 	getBlockType,
 	getSaveElement,
+	hasBlockSupport,
 	isReusableBlock,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
@@ -521,6 +522,7 @@ export class BlockListBlock extends Component {
 			isMultiSelected,
 			isFirstMultiSelected,
 			isLastInSelection,
+			rootHasManageNesting,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! this.props.isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -533,10 +535,11 @@ export class BlockListBlock extends Component {
 		// If the block is selected and we're typing the block should not appear as selected unless the selection is not collapsed.
 		// Empty paragraph blocks should always show up as unselected.
 		const isEmptyDefaultBlock = isUnmodifiedDefaultBlock( block );
-		const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
+		const showSideInserter = ! rootHasManageNesting && ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const isSelectedNotTyping = isSelected && ( ! this.props.isTyping || ! this.state.isSelectionCollapsed );
 		const shouldAppearSelected = ! showSideInserter && isSelectedNotTyping;
-		const shouldShowMovers = shouldAppearSelected || isHovered || ( isEmptyDefaultBlock && isSelectedNotTyping );
+		const shouldShowMovers = ! rootHasManageNesting &&
+			( shouldAppearSelected || isHovered || ( isEmptyDefaultBlock && isSelectedNotTyping ) );
 		const shouldShowSettingsMenu = shouldShowMovers;
 		const shouldShowContextualToolbar = shouldAppearSelected && isValid && showContextualToolbar;
 		const shouldShowMobileToolbar = shouldAppearSelected;
@@ -678,6 +681,7 @@ export class BlockListBlock extends Component {
 
 const mapStateToProps = ( state, { uid, rootUID } ) => {
 	const isSelected = isBlockSelected( state, uid );
+	const rootBlock = rootUID ? getBlock( state, rootUID ) : undefined;
 	return {
 		previousBlockUid: getPreviousBlockUid( state, uid ),
 		nextBlockUid: getNextBlockUid( state, uid ),
@@ -696,6 +700,8 @@ const mapStateToProps = ( state, { uid, rootUID } ) => {
 		postType: getCurrentPostType( state ),
 		initialPosition: getSelectedBlocksInitialCaretPosition( state ),
 		isSelected,
+		rootHasManageNesting: !! rootBlock &&
+			hasBlockSupport( rootBlock.name, 'managedNesting' ),
 	};
 };
 

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  */
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/element';
-import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { hasBlockSupport, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { withContext } from '@wordpress/components';
 
 /**
@@ -19,8 +19,8 @@ import BlockDropZone from '../block-drop-zone';
 import { appendDefaultBlock, startTyping } from '../../store/actions';
 import { getBlock, getBlockCount } from '../../store/selectors';
 
-export function DefaultBlockAppender( { isLocked, isVisible, onAppend, showPrompt } ) {
-	if ( isLocked || ! isVisible ) {
+export function DefaultBlockAppender( { isLocked, isVisible, onAppend, rootHasManageNesting, showPrompt } ) {
+	if ( isLocked || ! isVisible || rootHasManageNesting ) {
 		return null;
 	}
 
@@ -45,10 +45,14 @@ export default compose(
 			const isEmpty = ! getBlockCount( state, ownProps.rootUID );
 			const lastBlock = getBlock( state, ownProps.lastBlockUID );
 			const isLastBlockEmptyDefault = lastBlock && isUnmodifiedDefaultBlock( lastBlock );
+			const rootBlock = ownProps.rootUID ? getBlock( state, ownProps.rootUID ) : undefined;
 
 			return {
 				isVisible: isEmpty || ! isLastBlockEmptyDefault,
 				showPrompt: isEmpty,
+				rootHasManageNesting: !! rootBlock &&
+					hasBlockSupport( rootBlock.name, 'managedNesting' ),
+
 			};
 		},
 		( dispatch, ownProps ) => ( {


### PR DESCRIPTION

## Description
This PR adds a toggle that allows to easily nest a button inside the cover image block.
This PR also introduces the concept of "managedNesting", when a block declares support for this feature the block is responsible to have to UI to manage nestings inside it (in the cover image that is done using a toggle). So in nested the blocks, we don't allow insert /block appender, and the remove of nested blocks. The block is responsible for having the UI to do that.

The CSS of the cover image had to refactored, we now use flex-direction column and this changed the way we align elements, there including existing ones.

I'm totally open to discussing alternatives approach to this nesting concept if other ideas appear we can change the managedNesting concept.

## How Has This Been Tested?
Add a cover image. Use the text alignment verify it still works as expected ( the CSS had to be refactored).
Use the "Call to action" toggle to add a button verify you can use the button block without problems including the alignment/color options. Save the post and see it looks as expected.
Open a post saved with a button inside a cover image and verify it works as expected.

Closes: https://github.com/WordPress/gutenberg/issues/2765

## Screenshots (jpeg or gifs if applicable):
<img width="572" alt="screen shot 2018-02-25 at 12 57 09" src="https://user-images.githubusercontent.com/11271197/36670686-f545f20a-1af0-11e8-9929-99d6f9c1d63c.png">
<img width="576" alt="screen shot 2018-02-25 at 12 56 55" src="https://user-images.githubusercontent.com/11271197/36670687-f5666c7e-1af0-11e8-9883-be144369342c.png">
<img width="1178" alt="screen shot 2018-02-25 at 12 56 37" src="https://user-images.githubusercontent.com/11271197/36670688-f5861862-1af0-11e8-9964-09d3ac19eb01.png">
<img width="585" alt="screen shot 2018-02-25 at 12 52 51" src="https://user-images.githubusercontent.com/11271197/36670689-f5a83c6c-1af0-11e8-837b-1f1e9c81b818.png">
<img width="623" alt="screen shot 2018-02-25 at 12 47 14" src="https://user-images.githubusercontent.com/11271197/36670691-f5ca6f8a-1af0-11e8-88ca-5cd2fdacef43.png">


