### PR TITLE
Add a script that creates a PHP file based on a POT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cypress
 node_modules
 gutenberg.zip
 languages/gutenberg.pot
+/languages/gutenberg-translations.php
 
 # Directories/files that may appear in your environment
 .DS_Store

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -104,6 +104,7 @@ zip -r gutenberg.zip \
 	{blocks,components,date,editor,element,hooks,i18n,data,utils,edit-post,viewport}/build/*.{js,map} \
 	{blocks,components,editor,edit-post}/build/*.css \
 	languages/gutenberg.pot \
+	languages/gutenberg-translations.php \
 	README.md
 
 # Reset `gutenberg.php`

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -81,6 +81,8 @@ status "Generating build..."
 npm run build
 status "Generating translation messages..."
 npm run gettext-strings
+status "Generating PHP file for wordpress.org to parse translations..."
+npm run pot-to-php
 
 # Remove any existing zip file
 rm -f gutenberg.zip

--- a/bin/pot-to-php.js
+++ b/bin/pot-to-php.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+const gettextParser = require( 'gettext-parser' );
+const _isEmpty = require( 'lodash/isEmpty' );
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+const TAB = '\t';
+const NEWLINE = '\n';
+
+const fileHeader = [
+	'<?php',
+	'/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */',
+	'$generated_i18n_strings = array(',
+].join( NEWLINE ) + NEWLINE;
+
+const fileFooter = NEWLINE + [
+	');',
+	'/* THIS IS THE END OF THE GENERATED FILE */',
+].join( NEWLINE ) + NEWLINE;
+
+/**
+ * Escapes single quotes.
+ *
+ * @param {string} input The string to be escaped.
+ * @return {string} The escaped string.
+ */
+function escapeSingleQuotes( input ) {
+	return input.replace( /'/g, '\\\'' );
+}
+
+/**
+ * Converts a translation parsed from the POT file to lines of WP PHP.
+ *
+ * @param {Object} translation The translation to convert.
+ * @param {string} textdomain The text domain to use in the WordPress translation function call.
+ * @return {string} Lines of PHP that match the translation.
+ */
+function convertTranslationToPHP( translation, textdomain ) {
+	let php = '';
+
+	// The format of gettext-js matches the terminology in gettext itself.
+	let original = translation.msgid;
+	const comments = translation.comments;
+
+	if ( ! _isEmpty( comments ) ) {
+		if ( ! _isEmpty( comments.reference ) ) {
+			// All references are split by newlines, add a // Reference prefix to make them tidy.
+			php += TAB + '// Reference: ' +
+				comments.reference
+					.split( NEWLINE )
+					.join( NEWLINE + TAB + '// Reference: ' ) +
+				NEWLINE;
+		}
+
+		if ( ! _isEmpty( comments.extracted ) ) {
+			// All extracted comments are split by newlines, add a tab to line them up nicely.
+			const extracted = comments.extracted
+				.split( NEWLINE )
+				.join( NEWLINE + TAB + '   ' );
+
+			php += TAB + `/* ${ extracted } */${ NEWLINE }`;
+		}
+	}
+
+	if ( '' !== original ) {
+		original = escapeSingleQuotes( original );
+
+		if ( _isEmpty( translation.msgid_plural ) ) {
+			php += TAB + `__( '${ original }', '${ textdomain }' )`;
+		} else {
+			const plural = escapeSingleQuotes( translation.msgid_plural );
+
+			php += TAB + `_n_noop( '${ original }', '${ plural }', '${ textdomain }' )`;
+		}
+	}
+
+	return php;
+}
+
+function convertPotToPHP( potFile, phpFile, options ) {
+	const poContents = fs.readFileSync( potFile );
+	const parsedPO = gettextParser.po.parse( poContents );
+
+	const translations = parsedPO.translations[ '' ];
+
+	const output = Object.values( translations )
+		.map( ( translation ) => convertTranslationToPHP( translation, options.textdomain ) )
+		.filter( php => php !== '' );
+
+	const fileOutput = fileHeader + output.join( ',' + NEWLINE + NEWLINE ) + fileFooter;
+
+	fs.writeFileSync( phpFile, fileOutput );
+}
+
+convertPotToPHP(
+	path.join( __dirname, '../languages/gutenberg.pot' ),
+	path.join( __dirname, '../languages/gutenberg-translations.php' ),
+	{
+		textdomain: 'gutenberg',
+	}
+);

--- a/bin/pot-to-php.js
+++ b/bin/pot-to-php.js
@@ -104,7 +104,7 @@ function convertPOTToPHP( potFile, phpFile, options ) {
 			.map( ( translation ) => convertTranslationToPHP( translation, options.textdomain, context ) )
 			.filter( php => php !== '' );
 
-		output = [ output, ...newOutput ];
+		output = [ ...output, ...newOutput ];
 	}
 
 	const fileOutput = fileHeader + output.join( ',' + NEWLINE + NEWLINE ) + fileFooter;

--- a/bin/pot-to-php.js
+++ b/bin/pot-to-php.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const gettextParser = require( 'gettext-parser' );
-const _isEmpty = require( 'lodash/isEmpty' );
+const { isEmpty } = require( 'lodash' );
 const path = require( 'path' );
 const fs = require( 'fs' );
 
@@ -43,8 +43,8 @@ function convertTranslationToPHP( translation, textdomain ) {
 	let original = translation.msgid;
 	const comments = translation.comments;
 
-	if ( ! _isEmpty( comments ) ) {
-		if ( ! _isEmpty( comments.reference ) ) {
+	if ( ! isEmpty( comments ) ) {
+		if ( ! isEmpty( comments.reference ) ) {
 			// All references are split by newlines, add a // Reference prefix to make them tidy.
 			php += TAB + '// Reference: ' +
 				comments.reference
@@ -53,7 +53,7 @@ function convertTranslationToPHP( translation, textdomain ) {
 				NEWLINE;
 		}
 
-		if ( ! _isEmpty( comments.extracted ) ) {
+		if ( ! isEmpty( comments.extracted ) ) {
 			// All extracted comments are split by newlines, add a tab to line them up nicely.
 			const extracted = comments.extracted
 				.split( NEWLINE )
@@ -61,12 +61,16 @@ function convertTranslationToPHP( translation, textdomain ) {
 
 			php += TAB + `/* ${ extracted } */${ NEWLINE }`;
 		}
+
+		if ( ! isEmpty( comments.translator ) ) {
+			php += TAB + `/* translators: ${ comments.translator } */${ NEWLINE }`;
+		}
 	}
 
 	if ( '' !== original ) {
 		original = escapeSingleQuotes( original );
 
-		if ( _isEmpty( translation.msgid_plural ) ) {
+		if ( isEmpty( translation.msgid_plural ) ) {
 			php += TAB + `__( '${ original }', '${ textdomain }' )`;
 		} else {
 			const plural = escapeSingleQuotes( translation.msgid_plural );
@@ -78,7 +82,7 @@ function convertTranslationToPHP( translation, textdomain ) {
 	return php;
 }
 
-function convertPotToPHP( potFile, phpFile, options ) {
+function convertPOTToPHP( potFile, phpFile, options ) {
 	const poContents = fs.readFileSync( potFile );
 	const parsedPO = gettextParser.po.parse( poContents );
 
@@ -93,7 +97,7 @@ function convertPotToPHP( potFile, phpFile, options ) {
 	fs.writeFileSync( phpFile, fileOutput );
 }
 
-convertPotToPHP(
+convertPOTToPHP(
 	path.join( __dirname, '../languages/gutenberg.pot' ),
 	path.join( __dirname, '../languages/gutenberg-translations.php' ),
 	{

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
 		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
 		"package-plugin": "./bin/build-plugin-zip.sh",
+		"pot-to-php": "./bin/pot-to-php.js",
 		"precommit": "lint-staged",
 		"test-unit": "wp-scripts test-unit-js",
 		"test-unit-php": "docker-compose run --rm wordpress_phpunit phpunit",


### PR DESCRIPTION
## Description
This is a workaround to make Gutenberg translatable. translate.wordpress.org ignores the POT file provided by the plugin and parser the PHP file itself. We can work around this by providing a PHP file generated on the POT file.

## How Has This Been Tested?
I've copied the code from wordpress-seo and adapted it for a non-grunt environment. So the code has been tested by wordpress-seo. I've run it once to see that it generates something sensible.

The real tests can only be done once it is on translate.wordpress.org. Which this PR + a release will accomplish.

See #5169. Note that this PR is the short-term solution.