### PR TITLE
Refactored image uploads & Added auto fill caption using the image metadata.

### DIFF
--- a/blocks/library/gallery/index.js
+++ b/blocks/library/gallery/index.js
@@ -7,7 +7,7 @@ import { filter, every } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createMediaFromFile, preloadImage } from '@wordpress/utils';
+import { mediaUpload } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -131,23 +131,12 @@ export const settings = {
 					return files.length !== 1 && every( files, ( file ) => file.type.indexOf( 'image/' ) === 0 );
 				},
 				transform( files, onChange ) {
-					const block = createBlock( 'core/gallery', {
-						images: files.map( ( file ) => ( {
-							url: window.URL.createObjectURL( file ),
-						} ) ),
-					} );
-
-					Promise.all( files.map( ( file ) =>
-						createMediaFromFile( file )
-							.then( ( media ) => preloadImage( media.source_url ).then( () => media ) )
-					) ).then( ( medias ) => onChange( block.uid, {
-						images: medias.map( media => ( {
-							id: media.id,
-							url: media.source_url,
-							link: media.link,
-						} ) ),
-					} ) );
-
+					const block = createBlock( 'core/gallery' );
+					mediaUpload(
+						files,
+						( images ) => onChange( block.uid, { images } ),
+						'image'
+					);
 					return block;
 				},
 			},

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -16,7 +16,7 @@ import {
  */
 import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
-import { createMediaFromFile, getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
+import { getBlobByURL, revokeBlobURL, viewPort } from '@wordpress/utils';
 import {
 	IconButton,
 	SelectControl,
@@ -37,6 +37,7 @@ import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import UrlInputButton from '../../url-input/button';
 import ImageSize from './image-size';
+import { mediaUpload } from '../../../utils/mediaupload';
 
 /**
  * Module constants
@@ -65,13 +66,16 @@ class ImageBlock extends Component {
 
 		if ( ! id && url.indexOf( 'blob:' ) === 0 ) {
 			getBlobByURL( url )
-				.then( createMediaFromFile )
-				.then( ( media ) => {
-					setAttributes( {
-						id: media.id,
-						url: media.source_url,
-					} );
-				} );
+				.then(
+					( file ) =>
+						mediaUpload(
+							[ file ],
+							( [ image ] ) => {
+								setAttributes( { ...image } );
+							},
+							'image'
+						)
+				);
 		}
 	}
 

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { compact, startsWith } from 'lodash';
+import { compact, get, startsWith } from 'lodash';
 
 /**
  *	Media Upload is used by audio, image, gallery and video blocks to handle uploading a media file
@@ -35,7 +35,16 @@ export function mediaUpload( filesList, onFileChange, allowedType ) {
 
 		return createMediaFromFile( mediaFile ).then(
 			( savedMedia ) => {
-				setAndUpdateFiles( idx, { id: savedMedia.id, url: savedMedia.source_url, link: savedMedia.link } );
+				const mediaObject = {
+					id: savedMedia.id,
+					url: savedMedia.source_url,
+					link: savedMedia.link,
+				};
+				const caption = get( savedMedia, [ 'caption', 'raw' ] );
+				if ( caption ) {
+					mediaObject.caption = [ caption ];
+				}
+				setAndUpdateFiles( idx, mediaObject );
 			},
 			() => {
 				// Reset to empty on failure.
@@ -51,7 +60,7 @@ export function mediaUpload( filesList, onFileChange, allowedType ) {
  *
  * @return {Promise} Media Object Promise.
  */
-export function createMediaFromFile( file ) {
+function createMediaFromFile( file ) {
 	// Create upload payload
 	const data = new window.FormData();
 	data.append( 'file', file, file.name || file.type.replace( '/', '.' ) );


### PR DESCRIPTION
There were direct use cases of createMediaFromFile function that duplicated logic in mediaUpload. All direct usages of createMediaFromFile were removed, leading to the removal of duplicate logic.

mediaUpload was improved to read the caption field from the uploaded images, so the captions are automatically filled. The server fills the captions using the image metadata.
Closes: https://github.com/WordPress/gutenberg/issues/5321
 
There is a bug affecting the image block. When the metadata is automatically added, the placeholder of the caption may still be shown for some seconds until the mouse is moved. It seems like this issue may be related with RichText where placeholders are not removed until some prop changes if the value suffered a change external to TinyMCE. I will research this in separate.



## How Has This Been Tested?
Have an image with caption metadata e.g: the 300 one bellow and another one with no caption metadata e.g: the gif below.
Upload the image with caption metadata, to cover image block, image block, and gallery block with drag&drop and with the upload button, verify in all cases things work as expected, and in gallery and images, captions were automatically added.
Drag & drop to the editor just the image with the caption, see an image block is created with caption automatically added.
Repeat above for the image without caption metadata verify everything works as expected.
Drag & drop two images at the same time one with caption and another without the caption to the editor verify a gallery block is automatically created, and with one caption added.
Copy image data, (e.g: from an image editor) into the editor verify the upload from image data still works.

## Screenshots (jpeg or gifs if applicable):
Image with caption metadata:
![300](https://user-images.githubusercontent.com/11271197/36873864-bfdc6802-1da1-11e8-8071-311ce59494a3.jpg)
![mar-01-2018 17-37-30](https://user-images.githubusercontent.com/11271197/36873887-dd81d50e-1da1-11e8-9d16-f682562d1f7b.gif)