### PR TITLE
Update shortcode icon

### DIFF
--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -18,7 +18,7 @@ export const settings = {
 
 	description: __( 'A shortcode is a WordPress-specific code snippet that is written between square brackets as [shortcode]. ' ),
 
-	icon: 'marker',
+	icon: 'shortcode',
 
 	category: 'widgets',
 


### PR DESCRIPTION
A new Dashicons sprite, that included a new shortcode icon, was merged recently as part of a separate PR.
This PR applies that icon to the shortcode block.

<img width="419" alt="screen shot 2018-03-01 at 10 05 28" src="https://user-images.githubusercontent.com/1204802/36836042-6fdc5bc8-1d38-11e8-8a43-b4bac77265e1.png">
