### PR TITLE
Framework: Bump @wordpress/hooks to v1.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -310,9 +310,9 @@
 			"integrity": "sha512-1tmJLO2NDc45wxnUWv6F/4q8/00qSgqLvBXBKl7IayLvJbG25vt7lMQkdSfiY2gTwsujAqOgOuJdO5VOGuqQNg=="
 		},
 		"@wordpress/hooks": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-1.1.4.tgz",
-			"integrity": "sha512-V8HVPBKsEUh2hPfO21/i0TNUYduofIo4emuk/JfVyTT7+hSJZsj6Fn6oWt7Hs2mf7JTAi4DUVusX4gSDspzM6w=="
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-1.1.6.tgz",
+			"integrity": "sha512-+7s5j296RTXRabaubvNK35ED/+WUYJgM8oeiHWP6RvPGd/2rkei3cI0SNwjBdaRrlNQ22vtzvCfhdDCyb9W1xQ=="
 		},
 		"@wordpress/jest-console": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"dependencies": {
 		"@wordpress/a11y": "1.0.6",
 		"@wordpress/autop": "1.0.4",
-		"@wordpress/hooks": "1.1.4",
+		"@wordpress/hooks": "1.1.6",
 		"@wordpress/url": "1.0.3",
 		"classnames": "2.2.5",
 		"clipboard": "1.7.1",


### PR DESCRIPTION
This pull request seeks to bump the version of the `@wordpress/hooks` dependency. The latest patch version included some performance-oriented refactoring. See https://github.com/WordPress/packages/pull/85 for more context.

__Testing instructions:__

Verify there are no regressions in the behaviors of hooks. Any such issues would be very obvious, such as inability to register blocks or display blocks editable form, both of which are filtered with the hooks package.