### PR TITLE
Use a label element for the post title

### DIFF
--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { keycodes, decodeEntities } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { KeyboardShortcuts, withContext, withFocusOutside } from '@wordpress/components';
+import { KeyboardShortcuts, withContext, withInstanceId, withFocusOutside } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -86,7 +86,7 @@ class PostTitle extends Component {
 	}
 
 	render() {
-		const { title, placeholder } = this.props;
+		const { title, placeholder, instanceId } = this.props;
 		const { isSelected } = this.state;
 		const className = classnames( 'editor-post-title', { 'is-selected': isSelected } );
 
@@ -99,11 +99,11 @@ class PostTitle extends Component {
 						'mod+shift+z': this.redirectHistory,
 					} }
 				>
-					<label htmlFor="post-title" className="screen-reader-text">
-						{ placeholder || __( 'Add title' ) }
+					<label htmlFor={ `post-title-${ instanceId }` } className="screen-reader-text">
+						{ decodeEntities( placeholder ) || __( 'Add title' ) }
 					</label>
 					<Textarea
-						id="post-title"
+						id={ `post-title-${ instanceId }` }
 						className="editor-post-title__input"
 						value={ title }
 						onChange={ this.onChange }
@@ -158,5 +158,6 @@ export default compose(
 	applyWithSelect,
 	applyWithDispatch,
 	applyEditorSettings,
+	withInstanceId,
 	withFocusOutside
 )( PostTitle );

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -89,6 +89,7 @@ class PostTitle extends Component {
 		const { title, placeholder, instanceId } = this.props;
 		const { isSelected } = this.state;
 		const className = classnames( 'editor-post-title', { 'is-selected': isSelected } );
+		const decodedPlaceholder = decodeEntities( placeholder );
 
 		return (
 			<div className={ className }>
@@ -100,14 +101,14 @@ class PostTitle extends Component {
 					} }
 				>
 					<label htmlFor={ `post-title-${ instanceId }` } className="screen-reader-text">
-						{ decodeEntities( placeholder ) || __( 'Add title' ) }
+						{ decodedPlaceholder || __( 'Add title' ) }
 					</label>
 					<Textarea
 						id={ `post-title-${ instanceId }` }
 						className="editor-post-title__input"
 						value={ title }
 						onChange={ this.onChange }
-						placeholder={ decodeEntities( placeholder ) || __( 'Add title' ) }
+						placeholder={ decodedPlaceholder || __( 'Add title' ) }
 						onFocus={ this.onSelect }
 						onKeyDown={ this.onKeyDown }
 						onKeyPress={ this.onUnselect }

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -99,12 +99,15 @@ class PostTitle extends Component {
 						'mod+shift+z': this.redirectHistory,
 					} }
 				>
+					<label htmlFor="post-title" className="screen-reader-text">
+						{ placeholder || __( 'Add title' ) }
+					</label>
 					<Textarea
+						id="post-title"
 						className="editor-post-title__input"
 						value={ title }
 						onChange={ this.onChange }
 						placeholder={ decodeEntities( placeholder ) || __( 'Add title' ) }
-						aria-label={ decodeEntities( placeholder ) || __( 'Add title' ) }
 						onFocus={ this.onSelect }
 						onKeyDown={ this.onKeyDown }
 						onKeyPress={ this.onUnselect }

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,16 +253,6 @@
 				"lodash.once": "4.1.1"
 			}
 		},
-		"@romainberger/css-diff": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@romainberger/css-diff/-/css-diff-1.0.3.tgz",
-			"integrity": "sha1-ztOHU11PQqQqwf4TwJ3pf1rhNEw=",
-			"dev": true,
-			"requires": {
-				"lodash.merge": "4.6.1",
-				"postcss": "5.2.18"
-			}
-		},
 		"@types/autosize": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/@types/autosize/-/autosize-3.0.6.tgz",
@@ -596,12 +586,6 @@
 				"longest": "1.0.1",
 				"repeat-string": "1.6.1"
 			}
-		},
-		"alphanum-sort": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
-			"dev": true
 		},
 		"amdefine": {
 			"version": "1.0.1",
@@ -2040,30 +2024,6 @@
 				}
 			}
 		},
-		"caniuse-api": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-			"dev": true,
-			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-db": "1.0.30000804",
-				"lodash.memoize": "4.1.2",
-				"lodash.uniq": "4.5.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"dev": true,
-					"requires": {
-						"caniuse-db": "1.0.30000804",
-						"electron-to-chromium": "1.3.33"
-					}
-				}
-			}
-		},
 		"caniuse-db": {
 			"version": "1.0.30000804",
 			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000804.tgz",
@@ -2228,15 +2188,6 @@
 			"integrity": "sha512-ODYONMMNb3p658Zv+Pp+/XPa5s6q7afhz3Tzyvo+VRh9WIrJ64J76ZC4GQxnlye/NesTn09jvOiuE8+xxfpwhQ==",
 			"dev": true
 		},
-		"clap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-			"dev": true,
-			"requires": {
-				"chalk": "1.1.3"
-			}
-		},
 		"classnames": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
@@ -2318,12 +2269,6 @@
 				}
 			}
 		},
-		"clone": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
-			"dev": true
-		},
 		"clone-deep": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
@@ -2352,15 +2297,6 @@
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
-		},
-		"coa": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-			"dev": true,
-			"requires": {
-				"q": "1.5.1"
-			}
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -2527,17 +2463,6 @@
 				}
 			}
 		},
-		"color": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-			"dev": true,
-			"requires": {
-				"clone": "1.0.3",
-				"color-convert": "1.9.1",
-				"color-string": "0.3.0"
-			}
-		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -2552,26 +2477,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
-		},
-		"color-string": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"colormin": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-			"dev": true,
-			"requires": {
-				"color": "0.11.4",
-				"css-color-names": "0.0.4",
-				"has": "1.0.1"
-			}
 		},
 		"colors": {
 			"version": "0.5.1",
@@ -2913,12 +2818,6 @@
 				"randomfill": "1.0.3"
 			}
 		},
-		"css-color-names": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-			"dev": true
-		},
 		"css-select": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -2936,56 +2835,6 @@
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
 			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
 			"dev": true
-		},
-		"cssnano": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
-			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-			"dev": true,
-			"requires": {
-				"autoprefixer": "6.7.7",
-				"decamelize": "1.2.0",
-				"defined": "1.0.0",
-				"has": "1.0.1",
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-calc": "5.3.1",
-				"postcss-colormin": "2.2.2",
-				"postcss-convert-values": "2.6.1",
-				"postcss-discard-comments": "2.0.4",
-				"postcss-discard-duplicates": "2.1.0",
-				"postcss-discard-empty": "2.1.0",
-				"postcss-discard-overridden": "0.1.1",
-				"postcss-discard-unused": "2.2.3",
-				"postcss-filter-plugins": "2.0.2",
-				"postcss-merge-idents": "2.1.7",
-				"postcss-merge-longhand": "2.0.2",
-				"postcss-merge-rules": "2.1.2",
-				"postcss-minify-font-values": "1.0.5",
-				"postcss-minify-gradients": "1.0.5",
-				"postcss-minify-params": "1.2.2",
-				"postcss-minify-selectors": "2.1.1",
-				"postcss-normalize-charset": "1.1.1",
-				"postcss-normalize-url": "3.0.8",
-				"postcss-ordered-values": "2.2.3",
-				"postcss-reduce-idents": "2.4.0",
-				"postcss-reduce-initial": "1.0.1",
-				"postcss-reduce-transforms": "1.0.4",
-				"postcss-svgo": "2.1.6",
-				"postcss-unique-selectors": "2.0.2",
-				"postcss-value-parser": "3.3.0",
-				"postcss-zindex": "2.2.0"
-			}
-		},
-		"csso": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-			"dev": true,
-			"requires": {
-				"clap": "1.2.3",
-				"source-map": "0.5.7"
-			}
 		},
 		"cssom": {
 			"version": "0.3.2",
@@ -3385,12 +3234,6 @@
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
 			}
-		},
-		"defined": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-			"dev": true
 		},
 		"del": {
 			"version": "2.2.2",
@@ -4552,30 +4395,6 @@
 				"pinkie-promise": "2.0.1"
 			}
 		},
-		"findup": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-			"integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
-			"dev": true,
-			"requires": {
-				"colors": "0.6.2",
-				"commander": "2.1.0"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "0.6.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-					"integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-					"dev": true
-				},
-				"commander": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-					"integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
-					"dev": true
-				}
-			}
-		},
 		"flat-cache": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
@@ -4587,12 +4406,6 @@
 				"graceful-fs": "4.1.11",
 				"write": "0.2.1"
 			}
-		},
-		"flatten": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
-			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -6054,12 +5867,6 @@
 			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.2.0.tgz",
 			"integrity": "sha1-nGGLI5YqLXPW6Cugh0l4vLNov6I="
 		},
-		"html-comment-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
-			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
-			"dev": true
-		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -6166,12 +5973,6 @@
 			"requires": {
 				"repeating": "2.0.1"
 			}
-		},
-		"indexes-of": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-			"dev": true
 		},
 		"indexof": {
 			"version": "0.0.1",
@@ -6322,12 +6123,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-		},
-		"is-absolute-url": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
-			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
-			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -6510,12 +6305,6 @@
 				"path-is-inside": "1.0.2"
 			}
 		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
-		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -6588,15 +6377,6 @@
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
 			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
 			"dev": true
-		},
-		"is-svg": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-			"dev": true,
-			"requires": {
-				"html-comment-regex": "1.1.1"
-			}
 		},
 		"is-symbol": {
 			"version": "1.0.1",
@@ -8092,18 +7872,6 @@
 				"lodash.isarray": "3.0.4"
 			}
 		},
-		"lodash.memoize": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
-		},
-		"lodash.merge": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-			"dev": true
-		},
 		"lodash.mergewith": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
@@ -8126,12 +7894,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
 			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
-			"dev": true
-		},
-		"lodash.uniq": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -8193,12 +7955,6 @@
 				"pseudomap": "1.0.2"
 			}
 		},
-		"macaddress": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-			"dev": true
-		},
 		"make-dir": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
@@ -8241,12 +7997,6 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.5.tgz",
 			"integrity": "sha1-UpJZPmdUyxvMK5gDDk4Najr8nqE="
-		},
-		"math-expression-evaluator": {
-			"version": "1.2.17",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
-			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.4",
@@ -8867,16 +8617,3935 @@
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
 			"dev": true
 		},
-		"normalize-url": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"dev": true,
+		"npm": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz",
+			"integrity": "sha512-r1grvv6mcEt+nlMzMWPc5n/z5q8NNuBWj0TGFp1PBSFCl6ubnAoUGBsucYsnZYT7MOJn0ha1ptEjmdBoAdJ+SA==",
 			"requires": {
-				"object-assign": "4.1.1",
-				"prepend-http": "1.0.4",
-				"query-string": "4.3.4",
-				"sort-keys": "1.1.2"
+				"JSONStream": "1.3.2",
+				"abbrev": "1.1.1",
+				"ansi-regex": "3.0.0",
+				"ansicolors": "0.3.2",
+				"ansistyles": "0.1.3",
+				"aproba": "1.2.0",
+				"archy": "1.0.0",
+				"bin-links": "1.1.0",
+				"bluebird": "3.5.1",
+				"cacache": "10.0.4",
+				"call-limit": "1.1.0",
+				"chownr": "1.0.1",
+				"cli-table2": "0.2.0",
+				"cmd-shim": "2.0.2",
+				"columnify": "1.5.4",
+				"config-chain": "1.1.11",
+				"debuglog": "1.0.1",
+				"detect-indent": "5.0.0",
+				"dezalgo": "1.0.3",
+				"editor": "1.0.0",
+				"find-npm-prefix": "1.0.2",
+				"fs-vacuum": "1.2.10",
+				"fs-write-stream-atomic": "1.0.10",
+				"gentle-fs": "2.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"has-unicode": "2.0.1",
+				"hosted-git-info": "2.5.0",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"ini": "1.3.5",
+				"init-package-json": "1.10.1",
+				"is-cidr": "1.0.0",
+				"lazy-property": "1.0.0",
+				"libcipm": "1.3.3",
+				"libnpx": "9.7.1",
+				"lockfile": "1.0.3",
+				"lodash._baseindexof": "3.1.0",
+				"lodash._baseuniq": "4.6.0",
+				"lodash._bindcallback": "3.0.1",
+				"lodash._cacheindexof": "3.0.2",
+				"lodash._createcache": "3.1.2",
+				"lodash._getnative": "3.9.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.restparam": "3.6.1",
+				"lodash.union": "4.6.0",
+				"lodash.uniq": "4.5.0",
+				"lodash.without": "4.4.0",
+				"lru-cache": "4.1.1",
+				"meant": "1.0.1",
+				"mississippi": "2.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"nopt": "4.0.1",
+				"normalize-package-data": "2.4.0",
+				"npm-cache-filename": "1.0.2",
+				"npm-install-checks": "3.0.0",
+				"npm-lifecycle": "2.0.0",
+				"npm-package-arg": "6.0.0",
+				"npm-packlist": "1.1.10",
+				"npm-profile": "3.0.1",
+				"npm-registry-client": "8.5.0",
+				"npm-user-validate": "1.0.0",
+				"npmlog": "4.1.2",
+				"once": "1.4.0",
+				"opener": "1.4.3",
+				"osenv": "0.1.5",
+				"pacote": "7.3.3",
+				"path-is-inside": "1.0.2",
+				"promise-inflight": "1.0.1",
+				"qrcode-terminal": "0.11.0",
+				"query-string": "5.1.0",
+				"qw": "1.0.1",
+				"read": "1.0.7",
+				"read-cmd-shim": "1.0.1",
+				"read-installed": "4.0.3",
+				"read-package-json": "2.0.12",
+				"read-package-tree": "5.1.6",
+				"readable-stream": "2.3.4",
+				"readdir-scoped-modules": "1.0.2",
+				"request": "2.83.0",
+				"retry": "0.10.1",
+				"rimraf": "2.6.2",
+				"safe-buffer": "5.1.1",
+				"semver": "5.5.0",
+				"sha": "2.0.1",
+				"slide": "1.1.6",
+				"sorted-object": "2.0.1",
+				"sorted-union-stream": "2.1.3",
+				"ssri": "5.2.4",
+				"strip-ansi": "4.0.0",
+				"tar": "4.3.3",
+				"text-table": "0.2.0",
+				"uid-number": "0.0.6",
+				"umask": "1.1.0",
+				"unique-filename": "1.1.0",
+				"unpipe": "1.0.0",
+				"update-notifier": "2.3.0",
+				"uuid": "3.2.1",
+				"validate-npm-package-license": "3.0.1",
+				"validate-npm-package-name": "3.0.0",
+				"which": "1.3.0",
+				"worker-farm": "1.5.2",
+				"wrappy": "1.0.2",
+				"write-file-atomic": "2.1.0"
+			},
+			"dependencies": {
+				"JSONStream": {
+					"version": "1.3.2",
+					"bundled": true,
+					"requires": {
+						"jsonparse": "1.3.1",
+						"through": "2.3.8"
+					},
+					"dependencies": {
+						"jsonparse": {
+							"version": "1.3.1",
+							"bundled": true
+						},
+						"through": {
+							"version": "2.3.8",
+							"bundled": true
+						}
+					}
+				},
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"ansicolors": {
+					"version": "0.3.2",
+					"bundled": true
+				},
+				"ansistyles": {
+					"version": "0.1.3",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"bin-links": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"bluebird": "3.5.1",
+						"cmd-shim": "2.0.2",
+						"fs-write-stream-atomic": "1.0.10",
+						"gentle-fs": "2.0.1",
+						"graceful-fs": "4.1.11",
+						"slide": "1.1.6"
+					}
+				},
+				"bluebird": {
+					"version": "3.5.1",
+					"bundled": true
+				},
+				"cacache": {
+					"version": "10.0.4",
+					"bundled": true,
+					"requires": {
+						"bluebird": "3.5.1",
+						"chownr": "1.0.1",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"lru-cache": "4.1.1",
+						"mississippi": "2.0.0",
+						"mkdirp": "0.5.1",
+						"move-concurrently": "1.0.1",
+						"promise-inflight": "1.0.1",
+						"rimraf": "2.6.2",
+						"ssri": "5.2.4",
+						"unique-filename": "1.1.0",
+						"y18n": "4.0.0"
+					},
+					"dependencies": {
+						"y18n": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"call-limit": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"cli-table2": {
+					"version": "0.2.0",
+					"bundled": true,
+					"requires": {
+						"colors": "1.1.2",
+						"lodash": "3.10.1",
+						"string-width": "1.0.2"
+					},
+					"dependencies": {
+						"colors": {
+							"version": "1.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"lodash": {
+							"version": "3.10.1",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							},
+							"dependencies": {
+								"code-point-at": {
+									"version": "1.1.0",
+									"bundled": true
+								},
+								"is-fullwidth-code-point": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"number-is-nan": "1.0.1"
+									},
+									"dependencies": {
+										"number-is-nan": {
+											"version": "1.0.1",
+											"bundled": true
+										}
+									}
+								},
+								"strip-ansi": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"ansi-regex": "2.1.1"
+									},
+									"dependencies": {
+										"ansi-regex": {
+											"version": "2.1.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"cmd-shim": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"mkdirp": "0.5.1"
+					}
+				},
+				"columnify": {
+					"version": "1.5.4",
+					"bundled": true,
+					"requires": {
+						"strip-ansi": "3.0.1",
+						"wcwidth": "1.0.1"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "2.1.1"
+							},
+							"dependencies": {
+								"ansi-regex": {
+									"version": "2.1.1",
+									"bundled": true
+								}
+							}
+						},
+						"wcwidth": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"defaults": "1.0.3"
+							},
+							"dependencies": {
+								"defaults": {
+									"version": "1.0.3",
+									"bundled": true,
+									"requires": {
+										"clone": "1.0.2"
+									},
+									"dependencies": {
+										"clone": {
+											"version": "1.0.2",
+											"bundled": true
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"config-chain": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"ini": "1.3.5",
+						"proto-list": "1.2.4"
+					},
+					"dependencies": {
+						"proto-list": {
+							"version": "1.2.4",
+							"bundled": true
+						}
+					}
+				},
+				"debuglog": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"detect-indent": {
+					"version": "5.0.0",
+					"bundled": true
+				},
+				"dezalgo": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"asap": "2.0.5",
+						"wrappy": "1.0.2"
+					},
+					"dependencies": {
+						"asap": {
+							"version": "2.0.5",
+							"bundled": true
+						}
+					}
+				},
+				"editor": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"find-npm-prefix": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"fs-vacuum": {
+					"version": "1.2.10",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"path-is-inside": "1.0.2",
+						"rimraf": "2.6.2"
+					}
+				},
+				"fs-write-stream-atomic": {
+					"version": "1.0.10",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"iferr": "0.1.5",
+						"imurmurhash": "0.1.4",
+						"readable-stream": "2.3.4"
+					}
+				},
+				"gentle-fs": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "1.2.0",
+						"fs-vacuum": "1.2.10",
+						"graceful-fs": "4.1.11",
+						"iferr": "0.1.5",
+						"mkdirp": "0.5.1",
+						"path-is-inside": "1.0.2",
+						"read-cmd-shim": "1.0.1",
+						"slide": "1.1.6"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					},
+					"dependencies": {
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "1.1.8"
+							},
+							"dependencies": {
+								"brace-expansion": {
+									"version": "1.1.8",
+									"bundled": true,
+									"requires": {
+										"balanced-match": "1.0.0",
+										"concat-map": "0.0.1"
+									},
+									"dependencies": {
+										"balanced-match": {
+											"version": "1.0.0",
+											"bundled": true
+										},
+										"concat-map": {
+											"version": "0.0.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"hosted-git-info": {
+					"version": "2.5.0",
+					"bundled": true
+				},
+				"iferr": {
+					"version": "0.1.5",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true
+				},
+				"init-package-json": {
+					"version": "1.10.1",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2",
+						"npm-package-arg": "5.1.2",
+						"promzard": "0.3.0",
+						"read": "1.0.7",
+						"read-package-json": "2.0.12",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.1",
+						"validate-npm-package-name": "3.0.0"
+					},
+					"dependencies": {
+						"npm-package-arg": {
+							"version": "5.1.2",
+							"bundled": true,
+							"requires": {
+								"hosted-git-info": "2.5.0",
+								"osenv": "0.1.5",
+								"semver": "5.5.0",
+								"validate-npm-package-name": "3.0.0"
+							}
+						},
+						"promzard": {
+							"version": "0.3.0",
+							"bundled": true,
+							"requires": {
+								"read": "1.0.7"
+							}
+						}
+					}
+				},
+				"is-cidr": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"cidr-regex": "1.0.6"
+					},
+					"dependencies": {
+						"cidr-regex": {
+							"version": "1.0.6",
+							"bundled": true
+						}
+					}
+				},
+				"lazy-property": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"libcipm": {
+					"version": "1.3.3",
+					"bundled": true,
+					"requires": {
+						"bin-links": "1.1.0",
+						"bluebird": "3.5.1",
+						"find-npm-prefix": "1.0.2",
+						"graceful-fs": "4.1.11",
+						"lock-verify": "2.0.0",
+						"npm-lifecycle": "2.0.0",
+						"npm-logical-tree": "1.2.1",
+						"npm-package-arg": "6.0.0",
+						"pacote": "7.3.3",
+						"protoduck": "5.0.0",
+						"read-package-json": "2.0.12",
+						"rimraf": "2.6.2",
+						"worker-farm": "1.5.2"
+					},
+					"dependencies": {
+						"find-npm-prefix": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"lock-verify": {
+							"version": "2.0.0",
+							"bundled": true,
+							"requires": {
+								"npm-package-arg": "5.1.2",
+								"semver": "5.5.0"
+							},
+							"dependencies": {
+								"npm-package-arg": {
+									"version": "5.1.2",
+									"bundled": true,
+									"requires": {
+										"hosted-git-info": "2.5.0",
+										"osenv": "0.1.5",
+										"semver": "5.5.0",
+										"validate-npm-package-name": "3.0.0"
+									}
+								}
+							}
+						},
+						"npm-logical-tree": {
+							"version": "1.2.1",
+							"bundled": true
+						},
+						"protoduck": {
+							"version": "5.0.0",
+							"bundled": true,
+							"requires": {
+								"genfun": "4.0.1"
+							},
+							"dependencies": {
+								"genfun": {
+									"version": "4.0.1",
+									"bundled": true
+								}
+							}
+						},
+						"worker-farm": {
+							"version": "1.5.2",
+							"bundled": true,
+							"requires": {
+								"errno": "0.1.7",
+								"xtend": "4.0.1"
+							},
+							"dependencies": {
+								"errno": {
+									"version": "0.1.7",
+									"bundled": true,
+									"requires": {
+										"prr": "1.0.1"
+									},
+									"dependencies": {
+										"prr": {
+											"version": "1.0.1",
+											"bundled": true
+										}
+									}
+								},
+								"xtend": {
+									"version": "4.0.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"libnpx": {
+					"version": "9.7.1",
+					"bundled": true,
+					"requires": {
+						"dotenv": "4.0.0",
+						"npm-package-arg": "5.1.2",
+						"rimraf": "2.6.2",
+						"safe-buffer": "5.1.1",
+						"update-notifier": "2.3.0",
+						"which": "1.3.0",
+						"y18n": "3.2.1",
+						"yargs": "8.0.2"
+					},
+					"dependencies": {
+						"dotenv": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"npm-package-arg": {
+							"version": "5.1.2",
+							"bundled": true,
+							"requires": {
+								"hosted-git-info": "2.5.0",
+								"osenv": "0.1.5",
+								"semver": "5.5.0",
+								"validate-npm-package-name": "3.0.0"
+							}
+						},
+						"y18n": {
+							"version": "3.2.1",
+							"bundled": true
+						},
+						"yargs": {
+							"version": "8.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "4.1.0",
+								"cliui": "3.2.0",
+								"decamelize": "1.2.0",
+								"get-caller-file": "1.0.2",
+								"os-locale": "2.1.0",
+								"read-pkg-up": "2.0.0",
+								"require-directory": "2.1.1",
+								"require-main-filename": "1.0.1",
+								"set-blocking": "2.0.0",
+								"string-width": "2.1.1",
+								"which-module": "2.0.0",
+								"y18n": "3.2.1",
+								"yargs-parser": "7.0.0"
+							},
+							"dependencies": {
+								"camelcase": {
+									"version": "4.1.0",
+									"bundled": true
+								},
+								"cliui": {
+									"version": "3.2.0",
+									"bundled": true,
+									"requires": {
+										"string-width": "1.0.2",
+										"strip-ansi": "3.0.1",
+										"wrap-ansi": "2.1.0"
+									},
+									"dependencies": {
+										"string-width": {
+											"version": "1.0.2",
+											"bundled": true,
+											"requires": {
+												"code-point-at": "1.1.0",
+												"is-fullwidth-code-point": "1.0.0",
+												"strip-ansi": "3.0.1"
+											},
+											"dependencies": {
+												"code-point-at": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"is-fullwidth-code-point": {
+													"version": "1.0.0",
+													"bundled": true,
+													"requires": {
+														"number-is-nan": "1.0.1"
+													},
+													"dependencies": {
+														"number-is-nan": {
+															"version": "1.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"strip-ansi": {
+											"version": "3.0.1",
+											"bundled": true,
+											"requires": {
+												"ansi-regex": "2.1.1"
+											},
+											"dependencies": {
+												"ansi-regex": {
+													"version": "2.1.1",
+													"bundled": true
+												}
+											}
+										},
+										"wrap-ansi": {
+											"version": "2.1.0",
+											"bundled": true,
+											"requires": {
+												"string-width": "1.0.2",
+												"strip-ansi": "3.0.1"
+											}
+										}
+									}
+								},
+								"decamelize": {
+									"version": "1.2.0",
+									"bundled": true
+								},
+								"get-caller-file": {
+									"version": "1.0.2",
+									"bundled": true
+								},
+								"os-locale": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"execa": "0.7.0",
+										"lcid": "1.0.0",
+										"mem": "1.1.0"
+									},
+									"dependencies": {
+										"execa": {
+											"version": "0.7.0",
+											"bundled": true,
+											"requires": {
+												"cross-spawn": "5.1.0",
+												"get-stream": "3.0.0",
+												"is-stream": "1.1.0",
+												"npm-run-path": "2.0.2",
+												"p-finally": "1.0.0",
+												"signal-exit": "3.0.2",
+												"strip-eof": "1.0.0"
+											},
+											"dependencies": {
+												"cross-spawn": {
+													"version": "5.1.0",
+													"bundled": true,
+													"requires": {
+														"lru-cache": "4.1.1",
+														"shebang-command": "1.2.0",
+														"which": "1.3.0"
+													},
+													"dependencies": {
+														"shebang-command": {
+															"version": "1.2.0",
+															"bundled": true,
+															"requires": {
+																"shebang-regex": "1.0.0"
+															},
+															"dependencies": {
+																"shebang-regex": {
+																	"version": "1.0.0",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"get-stream": {
+													"version": "3.0.0",
+													"bundled": true
+												},
+												"is-stream": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"npm-run-path": {
+													"version": "2.0.2",
+													"bundled": true,
+													"requires": {
+														"path-key": "2.0.1"
+													},
+													"dependencies": {
+														"path-key": {
+															"version": "2.0.1",
+															"bundled": true
+														}
+													}
+												},
+												"p-finally": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"signal-exit": {
+													"version": "3.0.2",
+													"bundled": true
+												},
+												"strip-eof": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"lcid": {
+											"version": "1.0.0",
+											"bundled": true,
+											"requires": {
+												"invert-kv": "1.0.0"
+											},
+											"dependencies": {
+												"invert-kv": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"mem": {
+											"version": "1.1.0",
+											"bundled": true,
+											"requires": {
+												"mimic-fn": "1.1.0"
+											},
+											"dependencies": {
+												"mimic-fn": {
+													"version": "1.1.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"read-pkg-up": {
+									"version": "2.0.0",
+									"bundled": true,
+									"requires": {
+										"find-up": "2.1.0",
+										"read-pkg": "2.0.0"
+									},
+									"dependencies": {
+										"find-up": {
+											"version": "2.1.0",
+											"bundled": true,
+											"requires": {
+												"locate-path": "2.0.0"
+											},
+											"dependencies": {
+												"locate-path": {
+													"version": "2.0.0",
+													"bundled": true,
+													"requires": {
+														"p-locate": "2.0.0",
+														"path-exists": "3.0.0"
+													},
+													"dependencies": {
+														"p-locate": {
+															"version": "2.0.0",
+															"bundled": true,
+															"requires": {
+																"p-limit": "1.1.0"
+															},
+															"dependencies": {
+																"p-limit": {
+																	"version": "1.1.0",
+																	"bundled": true
+																}
+															}
+														},
+														"path-exists": {
+															"version": "3.0.0",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"read-pkg": {
+											"version": "2.0.0",
+											"bundled": true,
+											"requires": {
+												"load-json-file": "2.0.0",
+												"normalize-package-data": "2.4.0",
+												"path-type": "2.0.0"
+											},
+											"dependencies": {
+												"load-json-file": {
+													"version": "2.0.0",
+													"bundled": true,
+													"requires": {
+														"graceful-fs": "4.1.11",
+														"parse-json": "2.2.0",
+														"pify": "2.3.0",
+														"strip-bom": "3.0.0"
+													},
+													"dependencies": {
+														"parse-json": {
+															"version": "2.2.0",
+															"bundled": true,
+															"requires": {
+																"error-ex": "1.3.1"
+															},
+															"dependencies": {
+																"error-ex": {
+																	"version": "1.3.1",
+																	"bundled": true,
+																	"requires": {
+																		"is-arrayish": "0.2.1"
+																	},
+																	"dependencies": {
+																		"is-arrayish": {
+																			"version": "0.2.1",
+																			"bundled": true
+																		}
+																	}
+																}
+															}
+														},
+														"pify": {
+															"version": "2.3.0",
+															"bundled": true
+														},
+														"strip-bom": {
+															"version": "3.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"path-type": {
+													"version": "2.0.0",
+													"bundled": true,
+													"requires": {
+														"pify": "2.3.0"
+													},
+													"dependencies": {
+														"pify": {
+															"version": "2.3.0",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"require-directory": {
+									"version": "2.1.1",
+									"bundled": true
+								},
+								"require-main-filename": {
+									"version": "1.0.1",
+									"bundled": true
+								},
+								"set-blocking": {
+									"version": "2.0.0",
+									"bundled": true
+								},
+								"string-width": {
+									"version": "2.1.1",
+									"bundled": true,
+									"requires": {
+										"is-fullwidth-code-point": "2.0.0",
+										"strip-ansi": "4.0.0"
+									},
+									"dependencies": {
+										"is-fullwidth-code-point": {
+											"version": "2.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"which-module": {
+									"version": "2.0.0",
+									"bundled": true
+								},
+								"yargs-parser": {
+									"version": "7.0.0",
+									"bundled": true,
+									"requires": {
+										"camelcase": "4.1.0"
+									}
+								}
+							}
+						}
+					}
+				},
+				"lockfile": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"lodash._baseindexof": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"lodash._baseuniq": {
+					"version": "4.6.0",
+					"bundled": true,
+					"requires": {
+						"lodash._createset": "4.0.3",
+						"lodash._root": "3.0.1"
+					},
+					"dependencies": {
+						"lodash._createset": {
+							"version": "4.0.3",
+							"bundled": true
+						},
+						"lodash._root": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"lodash._bindcallback": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"lodash._cacheindexof": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"lodash._createcache": {
+					"version": "3.1.2",
+					"bundled": true,
+					"requires": {
+						"lodash._getnative": "3.9.1"
+					}
+				},
+				"lodash._getnative": {
+					"version": "3.9.1",
+					"bundled": true
+				},
+				"lodash.clonedeep": {
+					"version": "4.5.0",
+					"bundled": true
+				},
+				"lodash.restparam": {
+					"version": "3.6.1",
+					"bundled": true
+				},
+				"lodash.union": {
+					"version": "4.6.0",
+					"bundled": true
+				},
+				"lodash.uniq": {
+					"version": "4.5.0",
+					"bundled": true
+				},
+				"lodash.without": {
+					"version": "4.4.0",
+					"bundled": true
+				},
+				"lru-cache": {
+					"version": "4.1.1",
+					"bundled": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					},
+					"dependencies": {
+						"pseudomap": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"yallist": {
+							"version": "2.1.2",
+							"bundled": true
+						}
+					}
+				},
+				"meant": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"mississippi": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"concat-stream": "1.6.0",
+						"duplexify": "3.5.3",
+						"end-of-stream": "1.4.1",
+						"flush-write-stream": "1.0.2",
+						"from2": "2.3.0",
+						"parallel-transform": "1.1.0",
+						"pump": "2.0.1",
+						"pumpify": "1.4.0",
+						"stream-each": "1.2.2",
+						"through2": "2.0.3"
+					},
+					"dependencies": {
+						"concat-stream": {
+							"version": "1.6.0",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.4",
+								"typedarray": "0.0.6"
+							},
+							"dependencies": {
+								"typedarray": {
+									"version": "0.0.6",
+									"bundled": true
+								}
+							}
+						},
+						"duplexify": {
+							"version": "3.5.3",
+							"bundled": true,
+							"requires": {
+								"end-of-stream": "1.4.1",
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.4",
+								"stream-shift": "1.0.0"
+							},
+							"dependencies": {
+								"stream-shift": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"end-of-stream": {
+							"version": "1.4.1",
+							"bundled": true,
+							"requires": {
+								"once": "1.4.0"
+							}
+						},
+						"flush-write-stream": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.4"
+							}
+						},
+						"from2": {
+							"version": "2.3.0",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.4"
+							}
+						},
+						"parallel-transform": {
+							"version": "1.1.0",
+							"bundled": true,
+							"requires": {
+								"cyclist": "0.2.2",
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.4"
+							},
+							"dependencies": {
+								"cyclist": {
+									"version": "0.2.2",
+									"bundled": true
+								}
+							}
+						},
+						"pump": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"end-of-stream": "1.4.1",
+								"once": "1.4.0"
+							}
+						},
+						"pumpify": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"duplexify": "3.5.3",
+								"inherits": "2.0.3",
+								"pump": "2.0.1"
+							}
+						},
+						"stream-each": {
+							"version": "1.2.2",
+							"bundled": true,
+							"requires": {
+								"end-of-stream": "1.4.1",
+								"stream-shift": "1.0.0"
+							},
+							"dependencies": {
+								"stream-shift": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"through2": {
+							"version": "2.0.3",
+							"bundled": true,
+							"requires": {
+								"readable-stream": "2.3.4",
+								"xtend": "4.0.1"
+							},
+							"dependencies": {
+								"xtend": {
+									"version": "4.0.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						}
+					}
+				},
+				"move-concurrently": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "1.2.0",
+						"copy-concurrently": "1.0.5",
+						"fs-write-stream-atomic": "1.0.10",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"run-queue": "1.0.3"
+					},
+					"dependencies": {
+						"copy-concurrently": {
+							"version": "1.0.5",
+							"bundled": true,
+							"requires": {
+								"aproba": "1.2.0",
+								"fs-write-stream-atomic": "1.0.10",
+								"iferr": "0.1.5",
+								"mkdirp": "0.5.1",
+								"rimraf": "2.6.2",
+								"run-queue": "1.0.3"
+							}
+						},
+						"run-queue": {
+							"version": "1.0.3",
+							"bundled": true,
+							"requires": {
+								"aproba": "1.2.0"
+							}
+						}
+					}
+				},
+				"node-gyp": {
+					"version": "3.6.2",
+					"bundled": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"minimatch": "3.0.4",
+						"mkdirp": "0.5.1",
+						"nopt": "3.0.6",
+						"npmlog": "4.1.2",
+						"osenv": "0.1.5",
+						"request": "2.83.0",
+						"rimraf": "2.6.2",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"which": "1.3.0"
+					},
+					"dependencies": {
+						"fstream": {
+							"version": "1.0.11",
+							"bundled": true,
+							"requires": {
+								"graceful-fs": "4.1.11",
+								"inherits": "2.0.3",
+								"mkdirp": "0.5.1",
+								"rimraf": "2.6.2"
+							}
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "1.1.8"
+							},
+							"dependencies": {
+								"brace-expansion": {
+									"version": "1.1.8",
+									"bundled": true,
+									"requires": {
+										"balanced-match": "1.0.0",
+										"concat-map": "0.0.1"
+									},
+									"dependencies": {
+										"balanced-match": {
+											"version": "1.0.0",
+											"bundled": true
+										},
+										"concat-map": {
+											"version": "0.0.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"nopt": {
+							"version": "3.0.6",
+							"bundled": true,
+							"requires": {
+								"abbrev": "1.1.1"
+							}
+						},
+						"semver": {
+							"version": "5.3.0",
+							"bundled": true
+						},
+						"tar": {
+							"version": "2.2.1",
+							"bundled": true,
+							"requires": {
+								"block-stream": "0.0.9",
+								"fstream": "1.0.11",
+								"inherits": "2.0.3"
+							},
+							"dependencies": {
+								"block-stream": {
+									"version": "0.0.9",
+									"bundled": true,
+									"requires": {
+										"inherits": "2.0.3"
+									}
+								}
+							}
+						}
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"requires": {
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "2.5.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.1"
+					},
+					"dependencies": {
+						"is-builtin-module": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"builtin-modules": "1.1.1"
+							},
+							"dependencies": {
+								"builtin-modules": {
+									"version": "1.1.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"npm-cache-filename": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"npm-install-checks": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"semver": "5.5.0"
+					}
+				},
+				"npm-lifecycle": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"byline": "5.0.0",
+						"graceful-fs": "4.1.11",
+						"node-gyp": "3.6.2",
+						"resolve-from": "4.0.0",
+						"slide": "1.1.6",
+						"uid-number": "0.0.6",
+						"umask": "1.1.0",
+						"which": "1.3.0"
+					},
+					"dependencies": {
+						"byline": {
+							"version": "5.0.0",
+							"bundled": true
+						},
+						"resolve-from": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"npm-package-arg": {
+					"version": "6.0.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "2.5.0",
+						"osenv": "0.1.5",
+						"semver": "5.5.0",
+						"validate-npm-package-name": "3.0.0"
+					}
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"requires": {
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
+					},
+					"dependencies": {
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"minimatch": "3.0.4"
+							},
+							"dependencies": {
+								"minimatch": {
+									"version": "3.0.4",
+									"bundled": true,
+									"requires": {
+										"brace-expansion": "1.1.8"
+									},
+									"dependencies": {
+										"brace-expansion": {
+											"version": "1.1.8",
+											"bundled": true,
+											"requires": {
+												"balanced-match": "1.0.0",
+												"concat-map": "0.0.1"
+											},
+											"dependencies": {
+												"balanced-match": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"concat-map": {
+													"version": "0.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true
+						}
+					}
+				},
+				"npm-profile": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "1.2.0",
+						"make-fetch-happen": "2.6.0"
+					},
+					"dependencies": {
+						"make-fetch-happen": {
+							"version": "2.6.0",
+							"bundled": true,
+							"requires": {
+								"agentkeepalive": "3.3.0",
+								"cacache": "10.0.4",
+								"http-cache-semantics": "3.8.1",
+								"http-proxy-agent": "2.0.0",
+								"https-proxy-agent": "2.1.1",
+								"lru-cache": "4.1.1",
+								"mississippi": "1.3.1",
+								"node-fetch-npm": "2.0.2",
+								"promise-retry": "1.1.1",
+								"socks-proxy-agent": "3.0.1",
+								"ssri": "5.2.4"
+							},
+							"dependencies": {
+								"agentkeepalive": {
+									"version": "3.3.0",
+									"bundled": true,
+									"requires": {
+										"humanize-ms": "1.2.1"
+									},
+									"dependencies": {
+										"humanize-ms": {
+											"version": "1.2.1",
+											"bundled": true,
+											"requires": {
+												"ms": "2.1.1"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.1.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"http-cache-semantics": {
+									"version": "3.8.1",
+									"bundled": true
+								},
+								"http-proxy-agent": {
+									"version": "2.0.0",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "2.6.9"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "2.6.9",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"https-proxy-agent": {
+									"version": "2.1.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "3.1.0"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"mississippi": {
+									"version": "1.3.1",
+									"bundled": true,
+									"requires": {
+										"concat-stream": "1.6.0",
+										"duplexify": "3.5.3",
+										"end-of-stream": "1.4.1",
+										"flush-write-stream": "1.0.2",
+										"from2": "2.3.0",
+										"parallel-transform": "1.1.0",
+										"pump": "1.0.3",
+										"pumpify": "1.4.0",
+										"stream-each": "1.2.2",
+										"through2": "2.0.3"
+									},
+									"dependencies": {
+										"concat-stream": {
+											"version": "1.6.0",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4",
+												"typedarray": "0.0.6"
+											},
+											"dependencies": {
+												"typedarray": {
+													"version": "0.0.6",
+													"bundled": true
+												}
+											}
+										},
+										"duplexify": {
+											"version": "3.5.3",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4",
+												"stream-shift": "1.0.0"
+											},
+											"dependencies": {
+												"stream-shift": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"end-of-stream": {
+											"version": "1.4.1",
+											"bundled": true,
+											"requires": {
+												"once": "1.4.0"
+											}
+										},
+										"flush-write-stream": {
+											"version": "1.0.2",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4"
+											}
+										},
+										"from2": {
+											"version": "2.3.0",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4"
+											}
+										},
+										"parallel-transform": {
+											"version": "1.1.0",
+											"bundled": true,
+											"requires": {
+												"cyclist": "0.2.2",
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4"
+											},
+											"dependencies": {
+												"cyclist": {
+													"version": "0.2.2",
+													"bundled": true
+												}
+											}
+										},
+										"pump": {
+											"version": "1.0.3",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"once": "1.4.0"
+											}
+										},
+										"pumpify": {
+											"version": "1.4.0",
+											"bundled": true,
+											"requires": {
+												"duplexify": "3.5.3",
+												"inherits": "2.0.3",
+												"pump": "2.0.1"
+											},
+											"dependencies": {
+												"pump": {
+													"version": "2.0.1",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"once": "1.4.0"
+													}
+												}
+											}
+										},
+										"stream-each": {
+											"version": "1.2.2",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"stream-shift": "1.0.0"
+											},
+											"dependencies": {
+												"stream-shift": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"through2": {
+											"version": "2.0.3",
+											"bundled": true,
+											"requires": {
+												"readable-stream": "2.3.4",
+												"xtend": "4.0.1"
+											},
+											"dependencies": {
+												"xtend": {
+													"version": "4.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"node-fetch-npm": {
+									"version": "2.0.2",
+									"bundled": true,
+									"requires": {
+										"encoding": "0.1.12",
+										"json-parse-better-errors": "1.0.1",
+										"safe-buffer": "5.1.1"
+									},
+									"dependencies": {
+										"encoding": {
+											"version": "0.1.12",
+											"bundled": true,
+											"requires": {
+												"iconv-lite": "0.4.19"
+											},
+											"dependencies": {
+												"iconv-lite": {
+													"version": "0.4.19",
+													"bundled": true
+												}
+											}
+										},
+										"json-parse-better-errors": {
+											"version": "1.0.1",
+											"bundled": true
+										}
+									}
+								},
+								"promise-retry": {
+									"version": "1.1.1",
+									"bundled": true,
+									"requires": {
+										"err-code": "1.1.2",
+										"retry": "0.10.1"
+									},
+									"dependencies": {
+										"err-code": {
+											"version": "1.1.2",
+											"bundled": true
+										}
+									}
+								},
+								"socks-proxy-agent": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"socks": "1.1.10"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"socks": {
+											"version": "1.1.10",
+											"bundled": true,
+											"requires": {
+												"ip": "1.1.5",
+												"smart-buffer": "1.1.15"
+											},
+											"dependencies": {
+												"ip": {
+													"version": "1.1.5",
+													"bundled": true
+												},
+												"smart-buffer": {
+													"version": "1.1.15",
+													"bundled": true
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"npm-registry-client": {
+					"version": "8.5.0",
+					"bundled": true,
+					"requires": {
+						"concat-stream": "1.6.0",
+						"graceful-fs": "4.1.11",
+						"normalize-package-data": "2.4.0",
+						"npm-package-arg": "5.1.2",
+						"npmlog": "4.1.2",
+						"once": "1.4.0",
+						"request": "2.83.0",
+						"retry": "0.10.1",
+						"semver": "5.5.0",
+						"slide": "1.1.6",
+						"ssri": "4.1.6"
+					},
+					"dependencies": {
+						"concat-stream": {
+							"version": "1.6.0",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.4",
+								"typedarray": "0.0.6"
+							},
+							"dependencies": {
+								"typedarray": {
+									"version": "0.0.6",
+									"bundled": true
+								}
+							}
+						},
+						"npm-package-arg": {
+							"version": "5.1.2",
+							"bundled": true,
+							"requires": {
+								"hosted-git-info": "2.5.0",
+								"osenv": "0.1.5",
+								"semver": "5.5.0",
+								"validate-npm-package-name": "3.0.0"
+							}
+						},
+						"ssri": {
+							"version": "4.1.6",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "5.1.1"
+							}
+						}
+					}
+				},
+				"npm-user-validate": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					},
+					"dependencies": {
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"requires": {
+								"delegates": "1.0.0",
+								"readable-stream": "2.3.4"
+							},
+							"dependencies": {
+								"delegates": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"requires": {
+								"aproba": "1.2.0",
+								"console-control-strings": "1.1.0",
+								"has-unicode": "2.0.1",
+								"object-assign": "4.1.1",
+								"signal-exit": "3.0.2",
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wide-align": "1.1.2"
+							},
+							"dependencies": {
+								"object-assign": {
+									"version": "4.1.1",
+									"bundled": true
+								},
+								"signal-exit": {
+									"version": "3.0.2",
+									"bundled": true
+								},
+								"string-width": {
+									"version": "1.0.2",
+									"bundled": true,
+									"requires": {
+										"code-point-at": "1.1.0",
+										"is-fullwidth-code-point": "1.0.0",
+										"strip-ansi": "3.0.1"
+									},
+									"dependencies": {
+										"code-point-at": {
+											"version": "1.1.0",
+											"bundled": true
+										},
+										"is-fullwidth-code-point": {
+											"version": "1.0.0",
+											"bundled": true,
+											"requires": {
+												"number-is-nan": "1.0.1"
+											},
+											"dependencies": {
+												"number-is-nan": {
+													"version": "1.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"strip-ansi": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"ansi-regex": "2.1.1"
+									},
+									"dependencies": {
+										"ansi-regex": {
+											"version": "2.1.1",
+											"bundled": true
+										}
+									}
+								},
+								"wide-align": {
+									"version": "1.1.2",
+									"bundled": true,
+									"requires": {
+										"string-width": "1.0.2"
+									}
+								}
+							}
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"opener": {
+					"version": "1.4.3",
+					"bundled": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					},
+					"dependencies": {
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"pacote": {
+					"version": "7.3.3",
+					"bundled": true,
+					"requires": {
+						"bluebird": "3.5.1",
+						"cacache": "10.0.4",
+						"get-stream": "3.0.0",
+						"glob": "7.1.2",
+						"lru-cache": "4.1.1",
+						"make-fetch-happen": "2.6.0",
+						"minimatch": "3.0.4",
+						"mississippi": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"npm-package-arg": "6.0.0",
+						"npm-packlist": "1.1.10",
+						"npm-pick-manifest": "2.1.0",
+						"osenv": "0.1.5",
+						"promise-inflight": "1.0.1",
+						"promise-retry": "1.1.1",
+						"protoduck": "5.0.0",
+						"safe-buffer": "5.1.1",
+						"semver": "5.5.0",
+						"ssri": "5.2.4",
+						"tar": "4.3.3",
+						"unique-filename": "1.1.0",
+						"which": "1.3.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"make-fetch-happen": {
+							"version": "2.6.0",
+							"bundled": true,
+							"requires": {
+								"agentkeepalive": "3.3.0",
+								"cacache": "10.0.4",
+								"http-cache-semantics": "3.8.1",
+								"http-proxy-agent": "2.0.0",
+								"https-proxy-agent": "2.1.1",
+								"lru-cache": "4.1.1",
+								"mississippi": "1.3.1",
+								"node-fetch-npm": "2.0.2",
+								"promise-retry": "1.1.1",
+								"socks-proxy-agent": "3.0.1",
+								"ssri": "5.2.4"
+							},
+							"dependencies": {
+								"agentkeepalive": {
+									"version": "3.3.0",
+									"bundled": true,
+									"requires": {
+										"humanize-ms": "1.2.1"
+									},
+									"dependencies": {
+										"humanize-ms": {
+											"version": "1.2.1",
+											"bundled": true,
+											"requires": {
+												"ms": "2.1.1"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.1.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"http-cache-semantics": {
+									"version": "3.8.1",
+									"bundled": true
+								},
+								"http-proxy-agent": {
+									"version": "2.0.0",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "2.6.9"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "2.6.9",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"https-proxy-agent": {
+									"version": "2.1.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "3.1.0"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"mississippi": {
+									"version": "1.3.1",
+									"bundled": true,
+									"requires": {
+										"concat-stream": "1.6.0",
+										"duplexify": "3.5.3",
+										"end-of-stream": "1.4.1",
+										"flush-write-stream": "1.0.2",
+										"from2": "2.3.0",
+										"parallel-transform": "1.1.0",
+										"pump": "1.0.3",
+										"pumpify": "1.4.0",
+										"stream-each": "1.2.2",
+										"through2": "2.0.3"
+									},
+									"dependencies": {
+										"concat-stream": {
+											"version": "1.6.0",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4",
+												"typedarray": "0.0.6"
+											},
+											"dependencies": {
+												"typedarray": {
+													"version": "0.0.6",
+													"bundled": true
+												}
+											}
+										},
+										"duplexify": {
+											"version": "3.5.3",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4",
+												"stream-shift": "1.0.0"
+											},
+											"dependencies": {
+												"stream-shift": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"end-of-stream": {
+											"version": "1.4.1",
+											"bundled": true,
+											"requires": {
+												"once": "1.4.0"
+											}
+										},
+										"flush-write-stream": {
+											"version": "1.0.2",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4"
+											}
+										},
+										"from2": {
+											"version": "2.3.0",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4"
+											}
+										},
+										"parallel-transform": {
+											"version": "1.1.0",
+											"bundled": true,
+											"requires": {
+												"cyclist": "0.2.2",
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.4"
+											},
+											"dependencies": {
+												"cyclist": {
+													"version": "0.2.2",
+													"bundled": true
+												}
+											}
+										},
+										"pump": {
+											"version": "1.0.3",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"once": "1.4.0"
+											}
+										},
+										"pumpify": {
+											"version": "1.4.0",
+											"bundled": true,
+											"requires": {
+												"duplexify": "3.5.3",
+												"inherits": "2.0.3",
+												"pump": "2.0.1"
+											},
+											"dependencies": {
+												"pump": {
+													"version": "2.0.1",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"once": "1.4.0"
+													}
+												}
+											}
+										},
+										"stream-each": {
+											"version": "1.2.2",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"stream-shift": "1.0.0"
+											},
+											"dependencies": {
+												"stream-shift": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"through2": {
+											"version": "2.0.3",
+											"bundled": true,
+											"requires": {
+												"readable-stream": "2.3.4",
+												"xtend": "4.0.1"
+											},
+											"dependencies": {
+												"xtend": {
+													"version": "4.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"node-fetch-npm": {
+									"version": "2.0.2",
+									"bundled": true,
+									"requires": {
+										"encoding": "0.1.12",
+										"json-parse-better-errors": "1.0.1",
+										"safe-buffer": "5.1.1"
+									},
+									"dependencies": {
+										"encoding": {
+											"version": "0.1.12",
+											"bundled": true,
+											"requires": {
+												"iconv-lite": "0.4.19"
+											},
+											"dependencies": {
+												"iconv-lite": {
+													"version": "0.4.19",
+													"bundled": true
+												}
+											}
+										},
+										"json-parse-better-errors": {
+											"version": "1.0.1",
+											"bundled": true
+										}
+									}
+								},
+								"socks-proxy-agent": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"socks": "1.1.10"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"socks": {
+											"version": "1.1.10",
+											"bundled": true,
+											"requires": {
+												"ip": "1.1.5",
+												"smart-buffer": "1.1.15"
+											},
+											"dependencies": {
+												"ip": {
+													"version": "1.1.5",
+													"bundled": true
+												},
+												"smart-buffer": {
+													"version": "1.1.15",
+													"bundled": true
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "1.1.11"
+							},
+							"dependencies": {
+								"brace-expansion": {
+									"version": "1.1.11",
+									"bundled": true,
+									"requires": {
+										"balanced-match": "1.0.0",
+										"concat-map": "0.0.1"
+									},
+									"dependencies": {
+										"balanced-match": {
+											"version": "1.0.0",
+											"bundled": true
+										},
+										"concat-map": {
+											"version": "0.0.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"mississippi": {
+							"version": "2.0.0",
+							"bundled": true,
+							"requires": {
+								"concat-stream": "1.6.0",
+								"duplexify": "3.5.3",
+								"end-of-stream": "1.4.1",
+								"flush-write-stream": "1.0.2",
+								"from2": "2.3.0",
+								"parallel-transform": "1.1.0",
+								"pump": "2.0.1",
+								"pumpify": "1.4.0",
+								"stream-each": "1.2.2",
+								"through2": "2.0.3"
+							},
+							"dependencies": {
+								"concat-stream": {
+									"version": "1.6.0",
+									"bundled": true,
+									"requires": {
+										"inherits": "2.0.3",
+										"readable-stream": "2.3.4",
+										"typedarray": "0.0.6"
+									},
+									"dependencies": {
+										"typedarray": {
+											"version": "0.0.6",
+											"bundled": true
+										}
+									}
+								},
+								"duplexify": {
+									"version": "3.5.3",
+									"bundled": true,
+									"requires": {
+										"end-of-stream": "1.4.1",
+										"inherits": "2.0.3",
+										"readable-stream": "2.3.4",
+										"stream-shift": "1.0.0"
+									},
+									"dependencies": {
+										"stream-shift": {
+											"version": "1.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"end-of-stream": {
+									"version": "1.4.1",
+									"bundled": true,
+									"requires": {
+										"once": "1.4.0"
+									}
+								},
+								"flush-write-stream": {
+									"version": "1.0.2",
+									"bundled": true,
+									"requires": {
+										"inherits": "2.0.3",
+										"readable-stream": "2.3.4"
+									}
+								},
+								"from2": {
+									"version": "2.3.0",
+									"bundled": true,
+									"requires": {
+										"inherits": "2.0.3",
+										"readable-stream": "2.3.4"
+									}
+								},
+								"parallel-transform": {
+									"version": "1.1.0",
+									"bundled": true,
+									"requires": {
+										"cyclist": "0.2.2",
+										"inherits": "2.0.3",
+										"readable-stream": "2.3.4"
+									},
+									"dependencies": {
+										"cyclist": {
+											"version": "0.2.2",
+											"bundled": true
+										}
+									}
+								},
+								"pump": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"end-of-stream": "1.4.1",
+										"once": "1.4.0"
+									}
+								},
+								"pumpify": {
+									"version": "1.4.0",
+									"bundled": true,
+									"requires": {
+										"duplexify": "3.5.3",
+										"inherits": "2.0.3",
+										"pump": "2.0.1"
+									}
+								},
+								"stream-each": {
+									"version": "1.2.2",
+									"bundled": true,
+									"requires": {
+										"end-of-stream": "1.4.1",
+										"stream-shift": "1.0.0"
+									},
+									"dependencies": {
+										"stream-shift": {
+											"version": "1.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"through2": {
+									"version": "2.0.3",
+									"bundled": true,
+									"requires": {
+										"readable-stream": "2.3.4",
+										"xtend": "4.0.1"
+									},
+									"dependencies": {
+										"xtend": {
+											"version": "4.0.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"npm-pick-manifest": {
+							"version": "2.1.0",
+							"bundled": true,
+							"requires": {
+								"npm-package-arg": "6.0.0",
+								"semver": "5.5.0"
+							}
+						},
+						"promise-retry": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"err-code": "1.1.2",
+								"retry": "0.10.1"
+							},
+							"dependencies": {
+								"err-code": {
+									"version": "1.1.2",
+									"bundled": true
+								}
+							}
+						},
+						"protoduck": {
+							"version": "5.0.0",
+							"bundled": true,
+							"requires": {
+								"genfun": "4.0.1"
+							},
+							"dependencies": {
+								"genfun": {
+									"version": "4.0.1",
+									"bundled": true
+								}
+							}
+						},
+						"semver": {
+							"version": "5.5.0",
+							"bundled": true
+						}
+					}
+				},
+				"path-is-inside": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"promise-inflight": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"qrcode-terminal": {
+					"version": "0.11.0",
+					"bundled": true
+				},
+				"query-string": {
+					"version": "5.1.0",
+					"bundled": true,
+					"requires": {
+						"decode-uri-component": "0.2.0",
+						"object-assign": "4.1.1",
+						"strict-uri-encode": "1.1.0"
+					},
+					"dependencies": {
+						"decode-uri-component": {
+							"version": "0.2.0",
+							"bundled": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true
+						},
+						"strict-uri-encode": {
+							"version": "1.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"qw": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"read": {
+					"version": "1.0.7",
+					"bundled": true,
+					"requires": {
+						"mute-stream": "0.0.7"
+					},
+					"dependencies": {
+						"mute-stream": {
+							"version": "0.0.7",
+							"bundled": true
+						}
+					}
+				},
+				"read-cmd-shim": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11"
+					}
+				},
+				"read-installed": {
+					"version": "4.0.3",
+					"bundled": true,
+					"requires": {
+						"debuglog": "1.0.1",
+						"graceful-fs": "4.1.11",
+						"read-package-json": "2.0.12",
+						"readdir-scoped-modules": "1.0.2",
+						"semver": "5.5.0",
+						"slide": "1.1.6",
+						"util-extend": "1.0.3"
+					},
+					"dependencies": {
+						"util-extend": {
+							"version": "1.0.3",
+							"bundled": true
+						}
+					}
+				},
+				"read-package-json": {
+					"version": "2.0.12",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"json-parse-better-errors": "1.0.1",
+						"normalize-package-data": "2.4.0",
+						"slash": "1.0.0"
+					},
+					"dependencies": {
+						"json-parse-better-errors": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"slash": {
+							"version": "1.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"read-package-tree": {
+					"version": "5.1.6",
+					"bundled": true,
+					"requires": {
+						"debuglog": "1.0.1",
+						"dezalgo": "1.0.3",
+						"once": "1.4.0",
+						"read-package-json": "2.0.12",
+						"readdir-scoped-modules": "1.0.2"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.4",
+					"bundled": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					},
+					"dependencies": {
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"string_decoder": {
+							"version": "1.0.3",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "5.1.1"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"readdir-scoped-modules": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"debuglog": "1.0.1",
+						"dezalgo": "1.0.3",
+						"graceful-fs": "4.1.11",
+						"once": "1.4.0"
+					}
+				},
+				"request": {
+					"version": "2.83.0",
+					"bundled": true,
+					"requires": {
+						"aws-sign2": "0.7.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.3.1",
+						"har-validator": "5.0.3",
+						"hawk": "6.0.2",
+						"http-signature": "1.2.0",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.17",
+						"oauth-sign": "0.8.2",
+						"performance-now": "2.1.0",
+						"qs": "6.5.1",
+						"safe-buffer": "5.1.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.3",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.2.1"
+					},
+					"dependencies": {
+						"aws-sign2": {
+							"version": "0.7.0",
+							"bundled": true
+						},
+						"aws4": {
+							"version": "1.6.0",
+							"bundled": true
+						},
+						"caseless": {
+							"version": "0.12.0",
+							"bundled": true
+						},
+						"combined-stream": {
+							"version": "1.0.5",
+							"bundled": true,
+							"requires": {
+								"delayed-stream": "1.0.0"
+							},
+							"dependencies": {
+								"delayed-stream": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"extend": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"forever-agent": {
+							"version": "0.6.1",
+							"bundled": true
+						},
+						"form-data": {
+							"version": "2.3.1",
+							"bundled": true,
+							"requires": {
+								"asynckit": "0.4.0",
+								"combined-stream": "1.0.5",
+								"mime-types": "2.1.17"
+							},
+							"dependencies": {
+								"asynckit": {
+									"version": "0.4.0",
+									"bundled": true
+								}
+							}
+						},
+						"har-validator": {
+							"version": "5.0.3",
+							"bundled": true,
+							"requires": {
+								"ajv": "5.2.3",
+								"har-schema": "2.0.0"
+							},
+							"dependencies": {
+								"ajv": {
+									"version": "5.2.3",
+									"bundled": true,
+									"requires": {
+										"co": "4.6.0",
+										"fast-deep-equal": "1.0.0",
+										"json-schema-traverse": "0.3.1",
+										"json-stable-stringify": "1.0.1"
+									},
+									"dependencies": {
+										"co": {
+											"version": "4.6.0",
+											"bundled": true
+										},
+										"fast-deep-equal": {
+											"version": "1.0.0",
+											"bundled": true
+										},
+										"json-schema-traverse": {
+											"version": "0.3.1",
+											"bundled": true
+										},
+										"json-stable-stringify": {
+											"version": "1.0.1",
+											"bundled": true,
+											"requires": {
+												"jsonify": "0.0.0"
+											},
+											"dependencies": {
+												"jsonify": {
+													"version": "0.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"har-schema": {
+									"version": "2.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"hawk": {
+							"version": "6.0.2",
+							"bundled": true,
+							"requires": {
+								"boom": "4.3.1",
+								"cryptiles": "3.1.2",
+								"hoek": "4.2.0",
+								"sntp": "2.0.2"
+							},
+							"dependencies": {
+								"boom": {
+									"version": "4.3.1",
+									"bundled": true,
+									"requires": {
+										"hoek": "4.2.0"
+									}
+								},
+								"cryptiles": {
+									"version": "3.1.2",
+									"bundled": true,
+									"requires": {
+										"boom": "5.2.0"
+									},
+									"dependencies": {
+										"boom": {
+											"version": "5.2.0",
+											"bundled": true,
+											"requires": {
+												"hoek": "4.2.0"
+											}
+										}
+									}
+								},
+								"hoek": {
+									"version": "4.2.0",
+									"bundled": true
+								},
+								"sntp": {
+									"version": "2.0.2",
+									"bundled": true,
+									"requires": {
+										"hoek": "4.2.0"
+									}
+								}
+							}
+						},
+						"http-signature": {
+							"version": "1.2.0",
+							"bundled": true,
+							"requires": {
+								"assert-plus": "1.0.0",
+								"jsprim": "1.4.1",
+								"sshpk": "1.13.1"
+							},
+							"dependencies": {
+								"assert-plus": {
+									"version": "1.0.0",
+									"bundled": true
+								},
+								"jsprim": {
+									"version": "1.4.1",
+									"bundled": true,
+									"requires": {
+										"assert-plus": "1.0.0",
+										"extsprintf": "1.3.0",
+										"json-schema": "0.2.3",
+										"verror": "1.10.0"
+									},
+									"dependencies": {
+										"extsprintf": {
+											"version": "1.3.0",
+											"bundled": true
+										},
+										"json-schema": {
+											"version": "0.2.3",
+											"bundled": true
+										},
+										"verror": {
+											"version": "1.10.0",
+											"bundled": true,
+											"requires": {
+												"assert-plus": "1.0.0",
+												"core-util-is": "1.0.2",
+												"extsprintf": "1.3.0"
+											},
+											"dependencies": {
+												"core-util-is": {
+													"version": "1.0.2",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"sshpk": {
+									"version": "1.13.1",
+									"bundled": true,
+									"requires": {
+										"asn1": "0.2.3",
+										"assert-plus": "1.0.0",
+										"bcrypt-pbkdf": "1.0.1",
+										"dashdash": "1.14.1",
+										"ecc-jsbn": "0.1.1",
+										"getpass": "0.1.7",
+										"jsbn": "0.1.1",
+										"tweetnacl": "0.14.5"
+									},
+									"dependencies": {
+										"asn1": {
+											"version": "0.2.3",
+											"bundled": true
+										},
+										"bcrypt-pbkdf": {
+											"version": "1.0.1",
+											"bundled": true,
+											"optional": true,
+											"requires": {
+												"tweetnacl": "0.14.5"
+											}
+										},
+										"dashdash": {
+											"version": "1.14.1",
+											"bundled": true,
+											"requires": {
+												"assert-plus": "1.0.0"
+											}
+										},
+										"ecc-jsbn": {
+											"version": "0.1.1",
+											"bundled": true,
+											"optional": true,
+											"requires": {
+												"jsbn": "0.1.1"
+											}
+										},
+										"getpass": {
+											"version": "0.1.7",
+											"bundled": true,
+											"requires": {
+												"assert-plus": "1.0.0"
+											}
+										},
+										"jsbn": {
+											"version": "0.1.1",
+											"bundled": true,
+											"optional": true
+										},
+										"tweetnacl": {
+											"version": "0.14.5",
+											"bundled": true,
+											"optional": true
+										}
+									}
+								}
+							}
+						},
+						"is-typedarray": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"isstream": {
+							"version": "0.1.2",
+							"bundled": true
+						},
+						"json-stringify-safe": {
+							"version": "5.0.1",
+							"bundled": true
+						},
+						"mime-types": {
+							"version": "2.1.17",
+							"bundled": true,
+							"requires": {
+								"mime-db": "1.30.0"
+							},
+							"dependencies": {
+								"mime-db": {
+									"version": "1.30.0",
+									"bundled": true
+								}
+							}
+						},
+						"oauth-sign": {
+							"version": "0.8.2",
+							"bundled": true
+						},
+						"performance-now": {
+							"version": "2.1.0",
+							"bundled": true
+						},
+						"qs": {
+							"version": "6.5.1",
+							"bundled": true
+						},
+						"stringstream": {
+							"version": "0.0.5",
+							"bundled": true
+						},
+						"tough-cookie": {
+							"version": "2.3.3",
+							"bundled": true,
+							"requires": {
+								"punycode": "1.4.1"
+							},
+							"dependencies": {
+								"punycode": {
+									"version": "1.4.1",
+									"bundled": true
+								}
+							}
+						},
+						"tunnel-agent": {
+							"version": "0.6.0",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "5.1.1"
+							}
+						}
+					}
+				},
+				"retry": {
+					"version": "0.10.1",
+					"bundled": true
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"sha": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"readable-stream": "2.3.4"
+					}
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"sorted-object": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"sorted-union-stream": {
+					"version": "2.1.3",
+					"bundled": true,
+					"requires": {
+						"from2": "1.3.0",
+						"stream-iterate": "1.2.0"
+					},
+					"dependencies": {
+						"from2": {
+							"version": "1.3.0",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "1.1.14"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "1.1.14",
+									"bundled": true,
+									"requires": {
+										"core-util-is": "1.0.2",
+										"inherits": "2.0.3",
+										"isarray": "0.0.1",
+										"string_decoder": "0.10.31"
+									},
+									"dependencies": {
+										"core-util-is": {
+											"version": "1.0.2",
+											"bundled": true
+										},
+										"isarray": {
+											"version": "0.0.1",
+											"bundled": true
+										},
+										"string_decoder": {
+											"version": "0.10.31",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"stream-iterate": {
+							"version": "1.2.0",
+							"bundled": true,
+							"requires": {
+								"readable-stream": "2.3.4",
+								"stream-shift": "1.0.0"
+							},
+							"dependencies": {
+								"stream-shift": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"ssri": {
+					"version": "5.2.4",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"tar": {
+					"version": "4.3.3",
+					"bundled": true,
+					"requires": {
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.1",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"yallist": "3.0.2"
+					},
+					"dependencies": {
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"requires": {
+								"minipass": "2.2.1"
+							}
+						},
+						"minipass": {
+							"version": "2.2.1",
+							"bundled": true,
+							"requires": {
+								"yallist": "3.0.2"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"requires": {
+								"minipass": "2.2.1"
+							}
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"text-table": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true
+				},
+				"umask": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"unique-filename": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"unique-slug": "2.0.0"
+					},
+					"dependencies": {
+						"unique-slug": {
+							"version": "2.0.0",
+							"bundled": true,
+							"requires": {
+								"imurmurhash": "0.1.4"
+							}
+						}
+					}
+				},
+				"unpipe": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"update-notifier": {
+					"version": "2.3.0",
+					"bundled": true,
+					"requires": {
+						"boxen": "1.2.1",
+						"chalk": "2.1.0",
+						"configstore": "3.1.1",
+						"import-lazy": "2.1.0",
+						"is-installed-globally": "0.1.0",
+						"is-npm": "1.0.0",
+						"latest-version": "3.1.0",
+						"semver-diff": "2.1.0",
+						"xdg-basedir": "3.0.0"
+					},
+					"dependencies": {
+						"boxen": {
+							"version": "1.2.1",
+							"bundled": true,
+							"requires": {
+								"ansi-align": "2.0.0",
+								"camelcase": "4.1.0",
+								"chalk": "2.1.0",
+								"cli-boxes": "1.0.0",
+								"string-width": "2.1.1",
+								"term-size": "1.2.0",
+								"widest-line": "1.0.0"
+							},
+							"dependencies": {
+								"ansi-align": {
+									"version": "2.0.0",
+									"bundled": true,
+									"requires": {
+										"string-width": "2.1.1"
+									}
+								},
+								"camelcase": {
+									"version": "4.1.0",
+									"bundled": true
+								},
+								"cli-boxes": {
+									"version": "1.0.0",
+									"bundled": true
+								},
+								"string-width": {
+									"version": "2.1.1",
+									"bundled": true,
+									"requires": {
+										"is-fullwidth-code-point": "2.0.0",
+										"strip-ansi": "4.0.0"
+									},
+									"dependencies": {
+										"is-fullwidth-code-point": {
+											"version": "2.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"term-size": {
+									"version": "1.2.0",
+									"bundled": true,
+									"requires": {
+										"execa": "0.7.0"
+									},
+									"dependencies": {
+										"execa": {
+											"version": "0.7.0",
+											"bundled": true,
+											"requires": {
+												"cross-spawn": "5.1.0",
+												"get-stream": "3.0.0",
+												"is-stream": "1.1.0",
+												"npm-run-path": "2.0.2",
+												"p-finally": "1.0.0",
+												"signal-exit": "3.0.2",
+												"strip-eof": "1.0.0"
+											},
+											"dependencies": {
+												"cross-spawn": {
+													"version": "5.1.0",
+													"bundled": true,
+													"requires": {
+														"lru-cache": "4.1.1",
+														"shebang-command": "1.2.0",
+														"which": "1.3.0"
+													},
+													"dependencies": {
+														"shebang-command": {
+															"version": "1.2.0",
+															"bundled": true,
+															"requires": {
+																"shebang-regex": "1.0.0"
+															},
+															"dependencies": {
+																"shebang-regex": {
+																	"version": "1.0.0",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"get-stream": {
+													"version": "3.0.0",
+													"bundled": true
+												},
+												"is-stream": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"npm-run-path": {
+													"version": "2.0.2",
+													"bundled": true,
+													"requires": {
+														"path-key": "2.0.1"
+													},
+													"dependencies": {
+														"path-key": {
+															"version": "2.0.1",
+															"bundled": true
+														}
+													}
+												},
+												"p-finally": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"signal-exit": {
+													"version": "3.0.2",
+													"bundled": true
+												},
+												"strip-eof": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"widest-line": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"string-width": "1.0.2"
+									},
+									"dependencies": {
+										"string-width": {
+											"version": "1.0.2",
+											"bundled": true,
+											"requires": {
+												"code-point-at": "1.1.0",
+												"is-fullwidth-code-point": "1.0.0",
+												"strip-ansi": "3.0.1"
+											},
+											"dependencies": {
+												"code-point-at": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"is-fullwidth-code-point": {
+													"version": "1.0.0",
+													"bundled": true,
+													"requires": {
+														"number-is-nan": "1.0.1"
+													},
+													"dependencies": {
+														"number-is-nan": {
+															"version": "1.0.1",
+															"bundled": true
+														}
+													}
+												},
+												"strip-ansi": {
+													"version": "3.0.1",
+													"bundled": true,
+													"requires": {
+														"ansi-regex": "2.1.1"
+													},
+													"dependencies": {
+														"ansi-regex": {
+															"version": "2.1.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"chalk": {
+							"version": "2.1.0",
+							"bundled": true,
+							"requires": {
+								"ansi-styles": "3.2.0",
+								"escape-string-regexp": "1.0.5",
+								"supports-color": "4.4.0"
+							},
+							"dependencies": {
+								"ansi-styles": {
+									"version": "3.2.0",
+									"bundled": true,
+									"requires": {
+										"color-convert": "1.9.0"
+									},
+									"dependencies": {
+										"color-convert": {
+											"version": "1.9.0",
+											"bundled": true,
+											"requires": {
+												"color-name": "1.1.3"
+											},
+											"dependencies": {
+												"color-name": {
+													"version": "1.1.3",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"escape-string-regexp": {
+									"version": "1.0.5",
+									"bundled": true
+								},
+								"supports-color": {
+									"version": "4.4.0",
+									"bundled": true,
+									"requires": {
+										"has-flag": "2.0.0"
+									},
+									"dependencies": {
+										"has-flag": {
+											"version": "2.0.0",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"configstore": {
+							"version": "3.1.1",
+							"bundled": true,
+							"requires": {
+								"dot-prop": "4.2.0",
+								"graceful-fs": "4.1.11",
+								"make-dir": "1.0.0",
+								"unique-string": "1.0.0",
+								"write-file-atomic": "2.1.0",
+								"xdg-basedir": "3.0.0"
+							},
+							"dependencies": {
+								"dot-prop": {
+									"version": "4.2.0",
+									"bundled": true,
+									"requires": {
+										"is-obj": "1.0.1"
+									},
+									"dependencies": {
+										"is-obj": {
+											"version": "1.0.1",
+											"bundled": true
+										}
+									}
+								},
+								"make-dir": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"pify": "2.3.0"
+									},
+									"dependencies": {
+										"pify": {
+											"version": "2.3.0",
+											"bundled": true
+										}
+									}
+								},
+								"unique-string": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"crypto-random-string": "1.0.0"
+									},
+									"dependencies": {
+										"crypto-random-string": {
+											"version": "1.0.0",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"import-lazy": {
+							"version": "2.1.0",
+							"bundled": true
+						},
+						"is-installed-globally": {
+							"version": "0.1.0",
+							"bundled": true,
+							"requires": {
+								"global-dirs": "0.1.0",
+								"is-path-inside": "1.0.0"
+							},
+							"dependencies": {
+								"global-dirs": {
+									"version": "0.1.0",
+									"bundled": true,
+									"requires": {
+										"ini": "1.3.5"
+									}
+								},
+								"is-path-inside": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"path-is-inside": "1.0.2"
+									}
+								}
+							}
+						},
+						"is-npm": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"latest-version": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"package-json": "4.0.1"
+							},
+							"dependencies": {
+								"package-json": {
+									"version": "4.0.1",
+									"bundled": true,
+									"requires": {
+										"got": "6.7.1",
+										"registry-auth-token": "3.3.1",
+										"registry-url": "3.1.0",
+										"semver": "5.5.0"
+									},
+									"dependencies": {
+										"got": {
+											"version": "6.7.1",
+											"bundled": true,
+											"requires": {
+												"create-error-class": "3.0.2",
+												"duplexer3": "0.1.4",
+												"get-stream": "3.0.0",
+												"is-redirect": "1.0.0",
+												"is-retry-allowed": "1.1.0",
+												"is-stream": "1.1.0",
+												"lowercase-keys": "1.0.0",
+												"safe-buffer": "5.1.1",
+												"timed-out": "4.0.1",
+												"unzip-response": "2.0.1",
+												"url-parse-lax": "1.0.0"
+											},
+											"dependencies": {
+												"create-error-class": {
+													"version": "3.0.2",
+													"bundled": true,
+													"requires": {
+														"capture-stack-trace": "1.0.0"
+													},
+													"dependencies": {
+														"capture-stack-trace": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"duplexer3": {
+													"version": "0.1.4",
+													"bundled": true
+												},
+												"get-stream": {
+													"version": "3.0.0",
+													"bundled": true
+												},
+												"is-redirect": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"is-retry-allowed": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"is-stream": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"lowercase-keys": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"timed-out": {
+													"version": "4.0.1",
+													"bundled": true
+												},
+												"unzip-response": {
+													"version": "2.0.1",
+													"bundled": true
+												},
+												"url-parse-lax": {
+													"version": "1.0.0",
+													"bundled": true,
+													"requires": {
+														"prepend-http": "1.0.4"
+													},
+													"dependencies": {
+														"prepend-http": {
+															"version": "1.0.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"registry-auth-token": {
+											"version": "3.3.1",
+											"bundled": true,
+											"requires": {
+												"rc": "1.2.1",
+												"safe-buffer": "5.1.1"
+											},
+											"dependencies": {
+												"rc": {
+													"version": "1.2.1",
+													"bundled": true,
+													"requires": {
+														"deep-extend": "0.4.2",
+														"ini": "1.3.5",
+														"minimist": "1.2.0",
+														"strip-json-comments": "2.0.1"
+													},
+													"dependencies": {
+														"deep-extend": {
+															"version": "0.4.2",
+															"bundled": true
+														},
+														"minimist": {
+															"version": "1.2.0",
+															"bundled": true
+														},
+														"strip-json-comments": {
+															"version": "2.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"registry-url": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"rc": "1.2.1"
+											},
+											"dependencies": {
+												"rc": {
+													"version": "1.2.1",
+													"bundled": true,
+													"requires": {
+														"deep-extend": "0.4.2",
+														"ini": "1.3.5",
+														"minimist": "1.2.0",
+														"strip-json-comments": "2.0.1"
+													},
+													"dependencies": {
+														"deep-extend": {
+															"version": "0.4.2",
+															"bundled": true
+														},
+														"minimist": {
+															"version": "1.2.0",
+															"bundled": true
+														},
+														"strip-json-comments": {
+															"version": "2.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"semver-diff": {
+							"version": "2.1.0",
+							"bundled": true,
+							"requires": {
+								"semver": "5.5.0"
+							}
+						},
+						"xdg-basedir": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "1.0.2",
+						"spdx-expression-parse": "1.0.4"
+					},
+					"dependencies": {
+						"spdx-correct": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"spdx-license-ids": "1.2.2"
+							},
+							"dependencies": {
+								"spdx-license-ids": {
+									"version": "1.2.2",
+									"bundled": true
+								}
+							}
+						},
+						"spdx-expression-parse": {
+							"version": "1.0.4",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-name": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"builtins": "1.0.3"
+					},
+					"dependencies": {
+						"builtins": {
+							"version": "1.0.3",
+							"bundled": true
+						}
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isexe": "2.0.0"
+					},
+					"dependencies": {
+						"isexe": {
+							"version": "2.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"worker-farm": {
+					"version": "1.5.2",
+					"bundled": true,
+					"requires": {
+						"errno": "0.1.7",
+						"xtend": "4.0.1"
+					},
+					"dependencies": {
+						"errno": {
+							"version": "0.1.7",
+							"bundled": true,
+							"requires": {
+								"prr": "1.0.1"
+							},
+							"dependencies": {
+								"prr": {
+									"version": "1.0.1",
+									"bundled": true
+								}
+							}
+						},
+						"xtend": {
+							"version": "4.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				}
 			}
 		},
 		"npm-run-path": {
@@ -9369,94 +13038,6 @@
 				}
 			}
 		},
-		"postcss-calc": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-message-helpers": "2.0.0",
-				"reduce-css-calc": "1.3.0"
-			}
-		},
-		"postcss-colormin": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
-			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-			"dev": true,
-			"requires": {
-				"colormin": "1.1.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-convert-values": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
-			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-discard-comments": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
-			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-discard-duplicates": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
-			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-discard-empty": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
-			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-discard-overridden": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
-			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-discard-unused": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			}
-		},
-		"postcss-filter-plugins": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"uniqid": "4.1.1"
-			}
-		},
 		"postcss-load-config": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
@@ -9560,224 +13141,16 @@
 				}
 			}
 		},
-		"postcss-merge-idents": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
-			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-			"dev": true,
-			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-merge-longhand": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
-			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-merge-rules": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
-			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-			"dev": true,
-			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-api": "1.6.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3",
-				"vendors": "1.0.1"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"dev": true,
-					"requires": {
-						"caniuse-db": "1.0.30000804",
-						"electron-to-chromium": "1.3.33"
-					}
-				}
-			}
-		},
-		"postcss-message-helpers": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
-			"dev": true
-		},
-		"postcss-minify-font-values": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
-			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-			"dev": true,
-			"requires": {
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-minify-gradients": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
-			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-minify-params": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
-			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-			"dev": true,
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"uniqs": "2.0.0"
-			}
-		},
-		"postcss-minify-selectors": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
-			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-			"dev": true,
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3"
-			}
-		},
-		"postcss-normalize-charset": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
-			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-normalize-url": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
-			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-			"dev": true,
-			"requires": {
-				"is-absolute-url": "2.1.0",
-				"normalize-url": "1.9.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-ordered-values": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
-			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-reduce-idents": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
-			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-reduce-initial": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
-			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-			"dev": true,
-			"requires": {
-				"postcss": "5.2.18"
-			}
-		},
-		"postcss-reduce-transforms": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
-			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-			"dev": true,
-			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
-			}
-		},
-		"postcss-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-			"dev": true,
-			"requires": {
-				"flatten": "1.0.2",
-				"indexes-of": "1.0.1",
-				"uniq": "1.0.1"
-			}
-		},
-		"postcss-svgo": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
-			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-			"dev": true,
-			"requires": {
-				"is-svg": "2.1.0",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"svgo": "0.7.2"
-			}
-		},
-		"postcss-unique-selectors": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-			"dev": true,
-			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			}
-		},
 		"postcss-value-parser": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
 			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
 			"dev": true
 		},
-		"postcss-zindex": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
-			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-			"dev": true,
-			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
-			}
-		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
 		"preserve": {
@@ -9897,27 +13270,11 @@
 			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 			"dev": true
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
-		},
 		"qs": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
 			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
 			"dev": true
-		},
-		"query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"dev": true,
-			"requires": {
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
-			}
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -10310,42 +13667,6 @@
 				"strip-indent": "1.0.1"
 			}
 		},
-		"reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "0.4.2",
-				"math-expression-evaluator": "1.2.17",
-				"reduce-function-call": "1.0.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
-			}
-		},
-		"reduce-function-call": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "0.4.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
-			}
-		},
 		"redux": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
@@ -10644,78 +13965,6 @@
 			"requires": {
 				"lodash.flattendeep": "4.4.0",
 				"nearley": "2.11.1"
-			}
-		},
-		"rtlcss": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.2.1.tgz",
-			"integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
-			"dev": true,
-			"requires": {
-				"chalk": "2.3.0",
-				"findup": "0.1.5",
-				"mkdirp": "0.5.1",
-				"postcss": "6.0.17",
-				"strip-json-comments": "2.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.1"
-					}
-				},
-				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
-					"dev": true,
-					"requires": {
-						"chalk": "2.3.0",
-						"source-map": "0.6.1",
-						"supports-color": "5.1.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-							"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-							"dev": true,
-							"requires": {
-								"has-flag": "2.0.0"
-							}
-						}
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
-					"requires": {
-						"has-flag": "2.0.0"
-					}
-				}
 			}
 		},
 		"run-async": {
@@ -11125,15 +14374,6 @@
 				"hoek": "4.2.0"
 			}
 		},
-		"sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "1.1.0"
-			}
-		},
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -11259,12 +14499,6 @@
 			"integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
 			"dev": true
 		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"dev": true
-		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -11383,45 +14617,6 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 			"dev": true
-		},
-		"svgo": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-			"dev": true,
-			"requires": {
-				"coa": "1.0.4",
-				"colors": "1.1.2",
-				"csso": "2.3.2",
-				"js-yaml": "3.7.0",
-				"mkdirp": "0.5.1",
-				"sax": "1.2.4",
-				"whet.extend": "0.9.9"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-					"dev": true
-				},
-				"esprima": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-					"dev": true,
-					"requires": {
-						"argparse": "1.0.9",
-						"esprima": "2.7.3"
-					}
-				}
-			}
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
@@ -11844,27 +15039,6 @@
 			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
 			"dev": true
 		},
-		"uniq": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-			"dev": true
-		},
-		"uniqid": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-			"dev": true,
-			"requires": {
-				"macaddress": "0.2.8"
-			}
-		},
-		"uniqs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
-			"dev": true
-		},
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -11940,12 +15114,6 @@
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
 			}
-		},
-		"vendors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
-			"integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
-			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -12061,36 +15229,6 @@
 				}
 			}
 		},
-		"webpack-rtl-plugin": {
-			"version": "github:yoavf/webpack-rtl-plugin#fc5a2f20dd99fde8f86f297844aefde601780fa3",
-			"dev": true,
-			"requires": {
-				"@romainberger/css-diff": "1.0.3",
-				"async": "2.6.0",
-				"cssnano": "3.10.0",
-				"postcss": "5.2.18",
-				"rtlcss": "2.2.1",
-				"webpack-sources": "0.1.5"
-			},
-			"dependencies": {
-				"source-list-map": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
-					"integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
-					"dev": true
-				},
-				"webpack-sources": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
-					"integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-					"dev": true,
-					"requires": {
-						"source-list-map": "0.1.8",
-						"source-map": "0.5.7"
-					}
-				}
-			}
-		},
 		"webpack-sources": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
@@ -12133,12 +15271,6 @@
 				"tr46": "1.0.1",
 				"webidl-conversions": "4.0.2"
 			}
-		},
-		"whet.extend": {
-			"version": "0.9.9",
-			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
-			"dev": true
 		},
 		"which": {
 			"version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"moment": "2.21.0",
 		"moment-timezone": "0.5.13",
 		"mousetrap": "1.6.1",
+		"npm": "5.7.1",
 		"prop-types": "15.5.10",
 		"querystringify": "1.0.0",
 		"re-resizable": "4.0.3",


### PR DESCRIPTION
This PR reverts the change made in #5480 and removes the post title `aria-label` in favor of a visually hidden `<label>` element.

Thanks to the super helpful testing by @ewaccess on https://github.com/WordPress/gutenberg/issues/5468#issuecomment-373092461 it appears evident that, unfortunately, Dragon NaturallySpeaking doesn't support aria-label on a textarea. A traditional label is the only way to make Dragon execute the voice command "click Add Title".

Pending future changes on the post title, I'd recommend to use a `<label>` for textarea elements, as it's the most accessible solution at the moment.

Note: I guess the post title will be unique in a post so I'm not using the "with instance id" thinghy. 