### PR TITLE
#3578 Fix z-index issue with admin bar quick links and content structure tooltip

### DIFF
--- a/components/popover/style.scss
+++ b/components/popover/style.scss
@@ -48,6 +48,7 @@
 		&.is-bottom {
 			top: 100%;
 			margin-top: 8px;
+			z-index: z-index( ".components-popover.is-bottom" );
 
 			&:before {
 				top: -8px;

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -49,6 +49,11 @@ $z-layers: (
 	// Show popovers above wp-admin menus and submenus and sidebar:
 	// #adminmenuwrap { z-index: 9990 }
 	'.components-popover': 1000000,
+
+	// Shows adminbar quicklink submenu above bottom popover:
+	// #wpadminbar ul li {z-index: 99999;}
+	'.components-popover.is-bottom': 99990,
+
 	'.components-autocomplete__results': 1000000,
 );
 


### PR DESCRIPTION
## Description
Fix z-index issue with admin bar quick links and content structure tooltip

## How Has This Been Tested?
Local environment with multuple browsers.

## Screenshots (jpeg or gifs if applicable):
![2018-03-15 13_59_08](https://user-images.githubusercontent.com/1633818/37451943-2d00fe36-2859-11e8-83d7-148a4ea70e00.gif)

## Types of changes
Bug fix #3578 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
