### PR TITLE
Revert "Make preferences reducer deterministic"

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -175,7 +175,6 @@ export function replaceBlocks( uids, blocks ) {
 		type: 'REPLACE_BLOCKS',
 		uids: castArray( uids ),
 		blocks: castArray( blocks ),
-		time: Date.now(),
 	};
 }
 
@@ -222,7 +221,6 @@ export function insertBlocks( blocks, index, rootUID ) {
 		blocks: castArray( blocks ),
 		index,
 		rootUID,
-		time: Date.now(),
 	};
 }
 

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -705,7 +705,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					insertUsage: {
 						...prevState.insertUsage,
 						[ id ]: {
-							time: action.time,
+							time: Date.now(),
 							count: prevState.insertUsage[ id ] ? prevState.insertUsage[ id ].count + 1 : 1,
 							insert,
 						},

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -163,7 +163,6 @@ describe( 'actions', () => {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks: [ block ],
-				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -178,7 +177,6 @@ describe( 'actions', () => {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks,
-				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -189,12 +187,10 @@ describe( 'actions', () => {
 				uid: 'ribs',
 			};
 			const index = 5;
-			expect( insertBlock( block, index, 'test_uid' ) ).toEqual( {
+			expect( insertBlock( block, index ) ).toEqual( {
 				type: 'INSERT_BLOCKS',
 				blocks: [ block ],
 				index,
-				rootUID: 'test_uid',
-				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -205,12 +201,10 @@ describe( 'actions', () => {
 				uid: 'ribs',
 			} ];
 			const index = 3;
-			expect( insertBlocks( blocks, index, 'test_uid' ) ).toEqual( {
+			expect( insertBlocks( blocks, index ) ).toEqual( {
 				type: 'INSERT_BLOCKS',
 				blocks,
 				index,
-				rootUID: 'test_uid',
-				time: expect.any( Number ),
 			} );
 		} );
 	} );

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -151,14 +151,11 @@ describe( 'effects', () => {
 
 			expect( dispatch ).toHaveBeenCalledTimes( 2 );
 			expect( dispatch ).toHaveBeenCalledWith( selectBlock( 'chicken', -1 ) );
-			expect( dispatch ).toHaveBeenCalledWith( {
-				...replaceBlocks( [ 'chicken', 'ribs' ], [ {
-					uid: 'chicken',
-					name: 'core/test-block',
-					attributes: { content: 'chicken ribs' },
-				} ] ),
-				time: expect.any( Number ),
-			} );
+			expect( dispatch ).toHaveBeenCalledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
+				uid: 'chicken',
+				name: 'core/test-block',
+				attributes: { content: 'chicken ribs' },
+			} ] ) );
 		} );
 
 		it( 'should not merge the blocks have different types without transformation', () => {
@@ -884,13 +881,12 @@ describe( 'effects', () => {
 				expect( dispatch ).toHaveBeenCalledWith(
 					saveReusableBlock( expect.any( Number ) )
 				);
-				expect( dispatch ).toHaveBeenCalledWith( {
-					...replaceBlocks(
+				expect( dispatch ).toHaveBeenCalledWith(
+					replaceBlocks(
 						[ staticBlock.uid ],
 						[ createBlock( 'core/block', { ref: expect.any( Number ) } ) ]
-					),
-					time: expect.any( Number ),
-				} );
+					)
+				);
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1272,13 +1272,12 @@ describe( 'state', () => {
 					uid: 'bacon',
 					name: 'core-embed/twitter',
 				} ],
-				time: 123456,
 			} );
 
 			expect( state ).toEqual( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: 123456,
+						time: expect.any( Number ),
 						count: 1,
 						insert: { name: 'core-embed/twitter' },
 					},
@@ -1288,7 +1287,7 @@ describe( 'state', () => {
 			const twoRecentBlocks = preferences( deepFreeze( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: 123456,
+						time: expect.any( Number ),
 						count: 1,
 						insert: { name: 'core-embed/twitter' },
 					},
@@ -1303,18 +1302,17 @@ describe( 'state', () => {
 					name: 'core/block',
 					attributes: { ref: 123 },
 				} ],
-				time: 123457,
 			} );
 
 			expect( twoRecentBlocks ).toEqual( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: 123457,
+						time: expect.any( Number ),
 						count: 2,
 						insert: { name: 'core-embed/twitter' },
 					},
 					'core/block/123': {
-						time: 123457,
+						time: expect.any( Number ),
 						count: 1,
 						insert: { name: 'core/block', ref: 123 },
 					},


### PR DESCRIPTION
Reverts WordPress/gutenberg#5423

It looks like this is causing intermittent test failures.

<img width="1045" alt="screen shot 2018-03-08 at 16 09 28" src="https://user-images.githubusercontent.com/612155/37183487-266d27c0-22eb-11e8-84c1-f514391aa31a.png">
