### PR TITLE
Fixed handling of html captions on gallery and image.

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { filter } from 'lodash';
+import { filter, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -84,10 +84,7 @@ class GalleryBlock extends Component {
 
 	onSelectImages( images ) {
 		this.props.setAttributes( {
-			images: images.map( ( attributes ) => ( {
-				...attributes,
-				caption: attributes.caption ? [ attributes.caption ] : [],
-			} ) ),
+			images: images.map( ( image ) => pick( image, [ 'alt', 'caption', 'id', 'url' ] ) ),
 		} );
 	}
 

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -8,6 +8,7 @@ import {
 	isEmpty,
 	map,
 	get,
+	pick,
 } from 'lodash';
 
 /**
@@ -92,11 +93,7 @@ class ImageBlock extends Component {
 	}
 
 	onSelectImage( media ) {
-		const attributes = { url: media.url, alt: media.alt, id: media.id };
-		if ( media.caption ) {
-			attributes.caption = [ media.caption ];
-		}
-		this.props.setAttributes( attributes );
+		this.props.setAttributes( pick( media, [ 'alt', 'id', 'caption', 'url' ] ) );
 	}
 
 	onSetHref( value ) {


### PR DESCRIPTION
When adding an image with existing HTML captions they were not being parsed. Now we use the existing HTML parsing mechanisms (hpqParse plus children matcher) to correctly parse the captions.

Fixes: https://github.com/WordPress/gutenberg/issues/5338

## How Has This Been Tested?
Follow instructions provided in https://github.com/WordPress/gutenberg/issues/5338 and verify the problem is now fixed and we correctly use the HTML that was in the caption instead of showing the 
