### PR TITLE
Fix centering of small videos

### DIFF
--- a/blocks/library/video/editor.scss
+++ b/blocks/library/video/editor.scss
@@ -17,3 +17,7 @@
 		max-width: none;
 	}
 }
+
+.editor-block-list__block[data-align="center"] {
+	text-align: center;
+}

--- a/blocks/library/video/index.js
+++ b/blocks/library/video/index.js
@@ -59,7 +59,7 @@ export const settings = {
 
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
-		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
+		if ( 'left' === align || 'center' === align || 'right' === align || 'wide' === align || 'full' === align ) {
 			return { 'data-align': align };
 		}
 	},

--- a/blocks/library/video/style.scss
+++ b/blocks/library/video/style.scss
@@ -4,3 +4,7 @@
 	text-align: center;
 	font-size: $default-font-size;
 }
+
+.wp-block-video.aligncenter {
+	text-align: center;
+}

--- a/blocks/library/video/style.scss
+++ b/blocks/library/video/style.scss
@@ -1,10 +1,14 @@
-.wp-block-video figcaption {
-	margin-top: 0.5em;
-	color: $dark-gray-300;
-	text-align: center;
-	font-size: $default-font-size;
-}
+.wp-block-video {
+	margin: 0;
 
-.wp-block-video.aligncenter {
-	text-align: center;
+	figcaption {
+		margin-top: 0.5em;
+		color: $dark-gray-300;
+		text-align: center;
+		font-size: $default-font-size;
+	}
+
+	&.aligncenter {
+		text-align: center;
+	}
 }


### PR DESCRIPTION
Fixes #5256.

Centering did nothing on videos. Presumably because videos are almost always as wide as the main column. But if the image is smaller, centering does nothing. This PR fixes that, and removes the figure margin also.

![centered video](https://user-images.githubusercontent.com/1204802/37398409-b87a0790-277e-11e8-8e83-0e86e60bfe72.gif)
