### PR TITLE
Add a "Write your story" filter.

### DIFF
--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -19,10 +19,12 @@ import BlockDropZone from '../block-drop-zone';
 import { insertDefaultBlock, startTyping } from '../../store/actions';
 import { getBlock, getBlockCount } from '../../store/selectors';
 
-export function DefaultBlockAppender( { isLocked, isVisible, onAppend, showPrompt } ) {
+export function DefaultBlockAppender( { isLocked, isVisible, onAppend, showPrompt, placeholder } ) {
 	if ( isLocked || ! isVisible ) {
 		return null;
 	}
+
+	const value = placeholder || __( 'Write your story' );
 
 	return (
 		<div className="editor-default-block-appender">
@@ -34,7 +36,7 @@ export function DefaultBlockAppender( { isLocked, isVisible, onAppend, showPromp
 				onFocus={ onAppend }
 				onClick={ onAppend }
 				onKeyDown={ onAppend }
-				value={ showPrompt ? __( 'Write your story' ) : '' }
+				value={ showPrompt ? value : '' }
 			/>
 		</div>
 	);
@@ -66,10 +68,11 @@ export default compose(
 		} )
 	),
 	withContext( 'editor' )( ( settings ) => {
-		const { templateLock } = settings;
+		const { templateLock, bodyPlaceholder } = settings;
 
 		return {
 			isLocked: !! templateLock,
+			placeholder: bodyPlaceholder,
 		};
 	} ),
 )( DefaultBlockAppender );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -914,6 +914,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
+		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
 	);
 
 	if ( ! empty( $color_palette ) ) {


### PR DESCRIPTION
fixes #5466

## Description
Adds a `write_your_story` filter to match the `enter_title_here` filter, so the default block appender  prompt can be customized.

## How Has This Been Tested?
Verified that this updates the prompt:

```php
add_filter( 'write_your_story', function() {
	return 'Say something';
});
```

## Types of changes
1. New filter `write_your_story`.
2. `<DefaultBlockAppender />` accepts `placeholder` argument.
