### PR TITLE
Center block icon in the editor sidebar

### DIFF
--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -20,13 +20,14 @@
 }
 
 .editor-block-inspector__card-icon {
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	border: 1px solid $light-gray-700;
 	margin-right: 10px;
 	height: 36px;
 	width: 36px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+	min-width: 36px;
 }
 
 .editor-block-inspector__card-content {

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -21,10 +21,12 @@
 
 .editor-block-inspector__card-icon {
 	border: 1px solid $light-gray-700;
-	padding: 7px;
 	margin-right: 10px;
 	height: 36px;
 	width: 36px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }
 
 .editor-block-inspector__card-content {

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -20,14 +20,11 @@
 }
 
 .editor-block-inspector__card-icon {
-	display: flex;
-	justify-content: center;
-	align-items: center;
 	border: 1px solid $light-gray-700;
+	padding: 7px;
 	margin-right: 10px;
 	height: 36px;
 	width: 36px;
-	min-width: 36px;
 }
 
 .editor-block-inspector__card-content {

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -24,6 +24,7 @@
 	margin-right: 10px;
 	height: 36px;
 	width: 36px;
+	min-width: 36px;
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -21,7 +21,7 @@
 
 .editor-block-inspector__card-icon {
 	border: 1px solid $light-gray-700;
-	padding: 8px;
+	padding: 7px;
 	margin-right: 10px;
 	height: 36px;
 	width: 36px;


### PR DESCRIPTION
## Description
Fixes #5404

The Block icon card in the Editor has a with of 36px.
SVG Icon: 20px
Border: 2 x 1px
Padding: 2x 8px

36 - 20 -2 -16 = -2. 
To center the Icon we have to change the padding to 7px.
**Edit:** Flexbox is a better alternative, so we are independent from the svg size.

## Screenshots (jpeg or gifs if applicable):
Before:
![before_1](https://user-images.githubusercontent.com/695201/36977063-2eacbb48-2080-11e8-808d-3283cb427952.png)
After:
![after_1](https://user-images.githubusercontent.com/695201/36977065-304888f6-2080-11e8-88fc-c23a6f0a5f73.png)

