### PR TITLE
Accessibility: Fix mover icons accessibility

### DIFF
--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -20,6 +20,21 @@ import { getBlockMoverLabel } from './mover-label';
 import { getBlockIndex, getBlock } from '../../store/selectors';
 import { selectBlock } from '../../store/actions';
 
+/**
+ * Module constants
+ */
+const upArrow = (
+	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
+		<path d="M12.293 12.207L9 8.914l-3.293 3.293-1.414-1.414L9 6.086l4.707 4.707z" />
+	</svg>
+);
+
+const downArrow = (
+	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
+		<path d="M12.293 6.086L9 9.379 5.707 6.086 4.293 7.5 9 12.207 13.707 7.5z" />
+	</svg>
+);
+
 export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked } ) {
 	if ( isLocked ) {
 		return null;
@@ -34,7 +49,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ isFirst ? null : onMoveUp }
-				icon={ <svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg"><path d="M12.293 12.207L9 8.914l-3.293 3.293-1.414-1.414L9 6.086l4.707 4.707z" /></svg> }
+				icon={ upArrow }
 				tooltip={ __( 'Move Up' ) }
 				label={ getBlockMoverLabel(
 					uids.length,
@@ -49,7 +64,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 			<IconButton
 				className="editor-block-mover__control"
 				onClick={ isLast ? null : onMoveDown }
-				icon={ <svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg"><path d="M12.293 6.086L9 9.379 5.707 6.086 4.293 7.5 9 12.207 13.707 7.5z" /></svg> }
+				icon={ downArrow }
 				tooltip={ __( 'Move Down' ) }
 				label={ getBlockMoverLabel(
 					uids.length,


### PR DESCRIPTION
closes #5247

This PR adds the missing accessibility attributes to the custom svg icons used for the block movers.
I considered adding these inside the `IconButton` component but since we accept any component as an icon, I preferred avoiding this because it's not guaranteed that this component is an svg element and not a complex React component.