### PR TITLE
[i18n] Typos in strings

### DIFF
--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -375,7 +375,7 @@ export default {
 			},
 			( error ) => {
 				dispatch( { type: 'SAVE_REUSABLE_BLOCK_FAILURE', id } );
-				const message = __( 'An unknown error occured.' );
+				const message = __( 'An unknown error occurred.' );
 				dispatch( createErrorNotice( get( error.responseJSON, 'message', message ), {
 					id: REUSABLE_BLOCK_NOTICE_ID,
 					spokenMessage: message,
@@ -430,7 +430,7 @@ export default {
 					id,
 					optimist: { type: REVERT, id: transactionId },
 				} );
-				const message = __( 'An unknown error occured.' );
+				const message = __( 'An unknown error occurred.' );
 				dispatch( createErrorNotice( get( error.responseJSON, 'message', message ), {
 					id: REUSABLE_BLOCK_NOTICE_ID,
 					spokenMessage: message,


### PR DESCRIPTION
## Description
Change `An unknown error occured.` to `An unknown error occurred.`

## Types of changes
Changed 2 strings in effects.js file
Needs to propagate to `/languages/gutenberg-translations.php`

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
