### PR TITLE
Fix sidebar tab padding

### DIFF
--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -121,7 +121,7 @@
 	cursor: pointer;
 	height: 50px;
 	line-height: 50px;
-	padding: 0 20px;
+	padding: 0 15px;
 	margin-left: 0;
 	font-weight: 400;
 	@include square-style__neutral;

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -4,10 +4,12 @@
 	font-size: $default-font-size;
 	background: $white;
 	padding: ( $panel-padding * 2 ) $panel-padding;
-	border-bottom: 1px solid $light-gray-500;
 	text-align: center;
 }
 
+.editor-block-inspector__multi-blocks {
+	border-bottom: 1px solid $light-gray-500;
+}
 
 .editor-block-inspector__card {
 	display: flex;


### PR DESCRIPTION
This fixes #5304. It makes the sidebar tabs have the same padding as the sidebar panels, which means the text will align vertically:

<img width="370" alt="screen shot 2018-02-28 at 13 16 15" src="https://user-images.githubusercontent.com/1204802/36787274-dbbbe354-1c89-11e8-9c77-642ce1c71c56.png">

Also threw in a little fix for the block settings when no blocks are selected. Before:

<img width="338" alt="screen shot 2018-02-28 at 13 15 45" src="https://user-images.githubusercontent.com/1204802/36787280-e17358fe-1c89-11e8-9350-80f5063827e2.png">

After:

<img width="389" alt="screen shot 2018-02-28 at 13 16 11" src="https://user-images.githubusercontent.com/1204802/36787289-f147f3f2-1c89-11e8-8ddd-413e9ab21c1d.png">
