### PR TITLE
Increment the block usage when replacing blocks

### DIFF
--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -647,6 +647,7 @@ export function isInsertionPointVisible( state = false, action ) {
 export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 	switch ( action.type ) {
 		case 'INSERT_BLOCKS':
+		case 'REPLACE_BLOCKS':
 			return action.blocks.reduce( ( prevState, block ) => {
 				let id = block.name;
 				const insert = { name: block.name };


### PR DESCRIPTION
closes #5207 

Using the new empty paragraph inserter triggers a `REPLACE_BLOCKS` action instead of `INSERT_BLOCKS`. We should also track newly inserter blocks using this action in the `state.preferences.insertUsage` counter.

**Testing instructions**

 - Create an empty paragraph
 - Insert a block using one of the shortcuts in the side inserter
 - With the Redux Dev Tools (or localstorage) check that the `insertUsage` of this block has been incremented.