### PR TITLE
Toolbar: Return focus to selection when escape pressed

### DIFF
--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -15,7 +15,6 @@ import { KeyboardShortcuts, withContext } from '@wordpress/components';
  */
 import { getBlockOrder, getMultiSelectedBlockUids } from '../../store/selectors';
 import {
-	clearSelectedBlock,
 	multiSelect,
 	redo,
 	undo,
@@ -74,7 +73,6 @@ class EditorGlobalKeyboardShortcuts extends Component {
 						'mod+shift+z': this.undoOrRedo,
 						backspace: this.deleteSelectedBlocks,
 						del: this.deleteSelectedBlocks,
-						escape: this.props.clearSelectedBlock,
 					} }
 				/>
 				<KeyboardShortcuts
@@ -97,7 +95,6 @@ export default compose(
 			};
 		},
 		{
-			clearSelectedBlock,
 			onMultiSelect: multiSelect,
 			onRedo: redo,
 			onUndo: undo,

--- a/editor/components/editor-global-keyboard-shortcuts/index.js
+++ b/editor/components/editor-global-keyboard-shortcuts/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { first, last } from 'lodash';
 
 /**
@@ -9,26 +8,17 @@ import { first, last } from 'lodash';
  */
 import { Component, Fragment, compose } from '@wordpress/element';
 import { KeyboardShortcuts, withContext } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import { getBlockOrder, getMultiSelectedBlockUids } from '../../store/selectors';
-import {
-	multiSelect,
-	redo,
-	undo,
-	autosave,
-	removeBlocks,
-} from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 class EditorGlobalKeyboardShortcuts extends Component {
 	constructor() {
 		super( ...arguments );
+
 		this.selectAll = this.selectAll.bind( this );
 		this.undoOrRedo = this.undoOrRedo.bind( this );
 		this.save = this.save.bind( this );
 		this.deleteSelectedBlocks = this.deleteSelectedBlocks.bind( this );
+		this.clearMultiSelection = this.clearMultiSelection.bind( this );
 	}
 
 	selectAll( event ) {
@@ -63,6 +53,16 @@ class EditorGlobalKeyboardShortcuts extends Component {
 		}
 	}
 
+	/**
+	 * Clears current multi-selection, if one exists.
+	 */
+	clearMultiSelection() {
+		const { hasMultiSelection, clearSelectedBlock } = this.props;
+		if ( hasMultiSelection ) {
+			clearSelectedBlock();
+		}
+	}
+
 	render() {
 		return (
 			<Fragment>
@@ -73,6 +73,7 @@ class EditorGlobalKeyboardShortcuts extends Component {
 						'mod+shift+z': this.undoOrRedo,
 						backspace: this.deleteSelectedBlocks,
 						del: this.deleteSelectedBlocks,
+						escape: this.clearMultiSelection,
 					} }
 				/>
 				<KeyboardShortcuts
@@ -86,22 +87,39 @@ class EditorGlobalKeyboardShortcuts extends Component {
 	}
 }
 
-export default compose(
-	connect(
-		( state ) => {
-			return {
-				uids: getBlockOrder( state ),
-				multiSelectedBlockUids: getMultiSelectedBlockUids( state ),
-			};
-		},
-		{
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			getBlockOrder,
+			getMultiSelectedBlockUids,
+			hasMultiSelection,
+		} = select( 'core/editor' );
+
+		return {
+			uids: getBlockOrder(),
+			multiSelectedBlockUids: getMultiSelectedBlockUids(),
+			hasMultiSelection: hasMultiSelection(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const {
+			clearSelectedBlock,
+			multiSelect,
+			redo,
+			undo,
+			removeBlocks,
+			autosave,
+		} = dispatch( 'core/editor' );
+
+		return {
+			clearSelectedBlock,
 			onMultiSelect: multiSelect,
 			onRedo: redo,
 			onUndo: undo,
 			onRemove: removeBlocks,
 			onSave: autosave,
-		}
-	),
+		};
+	} ),
 	withContext( 'editor' )( ( settings ) => {
 		const { templateLock } = settings;
 
@@ -109,4 +127,4 @@ export default compose(
 			isLocked: !! templateLock,
 		};
 	} ),
-)( EditorGlobalKeyboardShortcuts );
+] )( EditorGlobalKeyboardShortcuts );

--- a/editor/components/navigable-toolbar/index.js
+++ b/editor/components/navigable-toolbar/index.js
@@ -1,9 +1,20 @@
 /**
+ * External dependencies
+ */
+import { cond, matchesProperty } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { NavigableMenu, KeyboardShortcuts } from '@wordpress/components';
 import { Component, findDOMNode } from '@wordpress/element';
 import { focus, keycodes } from '@wordpress/utils';
+
+/**
+ * Browser dependencies
+ */
+
+const { Node, getSelection } = window;
 
 /**
  * Module Constants
@@ -13,9 +24,14 @@ const { ESCAPE } = keycodes;
 class NavigableToolbar extends Component {
 	constructor() {
 		super( ...arguments );
+
 		this.bindNode = this.bindNode.bind( this );
 		this.focusToolbar = this.focusToolbar.bind( this );
-		this.onToolbarKeyDown = this.onToolbarKeyDown.bind( this );
+		this.focusSelection = this.focusSelection.bind( this );
+
+		this.switchOnKeyDown = cond( [
+			[ matchesProperty( [ 'keyCode' ], ESCAPE ), this.focusSelection ],
+		] );
 	}
 
 	bindNode( ref ) {
@@ -32,17 +48,27 @@ class NavigableToolbar extends Component {
 		}
 	}
 
-	onToolbarKeyDown( event ) {
-		if ( event.keyCode !== ESCAPE ) {
+	/**
+	 * Programmatically shifts focus to the element where the current selection
+	 * exists, if there is a selection.
+	 */
+	focusSelection() {
+		// Ensure that a selection exists.
+		const selection = getSelection();
+		if ( ! selection ) {
 			return;
 		}
 
-		// Is there a better way to focus the selected block
-		// TODO: separate focused/selected block state and use Redux actions instead
-		const selectedBlock = document.querySelector( '.editor-block-list__block.is-selected' );
-		if ( !! selectedBlock ) {
-			event.stopPropagation();
-			selectedBlock.focus();
+		// Focus node may be a text node, which cannot be focused directly.
+		// Find its parent element instead.
+		const { focusNode } = selection;
+		let focusElement = focusNode;
+		if ( focusElement.nodeType !== Node.ELEMENT_NODE ) {
+			focusElement = focusElement.parentElement;
+		}
+
+		if ( focusElement ) {
+			focusElement.focus();
 		}
 	}
 
@@ -54,7 +80,7 @@ class NavigableToolbar extends Component {
 				role="toolbar"
 				deep
 				ref={ this.bindNode }
-				onKeyDown={ this.onToolbarKeyDown }
+				onKeyDown={ this.switchOnKeyDown }
 				{ ...props }
 			>
 				<KeyboardShortcuts

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -871,7 +871,23 @@ export function isBlockWithinSelection( state, uid ) {
 }
 
 /**
- * Whether in the process of multi-selecting or not.
+ * Returns true if a multi-selection has been made, or false otherwise.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Whether multi-selection has been made.
+ */
+export function hasMultiSelection( state ) {
+	const { start, end } = state.blockSelection;
+	return start !== end;
+}
+
+/**
+ * Whether in the process of multi-selecting or not. This flag is only true
+ * while the multi-selection is being selected (by mouse move), and is false
+ * once the multi-selection has been settled.
+ *
+ * @see hasMultiSelection
  *
  * @param {Object} state Global application state.
  *

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -53,6 +53,7 @@ const {
 	getNextBlockUid,
 	isBlockSelected,
 	isBlockWithinSelection,
+	hasMultiSelection,
 	isBlockMultiSelected,
 	isFirstMultiSelectedBlock,
 	getBlockMode,
@@ -1801,6 +1802,41 @@ describe( 'selectors', () => {
 			};
 
 			expect( isBlockWithinSelection( state, 4 ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'hasMultiSelection', () => {
+		it( 'should return false if no selection', () => {
+			const state = {
+				blockSelection: {
+					start: null,
+					end: null,
+				},
+			};
+
+			expect( hasMultiSelection( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if singular selection', () => {
+			const state = {
+				blockSelection: {
+					start: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					end: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+				},
+			};
+
+			expect( hasMultiSelection( state ) ).toBe( false );
+		} );
+
+		it( 'should return true if multi-selection', () => {
+			const state = {
+				blockSelection: {
+					start: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					end: '9db792c6-a25a-495d-adbd-97d56a4c4189',
+				},
+			};
+
+			expect( hasMultiSelection( state ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
Closes #5501 (https://github.com/WordPress/gutenberg/issues/5501#issuecomment-372029875)

This pull request seeks to update the behavior of pressing enter within the toolbar (both contextual and pinned to top) to return focus to the current window selection, if one exists.

~This also removes the global escape-to-deselect-block behavior, which is already inconsistently applied, and where it is applied is usually not expected (e.g. without its removal, pressing escape here would deselect the block).~ This is still useful for clearing the current multi-selection, at least until #5548 and/or #5523 can be resolved. Partially restored (for multi-selection) in b4e6780.

**Testing instructions:**

Verify that when pressing escape within a toolbar, both contextual and pinned to top, that focus is returned to the selected text. The pinned toolbar can be focused by pressing Alt+F10 while a selection is made within a block.