### PR TITLE
Make any iframe embed responsive in the editor

### DIFF
--- a/core-blocks/embed/editor.scss
+++ b/core-blocks/embed/editor.scss
@@ -16,19 +16,4 @@
 			font-size: $default-font-size;
 		}
 	}
-
-	&.is-video > .wp-block-embed__wrapper {
-		position: relative;
-		width: 100%;
-		height: 0;
-		padding-top: 56.25%; /* 16:9 */
-	}
-
-	&.is-video > .wp-block-embed__wrapper > iframe {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-	}
 }


### PR DESCRIPTION
## Description

We used to reply on oEmbed's type information to make
YouTube embeds responsive in the editor. This change
removes that dependency, and looks for content embedded
in an iframe with a fixed size, and converts it to a responsive
iframe that keeps the correct aspect ratio when resized.

## How Has This Been Tested?

1. Create a new post with embeds for all the test content listed in `components/sandbox/README.md`
2. Resize the browser window to a narrow width
3. The YouTube videos should resize and keep the correct aspect ratio.

## Types of changes
Bug fix
