### PR TITLE
Fixed: Block cannot be removed after turned into another block type

### DIFF
--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -411,6 +411,10 @@ export const editor = flow( [
 
 				return flow( [
 					( nextState ) => omit( nextState, uids ),
+					( nextState ) => ( {
+						...nextState,
+						...omit( mappedBlocks, '' ),
+					} ),
 					( nextState ) => mapValues( nextState, ( subState ) => (
 						reduce( subState, ( result, uid ) => {
 							if ( uid === uids[ 0 ] ) {
@@ -427,10 +431,7 @@ export const editor = flow( [
 							return result;
 						}, [] )
 					) ),
-				] )( {
-					...state,
-					...omit( mappedBlocks, '' ),
-				} );
+				] )( state );
 			}
 
 			case 'REMOVE_BLOCKS':

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -183,6 +183,70 @@ describe( 'state', () => {
 			} );
 		} );
 
+		it( 'should replace the block even if the new block uid is the same', () => {
+			const originalState = editor( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
+					uid: 'chicken',
+					name: 'core/test-block',
+					attributes: {},
+					innerBlocks: [],
+				} ],
+			} );
+			const replacedState = editor( originalState, {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'chicken' ],
+				blocks: [ {
+					uid: 'chicken',
+					name: 'core/freeform',
+					innerBlocks: [],
+				} ],
+			} );
+
+			expect( Object.keys( replacedState.present.blocksByUid ) ).toHaveLength( 1 );
+			expect( values( originalState.present.blocksByUid )[ 0 ].name ).toBe( 'core/test-block' );
+			expect( values( replacedState.present.blocksByUid )[ 0 ].name ).toBe( 'core/freeform' );
+			expect( values( replacedState.present.blocksByUid )[ 0 ].uid ).toBe( 'chicken' );
+			expect( replacedState.present.blockOrder ).toEqual( {
+				'': [ 'chicken' ],
+				chicken: [],
+			} );
+
+			const nestedBlock = {
+				uid: 'chicken',
+				name: 'core/test-block',
+				attributes: {},
+				innerBlocks: [],
+			};
+			const wrapperBlock = createBlock( 'core/test-block', {}, [ nestedBlock ] );
+			const replacementNestedBlock = {
+				uid: 'chicken',
+				name: 'core/freeform',
+				attributes: {},
+				innerBlocks: [],
+			};
+
+			const originalNestedState = editor( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [ wrapperBlock ],
+			} );
+
+			const replacedNestedState = editor( originalNestedState, {
+				type: 'REPLACE_BLOCKS',
+				uids: [ nestedBlock.uid ],
+				blocks: [ replacementNestedBlock ],
+			} );
+
+			expect( replacedNestedState.present.blockOrder ).toEqual( {
+				'': [ wrapperBlock.uid ],
+				[ wrapperBlock.uid ]: [ replacementNestedBlock.uid ],
+				[ replacementNestedBlock.uid ]: [],
+			} );
+
+			expect( originalNestedState.present.blocksByUid.chicken.name ).toBe( 'core/test-block' );
+			expect( replacedNestedState.present.blocksByUid.chicken.name ).toBe( 'core/freeform' );
+		} );
+
 		it( 'should update the block', () => {
 			const original = editor( undefined, {
 				type: 'RESET_BLOCKS',


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/5369
This PR fixes a bug where it was impossible to delete blocks after transforming then.

The bug was in the blockOrder reducer. It was assuming that the replaced blocks have different UID's when compared to the original block. That is not the case and the UID's of the replaced blocks can be the same as the original block, so the logic of the reducer was corrected.


## How Has This Been Tested?
Add a paragraph, add some text and transform it into a list. Remove the list and verify everything worked as expected.
Do the same but nesting the paragraph inside a collumn.

