### PR TITLE
Block Menu: Fix arrow navigation

### DIFF
--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -24,28 +24,24 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 	if ( isLocked || ! possibleBlockTransformations.length ) {
 		return null;
 	}
-	return (
-		<div className="editor-block-settings-menu__section">
-			{ possibleBlockTransformations.map( ( { name, title, icon } ) => {
-			/* translators: label indicating the transformation of a block into another block */
-				const shownText = sprintf( __( 'Turn into %s' ), title );
-				return (
-					<IconButton
-						key={ name }
-						className="editor-block-settings-menu__control"
-						onClick={ ( event ) => {
-							onTransform( blocks, name );
-							onClick( event );
-						} }
-						icon={ icon }
-						label={ small ? shownText : undefined }
-					>
-						{ ! small && shownText }
-					</IconButton>
-				);
-			} ) }
-		</div>
-	);
+	return possibleBlockTransformations.map( ( { name, title, icon } ) => {
+		/* translators: label indicating the transformation of a block into another block */
+		const shownText = sprintf( __( 'Turn into %s' ), title );
+		return (
+			<IconButton
+				key={ name }
+				className="editor-block-settings-menu__control"
+				onClick={ ( event ) => {
+					onTransform( blocks, name );
+					onClick( event );
+				} }
+				icon={ icon }
+				label={ small ? shownText : undefined }
+			>
+				{ ! small && shownText }
+			</IconButton>
+		);
+	} );
 }
 export default compose(
 	connect(

--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { IconButton, withContext } from '@wordpress/components';
 import { getPossibleBlockTransformations, switchToBlockType } from '@wordpress/blocks';
-import { compose } from '@wordpress/element';
+import { compose, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,24 +24,29 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 	if ( isLocked || ! possibleBlockTransformations.length ) {
 		return null;
 	}
-	return possibleBlockTransformations.map( ( { name, title, icon } ) => {
-		/* translators: label indicating the transformation of a block into another block */
-		const shownText = sprintf( __( 'Turn into %s' ), title );
-		return (
-			<IconButton
-				key={ name }
-				className="editor-block-settings-menu__control"
-				onClick={ ( event ) => {
-					onTransform( blocks, name );
-					onClick( event );
-				} }
-				icon={ icon }
-				label={ small ? shownText : undefined }
-			>
-				{ ! small && shownText }
-			</IconButton>
-		);
-	} );
+	return (
+		<Fragment>
+			<div className="editor-block-settings-menu__separator" />
+			{ possibleBlockTransformations.map( ( { name, title, icon } ) => {
+			/* translators: label indicating the transformation of a block into another block */
+				const shownText = sprintf( __( 'Turn into %s' ), title );
+				return (
+					<IconButton
+						key={ name }
+						className="editor-block-settings-menu__control"
+						onClick={ ( event ) => {
+							onTransform( blocks, name );
+							onClick( event );
+						} }
+						icon={ icon }
+						label={ small ? shownText : undefined }
+					>
+						{ ! small && shownText }
+					</IconButton>
+				);
+			} ) }
+		</Fragment>
+	);
 }
 export default compose(
 	connect(

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -66,7 +66,6 @@ function BlockSettingsMenu( {
 						<BlockRemoveButton key="remove" uids={ uids } />,
 						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } />,
 						count === 1 && <ReusableBlockSettings key="reusable-block" uid={ uids[ 0 ] } onToggle={ onClose } />,
-						<div key="separator" className="editor-block-settings-menu__separator" />,
 						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } />,
 					] } ) }
 				</NavigableMenu>

--- a/editor/components/block-settings-menu/index.js
+++ b/editor/components/block-settings-menu/index.js
@@ -66,6 +66,7 @@ function BlockSettingsMenu( {
 						<BlockRemoveButton key="remove" uids={ uids } />,
 						<BlockDuplicateButton key="duplicate" uids={ uids } rootUID={ rootUID } />,
 						count === 1 && <ReusableBlockSettings key="reusable-block" uid={ uids[ 0 ] } onToggle={ onClose } />,
+						<div key="separator" className="editor-block-settings-menu__separator" />,
 						<BlockTransformations key="transformations" uids={ uids } onClick={ onClose } />,
 					] } ) }
 				</NavigableMenu>

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -28,10 +28,9 @@
 	}
 }
 
-.editor-block-settings-menu__section {
+.editor-block-settings-menu__separator {
 	margin-top: $item-spacing;
-	margin-bottom: -$item-spacing;
-	padding: $item-spacing 0;
+	margin-bottom: $item-spacing;
 	border-top: 1px solid $light-gray-500;
 }
 
@@ -56,10 +55,4 @@
 	.dashicon {
 		margin-right: 5px;
 	}
-}
-
-.editor-block-settings-menu__section {
-	margin-top: $item-spacing;
-	padding-top: $item-spacing;
-	border-top: 1px solid $light-gray-500;
 }


### PR DESCRIPTION
closes #5245

This PR fixes the arrow navigation in the block settings menu by making all the button children of the menu (which is recommended). 

**Testing instructions**

 - Repeat the instructions in #5245
