### PR TITLE
Layout: Expand editor canvas as flex region

### DIFF
--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -89,11 +89,9 @@ function Layout( {
 			<div className="edit-post-layout__content" role="region" aria-label={ __( 'Editor content' ) } tabIndex="-1">
 				<EditorNotices />
 				<PreserveScrollInReorder />
-				<div className="edit-post-layout__editor">
-					<EditorModeKeyboardShortcuts />
-					{ mode === 'text' && <TextEditor /> }
-					{ mode === 'visual' && <VisualEditor /> }
-				</div>
+				<EditorModeKeyboardShortcuts />
+				{ mode === 'text' && <TextEditor /> }
+				{ mode === 'visual' && <VisualEditor /> }
 				<div className="edit-post-layout__metaboxes">
 					<MetaBoxes location="normal" />
 				</div>

--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -70,12 +70,23 @@
 
 .edit-post-layout__content {
 	position: relative;
+	display: flex;
+	min-height: 100%;
+	flex-direction: column;
 
 	// on mobile the main content area has to scroll
 	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
 	@include break-small {
 		overflow-y: auto;
 		-webkit-overflow-scrolling: touch;
+	}
+
+	.edit-post-visual-editor {
+		flex-basis: 100%;
+	}
+
+	.edit-post-layout__metaboxes {
+		flex-shrink: 0;
 	}
 }
 

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -1,7 +1,5 @@
 .edit-post-visual-editor {
 	position: relative;
-	height: 100%;
-	margin: 0 auto;
 	padding: 50px 0;
 
 	&,

--- a/test/e2e/integration/002-adding-blocks.js
+++ b/test/e2e/integration/002-adding-blocks.js
@@ -13,7 +13,7 @@ describe( 'Adding blocks', () => {
 		// Default block appender is provisional
 		cy.get( lastBlockSelector ).then( ( firstBlock ) => {
 			cy.get( '.editor-default-block-appender' ).click();
-			cy.get( '.edit-post-visual-editor' ).click();
+			cy.focused().type( '{esc}' );
 			cy.get( lastBlockSelector ).should( 'have.text', firstBlock.text() );
 		} );
 


### PR DESCRIPTION
Closes #2322

This pull request seeks to use flex styling to ensure the visual editor canvas occupies the full height of the screen, thereby enabling users to clear the selected block by clicking below the editor on a new post.

One noticeable difference in this implementation is that, when meta boxes are present, they will be pushed to the bottom of the viewport rather than appearing immediately below the post content.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/37009484-2356c1fa-20b5-11e8-9aec-111b7fead7af.png)|![After](https://user-images.githubusercontent.com/1779930/37009479-1c1b8d30-20b5-11e8-9326-34f62fdf20fa.png)

__Testing instructions:__

Verify that with and without meta boxes, and with and without long content, that...

- Meta boxes appear at the bottom of the screen / post
- If there is any space below the post content (e.g. new post, it can be used to deselect the currently selected block)