### PR TITLE
Updated coding-guideline documentation to include experimental APIs

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -94,8 +94,8 @@ Example:
 
 ```js
 export {
-	exposedApi as experimental__exposedApi
-} from './exposedApi.js';
+	internalApi as experimental__exposedApi
+} from './internalApi.js';
 ```
 
 ## PHP

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -88,13 +88,13 @@ import VisualEditor from '../visual-editor';
 
 ### Experimental APIs
 
-Exposed APIs that are still being tested, discussed and are subject to change should be prefixed with `experimental__`, until they are finalized. This is meant to discourage developers from relying on the API, because it might be removed or changed in the (near) future.
+Exposed APIs that are still being tested, discussed and are subject to change should be prefixed with `__experimental`, until they are finalized. This is meant to discourage developers from relying on the API, because it might be removed or changed in the (near) future.
 
 Example:
 
 ```js
 export {
-	internalApi as experimental__exposedApi
+	internalApi as __experimentalExposedApi
 } from './internalApi.js';
 ```
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -86,6 +86,18 @@ Example:
 import VisualEditor from '../visual-editor';
 ```
 
+### Experimental APIs
+
+Exposed APIs that are still being tested, discussed and are subject to change should be prefixed with `experimental__`, until they are finalized. This is meant to discourage developers from relying on the API, because it might be removed or changed in the (near) future.
+
+Example:
+
+```js
+export {
+	exposedApi as experimental__exposedApi
+} from './exposedApi.js';
+```
+
 ## PHP
 
 We use


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Adds documentation to coding-guideline.md, regarding experimental exposed APIs.

### Experimental APIs

Exposed APIs that are still being tested, discussed and are subject to change should be prefixed with `__experimental`, until they are finalized. This is meant to discourage developers from relying on the API, because it might be removed or changed in the (near) future.

Example:

```js
export {
	internalApi as __experimentalExposedApi
} from './internalApi.js';
```

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Documentation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
