### PR TITLE
List: Break out of block upon Enter on last empty line

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -765,7 +765,7 @@ export class RichText extends Component {
 	 * @param {Array}  after  content after the split position
 	 * @param {?Array} blocks blocks to insert at the split position
 	 */
-	restoreContentAndSplit( before, after, blocks ) {
+	restoreContentAndSplit( before, after, blocks = [] ) {
 		this.updateContent();
 		this.props.onSplit( before, after, ...blocks );
 	}


### PR DESCRIPTION
Fixes #5284, a recent regression.

## How Has This Been Tested?

1. Add a list block
1. Add a few items to it
1. Hit Enter twice to move on to a new paragraph

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
