### PR TITLE
Updated blockSelection reducer to clear selection if we are removing the selected block

### DIFF
--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -626,6 +626,17 @@ export function blockSelection( state = {
 				initialPosition: null,
 				isMultiSelecting: false,
 			};
+		case 'REMOVE_BLOCKS':
+			if ( ! action.uids || ! action.uids.length || action.uids.indexOf( state.start ) === -1 ) {
+				return state;
+			}
+			return {
+				...state,
+				start: null,
+				end: null,
+				initialPosition: null,
+				isMultiSelecting: false,
+			};
 		case 'REPLACE_BLOCKS':
 			if ( ! action.blocks || ! action.blocks.length || action.uids.indexOf( state.start ) === -1 ) {
 				return state;

--- a/editor/store/test/reducer.js
+++ b/editor/store/test/reducer.js
@@ -1464,6 +1464,41 @@ describe( 'state', () => {
 
 			expect( state ).toBe( original );
 		} );
+
+		it( 'should remove the selection if we are removing the selected block', () => {
+			const original = deepFreeze( {
+				start: 'chicken',
+				end: 'chicken',
+				initialPosition: null,
+				isMultiSelecting: false,
+			} );
+			const state = blockSelection( original, {
+				type: 'REMOVE_BLOCKS',
+				uids: [ 'chicken' ],
+			} );
+
+			expect( state ).toEqual( {
+				start: null,
+				end: null,
+				initialPosition: null,
+				isMultiSelecting: false,
+			} );
+		} );
+
+		it( 'should keep the selection if we are not removing the selected block', () => {
+			const original = deepFreeze( {
+				start: 'chicken',
+				end: 'chicken',
+				initialPosition: null,
+				isMultiSelecting: false,
+			} );
+			const state = blockSelection( original, {
+				type: 'REMOVE_BLOCKS',
+				uids: [ 'ribs' ],
+			} );
+
+			expect( state ).toBe( original );
+		} );
 	} );
 
 	describe( 'preferences()', () => {


### PR DESCRIPTION
When we removed blocks the selection stayed the same, so in the most common case where we remove the selected block the selection becomes invalid.
This had to noticeable issue https://github.com/WordPress/gutenberg/issues/5446 where if we insert a block, after removing another one the block is inserted at the top of the document.
After this PR the block is inserted at the end. In my option, this is still not the best behavior and PR https://github.com/WordPress/gutenberg/pull/5568 makes use of effects to insert the block in the same position of the removed block.
But even if we decide on the other approach, this change is still valid and the problem in the reducer in to be addressed.


## How Has This Been Tested?
Verify it is still possible to remove and add blocks.
Remove a block in the middle of the document. Insert a new block, verify it is inserted at the end.

