### PR TITLE
Allow custom ColorPalette to enable Alpha Channel

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -16,7 +16,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import './style.scss';
 
-export function ColorPalette( { colors, disableCustomColors = false, value, onChange } ) {
+export function ColorPalette( { colors, disableCustomColors = false, disableAlpha = true, value, onChange } ) {
 	function applyOrUnset( color ) {
 		return () => onChange( value === color ? undefined : color );
 	}
@@ -61,7 +61,7 @@ export function ColorPalette( { colors, disableCustomColors = false, value, onCh
 							color={ value }
 							onChangeComplete={ ( color ) => onChange( color.hex ) }
 							style={ { width: '100%' } }
-							disableAlpha
+							disableAlpha={ disableAlpha }
 						/>
 					) }
 				/>
@@ -84,5 +84,8 @@ export default withContext( 'editor' )(
 		disableCustomColors: props.disableCustomColors !== undefined ?
 			props.disableCustomColors :
 			settings.disableCustomColors,
+		disableAlpha: props.disableAlpha !== undefined ?
+			props.disableAlpha :
+			settings.disableAlpha,
 	} )
 )( ColorPalette );


### PR DESCRIPTION
## Description
Resolves #4726 

## How Has This Been Tested?
Used internally on my own custom block for testing, and it didn't break any of the existing `ColorPalette` usaged.

## Types of changes
Introduced a way to allow `ColorPalette` to have Alpha Channels enabled by third-party developers.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
