### PR TITLE
Fixed active heading level's subscript color.

### DIFF
--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -88,13 +88,14 @@ div.components-toolbar {
 	}
 
 	// active & toggled style
-	&:not(:disabled).is-active{
-		& > svg {
-			@include formatting-button-style__active;
+	&:not(:disabled).is-active {
+		& > svg,
+		&[data-subscript]:after {
+			@include formatting-button-color__active;
 		}
 
-		&[data-subscript]:after {
-			color: $white;
+		& > svg {
+			@include formatting-button-style__active;
 		}
 	}
 

--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -88,8 +88,14 @@ div.components-toolbar {
 	}
 
 	// active & toggled style
-	&:not(:disabled).is-active > svg {
-		@include formatting-button-style__active;
+	&:not(:disabled).is-active{
+		& > svg {
+			@include formatting-button-style__active;
+		}
+
+		&[data-subscript]:after {
+			color: $white;
+		}
 	}
 
 	// focus style

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -147,9 +147,12 @@ $float-margin: calc( 50% - #{ $visual-editor-max-width-padding / 2 } );
 	box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
 }
 
+@mixin formatting-button-color__active() {
+	color: $white;
+}
+
 @mixin formatting-button-style__active() {
 	outline: none;
-	color: $white;
 	box-shadow: none;
 	background: $dark-gray-500;
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/5391
Props to @spencerbaynton for analyzing the issue.


## How Has This Been Tested?
Add a heading block, toggle some of the headings and verify the level appears in white instead of dark as it is right now.

