### PR TITLE
Embed preview API

### DIFF
--- a/blocks/test/fixtures/core-embed__funnyordie.html
+++ b/blocks/test/fixtures/core-embed__funnyordie.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/funnyordie {"url":"https://funnyordie.com/"} -->
-<figure class="wp-block-embed-funnyordie wp-block-embed">
+<figure class="wp-block-embed-funnyordie wp-block-embed wp-block-embed-funny-or-die">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core-embed__funnyordie.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed-funnyordie wp-block-embed\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed-funnyordie wp-block-embed wp-block-embed-funny-or-die\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core-embed__funnyordie.parsed.json
+++ b/blocks/test/fixtures/core-embed__funnyordie.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://funnyordie.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed-funnyordie wp-block-embed\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed-funnyordie wp-block-embed wp-block-embed-funny-or-die\">\n    https://funnyordie.com/\n    <figcaption>Embedded content from funnyordie</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core-embed__funnyordie.serialized.html
+++ b/blocks/test/fixtures/core-embed__funnyordie.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:core-embed/funnyordie {"url":"https://funnyordie.com/"} -->
-<figure class="wp-block-embed-funnyordie wp-block-embed">
+<figure class="wp-block-embed-funnyordie wp-block-embed wp-block-embed-funny-or-die">
     https://funnyordie.com/
     <figcaption>Embedded content from funnyordie</figcaption>
 </figure>

--- a/blocks/test/fixtures/core__embed.html
+++ b/blocks/test/fixtures/core__embed.html
@@ -1,5 +1,5 @@
 <!-- wp:core/embed {"url":"https://example.com/"} -->
-<figure class="wp-block-embed">
+<figure class="wp-block-embed wp-block-embed-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>
 </figure>

--- a/blocks/test/fixtures/core__embed.json
+++ b/blocks/test/fixtures/core__embed.json
@@ -10,6 +10,6 @@
             ]
         },
         "innerBlocks": [],
-        "originalContent": "<figure class=\"wp-block-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>"
+        "originalContent": "<figure class=\"wp-block-embed wp-block-embed-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>"
     }
 ]

--- a/blocks/test/fixtures/core__embed.parsed.json
+++ b/blocks/test/fixtures/core__embed.parsed.json
@@ -5,7 +5,7 @@
             "url": "https://example.com/"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<figure class=\"wp-block-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n"
+        "innerHTML": "\n<figure class=\"wp-block-embed wp-block-embed-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n"
     },
     {
         "attrs": {},

--- a/blocks/test/fixtures/core__embed.serialized.html
+++ b/blocks/test/fixtures/core__embed.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:embed {"url":"https://example.com/"} -->
-<figure class="wp-block-embed">
+<figure class="wp-block-embed wp-block-embed-embed">
     https://example.com/
     <figcaption>Embedded content from an example URL</figcaption>
 </figure>

--- a/lib/load.php
+++ b/lib/load.php
@@ -16,6 +16,7 @@ require dirname( __FILE__ ) . '/class-wp-rest-blocks-controller.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/compat.php';
+require dirname( __FILE__ ) . '/embed.php';
 require dirname( __FILE__ ) . '/plugin-compat.php';
 require dirname( __FILE__ ) . '/i18n.php';
 require dirname( __FILE__ ) . '/parser.php';

--- a/lib/register.php
+++ b/lib/register.php
@@ -482,6 +482,23 @@ function gutenberg_register_rest_api_post_revisions() {
 add_action( 'rest_api_init', 'gutenberg_register_rest_api_post_revisions' );
 
 /**
+ * Adds embed preview API endpoint.
+ *
+ * This is a replacement for the 'embed-parse' admin ajax action that the classic
+ * editor uses to preview embedded content.
+ *
+ * @since 2.6.0
+ */
+function gutenberg_register_rest_api_embed_preview() {
+	register_rest_route( 'gutenberg/v1', '/embed-preview/', array(
+		'methods'             => 'GET',
+		'callback'            => 'gutenberg_embed_preview',
+		'permission_callback' => 'gutenberg_embed_preview_permission_check',
+	) );
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_api_embed_preview' );
+
+/**
  * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
  *
  * @since 1.5.2


### PR DESCRIPTION
## Description

This removes all references to the oEmbed metadata, and provides
an API based on the 'embed-parse' admin ajax action that the
classic editor uses to preview embedded content.

Some class names have changed (most notably Funny or Die) because
the provider name is now taken from the title of the block.
Previously, this came from oEmbed, but that was not reliable
as some plugins override oEmbed behaviour and do not provide
any metadata, only HTML. With this change, we are able to
define all of that data in the blocks, and not have
plugins mess things up for us unexpectedly.

## How Has This Been Tested?

Create embed blocks for all tests listed in `components/sandbox/README.md`

Also, embed a KickStarter URL, because these were the ones that oEmbed frequently
only returns metadata for.

## Types of changes
Bug fix: for https://github.com/WordPress/gutenberg/issues/5530
Breaking change: Existing embed blocks may have to be converted, because we've got rid of some attributes.

Video embeds are no longer responsive in the editor with this change, https://github.com/WordPress/gutenberg/pull/5333 is required to reinstate that (and can be merged separately).