### PR TITLE
Inserter: Fix unmodified default block replace, insert after selected

### DIFF
--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -86,8 +86,8 @@ class Inserter extends Component {
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		insertionPoint: select( 'core/editor' ).getBlockInsertionPoint,
-		selectedBlock: select( 'core/editor' ).getSelectedBlock,
+		insertionPoint: select( 'core/editor' ).getBlockInsertionPoint(),
+		selectedBlock: select( 'core/editor' ).getSelectedBlock(),
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		showInsertionPoint: dispatch( 'core/editor' ).showInsertionPoint,


### PR DESCRIPTION
Fixes #5291 
Regression introduced in #5137 (34b7e210e0dd1a8751fe5da1a13ed39a1c003ede)

This pull request seeks to resolve a bug in the Inserter component where the selectors are incorrectly returned as functions, not invoked to retrieve their intended values. This prevents the expected behavior in `InserterWithShortcuts` from operating on the unmodified default block, because the value passed into `withDispatch`'s `onInsertBlock` for `selectedBlock` is a function, not the block value itself.

__Testing instructions:__

Repeat steps to reproduce from #5291, verifying that replacing the unmodified default block is replaced correctly.

A related issue not yet reported: Verify that inserting a block while another is selected will insert after the selected block.