### PR TITLE
Fixed crash on categories collapse, document sidebar close, resize from desktop to mobile

### DIFF
--- a/editor/components/post-taxonomies/hierarchical-term-selector.js
+++ b/editor/components/post-taxonomies/hierarchical-term-selector.js
@@ -145,6 +145,7 @@ class HierarchicalTermSelector extends Component {
 					)
 				);
 				this.props.speak( termAddedMessage, 'assertive' );
+				this.addRequest = null;
 				this.setState( {
 					adding: false,
 					formName: '',
@@ -157,6 +158,7 @@ class HierarchicalTermSelector extends Component {
 				if ( xhr.statusText === 'abort' ) {
 					return;
 				}
+				this.addRequest = null;
 				this.setState( {
 					adding: false,
 				} );
@@ -165,10 +167,12 @@ class HierarchicalTermSelector extends Component {
 
 	componentDidMount() {
 		const basePath = wp.api.getTaxonomyRoute( this.props.slug );
-		this.fetchRequest = wp.apiRequest( { path: `/wp/v2/${ basePath }?${ stringify( DEFAULT_QUERY ) }` } ).then(
+		this.fetchRequest = wp.apiRequest( { path: `/wp/v2/${ basePath }?${ stringify( DEFAULT_QUERY ) }` } );
+		this.fetchRequest.then(
 			( terms ) => { // resolve
 				const availableTermsTree = buildTermsTree( terms );
 
+				this.fetchRequest = null;
 				this.setState( {
 					loading: false,
 					availableTermsTree,
@@ -179,6 +183,7 @@ class HierarchicalTermSelector extends Component {
 				if ( xhr.statusText === 'abort' ) {
 					return;
 				}
+				this.fetchRequest = null;
 				this.setState( {
 					loading: false,
 				} );


### PR DESCRIPTION
In HierarchicalTermSelector we were not assigning the promise to this.fetchRequest as componentWillUnmount expected.
So each time componentWillUnmount was called the app crashed.

Fixes: https://github.com/WordPress/gutenberg/issues/5637

## How Has This Been Tested?
Verify it is possible to open and collapse categories panel without any problem.
Verify we can close sidebar with/without categories collapsed, and verify closing sidebar when resizing to mobile also works as expected.
Try to add a category as it generates a different request and see it is still possible to collapse the panel.
