### PR TITLE
Issue/5644 Adding custom CSS support in Latest Posts Block

### DIFF
--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -56,6 +56,10 @@ function render_block_core_latest_posts( $attributes ) {
 		$class .= ' columns-' . $attributes['columns'];
 	}
 
+	if ( isset( $attributes['className'] ) && ! empty( $attributes['className'] ) ) {
+		$class .= ' ' . $attributes['className'];
+	}
+
 	$block_content = sprintf(
 		'<ul class="%1$s">%2$s</ul>',
 		esc_attr( $class ),
@@ -101,6 +105,9 @@ function register_block_core_latest_posts() {
 			'orderBy'         => array(
 				'type'    => 'string',
 				'default' => 'date',
+			),
+			'className'       => array(
+				'type'    => 'string',
 			),
 		),
 		'render_callback' => 'render_block_core_latest_posts',


### PR DESCRIPTION
PR In Response to Issue [5644](https://github.com/WordPress/gutenberg/issues/5644). Latest post block doesn't have `customClassName` set to false that's why I assumed that this block should make use of custom class if it was provided.

This fix is defining `customClass` attribute in `register_block_type` function as well as it's adding a conditional check to see if the class was applied by a user. 

## How Has This Been Tested?
1. Write new post
2. Insert Latest Posts block
3. Add custom class in 'Additional CSS Class' input
4. Save post
5. Check if the class was rendered on the front-end

## Screenshots (jpeg or gifs if applicable):
After applying the fix:

Backend:
![image](https://user-images.githubusercontent.com/36142579/37495463-53281bde-28a5-11e8-9654-5404f6be19d2.png)

Frontend:
![image](https://user-images.githubusercontent.com/36142579/37495466-5630a31e-28a5-11e8-985a-dd059e367609.png)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
