### PR TITLE
Remove max-width for the meta boxes area inputs.

### DIFF
--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -41,10 +41,6 @@
 		margin: 0;
 	}
 
-	input {
-		max-width: 300px;
-	}
-
 	input,
 	select,
 	textarea {


### PR DESCRIPTION
This tiny PR tries to improve compatibility with plugins that add their content in the meta boxes area below the post removing a max-width property that was targeting all inputs. For details, please refer to the related issue.

Fixes #5463 