### PR TITLE
Inserter tab panels improved keyboard interaction.

### DIFF
--- a/components/tab-panel/index.js
+++ b/components/tab-panel/index.js
@@ -88,6 +88,7 @@ class TabPanel extends Component {
 						role="tabpanel"
 						id={ selectedId + '-view' }
 						className="components-tab-panel__tab-content"
+						tabIndex="0"
 					>
 						{ this.props.children( selectedTab.name ) }
 					</div>

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -151,6 +151,15 @@ input[type="search"].editor-inserter__search {
 	.components-tab-panel__tab-content {
 		overflow: auto;
 
+		&:focus {
+			outline: 1px solid $blue-medium-500;
+			outline-offset: -1px;
+
+			&:active {
+				outline: none;
+			}
+		}
+
 		@include break-medium {
 			height: $block-inserter-content-height;
 		}

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -150,14 +150,14 @@ input[type="search"].editor-inserter__search {
 
 	.components-tab-panel__tab-content {
 		overflow: auto;
+		@include square-style__neutral();
 
 		&:focus {
-			outline: 1px solid $blue-medium-500;
-			outline-offset: -1px;
+			@include square-style__focus-active()
+		}
 
-			&:active {
-				outline: none;
-			}
+		&:focus:active {
+			outline: none;
 		}
 
 		@include break-medium {


### PR DESCRIPTION
This PR tries to improve keyboard interaction with the Inserter tab panels scrollable divs. Scrollable divs behave differently across browsers, for more details please refer to the issue #5533 

Makes the scrollable divs focusable: this also meets the recommended ARIA patterns for the tab panels:
https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel
https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html
`tabindex=0`
- Puts the tabpanel in the page Tab sequence.
- Facilitates movement to panel content for assistive technology users.
- Especially helpful if there are panels that do not contain a focusable element.

Adds a focus style for the focusable divs:
- the focus style is only visible when using the keyboard
- when using the mouse and clicking on a block, the focus style is reset by `:focus:active { outline: none }`

@jasmussen please do feel free to improve the look and feel of the focus style, I've implemented a very basic style for now

Screenshot:

![screen shot 2018-03-09 at 16 35 06](https://user-images.githubusercontent.com/1682452/37215738-192cc060-23b9-11e8-9907-ed494372c42b.png)

Added bonus: making the tab panels focusable will also help screen readers announce their label (given by `aria-labelledby`):

![screen shot 2018-03-09 at 16 18 53](https://user-images.githubusercontent.com/1682452/37215791-3ef36362-23b9-11e8-89bc-bc58e66e75ef.png)

Fixes #5533.