### PR TITLE
Refactored meta box data collection. Fixed a bug where meta boxes may not be shown.

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -150,32 +150,6 @@ function gutenberg_filter_meta_boxes( $meta_boxes ) {
 	return $meta_boxes;
 }
 
-/**
- * Check whether a meta box is empty.
- *
- * @since 1.5.0
- *
- * @param array  $meta_boxes Meta box data.
- * @param string $context    Location of meta box, one of side, advanced, normal.
- * @param string $post_type  Post type to investigate.
- * @return boolean Whether the meta box is empty.
- */
-function gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type ) {
-	$page = $post_type;
-
-	if ( ! isset( $meta_boxes[ $page ][ $context ] ) ) {
-		return true;
-	}
-
-	foreach ( $meta_boxes[ $page ][ $context ] as $priority => $boxes ) {
-		if ( ! empty( $boxes ) ) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 add_filter( 'filter_gutenberg_meta_boxes', 'gutenberg_filter_meta_boxes' );
 
 /**
@@ -317,7 +291,7 @@ function the_gutenberg_metaboxes() {
 	 */
 	$wp_meta_boxes = apply_filters( 'filter_gutenberg_meta_boxes', $wp_meta_boxes );
 	$locations     = array( 'side', 'normal', 'advanced' );
-
+	$meta_box_data = array();
 	// Render meta boxes.
 	?>
 	<form class="metabox-base-form">
@@ -328,17 +302,32 @@ function the_gutenberg_metaboxes() {
 			<div id="poststuff" class="sidebar-open">
 				<div id="postbox-container-2" class="postbox-container">
 					<?php
-					do_meta_boxes(
+					$number_metaboxes = do_meta_boxes(
 						$current_screen,
 						$location,
 						$post
 					);
+
+					$meta_box_data[ $location ] = $number_metaboxes > 0;
 					?>
 				</div>
 			</div>
 		</form>
 	<?php endforeach; ?>
 	<?php
+
+	/**
+	 * Sadly we probably can not add this data directly into editor settings.
+	 *
+	 * ACF and other meta boxes need admin_head to fire for meta box registry.
+	 * admin_head fires after admin_enqueue_scripts which is where we create our
+	 * editor instance. If a cleaner solution can be imagined, please change
+	 * this, and try to get this data to load directly into the editor settings.
+	 */
+	wp_add_inline_script(
+		'wp-edit-post',
+		'window._wpLoadGutenbergEditor.then( function( editor ) { editor.initializeMetaBoxes( ' . wp_json_encode( $meta_box_data ) . ' ) } );'
+	);
 
 	// Reset meta box data.
 	$wp_meta_boxes = $_original_meta_boxes;

--- a/phpunit/class-meta-box-test.php
+++ b/phpunit/class-meta-box-test.php
@@ -112,55 +112,6 @@ class Meta_Box_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests for empty meta box.
-	 */
-	public function test_gutenberg_is_meta_box_empty_with_empty_meta_box() {
-		$context                              = 'side';
-		$post_type                            = 'post';
-		$meta_boxes                           = $this->meta_boxes;
-		$meta_boxes[ $post_type ][ $context ] = array();
-
-		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
-		$this->assertTrue( $is_empty );
-	}
-
-	/**
-	 * Tests for non empty meta box area.
-	 */
-	public function test_gutenberg_is_meta_box_empty_with_non_empty_meta_box() {
-		$context    = 'normal';
-		$post_type  = 'post';
-		$meta_boxes = $this->meta_boxes;
-
-		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
-		$this->assertFalse( $is_empty );
-	}
-
-	/**
-	 * Tests for non existant location.
-	 */
-	public function test_gutenberg_is_meta_box_empty_with_non_existant_location() {
-		$context    = 'test';
-		$post_type  = 'post';
-		$meta_boxes = $this->meta_boxes;
-
-		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
-		$this->assertTrue( $is_empty );
-	}
-
-	/**
-	 * Tests for non existant page.
-	 */
-	public function test_gutenberg_is_meta_box_empty_with_non_existant_page() {
-		$context    = 'normal';
-		$post_type  = 'test';
-		$meta_boxes = $this->meta_boxes;
-
-		$is_empty = gutenberg_is_meta_box_empty( $meta_boxes, $context, $post_type );
-		$this->assertTrue( $is_empty );
-	}
-
-	/**
 	 * Test filtering of meta box data.
 	 */
 	public function test_gutenberg_filter_meta_boxes() {


### PR DESCRIPTION
We were checking the locations where we have meta boxes in gutenberg_collect_meta_box_data. But our logic did not take into account that the locations of the meta boxes may be changed by the user.
**So if the user moved meta boxes that by default appeared in the normal location to the sidebar and had no default sidebar meta box, sidebar meta boxes would not be visible.**
To solve that we would need to copy the mechanism that reads user preferences for meta boxes to check their location from do_meta_boxes. Copying this logic makes gutenberg_collect_meta_box_data more complex and increases the maintainability efforts. It would also be very inefficient as that code would be executed multiple times.
So the computing of the array of locations where we have meta boxes was moved to the_gutenberg_metaboxes function where we invoke do_meta_boxes function. This way we can take advantage of the fact that do_meta_boxes returns the number of meta boxes that were outputted.


## How Has This Been Tested?
Verify that there are no regression in the meta boxes, they continue to show, we can still use them and save information.
Check that no meta box that appeared by default in the sidebar exists. E.g: extended settings are is not rendered. Activate one more plugin that render meta boxes in the "normal" location e.g: Open Graph Metabox, Simple CSS, Yoast SEO.
Verify that the meta boxes appear in Gutenberg.
In the classic editor move the meta boxes to the sidebar (darg&drop them).
Go to Gutenberg and verify the meta boxes appear in the sidebar as in the classic editor. In master, the meta boxes the user moved to the sidebar are not rendered.

## Screenshots (jpeg or gifs if applicable):
Before only meta boxes that were not moved are rendered. Sidebar meta box area does not appear:
![image](https://user-images.githubusercontent.com/11271197/37433459-f0a596fc-27d3-11e8-8211-3c436f5e5461.png)

After, moved meta boxes are also rendered in the correct place, and we have a sidebar meta box are:
![image](https://user-images.githubusercontent.com/11271197/37433495-0fab7918-27d4-11e8-816e-a2fd930fac3c.png)

