### PR TITLE
Fix typo in history tests

### DIFF
--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -869,7 +869,7 @@ describe( 'state', () => {
 				expect( state.past ).toHaveLength( 2 );
 			} );
 
-			it( 'should not overwrite present history if updating same attributes', () => {
+			it( 'should not overwrite present history if updating different attributes', () => {
 				let state;
 
 				state = editor( state, {


### PR DESCRIPTION
## Description
Detected by @mcsf. See https://github.com/WordPress/gutenberg/pull/4956#discussion_r168760079.
