### PR TITLE
Post Title: Insert initial block as provisional

### DIFF
--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -10,7 +10,6 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
-import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withContext, withFocusOutside } from '@wordpress/components';
 
@@ -97,11 +96,11 @@ const applyWithSelect = withSelect( ( select ) => {
 } );
 
 const applyWithDispatch = withDispatch( ( dispatch ) => {
-	const { insertBlock, editPost, clearSelectedBlock } = dispatch( 'core/editor' );
+	const { insertDefaultBlock, editPost, clearSelectedBlock } = dispatch( 'core/editor' );
 
 	return {
 		onEnterPress() {
-			insertBlock( createBlock( getDefaultBlockName() ), 0 );
+			insertDefaultBlock( undefined, undefined, 0 );
 		},
 		onUpdate( title ) {
 			editPost( { title } );

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import Textarea from 'react-autosize-textarea';
 import classnames from 'classnames';
 
@@ -12,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { keycodes } from '@wordpress/utils';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { withContext, withFocusOutside } from '@wordpress/components';
 
 /**
@@ -19,8 +19,6 @@ import { withContext, withFocusOutside } from '@wordpress/components';
  */
 import './style.scss';
 import PostPermalink from '../post-permalink';
-import { getEditedPostAttribute } from '../../store/selectors';
-import { insertBlock, editPost, clearSelectedBlock } from '../../store/actions';
 
 /**
  * Constants
@@ -90,20 +88,27 @@ class PostTitle extends Component {
 	}
 }
 
-const applyConnect = connect(
-	( state ) => ( {
-		title: getEditedPostAttribute( state, 'title' ),
-	} ),
-	{
+const applyWithSelect = withSelect( ( select ) => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+
+	return {
+		title: getEditedPostAttribute( 'title' ),
+	};
+} );
+
+const applyWithDispatch = withDispatch( ( dispatch ) => {
+	const { insertBlock, editPost, clearSelectedBlock } = dispatch( 'core/editor' );
+
+	return {
 		onEnterPress() {
-			return insertBlock( createBlock( getDefaultBlockName() ), 0 );
+			insertBlock( createBlock( getDefaultBlockName() ), 0 );
 		},
 		onUpdate( title ) {
-			return editPost( { title } );
+			editPost( { title } );
 		},
 		clearSelectedBlock,
-	}
-);
+	};
+} );
 
 const applyEditorSettings = withContext( 'editor' )(
 	( settings ) => ( {
@@ -112,7 +117,8 @@ const applyEditorSettings = withContext( 'editor' )(
 );
 
 export default compose(
-	applyConnect,
+	applyWithSelect,
+	applyWithDispatch,
 	applyEditorSettings,
 	withFocusOutside
 )( PostTitle );


### PR DESCRIPTION
This pull request seeks to update the behavior of pressing enter from the title field to leverage the same `insertDefaultBlock` as the default block appender and betweenserter for consistency and so that it inherits the same "provisional" block behavior introduced in #5417.

__Testing instructions:__

1. Create a new post
2. Insert a title
3. Press enter
4. Press arrow up
5. Note that after focus transitions into the title, the block which had been inserted after step 3 has been removed (the "Write your story" prompt returns)