### PR TITLE
Revert "Default to content-box box-sizing for the metabox area."

### DIFF
--- a/components/form-toggle/style.scss
+++ b/components/form-toggle/style.scss
@@ -38,7 +38,6 @@ $toggle-border-width: 2px;
 		border: 2px solid $dark-gray-500;
 		background: $white;
 		transition: 0.1s transform ease;
-		box-sizing: border-box;
 	}
 
 	&__input:focus {

--- a/components/menu-items/style.scss
+++ b/components/menu-items/style.scss
@@ -1,7 +1,6 @@
 .components-menu-items__group {
 	width: 100%;
 	padding: 10px;
-	box-sizing: border-box;
 }
 
 .components-menu-items__group-label {

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -20,7 +20,6 @@
 .components-panel__body {
 	border-top: 1px solid $light-gray-500;
 	border-bottom: 1px solid $light-gray-500;
-	box-sizing: border-box;
 
 	h3 {
 		margin: 0 0 .5em 0;

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -82,6 +82,10 @@ body.gutenberg-editor-page {
 }
 
 .gutenberg {
+	* {
+		box-sizing: border-box;
+	}
+
 	select {
 		font-size: $default-font-size;
 		color: $dark-gray-500;

--- a/edit-post/components/header/style.scss
+++ b/edit-post/components/header/style.scss
@@ -10,7 +10,6 @@
 	z-index: z-index( '.edit-post-header' );
 	left: 0;
 	right: 0;
-	box-sizing: border-box;
 
 	// mobile edgecase for toolbar
 	top: 0;

--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -5,7 +5,6 @@
 
 .edit-post-layout {
 	position: relative;
-	box-sizing: border-box;
 
 	.components-notice-list {
 		position: sticky;

--- a/edit-post/components/sidebar/last-revision/style.scss
+++ b/edit-post/components/sidebar/last-revision/style.scss
@@ -5,5 +5,4 @@
 
 .editor-post-last-revision__title {
 	padding: #{ $panel-padding - 3px } $panel-padding;	// subtract extra height of dashicon
-	box-sizing: border-box;
 }

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -10,7 +10,6 @@
 	color: $dark-gray-500;
 	height: 100vh;
 	overflow: hidden;
-	box-sizing: border-box;
 
 	@include break-small() {
 		top: $admin-bar-height-big + $header-height;

--- a/edit-post/components/text-editor/style.scss
+++ b/edit-post/components/text-editor/style.scss
@@ -20,10 +20,6 @@
 		padding-right: calc( 50% - #{ $text-editor-max-width / 2 } );
 	}
 
-	* {
-		box-sizing: border-box;
-	}
-
 	.edit-post-post-text-editor__toolbar {
 		width: 100%;
 		max-width: $text-editor-max-width;

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -22,10 +22,6 @@
 	& ol {
 		list-style-type: decimal;
 	}
-
-	* {
-		box-sizing: border-box;
-	}
 }
 
 .edit-post-visual-editor .editor-block-list__block {

--- a/editor/components/block-inspector/style.scss
+++ b/editor/components/block-inspector/style.scss
@@ -25,7 +25,6 @@
 	margin-right: 10px;
 	height: 36px;
 	width: 36px;
-	box-sizing: border-box;
 }
 
 .editor-block-inspector__card-content {


### PR DESCRIPTION
Reverts WordPress/gutenberg#5433

See:

- https://github.com/WordPress/gutenberg/pull/5433#issuecomment-372332738
- https://github.com/WordPress/gutenberg/pull/5433#issuecomment-372338479