### PR TITLE
Show custom classes in markup while editing for heading, paragraph, l…

### DIFF
--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -65,13 +65,13 @@ export const settings = {
 			this.state = {
 				editing: ! this.props.attributes.src,
 				src: this.props.attributes.src,
-				className,
 			};
 		}
+		
 		render() {
 			const { caption, id } = this.props.attributes;
-			const { setAttributes, isSelected } = this.props;
-			const { editing, className, src } = this.state;
+			const { setAttributes, isSelected, className } = this.props;
+			const { editing, src } = this.state;
 			const switchToEditing = () => {
 				this.setState( { editing: true } );
 			};

--- a/blocks/library/audio/index.js
+++ b/blocks/library/audio/index.js
@@ -58,7 +58,7 @@ export const settings = {
 	},
 
 	edit: class extends Component {
-		constructor( { className } ) {
+		constructor() {
 			super( ...arguments );
 			// edit component has its own src in the state so it can be edited
 			// without setting the actual value outside of the edit UI
@@ -67,7 +67,7 @@ export const settings = {
 				src: this.props.attributes.src,
 			};
 		}
-		
+
 		render() {
 			const { caption, id } = this.props.attributes;
 			const { setAttributes, isSelected, className } = this.props;

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -143,7 +143,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			render() {
 				const { html, type, error, fetching } = this.state;
 				const { align, url, caption } = this.props.attributes;
-				const { setAttributes, isSelected } = this.props;
+				const { setAttributes, isSelected, className } = this.props;
 				const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 
 				const controls = isSelected && (
@@ -207,7 +207,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 						/>
 					</div>
 				);
-				let typeClassName = 'wp-block-embed';
+				let typeClassName = classnames( className, 'wp-block-embed' );
 				if ( 'video' === type ) {
 					typeClassName += ' is-video';
 				}

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -158,7 +158,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				if ( fetching ) {
 					return [
 						controls,
-						<div key="loading" className={ classnames( className, 'is-loading' ) }>
+						<div key="loading" className="wp-block-embed is-loading">
 							<Spinner />
 							<p>{ __( 'Embedding…' ) }</p>
 						</div>,
@@ -170,7 +170,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 
 					return [
 						controls,
-						<Placeholder key="placeholder" icon={ icon } label={ label } className={ className }>
+						<Placeholder key="placeholder" icon={ icon } label={ label } className="wp-block-embed">
 							<form onSubmit={ this.doServerSideRender }>
 								<input
 									type="url"
@@ -239,7 +239,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				return;
 			}
 
-			const embedClassName = classnames( {
+			const embedClassName = classnames( 'wp-block-embed', {
 				[ `align${ align }` ]: align,
 				[ `is-type-${ type }` ]: type,
 				[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -158,7 +158,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				if ( fetching ) {
 					return [
 						controls,
-						<div key="loading" className="wp-block-embed is-loading">
+						<div key="loading" className={ classnames( className, 'is-loading' ) }>
 							<Spinner />
 							<p>{ __( 'Embedding…' ) }</p>
 						</div>,
@@ -170,7 +170,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 
 					return [
 						controls,
-						<Placeholder key="placeholder" icon={ icon } label={ label } className="wp-block-embed">
+						<Placeholder key="placeholder" icon={ icon } label={ label } className={ className }>
 							<form onSubmit={ this.doServerSideRender }>
 								<input
 									type="url"
@@ -207,14 +207,10 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 						/>
 					</div>
 				);
-				let typeClassName = classnames( className, 'wp-block-embed' );
-				if ( 'video' === type ) {
-					typeClassName += ' is-video';
-				}
 
 				return [
 					controls,
-					<figure key="embed" className={ typeClassName }>
+					<figure key="embed" className={ classnames( className, { 'is-video': 'video' === type } ) }>
 						{ ( cannotPreview ) ? (
 							<Placeholder icon={ icon } label={ __( 'Embed URL' ) }>
 								<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>
@@ -243,7 +239,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				return;
 			}
 
-			const embedClassName = classnames( 'wp-block-embed', {
+			const embedClassName = classnames( {
 				[ `align${ align }` ]: align,
 				[ `is-type-${ type }` ]: type,
 				[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,

--- a/blocks/library/heading/index.js
+++ b/blocks/library/heading/index.js
@@ -101,7 +101,7 @@ export const settings = {
 		};
 	},
 
-	edit( { attributes, setAttributes, isSelected, mergeBlocks, insertBlocksAfter, onReplace } ) {
+	edit( { attributes, setAttributes, isSelected, mergeBlocks, insertBlocksAfter, onReplace, className } ) {
 		const { align, content, nodeName, placeholder } = attributes;
 
 		return [
@@ -163,6 +163,7 @@ export const settings = {
 				}
 				onRemove={ () => onReplace( [] ) }
 				style={ { textAlign: align } }
+				className={ className }
 				placeholder={ placeholder || __( 'Write heading…' ) }
 				isSelected={ isSelected }
 			/>,

--- a/blocks/library/list/index.js
+++ b/blocks/library/list/index.js
@@ -234,6 +234,7 @@ export const settings = {
 				setAttributes,
 				mergeBlocks,
 				onReplace,
+				className,
 			} = this.props;
 			const { nodeName, values } = attributes;
 
@@ -276,6 +277,7 @@ export const settings = {
 					onChange={ this.setNextValues }
 					value={ values }
 					wrapperClassName="blocks-list"
+					className={ className }
 					placeholder={ __( 'Write list…' ) }
 					onMerge={ mergeBlocks }
 					onSplit={

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -89,6 +89,7 @@ class ParagraphBlock extends Component {
 			isSelected,
 			mergeBlocks,
 			onReplace,
+			className,
 		} = this.props;
 
 		const {
@@ -101,8 +102,6 @@ class ParagraphBlock extends Component {
 			textColor,
 			width,
 		} = attributes;
-
-		const className = dropCap ? 'has-drop-cap' : null;
 
 		return [
 			isSelected && (
@@ -169,6 +168,7 @@ class ParagraphBlock extends Component {
 							tagName="p"
 							className={ classnames( 'wp-block-paragraph', className, {
 								'has-background': backgroundColor,
+								'has-drop-cap': dropCap,
 							} ) }
 							style={ {
 								backgroundColor: backgroundColor,

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -65,7 +65,7 @@ export const settings = {
 	},
 
 	edit: class extends Component {
-		constructor( { className } ) {
+		constructor() {
 			super( ...arguments );
 			// edit component has its own src in the state so it can be edited
 			// without setting the actual value outside of the edit UI

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -72,14 +72,13 @@ export const settings = {
 			this.state = {
 				editing: ! this.props.attributes.src,
 				src: this.props.attributes.src,
-				className,
 			};
 		}
 
 		render() {
 			const { align, caption, id } = this.props.attributes;
-			const { setAttributes, isSelected } = this.props;
-			const { editing, className, src } = this.state;
+			const { setAttributes, isSelected, className } = this.props;
+			const { editing, src } = this.state;
 			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 			const switchToEditing = () => {
 				this.setState( { editing: true } );


### PR DESCRIPTION
Not every block that supports custom classes adds the class name to the block's markup while editing. 

Most blocks that support custom classes add the entered classes to the block markup in the editor. This is great. You can add your custom defined styles and they immediately get reflected in Gutenberg while you are editing. However some blocks only add the custom class when viewed on the front-end and not while in the editor. This is a broken experience. I think a fix should be made to any block that supports custom classes to actually render the classes in edit mode.

Partial fix for [#5486](https://github.com/WordPress/gutenberg/issues/5486)

## Description
<!-- Please describe your changes -->
This adds the className property to the return of the edit function for the following blocks:
* Heading
* Paragraph
* List
* Embed

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
These appear to work as expected in a fresh install of WP locally. I referenced the code for the subheading block in adding the className property.
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
These changes shouldn't affect other areas of the code but someone will need to review that.

## Screenshots (jpeg or gifs if applicable):

Current:
![image](https://user-images.githubusercontent.com/2252216/37124542-911621cc-221d-11e8-8fb5-1c74143ddc65.png)

Fix:
![image](https://user-images.githubusercontent.com/2252216/37124553-a00a29da-221d-11e8-8f1a-d151cd8b28fb.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
This should be a non-breaking change that fixes a bug in supporting custom class names.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
