### PR TITLE
Inserter: Fix the in-between inserter on nested blocks

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -674,6 +674,7 @@ export class BlockListBlock extends Component {
 					<BlockInsertionPoint
 						uid={ block.uid }
 						rootUID={ rootUID }
+						layout={ layout }
 					/>
 				) }
 				{ showSideInserter && (

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -216,7 +216,7 @@ class BlockListLayout extends Component {
 
 		return (
 			<BlockSelectionClearer className={ classes }>
-				{ !! blockUIDs.length && <BlockInsertionPoint /> }
+				{ !! blockUIDs.length && <BlockInsertionPoint rootUID={ rootUID } layout={ defaultLayout } /> }
 				{ map( blockUIDs, ( uid, blockIndex ) => (
 					<BlockListBlock
 						key={ 'block-' + uid }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -439,9 +439,11 @@
 	left: 0;
 	right: 0;
 
-	@include break-small {
-		left: $block-mover-padding-visible;
-		right: $block-mover-padding-visible;
+	.editor-block-list__insertion-point-inserter:before {
+		@include break-small {
+			left: $block-mover-padding-visible;
+			right: $block-mover-padding-visible;
+		}
 	}
 }
 


### PR DESCRIPTION
related https://github.com/WordPress/gutenberg/pull/5198#pullrequestreview-99434537

This fixes the inserter (ine) showing up when you hover between blocks for nested blocks.

**Testing instructions**

 - Trying clicking this line above and between nested blocks
 - Try cliking this line at the beginning of the post.
 - It should work and look well.