### PR TITLE
DropZone: Avoid calling callbacks if file dropped on another dropzone

### DIFF
--- a/components/drop-zone/provider.js
+++ b/components/drop-zone/provider.js
@@ -169,14 +169,14 @@ class DropZoneProvider extends Component {
 
 		const { position, hoveredDropZone } = this.state;
 		const dropzone = hoveredDropZone !== -1 ? this.dropzones[ hoveredDropZone ] : null;
+		const isValidDropzone = !! dropzone && dropzone.element.contains( event.target );
 
 		this.resetDragState();
-
-		if ( !! dropzone && !! dropzone.onDrop ) {
+		if ( isValidDropzone && !! dropzone.onDrop ) {
 			dropzone.onDrop( event, position );
 		}
 
-		if ( event.dataTransfer && !! dropzone ) {
+		if ( event.dataTransfer && isValidDropzone ) {
 			const files = event.dataTransfer.files;
 			const HTML = event.dataTransfer.getData( 'text/html' );
 


### PR DESCRIPTION
closes #3393 and closes #3392 

The Media Modal contains a dropzone and if we try to drop a file there, it will be uploaded twice and maybe inserter into the editor canvas because the editor is full of dropzones under the modal.

This PR updates the dropzones behavior to only trigger the callbacks if the hovered dropzone is the dropzone being dropped into.

**Testing instructions**

 - In a post full of content
 - Try assigning a featured image by drag and dropping an image to the media modal
 - The image should upload once and should not be inserted to the post content.

