### PR TITLE
Make block more menu transformations consistent

### DIFF
--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -7,7 +7,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { IconButton, withContext } from '@wordpress/components';
 import { getPossibleBlockTransformations, switchToBlockType } from '@wordpress/blocks';
 import { compose, Fragment } from '@wordpress/element';
@@ -27,9 +27,12 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 	return (
 		<Fragment>
 			<div className="editor-block-settings-menu__separator" />
+			<span
+				className="editor-block-switcher__menu-title"
+			>
+				{ __( 'Transform into:' ) }
+			</span>
 			{ possibleBlockTransformations.map( ( { name, title, icon } ) => {
-			/* translators: label indicating the transformation of a block into another block */
-				const shownText = sprintf( __( 'Turn into %s' ), title );
 				return (
 					<IconButton
 						key={ name }
@@ -39,9 +42,9 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 							onClick( event );
 						} }
 						icon={ icon }
-						label={ small ? shownText : undefined }
+						label={ small ? title : undefined }
 					>
-						{ ! small && shownText }
+						{ ! small && title }
 					</IconButton>
 				);
 			} ) }

--- a/editor/components/block-settings-menu/block-transformations.js
+++ b/editor/components/block-settings-menu/block-transformations.js
@@ -28,7 +28,7 @@ function BlockTransformations( { blocks, small = false, onTransform, onClick = n
 		<Fragment>
 			<div className="editor-block-settings-menu__separator" />
 			<span
-				className="editor-block-switcher__menu-title"
+				className="editor-block-settings-menu__title"
 			>
 				{ __( 'Transform into:' ) }
 			</span>

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -34,6 +34,12 @@
 	border-top: 1px solid $light-gray-500;
 }
 
+.editor-block-settings-menu__title {
+	display: block;
+	padding: 6px;
+	color: $dark-gray-300;
+}
+
 // Popout menu
 .editor-block-settings-menu__control {
 	width: 100%;


### PR DESCRIPTION
This fixes #5049. It removes the "Turn into" repetitive titles, in favor of a single header, like there is for the Block menu switcher.

![turn into](https://user-images.githubusercontent.com/1204802/37397812-d90d78b8-277c-11e8-9338-493f4a6ec667.gif)
