### PR TITLE
CheckboxControl > Fix the parameter send to the onChange function

### DIFF
--- a/components/checkbox-control/index.js
+++ b/components/checkbox-control/index.js
@@ -7,7 +7,7 @@ import './style.scss';
 
 function CheckboxControl( { label, heading, checked, help, instanceId, onChange, ...props } ) {
 	const id = `inspector-checkbox-control-${ instanceId }`;
-	const onChangeValue = ( event ) => onChange( event.target.value );
+	const onChangeValue = ( event ) => onChange( event.target.checked );
 
 	return (
 		<BaseControl label={ heading } id={ id } help={ help }>


### PR DESCRIPTION
## Description
Send the checked state to the onChange function of the CheckboxControl instead of the name.

## How Has This Been Tested?
Just looked a what the function received and with this change i received the correct parameter.
Run `npm test` and everything look ok


## Types of changes
Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
