### PR TITLE
Paragraph: Respect HTML when readding P-tags

### DIFF
--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { concatChildren, Component } from '@wordpress/element';
+import { concatChildren, Component, RawHTML } from '@wordpress/element';
 import {
 	Autocomplete,
 	PanelBody,
@@ -290,7 +290,9 @@ export const settings = {
 			migrate( attributes ) {
 				return {
 					...attributes,
-					content: [ attributes.content ],
+					content: [
+						<RawHTML key="html">{ attributes.content }</RawHTML>,
+					],
 				};
 			},
 		},

--- a/blocks/test/fixtures/core__paragraph__deprecated.html
+++ b/blocks/test/fixtures/core__paragraph__deprecated.html
@@ -1,3 +1,3 @@
 <!-- wp:paragraph -->
-Unwrapped is still valid.
+Unwrapped is <em>still</em> valid.
 <!-- /wp:paragraph -->

--- a/blocks/test/fixtures/core__paragraph__deprecated.json
+++ b/blocks/test/fixtures/core__paragraph__deprecated.json
@@ -5,11 +5,19 @@
         "isValid": true,
         "attributes": {
             "content": [
-                "Unwrapped is still valid."
+                {
+                    "_owner": null,
+                    "_store": {},
+                    "key": "html",
+                    "props": {
+                        "children": "Unwrapped is <em>still</em> valid."
+                    },
+                    "ref": null
+                }
             ],
             "dropCap": false
         },
         "innerBlocks": [],
-        "originalContent": "Unwrapped is still valid."
+        "originalContent": "Unwrapped is <em>still</em> valid."
     }
 ]

--- a/blocks/test/fixtures/core__paragraph__deprecated.parsed.json
+++ b/blocks/test/fixtures/core__paragraph__deprecated.parsed.json
@@ -3,7 +3,7 @@
         "blockName": "core/paragraph",
         "attrs": null,
         "innerBlocks": [],
-        "innerHTML": "\nUnwrapped is still valid.\n"
+        "innerHTML": "\nUnwrapped is <em>still</em> valid.\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__paragraph__deprecated.serialized.html
+++ b/blocks/test/fixtures/core__paragraph__deprecated.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:paragraph -->
-<p>Unwrapped is still valid.</p>
+<p>Unwrapped is <em>still</em> valid.</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
## Description
Fixes #5270.

## How Has This Been Tested?
- See parent issue, as well as screencast below.
- Full-content test `core__paragraph__deprecated` updated.

## Screenshots (jpeg or gifs if applicable):
![gutenberg-paragraph-rawhtml](https://user-images.githubusercontent.com/150562/37090164-2471239a-21fb-11e8-9df0-caf4c3c5f4fc.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
