### PR TITLE
Fix IconButton indent regression

### DIFF
--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -43,9 +43,7 @@ function InserterWithShortcuts( { items, isLocked, onToggle, onInsert } ) {
 					onClick={ () => onInsert( item ) }
 					label={ sprintf( __( 'Add %s' ), item.title ) }
 					icon={ (
-						<span className="editor-inserter-with-shortcuts__block-icon">
-							<BlockIcon icon={ item.icon } />
-						</span>
+						<BlockIcon icon={ item.icon } />
 					) }
 				/>
 			) ) }


### PR DESCRIPTION
Yesterday I merged a fix to the IconButton component which adds a `text-indent` for when the component has text. This works because the SVG inside is not affected by text-indent.

But the quick-shortcuts in the block appender wrap this icon with a `span`, which _is_ affected by the text-indent.

I can look for other solutions that do not rely on text-indent, but simply removing this span entirely seems to have no negative effects. Why was it added? No CSS appears to target the element.

In master:

<img width="783" alt="screen shot 2018-03-01 at 08 58 38" src="https://user-images.githubusercontent.com/1204802/36833317-4322ce18-1d2f-11e8-88f6-4be0797ea013.png">

In this branch:

<img width="344" alt="screen shot 2018-03-01 at 08 59 15" src="https://user-images.githubusercontent.com/1204802/36833324-477e0e28-1d2f-11e8-9184-6b223cfb5ff4.png">

