### PR TITLE
Add aria-label to the post title.

### DIFF
--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -80,6 +80,7 @@ class PostTitle extends Component {
 					value={ title }
 					onChange={ this.onChange }
 					placeholder={ placeholder || __( 'Add title' ) }
+					aria-label={ placeholder || __( 'Add title' ) }
 					onFocus={ this.onSelect }
 					onKeyDown={ this.onKeyDown }
 					onKeyPress={ this.onUnselect }


### PR DESCRIPTION
Partially solves the first issue from #5468

Adds an `aria-label` attribute to the post title, using the same value used for the `placeholder` attribute.

Reason: seems some speech recognition software (Dragon) don't take into account the `placeholder` attribute for the accessible name calculation. Adding an `aria-label` attribute with the same value of the placeholder works around this issue and:
- users will see the visible placeholder "Add title"
- Dragon will get the accessible name from the aria-label "Add title"
- the aria-label attribute overrides any other labeling of this field so the actual computed accessible name of the post title will be "Add title"
- by saying "Click Add title" Dragon users _should_ now be able to move focus to the field

Some testing would be nice, but I can't test on Dragon. If no objections, merging would be nice to allow Dragon testers to test.

See #5468 