### PR TITLE
Improve inserter UI on mobile devices

### DIFF
--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -85,3 +85,11 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
  - Type: `Boolean`
  - Required: No
  - Default: `false`
+
+ ## headerTitle
+
+ Set this to customize the text that is shown in the dropdown's header when
+ it is fullscreen on mobile.
+
+ - Type: `String`
+ - Required: No

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -65,6 +65,7 @@ class Dropdown extends Component {
 			className,
 			contentClassName,
 			expandOnMobile,
+			headerTitle,
 		} = this.props;
 
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
@@ -84,6 +85,7 @@ class Dropdown extends Component {
 							onClose={ this.close }
 							onClickOutside={ this.clickOutside }
 							expandOnMobile={ expandOnMobile }
+							headerTitle={ headerTitle }
 						>
 							{ renderContent( args ) }
 						</Popover>

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -102,3 +102,10 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
  - Type: `Boolean`
  - Required: No
  - Default: `false`
+
+ ## headerTitle
+
+ Set this to customize the text that is shown in popover's header when it is fullscreen on mobile.
+
+ - Type: `String`
+ - Required: No

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -252,6 +252,7 @@ class Popover extends Component {
 
 	render() {
 		const {
+			headerTitle,
 			onClose,
 			children,
 			className,
@@ -293,6 +294,9 @@ class Popover extends Component {
 				>
 					{ this.state.isMobile && (
 						<div className="components-popover__header">
+							<span className="components-popover__header-title">
+								{ headerTitle }
+							</span>
 							<IconButton className="components-popover__close" icon="no-alt" onClick={ onClose } />
 						</div>
 					) }

--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -111,16 +111,22 @@
 }
 
 .components-popover__header {
-	height: $panel-header-height;
-	background: $light-gray-300;
-	padding: 0 $panel-padding;
+	align-items: center;
+	background: $white;
 	border: 1px solid $light-gray-500;
-	position: relative;
+	display: flex;
+	height: $panel-header-height;
+	justify-content: space-between;
+	padding: 0 8px 0 $panel-padding;
+}
+
+.components-popover__header-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: 100%;
 }
 
 .components-popover__close.components-icon-button {
-	position: absolute;
-	top: 6px;
-	right: 6px;
 	z-index: z-index( '.components-popover__close' );
 }

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -42,6 +42,7 @@ class Inserter extends Component {
 	render() {
 		const {
 			position,
+			title,
 			children,
 			onInsertBlock,
 			hasSupportedBlocks,
@@ -58,6 +59,7 @@ class Inserter extends Component {
 				position={ position }
 				onToggle={ this.onToggle }
 				expandOnMobile
+				headerTitle={ title }
 				renderToggle={ ( { onToggle, isOpen } ) => (
 					<IconButton
 						icon="insert"
@@ -86,6 +88,7 @@ class Inserter extends Component {
 
 export default compose( [
 	withSelect( ( select ) => ( {
+		title: select( 'core/editor' ).getEditedPostAttribute( 'title' ),
 		insertionPoint: select( 'core/editor' ).getBlockInsertionPoint(),
 		selectedBlock: select( 'core/editor' ).getSelectedBlock(),
 	} ) ),

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -30,7 +30,7 @@ input[type="search"].editor-inserter__search {
 	display: block;
 	width: 100%;
 	margin: 0;
-	padding: 8px 11px;
+	padding: 8px 16px;
 	position: relative;
 	z-index: 1;
 	border: none;


### PR DESCRIPTION
## Description

Closes #4077.

| Before | After |
| --- | --- |
| ![local wordpress test_wp-admin_post-new php_gutenberg-demo iphone 6_7_8 3](https://user-images.githubusercontent.com/612155/37180892-97d3849c-22df-11e8-822c-f89ff7472376.png)  | ![local wordpress test_wp-admin_post-new php_gutenberg-demo iphone 6_7_8 2](https://user-images.githubusercontent.com/612155/37180895-9a73e5f2-22df-11e8-9f66-73714f98ee09.png) |

Tweaks the inserter UI on mobile to display the post title in a header above the search bar. We accomplish this by adding a new `headerTitle` property to `<Popover>` and `<Dropdown>`.

## How Has This Been Tested?

1. Check that the new UI behaves correctly when viewed on a mobile device
2. Check that long post titles appear truncated with an ellipsis
3. Check that the UI has not changed when viewed on a desktop