### PR TITLE
Table Block: Fix toolbars

### DIFF
--- a/blocks/library/table/index.js
+++ b/blocks/library/table/index.js
@@ -72,6 +72,7 @@ export const settings = {
 				} }
 				content={ content }
 				className={ className }
+				isSelected={ isSelected }
 			/>,
 		];
 	},


### PR DESCRIPTION
closes #5260

This PR fixes a regression that happened in #4872 where the `isSelected` prop was not being passed to the Table Block causing its toolbars to never show up.

**Testing instructions**

 - Add a table block
 - Ensures the toolbar item to add/remove columns and rows is visible in the toolbar.