### PR TITLE
Framework: Try to render React based components on the frontend

### DIFF
--- a/blocks/library/latest-posts/index.php
+++ b/blocks/library/latest-posts/index.php
@@ -103,7 +103,8 @@ function register_block_core_latest_posts() {
 				'default' => 'date',
 			),
 		),
-		'render_callback' => 'render_block_core_latest_posts',
+		// TODO: render client side instead?
+		//'render_callback' => 'render_block_core_latest_posts',
 	) );
 }
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -134,6 +134,7 @@ function gutenberg_pre_init() {
 	}
 
 	add_filter( 'replace_editor', 'gutenberg_init', 10, 2 );
+	add_action( 'wp_enqueue_scripts', 'gutenberg_view_post_scripts_and_styles' );
 }
 
 /**

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -199,9 +199,20 @@ function do_blocks( $content ) {
 	// Append remaining unmatched content.
 	$rendered_content .= $content;
 
-	// Strip remaining block comment demarcations.
-	$rendered_content = preg_replace( '/<!--\s+\/?wp:.*?-->\r?\n?/m', '', $rendered_content );
-
 	return $rendered_content;
 }
 add_filter( 'the_content', 'do_blocks', 9 ); // BEFORE do_shortcode().
+
+/**
+ * Strips remaining block comment demarcations.
+ *
+ * @since 2.5.0
+ *
+ * @param  string $content Post content.
+ * @return string          Updated post content.
+ */
+function do_blocks_strip_comment_demarcations( $content ) {
+	return preg_replace( '/<!--\s+\/?wp:.*?-->\r?\n?/m', '', $content );
+}
+// TODO: It should be possible to leave comments for the processing on the frontend
+//add_filter( 'the_content', 'do_blocks_strip_comment_demarcations', 9 ); // AFTER do_blocks

--- a/view-post/index.js
+++ b/view-post/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment-timezone';
+import 'moment-timezone/moment-timezone-utils';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, ifCondition, Tooltip } from '@wordpress/components';
+import { compose, render } from '@wordpress/element';
+import { settings as dateSettings } from '@wordpress/date';
+
+// Configure moment globally
+moment.locale( dateSettings.l10n.locale );
+if ( dateSettings.timezone.string ) {
+	moment.tz.setDefault( dateSettings.timezone.string );
+} else {
+	const momentTimezone = {
+		name: 'WP',
+		abbrs: [ 'WP' ],
+		untils: [ null ],
+		offsets: [ -dateSettings.timezone.offset * 60 ],
+	};
+	const unpackedTimezone = moment.tz.pack( momentTimezone );
+	moment.tz.add( unpackedTimezone );
+	moment.tz.setDefault( 'WP' );
+}
+
+const Categories = compose(
+	// TODO: withAPIData depends on editor because of the context used?!!!!
+	/*withAPIData( () => {
+		return {
+			categories: '/wp/v2/categories',
+		};
+	} ),*/
+	ifCondition( ( categories ) => categories && categories.length )
+)( ( { categories } ) => (
+	<div>
+		<h3>Categories from API</h3>
+		{ categories.map(
+			( category ) => <p key={ category.id }>{ category.name }</p>
+		) }
+	</div>
+) );
+
+const ViewPost = ( ) => (
+	<div>
+		<Tooltip text="More information">
+			<Button>
+				Hover for more information
+			</Button>
+		</Tooltip>
+		<Categories />
+	</div>
+);
+
+/**
+ * Renders post's view.
+ *
+ * The return value of this function is not necessary if we change where we
+ * call initializeEditor(). This is due to metaBox timing.
+ */
+export function init() {
+	const target = document.querySelector( '.entry-content' );
+
+	render(
+		<ViewPost />,
+		target
+	);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,7 @@ const entryPointNames = [
 	'data',
 	'viewport',
 	[ 'editPost', 'edit-post' ],
+	[ 'viewPost', 'view-post' ],
 ];
 
 const packageNames = [


### PR DESCRIPTION
## Description

This is just an experiment to explore how much work it is needed to make it possible to render blocks also on the frontend. 

I was able to render an existing component with not that much code. I also disable the part that strips demarcation comment and renders callback for the Latest Posts block which allows producing the following code on the frontend.

```html
<div class="entry-content">
  <!-- wp:paragraph -->
  <p>My test paragraph</p>
  <!-- /wp:paragraph -->
 
  <!-- wp:latest-posts {"postsToShow":9,"displayPostDate":true,"align":"wide","layout":"grid"} /-->	</div>
```

### Next steps
* Find a way to render the Latest Posts block using client-side code only. The same way it happens at the moment in the editor with `edit`.


### Issues discovered
`withAPIData` depends on the `editor` module's code because it uses context with some props declared there. It is going to be replaced soon with `data` module so we should rather focus on that at the moment. See #5219 for more info.