### PR TITLE
Predefined set of font sizes

### DIFF
--- a/blocks/library/paragraph/editor.scss
+++ b/blocks/library/paragraph/editor.scss
@@ -1,3 +1,8 @@
 .editor-block-list__block:not( .is-multi-selected ) .wp-block-paragraph {
 	background: white;
 }
+
+.blocks-font-size__main {
+	display: flex;
+	justify-content: space-between;
+}

--- a/blocks/library/paragraph/editor.scss
+++ b/blocks/library/paragraph/editor.scss
@@ -6,3 +6,8 @@
 	display: flex;
 	justify-content: space-between;
 }
+
+.blocks-font-size .blocks-range-control__slider + .dashicon {
+	width: 30px;
+	height: 30px;
+}

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -379,12 +379,23 @@ export const settings = {
 	edit: ParagraphBlock,
 
 	save( { attributes } ) {
-		const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
+		const {
+			width,
+			align,
+			content,
+			dropCap,
+			backgroundColor,
+			textColor,
+			textClass,
+			fontSize,
+		} = attributes;
+
 		const className = classnames( {
 			[ `align${ width }` ]: width,
 			'has-background': backgroundColor,
 			'has-drop-cap': dropCap,
-		} );
+		}, textClass );
+
 		const styles = {
 			backgroundColor: backgroundColor,
 			color: textColor,

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -189,7 +189,7 @@ class ParagraphBlock extends Component {
 							value={ this.getFontSize() || '' }
 							onChange={ ( value ) => this.setFontSize( value ) }
 							min={ 10 }
-							max={ 200 }
+							max={ 100 }
 							beforeIcon="editor-textcolor"
 							allowReset
 						/>

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { findKey } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -48,7 +49,12 @@ const ContrastCheckerWithFallbackStyles = withFallbackStyles( ( node, ownProps )
 	};
 } )( ContrastChecker );
 
-const fontSizeValues = [ 14, 16, 36, 48 ];
+const FONT_SIZES = {
+	small: 14,
+	regular: 16,
+	large: 36,
+	larger: 48,
+};
 
 class ParagraphBlock extends Component {
 	constructor() {
@@ -85,37 +91,21 @@ class ParagraphBlock extends Component {
 		this.nodeRef = node;
 	}
 
-	setFontSize( value ) {
+	setFontSize( fontSize ) {
 		const { setAttributes } = this.props;
-		if ( fontSizeValues.includes( value ) ) {
-			if ( fontSizeValues[ 0 ] === value ) {
-				setAttributes( { fontSize: fontSizeValues[ 0 ], textClass: 'is-small-text' } );
-			} else if ( fontSizeValues[ 1 ] === value ) {
-				setAttributes( { fontSize: fontSizeValues[ 1 ], textClass: 'is-regular-text' } );
-			} else if ( fontSizeValues[ 2 ] === value ) {
-				setAttributes( { fontSize: fontSizeValues[ 2 ], textClass: 'is-large-text' } );
-			} else if ( fontSizeValues[ 3 ] === value ) {
-				setAttributes( { fontSize: fontSizeValues[ 3 ], textClass: 'is-larger-text' } );
-			}
-		} else {
-			setAttributes( { fontSize: value, textClass: '' } );
+		const size = findKey( FONT_SIZES, ( value ) => value === fontSize );
+
+		let textClass;
+		if ( size ) {
+			textClass = `is-${ size }-text`;
 		}
+
+		setAttributes( { fontSize, textClass } );
 	}
 
 	getFontSize() {
 		const { fontSize, textClass } = this.props.attributes;
-		switch ( textClass ) {
-			case 'is-small-text':
-				return fontSizeValues[ 0 ];
-			case 'is-regular-text':
-				return fontSizeValues[ 1 ];
-			case 'is-large-text':
-				return fontSizeValues[ 2 ];
-			case 'is-larger-text':
-				return fontSizeValues[ 3 ];
-			default:
-				return fontSize;
-		}
+		return FONT_SIZES[ textClass ] || fontSize;
 	}
 
 	render() {
@@ -159,28 +149,28 @@ class ParagraphBlock extends Component {
 								<Button
 									isLarge
 									isPrimary={ attributes.textClass === 'is-small-text' }
-									onClick={ () => this.setFontSize( fontSizeValues[ 0 ] ) }
+									onClick={ () => this.setFontSize( FONT_SIZES.small ) }
 								>
 									S
 								</Button>
 								<Button
 									isLarge
 									isPrimary={ attributes.textClass === 'is-regular-text' }
-									onClick={ () => this.setFontSize( fontSizeValues[ 1 ] ) }
+									onClick={ () => this.setFontSize( FONT_SIZES.regular ) }
 								>
 									M
 								</Button>
 								<Button
 									isLarge
 									isPrimary={ attributes.textClass === 'is-large-text' }
-									onClick={ () => this.setFontSize( fontSizeValues[ 2 ] ) }
+									onClick={ () => this.setFontSize( FONT_SIZES.large ) }
 								>
 									L
 								</Button>
 								<Button
 									isLarge
 									isPrimary={ attributes.textClass === 'is-larger-text' }
-									onClick={ () => this.setFontSize( fontSizeValues[ 3 ] ) }
+									onClick={ () => this.setFontSize( FONT_SIZES.larger ) }
 								>
 									XL
 								</Button>
@@ -196,7 +186,7 @@ class ParagraphBlock extends Component {
 							label={ __( 'Custom Size' ) }
 							value={ this.getFontSize() || '' }
 							onChange={ ( value ) => this.setFontSize( value ) }
-							min={ 10 }
+							min={ 12 }
 							max={ 100 }
 							beforeIcon="editor-textcolor"
 						/>
@@ -317,6 +307,9 @@ const schema = {
 	fontSize: {
 		type: 'number',
 	},
+	textClass: {
+		type: 'string',
+	},
 };
 
 export const name = 'core/paragraph';
@@ -409,7 +402,7 @@ export const settings = {
 		const styles = {
 			backgroundColor: backgroundColor,
 			color: textColor,
-			fontSize: fontSizeValues.includes( fontSize ) ? null : fontSize,
+			fontSize: textClass ? null : fontSize,
 			textAlign: align,
 		};
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -154,44 +154,51 @@ class ParagraphBlock extends Component {
 			isSelected && (
 				<InspectorControls key="inspector">
 					<PanelBody title={ __( 'Text Settings' ) }>
-						<ButtonGroup aria-label={ __( 'Select font size' ) }>
+						<div className="blocks-font-size__main">
+							<ButtonGroup aria-label={ __( 'Font Size' ) }>
+								<Button
+									isLarge
+									isPrimary={ attributes.textClass === 'is-small-text' }
+									onClick={ () => this.setFontSize( fontSizeValues[ 0 ] ) }
+								>
+									S
+								</Button>
+								<Button
+									isLarge
+									isPrimary={ attributes.textClass === 'is-regular-text' }
+									onClick={ () => this.setFontSize( fontSizeValues[ 1 ] ) }
+								>
+									M
+								</Button>
+								<Button
+									isLarge
+									isPrimary={ attributes.textClass === 'is-large-text' }
+									onClick={ () => this.setFontSize( fontSizeValues[ 2 ] ) }
+								>
+									L
+								</Button>
+								<Button
+									isLarge
+									isPrimary={ attributes.textClass === 'is-larger-text' }
+									onClick={ () => this.setFontSize( fontSizeValues[ 3 ] ) }
+								>
+									XL
+								</Button>
+							</ButtonGroup>
 							<Button
 								isLarge
-								isPrimary={ attributes.textClass === 'is-small-text' }
-								onClick={ () => this.setFontSize( fontSizeValues[ 0 ] ) }
+								onClick={ () => this.setFontSize( null ) }
 							>
-								S
+								{ __( 'Reset' ) }
 							</Button>
-							<Button
-								isLarge
-								isPrimary={ attributes.textClass === 'is-regular-text' }
-								onClick={ () => this.setFontSize( fontSizeValues[ 1 ] ) }
-							>
-								M
-							</Button>
-							<Button
-								isLarge
-								isPrimary={ attributes.textClass === 'is-large-text' }
-								onClick={ () => this.setFontSize( fontSizeValues[ 2 ] ) }
-							>
-								L
-							</Button>
-							<Button
-								isLarge
-								isPrimary={ attributes.textClass === 'is-larger-text' }
-								onClick={ () => this.setFontSize( fontSizeValues[ 3 ] ) }
-							>
-								XL
-							</Button>
-						</ButtonGroup>
+						</div>
 						<RangeControl
-							label={ __( 'Font Size' ) }
+							label={ __( 'Custom Size' ) }
 							value={ this.getFontSize() || '' }
 							onChange={ ( value ) => this.setFontSize( value ) }
 							min={ 10 }
 							max={ 100 }
 							beforeIcon="editor-textcolor"
-							allowReset
 						/>
 						<span>{ attributes.textClass }</span>
 						<ToggleControl

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -93,19 +93,8 @@ class ParagraphBlock extends Component {
 
 	setFontSize( fontSize ) {
 		const { setAttributes } = this.props;
-		const size = findKey( FONT_SIZES, ( value ) => value === fontSize );
 
-		let textClass;
-		if ( size ) {
-			textClass = `is-${ size }-text`;
-		}
-
-		setAttributes( { fontSize, textClass } );
-	}
-
-	getFontSize() {
-		const { fontSize, textClass } = this.props.attributes;
-		return FONT_SIZES[ textClass ] || fontSize;
+		setAttributes( { fontSize } );
 	}
 
 	render() {
@@ -155,8 +144,8 @@ class ParagraphBlock extends Component {
 									<Button
 										key={ label }
 										isLarge
-										isPrimary={ attributes.textClass === `is-${ size }-text` }
-										aria-pressed={ attributes.textClass === `is-${ size }-text` }
+										isPrimary={ fontSize === FONT_SIZES[ size ] }
+										aria-pressed={ fontSize === FONT_SIZES[ size ] }
 										onClick={ () => this.setFontSize( FONT_SIZES[ size ] ) }
 									>
 										{ label }
@@ -172,7 +161,7 @@ class ParagraphBlock extends Component {
 						</div>
 						<RangeControl
 							label={ __( 'Custom Size' ) }
-							value={ this.getFontSize() || '' }
+							value={ fontSize || '' }
 							onChange={ ( value ) => this.setFontSize( value ) }
 							min={ 12 }
 							max={ 100 }
@@ -295,9 +284,6 @@ const schema = {
 	fontSize: {
 		type: 'number',
 	},
-	textClass: {
-		type: 'string',
-	},
 };
 
 export const name = 'core/paragraph';
@@ -377,20 +363,21 @@ export const settings = {
 			dropCap,
 			backgroundColor,
 			textColor,
-			textClass,
 			fontSize,
 		} = attributes;
+
+		const thresholdFontSize = findKey( FONT_SIZES, ( size ) => size === fontSize );
 
 		const className = classnames( {
 			[ `align${ width }` ]: width,
 			'has-background': backgroundColor,
 			'has-drop-cap': dropCap,
-		}, textClass );
+		}, thresholdFontSize ? `is-${ thresholdFontSize }-text` : undefined );
 
 		const styles = {
 			backgroundColor: backgroundColor,
 			color: textColor,
-			fontSize: textClass ? null : fontSize,
+			fontSize: thresholdFontSize ? null : fontSize,
 			textAlign: align,
 		};
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -143,12 +143,13 @@ class ParagraphBlock extends Component {
 			),
 			isSelected && (
 				<InspectorControls key="inspector">
-					<PanelBody title={ __( 'Text Settings' ) }>
+					<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
 						<div className="blocks-font-size__main">
 							<ButtonGroup aria-label={ __( 'Font Size' ) }>
 								<Button
 									isLarge
 									isPrimary={ attributes.textClass === 'is-small-text' }
+									aria-pressed={ attributes.textClass === 'is-small-text' }
 									onClick={ () => this.setFontSize( FONT_SIZES.small ) }
 								>
 									S
@@ -156,6 +157,7 @@ class ParagraphBlock extends Component {
 								<Button
 									isLarge
 									isPrimary={ attributes.textClass === 'is-regular-text' }
+									aria-pressed={ attributes.textClass === 'is-regular-text' }
 									onClick={ () => this.setFontSize( FONT_SIZES.regular ) }
 								>
 									M
@@ -163,6 +165,7 @@ class ParagraphBlock extends Component {
 								<Button
 									isLarge
 									isPrimary={ attributes.textClass === 'is-large-text' }
+									aria-pressed={ attributes.textClass === 'is-large-text' }
 									onClick={ () => this.setFontSize( FONT_SIZES.large ) }
 								>
 									L
@@ -170,6 +173,7 @@ class ParagraphBlock extends Component {
 								<Button
 									isLarge
 									isPrimary={ attributes.textClass === 'is-larger-text' }
+									aria-pressed={ attributes.textClass === 'is-larger-text' }
 									onClick={ () => this.setFontSize( FONT_SIZES.larger ) }
 								>
 									XL
@@ -189,6 +193,7 @@ class ParagraphBlock extends Component {
 							min={ 12 }
 							max={ 100 }
 							beforeIcon="editor-textcolor"
+							afterIcon="editor-textcolor"
 						/>
 						<span>{ attributes.textClass }</span>
 						<ToggleControl

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -15,6 +15,7 @@ import {
 	RangeControl,
 	ToggleControl,
 	Button,
+	ButtonGroup,
 	withFallbackStyles,
 } from '@wordpress/components';
 
@@ -153,34 +154,36 @@ class ParagraphBlock extends Component {
 			isSelected && (
 				<InspectorControls key="inspector">
 					<PanelBody title={ __( 'Text Settings' ) }>
-						<Button
-							isSmall
-							isPrimary={ attributes.textClass === 'is-small-text' }
-							onClick={ () => this.setFontSize( fontSizeValues[ 0 ] ) }
-						>
-							Small
-						</Button>
-						<Button
-							isSmall
-							isPrimary={ attributes.textClass === 'is-regular-text' }
-							onClick={ () => this.setFontSize( fontSizeValues[ 1 ] ) }
-						>
-							Regular
-						</Button>
-						<Button
-							isSmall
-							isPrimary={ attributes.textClass === 'is-large-text' }
-							onClick={ () => this.setFontSize( fontSizeValues[ 2 ] ) }
-						>
-							Large
-						</Button>
-						<Button
-							isSmall
-							isPrimary={ attributes.textClass === 'is-larger-text' }
-							onClick={ () => this.setFontSize( fontSizeValues[ 3 ] ) }
-						>
-							Larger
-						</Button>
+						<ButtonGroup aria-label={ __( 'Select font size' ) }>
+							<Button
+								isLarge
+								isPrimary={ attributes.textClass === 'is-small-text' }
+								onClick={ () => this.setFontSize( fontSizeValues[ 0 ] ) }
+							>
+								S
+							</Button>
+							<Button
+								isLarge
+								isPrimary={ attributes.textClass === 'is-regular-text' }
+								onClick={ () => this.setFontSize( fontSizeValues[ 1 ] ) }
+							>
+								M
+							</Button>
+							<Button
+								isLarge
+								isPrimary={ attributes.textClass === 'is-large-text' }
+								onClick={ () => this.setFontSize( fontSizeValues[ 2 ] ) }
+							>
+								L
+							</Button>
+							<Button
+								isLarge
+								isPrimary={ attributes.textClass === 'is-larger-text' }
+								onClick={ () => this.setFontSize( fontSizeValues[ 3 ] ) }
+							>
+								XL
+							</Button>
+						</ButtonGroup>
 						<RangeControl
 							label={ __( 'Font Size' ) }
 							value={ this.getFontSize() || '' }

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { findKey } from 'lodash';
+import { findKey, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -146,38 +146,22 @@ class ParagraphBlock extends Component {
 					<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
 						<div className="blocks-font-size__main">
 							<ButtonGroup aria-label={ __( 'Font Size' ) }>
-								<Button
-									isLarge
-									isPrimary={ attributes.textClass === 'is-small-text' }
-									aria-pressed={ attributes.textClass === 'is-small-text' }
-									onClick={ () => this.setFontSize( FONT_SIZES.small ) }
-								>
-									S
-								</Button>
-								<Button
-									isLarge
-									isPrimary={ attributes.textClass === 'is-regular-text' }
-									aria-pressed={ attributes.textClass === 'is-regular-text' }
-									onClick={ () => this.setFontSize( FONT_SIZES.regular ) }
-								>
-									M
-								</Button>
-								<Button
-									isLarge
-									isPrimary={ attributes.textClass === 'is-large-text' }
-									aria-pressed={ attributes.textClass === 'is-large-text' }
-									onClick={ () => this.setFontSize( FONT_SIZES.large ) }
-								>
-									L
-								</Button>
-								<Button
-									isLarge
-									isPrimary={ attributes.textClass === 'is-larger-text' }
-									aria-pressed={ attributes.textClass === 'is-larger-text' }
-									onClick={ () => this.setFontSize( FONT_SIZES.larger ) }
-								>
-									XL
-								</Button>
+								{ map( {
+									S: 'small',
+									M: 'regular',
+									L: 'large',
+									XL: 'larger',
+								}, ( size, label ) => (
+									<Button
+										key={ label }
+										isLarge
+										isPrimary={ attributes.textClass === `is-${ size }-text` }
+										aria-pressed={ attributes.textClass === `is-${ size }-text` }
+										onClick={ () => this.setFontSize( FONT_SIZES[ size ] ) }
+									>
+										{ label }
+									</Button>
+								) ) }
 							</ButtonGroup>
 							<Button
 								isLarge

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { findKey, map } from 'lodash';
+import { findKey, isFinite, map, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -344,6 +344,40 @@ export const settings = {
 	},
 
 	deprecated: [
+		{
+			supports,
+			attributes: omit( {
+				...schema,
+				fontSize: {
+					type: 'number',
+				},
+			}, 'customFontSize' ),
+			save( { attributes } ) {
+				const { width, align, content, dropCap, backgroundColor, textColor, fontSize } = attributes;
+				const className = classnames( {
+					[ `align${ width }` ]: width,
+					'has-background': backgroundColor,
+					'has-drop-cap': dropCap,
+				} );
+				const styles = {
+					backgroundColor: backgroundColor,
+					color: textColor,
+					fontSize: fontSize,
+					textAlign: align,
+				};
+
+				return <p style={ styles } className={ className ? className : undefined }>{ content }</p>;
+			},
+			migrate( attributes ) {
+				if ( isFinite( attributes.fontSize ) ) {
+					return omit( {
+						...attributes,
+						customFontSize: attributes.fontSize,
+					}, 'fontSize' );
+				}
+				return attributes;
+			},
+		},
 		{
 			supports,
 			attributes: {

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -195,7 +195,6 @@ class ParagraphBlock extends Component {
 							beforeIcon="editor-textcolor"
 							afterIcon="editor-textcolor"
 						/>
-						<span>{ attributes.textClass }</span>
 						<ToggleControl
 							label={ __( 'Drop Cap' ) }
 							checked={ !! dropCap }

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -14,6 +14,7 @@ import {
 	PanelColor,
 	RangeControl,
 	ToggleControl,
+	Button,
 	withFallbackStyles,
 } from '@wordpress/components';
 
@@ -45,6 +46,8 @@ const ContrastCheckerWithFallbackStyles = withFallbackStyles( ( node, ownProps )
 		fallbackTextColor: textColor || ! computedStyles ? undefined : computedStyles.color,
 	};
 } )( ContrastChecker );
+
+const fontSizeValues = [ 14, 16, 36, 48 ];
 
 class ParagraphBlock extends Component {
 	constructor() {
@@ -79,6 +82,39 @@ class ParagraphBlock extends Component {
 			return;
 		}
 		this.nodeRef = node;
+	}
+
+	setFontSize( value ) {
+		const { setAttributes } = this.props;
+		if ( fontSizeValues.includes( value ) ) {
+			if ( fontSizeValues[ 0 ] === value ) {
+				setAttributes( { fontSize: fontSizeValues[ 0 ], textClass: 'is-small-text' } );
+			} else if ( fontSizeValues[ 1 ] === value ) {
+				setAttributes( { fontSize: fontSizeValues[ 1 ], textClass: 'is-regular-text' } );
+			} else if ( fontSizeValues[ 2 ] === value ) {
+				setAttributes( { fontSize: fontSizeValues[ 2 ], textClass: 'is-large-text' } );
+			} else if ( fontSizeValues[ 3 ] === value ) {
+				setAttributes( { fontSize: fontSizeValues[ 3 ], textClass: 'is-larger-text' } );
+			}
+		} else {
+			setAttributes( { fontSize: value, textClass: '' } );
+		}
+	}
+
+	getFontSize() {
+		const { fontSize, textClass } = this.props.attributes;
+		switch ( textClass ) {
+			case 'is-small-text':
+				return fontSizeValues[ 0 ];
+			case 'is-regular-text':
+				return fontSizeValues[ 1 ];
+			case 'is-large-text':
+				return fontSizeValues[ 2 ];
+			case 'is-larger-text':
+				return fontSizeValues[ 3 ];
+			default:
+				return fontSize;
+		}
 	}
 
 	render() {
@@ -117,19 +153,48 @@ class ParagraphBlock extends Component {
 			isSelected && (
 				<InspectorControls key="inspector">
 					<PanelBody title={ __( 'Text Settings' ) }>
-						<ToggleControl
-							label={ __( 'Drop Cap' ) }
-							checked={ !! dropCap }
-							onChange={ this.toggleDropCap }
-						/>
+						<Button
+							isSmall
+							isPrimary={ attributes.textClass === 'is-small-text' }
+							onClick={ () => this.setFontSize( fontSizeValues[ 0 ] ) }
+						>
+							Small
+						</Button>
+						<Button
+							isSmall
+							isPrimary={ attributes.textClass === 'is-regular-text' }
+							onClick={ () => this.setFontSize( fontSizeValues[ 1 ] ) }
+						>
+							Regular
+						</Button>
+						<Button
+							isSmall
+							isPrimary={ attributes.textClass === 'is-large-text' }
+							onClick={ () => this.setFontSize( fontSizeValues[ 2 ] ) }
+						>
+							Large
+						</Button>
+						<Button
+							isSmall
+							isPrimary={ attributes.textClass === 'is-larger-text' }
+							onClick={ () => this.setFontSize( fontSizeValues[ 3 ] ) }
+						>
+							Larger
+						</Button>
 						<RangeControl
 							label={ __( 'Font Size' ) }
-							value={ fontSize || '' }
-							onChange={ ( value ) => setAttributes( { fontSize: value } ) }
+							value={ this.getFontSize() || '' }
+							onChange={ ( value ) => this.setFontSize( value ) }
 							min={ 10 }
 							max={ 200 }
 							beforeIcon="editor-textcolor"
 							allowReset
+						/>
+						<span>{ attributes.textClass }</span>
+						<ToggleControl
+							label={ __( 'Drop Cap' ) }
+							checked={ !! dropCap }
+							onChange={ this.toggleDropCap }
 						/>
 					</PanelBody>
 					<PanelColor title={ __( 'Background Color' ) } colorValue={ backgroundColor } initialOpen={ false }>
@@ -323,7 +388,7 @@ export const settings = {
 		const styles = {
 			backgroundColor: backgroundColor,
 			color: textColor,
-			fontSize: fontSize,
+			fontSize: fontSizeValues.includes( fontSize ) ? null : fontSize,
 			textAlign: align,
 		};
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -63,6 +63,8 @@ class ParagraphBlock extends Component {
 		this.bindRef = this.bindRef.bind( this );
 		this.onReplace = this.onReplace.bind( this );
 		this.toggleDropCap = this.toggleDropCap.bind( this );
+		this.getFontSize = this.getFontSize.bind( this );
+		this.setFontSize = this.setFontSize.bind( this );
 	}
 
 	onReplace( blocks ) {
@@ -91,10 +93,31 @@ class ParagraphBlock extends Component {
 		this.nodeRef = node;
 	}
 
-	setFontSize( fontSize ) {
-		const { setAttributes } = this.props;
+	getFontSize() {
+		const { customFontSize, fontSize } = this.props.attributes;
+		if ( fontSize ) {
+			return FONT_SIZES[ fontSize ];
+		}
 
-		setAttributes( { fontSize } );
+		if ( customFontSize ) {
+			return customFontSize;
+		}
+	}
+
+	setFontSize( fontSizeValue ) {
+		const { setAttributes } = this.props;
+		const thresholdFontSize = findKey( FONT_SIZES, ( size ) => size === fontSizeValue );
+		if ( thresholdFontSize ) {
+			setAttributes( {
+				fontSize: thresholdFontSize,
+				customFontSize: undefined,
+			} );
+			return;
+		}
+		setAttributes( {
+			fontSize: undefined,
+			customFontSize: fontSizeValue,
+		} );
 	}
 
 	render() {
@@ -113,11 +136,12 @@ class ParagraphBlock extends Component {
 			content,
 			dropCap,
 			placeholder,
-			fontSize,
 			backgroundColor,
 			textColor,
 			width,
 		} = attributes;
+
+		const fontSize = this.getFontSize();
 
 		return [
 			isSelected && (
@@ -154,7 +178,7 @@ class ParagraphBlock extends Component {
 							</ButtonGroup>
 							<Button
 								isLarge
-								onClick={ () => this.setFontSize( null ) }
+								onClick={ () => this.setFontSize( undefined ) }
 							>
 								{ __( 'Reset' ) }
 							</Button>
@@ -282,6 +306,9 @@ const schema = {
 		type: 'string',
 	},
 	fontSize: {
+		type: 'string',
+	},
+	customFontSize: {
 		type: 'number',
 	},
 };
@@ -364,21 +391,20 @@ export const settings = {
 			backgroundColor,
 			textColor,
 			fontSize,
+			customFontSize,
 		} = attributes;
-
-		const thresholdFontSize = findKey( FONT_SIZES, ( size ) => size === fontSize );
 
 		const className = classnames( {
 			[ `align${ width }` ]: width,
 			'has-background': backgroundColor,
 			'has-drop-cap': dropCap,
-			[ `is-${ thresholdFontSize }-text` ]: thresholdFontSize,
+			[ `is-${ fontSize }-text` ]: fontSize && FONT_SIZES[ fontSize ],
 		} );
 
 		const styles = {
 			backgroundColor: backgroundColor,
 			color: textColor,
-			fontSize: thresholdFontSize ? null : fontSize,
+			fontSize: ! fontSize && customFontSize ? customFontSize : undefined,
 			textAlign: align,
 		};
 

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -372,7 +372,8 @@ export const settings = {
 			[ `align${ width }` ]: width,
 			'has-background': backgroundColor,
 			'has-drop-cap': dropCap,
-		}, thresholdFontSize ? `is-${ thresholdFontSize }-text` : undefined );
+			[ `is-${ thresholdFontSize }-text` ]: thresholdFontSize,
+		} );
 
 		const styles = {
 			backgroundColor: backgroundColor,

--- a/blocks/library/paragraph/style.scss
+++ b/blocks/library/paragraph/style.scss
@@ -1,13 +1,31 @@
-p.has-drop-cap {
-	&:first-letter {
-		float: left;
-		font-size: 4.1em;
-		line-height: 0.7;
-		font-family: serif;
-		font-weight: bold;
-		margin: .07em .23em 0 0;
-		text-transform: uppercase;
-		font-style: normal;
+p {
+	&.is-small-text {
+		font-size: 14px;
+	}
+
+	&.is-regular-text {
+		font-size: 16px;
+	}
+
+	&.is-large-text {
+		font-size: 36px;
+	}
+
+	&.is-larger-text {
+		font-size: 48px;
+	}
+
+	&.has-drop-cap {
+		&:first-letter {
+			float: left;
+			font-size: 4.1em;
+			line-height: 0.7;
+			font-family: serif;
+			font-weight: bold;
+			margin: .07em .23em 0 0;
+			text-transform: uppercase;
+			font-style: normal;
+		}
 	}
 }
 

--- a/components/button-group/index.js
+++ b/components/button-group/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function ButtonGroup( { className, ...props } ) {
+	const classes = classnames( 'components-button-group', className );
+
+	return (
+		<div { ...props } className={ classes } role="group" />
+	);
+}
+
+export default ButtonGroup;

--- a/components/button-group/style.scss
+++ b/components/button-group/style.scss
@@ -1,0 +1,19 @@
+.components-button-group {
+	display: inline-block;
+	margin-bottom: 20px;
+
+	.components-button {
+		border-radius: 0;
+		& + .components-button {
+			margin-left: -1px;
+		}
+
+		&:first-child {
+			border-radius: 3px 0 0 3px;
+		}
+
+		&:last-child {
+			border-radius: 0 3px 3px 0;
+		}
+	}
+}

--- a/components/index.js
+++ b/components/index.js
@@ -3,6 +3,7 @@ export { default as APIProvider } from './higher-order/with-api-data/provider';
 export { default as Autocomplete } from './autocomplete';
 export { default as BaseControl } from './base-control';
 export { default as Button } from './button';
+export { default as ButtonGroup } from './button-group';
 export { default as CheckboxControl } from './checkbox-control';
 export { default as ClipboardButton } from './clipboard-button';
 export { default as CodeEditor } from './code-editor';


### PR DESCRIPTION
Allow font-size control to have a predefined set of sizes (small, regular, large, larger) which applies classes instead of inline font-size style values. If the value does not correspond to a value in the supplied set, it falls back to previous mechanism.

Themes will be able to define their own set to overwrite the default.

The design aim would be to add a new component (segmented control) which we could use for the image size set as well.

## Implementation

- Introduce new `ButtonGroup` component.
- Add notion of text class to paragraph block.
- Define predefined set of font sizes.
- If a font size matches a class, use class instead of inline style.

## Current State

![image](https://user-images.githubusercontent.com/548849/37161283-82b2a620-22f2-11e8-95a1-e7e9843755a0.png)

