### PR TITLE
Fixed: Inserting a block right after removal, inserts a block in the top of the document

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -329,14 +329,16 @@ export function createUndoLevel() {
  * Returns an action object used in signalling that the blocks
  * corresponding to the specified UID set are to be removed.
  *
- * @param {string[]} uids Block UIDs.
+ * @param {string[]} uids               Block UIDs.
+ * @param {boolean}  isProvisionalBlock True if the action is being used to remove a provisional block.
  *
  * @return {Object} Action object.
  */
-export function removeBlocks( uids ) {
+export function removeBlocks( uids, isProvisionalBlock = false ) {
 	return {
 		type: 'REMOVE_BLOCKS',
 		uids,
+		isProvisionalBlock,
 	};
 }
 
@@ -344,12 +346,13 @@ export function removeBlocks( uids ) {
  * Returns an action object used in signalling that the block with the
  * specified UID is to be removed.
  *
- * @param {string} uid Block UID.
+ * @param {string}  uid                Block UID.
+ * @param {boolean} isProvisionalBlock True if the action is being used to remove a provisional block.
  *
  * @return {Object} Action object.
  */
-export function removeBlock( uid ) {
-	return removeBlocks( [ uid ] );
+export function removeBlock( uid, isProvisionalBlock = false ) {
+	return removeBlocks( [ uid ], isProvisionalBlock );
 }
 
 /**

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { get, includes, map, castArray, uniqueId } from 'lodash';
+import { get, includes, last, map, castArray, uniqueId } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -49,9 +49,12 @@ import {
 	isEditedPostSaveable,
 	getBlock,
 	getBlockCount,
+	getBlockRootUID,
 	getBlocks,
 	getReusableBlock,
+	getPreviousBlockUid,
 	getProvisionalBlockUID,
+	getSelectedBlock,
 	isBlockSelected,
 	POST_UPDATE_TRANSACTION_ID,
 } from './selectors';
@@ -76,7 +79,7 @@ export function removeProvisionalBlock( action, store ) {
 	const state = store.getState();
 	const provisionalBlockUID = getProvisionalBlockUID( state );
 	if ( provisionalBlockUID && ! isBlockSelected( state, provisionalBlockUID ) ) {
-		return removeBlock( provisionalBlockUID );
+		return removeBlock( provisionalBlockUID, true );
 	}
 }
 
@@ -499,4 +502,31 @@ export default {
 	SELECT_BLOCK: removeProvisionalBlock,
 
 	MULTI_SELECT: removeProvisionalBlock,
+
+	REMOVE_BLOCKS( action, { getState, dispatch } ) {
+		// if we are removing the provisional block don't do anything.
+		if ( action.isProvisionalBlock ) {
+			return;
+		}
+
+		const firstRemovedBlockUID = action.uids[ 0 ];
+		const state = getState();
+		const currentSelectedBlock = getSelectedBlock( state );
+
+		// recreate the state before the block was removed.
+		const previousState = { ...state, editor: { present: last( state.editor.past ) } };
+
+		// rootUID of the removed block.
+		const rootUID = getBlockRootUID( previousState, firstRemovedBlockUID );
+
+		// UID of the block that was before the removed block
+		// or the rootUID if the removed block was the first amongst his siblings.
+		const blockUIDToSelect = getPreviousBlockUid( previousState, firstRemovedBlockUID ) || rootUID;
+
+		// Dispatch select block action if the currently selected block
+		// is not already the block we want to be selected.
+		if ( blockUIDToSelect !== currentSelectedBlock ) {
+			dispatch( selectBlock( blockUIDToSelect ) );
+		}
+	},
 };

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -302,6 +302,7 @@ describe( 'actions', () => {
 			expect( removeBlocks( uids ) ).toEqual( {
 				type: 'REMOVE_BLOCKS',
 				uids,
+				isProvisionalBlock: false,
 			} );
 		} );
 	} );
@@ -314,6 +315,14 @@ describe( 'actions', () => {
 				uids: [
 					uid,
 				],
+				isProvisionalBlock: false,
+			} );
+			expect( removeBlock( uid, true ) ).toEqual( {
+				type: 'REMOVE_BLOCKS',
+				uids: [
+					uid,
+				],
+				isProvisionalBlock: true,
 			} );
 		} );
 	} );

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -84,7 +84,7 @@ describe( 'effects', () => {
 			selectors.isBlockSelected.mockImplementation( ( state, uid ) => uid === 'ribs' );
 			const action = removeProvisionalBlock( {}, store );
 
-			expect( action ).toEqual( removeBlock( 'chicken' ) );
+			expect( action ).toEqual( removeBlock( 'chicken', true ) );
 		} );
 	} );
 


### PR DESCRIPTION
The problem was that block selection becomes invalid after block removal. The selection was still pointing to the removed blocks UID's. Now we select the block that was before the removed block(s). So if we insert a block right after removing the inserted block goes to the position of the removed block.

The effect receives the state with the block already removed. So to retrieve the block position in the state we make use if editor.past. The alternatives to that seem to be a top-level higher order reducer or a middleware. So this option seems like the simpler and it looks like it works well.


Fixes: https://github.com/WordPress/gutenberg/issues/5446

## How Has This Been Tested?
Reproduce the steps in https://github.com/WordPress/gutenberg/issues/5446 and verify the problems get solved. Namely, remove a block and use the global inserter to insert a new block right away, verify the new block was inserted at the position where the removed blocks were.