### PR TITLE
Decode hmtl entities in placeholders

### DIFF
--- a/editor/components/default-block-appender/index.js
+++ b/editor/components/default-block-appender/index.js
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/element';
 import { getDefaultBlockName } from '@wordpress/blocks';
 import { withContext } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -35,7 +36,7 @@ export function DefaultBlockAppender( {
 		return null;
 	}
 
-	const value = placeholder || __( 'Write your story' );
+	const value = decodeEntities( placeholder ) || __( 'Write your story' );
 
 	return (
 		<div

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
-import { keycodes } from '@wordpress/utils';
+import { keycodes, decodeEntities } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withContext, withFocusOutside } from '@wordpress/components';
 
@@ -76,8 +76,8 @@ class PostTitle extends Component {
 					className="editor-post-title__input"
 					value={ title }
 					onChange={ this.onChange }
-					placeholder={ placeholder || __( 'Add title' ) }
-					aria-label={ placeholder || __( 'Add title' ) }
+					placeholder={ decodeEntities( placeholder ) || __( 'Add title' ) }
+					aria-label={ decodeEntities( placeholder ) || __( 'Add title' ) }
 					onFocus={ this.onSelect }
 					onKeyDown={ this.onKeyDown }
 					onKeyPress={ this.onUnselect }


### PR DESCRIPTION
## Description
This is my attempt at fixing #4933, I'm using `decodeEntities` to decode special HTML characters that might be present on the post title / content when using custom placeholders using the `write_your_story` or `enter_title_here` filters.

## How Has This Been Tested?
1. Set new post title and content placeholder using special characters.
2. Checked that the placeholders render the special character itself and not the entity code.

## Screenshots (jpeg or gifs if applicable):
| Before | After |
| --- | --- |
| <img width="603" alt="screen shot 2018-03-11 at 3 47 31 pm" src="https://user-images.githubusercontent.com/661330/37255397-c8fb8644-2543-11e8-8b9a-22daa61ee786.png"> | <img width="635" alt="screen shot 2018-03-11 at 3 49 01 pm" src="https://user-images.githubusercontent.com/661330/37255399-ce6afa42-2543-11e8-9b7b-d7dbedef8a61.png"> |


## Types of changes
Fixes #4933 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
