### PR TITLE
Fixed CSS bug that made impossible close sidebar on mobile with meta boxes

### DIFF
--- a/edit-post/components/meta-boxes/meta-boxes-panel/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-panel/style.scss
@@ -6,6 +6,10 @@
 	.is-sidebar-opened & {
 		display: block;
 	}
+
+	.edit-post-meta-boxes-panel__toggle .components-panel__header {
+		position: inherit;
+	}
 }
 
 .edit-post-meta-boxes-panel__body {


### PR DESCRIPTION
When meta-boxes existed in mobile their panel header appeared above the normal panel header of the sidebar making it impossible to close the sidebar on mobile.
 

## How Has This Been Tested?
To test first we need a meta box to render in the editor.
Then resize the editor to mobile resolutions, open the sidebar and see before this PR it was impossible to close it (panel header of the meta boxes may appear above), and with this PR things work as expected.
Verify the inserter and other panels also work as before.

## Screenshots (jpeg or gifs if applicable):
In safari from iPhone the panel header of meta boxes appeared below the normal header, but clicking on the normal heading did not close the sidebar and just opened and collapsed the meta boxes. The meta boxes heading title "Extended settings" was never visible.
![img_5191](https://user-images.githubusercontent.com/11271197/36736909-a571a184-1bd1-11e8-89f5-1e60bf23ca44.JPG)



In chrome, the meta boxes appeared above the normal sidebar heading making closing the sidebar impossible.
<img width="285" alt="screen shot 2018-02-27 at 15 09 12" src="https://user-images.githubusercontent.com/11271197/36736842-72962302-1bd1-11e8-83b9-2cb5ccd615cd.png">


After:
<img width="286" alt="screen shot 2018-02-27 at 15 03 50" src="https://user-images.githubusercontent.com/11271197/36736841-7268e69e-1bd1-11e8-9995-071606b678f6.png">
![img_5190](https://user-images.githubusercontent.com/11271197/36736908-a51db696-1bd1-11e8-9a90-0ad8ade27fa5.JPG)
