### PR TITLE
Fixes to improve readability without changing meaning

### DIFF
--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -61,7 +61,7 @@ When the component renders it will store a reference to the meta boxes container
 
 When the post is updated, only meta box areas that are active will be submitted. This prevents unnecessary requests. No extra revisions are created by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any active meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta box's state to `isUpdating`. The `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
 
-When the meta box area is saving, we display an updating overlay, to prevent users from changing the form values in mid-save.
+When the meta box area is saving, we display an updating overlay, to prevent users from changing the form values while a save is in progress.
 
 After the new block editor is made into the default editor, it will be necessary to provide the classic-editor flag to access the meta box partial page.
 

--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -1,6 +1,6 @@
 # Meta Boxes
 
-This is a brief document detailing how meta box support works in Gutenberg. With the superior developer and user experience of blocks however, especially once block templates are available, **converting PHP meta boxes to blocks is highly encouraged!**
+This is a brief document detailing how meta box support works in Gutenberg. With the superior developer and user experience of blocks, especially once block templates are available, **converting PHP meta boxes to blocks is highly encouraged!**
 
 ### Testing, Converting, and Maintaining Existing Meta Boxes
 
@@ -17,9 +17,9 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 );
 ```
 
-This will cause WordPress to fall back to the Classic editor, where the meta box will continue working as before.
+WordPress will fall back to the Classic editor, where the meta box will continue working as before.
 
-Explicitly setting `__block_editor_compatible_meta_box` to `true` will cause WordPress to stay in Gutenberg (assuming another meta box doesn't cause a fallback, of course).
+Explicitly setting `__block_editor_compatible_meta_box` to `true` will cause WordPress to stay in Gutenberg (assuming another meta box doesn't cause a fallback).
 
 After a meta box is converted to a block, it can be declared as existing for backwards compatibility:
 
@@ -32,7 +32,7 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 );
 ```
 
-When Gutenberg is run, this meta box will no longer be displayed in the meta box area, as it now only exists for backwards compatibility purposes. It will continue to be displayed correctly in the Classic editor, should some other meta box cause a fallback.
+When Gutenberg is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backwards compatibility purposes. It will continue to display correctly in the Classic editor, should some other meta box cause a fallback.
 
 ### Meta Box Data Collection
 
@@ -52,20 +52,20 @@ Ideally, this could be done at instantiation of the editor and help simplify thi
 
 When rendering the Gutenberg Page, the metaboxes are rendered to a hidden div `#metaboxes`.
 
-*The Redux store by default will hold all meta boxes as inactive*. When
+*The Redux store will hold all meta boxes as inactive by default*. When
 `INITIALIZE_META_BOX_STATE` comes in, the store will update any active meta box areas by setting the `isActive` flag to `true`. Once this happens React will check for the new props sent in by Redux on the `MetaBox` component. If that `MetaBox` is now active, instead of rendering null, a `MetaBoxArea` component will be rendered. The `MetaBox` component is the container component that mediates between the `MetaBoxArea` and the Redux Store. *If no meta boxes are active, nothing happens. This will be the default behavior, as all core meta boxes have been stripped.*
 
 #### MetaBoxArea Component
 
-When the component renders it will store a ref to the metaboxes container, retrieve the metaboxes HTML from the prefetch location.
+When the component renders it will store a reference to the metaboxes container and retrieve the metaboxes HTML from the prefetch location.
 
-When the post is updated, only meta boxes areas that are active will be submitted. This removes any unnecessary requests being made. No extra revisions, are created either by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any active meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta boxes' state to `isUpdating`, the `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
+When the post is updated, only metabox areas that are active will be submitted. This prevents unnecessary requests. No extra revisions are created by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any active meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta box's state to `isUpdating`. The `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
 
-If the metabox area is saving, we display an updating overlay, to prevent users from changing the form values while the meta box is submitting.
+When the metabox area is saving, we display an updating overlay, to prevent users from changing the form values in mid-save.
 
-When the new block editor was made into the default editor it is now required to provide the classic-editor flag to access the metabox partial page.
+After the new block editor is made into the default editor, it will be necessary to provide the classic-editor flag to access the metabox partial page.
 
-`gutenberg_meta_box_save()` is used to save the meta boxes changes. A `meta_box` request parameter should be present and should match one of `'advanced'`, `'normal'`, or `'side'`. This value will determine which meta box area is served.
+`gutenberg_meta_box_save()` saves meta box changes. A `meta_box` request parameter should be present and should match one of `'advanced'`, `'normal'`, or `'side'`. This value will determine which meta box area is served.
 
 So an example url would look like:
 
@@ -73,12 +73,11 @@ So an example url would look like:
 
 This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
 
-Thus page page mimics the `post.php` post form, so when it is submitted it will normally fire all of the necessary hooks and actions, and have the proper global state to correctly fire any PHP meta box mumbo jumbo without needing to modify any existing code. On successful submission, React will signal a `handleMetaBoxReload` to remove the updating overlay, and set the store to no longer be updating the meta box area.
-
+This page page mimics the `post.php` post form, so when it is submitted it will fire all of the normal hooks and actions, and have the proper global state to correctly fire any PHP meta box mumbo jumbo without needing to modify any existing code. On successful submission, React will signal a `handleMetaBoxReload` to remove the updating overlay.
 
 ### Common Compatibility Issues
 
-Most PHP meta boxes should continue to work in Gutenberg, however some meta boxes that include advanced functionality could break. The following list describes some of the most common reasons why meta boxes might not work as expected in Gutenberg:
+Most PHP meta boxes should continue to work in Gutenberg, but some meta boxes that include advanced functionality could break. Here are some common reasons why meta boxes might not work as expected in Gutenberg:
 
 - Plugins relying on selectors that target the post title, post content fields, and other metaboxes (of the old editor).
 - Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in Gutenberg.

--- a/docs/meta-box.md
+++ b/docs/meta-box.md
@@ -50,20 +50,20 @@ Ideally, this could be done at instantiation of the editor and help simplify thi
 
 ### Redux and React Meta Box Management
 
-When rendering the Gutenberg Page, the metaboxes are rendered to a hidden div `#metaboxes`.
+When rendering the Gutenberg Page, the meta boxes are rendered to a hidden div `#metaboxes`.
 
 *The Redux store will hold all meta boxes as inactive by default*. When
 `INITIALIZE_META_BOX_STATE` comes in, the store will update any active meta box areas by setting the `isActive` flag to `true`. Once this happens React will check for the new props sent in by Redux on the `MetaBox` component. If that `MetaBox` is now active, instead of rendering null, a `MetaBoxArea` component will be rendered. The `MetaBox` component is the container component that mediates between the `MetaBoxArea` and the Redux Store. *If no meta boxes are active, nothing happens. This will be the default behavior, as all core meta boxes have been stripped.*
 
 #### MetaBoxArea Component
 
-When the component renders it will store a reference to the metaboxes container and retrieve the metaboxes HTML from the prefetch location.
+When the component renders it will store a reference to the meta boxes container and retrieve the meta boxes HTML from the prefetch location.
 
-When the post is updated, only metabox areas that are active will be submitted. This prevents unnecessary requests. No extra revisions are created by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any active meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta box's state to `isUpdating`. The `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
+When the post is updated, only meta box areas that are active will be submitted. This prevents unnecessary requests. No extra revisions are created by the meta box submissions. A Redux action will trigger on `REQUEST_POST_UPDATE` for any active meta box. See `editor/effects.js`. The `REQUEST_META_BOX_UPDATES` action will set that meta box's state to `isUpdating`. The `isUpdating` prop will be sent into the `MetaBoxArea` and cause a form submission.
 
-When the metabox area is saving, we display an updating overlay, to prevent users from changing the form values in mid-save.
+When the meta box area is saving, we display an updating overlay, to prevent users from changing the form values in mid-save.
 
-After the new block editor is made into the default editor, it will be necessary to provide the classic-editor flag to access the metabox partial page.
+After the new block editor is made into the default editor, it will be necessary to provide the classic-editor flag to access the meta box partial page.
 
 `gutenberg_meta_box_save()` saves meta box changes. A `meta_box` request parameter should be present and should match one of `'advanced'`, `'normal'`, or `'side'`. This value will determine which meta box area is served.
 


### PR DESCRIPTION
## Description
Documentation fixes. Fix comma placement, improve word order, remove unneeded words.

## Types of changes
Metabox documentation. Wordsmithing only, no changed information. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
