### PR TITLE
Try: Writing Flow: Clickable text canvas to focus closest tabbable

### DIFF
--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -7,7 +7,6 @@ import {
 	PostTitle,
 	WritingFlow,
 	EditorGlobalKeyboardShortcuts,
-	BlockSelectionClearer,
 	MultiSelectScrollIntoView,
 } from '@wordpress/editor';
 import { Fragment, compose } from '@wordpress/element';
@@ -22,23 +21,21 @@ import BlockInspectorButton from './block-inspector-button';
 
 function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
 	return (
-		<BlockSelectionClearer className="edit-post-visual-editor">
+		<WritingFlow className="edit-post-visual-editor">
 			<EditorGlobalKeyboardShortcuts />
 			<CopyHandler />
 			<MultiSelectScrollIntoView />
-			<WritingFlow>
-				<PostTitle />
-				<BlockList
-					showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
-					renderBlockMenu={ ( { children, onClose } ) => (
-						<Fragment>
-							<BlockInspectorButton onClick={ onClose } />
-							{ children }
-						</Fragment>
-					) }
-				/>
-			</WritingFlow>
-		</BlockSelectionClearer>
+			<PostTitle />
+			<BlockList
+				showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
+				renderBlockMenu={ ( { children, onClose } ) => (
+					<Fragment>
+						<BlockInspectorButton onClick={ onClose } />
+						{ children }
+					</Fragment>
+				) }
+			/>
+		</WritingFlow>
 	);
 }
 

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/element';
-import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { getDefaultBlockName } from '@wordpress/blocks';
 import { withContext } from '@wordpress/components';
 
 /**
@@ -44,10 +45,10 @@ export default compose(
 		( state, ownProps ) => {
 			const isEmpty = ! getBlockCount( state, ownProps.rootUID );
 			const lastBlock = getBlock( state, ownProps.lastBlockUID );
-			const isLastBlockEmptyDefault = lastBlock && isUnmodifiedDefaultBlock( lastBlock );
+			const isLastBlockDefault = get( lastBlock, 'name' ) === getDefaultBlockName();
 
 			return {
-				isVisible: isEmpty || ! isLastBlockEmptyDefault,
+				isVisible: isEmpty || ! isLastBlockDefault,
 				showPrompt: isEmpty,
 			};
 		},

--- a/editor/components/post-title/style.scss
+++ b/editor/components/post-title/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	&.is-selected .editor-post-title__input,
-	.editor-post-title__input:focus {
+	.editor-post-title__input:hover {
 		border: 1px solid $light-gray-500;
 	}
 }

--- a/editor/components/writing-flow/style.scss
+++ b/editor/components/writing-flow/style.scss
@@ -1,0 +1,3 @@
+.editor-writing-flow {
+	cursor: text;
+}


### PR DESCRIPTION
_Note:_ Work-in progress. While the basic behaviors work fairly well, it's not expected to be flawless and at this point serves more for demonstration.

This pull request seeks to experiment with an idea for more easily navigating into tabbable fields by clicking on the canvas surrounding the list of blocks. This is inspired by behaviors from typical Word processors like Google Docs, where clicking anywhere on the edge of the document will place the caret at the most relevant piece of text.

The effect is a bit hard to describe without trying it for yourself, but I've attempted to demonstrate in the GIF below:

![clickable](https://user-images.githubusercontent.com/1779930/37137751-3dc34bfa-2275-11e8-8707-00afa6af0eb0.gif)

Note that...

- To start writing, I click anywhere below the title. The behavior is such that if the last block is not a paragraph block, one will be added (including when there are no blocks).
- Again I add another paragraph after the image block by clicking arbitrary below it on the page.
- After adding some text to the paragraph block, I start clicking below the text.
   - Despite not clicking on the paragraph block itself, the caret moves to the corresponding X position of the text within.
   - As I start clicking up the side gutters of the canvas, the block at the corresponding Y position becomes selected

Remaining tasks:

- Probably don't need the hover effect for the default block appender, since the user no longer needs to click explicitly within it
- Restore behavior where arrow down within paragraph block creates a new paragraph block below
- X coordinate aligning of caret doesn't work for textareas (i.e. post title). I _think_ this should be possible to support.
- Lots of implementation details: click behaviors too aggressive, inline code comments, corrected function names (early implementation was specific to blocks, not tabbables)