### PR TITLE
Improve reusable block creation flow

### DIFF
--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -59,9 +59,9 @@ class ReusableBlockEditPanel extends Component {
 			<Fragment>
 				{ ( ! isEditing && ! isSaving ) && (
 					<div className="reusable-block-edit-panel">
-						<span className="reusable-block-edit-panel__info">
-							<b>{ title }</b>
-						</span>
+						<b className="reusable-block-edit-panel__info">
+							{ title }
+						</b>
 						<Button isLarge className="reusable-block-edit-panel__button" onClick={ onEdit }>
 							{ __( 'Edit' ) }
 						</Button>

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -26,14 +26,14 @@ class ReusableBlockEditPanel extends Component {
 		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
 	}
 
-	bindTitleRef( ref ) {
-		this.titleRef = ref;
-	}
-
 	componentDidMount() {
 		if ( this.props.isEditing ) {
 			this.titleRef.select();
 		}
+	}
+
+	bindTitleRef( ref ) {
+		this.titleRef = ref;
 	}
 
 	handleFormSubmit( event ) {

--- a/blocks/library/block/edit-panel/index.js
+++ b/blocks/library/block/edit-panel/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { keycodes } from '@wordpress/utils';
 
@@ -10,66 +11,97 @@ import { keycodes } from '@wordpress/utils';
  */
 import './style.scss';
 
+/**
+ * Module constants
+ */
 const { ESCAPE } = keycodes;
 
-function ReusableBlockEditPanel( props ) {
-	const { isEditing, title, isSaving, onEdit, onChangeTitle, onSave, onCancel } = props;
+class ReusableBlockEditPanel extends Component {
+	constructor() {
+		super( ...arguments );
 
-	return [
-		( ! isEditing && ! isSaving ) && (
-			<div key="view" className="reusable-block-edit-panel">
-				<span className="reusable-block-edit-panel__info">
-					<b>{ title }</b>
-				</span>
-				<Button
-					isLarge
-					className="reusable-block-edit-panel__button"
-					onClick={ onEdit }>
-					{ __( 'Edit' ) }
-				</Button>
-			</div>
-		),
-		( isEditing || isSaving ) && (
-			<form
-				key="edit"
-				className="reusable-block-edit-panel"
-				onSubmit={ ( event ) => {
-					event.preventDefault();
-					onSave();
-				} }>
-				<input
-					type="text"
-					disabled={ isSaving }
-					className="reusable-block-edit-panel__title"
-					value={ title }
-					onChange={ ( event ) => onChangeTitle( event.target.value ) }
-					onKeyDown={ ( event ) => {
-						if ( event.keyCode === ESCAPE ) {
-							event.stopPropagation();
-							onCancel();
-						}
-					} } />
-				<Button
-					type="submit"
-					isPrimary
-					isLarge
-					isBusy={ isSaving }
-					disabled={ ! title || isSaving }
-					className="reusable-block-edit-panel__button"
-					onClick={ onSave }>
-					{ __( 'Save' ) }
-				</Button>
-				<Button
-					isLarge
-					disabled={ isSaving }
-					className="reusable-block-edit-panel__button"
-					onClick={ onCancel }>
-					{ __( 'Cancel' ) }
-				</Button>
-			</form>
-		),
-	];
+		this.bindTitleRef = this.bindTitleRef.bind( this );
+		this.handleFormSubmit = this.handleFormSubmit.bind( this );
+		this.handleTitleChange = this.handleTitleChange.bind( this );
+		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
+	}
+
+	bindTitleRef( ref ) {
+		this.titleRef = ref;
+	}
+
+	componentDidMount() {
+		if ( this.props.isEditing ) {
+			this.titleRef.select();
+		}
+	}
+
+	handleFormSubmit( event ) {
+		event.preventDefault();
+		this.props.onSave();
+	}
+
+	handleTitleChange( event ) {
+		this.props.onChangeTitle( event.target.value );
+	}
+
+	handleTitleKeyDown( event ) {
+		if ( event.keyCode === ESCAPE ) {
+			event.stopPropagation();
+			this.props.onCancel();
+		}
+	}
+
+	render() {
+		const { isEditing, title, isSaving, onEdit, onSave, onCancel } = this.props;
+
+		return (
+			<Fragment>
+				{ ( ! isEditing && ! isSaving ) && (
+					<div className="reusable-block-edit-panel">
+						<span className="reusable-block-edit-panel__info">
+							<b>{ title }</b>
+						</span>
+						<Button isLarge className="reusable-block-edit-panel__button" onClick={ onEdit }>
+							{ __( 'Edit' ) }
+						</Button>
+					</div>
+				) }
+				{ ( isEditing || isSaving ) && (
+					<form className="reusable-block-edit-panel" onSubmit={ this.handleFormSubmit }>
+						<input
+							ref={ this.bindTitleRef }
+							type="text"
+							disabled={ isSaving }
+							className="reusable-block-edit-panel__title"
+							value={ title }
+							onChange={ this.handleTitleChange }
+							onKeyDown={ this.handleTitleKeyDown }
+						/>
+						<Button
+							type="submit"
+							isPrimary
+							isLarge
+							isBusy={ isSaving }
+							disabled={ ! title || isSaving }
+							className="reusable-block-edit-panel__button"
+							onClick={ onSave }
+						>
+							{ __( 'Save' ) }
+						</Button>
+						<Button
+							isLarge
+							disabled={ isSaving }
+							className="reusable-block-edit-panel__button"
+							onClick={ onCancel }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+					</form>
+				) }
+			</Fragment>
+		);
+	}
 }
 
 export default ReusableBlockEditPanel;
-

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -18,7 +18,7 @@ import BlockEdit from '../../block-edit';
 import ReusableBlockEditPanel from './edit-panel';
 
 class ReusableBlockEdit extends Component {
-	constructor() {
+	constructor( { reusableBlock } ) {
 		super( ...arguments );
 
 		this.startEditing = this.startEditing.bind( this );
@@ -26,8 +26,6 @@ class ReusableBlockEdit extends Component {
 		this.setAttributes = this.setAttributes.bind( this );
 		this.setTitle = this.setTitle.bind( this );
 		this.updateReusableBlock = this.updateReusableBlock.bind( this );
-
-		const { reusableBlock } = this.props;
 
 		this.state = {
 			isEditing: !! ( reusableBlock && reusableBlock.isTemporary ),

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -27,8 +27,10 @@ class ReusableBlockEdit extends Component {
 		this.setTitle = this.setTitle.bind( this );
 		this.updateReusableBlock = this.updateReusableBlock.bind( this );
 
+		const { reusableBlock } = this.props;
+
 		this.state = {
-			isEditing: false,
+			isEditing: !! ( reusableBlock && reusableBlock.isTemporary ),
 			title: null,
 			attributes: null,
 		};
@@ -40,9 +42,6 @@ class ReusableBlockEdit extends Component {
 		}
 	}
 
-	/**
-	 * @inheritdoc
-	 */
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.focus && ! nextProps.focus ) {
 			this.stopEditing();


### PR DESCRIPTION
## Description

Closes #4527.

Modifies the flow to create a reusable block to look like this:

1) The user selects a block and clicks _Convert to Reusable Block_.

<img width="713" alt="screen shot 2018-02-28 at 10 28 02" src="https://user-images.githubusercontent.com/612155/36761290-74e7dc26-1c72-11e8-8797-518a2ed21f66.png">

2) The reusable block is created and is immediately in editing mode. **The title of the block is selected, allowing the user to start typing the title straight away.** If the user abandons the flow at this point, the new block will be titled  _Untitled block_.

<img width="709" alt="screen shot 2018-02-28 at 10 28 18" src="https://user-images.githubusercontent.com/612155/36761296-7ad085a2-1c72-11e8-9526-62087b396bd3.png">

3) The user clicks _Save_ to rename their reusable block.

<img width="697" alt="screen shot 2018-02-28 at 10 28 41" src="https://user-images.githubusercontent.com/612155/36761338-aca7e458-1c72-11e8-8cb4-d27101fdab7e.png">

This removes two steps from the flow of creating a reusable block.

<!-- Please describe your changes -->

## Testing

1. Create a block
2. Convert it to a reusable block. Confirm that the title input is selected straight away
3. Test creating and inserting reusable blocks