### PR TITLE
Improve content structure initial focus

### DIFF
--- a/editor/components/table-of-contents/panel.js
+++ b/editor/components/table-of-contents/panel.js
@@ -21,7 +21,12 @@ function TableOfContentsPanel( { blocks } ) {
 
 	return (
 		<Fragment>
-			<div className="table-of-contents__counts">
+			<div
+				className="table-of-contents__counts"
+				role="note"
+				aria-label={ __( 'Document Statistics' ) }
+				tabIndex="0"
+			>
 				<div className="table-of-contents__count">
 					{ __( 'Words' ) }
 					<WordCount />


### PR DESCRIPTION
This PR tries to solve the last pending issue from #3216. Initial focus on the "Content Structure" Popover needs to take into account post without any headings.

- when there are no headings, this Popover has no focusable elements to move focus to
- when there are headings, focus is currently moved to the first item in the headings tree; however, this way all the previous content (the "counts") is basically "skipped" and screen reader users would have no clue some content exists before the focus

By making the "counts" section a focusable div, with a proper role and aria-label, the first focusable element in this Popover is always the counts section.

- note: I'm fine with having no focus style in this case, it's a trade-off for a greater good
- about the `note` role, see https://www.w3.org/TR/wai-aria-1.1/#note
> A section whose content is parenthetic or ancillary to the main content of the resource.

Seems appropriate to me, can certainly be changed if anyone suggests a better role.