### PR TITLE
Ignore "Disable visual editor" setting

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -788,6 +788,12 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// to disable it outright.
 	wp_enqueue_script( 'heartbeat' );
 
+	// Ignore Classic Editor's `rich_editing` user option, aka "Disable visual
+	// editor". Forcing this to be true guarantees that TinyMCE and its plugins
+	// are available in Gutenberg. Fixes
+	// https://github.com/WordPress/gutenberg/issues/5667.
+	add_filter( 'user_can_richedit', '__return_true' );
+
 	wp_enqueue_script( 'wp-edit-post' );
 
 	// Register `wp-utils` as a dependency of `word-count` to ensure that


### PR DESCRIPTION
Fixes #5667

See `wp-includes/class-wp-editor`'s behavior around `self::$this_tinymce`:

https://github.com/WordPress/WordPress/blob/176a28905041fd79c439946a4ba290a87db5991f/wp-includes/class-wp-editor.php#L360

## How Has This Been Tested?
Follow steps in parent issue.

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
