### PR TITLE
Framework: Use a single way to call APIs: wp.apiRequest

### DIFF
--- a/blocks/autocompleters/index.js
+++ b/blocks/autocompleters/index.js
@@ -108,7 +108,7 @@ export function blockAutocompleter( { onReplace } ) {
  */
 export function userAutocompleter() {
 	const getOptions = () => {
-		return ( new wp.api.collections.Users() ).fetch().then( ( users ) => {
+		return wp.apiRequest( { path: '/wp/v2/users' } ).then( ( users ) => {
 			return users.map( ( user ) => {
 				return {
 					value: user,

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -111,31 +111,33 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				const { setAttributes } = this.props;
 
 				this.setState( { error: false, fetching: true } );
-				wp.apiRequest( { path: `/oembed/1.0/proxy?${ stringify( { url } ) }` } ).then(
-					( obj ) => {
-						if ( this.unmounting ) {
-							return;
-						}
+				wp.apiRequest( { path: `/oembed/1.0/proxy?${ stringify( { url } ) }` } )
+					.then(
+						( obj ) => {
+							if ( this.unmounting ) {
+								return;
+							}
 
-						const { html, provider_name: providerName } = obj;
-						const providerNameSlug = kebabCase( toLower( providerName ) );
-						let { type } = obj;
+							const { html, provider_name: providerName } = obj;
+							const providerNameSlug = kebabCase( toLower( providerName ) );
+							let { type } = obj;
 
-						if ( includes( html, 'class="wp-embedded-content" data-secret' ) ) {
-							type = 'wp-embed';
+							if ( includes( html, 'class="wp-embedded-content" data-secret' ) ) {
+								type = 'wp-embed';
+							}
+							if ( html ) {
+								this.setState( { html, type, providerNameSlug } );
+								setAttributes( { type, providerNameSlug } );
+							} else if ( 'photo' === type ) {
+								this.setState( { html: this.getPhotoHtml( obj ), type, providerNameSlug } );
+								setAttributes( { type, providerNameSlug } );
+							}
+							this.setState( { fetching: false } );
+						},
+						() => {
+							this.setState( { fetching: false, error: true } );
 						}
-						if ( html ) {
-							this.setState( { html, type, providerNameSlug } );
-							setAttributes( { type, providerNameSlug } );
-						} else if ( 'photo' === type ) {
-							this.setState( { html: this.getPhotoHtml( obj ), type, providerNameSlug } );
-							setAttributes( { type, providerNameSlug } );
-						} else {
-							this.setState( { error: true } );
-						}
-						this.setState( { fetching: false } );
-					}
-				);
+					);
 			}
 
 			render() {

--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -4,6 +4,7 @@
 import { throttle } from 'lodash';
 import classnames from 'classnames';
 import scrollIntoView from 'dom-scroll-into-view';
+import { stringify } from 'querystringify';
 
 /**
  * WordPress dependencies
@@ -66,11 +67,13 @@ class UrlInput extends Component {
 			selectedSuggestion: null,
 			loading: true,
 		} );
-		this.suggestionsRequest = new wp.api.collections.Posts().fetch( { data: {
-			search: value,
-			per_page: 20,
-			orderby: 'relevance',
-		} } );
+		this.suggestionsRequest = wp.apiRequest( {
+			path: `/wp/v2/posts?${ stringify( {
+				search: value,
+				per_page: 20,
+				orderby: 'relevance',
+			} ) }`,
+		} );
 
 		this.suggestionsRequest
 			.then(

--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -72,15 +72,14 @@ const effects = {
 			.concat( jQuery( '.metabox-base-form' ).serialize() )
 			.concat( additionalData )
 			.join( '&' );
-		const fetchOptions = {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: formData,
-			credentials: 'include',
-		};
 
 		// Save the metaboxes
-		window.fetch( window._wpMetaBoxUrl, fetchOptions )
+		wp.apiRequest( {
+			url: window._wpMetaBoxUrl,
+			method: 'POST',
+			contentType: 'application/x-www-form-urlencoded',
+			data: formData,
+		} )
 			.then( () => store.dispatch( metaBoxUpdatesSuccess() ) );
 	},
 };

--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { get, unescape as unescapeString, without, find, some } from 'lodash';
+import { stringify } from 'querystring';
 
 /**
  * WordPress dependencies
@@ -25,7 +26,7 @@ const DEFAULT_QUERY = {
 	per_page: 100,
 	orderby: 'count',
 	order: 'desc',
-	_fields: [ 'id', 'name', 'parent' ],
+	_fields: 'id,name,parent',
 };
 
 class HierarchicalTermSelector extends Component {
@@ -107,19 +108,23 @@ class HierarchicalTermSelector extends Component {
 				adding: true,
 			} );
 			// Tries to create a term or fetch it if it already exists
-			const Model = wp.api.getTaxonomyModel( this.props.slug );
-			this.addRequest = new Model( {
-				name: formName,
-				parent: formParent ? formParent : undefined,
-			} ).save();
+			const basePath = wp.api.getTaxonomyRoute( this.props.slug );
+			this.addRequest = wp.apiRequest( {
+				path: `/wp/v2/${ basePath }`,
+				method: 'POST',
+				data: {
+					name: formName,
+					parent: formParent ? formParent : undefined,
+				},
+			} );
 			this.addRequest
 				.then( resolve, ( xhr ) => {
 					const errorCode = xhr.responseJSON && xhr.responseJSON.code;
 					if ( errorCode === 'term_exists' ) {
 						// search the new category created since last fetch
-						this.addRequest = new Model().fetch(
-							{ data: { ...DEFAULT_QUERY, parent: formParent || 0, search: formName } }
-						);
+						this.addRequest = wp.apiRequest( {
+							path: `/wp/v2/${ basePath }?${ stringify( { ...DEFAULT_QUERY, parent: formParent || 0, search: formName } ) }`,
+						} );
 						return this.addRequest.then( searchResult => {
 							resolve( this.findTerm( searchResult, formParent, formName ) );
 						}, reject );
@@ -159,9 +164,8 @@ class HierarchicalTermSelector extends Component {
 	}
 
 	componentDidMount() {
-		const Collection = wp.api.getTaxonomyCollection( this.props.slug );
-		this.fetchRequest = new Collection()
-			.fetch( { data: DEFAULT_QUERY } )
+		const basePath = wp.api.getTaxonomyRoute( this.props.slug );
+		this.fetchRequest = wp.apiRequest( { path: `/wp/v2/${ basePath }?${ stringify( DEFAULT_QUERY ) }` } )
 			.done( ( terms ) => {
 				const availableTermsTree = buildTermsTree( terms );
 

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -494,10 +494,9 @@ describe( 'effects', () => {
 					},
 				] );
 
-				set( global, 'wp.api.collections.Blocks', class {
-					fetch() {
-						return promise;
-					}
+				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
+				set( global, 'wp.apiRequest', () => {
+					return promise;
 				} );
 
 				const dispatch = jest.fn();
@@ -525,29 +524,19 @@ describe( 'effects', () => {
 			it( 'should fetch a single reusable block', () => {
 				const id = 123;
 
-				let modelAttributes;
 				const promise = Promise.resolve( {
 					id,
 					title: 'My cool block',
 					content: '<!-- wp:core/test-block {"name":"Big Bird"} /-->',
 				} );
-
-				set( global, 'wp.api.models.Blocks', class {
-					constructor( attributes ) {
-						modelAttributes = attributes;
-					}
-
-					fetch() {
-						return promise;
-					}
-				} );
+				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
+				set( global, 'wp.apiRequest', () => promise );
 
 				const dispatch = jest.fn();
 				const store = { getState: () => {}, dispatch };
 
 				handler( fetchReusableBlocks( id ), store );
 
-				expect( modelAttributes ).toEqual( { id } );
 				return promise.then( () => {
 					expect( dispatch ).toHaveBeenCalledWith( {
 						type: 'FETCH_REUSABLE_BLOCKS_SUCCESS',
@@ -568,12 +557,8 @@ describe( 'effects', () => {
 
 			it( 'should handle an API error', () => {
 				const promise = Promise.reject( {} );
-
-				set( global, 'wp.api.collections.Blocks', class {
-					fetch() {
-						return promise;
-					}
-				} );
+				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
+				set( global, 'wp.apiRequest', () => promise );
 
 				const dispatch = jest.fn();
 				const store = { getState: () => {}, dispatch };
@@ -598,15 +583,10 @@ describe( 'effects', () => {
 			it( 'should save a reusable block and swaps its id', () => {
 				let modelAttributes;
 				const promise = Promise.resolve( { id: 3 } );
-
-				set( global, 'wp.api.models.Blocks', class {
-					constructor( attributes ) {
-						modelAttributes = attributes;
-					}
-
-					save() {
-						return promise;
-					}
+				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
+				set( global, 'wp.apiRequest', ( request ) => {
+					modelAttributes = request.data;
+					return promise;
 				} );
 
 				const reusableBlock = createReusableBlock( 'core/test-block', {
@@ -637,12 +617,8 @@ describe( 'effects', () => {
 
 			it( 'should handle an API error', () => {
 				const promise = Promise.reject( {} );
-
-				set( global, 'wp.api.models.Blocks', class {
-					save() {
-						return promise;
-					}
-				} );
+				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
+				set( global, 'wp.apiRequest', () => promise );
 
 				const reusableBlock = createReusableBlock( 'core/test-block', {
 					name: 'Big Bird',
@@ -670,18 +646,9 @@ describe( 'effects', () => {
 			const handler = effects.DELETE_REUSABLE_BLOCK;
 
 			it( 'should delete a reusable block', () => {
-				let modelAttributes;
 				const promise = Promise.resolve( {} );
-
-				set( global, 'wp.api.models.Blocks', class {
-					constructor( attributes ) {
-						modelAttributes = attributes;
-					}
-
-					destroy() {
-						return promise;
-					}
-				} );
+				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
+				set( global, 'wp.apiRequest', () => promise );
 
 				const id = 123;
 
@@ -706,7 +673,6 @@ describe( 'effects', () => {
 					associatedBlockUids: [ associatedBlock.uid ],
 					optimist: expect.any( Object ),
 				} );
-				expect( modelAttributes ).toEqual( { id } );
 				return promise.then( () => {
 					expect( dispatch ).toHaveBeenCalledWith( {
 						type: 'DELETE_REUSABLE_BLOCK_SUCCESS',
@@ -718,12 +684,8 @@ describe( 'effects', () => {
 
 			it( 'should handle an API error', () => {
 				const promise = Promise.reject( {} );
-
-				set( global, 'wp.api.models.Blocks', class {
-					destroy() {
-						return promise;
-					}
-				} );
+				set( global, 'wp.api.getPostTypeRoute', () => 'blocks' );
+				set( global, 'wp.apiRequest', () => promise );
 
 				const state = reducer( undefined, updateReusableBlock( 123, {} ) );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -568,23 +568,11 @@ function gutenberg_extend_wp_api_backbone_client() {
 	$script  = sprintf( 'wp.api.postTypeRestBaseMapping = %s;', wp_json_encode( $post_type_rest_base_mapping ) );
 	$script .= sprintf( 'wp.api.taxonomyRestBaseMapping = %s;', wp_json_encode( $taxonomy_rest_base_mapping ) );
 	$script .= <<<JS
-		wp.api.getPostTypeModel = function( postType ) {
-			var route = '/' + wpApiSettings.versionString + this.postTypeRestBaseMapping[ postType ] + '/(?P<id>[\\\\d]+)';
-			return _.find( wp.api.models, function( model ) {
-				return model.prototype.route && route === model.prototype.route.index;
-			} );
+		wp.api.getPostTypeRoute = function( postType ) {
+			return wp.api.postTypeRestBaseMapping[ postType ];
 		};
-		wp.api.getTaxonomyModel = function( taxonomy ) {
-			var route = '/' + wpApiSettings.versionString + this.taxonomyRestBaseMapping[ taxonomy ] + '/(?P<id>[\\\\d]+)';
-			return _.find( wp.api.models, function( model ) {
-				return model.prototype.route && route === model.prototype.route.index;
-			} );
-		};
-		wp.api.getTaxonomyCollection = function( taxonomy ) {
-			var route = '/' + wpApiSettings.versionString + this.taxonomyRestBaseMapping[ taxonomy ];
-			return _.find( wp.api.collections, function( model ) {
-				return model.prototype.route && route === model.prototype.route.index;
-			} );
+		wp.api.getTaxonomyRoute = function( taxonomy ) {
+			return wp.api.taxonomyRestBaseMapping[ taxonomy ];
 		};
 JS;
 	wp_add_inline_script( 'wp-api', $script );

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -54,10 +54,12 @@ export function createMediaFromFile( file ) {
 	// Create upload payload
 	const data = new window.FormData();
 	data.append( 'file', file, file.name || file.type.replace( '/', '.' ) );
-
-	return new wp.api.models.Media().save( null, {
-		data: data,
+	return wp.apiRequest( {
+		path: '/wp/v2/media',
+		data,
 		contentType: false,
+		processData: false,
+		method: 'POST',
 	} );
 }
 


### PR DESCRIPTION
This PR refactors API calls in Gutenberg to always use `wp.apiRequest`.
In addition to consistency, this makes it easier for third-party Gutenberg USAGE to use it without a WordPress backend and just provide an alternative implementation to `wp.apiRequest`

**Testing instructions**

 - Test that saving/updating and removing posts works
 - Test that adding/removing tags and categories works
 - Test that embed blocks still work
 - Test that saving metaboxes work
 - Test that you can create/update and delete reusable blocks.