### PR TITLE
Data: Avoid calling listeners on unchanging state

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -72,7 +72,19 @@ export function registerReducer( reducerKey, reducer ) {
 	}
 	const store = createStore( reducer, flowRight( enhancers ) );
 	stores[ reducerKey ] = store;
-	store.subscribe( globalListener );
+
+	// Customize subscribe behavior to call listeners only on effective change,
+	// not on every dispatch.
+	let lastState = store.getState();
+	store.subscribe( () => {
+		const state = store.getState();
+		const hasChanged = state !== lastState;
+		lastState = state;
+
+		if ( hasChanged ) {
+			globalListener();
+		}
+	} );
 
 	return store;
 }

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -253,6 +253,26 @@ describe( 'withSelect', () => {
 
 			store.dispatch( { type: 'increment' } );
 		} );
+
+		itWithExtraAssertions( 'should not rerun selection on unchanging state', () => {
+			const store = registerReducer( 'unchanging', ( state = {} ) => state );
+
+			registerSelectors( 'unchanging', {
+				getState: ( state ) => state,
+			} );
+
+			const mapSelectToProps = jest.fn();
+
+			const Component = compose( [
+				withSelectImplementation( mapSelectToProps ),
+			] )( () => <div /> );
+
+			wrapper = mount( <Component /> );
+
+			store.dispatch( { type: 'dummy' } );
+
+			expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		} );
 	}
 
 	cases( withSelect );
@@ -379,6 +399,16 @@ describe( 'subscribe', () => {
 		store.dispatch( { type: 'dummy' } );
 
 		expect( secondListener ).toHaveBeenCalled();
+	} );
+
+	it( 'does not call listeners if state has not changed', () => {
+		const store = registerReducer( 'unchanging', ( state = {} ) => state );
+		const listener = jest.fn();
+		subscribeWithUnsubscribe( listener );
+
+		store.dispatch( { type: 'dummy' } );
+
+		expect( listener ).not.toHaveBeenCalled();
 	} );
 } );
 


### PR DESCRIPTION
Related: #5334

This pull request seeks to optimize the behavior of `subscribe` to avoid calling a listener except in the case that state has in-fact changed. This is a departure from Redux where `subscribe` is called on every dispatch, whether or not it results in a changed state. It's a departure I'd argue is warranted: listener callbacks don't and shouldn't have access to the dispatched action. That they are expected only to read from state implies that a subscriber react to a change, so an expectation better reflected in these changes.

Further, it would be difficult to introduce the desired optimization mentioned in #5334 to avoid running `mapSelectToProps` of `withSelect` without this change, as we don't know _which_ store the mapping function will select from and to implement would require a shallow equality test on all stores (in some cases more wasteful than to just allow the mapping to be performed).

__Testing instructions:__

Verify unit tests pass:

```
npm run test-unit
```