### PR TITLE
Inserter: Remove margin from initial insertion point

### DIFF
--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -432,7 +432,6 @@
 
 .editor-block-list__layout > .editor-block-list__insertion-point {
 	position: relative;
-	margin-top: -15px;
 	margin-left: auto;
 	margin-right: auto;
 	top: -19px;


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/5198#discussion_r170707274
Related: #5282

This pull request seeks to resolve a misalignment which occurs for the initial block in a block list, both for the top-level block list and in a nested context. From what I can discern from the styling, the negative margin is redundant with the negative relative positioning, and causes the first block to move upward in its entirety. The affected styling only impacts the very first insertion point, as others will not qualify for the child selector of `.editor-block-list__layout`.

__Testing instructions:__

Verify that when clicking in the writing prompt, the vertical positioning of the text aligns with where the writing prompt had been shown.