### PR TITLE
Blocks: Add Upload button to audio and video blocks

### DIFF
--- a/blocks/image-placeholder/index.js
+++ b/blocks/image-placeholder/index.js
@@ -25,13 +25,13 @@ import { rawHandler } from '../api';
  */
 export default function ImagePlaceholder( { className, icon, label, onSelectImage, multiple = false } ) {
 	const setImage = multiple ? onSelectImage : ( [ image ] ) => onSelectImage( image );
-	const onFilesDrop = ( files ) => mediaUpload( files, setImage );
+	const onFilesDrop = ( files ) => mediaUpload( files, setImage, 'image' );
 	const onHTMLDrop = ( HTML ) => setImage( map(
 		rawHandler( { HTML, mode: 'BLOCKS' } )
 			.filter( ( { name } ) => name === 'core/image' ),
 		'attributes'
 	) );
-	const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setImage );
+	const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setImage, 'image' );
 	return (
 		<Placeholder
 			className={ className }

--- a/blocks/library/audio/editor.scss
+++ b/blocks/library/audio/editor.scss
@@ -11,7 +11,6 @@
 }
 
 .wp-block-audio .components-placeholder__fieldset {
-	display: block;
 	max-width: 400px;
 
 	form {

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -6,8 +6,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, IconButton, Placeholder, Toolbar } from '@wordpress/components';
+import {
+	Button,
+	FormFileUpload,
+	IconButton,
+	Placeholder,
+	Toolbar,
+} from '@wordpress/components';
 import { Component } from '@wordpress/element';
+import { mediaUpload } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -85,24 +92,12 @@ export const settings = {
 				}
 				return false;
 			};
-			const controls = isSelected && (
-				<BlockControls key="controls">
-					<Toolbar>
-						<IconButton
-							className="components-icon-button components-toolbar__control"
-							label={ __( 'Edit audio' ) }
-							onClick={ switchToEditing }
-							icon="edit"
-						/>
-					</Toolbar>
-				</BlockControls>
-			);
+			const setAudio = ( [ audio ] ) => onSelectAudio( audio );
+			const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setAudio, 'audio' );
 
 			if ( editing ) {
-				return [
-					controls,
+				return (
 					<Placeholder
-						key="placeholder"
 						icon="media-audio"
 						label={ __( 'Audio' ) }
 						instructions={ __( 'Select an audio file from your library, or upload a new one' ) }
@@ -120,6 +115,14 @@ export const settings = {
 								{ __( 'Use URL' ) }
 							</Button>
 						</form>
+						<FormFileUpload
+							isLarge
+							className="wp-block-audio__upload-button"
+							onChange={ uploadFromFiles }
+							accept="audio/*"
+						>
+							{ __( 'Upload' ) }
+						</FormFileUpload>
 						<MediaUpload
 							onSelect={ onSelectAudio }
 							type="audio"
@@ -130,13 +133,24 @@ export const settings = {
 								</Button>
 							) }
 						/>
-					</Placeholder>,
-				];
+					</Placeholder>
+				);
 			}
 
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 			return [
-				controls,
+				isSelected && (
+					<BlockControls key="controls">
+						<Toolbar>
+							<IconButton
+								className="components-icon-button components-toolbar__control"
+								label={ __( 'Edit audio' ) }
+								onClick={ switchToEditing }
+								icon="edit"
+							/>
+						</Toolbar>
+					</BlockControls>
+				),
 				<figure key="audio" className={ className }>
 					<audio controls="controls" src={ src } />
 					{ ( ( caption && caption.length ) || !! isSelected ) && (

--- a/blocks/library/audio/test/__snapshots__/index.js.snap
+++ b/blocks/library/audio/test/__snapshots__/index.js.snap
@@ -45,6 +45,35 @@ exports[`core/audio block edit matches snapshot 1`] = `
         Use URL
       </button>
     </form>
+    <div
+      class="components-form-file-upload"
+    >
+      <button
+        class="components-button components-icon-button wp-block-audio__upload-button button button-large"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload"
+          focusable="false"
+          height="20"
+          role="img"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        Upload
+      </button>
+      <input
+        accept="audio/*"
+        style="display:none"
+        type="file"
+      />
+    </div>
     *** Mock(Media upload button) ***
   </div>
 </div>

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -137,7 +137,8 @@ class GalleryBlock extends Component {
 				setAttributes( {
 					images: currentImages.concat( images ),
 				} );
-			}
+			},
+			'image',
 		);
 	}
 

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -62,7 +62,9 @@
 	}
 }
 
-.wp-core-ui .wp-block-image__upload-button.button {
+.wp-core-ui .wp-block-audio__upload-button.button,
+.wp-core-ui .wp-block-image__upload-button.button,
+.wp-core-ui .wp-block-video__upload-button.button {
 	margin-right: 5px;
 
 	.dashicon {

--- a/blocks/library/video/editor.scss
+++ b/blocks/library/video/editor.scss
@@ -11,7 +11,6 @@
 }
 
 .wp-block-video .components-placeholder__fieldset {
-	display: block;
 	max-width: 400px;
 
 	form {

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -6,8 +6,15 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Placeholder, Toolbar, IconButton, Button } from '@wordpress/components';
+import {
+	Button,
+	FormFileUpload,
+	IconButton,
+	Placeholder,
+	Toolbar,
+} from '@wordpress/components';
 import { Component } from '@wordpress/element';
+import { mediaUpload } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -94,20 +101,24 @@ export const settings = {
 				}
 				return false;
 			};
+			const setVideo = ( [ audio ] ) => onSelectVideo( audio );
+			const uploadFromFiles = ( event ) => mediaUpload( event.target.files, setVideo, 'video' );
 			const controls = isSelected && (
 				<BlockControls key="controls">
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
 					/>
-					<Toolbar>
-						<IconButton
-							className="components-icon-button components-toolbar__control"
-							label={ __( 'Edit video' ) }
-							onClick={ switchToEditing }
-							icon="edit"
-						/>
-					</Toolbar>
+					{ ! editing && (
+						<Toolbar>
+							<IconButton
+								className="components-icon-button components-toolbar__control"
+								label={ __( 'Edit video' ) }
+								onClick={ switchToEditing }
+								icon="edit"
+							/>
+						</Toolbar>
+					) }
 				</BlockControls>
 			);
 
@@ -133,6 +144,14 @@ export const settings = {
 								{ __( 'Use URL' ) }
 							</Button>
 						</form>
+						<FormFileUpload
+							isLarge
+							className="wp-block-video__upload-button"
+							onChange={ uploadFromFiles }
+							accept="video/*"
+						>
+							{ __( 'Upload' ) }
+						</FormFileUpload>
 						<MediaUpload
 							onSelect={ onSelectVideo }
 							type="video"

--- a/blocks/library/video/test/__snapshots__/index.js.snap
+++ b/blocks/library/video/test/__snapshots__/index.js.snap
@@ -45,6 +45,35 @@ exports[`core/video block edit matches snapshot 1`] = `
         Use URL
       </button>
     </form>
+    <div
+      class="components-form-file-upload"
+    >
+      <button
+        class="components-button components-icon-button wp-block-video__upload-button button button-large"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="dashicon dashicons-upload"
+          focusable="false"
+          height="20"
+          role="img"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
+          />
+        </svg>
+        Upload
+      </button>
+      <input
+        accept="video/*"
+        style="display:none"
+        type="file"
+      />
+    </div>
     *** Mock(Media upload button) ***
   </div>
 </div>

--- a/utils/mediaupload.js
+++ b/utils/mediaupload.js
@@ -1,45 +1,46 @@
 /**
  * External Dependencies
  */
-import { compact } from 'lodash';
+import { compact, startsWith } from 'lodash';
 
 /**
- *	Media Upload is used by image and gallery blocks to handle uploading an image.
+ *	Media Upload is used by audio, image, gallery and video blocks to handle uploading a media file
  *	when a file upload button is activated.
  *
  *	TODO: future enhancement to add an upload indicator.
  *
- * @param {Array}    filesList      List of files.
- * @param {Function} onImagesChange Function to be called each time a file or a temporary representation of the file is available.
+ * @param {Array}    filesList    List of files.
+ * @param {Function} onFileChange Function to be called each time a file or a temporary representation of the file is available.
+ * @param {string}   allowedType  The type of media that can be uploaded.
  */
-export function mediaUpload( filesList, onImagesChange ) {
+export function mediaUpload( filesList, onFileChange, allowedType ) {
 	// Cast filesList to array
 	const files = [ ...filesList ];
 
-	const imagesSet = [];
-	const setAndUpdateImages = ( idx, value ) => {
-		imagesSet[ idx ] = value;
-		onImagesChange( compact( imagesSet ) );
+	const filesSet = [];
+	const setAndUpdateFiles = ( idx, value ) => {
+		filesSet[ idx ] = value;
+		onFileChange( compact( filesSet ) );
 	};
+	const isAllowedType = ( fileType ) => startsWith( fileType, `${ allowedType }/` );
 	files.forEach( ( mediaFile, idx ) => {
-		// Only allow image uploads, may need updating if used for video
-		if ( ! /^image\//.test( mediaFile.type ) ) {
+		if ( ! isAllowedType( mediaFile.type ) ) {
 			return;
 		}
 
-		// Set temporary URL to create placeholder image, this is replaced
-		// with final image from media gallery when upload is `done` below
-		imagesSet.push( { url: window.URL.createObjectURL( mediaFile ) } );
-		onImagesChange( imagesSet );
+		// Set temporary URL to create placeholder media file, this is replaced
+		// with final file from media gallery when upload is `done` below
+		filesSet.push( { url: window.URL.createObjectURL( mediaFile ) } );
+		onFileChange( filesSet );
 
 		return createMediaFromFile( mediaFile ).then(
 			( savedMedia ) => {
-				setAndUpdateImages( idx, { id: savedMedia.id, url: savedMedia.source_url, link: savedMedia.link } );
+				setAndUpdateFiles( idx, { id: savedMedia.id, url: savedMedia.source_url, link: savedMedia.link } );
 			},
 			() => {
 				// Reset to empty on failure.
 				// TODO: Better failure messaging
-				setAndUpdateImages( idx, null );
+				setAndUpdateFiles( idx, null );
 			}
 		);
 	} );


### PR DESCRIPTION
## Description
As suggested by @youknowriad [here](https://github.com/WordPress/gutenberg/pull/5211#issuecomment-370389131):
> Add an "Upload" button to the audio and video blocks (similar to the image and gallery blocks)

This PR adds the `Upload` button for the audio and video blocks.

I also added a few refactorings to make code more generic and work properly with the new requirements. `mediaUpload` util accepts a type of file as a param to work with audio and video formats.

I also fixed a broken behavior of the `edit` button which did nothing when the placeholder was displayed in the audio or video block. I updated the logic to display the button only when the file is selected.

This should conclude pre-requirements to make it possible to merge #5211.

## How Has This Been Tested?
Manually:
* Make sure there are no regression for the following blocks: image, gallery and cover image.
* Use new `Upload` button to add a new audio file in he audio block.
* Use new `Upload` button to add a new video file in the video block.
* Make sure that `Edit` button is not visible when in the edit mode for audio and video blocks. 

## Screenshots (jpeg or gifs if applicable):

Please ignore `wide` and `full` buttons in the block's toolbar - I used 2 different websites to create screenshots :)

### Audio - file selected
![screen shot 2018-03-06 at 10 24 47](https://user-images.githubusercontent.com/699132/37024295-b309420a-2128-11e8-9114-27e25083dc3e.png)

### Audio - editing

**Before**
![screen shot 2018-03-06 at 10 36 35](https://user-images.githubusercontent.com/699132/37025108-1ee101d2-212b-11e8-9014-7c2972fa3f69.png)


**After**
![screen shot 2018-03-06 at 10 24 54](https://user-images.githubusercontent.com/699132/37024296-b32900fe-2128-11e8-8a8a-9e26236590d8.png)

### Video - file selected
![screen shot 2018-03-06 at 10 25 07](https://user-images.githubusercontent.com/699132/37024297-b34c86dc-2128-11e8-8b57-b99f9a967ef2.png)

### Video - editing
**Before**
![screen shot 2018-03-06 at 10 36 55](https://user-images.githubusercontent.com/699132/37025119-29209ec8-212b-11e8-8248-9b1a7559722f.png)


**After**
![screen shot 2018-03-06 at 10 25 15](https://user-images.githubusercontent.com/699132/37024298-b3680d80-2128-11e8-9638-474fa14ef580.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
