### PR TITLE
Button: Wrap text

### DIFF
--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -37,3 +37,9 @@ $blocks-button__line-height: $big-font-size + 6px;
 		text-align: right;
 	}
 }
+
+.wp-block-button .wp-block-button__link{
+    white-space: normal;
+    word-break: break-all;
+    height: auto; 
+}

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -38,7 +38,7 @@ $blocks-button__line-height: $big-font-size + 6px;
 	}
 }
 
-.wp-block-button .wp-block-button__link{
+.wp-block-button .wp-block-button__link {
     white-space: normal;
     word-break: break-all;
     height: auto; 

--- a/blocks/library/button/style.scss
+++ b/blocks/library/button/style.scss
@@ -18,8 +18,8 @@ $blocks-button__line-height: $big-font-size + 6px;
 		padding: ( $blocks-button__height - $blocks-button__line-height ) / 2 24px;
 		text-align: center;
 		text-decoration: none;
-		white-space: nowrap;
-		word-break: break-word;
+		white-space: normal;
+		word-break: break-all;
 
 		&:hover,
 		&:focus,
@@ -36,10 +36,4 @@ $blocks-button__line-height: $big-font-size + 6px;
 	&.alignright {
 		text-align: right;
 	}
-}
-
-.wp-block-button .wp-block-button__link {
-    white-space: normal;
-    word-break: break-all;
-    height: auto; 
 }

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -147,9 +147,3 @@ body.gutenberg-editor-page {
 		padding: 6px 10px;
 	}
 }
-
-.wp-block-button .wp-block-button__link{
-    white-space: normal;
-    word-break: break-all;
-    height: auto; 
-}

--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -147,3 +147,9 @@ body.gutenberg-editor-page {
 		padding: 6px 10px;
 	}
 }
+
+.wp-block-button .wp-block-button__link{
+    white-space: normal;
+    word-break: break-all;
+    height: auto; 
+}


### PR DESCRIPTION
## Description
There was an [issue(5628)](https://github.com/WordPress/gutenberg/issues/5628) on adding new **Button**  block. When we add more text on button label then text on button was not wrapping.

## How Has This Been Tested?
I have tested the issue after fixing it on my local environment.
## Screenshots (jpeg or gifs if applicable):
![screenshot_1](https://user-images.githubusercontent.com/32568073/37463196-79af60e4-287a-11e8-8114-12c62bb56a5e.jpg)

## Types of changes
I have added single line of css in **main.scss**. By adding this single line of css issue of non wrapping of text is solved now.

## Checklist:
- [Yes] My code is tested.
- [Yes] My code follows the WordPress code style.
- [Yes] My code has proper inline documentation.

@maddisondesigns I have solved the issue.