### PR TITLE
Block List: Use ifViewportMatches to render BlockMobileToolbar as appropriate

### DIFF
--- a/editor/components/block-list/block-mobile-toolbar.js
+++ b/editor/components/block-list/block-mobile-toolbar.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { ifViewportMatches } from '@wordpress/viewport';
+
+/**
  * Internal dependencies
  */
 import BlockMover from '../block-mover';
@@ -17,4 +22,4 @@ function BlockMobileToolbar( { rootUID, uid, renderBlockMenu } ) {
 	);
 }
 
-export default BlockMobileToolbar;
+export default ifViewportMatches( '< small' )( BlockMobileToolbar );

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -320,10 +320,6 @@
 		flex-direction: row;
 		margin-top: $item-spacing;
 
-		@include break-small() {
-			display: none;
-		}
-
 		// Movers, inserter, trash & ellipsis
 		.editor-inserter {
 			position: relative;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -236,7 +236,21 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-editor',
 		gutenberg_url( 'editor/build/index.js' ),
-		array( 'postbox', 'jquery', 'wp-api', 'wp-data', 'wp-date', 'wp-i18n', 'wp-blocks', 'wp-element', 'wp-components', 'wp-utils', 'word-count', 'editor' ),
+		array(
+			'postbox',
+			'jquery',
+			'wp-api',
+			'wp-data',
+			'wp-date',
+			'wp-i18n',
+			'wp-blocks',
+			'wp-element',
+			'wp-components',
+			'wp-utils',
+			'wp-viewport',
+			'word-count',
+			'editor',
+		),
 		filemtime( gutenberg_dir_path() . 'editor/build/index.js' )
 	);
 


### PR DESCRIPTION
Related: #5206

This pull request seeks to update the `BlockMobileToolbar` component to avoid rendering altogether if within a non-small viewport size via the new `@wordpress/viewport` module introduced in #5206 (specifically, the `ifViewportMatches` higher-order component). The intent of these changes is to avoid render reconciliation for non-visible components, because despite being hidden with CSS, the DOM elements themselves continue to be managed by React.

__Testing instructions:__

Verify that there are no regressions in the display / hiding of the mobile block toolbar the "small" breakpoint threshold. 