### PR TITLE
Fix/remove heartbeat dependency

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -774,7 +774,11 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	gutenberg_extend_wp_api_backbone_client();
 
+	// Enqueue heartbeat separately as an "optional" dependency of the editor.
+	// Heartbeat is used for automatic nonce refreshing, but some hosts choose
+	// to disable it outright.
 	wp_enqueue_script( 'heartbeat' );
+
 	wp_enqueue_script( 'wp-edit-post' );
 
 	// Register `wp-utils` as a dependency of `word-count` to ensure that

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -243,7 +243,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-edit-post',
 		gutenberg_url( 'edit-post/build/index.js' ),
-		array( 'jquery', 'heartbeat', 'wp-element', 'wp-components', 'wp-editor', 'wp-i18n', 'wp-date', 'wp-utils', 'wp-data', 'wp-embed', 'wp-viewport' ),
+		array( 'jquery', 'wp-element', 'wp-components', 'wp-editor', 'wp-i18n', 'wp-date', 'wp-utils', 'wp-data', 'wp-embed', 'wp-viewport' ),
 		filemtime( gutenberg_dir_path() . 'edit-post/build/index.js' ),
 		true
 	);
@@ -774,6 +774,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 
 	gutenberg_extend_wp_api_backbone_client();
 
+	wp_enqueue_script( 'heartbeat' );
 	wp_enqueue_script( 'wp-edit-post' );
 
 	// Register `wp-utils` as a dependency of `word-count` to ensure that


### PR DESCRIPTION
## Description
Heartbeat is used in Gutenberg to keep the api nonce refreshed. It is not uncommon for hosts or user to have disabled heartbeat, and this currently prevents Gutenberg from loading.

Remove hard dependency on heartbeat.

Fixes https://github.com/WordPress/gutenberg/issues/4547

## Types of changes
* remove heartbead from dependency array
* inject heartbeat script manually (when available)

## Checklist:
- [*] My code is tested.
- [*] My code follows the WordPress code style.
- [*] My code has proper inline documentation.
