### PR TITLE
Try: Make input styles consistent

### DIFF
--- a/blocks/library/code/editor.scss
+++ b/blocks/library/code/editor.scss
@@ -3,7 +3,6 @@
 	font-size: $text-editor-font-size;
 	color: $dark-gray-800;
 	padding: .8em 1.6em;
-	overflow-x: auto !important;
 	border: 1px solid $light-gray-500;
 	border-radius: 4px;
 }

--- a/blocks/library/shortcode/editor.scss
+++ b/blocks/library/shortcode/editor.scss
@@ -1,8 +1,10 @@
 .wp-block-shortcode {
 	display: flex;
 	flex-direction: row;
-	padding: 1em;
+	padding: $block-padding;
 	background-color: $light-gray-100;
+	font-size: $default-font-size;
+	font-family: $default-font;
 
 	label {
 		flex-basis: 0;
@@ -10,6 +12,7 @@
 		align-items: center;
 		margin-right: $item-spacing;
 		white-space: nowrap;
+		font-weight: 600;
 	}
 
 	.blocks-plain-text {
@@ -18,14 +21,6 @@
 		 * https://github.com/philipwalton/flexbugs#flexbug-4
 		 */
 		flex: 1 0 0%;
-		padding: 4px 8px;
-		border: 1px solid $light-gray-500;
-		font-family: $default-font;
-		font-size: $default-font-size;
-
-		&:focus {
-			border: 1px solid $dark-gray-500;
-		}
 	}
 
 	.dashicon {

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -67,10 +67,11 @@ export const settings = {
 			return (
 				<div className="wp-block-shortcode">
 					<label htmlFor={ inputId }>
-						<Dashicon icon="editor-code" />
+						<Dashicon icon="shortcode" />
 						{ __( 'Shortcode' ) }
 					</label>
 					<PlainText
+						className="input-control"
 						id={ inputId }
 						value={ attributes.text }
 						placeholder={ __( 'Write shortcode here…' ) }

--- a/blocks/library/shortcode/test/__snapshots__/index.js.snap
+++ b/blocks/library/shortcode/test/__snapshots__/index.js.snap
@@ -9,7 +9,7 @@ exports[`core/shortcode block edit matches snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="dashicon dashicons-editor-code"
+      class="dashicon dashicons-shortcode"
       focusable="false"
       height="20"
       role="img"
@@ -18,13 +18,13 @@ exports[`core/shortcode block edit matches snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M9 6l-4 4 4 4-1 2-6-6 6-6zm2 8l4-4-4-4 1-2 6 6-6 6z"
+        d="M6 14H4V6h2V4H2v12h4M7.1 17h2.1l3.7-14h-2.1M14 4v2h2v8h-2v2h4V4"
       />
     </svg>
     Shortcode
   </label>
   <textarea
-    class="blocks-plain-text"
+    class="blocks-plain-text input-control"
     id="blocks-shortcode-input-0"
     placeholder="Write shortcode here…"
     rows="1"

--- a/components/form-token-field/style.scss
+++ b/components/form-token-field/style.scss
@@ -1,18 +1,13 @@
 .components-form-token-field {
-	box-sizing: border-box;
 	width: 100%;
 	margin: 0;
 	padding: 0;
 	background-color: $white;
-	border-radius: 4px;
-	border: 1px solid $light-gray-500;
+	border: 1px solid $light-gray-700;
 	color: $dark-gray-700;
 	cursor: text;
-	transition: all .15s ease-in-out;
 
-	&:hover {
-		border-color: $light-gray-700;
-	}
+	@include input-style__neutral();
 
 	&.is-disabled {
 		background: $light-gray-500;
@@ -20,8 +15,7 @@
 	}
 
 	&.is-active {
-		border-color: $blue-wordpress;
-		box-shadow: 0 0 0 2px $blue-medium-200;
+		@include input-style__focus();
 	}
 }
 
@@ -30,26 +24,26 @@
 	flex-wrap: wrap;
 	align-items: flex-start;
 	padding: 4px;
-}
 
-// Token input
-input[type="text"].components-form-token-field__input {
-	display: inline-block;
-	width: auto;
-	max-width: 100%;
-	margin: 2px 0 2px 8px;
-	padding: 0;
-	line-height: 24px;
-	background: inherit;
-	border: 0;
-	outline: none;
-	font-family: inherit;
-	font-size: $default-font-size;
-	color: $dark-gray-800;
-	box-shadow: none;
-
-	&:focus {
+	// Token input
+	input[type="text"].components-form-token-field__input {
+		display: inline-block;
+		width: auto;
+		max-width: 100%;
+		margin: 2px 0 2px 8px;
+		padding: 0;
+		line-height: 24px;
+		background: inherit;
+		border: 0;
+		font-size: $default-font-size;
+		color: $dark-gray-800;
 		box-shadow: none;
+
+		&:focus,
+		.components-form-token-field.is-active & {
+			outline: none;
+			box-shadow: none;
+		}
 	}
 }
 

--- a/components/panel/style.scss
+++ b/components/panel/style.scss
@@ -73,6 +73,7 @@
 	width: 100%;
 	font-weight: 600;
 	text-align: left;
+	color: $dark-gray-900;
 	@include menu-style__neutral;
 
 	&:focus {

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -177,13 +177,27 @@ $float-margin: calc( 50% - #{ $content-width-padding / 2 } );
 }
 
 // Tabs, Inputs, Square buttons
+@mixin input-style__neutral() {
+	outline-offset: -1px;
+	box-shadow: 0 0 0 transparent;
+	transition: box-shadow .05s linear;
+}
+
+@mixin input-style__focus() {
+	color: $dark-gray-900;
+	outline: 1px solid $dark-gray-300;
+	box-shadow: 0 0 0 2px $blue-medium-200;
+}
+
+// Square buttons
 @mixin square-style__neutral() {
 	outline-offset: -1px;
 }
 
-@mixin square-style__focus-active() {
+@mixin square-style__focus() {
 	color: $dark-gray-900;
 	outline: 1px solid $dark-gray-300;
+	box-shadow: none;
 }
 
 // Menu items

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -186,7 +186,7 @@ $float-margin: calc( 50% - #{ $content-width-padding / 2 } );
 @mixin input-style__focus() {
 	color: $dark-gray-900;
 	outline: 1px solid $dark-gray-300;
-	box-shadow: 0 0 0 2px $blue-medium-200;
+	box-shadow: 0 0 0 2px $blue-medium-300;
 }
 
 // Square buttons

--- a/edit-post/assets/stylesheets/_mixins.scss
+++ b/edit-post/assets/stylesheets/_mixins.scss
@@ -185,8 +185,8 @@ $float-margin: calc( 50% - #{ $content-width-padding / 2 } );
 
 @mixin input-style__focus() {
 	color: $dark-gray-900;
-	outline: 1px solid $dark-gray-300;
-	box-shadow: 0 0 0 2px $blue-medium-300;
+	outline: 1px solid $blue-medium-600;
+	box-shadow: 0 0 0 2px $blue-medium-200;
 }
 
 // Square buttons

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -145,7 +145,7 @@ body.gutenberg-editor-page {
 		border: 1px solid $light-gray-700;
 		font-family: $default-font;
 		font-size: $default-font-size;
-		padding: 6px 10px;
+		padding: 6px 8px;
 		@include input-style__neutral();
 
 		&:focus {

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -118,6 +118,43 @@ body.gutenberg-editor-page {
 	}
 }
 
+// Override core input styles to provide ones consistent with Gutenberg
+// @todo submit as upstream patch as well
+.edit-post-sidebar,
+.editor-post-publish-panel,
+.editor-block-list__block {
+	.input-control, // upstream name is .regular-text
+	input[type=text],
+	input[type=search],
+	input[type=radio],
+	input[type=tel],
+	input[type=time],
+	input[type=url],
+	input[type=week],
+	input[type=password],
+	input[type=checkbox],
+	input[type=color],
+	input[type=date],
+	input[type=datetime],
+	input[type=datetime-local],
+	input[type=email],
+	input[type=month],
+	input[type=number],
+	select,
+	textarea {
+		border: 1px solid $light-gray-700;
+		font-family: $default-font;
+		font-size: $default-font-size;
+		padding: 6px 10px;
+		@include input-style__neutral();
+
+		&:focus {
+			@include input-style__focus();
+		}
+	}
+}
+
+// Placeholder colors
 .editor-post-title,
 .editor-block-list__block {
 	input,
@@ -134,17 +171,6 @@ body.gutenberg-editor-page {
 		&:-moz-placeholder {
 			color: $dark-gray-300;
 		}
-	}
-}
-
-.editor-block-list__block {
-	input,
-	textarea {
-		border-radius: 4px;
-		border-color: $light-gray-500;
-		font-family: $default-font;
-		font-size: $default-font-size;
-		padding: 6px 10px;
 	}
 }
 

--- a/edit-post/components/sidebar/settings-header/style.scss
+++ b/edit-post/components/sidebar/settings-header/style.scss
@@ -14,6 +14,7 @@
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 400;
+	color: $dark-gray-900;
 	@include square-style__neutral;
 
 	&.is-active {
@@ -23,6 +24,6 @@
 	}
 
 	&:focus {
-		@include square-style__focus-active;
+		@include square-style__focus;
 	}
 }

--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -109,3 +109,59 @@
 		}
 	}
 }
+
+/* Text Editor specific */
+.components-panel__header.edit-post-sidebar__header {
+	background: $white;
+	padding-right: $panel-padding / 2;
+
+	.edit-post-sidebar__title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		width: 100%;
+	}
+
+	@include break-medium() {
+		display: none;
+	}
+}
+
+.components-panel__header.edit-post-sidebar__panel-tabs {
+	justify-content: flex-start;
+	padding-left: 0;
+	padding-right: $panel-padding / 2;
+	border-top: 0;
+	margin-top: 0;
+
+	.components-icon-button {
+		display: none;
+		margin-left: auto;
+
+		@include break-medium() {
+			display: flex;
+		}
+	}
+}
+
+.edit-post-sidebar__panel-tab {
+	background: transparent;
+	border: none;
+	border-radius: 0;
+	cursor: pointer;
+	height: 50px;
+	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
+	margin-left: 0;
+	font-weight: 400;
+	@include square-style__neutral;
+
+	&.is-active {
+		padding-bottom: 0;
+		border-bottom: 3px solid $blue-medium-500;
+		font-weight: 600;
+	}
+
+	&:focus {
+		@include square-style__focus;
+	}
+}

--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -15,6 +15,7 @@ $empty-paragraph-height: $text-editor-font-size * 4;
 		cursor: text;
 		width: 100%;
 		color: $dark-gray-300;
+		font-family: $editor-font;
 		outline: 1px solid transparent;
 		transition: 0.2s outline;
 	}

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -44,7 +44,7 @@ input[type="search"].editor-inserter__search {
 	}
 
 	&:focus {
-		@include square-style__focus-active;
+		@include square-style__focus;
 	}
 }
 
@@ -162,7 +162,7 @@ input[type="search"].editor-inserter__search {
 		@include square-style__neutral();
 
 		&:focus {
-			@include square-style__focus-active()
+			@include square-style__focus()
 		}
 
 		&:focus:active {
@@ -210,6 +210,6 @@ input[type="search"].editor-inserter__search {
 	&:active,
 	&:focus {
 		z-index: z-index( '.editor-inserter__tab.is-active' );
-		@include square-style__focus-active();
+		@include square-style__focus();
 	}
 }

--- a/editor/components/post-publish-panel/style.scss
+++ b/editor/components/post-publish-panel/style.scss
@@ -96,9 +96,7 @@
 
 .post-publish-panel__postpublish-link-input[readonly] {
 	width: 100%;
-	border: 1px solid $light-gray-500;
 	padding: 10px;
-	border-radius: $button-style__radius-roundrect;
 	margin: 15px 0;
 	background: $white;
 	overflow: hidden;


### PR DESCRIPTION
Maybe fixes #4963.

This takes a stab at unifying all basic input fields to inherit and have the same styles. That includes blocks that use input fields, and input fields in the sidebar, for example the alt text on an image block.

Blocks using the PlainText component (which is intentionally unstyled by default) can apply a `regular-text` style that is inherited from upstream. This is now applied to the Shortcode block, which also gets a visual enhancement.

While I believe this PR is a definite enhancement and adds much needed consistency, it should also get many eyes as it unstyles some upstream styles in order to achieve the goal. For example upstream input fields get a glowing blue border, and a drop shadow inside. This unstyles that to achieve consistency in Gutenberg.

As such, before I spend too much time on this, we should decide:

- A) what is the ideal _basic input style_?
- B) once we have that, is it okay to not inherit styles from the rest of WordPress? Should we create an upstream trac ticket to apply Gutenberg input styles to the rest of the admin?

Depending on discussions, I will amend this PR. CC: @paulwilde 

Border styles were also darkened slightly, CC #5482 and @afercia. 

![focusstyles](https://user-images.githubusercontent.com/1204802/37397039-e908466e-277a-11e8-8d90-23ccce58a34f.gif)
