### PR TITLE
Allow blocks to specify that they can't be made reusable

### DIFF
--- a/blocks/library/columns/index.js
+++ b/blocks/library/columns/index.js
@@ -49,6 +49,10 @@ export const settings = {
 
 	category: 'layout',
 
+	supports: {
+		reusable: false,
+	},
+
 	attributes: {
 		columns: {
 			type: 'number',

--- a/editor/components/block-settings-menu/reusable-block-settings.js
+++ b/editor/components/block-settings-menu/reusable-block-settings.js
@@ -10,16 +10,12 @@ import { noop } from 'lodash';
 import { Fragment } from '@wordpress/element';
 import { IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { isReusableBlock } from '@wordpress/blocks';
+import { isReusableBlock, getBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import {
-	getBlock,
-	getBlockOrder,
-	getReusableBlock,
-} from '../../store/selectors';
+import { getBlock, getReusableBlock } from '../../store/selectors';
 import { convertBlockToStatic, convertBlockToReusable, deleteReusableBlock } from '../../store/actions';
 
 export function ReusableBlockSettings( {
@@ -69,7 +65,7 @@ export default connect(
 		const block = getBlock( state, uid );
 
 		return {
-			isValidForConvert: ! getBlockOrder( state, block.uid ).length,
+			isValidForConvert: getBlockSupport( block.name, 'reusable', true ),
 			reusableBlock: isReusableBlock( block ) ? getReusableBlock( state, block.attributes.ref ) : null,
 		};
 	},


### PR DESCRIPTION
Closes #4722.

## Description

Allows blocks to specify that they can't be made reusable by setting `supports.reusable` to false.

Right now, the Columns (experimental) block is the only core block that we don't support converting into a reusable block. @aduth is working on that over in https://github.com/WordPress/gutenberg/pull/5228.

## How to test

1. Create a block
2. Click on the 'More options' ellipsis and convert it to a reusable block
3. Create a Columns (experimental) block
4. Click on the 'More options' ellipsis and verify that you cannot convert it to a reusable block