### PR TITLE
Fix extraction of _nx translation function

### DIFF
--- a/i18n/babel-plugin.js
+++ b/i18n/babel-plugin.js
@@ -58,7 +58,7 @@ const DEFAULT_FUNCTIONS = {
 	__: [ 'msgid' ],
 	_n: [ 'msgid', 'msgid_plural' ],
 	_x: [ 'msgid', 'msgctxt' ],
-	_nx: [ 'msgid', 'msgctxt', 'msgid_plural' ],
+	_nx: [ 'msgid', 'msgid_plural', null, 'msgctxt' ],
 };
 
 /**


### PR DESCRIPTION
## Description

While working on #5310 I found that the babel plugin was not correctly extracting the `_nx` function. I have used `null` as a placeholder for the number argument because that explicitly signals a not-used value.

## How Has This Been Tested?

Ran in combination with #5310. The PHP file corresponded to my test values of `_nx`.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.