### PR TITLE
Data: Include combineReducer helper

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -130,6 +130,40 @@ const unsubscribe = subscribe( () => {
 unsubscribe();
 ```
 
+### Helpers
+
+#### `combineReducers( reducers: Object ): Function`
+
+As your app grows more complex, you'll want to split your reducing function into separate functions, each managing independent parts of the state. The `combineReducers` helper function turns an object whose values are different reducing functions into a single reducing function you can pass to `registerStore`.
+
+_Example:_
+
+```js
+const { combineReducers, registerStore } = wp.data;
+
+const prices = ( state = {}, action ) => {
+	return action.type === 'SET_PRICE' ?
+		{
+			...state,
+			[ action.item ]: action.price,
+		} :
+		state;
+};
+
+const discountPercent = ( state = 0, action ) => {
+	return action.type === 'START_SALE' ?
+		action.discountPercent :
+		state;
+};
+
+registerStore( 'my-shop', {
+	reducer: combineReducers( {
+		prices,
+		discountPercent,
+	} ),
+} );
+```
+
 ### Higher-Order Components
 
 A higher-order component is a function which accepts a [component](https://github.com/WordPress/gutenberg/tree/master/element) and returns a new, enhanced component. A stateful user interface should respond to changes in the underlying state and updates its displayed element accordingly. WordPress uses higher-order components both as a means to separate the purely visual aspects of an interface from its data backing, and to ensure that the data is kept in-sync with the stores.

--- a/data/index.js
+++ b/data/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import isShallowEqual from 'shallowequal';
-import { createStore } from 'redux';
+import { combineReducers, createStore } from 'redux';
 import { flowRight, without, mapValues } from 'lodash';
 
 /**
@@ -88,6 +88,18 @@ export function registerReducer( reducerKey, reducer ) {
 
 	return store;
 }
+
+/**
+ * The combineReducers helper function turns an object whose values are different
+ * reducing functions into a single reducing function you can pass to registerReducer.
+ *
+ * @param {Object} reducers An object whose values correspond to different reducing
+ *                          functions that need to be combined into one.
+ *
+ * @return {Function}       A reducer that invokes every reducer inside the reducers
+ *                          object, and constructs a state object with the same shape.
+ */
+export { combineReducers };
 
 /**
  * Registers selectors for external usage.

--- a/edit-post/store/reducer.js
+++ b/edit-post/store/reducer.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import optimist from 'redux-optimist';
-import { combineReducers } from 'redux';
 import {
 	flow,
 	reduce,
@@ -24,6 +23,7 @@ import {
  * WordPress dependencies
  */
 import { isReusableBlock } from '@wordpress/blocks';
+import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## Description

This PR adds `combineReducer` helper to the `data` module. It seems like it doesn't have any impact on the size of bundles because there is still `react-redux` dependency loaded for the `editPost` and `editor` modules. This should change once we migrate all `connect` occurrences to work with `withSelect` and `withDispatch`. There is also one occurrence of `bindActionCreators` which probably should be replaces by the inline implementation (this helper is very simple).

**Before**
> data/build/index.js  59.4 kB       4  [emitted]         data
> edit-post/build/index.js   306 kB       3  [emitted]  [big]  editPost
> editor/build/index.js   300 kB       1  [emitted]  [big]  editor

**After**
> data/build/index.js  59.5 kB       4  [emitted]         data
> edit-post/build/index.js   306 kB       3  [emitted]  [big]  editPost
> editor/build/index.js   300 kB       1  [emitted]  [big]  editor

## How Has This Been Tested?
Manually. Make sure there are no regressions.

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
