### PR TITLE
Blocks: Remove is- prefix from embed alignment class

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -249,7 +249,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			}
 
 			const embedClassName = classnames( 'wp-block-embed', {
-				[ `is-align${ align }` ]: align,
+				[ `align${ align }` ]: align,
 				[ `is-type-${ type }` ]: type,
 				[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,
 			} );


### PR DESCRIPTION
Related: #4118 (specifically https://github.com/WordPress/gutenberg/pull/4118#issuecomment-368187910) 

This pull request seeks to partially revert changes introduced in #4118, specifically with regards to the alignment class. Prior to #4118, the alignment class applied to embed blocks had intentionally targeted compatibility with common theme styling for `.alignleft`, `.alignright`, etc . These changes restore that intended class name.

__Testing instructions:__

Verify there are no invalid blocks in demo content (as there is on master).

Verify that aligning a block is styled correctly when viewed on the front-end. Depending on your theme, this may not have much of an impact, if any at all.

cc @Luehrsen