### PR TITLE
Generalise and comment on DOMRect calculation and storage

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -21,7 +21,7 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { createElement, Component, renderToString } from '@wordpress/element';
-import { keycodes, createBlobURL, isHorizontalEdge, getClientRectFromRange } from '@wordpress/utils';
+import { keycodes, createBlobURL, isHorizontalEdge, getRectangleFromRange } from '@wordpress/utils';
 import { withSafeTimeout, Slot, Fill } from '@wordpress/components';
 
 /**
@@ -417,7 +417,7 @@ export class RichText extends Component {
 	 * @return {{top: number, left: number}} The desired position of the toolbar.
 	 */
 	getFocusPosition() {
-		const position = getClientRectFromRange( this.editor.selection.getRng() );
+		const position = getRectangleFromRange( this.editor.selection.getRng() );
 
 		// Find the parent "relative" or "absolute" positioned container
 		const findRelativeParent = ( node ) => {

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -74,7 +74,7 @@ class WritingFlow extends Component {
 		/**
 		 * Here a rectangle is stored while moving the caret vertically so
 		 * vertical position of the start position can be restored.
-		 * This is to recreate browser behaviour.
+		 * This is to recreate browser behaviour across blocks.
 		 *
 		 * @type {?DOMRect}
 		 */

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -70,8 +70,14 @@ class WritingFlow extends Component {
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
 		this.clearVerticalRect = this.clearVerticalRect.bind( this );
-		this.focusLastTextField = this.focusLastTextField.bind( this );
 
+		/**
+		 * Here a rectangle is stored while moving the caret vertically so
+		 * vertical position of the start position can be restored.
+		 * This is to recreate browser behaviour.
+		 *
+		 * @type {?DOMRect}
+		 */
 		this.verticalRect = null;
 	}
 

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
+import { includes, first } from 'lodash';
 import tinymce from 'tinymce';
 
 /**
@@ -144,10 +144,22 @@ export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
  * @return {DOMRect} The rectangle.
  */
 export function getClientRectFromRange( range ) {
-	// Adjust for empty containers.
-	return range.startContainer.nodeType === ELEMENT_NODE ?
-		range.startContainer.getBoundingClientRect() :
-		range.getClientRects()[ 0 ];
+	// For uncollapsed ranges `getBoundingClientRect` works as expected. It is
+	// the sum of `getClientRects`.
+	if ( ! range.collapsed ) {
+		return range.getBoundingClientRect();
+	}
+
+	// If the collapsed ranged starts (and therefore ends) at an element node,
+	// use `getBoundingClientRect` on that element node. `getClientRects` will
+	// return empty.
+	if ( range.startContainer.nodeType === ELEMENT_NODE ) {
+		return range.startContainer.getBoundingClientRect();
+	}
+
+	// For normal collapsed ranges, the trick is to use the first (and only)
+	// untouched client rect from `getClientRects`.
+	return first( range.getClientRects() );
 }
 
 /**

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -114,7 +114,7 @@ export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
 		return false;
 	}
 
-	const rangeRect = getClientRect( range );
+	const rangeRect = getClientRectFromRange( range );
 
 	if ( ! rangeRect ) {
 		return false;
@@ -143,7 +143,7 @@ export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
  *
  * @return {DOMRect} The rectangle.
  */
-export function getClientRect( range ) {
+export function getClientRectFromRange( range ) {
 	// Adjust for empty containers.
 	return range.startContainer.nodeType === ELEMENT_NODE ?
 		range.startContainer.getBoundingClientRect() :
@@ -169,7 +169,7 @@ export function computeCaretRect( container ) {
 		return;
 	}
 
-	return getClientRect( range );
+	return getClientRectFromRange( range );
 }
 
 /**

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -8,7 +8,7 @@ import tinymce from 'tinymce';
  * Browser dependencies
  */
 const { getComputedStyle } = window;
-const { TEXT_NODE } = window.Node;
+const { TEXT_NODE, ELEMENT_NODE } = window.Node;
 
 /**
  * Check whether the caret is horizontally at the edge of the container.
@@ -114,11 +114,7 @@ export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
 		return false;
 	}
 
-	// Adjust for empty containers.
-	const rangeRect =
-		range.startContainer.nodeType === window.Node.ELEMENT_NODE ?
-			range.startContainer.getBoundingClientRect() :
-			range.getClientRects()[ 0 ];
+	const rangeRect = getClientRect( range );
 
 	if ( ! rangeRect ) {
 		return false;
@@ -140,11 +136,29 @@ export function isVerticalEdge( container, isReverse, collapseRanges = false ) {
 	return true;
 }
 
+/**
+ * Get the rectangle of a given Range.
+ *
+ * @param {Range} range The range.
+ *
+ * @return {DOMRect} The rectangle.
+ */
+export function getClientRect( range ) {
+	// Adjust for empty containers.
+	return range.startContainer.nodeType === ELEMENT_NODE ?
+		range.startContainer.getBoundingClientRect() :
+		range.getClientRects()[ 0 ];
+}
+
+/**
+ * Get the rectangle for the selection in a container.
+ *
+ * @param {Element} container Editable container.
+ *
+ * @return {?DOMRect} The rectangle.
+ */
 export function computeCaretRect( container ) {
-	if (
-		includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ||
-		! container.isContentEditable
-	) {
+	if ( ! container.isContentEditable ) {
 		return;
 	}
 
@@ -155,10 +169,7 @@ export function computeCaretRect( container ) {
 		return;
 	}
 
-	// Adjust for empty containers.
-	return range.startContainer.nodeType === window.Node.ELEMENT_NODE ?
-		range.startContainer.getBoundingClientRect() :
-		range.getClientRects()[ 0 ];
+	return getClientRect( range );
 }
 
 /**


### PR DESCRIPTION
## Description
I remember @aduth Kindly asking for a comment here but I forgot where. Also merges some duplicate logic. Let me know if it can be more clear and/or suggestions.

The calculation in the `RichText` component is quite strange and can be done more easily with the right APIs. Introduced in 726ef2fda049f501845acdc62470dc72a8ab1c51...

## How Has This Been Tested?
Ensure caret movement across blocks still works.
Ensure the link toolbar gets positioned rightly.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.