### PR TITLE
RichText: Fix delete key in empty contenteditables

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -21,7 +21,7 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { createElement, Component, renderToString } from '@wordpress/element';
-import { keycodes, createBlobURL } from '@wordpress/utils';
+import { keycodes, createBlobURL, isHorizontalEdge } from '@wordpress/utils';
 import { withSafeTimeout, Slot, Fill } from '@wordpress/components';
 
 /**
@@ -469,52 +469,6 @@ export class RichText extends Component {
 	}
 
 	/**
-	 * Determines if the current selection within the editor is at the start.
-	 *
-	 * @return {boolean} Whether or not the selection is at the start of the editor.
-	 */
-	isStartOfEditor() {
-		const range = this.editor.selection.getRng();
-		if ( range.startOffset !== 0 || ! range.collapsed ) {
-			return false;
-		}
-		const start = range.startContainer;
-		const body = this.editor.getBody();
-		let element = start;
-		while ( element !== body ) {
-			const child = element;
-			element = element.parentNode;
-			if ( element.firstChild !== child ) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * Determines if the current selection within the editor is at the end.
-	 *
-	 * @return {boolean} Whether or not the selection is at the end of the editor.
-	 */
-	isEndOfEditor() {
-		const range = this.editor.selection.getRng();
-		if ( range.endOffset !== range.endContainer.textContent.length || ! range.collapsed ) {
-			return false;
-		}
-		const start = range.endContainer;
-		const body = this.editor.getBody();
-		let element = start;
-		while ( element !== body ) {
-			const child = element;
-			element = element.parentNode;
-			if ( element.lastChild !== child ) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
 	 * Handles a keydown event from tinyMCE.
 	 *
 	 * @param {KeydownEvent} event The keydow event as triggered by tinyMCE.
@@ -524,8 +478,8 @@ export class RichText extends Component {
 		const rootNode = this.editor.getBody();
 
 		if (
-			( event.keyCode === BACKSPACE && this.isStartOfEditor() ) ||
-			( event.keyCode === DELETE && this.isEndOfEditor() )
+			( event.keyCode === BACKSPACE && isHorizontalEdge( rootNode, true ) ) ||
+			( event.keyCode === DELETE && isHorizontalEdge( rootNode, false ) )
 		) {
 			if ( ! this.props.onMerge && ! this.props.onRemove ) {
 				return;

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -21,7 +21,7 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { createElement, Component, renderToString } from '@wordpress/element';
-import { keycodes, createBlobURL, isHorizontalEdge } from '@wordpress/utils';
+import { keycodes, createBlobURL } from '@wordpress/utils';
 import { withSafeTimeout, Slot, Fill } from '@wordpress/components';
 
 /**
@@ -469,6 +469,52 @@ export class RichText extends Component {
 	}
 
 	/**
+	 * Determines if the current selection within the editor is at the start.
+	 *
+	 * @return {boolean} Whether or not the selection is at the start of the editor.
+	 */
+	isStartOfEditor() {
+		const range = this.editor.selection.getRng();
+		if ( range.startOffset !== 0 || ! range.collapsed ) {
+			return false;
+		}
+		const start = range.startContainer;
+		const body = this.editor.getBody();
+		let element = start;
+		while ( element !== body ) {
+			const child = element;
+			element = element.parentNode;
+			if ( element.firstChild !== child ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Determines if the current selection within the editor is at the end.
+	 *
+	 * @return {boolean} Whether or not the selection is at the end of the editor.
+	 */
+	isEndOfEditor() {
+		const range = this.editor.selection.getRng();
+		if ( range.endOffset !== range.endContainer.textContent.length || ! range.collapsed ) {
+			return false;
+		}
+		const start = range.endContainer;
+		const body = this.editor.getBody();
+		let element = start;
+		while ( element !== body ) {
+			const child = element;
+			element = element.parentNode;
+			if ( element.lastChild !== child ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Handles a keydown event from tinyMCE.
 	 *
 	 * @param {KeydownEvent} event The keydow event as triggered by tinyMCE.
@@ -478,8 +524,8 @@ export class RichText extends Component {
 		const rootNode = this.editor.getBody();
 
 		if (
-			( event.keyCode === BACKSPACE && isHorizontalEdge( rootNode, true ) ) ||
-			( event.keyCode === DELETE && isHorizontalEdge( rootNode, false ) )
+			( event.keyCode === BACKSPACE && this.isStartOfEditor() ) ||
+			( event.keyCode === DELETE && this.isEndOfEditor() )
 		) {
 			if ( ! this.props.onMerge && ! this.props.onRemove ) {
 				return;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -85,7 +85,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-utils',
 		gutenberg_url( 'utils/build/index.js' ),
-		array(),
+		array( 'tinymce-latest' ),
 		filemtime( gutenberg_dir_path() . 'utils/build/index.js' )
 	);
 	wp_register_script(

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { includes } from 'lodash';
+import tinymce from 'tinymce';
 
 /**
  * Browser dependencies
@@ -57,8 +58,14 @@ export function isHorizontalEdge( container, isReverse, collapseRanges = false )
 	}
 
 	const maxOffset = node.nodeType === TEXT_NODE ? node.nodeValue.length : node.childNodes.length;
+	const editor = tinymce.get( node.id );
 
-	if ( ! isReverse && offset !== maxOffset ) {
+	if (
+		! isReverse &&
+		offset !== maxOffset &&
+		// content editables with only a BR element are considered empty
+		( ! editor || ! editor.dom.isEmpty( node ) )
+	) {
 		return false;
 	}
 


### PR DESCRIPTION
closes #5345 related #5159

On empty content editables, there's always a `<br />` element added by TinyMCE, this makes `isHorizontalEdge` return false where it should return `true`. This fixes this issue.

Also, another issue I found related to #5159 is that we want to trigger onSplit only if we click delete at the end of RichText or backspace at the beginning. So we need to check both the vertical and the horizontal edge in both cases.

**Testing instructions**

 - Try backspacing or clicking delete on empty paragraph, at the beginning, end, middle of paragraphs. It should behave properly.