### PR TITLE
Simplify quote values

### DIFF
--- a/blocks/api/parser.js
+++ b/blocks/api/parser.js
@@ -79,9 +79,13 @@ export function matcherFromSource( sourceConfig ) {
 			return children( sourceConfig.selector );
 		case 'node':
 			return node( sourceConfig.selector );
-		case 'query':
-			const subMatchers = mapValues( sourceConfig.query, matcherFromSource );
+		case 'query': {
+			const subMatchers = sourceConfig.query ?
+				mapValues( sourceConfig.query, matcherFromSource ) :
+				( element ) => node()( element );
+
 			return query( sourceConfig.selector, subMatchers );
+		}
 		default:
 			// eslint-disable-next-line no-console
 			console.error( `Unknown source type "${ sourceConfig.source }"` );

--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -18,20 +13,11 @@ import RichText from '../../rich-text';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 
-const toRichTextValue = value => map( value, ( subValue => subValue.children ) );
-const fromRichTextValue = value => map( value, ( subValue ) => ( {
-	children: subValue,
-} ) );
 const blockAttributes = {
 	value: {
 		type: 'array',
 		source: 'query',
 		selector: 'blockquote > p',
-		query: {
-			children: {
-				source: 'node',
-			},
-		},
 	},
 	citation: {
 		type: 'array',
@@ -84,10 +70,10 @@ export const settings = {
 			<blockquote key="quote" className={ className }>
 				<RichText
 					multiline="p"
-					value={ toRichTextValue( value ) }
+					value={ value }
 					onChange={
 						( nextValue ) => setAttributes( {
-							value: fromRichTextValue( nextValue ),
+							value: nextValue,
 						} )
 					}
 					placeholder={ __( 'Write quote…' ) }
@@ -118,9 +104,7 @@ export const settings = {
 
 		return (
 			<blockquote className={ `align${ align }` }>
-				{ value && value.map( ( paragraph, i ) =>
-					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-				) }
+				{ [ value ] /* Prevent keys warning... */ }
 				{ citation && citation.length > 0 && (
 					<cite>{ citation }</cite>
 				) }

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, get, isString } from 'lodash';
+import { castArray, get, isString, first } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -20,21 +20,11 @@ import AlignmentToolbar from '../../alignment-toolbar';
 import BlockControls from '../../block-controls';
 import RichText from '../../rich-text';
 
-const toRichTextValue = value => value.map( ( subValue => subValue.children ) );
-const fromRichTextValue = value => value.map( ( subValue ) => ( {
-	children: subValue,
-} ) );
-
 const blockAttributes = {
 	value: {
 		type: 'array',
 		source: 'query',
 		selector: 'blockquote > p',
-		query: {
-			children: {
-				source: 'node',
-			},
-		},
 		default: [],
 	},
 	citation: {
@@ -69,7 +59,7 @@ export const settings = {
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
 						value: [
-							{ children: <p key="1">{ content }</p> },
+							<p key="1">{ content }</p>,
 						],
 					} );
 				},
@@ -80,7 +70,7 @@ export const settings = {
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
 						value: [
-							{ children: <p key="1">{ content }</p> },
+							<p key="1">{ content }</p>,
 						],
 					} );
 				},
@@ -91,7 +81,7 @@ export const settings = {
 				transform: ( { content } ) => {
 					return createBlock( 'core/quote', {
 						value: [
-							{ children: <p key="1">{ content }</p> },
+							<p key="1">{ content }</p>,
 						],
 					} );
 				},
@@ -112,7 +102,7 @@ export const settings = {
 					}
 					// transforming a quote with content
 					return ( value || [] ).map( item => createBlock( 'core/paragraph', {
-						content: [ get( item, 'children.props.children', '' ) ],
+						content: [ get( item, 'props.children', '' ) ],
 					} ) ).concat( citation ? createBlock( 'core/paragraph', {
 						content: citation,
 					} ) : [] );
@@ -130,7 +120,7 @@ export const settings = {
 						} );
 					}
 
-					const firstValue = get( value, [ 0, 'children' ] );
+					const firstValue = first( value );
 					const headingContent = castArray( isString( firstValue ) ?
 						firstValue :
 						get( firstValue, [ 'props', 'children' ], '' )
@@ -197,10 +187,10 @@ export const settings = {
 			>
 				<RichText
 					multiline="p"
-					value={ toRichTextValue( value ) }
+					value={ value }
 					onChange={
 						( nextValue ) => setAttributes( {
-							value: fromRichTextValue( nextValue ),
+							value: nextValue,
 						} )
 					}
 					onMerge={ mergeBlocks }
@@ -240,9 +230,7 @@ export const settings = {
 				className={ style === 2 ? 'is-large' : '' }
 				style={ { textAlign: align ? align : null } }
 			>
-				{ value.map( ( paragraph, i ) => (
-					<p key={ i }>{ paragraph.children && paragraph.children.props.children }</p>
-				) ) }
+				{ [ value ] /* Prevent keys warning... */ }
 				{ citation && citation.length > 0 && (
 					<cite>{ citation }</cite>
 				) }

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -146,6 +146,7 @@ export class RichText extends Component {
 		};
 
 		this.isEmpty = ! value || ! value.length;
+		this.savedContent = value;
 	}
 
 	/**
@@ -695,13 +696,7 @@ export class RichText extends Component {
 			!! this.editor &&
 			this.props.tagName === prevProps.tagName &&
 			this.props.value !== prevProps.value &&
-			this.props.value !== this.savedContent &&
-
-			// Comparing using isEqual is necessary especially to avoid unnecessary updateContent calls
-			// This fixes issues in multi richText blocks like quotes when moving the focus between
-			// the different editables.
-			! isEqual( this.props.value, prevProps.value ) &&
-			! isEqual( this.props.value, this.savedContent )
+			this.props.value !== this.savedContent
 		) {
 			this.updateContent();
 		}

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -35,6 +35,11 @@ import { pickAriaProps } from './aria';
 import patterns from './patterns';
 import { EVENTS } from './constants';
 
+/**
+ * Browser dependencies
+ */
+const { console } = window;
+
 const { BACKSPACE, DELETE, ENTER } = keycodes;
 
 export function createTinyMCEElement( type, props, ...children ) {
@@ -699,6 +704,13 @@ export class RichText extends Component {
 			this.props.value !== this.savedContent
 		) {
 			this.updateContent();
+
+			if (
+				'development' === process.env.NODE_ENV &&
+				isEqual( this.props.value, prevProps.value )
+			) {
+				console.warn( 'The current and previous value props are not strictly equal but the contents are the same. Please ensure the value prop reference does not change.' );
+			}
 		}
 	}
 

--- a/blocks/test/fixtures/core__pullquote.json
+++ b/blocks/test/fixtures/core__pullquote.json
@@ -6,16 +6,8 @@
         "attributes": {
             "value": [
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "Testing pullquote block..."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "type": "p",
+                    "children": "Testing pullquote block..."
                 }
             ],
             "citation": [

--- a/blocks/test/fixtures/core__pullquote__multi-paragraph.json
+++ b/blocks/test/fixtures/core__pullquote__multi-paragraph.json
@@ -6,40 +6,18 @@
         "attributes": {
             "value": [
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": [
-                                "Paragraph ",
-                                {
-                                    "type": "strong",
-                                    "key": "_domReact71",
-                                    "ref": null,
-                                    "props": {
-                                        "children": "one"
-                                    },
-                                    "_owner": null,
-                                    "_store": {}
-                                }
-                            ]
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "type": "p",
+                    "children": [
+                        "Paragraph ",
+                        {
+                            "type": "strong",
+                            "children": "one"
+                        }
+                    ]
                 },
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "Paragraph two"
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "type": "p",
+                    "children": "Paragraph two"
                 }
             ],
             "citation": [

--- a/blocks/test/fixtures/core__quote__style-1.json
+++ b/blocks/test/fixtures/core__quote__style-1.json
@@ -6,16 +6,8 @@
         "attributes": {
             "value": [
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "type": "p",
+                    "children": "The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery."
                 }
             ],
             "citation": [

--- a/blocks/test/fixtures/core__quote__style-2.json
+++ b/blocks/test/fixtures/core__quote__style-2.json
@@ -6,16 +6,8 @@
         "attributes": {
             "value": [
                 {
-                    "children": {
-                        "type": "p",
-                        "key": null,
-                        "ref": null,
-                        "props": {
-                            "children": "There is no greater agony than bearing an untold story inside you."
-                        },
-                        "_owner": null,
-                        "_store": {}
-                    }
+                    "type": "p",
+                    "children": "There is no greater agony than bearing an untold story inside you."
                 }
             ],
             "citation": [


### PR DESCRIPTION
## Description

See #5252.

Currently there are `isEqual` checks on a React objects every time a quote block re-renders. This branch avoids these isEqual checks in the `RichText` component by changing the quote values to not get recalculated every time `render` is called.

## How Has This Been Tested?
* Make sure quotes render and transformations work.
* Make sure you can move the caret to both fields in the quote.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.