### PR TITLE
Unify citation strings for quotes and pullquotes.

### DIFF
--- a/blocks/library/pullquote/index.js
+++ b/blocks/library/pullquote/index.js
@@ -90,6 +90,7 @@ export const settings = {
 							value: fromRichTextValue( nextValue ),
 						} )
 					}
+					/* translators: the text of the quotation */
 					placeholder={ __( 'Write quote…' ) }
 					wrapperClassName="blocks-pullquote__content"
 					isSelected={ isSelected && editable === 'content' }
@@ -99,7 +100,8 @@ export const settings = {
 					<RichText
 						tagName="cite"
 						value={ citation }
-						placeholder={ __( 'Write caption…' ) }
+						/* translators: the individual or entity quoted */
+						placeholder={ __( 'Write citation…' ) }
 						onChange={
 							( nextCitation ) => setAttributes( {
 								citation: nextCitation,

--- a/blocks/library/quote/index.js
+++ b/blocks/library/quote/index.js
@@ -210,6 +210,7 @@ export const settings = {
 							onReplace( [] );
 						}
 					} }
+					/* translators: the text of the quotation */
 					placeholder={ __( 'Write quote…' ) }
 					isSelected={ isSelected && editable === 'content' }
 					onFocus={ onSetActiveEditable( 'content' ) }
@@ -223,6 +224,7 @@ export const settings = {
 								citation: nextCitation,
 							} )
 						}
+						/* translators: the individual or entity quoted */
 						placeholder={ __( 'Write citation…' ) }
 						isSelected={ isSelected && editable === 'cite' }
 						onFocus={ onSetActiveEditable( 'cite' ) }


### PR DESCRIPTION
See #5401

## Description
<!-- Please describe your changes -->
Use the same text for the `<cite>` element in both quotes and pullquotes and add translator notes to clarify the purpose.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
JavaScript changes, ran `npm test`.

## Screenshots (jpeg or gifs if applicable):
![quote_and_pull-quote___ _gutenberg_ _wordpress](https://user-images.githubusercontent.com/519727/37320660-d953996a-26c8-11e8-8b78-27093c0eaf21.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
* String reduction
* Translator comments

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
