### PR TITLE
Fix heading subscript regression

### DIFF
--- a/components/toolbar/style.scss
+++ b/components/toolbar/style.scss
@@ -92,6 +92,10 @@ div.components-toolbar {
 		@include formatting-button-style__active;
 	}
 
+	&:not(:disabled).is-active[data-subscript]:after {
+		color: $white;
+	}
+
 	// focus style
 	&:not(:disabled):focus > svg {
 		@include formatting-button-style__focus;


### PR DESCRIPTION
My apologies on this one. In refactoring how we colorize focus and hover styles, I accidentally missed the heading subscript. This fixes it.

![headings](https://user-images.githubusercontent.com/1204802/37273451-30995376-25da-11e8-844c-ebc67273f2db.gif)
