### PR TITLE
Tiny fix: Don't hide Upload button text

### DIFF
--- a/components/form-file-upload/style.scss
+++ b/components/form-file-upload/style.scss
@@ -1,14 +1,9 @@
 .wp-core-ui .components-form-file-upload {
 	.button.button-large {
-		font-size: 0;
-		padding: 6px 0 3px;
+		padding: 6px 12px 2px 3px;
 
 		@include break-medium() {
-			padding: 0 12px 2px;
-		}
-
-		@include break-large() {
-			font-size: inherit;
+			padding: 0 12px 2px 3px;
 		}
 	}
 }


### PR DESCRIPTION
With recent changes to the IconButton, the Upload button regressed slightly with padding. This both addresses that, and fixes some text hiding iffiness.

Before:

<img width="364" alt="screen shot 2018-03-02 at 11 20 52" src="https://user-images.githubusercontent.com/1204802/36894671-75bd2d9a-1e0c-11e8-8b4f-9a7fbca448d7.png">

After

![upload button](https://user-images.githubusercontent.com/1204802/36894683-7a6906e8-1e0c-11e8-9195-86d4e2f5c8fd.gif)
