### PR TITLE
Framework: Bump redux-optimist to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10768,9 +10768,9 @@
       "integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI="
     },
     "redux-optimist": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/redux-optimist/-/redux-optimist-0.0.2.tgz",
-      "integrity": "sha1-cNoX6GPFOoYE1YHKIKJpCL2haX4="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redux-optimist/-/redux-optimist-1.0.0.tgz",
+      "integrity": "sha512-AG1v8o6UZcGXTEH2jVcWG6KD+gEix+Cj9JXAAzln9MPkauSVd98H7N7EOOyT/v4c9N1mJB4sm1zfspGlLDkUEw=="
     },
     "refx": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"react-redux": "5.0.6",
 		"redux": "3.7.2",
 		"redux-multi": "0.1.12",
-		"redux-optimist": "0.0.2",
+		"redux-optimist": "1.0.0",
 		"refx": "3.0.0",
 		"rememo": "2.4.0",
 		"showdown": "1.7.4",


### PR DESCRIPTION
Closes #4593

This pull request seeks to update the `redux-optimist` dependency from `0.0.2` to `1.0.0`, the result of an upstream patch at https://github.com/ForbesLindesay/redux-optimist/pull/25 .

__Testing instructions:__

There should be no regressions in optimistic behavior, notably around saving a post (subsequent changes reflected, failure reverting to previous state, see #1093).

__Follow-up Tasks:__

- We need to update `withSelect` to check whether the state after a `subscribe` callback is referentially unequal to the previous state, as [`subscribe` callbacks are triggered whether or not a change occurs](http://jsbin.com/dugavuz/2/edit?html,js,console,output).