### PR TITLE
Writing Flow: Redirect click below editor to last text field

### DIFF
--- a/edit-post/components/visual-editor/index.js
+++ b/edit-post/components/visual-editor/index.js
@@ -27,8 +27,8 @@ function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
 			<EditorGlobalKeyboardShortcuts />
 			<CopyHandler />
 			<MultiSelectScrollIntoView />
-			<ObserveTyping>
-				<WritingFlow>
+			<WritingFlow>
+				<ObserveTyping>
 					<PostTitle />
 					<BlockList
 						showContextualToolbar={ ! isLargeViewport || ! hasFixedToolbar }
@@ -39,8 +39,8 @@ function VisualEditor( { hasFixedToolbar, isLargeViewport } ) {
 							</Fragment>
 						) }
 					/>
-				</WritingFlow>
-			</ObserveTyping>
+				</ObserveTyping>
+			</WritingFlow>
 		</BlockSelectionClearer>
 	);
 }

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -24,6 +24,14 @@
 	}
 }
 
+.edit-post-visual-editor .editor-writing-flow__click-redirect {
+	// Collapse to minimum height of 50px, to fully occupy editor bottom pad.
+	height: 50px;
+	width: $visual-editor-max-width;
+	// Offset for: Visual editor padding, block (default appender) margin.
+	margin: #{ -1 * $block-spacing } auto -50px;
+}
+
 .edit-post-visual-editor .editor-block-list__block {
 	margin-left: auto;
 	margin-right: auto;
@@ -88,6 +96,12 @@
 	margin-left: auto;
 	margin-right: auto;
 	position: relative;
+
+	&[data-root-uid=""] .editor-default-block-appender__content:hover {
+		// Outline on root-level default block appender is redundant with the
+		// WritingFlow click redirector.
+		outline: 1px solid transparent;
+	}
 
 	@include break-small() {
 		padding: 0 $block-mover-padding-visible;	// don't subtract 1px border because it's a border not an outline

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/element';
-import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { getDefaultBlockName } from '@wordpress/blocks';
 import { withContext } from '@wordpress/components';
 
 /**
@@ -50,10 +51,10 @@ export default compose(
 		( state, ownProps ) => {
 			const isEmpty = ! getBlockCount( state, ownProps.rootUID );
 			const lastBlock = getBlock( state, ownProps.lastBlockUID );
-			const isLastBlockEmptyDefault = lastBlock && isUnmodifiedDefaultBlock( lastBlock );
+			const isLastBlockDefault = get( lastBlock, 'name' ) === getDefaultBlockName();
 
 			return {
-				isVisible: isEmpty || ! isLastBlockEmptyDefault,
+				isVisible: isEmpty || ! isLastBlockDefault,
 				showPrompt: isEmpty,
 			};
 		},

--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -22,7 +22,15 @@ import { getBlock, getBlockCount } from '../../store/selectors';
 import InserterWithShortcuts from '../inserter-with-shortcuts';
 import Inserter from '../inserter';
 
-export function DefaultBlockAppender( { isLocked, isVisible, onAppend, showPrompt, placeholder, layout, rootUID } ) {
+export function DefaultBlockAppender( {
+	isLocked,
+	isVisible,
+	onAppend,
+	showPrompt,
+	placeholder,
+	layout,
+	rootUID,
+} ) {
 	if ( isLocked || ! isVisible ) {
 		return null;
 	}
@@ -30,7 +38,9 @@ export function DefaultBlockAppender( { isLocked, isVisible, onAppend, showPromp
 	const value = placeholder || __( 'Write your story' );
 
 	return (
-		<div className="editor-default-block-appender">
+		<div
+			data-root-uid={ rootUID || '' }
+			className="editor-default-block-appender">
 			<BlockDropZone />
 			<input
 				className="editor-default-block-appender__content"

--- a/editor/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/editor/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -3,6 +3,7 @@
 exports[`DefaultBlockAppender should append a default block when input focused 1`] = `
 <div
   className="editor-default-block-appender"
+  data-root-uid=""
 >
   <Connect(WrappedComponent) />
   <input
@@ -42,6 +43,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
 exports[`DefaultBlockAppender should match snapshot 1`] = `
 <div
   className="editor-default-block-appender"
+  data-root-uid=""
 >
   <Connect(WrappedComponent) />
   <input
@@ -63,6 +65,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
 exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
 <div
   className="editor-default-block-appender"
+  data-root-uid=""
 >
   <Connect(WrappedComponent) />
   <input

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { find, reverse, get } from 'lodash';
+import { overEvery, find, findLast, reverse, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +22,7 @@ import {
 /**
  * Internal dependencies
  */
+import './style.scss';
 import {
 	getPreviousBlockUid,
 	getNextBlockUid,
@@ -39,9 +40,28 @@ import {
 } from '../../utils/dom';
 
 /**
+ * Browser dependencies
+ */
+
+const { DOMRect } = window;
+
+/**
  * Module Constants
  */
 const { UP, DOWN, LEFT, RIGHT } = keycodes;
+
+/**
+ * Given an element, returns true if the element is a tabbable text field, or
+ * false otherwise.
+ *
+ * @param {Element} element Element to test.
+ *
+ * @return {boolean} Whether element is a tabbable text field.
+ */
+const isTabbableTextField = overEvery( [
+	isTextField,
+	focus.tabbable.isTabbableIndex,
+] );
 
 class WritingFlow extends Component {
 	constructor() {
@@ -50,6 +70,8 @@ class WritingFlow extends Component {
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
 		this.clearVerticalRect = this.clearVerticalRect.bind( this );
+		this.focusLastTextField = this.focusLastTextField.bind( this );
+
 		this.verticalRect = null;
 	}
 
@@ -194,13 +216,35 @@ class WritingFlow extends Component {
 			this.moveSelection( isReverse );
 		} else if ( isVertical && isVerticalEdge( target, isReverse, isShift ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
-			placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
-			event.preventDefault();
+			if ( closestTabbable ) {
+				placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
+				event.preventDefault();
+			}
 		} else if ( isHorizontal && isHorizontalEdge( target, isReverse, isShift ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
 			event.preventDefault();
 		}
+	}
+
+	/**
+	 * Shifts focus to the last tabbable text field — if one exists — at the
+	 * given mouse event's X coordinate.
+	 *
+	 * @param {MouseEvent} event Mouse event to align caret X offset.
+	 */
+	focusLastTextField( event ) {
+		const focusableNodes = focus.focusable.find( this.container );
+		const target = findLast( focusableNodes, isTabbableTextField );
+		if ( ! target ) {
+			return;
+		}
+
+		// Emulate a rect at which caret should be placed using mouse event.
+		const rect = target.getBoundingClientRect();
+		const targetRect = new DOMRect( event.clientX, rect.top, 0, rect.height );
+
+		placeCaretAtVerticalEdge( target, false, targetRect );
 	}
 
 	render() {
@@ -210,12 +254,20 @@ class WritingFlow extends Component {
 		// bubbling events from children to determine focus transition intents.
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
-			<div
-				ref={ this.bindContainer }
-				onKeyDown={ this.onKeyDown }
-				onMouseDown={ this.clearVerticalRect }
-			>
-				{ children }
+			<div className="editor-writing-flow">
+				<div
+					ref={ this.bindContainer }
+					onKeyDown={ this.onKeyDown }
+					onMouseDown={ this.clearVerticalRect }
+				>
+					{ children }
+				</div>
+				<div
+					aria-hidden
+					tabIndex={ -1 }
+					onClick={ this.focusLastTextField }
+					className="editor-writing-flow__click-redirect"
+				/>
 			</div>
 		);
 		/* eslint-disable jsx-a11y/no-static-element-interactions */

--- a/editor/components/writing-flow/style.scss
+++ b/editor/components/writing-flow/style.scss
@@ -1,0 +1,10 @@
+.editor-writing-flow {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.editor-writing-flow__click-redirect {
+	flex-basis: 100%;
+	cursor: text;
+}

--- a/test/e2e/integration/002-adding-blocks.js
+++ b/test/e2e/integration/002-adding-blocks.js
@@ -4,18 +4,14 @@ describe( 'Adding blocks', () => {
 	} );
 
 	it( 'Should insert content using the placeholder and the regular inserter', () => {
-		const lastBlockSelector = '.editor-block-list__block-edit:last';
+		// Default block appender is provisional
+		cy.get( '.editor-default-block-appender' ).click();
+		cy.get( '.editor-post-title__input' ).click();
+		cy.get( '[data-type="core/paragraph"]' ).should( 'have.length', 0 );
 
 		// Using the placeholder
 		cy.get( '.editor-default-block-appender' ).click();
 		cy.focused().type( 'Paragraph block' );
-
-		// Default block appender is provisional
-		cy.get( lastBlockSelector ).then( ( firstBlock ) => {
-			cy.get( '.editor-default-block-appender' ).click();
-			cy.get( '.editor-post-title__input' ).click();
-			cy.get( lastBlockSelector ).should( 'have.text', firstBlock.text() );
-		} );
 
 		// Using the slash command
 		// TODO: Test omitted because Cypress doesn't update the selection


### PR DESCRIPTION
Supersedes #5493

This pull request seeks to apply some of the ideas from #5493, albeit at a more limited scope. It seeks to turn the entire block list column into a clickable text target, effectively equivalent to the default block appender spanning the entire viewport height of the editable canvas. In the process, it reverts #5199; when the last block is a text block, clicking below the text editor moves the text caret to the last block aligned at the X coordinate of the click. This should feel very familiar to the experience of a word processor like Google Docs.

The behavior is complemented well by #5417, where clicking into and out of the default appended block is quite seamless.

As with #5493, the effect is difficult to describe, and is better experienced live.

Given the revert of #5199, this does conflict with the proposed goals of #5478, where with these changes we cannot assume that the default block appender will always be present at the end of content.

__Testing instructions:__

Verify that clicking below the last block appends a new text block if the last block is not already a paragraph block.

If the last block is a paragraph block, verify that clicking below the block aligns the text caret corresponding to the X coordinate of the click.

Verify that you can still clear the selected block by clicking to the left or right of the area below the block list (where the cursor changes from `cursor: text` to `cursor: default`).

Repeat above instructions in various viewport sizes† and content length.

_† The effect doesn't work at small viewports, because the editor does not occupy the full height until reaching 600px or wider because of [this style](https://github.com/WordPress/gutenberg/blob/4cb41ab3113070cca81f17c11198333f12f9ba8d/edit-post/assets/stylesheets/main.scss#L96-L105). We should consider how we can otherwise allow the editor to occupy the full height on small viewport sizes. I expect "click below to clear" currently doesn't work either, in master._