### PR TITLE
Keep wp.apiRequest to use Promise .then( resolve, reject )

### DIFF
--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -165,8 +165,8 @@ class HierarchicalTermSelector extends Component {
 
 	componentDidMount() {
 		const basePath = wp.api.getTaxonomyRoute( this.props.slug );
-		this.fetchRequest = wp.apiRequest( { path: `/wp/v2/${ basePath }?${ stringify( DEFAULT_QUERY ) }` } )
-			.done( ( terms ) => {
+		this.fetchRequest = wp.apiRequest( { path: `/wp/v2/${ basePath }?${ stringify( DEFAULT_QUERY ) }` } ).then(
+			( terms ) => { // resolve
 				const availableTermsTree = buildTermsTree( terms );
 
 				this.setState( {
@@ -174,15 +174,16 @@ class HierarchicalTermSelector extends Component {
 					availableTermsTree,
 					availableTerms: terms,
 				} );
-			} )
-			.fail( ( xhr ) => {
+			},
+			( xhr ) => { // reject
 				if ( xhr.statusText === 'abort' ) {
 					return;
 				}
 				this.setState( {
 					loading: false,
 				} );
-			} );
+			}
+		);
 	}
 
 	componentWillUnmount() {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -80,26 +80,29 @@ export default {
 		} );
 		dispatch( removeNotice( SAVE_POST_NOTICE_ID ) );
 		const basePath = wp.api.getPostTypeRoute( getCurrentPostType( state ) );
-		wp.apiRequest( { path: `/wp/v2/${ basePath }/${ post.id }`, method: 'PUT', data: toSend } ).done( ( newPost ) => {
-			dispatch( resetPost( newPost ) );
-			dispatch( {
-				type: 'REQUEST_POST_UPDATE_SUCCESS',
-				previousPost: post,
-				post: newPost,
-				optimist: { type: COMMIT, id: POST_UPDATE_TRANSACTION_ID },
-			} );
-		} ).fail( ( err ) => {
-			dispatch( {
-				type: 'REQUEST_POST_UPDATE_FAILURE',
-				error: get( err, 'responseJSON', {
-					code: 'unknown_error',
-					message: __( 'An unknown error occurred.' ),
-				} ),
-				post,
-				edits,
-				optimist: { type: REVERT, id: POST_UPDATE_TRANSACTION_ID },
-			} );
-		} );
+		wp.apiRequest( { path: `/wp/v2/${ basePath }/${ post.id }`, method: 'PUT', data: toSend } ).then(
+			( newPost ) => {
+				dispatch( resetPost( newPost ) );
+				dispatch( {
+					type: 'REQUEST_POST_UPDATE_SUCCESS',
+					previousPost: post,
+					post: newPost,
+					optimist: { type: COMMIT, id: POST_UPDATE_TRANSACTION_ID },
+				} );
+			},
+			( err ) => {
+				dispatch( {
+					type: 'REQUEST_POST_UPDATE_FAILURE',
+					error: get( err, 'responseJSON', {
+						code: 'unknown_error',
+						message: __( 'An unknown error occurred.' ),
+					} ),
+					post,
+					edits,
+					optimist: { type: REVERT, id: POST_UPDATE_TRANSACTION_ID },
+				} );
+			}
+		);
 	},
 	REQUEST_POST_UPDATE_SUCCESS( action, store ) {
 		const { previousPost, post } = action;


### PR DESCRIPTION
## Description

The response from wp.apiRequest should not assume it is an jQuery ajax response, but should be a Promise with the signature `.then( resolve, reject )` this is consistent with the other calls of 
wp.apiRequest.


## How Has This Been Tested?

This change applies to `UPDATE_POST` so testing confirmed creating and updating posts still work.


## Types of changes

Bug fix (non-breaking change which fixes an issue). Our use case has us proxying the behavior for wp.apiRequest so it does not return jQuery.ajax request but a Promise.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.

