### PR TITLE
Polish focus style for inbetween inserter

### DIFF
--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -187,18 +187,6 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 	outline: 1px dotted $dark-gray-500;
 }
 
-// Old
-@mixin tab-style__focus-active() {
-	outline: none;
-	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $dark-gray-300;
-}
-
-@mixin input-style__focus-active() {
-	outline: none;
-	color: $dark-gray-900;
-	box-shadow: 0 0 0 1px $dark-gray-300;
-}
 
 /**
  * Applies editor left position to the selector passed as argument

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -410,9 +410,21 @@
 		transition: opacity 0.2s linear 0.5s;
 	}
 
+	&:focus {
+		outline: none;
+	}
+
+	// Show focus style when tabbing
 	&:focus:before {
 		opacity: 1;
 		transition: opacity 0.2s linear;
+		outline: 1px solid $dark-gray-300;
+		outline-offset: 2px;
+	}
+
+	// Don't show focus style when clicking
+	&:focus:active:before {
+		outline: none;
 	}
 }
 

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -181,6 +181,7 @@ input[type="search"].editor-inserter__search {
 	margin: 0;
 	color: $dark-gray-500;
 	cursor: pointer;
+	@include square-style__neutral();
 
 	&.is-active {
 		font-weight: 600;
@@ -192,6 +193,6 @@ input[type="search"].editor-inserter__search {
 	&:active,
 	&:focus {
 		z-index: z-index( '.editor-inserter__tab.is-active' );
-		@include tab-style__focus-active;
+		@include square-style__focus-active();
 	}
 }


### PR DESCRIPTION
This PR polishes the focus style for the inbetween inserter, so it shows when you tab, but not when you click, which makes sense to me since the presence of the separator line itself is sufficient indicator when mousing, and the line immediately disappears on click anyway.

Screenshot when you tab:

![screen shot 2018-03-05 at 09 35 56](https://user-images.githubusercontent.com/1204802/36965102-ed8063d0-2058-11e8-9a48-84da198e0549.png)

When you just click, you don't see that focus outline. 

In addition to the above changes, I removed some obsolete focus styles, including for the inserter tabs. 