### PR TITLE
ColorPalette: white palette color merging with white background

### DIFF
--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -25,7 +25,13 @@ export function ColorPalette( { colors, disableCustomColors = false, value, onCh
 		<div className="blocks-color-palette">
 			{ map( colors, ( color ) => {
 				const style = { color: color };
-				const className = classnames( 'blocks-color-palette__item', { 'is-active': value === color } );
+				const className = classnames( 
+					'blocks-color-palette__item', 
+					{
+						'is-active': value === color ,
+				 		'has-border': '#fff' === color 
+					} 
+				);
 
 				return (
 					<div key={ color } className="blocks-color-palette__item-wrapper">

--- a/blocks/color-palette/index.js
+++ b/blocks/color-palette/index.js
@@ -25,13 +25,7 @@ export function ColorPalette( { colors, disableCustomColors = false, value, onCh
 		<div className="blocks-color-palette">
 			{ map( colors, ( color ) => {
 				const style = { color: color };
-				const className = classnames( 
-					'blocks-color-palette__item', 
-					{
-						'is-active': value === color ,
-				 		'has-border': '#fff' === color 
-					} 
-				);
+				const className = classnames( 'blocks-color-palette__item', { 'is-active': value === color } );
 
 				return (
 					<div key={ color } className="blocks-color-palette__item-wrapper">

--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -35,7 +35,7 @@ $color-palette-circle-spacing: 14px;
 	vertical-align: top;
 	height: 100%;
 	width: 100%;
-	border: none;
+	border: 1px solid rgba(0, 0, 0, 0.2);
 	border-radius: 50%;
 	background: transparent;
 	box-shadow: inset 0 0 0 ( $color-palette-circle-size / 2 );
@@ -44,10 +44,6 @@ $color-palette-circle-spacing: 14px;
 
 	&.is-active {
 		box-shadow: inset 0 0 0 4px;
-	}
-
-	&.has-border {
-		border: 1px solid #DADADA;
 	}
 
 	&:focus {

--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -35,7 +35,7 @@ $color-palette-circle-spacing: 14px;
 	vertical-align: top;
 	height: 100%;
 	width: 100%;
-	border: 1px solid rgba(0, 0, 0, 0.2);
+	border: none;
 	border-radius: 50%;
 	background: transparent;
 	box-shadow: inset 0 0 0 ( $color-palette-circle-size / 2 );
@@ -44,6 +44,17 @@ $color-palette-circle-spacing: 14px;
 
 	&.is-active {
 		box-shadow: inset 0 0 0 4px;
+	}
+
+	&::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		border-radius: 50%;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .2);
 	}
 
 	&:focus {

--- a/blocks/color-palette/style.scss
+++ b/blocks/color-palette/style.scss
@@ -46,6 +46,10 @@ $color-palette-circle-spacing: 14px;
 		box-shadow: inset 0 0 0 4px;
 	}
 
+	&.has-border {
+		border: 1px solid #DADADA;
+	}
+
 	&:focus {
 		outline: none;
 		&::after {


### PR DESCRIPTION
ColorPalette block allows to provide custom colors but in case we have white (#fff) color among them it may be confusing for the users as it will merge with the background.

This PR solves it by adding a thin border around the white colour so it stands out (border color matches the border from '.components-panel__color-area' class)


## How Has This Been Tested?
Insert ColorPalette component in some part of the editor i.e: existing 'paragraph' block for test purposes and verify that white colour stands out.
Sample: 
```javascript
<PanelColor title={ __( 'Text Color' ) } colorValue={ textColor } initialOpen={ false }>
	<ColorPalette
		colors={ [ '#fff', '#000', '#ccc' ] }
		value={ textColor }
		onChange={ ( colorValue ) => setAttributes( { textColor: colorValue } ) }
	/>
</PanelColor>
```

## Screenshots (jpeg or gifs if applicable):

Before fix:
![image](https://user-images.githubusercontent.com/36142579/37379268-b6680bf4-272a-11e8-8807-8f6443fbcfff.png)

After fix:
![image](https://user-images.githubusercontent.com/36142579/37379273-bb126866-272a-11e8-92be-39c44e9e8632.png)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
