### PR TITLE
Chrome: Restore hover effects on title input

### DIFF
--- a/editor/components/post-title/style.scss
+++ b/editor/components/post-title/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	&.is-selected .editor-post-title__input,
-	.editor-post-title__input:focus {
+	.editor-post-title__input:hover {
 		border: 1px solid $light-gray-500;
 	}
 }


### PR DESCRIPTION
Regression introduced in #5422 (394c6edb0c41f671aab6fd0610abc240e6eae561)

This pull request seeks to restore hover effects to the title input, inadvertently removed in #5422 as part of a refactor which intended to sync focus effects to the permalink display via `.is-selected` modifier, where the hover effects were removed instead of the focus effects.

__Testing instructions:__

Verify that the title border appears when it is hovered or focused.