### PR TITLE
Blocks: Make it possible to override the default class name generation logic

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -11,6 +11,7 @@ export {
 	default as serialize,
 	getBlockContent,
 	getBlockDefaultClassname,
+	getBlockDefaultClassName,
 	getSaveElement,
 } from './serializer';
 export { isValidBlock } from './validation';

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -27,7 +27,9 @@ import BlockContentProvider from '../block-content-provider';
 export function getBlockDefaultClassname( blockName ) {
 	// Generated HTML classes for blocks follow the `wp-block-{name}` nomenclature.
 	// Blocks provided by WordPress drop the prefixes 'core/' or 'core-' (used in 'core-embed/').
-	return 'wp-block-' + blockName.replace( /\//, '-' ).replace( /^core-/, '' );
+	const className = 'wp-block-' + blockName.replace( /\//, '-' ).replace( /^core-/, '' );
+
+	return applyFilters( 'blocks.getBlockDefaultClassname', className, blockName );
 }
 
 /**

--- a/blocks/api/serializer.js
+++ b/blocks/api/serializer.js
@@ -10,6 +10,7 @@ import isShallowEqual from 'shallowequal';
  */
 import { Component, cloneElement, renderToString } from '@wordpress/element';
 import { hasFilter, applyFilters } from '@wordpress/hooks';
+import { deprecated } from '@wordpress/utils';
 
 /**
  * Internal dependencies
@@ -24,12 +25,28 @@ import BlockContentProvider from '../block-content-provider';
  *
  * @return {string} The block's default class.
  */
-export function getBlockDefaultClassname( blockName ) {
+export function getBlockDefaultClassName( blockName ) {
 	// Generated HTML classes for blocks follow the `wp-block-{name}` nomenclature.
 	// Blocks provided by WordPress drop the prefixes 'core/' or 'core-' (used in 'core-embed/').
 	const className = 'wp-block-' + blockName.replace( /\//, '-' ).replace( /^core-/, '' );
 
-	return applyFilters( 'blocks.getBlockDefaultClassname', className, blockName );
+	return applyFilters( 'blocks.getBlockDefaultClassName', className, blockName );
+}
+
+/**
+ * Returns the block's default classname from its name.
+ *
+ * @param {string} blockName The block name.
+ *
+ * @return {string} The block's default class.
+ */
+export function getBlockDefaultClassname( blockName ) {
+	deprecated( 'getBlockDefaultClassname', {
+		version: '2.6',
+		alternative: 'wp.blocks.getBlockDefaultClassName',
+		plugin: 'Gutenberg',
+	} );
+	return getBlockDefaultClassName( blockName );
 }
 
 /**

--- a/blocks/block-edit/index.js
+++ b/blocks/block-edit/index.js
@@ -16,7 +16,7 @@ import { withContext, withFilters, withAPIData } from '@wordpress/components';
  */
 import {
 	getBlockType,
-	getBlockDefaultClassname,
+	getBlockDefaultClassName,
 	hasBlockSupport,
 } from '../api';
 
@@ -47,7 +47,7 @@ export class BlockEdit extends Component {
 
 		// Generate a class name for the block's editable form
 		const generatedClassName = hasBlockSupport( blockType, 'className', true ) ?
-			getBlockDefaultClassname( name ) :
+			getBlockDefaultClassName( name ) :
 			null;
 		const className = classnames( generatedClassName, attributes.className );
 

--- a/blocks/hooks/generated-class-name.js
+++ b/blocks/hooks/generated-class-name.js
@@ -11,7 +11,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { hasBlockSupport, getBlockDefaultClassname } from '../api';
+import { hasBlockSupport, getBlockDefaultClassName } from '../api';
 
 /**
  * Override props assigned to save component to inject generated className if
@@ -31,13 +31,13 @@ export function addGeneratedClassName( extraProps, blockType ) {
 			// We use uniq to prevent duplicate classnames
 
 			extraProps.className = uniq( [
-				getBlockDefaultClassname( blockType.name ),
+				getBlockDefaultClassName( blockType.name ),
 				...extraProps.className.split( ' ' ),
 			] ).join( ' ' ).trim();
 		} else {
 			// There is no string in the className variable,
 			// so we just dump the default name in there
-			extraProps.className = getBlockDefaultClassname( blockType.name );
+			extraProps.className = getBlockDefaultClassName( blockType.name );
 		}
 	}
 	return extraProps;

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,5 +1,8 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for two minor releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 2.6.0
+- `wp.blocks.getBlockDefaultClassname` function removed. Please use `wp.blocks.getBlockDefaultClassName` instead.
+
 ## 2.5.0
 
  - Returning raw HTML from block `save` is unsupported. Please use the `wp.element.RawHTML` component instead.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -92,29 +92,57 @@ add_filter( 'allowed_block_types', function() {
 
 To modify the behaviour of existing blocks, Gutenberg exposes a list of filters:
 
-- `blocks.registerBlockType`: Used to filter the block settings. It receives the block settings and the name of the block the registered block as arguments.
+#### `blocks.registerBlockType`
 
-- `blocks.getSaveElement`: A filter that applies to the result of a block's `save` function. This filter is used to replace or extend the element, for example using `wp.element.cloneElement` to modify the element's props or replace its children, or returning an entirely new element.
+Used to filter the block settings. It receives the block settings and the name of the block the registered block as arguments.
 
-- `blocks.getSaveContent.extraProps`: A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block Type and the block attributes as arguments.
+#### `blocks.BlockEdit`
 
-- `blocks.BlockEdit`: Used to modify the block's `edit` component. It receives the original block `edit` component and returns a new wrapped component.
+Used to modify the block's `edit` component. It receives the original block `edit` component and returns a new wrapped component.
 
-**Example**
+#### `blocks.getBlockDefaultClassname`
 
-Adding a background by default to all blocks.
+Generated HTML classes for blocks follow the `wp-block-{name}` nomenclature. This filter allows to provide an alternative class name.
+
+_Example:_
 
 ```js
 // Our filter function
-function addBackgroundProp( props ) {
-	return Object.assign( props, { style: { backgroundColor: 'red' } } );
+function setBlockCustomClassName( className, blockName ) {
+	return blockName === 'core/paragraph' ?
+		'my-plugin-paragraph' :
+		className;
 }
 
 // Adding the filter
 wp.hooks.addFilter(
+	'blocks.getBlockDefaultClassname',
+	'my-plugin/set-block-custom-class-name',
+	setBlockCustomClassName
+);
+```
+
+#### `blocks.getSaveElement`
+
+A filter that applies to the result of a block's `save` function. This filter is used to replace or extend the element, for example using `wp.element.cloneElement` to modify the element's props or replace its children, or returning an entirely new element.
+
+#### `blocks.getSaveContent.extraProps
+ 
+A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block Type and the block attributes as arguments.
+
+_Example:_
+
+Adding a background by default to all blocks.
+
+```js
+function addBackgroundColorStyle( props ) {
+	return Object.assign( props, { style: { backgroundColor: 'red' } } );
+}
+
+wp.hooks.addFilter(
 	'blocks.getSaveContent.extraProps',
-	'myplugin/add-background',
-	addBackgroundProp
+	'my-plugin/add-background-color-style',
+	addBackgroundColorStyle
 );
 ```
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -100,7 +100,7 @@ Used to filter the block settings. It receives the block settings and the name o
 
 Used to modify the block's `edit` component. It receives the original block `edit` component and returns a new wrapped component.
 
-#### `blocks.getBlockDefaultClassname`
+#### `blocks.getBlockDefaultClassName`
 
 Generated HTML classes for blocks follow the `wp-block-{name}` nomenclature. This filter allows to provide an alternative class name.
 
@@ -116,7 +116,7 @@ function setBlockCustomClassName( className, blockName ) {
 
 // Adding the filter
 wp.hooks.addFilter(
-	'blocks.getBlockDefaultClassname',
+	'blocks.getBlockDefaultClassName',
 	'my-plugin/set-block-custom-class-name',
 	setBlockCustomClassName
 );
@@ -126,9 +126,9 @@ wp.hooks.addFilter(
 
 A filter that applies to the result of a block's `save` function. This filter is used to replace or extend the element, for example using `wp.element.cloneElement` to modify the element's props or replace its children, or returning an entirely new element.
 
-#### `blocks.getSaveContent.extraProps
+#### `blocks.getSaveContent.extraProps`
  
-A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block Type and the block attributes as arguments.
+A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element. It receives the current props of the `save` element, the block type and the block attributes as arguments.
 
 _Example:_
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -109,8 +109,8 @@ _Example:_
 ```js
 // Our filter function
 function setBlockCustomClassName( className, blockName ) {
-	return blockName === 'core/paragraph' ?
-		'my-plugin-paragraph' :
+	return blockName === 'core/code' ?
+		'my-plugin-code' :
 		className;
 }
 


### PR DESCRIPTION
## Description

Implements #5299.

As noted by @mtias in one of the comments (https://github.com/WordPress/gutenberg/pull/5226/files/0dab724e701d9760e8c4c8929a021d0306c17dd5#r170363193), we should make it possible to override the default implementation which is used to generate the class name for the block.

## How Has This Been Tested?
Manually using the example from README:

https://github.com/WordPress/gutenberg/blob/ac40937e784ce729e7a2b50ac5dc73cbd3874b83/docs/extensibility.md#blocksgetblockdefaultclassname

```js
// Our filter function
function setBlockCustomClassName( className, blockName ) {
	return blockName === 'core/code' ?
		'my-plugin-code' :
		className;
}

// Adding the filter
wp.hooks.addFilter(
	'blocks.getBlockDefaultClassName',
	'my-plugin/set-block-custom-class-name',
	setBlockCustomClassName
);
```

With this code applied, the class name generated for code block should be `my-plugin-code` - this might break your content :)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
