### PR TITLE
Data: Allow undefined return from withSelect mapSelectToProps

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -218,14 +218,18 @@ export const withSelect = ( mapStateToProps ) => ( WrappedComponent ) => {
 				return;
 			}
 
-			const newState = mapStateToProps( select, props );
-			if ( ! isEqualShallow( newState, this.state ) ) {
-				this.setState( newState );
+			const { mergeProps } = this.state;
+			const nextMergeProps = mapStateToProps( select, props );
+
+			if ( ! isEqualShallow( nextMergeProps, mergeProps ) ) {
+				this.setState( {
+					mergeProps: nextMergeProps,
+				} );
 			}
 		}
 
 		render() {
-			return <WrappedComponent { ...this.props } { ...this.state } />;
+			return <WrappedComponent { ...this.props } { ...this.state.mergeProps } />;
 		}
 	}
 

--- a/data/index.js
+++ b/data/index.js
@@ -219,7 +219,7 @@ export const withSelect = ( mapStateToProps ) => ( WrappedComponent ) => {
 			}
 
 			const { mergeProps } = this.state;
-			const nextMergeProps = mapStateToProps( select, props );
+			const nextMergeProps = mapStateToProps( select, props ) || {};
 
 			if ( ! isEqualShallow( nextMergeProps, mergeProps ) ) {
 				this.setState( {

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -273,6 +273,27 @@ describe( 'withSelect', () => {
 
 			expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		itWithExtraAssertions( 'omits props which are not returned on subsequent mappings', () => {
+			registerReducer( 'demo', ( state = 'OK' ) => state );
+			registerSelectors( 'demo', {
+				getValue: ( state ) => state,
+			} );
+
+			const Component = withSelectImplementation( ( _select, ownProps ) => {
+				return {
+					[ ownProps.propName ]: _select( 'demo' ).getValue(),
+				};
+			} )( () => <div /> );
+
+			wrapper = mount( <Component propName="foo" /> );
+
+			expect( wrapper.childAt( 0 ).props() ).toEqual( { foo: 'OK', propName: 'foo' } );
+
+			wrapper.setProps( { propName: 'bar' } );
+
+			expect( wrapper.childAt( 0 ).props() ).toEqual( { bar: 'OK', propName: 'bar' } );
+		} );
 	}
 
 	cases( withSelect );

--- a/data/test/index.js
+++ b/data/test/index.js
@@ -294,6 +294,33 @@ describe( 'withSelect', () => {
 
 			expect( wrapper.childAt( 0 ).props() ).toEqual( { bar: 'OK', propName: 'bar' } );
 		} );
+
+		itWithExtraAssertions( 'allows undefined return from mapSelectToProps', () => {
+			registerReducer( 'demo', ( state = 'OK' ) => state );
+			registerSelectors( 'demo', {
+				getValue: ( state ) => state,
+			} );
+
+			const Component = withSelectImplementation( ( _select, ownProps ) => {
+				if ( ownProps.pass ) {
+					return {
+						count: _select( 'demo' ).getValue(),
+					};
+				}
+			} )( ( props ) => <div>{ props.count || 'Unknown' }</div> );
+
+			wrapper = mount( <Component pass={ false } /> );
+
+			expect( wrapper.childAt( 0 ).text() ).toBe( 'Unknown' );
+
+			wrapper.setProps( { pass: true } );
+
+			expect( wrapper.childAt( 0 ).text() ).toBe( 'OK' );
+
+			wrapper.setProps( { pass: false } );
+
+			expect( wrapper.childAt( 0 ).text() ).toBe( 'Unknown' );
+		} );
 	}
 
 	cases( withSelect );


### PR DESCRIPTION
This pull request seeks to allow a falsey return value from a `withSelect` mapping function `mapSelectToProps` . This is a divergence from React Redux which enforces that this value be an object, leading to some [awkward workarounds](https://github.com/WordPress/gutenberg/pull/4484#discussion_r171360659) to ensure an object is returned. With these changes, a falsey value is assumed as equivalent to an empty object of props.

Further, the changes here resolve an issue where props may linger after a subsequent mapping call returns a different set of object keys. Previously we used a component's `setState` to update mapped props, but this behaves as a patch application. Previously React supported a `this.replaceState` method (deprecated in [React 0.13](https://reactjs.org/blog/2015/03/10/react-v0.13.html#deprecations)) for this purpose, but it's easy enough to replicate with choosing an arbitrary key in state to apply the mapped value to.

__Testing instructions:__

Ensure unit tests pass:

```
npm run test-unit
```