### PR TITLE
Use border-box for input, textarea to revert radio buttons to normal appearance

### DIFF
--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -6,6 +6,10 @@
 		box-sizing: content-box;
 	}
 
+	input, textarea {
+		box-sizing: border-box;
+	}
+
 	/* Match width and positioning of the meta boxes. Override default styles. */
 	#poststuff {
 		margin: 0 auto;

--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -2,11 +2,14 @@
 .edit-post-meta-boxes-area {
 	position: relative;
 
+    /** The wordpress default for most meta-box elements is content-box. Some elements, such as textarea and input, are
+    set to border-box in forms.css. These elements are therefore specifically set back to border-box here, while other
+    elements (such as .button) are unaffected by Gutenberg's style because of their higher specificity. */
 	* {
 		box-sizing: content-box;
 	}
 
-	textarea, input, .button {
+	textarea, input {
 		box-sizing: border-box;
 	}
 

--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -6,7 +6,7 @@
 		box-sizing: content-box;
 	}
 
-	input, textarea {
+	textarea, input, .button {
 		box-sizing: border-box;
 	}
 

--- a/edit-post/components/meta-boxes/meta-boxes-area/style.scss
+++ b/edit-post/components/meta-boxes/meta-boxes-area/style.scss
@@ -2,9 +2,13 @@
 .edit-post-meta-boxes-area {
 	position: relative;
 
-    /** The wordpress default for most meta-box elements is content-box. Some elements, such as textarea and input, are
-    set to border-box in forms.css. These elements are therefore specifically set back to border-box here, while other
-    elements (such as .button) are unaffected by Gutenberg's style because of their higher specificity. */
+	/**
+	 * The wordpress default for most meta-box elements is content-box. Some
+	 * elements such as textarea and input are set to border-box in forms.css.
+	 * These elements therefore specifically set back to border-box here, while
+	 * other elements (such as .button) are unaffected by Gutenberg's style
+	 * because of their higher specificity.
+	 */
 	* {
 		box-sizing: content-box;
 	}


### PR DESCRIPTION
## Description
Recent changes to the styling of meta boxes caused certain input fields to have a strange appearance, such as radio buttons having their selection dot off-centre. This commit changes the box-sizing back to border-box, which is in line with standard Wordpress appearance. 


## How Has This Been Tested?
Manually checked the radio buttons to make sure that the selection is centred, and made sure other fields still look the same.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
