### PR TITLE
i18n: Decode entities in translated text

### DIFF
--- a/i18n/index.js
+++ b/i18n/index.js
@@ -31,17 +31,45 @@ export function getI18n() {
 }
 
 /**
+ * Wrapper for Jed's `dcnpgettext`, its most qualified function. Absorbs errors
+ * which are thrown as the result of invalid translation.
+ *
+ * @param {?string} domain  Domain to retrieve the translated text.
+ * @param {?string} context Context information for the translators.
+ * @param {string}  single  Text to translate if non-plural. Used as fallback
+ *                          return value on a caught error.
+ * @param {?string} plural  The text to be used if the number is plural.
+ * @param {?number} number  The number to compare against to use either the
+ *                          singular or plural form.
+ *
+ * @return {string} The translated string.
+ */
+export function dcnpgettext( domain, context, single, plural, number ) {
+	try {
+		return getI18n().dcnpgettext( domain, context, single, plural, number );
+	} catch ( error ) {
+		// Disable reason: Jed throws errors. To avoid crashing the application
+		// we log these to the console instead, and return a default value.
+
+		// eslint-disable-next-line no-console
+		console.error( 'Jed localization error: \n\n' + error.toString() );
+
+		return single;
+	}
+}
+
+/**
  * Retrieve the translation of text.
  *
  * @see https://developer.wordpress.org/reference/functions/__/
  *
- * @param {string} text Text to translate.
- * @param {string} domain Domain to retrieve the translated text.
+ * @param {string}  text   Text to translate.
+ * @param {?string} domain Domain to retrieve the translated text.
  *
  * @return {string} Translated text.
  */
 export function __( text, domain ) {
-	return getI18n().dgettext( domain, text );
+	return dcnpgettext( domain, undefined, text );
 }
 
 /**
@@ -49,14 +77,14 @@ export function __( text, domain ) {
  *
  * @see https://developer.wordpress.org/reference/functions/_x/
  *
- * @param {string} text    Text to translate.
- * @param {string} context Context information for the translators.
- * @param {string} domain Domain to retrieve the translated text.
+ * @param {string}  text    Text to translate.
+ * @param {string}  context Context information for the translators.
+ * @param {?string} domain  Domain to retrieve the translated text.
  *
  * @return {string} Translated context string without pipe.
  */
 export function _x( text, context, domain ) {
-	return getI18n().dpgettext( domain, context, text );
+	return dcnpgettext( domain, context, text );
 }
 
 /**
@@ -65,16 +93,16 @@ export function _x( text, context, domain ) {
  *
  * @see https://developer.wordpress.org/reference/functions/_n/
  *
- * @param {string} single The text to be used if the number is singular.
- * @param {string} plural The text to be used if the number is plural.
- * @param {number} number The number to compare against to use either the
+ * @param {string}  single The text to be used if the number is singular.
+ * @param {string}  plural The text to be used if the number is plural.
+ * @param {number}  number The number to compare against to use either the
  *                         singular or plural form.
- * @param {string} domain Domain to retrieve the translated text.
+ * @param {?string} domain Domain to retrieve the translated text.
  *
  * @return {string} The translated singular or plural form.
  */
 export function _n( single, plural, number, domain ) {
-	return getI18n().dngettext( domain, single, plural, number );
+	return dcnpgettext( domain, undefined, single, plural, number );
 }
 
 /**
@@ -83,24 +111,40 @@ export function _n( single, plural, number, domain ) {
  *
  * @see https://developer.wordpress.org/reference/functions/_nx/
  *
- * @param {string} single  The text to be used if the number is singular.
- * @param {string} plural  The text to be used if the number is plural.
- * @param {number} number  The number to compare against to use either the
+ * @param {string}  single  The text to be used if the number is singular.
+ * @param {string}  plural  The text to be used if the number is plural.
+ * @param {number}  number  The number to compare against to use either the
  *                          singular or plural form.
- * @param {string} context Context information for the translators.
- * @param {string} domain Domain to retrieve the translated text.
+ * @param {string}  context Context information for the translators.
+ * @param {?string} domain  Domain to retrieve the translated text.
  *
  * @return {string} The translated singular or plural form.
  */
 export function _nx( single, plural, number, context, domain ) {
-	return getI18n().dnpgettext( domain, context, single, plural, number );
+	return dcnpgettext( domain, context, single, plural, number );
 }
 
 /**
- * Returns a formatted string.
+ * Returns a formatted string. If an error occurs in applying the format, the
+ * original format string is returned.
+ *
+ * @param {string}   format  The format of the string to generate.
+ * @param {string[]} ...args Arguments to apply to the format.
  *
  * @see http://www.diveintojavascript.com/projects/javascript-sprintf
  *
- * @type {string}
+ * @return {string} The formatted string.
  */
-export const sprintf = Jed.sprintf;
+export function sprintf( format, ...args ) {
+	try {
+		return Jed.sprintf( format, ...args );
+	} catch ( error ) {
+		// Disable reason: Jed throws errors. To avoid crashing the application
+		// we log these to the console instead, and return a default value.
+
+		// eslint-disable-next-line no-console
+		console.error( 'Jed sprintf error: \n\n' + error.stack );
+
+		return format;
+	}
+}

--- a/i18n/index.js
+++ b/i18n/index.js
@@ -3,6 +3,11 @@
  */
 import Jed from 'jed';
 
+/**
+ * WordPress dependencies
+ */
+import { decodeEntities } from '@wordpress/utils';
+
 let i18n;
 
 /**
@@ -46,7 +51,8 @@ export function getI18n() {
  */
 export function dcnpgettext( domain, context, single, plural, number ) {
 	try {
-		return getI18n().dcnpgettext( domain, context, single, plural, number );
+		const text = getI18n().dcnpgettext( domain, context, single, plural, number );
+		return decodeEntities( text );
 	} catch ( error ) {
 		// Disable reason: Jed throws errors. To avoid crashing the application
 		// we log these to the console instead, and return a default value.

--- a/i18n/test/index.js
+++ b/i18n/test/index.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { dcnpgettext, sprintf } from '../';
+
+describe( 'i18n', () => {
+	describe( 'dcnpgettext()', () => {
+		it( 'absorbs errors', () => {
+			const result = dcnpgettext( 'domain-without-data', undefined, 'Hello' );
+
+			expect( console ).toHaveErrored();
+			expect( result ).toBe( 'Hello' );
+		} );
+	} );
+
+	describe( 'sprintf()', () => {
+		it( 'absorbs errors', () => {
+			const result = sprintf( 'Hello %(placeholder-not-provided)s' );
+
+			expect( console ).toHaveErrored();
+			expect( result ).toBe( 'Hello %(placeholder-not-provided)s' );
+		} );
+	} );
+} );

--- a/i18n/test/index.js
+++ b/i18n/test/index.js
@@ -11,6 +11,12 @@ describe( 'i18n', () => {
 			expect( console ).toHaveErrored();
 			expect( result ).toBe( 'Hello' );
 		} );
+
+		it( 'decodes entities', () => {
+			const result = dcnpgettext( undefined, undefined, 'Ribs &amp; Chicken' );
+
+			expect( result ).toBe( 'Ribs & Chicken' );
+		} );
 	} );
 
 	describe( 'sprintf()', () => {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -129,7 +129,7 @@ function gutenberg_register_scripts_and_styles() {
 	wp_register_script(
 		'wp-i18n',
 		gutenberg_url( 'i18n/build/index.js' ),
-		array(),
+		array( 'wp-utils' ),
 		filemtime( gutenberg_dir_path() . 'i18n/build/index.js' )
 	);
 	wp_register_script(


### PR DESCRIPTION
Cherry-picks 748e046 from #5481

This pull request seeks to decode entities in a string. Since [React will double-escape entities in strings](https://shripadk.github.io/react/docs/jsx-gotchas.html#html-entities), these entity sequences are currently being shown verbatim.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/37126169-be4ad302-223d-11e8-96bd-81dd439cc4c2.png)|![After](https://user-images.githubusercontent.com/1779930/37126158-b3846366-223d-11e8-8fe5-5f3c5557f180.png)

**Code implementation notes:**

Due to cherry-picking (to take advantage of centralized `dcnpgettext`), review attention should be focused primarily on d372392. #5481 can be considered a blocker if necessary.

**Testing instructions:**

Verify that with German language configured (and the corresponding Gutenberg language pack downloaded), the publish button shows decoded entities.