### PR TITLE
Writing Flow: Remove onBottomReached handling

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import 'element-closest';
-import { find, last, reverse, get } from 'lodash';
+import { find, reverse, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,7 +22,6 @@ import {
 /**
  * Internal dependencies
  */
-import { BlockListBlock } from '../block-list/block';
 import {
 	getPreviousBlockUid,
 	getNextBlockUid,
@@ -32,7 +31,6 @@ import {
 } from '../../store/selectors';
 import {
 	multiSelect,
-	insertDefaultBlock,
 	selectBlock,
 } from '../../store/actions';
 
@@ -40,10 +38,6 @@ import {
  * Module Constants
  */
 const { UP, DOWN, LEFT, RIGHT } = keycodes;
-
-function isElementNonEmpty( el ) {
-	return !! el.innerText.trim();
-}
 
 class WritingFlow extends Component {
 	constructor() {
@@ -107,37 +101,6 @@ class WritingFlow extends Component {
 
 			return true;
 		} );
-	}
-
-	isInLastNonEmptyBlock( target ) {
-		const tabbables = this.getVisibleTabbables();
-
-		// Find last tabbable, compare with target
-		const lastTabbable = last( tabbables );
-		if ( ! lastTabbable || ! lastTabbable.contains( target ) ) {
-			return false;
-		}
-
-		// Find block-level ancestor of said last tabbable
-		const blockEl = lastTabbable.closest( '.' + BlockListBlock.className );
-		const blockIndex = tabbables.indexOf( blockEl );
-
-		// Unexpected, so we'll leave quietly.
-		if ( blockIndex === -1 ) {
-			return false;
-		}
-
-		// Maybe there are no descendants, and the target is the block itself?
-		if ( lastTabbable === blockEl ) {
-			return isElementNonEmpty( blockEl );
-		}
-
-		// Otherwise, find the descendants of the ancestor, i.e. the target and
-		// its siblings, and check them instead.
-		return tabbables
-			.slice( blockIndex + 1 )
-			.some( ( el ) =>
-				blockEl.contains( el ) && isElementNonEmpty( el ) );
 	}
 
 	expandSelection( currentStartUid, isReverse ) {
@@ -229,13 +192,6 @@ class WritingFlow extends Component {
 			this.selectParentBlock( closestTabbable );
 			event.preventDefault();
 		}
-
-		if ( isDown && ! isShift && ! hasMultiSelection &&
-				this.isInLastNonEmptyBlock( target ) &&
-				isVerticalEdge( target, false, false )
-		) {
-			this.props.onBottomReached();
-		}
 	}
 
 	render() {
@@ -267,7 +223,6 @@ export default connect(
 	} ),
 	{
 		onMultiSelect: multiSelect,
-		onBottomReached: insertDefaultBlock,
 		onSelectBlock: selectBlock,
 	}
 )( WritingFlow );


### PR DESCRIPTION
Related: #3973

This pull request seeks to remove explicit handling of "bottom reached" within writing flow. This logic is redundant because the default writing flow behavior of transitioning focus into the next input upon reaching the vertical edge will automatically cause this to take effect, since the [DefaultBlockAppender is an input](https://github.com/WordPress/gutenberg/blob/f3c1e22a73ce3c9b998fbc8676ba64fa70d83dbc/editor/components/default-block-appender/index.js#L30-L38):

- https://github.com/WordPress/gutenberg/blob/f3c1e22/editor/components/writing-flow/index.js#L221-L223
- https://github.com/WordPress/gutenberg/blob/f3c1e22/editor/components/writing-flow/index.js#L76-L110
- https://github.com/WordPress/gutenberg/blob/f3c1e22/utils/dom.js#L262-L265
- https://github.com/WordPress/gutenberg/blob/f3c1e22/utils/dom.js#L169
- https://github.com/WordPress/gutenberg/blob/f3c1e22/editor/components/default-block-appender/index.js#L34

__Implementation notes:__

Discovered this in course of trying to resolve a related issue with nested blocks, where the "on bottom reached" logic will not work as-is anyways since `insertDefaultBlock` is not being provided with the root UID of the block list in which the end has been reached.

__Testing instructions:__

Verify there are no regressions in creating a new default block at the end of content by pressing the Down arrow.