### PR TITLE
Styles: Remove edit-post styles from editor components

### DIFF
--- a/edit-post/hooks/validate-use-once/index.js
+++ b/edit-post/hooks/validate-use-once/index.js
@@ -66,26 +66,31 @@ function withUseOnceValidation( BlockEdit ) {
 			<div key="invalid-preview" style={ { minHeight: '100px' } }>
 				<BlockEdit key="block-edit" { ...props } />
 			</div>,
-			<Warning key="use-once-warning">
-				<p>
-					<strong>{ blockType.title }: </strong>
-					{ __( 'This block may not be used more than once.' ) }</p>
-				<p>
-					<Button isLarge onClick={
-						selectFirst
-					}>{ __( 'Find original' ) }</Button>
-					<Button isLarge onClick={
-						() => props.onReplace( [] )
-					}>{ __( 'Remove' ) }</Button>
-					{ outboundType &&
-						<Button isLarge onClick={ () => props.onReplace(
-							createBlock( outboundType.name, props.attributes )
-						) }>
+			<Warning
+				key="use-once-warning"
+				actions={ [
+					<Button key="find-original" isLarge onClick={ selectFirst }>
+						{ __( 'Find original' ) }
+					</Button>,
+					<Button key="remove" isLarge onClick={ () => props.onReplace( [] ) }>
+						{ __( 'Remove' ) }
+					</Button>,
+					outboundType && (
+						<Button
+							key="transform"
+							isLarge
+							onClick={ () => props.onReplace(
+								createBlock( outboundType.name, props.attributes )
+							) }
+						>
 							{ __( 'Transform into:' ) }{ ' ' }
 							{ outboundType.title }
 						</Button>
-					}
-				</p>
+					),
+				] }
+			>
+				<strong>{ blockType.title }: </strong>
+				{ __( 'This block may not be used more than once.' ) }
 			</Warning>,
 		];
 	};

--- a/editor/components/block-list/block-crash-warning.js
+++ b/editor/components/block-list/block-crash-warning.js
@@ -10,9 +10,7 @@ import Warning from '../warning';
 
 const warning = (
 	<Warning>
-		<p>{ __(
-			'This block has encountered an error and cannot be previewed.'
-		) }</p>
+		{ __( 'This block has encountered an error and cannot be previewed.' ) }
 	</Warning>
 );
 

--- a/editor/components/block-list/invalid-block-warning.js
+++ b/editor/components/block-list/invalid-block-warning.js
@@ -24,18 +24,19 @@ function InvalidBlockWarning( { convertToHTML, convertToBlocks } ) {
 	const hasHTMLBlock = !! getBlockType( 'core/html' );
 
 	return (
-		<Warning>
-			<p>{ __( 'This block appears to have been modified externally.' ) }</p>
-			<p>
-				<Button onClick={ convertToBlocks } isLarge isPrimary={ ! hasHTMLBlock }>
+		<Warning
+			actions={ [
+				<Button key="convert" onClick={ convertToBlocks } isLarge isPrimary={ ! hasHTMLBlock }>
 					{ __( 'Convert to Blocks' ) }
-				</Button>
-				{ hasHTMLBlock && (
-					<Button onClick={ convertToHTML } isLarge isPrimary>
+				</Button>,
+				hasHTMLBlock && (
+					<Button key="edit" onClick={ convertToHTML } isLarge isPrimary>
 						{ __( 'Edit as HTML' ) }
 					</Button>
-				) }
-			</p>
+				),
+			] }
+		>
+			{ __( 'This block appears to have been modified externally.' ) }
 		</Warning>
 	);
 }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -491,8 +491,8 @@
 	margin-bottom: $block-padding + 1px;
 
 	// Floated items have special needs for the contextual toolbar position
-	.edit-post-visual-editor .editor-block-list__block[data-align="left"] &,
-	.edit-post-visual-editor .editor-block-list__block[data-align="right"] & {
+	.editor-block-list__block[data-align="left"] &,
+	.editor-block-list__block[data-align="right"] & {
 		margin-bottom: 1px;
 		margin-top: -$block-toolbar-height - 1px;
 	}

--- a/editor/components/error-boundary/index.js
+++ b/editor/components/error-boundary/index.js
@@ -49,21 +49,20 @@ class ErrorBoundary extends Component {
 		}
 
 		return (
-			<Warning>
-				<p>{ __(
-					'The editor has encountered an unexpected error.'
-				) }</p>
-				<p>
-					<Button onClick={ this.reboot } isLarge>
+			<Warning
+				actions={ [
+					<Button key="recovery" onClick={ this.reboot } isLarge>
 						{ __( 'Attempt Recovery' ) }
-					</Button>
-					<ClipboardButton text={ this.getContent } isLarge>
+					</Button>,
+					<ClipboardButton key="copy-post" text={ this.getContent } isLarge>
 						{ __( 'Copy Post Text' ) }
-					</ClipboardButton>
-					<ClipboardButton text={ error.stack } isLarge>
+					</ClipboardButton>,
+					<ClipboardButton key="copy-error" text={ error.stack } isLarge>
 						{ __( 'Copy Error' ) }
-					</ClipboardButton>
-				</p>
+					</ClipboardButton>,
+				] }
+			>
+				{ __( 'The editor has encountered an unexpected error.' ) }
 			</Warning>
 		);
 	}

--- a/editor/components/warning/index.js
+++ b/editor/components/warning/index.js
@@ -1,12 +1,26 @@
 /**
+ * WordPress dependencies
+ */
+import { Children } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 
-function Warning( { children } ) {
+function Warning( { actions, children } ) {
 	return (
 		<div className="editor-warning">
 			{ children }
+			{ Children.count( actions ) > 0 && (
+				<div className="editor-warning__actions">
+					{ Children.map( actions, ( action, i ) => (
+						<span key={ i } className="editor-warning__action">
+							{ action }
+						</span>
+					) ) }
+				</div>
+			) }
 		</div>
 	);
 }

--- a/editor/components/warning/style.scss
+++ b/editor/components/warning/style.scss
@@ -10,24 +10,21 @@
 	align-items: center;
 	width: 96%;
 	max-width: 780px;
-	padding: 20px 20px 0px 20px;
+	padding: 20px;
 	background-color: $white;
 	border: 1px solid $light-gray-500;
 	text-align: center;
 	line-height: $default-line-height;
 	box-shadow: $shadow-popover;
+	font-family: $default-font;
+	font-size: $default-font-size;
+}
 
-	p:first-child {
-		margin-top: 0;
-	}
+.editor-warning__actions {
+	display: flex;
+	margin-top: 20px;
+}
 
-	.edit-post-visual-editor & p {
-		width: 100%;
-		font-family: $default-font;
-		font-size: $default-font-size;
-	}
-
-	.components-button {
-		margin: 0 #{ $item-spacing / 2 } 5px;
-	}
+.editor-warning__action {
+	margin: 0 #{ $item-spacing / 2 } 5px;
 }

--- a/editor/components/warning/test/index.js
+++ b/editor/components/warning/test/index.js
@@ -11,14 +11,25 @@ import Warning from '../index';
 describe( 'Warning', () => {
 	it( 'should match snapshot', () => {
 		const wrapper = shallow( <Warning>error</Warning> );
+
 		expect( wrapper ).toMatchSnapshot();
 	} );
+
 	it( 'should has valid class', () => {
 		const wrapper = shallow( <Warning /> );
+
 		expect( wrapper.hasClass( 'editor-warning' ) ).toBe( true );
+		expect( wrapper.find( '.editor-warning__actions' ) ).toHaveLength( 0 );
 	} );
+
 	it( 'should show child error message element', () => {
-		const wrapper = shallow( <Warning><p>message</p></Warning> );
-		expect( wrapper.find( 'p' ).text() ).toBe( 'message' );
+		const wrapper = shallow( <Warning actions={ <button /> }>Message</Warning> );
+
+		const actions = wrapper.find( '.editor-warning__actions' );
+		const action = actions.childAt( 0 );
+
+		expect( actions ).toHaveLength( 1 );
+		expect( action.hasClass( 'editor-warning__action' ) ).toBe( true );
+		expect( action.childAt( 0 ).type() ).toBe( 'button' );
 	} );
 } );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/4813#discussion_r167720218

This pull request seeks to eliminate direct references to `edit-post` from editor stylesheets. `edit-post` is intended as an extension of the underlying `editor` components, so it is not appropriate for `editor` to circularly reference `edit-post`. 

As part of these changes, the `Warning` component has been updated to...

- Not make assumptions about the type of content
- Not force implementer to apply specific markup structure, instead providing `actions` if button options are intended

__Testing instructions:__

Verify that there are no regressions in...

- Toolbar positioning for floated elements
- Warning displays (try invalidating a block by removing classes from the cover image markup in `post-content.js`)
   - Particularly: Font size, family, and button placement