### PR TITLE
Framework: Use CustomTemplatedPathPlugin updated for Webpack 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -387,6 +387,15 @@
 			"integrity": "sha512-qYfKfxrksXWSfrmU+JGixKskVytdKWXv5vIYxzXojl2V6OOs/j2Crspi2Hona0Iv5LTUdg02WX7X1rPlmQHmLg==",
 			"dev": true
 		},
+		"@wordpress/custom-templated-path-webpack-plugin": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/custom-templated-path-webpack-plugin/-/custom-templated-path-webpack-plugin-1.0.0.tgz",
+			"integrity": "sha512-7GDENg5juXusGye4JqKAjfAr1EcKNNmJ6GUnnUrdOkXgjnT5CoAw2ADJxvtALtl4vx6o/nqzJxp9YQ/bZi85Dg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
 		"@wordpress/dom-ready": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 	},
 	"devDependencies": {
 		"@wordpress/babel-preset-default": "1.1.1",
+		"@wordpress/custom-templated-path-webpack-plugin": "1.0.0",
 		"@wordpress/jest-preset-default": "1.0.3",
 		"@wordpress/scripts": "1.1.0",
 		"autoprefixer": "6.7.7",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,13 @@
  */
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
-const { reduce, escapeRegExp, castArray, get } = require( 'lodash' );
+const { castArray, get } = require( 'lodash' );
 const { basename } = require( 'path' );
+
+/**
+ * WordPress dependencies
+ */
+const CustomTemplatedPathPlugin = require( '@wordpress/custom-templated-path-webpack-plugin' );
 
 // Main CSS loader for everything but blocks..
 const mainCSSExtractTextPlugin = new ExtractTextPlugin( {
@@ -77,54 +82,6 @@ const externals = {
 	};
 } );
 
-/**
- * Webpack plugin for handling specific template tags in Webpack configuration
- * values like those supported in the base Webpack functionality (e.g. `name`).
- *
- * @see webpack.TemplatedPathPlugin
- */
-class CustomTemplatedPathPlugin {
-	/**
-	 * CustomTemplatedPathPlugin constructor. Initializes handlers as a tuple
-	 * set of RegExp, handler, where the regular expression is used in matching
-	 * a Webpack asset path.
-	 *
-	 * @param {Object.<string,Function>} handlers Object keyed by tag to match,
-	 *                                            with function value returning
-	 *                                            replacement string.
-	 *
-	 * @return {void}
-	 */
-	constructor( handlers ) {
-		this.handlers = reduce( handlers, ( result, handler, key ) => {
-			const regexp = new RegExp( `\\[${ escapeRegExp( key ) }\\]`, 'gi' );
-			return [ ...result, [ regexp, handler ] ];
-		}, [] );
-	}
-
-	/**
-	 * Webpack plugin application logic.
-	 *
-	 * @param {Object} compiler Webpack compiler
-	 *
-	 * @return {void}
-	 */
-	apply( compiler ) {
-		compiler.plugin( 'compilation', ( compilation ) => {
-			compilation.mainTemplate.plugin( 'asset-path', ( path, data ) => {
-				for ( let i = 0; i < this.handlers.length; i++ ) {
-					const [ regexp, handler ] = this.handlers[ i ];
-					if ( regexp.test( path ) ) {
-						return path.replace( regexp, handler( path, data ) );
-					}
-				}
-
-				return path;
-			} );
-		} );
-	}
-}
-
 const config = {
 	mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
 
@@ -145,7 +102,7 @@ const config = {
 		}, {} )
 	),
 	output: {
-		filename: '[name]/build/index.js',
+		filename: '[basename]/build/index.js',
 		path: __dirname,
 		library: [ 'wp', '[name]' ],
 		libraryTarget: 'this',
@@ -202,7 +159,19 @@ const config = {
 		} ),
 		new CustomTemplatedPathPlugin( {
 			basename( path, data ) {
-				const rawRequest = get( data, [ 'chunk', 'entryModule', 'rawRequest' ] );
+				let rawRequest;
+
+				const entryModule = get( data, [ 'chunk', 'entryModule' ], {} );
+				switch ( entryModule.type ) {
+					case 'javascript/auto':
+						rawRequest = entryModule.rawRequest;
+						break;
+
+					case 'javascript/esm':
+						rawRequest = entryModule.rootModule.rawRequest;
+						break;
+				}
+
 				if ( rawRequest ) {
 					return basename( rawRequest );
 				}


### PR DESCRIPTION
Merges to `try/webpack4` (#5267)
Related: https://github.com/WordPress/packages/pull/93

This pull request seeks to update the custom `CustomTemplatedPathPlugin` Webpack plugin to point to the newly-extracted-and-updated-for-Webpack-4 `@wordpress/custom-templated-path-webpack-plugin`.

__Testing instructions:__

Since `@wordpress/custom-templated-path-webpack-plugin` is not yet published, and it's [not possible to define an npm package as a subdirectory of a monorepo](https://github.com/npm/npm/issues/2974), you must use [npm's symlink feature](https://docs.npmjs.com/cli/link) to test from the new package.

In packages:

1. Clone [`WordPress/packages`](https://github.com/WordPress/packages) if you don't already have a local copy
2. `cd packages`
3. `git checkout add/custom-templated-path-plugin`
4. `npm ln`

In Gutenberg:

1. `git checkout update/webpack-custom-templated-path`
2. `npm install`
3. `npm ln @wordpress/custom-templated-path-webpack-plugin`
4. `npm run build`

There should be no errors (but perhaps some warnings related to the Webpack 4 upgrade).