### PR TITLE
Writing Flow: Move selection to block's focus handler

### DIFF
--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -31,6 +31,7 @@ function Toolbar( { controls = [], children, className } ) {
 					<div
 						key={ [ setIndex, controlIndex ].join() }
 						className={ setIndex > 0 && controlIndex === 0 ? 'has-left-divider' : null }
+						tabIndex={ -1 }
 					>
 						<IconButton
 							icon={ control.icon }

--- a/components/toolbar/index.js
+++ b/components/toolbar/index.js
@@ -31,7 +31,6 @@ function Toolbar( { controls = [], children, className } ) {
 					<div
 						key={ [ setIndex, controlIndex ].join() }
 						className={ setIndex > 0 && controlIndex === 0 ? 'has-left-divider' : null }
-						tabIndex={ -1 }
 					>
 						<IconButton
 							icon={ control.icon }

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -53,11 +53,13 @@
 
 // This is a focus style shown for blocks that need an indicator even when in an isEditing state
 // like for example an image block that receives arrowkey focus.
-.edit-post-visual-editor .editor-block-list__block:not( .is-selected ) .editor-block-list__block-edit  {
-	box-shadow: 0 0 0 0 $white, 0 0 0 0 $dark-gray-900;
-	transition: .1s box-shadow .05s;
+.edit-post-visual-editor .editor-block-list__block:not( .is-selected )   {
+	.editor-block-list__block-edit {
+		box-shadow: 0 0 0 0 $white, 0 0 0 0 $dark-gray-900;
+		transition: .1s box-shadow .05s;
+	}
 
-	&:focus {
+	&:focus .editor-block-list__block-edit {
 		box-shadow: 0 0 0 1px $white, 0 0 0 3px $dark-gray-900;
 	}
 }

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -417,10 +417,6 @@ export class BlockListBlock extends Component {
 			}
 		} else {
 			this.props.onSelectionStart( this.props.uid );
-
-			if ( ! this.props.isSelected ) {
-				this.props.onSelect();
-			}
 		}
 	}
 

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -579,6 +579,7 @@ export class BlockListBlock extends Component {
 				data-type={ block.name }
 				onTouchStart={ this.onTouchStart }
 				onClick={ this.onClick }
+				tabIndex="0"
 				childHandledEvents={ [
 					'onKeyPress',
 					'onDragStart',
@@ -619,7 +620,6 @@ export class BlockListBlock extends Component {
 					onKeyDown={ this.onKeyDown }
 					onFocus={ this.onFocus }
 					className={ BlockListBlock.className }
-					tabIndex="0"
 					aria-label={ blockLabel }
 					data-block={ block.uid }
 				>

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -196,6 +196,8 @@ export class BlockListBlock extends Component {
 		// eslint-disable-next-line react/no-find-dom-node
 		node = findDOMNode( node );
 
+		this.wrapperNode = node;
+
 		this.props.blockRef( node, this.props.uid );
 	}
 
@@ -214,7 +216,11 @@ export class BlockListBlock extends Component {
 	focusTabbable() {
 		const { initialPosition } = this.props;
 
-		if ( this.node.contains( document.activeElement ) ) {
+		// Focus is captured by the wrapper node, so while focus transition
+		// should only consider tabbables within editable display, since it
+		// may be the wrapper itself or a side control which triggered the
+		// focus event, don't unnecessary transition to an inner tabbable.
+		if ( this.wrapperNode.contains( document.activeElement ) ) {
 			return;
 		}
 
@@ -578,6 +584,7 @@ export class BlockListBlock extends Component {
 				className={ wrapperClassName }
 				data-type={ block.name }
 				onTouchStart={ this.onTouchStart }
+				onFocus={ this.onFocus }
 				onClick={ this.onClick }
 				tabIndex="0"
 				childHandledEvents={ [
@@ -585,7 +592,6 @@ export class BlockListBlock extends Component {
 					'onDragStart',
 					'onMouseDown',
 					'onKeyDown',
-					'onFocus',
 				] }
 				{ ...wrapperProps }
 			>
@@ -618,7 +624,6 @@ export class BlockListBlock extends Component {
 					onDragStart={ this.preventDrag }
 					onMouseDown={ this.onPointerDown }
 					onKeyDown={ this.onKeyDown }
-					onFocus={ this.onFocus }
 					className="editor-block-list__block-edit"
 					aria-label={ blockLabel }
 					data-block={ block.uid }

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -383,7 +383,7 @@ export class BlockListBlock extends Component {
 			return;
 		}
 
-		if ( event.target === this.node && ! this.props.isSelected ) {
+		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
 		}
 	}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -417,6 +417,15 @@ export class BlockListBlock extends Component {
 			}
 		} else {
 			this.props.onSelectionStart( this.props.uid );
+
+			// Allow user to escape out of a multi-selection to a singular
+			// selection of a block via click. This is handled here since
+			// onFocus excludes blocks involved in a multiselection, as
+			// focus can be incurred by starting a multiselection (focus
+			// moved to first block's multi-controls).
+			if ( this.props.isMultiSelected ) {
+				this.props.onSelect();
+			}
 		}
 	}
 

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -370,19 +370,9 @@ export class BlockListBlock extends Component {
 	 * specifically handles the case where block does not set focus on its own
 	 * (via `setFocus`), typically if there is no focusable input in the block.
 	 *
-	 * @param {FocusEvent} event A focus event
-	 *
 	 * @return {void}
 	 */
-	onFocus( event ) {
-		// Firefox-specific: Firefox will redirect focus of an already-focused
-		// node to its parent, but assign a property before doing so. If that
-		// property exists, ensure that it is the node, or abort.
-		const { explicitOriginalTarget } = event.nativeEvent;
-		if ( explicitOriginalTarget && explicitOriginalTarget !== this.node ) {
-			return;
-		}
-
+	onFocus() {
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
 		}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -619,7 +619,7 @@ export class BlockListBlock extends Component {
 					onMouseDown={ this.onPointerDown }
 					onKeyDown={ this.onKeyDown }
 					onFocus={ this.onFocus }
-					className={ BlockListBlock.className }
+					className="editor-block-list__block-edit"
 					aria-label={ blockLabel }
 					data-block={ block.uid }
 				>
@@ -756,8 +756,6 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 		dispatch( toggleSelection( selectionEnabled ) );
 	},
 } );
-
-BlockListBlock.className = 'editor-block-list__block-edit';
 
 BlockListBlock.childContextTypes = {
 	BlockList: noop,

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -379,7 +379,7 @@ export class BlockListBlock extends Component {
 	 * @return {void}
 	 */
 	onFocus() {
-		if ( ! this.props.isSelected ) {
+		if ( ! this.props.isSelected && ! this.props.isMultiSelected ) {
 			this.props.onSelect();
 		}
 	}

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -25,6 +25,7 @@ import { Component } from '@wordpress/element';
 import './style.scss';
 import BlockListBlock from './block';
 import BlockInsertionPoint from './insertion-point';
+import IgnoreNestedEvents from './ignore-nested-events';
 import BlockSelectionClearer from '../block-selection-clearer';
 import DefaultBlockAppender from '../default-block-appender';
 import {
@@ -233,11 +234,13 @@ class BlockListLayout extends Component {
 						renderBlockMenu={ renderBlockMenu }
 					/>
 				) ) }
-				<DefaultBlockAppender
-					rootUID={ rootUID }
-					lastBlockUID={ last( blockUIDs ) }
-					layout={ defaultLayout }
-				/>
+				<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
+					<DefaultBlockAppender
+						rootUID={ rootUID }
+						lastBlockUID={ last( blockUIDs ) }
+						layout={ defaultLayout }
+					/>
+				</IgnoreNestedEvents>
 			</BlockSelectionClearer>
 		);
 	}

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -18,7 +18,6 @@ import { compose } from '@wordpress/element';
 import './style.scss';
 import { getBlockMoverLabel } from './mover-label';
 import { getBlockIndex, getBlock } from '../../store/selectors';
-import { selectBlock } from '../../store/actions';
 
 /**
  * Module constants
@@ -94,10 +93,6 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 function createOnMove( type, dispatch, ownProps ) {
 	return () => {
 		const { uids, rootUID } = ownProps;
-		if ( uids.length === 1 ) {
-			dispatch( selectBlock( first( uids ) ) );
-		}
-
 		dispatch( { type, uids, rootUID } );
 	};
 }

--- a/editor/components/navigable-toolbar/index.js
+++ b/editor/components/navigable-toolbar/index.js
@@ -39,7 +39,7 @@ class NavigableToolbar extends Component {
 
 		// Is there a better way to focus the selected block
 		// TODO: separate focused/selected block state and use Redux actions instead
-		const selectedBlock = document.querySelector( '.editor-block-list__block.is-selected .editor-block-list__block-edit' );
+		const selectedBlock = document.querySelector( '.editor-block-list__block.is-selected' );
 		if ( !! selectedBlock ) {
 			event.stopPropagation();
 			selectedBlock.focus();

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -128,25 +128,6 @@ class WritingFlow extends Component {
 		return editables.length > 0 && index === edgeIndex;
 	}
 
-	/**
-	 * Function called to ensure the block parent of the target node is selected.
-	 *
-	 * @param {DOMElement} target
-	 */
-	selectParentBlock( target ) {
-		if ( ! target ) {
-			return;
-		}
-
-		const parentBlock = target.hasAttribute( 'data-block' ) ? target : target.closest( '[data-block]' );
-		if (
-			parentBlock &&
-			( ! this.props.selectedBlockUID || parentBlock.getAttribute( 'data-block' ) !== this.props.selectedBlockUID )
-		) {
-			this.props.onSelectBlock( parentBlock.getAttribute( 'data-block' ) );
-		}
-	}
-
 	onKeyDown( event ) {
 		const { selectedBlockUID, selectionStart, hasMultiSelection } = this.props;
 
@@ -184,12 +165,10 @@ class WritingFlow extends Component {
 		} else if ( isVertical && isVerticalEdge( target, isReverse, isShift ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
-			this.selectParentBlock( closestTabbable );
 			event.preventDefault();
 		} else if ( isHorizontal && isHorizontalEdge( target, isReverse, isShift ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
-			this.selectParentBlock( closestTabbable );
 			event.preventDefault();
 		}
 	}

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -58,7 +58,7 @@ class WritingFlow extends Component {
 	}
 
 	getEditables( target ) {
-		const outer = target.closest( '.editor-block-list__block-edit' );
+		const outer = target.closest( '.editor-block-list__block' );
 		if ( ! outer || target === outer ) {
 			return [ target ];
 		}
@@ -74,7 +74,7 @@ class WritingFlow extends Component {
 				node.nodeName === 'INPUT' ||
 				node.nodeName === 'TEXTAREA' ||
 				node.contentEditable === 'true' ||
-				node.classList.contains( 'editor-block-list__block-edit' )
+				node.classList.contains( 'editor-block-list__block' )
 			) );
 	}
 


### PR DESCRIPTION
This pull request seeks to resolve conflicts between the WritingFlow's selection transitioning and nested blocks. Prior to these changes, when attempting to press "Down" from the first block in a column, the new block would be added, but focus would be moved back to the first block in the column. This was caused by two related issues:

- In WritingFlow's handling of vertically moving from one block to the next, we [explicitly call to select the parent block](https://github.com/WordPress/gutenberg/blob/cc87946285058264938602451a11e973c097d145/editor/components/writing-flow/index.js#L184-L188). In both nested and unnested contexts, when this occurs as a result of moving into the default block appender, the `closestTabbable` is the default block appender itself. For non-nested blocks, attempting to select parent block has no effect because there is no "closest block" for the appender. In a nested context, however, the closest block is the wrapper block (Columns), so therefore it becomes selected and [focuses its first tabbable](https://github.com/WordPress/gutenberg/blob/cc87946285058264938602451a11e973c097d145/editor/components/block-list/block.js#L177-L179) which is the first block's wrapper.
   - This is resolved by moving selection handling in response to _any_ focus which occurs within the selected block, not just the current fallback logic for testing against `this.node` (i.e. clicking at the edge of a block, or a block without its own focusable elements).
- The previous resolution introduces another issue, which is that we rely on the [`IgnoreNestedEvents` component](https://github.com/WordPress/gutenberg/blob/cc87946285058264938602451a11e973c097d145/editor/components/block-list/ignore-nested-events.js) to flag events as handled so that ancestor blocks don't attempt to handle them. With 8bd012a, since any focus event would cause the block to select itself if not already selected, we need to ensure that focus events from nested blocks are appropriately flagged. However, the previously described behavior of focusing the default block appender occurs outside the block itself, so it will never apply the expected `_blockHandled` flag.
   - This is resolved by wrapping `DefaultBlockAppender` with its own `IgnoreNestedEvents`, capturing and applying the handled flag to events managed in the appender.
   - I really don't like this approach, because it introduces a dependency from the parent `BlockListLayout` to a child's rendering behavior (the `DefaultBlockAppender`). I had unsuccessfully explored other options, including a `IgnoreNestedEvents.Barrier` component sitting at the top of a nested context and flagging **every** event. Besides being wasteful (not all events are monitored, and some events dispatch very often like `mousemove`), it introduced more problems of its own where expected events were not being handled correctly (like a block dismissing its hover effects).

__Testing instructions:__

Verify that there are no regressions in the behavior of selecting a block via focus, both for blocks with their own inputs (paragraph) and those without (image placeholder).

Verify that you can add a default block to the end of a block list, both in a nested and non-nested context, by pressing "Down" from the last non-empty block.