### PR TITLE
Fix conflicts with markdown plugins

### DIFF
--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -25,10 +25,12 @@
  * @param  array $post      Post object which contains content to check for block.
  * @return array $post      Post object.
  */
-function gutenberg_remove_wpcom_markdown_support( $post ) {
-	if ( gutenberg_content_has_blocks( $post->post_content ) ) {
-		remove_post_type_support( 'post', 'wpcom-markdown' );
+function gutenberg_remove_wpcom_markdown_support( $post_data ) {
+	if ( gutenberg_content_has_blocks( implode( "\n", $post_data ) ) ) {
+        if ( class_exists ( 'WPCom_Markdown' ) ) {
+            WPCom_Markdown::get_instance()->unload_markdown_for_posts();
+        }
 	}
-	return $post;
+	return $post_data;
 }
-add_filter( 'rest_pre_insert_post', 'gutenberg_remove_wpcom_markdown_support' );
+add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 1, 1 );

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -27,9 +27,9 @@
  */
 function gutenberg_remove_wpcom_markdown_support( $post_data ) {
 	if ( gutenberg_content_has_blocks( implode( "\n", $post_data ) ) ) {
-        if ( class_exists ( 'WPCom_Markdown' ) ) {
-            WPCom_Markdown::get_instance()->unload_markdown_for_posts();
-        }
+		if ( class_exists ( 'WPCom_Markdown' ) ) {
+			WPCom_Markdown::get_instance()->unload_markdown_for_posts();
+		}
 	}
 	return $post_data;
 }

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -33,4 +33,4 @@ function gutenberg_remove_wpcom_markdown_support( $post_data ) {
 	}
 	return $post_data;
 }
-add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 1, 1 );
+add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -25,12 +25,10 @@
  * @param  array $post      Post object which contains content to check for block.
  * @return array $post      Post object.
  */
-function gutenberg_remove_wpcom_markdown_support( $post_data ) {
-	if ( gutenberg_content_has_blocks( implode( "\n", $post_data ) ) ) {
-		if ( class_exists ( 'WPCom_Markdown' ) ) {
-			WPCom_Markdown::get_instance()->unload_markdown_for_posts();
-		}
+function gutenberg_remove_wpcom_markdown_support( $post ) {
+	if ( class_exists( 'WPCom_Markdown' ) && gutenberg_content_has_blocks( $post['post_content'] ) ) {
+		WPCom_Markdown::get_instance()->unload_markdown_for_posts();
 	}
-	return $post_data;
+	return $post;
 }
 add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );


### PR DESCRIPTION
There is a conflict with wpcom-markdown which is used in Jetpack  and other plugins which add markdown support.

Here's the test case that duplicates the issue:

1. Install Jetpack (or other wpcom markdown implementation) and enable markdown
2. Create post in Gutenberg with a couple paragraphs.
3. Open post in classic editor and click update
4. One big paragraph.

## Description

This change adds the filter on `wp_insert_post_data` since
edits in classic editor do not go through the rest API.

Additionally, it changes the call to remove markdown which
is more inclusive of all the actions and filters this markdown
implementation touches.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
