### PR TITLE
RichText: comment isEqual checks to avoid regressing in the future

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -696,6 +696,10 @@ export class RichText extends Component {
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
 			this.props.value !== this.savedContent &&
+
+			// Comparing using isEqual is necessary especially to avoid unnecessary updateContent calls
+			// This fixes issues in multi richText blocks like quotes when moving the focus between
+			// the different editables.
 			! isEqual( this.props.value, prevProps.value ) &&
 			! isEqual( this.props.value, this.savedContent )
 		) {


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/5100#discussion_r170005245

These checks have been added and removed several times, this comment ensures we don't remove them anymore unless we check the correct regression they introduce.