### PR TITLE
Taxonomies: Consider term names as case insensitive

### DIFF
--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -18,6 +18,9 @@ import { buildTermsTree } from '@wordpress/utils';
 import { getEditedPostAttribute } from '../../store/selectors';
 import { editPost } from '../../store/actions';
 
+/**
+ * Module Constants
+ */
 const DEFAULT_QUERY = {
 	per_page: 100,
 	orderby: 'count',
@@ -73,7 +76,7 @@ class HierarchicalTermSelector extends Component {
 	findTerm( terms, parent, name ) {
 		return find( terms, term => {
 			return ( ( ! term.parent && ! parent ) || parseInt( term.parent ) === parseInt( parent ) ) &&
-				term.name === name;
+				term.name.toLowerCase() === name.toLowerCase();
 		} );
 	}
 


### PR DESCRIPTION
closes #5255 

This PR considers the term names as case insenstive to match the backend's behavior. It fixes some JS errors when adding existing terms with different case.

**Testing instructions**

 - Repeat testing instructions from #52555
 - You shouldn't see JS errors. The terms are just ignored.