### PR TITLE
Documentation: Rewrite Data docs as tutorial

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -13,7 +13,7 @@ const { registerStore } = wp.data;
 
 const DEFAULT_STATE = {
 	prices: {},
-	sale: false,
+	discountPercent: 0,
 };
 
 registerStore( 'my-shop', {
@@ -31,7 +31,7 @@ registerStore( 'my-shop', {
 			case 'START_SALE':
 				return {
 					...state,
-					sale: true,
+					discountPercent: action.discountPercent,
 				};
 		}
 
@@ -46,22 +46,20 @@ registerStore( 'my-shop', {
 				price,
 			};
 		},
-		startSale() {
+		startSale( discountPercent ) {
 			return {
 				type: 'START_SALE',
+				discountPercent,
 			};
 		},
 	},
 
 	selectors: {
 		getPrice( item ) {
-			const price = state.prices[ item ];
+			const { prices, discountPercent } = state;
+			const price = prices[ item ];
 
-			if ( state.sale ) {
-				return price * 0.8;
-			}
-
-			return price;
+			return price * ( 1 - ( 0.01 * discountPercent ) );
 		},
 	},
 } );
@@ -177,11 +175,14 @@ function Button( { onClick, children } ) {
 	return <button type="button" onClick={ onClick }>{ children }</button>;
 }
 
-const SaleButton = withDispatch( ( dispatch ) => {
+const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 	const { startSale } = dispatch( 'my-shop' );
+	const { discountPercent = 20 } = ownProps;
 
 	return {
-		onClick: startSale,
+		onClick() {
+			startSale( discountPercent );
+		},
 	};
 } );
 

--- a/data/README.md
+++ b/data/README.md
@@ -2,6 +2,8 @@
 
 WordPress' data module serves as a hub to manage application state for both plugins and WordPress itself, providing tools to manage data within and between distinct modules. It is designed as a modular pattern for organizing and sharing data: simple enough to satisfy the needs of a small plugin, while scalable to serve the requirements of a complex single-page application.
 
+The data module is built upon and shares many of the same core principles of [Redux](https://redux.js.org/), but shouldn't be mistaken as merely _Redux for WordPress_, as it includes a few of its own [distinguishing characteristics](#comparison-with-redux).
+
 ## Registering a Store
 
 Use the `registerStore` function to add your own store to the centralized data registry. This function accepts two arguments: a name to identify the module, and an object with values describing how your state is represented, modified, and accessed. At a minimum, you must provide a reducer function describing the shape of your state and how it changes in response to actions dispatched to the store.

--- a/data/README.md
+++ b/data/README.md
@@ -79,8 +79,6 @@ The return value of `registerStore` is a [Redux-like store object](https://redux
    - _Redux parallel:_ [`getState`](https://redux.js.org/api-reference/store#getState)
 - `store.subscribe( listener: Function )`: Registers a function called any time the value of state changes.
    - _Redux parallel:_ [`subscribe`](https://redux.js.org/api-reference/store#subscribe(listener))
-   - Differences from Redux:
-      - In Redux, a subscriber is called on every dispatch, regardless of whether a change has occurred. In `@wordpress/data`, a subscriber is only called when state has changed.
 - `store.dispatch( action: Object )`: Given an action object, calls the registered reducer and updates the state value.
    - _Redux parallel:_ [`dispatch`](https://redux.js.org/api-reference/store#dispatch(action))
 
@@ -199,3 +197,12 @@ const SaleButton = withDispatch( ( dispatch ) => {
 The data module shares many of the same [core principles](https://redux.js.org/introduction/three-principles) and [API method naming](https://redux.js.org/api-reference) of [Redux](https://redux.js.org/). In fact, it is implemented atop Redux. Where it differs is in establishing a modularization pattern for creating separate but interdependent stores, and in codifying conventions such as selector functions as the primary entry point for data access.
 
 The [higher-order components](#higher-order-components) were created to complement this distinction. The intention with splitting `withSelect` and `withDispatch` — where in React Redux they are combined under `connect` as `mapStateToProps` and `mapDispatchToProps` arguments — is to more accurately reflect that dispatch is not dependent upon a subscription to state changes, and to allow for state-derived values to be used in `withDispatch` (via [higher-order component composition](https://github.com/WordPress/gutenberg/tree/master/element#compose)).
+
+Specific implementation differences from Redux and React Redux:
+
+- In Redux, a `subscribe` listener is called on every dispatch, regardless of whether the value of state has changed.
+   - In `@wordpress/data`, a subscriber is only called when state has changed.
+- In React Redux, a `mapStateToProps` function must return an object.
+   - In `@wordpress/data`, a `withSelect` mapping function can return `undefined` if it has no props to inject.
+- In React Redux, the `mapDispatchToProps` argument can be defined as an object or a function.
+   - In `@wordpress/data`, the `withDispatch` higher-order component creator must be passed a function.

--- a/data/README.md
+++ b/data/README.md
@@ -136,8 +136,6 @@ unsubscribe();
 
 A higher-order component is a function which accepts a [component](https://github.com/WordPress/gutenberg/tree/master/element) and returns a new, enhanced component. A stateful user interface should respond to changes in the underlying state and updates its displayed element accordingly. WordPress uses higher-order components both as a means to separate the purely visual aspects of an interface from its data backing, and to ensure that the data is kept in-sync with the stores.
 
-In the React/Redux ecosystem, this distinction is often labelled [_Presentational and Container Components_](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0). [React Redux](https://github.com/reactjs/react-redux) is the official bindings between React and Redux for providing this behavior. The higher-order components offered in the data module are very much like React Redux's `connect` function, but offered as independent functions for retrieving and manipulating data: `withSelect` and `withDispatch`.
-
 #### `withSelect( mapSelectToProps: Function ): Function`
 
 Use `withSelect` to inject state-derived props into a component. Passed a function which returns an object mapping prop names to the subscribed data source, a higher-order component function is returned. The higher-order component can be used to enhance a presentational component, updating it automatically when state changes. The mapping function is passed the [`select` function](#select) and the props passed to the original component.

--- a/data/README.md
+++ b/data/README.md
@@ -170,11 +170,11 @@ In the above example, when `HammerPriceDisplay` is rendered into an application,
 
 #### `withDispatch( mapDispatchToProps: Function ): Function`
 
-Use `withDispatch` to inject dispatching action props into your component. Passed a function which returns an object mapping prop names to action dispatchers, a higher-order component function is returned. The higher-order component can be used to enhance a presentational component, often providing callback behaviors for user interactions. The mapping function is passed the [`dispatch` function](#dispatch) and the props passed to the original component.
+Use `withDispatch` to inject dispatching action props into your component. Passed a function which returns an object mapping prop names to action dispatchers, a higher-order component function is returned. The higher-order component can be used to enhance a component. For example, you can define callback behaviors as props for responding to user interactions. The mapping function is passed the [`dispatch` function](#dispatch) and the props passed to the original component.
 
 ```jsx
 function Button( { onClick, children } ) {
-	return <button type="buttton" onClick={ onClick }>{ children }</button>;
+	return <button type="button" onClick={ onClick }>{ children }</button>;
 }
 
 const SaleButton = withDispatch( ( dispatch ) => {

--- a/data/README.md
+++ b/data/README.md
@@ -1,132 +1,199 @@
-Data
-====
+# Data
 
-The more WordPress UI moves to the client, the more there's a need for a centralized data module allowing data management and sharing between several WordPress modules and plugins.
+WordPress' data module serves as a hub to manage application state for both plugins and WordPress itself, providing tools to manage data within and between distinct modules. It is designed as a modular pattern for organizing and sharing data: simple enough to satisfy the needs of a small plugin, while scalable to serve the requirements of a complex single-page application.
 
-This module holds a global state variable and exposes a "Redux-like" API containing the following methods:
+## Registering a Store
 
-
-### `wp.data.registerReducer( key: string, reducer: function )`
-
-If your module or plugin needs to store and manipulate client-side data, you'll have to register a "reducer" to do so. A reducer is a function taking the previous `state` and `action` and returns an update `state`. You can learn more about reducers on the [Redux Documentation](https://redux.js.org/docs/basics/Reducers.html)
-
-This function takes two arguments: a `key` to identify the module (example: `myAwesomePlugin`) and the reducer function. It returns a [Redux-like store object](https://redux.js.org/docs/basics/Store.html) with the following methods:
-
-#### `store.getState()`
-
-Returns the [state object](https://redux.js.org/docs/Glossary.html#state) of the registered reducer. See: https://redux.js.org/docs/api/Store.html#getState
-
-#### `store.subscribe( listener: function )`
-
-Registers a [`listener`](https://redux.js.org/docs/api/Store.html#subscribe) function called everytime the state is updated.
-
-#### `store.dispatch( action: object )`
-
-The dispatch function should be called to trigger the registered reducers function and update the state. An [`action`](https://redux.js.org/docs/api/Store.html#dispatch) object should be passed to this function. This action is passed to the registered reducers in addition to the previous state.
-
-
-### `wp.data.registerSelectors( reducerKey: string, newSelectors: object )`
-
-If your module or plugin needs to expose its state to other modules and plugins, you'll have to register state selectors.
-
-A selector is a function that takes the current state value as a first argument and extra arguments if needed and returns any data extracted from the state.
-
-#### Example:
-
-Let's say the state of our plugin (registered with the key `myPlugin`) has the following shape: `{ title: 'My post title' }`. We can register a `getTitle` selector to make this state value available like so:
+Use the `registerStore` function to add your own store to the centralized data registry. This function accepts two arguments: a name to identify the module, and an object with values describing how your state is represented, modified, and accessed. At a minimum, you must provide a reducer function describing the shape of your state and how it changes in response to actions dispatched to the store.
 
 ```js
-wp.data.registerSelectors( 'myPlugin', { getTitle: ( state ) => state.title } );
-```
+const { registerStore } = wp.data;
 
-### `wp.data.registerActions( reducerKey: string, newActions: object )`
+const DEFAULT_STATE = {
+	prices: {},
+	sale: false,
+};
 
-If your module or plugin needs to expose its actions to other modules and plugins, you'll have to register action creators.
+registerStore( 'my-shop', {
+	reducer( state = DEFAULT_STATE, action ) {
+		switch ( action.type ) {
+			case 'SET_PRICE':
+				return {
+					...state,
+					prices: {
+						...state.prices,
+						[ action.item ]: action.price,
+					},
+				};
 
-An action creator is a function that takes arguments and returns an action object dispatch to the registered reducer to update the state.
+			case 'START_SALE':
+				return {
+					...state,
+					sale: true,
+				};
+		}
 
-#### Example:
+		return state;
+	},
 
-```js
-wp.data.registerActions( 'myPlugin', {
-	setTitle( newTitle ) {
-		return {
-			type: 'SET_TITLE',
-			title: newTitle,
-		};
+	actions: {
+		setPrice( item, price ) {
+			return {
+				type: 'SET_PRICE',
+				item,
+				price,
+			};
+		},
+		startSale() {
+			return {
+				type: 'START_SALE',
+			};
+		},
+	},
+
+	selectors: {
+		getPrice( item ) {
+			const price = state.prices[ item ];
+
+			if ( state.sale ) {
+				return price * 0.8;
+			}
+
+			return price;
+		},
 	},
 } );
 ```
 
-### `wp.data.select( key: string )`
+A [**reducer**](https://redux.js.org/docs/basics/Reducers.html) is a function accepting the previous `state` and `action` as arguments and returns an updated `state` value.
 
-This function allows calling any registered selector. Given a module's key, this function returns an object of all selector functions registered for the module.
+The **`actions`** object should describe all [action creators](https://redux.js.org/glossary#action-creator) available for your store. An action creator is a function that optionally accepts arguments and returns an action object to dispatch to the registered reducer. _Dispatching actions is the primary mechanism for making changes to your state._
 
-#### Example:
+The **`selectors`** object includes a set of functions for accessing and deriving state values. A selector is a function which accepts state and optional arguments and returns some value from state. _Calling selectors is the primary mechanism for retrieving data from your state_, and serve as a useful abstraction over the raw data which is typically more susceptible to change and less readily usable as a [normalized object](https://redux.js.org/recipes/structuring-reducers/normalizing-state-shape#designing-a-normalized-state).
+
+The return value of `registerStore` is a [Redux-like store object](https://redux.js.org/docs/basics/Store.html) with the following methods:
+
+- `store.getState()`: Returns the state value of the registered reducer
+   - _Redux parallel:_ [`getState`](https://redux.js.org/api-reference/store#getState)
+- `store.subscribe( listener: Function )`: Registers a function called any time the value of state changes.
+   - _Redux parallel:_ [`subscribe`](https://redux.js.org/api-reference/store#subscribe(listener))
+   - Differences from Redux:
+      - In Redux, a subscriber is called on every dispatch, regardless of whether a change has occurred. In `@wordpress/data`, a subscriber is only called when state has changed.
+- `store.dispatch( action: Object )`: Given an action object, calls the registered reducer and updates the state value.
+   - _Redux parallel:_ [`dispatch`](https://redux.js.org/api-reference/store#dispatch(action))
+
+## Data Access and Manipulation
+
+It is very rare that you should access store methods directly. Instead, the following suite of functions and higher-order components is provided for the most common data access and manipulation needs.
+
+### Data API
+
+The top-level API of `@wordpress/data` includes a number of functions which allow immediate access to select from and dispatch to a registered store. These are most useful in low-level code where a selector or action dispatch is called a single time or at known intervals. For displaying data in a user interface, you should use [higher-order components](#higher-order-components) instead.
+
+#### `select( storeName: string ): Object`
+
+Given the name of a registered store, returns an object of the store's selectors. The selector functions are been pre-bound to pass the current state automatically. As a consumer, you need only pass arguments of the selector, if applicable.
+
+_Example:_
 
 ```js
-wp.data.select( 'myPlugin' ).getTitle(); // Returns "My post title"
+const { select } = wp.data;
+
+select( 'my-shop' ).getPrice( 'hammer' );
 ```
 
-### `wp.data.dispatch( key: string )`
+#### `dispatch( storeName: string ): Object`
 
-This function allows calling any registered action. Given a module's key, this function returns an object of all action creators functions registered for the module.
+Given the name of a registered store, returns an object of the store's action creators. Calling an action creator will cause it to be dispatched, updating the state value accordingly.
 
-#### Example:
+_Example:_
 
 ```js
-wp.data.dispatch( 'myPlugin' ).setTitle( 'new Title' ); // Dispatches the setTitle action to the reducer
+const { dispatch } = wp.data;
+
+dispatch( 'my-shop' ).setPrice( 'hammer', 9.75 );
 ```
 
-### `wp.data.subscribe( listener: function )`
+#### `subscribe(): Function`
 
-Function used to subscribe to data changes. The listener function is called each time a change is made to any of the registered reducers. This function returns a `unsubscribe` function used to abort the subscription.
+Given a listener function, the function will be called any time the state value of one of the registered stores has changed. This function returns a `unsubscribe` function used to stop the subscription.
+
+_Example:_
 
 ```js
-// Subscribe.
-const unsubscribe = wp.data.subscribe( () => {
-	const data = {
-		slug: wp.data.select( 'core/editor' ).getEditedPostSlug(),
-	};
+const { subscribe } = wp.data;
 
-	console.log( 'data changed', data );
+const unsubscribe = subscribe( () => {
+	// You could use this opportunity to test whether the derived result of a
+	// selector has subsequently changed as the result of a state update.
 } );
 
-// Unsubcribe.
+// Later, if necessary...
 unsubscribe();
 ```
 
-### `wp.data.withSelect( mapStateToProps: Object|Function )( WrappedComponent: Component )`
+### Higher-Order Components
 
-To inject state-derived props into a WordPress Element Component, use the `withSelect` higher-order component:
+A higher-order component is a function which accepts a [component](https://github.com/WordPress/gutenberg/tree/master/element) and returns a new, enhanced component. A stateful user interface should respond to changes in the underlying state and updates its displayed element accordingly. WordPress uses higher-order components both as a means to separate the purely visual aspects of an interface from its data backing, and to ensure that the data is kept in-sync with the stores.
 
-```jsx
-const Component = ( { title } ) => <div>{ title }</div>;
+In the React/Redux ecosystem, this distinction is often labelled [_Presentational and Container Components_](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0). [React Redux](https://github.com/reactjs/react-redux) is the official bindings between React and Redux for providing this behavior. The higher-order components offered in the data module are very much like React Redux's `connect` function, but offered as independent functions for retrieving and manipulating data: `withSelect` and `withDispatch`.
 
-const EnhancedComponent = wp.data.withSelect( ( select ) => {
+#### `withSelect( mapSelectToProps: Function ): Function`
+
+Use `withSelect` to inject state-derived props into a component. Passed a function which returns an object mapping prop names to the subscribed data source, a higher-order component function is returned. The higher-order component can be used to enhance a presentational component, updating it automatically when state changes. The mapping function is passed the [`select` function](#select) and the props passed to the original component.
+
+__Example:__
+
+```js
+function PriceDisplay( { price, currency } ) {
+	return new Intl.NumberFormat( 'en-US', {
+		style: 'currency',
+		currency,
+	} ).format( price );
+}
+
+const { withSelect } = wp.data;
+
+const HammerPriceDisplay = withSelect( ( select, ownProps ) => {
+	const { getPrice } = select( 'my-shop' );
+	const { currency } = ownProps;
+
 	return {
-		title: select( 'myPlugin' ).getTitle,		
+		price: getPrice( 'hammer', currency ),
 	};
-} )( Component );
+} )( PriceDisplay );
+
+// Rendered in the application:
+//
+//  <HammerPriceDisplay currency="USD" />
 ```
 
-### `wp.data.withDispatch( propsToDispatchers: Object )( WrappedComponent: Component )`
+In the above example, when `HammerPriceDisplay` is rendered into an application, it will pass the price into the underlying `PriceDisplay` component and update automatically if the price of a hammer ever changes in the store.
 
-To manipulate store data, you can pass dispatching actions into your component as props using the `withDispatch` higher-order component:
+#### `withDispatch( mapDispatchToProps: Function ): Function`
+
+Use `withDispatch` to inject dispatching action props into your component. Passed a function which returns an object mapping prop names to action dispatchers, a higher-order component function is returned. The higher-order component can be used to enhance a presentational component, often providing callback behaviors for user interactions. The mapping function is passed the [`dispatch` function](#dispatch) and the props passed to the original component.
 
 ```jsx
-const Component = ( { title, updateTitle } ) => <input value={ title } onChange={ updateTitle } />;
+function Button( { onClick, children } ) {
+	return <button type="buttton" onClick={ onClick }>{ children }</button>;
+}
 
-const EnhancedComponent = wp.element.compose( [
-	wp.data.withSelect( ( select ) => {
-		return {
-			title: select( 'myPlugin' ).getTitle(),
-		};
-	} ),
-	wp.data.withDispatch( ( dispatch ) => {
-		return {
-			updateTitle: dispatch( 'myPlugin' ).setTitle,			
-		};
-	} ),
-] )( Component );
+const SaleButton = withDispatch( ( dispatch ) => {
+	const { startSale } = dispatch( 'my-shop' );
+
+	return {
+		onClick: startSale,
+	};
+} );
+
+// Rendered in the application:
+//
+//  <SaleButton>Start Sale!</SaleButton>
 ```
+
+## Comparison with Redux
+
+The data module shares many of the same [core principles](https://redux.js.org/introduction/three-principles) and [API method naming](https://redux.js.org/api-reference) of [Redux](https://redux.js.org/). In fact, it is implemented atop Redux. Where it differs is in establishing a modularization pattern for creating separate but interdependent stores, and in codifying conventions such as selector functions as the primary entry point for data access.
+
+The [higher-order components](#higher-order-components) were created to complement this distinction. The intention with splitting `withSelect` and `withDispatch` — where in React Redux they are combined under `connect` as `mapStateToProps` and `mapDispatchToProps` arguments — is to more accurately reflect that dispatch is not dependent upon a subscription to state changes, and to allow for state-derived values to be used in `withDispatch` (via [higher-order component composition](https://github.com/WordPress/gutenberg/tree/master/element#compose)).

--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,7 @@
 
 WordPress' data module serves as a hub to manage application state for both plugins and WordPress itself, providing tools to manage data within and between distinct modules. It is designed as a modular pattern for organizing and sharing data: simple enough to satisfy the needs of a small plugin, while scalable to serve the requirements of a complex single-page application.
 
-The data module is built upon and shares many of the same core principles of [Redux](https://redux.js.org/), but shouldn't be mistaken as merely _Redux for WordPress_, as it includes a few of its own [distinguishing characteristics](#comparison-with-redux).
+The data module is built upon and shares many of the same core principles of [Redux](https://redux.js.org/), but shouldn't be mistaken as merely _Redux for WordPress_, as it includes a few of its own [distinguishing characteristics](#comparison-with-redux). As you read through this guide, you may find it useful to reference the Redux documentation — particularly [its glossary](https://redux.js.org/glossary) — for more detail on core concepts.
 
 ## Registering a Store
 


### PR DESCRIPTION
This pull request seeks to rewrite documentation for [`@wordpress/data`](https://github.com/WordPress/gutenberg/tree/master/data) to be less of a API overview and more of a walkthrough of expected uses of the module, explanations of key concepts, and contrasting with the Redux library upon which it is built. Importantly, it surfaces `registerStore` as the preferred registration point (introduced in #5206).

[View Documentation](https://github.com/WordPress/gutenberg/blob/9445d4ad174e737521fdbe25e0a78a72a5581d6a/data/README.md)

__Testing instructions:__

There are no code changes.