### PR TITLE
Correctly handle pasting/convert to blocks of linked images.

### DIFF
--- a/blocks/api/raw-handling/embedded-content-reducer.js
+++ b/blocks/api/raw-handling/embedded-content-reducer.js
@@ -24,24 +24,16 @@ export default function( node ) {
 		return;
 	}
 
-	let nodeToInsert = node;
-	// if the embedded is an image and its parent is an anchor with just the image
-	// take the anchor out instead of just the image
-	if (
-		'IMG' === node.nodeName &&
-		1 === node.parentNode.childNodes.length &&
-		'A' === node.parentNode.nodeName
-	) {
-		nodeToInsert = node.parentNode;
-	}
+	// Consider parent anchor part of the embedded content.
+	const targetNode = node.parentElement.nodeName === 'A' ? node.parentElement : node;
 
-	let wrapper = nodeToInsert;
+	let wrapper = targetNode;
 
 	while ( wrapper && wrapper.nodeName !== 'P' ) {
 		wrapper = wrapper.parentElement;
 	}
 
 	if ( wrapper ) {
-		wrapper.parentNode.insertBefore( nodeToInsert, wrapper );
+		wrapper.parentNode.insertBefore( targetNode, wrapper );
 	}
 }

--- a/blocks/api/raw-handling/test/integration/anchor-image-in.html
+++ b/blocks/api/raw-handling/test/integration/anchor-image-in.html
@@ -1,0 +1,1 @@
+<a href="#"><img src="http://http://example.com/" alt="tapestry" width="400" height="800"></a>

--- a/blocks/api/raw-handling/test/integration/anchor-image-out.html
+++ b/blocks/api/raw-handling/test/integration/anchor-image-out.html
@@ -1,0 +1,3 @@
+<!-- wp:image -->
+<figure class="wp-block-image"><a href="#"><img src="http://http://example.com/" alt="tapestry"/></a></figure>
+<!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/figure-anchor-in.html
+++ b/blocks/api/raw-handling/test/integration/figure-anchor-in.html
@@ -1,0 +1,1 @@
+<figure class="wp-block-image"><a href="#"><img src="http://http://example.com/" alt="tapestry"/></a></figure>

--- a/blocks/api/raw-handling/test/integration/figure-anchor-out.html
+++ b/blocks/api/raw-handling/test/integration/figure-anchor-out.html
@@ -1,0 +1,3 @@
+<!-- wp:image -->
+<figure class="wp-block-image"><a href="#"><img src="http://http://example.com/" alt="tapestry"/></a></figure>
+<!-- /wp:image -->

--- a/blocks/api/raw-handling/test/integration/index.js
+++ b/blocks/api/raw-handling/test/integration/index.js
@@ -13,6 +13,7 @@ import rawHandler from '../../index';
 import serialize from '../../../serializer';
 
 const types = [
+	'anchor-image',
 	'plain',
 	'classic',
 	'apple',

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -152,6 +152,15 @@ export function isInvalidInline( element ) {
 		return false;
 	}
 
+	// an image inside an anchor is not invalid inline
+	if (
+		element.nodeName === 'A' &&
+		element.childNodes.length === 1 &&
+		element.firstChild.nodeName === 'IMG'
+	) {
+		return false;
+	}
+
 	return Array.from( element.childNodes ).some( ( node ) => {
 		if ( node.nodeType === ELEMENT_NODE ) {
 			if ( ! isInline( node ) ) {

--- a/blocks/api/raw-handling/utils.js
+++ b/blocks/api/raw-handling/utils.js
@@ -144,20 +144,12 @@ export function isAllowedBlock( parentNode, node ) {
 }
 
 export function isInvalidInline( element ) {
-	if ( ! isInline( element ) ) {
+	// Allow anchor tag to wrap non-inline elements.
+	if ( ! isInline( element ) || element.nodeName === 'A' ) {
 		return false;
 	}
 
 	if ( ! element.hasChildNodes() ) {
-		return false;
-	}
-
-	// an image inside an anchor is not invalid inline
-	if (
-		element.nodeName === 'A' &&
-		element.childNodes.length === 1 &&
-		element.firstChild.nodeName === 'IMG'
-	) {
 		return false;
 	}
 

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -70,22 +70,10 @@ export const settings = {
 			{
 				type: 'raw',
 				isMatch( node ) {
-					const tag = node.nodeName.toLowerCase();
-					const hasImage = node.querySelector( 'img' );
-					const isAnchorWithOneImage = ( nodeToCheck ) =>
-						'A' === nodeToCheck.nodeName &&
-						1 === nodeToCheck.childNodes.length &&
-						'IMG' === nodeToCheck.firstChild.nodeName;
+					const isImage = node.nodeName === 'IMG';
+					const hasImage = !! node.querySelector( 'img' );
 
-					const isParagraphWithAnchorImage =
-						'P' ===	node.nodeName &&
-						1 === node.childNodes.length &&
-						isAnchorWithOneImage( node.firstChild );
-
-					return tag === 'img' ||
-						( hasImage && tag === 'figure' ) ||
-						isParagraphWithAnchorImage ||
-						isAnchorWithOneImage( node );
+					return isImage || hasImage;
 				},
 				transform( node ) {
 					const matches = /align(left|center|right)/.exec( node.className );

--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -72,8 +72,20 @@ export const settings = {
 				isMatch( node ) {
 					const tag = node.nodeName.toLowerCase();
 					const hasImage = node.querySelector( 'img' );
+					const isAnchorWithOneImage = ( nodeToCheck ) =>
+						'A' === nodeToCheck.nodeName &&
+						1 === nodeToCheck.childNodes.length &&
+						'IMG' === nodeToCheck.firstChild.nodeName;
 
-					return tag === 'img' || ( hasImage && tag === 'figure' );
+					const isParagraphWithAnchorImage =
+						'P' ===	node.nodeName &&
+						1 === node.childNodes.length &&
+						isAnchorWithOneImage( node.firstChild );
+
+					return tag === 'img' ||
+						( hasImage && tag === 'figure' ) ||
+						isParagraphWithAnchorImage ||
+						isAnchorWithOneImage( node );
 				},
 				transform( node ) {
 					const matches = /align(left|center|right)/.exec( node.className );


### PR DESCRIPTION
Until now when we pasted link images the link was removed and just the image was pasted. This commits updates rawHandler to not extract images from the inside of an anchor and updates the image block to correctly handle the raw transform of an anchor with an image with or without a paragraph wrapper.

The problem is more critical because Gutenberg supports the creation of hyperlinks on the image block, so if we pasted the output of an image block without the comments, the editor was not able to correctly parse the block and removed the hyperlink.


## How Has This Been Tested?
Paste the following content as plain text in the editor:

`<figure class="wp-block-image"><a href="#text"><img src="https://dummyimage.com/600x400/000/fff" alt="tapestry"></a></figure>`
(editor output of an image block without comments)

`<a href="#text"><img src="https://dummyimage.com/600x400/000/fff" alt="tapestry"></a>`
`<p><a href="#text"><img src="https://dummyimage.com/600x400/000/fff" alt="tapestry"></a></p>`
