### PR TITLE
Rename isProvisionalBlock action property to selectPrevious in removeBlock and removeBlocks

### DIFF
--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -381,16 +381,16 @@ export function createUndoLevel() {
  * Returns an action object used in signalling that the blocks
  * corresponding to the specified UID set are to be removed.
  *
- * @param {string[]} uids               Block UIDs.
- * @param {boolean}  isProvisionalBlock True if the action is being used to remove a provisional block.
+ * @param {string[]} uids           Block UIDs.
+ * @param {boolean}  selectPrevious True if the previous block should be selected when a block is removed.
  *
  * @return {Object} Action object.
  */
-export function removeBlocks( uids, isProvisionalBlock = false ) {
+export function removeBlocks( uids, selectPrevious = true ) {
 	return {
 		type: 'REMOVE_BLOCKS',
 		uids,
-		isProvisionalBlock,
+		selectPrevious,
 	};
 }
 
@@ -398,13 +398,13 @@ export function removeBlocks( uids, isProvisionalBlock = false ) {
  * Returns an action object used in signalling that the block with the
  * specified UID is to be removed.
  *
- * @param {string}  uid                Block UID.
- * @param {boolean} isProvisionalBlock True if the action is being used to remove a provisional block.
+ * @param {string}  uid            Block UID.
+ * @param {boolean} selectPrevious True if the previous block should be selected when a block is removed.
  *
  * @return {Object} Action object.
  */
-export function removeBlock( uid, isProvisionalBlock = false ) {
-	return removeBlocks( [ uid ], isProvisionalBlock );
+export function removeBlock( uid, selectPrevious = true ) {
+	return removeBlocks( [ uid ], selectPrevious );
 }
 
 /**

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -87,7 +87,7 @@ export function removeProvisionalBlock( action, store ) {
 	const state = store.getState();
 	const provisionalBlockUID = getProvisionalBlockUID( state );
 	if ( provisionalBlockUID && ! isBlockSelected( state, provisionalBlockUID ) ) {
-		return removeBlock( provisionalBlockUID, true );
+		return removeBlock( provisionalBlockUID, false );
 	}
 }
 
@@ -572,8 +572,8 @@ export default {
 	MULTI_SELECT: removeProvisionalBlock,
 
 	REMOVE_BLOCKS( action, { getState, dispatch } ) {
-		// if we are removing the provisional block don't do anything.
-		if ( action.isProvisionalBlock ) {
+		// if the action says previous block should not be selected don't do anything.
+		if ( ! action.selectPrevious ) {
 			return;
 		}
 

--- a/editor/store/test/actions.js
+++ b/editor/store/test/actions.js
@@ -301,7 +301,7 @@ describe( 'actions', () => {
 			expect( removeBlocks( uids ) ).toEqual( {
 				type: 'REMOVE_BLOCKS',
 				uids,
-				isProvisionalBlock: false,
+				selectPrevious: true,
 			} );
 		} );
 	} );
@@ -314,14 +314,14 @@ describe( 'actions', () => {
 				uids: [
 					uid,
 				],
-				isProvisionalBlock: false,
+				selectPrevious: true,
 			} );
-			expect( removeBlock( uid, true ) ).toEqual( {
+			expect( removeBlock( uid, false ) ).toEqual( {
 				type: 'REMOVE_BLOCKS',
 				uids: [
 					uid,
 				],
-				isProvisionalBlock: true,
+				selectPrevious: false,
 			} );
 		} );
 	} );

--- a/editor/store/test/effects.js
+++ b/editor/store/test/effects.js
@@ -81,7 +81,7 @@ describe( 'effects', () => {
 			selectors.isBlockSelected.mockImplementation( ( state, uid ) => uid === 'ribs' );
 			const action = removeProvisionalBlock( {}, store );
 
-			expect( action ).toEqual( removeBlock( 'chicken', true ) );
+			expect( action ).toEqual( removeBlock( 'chicken', false ) );
 		} );
 	} );
 


### PR DESCRIPTION
selectPrevious better expresses the intent of the flag. Its value is only false when we are removing the provisional block.

Props to @aduth for making this sugestion in: https://github.com/WordPress/gutenberg/pull/5568#issuecomment-373701633


## How Has This Been Tested?
Verify that when removing a block the previous block always gets selected.
Verify that removing provisionalBlock works as expected e.g: in Columns block add provisional paragraphs then select other block and see provisional paragraphs get removed and the block we want to select is selected.

