### PR TITLE
Improve settings UI on mobile devices

### DIFF
--- a/edit-post/components/sidebar/header.js
+++ b/edit-post/components/sidebar/header.js
@@ -1,43 +1,56 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/element';
+import { Fragment, compose } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 
-const SidebarHeader = ( { activeSidebarName, openSidebar, closeSidebar, count } ) => {
+const SidebarHeader = ( { count, title, activeSidebarName, openSidebar, closeSidebar } ) => {
 	// Do not display "0 Blocks".
 	count = count === 0 ? 1 : count;
 
 	return (
-		<div className="components-panel__header edit-post-sidebar__panel-tabs">
-			<button
-				onClick={ () => openSidebar( 'edit-post/document' ) }
-				className={ `edit-post-sidebar__panel-tab ${ activeSidebarName === 'edit-post/document' ? 'is-active' : '' }` }
-				aria-label={ __( 'Document settings' ) }
-			>
-				{ __( 'Document' ) }
-			</button>
-			<button
-				onClick={ () => openSidebar( 'edit-post/block' ) }
-				className={ `edit-post-sidebar__panel-tab ${ activeSidebarName === 'edit-post/block' ? 'is-active' : '' }` }
-				aria-label={ __( 'Block settings' ) }
-			>
-				{ sprintf( _n( 'Block', '%d Blocks', count ), count ) }
-			</button>
-			<IconButton
-				onClick={ closeSidebar }
-				icon="no-alt"
-				label={ __( 'Close settings' ) }
-			/>
-		</div>
+		<Fragment>
+			<div className="components-panel__header edit-post-sidebar__header">
+				<span className="edit-post-sidebar__title">
+					{ title }
+				</span>
+				<IconButton
+					onClick={ closeSidebar }
+					icon="no-alt"
+					label={ __( 'Close settings' ) }
+				/>
+			</div>
+			<div className="components-panel__header edit-post-sidebar__panel-tabs">
+				<button
+					onClick={ () => openSidebar( 'edit-post/document' ) }
+					className={ `edit-post-sidebar__panel-tab ${ activeSidebarName === 'edit-post/document' ? 'is-active' : '' }` }
+					aria-label={ __( 'Document settings' ) }
+				>
+					{ __( 'Document' ) }
+				</button>
+				<button
+					onClick={ () => openSidebar( 'edit-post/block' ) }
+					className={ `edit-post-sidebar__panel-tab ${ activeSidebarName === 'edit-post/block' ? 'is-active' : '' }` }
+					aria-label={ __( 'Block settings' ) }
+				>
+					{ sprintf( _n( 'Block', '%d Blocks', count ), count ) }
+				</button>
+				<IconButton
+					onClick={ closeSidebar }
+					icon="no-alt"
+					label={ __( 'Close settings' ) }
+				/>
+			</div>
+		</Fragment>
 	);
 };
 
 export default compose(
 	withSelect( ( select ) => ( {
 		count: select( 'core/editor' ).getSelectedBlockCount(),
+		title: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
 		activeSidebarName: select( 'core/edit-post' ).getActiveGeneralSidebarName(),
 	} ) ),
 	withDispatch( ( dispatch ) => ( {

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -102,6 +102,22 @@
 }
 
 /* Text Editor specific */
+.components-panel__header.edit-post-sidebar__header {
+	background: $white;
+	padding-right: $panel-padding / 2;
+
+	.edit-post-sidebar__title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		width: 100%;
+	}
+
+	@include break-medium() {
+		display: none;
+	}
+}
+
 .components-panel__header.edit-post-sidebar__panel-tabs {
 	justify-content: flex-start;
 	padding-left: 0;
@@ -109,7 +125,12 @@
 	border-top: 0;
 
 	.components-icon-button {
+		display: none;
 		margin-left: auto;
+
+		@include break-medium() {
+			display: flex;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Closes #4078.

| Before | After |
| --- | --- |
| ![local wordpress test_wp-admin_post-new php_gutenberg-demo iphone 6_7_8 1](https://user-images.githubusercontent.com/612155/37173160-b2a6ddfe-22c7-11e8-8645-358a76b741ad.png) | ![local wordpress test_wp-admin_post-new php_gutenberg-demo iphone 6_7_8](https://user-images.githubusercontent.com/612155/37173057-6e5989da-22c7-11e8-8992-5c59c41df669.png) |

Tweaks the settings UI on mobile to display the post title in a header at the top of the panel.

## How Has This Been Tested?

1. Check that the new UI behaves correctly when viewed on a mobile device
2. Check that long post titles appear truncated with an ellipsis
3. Check that the UI has not changed when viewed on a desktop