### PR TITLE
Edit Post: Refactor state handling for the sidebar

### DIFF
--- a/edit-post/api/sidebar.js
+++ b/edit-post/api/sidebar.js
@@ -96,5 +96,5 @@ export function getSidebarSettings( name ) {
  * @return {void}
  */
 export function activateSidebar( name ) {
-	dispatch( 'edit-post' ).openGeneralSidebar( 'plugin', name );
+	dispatch( 'edit-post' ).openGeneralSidebar( name );
 }

--- a/edit-post/api/sidebar.js
+++ b/edit-post/api/sidebar.js
@@ -3,9 +3,12 @@
 /* External dependencies */
 import { isFunction } from 'lodash';
 
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+
 /* Internal dependencies */
-import store from '../store';
-import { setGeneralSidebarActivePanel, openGeneralSidebar } from '../store/actions';
 import { applyFilters } from '@wordpress/hooks';
 
 const sidebars = {};
@@ -93,6 +96,5 @@ export function getSidebarSettings( name ) {
  * @return {void}
  */
 export function activateSidebar( name ) {
-	store.dispatch( openGeneralSidebar( 'plugin' ) );
-	store.dispatch( setGeneralSidebarActivePanel( 'plugin', name ) );
+	dispatch( 'edit-post' ).openGeneralSidebar( 'plugin', name );
 }

--- a/edit-post/api/sidebar.js
+++ b/edit-post/api/sidebar.js
@@ -96,5 +96,5 @@ export function getSidebarSettings( name ) {
  * @return {void}
  */
 export function activateSidebar( name ) {
-	dispatch( 'edit-post' ).openGeneralSidebar( name );
+	dispatch( 'core/edit-post' ).openGeneralSidebar( name );
 }

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -21,7 +21,7 @@ import './style.scss';
 import MoreMenu from './more-menu';
 import HeaderToolbar from './header-toolbar';
 import {
-	getOpenedGeneralSidebar,
+	isEditorSidebarOpened,
 	isPublishSidebarOpened,
 	hasMetaBoxes,
 	isSavingMetaBoxes,
@@ -33,7 +33,7 @@ import {
 } from '../../store/actions';
 
 function Header( {
-	isGeneralSidebarEditorOpen,
+	isEditorSidebarOpen,
 	onOpenGeneralSidebar,
 	onCloseGeneralSidebar,
 	isPublishSidebarOpen,
@@ -41,7 +41,7 @@ function Header( {
 	hasActiveMetaboxes,
 	isSaving,
 } ) {
-	const toggleGeneralSidebar = isGeneralSidebarEditorOpen ? onCloseGeneralSidebar : onOpenGeneralSidebar;
+	const toggleGeneralSidebar = isEditorSidebarOpen ? onCloseGeneralSidebar : onOpenGeneralSidebar;
 
 	return (
 		<div
@@ -67,9 +67,9 @@ function Header( {
 					<IconButton
 						icon="admin-generic"
 						onClick={ toggleGeneralSidebar }
-						isToggled={ isGeneralSidebarEditorOpen }
+						isToggled={ isEditorSidebarOpen }
 						label={ __( 'Settings' ) }
-						aria-expanded={ isGeneralSidebarEditorOpen }
+						aria-expanded={ isEditorSidebarOpen }
 					/>
 					<MoreMenu key="more-menu" />
 				</div>
@@ -80,13 +80,13 @@ function Header( {
 
 export default connect(
 	( state ) => ( {
-		isGeneralSidebarEditorOpen: getOpenedGeneralSidebar( state ) === 'editor',
+		isEditorSidebarOpen: isEditorSidebarOpened( state ),
 		isPublishSidebarOpen: isPublishSidebarOpened( state ),
 		hasActiveMetaboxes: hasMetaBoxes( state ),
 		isSaving: isSavingMetaBoxes( state ),
 	} ),
 	{
-		onOpenGeneralSidebar: () => openGeneralSidebar( 'editor' ),
+		onOpenGeneralSidebar: () => openGeneralSidebar( 'edit-post/document' ),
 		onCloseGeneralSidebar: closeGeneralSidebar,
 		onTogglePublishSidebar: togglePublishSidebar,
 	},

--- a/edit-post/components/header/index.js
+++ b/edit-post/components/header/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -13,6 +8,8 @@ import {
 	PostSavedState,
 	PostPublishPanelToggle,
 } from '@wordpress/editor';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,28 +17,17 @@ import {
 import './style.scss';
 import MoreMenu from './more-menu';
 import HeaderToolbar from './header-toolbar';
-import {
-	isEditorSidebarOpened,
-	isPublishSidebarOpened,
-	hasMetaBoxes,
-	isSavingMetaBoxes,
-} from '../../store/selectors';
-import {
-	openGeneralSidebar,
-	closeGeneralSidebar,
-	togglePublishSidebar,
-} from '../../store/actions';
 
 function Header( {
-	isEditorSidebarOpen,
-	onOpenGeneralSidebar,
-	onCloseGeneralSidebar,
-	isPublishSidebarOpen,
-	onTogglePublishSidebar,
+	isEditorSidebarOpened,
+	openGeneralSidebar,
+	closeGeneralSidebar,
+	isPublishSidebarOpened,
+	togglePublishSidebar,
 	hasActiveMetaboxes,
 	isSaving,
 } ) {
-	const toggleGeneralSidebar = isEditorSidebarOpen ? onCloseGeneralSidebar : onOpenGeneralSidebar;
+	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
 	return (
 		<div
@@ -51,7 +37,7 @@ function Header( {
 			tabIndex="-1"
 		>
 			<HeaderToolbar />
-			{ ! isPublishSidebarOpen && (
+			{ ! isPublishSidebarOpened && (
 				<div className="edit-post-header__settings">
 					<PostSavedState
 						forceIsDirty={ hasActiveMetaboxes }
@@ -59,17 +45,17 @@ function Header( {
 					/>
 					<PostPreviewButton />
 					<PostPublishPanelToggle
-						isOpen={ isPublishSidebarOpen }
-						onToggle={ onTogglePublishSidebar }
+						isOpen={ isPublishSidebarOpened }
+						onToggle={ togglePublishSidebar }
 						forceIsDirty={ hasActiveMetaboxes }
 						forceIsSaving={ isSaving }
 					/>
 					<IconButton
 						icon="admin-generic"
 						onClick={ toggleGeneralSidebar }
-						isToggled={ isEditorSidebarOpen }
+						isToggled={ isEditorSidebarOpened }
 						label={ __( 'Settings' ) }
-						aria-expanded={ isEditorSidebarOpen }
+						aria-expanded={ isEditorSidebarOpened }
 					/>
 					<MoreMenu key="more-menu" />
 				</div>
@@ -78,18 +64,16 @@ function Header( {
 	);
 }
 
-export default connect(
-	( state ) => ( {
-		isEditorSidebarOpen: isEditorSidebarOpened( state ),
-		isPublishSidebarOpen: isPublishSidebarOpened( state ),
-		hasActiveMetaboxes: hasMetaBoxes( state ),
-		isSaving: isSavingMetaBoxes( state ),
-	} ),
-	{
-		onOpenGeneralSidebar: () => openGeneralSidebar( 'edit-post/document' ),
-		onCloseGeneralSidebar: closeGeneralSidebar,
-		onTogglePublishSidebar: togglePublishSidebar,
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
+export default compose(
+	withSelect( ( select ) => ( {
+		isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
+		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
+		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
+		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
+		openGeneralSidebar: () => dispatch( 'core/edit-post' ).openGeneralSidebar( 'edit-post/document' ),
+		closeGeneralSidebar: dispatch( 'core/edit-post' ).closeGeneralSidebar,
+		togglePublishSidebar: dispatch( 'core/edit-post' ).togglePublishSidebar,
+	} ) ),
 )( Header );

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -31,46 +31,30 @@ import MetaBoxes from '../meta-boxes';
 import { getMetaBoxContainer } from '../../utils/meta-boxes';
 import {
 	getEditorMode,
-	hasOpenSidebar,
+	isEditorSidebarOpened,
 	isFeatureActive,
-	getOpenedGeneralSidebar,
+	isPluginSidebarOpened,
 	isPublishSidebarOpened,
-	getActivePlugin,
 	getMetaBoxes,
 	hasMetaBoxes,
 	isSavingMetaBoxes,
 } from '../../store/selectors';
 import { closePublishSidebar } from '../../store/actions';
 import PluginsPanel from '../../components/plugins-panel/index.js';
-import { getSidebarSettings } from '../../api/sidebar';
-
-function GeneralSidebar( { openedGeneralSidebar } ) {
-	switch ( openedGeneralSidebar ) {
-		case 'editor':
-			return <Sidebar />;
-		case 'plugin':
-			return <PluginsPanel />;
-		default:
-	}
-	return null;
-}
 
 function Layout( {
 	mode,
-	layoutHasOpenSidebar,
+	editorSidebarOpen,
+	pluginSidebarOpen,
 	publishSidebarOpen,
-	openedGeneralSidebar,
 	hasFixedToolbar,
 	onClosePublishSidebar,
-	plugin,
 	metaBoxes,
 	hasActiveMetaboxes,
 	isSaving,
 } ) {
-	const isSidebarOpened = layoutHasOpenSidebar &&
-		( openedGeneralSidebar !== 'plugin' || getSidebarSettings( plugin ) );
 	const className = classnames( 'edit-post-layout', {
-		'is-sidebar-opened': isSidebarOpened,
+		'is-sidebar-opened': editorSidebarOpen || pluginSidebarOpen || publishSidebarOpen,
 		'has-fixed-toolbar': hasFixedToolbar,
 	} );
 
@@ -106,10 +90,8 @@ function Layout( {
 					forceIsSaving={ isSaving }
 				/>
 			) }
-			{
-				openedGeneralSidebar !== null && <GeneralSidebar
-					openedGeneralSidebar={ openedGeneralSidebar } />
-			}
+			{ editorSidebarOpen && <Sidebar /> }
+			{ pluginSidebarOpen && <PluginsPanel /> }
 			<Popover.Slot />
 		</div>
 	);
@@ -118,11 +100,10 @@ function Layout( {
 export default connect(
 	( state ) => ( {
 		mode: getEditorMode( state ),
-		layoutHasOpenSidebar: hasOpenSidebar( state ),
-		openedGeneralSidebar: getOpenedGeneralSidebar( state ),
+		editorSidebarOpen: isEditorSidebarOpened( state ),
+		pluginSidebarOpen: isPluginSidebarOpened( state ),
 		publishSidebarOpen: isPublishSidebarOpened( state ),
 		hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
-		plugin: getActivePlugin( state ),
 		metaBoxes: getMetaBoxes( state ),
 		hasActiveMetaboxes: hasMetaBoxes( state ),
 		isSaving: isSavingMetaBoxes( state ),

--- a/edit-post/components/plugins-panel/index.js
+++ b/edit-post/components/plugins-panel/index.js
@@ -14,12 +14,10 @@ import { IconButton, withFocusReturn } from '@wordpress/components';
  */
 import './style.scss';
 import { getSidebarSettings } from '../../api/sidebar';
-import { getActivePlugin } from '../../store/selectors';
+import { getActiveGeneralSidebarName } from '../../store/selectors';
 import { closeGeneralSidebar } from '../../store/actions';
 
-function PluginsPanel( { onClose, plugin } ) {
-	const pluginSidebar = getSidebarSettings( plugin );
-
+function PluginsPanel( { onClose, pluginSidebar } ) {
 	if ( ! pluginSidebar ) {
 		return null;
 	}
@@ -53,7 +51,7 @@ function PluginsPanel( { onClose, plugin } ) {
 export default connect(
 	( state ) => {
 		return {
-			plugin: getActivePlugin( state ),
+			pluginSidebar: getSidebarSettings( getActiveGeneralSidebarName( state ) ),
 		};
 	}, {
 		onClose: closeGeneralSidebar,

--- a/edit-post/components/plugins-panel/index.js
+++ b/edit-post/components/plugins-panel/index.js
@@ -1,21 +1,16 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton, withFocusReturn } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
 import { getSidebarSettings } from '../../api/sidebar';
-import { getActiveGeneralSidebarName } from '../../store/selectors';
-import { closeGeneralSidebar } from '../../store/actions';
 
 function PluginsPanel( { onClose, pluginSidebar } ) {
 	if ( ! pluginSidebar ) {
@@ -48,14 +43,12 @@ function PluginsPanel( { onClose, pluginSidebar } ) {
 	);
 }
 
-export default connect(
-	( state ) => {
-		return {
-			pluginSidebar: getSidebarSettings( getActiveGeneralSidebarName( state ) ),
-		};
-	}, {
-		onClose: closeGeneralSidebar,
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-)( withFocusReturn( PluginsPanel ) );
+export default compose(
+	withSelect( ( select ) => ( {
+		pluginSidebar: getSidebarSettings( select( 'core/edit-post' ).getActiveGeneralSidebarName() ),
+	} ) ),
+	withDispatch( ( dispatch ) => ( {
+		onClose: dispatch( 'core/edit-post' ).closeGeneralSidebar,
+	} ) ),
+	withFocusReturn,
+)( PluginsPanel );

--- a/edit-post/components/sidebar/header.js
+++ b/edit-post/components/sidebar/header.js
@@ -14,31 +14,31 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal Dependencies
  */
-import { getActiveEditorPanel } from '../../store/selectors';
+import { getActiveGeneralSidebarName } from '../../store/selectors';
 import { closeGeneralSidebar, openGeneralSidebar } from '../../store/actions';
 
-const SidebarHeader = ( { panel, onSetPanel, onCloseSidebar, count } ) => {
+const SidebarHeader = ( { activeSidebarName, openSidebar, closeSidebar, count } ) => {
 	// Do not display "0 Blocks".
 	count = count === 0 ? 1 : count;
 
 	return (
 		<div className="components-panel__header edit-post-sidebar__panel-tabs">
 			<button
-				onClick={ () => onSetPanel( 'document' ) }
-				className={ `edit-post-sidebar__panel-tab ${ panel === 'document' ? 'is-active' : '' }` }
+				onClick={ () => openSidebar( 'edit-post/document' ) }
+				className={ `edit-post-sidebar__panel-tab ${ activeSidebarName === 'edit-post/document' ? 'is-active' : '' }` }
 				aria-label={ __( 'Document settings' ) }
 			>
 				{ __( 'Document' ) }
 			</button>
 			<button
-				onClick={ () => onSetPanel( 'block' ) }
-				className={ `edit-post-sidebar__panel-tab ${ panel === 'block' ? 'is-active' : '' }` }
+				onClick={ () => openSidebar( 'edit-post/block' ) }
+				className={ `edit-post-sidebar__panel-tab ${ activeSidebarName === 'edit-post/block' ? 'is-active' : '' }` }
 				aria-label={ __( 'Block settings' ) }
 			>
 				{ sprintf( _n( 'Block', '%d Blocks', count ), count ) }
 			</button>
 			<IconButton
-				onClick={ onCloseSidebar }
+				onClick={ closeSidebar }
 				icon="no-alt"
 				label={ __( 'Close settings' ) }
 			/>
@@ -52,11 +52,11 @@ export default compose(
 	} ) ),
 	connect(
 		( state ) => ( {
-			panel: getActiveEditorPanel( state ),
+			activeSidebarName: getActiveGeneralSidebarName( state ),
 		} ),
 		{
-			onSetPanel: openGeneralSidebar.bind( null, 'editor' ),
-			onCloseSidebar: closeGeneralSidebar,
+			openSidebar: openGeneralSidebar,
+			closeSidebar: closeGeneralSidebar,
 		},
 		undefined,
 		{ storeKey: 'edit-post' }

--- a/edit-post/components/sidebar/header.js
+++ b/edit-post/components/sidebar/header.js
@@ -15,7 +15,7 @@ import { withSelect } from '@wordpress/data';
  * Internal Dependencies
  */
 import { getActiveEditorPanel } from '../../store/selectors';
-import { closeGeneralSidebar, setGeneralSidebarActivePanel } from '../../store/actions';
+import { closeGeneralSidebar, openGeneralSidebar } from '../../store/actions';
 
 const SidebarHeader = ( { panel, onSetPanel, onCloseSidebar, count } ) => {
 	// Do not display "0 Blocks".
@@ -55,7 +55,7 @@ export default compose(
 			panel: getActiveEditorPanel( state ),
 		} ),
 		{
-			onSetPanel: setGeneralSidebarActivePanel.bind( null, 'editor' ),
+			onSetPanel: openGeneralSidebar.bind( null, 'editor' ),
 			onCloseSidebar: closeGeneralSidebar,
 		},
 		undefined,

--- a/edit-post/components/sidebar/header.js
+++ b/edit-post/components/sidebar/header.js
@@ -1,21 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
-
-/**
- * Internal Dependencies
- */
-import { getActiveGeneralSidebarName } from '../../store/selectors';
-import { closeGeneralSidebar, openGeneralSidebar } from '../../store/actions';
+import { withDispatch, withSelect } from '@wordpress/data';
 
 const SidebarHeader = ( { activeSidebarName, openSidebar, closeSidebar, count } ) => {
 	// Do not display "0 Blocks".
@@ -49,16 +38,10 @@ const SidebarHeader = ( { activeSidebarName, openSidebar, closeSidebar, count } 
 export default compose(
 	withSelect( ( select ) => ( {
 		count: select( 'core/editor' ).getSelectedBlockCount(),
+		activeSidebarName: select( 'core/edit-post' ).getActiveGeneralSidebarName(),
 	} ) ),
-	connect(
-		( state ) => ( {
-			activeSidebarName: getActiveGeneralSidebarName( state ),
-		} ),
-		{
-			openSidebar: openGeneralSidebar,
-			closeSidebar: closeGeneralSidebar,
-		},
-		undefined,
-		{ storeKey: 'edit-post' }
-	)
+	withDispatch( ( dispatch ) => ( {
+		openSidebar: dispatch( 'core/edit-post' ).openGeneralSidebar,
+		closeSidebar: dispatch( 'core/edit-post' ).closeGeneralSidebar,
+	} ) ),
 )( SidebarHeader );

--- a/edit-post/components/sidebar/index.js
+++ b/edit-post/components/sidebar/index.js
@@ -16,25 +16,7 @@ import './style.scss';
 import PostSettings from './post-settings';
 import BlockInspectorPanel from './block-inspector-panel';
 import Header from './header';
-import { getActiveEditorPanel } from '../../store/selectors';
-
-/**
- * Returns the panel that should be rendered in the sidebar.
- *
- * @param {string} panel The currently active panel.
- *
- * @return {Object} The React element to render as a panel.
- */
-function getPanel( panel ) {
-	switch ( panel ) {
-		case 'document':
-			return PostSettings;
-		case 'block':
-			return BlockInspectorPanel;
-		default:
-			return PostSettings;
-	}
-}
+import { getActiveGeneralSidebarName } from '../../store/selectors';
 
 /**
  * Renders a sidebar with the relevant panel.
@@ -43,13 +25,7 @@ function getPanel( panel ) {
  *
  * @return {Object} The rendered sidebar.
  */
-const Sidebar = ( { panel } ) => {
-	const ActivePanel = getPanel( panel );
-
-	const props = {
-		panel,
-	};
-
+const Sidebar = ( { activeSidebarName } ) => {
 	return (
 		<div
 			className="edit-post-sidebar"
@@ -58,7 +34,10 @@ const Sidebar = ( { panel } ) => {
 			tabIndex="-1"
 		>
 			<Header />
-			<ActivePanel { ...props } />
+			{ activeSidebarName === 'edit-post/block' ?
+				<BlockInspectorPanel /> :
+				<PostSettings />
+			}
 		</div>
 	);
 };
@@ -66,7 +45,7 @@ const Sidebar = ( { panel } ) => {
 export default connect(
 	( state ) => {
 		return {
-			panel: getActiveEditorPanel( state ),
+			activeSidebarName: getActiveGeneralSidebarName( state ),
 		};
 	},
 	undefined,

--- a/edit-post/components/sidebar/index.js
+++ b/edit-post/components/sidebar/index.js
@@ -1,13 +1,10 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress Dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { withFocusReturn } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/element';
 
 /**
  * Internal Dependencies
@@ -16,7 +13,6 @@ import './style.scss';
 import PostSettings from './post-settings';
 import BlockInspectorPanel from './block-inspector-panel';
 import Header from './header';
-import { getActiveGeneralSidebarName } from '../../store/selectors';
 
 /**
  * Renders a sidebar with the relevant panel.
@@ -42,13 +38,9 @@ const Sidebar = ( { activeSidebarName } ) => {
 	);
 };
 
-export default connect(
-	( state ) => {
-		return {
-			activeSidebarName: getActiveGeneralSidebarName( state ),
-		};
-	},
-	undefined,
-	undefined,
-	{ storeKey: 'edit-post' }
-)( withFocusReturn( Sidebar ) );
+export default compose(
+	withSelect( ( select ) => ( {
+		activeSidebarName: select( 'core/edit-post' ).getActiveGeneralSidebarName(),
+	} ) ),
+	withFocusReturn,
+)( Sidebar );

--- a/edit-post/components/visual-editor/block-inspector-button.js
+++ b/edit-post/components/visual-editor/block-inspector-button.js
@@ -13,26 +13,26 @@ import { IconButton, withSpokenMessages } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { getActiveEditorPanel, isGeneralSidebarPanelOpened } from '../../store/selectors';
+import { getActiveGeneralSidebarName, isEditorSidebarOpened } from '../../store/selectors';
 import { openGeneralSidebar } from '../../store/actions';
 
 export function BlockInspectorButton( {
-	isGeneralSidebarEditorOpened,
+	isEditorSidebarOpen,
 	onOpenGeneralSidebarEditor,
-	panel,
+	activeSidebarName,
 	onClick = noop,
 	small = false,
 	speak,
 } ) {
 	const speakMessage = () => {
-		if ( ! isGeneralSidebarEditorOpened || ( isGeneralSidebarEditorOpened && panel !== 'block' ) ) {
+		if ( ! isEditorSidebarOpen || ( isEditorSidebarOpen && activeSidebarName !== 'edit-post/block' ) ) {
 			speak( __( 'Additional settings are now available in the Editor advanced settings sidebar' ) );
 		} else {
 			speak( __( 'Advanced settings closed' ) );
 		}
 	};
 
-	const label = ( isGeneralSidebarEditorOpened && panel === 'block' ) ? __( 'Hide Advanced Settings' ) : __( 'Show Advanced Settings' );
+	const label = ( isEditorSidebarOpen && activeSidebarName === 'edit-post/block' ) ? __( 'Hide Advanced Settings' ) : __( 'Show Advanced Settings' );
 
 	return (
 		<IconButton
@@ -48,12 +48,12 @@ export function BlockInspectorButton( {
 
 export default connect(
 	( state ) => ( {
-		isGeneralSidebarEditorOpened: isGeneralSidebarPanelOpened( state, 'editor' ),
-		panel: getActiveEditorPanel( state ),
+		isEditorSidebarOpen: isEditorSidebarOpened( state ),
+		activeSidebarName: getActiveGeneralSidebarName( state ),
 	} ),
 	( dispatch ) => ( {
 		onOpenGeneralSidebarEditor() {
-			dispatch( openGeneralSidebar( 'editor', 'block' ) );
+			dispatch( openGeneralSidebar( 'edit-post/block' ) );
 		},
 	} ),
 	undefined,

--- a/edit-post/components/visual-editor/block-inspector-button.js
+++ b/edit-post/components/visual-editor/block-inspector-button.js
@@ -11,12 +11,6 @@ import { IconButton, withSpokenMessages } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/element';
 
-/**
- * Internal dependencies
- */
-import { getActiveGeneralSidebarName, isEditorSidebarOpened } from '../../store/selectors';
-import { openGeneralSidebar } from '../../store/actions';
-
 export function BlockInspectorButton( {
 	areAdvancedSettingsOpened,
 	closeSidebar,

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -1,15 +1,13 @@
 /**
- * Returns an action object used in signalling that the user opened a sidebar.
+ * Returns an action object used in signalling that the user opened an editor sidebar.
  *
- * @param {string} sidebar        Sidebar to open.
- * @param {string} [panel = null] Panel to open in the sidebar. Null if unchanged.
- * @return {Object}              Action object.
+ * @param {string} name        Sidebar name to be opened.
+ * @return {Object}            Action object.
  */
-export function openGeneralSidebar( sidebar, panel = null ) {
+export function openGeneralSidebar( name ) {
 	return {
 		type: 'OPEN_GENERAL_SIDEBAR',
-		sidebar,
-		panel,
+		name,
 	};
 }
 

--- a/edit-post/store/actions.js
+++ b/edit-post/store/actions.js
@@ -1,20 +1,3 @@
-
-/**
- * Returns an action object used in signalling that the user switched the active
- * sidebar tab panel.
- *
- * @param  {string} sidebar Sidebar name
- * @param  {string} panel   Panel name
- * @return {Object}         Action object
- */
-export function setGeneralSidebarActivePanel( sidebar, panel ) {
-	return {
-		type: 'SET_GENERAL_SIDEBAR_ACTIVE_PANEL',
-		sidebar,
-		panel,
-	};
-}
-
 /**
  * Returns an action object used in signalling that the user opened a sidebar.
  *

--- a/edit-post/store/defaults.js
+++ b/edit-post/store/defaults.js
@@ -1,10 +1,6 @@
 export const PREFERENCES_DEFAULTS = {
 	editorMode: 'visual',
-	activeGeneralSidebar: 'editor', // null | 'editor' | 'plugin'
-	activeSidebarPanel: { // The keys in this object should match activeSidebarPanel values
-		editor: null, // 'document' | 'block'
-		plugin: null, // pluginId
-	},
+	activeGeneralSidebar: 'edit-post/document', // null | 'edit-post/block' | 'edit-post/document' | 'plugin/*'
 	panels: { 'post-status': true },
 	features: {
 		fixedToolbar: false,

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { get, omit } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,14 +23,9 @@ import { PREFERENCES_DEFAULTS } from './defaults';
 export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 	switch ( action.type ) {
 		case 'OPEN_GENERAL_SIDEBAR':
-			const activeSidebarPanel = action.panel ? action.panel : state.activeSidebarPanel[ action.sidebar ];
 			return {
 				...state,
-				activeGeneralSidebar: action.sidebar,
-				activeSidebarPanel: {
-					...state.activeSidebarPanel,
-					[ action.sidebar ]: activeSidebarPanel,
-				},
+				activeGeneralSidebar: action.name,
 			};
 		case 'CLOSE_GENERAL_SIDEBAR':
 			return {
@@ -59,7 +54,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 				},
 			};
 		case 'SERIALIZE':
-			return omit( state, [ 'sidebars.mobile', 'sidebars.publish' ] );
+			return state;
 	}
 
 	return state;

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -32,14 +32,6 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					[ action.sidebar ]: activeSidebarPanel,
 				},
 			};
-		case 'SET_GENERAL_SIDEBAR_ACTIVE_PANEL':
-			return {
-				...state,
-				activeSidebarPanel: {
-					...state.activeSidebarPanel,
-					[ action.sidebar ]: action.panel,
-				},
-			};
 		case 'CLOSE_GENERAL_SIDEBAR':
 			return {
 				...state,

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -5,6 +5,11 @@ import createSelector from 'rememo';
 import { some } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { getSidebarSettings } from '../api/sidebar';
+
+/**
  * Returns the current editing mode.
  *
  * @param {Object} state Global application state.
@@ -16,24 +21,42 @@ export function getEditorMode( state ) {
 }
 
 /**
- * Returns the current active panel for the sidebar.
+ * Returns true if the editor sidebar is opened.
  *
- * @param {Object} state Global application state.
- *
- * @return {string} Active sidebar panel.
+ * @param {Object} state Global application state
+ * @return {boolean}     Whether the editor sidebar is opened.
  */
-export function getActiveEditorPanel( state ) {
-	return getPreference( state, 'activeSidebarPanel', {} ).editor;
+export function isEditorSidebarOpened( state ) {
+	const activeGeneralSidebar = getPreference( state, 'activeGeneralSidebar', null );
+
+	return [ 'edit-post/document', 'edit-post/block' ].includes( activeGeneralSidebar );
 }
 
 /**
- * Returns the current active plugin for the plugin sidebar.
+ * Returns true if the plugin sidebar is opened.
  *
- * @param  {Object}  state Global application state
- * @return {string}        Active plugin sidebar plugin
+ * @param {Object} state Global application state
+ * @return {boolean}     Whether the plugin sidebar is opened.
  */
-export function getActivePlugin( state ) {
-	return getPreference( state, 'activeSidebarPanel', {} ).plugin;
+export function isPluginSidebarOpened( state ) {
+	const activeGeneralSidebar = getPreference( state, 'activeGeneralSidebar', null );
+
+	return Boolean( getSidebarSettings( activeGeneralSidebar ) );
+}
+
+/**
+ * Returns the current active general sidebar name.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {?string} Active general sidebar name.
+ */
+export function getActiveGeneralSidebarName( state ) {
+	const activeGeneralSidebar = getPreference( state, 'activeGeneralSidebar', null );
+
+	return activeGeneralSidebar && ( isEditorSidebarOpened( state ) || isPluginSidebarOpened( state ) ) ?
+		activeGeneralSidebar :
+		null;
 }
 
 /**
@@ -62,30 +85,6 @@ export function getPreference( state, preferenceKey, defaultValue ) {
 }
 
 /**
- * Returns the opened general sidebar and null if the sidebar is closed.
- *
- * @param {Object} state Global application state.
- * @return {string}     The opened general sidebar panel.
- */
-export function getOpenedGeneralSidebar( state ) {
-	return getPreference( state, 'activeGeneralSidebar' );
-}
-
-/**
- * Returns true if the panel is open in the currently opened sidebar.
- *
- * @param  {Object}  state   Global application state
- * @param  {string}  sidebar Sidebar name (leave undefined for the default sidebar)
- * @param  {string}  panel   Sidebar panel name (leave undefined for the default panel)
- * @return {boolean}        Whether the given general sidebar panel is open
- */
-export function isGeneralSidebarPanelOpened( state, sidebar, panel ) {
-	const activeGeneralSidebar = getPreference( state, 'activeGeneralSidebar' );
-	const activeSidebarPanel = getPreference( state, 'activeSidebarPanel' );
-	return activeGeneralSidebar === sidebar && activeSidebarPanel === panel;
-}
-
-/**
  * Returns true if the publish sidebar is opened.
  *
  * @param {Object} state Global application state
@@ -93,20 +92,6 @@ export function isGeneralSidebarPanelOpened( state, sidebar, panel ) {
  */
 export function isPublishSidebarOpened( state ) {
 	return state.publishSidebarActive;
-}
-
-/**
- * Returns true if there's any open sidebar (mobile, desktop or publish).
- *
- * @param {Object} state Global application state.
- *
- * @return {boolean} Whether sidebar is open.
- */
-export function hasOpenSidebar( state ) {
-	const generalSidebarOpen = getPreference( state, 'activeGeneralSidebar' ) !== null;
-	const publishSidebarOpen = state.publishSidebarActive;
-
-	return generalSidebarOpen || publishSidebarOpen;
 }
 
 /**

--- a/edit-post/store/test/actions.js
+++ b/edit-post/store/test/actions.js
@@ -16,12 +16,10 @@ import {
 describe( 'actions', () => {
 	describe( 'openGeneralSidebar', () => {
 		it( 'should return OPEN_GENERAL_SIDEBAR action', () => {
-			const sidebar = 'sidebarName';
-			const panel = 'panelName';
-			expect( openGeneralSidebar( sidebar, panel ) ).toEqual( {
+			const name = 'plugin/my-name';
+			expect( openGeneralSidebar( name ) ).toEqual( {
 				type: 'OPEN_GENERAL_SIDEBAR',
-				sidebar,
-				panel,
+				name,
 			} );
 		} );
 	} );

--- a/edit-post/store/test/actions.js
+++ b/edit-post/store/test/actions.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import {
-	setGeneralSidebarActivePanel,
 	toggleGeneralSidebarEditorPanel,
 	openGeneralSidebar,
 	closeGeneralSidebar,
@@ -15,16 +14,6 @@ import {
 } from '../actions';
 
 describe( 'actions', () => {
-	describe( 'setGeneralSidebarActivePanel', () => {
-		it( 'should return SET_GENERAL_SIDEBAR_ACTIVE_PANEL action', () => {
-			expect( setGeneralSidebarActivePanel( 'editor', 'document' ) ).toEqual( {
-				type: 'SET_GENERAL_SIDEBAR_ACTIVE_PANEL',
-				sidebar: 'editor',
-				panel: 'document',
-			} );
-		} );
-	} );
-
 	describe( 'openGeneralSidebar', () => {
 		it( 'should return OPEN_GENERAL_SIDEBAR action', () => {
 			const sidebar = 'sidebarName';

--- a/edit-post/store/test/reducer.js
+++ b/edit-post/store/test/reducer.js
@@ -18,11 +18,7 @@ describe( 'state', () => {
 			const state = preferences( undefined, {} );
 
 			expect( state ).toEqual( {
-				activeGeneralSidebar: 'editor',
-				activeSidebarPanel: {
-					editor: null,
-					plugin: null,
-				},
+				activeGeneralSidebar: 'edit-post/document',
 				editorMode: 'visual',
 				panels: { 'post-status': true },
 				features: { fixedToolbar: false },
@@ -32,21 +28,12 @@ describe( 'state', () => {
 		it( 'should set the general sidebar active panel', () => {
 			const state = preferences( deepFreeze( {
 				activeGeneralSidebar: 'editor',
-				activeSidebarPanel: {
-					editor: null,
-					plugin: null,
-				},
 			} ), {
 				type: 'SET_GENERAL_SIDEBAR_ACTIVE_PANEL',
-				sidebar: 'editor',
-				panel: 'document',
+				name: 'edit-post/document',
 			} );
 			expect( state ).toEqual( {
 				activeGeneralSidebar: 'editor',
-				activeSidebarPanel: {
-					editor: 'document',
-					plugin: null,
-				},
 			} );
 		} );
 

--- a/edit-post/store/test/selectors.js
+++ b/edit-post/store/test/selectors.js
@@ -4,15 +4,20 @@
 import {
 	getEditorMode,
 	getPreference,
-	isGeneralSidebarPanelOpened,
-	hasOpenSidebar,
+	isEditorSidebarOpened,
 	isEditorSidebarPanelOpened,
 	isFeatureActive,
+	isPluginSidebarOpened,
 	getMetaBoxes,
 	hasMetaBoxes,
 	isSavingMetaBoxes,
 	getMetaBox,
 } from '../selectors';
+import { getSidebarSettings as getSidebarSettingsMock } from '../../api/sidebar';
+
+jest.mock( '../../api/sidebar', () => ( {
+	getSidebarSettings: jest.fn().mockReturnValue( null ),
+} ) );
 
 describe( 'selectors', () => {
 	describe( 'getEditorMode', () => {
@@ -59,67 +64,73 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isGeneralSidebarPanelOpened', () => {
-		it( 'should return true when specified the sidebar panel is opened', () => {
-			const state = {
-				preferences: {
-					activeGeneralSidebar: 'editor',
-					activeSidebarPanel: 'document',
-				},
-			};
-			const panel = 'document';
-			const sidebar = 'editor';
-
-			expect( isGeneralSidebarPanelOpened( state, sidebar, panel ) ).toBe( true );
-		} );
-
-		it( 'should return false when another panel than the specified sidebar panel is opened', () => {
-			const state = {
-				preferences: {
-					activeGeneralSidebar: 'editor',
-					activeSidebarPanel: 'blocks',
-				},
-			};
-			const panel = 'document';
-			const sidebar = 'editor';
-
-			expect( isGeneralSidebarPanelOpened( state, sidebar, panel ) ).toBe( false );
-		} );
-
-		it( 'should return false when no sidebar panel is opened', () => {
+	describe( 'isEditorSidebarOpened', () => {
+		it( 'should return false when the editor sidebar is not opened', () => {
 			const state = {
 				preferences: {
 					activeGeneralSidebar: null,
-					activeSidebarPanel: null,
 				},
 			};
-			const panel = 'blocks';
-			const sidebar = 'editor';
 
-			expect( isGeneralSidebarPanelOpened( state, sidebar, panel ) ).toBe( false );
+			expect( isEditorSidebarOpened( state ) ).toBe( false );
+		} );
+
+		it( 'should return false when the plugin sidebar is opened', () => {
+			const state = {
+				preferences: {
+					activeGeneralSidebar: 'my-plugin/my-sidebar',
+				},
+			};
+
+			expect( isEditorSidebarOpened( state ) ).toBe( false );
+		} );
+
+		it( 'should return true when the editor sidebar is opened', () => {
+			const state = {
+				preferences: {
+					activeGeneralSidebar: 'edit-post/document',
+				},
+			};
+
+			expect( isEditorSidebarOpened( state ) ).toBe( true );
 		} );
 	} );
 
-	describe( 'hasOpenSidebar', () => {
-		it( 'should return true if at least one sidebar is open', () => {
+	describe( 'isPluginSidebarOpened', () => {
+		it( 'should return false when the plugin sidebar is not opened', () => {
 			const state = {
-				preferences: {
-					activeSidebarPanel: null,
-				},
-			};
-
-			expect( hasOpenSidebar( state ) ).toBe( true );
-		} );
-
-		it( 'should return false if no sidebar is open', () => {
-			const state = {
-				publishSidebarActive: false,
 				preferences: {
 					activeGeneralSidebar: null,
 				},
 			};
 
-			expect( hasOpenSidebar( state ) ).toBe( false );
+			expect( isPluginSidebarOpened( state ) ).toBe( false );
+		} );
+
+		it( 'should return false when the editor sidebar is opened', () => {
+			const state = {
+				preferences: {
+					activeGeneralSidebar: 'edit-post/document',
+				},
+			};
+
+			expect( isPluginSidebarOpened( state ) ).toBe( false );
+		} );
+
+		it( 'should return true when the plugin sidebar is opened', () => {
+			getSidebarSettingsMock.mockReturnValueOnce( {
+				title: 'My Sidebar',
+				render: () => 'My Sidebar',
+			} );
+			const name = 'my-plugin/my-sidebar';
+			const state = {
+				preferences: {
+					activeGeneralSidebar: name,
+				},
+			};
+
+			expect( isPluginSidebarOpened( state ) ).toBe( true );
+			expect( getSidebarSettingsMock ).toHaveBeenCalledWith( name );
 		} );
 	} );
 


### PR DESCRIPTION
## Description

Follow-up for #4777.

This PR aims to simplify the state management for the sidebars to make it easier to maintain with the upcoming changes from #5430. I figured out we can treat `editor` related sidebars in a similar way as plugins (maybe even combine them in the future) and store the active sidebar name together. I could take this approach because they are mutually exclusive in a sense that you can display only one of them at the same time in the same space.

At the same time, I refactored a few updated files to make them work with the new `data` module to get a better feeling how it all integrates with our codebase.

## How Has This Been Tested?
Register sidebar using the following code:
```js
wp.editPost.__experimentalRegisterSidebar( 
	"my-plugin/my-sidebar-x", 
	{
		title: "Name",
		render: () => { return wp.element.createElement( 'div', {}, 'My sidebar' ) }
	} 
);
```

To activate it use the following:
```js
wp.editPost.__experimentalActivateSidebar( 
	"my-plugin/my-sidebar-x"
);
```

I tested the following manually:
1. Opened document settings using the cog icon in the header.
1. Closed document settings using the cog icon in the header.
1. Opened block settings using the block's dropdown menu and the `Show Advanced Settings` button.
1. Closed block settings using the block's dropdown menu and the `Hide Advanced Settings` button.
1. I could close the sidebar using the cross icon for both block and document tabs.
1. I could activate the plugin using the code shared above.
1. I could close the plugin sidebar using the cross icon.
1. Activated the plugin and refreshed the page and sidebar got deactivated, because the plugin is no longer registered.
1. Tested also a few flows when flipping the sidebar type using all navigation options.

All unit tests should still pass: `npm test`.

## Screenshots (jpeg or gifs if applicable):

![screen shot 2018-03-07 at 10 04 32](https://user-images.githubusercontent.com/699132/37083153-f8287b50-21ee-11e8-98c8-321a3e5c2c43.png)

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
