### PR TITLE
State: Batch updates to title (and other post properties) for undo

### DIFF
--- a/components/keyboard-shortcuts/README.md
+++ b/components/keyboard-shortcuts/README.md
@@ -1,7 +1,9 @@
 Keyboard Shortcuts
 ==================
 
-`<KeyboardShortcuts />` is a component which renders no children of its own, but instead handles keyboard sequences during the lifetime of the rendering element.
+`<KeyboardShortcuts />` is a component which handles keyboard sequences during the lifetime of the rendering element.
+
+When passed children, it will capture key events which occur on or within the children. If no children are passed, events are captured on the document.
 
 It uses the [Mousetrap](https://craig.is/killing/mice) library to implement keyboard sequence bindings.
 
@@ -39,6 +41,13 @@ class SelectAllDetection extends Component {
 ## Props
 
 The component accepts the following props:
+
+### children
+
+Elements to render, upon whom key events are to be monitored.
+
+- Type: `Element` | `Element[]`
+- Required: No
 
 ### shortcuts
 

--- a/components/keyboard-shortcuts/index.js
+++ b/components/keyboard-shortcuts/index.js
@@ -8,11 +8,19 @@ import { forEach } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Children } from '@wordpress/element';
 
 class KeyboardShortcuts extends Component {
-	componentWillMount() {
-		this.mousetrap = new Mousetrap;
+	constructor() {
+		super( ...arguments );
+
+		this.bindKeyTarget = this.bindKeyTarget.bind( this );
+	}
+
+	componentDidMount() {
+		const { keyTarget = document } = this;
+
+		this.mousetrap = new Mousetrap( keyTarget );
 		forEach( this.props.shortcuts, ( callback, key ) => {
 			const { bindGlobal, eventName } = this.props;
 			const bindFn = bindGlobal ? 'bindGlobal' : 'bind';
@@ -24,8 +32,25 @@ class KeyboardShortcuts extends Component {
 		this.mousetrap.reset();
 	}
 
+	/**
+	 * When rendering with children, binds the wrapper node on which events
+	 * will be bound.
+	 *
+	 * @param {Element} node Key event target.
+	 */
+	bindKeyTarget( node ) {
+		this.keyTarget = node;
+	}
+
 	render() {
-		return null;
+		// Render as non-visual if there are no children pressed. Keyboard
+		// events will be bound to the document instead.
+		const { children } = this.props;
+		if ( ! Children.count( children ) ) {
+			return null;
+		}
+
+		return <div ref={ this.bindKeyTarget }>{ children }</div>;
 	}
 }
 

--- a/components/keyboard-shortcuts/test/index.js
+++ b/components/keyboard-shortcuts/test/index.js
@@ -82,4 +82,34 @@ describe( 'KeyboardShortcuts', () => {
 		expect( spy ).toHaveBeenCalled();
 		expect( spy.mock.calls[ 0 ][ 0 ].type ).toBe( 'keyup' );
 	} );
+
+	it( 'should capture key events on children', () => {
+		const spy = jest.fn();
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		const wrapper = mount(
+			<div>
+				<KeyboardShortcuts
+					shortcuts={ {
+						d: spy,
+					} }
+				>
+					<textarea></textarea>
+				</KeyboardShortcuts>
+				<textarea></textarea>
+			</div>,
+			{ attachTo: attachNode }
+		);
+
+		const textareas = wrapper.find( 'textarea' );
+
+		// Outside scope
+		keyPress( 68, textareas.at( 1 ).getDOMNode() );
+		expect( spy ).not.toHaveBeenCalled();
+
+		// Inside scope
+		keyPress( 68, textareas.at( 0 ).getDOMNode() );
+		expect( spy ).toHaveBeenCalled();
+	} );
 } );

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -17,6 +17,7 @@ import {
 	keys,
 	isEqual,
 	includes,
+	overSome,
 } from 'lodash';
 
 /**
@@ -98,28 +99,72 @@ function getFlattenedBlocks( blocks ) {
 }
 
 /**
- * Option for the history reducer. When the block ID and updated attirbute keys
- * are the same as previously, the history reducer should overwrite its present
- * state.
+ * Returns true if the two object arguments have the same keys, or false
+ * otherwise.
  *
- * @param {Object} action         The currently dispatched action.
- * @param {Object} previousAction The previously dispatched action.
+ * @param {Object} a First object.
+ * @param {Object} b Second object.
  *
- * @return {boolean} Whether or not to overwrite present state.
+ * @return {boolean} Whether the two objects have the same keys.
  */
-function shouldOverwriteState( action, previousAction ) {
-	if (
-		previousAction &&
-		action.type === 'UPDATE_BLOCK_ATTRIBUTES' &&
-		action.type === previousAction.type
-	) {
-		const attributes = keys( action.attributes );
-		const previousAttributes = keys( previousAction.attributes );
+export function hasSameKeys( a, b ) {
+	return isEqual( keys( a ), keys( b ) );
+}
 
-		return action.uid === previousAction.uid && isEqual( attributes, previousAttributes );
+/**
+ * Returns true if, given the currently dispatching action and the previously
+ * dispatched action, the two actions are updating the same block attribute, or
+ * false otherwise.
+ *
+ * @param {Object} action         Currently dispatching action.
+ * @param {Object} previousAction Previously dispatched action.
+ *
+ * @return {boolean} Whether actions are updating the same block attribute.
+ */
+export function isUpdatingSameBlockAttribute( action, previousAction ) {
+	return (
+		action.type === 'UPDATE_BLOCK_ATTRIBUTES' &&
+		action.uid === previousAction.uid &&
+		hasSameKeys( action.attributes, previousAction.attributes )
+	);
+}
+
+/**
+ * Returns true if, given the currently dispatching action and the previously
+ * dispatched action, the two actions are editing the same post property, or
+ * false otherwise.
+ *
+ * @param {Object} action         Currently dispatching action.
+ * @param {Object} previousAction Previously dispatched action.
+ *
+ * @return {boolean} Whether actions are updating the same post property.
+ */
+export function isUpdatingSamePostProperty( action, previousAction ) {
+	return (
+		action.type === 'EDIT_POST' &&
+		hasSameKeys( action.edits, previousAction.edits )
+	);
+}
+
+/**
+ * Returns true if, given the currently dispatching action and the previously
+ * dispatched action, the two actions are modifying the same property such that
+ * undo history should be batched.
+ *
+ * @param {Object} action         Currently dispatching action.
+ * @param {Object} previousAction Previously dispatched action.
+ *
+ * @return {boolean} Whether to overwrite present state.
+ */
+export function shouldOverwriteState( action, previousAction ) {
+	if ( ! previousAction || action.type !== previousAction.type ) {
+		return false;
 	}
 
-	return false;
+	return overSome( [
+		isUpdatingSameBlockAttribute,
+		isUpdatingSamePostProperty,
+	] )( action, previousAction );
 }
 
 /**


### PR DESCRIPTION
Closes #4057
Related: #4956

This pull request seeks to apply the same undo buffering introduced in #4956 for blocks to apply to all post property updates. This particularly impacts the post title, where the changes proposed here will improve undo to apply to aggregate of the changes applied to the title, rather than a single character at a time.

In the process, the `KeyboardShortcuts` component has been updated to accept `children` to which keyboard events should be monitored. This was proposed as a future enhancement in the original implementation (#1944).

Due to issues with React controlled textareas (https://github.com/facebook/react/issues/8514), key events for undo/redo must be monitored manually within the title, and redirected as dispatching actions to the editor store.

__Testing instructions:__

Verify that when entering a title, pressing Undo no longer reverts one character at a time, but rather all changes made in sequence.

This same behavior applies to any other post property change (e.g. status, author, etc).