### PR TITLE
Issue-5604: Embed placeholder breaks upon reload

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -240,7 +240,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			const { url, caption, align, type, providerNameSlug } = attributes;
 
 			if ( ! url ) {
-				return;
+				return null;
 			}
 
 			const embedClassName = classnames( 'wp-block-embed', {


### PR DESCRIPTION
## Description
PR for issue [#5604](https://github.com/WordPress/gutenberg/issues/5604) If you insert an embed block that's empty, then reload the page, you get an error. The solution seems to be pretty simple: return null to return nothing in React.

## How Has This Been Tested?
1. Write new post
2. Insert embed block
3. Save draft or wait for autosave to kick in
4. Reload the page

## Screenshots (jpeg or gifs if applicable):
After fix:
![embed_bug](https://user-images.githubusercontent.com/36142579/37437765-cff00c04-27e6-11e8-80f0-ba187e991d09.gif)


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
