### PR TITLE
Data: correct readme example

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -218,7 +218,7 @@ const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 			startSale( discountPercent );
 		},
 	};
-} );
+} )( Button );
 
 // Rendered in the application:
 //

--- a/data/README.md
+++ b/data/README.md
@@ -209,6 +209,8 @@ function Button( { onClick, children } ) {
 	return <button type="button" onClick={ onClick }>{ children }</button>;
 }
 
+const { withDispatch } = wp.data;
+
 const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 	const { startSale } = dispatch( 'my-shop' );
 	const { discountPercent = 20 } = ownProps;


### PR DESCRIPTION
Just a small correction to the `withDispatch` README example.
