### PR TITLE
Fix regression with inserter tabs

### DIFF
--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -172,8 +172,6 @@ input[type="search"].editor-inserter__search {
 .editor-inserter__tab {
 	border: none;
 	background: none;
-	//border-bottom: 3px solid transparent;
-	//border-top: 3px solid transparent;
 	font-size: $default-font;
 	padding: #{ 8px + 3px } 8px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	width: 100%;
@@ -186,7 +184,7 @@ input[type="search"].editor-inserter__search {
 	&.is-active {
 		padding-bottom: 8px;
 		font-weight: 600;
-		border-bottom-color: $blue-medium-500;
+		border-bottom: 3px solid $blue-medium-500;
 		position: relative;
 		z-index: z-index( '.editor-inserter__tab.is-active' );
 	}


### PR DESCRIPTION
This fixes a regression I introduced in https://github.com/WordPress/gutenberg/pull/5526. If you have a color scheme enabled that isn't the standard one, everything would look fine, but the default color scheme lacked the bottom border indicator for tabs in the inserter. This fixes it.

![screen shot 2018-03-09 at 16 19 32](https://user-images.githubusercontent.com/1204802/37214626-df604710-23b5-11e8-9e77-bf69f8534766.png)