### PR TITLE
Build: Include string extraction in production build

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -79,8 +79,6 @@ status "Installing dependencies..."
 npm install
 status "Generating build..."
 npm run build
-status "Generating translation messages..."
-npm run gettext-strings
 status "Generating PHP file for wordpress.org to parse translations..."
 npm run pot-to-php
 

--- a/languages/README.md
+++ b/languages/README.md
@@ -4,7 +4,7 @@ Languages
 The generated POT template file is not included in this repository. To create this file locally, follow instructions from [CONTRIBUTING.md](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md) to install the project, then run the following command:
 
 ```
-npm run gettext-strings
+npm run build
 ```
 
 After the build completes, you'll find a `gutenberg.pot` strings file in this directory.

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 			"@wordpress/default"
 		],
 		"env": {
-			"gettext": {
+			"production": {
 				"plugins": [
 					[
 						"./i18n/babel-plugin",
@@ -137,13 +137,12 @@
 	},
 	"scripts": {
 		"prebuild": "check-node-version --package",
-		"build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
-		"gettext-strings": "cross-env BABEL_ENV=gettext webpack",
+		"build": "cross-env NODE_ENV=production webpack",
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
 		"lint-php": "docker-compose run --rm composer run-script lint",
 		"predev": "check-node-version --package",
-		"dev": "cross-env BABEL_ENV=default webpack --watch",
+		"dev": "cross-env webpack --watch",
 		"test": "npm run lint && npm run test-unit",
 		"test-php": "npm run lint-php && npm run test-unit-php",
 		"ci": "concurrently \"npm run lint && npm run build\" \"npm run test-unit:coverage-ci\"",


### PR DESCRIPTION
Context: https://wordpress.slack.com/archives/C02QB2JS7/p1518814768000558

This pull request seeks to resolve an issue where generating the plugin build will produce unminified code due to the fact that string extraction occurs after the production build, in development mode, and replaces the files produced by the production build.

The changes here seek to eliminate a separate step for string extraction, instead incorporating into the production build itself. In doing so, it removes the `npm run getttext-strings` standalone script. The Babel plugin is now included in the production environment.

__Testing instructions:__

Verify that packaging a plugin results in the `languages/gutenberg.pot` file being included in the packaged archive, and that built files are minified.