### PR TITLE
Build: Dynamically pick JS/CSS build files for ZIP gen

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -91,6 +91,8 @@ rm -f gutenberg.zip
 php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
+build_files=$(ls **/build/*.{js,css})
+
 # Generate the plugin zip file
 status "Creating archive..."
 zip -r gutenberg.zip \
@@ -99,8 +101,7 @@ zip -r gutenberg.zip \
 	blocks/library/*/*.php \
 	post-content.js \
 	$vendor_scripts \
-	{blocks,components,date,editor,element,hooks,i18n,data,utils,edit-post,viewport,plugins,core-data}/build/*.{js,map} \
-	{blocks,components,editor,edit-post}/build/*.css \
+	$build_files \
 	languages/gutenberg.pot \
 	languages/gutenberg-translations.php \
 	README.md


### PR DESCRIPTION
## Description

Sparked by https://github.com/WordPress/gutenberg/pull/5430#discussion_r175141098, this aims to reduce the need for manual synchronization between `webpack.config.js`, `bin/build-plugin-zip.sh`, `.eslintrc.js`, and any other place where knowledge of which entry points Gutenberg has is needed.

To keep it short, this PR only targets `bin/build-plugin-zip.sh` and uses the shell's `**` file expansion.

### Previously

An initial exploration saw the creation of a small `bin/list-entry-points.js` script which read `webpack.config.js` (thus treating it as the canonical source for entry-point information) and roughly did:

```sh
$entry_points=$(bin/list-entry-points.js | tr \\n , | sed 's/,$//') # comma-separated list
$build_files=$(eval echo {$entry_points}/build/*.{js,css) # actually wrong, because `*.css* will emerge whenever a proper CSS file is missing
```

```js
#!/usr/bin/env node
// For reference, here's bin/list-entry-points.js

const config = require( '../webpack.config.js' );

Object.keys( config.externals )
	// Filter out other externals, keep entry points
	.filter( k => k.indexOf( '@wordpress/' ) >= 0 )
	// Remove the '@wordpress/' prefix
	.map( k => k.substr( 11 ) )
	// Fix key 'editPost,edit-post'
	.map( k => k.indexOf( 'editPost' ) >= 0 ? 'edit-post' : k )
	.forEach( k => console.log( k ) );
```

## How Has This Been Tested?

Run `./bin/build-plugin-zip.sh`. Make sure no errors are found. Inspect the generated ZIP file. Compare its manifesto (e.g. `unzip -l <file>`) with the one from the latest release or one generated from `master`.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
