### PR TITLE
Fade side inserter when typing is true.

### DIFF
--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -452,6 +452,7 @@ export class BlockListBlock extends Component {
 			'is-multi-selected': isMultiSelected,
 			'is-hovered': isHovered,
 			'is-reusable': isReusableBlock( blockType ),
+			'is-typing': isTypingWithinBlock,
 		} );
 
 		const { onReplace } = this.props;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -81,6 +81,17 @@
 		right: 6px;
 	}
 
+	&.is-typing .editor-block-list__empty-block-inserter,
+	&.is-typing .editor-block-list__side-inserter {
+		opacity: 0;
+	}
+
+	.editor-block-list__empty-block-inserter,
+	.editor-block-list__side-inserter {
+		opacity: 1;
+		transition: opacity 0.2s;
+	}
+
 	&.is-reusable.is-selected > .editor-block-mover:before {
 		border-right: none;
 	}


### PR DESCRIPTION
This is a small tweak that reduces the weight the side inserter has when adding new paragraphs using the keyboard. To test, start writing something and hit enter—the result should be just a caret on the page until you move the mouse or use keyboard shortcuts.

Video: https://cloudup.com/cnKWOsFdf4Q