### PR TITLE
More specific CSS selector for SVG icons.

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -70,11 +70,6 @@ body.gutenberg-editor-page {
 		top: -1px;
 	}
 
-	svg {
-		fill: currentColor;
-		outline: none;
-	}
-
 	ul#adminmenu a.wp-has-current-submenu:after,
 	ul#adminmenu>li.current>a.current:after {
 		border-right-color: $white;
@@ -103,6 +98,11 @@ body.gutenberg-editor-page {
 	select {
 		font-size: $default-font-size;
 		color: $dark-gray-500;
+	}
+
+	svg.dashicon {
+		fill: currentColor;
+		outline: none;
 	}
 }
 

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -24,13 +24,13 @@ import { selectBlock } from '../../store/actions';
  * Module constants
  */
 const upArrow = (
-	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
+	<svg className="dashicon" width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
 		<path d="M12.293 12.207L9 8.914l-3.293 3.293-1.414-1.414L9 6.086l4.707 4.707z" />
 	</svg>
 );
 
 const downArrow = (
-	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
+	<svg className="dashicon" width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
 		<path d="M12.293 6.086L9 9.379 5.707 6.086 4.293 7.5 9 12.207 13.707 7.5z" />
 	</svg>
 );


### PR DESCRIPTION
## Description

This PR tries to use a more scoped CSS selector for the SVG icons. 
- targets only the editor area, excluding the core admin menu, toolbar, and footer
- targets only the SVG icons with a `dashicon` class

Solves a problem when plugins use their own SVG icons and the previous selector is too aggressive:
`body.gutenberg-editor-page svg { ... }`

is a bit overqualified and targets _any_ SVG in the whole page, even SVG that aren't actual icons. Plugins may also use SVG images, logos, etc..

## How Has This Been Tested?
I've manually tested the Gutenberg icons still look good.

Note: about the new block mover icons, I've noticed they inherit a slightly different color /cc @jasmussen 

Fixes #5302