### PR TITLE
Capture admin notices and summarize them in editor

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -57,7 +57,7 @@ body.gutenberg-editor-page {
 
 	/* We hide legacy notices in Gutenberg, because they were not designed in a way that scaled well.
 	   Plugins can use Gutenberg notices if they need to pass on information to the user when they are editing. */
-	#wpbody-content > div:not( .gutenberg ):not( #screen-meta ) {
+	#admin-notice-list {
 		display: none;
 	}
 

--- a/edit-post/components/admin-notices/index.js
+++ b/edit-post/components/admin-notices/index.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { isEmpty, intersection } from 'lodash';
+
+/**
+ * WordPress Dependencies
+ */
+import { _n, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Notice } from '@wordpress/components';
+
+/**
+ * Internal Dependencies
+ */
+// TODO: This may not be right to import from, figure out what is.
+import { getWPAdminURL } from '../../../editor/utils/url';
+
+const noticeClassNames = [
+	'notice',
+	'notice-error',
+	'notice-warning',
+	'notice-success',
+	'notice-info',
+	'error',
+	'warning',
+	'success',
+	'info',
+	'updated',
+	'update-nag',
+];
+
+function countNotices( noticeList ) {
+	const noticeElements = [ ...noticeList.children ];
+
+	return noticeElements.reduce( ( count, element ) => {
+		const classMatches = intersection( element.classList, noticeClassNames );
+		return isEmpty( classMatches ) ? count : count + 1;
+	}, 0 );
+}
+
+class AdminNotices extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = { noticeCount: 0 };
+	}
+
+	componentWillMount() {
+		const noticeList = document.getElementById( 'admin-notice-list' );
+		const noticeCount = countNotices( noticeList );
+
+		this.setState( () => {
+			return { noticeCount };
+		} );
+	}
+
+	render() {
+		const { noticeCount } = this.state;
+
+		if ( noticeCount === 0 ) {
+			return null;
+		}
+
+		const msg = sprintf( _n(
+			'There is a WordPress notice which needs your attention.',
+			'There are %d WordPress notices which need your attention.',
+			noticeCount ), noticeCount );
+
+		const content = <p><a href={ getWPAdminURL( 'index.php' ) }>{ msg }</a></p>;
+
+		return (
+			<div className="admin-notices-summary">
+				<Notice status="info" content={ content } isDismissible={ false } />
+			</div>
+		);
+	}
+}
+
+export default AdminNotices;
+

--- a/edit-post/components/admin-notices/index.js
+++ b/edit-post/components/admin-notices/index.js
@@ -8,13 +8,15 @@ import { isEmpty, intersection } from 'lodash';
  */
 import { _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Notice } from '@wordpress/components';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal Dependencies
  */
 // TODO: This may not be right to import from, figure out what is.
 import { getWPAdminURL } from '../../../editor/utils/url';
+
+const ADMIN_MESSAGES_NOTICE_ID = 'ADMIN_MESSAGES_NOTICES_ID';
 
 const noticeClassNames = [
 	'notice',
@@ -40,27 +42,10 @@ function countNotices( noticeList ) {
 }
 
 class AdminNotices extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.state = { noticeCount: 0 };
-	}
-
 	componentWillMount() {
 		const noticeList = document.getElementById( 'admin-notice-list' );
 		const noticeCount = countNotices( noticeList );
-
-		this.setState( () => {
-			return { noticeCount };
-		} );
-	}
-
-	render() {
-		const { noticeCount } = this.state;
-
-		if ( noticeCount === 0 ) {
-			return null;
-		}
+		const { createNotice } = this.props;
 
 		const msg = sprintf( _n(
 			'There is a WordPress notice which needs your attention.',
@@ -69,13 +54,18 @@ class AdminNotices extends Component {
 
 		const content = <p><a href={ getWPAdminURL( 'index.php' ) }>{ msg }</a></p>;
 
-		return (
-			<div className="admin-notices-summary">
-				<Notice status="info" content={ content } isDismissible={ false } />
-			</div>
+		createNotice(
+			content,
+			{ id: ADMIN_MESSAGES_NOTICE_ID, spokenMessage: msg }
 		);
+	}
+
+	render() {
+		return null;
 	}
 }
 
-export default AdminNotices;
+export default withDispatch( ( dispatch ) => ( {
+	createNotice: dispatch( 'core/editor' ).createInfoNotice,
+} ) )( AdminNotices );
 

--- a/edit-post/components/layout/index.js
+++ b/edit-post/components/layout/index.js
@@ -25,6 +25,7 @@ import { PluginArea } from '@wordpress/plugins';
  * Internal dependencies
  */
 import './style.scss';
+import AdminNotices from '../admin-notices';
 import Header from '../header';
 import Sidebar from '../sidebar';
 import TextEditor from '../text-editor';
@@ -63,6 +64,7 @@ function Layout( {
 			<AutosaveMonitor />
 			<Header />
 			<div className="edit-post-layout__content" role="region" aria-label={ __( 'Editor content' ) } tabIndex="-1">
+				<AdminNotices />
 				<EditorNotices />
 				<PreserveScrollInReorder />
 				<EditorModeKeyboardShortcuts />

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -158,6 +158,8 @@ function gutenberg_init( $return, $post ) {
 		return false;
 	}
 
+	add_action( 'admin_notices', 'gutenberg_before_notices', 0 );
+	add_action( 'admin_notices', 'gutenberg_after_notices', PHP_INT_MAX );
 	add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );
 	add_filter( 'screen_options_show_screen', '__return_false' );
 	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
@@ -527,3 +529,23 @@ add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_b
 function gutenberg_add_admin_body_class( $classes ) {
 	return "$classes gutenberg-editor-page";
 }
+
+/**
+ * Adds an opening div tag before all notices in order to corral and hide them.
+ *
+ * @since 2.3.0
+ */
+function gutenberg_before_notices() {
+	echo '<div id="admin-notice-list">';
+}
+
+
+/**
+ * Adds a closing div tag after all notices in order to corral and hide them.
+ *
+ * @since 2.3.0
+ */
+function gutenberg_after_notices() {
+	echo '</div>';
+}
+


### PR DESCRIPTION
## Description
This surrounds all admin notices with a containing div that then hides
them, and shows a count of admin notices rendered above the editor
content.

## How Has This Been Tested?
Test with any admin notices that normally show up on a classic post edit. This will instead render a summary notice at the top of the post with a link to the dashboard, which displays admin notices normally.

I made a very big, annoying admin notice just to test this. It does everything in CSS that an admin notice shouldn't and therefore makes a good test: https://github.com/coderkevin/annoying-admin-notice

## Screenshots (jpeg or gifs if applicable):
<img width="1153" alt="new_gutenberg_post___ _woo-test_ _wordpress" src="https://user-images.githubusercontent.com/945228/37727483-493a712c-2d0e-11e8-97c9-2495ae82cf6e.png">

## Types of changes
This PR does two things for admin notices:

Bug fix: Wraps all admin notices in a containing div, so they can be more effectively hidden.

New feature: Uses `createInfoNotice` to display a summary notice to show the user that there are WordPress notifications in a more pleasing way, with a convenient link to the dashboard for more information.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
