### PR TITLE
Framework: Try to establish a pattern for the namespace param in addFilter hook

### DIFF
--- a/blocks/hooks/align.js
+++ b/blocks/hooks/align.js
@@ -138,8 +138,8 @@ export function addAssignedAlign( props, blockType, attributes ) {
 	return props;
 }
 
-addFilter( 'blocks.registerBlockType', 'core/align/addAttribute', addAttribute );
-addFilter( 'editor.BlockListBlock', 'core/align/withAlign', withAlign );
-addFilter( 'blocks.BlockEdit', 'core/align/withToolbarControls', withToolbarControls );
-addFilter( 'blocks.getSaveContent.extraProps', 'core/align/addAssignedAlign', addAssignedAlign );
+addFilter( 'blocks.registerBlockType', 'core/blocks/align/add-attribute', addAttribute );
+addFilter( 'editor.BlockListBlock', 'core/blocks/align/with-align', withAlign );
+addFilter( 'blocks.BlockEdit', 'core/blocks/align/with-toolbar-controls', withToolbarControls );
+addFilter( 'blocks.getSaveContent.extraProps', 'core/blocks/align/add-assigned-align', addAssignedAlign );
 

--- a/blocks/hooks/anchor.js
+++ b/blocks/hooks/anchor.js
@@ -99,6 +99,6 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 	return extraProps;
 }
 
-addFilter( 'blocks.registerBlockType', 'core/anchor/attribute', addAttribute );
-addFilter( 'blocks.BlockEdit', 'core/anchor/inspector-control', withInspectorControl );
-addFilter( 'blocks.getSaveContent.extraProps', 'core/anchor/save-props', addSaveProps );
+addFilter( 'blocks.registerBlockType', 'core/blocks/anchor/add-attribute', addAttribute );
+addFilter( 'blocks.BlockEdit', 'core/blocks/anchor/with-inspector-control', withInspectorControl );
+addFilter( 'blocks.getSaveContent.extraProps', 'core/blocks/anchor/add-save-props', addSaveProps );

--- a/blocks/hooks/custom-class-name.js
+++ b/blocks/hooks/custom-class-name.js
@@ -90,6 +90,6 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 	return extraProps;
 }
 
-addFilter( 'blocks.registerBlockType', 'core/custom-class-name/attribute', addAttribute );
-addFilter( 'blocks.BlockEdit', 'core/custom-class-name/inspector-control', withInspectorControl );
-addFilter( 'blocks.getSaveContent.extraProps', 'core/custom-class-name/save-props', addSaveProps );
+addFilter( 'blocks.registerBlockType', 'core/blocks/custom-class-name/add-attribute', addAttribute );
+addFilter( 'blocks.BlockEdit', 'core/blocks/custom-class-name/with-inspector-control', withInspectorControl );
+addFilter( 'blocks.getSaveContent.extraProps', 'core/blocks/custom-class-name/add-save-props', addSaveProps );

--- a/blocks/hooks/deprecated.js
+++ b/blocks/hooks/deprecated.js
@@ -57,6 +57,6 @@ export function shimRawHTML( element ) {
 
 addFilter(
 	'blocks.getSaveElement',
-	'core/deprecated/shim-dangerous-html',
+	'core/blocks/deprecated/shim-raw-html',
 	shimRawHTML
 );

--- a/blocks/hooks/generated-class-name.js
+++ b/blocks/hooks/generated-class-name.js
@@ -43,4 +43,4 @@ export function addGeneratedClassName( extraProps, blockType ) {
 	return extraProps;
 }
 
-addFilter( 'blocks.getSaveContent.extraProps', 'core/generated-class-name/save-props', addGeneratedClassName );
+addFilter( 'blocks.getSaveContent.extraProps', 'core/blocks/generated-class-name/add-generated-class-name', addGeneratedClassName );

--- a/blocks/hooks/layout.js
+++ b/blocks/hooks/layout.js
@@ -82,7 +82,7 @@ function excludeLayoutFromUnmodifiedBlockCheck( attributeKeys ) {
 	return without( attributeKeys, 'layout' );
 }
 
-addFilter( 'blocks.registerBlockType', 'core/layout/attribute', addAttribute );
-addFilter( 'blocks.getSaveContent.extraProps', 'core/layout/save-props', addSaveProps );
-addFilter( 'blocks.switchToBlockType.transformedBlock', 'core/layout/preserve-layout', preserveLayoutAttribute );
-addFilter( 'blocks.isUnmodifiedDefaultBlock.attributes', 'core/layout/exclude-layout-attribute-check', excludeLayoutFromUnmodifiedBlockCheck );
+addFilter( 'blocks.registerBlockType', 'core/blocks/layout/add-attribute', addAttribute );
+addFilter( 'blocks.getSaveContent.extraProps', 'core/blocks/layout/add-save-props', addSaveProps );
+addFilter( 'blocks.switchToBlockType.transformedBlock', 'core/blcoks/layout/preserve-layout-attribute', preserveLayoutAttribute );
+addFilter( 'blocks.isUnmodifiedDefaultBlock.attributes', 'core/blocks/layout/exclude-layout-from-unmodified-block-check', excludeLayoutFromUnmodifiedBlockCheck );

--- a/blocks/hooks/matchers.js
+++ b/blocks/hooks/matchers.js
@@ -99,4 +99,4 @@ export function resolveAttributes( settings ) {
 	return settings;
 }
 
-addFilter( 'blocks.registerBlockType', 'core/matchers', resolveAttributes );
+addFilter( 'blocks.registerBlockType', 'core/blocks/matchers/resolve-attributes', resolveAttributes );

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -113,7 +113,7 @@ function addBackgroundProp( props ) {
 // Adding the filter
 wp.hooks.addFilter(
 	'blocks.getSaveContent.extraProps',
-	'myplugin/add-background',
+	'myplugin/add-background-prop',
 	addBackgroundProp
 );
 ```

--- a/edit-post/hooks/more-menu/index.js
+++ b/edit-post/hooks/more-menu/index.js
@@ -15,6 +15,6 @@ const withCopyContentMenuItem = ( menuItems ) => [
 
 addFilter(
 	'editPost.MoreMenu.tools',
-	'core/edit-post/more-menu/withCopyContentMenuItem',
+	'core/edit-post/more-menu/with-copy-content-menu-item',
 	withCopyContentMenuItem
 );

--- a/edit-post/hooks/validate-use-once/index.js
+++ b/edit-post/hooks/validate-use-once/index.js
@@ -118,6 +118,6 @@ function getOutboundType( blockType ) {
 
 addFilter(
 	'blocks.BlockEdit',
-	'core/validation/useOnce',
+	'core/edit-post/validate-use-once/with-use-once-validation',
 	withUseOnceValidation
 );


### PR DESCRIPTION
## Description

I'm trying to establish a shared pattern for the 2nd param in all `addFilter` calls. The current API of hooks library enforces a namespace param which can be used to remove the filter. It's a string which should be unique. I identified that we use a few different patterns. This PR tries to unify it. I don't think I found a perfect solution, but I want to open a discussion with one way of doing the same thing.

Examples:

```js
addFilter(
	'blocks.BlockEdit',
	'core/blocks/align/with-toolbar-controls',
	withToolbarControls
);
addFilter(
	'editPost.MoreMenu.tools',
	'core/edit-post/more-menu/with-copy-content-menu-item',
	withCopyContentMenuItem
);
```

I composed the namespace as follows:
`${ moduleName }/${ featureName }/${ functionName }`
where:
* `moduleName` - similar to what we use with `data` API: `core/edit-post`, `core/blocks`
* ` featureName` - e.g. `align` or `more-menu` - can be more nested when necessary
* `functionName` - mirrors the function name that implements hook

I made everything kebab case, but I guess it would also go camel case to mirror the hook name. There is still this issue with `.` vs `/` in both params.

I'm happy to put what I shared above in some docs as soon as we agree how to proceed.