### PR TITLE
Make preferences reducer deterministic (again)

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -175,6 +175,7 @@ export function replaceBlocks( uids, blocks ) {
 		type: 'REPLACE_BLOCKS',
 		uids: castArray( uids ),
 		blocks: castArray( blocks ),
+		time: Date.now(),
 	};
 }
 
@@ -221,6 +222,7 @@ export function insertBlocks( blocks, index, rootUID ) {
 		blocks: castArray( blocks ),
 		index,
 		rootUID,
+		time: Date.now(),
 	};
 }
 

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -705,7 +705,7 @@ export function preferences( state = PREFERENCES_DEFAULTS, action ) {
 					insertUsage: {
 						...prevState.insertUsage,
 						[ id ]: {
-							time: Date.now(),
+							time: action.time,
 							count: prevState.insertUsage[ id ] ? prevState.insertUsage[ id ].count + 1 : 1,
 							insert,
 						},

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -163,6 +163,7 @@ describe( 'actions', () => {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks: [ block ],
+				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -177,6 +178,7 @@ describe( 'actions', () => {
 				type: 'REPLACE_BLOCKS',
 				uids: [ 'chicken' ],
 				blocks,
+				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -187,10 +189,12 @@ describe( 'actions', () => {
 				uid: 'ribs',
 			};
 			const index = 5;
-			expect( insertBlock( block, index ) ).toEqual( {
+			expect( insertBlock( block, index, 'test_uid' ) ).toEqual( {
 				type: 'INSERT_BLOCKS',
 				blocks: [ block ],
 				index,
+				rootUID: 'test_uid',
+				time: expect.any( Number ),
 			} );
 		} );
 	} );
@@ -201,10 +205,12 @@ describe( 'actions', () => {
 				uid: 'ribs',
 			} ];
 			const index = 3;
-			expect( insertBlocks( blocks, index ) ).toEqual( {
+			expect( insertBlocks( blocks, index, 'test_uid' ) ).toEqual( {
 				type: 'INSERT_BLOCKS',
 				blocks,
 				index,
+				rootUID: 'test_uid',
+				time: expect.any( Number ),
 			} );
 		} );
 	} );

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -249,11 +249,14 @@ describe( 'effects', () => {
 
 			expect( dispatch ).toHaveBeenCalledTimes( 2 );
 			// expect( dispatch ).toHaveBeenCalledWith( focusBlock( 'chicken', { offset: -1 } ) );
-			expect( dispatch ).toHaveBeenCalledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
-				uid: 'chicken',
-				name: 'core/test-block',
-				attributes: { content: 'chicken ribs' },
-			} ] ) );
+			expect( dispatch ).toHaveBeenCalledWith( {
+				...replaceBlocks( [ 'chicken', 'ribs' ], [ {
+					uid: 'chicken',
+					name: 'core/test-block',
+					attributes: { content: 'chicken ribs' },
+				} ] ),
+				time: expect.any( Number ),
+			} );
 		} );
 	} );
 
@@ -847,12 +850,13 @@ describe( 'effects', () => {
 
 				handler( convertBlockToStatic( staticBlock.uid ), store );
 
-				expect( dispatch ).toHaveBeenCalledWith(
-					replaceBlocks(
+				expect( dispatch ).toHaveBeenCalledWith( {
+					...replaceBlocks(
 						[ staticBlock.uid ],
 						createBlock( reusableBlock.type, reusableBlock.attributes )
-					)
-				);
+					),
+					time: expect.any( Number ),
+				} );
 			} );
 		} );
 

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -151,11 +151,14 @@ describe( 'effects', () => {
 
 			expect( dispatch ).toHaveBeenCalledTimes( 2 );
 			expect( dispatch ).toHaveBeenCalledWith( selectBlock( 'chicken', -1 ) );
-			expect( dispatch ).toHaveBeenCalledWith( replaceBlocks( [ 'chicken', 'ribs' ], [ {
-				uid: 'chicken',
-				name: 'core/test-block',
-				attributes: { content: 'chicken ribs' },
-			} ] ) );
+			expect( dispatch ).toHaveBeenCalledWith( {
+				...replaceBlocks( [ 'chicken', 'ribs' ], [ {
+					uid: 'chicken',
+					name: 'core/test-block',
+					attributes: { content: 'chicken ribs' },
+				} ] ),
+				time: expect.any( Number ),
+			} );
 		} );
 
 		it( 'should not merge the blocks have different types without transformation', () => {
@@ -881,12 +884,13 @@ describe( 'effects', () => {
 				expect( dispatch ).toHaveBeenCalledWith(
 					saveReusableBlock( expect.any( Number ) )
 				);
-				expect( dispatch ).toHaveBeenCalledWith(
-					replaceBlocks(
+				expect( dispatch ).toHaveBeenCalledWith( {
+					...replaceBlocks(
 						[ staticBlock.uid ],
 						[ createBlock( 'core/block', { ref: expect.any( Number ) } ) ]
-					)
-				);
+					),
+					time: expect.any( Number ),
+				} );
 			} );
 		} );
 	} );

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1272,12 +1272,13 @@ describe( 'state', () => {
 					uid: 'bacon',
 					name: 'core-embed/twitter',
 				} ],
+				time: 123456,
 			} );
 
 			expect( state ).toEqual( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: expect.any( Number ),
+						time: 123456,
 						count: 1,
 						insert: { name: 'core-embed/twitter' },
 					},
@@ -1287,7 +1288,7 @@ describe( 'state', () => {
 			const twoRecentBlocks = preferences( deepFreeze( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: expect.any( Number ),
+						time: 123456,
 						count: 1,
 						insert: { name: 'core-embed/twitter' },
 					},
@@ -1302,17 +1303,18 @@ describe( 'state', () => {
 					name: 'core/block',
 					attributes: { ref: 123 },
 				} ],
+				time: 123457,
 			} );
 
 			expect( twoRecentBlocks ).toEqual( {
 				insertUsage: {
 					'core-embed/twitter': {
-						time: expect.any( Number ),
+						time: 123457,
 						count: 2,
 						insert: { name: 'core-embed/twitter' },
 					},
 					'core/block/123': {
-						time: expect.any( Number ),
+						time: 123457,
 						count: 1,
 						insert: { name: 'core/block', ref: 123 },
 					},


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/5423, we updated `INSERT_BLOCKS` and `REPLACE_BLOCKS` to contain a `time` property which contains the current timestamp (`Date.now()`). This required updating our effects tests to be less strict in what they asserted. Namely, we had to allow `time` to be any number (`expect.any( Number )`).

Unfortunately, I made a mistake and did not update two tests that needed to be less strict. `npm test` and Travis CI did not catch my mistake as the tests happened to run fast enough such that `Date.now()` returned the same timestamp for both the expected result and the actual result. I reverted the PR (https://github.com/WordPress/gutenberg/pull/5517) when I noticed the error showing up in unrelated Travis builds.

This PR reverts the revert and updates the two test cases that I missed. To check that I correctly handled every case, I applied [this diff](https://gist.github.com/noisysocks/a1d8e4179f7e6707b21d379758d5adf3) and ran `npm test`.

😅 