### PR TITLE
Only allow whitespace around URL pasting for Embed

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -268,7 +268,7 @@ export const settings = getEmbedBlockSettings( {
 		from: [
 			{
 				type: 'raw',
-				isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*/i.test( node.textContent ),
+				isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ),
 				transform: ( node ) => {
 					return createBlock( 'core/embed', {
 						url: node.textContent.trim(),


### PR DESCRIPTION
## Description
Prevents URLs with text after it to match on Embed on pasting inside of Paragraph
_Related:_ #5340 #4799

## How Has This Been Tested?
Tested a few times with my Localhost

## Types of changes
Just a change to the Embed Block transformation `from` param.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
