### PR TITLE
I18N: Change string to merge with similar - "Editor Toolbar"

### DIFF
--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -46,7 +46,7 @@ function Header( {
 	return (
 		<div
 			role="region"
-			aria-label={ __( 'Editor toolbar' ) }
+			aria-label={ __( 'Editor Toolbar' ) }
 			className="edit-post-header"
 			tabIndex="-1"
 		>


### PR DESCRIPTION
## Description
This PR changes `Editor toolbar` to `Editor Toolbar` to merge the strings for i18n.

`Editor toolbar`
https://github.com/WordPress/gutenberg/blob/v2.3.0/edit-post/components/header/index.js#L49

`Editor Toolbar`
https://github.com/WordPress/gutenberg/blob/v2.3.0/edit-post/components/header/header-toolbar/index.js#L31