### PR TITLE
Handle calculateFrequency edge case

### DIFF
--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1242,6 +1242,10 @@ function getItemsFromInserts( state, inserts, enabledBlockTypes = true, maximum 
  */
 export function getFrecentInserterItems( state, enabledBlockTypes = true, maximum = MAX_RECENT_BLOCKS ) {
 	const calculateFrecency = ( time, count ) => {
+		if ( ! time ) {
+			return count;
+		}
+
 		const duration = Date.now() - time;
 		switch ( true ) {
 			case duration < 3600:

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -2450,6 +2450,54 @@ describe( 'selectors', () => {
 			] );
 		} );
 
+		it( 'should weight by time', () => {
+			const state = {
+				preferences: {
+					insertUsage: {
+						'core/image': { time: Date.now() - 1000, count: 2, insert: { name: 'core/image' } },
+						'core/paragraph': { time: Date.now() - 4000, count: 3, insert: { name: 'core/paragraph' } },
+					},
+				},
+				editor: {
+					present: {
+						blockOrder: [],
+					},
+				},
+				reusableBlocks: {
+					data: {},
+				},
+			};
+
+			expect( getFrecentInserterItems( state, true, 2 ) ).toMatchObject( [
+				{ name: 'core/image', initialAttributes: {} },
+				{ name: 'core/paragraph', initialAttributes: {} },
+			] );
+		} );
+
+		it( 'should be backwards-compatible with old preferences values', () => {
+			const state = {
+				preferences: {
+					insertUsage: {
+						'core/image': { time: Date.now(), count: 1, insert: { name: 'core/image' } },
+						'core/paragraph': { time: undefined, count: 5, insert: { name: 'core/paragraph' } },
+					},
+				},
+				editor: {
+					present: {
+						blockOrder: [],
+					},
+				},
+				reusableBlocks: {
+					data: {},
+				},
+			};
+
+			expect( getFrecentInserterItems( state, true, 2 ) ).toMatchObject( [
+				{ name: 'core/paragraph', initialAttributes: {} },
+				{ name: 'core/image', initialAttributes: {} },
+			] );
+		} );
+
 		it( 'should pad list out with blocks from the common category', () => {
 			const state = {
 				preferences: {


### PR DESCRIPTION
This updates `calculateFrequency` to explicitly handle an edge case spotted by @aduth in https://github.com/WordPress/gutenberg/pull/5342#issuecomment-371362768.

The edge case is that `time` will be `undefined` for all blocks when a user first upgrades Gutenberg to the version that contains [this new functionality](https://github.com/WordPress/gutenberg/pull/5342).

In this case, we'll simply assume that the block was used somewhere between a day and one week ago.