### PR TITLE
Block conversion: Preserve "More" order

### DIFF
--- a/blocks/api/raw-handling/special-comment-converter.js
+++ b/blocks/api/raw-handling/special-comment-converter.js
@@ -55,8 +55,7 @@ export default function( node ) {
 	while ( parent.nodeName !== 'BODY' ) {
 		parent = parent.parentNode;
 	}
-	parent.appendChild( more );
-	node.parentNode.removeChild( node );
+	replace( node, more );
 }
 
 function createMore( customText, noTeaser ) {
@@ -70,4 +69,17 @@ function createMore( customText, noTeaser ) {
 		node.dataset.noTeaser = '';
 	}
 	return node;
+}
+
+function replace( processedNode, newNode ) {
+	insertAfter( newNode, processedNode.parentNode );
+	remove( processedNode );
+}
+
+function remove( node ) {
+	node.parentNode.removeChild( node );
+}
+
+function insertAfter( newNode, referenceNode ) {
+	referenceNode.parentNode.insertBefore( newNode, referenceNode.nextSibling );
 }

--- a/blocks/api/raw-handling/special-comment-converter.js
+++ b/blocks/api/raw-handling/special-comment-converter.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { remove, replace } from '@wordpress/utils';
+
+/**
  * Browser dependencies
  */
 const { COMMENT_NODE } = window.Node;
@@ -42,7 +47,7 @@ export default function( node ) {
 			sibling.nodeValue === 'noteaser'
 		) {
 			noTeaser = true;
-			sibling.parentNode.removeChild( sibling );
+			remove( sibling );
 			break;
 		}
 	}
@@ -69,17 +74,4 @@ function createMore( customText, noTeaser ) {
 		node.dataset.noTeaser = '';
 	}
 	return node;
-}
-
-function replace( processedNode, newNode ) {
-	insertAfter( newNode, processedNode.parentNode );
-	remove( processedNode );
-}
-
-function remove( node ) {
-	node.parentNode.removeChild( node );
-}
-
-function insertAfter( newNode, referenceNode ) {
-	referenceNode.parentNode.insertBefore( newNode, referenceNode.nextSibling );
 }

--- a/blocks/api/raw-handling/test/integration/classic-in.html
+++ b/blocks/api/raw-handling/test/integration/classic-in.html
@@ -1,4 +1,8 @@
-<p>First paragraph.</p>
+<p>First paragraph</p>
 <p><!--more--></p>
 <p>Second paragraph</p>
 <p>Third paragraph</p>
+
+<p>Fourth <!--more--> paragraph</p>
+<p>Fifth paragraph</p>
+<p>Sixth paragraph</p>

--- a/blocks/api/raw-handling/test/integration/classic-in.html
+++ b/blocks/api/raw-handling/test/integration/classic-in.html
@@ -1,0 +1,4 @@
+<p>First paragraph.</p>
+<p><!--more--></p>
+<p>Second paragraph</p>
+<p>Third paragraph</p>

--- a/blocks/api/raw-handling/test/integration/classic-out.html
+++ b/blocks/api/raw-handling/test/integration/classic-out.html
@@ -1,5 +1,5 @@
 <!-- wp:paragraph -->
-<p>First paragraph.</p>
+<p>First paragraph</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:more -->
@@ -12,4 +12,20 @@
 
 <!-- wp:paragraph -->
 <p>Third paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Fourth paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->
+
+<!-- wp:paragraph -->
+<p>Fifth paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Sixth paragraph</p>
 <!-- /wp:paragraph -->

--- a/blocks/api/raw-handling/test/integration/classic-out.html
+++ b/blocks/api/raw-handling/test/integration/classic-out.html
@@ -1,0 +1,15 @@
+<!-- wp:paragraph -->
+<p>First paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Third paragraph</p>
+<!-- /wp:paragraph -->

--- a/blocks/api/raw-handling/test/integration/index.js
+++ b/blocks/api/raw-handling/test/integration/index.js
@@ -14,6 +14,7 @@ import serialize from '../../../serializer';
 
 const types = [
 	'plain',
+	'classic',
 	'apple',
 	'google-docs',
 	'ms-word',

--- a/blocks/api/raw-handling/test/special-comment-converter.js
+++ b/blocks/api/raw-handling/test/special-comment-converter.js
@@ -3,18 +3,6 @@
  */
 import { equal } from 'assert';
 
-function trimWhitespace( string ) {
-	return string.replace( /(  +)|\n|\t/g, '' );
-}
-
-function wrapInP( string ) {
-	return `<p>${ string }</p>`;
-}
-
-function withEmptyP( string ) {
-	return `<p></p>${ string }`;
-}
-
 /**
  * Internal dependencies
  */
@@ -24,27 +12,29 @@ import { deepFilterHTML } from '../utils';
 describe( 'specialCommentConverter', () => {
 	it( 'should convert a single comment into a basic block', () => {
 		equal(
-			deepFilterHTML( wrapInP(
-				'<!--more-->'
-			), [ specialCommentConverter ] ),
-			withEmptyP( '<wp-block data-block="core/more"></wp-block>' )
+			deepFilterHTML(
+				'<p><!--more--></p>',
+				[ specialCommentConverter ]
+			),
+			'<p></p><wp-block data-block="core/more"></wp-block>'
 		);
 	} );
 	it( 'should convert two comments into a block', () => {
 		equal(
-			deepFilterHTML( wrapInP(
-				'<!--more--><!--noteaser-->'
-			), [ specialCommentConverter ] ),
-			withEmptyP( '<wp-block data-block="core/more" data-no-teaser=""></wp-block>' )
+			deepFilterHTML(
+				'<p><!--more--><!--noteaser--></p>',
+				[ specialCommentConverter ]
+			),
+			'<p></p><wp-block data-block="core/more" data-no-teaser=""></wp-block>'
 		);
 	} );
 	it( 'should pass custom text to the block', () => {
 		equal(
-			deepFilterHTML( wrapInP(
-				'<!--more Read all about it!--><!--noteaser-->'
-			), [ specialCommentConverter ]
+			deepFilterHTML(
+				'<p><!--more Read all about it!--><!--noteaser--></p>',
+				[ specialCommentConverter ]
 			),
-			withEmptyP( '<wp-block data-block="core/more" data-custom-text="Read all about it!" data-no-teaser=""></wp-block>' )
+			'<p></p><wp-block data-block="core/more" data-custom-text="Read all about it!" data-no-teaser=""></wp-block>'
 		);
 	} );
 	it( 'should not break content order', () => {
@@ -55,26 +45,22 @@ describe( 'specialCommentConverter', () => {
 			[ specialCommentConverter ]
 		);
 		equal(
-			trimWhitespace( output ),
-			trimWhitespace( `<p>First paragraph.</p>
-			<wp-block data-block=\"core/more\"></wp-block>
+			output,
+			`<p>First paragraph.</p><wp-block data-block=\"core/more\"></wp-block>
 			<p>Second paragraph</p>
-			<p>Third paragraph</p>` )
+			<p>Third paragraph</p>`
 		);
 	} );
 
 	describe( 'when tags have been reformatted', () => {
 		it( 'should parse special comments', () => {
 			const output = deepFilterHTML(
-				`<p>
-					<!--more-->
-					<!--noteaser-->
-				</p>`,
+				'<p><!--more--><!--noteaser--></p>',
 				[ specialCommentConverter ]
 			);
 			equal(
-				trimWhitespace( output ),
-				withEmptyP( '<wp-block data-block="core/more" data-no-teaser=""></wp-block>' )
+				output,
+				'<p></p><wp-block data-block="core/more" data-no-teaser=""></wp-block>'
 			);
 		} );
 		it( 'should not break content order', () => {
@@ -86,12 +72,11 @@ describe( 'specialCommentConverter', () => {
 				[ specialCommentConverter ]
 			);
 			equal(
-				trimWhitespace( output ),
-				trimWhitespace( `<p>First paragraph.</p>
-				<p></p>
-				<wp-block data-block=\"core/more\"></wp-block>
+				output,
+				`<p>First paragraph.</p>
+				<p></p><wp-block data-block=\"core/more\"></wp-block>
 				<p>Second paragraph</p>
-				<p>Third paragraph</p>` )
+				<p>Third paragraph</p>`
 			);
 		} );
 	} );

--- a/blocks/api/raw-handling/test/special-comment-converter.js
+++ b/blocks/api/raw-handling/test/special-comment-converter.js
@@ -3,6 +3,18 @@
  */
 import { equal } from 'assert';
 
+function trimWhitespace( string ) {
+	return string.replace( /(  +)|\n|\t/g, '' );
+}
+
+function wrapInP( string ) {
+	return `<p>${ string }</p>`;
+}
+
+function withEmptyP( string ) {
+	return `<p></p>${ string }`;
+}
+
 /**
  * Internal dependencies
  */
@@ -12,38 +24,75 @@ import { deepFilterHTML } from '../utils';
 describe( 'specialCommentConverter', () => {
 	it( 'should convert a single comment into a basic block', () => {
 		equal(
-			deepFilterHTML( '<!--more-->', [ specialCommentConverter ] ),
-			'<wp-block data-block="core/more"></wp-block>'
+			deepFilterHTML( wrapInP(
+				'<!--more-->'
+			), [ specialCommentConverter ] ),
+			withEmptyP( '<wp-block data-block="core/more"></wp-block>' )
 		);
 	} );
 	it( 'should convert two comments into a block', () => {
 		equal(
-			deepFilterHTML( '<!--more--><!--noteaser-->', [ specialCommentConverter ] ),
-			'<wp-block data-block="core/more" data-no-teaser=""></wp-block>'
+			deepFilterHTML( wrapInP(
+				'<!--more--><!--noteaser-->'
+			), [ specialCommentConverter ] ),
+			withEmptyP( '<wp-block data-block="core/more" data-no-teaser=""></wp-block>' )
 		);
 	} );
 	it( 'should pass custom text to the block', () => {
 		equal(
-			deepFilterHTML(
-				'<!--more Read all about it!--><!--noteaser-->',
-				[ specialCommentConverter ]
+			deepFilterHTML( wrapInP(
+				'<!--more Read all about it!--><!--noteaser-->'
+			), [ specialCommentConverter ]
 			),
-			'<wp-block data-block="core/more" data-custom-text="Read all about it!" data-no-teaser=""></wp-block>'
+			withEmptyP( '<wp-block data-block="core/more" data-custom-text="Read all about it!" data-no-teaser=""></wp-block>' )
 		);
 	} );
-	it( 'should handle reformatted content', () => {
+	it( 'should not break content order', () => {
 		const output = deepFilterHTML(
-			`<p>
-				<!--more-->
-				<!--noteaser-->
-			</p>`,
+			`<p>First paragraph.<!--more--></p>
+			<p>Second paragraph</p>
+			<p>Third paragraph</p>`,
 			[ specialCommentConverter ]
 		);
-		// Skip the empty paragraph, which other transforms would eliminate
-		const start = output.indexOf( '</p>' ) + '</p>'.length;
 		equal(
-			output.substr( start ),
-			'<wp-block data-block="core/more" data-no-teaser=""></wp-block>'
+			trimWhitespace( output ),
+			trimWhitespace( `<p>First paragraph.</p>
+			<wp-block data-block=\"core/more\"></wp-block>
+			<p>Second paragraph</p>
+			<p>Third paragraph</p>` )
 		);
+	} );
+
+	describe( 'when tags have been reformatted', () => {
+		it( 'should parse special comments', () => {
+			const output = deepFilterHTML(
+				`<p>
+					<!--more-->
+					<!--noteaser-->
+				</p>`,
+				[ specialCommentConverter ]
+			);
+			equal(
+				trimWhitespace( output ),
+				withEmptyP( '<wp-block data-block="core/more" data-no-teaser=""></wp-block>' )
+			);
+		} );
+		it( 'should not break content order', () => {
+			const output = deepFilterHTML(
+				`<p>First paragraph.</p>
+				<p><!--more--></p>
+				<p>Second paragraph</p>
+				<p>Third paragraph</p>`,
+				[ specialCommentConverter ]
+			);
+			equal(
+				trimWhitespace( output ),
+				trimWhitespace( `<p>First paragraph.</p>
+				<p></p>
+				<wp-block data-block=\"core/more\"></wp-block>
+				<p>Second paragraph</p>
+				<p>Third paragraph</p>` )
+			);
+		} );
 	} );
 } );

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -373,3 +373,37 @@ export function getScrollContainer( node ) {
 	// Continue traversing
 	return getScrollContainer( node.parentNode );
 }
+
+/**
+ * Given two DOM nodes, replaces the former with the latter in the DOM.
+ *
+ * @param {Element} processedNode Node to be removed.
+ * @param {Element} newNode       Node to be inserted in its place.
+ * @return {void}
+ */
+export function replace( processedNode, newNode ) {
+	insertAfter( newNode, processedNode.parentNode );
+	remove( processedNode );
+}
+
+/**
+ * Given a DOM node, removes it from the DOM.
+ *
+ * @param {Element} node Node to be removed.
+ * @return {void}
+ */
+export function remove( node ) {
+	node.parentNode.removeChild( node );
+}
+
+/**
+ * Given two DOM nodes, inserts the former in the DOM as the next sibling of
+ * the latter.
+ *
+ * @param {Element} newNode       Node to be inserted.
+ * @param {Element} referenceNode Node after which to perform the insertion.
+ * @return {void}
+ */
+export function insertAfter( newNode, referenceNode ) {
+	referenceNode.parentNode.insertBefore( newNode, referenceNode.nextSibling );
+}


### PR DESCRIPTION
Fixes the issue described by @swissspidy in https://github.com/WordPress/gutenberg/pull/1467#issuecomment-369926260

Kudos @swissspidy for the fix; I merely added tests.

_(drive-by pull request; can provide further details later)_

## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
