### PR TITLE
Make preferences reducer deterministic

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -167,6 +167,7 @@ export function replaceBlocks( uids, blocks ) {
 		type: 'REPLACE_BLOCKS',
 		uids: castArray( uids ),
 		blocks: castArray( blocks ),
+		time: Date.now(),
 	};
 }
 
@@ -213,6 +214,7 @@ export function insertBlocks( blocks, index, rootUID ) {
 		blocks: castArray( blocks ),
 		index,
 		rootUID,
+		time: Date.now(),
 	};
 }
 

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -661,7 +661,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					insertUsage: {
 						...prevState.insertUsage,
 						[ id ]: {
-							time: Date.now(),
+							time: action.time,
 							count: prevState.insertUsage[ id ] ? prevState.insertUsage[ id ].count + 1 : 1,
 							insert,
 						},

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -163,6 +163,7 @@ describe( 'actions', () => {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks: [ block ],
+				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -177,6 +178,7 @@ describe( 'actions', () => {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks,
+				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -187,10 +189,12 @@ describe( 'actions', () => {
 				uid: 'ribs',
 			};
 			const index = 5;
-			expect( insertBlock( block, index ) ).toEqual( {
+			expect( insertBlock( block, index, 'test_uid' ) ).toEqual( {
 				type: 'INSERT_BLOCKS',
 				blocks: [ block ],
 				index,
+				rootUID: 'test_uid',
+				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -201,10 +205,12 @@ describe( 'actions', () => {
 				uid: 'ribs',
 			} ];
 			const index = 3;
-			expect( insertBlocks( blocks, index ) ).toEqual( {
+			expect( insertBlocks( blocks, index, 'test_uid' ) ).toEqual( {
 				type: 'INSERT_BLOCKS',
 				blocks,
 				index,
+				rootUID: 'test_uid',
+				time: expect.any( Number ),
 			} );
 		} );
 	} );

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -106,11 +106,14 @@ describe( 'effects', () => {
 
 			expect( dispatch ).toHaveBeenCalledTimes( 2 );
 			expect( dispatch ).toHaveBeenCalledWith( selectBlock( 'chicken', -1 ) );
-			expect( dispatch ).toHaveBeenCalledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
-				uid: 'chicken',
-				name: 'core/test-block',
-				attributes: { content: 'chicken ribs' },
-			} ] ) );
+			expect( dispatch ).toHaveBeenCalledWith( {
+				...replaceBlocks( [ 'chicken', 'ribs' ], [ {
+					uid: 'chicken',
+					name: 'core/test-block',
+					attributes: { content: 'chicken ribs' },
+				} ] ),
+				time: expect.any( Number ),
+			} );
 		} );
 
 		it( 'should not merge the blocks have different types without transformation', () => {
@@ -780,12 +783,13 @@ describe( 'effects', () => {
 				expect( dispatch ).toHaveBeenCalledWith(
 					saveReusableBlock( expect.any( Number ) )
 				);
-				expect( dispatch ).toHaveBeenCalledWith(
-					replaceBlocks(
+				expect( dispatch ).toHaveBeenCalledWith( {
+					...replaceBlocks(
 						[ staticBlock.uid ],
 						[ createBlock( 'core/block', { ref: expect.any( Number ) } ) ]
-					)
-				);
+					),
+					time: expect.any( Number ),
+				} );
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1207,12 +1207,13 @@ describe( 'state', () => {
 					uid: 'bacon',
 					name: 'core-embed/twitter',
 				} ],
+				time: 123456,
 			} );
 
 			expect( state ).toEqual( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: expect.any( Number ),
+						time: 123456,
 						count: 1,
 						insert: { name: 'core-embed/twitter' },
 					},
@@ -1222,7 +1223,7 @@ describe( 'state', () => {
 			const twoRecentBlocks = preferences( deepFreeze( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: expect.any( Number ),
+						time: 123456,
 						count: 1,
 						insert: { name: 'core-embed/twitter' },
 					},
@@ -1237,17 +1238,18 @@ describe( 'state', () => {
 					name: 'core/block',
 					attributes: { ref: 123 },
 				} ],
+				time: 123457,
 			} );
 
 			expect( twoRecentBlocks ).toEqual( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: expect.any( Number ),
+						time: 123457,
 						count: 2,
 						insert: { name: 'core-embed/twitter' },
 					},
 					'core/block/123': {
-						time: expect.any( Number ),
+						time: 123457,
 						count: 1,
 						insert: { name: 'core/block', ref: 123 },
 					},


### PR DESCRIPTION
Calling `Date.now()` from the preferences reducer makes the reducer impure, which will bite us if we use any of the time travelling features that Redux enables. To fix this, I've moved the call to `Date.now()` to the action creator as an optional argument.

This is a small mistake introduced in https://github.com/WordPress/gutenberg/pull/5342, and pointed out by @aduth in https://github.com/WordPress/gutenberg/pull/5342#discussion_r172350724.