### PR TITLE
Try a perfect fourth heading

### DIFF
--- a/blocks/library/heading/editor.scss
+++ b/blocks/library/heading/editor.scss
@@ -8,33 +8,29 @@
 		margin: 0;
 	}
 
+	// These follow a Major Third type scale
+	// http://type-scale.com/?size=16&scale=1.333&text=A%20Visual%20Type%20Scale&webfont=Noto%2BSerif&font-family=%27Noto%20Serif%27%2C%20serif&font-weight=600&font-family-headers=&font-weight-headers=inherit&background-color=white&font-color=%2324282d
 	h1 {
-		font-size: 3.157em;
-		//font-size: 2em;
+		font-size: 2.44em;
 	}
 
 	h2 {
-		font-size: 2.369em;
-		//font-size: 1.6em;
+		font-size: 1.95em;
 	}
 
 	h3 {
-		font-size: 1.777em;
-		//font-size: 1.4em;
+		font-size: 1.56em;
 	}
 
 	h4 {
-		font-size: 1.333em;
-		//font-size: 1.2em;
+		font-size: 1.25em;
 	}
 
 	h5 {
 		font-size: 1em;
-		//font-size: 1.1em;
 	}
 
 	h6 {
-		font-size: 0.75em;
-		//font-size: 1em;
+		font-size: 0.8em;
 	}
 }

--- a/blocks/library/heading/editor.scss
+++ b/blocks/library/heading/editor.scss
@@ -9,7 +9,6 @@
 	}
 
 	// These follow a Major Third type scale
-	// http://type-scale.com/?size=16&scale=1.333&text=A%20Visual%20Type%20Scale&webfont=Noto%2BSerif&font-family=%27Noto%20Serif%27%2C%20serif&font-weight=600&font-family-headers=&font-weight-headers=inherit&background-color=white&font-color=%2324282d
 	h1 {
 		font-size: 2.44em;
 	}

--- a/blocks/library/heading/editor.scss
+++ b/blocks/library/heading/editor.scss
@@ -9,26 +9,32 @@
 	}
 
 	h1 {
-		font-size: 2em;
+		font-size: 3.157em;
+		//font-size: 2em;
 	}
 
 	h2 {
-		font-size: 1.6em;
+		font-size: 2.369em;
+		//font-size: 1.6em;
 	}
 
 	h3 {
-		font-size: 1.4em;
+		font-size: 1.777em;
+		//font-size: 1.4em;
 	}
 
 	h4 {
-		font-size: 1.2em;
+		font-size: 1.333em;
+		//font-size: 1.2em;
 	}
 
 	h5 {
-		font-size: 1.1em;
+		font-size: 1em;
+		//font-size: 1.1em;
 	}
 
 	h6 {
-		font-size: 1em;
+		font-size: 0.75em;
+		//font-size: 1em;
 	}
 }

--- a/editor/components/post-title/style.scss
+++ b/editor/components/post-title/style.scss
@@ -9,11 +9,11 @@
 		margin: 0;
 		box-shadow: none;
 		border: 1px solid transparent;
-		font-size: 2em;
 		font-family: $editor-font;
 		line-height: $default-line-height;
 
-		// inherited from h1
+		// Match h1 heading
+		font-size: 3.157em;
 		font-weight: 600;
 	}
 

--- a/editor/components/post-title/style.scss
+++ b/editor/components/post-title/style.scss
@@ -13,7 +13,7 @@
 		line-height: $default-line-height;
 
 		// Match h1 heading
-		font-size: 3.157em;
+		font-size: 2.441em;
 		font-weight: 600;
 	}
 


### PR DESCRIPTION
This fixes #4965. It's very much an attempt at this point, and it needs design feedback. It uses this typographic scale: http://type-scale.com/?size=16&scale=1.333&te
xt=A%20Visual%20Type%20Scale&webfont=Noto%2BSerif&font-family=%27Noto%20Serif%27%2C%20serif&font-weight=600&font-family-headers=&font-weight-headers=inherit&backgroun
d-color=white&font-color=%2324282d

We may want to try a perfect fifth instead. Unlike the preview seen at the link above, it looks quite monstrously big in Gutenberg. See screenshot:

<img width="1425" alt="screen shot 2018-03-15 at 11 03 56" src="https://user-images.githubusercontent.com/1204802/37456918-c844f8e8-2840-11e8-9219-bea50c7a0909.png">

Other downsides include the fact that heading sizes become very uneven in the em sizes, with 4 digits after the comma. Additionally, are we okay with the H6 being smaller than body text? It feels weird to me to have any heading that's smaller than the body text.

It is important to remember that what we are adjusting here is the _base_ Gutenberg stylesheet. If themes load their own stylesheet into the editor, they will control the heading sizes themselves. 

CC: @webmatros