### PR TITLE
Fixed meta box configuration persistence to be per postType as in the classic editor.

### DIFF
--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -27,7 +27,7 @@ const effects = {
 		}
 
 		// Allow toggling metaboxes panels
-		window.postboxes.add_postbox_toggles( 'post' );
+		window.postboxes.add_postbox_toggles( select( 'core/editor' ).getCurrentPostType() );
 
 		// Initialize metaboxes state
 		const dataPerLocation = reduce( action.metaBoxes, ( memo, isActive, location ) => {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/5512

We were calling window.postboxes.add_postbox_toggles with a fixed post type of 'post'. Now we call with the correct post type we are editing.
To do that, the post type was added to INITIALIZE_META_BOX_STATE action so our effects can correctly call add_postbox_toggles.

## How Has This Been Tested?
Have at least 2 meta boxes (I used "Open Graph Metabox" and "Yoast SEO" plugins in my tests).
Open a post and change the order/collapsed state of the meta boxes.
Open a different post type and verify the last changes to meta box state don't affect this post type. I
In the CPT change the meta box state and verify the changes are persisted.
Verify that the classic editor shows exactly the same meta box ordering and collapsing state as Gutenberg and changes in the classic editor for posts and CPT's are reflected in Gutenberg and changes in Gutenberg are reflected in the classic editor.

