### PR TITLE
Writing Flow: Cancel isTyping when focusing non text field

### DIFF
--- a/editor/components/observe-typing/index.js
+++ b/editor/components/observe-typing/index.js
@@ -40,6 +40,7 @@ class ObserveTyping extends Component {
 		this.stopTypingOnSelectionUncollapse = this.stopTypingOnSelectionUncollapse.bind( this );
 		this.stopTypingOnMouseMove = this.stopTypingOnMouseMove.bind( this );
 		this.startTypingInTextField = this.startTypingInTextField.bind( this );
+		this.stopTypingOnNonTextField = this.stopTypingOnNonTextField.bind( this );
 
 		this.lastMouseMove = null;
 	}
@@ -132,6 +133,20 @@ class ObserveTyping extends Component {
 		onStartTyping();
 	}
 
+	/**
+	 * Stops typing when focus transitions to a non-text field element.
+	 *
+	 * @param {FocusEvent} event Focus event.
+	 */
+	stopTypingOnNonTextField( event ) {
+		const { isTyping, onStopTyping } = this.props;
+		const { target } = event;
+
+		if ( isTyping && ! isTextField( target ) ) {
+			onStopTyping();
+		}
+	}
+
 	render() {
 		const { children } = this.props;
 
@@ -141,6 +156,7 @@ class ObserveTyping extends Component {
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
 			<div
+				onFocus={ this.stopTypingOnNonTextField }
 				onKeyPress={ this.startTypingInTextField }
 				onKeyDown={ this.startTypingInTextField }
 			>
@@ -153,14 +169,18 @@ class ObserveTyping extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
+		const { isTyping } = select( 'core/editor' );
+
 		return {
-			isTyping: select( 'core/editor' ).isTyping(),
+			isTyping: isTyping(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
+		const { startTyping, stopTyping } = dispatch( 'core/editor' );
+
 		return {
-			onStartTyping: dispatch( 'core/editor' ).startTyping,
-			onStopTyping: dispatch( 'core/editor' ).stopTyping,
+			onStartTyping: startTyping,
+			onStopTyping: stopTyping,
 		};
 	} ),
 ] )( ObserveTyping );


### PR DESCRIPTION
This pull request seeks to cancel the `isTyping` flag when focus transitions to a non-text element. This is particularly helpful for reactivating toolbars in elements which don't have text fields, where previously the toolbars only reactivate when the selection becomes uncollapsed.

__Testing instructions:__

1. Create new post
2. Insert a paragraph block
3. Insert an image block (leave as placeholder)
4. Start typing in the paragraph block
5. Arrow down
6. Note that the image block is selected, and its toolbar visible
   - In master, at this point it would be impossible to use the image toolbar by keyboard alone (without convoluted steps to cancel `isTyping` by navigating back into the paragraph block)