### PR TITLE
Adjust after #5348

### DIFF
--- a/utils/dom.js
+++ b/utils/dom.js
@@ -36,6 +36,11 @@ export function isHorizontalEdge( container, isReverse, collapseRanges = false )
 		return true;
 	}
 
+	// If the container is empty, the caret is always at the edge.
+	if ( tinymce.DOM.isEmpty( container ) ) {
+		return true;
+	}
+
 	const selection = window.getSelection();
 	let range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 	if ( collapseRanges ) {
@@ -58,14 +63,8 @@ export function isHorizontalEdge( container, isReverse, collapseRanges = false )
 	}
 
 	const maxOffset = node.nodeType === TEXT_NODE ? node.nodeValue.length : node.childNodes.length;
-	const editor = tinymce.get( node.id );
 
-	if (
-		! isReverse &&
-		offset !== maxOffset &&
-		// content editables with only a BR element are considered empty
-		( ! editor || ! editor.dom.isEmpty( node ) )
-	) {
+	if ( ! isReverse && offset !== maxOffset ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Description
I don't really agree with all of the changes made in #5348.

1) `node` will not always be a TinyMCE container, and therefore not always have an ID. Better to check right at the start if the _container_ is empty?
2) We don't really need the ID at all to use the TinyMCE utility function.

## How Has This Been Tested?
Ensure fix in #5348 still works. In addition you can now use horizontal arrow keys on e.g. an empty paragraph.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.