### PR TITLE
Inherit color in meta boxes

### DIFF
--- a/edit-post/assets/stylesheets/_colors.scss
+++ b/edit-post/assets/stylesheets/_colors.scss
@@ -10,7 +10,6 @@ $dark-gray-800: #23282d;
 $dark-gray-700: #32373c;
 $dark-gray-600: #40464d;
 $dark-gray-500: #555d66;    // use this most of the time for dark items
-$meta-box-dark-gray-500: #444;
 $dark-gray-400: #606a73;
 $dark-gray-300: #6c7781;
 $dark-gray-200: #7e8993;

--- a/edit-post/assets/stylesheets/_colors.scss
+++ b/edit-post/assets/stylesheets/_colors.scss
@@ -10,6 +10,7 @@ $dark-gray-800: #23282d;
 $dark-gray-700: #32373c;
 $dark-gray-600: #40464d;
 $dark-gray-500: #555d66;    // use this most of the time for dark items
+$meta-box-dark-gray-500: #444;
 $dark-gray-400: #606a73;
 $dark-gray-300: #6c7781;
 $dark-gray-200: #7e8993;

--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -20,7 +20,7 @@
 	#poststuff h2.hndle { /* WordPress selectors yolo */
 		border-bottom: 1px solid $light-gray-500;
 		box-sizing: border-box;
-		color: $meta-box-dark-gray-500;
+		color: inherit;
 		font-weight: 600;
 		outline: none;
 		padding: 15px;
@@ -30,13 +30,13 @@
 
 	.postbox {
 		border: 0;
-		color: $meta-box-dark-gray-500;
+		color: inherit;
 		margin-bottom: 0;
 	}
 
 	.postbox > .inside {
 		border-bottom: 1px solid $light-gray-500;
-		color: $meta-box-dark-gray-500;
+		color: inherit;
 		padding: 0 $block-padding $block-padding;
 		margin: 0;
 	}

--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -20,7 +20,7 @@
 	#poststuff h2.hndle { /* WordPress selectors yolo */
 		border-bottom: 1px solid $light-gray-500;
 		box-sizing: border-box;
-		color: $dark-gray-500;
+		color: $meta-box-dark-gray-500;
 		font-weight: 600;
 		outline: none;
 		padding: 15px;
@@ -30,13 +30,13 @@
 
 	.postbox {
 		border: 0;
-		color: $dark-gray-500;
+		color: $meta-box-dark-gray-500;
 		margin-bottom: 0;
 	}
 
 	.postbox > .inside {
 		border-bottom: 1px solid $light-gray-500;
-		color: $dark-gray-500;
+		color: $meta-box-dark-gray-500;
 		padding: 0 $block-padding $block-padding;
 		margin: 0;
 	}


### PR DESCRIPTION
## Description
Gutenberg overwrites text color in meta boxes, and this fix makes sure that the color is inherited from the parent element instead.

## How Has This Been Tested?
Confirmed that the text color in the meta boxes has changed and that the color in other parts remain the same.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
