### PR TITLE
Force HTML blocks to be in preview mode when in a reusable block

### DIFF
--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -106,6 +106,7 @@ class ReusableBlockEdit extends Component {
 					{ ...this.props }
 					name={ reusableBlock.type }
 					isSelected={ isEditing && isSelected }
+					isReadOnly={ ! isEditing }
 					attributes={ reusableBlockAttributes }
 					setAttributes={ isEditing ? this.setAttributes : noop }
 				/>

--- a/blocks/library/html/index.js
+++ b/blocks/library/html/index.js
@@ -48,7 +48,7 @@ export const settings = {
 
 	edit: withState( {
 		preview: false,
-	} )( ( { attributes, setAttributes, setState, isSelected, toggleSelection, preview } ) => (
+	} )( ( { attributes, setAttributes, setState, isSelected, toggleSelection, preview, isReadOnly } ) => (
 		<div className="wp-block-html">
 			{ isSelected && (
 				<BlockControls>
@@ -68,7 +68,7 @@ export const settings = {
 					</div>
 				</BlockControls>
 			) }
-			{ preview ? (
+			{ ( preview || isReadOnly ) ? (
 				<SandBox html={ attributes.content } />
 			) : (
 				<CodeEditor


### PR DESCRIPTION
## Description
Closes #4875.

![html](https://user-images.githubusercontent.com/612155/36770418-4b6f68d8-1c9e-11e8-80ae-bf1066898b95.gif)

When a HTML block is made reusable, and the reusable block is not being edited, we should not display the HTML.

## How to test

1. Create a HTML block, type in some HTML
2. Convert it to a reusable block
3. A preview of HTML should be displayed
4. Edit the reusable block
5. The HTML source code should be displayed