### PR TITLE
Fixed sidebar close button on mobile

### DIFF
--- a/edit-post/components/sidebar/style.scss
+++ b/edit-post/components/sidebar/style.scss
@@ -123,6 +123,10 @@
 	padding-left: 0;
 	padding-right: $panel-padding / 2;
 	border-top: 0;
+	margin-top: - $panel-header-height; // to be under close button panel header on mobile.
+	@include break-medium() {
+		margin-top: 0;
+	}
 
 	.components-icon-button {
 		display: none;


### PR DESCRIPTION
The button was occupying a row above the tabs.
Leaving to an empty line that did not look good.

## How Has This Been Tested?
Verify the sidebars work as expected in small, medium and normal resolution.
Verify that on the mobile resolution the close sidebar button is on the same line that the tabs.

## Screenshots before:
![image](https://user-images.githubusercontent.com/11271197/37537950-181a0834-2947-11e8-975a-3b15b7af5056.png)
![image](https://user-images.githubusercontent.com/11271197/37537962-23b23a2c-2947-11e8-8093-2bff080716b7.png)

## Screenshots after:
![image](https://user-images.githubusercontent.com/11271197/37538079-74e66f58-2947-11e8-8efd-3e64c6b877a9.png)

![image](https://user-images.githubusercontent.com/11271197/37538106-7e701182-2947-11e8-9bc8-02d4af3842cc.png)
