### PR TITLE
Implement nesting in cover image block

### DIFF
--- a/blocks/inner-blocks/index.js
+++ b/blocks/inner-blocks/index.js
@@ -3,8 +3,8 @@
  */
 import { withContext } from '@wordpress/components';
 
-function InnerBlocks( { BlockList, layouts } ) {
-	return <BlockList layouts={ layouts } />;
+function InnerBlocks( { BlockList, layouts, allowedBlocks, template } ) {
+	return <BlockList { ...{ layouts, allowedBlocks, template } } />;
 }
 
 InnerBlocks = withContext( 'BlockList' )()( InnerBlocks );

--- a/core-blocks/cover-image/editor.scss
+++ b/core-blocks/cover-image/editor.scss
@@ -22,10 +22,52 @@
 	}
 
 	&.has-left-content .block-rich-text__inline-toolbar {
-		justify-content: flex-start;
+		display: inline-block;
 	}
 
 	&.has-right-content .block-rich-text__inline-toolbar{
-		justify-content: flex-end;
+		display: inline-block;
+	}
+
+	.editor-block-list__layout {
+		width: 100%;
+	}
+
+	.wp-block-cover-image__inner-container {
+		width: calc( 100% - 70px );
+		margin-left: auto;
+		margin-right: auto;
+		// avoid text align inherit from cover image align.
+		text-align: left;
+
+		.editor-inserter-with-shortcuts .components-icon-button,
+		.editor-block-list__empty-block-inserter .components-icon-button {
+			color: $white;
+		}
+		.editor-default-block-appender {
+			&:hover {
+				.components-icon-button {
+					color: $white;
+				}
+			}
+
+			.components-icon-button {
+				color: $light-gray-900;
+			}
+		}
+
+
+		.editor-block-list__insertion-point-inserter:before {
+			background: $white;
+		}
+
+		p.wp-block-subhead {
+			color: $light-gray-100;
+		}
+
+		.components-draggable__clone > .editor-block-list__block > .editor-block-list__block-draggable,
+		.editor-block-list__block-draggable > .editor-block-list__block-draggable-inner {
+				background-color: rgba( $white, 0.3 );
+		}
 	}
 }

--- a/core-blocks/cover-image/index.js
+++ b/core-blocks/cover-image/index.js
@@ -17,7 +17,6 @@ import {
 	BlockAlignmentToolbar,
 	ImagePlaceholder,
 	MediaUpload,
-	AlignmentToolbar,
 	RichText,
 	InnerBlocks,
 } from '@wordpress/blocks';
@@ -114,12 +113,6 @@ export const settings = {
 					<BlockAlignmentToolbar
 						value={ align }
 						onChange={ updateAlignment }
-					/>
-					<AlignmentToolbar
-						value={ contentAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { contentAlign: nextAlign } );
-						} }
 					/>
 					<Toolbar>
 						<MediaUpload

--- a/core-blocks/cover-image/style.scss
+++ b/core-blocks/cover-image/style.scss
@@ -79,4 +79,18 @@
 		max-width: $content-width / 2;
 		width: 100%;
 	}
+
+	.wp-block-cover-image__inner-container {
+		width: calc( 100% - 70px );
+		color: $light-gray-100;
+		z-index: z-index( '.wp-block-cover-image__inner-container' );
+		p {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+	}
+
+	h1, h2, h3, h4, h5, h6, .wp-block-subhead {
+		color: inherit;
+	}
 }

--- a/core-blocks/test/fixtures/core__cover-image.html
+++ b/core-blocks/test/fixtures/core__cover-image.html
@@ -1,5 +1,9 @@
-<!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
-<div class="wp-block-cover-image has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)">
-    <p class="wp-block-cover-image-text">Guten Berg!</p>
+<!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","id":8398,"dimRatio": 40} -->
+<div class="wp-block-cover-image has-background-dim has-background-dim-40" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)">
+    <div class="wp-block-cover-image__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p style="text-align:center" class="is-large-text">Paragraph 1</p>
+		<!-- /wp:paragraph -->
+    </div>
 </div>
-<!-- /wp:core/cover-image -->
+<!-- /wp:cover-image -->

--- a/core-blocks/test/fixtures/core__cover-image.json
+++ b/core-blocks/test/fixtures/core__cover-image.json
@@ -4,15 +4,29 @@
         "name": "core/cover-image",
         "isValid": true,
         "attributes": {
-            "title": [
-                "Guten Berg!"
-            ],
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
-            "contentAlign": "center",
+            "id": 8398,
             "hasParallax": false,
             "dimRatio": 40
         },
-        "innerBlocks": [],
-        "originalContent": "<div class=\"wp-block-cover-image has-background-dim-40 has-background-dim\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <p class=\"wp-block-cover-image-text\">Guten Berg!</p>\n</div>"
+        "innerBlocks": [
+            {
+                "uid": "_uid_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": [
+                        "Paragraph 1"
+                    ],
+                    "align": "center",
+                    "dropCap": false,
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p style=\"text-align:center\" class=\"is-large-text\">Paragraph 1</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-cover-image has-background-dim has-background-dim-40\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <div class=\"wp-block-cover-image__inner-container\">\n\t\t\n    </div>\n</div>"
     }
 ]

--- a/core-blocks/test/fixtures/core__cover-image.parsed.json
+++ b/core-blocks/test/fixtures/core__cover-image.parsed.json
@@ -3,10 +3,22 @@
         "blockName": "core/cover-image",
         "attrs": {
             "url": "https://cldup.com/uuUqE_dXzy.jpg",
+            "id": 8398,
             "dimRatio": 40
         },
-        "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-cover-image has-background-dim-40 has-background-dim\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <p class=\"wp-block-cover-image-text\">Guten Berg!</p>\n</div>\n"
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "center",
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p style=\"text-align:center\" class=\"is-large-text\">Paragraph 1</p>\n\t\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-cover-image has-background-dim has-background-dim-40\" style=\"background-image:url(https://cldup.com/uuUqE_dXzy.jpg)\">\n    <div class=\"wp-block-cover-image__inner-container\">\n\t\t\n    </div>\n</div>\n"
     },
     {
         "attrs": {},

--- a/core-blocks/test/fixtures/core__cover-image.serialized.html
+++ b/core-blocks/test/fixtures/core__cover-image.serialized.html
@@ -1,5 +1,9 @@
-<!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} -->
+<!-- wp:cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","id":8398,"dimRatio":40} -->
 <div class="wp-block-cover-image has-background-dim-40 has-background-dim" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)">
-	<p class="wp-block-cover-image-text">Guten Berg!</p>
+	<div class="wp-block-cover-image__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p style="text-align:center" class="is-large-text">Paragraph 1</p>
+		<!-- /wp:paragraph -->
+	</div>
 </div>
 <!-- /wp:cover-image -->

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -72,6 +72,8 @@ $z-layers: (
 	'.components-autocomplete__results': 1000000,
 
 	'.skip-to-selected-block': 100000,
+
+	'.wp-block-cover-image__inner-container': 0,
 );
 
 @function z-index( $key ) {

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -591,7 +591,7 @@ export class BlockListBlock extends Component {
 				{ showSideInserter && (
 					<Fragment>
 						<div className="editor-block-list__side-inserter">
-							<InserterWithShortcuts uid={ uid } layout={ layout } onToggle={ this.selectOnOpen } />
+							<InserterWithShortcuts uid={ uid } rootUID={ rootUID } layout={ layout } onToggle={ this.selectOnOpen } />
 						</div>
 						<div className="editor-block-list__empty-block-inserter">
 							<Inserter

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -36,7 +36,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     value="Write your story"
   />
   <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
-  <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
+  <WithEditorSettings(WithSelect(WithDispatch(Inserter)))
     position="top right"
   />
 </div>
@@ -60,7 +60,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     value="Write your story"
   />
   <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
-  <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
+  <WithEditorSettings(WithSelect(WithDispatch(Inserter)))
     position="top right"
   />
 </div>
@@ -84,7 +84,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     value=""
   />
   <WithEditorSettings(WithSelect(WithDispatch(InserterWithShortcuts))) />
-  <WithSelect(WithDispatch(WithEditorSettings(Inserter)))
+  <WithEditorSettings(WithSelect(WithDispatch(Inserter)))
     position="top right"
   />
 </div>

--- a/editor/components/inserter-with-shortcuts/index.js
+++ b/editor/components/inserter-with-shortcuts/index.js
@@ -52,9 +52,13 @@ export default compose(
 			allowedBlockTypes,
 		};
 	} ),
-	withSelect( ( select, { allowedBlockTypes } ) => ( {
-		items: select( 'core/editor' ).getFrecentInserterItems( allowedBlockTypes, 4 ),
-	} ) ),
+	withSelect( ( select, { allowedBlockTypes, rootUID } ) => {
+		const { getFrecentInserterItems, getSupportedBlocks } = select( 'core/editor' );
+		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
+		return {
+			items: getFrecentInserterItems( supportedBlocks, 4 ),
+		};
+	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const { uid, rootUID, layout } = ownProps;
 

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -344,10 +344,17 @@ export default compose(
 		};
 	} ),
 	withSelect( ( select, { allowedBlockTypes } ) => {
-		const { getInserterItems, getFrecentInserterItems } = select( 'core/editor' );
+		const {
+			getBlockInsertionPoint,
+			getInserterItems,
+			getFrecentInserterItems,
+			getSupportedBlocks,
+		} = select( 'core/editor' );
+		const { rootUID } = getBlockInsertionPoint();
+		const supportedBlocks = getSupportedBlocks( rootUID, allowedBlockTypes );
 		return {
-			items: getInserterItems( allowedBlockTypes ),
-			frecentItems: getFrecentInserterItems( allowedBlockTypes ),
+			items: getInserterItems( supportedBlocks ),
+			frecentItems: getFrecentInserterItems( supportedBlocks ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -666,3 +666,19 @@ export function insertDefaultBlock( attributes, rootUID, index ) {
 		isProvisional: true,
 	};
 }
+
+/**
+ * Returns an action object that changes the nested settings of a given block.
+ *
+ * @param {string} id       UID of the block whose nested setting.
+ * @param {Object} settings Object with the new settings for the nested block.
+ *
+ * @return {Object} Action object
+ */
+export function updateBlockListSettings( id, settings ) {
+	return {
+		type: 'UPDATE_BLOCK_LIST_SETTINGS',
+		id,
+		settings,
+	};
+}

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -1006,6 +1006,42 @@ export const sharedBlocks = combineReducers( {
 	},
 } );
 
+/**
+ * Reducer that for each block uid stores an object that represents its nested settings.
+ * E.g: what blocks can be nested inside a block.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export const blockListSettings = ( state = {}, action ) => {
+	switch ( action.type ) {
+		// even if the replaced blocks have the same uid our logic should correct the state.
+		case 'REPLACE_BLOCKS' :
+		case 'REMOVE_BLOCKS': {
+			return omit( state, action.uids );
+		}
+		case 'UPDATE_BLOCK_LIST_SETTINGS': {
+			const { id, settings } = action;
+			if ( id && ! settings ) {
+				return omit( state, id );
+			}
+			const blockSettings = state[ id ];
+			const updateIsRequired = ! isEqual( blockSettings, settings );
+			if ( updateIsRequired ) {
+				return {
+					...state,
+					[ id ]: {
+						...settings,
+					},
+				};
+			}
+		}
+	}
+	return state;
+};
+
 export default optimist( combineReducers( {
 	editor,
 	currentPost,
@@ -1013,6 +1049,7 @@ export default optimist( combineReducers( {
 	blockSelection,
 	provisionalBlockUID,
 	blocksMode,
+	blockListSettings,
 	isInsertionPointVisible,
 	preferences,
 	saving,

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -6,6 +6,7 @@ import {
 	first,
 	get,
 	has,
+	intersection,
 	last,
 	reduce,
 	size,
@@ -1589,4 +1590,45 @@ export function inSomeHistory( state, predicate ) {
 	return optimist.some( ( { beforeState } ) => (
 		beforeState && predicate( beforeState )
 	) );
+}
+
+/**
+ * Returns the Block List settings of a block if any.
+ *
+ * @param {Object}  state Editor state.
+ * @param {?string} uid   Block UID.
+ *
+ * @return {?Object} Block settings of the block if set.
+ */
+export function getBlockListSettings( state, uid ) {
+	return state.blockListSettings[ uid ];
+}
+
+/**
+ * Determines the blocks that can be nested inside a given block. Or globally if a block is not specified.
+ *
+ * @param {Object}           state                     Global application state.
+ * @param {?string}          uid                       Block UID.
+ * @param {string[]|boolean} globallyEnabledBlockTypes Globally enabled block types, or true/false to enable/disable all types.
+ *
+ * @return {string[]|boolean} Blocks that can be nested inside the block with the specified uid, or true/false to enable/disable all types.
+ */
+export function getSupportedBlocks( state, uid, globallyEnabledBlockTypes ) {
+	if ( ! globallyEnabledBlockTypes ) {
+		return false;
+	}
+
+	const supportedNestedBlocks = get( getBlockListSettings( state, uid ), [ 'supportedBlocks' ] );
+	if ( supportedNestedBlocks === true || supportedNestedBlocks === undefined ) {
+		return globallyEnabledBlockTypes;
+	}
+
+	if ( ! supportedNestedBlocks ) {
+		return false;
+	}
+
+	if ( globallyEnabledBlockTypes === true ) {
+		return supportedNestedBlocks;
+	}
+	return intersection( globallyEnabledBlockTypes, supportedNestedBlocks );
 }

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -42,6 +42,7 @@ import {
 	createErrorNotice,
 	createWarningNotice,
 	removeNotice,
+	updateBlockListSettings,
 } from '../actions';
 
 describe( 'actions', () => {
@@ -527,6 +528,24 @@ describe( 'actions', () => {
 			expect( toggleSelection( false ) ).toEqual( {
 				type: 'TOGGLE_SELECTION',
 				isSelectionEnabled: false,
+			} );
+		} );
+	} );
+
+	describe( 'updateBlockListSettings', () => {
+		it( 'should return the UPDATE_BLOCK_LIST_SETTINGS with undefined settings', () => {
+			expect( updateBlockListSettings( 'chicken' ) ).toEqual( {
+				type: 'UPDATE_BLOCK_LIST_SETTINGS',
+				id: 'chicken',
+				settings: undefined,
+			} );
+		} );
+
+		it( 'should return the UPDATE_BLOCK_LIST_SETTINGS action with the passed settings', () => {
+			expect( updateBlockListSettings( 'chicken', { chicken: 'ribs' } ) ).toEqual( {
+				type: 'UPDATE_BLOCK_LIST_SETTINGS',
+				id: 'chicken',
+				settings: { chicken: 'ribs' },
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -35,6 +35,7 @@ import {
 	isInsertionPointVisible,
 	sharedBlocks,
 	template,
+	blockListSettings,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -2187,6 +2188,83 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( { isValid: true, template: [] } );
+		} );
+	} );
+
+	describe( 'blockListSettings', () => {
+		it( 'should add new settings', () => {
+			const original = deepFreeze( {} );
+			const state = blockListSettings( original, {
+				type: 'UPDATE_BLOCK_LIST_SETTINGS',
+				id: 'chicken',
+				settings: {
+					chicken: 'ribs',
+				},
+			} );
+			expect( state ).toEqual( {
+				chicken: {
+					chicken: 'ribs',
+				},
+			} );
+		} );
+
+		it( 'should update the settings of a block', () => {
+			const original = deepFreeze( {
+				chicken: {
+					chicken: 'ribs',
+				},
+				otherBlock: {
+					setting1: true,
+				},
+			} );
+			const state = blockListSettings( original, {
+				type: 'UPDATE_BLOCK_LIST_SETTINGS',
+				id: 'chicken',
+				settings: {
+					ribs: 'not-chicken',
+				},
+			} );
+			expect( state ).toEqual( {
+				chicken: {
+					ribs: 'not-chicken',
+				},
+				otherBlock: {
+					setting1: true,
+				},
+			} );
+		} );
+
+		it( 'should remove the settings of a block when it is replaced', () => {
+			const original = deepFreeze( {
+				chicken: {
+					chicken: 'ribs',
+				},
+				otherBlock: {
+					setting1: true,
+				},
+			} );
+			const state = blockListSettings( original, {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'otherBlock' ],
+			} );
+			expect( state ).toEqual( {
+				chicken: {
+					chicken: 'ribs',
+				},
+			} );
+		} );
+
+		it( 'should remove the settings of a block when it is removed', () => {
+			const original = deepFreeze( {
+				otherBlock: {
+					setting1: true,
+				},
+			} );
+			const state = blockListSettings( original, {
+				type: 'REPLACE_BLOCKS',
+				uids: [ 'otherBlock' ],
+			} );
+			expect( state ).toEqual( {} );
 		} );
 	} );
 } );

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -84,6 +84,8 @@ const {
 	isValidTemplate,
 	getTemplate,
 	getTemplateLock,
+	getBlockListSettings,
+	getSupportedBlocks,
 	POST_UPDATE_TRANSACTION_ID,
 	isPermalinkEditable,
 	getPermalink,
@@ -3251,6 +3253,121 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPermalinkParts( state ) ).toEqual( parts );
+		} );
+	} );
+
+	describe( 'getBlockListSettings', () => {
+		it( 'should return the settings of a block', () => {
+			const state = {
+				blockListSettings: {
+					chicken: {
+						setting1: false,
+					},
+					ribs: {
+						setting2: true,
+					},
+				},
+			};
+
+			expect( getBlockListSettings( state, 'chicken' ) ).toEqual( {
+				setting1: false,
+			} );
+		} );
+
+		it( 'should return undefined if settings for the block don\'t exist', () => {
+			const state = {
+				blockListSettings: {},
+			};
+
+			expect( getBlockListSettings( state, 'chicken' ) ).toBe( undefined );
+		} );
+	} );
+
+	describe( 'getSupportedBlocks', () => {
+		it( 'should return false if all blocks are disabled globally', () => {
+			const state = {
+				blockListSettings: {
+					block1: {
+						supportedBlocks: [ 'core/block1' ],
+					},
+				},
+			};
+
+			expect( getSupportedBlocks( state, 'block1', false ) ).toBe( false );
+		} );
+
+		it( 'should return the supportedBlocks of root block if all blocks are supported globally', () => {
+			const state = {
+				blockListSettings: {
+					block1: {
+						supportedBlocks: [ 'core/block1' ],
+					},
+				},
+			};
+
+			expect( getSupportedBlocks( state, 'block1', true ) ).toEqual( [ 'core/block1' ] );
+		} );
+
+		it( 'should return the globally supported blocks if all blocks are enable inside the root block', () => {
+			const state = {
+				blockListSettings: {
+					block1: {
+						supportedBlocks: true,
+					},
+				},
+			};
+
+			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
+		} );
+
+		it( 'should return the globally supported blocks if the root block does not sets the supported blocks', () => {
+			const state = {
+				blockListSettings: {
+					block1: {
+						chicken: 'ribs',
+					},
+				},
+			};
+
+			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
+		} );
+
+		it( 'should return the globally supported blocks if there are no settings for the root block', () => {
+			const state = {
+				blockListSettings: {
+					block1: {
+						supportedBlocks: true,
+					},
+				},
+			};
+
+			expect( getSupportedBlocks( state, 'block2', [ 'core/block1' ] ) ).toEqual( [ 'core/block1' ] );
+		} );
+
+		it( 'should return false if all blocks are disabled inside the root block ', () => {
+			const state = {
+				blockListSettings: {
+					block1: {
+						supportedBlocks: false,
+					},
+				},
+			};
+
+			expect( getSupportedBlocks( state, 'block1', [ 'core/block1' ] ) ).toBe( false );
+		} );
+
+		it( 'should return the intersection of globally supported blocks with the supported blocks of the root block if both sets are defined', () => {
+			const state = {
+				blockListSettings: {
+					block1: {
+						supportedBlocks: [ 'core/block1', 'core/block2', 'core/block3' ],
+					},
+				},
+			};
+
+			expect( getSupportedBlocks( state, 'block1', [ 'core/block2', 'core/block4', 'core/block5' ] ) ).toEqual(
+				[ 'core/block2' ]
+			);
 		} );
 	} );
 } );

--- a/editor/utils/block-list.js
+++ b/editor/utils/block-list.js
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { isEqual, noop, omit } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
+import {
+	synchronizeBlocksWithTemplate,
+} from '@wordpress/blocks';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -35,33 +39,87 @@ const INNER_BLOCK_LIST_CACHE = {};
  */
 export function createInnerBlockList( uid, renderBlockMenu = noop ) {
 	if ( ! INNER_BLOCK_LIST_CACHE[ uid ] ) {
+		const InnerBlockListComponent = class extends Component {
+			componentWillReceiveProps( nextProps ) {
+				this.updateNestedSettings( {
+					supportedBlocks: nextProps.allowedBlocks,
+				} );
+			}
+
+			componentWillUnmount() {
+				// If, after decrementing the tracking count, there are no
+				// remaining instances of the component, remove from cache.
+				if ( ! INNER_BLOCK_LIST_CACHE[ uid ][ 1 ]-- ) {
+					delete INNER_BLOCK_LIST_CACHE[ uid ];
+				}
+			}
+
+			componentDidMount() {
+				INNER_BLOCK_LIST_CACHE[ uid ][ 1 ]++;
+				this.updateNestedSettings( {
+					supportedBlocks: this.props.allowedBlocks,
+				} );
+				this.insertTemplateBlocks( this.props.template );
+			}
+
+			insertTemplateBlocks( template ) {
+				const { block, insertBlocks } = this.props;
+				if ( template && ! block.innerBlocks.length ) {
+					// synchronizeBlocksWithTemplate( [], template ) parses the template structure,
+					// and returns/creates the necessary blocks to represent it.
+					insertBlocks( synchronizeBlocksWithTemplate( [], template ) );
+				}
+			}
+
+			updateNestedSettings( newSettings ) {
+				if ( ! isEqual( this.props.blockListSettings, newSettings ) ) {
+					this.props.updateNestedSettings( newSettings );
+				}
+			}
+
+			render() {
+				return (
+					<BlockList
+						rootUID={ uid }
+						renderBlockMenu={ renderBlockMenu }
+						{ ...omit(
+							this.props, [
+								'allowedBlocks',
+								'block',
+								'blockListSettings',
+								'insertBlocks',
+								'template',
+								'updateNestedSettings',
+							]
+						) } />
+				);
+			}
+		};
+
+		const InnerBlockListComponentContainer = compose(
+			withSelect( ( select ) => {
+				const { getBlock, getBlockListSettings } = select( 'core/editor' );
+				return {
+					block: getBlock( uid ),
+					blockListSettings: getBlockListSettings( uid ),
+				};
+			} ),
+			withDispatch( ( dispatch ) => {
+				const { insertBlocks, updateBlockListSettings } = dispatch( 'core/editor' );
+				return {
+					insertBlocks( blocks ) {
+						dispatch( insertBlocks( blocks, undefined, uid ) );
+					},
+					updateNestedSettings( settings ) {
+						dispatch( updateBlockListSettings( uid, settings ) );
+					},
+				};
+			} ),
+		)( InnerBlockListComponent );
+
 		INNER_BLOCK_LIST_CACHE[ uid ] = [
-			// The component class:
-			class extends Component {
-				componentWillMount() {
-					INNER_BLOCK_LIST_CACHE[ uid ][ 1 ]++;
-				}
-
-				componentWillUnmount() {
-					// If, after decrementing the tracking count, there are no
-					// remaining instances of the component, remove from cache.
-					if ( ! INNER_BLOCK_LIST_CACHE[ uid ][ 1 ]-- ) {
-						delete INNER_BLOCK_LIST_CACHE[ uid ];
-					}
-				}
-
-				render() {
-					return (
-						<BlockList
-							rootUID={ uid }
-							renderBlockMenu={ renderBlockMenu }
-							{ ...this.props } />
-					);
-				}
-			},
-
-			// A counter tracking active mounted instances:
-			0,
+			InnerBlockListComponentContainer,
+			0, // A counter tracking active mounted instances:
 		];
 	}
 


### PR DESCRIPTION
## Description
This PR implements the concepts described in https://github.com/WordPress/gutenberg/issues/5448.
E.g: 
```
<InnerBlocks
	template={ [
		[ 'core/paragraph', {
			align: 'center',
			fontSize: 37,
			placeholder: 'Write title…',
			textColor: '#fff',
		} ],
	] }
	allowedBlockNames={ [ 'core/button', 'core/heading', 'core/paragraph', 'core/subhead' ] }
/>
```

As future work template_lock will be added. This opens the path for a whole new type of blocks.
Blocks that make use of nesting and just apply a special arrangement/design to existing blocks. 
E.g: we can have a package of landing page blocks, where all of the blocks are based on paragraphs, headings, buttons etc... arranging them in a special way and applying some styles. Themes may take advantage of this to create theme-specific blocks.

The fact that the InnerBlocks settings are just props has some advantages e.g: depending on the settings in the block inspector we may allow different blocks. But it is much more complex to implement when compared to `Add a property to the block API, allowedRootBlockNames: [ ... ] `.

Right now this implementation is not very clean ( being nice to myself ) we are using a property in the state the save the current InnerBlock settings of each block uid with custom settings. This was required because we need to globally know the allowed blocks, so the inserter can filter them. Maybe there is a better way to solve this problem. I'm thinking about an impossible way to improve this and I'm totally open to suggestions.

To define templates we are using the same logic as the one used in CPT's but this makes the data structure strange in javascript (until know templates were only defined in PHP so this was unnoticeable).

Cover image block was updated to make use of this concepts.




## Know problems / related work

**Using the autocomplete, we can insert allowed blocks.** Autocomplete logic is different from other inserters and we already have some problems e.g: if the template lock the blocks, autocomplete inserter is not aware of the lock and then we get a big js error because onReplace does not exist in this case. In parallel, I will improve the logic of autocomplete inserter so changes required here are easier.
 

## Testing
Test the cover image block try to add blocks remove see things work as expected. The design will benefit from https://github.com/WordPress/gutenberg/pull/5658.
Test that templates also work with layouts by adding this template to columns block.
```
                    template={ [
                        [ 'core/paragraph', {
                            placeholder: 'Enter column 1 content…',
                            layout: 'column-1',
                        } ],
                        [ 'core/paragraph', {
                            placeholder: 'Enter column 2 content…',
                            layout: 'column-2',
                        } ],
                    ] }
```

Test that we are backcompatible with existing cover images by pasting the following code in the code editor and verifying it works as expected:
```
<!-- wp:cover-image {"url":"http://via.placeholder.com/350x150","id":10559} -->
<div class="wp-block-cover-image has-background-dim" style="background-image:url(http://via.placeholder.com/350x150)">
	<p class="wp-block-cover-image-text">Test</p>
</div>
<!-- /wp:cover-image -->
```

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/11271197/37062915-b8f715d6-218f-11e8-9320-74762eb0335e.png)


