### PR TITLE
Fixed sidebar heights on mobile.

### DIFF
--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -28,13 +28,15 @@
 		border-right: none;
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;
-		height: 100%;
+		height: auto;
+		max-height: calc( 100vh - #{ $admin-bar-height-big + $panel-header-height } );
 		margin-top: -1px;
 		margin-bottom: -1px;
 
 		@include break-small() {
 			overflow: inherit;
 			height: auto;
+			max-height: none;
 		}
 	}
 


### PR DESCRIPTION
## Description
On mobile sidebars had two problems: 

- If the content did not have enough height to fill the screen the background was white as the sidebar took full width anyway.
- If the content was bigger than the screen +-100px of content was cut and it was not possible to see it because the sidebar bar did not take into consideration the height of the headers.

This PR addresses both issues.

## How Has This Been Tested?
Verify both issues are solved.
Verify that there is no regression on the sidebar try to use in different resolutions.


## Screenshots Before:
![image](https://user-images.githubusercontent.com/11271197/37536386-56879cc6-2942-11e8-92cb-a9fa6ca4ba62.png)
![image](https://user-images.githubusercontent.com/11271197/37536566-d85a7c82-2942-11e8-8ecc-ee889a799958.png)



## Screenshots After:
![image](https://user-images.githubusercontent.com/11271197/37536441-7c00da80-2942-11e8-9e73-2518abb7eabd.png)
![image](https://user-images.githubusercontent.com/11271197/37536451-806639bc-2942-11e8-8186-98489f63d9b6.png)




