### PR TITLE
Image block: Fix duplicate upload on drag

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createMediaFromFile, preloadImage } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -89,16 +88,14 @@ export const settings = {
 				isMatch( files ) {
 					return files.length === 1 && files[ 0 ].type.indexOf( 'image/' ) === 0;
 				},
-				transform( files, onChange ) {
+				transform( files ) {
 					const file = files[ 0 ];
+					// We don't need to upload the media directly here
+					// It's already done as part of the `componentDidMount`
+					// int the image block
 					const block = createBlock( 'core/image', {
 						url: window.URL.createObjectURL( file ),
 					} );
-
-					createMediaFromFile( file )
-						.then( ( media ) => preloadImage( media.source_url ).then(
-							() => onChange( block.uid, { id: media.id, url: media.source_url } )
-						) );
 
 					return block;
 				},


### PR DESCRIPTION
closes #5254 

The image block has logic to upload a temporary image when it's mounted. This logic is necessary when pasting images. This means we don't need to upload the image in the drag and drop transformation and just rely on this behavior to avoid duplicate images.

**Testing instructions**

 - Drag and Drop an image to the post
 - The image should be uploaded only once