### PR TITLE
Chrome: Fix updating the author on published posts

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -22,11 +22,12 @@ import { getMetaBoxContainer } from '../utils/meta-boxes';
 const effects = {
 	INITIALIZE_META_BOX_STATE( action, store ) {
 		const hasActiveMetaBoxes = some( action.metaBoxes );
+		if ( ! hasActiveMetaBoxes ) {
+			return;
+		}
 
 		// Allow toggling metaboxes panels
-		if ( hasActiveMetaBoxes ) {
-			window.postboxes.add_postbox_toggles( 'post' );
-		}
+		window.postboxes.add_postbox_toggles( 'post' );
 
 		// Initialize metaboxes state
 		const dataPerLocation = reduce( action.metaBoxes, ( memo, isActive, location ) => {
@@ -64,6 +65,7 @@ const effects = {
 		const additionalData = [
 			post.comment_status && `comment_status=${ post.comment_status }`,
 			post.ping_status && `ping_status=${ post.ping_status }`,
+			`post_author=${ post.author }`,
 		].filter( Boolean );
 
 		// To save the metaboxes, we serialize each one of the location forms and combine them

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -367,7 +367,6 @@ function gutenberg_meta_box_post_form_hidden_fields( $post ) {
 	<input type="hidden" id="user-id" name="user_ID" value="<?php echo (int) $user_id; ?>" />
 	<input type="hidden" id="hiddenaction" name="action" value="<?php echo esc_attr( $form_action ); ?>" />
 	<input type="hidden" id="originalaction" name="originalaction" value="<?php echo esc_attr( $form_action ); ?>" />
-	<input type="hidden" id="post_author" name="post_author" value="<?php echo esc_attr( $post->post_author ); ?>" />
 	<input type="hidden" id="post_type" name="post_type" value="<?php echo esc_attr( $post->post_type ); ?>" />
 	<input type="hidden" id="original_post_status" name="original_post_status" value="<?php echo esc_attr( $post->post_status ); ?>" />
 	<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>" />


### PR DESCRIPTION
closes #5395 #5072 

The meta box saving request was resetting the post author to the initial value.

**Testing instructions**

Repeat the testing instructions in #5395 and ensure the author is updated.