### PR TITLE
unused blank array variable

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -70,8 +70,6 @@ function gutenberg_collect_meta_box_data() {
 	 * do_meta_boxes( null, 'normal', $post );
 	 * do_meta_boxes( null, 'advanced', $post );
 	 */
-	$meta_boxes_output = array();
-
 	$publish_callback_args = null;
 	if ( post_type_supports( $post_type, 'revisions' ) && 'auto-draft' !== $post->post_status ) {
 		$revisions = wp_get_post_revisions( $post->ID );


### PR DESCRIPTION
## Description

I have suggested to a removed unused $meta_boxes_output blank array variable. This variable didn't use anywhere in the plugin.

