### PR TITLE
Block Toolbar: Do not hide the block toolbar on mobile

### DIFF
--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -29,7 +29,7 @@ function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
 			<WritingFlow>
 				<PostTitle />
 				<BlockList
-					showContextualToolbar={ isLargeViewport && ! hasFixedToolbar }
+					showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
 					renderBlockMenu={ ( { children, onClose } ) => (
 						<Fragment>
 							<BlockInspectorButton onClick={ onClose } />


### PR DESCRIPTION
closes #5346 

When introducing the `viewport` module, the block toolbar has been hidden in mobile. I don't know the exact reasons for this but I think we still want it in mobile. So I'm bringing it back here.

**Testing instructions**

 - select a block in mobile
 - The block toolbar should appear
 - Try in both docker and undocker toolbar.