### PR TITLE
Components: Restrict Popover focusOnMount to keyboard interaction

### DIFF
--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEqual, noop } from 'lodash';
+import { defer, isEqual, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,6 +18,19 @@ import withFocusReturn from '../higher-order/with-focus-return';
 import PopoverDetectOutside from './detect-outside';
 import IconButton from '../icon-button';
 import { Slot, Fill } from '../slot-fill';
+
+/**
+ * Value representing whether a key is currently pressed. Bound to the document
+ * for use in determining whether the Popover component has mounted in response
+ * to a keyboard event. Popover's focusOnMount behavior is specific to keyboard
+ * interaction. Must be bound at the top-level and its unsetting deferred since
+ * the component will have already mounted by the time keyup occurs.
+ *
+ * @type {boolean}
+ */
+let isKeyDown = false;
+document.addEventListener( 'keydown', () => isKeyDown = true );
+document.addEventListener( 'keyup', defer.bind( null, () => isKeyDown = false ) );
 
 const FocusManaged = withFocusReturn( ( { children } ) => children );
 
@@ -94,7 +107,7 @@ class Popover extends Component {
 
 	focus() {
 		const { focusOnMount = true } = this.props;
-		if ( ! focusOnMount ) {
+		if ( ! focusOnMount || ! isKeyDown ) {
 			return;
 		}
 

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -25,6 +25,14 @@ describe( 'Popover', () => {
 
 		afterEach( () => {
 			jest.restoreAllMocks();
+
+			// Resetting keyboard state is deferred, so ensure that timers are
+			// consumed to avoid leaking into other tests.
+			jest.runAllTimers();
+
+			if ( document.activeElement ) {
+				document.activeElement.blur();
+			}
 		} );
 
 		it( 'should add window events', () => {
@@ -59,7 +67,12 @@ describe( 'Popover', () => {
 			expect( Popover.prototype.setForcedPositions ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should focus when opening', () => {
+		it( 'should focus when opening in response to keyboard event', () => {
+			// As in the real world, these occur in sequence before the popover
+			// has been mounted. Keyup's resetting is deferred.
+			document.dispatchEvent( new window.KeyboardEvent( 'keydown' ) );
+			document.dispatchEvent( new window.KeyboardEvent( 'keyup' ) );
+
 			// An ideal test here would mount with an input child and focus the
 			// child, but in context of JSDOM the inputs are not visible and
 			// are therefore skipped as tabbable, defaulting to popover.
@@ -68,6 +81,12 @@ describe( 'Popover', () => {
 			const content = wrapper.find( '.components-popover__content' ).getDOMNode();
 
 			expect( document.activeElement ).toBe( content );
+		} );
+
+		it( 'should not focus when opening in response to pointer event', () => {
+			wrapper = mount( <Popover /> );
+
+			expect( document.activeElement ).toBe( document.body );
 		} );
 
 		it( 'should allow focus-on-open behavior to be disabled', () => {

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -270,6 +270,11 @@ export class InserterMenu extends Component {
 		const { selectedItem } = this.state;
 		const isSearching = this.state.filterValue;
 
+		// Disable reason: The inserter menu is a modal display, not one which
+		// is always visible, and one which already incurs this behavior of
+		// autoFocus via Popover's focusOnMount.
+
+		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<TabbableContainer
 				className="editor-inserter__menu"
@@ -285,6 +290,7 @@ export class InserterMenu extends Component {
 					placeholder={ __( 'Search for a block' ) }
 					className="editor-inserter__search"
 					onChange={ this.filter }
+					autoFocus
 				/>
 				{ ! isSearching &&
 					<TabPanel className="editor-inserter__tabs" activeClass="is-active"
@@ -329,6 +335,7 @@ export class InserterMenu extends Component {
 				}
 			</TabbableContainer>
 		);
+		/* eslint-enable jsx-a11y/no-autofocus */
 	}
 }
 


### PR DESCRIPTION
Related: #2323

This pull request seeks to improve the behavior of `Popover`'s `focusOnMount` prop to apply only when the component mounts in response to a keyboard interaction. The `focusOnMount` prop (and its `FocusManaged` counterpart) are particularly useful for enabling a keyboard user to navigate contents of a popover after it's been opened. This behavior is not applicable for touch or pointer device users, and has historically caused some uncertainty, particularly in the editor menu where the focus styling effects can be mistaken for the selected item.

Before (Pointer)|After (Pointer)
---|---
![Before (Pointer)](https://user-images.githubusercontent.com/1779930/36815915-3f623438-1caa-11e8-90e4-18607ed17ecf.png)|![After (Pointer)](https://user-images.githubusercontent.com/1779930/36816076-bf0b4ff8-1caa-11e8-8750-3ed491a0ee5b.png)

Before (Keyboard)|After (Keyboard)
---|---
![Before (Keyboard)](https://user-images.githubusercontent.com/1779930/36815915-3f623438-1caa-11e8-90e4-18607ed17ecf.png)|![After (Keyboard)](https://user-images.githubusercontent.com/1779930/36815915-3f623438-1caa-11e8-90e4-18607ed17ecf.png)

__Testing instructions:__

Verify that `focusOnMount` behavior takes effect when navigating via keyboard.

Verify that `focusOnMount` behavior does not take effect when navigating via touch or pointer device.