### PR TITLE
Demo: Fix dirtying demo (and subsequent autosave)

### DIFF
--- a/post-content.js
+++ b/post-content.js
@@ -126,8 +126,8 @@ window._wpGutenbergPost.content = {
 		'<p>Any block can opt into these alignments. The embed block has them also, and is responsive out of the box:</p>',
 		'<!-- /wp:paragraph -->',
 
-		'<!-- wp:embed {"url":"https://vimeo.com/22439234","align":"wide"} -->',
-		'<figure class="wp-block-embed alignwide">https://vimeo.com/22439234</figure>',
+		'<!-- wp:embed {"url":"https://vimeo.com/22439234","align":"wide","type":"video","providerNameSlug":"vimeo"} -->',
+		'<figure class="wp-block-embed alignwide is-type-video is-provider-vimeo">https://vimeo.com/22439234</figure>',
 		'<!-- /wp:embed -->',
 
 		'<!-- wp:paragraph -->',


### PR DESCRIPTION
Related: #4118

This pull request seeks to resolve an issue where the demo post is immediately marked as "dirty", prompting the user if they attempt to navigate away, and incurring an autosave merely by viewing the demo page.

This is caused by the introduction of new attributes for embed block in #4118 which are set after load (upon retrieving embed details), and cause post dirtying.

__Testing instructions:__

1. Navigate to Gutenberg > Demo
2. Refresh the page
3. Note you are not prompted about unsaved changes

__Follow-up Task:__

I notice we're still dispatching `UPDATE_BLOCK_ATTRIBUTES` regardless of whether there's a change in the `providerNameSlug` and `type` for an embed. We should probably avoid this if it's not necessary to dispatch, which should be known from the embed block itself.