### PR TITLE
Remove max-width from metabox.

### DIFF
--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -64,7 +64,6 @@
 
 	.edit-post-meta-boxes-area {
 		margin: auto 20px;
-		max-width: $content-width;
 	}
 }
 


### PR DESCRIPTION
Something went wrong when solving the merge conflict in https://github.com/WordPress/gutenberg/pull/5565.

This PR removes the max-width of the metabox for real 😄 