### PR TITLE
Default to content-box box-sizing for the metabox area.

### DIFF
--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -2,6 +2,10 @@
 .edit-post-meta-boxes-area {
 	position: relative;
 
+	* {
+		box-sizing: content-box;
+	}
+
 		/* Match width and positioning of the meta boxes. Override default styles. */
 	#poststuff {
 		margin: 0 auto;


### PR DESCRIPTION
## Description

This is meant to keep the plugin default box-sizing the same as used in WordPress.
By applying `box-sizing: content-box;` to the `.edit-post-meta-boxes-area` class.

As per @afercia 's [comment](https://github.com/WordPress/gutenberg/issues/5353#issuecomment-369926527).

## How Has This Been Tested?

I tested it with Yoast SEO plugin to see the CSS came through the build properly.

Previous PR of this tried a couple of ways: https://github.com/WordPress/gutenberg/pull/5433
Fixes: #5353