### PR TITLE
Issue #5216 - Used cached file if replacement can't be loaded

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -538,21 +538,24 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 		fclose( $f );
 		$response = wp_remote_get( $src );
 		if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
-			// The request failed; just enqueue the script directly from the
-			// URL.  This will probably fail too, but surfacing the error to
-			// the browser is probably the best we can do.
-			wp_register_script( $handle, $src, $deps, null );
-			// If our file was newly created above, it will have a size of
-			// zero, and we need to delete it so that we don't think it's
-			// already cached on the next request.
+			// The request failed. If the file is already cached we should
+			// continue to use this file.
+			// If not, then we need to unlink the
+			// 0 byte file that's been created,
+			// and enqueue the script directly from the URL.
+			// The browser may also fail to load the file
+			// leading to a very poor user experience.
+			// That's development mode for you!
 			if ( ! filesize( $full_path ) ) {
+				wp_register_script( $handle, $src, $deps, null );
 				unlink( $full_path );
+				return;
 			}
-			return;
+		} else {
+			$f = fopen( $full_path, 'w' );
+			fwrite( $f, wp_remote_retrieve_body( $response ) );
+			fclose( $f );
 		}
-		$f = fopen( $full_path, 'w' );
-		fwrite( $f, wp_remote_retrieve_body( $response ) );
-		fclose( $f );
 	}
 
 	wp_register_script(


### PR DESCRIPTION
## Description
Refreshed fix for the WSOD problem when working in flight mode and cached files need updating.
If the request to download a new version of the file failed then continue to use the cached file that's present. 

This is another attempt to check in a version of code that will please PHPCS. 
<!-- Please describe your changes -->

## How Has This Been Tested?
Manually using the technique used to reproduce the problem.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Another attempt to check in a version of code that will please PHPCS. 
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
