### PR TITLE
Blocks: Add transform from Paragraph block to Cover Image block

### DIFF
--- a/blocks/library/cover-image/index.js
+++ b/blocks/library/cover-image/index.js
@@ -72,7 +72,7 @@ export const settings = {
 		from: [
 			{
 				type: 'block',
-				blocks: [ 'core/heading' ],
+				blocks: [ 'core/heading', 'core/paragraph' ],
 				transform: ( { content } ) => (
 					createBlock( 'core/cover-image', { title: content } )
 				),
@@ -86,6 +86,14 @@ export const settings = {
 					createBlock( 'core/heading', { content: title } )
 				),
 			},
+			{
+				type: 'block',
+				blocks: [ 'core/paragraph' ],
+				transform: ( { title } ) => (
+					createBlock( 'core/paragraph', { content: title } )
+				),
+			},
+
 		],
 	},
 


### PR DESCRIPTION
## Description

I found it useful when copying the text from the external document. I wasn't able to convert a paragraph into a cover image directly. I had to transform the paragraph into a heading and finally into a cover image. I figured out it might simplify the flow if we provide also a direct transformation. I guess it might be not expected in some circumstances but I thought that it is still worth opening a PR since I need this code anyway to record a demo of Gutenberg :)

## Screenshots (jpeg or gifs if applicable):

![cover-transform](https://user-images.githubusercontent.com/699132/37337492-beaf555e-26b4-11e8-9b75-6e335dac1673.gif)
