### PR TITLE
E2e testing: Add test for merging paragraph blocks with 'backspace'

### DIFF
--- a/test/e2e/integration/005-splitting-merging-blocks.js
+++ b/test/e2e/integration/005-splitting-merging-blocks.js
@@ -9,10 +9,15 @@ describe( 'Splitting and merging paragraph blocks', () => {
 		// text while typing, which is necessary to navigate to the middle
 		// of some text and type Enter to split it.
 
-		// Insert two separate paragraph blocks to be merged
-		cy.get( '.editor-default-block-appender' ).click();
+		//Add two paragraph blocks to merge
+		cy.get( '.edit-post-header [aria-label="Add block"]' ).click();
+		cy.get( '[placeholder="Search for a block"]' ).type( 'paragraph' );
+		cy.get( '.editor-inserter__block' ).contains( 'Paragraph' ).click();
 		cy.focused().type( 'First' );
-		cy.get( '.editor-default-block-appender' ).click();
+
+		cy.get( '.edit-post-header [aria-label="Add block"]' ).click();
+		cy.get( '[placeholder="Search for a block"]' ).type( 'paragraph' );
+		cy.get( '.editor-inserter__block' ).contains( 'Paragraph' ).click();
 		cy.focused().type( 'Second' );
 
 		// Switch to Code Editor to check HTML Output

--- a/test/e2e/integration/005-splitting-merging-blocks.js
+++ b/test/e2e/integration/005-splitting-merging-blocks.js
@@ -1,0 +1,56 @@
+describe( 'Splitting and merging paragraph blocks', () => {
+	before( () => {
+		cy.newPost();
+	} );
+
+	it( 'Should split and merge paragraph blocks using Enter and Backspace', () => {
+		const lastBlockSelector = '.editor-block-list__block-edit:last [contenteditable="true"]:first';
+
+		// TODO: Test splitting blocks by using Enter.  Due to a current bug
+		// with Cypress, the text caret does not move from the start of the
+		// text while typing, which is necessary to navigate to the middle
+		// of some text and type Enter to split it.
+
+		// Insert two separate paragraph blocks to be merged
+		cy.get( '.editor-default-block-appender' ).click();
+		cy.focused().type( 'First' );
+		cy.get( '.editor-default-block-appender' ).click();
+		cy.focused().type( 'Second' );
+
+		// Switch to Code Editor to check HTML Output
+		cy.get( '.edit-post-more-menu [aria-label="More"]' ).click();
+		cy.get( 'button' ).contains( 'Code Editor' ).click();
+
+		//Assertion to check for two paragraph blocks before merge
+		cy.get( '.editor-post-text-editor' ).should( 'have.value', [
+			'<!-- wp:paragraph -->',
+			'<p>First</p>',
+			'<!-- /wp:paragraph -->',
+			'',
+			'<!-- wp:paragraph -->',
+			'<p>Second</p>',
+			'<!-- /wp:paragraph -->',
+		].join( '\n' ) );
+
+		// Switch to Visual Editor to ccontinue testing
+		cy.get( '.edit-post-more-menu [aria-label="More"]' ).click();
+		cy.get( 'button' ).contains( 'Visual Editor' ).click();
+
+		cy.focused().type( '{backspace}' );
+
+		// Switch to Code Editor to check HTML Output
+		cy.get( '.edit-post-more-menu [aria-label="More"]' ).click();
+		cy.get( 'button' ).contains( 'Code Editor' ).click();
+
+		//Assertion to check for one paragraph blocks after merge
+		cy.get( '.editor-post-text-editor' ).should( 'have.value', [
+			'<!-- wp:paragraph -->',
+			'<p>FirstSecond</p>',
+			'<!-- /wp:paragraph -->',
+		].join( '\n' ) );
+	} );
+} );
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+	return false
+})

--- a/test/e2e/integration/005-splitting-merging-blocks.js
+++ b/test/e2e/integration/005-splitting-merging-blocks.js
@@ -4,8 +4,6 @@ describe( 'Splitting and merging paragraph blocks', () => {
 	} );
 
 	it( 'Should split and merge paragraph blocks using Enter and Backspace', () => {
-		const lastBlockSelector = '.editor-block-list__block-edit:last [contenteditable="true"]:first';
-
 		// TODO: Test splitting blocks by using Enter.  Due to a current bug
 		// with Cypress, the text caret does not move from the start of the
 		// text while typing, which is necessary to navigate to the middle
@@ -50,7 +48,3 @@ describe( 'Splitting and merging paragraph blocks', () => {
 		].join( '\n' ) );
 	} );
 } );
-
-Cypress.on('uncaught:exception', (err, runnable) => {
-	return false
-})


### PR DESCRIPTION
## Description
Added 005-splitting-merging.js, which currently performs an e2e test to ensure that 'backspace' correctly merges paragraph blocks.  Due to a current bug in Cypress, testing the splitting of paragraph blocks with 'enter' is not included in this test script, but will be added later.

## How Has This Been Tested?
This script was tested using Cypress and a version of Gutenberg running on localhost.  The test was performed by running the command 'npx cypress open' and using the Cypress UI to run the test.  I compared Cypress's results to the results from manually merging paragraph blocks, and they were the same.

This change does not affect any other areas of the project.

## Screenshots (jpeg or gifs if applicable):
![capture](https://user-images.githubusercontent.com/12479754/37474619-29efcdd8-2847-11e8-8121-f5ab995395a7.PNG)

## Types of changes
This is a non-breaking change that adds an e2e test of basic functionality.

## Checklist:
- [ X ] My code is tested.
- [ X ] My code follows the WordPress code style.
- [ X ] My code has proper inline documentation.
