### PR TITLE
Try improving the side UI for nested blocks

### DIFF
--- a/blocks/library/columns/editor.scss
+++ b/blocks/library/columns/editor.scss
@@ -1,0 +1,21 @@
+// These margins make sure that nested blocks stack/overlay with the parent block chrome
+// This is sort of an experiment at making sure the editor looks as much like the end result as possible
+// Potentially the rules here can apply to all nested blocks and enable stacking, in which case it should be moved elsewhere
+.wp-block-columns .editor-block-list__layout {
+	&:first-child {
+		margin-left: -$block-padding;
+	}
+	&:last-child {
+		margin-right: -$block-padding;
+	}
+}
+
+// Prevent the parent block from being hovered, allow only nested blocks
+// Selecting the parent block can be an explicit choice using a separate control
+.editor-block-list__block[data-type="core/columns"] {
+	pointer-events: none;
+
+	> .editor-block-list__block-edit .editor-block-list__block {
+		pointer-events: all;
+	}
+}

--- a/blocks/library/columns/editor.scss
+++ b/blocks/library/columns/editor.scss
@@ -9,13 +9,3 @@
 		margin-right: -$block-padding;
 	}
 }
-
-// Prevent the parent block from being hovered, allow only nested blocks
-// Selecting the parent block can be an explicit choice using a separate control
-.editor-block-list__block[data-type="core/columns"] {
-	pointer-events: none;
-
-	> .editor-block-list__block-edit .editor-block-list__block {
-		pointer-events: all;
-	}
-}

--- a/blocks/library/columns/editor.scss
+++ b/blocks/library/columns/editor.scss
@@ -37,3 +37,18 @@
 		margin-right: $block-side-ui-padding;
 	}
 }
+
+// Hide appender shortcuts in columns
+// @todo This essentially duplicates the mobile styles for the appender component
+// It would be nice to be able to use element queries in that component instead https://github.com/tomhodgins/element-queries-spec
+.wp-block-columns {
+	.editor-inserter-with-shortcuts {
+		display: none;
+	}
+
+	.editor-block-list__empty-block-inserter,
+	.editor-default-block-appender .editor-inserter {
+		left: auto;
+		right: $item-spacing;
+	}
+}

--- a/blocks/library/columns/editor.scss
+++ b/blocks/library/columns/editor.scss
@@ -8,15 +8,32 @@
 	&:last-child {
 		margin-right: -$block-padding;
 	}
+
+	// This max-width is used to constrain the main editor column, it should not cascade into columns
+	.editor-block-list__block {
+		max-width: none;
+	}
 }
 
-
-.editor-block-list__block[data-align="full"] .wp-block-columns .editor-block-list__layout,
+// Wide: show no left/right margin on wide, so they stack with the column side UI
 .editor-block-list__block[data-align="wide"] .wp-block-columns .editor-block-list__layout {
 	&:first-child {
 		margin-left: 0;
 	}
 	&:last-child {
 		margin-right: 0;
+	}
+}
+
+// Fullwide: show margin left/right to ensure there's room for the side UI
+// This is not a 1:1 preview with the front-end where these margins would presumably be zero
+// @todo this could be revisited, by for example showing this margin only when the parent block was selected first
+// Then at least an unselected columns block would be an accurate preview
+.editor-block-list__block[data-align="full"] .wp-block-columns .editor-block-list__layout {
+	&:first-child {
+		margin-left: $block-side-ui-padding;
+	}
+	&:last-child {
+		margin-right: $block-side-ui-padding;
 	}
 }

--- a/blocks/library/columns/editor.scss
+++ b/blocks/library/columns/editor.scss
@@ -9,3 +9,14 @@
 		margin-right: -$block-padding;
 	}
 }
+
+
+.editor-block-list__block[data-align="full"] .wp-block-columns .editor-block-list__layout,
+.editor-block-list__block[data-align="wide"] .wp-block-columns .editor-block-list__layout {
+	&:first-child {
+		margin-left: 0;
+	}
+	&:last-child {
+		margin-right: 0;
+	}
+}

--- a/blocks/library/columns/index.js
+++ b/blocks/library/columns/index.js
@@ -15,6 +15,7 @@ import { RangeControl } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
+import './editor.scss';
 import InspectorControls from '../../inspector-controls';
 import BlockControls from '../../block-controls';
 import BlockAlignmentToolbar from '../../block-alignment-toolbar';

--- a/blocks/library/paragraph/editor.scss
+++ b/blocks/library/paragraph/editor.scss
@@ -2,6 +2,11 @@
 	background: white;
 }
 
+// Don't show white background when a nesting parent is selected
+.editor-block-list__layout .editor-block-list__layout .editor-block-list__block .wp-block-paragraph {
+	background: inherit;
+}
+
 .blocks-font-size__main {
 	display: flex;
 	justify-content: space-between;

--- a/edit-post/assets/stylesheets/_variables.scss
+++ b/edit-post/assets/stylesheets/_variables.scss
@@ -46,6 +46,7 @@ $block-padding: 14px;
 $block-mover-margin: 18px;
 $block-spacing: 4px;
 $block-side-ui-padding: 36px;
+$block-side-ui-width: 28px;		// The side UI max height matches a single line of text, 56px. 28px is half, allowing 2 mover arrows
 
 // Buttons & UI Widgets
 $button-style__radius-roundrect: 4px;

--- a/edit-post/assets/stylesheets/_z-index.scss
+++ b/edit-post/assets/stylesheets/_z-index.scss
@@ -33,6 +33,10 @@ $z-layers: (
 	'.components-drop-zone': 100,
 	'.components-drop-zone__content': 110,
 
+	// Block controls, particularly in nested contexts, floats aside block and
+	// should overlap most block content.
+	'.editor-block-list__block.is-{selected,hovered} .editor-block-{settings-menu,mover}': 100,
+
 	// Show sidebar above wp-admin navigation bar for mobile viewports:
 	// #wpadminbar { z-index: 99999 }
 	'.edit-post-sidebar': 100000,

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -47,8 +47,8 @@
 			margin-right: -$block-side-ui-padding;
 		}
 
-		&[data-align="full"] .editor-block-contextual-toolbar,
-		&[data-align="wide"] .editor-block-contextual-toolbar {
+		&[data-align="full"] > .editor-block-contextual-toolbar,
+		&[data-align="wide"] > .editor-block-contextual-toolbar { // don't affect nested block toolbars
 			max-width: $content-width + 2;	// 1px border left and right
 			margin-left: auto;
 			margin-right: auto;

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -438,11 +438,11 @@ export class BlockListBlock extends Component {
 
 		// Insertion point can only be made visible when the side inserter is
 		// not present, and either the block is at the extent of a selection or
-		// is the last block in the top-level list rendering.
+		// is the first block in the top-level list rendering.
 		const shouldShowInsertionPoint = (
-			( ! isMultiSelected && ! isLast ) ||
+			( ! isMultiSelected && ! isFirst ) ||
 			( isMultiSelected && isLastInSelection ) ||
-			( isLast && ! rootUID && ! isEmptyDefaultBlock )
+			( isFirst && ! rootUID && ! isEmptyDefaultBlock )
 		);
 
 		// Generate the wrapper class names handling the different states of the block.
@@ -493,6 +493,13 @@ export class BlockListBlock extends Component {
 				] }
 				{ ...wrapperProps }
 			>
+				{ shouldShowInsertionPoint && (
+					<BlockInsertionPoint
+						uid={ block.uid }
+						rootUID={ rootUID }
+						layout={ layout }
+					/>
+				) }
 				<BlockDropZone
 					index={ order }
 					rootUID={ rootUID }
@@ -561,13 +568,6 @@ export class BlockListBlock extends Component {
 					) }
 				</IgnoreNestedEvents>
 				{ !! error && <BlockCrashWarning /> }
-				{ shouldShowInsertionPoint && (
-					<BlockInsertionPoint
-						uid={ block.uid }
-						rootUID={ rootUID }
-						layout={ layout }
-					/>
-				) }
 				{ showSideInserter && (
 					<Fragment>
 						<div className="editor-block-list__side-inserter">

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -480,6 +480,7 @@ export class BlockListBlock extends Component {
 			<IgnoreNestedEvents
 				ref={ this.setBlockListRef }
 				onMouseOver={ this.maybeHover }
+				onMouseOverHandled={ this.hideHoverEffects }
 				onMouseLeave={ this.hideHoverEffects }
 				className={ wrapperClassName }
 				data-type={ block.name }

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -39,6 +39,7 @@ import InvalidBlockWarning from './invalid-block-warning';
 import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
+import BlockBreadcrumb from './breadcrumb';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import BlockMultiControls from './multi-controls';
 import BlockMobileToolbar from './block-mobile-toolbar';
@@ -521,6 +522,7 @@ export class BlockListBlock extends Component {
 						renderBlockMenu={ renderBlockMenu }
 					/>
 				) }
+				{ isHovered && <BlockBreadcrumb uid={ block.uid } /> }
 				{ shouldShowContextualToolbar && <BlockContextualToolbar /> }
 				{ isFirstMultiSelected && <BlockMultiControls rootUID={ rootUID } /> }
 				<IgnoreNestedEvents

--- a/editor/components/block-list/breadcrumb.js
+++ b/editor/components/block-list/breadcrumb.js
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/element';
+import { Dashicon, Tooltip, Toolbar, Button } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import NavigableToolbar from '../navigable-toolbar';
+import BlockTitle from '../block-title';
+
+/**
+ * Stops propagation of the given event argument. Assumes that the event has
+ * been completely handled and no other listeners should be informed.
+ *
+ * For the breadcrumb component, this is used for improved interoperability
+ * with the block's `onFocus` handler which selects the block, thus conflicting
+ * with the intention to select the root block.
+ *
+ * @param {Event} event Event for which propagation should be stopped.
+ */
+function stopPropagation( event ) {
+	event.stopPropagation();
+}
+
+/**
+ * Block breadcrumb component, displaying the label of the block. If the block
+ * descends from a root block, a button is displayed enabling the user to select
+ * the root block.
+ *
+ * @param {string}   props.uid             UID of block.
+ * @param {string}   props.rootUID         UID of block's root.
+ * @param {Function} props.selectRootBlock Callback to select root block.
+ *
+ * @return {WPElement} Breadcrumb element.
+ */
+function BlockBreadcrumb( { uid, rootUID, selectRootBlock } ) {
+	return (
+		<NavigableToolbar className="editor-block-breadcrumb">
+			<Toolbar>
+				{ rootUID && (
+					<Tooltip text={ __( 'Select parent block' ) }>
+						<Button
+							onClick={ selectRootBlock }
+							onFocus={ stopPropagation }
+						>
+							<Dashicon icon="arrow-left" uid={ uid } />
+						</Button>
+					</Tooltip>
+				) }
+				<BlockTitle uid={ uid } />
+			</Toolbar>
+		</NavigableToolbar>
+	);
+}
+
+export default compose( [
+	withSelect( ( select, ownProps ) => {
+		const { getBlockRootUID } = select( 'core/editor' );
+		const { uid } = ownProps;
+
+		return {
+			rootUID: getBlockRootUID( uid ),
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		const { rootUID } = ownProps;
+		const { selectBlock } = dispatch( 'core/editor' );
+
+		return {
+			selectRootBlock: () => selectBlock( rootUID ),
+		};
+	} ),
+] )( BlockBreadcrumb );

--- a/editor/components/block-list/insertion-point.js
+++ b/editor/components/block-list/insertion-point.js
@@ -60,7 +60,7 @@ export default compose(
 	connect(
 		( state, { uid, rootUID } ) => {
 			const blockIndex = uid ? getBlockIndex( state, uid, rootUID ) : -1;
-			const insertIndex = blockIndex + 1;
+			const insertIndex = blockIndex;
 			const insertionPoint = getBlockInsertionPoint( state );
 			const block = uid ? getBlock( state, uid ) : null;
 

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -24,7 +24,6 @@ import { Component } from '@wordpress/element';
  */
 import './style.scss';
 import BlockListBlock from './block';
-import BlockInsertionPoint from './insertion-point';
 import IgnoreNestedEvents from './ignore-nested-events';
 import DefaultBlockAppender from '../default-block-appender';
 import {
@@ -216,7 +215,6 @@ class BlockListLayout extends Component {
 
 		return (
 			<div className={ classes }>
-				{ !! blockUIDs.length && <BlockInsertionPoint rootUID={ rootUID } layout={ defaultLayout } /> }
 				{ map( blockUIDs, ( uid, blockIndex ) => (
 					<BlockListBlock
 						key={ 'block-' + uid }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -526,7 +526,8 @@
  * Block Toolbar
  */
 
-.editor-block-contextual-toolbar {
+.editor-block-contextual-toolbar,
+.editor-block-breadcrumb {
 	position: sticky;
 	z-index: z-index( '.editor-block-contextual-toolbar' );
 	white-space: nowrap;
@@ -560,35 +561,53 @@
 		top: -1px;	// stack borders
 	}
 
-	.editor-block-toolbar {
-		border: 1px solid $light-gray-500;
-		width: 100%;
-
-		// this prevents floats from messing up the position
-		position: absolute;
-		left: 0;
-
-		.editor-block-list__block[data-align="right"] & {
-			left: auto;
-			right: 0;
-		}
-
-		// remove stacked borders in inline toolbar
-		> div:first-child {
-			margin-left: -1px;
-		}
-
-		> .editor-block-switcher:first-child {
-			margin-left: -2px;
-		}
-
-		@include break-small() {
-			width: auto;
-		}
-	}
-
 	// Reset pointer-events on children.
 	& > * {
 		pointer-events: auto;
+	}
+}
+
+.editor-block-contextual-toolbar .editor-block-toolbar,
+.editor-block-breadcrumb .components-toolbar {
+	border: 1px solid $light-gray-500;
+	width: 100%;
+
+	// this prevents floats from messing up the position
+	position: absolute;
+	left: 0;
+
+	.editor-block-list__block[data-align="right"] & {
+		left: auto;
+		right: 0;
+	}
+
+	// remove stacked borders in inline toolbar
+	> div:first-child {
+		margin-left: -1px;
+	}
+
+	> .editor-block-switcher:first-child {
+		margin-left: -2px;
+	}
+
+	@include break-small() {
+		width: auto;
+	}
+}
+
+.editor-block-breadcrumb .components-toolbar {
+	padding: 0px 12px;
+	line-height: $block-toolbar-height - 1px;
+	font-family: $default-font;
+	font-size: $default-font-size;
+	color: $dark-gray-500;
+	cursor: default;
+
+	.components-button {
+		margin-left: -12px;
+		margin-right: 12px;
+		border-right: 1px solid $light-gray-500;
+		color: $dark-gray-500;
+		padding-top: 6px;
 	}
 }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -34,6 +34,10 @@
 	.editor-block-list__block-edit {
 		margin-top: $block-padding;
 		margin-bottom: $block-padding;
+
+		// Prevent collapsing margins @todo try and revisit this, it's conducive to theming to allow these to collapse
+		padding-top: .1px;
+		padding-bottom: .1px;	
 	}
 
 	margin-bottom: $block-spacing;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -493,22 +493,11 @@
 	}
 }
 
-// In between blocks
 .editor-block-list__block > .editor-block-list__insertion-point {
 	position: absolute;
-	bottom: -$block-padding;
-	height: $block-padding * 2; // Matches the whole empty space between two blocks
-	top: auto;
-	left: 0;
-	right: 0;
-}
-
-// Before the first block
-.editor-block-list__layout > .editor-block-list__insertion-point {
-	position: relative;
 	top: -$block-padding;
-	margin-left: auto;
-	margin-right: auto;
+	height: $block-padding * 2; // Matches the whole empty space between two blocks
+	bottom: auto;
 	left: 0;
 	right: 0;
 }

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -5,6 +5,12 @@
 		padding-left: $block-side-ui-padding;
 		padding-right: $block-side-ui-padding;
 	}
+
+	// Don't add side padding for nested blocks, @todo see if this can be scoped better
+	.editor-block-list__block & {
+		padding-left: 0;
+		padding-right: 0;
+	}
 }
 
 .editor-block-list__layout .editor-block-list__block {
@@ -78,7 +84,13 @@
 	&.is-selected > .editor-block-mover:before,
 	&.is-hovered > .editor-block-mover:before {
 		border-right: 1px solid $light-gray-500;
-		right: 6px;
+		right: 0;
+	}
+
+	&.is-selected > .editor-block-settings-menu:before,
+	&.is-hovered > .editor-block-settings-menu:before {
+		border-left: 1px solid $light-gray-500;
+		left: 0;
 	}
 
 	&.is-typing .editor-block-list__empty-block-inserter,
@@ -90,12 +102,6 @@
 	.editor-block-list__side-inserter {
 		opacity: 1;
 		transition: opacity 0.2s;
-	}
-
-	&.is-selected > .editor-block-settings-menu:before,
-	&.is-hovered > .editor-block-settings-menu:before {
-		border-left: 1px solid $light-gray-500;
-		left: 6px;
 	}
 
 	/**
@@ -159,26 +165,6 @@
 	&.is-reusable > .editor-block-list__block-edit:before {
 		outline: 1px dashed $light-gray-500;
 	}
-
-	// @todo, this appears to be unused
-	.iframe-overlay {
-		position: relative;
-	}
-
-	.iframe-overlay:before {
-		content: '';
-		display: block;
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-	}
-
-	&.is-selected .iframe-overlay:before {
-		display: none;
-	}
-
 
 	/**
 	 * Alignments
@@ -334,23 +320,37 @@
 			border-bottom: 3px solid $blue-medium-500;
 		}
 	}
+}
 
 
-	/**
-	 * Left and right side UI
-	 */
+/**
+ * Left and right side UI
+ */
 
+.editor-block-list__block {
+
+	// Left and right
 	> .editor-block-settings-menu,
 	> .editor-block-mover {
 		position: absolute;
-		top: 0;
+		top: -.9px; // .9px because of the collapsing margins hack, see line 27, @todo revisit when we allow margins to collapse
+		bottom: -.9px; // utilize full vertical space to increase hoverable area
 		padding: 0;
+		width: $block-side-ui-width;
+	}
+
+	// Elevate when selected or hovered
+	&.is-selected,
+	&.is-hovered {
+		.editor-block-settings-menu,
+		.editor-block-mover {
+			z-index: 9999;	// @todo
+		}
 	}
 
 	// Right side UI
 	> .editor-block-settings-menu {
-		right: #{ -1 * $block-mover-margin - $block-padding + 2px };
-		padding-top: 2px;
+		right: -$block-side-ui-width;
 
 		// Mobile
 		display: none;
@@ -362,8 +362,7 @@
 
 	// Left side UI
 	> .editor-block-mover {
-		left: -$block-mover-margin - $block-padding + 4px;
-		padding-top: 6px;
+		left: -$block-side-ui-width;
 		z-index: z-index( '.editor-block-mover' );
 
 		// Mobile
@@ -373,7 +372,7 @@
 		}
 	}
 
-	// Mobile tools
+	// Show side UI inline below the block on mobile
 	.editor-block-list__block-mobile-toolbar {
 		display: flex;
 		flex-direction: row;
@@ -419,6 +418,11 @@
 		}
 	}
 }
+
+
+/**
+ * In-Canvas Inserter
+ */
 
 .editor-block-list .editor-inserter {
 	margin: $item-spacing;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -242,7 +242,7 @@
 			margin-right: -$block-side-ui-padding;
 		}
 
-		.editor-block-list__block-edit {
+		> .editor-block-list__block-edit {
 			margin-left: -$block-padding;
 			margin-right: -$block-padding;
 
@@ -252,7 +252,7 @@
 			}
 		}
 
-		.editor-block-list__block-edit:before {
+		> .editor-block-list__block-edit:before {
 			left: 0;
 			right: 0;
 			border-left-width: 0;

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -37,7 +37,7 @@
 
 		// Prevent collapsing margins @todo try and revisit this, it's conducive to theming to allow these to collapse
 		padding-top: .1px;
-		padding-bottom: .1px;	
+		padding-bottom: .1px;
 	}
 
 	margin-bottom: $block-spacing;
@@ -259,34 +259,32 @@
 			border-right-width: 0;
 		}
 
-		.editor-block-mover {
+		// Adjust how movers behave on the full-wide block, and don't affect children
+		> .editor-block-mover {
 			display: none;
 		}
 
 		@include break-wide() {
-			.editor-block-mover {
+			> .editor-block-mover {
 				display: block;
 				top: -29px;
 				left: 10px;
 				height: auto;
+				width: auto;
+				z-index: inherit;
 
 				&:before {
 					content: none;
 				}
 			}
 
-			.editor-block-mover__control {
+			> .editor-block-mover .editor-block-mover__control {
 				float: left;
-				margin-right: 8px;
 			}
 		}
 
-		.editor-block-settings-menu__control {
-			float: left;
-			margin-right: 8px;
-		}
-
-		.editor-block-settings-menu {
+		// Also adjust block settings menu
+		> .editor-block-settings-menu {
 			top: -41px;
 			right: 10px;
 			height: auto;
@@ -294,6 +292,10 @@
 			&:before {
 				content: none;
 			}
+		}
+
+		> .editor-block-settings-menu .editor-block-settings-menu__control {
+			float: left;
 		}
 	}
 
@@ -555,8 +557,15 @@
 	margin-right: -$block-padding - 1px;
 
 	@include break-small() {
-		margin-left: -$block-padding - $block-side-ui-padding - 1px;	// stack borders
+		// stack borders
+		margin-left: -$block-padding - $block-side-ui-padding - 1px;
 		margin-right: -$block-padding - $block-side-ui-padding - 1px;
+
+		// except for wide elements, this causes a horizontal scrollbar
+		[data-align="full"] & {
+			margin-left: -$block-padding - $block-side-ui-padding;
+			margin-right: -$block-padding - $block-side-ui-padding;
+		}
 	}
 
 	// on mobile, toolbars fix differently
@@ -569,6 +578,7 @@
 	& > * {
 		pointer-events: auto;
 	}
+
 }
 
 .editor-block-contextual-toolbar .editor-block-toolbar,

--- a/editor/components/block-list/style.scss
+++ b/editor/components/block-list/style.scss
@@ -350,7 +350,7 @@
 	&.is-hovered {
 		.editor-block-settings-menu,
 		.editor-block-mover {
-			z-index: 9999;	// @todo
+			z-index: z-index( '.editor-block-list__block.is-{selected,hovered} .editor-block-{settings-menu,mover}' );
 		}
 	}
 

--- a/editor/components/block-list/test/ignore-nested-events.js
+++ b/editor/components/block-list/test/ignore-nested-events.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -10,24 +10,24 @@ import IgnoreNestedEvents from '../ignore-nested-events';
 
 describe( 'IgnoreNestedEvents', () => {
 	it( 'passes props to its rendered div', () => {
-		const wrapper = shallow(
+		const wrapper = mount(
 			<IgnoreNestedEvents className="foo" />
 		);
 
-		expect( wrapper.type() ).toBe( 'div' );
+		expect( wrapper.find( 'div' ) ).toHaveLength( 1 );
 		expect( wrapper.prop( 'className' ) ).toBe( 'foo' );
 	} );
 
 	it( 'stops propagation of events to ancestor IgnoreNestedEvents', () => {
 		const spyOuter = jest.fn();
 		const spyInner = jest.fn();
-		const wrapper = shallow(
+		const wrapper = mount(
 			<IgnoreNestedEvents onClick={ spyOuter }>
 				<IgnoreNestedEvents onClick={ spyInner } />
 			</IgnoreNestedEvents>
 		);
 
-		wrapper.childAt( 0 ).simulate( 'click' );
+		wrapper.find( 'div' ).last().simulate( 'click' );
 
 		expect( spyInner ).toHaveBeenCalled();
 		expect( spyOuter ).not.toHaveBeenCalled();
@@ -36,7 +36,7 @@ describe( 'IgnoreNestedEvents', () => {
 	it( 'stops propagation of child handled events', () => {
 		const spyOuter = jest.fn();
 		const spyInner = jest.fn();
-		const wrapper = shallow(
+		const wrapper = mount(
 			<IgnoreNestedEvents onClick={ spyOuter }>
 				<IgnoreNestedEvents childHandledEvents={ [ 'onClick' ] }>
 					<div />
@@ -50,5 +50,24 @@ describe( 'IgnoreNestedEvents', () => {
 
 		expect( spyInner ).not.toHaveBeenCalled();
 		expect( spyOuter ).not.toHaveBeenCalled();
+	} );
+
+	it( 'invokes callback of Handled-suffixed prop if handled', () => {
+		const spyOuter = jest.fn();
+		const spyInner = jest.fn();
+		const wrapper = mount(
+			<IgnoreNestedEvents onClickHandled={ spyOuter }>
+				<IgnoreNestedEvents childHandledEvents={ [ 'onClick' ] }>
+					<div />
+					<IgnoreNestedEvents onClick={ spyInner } />
+				</IgnoreNestedEvents>
+			</IgnoreNestedEvents>
+		);
+
+		const div = wrapper.childAt( 0 ).childAt( 0 );
+		div.simulate( 'click' );
+
+		expect( spyInner ).not.toHaveBeenCalled();
+		expect( spyOuter ).toHaveBeenCalled();
 	} );
 } );

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -22,6 +22,7 @@
 			background: $white;
 			border-color: $light-gray-500;
 			border-style: solid;
+			border-width: 1px;
 
 			&:first-child {
 				border-width: 1px 1px 0 1px;

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -1,20 +1,35 @@
 // Mover icon buttons
 .editor-block-mover__control {
 	display: block;
-	padding: 2px;
-	margin: 0 6px 0 4px;
 	border: none;
 	outline: none;
 	background: none;
 	color: $dark-gray-300;
 	cursor: pointer;
-	border-radius: 50%;
-	width: $icon-button-size-small;
+	padding: 0;
+	width: $block-side-ui-width;
+	height: $block-side-ui-width;	// the side UI can be no taller than 2 * $block-side-ui-width, which matches the height of a line of text
 
 	&[aria-disabled="true"] {
 		cursor: default;
 		color: $light-gray-300;
 		pointer-events: none;
+	}
+
+	// Try a background, only for nested situations @todo
+	@include break-small() {
+		.editor-block-list__layout .editor-block-list__layout & {
+			background: $white;
+			border-color: $light-gray-500;
+			border-style: solid;
+
+			&:first-child {
+				border-width: 1px 1px 0 1px;
+			}
+			&:last-child {
+				border-width: 0 1px 1px 1px;
+			}
+		}
 	}
 
 	// apply styles to SVG for movers on the desktop breakpoint

--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -1,3 +1,26 @@
+// The Blocks "More" Menu ellipsis icon button
+.editor-block-settings-menu__toggle {
+	justify-content: center;
+	padding: 0;
+	width: $block-side-ui-width;
+	height: $block-side-ui-width * 2;	// same height as a single line of text, our smallest block
+
+	// Try a background, only for nested situations @todo
+	@include break-small() {
+		.editor-block-list__layout .editor-block-list__layout & {
+			background: $white;
+			border-color: $light-gray-500;
+			border-style: solid;
+			border-width: 1px;
+		}
+	}
+
+	.dashicon {
+		transform: rotate( 90deg );
+	}
+}
+
+// Popout menu
 .editor-block-settings-menu__popover {
 	z-index: z-index( '.editor-block-settings-menu__popover' );
 
@@ -9,57 +32,44 @@
 	.components-popover__content {
 		width: 182px;
 	}
-}
 
-.editor-block-settings-menu__content {
-	width: 100%;
-}
-
-// The ellipsis icon button
-.editor-block-settings-menu__toggle {
-	border-radius: 50%;
-	width: auto;
-	padding: 2px;
-	margin: 14px 4px 14px 8px;
-	width: $icon-button-size-small;
-
-	.dashicon {
-		transform: rotate( 90deg );
-	}
-}
-
-.editor-block-settings-menu__separator {
-	margin-top: $item-spacing;
-	margin-bottom: $item-spacing;
-	border-top: 1px solid $light-gray-500;
-}
-
-.editor-block-settings-menu__title {
-	display: block;
-	padding: 6px;
-	color: $dark-gray-300;
-}
-
-// Popout menu
-.editor-block-settings-menu__control {
-	width: 100%;
-	justify-content: flex-start;
-	padding: 8px;
-	background: none;
-	outline: none;
-	border-radius: 0;
-	color: $dark-gray-500;
-	text-align: left;
-	cursor: pointer;
-	@include menu-style__neutral;
-
-	&:hover,
-	&:focus,
-	&:not(:disabled):hover {
-		@include menu-style__focus;
+	.editor-block-settings-menu__content {
+		width: 100%;
 	}
 
-	.dashicon {
-		margin-right: 5px;
+	.editor-block-settings-menu__separator {
+		margin-top: $item-spacing;
+		margin-bottom: $item-spacing;
+		border-top: 1px solid $light-gray-500;
+	}
+
+	.editor-block-settings-menu__title {
+		display: block;
+		padding: 6px;
+		color: $dark-gray-300;
+	}
+
+	// Menu items
+	.editor-block-settings-menu__control {
+		width: 100%;
+		justify-content: flex-start;
+		padding: 8px;
+		background: none;
+		outline: none;
+		border-radius: 0;
+		color: $dark-gray-500;
+		text-align: left;
+		cursor: pointer;
+		@include menu-style__neutral;
+
+		&:hover,
+		&:focus,
+		&:not(:disabled):hover {
+			@include menu-style__focus;
+		}
+
+		.dashicon {
+			margin-right: 5px;
+		}
 	}
 }

--- a/editor/components/block-title/README.md
+++ b/editor/components/block-title/README.md
@@ -1,0 +1,10 @@
+Block Title
+===========
+
+Renders the block's configured title as a string, or empty if the title cannot be determined.
+
+## Usage
+
+```jsx
+<BlockTitle uid="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+```

--- a/editor/components/block-title/index.js
+++ b/editor/components/block-title/index.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+import { getBlockType } from '@wordpress/blocks';
+
+/**
+ * Renders the block's configured title as a string, or empty if the title
+ * cannot be determined.
+ *
+ * @example
+ *
+ * ```jsx
+ * <BlockTitle uid="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+ * ```
+ *
+ * @param {?string} props.name Block name.
+ *
+ * @return {?string} Block title.
+ */
+export function BlockTitle( { name } ) {
+	if ( ! name ) {
+		return null;
+	}
+
+	const blockType = getBlockType( name );
+	if ( ! blockType ) {
+		return null;
+	}
+
+	return blockType.title;
+}
+
+export default withSelect( ( select, ownProps ) => {
+	const { getBlockName } = select( 'core/editor' );
+	const { uid } = ownProps;
+
+	return {
+		name: getBlockName( uid ),
+	};
+} )( BlockTitle );

--- a/editor/components/block-title/test/index.js
+++ b/editor/components/block-title/test/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { BlockTitle } from '../';
+
+jest.mock( '@wordpress/blocks', () => {
+	return {
+		getBlockType( name ) {
+			switch ( name ) {
+				case 'name-not-exists':
+					return null;
+
+				case 'name-exists':
+					return { title: 'Block Title' };
+			}
+		},
+	};
+} );
+
+describe( 'BlockTitle', () => {
+	it( 'renders nothing if name is falsey', () => {
+		const wrapper = shallow( <BlockTitle /> );
+
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'renders nothing if block type does not exist', () => {
+		const wrapper = shallow( <BlockTitle name="name-not-exists" /> );
+
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	it( 'renders title if block type exists', () => {
+		const wrapper = shallow( <BlockTitle name="name-exists" /> );
+
+		expect( wrapper.text() ).toBe( 'Block Title' );
+	} );
+} );

--- a/editor/components/default-block-appender/style.scss
+++ b/editor/components/default-block-appender/style.scss
@@ -11,6 +11,7 @@ $empty-paragraph-height: $text-editor-font-size * 4;
 		padding: $block-padding;
 		height: $empty-paragraph-height;
 		font-size: $editor-font-size;
+		font-family: $editor-font;
 		cursor: text;
 		width: 100%;
 		height: $empty-paragraph-height;

--- a/editor/components/index.js
+++ b/editor/components/index.js
@@ -57,6 +57,7 @@ export { default as BlockList } from './block-list';
 export { default as BlockMover } from './block-mover';
 export { default as BlockSelectionClearer } from './block-selection-clearer';
 export { default as BlockSettingsMenu } from './block-settings-menu';
+export { default as BlockTitle } from './block-title';
 export { default as BlockToolbar } from './block-toolbar';
 export { default as CopyHandler } from './copy-handler';
 export { default as DefaultBlockAppender } from './default-block-appender';

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -380,6 +380,20 @@ export const getBlockDependantsCacheBust = createSelector(
 );
 
 /**
+ * Returns a block's name given its UID, or null if no block exists with the
+ * UID.
+ *
+ * @param {Object} state Editor state.
+ * @param {string} uid   Block unique ID.
+ *
+ * @return {string} Block name.
+ */
+export function getBlockName( state, uid ) {
+	const block = state.editor.present.blocksByUid[ uid ];
+	return block ? block.name : null;
+}
+
+/**
  * Returns a block given its unique ID. This is a parsed copy of the block,
  * containing its `blockName`, identifier (`uid`), and current `attributes`
  * state. This is not the block's registration settings, which must be

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -39,6 +39,7 @@ const {
 	isEditedPostBeingScheduled,
 	getEditedPostPreviewLink,
 	getBlockDependantsCacheBust,
+	getBlockName,
 	getBlock,
 	getBlocks,
 	getBlockCount,
@@ -1219,6 +1220,51 @@ describe( 'selectors', () => {
 			expect(
 				getBlockDependantsCacheBust( state, 123 )
 			).not.toBe( getBlockDependantsCacheBust( nextState, 123 ) );
+		} );
+	} );
+
+	describe( 'getBlockName', () => {
+		it( 'returns null if no block by uid', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocksByUid: {},
+						blockOrder: {},
+						edits: {},
+					},
+				},
+			};
+
+			const name = getBlockName( state, 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' );
+
+			expect( name ).toBe( null );
+		} );
+
+		it( 'returns block name', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocksByUid: {
+							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+								uid: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+								name: 'core/paragraph',
+								attributes: {},
+							},
+						},
+						blockOrder: {
+							'': [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
+							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
+						},
+						edits: {},
+					},
+				},
+			};
+
+			const name = getBlockName( state, 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' );
+
+			expect( name ).toBe( 'core/paragraph' );
 		} );
 	} );
 

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -39,7 +39,7 @@ describe( 'adding blocks', () => {
 		// Using the between inserter
 		await page.mouse.move( 200, 300 );
 		await page.mouse.move( 250, 350 );
-		await page.click( '[data-type="core/paragraph"] .editor-block-list__insertion-point-inserter' );
+		await page.click( '[data-type="core/quote"] .editor-block-list__insertion-point-inserter' );
 		await page.keyboard.type( 'Second paragraph' );
 
 		// Switch to Text Mode to check HTML Output

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -10,6 +10,29 @@ describe( 'adding blocks', () => {
 		await newPost();
 	} );
 
+	/**
+	 * Given a Puppeteer ElementHandle, clicks around the center-right point.
+	 *
+	 * TEMPORARY: This is a mild hack to work around a bug in the application
+	 * which prevents clicking at center of the inserter, due to conflicting
+	 * overlap of focused block contextual toolbar.
+	 *
+	 * @see Puppeteer.ElementHandle#click
+	 *
+	 * @link https://github.com/WordPress/gutenberg/pull/5658#issuecomment-376943568
+	 *
+	 * @param {Puppeteer.ElementHandle} elementHandle Element handle.
+	 *
+	 * @return {Promise} Promise resolving when element clicked.
+	 */
+	async function clickAtRightish( elementHandle ) {
+		await elementHandle._scrollIntoViewIfNeeded();
+		const box = await elementHandle._assertBoundingBox();
+		const x = box.x + ( box.width * 0.75 );
+		const y = box.y + ( box.height / 2 );
+		return page.mouse.click( x, y );
+	}
+
 	it( 'Should insert content using the placeholder and the regular inserter', async () => {
 		// Default block appender is provisional
 		await page.click( '.editor-default-block-appender' );
@@ -39,7 +62,8 @@ describe( 'adding blocks', () => {
 		// Using the between inserter
 		await page.mouse.move( 200, 300 );
 		await page.mouse.move( 250, 350 );
-		await page.click( '[data-type="core/quote"] .editor-block-list__insertion-point-inserter' );
+		const inserter = await page.$( '[data-type="core/quote"] .editor-block-list__insertion-point-inserter' );
+		await clickAtRightish( inserter );
 		await page.keyboard.type( 'Second paragraph' );
 
 		// Switch to Text Mode to check HTML Output


### PR DESCRIPTION
This PR leverages the recent block margin refactor to try and improve how nested blocks UI works.

This is a first step, with many possible steps to take in the future, but from a high level it seeks to make immediate improvements to:

- Reducing the visual weight of nested blocks UI, including the dimensions & paddings
- Making the editor appearance look as much the same as the frontend, as possible

![side ui improvements](https://user-images.githubusercontent.com/1204802/37518360-166234bc-2915-11e8-9fcd-6a044a541336.gif)

It's still very much a work in progress, but even now it has a lot of benefits over master:

- Because the block UI is stacked, the block dimensions are now no longer marred by the excessive margins we used to make the side UI work
- The side UI has a background (experimental) to make it visible even when it covers content

There are still many more todos (I won't list them, some of them will be obvious), but before I go too much farther I would love some thoughts on this implementation as it stands. 

If the approach has merit, then there is one additional change we should make in this PR before it's ship ready, and that is to ensure that the _parent block is easily selectable_. One way to do this could be to _always show the gray borders around the parent block, when interacting with a child block_. An alternative would be to always show a side-UI type-icon in the vicinity of the parent block, which when clicked selects the parent. This could also serve as a drag handle, now that the side UI is stacking. 

Additional ideas for future enhancements could be to _dim_ adjecent blocks when a child block is selected. It would also be nice to look at improving how hovering the parent block works. It can be hard to _unhover_ as it stands.

---

The key point of this PR is to address the side UI and how it affects nested blocks. The approach outlined in this PR was chosen because it was the simplest of them all, and requires the least UI rejiggering to work. 

If for whatever reason this approach isn't feasible after all, an alternative approach we've discussed involves surfacing the mobile UI for nested contexts, which would look something like this:

![plan b](https://user-images.githubusercontent.com/1204802/37518320-f3c2cf7a-2914-11e8-9517-94161cb13b88.png)

This UI will still definitely be surfaced on phone breakpoints, but the downside it has is that it increases the height of the selected blocks, which presumably can feel jumpy.

---

Here is some demo markup you can use to test the columns block:

```
<!-- wp:paragraph -->
<p>Loem ipsum dolor sit amet, ferri vidisse nam eu, ad nec copiosae mnesarchum vituperatoribus.</p>
<!-- /wp:paragraph -->

<!-- wp:columns -->
<div class="wp-block-columns has-2-columns">
    <!-- wp:paragraph {"layout":"column-1"} -->
    <p class="layout-column-1">Lorem ipsum dolor sit amet, ferri vidisse nam eu, ad nec copiosae mnesarchum vituperatoribus.</p>
    <!-- /wp:paragraph -->

    <!-- wp:paragraph {"layout":"column-1"} -->
    <p class="layout-column-1">Te brute dicunt sea, ut vis omnium menandri, ut sumo aliquam has. Eum aperiam interpretaris at, sea et recusabo expetenda, omnis tibique mea no.</p>
    <!-- /wp:paragraph -->

    <!-- wp:paragraph {"layout":"column-1"} -->
    <p class="layout-column-1">Pri suas partem ea, ius sonet numquam offendit cu, ad simul admodum pri. Eum cu unum choro albucius.</p>
    <!-- /wp:paragraph -->

    <!-- wp:paragraph {"layout":"column-2"} -->
    <p class="layout-column-2">Lorem ipsum dolor sit amet, ferri vidisse nam eu, ad nec copiosae mnesarchum vituperatoribus.</p>
    <!-- /wp:paragraph -->

    <!-- wp:paragraph {"layout":"column-2"} -->
    <p class="layout-column-2">Eum cu unum choro albucius.</p>
    <!-- /wp:paragraph -->

    <!-- wp:paragraph {"layout":"column-2"} -->
    <p class="layout-column-2">Te brute dicunt sea, ut vis omnium menandri, ut sumo aliquam has. Eum aperiam interpretaris at, sea et recusabo expetenda, omnis tibique mea no. Pri suas partem ea, ius sonet numquam offendit cu, ad simul admodum pri.</p>
    <!-- /wp:paragraph -->
</div>
<!-- /wp:columns -->

<!-- wp:paragraph -->
<p>Sea id autem nominavi deseruisse. Te brute dicunt sea, ut vis omnium menandri, ut sumo aliquam has.</p>
<!-- /wp:paragraph -->
```