### PR TITLE
Data: Fix issue with in-stack unsubscribe

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -28,7 +28,13 @@ let listeners = [];
  * Global listener called for each store's update.
  */
 export function globalListener() {
-	listeners.forEach( listener => listener() );
+	// Use for loop instead of Array#forEach, as it's possible a listener's
+	// behavior causes one further in the stack to be unsubscribed. The
+	// latter's callback should not be called, which requires monitoring
+	// changes to the array as they occur in iteration.
+	for ( let i = 0; i < listeners.length; i++ ) {
+		listeners[ i ]();
+	}
 }
 
 /**

--- a/data/index.js
+++ b/data/index.js
@@ -28,13 +28,7 @@ let listeners = [];
  * Global listener called for each store's update.
  */
 export function globalListener() {
-	// Use for loop instead of Array#forEach, as it's possible a listener's
-	// behavior causes one further in the stack to be unsubscribed. The
-	// latter's callback should not be called, which requires monitoring
-	// changes to the array as they occur in iteration.
-	for ( let i = 0; i < listeners.length; i++ ) {
-		listeners[ i ]();
-	}
+	listeners.forEach( ( listener ) => listener() );
 }
 
 /**

--- a/data/index.js
+++ b/data/index.js
@@ -163,6 +163,12 @@ export const withSelect = ( mapStateToProps ) => ( WrappedComponent ) => {
 
 		componentWillUnmount() {
 			this.unsubscribe();
+
+			// While above unsubscribe avoids future listener calls, callbacks
+			// are snapshotted before being invoked, so if unmounting occurs
+			// during a previous callback, we need to explicitly track and
+			// avoid the `runSelection` that is scheduled to occur.
+			this.isUnmounting = true;
 		}
 
 		subscribe() {
@@ -170,6 +176,10 @@ export const withSelect = ( mapStateToProps ) => ( WrappedComponent ) => {
 		}
 
 		runSelection( props = this.props ) {
+			if ( this.isUnmounting ) {
+				return;
+			}
+
 			const newState = mapStateToProps( select, props );
 			if ( ! isEqualShallow( newState, this.state ) ) {
 				this.setState( newState );

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -248,7 +248,21 @@ describe( 'subscribe', () => {
 		expect( incrementedValue ).toBe( 3 );
 	} );
 
-	it( 'avoids calling a later listener if unsubscribed during earlier callback', () => {
+	it( 'snapshots listeners on change, avoiding a later listener if subscribed during earlier callback', () => {
+		const store = registerReducer( 'myAwesomeReducer', ( state = 0 ) => state + 1 );
+		const secondListener = jest.fn();
+		const firstListener = jest.fn( () => {
+			subscribeWithUnsubscribe( secondListener );
+		} );
+
+		subscribeWithUnsubscribe( firstListener );
+
+		store.dispatch( { type: 'dummy' } );
+
+		expect( secondListener ).not.toHaveBeenCalled();
+	} );
+
+	it( 'snapshots listeners on change, calling a later listener even if unsubscribed during earlier callback', () => {
 		const store = registerReducer( 'myAwesomeReducer', ( state = 0 ) => state + 1 );
 		const firstListener = jest.fn( () => {
 			secondUnsubscribe();
@@ -260,7 +274,7 @@ describe( 'subscribe', () => {
 
 		store.dispatch( { type: 'dummy' } );
 
-		expect( secondListener ).not.toHaveBeenCalled();
+		expect( secondListener ).toHaveBeenCalled();
 	} );
 } );
 


### PR DESCRIPTION
This pull request seeks to resolve an issue with the `data` module's unsubscribe behavior which can result in a listener callback being invoked even after its been unsubscribed. In practice, this has been observed in #5206 where a `withSelect`'s `setState` would be called even after the component has unmounted. The solution is using a `for` loop in place of `Array#forEach`, where the latter does not account for modifications which occur to the underlying array while it is being iterated over. Since we might assume a listener's behavior could cause a later listener to become unsubscribed, we should support this by operating on the raw array, including modifications, while iterating.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```