### PR TITLE
Restyle block warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ phpcs.xml
 yarn.lock
 docker-compose.override.yml
 cypress.env.json
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ phpcs.xml
 yarn.lock
 docker-compose.override.yml
 cypress.env.json
+*.swp

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -44,6 +44,8 @@
 	&.has-warning .editor-block-list__block-edit {
 		position: relative;
 		min-height: 250px;
+		max-height: 500px;
+		overflow: hidden;
 
 		> :not( .editor-warning ) {
 			pointer-events: none;
@@ -59,6 +61,7 @@
 		bottom: 0;
 		left: 0;
 		background-color: rgba( $white, 0.6 );
+		background-image: linear-gradient( to bottom, transparent, #fff );
 	}
 
 	// simpler style for a block that has cursor focus (but hasn't been selected)

--- a/editor/components/warning/style.scss
+++ b/editor/components/warning/style.scss
@@ -3,7 +3,7 @@
 	position: absolute;
 	top: 15px;
 	left: 50%;
-	transform: translate( -50%, 0 );
+	transform: translateX( -50% );
 	display: flex;
 	flex-direction: column;
 	justify-content: space-around;

--- a/editor/components/warning/style.scss
+++ b/editor/components/warning/style.scss
@@ -1,9 +1,9 @@
 .editor-warning {
 	z-index: z-index( '.editor-warning' );
 	position: absolute;
-	top: 50%;
+	top: 15px;
 	left: 50%;
-	transform: translate( -50%, -50% );
+	transform: translate( -50%, 0 );
 	display: flex;
 	flex-direction: column;
 	justify-content: space-around;


### PR DESCRIPTION
## Description
This PR is to address #5201, where large blocks that throw a warning make the warning hard to find and interact with. The change shortens blocks with warnings with a `max-height`, and warnings hug the top of the blocks.

## How Has This Been Tested?
1. Created a paragraph block
2. Wrote in a large amount of text (such that scrolling is necessary to see the full block)
3. Edited the block as HTML
4. Wrote in invalid HTML, e.g. `<alskdjfl`
5. Blurred the block

## Screenshots (jpeg or gifs if applicable):
![screenshot-2018-3-4 hello world gutenberg wordpress](https://user-images.githubusercontent.com/1121087/36941154-92c49d4e-1f22-11e8-9610-066d38ca8c17.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
