### PR TITLE
Fix edgecases for Windows high contrast mode

### DIFF
--- a/edit-post/assets/stylesheets/_admin-schemes.scss
+++ b/edit-post/assets/stylesheets/_admin-schemes.scss
@@ -32,7 +32,7 @@ $scheme-sunrise__spot-color: #de823f;
 		// Tab indicators
 		.edit-post-sidebar__panel-tab.is-active,
 		.editor-inserter__tab.is-active {
-			border-bottom-color: $spot-color;
+			border-bottom: 3px solid $spot-color;
 		}
 
 		// Switch
@@ -64,7 +64,7 @@ $scheme-sunrise__spot-color: #de823f;
 				background-image: repeating-linear-gradient( -45deg, darken( $spot-color, 20 ), darken( $spot-color, 20 ) 11px, darken( $spot-color, 10 ) 10px, darken( $spot-color, 10 ) 20px );
 			}
 		}
-		
+
 		// Datepicker
 		.react-datepicker__day--selected {
 			background-color: $spot-color;

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -53,7 +53,7 @@
 	}
 
 	// put the gray background on a separate layer, so as to match the size of the publish button (34px)
-	&.is-toggled::before {
+	&.is-toggled:before {
 		content: "";
 		border-radius: $button-style__radius-roundrect;
 		position: absolute;
@@ -67,7 +67,6 @@
 
 	&.is-toggled:hover,
 	&.is-toggled:focus {
-		outline: none;
 		box-shadow: 0 0 0 1px $dark-gray-500, inset 0 0 0 1px $white;
 		color: $white;
 		background: $dark-gray-500;

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -116,18 +116,17 @@
 .edit-post-sidebar__panel-tab {
 	background: transparent;
 	border: none;
-	border-bottom: 3px solid transparent;
 	border-radius: 0;
 	cursor: pointer;
 	height: 50px;
-	line-height: 50px;
-	padding: 0 15px;
+	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 400;
 	@include square-style__neutral;
 
 	&.is-active {
-		border-bottom-color: $blue-medium-500;
+		padding-bottom: 0;
+		border-bottom: 3px solid $blue-medium-500;
 		font-weight: 600;
 	}
 

--- a/editor/components/document-outline/style.scss
+++ b/editor/components/document-outline/style.scss
@@ -11,28 +11,28 @@
 	display: flex;
 	margin: 4px 0;
 
-	.document-outline__emdash::before {
+	.document-outline__emdash:before {
 		color: $light-gray-500;
 		margin-right: 4px;
 	}
 
-	&.is-h2 .document-outline__emdash::before {
+	&.is-h2 .document-outline__emdash:before {
 		content: '—';
 	}
 
-	&.is-h3 .document-outline__emdash::before {
+	&.is-h3 .document-outline__emdash:before {
 		content: '——';
 	}
 
-	&.is-h4 .document-outline__emdash::before {
+	&.is-h4 .document-outline__emdash:before {
 		content: '———';
 	}
 
-	&.is-h5 .document-outline__emdash::before {
+	&.is-h5 .document-outline__emdash:before {
 		content: '————';
 	}
 
-	&.is-h6 .document-outline__emdash::before {
+	&.is-h6 .document-outline__emdash:before {
 		content: '—————';
 	}
 }

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -172,10 +172,10 @@ input[type="search"].editor-inserter__search {
 .editor-inserter__tab {
 	border: none;
 	background: none;
-	border-bottom: 3px solid transparent;
-	border-top: 3px solid transparent;
+	//border-bottom: 3px solid transparent;
+	//border-top: 3px solid transparent;
 	font-size: $default-font;
-	padding: 8px 8px;
+	padding: #{ 8px + 3px } 8px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	width: 100%;
 	border-radius: 0;
 	margin: 0;
@@ -184,6 +184,7 @@ input[type="search"].editor-inserter__search {
 	@include square-style__neutral();
 
 	&.is-active {
+		padding-bottom: 8px;
 		font-weight: 600;
 		border-bottom-color: $blue-medium-500;
 		position: relative;


### PR DESCRIPTION
Fixes #5244.

This PR makes two changes to how focus and active state styles are rendered, so as to accommodate Windows high contrast mode. 

The first is to the Settings button which did not have a focus style, it does now:

![settings](https://user-images.githubusercontent.com/1204802/37201939-6d1f049c-2389-11e8-967f-fd8c5e485384.gif)

The second is for tabs, both the Document & Block tabs, but also the Inserter tabs:

![high contrast](https://user-images.githubusercontent.com/1204802/37201956-7c73d7b0-2389-11e8-8cab-05b6acc14759.gif)

They look unchanged in normal mode:

![normal](https://user-images.githubusercontent.com/1204802/37201964-81bc021a-2389-11e8-9839-270fc36216c1.gif)

#5138 also suggests a change to the Publish and Preview buttons, because these do not have a focus style in high contrast mode. I tried to address this, but decided this should be fixed upstream in WordPress, due to this rule that is inherited:

```
.wp-core-ui .button:active, .wp-core-ui .button:focus {
    outline: 0;
}
```

While we can override this, it would create technical debt and still benefit only the editor. As such, I would suggest instead that this is addressed as part of https://core.trac.wordpress.org/ticket/41286. Here's a psuedo patch:

```
.wp-core-ui .button:active, .wp-core-ui .button:focus {
    outline: 2px solid transparent;
    outline-offset: 2px;
}
```

This would result in the following:

<img width="377" alt="screen shot 2018-03-09 at 10 43 07" src="https://user-images.githubusercontent.com/1204802/37202141-fa82fca8-2389-11e8-9bef-a1ffda74f421.png">
