### PR TITLE
Polish header for mobile and more languages

### DIFF
--- a/edit-post/components/header/more-menu/style.scss
+++ b/edit-post/components/header/more-menu/style.scss
@@ -1,12 +1,18 @@
 .edit-post-more-menu {
+	margin-left: -4px;
+
 	// the padding and margin of the more menu is intentionally non-standard
-	@include break-small() {
-		margin-left: 4px;
+	.components-icon-button {
+		width: auto;
+		padding: 8px 2px;
 	}
 
-	.components-icon-button {
-		padding: 8px 4px;
-		width: auto;
+	@include break-small() {
+		margin-left: 4px;
+
+		.components-icon-button {
+			padding: 8px 4px;
+		}
 	}
 
 	.components-button svg {

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -1,6 +1,6 @@
 .edit-post-header {
 	height: $header-height;
-	padding: $item-spacing;
+	padding: $item-spacing 2px;
 	border-bottom: 1px solid $light-gray-500;
 	background: $white;
 	display: flex;
@@ -19,6 +19,7 @@
 	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
 	@include break-small {
 		position: fixed;
+		padding: $item-spacing;
 		top: $admin-bar-height-big;
 	}
 
@@ -70,7 +71,12 @@
 		margin: 2px;
 		height: 33px;
 		line-height: 32px;
-		padding: 0 12px 2px;
+		padding: 0 6px 2px;
+		font-size: $default-font-size;
+
+		@include break-small() {
+			padding: 0 12px 2px;
+		}
 	}
 
 	@include break-medium() {

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -27,7 +27,8 @@
 		top: $admin-bar-height;
 	}
 
-	.editor-post-switch-to-draft + .editor-post-preview {
+	.editor-post-switch-to-draft + .editor-post-preview,
+	.editor-post-switch-to-draft + .editor-post-preview + .editor-post-publish-button {
 		display: none;
 
 		@include break-small {
@@ -79,7 +80,7 @@
 		margin: 2px;
 		height: 33px;
 		line-height: 32px;
-		padding: 0 6px 2px;
+		padding: 0 5px 2px;
 		font-size: $default-font-size;
 
 		@include break-small() {

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -26,6 +26,14 @@
 	@include break-medium() {
 		top: $admin-bar-height;
 	}
+
+	.editor-post-switch-to-draft + .editor-post-preview {
+		display: none;
+
+		@include break-small {
+			display: inline-block;
+		}
+	}
 }
 
 @include editor-left('.edit-post-header');

--- a/editor/components/post-saved-state/index.js
+++ b/editor/components/post-saved-state/index.js
@@ -31,11 +31,10 @@ import {
  * @return {WPElement}       WordPress Element.
  */
 export function PostSavedState( { isNew, isPublished, isDirty, isSaving, isSaveable, onSave } ) {
-	const className = 'editor-post-saved-state';
-
 	if ( isSaving ) {
 		return (
-			<span className={ className }>
+			<span className="editor-post-saved-state editor-post-saved-state__saving">
+				<Dashicon icon="cloud" />
 				{ __( 'Saving' ) }
 			</span>
 		);
@@ -51,7 +50,7 @@ export function PostSavedState( { isNew, isPublished, isDirty, isSaving, isSavea
 
 	if ( ! isNew && ! isDirty ) {
 		return (
-			<span className={ className }>
+			<span className="editor-post-saved-state">
 				<Dashicon icon="saved" />
 				{ __( 'Saved' ) }
 			</span>
@@ -63,10 +62,8 @@ export function PostSavedState( { isNew, isPublished, isDirty, isSaving, isSavea
 			className="editor-post-save-draft"
 			onClick={ onSave }
 			icon="cloud-upload"
-			label={ __( 'Save Draft' ) }
 		>
-			<span className="editor-post-saved-state__mobile">{ __( 'Save' ) }</span>
-			<span className="editor-post-saved-state__desktop">{ __( 'Save Draft' ) }</span>
+			{ __( 'Save Draft' ) }
 		</IconButton>
 	);
 }

--- a/editor/components/post-saved-state/style.scss
+++ b/editor/components/post-saved-state/style.scss
@@ -1,7 +1,6 @@
 .editor-post-saved-state {
 	display: flex;
 	align-items: center;
-	padding: 8px;
 	color: $dark-gray-500;
 	overflow: hidden;
 
@@ -14,13 +13,15 @@
 .editor-post-saved-state,
 .editor-post-save-draft {
 	white-space: nowrap;
-	width: $icon-button-size;
+	padding: 8px 4px;
+	width: $icon-button-size - 8px;
 
 	.dashicon {
 		margin-right: 8px;
 	}
 
 	@include break-small() {
+		padding: 8px;
 		width: auto;
 		text-indent: inherit;
 

--- a/editor/components/post-saved-state/style.scss
+++ b/editor/components/post-saved-state/style.scss
@@ -1,33 +1,35 @@
 .editor-post-saved-state {
 	display: flex;
 	align-items: center;
-	margin-right: $item-spacing;
+	padding: 8px;
 	color: $dark-gray-500;
+	overflow: hidden;
 
 	.dashicon {
-		margin-right: 4px;
-		margin-left: -4px;
+		display: inline-block;
+	    flex: 0 0 auto;
+	}
+}
+
+.editor-post-saved-state,
+.editor-post-save-draft {
+	white-space: nowrap;
+	width: $icon-button-size;
+
+	.dashicon {
+		margin-right: 8px;
 	}
 
-	.wp-core-ui &.button-link {
-		margin-right: $item-spacing;
-		padding: 0;
+	@include break-small() {
+		width: auto;
+		text-indent: inherit;
 
-		&:hover {
-			background: none;
+		.dashicon {
+			margin-right: 4px;
 		}
 	}
 }
 
-.editor-post-saved-state__mobile {
-	@include break-small {
-		display: none;
-	}
-}
-
-.editor-post-saved-state__desktop {
-	display: none;
-	@include break-small {
-		display: inline;
-	}
+.editor-post-saved-state__saving {
+	animation: loading_fade .5s infinite;
 }

--- a/editor/components/post-saved-state/test/index.js
+++ b/editor/components/post-saved-state/test/index.js
@@ -18,7 +18,7 @@ describe( 'PostSavedState', () => {
 				isSaveable={ false } />
 		);
 
-		expect( wrapper.text() ).toBe( 'Saving' );
+		expect( wrapper.text() ).toContain( 'Saving' );
 	} );
 
 	it( 'returns null if the post is not saveable', () => {

--- a/editor/components/post-switch-to-draft-button/index.js
+++ b/editor/components/post-switch-to-draft-button/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -31,14 +31,14 @@ function PostSwitchToDraftButton( { isSaving, isPublished, onClick } ) {
 	};
 
 	return (
-		<IconButton
+		<Button
 			className="editor-post-switch-to-draft"
 			isLarge
 			onClick={ onSwitch }
 			disabled={ isSaving }
 		>
 			{ __( 'Switch to Draft' ) }
-		</IconButton>
+		</Button>
 	);
 }
 


### PR DESCRIPTION
Fixes #4231.

This PR enhances the editor-bar for mobile, and has been tested with German on an iPhone 5 screen. 

It does a few things to free up space and be smart about the mobile UI:

- It tweaks paddings, margins widths
- It hides the "Preview" and "Publish" buttons when the "Switch to Draft" button is showing — publish is disabled at that point anyway
- It adds an icon for the "Saving" state (CSS animated with a little pulse), and as such we can make the save indicator be icon-only on mobile. 

Many further improvements can, and should, be made to the mobile UI. But this addresses the things that are directly broken, and aside from general future mobile polish, I would encourage opening separate tickets for mobile header space issues.

Screenshots:

<img width="405" alt="screen shot 2018-03-01 at 13 24 20" src="https://user-images.githubusercontent.com/1204802/36845396-d83c0d12-1d56-11e8-88bb-b06bdaf8c65f.png">

<img width="410" alt="screen shot 2018-03-01 at 13 37 15" src="https://user-images.githubusercontent.com/1204802/36845397-d99aaefc-1d56-11e8-8493-909568777e58.png">

![english](https://user-images.githubusercontent.com/1204802/36845401-db6fb056-1d56-11e8-8f69-36af331ccf2c.gif)
