### PR TITLE
Use lodash includes in the navigable menu.

### DIFF
--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { omit, noop } from 'lodash';
+import { omit, noop, includes } from 'lodash';
 
 /**
  * WordPress Dependencies
@@ -138,9 +138,9 @@ export class NavigableMenu extends Component {
 				previous = [ LEFT, UP ];
 			}
 
-			if ( next.includes( keyCode ) ) {
+			if ( includes( next, keyCode ) ) {
 				return 1;
-			} else if ( previous.includes( keyCode ) ) {
+			} else if ( includes( previous, keyCode ) ) {
 				return -1;
 			}
 		};

--- a/edit-post/store/selectors.js
+++ b/edit-post/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { some } from 'lodash';
+import { includes, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ export function getEditorMode( state ) {
 export function isEditorSidebarOpened( state ) {
 	const activeGeneralSidebar = getPreference( state, 'activeGeneralSidebar', null );
 
-	return [ 'edit-post/document', 'edit-post/block' ].includes( activeGeneralSidebar );
+	return includes( [ 'edit-post/document', 'edit-post/block' ], activeGeneralSidebar );
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1098,7 +1098,7 @@ function buildInserterItemFromBlockType( state, enabledBlockTypes, blockType ) {
 		return null;
 	}
 
-	const blockTypeIsDisabled = Array.isArray( enabledBlockTypes ) && ! enabledBlockTypes.includes( blockType.name );
+	const blockTypeIsDisabled = Array.isArray( enabledBlockTypes ) && ! includes( enabledBlockTypes, blockType.name );
 	if ( blockTypeIsDisabled ) {
 		return null;
 	}
@@ -1132,7 +1132,7 @@ function buildInserterItemFromReusableBlock( enabledBlockTypes, reusableBlock ) 
 		return null;
 	}
 
-	const blockTypeIsDisabled = Array.isArray( enabledBlockTypes ) && ! enabledBlockTypes.includes( 'core/block' );
+	const blockTypeIsDisabled = Array.isArray( enabledBlockTypes ) && ! includes( enabledBlockTypes, 'core/block' );
 	if ( blockTypeIsDisabled ) {
 		return null;
 	}


### PR DESCRIPTION
This PR tries to fix a bug where the `NavigableMenu` component used the native `includes` which is not supported in IE11, causing the arrows navigation to break.

Fixes #5527 