### PR TITLE
UrlInput: Make the component controlled

### DIFF
--- a/blocks/url-input/index.js
+++ b/blocks/url-input/index.js
@@ -178,7 +178,7 @@ class UrlInput extends Component {
 	}
 
 	render() {
-		const { value, instanceId } = this.props;
+		const { value = '', instanceId } = this.props;
 		const { showSuggestions, posts, selectedSuggestion, loading } = this.state;
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (


### PR DESCRIPTION
Tiny PR to fix the REACT uncontrolled input warning 

closes #5441 

**Instructions**

 - Try inserting a button block and typing in the url field.