### PR TITLE
Refer to reusable blocks as 'Shared Blocks'

### DIFF
--- a/blocks/api/categories.js
+++ b/blocks/api/categories.js
@@ -17,7 +17,7 @@ const categories = [
 	{ slug: 'layout', title: __( 'Layout Blocks' ) },
 	{ slug: 'widgets', title: __( 'Widgets' ) },
 	{ slug: 'embed', title: __( 'Embed' ) },
-	{ slug: 'reusable-blocks', title: __( 'Saved Blocks' ) },
+	{ slug: 'reusable-blocks', title: __( 'Shared Blocks' ) },
 ];
 
 /**

--- a/editor/components/block-settings-menu/reusable-block-settings.js
+++ b/editor/components/block-settings-menu/reusable-block-settings.js
@@ -38,7 +38,7 @@ export function ReusableBlockSettings( {
 					onClick={ onConvertToReusable }
 					disabled={ ! isValidForConvert }
 				>
-					{ __( 'Convert to Reusable Block' ) }
+					{ __( 'Convert to Shared Block' ) }
 				</IconButton>
 			) }
 			{ reusableBlock && (
@@ -48,7 +48,7 @@ export function ReusableBlockSettings( {
 						icon="controls-repeat"
 						onClick={ onConvertToStatic }
 					>
-						{ __( 'Detach from Reusable Block' ) }
+						{ __( 'Convert to Regular Block' ) }
 					</IconButton>
 					<IconButton
 						className="editor-block-settings-menu__control"
@@ -56,7 +56,7 @@ export function ReusableBlockSettings( {
 						disabled={ reusableBlock.isTemporary }
 						onClick={ () => onDelete( reusableBlock.id ) }
 					>
-						{ __( 'Delete Reusable Block' ) }
+						{ __( 'Delete Shared Block' ) }
 					</IconButton>
 				</div>
 			) }
@@ -86,7 +86,7 @@ export default connect(
 			// TODO: Make this a <Confirm /> component or similar
 			// eslint-disable-next-line no-alert
 			const hasConfirmed = window.confirm( __(
-				'Are you sure you want to delete this Reusable Block?\n\n' +
+				'Are you sure you want to delete this Shared Block?\n\n' +
 				'It will be permanently removed from all posts and pages that use it.'
 			) );
 

--- a/editor/components/block-settings-menu/test/reusable-block-settings.js
+++ b/editor/components/block-settings-menu/test/reusable-block-settings.js
@@ -19,7 +19,7 @@ describe( 'ReusableBlockSettings', () => {
 		);
 
 		const text = wrapper.find( 'IconButton' ).children().text();
-		expect( text ).toEqual( 'Convert to Reusable Block' );
+		expect( text ).toEqual( 'Convert to Shared Block' );
 
 		wrapper.find( 'IconButton' ).simulate( 'click' );
 		expect( onConvert ).toHaveBeenCalled();
@@ -35,7 +35,7 @@ describe( 'ReusableBlockSettings', () => {
 		);
 
 		const text = wrapper.find( 'IconButton' ).first().children().text();
-		expect( text ).toEqual( 'Detach from Reusable Block' );
+		expect( text ).toEqual( 'Convert to Regular Block' );
 
 		wrapper.find( 'IconButton' ).first().simulate( 'click' );
 		expect( onConvert ).toHaveBeenCalled();
@@ -51,7 +51,7 @@ describe( 'ReusableBlockSettings', () => {
 		);
 
 		const text = wrapper.find( 'IconButton' ).last().children().text();
-		expect( text ).toEqual( 'Delete Reusable Block' );
+		expect( text ).toEqual( 'Delete Shared Block' );
 
 		wrapper.find( 'IconButton' ).last().simulate( 'click' );
 		expect( onDelete ).toHaveBeenCalledWith( 123 );

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -138,7 +138,7 @@ export class InserterMenu extends Component {
 				predicate = ( item ) => item.category === 'embed';
 				break;
 
-			case 'saved':
+			case 'shared':
 				predicate = ( item ) => item.category === 'reusable-blocks';
 				break;
 		}
@@ -225,11 +225,11 @@ export class InserterMenu extends Component {
 			return this.renderItems( itemsForTab );
 		}
 
-		// If the Saved tab is selected and we have no results, display a friendly message
-		if ( 'saved' === tab && itemsForTab.length === 0 ) {
+		// If the Shared tab is selected and we have no results, display a friendly message
+		if ( 'shared' === tab && itemsForTab.length === 0 ) {
 			return (
 				<NoBlocks>
-					{ __( 'No saved blocks.' ) }
+					{ __( 'No shared blocks.' ) }
 				</NoBlocks>
 			);
 		}
@@ -306,8 +306,8 @@ export class InserterMenu extends Component {
 								className: 'editor-inserter__tab',
 							},
 							{
-								name: 'saved',
-								title: __( 'Saved' ),
+								name: 'shared',
+								title: __( 'Shared' ),
 								className: 'editor-inserter__tab',
 							},
 						] }

--- a/editor/components/inserter/test/menu.js
+++ b/editor/components/inserter/test/menu.js
@@ -167,7 +167,7 @@ describe( 'InserterMenu', () => {
 		expect( visibleBlocks.at( 1 ).text() ).toBe( 'A Text Embed' );
 	} );
 
-	it( 'should show reusable items in the saved tab', () => {
+	it( 'should show reusable items in the shared tab', () => {
 		const wrapper = mount(
 			<InserterMenu
 				position={ 'top center' }
@@ -179,11 +179,11 @@ describe( 'InserterMenu', () => {
 			/>
 		);
 		const embedTab = wrapper.find( '.editor-inserter__tab' )
-			.filterWhere( ( node ) => node.text() === 'Saved' && node.name() === 'button' );
+			.filterWhere( ( node ) => node.text() === 'Shared' && node.name() === 'button' );
 		embedTab.simulate( 'click' );
 
 		const activeCategory = wrapper.find( '.editor-inserter__tab button.is-active' );
-		expect( activeCategory.text() ).toBe( 'Saved' );
+		expect( activeCategory.text() ).toBe( 'Shared' );
 
 		const visibleBlocks = wrapper.find( '.editor-inserter__block' );
 		expect( visibleBlocks ).toHaveLength( 1 );


### PR DESCRIPTION
Closes #3810.

Makes the UI surrounding reusable blocks more consistent by referring to them as _Shared Blocks_.  See #3810 and below for discussion on the name.

Internally and within the codebase we will still refer to them as reusable blocks—that name has stuck, I think.

| For a regular block | For a reusable block |
| --- | --- |
|  <img width="268" alt="screen shot 2018-03-01 at 15 37 15" src="https://user-images.githubusercontent.com/612155/36827320-fcf80f92-1d66-11e8-898c-e28928ae7a78.png"> | <img width="268" alt="screen shot 2018-03-01 at 15 39 02" src="https://user-images.githubusercontent.com/612155/36827322-009e7cee-1d67-11e8-8011-1317a22904a6.png"> |