### PR TITLE
i18n: Absorb errors from Jed localization

### DIFF
--- a/i18n/index.js
+++ b/i18n/index.js
@@ -2,8 +2,18 @@
  * External dependencies
  */
 import Jed from 'jed';
+import memoize from 'memize';
 
 let i18n;
+
+/**
+ * Log to console, once per message; or more precisely, per referentially equal
+ * argument set. Because Jed throws errors, we log these to the console instead
+ * to avoid crashing the application.
+ *
+ * @param {...*} args Arguments to pass to `console.error`
+ */
+const logErrorOnce = memoize( console.error ); // eslint-disable-line no-console
 
 /**
  * Merges locale data into the Jed instance by domain. Creates a new Jed
@@ -59,11 +69,7 @@ export function dcnpgettext( domain = 'default', context, single, plural, number
 	try {
 		return getI18n().dcnpgettext( domain, context, single, plural, number );
 	} catch ( error ) {
-		// Disable reason: Jed throws errors. To avoid crashing the application
-		// we log these to the console instead, and return a default value.
-
-		// eslint-disable-next-line no-console
-		console.error( 'Jed localization error: \n\n' + error.toString() );
+		logErrorOnce( 'Jed localization error: \n\n' + error.toString() );
 
 		return single;
 	}
@@ -150,11 +156,7 @@ export function sprintf( format, ...args ) {
 	try {
 		return Jed.sprintf( format, ...args );
 	} catch ( error ) {
-		// Disable reason: Jed throws errors. To avoid crashing the application
-		// we log these to the console instead, and return a default value.
-
-		// eslint-disable-next-line no-console
-		console.error( 'Jed sprintf error: \n\n' + error.stack );
+		logErrorOnce( 'Jed sprintf error: \n\n' + error.toString() );
 
 		return format;
 	}

--- a/i18n/test/index.js
+++ b/i18n/test/index.js
@@ -3,6 +3,10 @@
  */
 import { dcnpgettext, sprintf } from '../';
 
+// Mock memoization as identity function. Inline since Jest errors on out-of-
+// scope references in a mock callback.
+jest.mock( 'memize', () => ( fn ) => fn );
+
 describe( 'i18n', () => {
 	describe( 'dcnpgettext()', () => {
 		it( 'absorbs errors', () => {


### PR DESCRIPTION
Fixes #5459

This pull request seeks to update localization functions to wrap Jed localization functions, as they throw errors on invalid input, which as can be seen in #5459 causes the entire application to crash. The wrapper absorbs the error, logging it to the console, and returning a sensible default (the untranslated singular string or format).

__Testing instructions:__

Verify that there are no regressions in the display of localized strings.

Extra credit: Verify that, with an invalid string (e.g. missing placeholder value), no crash occurs and the sensible default is shown.