### PR TITLE
Limit CSS rules for lists to the visual editor area.

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -86,20 +86,6 @@ body.gutenberg-editor-page {
 		box-sizing: border-box;
 	}
 
-	ul:not(.wp-block-gallery) {
-		list-style-type: disc;
-	}
-
-	ol:not(.wp-block-gallery) {
-		list-style-type: decimal;
-	}
-
-	ul,
-	ol {
-		margin: 0;
-		padding: 0;
-	}
-
 	select {
 		font-size: $default-font-size;
 		color: $dark-gray-500;

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -10,6 +10,20 @@
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
 	}
+
+	& ul,
+	& ol {
+		margin: 0;
+		padding: 0;
+	}
+
+	& ul:not(.wp-block-gallery) {
+		list-style-type: disc;
+	}
+
+	& ol {
+		list-style-type: decimal;
+	}
 }
 
 .edit-post-visual-editor .editor-block-list__block {

--- a/editor/components/document-outline/style.scss
+++ b/editor/components/document-outline/style.scss
@@ -1,5 +1,10 @@
 .document-outline {
 	margin: 20px 0;
+
+	ul {
+		margin: 0;
+		padding: 0;
+	}
 }
 
 .document-outline__item {


### PR DESCRIPTION
## Description

This PR tries to limit the CSS rules used for unordered and ordered lists only where necessary, targeting only the visual editor area.

Right now, these rules target also the meta boxes area, where plugins may use lists in their content. See the related issue #5403 for more details. Ideally, Gutenberg should strive to style only its content and keep CSS specificity as low as possible. By targeting only the visual editor area, plugins are allowed to style their content without being forced to use overqualified selector and trigger a chain reaction with progressively increasing CSS selectors.

## How Has This Been Tested?
I've scanned the codebase for all the usages of `<ul>` and `<ol>` elements and then manually checked the related components for potential layout changes. Haven't found any usage of `<ol>`. Unordered lists are used for example in these places, worth checking:

gallery 
categories
latest posts 
tags suggestions list 
document outline 

Fixes #5403 