### PR TITLE
Preview: Unset popup window upon close

### DIFF
--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -74,6 +74,10 @@ export class PostPreviewButton extends Component {
 			this.getWindowTarget()
 		);
 
+		// When popup is closed, delete reference to avoid later assignment of
+		// location in a post update.
+		this.previewWindow.onbeforeunload = () => delete this.previewWindow;
+
 		const markup = `
 			<div>
 				<p>Please wait&hellip;</p>


### PR DESCRIPTION
Fixes #5634 

This pull request seeks to resolve an issue where previewing, closing the preview, and then proceeding to update a post in Firefox will cause the editor to crash. This is because we attempt to set the preview popup window to the updated URL if it is still open after the post is updated:

https://github.com/WordPress/gutenberg/blob/ba7159e1020be8310cb03f420c8ba427933dc366/editor/components/post-preview-button/index.js#L44-L45

This issue primarily impacts Firefox, where the window reference of `this.previewWindow` still exists even after the popup has been closed. The changes here resolve the issue by ensuring that the value is unset if the popup is closed.

__Testing instructions:__

Repeat testing instructions from #5634 . Note that the error would only have occurred when, after step 2, you return to the post _by closing the popup window_. This should work in both Firefox and in your preferred browser.