### PR TITLE
Components: Refactor Popover to focus content wrapper on open

### DIFF
--- a/components/dropdown-menu/index.js
+++ b/components/dropdown-menu/index.js
@@ -4,11 +4,6 @@
 import classnames from 'classnames';
 
 /**
- * WordPress dependencies
- */
-import { keycodes } from '@wordpress/utils';
-
-/**
  * Internal dependencies
  */
 import './style.scss';
@@ -16,8 +11,6 @@ import IconButton from '../icon-button';
 import Dashicon from '../dashicon';
 import Dropdown from '../dropdown';
 import { NavigableMenu } from '../navigable-container';
-
-const { DOWN } = keycodes;
 
 function DropdownMenu( {
 	icon = 'menu',
@@ -34,13 +27,6 @@ function DropdownMenu( {
 			className="components-dropdown-menu"
 			contentClassName="components-dropdown-menu__popover"
 			renderToggle={ ( { isOpen, onToggle } ) => {
-				const openOnArrowDown = ( event ) => {
-					if ( ! isOpen && event.keyCode === DOWN ) {
-						event.preventDefault();
-						event.stopPropagation();
-						onToggle();
-					}
-				};
 				return (
 					<IconButton
 						className={
@@ -50,7 +36,6 @@ function DropdownMenu( {
 						}
 						icon={ icon }
 						onClick={ onToggle }
-						onKeyDown={ openOnArrowDown }
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						label={ label }

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -1,22 +1,45 @@
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * WordPress Dependeencies
  */
 import { Component } from '@wordpress/element';
+import { keycodes } from '@wordpress/utils';
 
 /**
  * Internal Dependencies
  */
 import Popover from '../popover';
+import FocusOutside from '../focus-outside';
+
+const {
+	ENTER,
+	SPACE,
+	DOWN,
+} = keycodes;
+
+/**
+ * Set of keys on which focus should shift to menu tabbable.
+ *
+ * @type {number[]}
+ */
+const FOCUS_MENU_KEYCODES = [ ENTER, SPACE, DOWN ];
 
 class Dropdown extends Component {
 	constructor() {
 		super( ...arguments );
+
+		this.bindPopover = this.bindPopover.bind( this );
 		this.toggle = this.toggle.bind( this );
 		this.close = this.close.bind( this );
-		this.clickOutside = this.clickOutside.bind( this );
-		this.bindContainer = this.bindContainer.bind( this );
+		this.focusPopoverTabbable = this.focusPopoverTabbable.bind( this );
+
 		this.state = {
 			isOpen: false,
+			focusFirstTabbable: false,
 		};
 	}
 
@@ -36,24 +59,68 @@ class Dropdown extends Component {
 		}
 	}
 
-	bindContainer( ref ) {
-		this.container = ref;
-	}
-
-	toggle() {
-		this.setState( ( state ) => ( {
-			isOpen: ! state.isOpen,
-		} ) );
-	}
-
-	clickOutside( event ) {
-		if ( ! this.container.contains( event.target ) ) {
-			this.close();
+	componentDidUpdate( prevProps, prevState ) {
+		const { isOpen, focusFirstTabbable } = this.state;
+		if ( isOpen && ! prevState.isOpen && focusFirstTabbable ) {
+			this.popover.focusFirstTabbable();
 		}
 	}
 
+	/**
+	 * Binds the popover component instance. Keying into menu will call its
+	 * focusFirstTabbable instance method.
+	 *
+	 * @param {Object} popover Popover instance.
+	 */
+	bindPopover( popover ) {
+		this.popover = popover;
+	}
+
+	/**
+	 * Toggles display of the dropdown menu options. By default, toggles to the
+	 * inverse of the current state. Optionally focus first tabbable upon menu
+	 * opening.
+	 *
+	 * @param {?boolean} isOpen             Whether menu is to be visible.
+	 * @param {?boolean} focusFirstTabbable Whether to focus first tabbable.
+	 */
+	toggle( isOpen, focusFirstTabbable = false ) {
+		this.setState( ( state ) => {
+			if ( isOpen === undefined ) {
+				isOpen = ! state.isOpen;
+			}
+
+			if ( ! isOpen ) {
+				focusFirstTabbable = false;
+			}
+
+			return { isOpen, focusFirstTabbable };
+		} );
+	}
+
 	close() {
-		this.setState( { isOpen: false } );
+		this.setState( {
+			isOpen: false,
+			focusFirstTabbable: false,
+		} );
+	}
+
+	/**
+	 * On key down, shifts focus into menu if one of menu focus keycodes. Opens
+	 * menu if not already open.
+	 *
+	 * @param {KeyboardEvent} event Key down event.
+	 */
+	focusPopoverTabbable( event ) {
+		if ( ! includes( FOCUS_MENU_KEYCODES, event.keyCode ) ) {
+			return;
+		}
+
+		if ( this.state.isOpen ) {
+			this.popover.focusFirstTabbable();
+		} else {
+			this.toggle( true, true );
+		}
 	}
 
 	render() {
@@ -70,29 +137,34 @@ class Dropdown extends Component {
 
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
 
+		// Disable reason: The toggle wrapper is not a button. The implementing
+		// developer is expected to return a button from `renderToggle`, but
+		// capture bubbling key events here to ensure focus shifts into.
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
-			<div className={ className } ref={ this.bindContainer }>
-				{ /**
-				   * This seemingly redundant wrapper node avoids root return
-				   * element styling impacting popover positioning.
-				   */ }
-				<div>
-					{ renderToggle( args ) }
+			<div className={ className }>
+				<FocusOutside onFocusOutside={ this.close }>
+					<div onKeyDown={ this.focusPopoverTabbable }>
+						{ renderToggle( args ) }
+					</div>
 					{ isOpen && (
 						<Popover
+							ref={ this.bindPopover }
 							className={ contentClassName }
 							position={ position }
 							onClose={ this.close }
-							onClickOutside={ this.clickOutside }
 							expandOnMobile={ expandOnMobile }
 							headerTitle={ headerTitle }
+							focusOnMount={ false }
 						>
 							{ renderContent( args ) }
 						</Popover>
 					) }
-				</div>
+				</FocusOutside>
 			</div>
 		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
 

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -122,7 +122,14 @@ class Dropdown extends Component {
 			this.toggle( true, true );
 		}
 
+		// Consider this key handled, since otherwise the behavior of other
+		// handlers may conflict with intended focus.
 		event.stopPropagation();
+
+		// Prevent scroll on arrow press.
+		if ( event.keyCode === DOWN ) {
+			event.preventDefault();
+		}
 	}
 
 	render() {

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -165,7 +165,6 @@ class Dropdown extends Component {
 							onClose={ this.close }
 							expandOnMobile={ expandOnMobile }
 							headerTitle={ headerTitle }
-							focusOnMount={ false }
 						>
 							{ renderContent( args ) }
 						</Popover>

--- a/components/dropdown/index.js
+++ b/components/dropdown/index.js
@@ -121,6 +121,8 @@ class Dropdown extends Component {
 		} else {
 			this.toggle( true, true );
 		}
+
+		event.stopPropagation();
 	}
 
 	render() {

--- a/components/focus-outside/README.md
+++ b/components/focus-outside/README.md
@@ -1,0 +1,8 @@
+Focus Outside
+=============
+
+`<FocusOutside />` is a convenience component for the [`withFocusOutside` higher-order component](../higher-order/with-focus-outside/). Since `withFocusOutside` applies its own wrapper component to intercept focus events, it can occasionally conflict where a DOM parent-child relationship is expected (e.g. CSS styling).
+
+Eventually, this component may become unnecessary, if React natively supports event capture on `Fragment` elements.
+
+See: https://github.com/facebook/react/issues/12051

--- a/components/focus-outside/index.js
+++ b/components/focus-outside/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import withFocusOutside from '../higher-order/with-focus-outside';
+
+class FocusOutside extends Component {
+	handleFocusOutside() {
+		this.props.onFocusOutside();
+	}
+
+	render() {
+		return this.props.children;
+	}
+}
+
+export default withFocusOutside( FocusOutside );

--- a/components/higher-order/with-focus-return/index.js
+++ b/components/higher-order/with-focus-return/index.js
@@ -27,13 +27,20 @@ function withFocusReturn( WrappedComponent ) {
 		}
 
 		componentWillUnmount() {
-			const { activeElementOnMount, isFocused } = this;
-			if ( ! activeElementOnMount ) {
-				return;
-			}
+			this.returnFocus();
+		}
 
-			const { body, activeElement } = document;
-			if ( isFocused || null === activeElement || body === activeElement ) {
+		/**
+		 * Upon component unmount, verify whether focus is within the element
+		 * and, if it is, return focus to the element where focus had existed
+		 * at the point of component mount.
+		 */
+		returnFocus() {
+			const { activeElementOnMount, isFocused } = this;
+
+			// Verify there is an element to which focus should return, and
+			// that focus is within the wrapped element while unmount occurs.
+			if ( activeElementOnMount && isFocused ) {
 				activeElementOnMount.focus();
 			}
 		}

--- a/components/higher-order/with-focus-return/test/index.js
+++ b/components/higher-order/with-focus-return/test/index.js
@@ -64,10 +64,6 @@ describe( 'withFocusReturn()', () => {
 			const mountedComposite = mount( <Composite /> );
 			expect( mountedComposite.instance().activeElementOnMount ).toBe( activeElement );
 
-			// Change activeElement.
-			document.activeElement.blur();
-			expect( document.activeElement ).toBe( document.body );
-
 			// Should return to the activeElement saved with this component.
 			mountedComposite.unmount();
 			expect( document.activeElement ).toBe( activeElement );

--- a/components/index.js
+++ b/components/index.js
@@ -15,6 +15,7 @@ export { default as DropZoneProvider } from './drop-zone/provider';
 export { default as Dropdown } from './dropdown';
 export { default as DropdownMenu } from './dropdown-menu';
 export { default as ExternalLink } from './external-link';
+export { default as FocusOutside } from './focus-outside';
 export { default as FormFileUpload } from './form-file-upload';
 export { default as FormToggle } from './form-toggle';
 export { default as FormTokenField } from './form-token-field';

--- a/components/popover/README.md
+++ b/components/popover/README.md
@@ -88,13 +88,6 @@ A callback invoked when the popover should be closed.
 - Type: `Function`
 - Required: No
 
-### onClickOutside
-
-A callback invoked when the user clicks outside the opened popover, passing the click event. The popover should be closed in response to this interaction. Defaults to `onClose`.
-
-- Type: `Function`
-- Required: No
-
 ### expandOnMobile
 
 Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to avoid this behavior.

--- a/components/popover/detect-outside.js
+++ b/components/popover/detect-outside.js
@@ -1,18 +1,19 @@
 /**
  * External dependencies
  */
-import clickOutside from 'react-click-outside';
+import withFocusReturn from '../higher-order/with-focus-return';
+import withFocusOutside from '../higher-order/with-focus-outside';
 
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, compose } from '@wordpress/element';
 
 class PopoverDetectOutside extends Component {
-	handleClickOutside( event ) {
-		const { onClickOutside } = this.props;
-		if ( onClickOutside ) {
-			onClickOutside( event );
+	handleFocusOutside( event ) {
+		const { onFocusOutside } = this.props;
+		if ( onFocusOutside ) {
+			onFocusOutside( event );
 		}
 	}
 
@@ -21,4 +22,7 @@ class PopoverDetectOutside extends Component {
 	}
 }
 
-export default clickOutside( PopoverDetectOutside );
+export default compose( [
+	withFocusReturn,
+	withFocusOutside,
+] )( PopoverDetectOutside );

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -57,7 +57,7 @@ class Popover extends Component {
 
 		const { focusOnMount = true } = this.props;
 		if ( focusOnMount ) {
-			this.focusContentIfTabbables();
+			this.focusContent();
 		}
 	}
 
@@ -110,23 +110,17 @@ class Popover extends Component {
 	}
 
 	/**
-	 * Shifts focus to the non-tabbable content wrapper if there are focusable
-	 * inputs within the content, and if focus is not already within content.
-	 * This enables the user to proceed with tabbing or arrowing into the
+	 * Shifts focus to the non-tabbable content wrapper if focus is not already
+	 * within content. This allows the user to proceed to tab or arrow into the
 	 * content, to mimic the behavior as if the popover were rendered in the
 	 * markup immediately following the triggering element which is not
 	 * guaranteed with the slot / fill implementation.
 	 */
-	focusContentIfTabbables() {
+	focusContent() {
 		const { content } = this.nodes;
 
 		// Don't shift focus if focus already within (e.g. autoFocus).
-		if ( content.contains( document.activeElement ) ) {
-			return;
-		}
-
-		const hasTabbables = focus.tabbable.find( content ).length > 0;
-		if ( hasTabbables ) {
+		if ( ! content.contains( document.activeElement ) ) {
 			content.focus();
 		}
 	}

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { defer, isEqual, noop } from 'lodash';
+import { isEqual, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,19 +19,6 @@ import PopoverDetectOutside from './detect-outside';
 import IconButton from '../icon-button';
 import ScrollLock from '../scroll-lock';
 import { Slot, Fill } from '../slot-fill';
-
-/**
- * Value representing whether a key is currently pressed. Bound to the document
- * for use in determining whether the Popover component has mounted in response
- * to a keyboard event. Popover's focusOnMount behavior is specific to keyboard
- * interaction. Must be bound at the top-level and its unsetting deferred since
- * the component will have already mounted by the time keyup occurs.
- *
- * @type {boolean}
- */
-let isKeyDown = false;
-document.addEventListener( 'keydown', () => isKeyDown = true );
-document.addEventListener( 'keyup', defer.bind( null, () => isKeyDown = false ) );
 
 const FocusManaged = withFocusReturn( ( { children } ) => children );
 
@@ -108,7 +95,7 @@ class Popover extends Component {
 
 	focus() {
 		const { focusOnMount = true } = this.props;
-		if ( ! focusOnMount || ! isKeyDown ) {
+		if ( ! focusOnMount ) {
 			return;
 		}
 

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -111,13 +111,19 @@ class Popover extends Component {
 
 	/**
 	 * Shifts focus to the non-tabbable content wrapper if there are focusable
-	 * inputs within the content. This enables the user to proceed with tabbing
-	 * or arrowing into the content, to mimic the behavior as if the popover
-	 * were rendered in the markup immediately following the triggering element
-	 * which is not guaranteed with the slot / fill implementation.
+	 * inputs within the content, and if focus is not already within content.
+	 * This enables the user to proceed with tabbing or arrowing into the
+	 * content, to mimic the behavior as if the popover were rendered in the
+	 * markup immediately following the triggering element which is not
+	 * guaranteed with the slot / fill implementation.
 	 */
 	focusContentIfTabbables() {
 		const { content } = this.nodes;
+
+		// Don't shift focus if focus already within (e.g. autoFocus).
+		if ( content.contains( document.activeElement ) ) {
+			return;
+		}
 
 		const hasTabbables = focus.tabbable.find( content ).length > 0;
 		if ( hasTabbables ) {

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -100,6 +100,19 @@ describe( 'Popover', () => {
 			expect( document.activeElement ).toBe( content );
 		} );
 
+		it( 'should not shift focus when opening if tabbables and focus already within', () => {
+			focus.tabbable.find.mockImplementation( ( content ) => {
+				return [ content.querySelector( 'input' ) ];
+			} );
+
+			// eslint-disable-next-line jsx-a11y/no-autofocus
+			wrapper = mount( <Popover><input autoFocus /></Popover> );
+
+			const input = wrapper.find( 'input' ).getDOMNode();
+
+			expect( document.activeElement ).toBe( input );
+		} );
+
 		it( 'should allow focus-on-open behavior to be disabled', () => {
 			const activeElement = document.activeElement;
 

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -5,26 +5,47 @@ import { shallow, mount } from 'enzyme';
 import { noop } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { focus } from '@wordpress/utils';
+
+/**
  * Internal dependencies
  */
 import Popover from '../';
 
+jest.mock( '@wordpress/utils', () => {
+	const utils = require.requireActual( '@wordpress/utils' );
+	return {
+		...utils,
+		focus: {
+			tabbable: {
+				find: jest.fn().mockReturnValue( [] ),
+			},
+		},
+	};
+} );
+
 describe( 'Popover', () => {
 	describe( '#componentDidUpdate()', () => {
 		let wrapper;
-		beforeEach( () => {
+
+		beforeAll( () => {
 			jest.spyOn( Popover.prototype, 'toggleWindowEvents' ).mockImplementation( noop );
 			jest.spyOn( Popover.prototype, 'setOffset' ).mockImplementation( noop );
 			jest.spyOn( Popover.prototype, 'setForcedPositions' ).mockImplementation( noop );
-
-			wrapper = shallow(
-				<Popover />,
-				{ lifecycleExperimental: true }
-			);
 		} );
 
-		afterEach( () => {
-			jest.restoreAllMocks();
+		beforeEach( () => {
+			jest.clearAllMocks();
+
+			wrapper = mount( <Popover /> );
+		} );
+
+		afterAll( () => {
+			Popover.prototype.toggleWindowEvents.mockRestore();
+			Popover.prototype.setOffset.mockRestore();
+			Popover.prototype.setForcedPositions.mockRestore();
 		} );
 
 		it( 'should add window events', () => {
@@ -59,21 +80,36 @@ describe( 'Popover', () => {
 			expect( Popover.prototype.setForcedPositions ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should focus when opening', () => {
-			// An ideal test here would mount with an input child and focus the
-			// child, but in context of JSDOM the inputs are not visible and
-			// are therefore skipped as tabbable, defaulting to popover.
+		it( 'should not focus when opening if no tabbables', () => {
+			const activeElement = document.activeElement;
+
 			wrapper = mount( <Popover /> );
 
-			const content = wrapper.find( '.components-popover__content' ).getDOMNode();
+			expect( document.activeElement ).toBe( activeElement );
+		} );
 
-			expect( document.activeElement ).toBe( content );
+		it( 'should focus when opening if tabbables', () => {
+			focus.tabbable.find.mockImplementation( ( content ) => {
+				return [ content.querySelector( 'input' ) ];
+			} );
+
+			wrapper = mount( <Popover><input /></Popover> );
+
+			const input = wrapper.find( 'input' ).getDOMNode();
+
+			expect( document.activeElement ).toBe( input );
 		} );
 
 		it( 'should allow focus-on-open behavior to be disabled', () => {
 			const activeElement = document.activeElement;
 
-			wrapper = mount( <Popover focusOnMount={ false } /> );
+			focus.tabbable.find.mockImplementation( ( content ) => {
+				return [ content.querySelector( 'input' ) ];
+			} );
+
+			wrapper = mount( <Popover focusOnMount={ false }><input /></Popover> );
+
+			const input = wrapper.find( 'input' ).getDOMNode();
 
 			expect( document.activeElement ).toBe( activeElement );
 		} );

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -25,14 +25,6 @@ describe( 'Popover', () => {
 
 		afterEach( () => {
 			jest.restoreAllMocks();
-
-			// Resetting keyboard state is deferred, so ensure that timers are
-			// consumed to avoid leaking into other tests.
-			jest.runAllTimers();
-
-			if ( document.activeElement ) {
-				document.activeElement.blur();
-			}
 		} );
 
 		it( 'should add window events', () => {
@@ -67,12 +59,7 @@ describe( 'Popover', () => {
 			expect( Popover.prototype.setForcedPositions ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should focus when opening in response to keyboard event', () => {
-			// As in the real world, these occur in sequence before the popover
-			// has been mounted. Keyup's resetting is deferred.
-			document.dispatchEvent( new window.KeyboardEvent( 'keydown' ) );
-			document.dispatchEvent( new window.KeyboardEvent( 'keyup' ) );
-
+		it( 'should focus when opening', () => {
 			// An ideal test here would mount with an input child and focus the
 			// child, but in context of JSDOM the inputs are not visible and
 			// are therefore skipped as tabbable, defaulting to popover.
@@ -81,12 +68,6 @@ describe( 'Popover', () => {
 			const content = wrapper.find( '.components-popover__content' ).getDOMNode();
 
 			expect( document.activeElement ).toBe( content );
-		} );
-
-		it( 'should not focus when opening in response to pointer event', () => {
-			wrapper = mount( <Popover /> );
-
-			expect( document.activeElement ).toBe( document.body );
 		} );
 
 		it( 'should allow focus-on-open behavior to be disabled', () => {

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -80,19 +80,7 @@ describe( 'Popover', () => {
 			expect( Popover.prototype.setForcedPositions ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should not focus when opening if no tabbables', () => {
-			const activeElement = document.activeElement;
-
-			wrapper = mount( <Popover /> );
-
-			expect( document.activeElement ).toBe( activeElement );
-		} );
-
-		it( 'should focus when opening if tabbables', () => {
-			focus.tabbable.find.mockImplementation( ( content ) => {
-				return [ content.querySelector( 'input' ) ];
-			} );
-
+		it( 'should focus when opening', () => {
 			wrapper = mount( <Popover><input /></Popover> );
 
 			const content = wrapper.find( '.components-popover__content' ).getDOMNode();

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -95,9 +95,9 @@ describe( 'Popover', () => {
 
 			wrapper = mount( <Popover><input /></Popover> );
 
-			const input = wrapper.find( 'input' ).getDOMNode();
+			const content = wrapper.find( '.components-popover__content' ).getDOMNode();
 
-			expect( document.activeElement ).toBe( input );
+			expect( document.activeElement ).toBe( content );
 		} );
 
 		it( 'should allow focus-on-open behavior to be disabled', () => {
@@ -108,8 +108,6 @@ describe( 'Popover', () => {
 			} );
 
 			wrapper = mount( <Popover focusOnMount={ false }><input /></Popover> );
-
-			const input = wrapper.find( 'input' ).getDOMNode();
 
 			expect( document.activeElement ).toBe( activeElement );
 		} );

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -173,6 +173,7 @@ class Tooltip extends Component {
 				child.props.children,
 				isOver && (
 					<Popover
+						focusOnMount={ false }
 						position={ position }
 						className="components-tooltip"
 						aria-hidden="true"

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -173,7 +173,6 @@ class Tooltip extends Component {
 				child.props.children,
 				isOver && (
 					<Popover
-						focusOnMount={ false }
 						position={ position }
 						className="components-tooltip"
 						aria-hidden="true"

--- a/components/tooltip/test/index.js
+++ b/components/tooltip/test/index.js
@@ -47,7 +47,6 @@ describe( 'Tooltip', () => {
 			expect( button.children() ).toHaveLength( 2 );
 			expect( button.childAt( 0 ).text() ).toBe( 'Hover Me!' );
 			expect( button.childAt( 1 ).name() ).toBe( 'Popover' );
-			expect( popover.prop( 'focusOnMount' ) ).toBe( false );
 			expect( popover.prop( 'position' ) ).toBe( 'bottom right' );
 			expect( popover.children().text() ).toBe( 'Help text' );
 		} );

--- a/edit-post/components/header/more-menu/index.js
+++ b/edit-post/components/header/more-menu/index.js
@@ -19,7 +19,7 @@ const MoreMenu = () => (
 			<IconButton
 				icon="ellipsis"
 				label={ __( 'More' ) }
-				onClick={ onToggle }
+				onClick={ () => onToggle() }
 				aria-expanded={ isOpen }
 			/>
 		) }

--- a/edit-post/components/header/more-menu/index.js
+++ b/edit-post/components/header/more-menu/index.js
@@ -20,6 +20,7 @@ const MoreMenu = () => (
 				icon="ellipsis"
 				label={ __( 'More' ) }
 				onClick={ () => onToggle() }
+				role="menu"
 				aria-expanded={ isOpen }
 			/>
 		) }

--- a/edit-post/components/header/more-menu/index.js
+++ b/edit-post/components/header/more-menu/index.js
@@ -20,7 +20,6 @@ const MoreMenu = () => (
 				icon="ellipsis"
 				label={ __( 'More' ) }
 				onClick={ () => onToggle() }
-				role="menu"
 				aria-expanded={ isOpen }
 			/>
 		) }

--- a/edit-post/components/sidebar/post-schedule/index.js
+++ b/edit-post/components/sidebar/post-schedule/index.js
@@ -22,7 +22,7 @@ export function PostSchedule() {
 						<button
 							type="button"
 							className="edit-post-post-schedule__toggle button-link"
-							onClick={ onToggle }
+							onClick={ () => onToggle() }
 							aria-expanded={ isOpen }
 						>
 							<PostScheduleLabel />

--- a/edit-post/components/sidebar/post-visibility/index.js
+++ b/edit-post/components/sidebar/post-visibility/index.js
@@ -25,7 +25,7 @@ export function PostVisibility() {
 								type="button"
 								aria-expanded={ isOpen }
 								className="edit-post-post-visibility__toggle button-link"
-								onClick={ onToggle }
+								onClick={ () => onToggle() }
 							>
 								<PostVisibilityLabel />
 							</button>

--- a/editor/components/inserter/index.js
+++ b/editor/components/inserter/index.js
@@ -64,7 +64,7 @@ class Inserter extends Component {
 					<IconButton
 						icon="insert"
 						label={ __( 'Add block' ) }
-						onClick={ onToggle }
+						onClick={ () => onToggle() }
 						className="editor-inserter__toggle"
 						aria-haspopup="true"
 						aria-expanded={ isOpen }

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -270,9 +270,9 @@ export class InserterMenu extends Component {
 		const { selectedItem } = this.state;
 		const isSearching = this.state.filterValue;
 
-		// Disable reason: The inserter menu is a modal display, not one which
-		// is always visible, and one which already incurs this behavior of
-		// autoFocus via Popover's focusOnMount.
+		// Disable reason: The inserter menu is a modal display, one which is
+		// not always visible. Focusing search enables quick input for intended
+		// action, and because is first tabbable anyways, not unexpected shift.
 
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (

--- a/editor/components/table-of-contents/index.js
+++ b/editor/components/table-of-contents/index.js
@@ -19,7 +19,7 @@ function TableOfContents( { hasBlocks } ) {
 			contentClassName="table-of-contents__popover"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<IconButton
-					onClick={ onToggle }
+					onClick={ () => onToggle() }
 					icon="info-outline"
 					aria-expanded={ isOpen }
 					label={ __( 'Content Structure' ) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5597,11 +5597,6 @@
 			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
 			"dev": true
 		},
-		"hoist-non-react-statics": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-			"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
-		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -9548,14 +9543,6 @@
 				"autosize": "4.0.0",
 				"line-height": "0.3.1",
 				"prop-types": "15.5.10"
-			}
-		},
-		"react-click-outside": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.3.1.tgz",
-			"integrity": "sha1-MYc3698IGko7zUaCVmNnTL6YNus=",
-			"requires": {
-				"hoist-non-react-statics": "1.2.0"
 			}
 		},
 		"react-color": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"re-resizable": "4.0.3",
 		"react": "16.2.0",
 		"react-autosize-textarea": "2.0.0",
-		"react-click-outside": "2.3.1",
 		"react-color": "2.13.4",
 		"react-datepicker": "0.61.0",
 		"react-dom": "16.2.0",

--- a/test/e2e/specs/managing-links.test.js
+++ b/test/e2e/specs/managing-links.test.js
@@ -42,7 +42,7 @@ describe( 'Managing links', () => {
 	} );
 
 	it( 'Pressing Left and Esc in Link Dialog in "Docked Toolbar" mode', async () => {
-		setFixedToolbar( false );
+		await setFixedToolbar( false );
 
 		await page.click( '.editor-default-block-appender' );
 		await page.keyboard.type( 'Text' );


### PR DESCRIPTION
Closes #5559
Reverts #5318

This pull request seeks to refactor the `Popover` component to be smarter about its focus-on-mount behavior, removing any distinction between keyboard and click interaction (removes `react-click-outside` as a dependency!), and hopefully making awareness of this prop less of a prerequisite (e.g. `Tooltip` no longer needs to assign, because there are no tabbables anyways).

Further, it leverages this behavior to enhance the Dropdown to "focus to first" when pressing Arrow Down (also Enter, Space). This works when the button is focused, either by keyboard or click.

__Testing instructions:__

Verify that upon clicking or focusing a dropdown button (e.g. "More Options"), you can press Enter/Down/Space to activate the first item in the menu.

Verify that there are no regressions in the dismissal of popovers, whether by shifting focus by tab or clicking elsewhere on the page.