### PR TITLE
Adjust the metaboxes inside padding to make plugins happy.

### DIFF
--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -37,7 +37,7 @@
 	.postbox > .inside {
 		border-bottom: 1px solid $light-gray-500;
 		color: $dark-gray-500;
-		padding: 15px;
+		padding: 0 $block-padding $block-padding;
 		margin: 0;
 	}
 


### PR DESCRIPTION
This PR proposes a small change to the meta boxes inside area padding to make plugins happy. Please refer to the related issue #5356 for more details.

Fixes #5356 