### PR TITLE
Paste: Treat single-item lists as paragraphs

### DIFF
--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -19,6 +19,7 @@ import isInlineContent from './is-inline-content';
 import formattingTransformer from './formatting-transformer';
 import msListConverter from './ms-list-converter';
 import listReducer from './list-reducer';
+import singleItemListConverter from './single-item-list-converter';
 import imageCorrector from './image-corrector';
 import blockquoteNormaliser from './blockquote-normaliser';
 import tableNormaliser from './table-normaliser';
@@ -81,14 +82,17 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 		}
 	}
 
-	// An array of HTML strings and block objects. The blocks replace matched shortcodes.
+	// An array of HTML strings and block objects. The blocks replace matched
+	// shortcodes.
 	const pieces = shortcodeConverter( HTML );
 
-	// The call to shortcodeConverter will always return more than one element if shortcodes are matched.
-	// The reason is when shortcodes are matched empty HTML strings are included.
+	// The call to shortcodeConverter will always return more than one element
+	// if shortcodes are matched. The reason is when shortcodes are matched
+	// empty HTML strings are included.
 	const hasShortcodes = pieces.length > 1;
 
-	// True if mode is auto, no shortcode is included and HTML verifies the isInlineContent condition
+	// True if mode is auto, no shortcode is included and HTML verifies the
+	// isInlineContent condition
 	const isAutoModeInline = mode === 'AUTO' && isInlineContent( HTML, tagName ) && ! hasShortcodes;
 
 	// Return filtered HTML if condition is true
@@ -137,6 +141,7 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 		] ) );
 
 		piece = deepFilterHTML( piece, [
+			singleItemListConverter,
 			createUnwrapper( isInvalidInline ),
 		] );
 

--- a/blocks/api/raw-handling/single-item-list-converter.js
+++ b/blocks/api/raw-handling/single-item-list-converter.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Browser dependencies
+ */
+const { ELEMENT_NODE } = window.Node;
+
+function isListRelated( node ) {
+	return includes( [ 'UL', 'OL', 'LI' ], node.nodeName );
+}
+
+function isTopLevel( node ) {
+	return (
+		! node.parentNode ||
+		node.parentNode.nodeName === 'BODY'
+	);
+}
+
+export default function( node ) {
+	// Only act at the root of the content and on a list with no siblings.
+	if (
+		node.nodeType !== ELEMENT_NODE ||
+		! isTopLevel( node ) ||
+		! node.childNodes ||
+		node.childNodes.length !== 1 ||
+		! isListRelated( node.firstChild )
+	) {
+		return;
+	}
+
+	const listType = node.nodeName;
+	const isList = includes( [ 'UL', 'OL' ], listType );
+
+	if ( ! isList ) {
+		return;
+	}
+
+	// Flatten double lists, e.g.
+	//   <ul><ul><li>…</li></ul></ul>
+	// becomes
+	//   <ul><li>…</li></ul>
+	if (
+		node.childNodes.length === 1 &&
+		node.firstChild.nodeName === listType &&
+		node.firstChild.childNodes.length === 1
+	) {
+		const nestedList = node.firstChild;
+		while ( nestedList.hasChildNodes() ) {
+			node.appendChild( nestedList.removeChild( nestedList.firstChild ) );
+		}
+		node.removeChild( nestedList );
+	}
+
+	// Convert single-item lists, e.g.
+	//   <ul><li>Hello</li></ul>
+	// becomes
+	//   <p>Hello</p>
+	if ( node.childNodes.length === 1 && node.firstChild.nodeName === 'LI' ) {
+		// Create P node, transfer contents of LI to it.
+		const singleListItem = node.firstChild;
+		const paragraph = document.createElement( 'p' );
+		while ( singleListItem.hasChildNodes() ) {
+			paragraph.appendChild( singleListItem.removeChild( singleListItem.firstChild ) );
+		}
+
+		// Replace in body
+		node.parentNode.replaceChild( paragraph, node );
+	}
+}

--- a/blocks/api/raw-handling/test/integration/index.js
+++ b/blocks/api/raw-handling/test/integration/index.js
@@ -38,7 +38,7 @@ describe( 'raw handling: integration', () => {
 			const converted = rawHandler( { HTML: input, canUserUseUnfilteredHTML: true } );
 			const serialized = typeof converted === 'string' ? converted : serialize( converted );
 
-			equal( output, serialized );
+			equal( serialized, output );
 		} );
 	} );
 } );

--- a/blocks/api/raw-handling/test/single-item-list-converter.js
+++ b/blocks/api/raw-handling/test/single-item-list-converter.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { equal } from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import singleItemListConverter from '../single-item-list-converter';
+import { deepFilterHTML } from '../utils';
+
+describe( 'singleItemListConverter', () => {
+	it( 'should treat a single-item list as a paragraph', () => {
+		const input = '<ul><li>Lorem ipsum, dolor sit amet.</li></ul>';
+		const output = '<p>Lorem ipsum, dolor sit amet.</p>';
+		equal( deepFilterHTML( input, [ singleItemListConverter ] ), output );
+	} );
+	it( 'shouldn\'t affect multi-item lists', () => {
+		const input = '<ul><li>Lorem ipsum</li><li>Dolor sit amet</li></ul>';
+		equal( deepFilterHTML( input, [ singleItemListConverter ] ), input );
+	} );
+	it( 'should squash single-item nested lists', () => {
+		const input = '<ul><ul><li>Lorem ipsum</li></ul></ul>';
+		const output = '<p>Lorem ipsum</p>';
+		equal( deepFilterHTML( input, [ singleItemListConverter ] ), output );
+	} );
+	it( 'shouldn\'t squash multi-item nested lists', () => {
+		const input = '<ul><ul><li>Lorem ipsum</li><li>Dolor sit amet</li></ul></ul>';
+		equal( deepFilterHTML( input, [ singleItemListConverter ] ), input );
+	} );
+	it( 'shouldn\'t affect valid nested lists', () => {
+		const input = `
+<ul>
+    <li>A</li>
+    <li>Bulleted</li>
+    <ul>
+        <li>Indented</li>
+    </ul>
+    <li>List</li>
+</ul>`;
+		equal( deepFilterHTML( input, [ singleItemListConverter ] ), input );
+	} );
+} );


### PR DESCRIPTION
## Description

When pasting content from rich-text sources, if the object being pasted is a single item from a list, treat it as a paragraph. That is, pasting the object will not result in a new List block with a single item, but rather a Paragraph block with the text content copied from the source.

![gutenberg-single-item-list-paste](https://user-images.githubusercontent.com/150562/36907566-d7d08eae-1e30-11e8-80bc-c6301eac2d31.gif)

## How Has This Been Tested?
- Own tests for the new transformer.
- Integration tests for `blocks/api/raw-handler`
- Manual testing — see screencast above. Try the same but with some formatting, e.g. bold in the list items.

## Types of changes
Enhancement. This is an opinionated optimization for something that has emerged as a common enough pattern.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
