### PR TITLE
Block API: Add support for transforms prioritization

### DIFF
--- a/blocks/api/factory.js
+++ b/blocks/api/factory.js
@@ -4,14 +4,12 @@
 import uuid from 'uuid/v4';
 import {
 	every,
-	get,
 	reduce,
 	castArray,
 	findIndex,
 	includes,
 	isObjectLike,
 	filter,
-	find,
 	first,
 	flatMap,
 } from 'lodash';
@@ -19,7 +17,7 @@ import {
 /**
  * WordPress dependencies
  */
-import { applyFilters } from '@wordpress/hooks';
+import { createHooks, applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -111,10 +109,10 @@ const isTransformForBlockSource = ( sourceName, isMultiBlock = false ) => ( tran
  *
  * @return {Function} Predicate that receives a block type.
  */
-const createIsTypeTransformableFrom = ( sourceName, isMultiBlock = false ) => ( type ) => (
-	!! find(
-		get( type, 'transforms.from', [] ),
-		isTransformForBlockSource( sourceName, isMultiBlock ),
+const createIsTypeTransformableFrom = ( sourceName, isMultiBlock = false ) => ( blockType ) => (
+	!! findTransform(
+		getBlockTransforms( 'from', blockType.name ),
+		isTransformForBlockSource( sourceName, isMultiBlock )
 	)
 );
 
@@ -145,7 +143,7 @@ export function getPossibleBlockTransformations( blocks ) {
 	).map( type => type.name );
 
 	const blockType = getBlockType( sourceBlockName );
-	const transformsTo = get( blockType, 'transforms.to', [] );
+	const transformsTo = getBlockTransforms( 'to', blockType.name );
 
 	// Generate list of block transformations using the supplied "transforms to".
 	const blocksToBeTransformedTo = flatMap(
@@ -164,6 +162,72 @@ export function getPossibleBlockTransformations( blocks ) {
 		}
 		return result;
 	}, [] );
+}
+
+/**
+ * Given an array of transforms, returns the highest-priority transform where
+ * the predicate function returns a truthy value. A higher-priority transform
+ * is one with a lower priority value (i.e. first in priority order). Returns
+ * null if the transforms set is empty or the predicate function returns a
+ * falsey value for all entries.
+ *
+ * @param {Object[]} transforms Transforms to search.
+ * @param {Function} predicate  Function returning true on matching transform.
+ *
+ * @return {?Object} Highest-priority transform candidate.
+ */
+export function findTransform( transforms, predicate ) {
+	// The hooks library already has built-in mechanisms for managing priority
+	// queue, so leverage via locally-defined instance.
+	const hooks = createHooks();
+
+	for ( let i = 0; i < transforms.length; i++ ) {
+		const candidate = transforms[ i ];
+		if ( predicate( candidate ) ) {
+			hooks.addFilter(
+				'transform',
+				'transform/' + i.toString(),
+				( result ) => result ? result : candidate,
+				candidate.priority
+			);
+		}
+	}
+
+	// Filter name is arbitrarily chosen but consistent with above aggregation.
+	return hooks.applyFilters( 'transform', null );
+}
+
+/**
+ * Returns normal block transforms for a given transform direction, optionally
+ * for a specific block by name, or an empty array if there are no transforms.
+ * If no block name is provided, returns transforms for all blocks. A normal
+ * transform object includes `blockName` as a property.
+ *
+ * @param {string}  direction Transform direction ("to", "from").
+ * @param {?string} blockName Optional block name.
+ *
+ * @return {Array} Block transforms for direction.
+ */
+export function getBlockTransforms( direction, blockName ) {
+	// When retrieving transforms for all block types, recurse into self.
+	if ( blockName === undefined ) {
+		return flatMap(
+			getBlockTypes(),
+			( { name } ) => getBlockTransforms( direction, name )
+		);
+	}
+
+	// Validate that block type exists and has array of direction.
+	const { transforms } = getBlockType( blockName ) || {};
+	if ( ! transforms || ! Array.isArray( transforms[ direction ] ) ) {
+		return [];
+	}
+
+	// Map transforms to normal form.
+	return transforms[ direction ].map( ( transform ) => ( {
+		...transform,
+		blockName,
+	} ) );
 }
 
 /**
@@ -186,21 +250,19 @@ export function switchToBlockType( blocks, name ) {
 
 	// Find the right transformation by giving priority to the "to"
 	// transformation.
-	const destinationType = getBlockType( name );
-	const sourceType = getBlockType( sourceName );
-	const transformationsFrom = get( destinationType, 'transforms.from', [] );
-	const transformationsTo = get( sourceType, 'transforms.to', [] );
+	const transformationsFrom = getBlockTransforms( 'from', name );
+	const transformationsTo = getBlockTransforms( 'to', sourceName );
 	const transformation =
-		find(
+		findTransform(
 			transformationsTo,
 			t => t.type === 'block' && t.blocks.indexOf( name ) !== -1 && ( ! isMultiBlock || t.isMultiBlock )
 		) ||
-		find(
+		findTransform(
 			transformationsFrom,
 			t => t.type === 'block' && t.blocks.indexOf( sourceName ) !== -1 && ( ! isMultiBlock || t.isMultiBlock )
 		);
 
-	// Stop if there is no valid transformation. (How did we get here?)
+	// Stop if there is no valid transformation.
 	if ( ! transformation ) {
 		return null;
 	}

--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -3,6 +3,8 @@ export {
 	cloneBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,
+	getBlockTransforms,
+	findTransform,
 } from './factory';
 export { default as parse, getBlockAttributes } from './parser';
 export { default as rawHandler } from './raw-handling';

--- a/blocks/api/raw-handling/index.js
+++ b/blocks/api/raw-handling/index.js
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { find, get, compact } from 'lodash';
+import { compact } from 'lodash';
 import showdown from 'showdown';
 
 /**
  * Internal dependencies
  */
-import { createBlock } from '../factory';
-import { getBlockTypes, getUnknownTypeHandlerName } from '../registration';
+import { createBlock, getBlockTransforms, findTransform } from '../factory';
+import { getBlockType, getUnknownTypeHandlerName } from '../registration';
 import { getBlockAttributes, parseWithGrammar } from '../parser';
 import normaliseBlocks from './normalise-blocks';
 import stripAttributes from './strip-attributes';
@@ -150,34 +150,26 @@ export default function rawHandler( { HTML, plainText = '', mode = 'AUTO', tagNa
 
 		doc.body.innerHTML = piece;
 
+		const transformsFrom = getBlockTransforms( 'from' );
+
 		const blocks = Array.from( doc.body.children ).map( ( node ) => {
-			const block = getBlockTypes().reduce( ( acc, blockType ) => {
-				if ( acc ) {
-					return acc;
-				}
+			const transformation = findTransform( transformsFrom, ( transform ) => (
+				transform.type === 'raw' &&
+				transform.isMatch( node )
+			) );
 
-				const transformsFrom = get( blockType, 'transforms.from', [] );
-				const transform = find( transformsFrom, ( { type } ) => type === 'raw' );
-
-				if ( ! transform || ! transform.isMatch( node ) ) {
-					return acc;
-				}
-
-				if ( transform.transform ) {
-					return transform.transform( node );
+			if ( transformation ) {
+				if ( transformation.transform ) {
+					return transformation.transform( node );
 				}
 
 				return createBlock(
-					blockType.name,
+					transformation.blockName,
 					getBlockAttributes(
-						blockType,
+						getBlockType( transformation.blockName ),
 						node.outerHTML
 					)
 				);
-			}, null );
-
-			if ( block ) {
-				return block;
 			}
 
 			return createBlock( getUnknownTypeHandlerName(), {

--- a/blocks/api/raw-handling/shortcode-converter.js
+++ b/blocks/api/raw-handling/shortcode-converter.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { castArray, find, get, dropRight, last, mapValues, pickBy } from 'lodash';
+import { some, castArray, first, mapValues, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { createBlock } from '../factory';
-import { getBlockTypes } from '../registration';
+import { createBlock, getBlockTransforms, findTransform } from '../factory';
+import { getBlockType } from '../registration';
 import { getBlockAttributes } from '../parser';
 
 /**
@@ -15,71 +15,57 @@ import { getBlockAttributes } from '../parser';
  */
 const { shortcode } = window.wp;
 
-export default function( HTML ) {
-	// Get all matches. These are *not* ordered.
-	const matches = getBlockTypes().reduce( ( acc, blockType ) => {
-		const transformsFrom = get( blockType, 'transforms.from', [] );
-		const transform = find( transformsFrom, ( { type } ) => type === 'shortcode' );
+function segmentHTMLToShortcodeBlock( HTML ) {
+	// Get all matches.
+	const transformsFrom = getBlockTransforms( 'from' );
 
-		if ( ! transform ) {
-			return acc;
-		}
+	const transformation = findTransform( transformsFrom, ( transform ) => (
+		transform.type === 'shortcode' &&
+		some( castArray( transform.tag ), ( tag ) => shortcode.regexp( tag ).test( HTML ) )
+	) );
 
-		const transformTags = castArray( transform.tag );
+	if ( ! transformation ) {
+		return [ HTML ];
+	}
 
-		let match;
-		let lastIndex = 0;
+	const transformTags = castArray( transformation.tag );
+	const transformTag = first( transformTags );
 
-		for ( const transformTag of transformTags ) {
-			while ( ( match = shortcode.next( transformTag, HTML, lastIndex ) ) ) {
-				lastIndex = match.index + match.content.length;
+	let match;
+	let lastIndex = 0;
 
-				const attributes = mapValues(
-					pickBy( transform.attributes, ( schema ) => schema.shortcode ),
-					// Passing all of `match` as second argument is intentionally
-					// broad but shouldn't be too relied upon. See
-					// https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
-					( schema ) => schema.shortcode( match.shortcode.attrs, match ),
-				);
+	if ( ( match = shortcode.next( transformTag, HTML, lastIndex ) ) ) {
+		lastIndex = match.index + match.content.length;
 
-				const block = createBlock(
-					blockType.name,
-					getBlockAttributes(
-						{
-							...blockType,
-							attributes: transform.attributes,
-						},
-						match.shortcode.content,
-						attributes,
-					)
-				);
+		const attributes = mapValues(
+			pickBy( transformation.attributes, ( schema ) => schema.shortcode ),
+			// Passing all of `match` as second argument is intentionally broad
+			// but shouldn't be too relied upon.
+			//
+			// See: https://github.com/WordPress/gutenberg/pull/3610#discussion_r152546926
+			( schema ) => schema.shortcode( match.shortcode.attrs, match ),
+		);
 
-				acc[ match.index ] = { block, lastIndex };
-			}
-		}
+		const block = createBlock(
+			transformation.blockName,
+			getBlockAttributes(
+				{
+					...getBlockType( transformation.blockName ),
+					attributes: transformation.attributes,
+				},
+				match.shortcode.content,
+				attributes,
+			)
+		);
 
-		return acc;
-	}, {} );
-
-	let negativeI = 0;
-
-	// Sort the matches and return an array of text pieces and blocks.
-	return Object.keys( matches ).sort( ( a, b ) => a - b ).reduce( ( acc, index ) => {
-		const match = matches[ index ];
-
-		acc = [
-			// Add all pieces except the last text piece.
-			...dropRight( acc ),
-			// Add the start of the last text piece.
-			last( acc ).slice( 0, index - negativeI ),
-			// Add the block.
-			match.block,
-			// Add the rest of the last text piece.
-			last( acc ).slice( match.lastIndex - negativeI ),
+		return [
+			HTML.substr( 0, match.index ),
+			block,
+			...segmentHTMLToShortcodeBlock( HTML.substr( match.index + match.content.length ) ),
 		];
+	}
 
-		negativeI = match.lastIndex;
-
-		return acc;
-	}, [ HTML ] );
+	return [ HTML ];
 }
+
+export default segmentHTMLToShortcodeBlock;

--- a/blocks/library/index.js
+++ b/blocks/library/index.js
@@ -36,26 +36,6 @@ import * as video from './video';
 
 export const registerCoreBlocks = () => {
 	[
-		// FIXME: Temporary fix.
-		//
-		// The Shortcode block declares a catch-all shortcode transform,
-		// meaning it will attempt to intercept pastes and block conversions of
-		// any valid shortcode-like content. Other blocks (e.g. Gallery) may
-		// declare specific shortcode transforms (e.g. `[gallery]`), with which
-		// this block would conflict. Thus, the Shortcode block needs to be
-		// registered as early as possible, so that any other block types'
-		// shortcode transforms can be honoured.
-		//
-		// This isn't a proper solution, as it is at odds with the
-		// specification of shortcode conversion, in the sense that conversion
-		// is explicitly independent of block order. Thus, concurrent parse
-		// rules (i.e. a same text input can yield two different transforms,
-		// like `[gallery] -> { Gallery, Shortcode }`) are unsupported,
-		// yielding non-deterministic results. A proper solution could be to
-		// let the editor (or site owners) determine a default block handler of
-		// unknown shortcodes — see `setUnknownTypeHandlerName`.
-		shortcode,
-
 		// Common blocks are grouped at the top to prioritize their display
 		// in various contexts — like the inserter and auto-complete components.
 		paragraph,
@@ -66,6 +46,7 @@ export const registerCoreBlocks = () => {
 		quote,
 
 		// Register all remaining core blocks.
+		shortcode,
 		audio,
 		button,
 		categories,

--- a/blocks/library/paragraph/index.js
+++ b/blocks/library/paragraph/index.js
@@ -334,6 +334,7 @@ export const settings = {
 		from: [
 			{
 				type: 'raw',
+				priority: 20,
 				isMatch: ( node ) => (
 					node.nodeName === 'P' &&
 					// Do not allow embedded content.

--- a/blocks/library/shortcode/index.js
+++ b/blocks/library/shortcode/index.js
@@ -49,6 +49,7 @@ export const settings = {
 						},
 					},
 				},
+				priority: 20,
 			},
 		],
 	},

--- a/blocks/rich-text/patterns.js
+++ b/blocks/rich-text/patterns.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import tinymce from 'tinymce';
-import { find, get, escapeRegExp, groupBy, drop } from 'lodash';
+import { filter, escapeRegExp, groupBy, drop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,7 +12,7 @@ import { keycodes } from '@wordpress/utils';
 /**
  * Internal dependencies
  */
-import { getBlockTypes } from '../api/registration';
+import { getBlockTransforms, findTransform } from '../api/factory';
 
 const { ESCAPE, ENTER, SPACE, BACKSPACE } = keycodes;
 
@@ -26,11 +26,7 @@ export default function( editor ) {
 	const {
 		enter: enterPatterns,
 		undefined: spacePatterns,
-	} = groupBy( getBlockTypes().reduce( ( acc, blockType ) => {
-		const transformsFrom = get( blockType, 'transforms.from', [] );
-		const transforms = transformsFrom.filter( ( { type } ) => type === 'pattern' );
-		return [ ...acc, ...transforms ];
-	}, [] ), 'trigger' );
+	} = groupBy( filter( getBlockTransforms( 'from' ), { type: 'pattern' } ), 'trigger' );
 
 	const inlinePatterns = settings.inline || [
 		{ delimiter: '`', format: 'code' },
@@ -181,16 +177,15 @@ export default function( editor ) {
 
 		const firstText = content[ 0 ];
 
-		const { result, pattern } = patterns.reduce( ( acc, item ) => {
-			return acc.result ? acc : {
-				result: item.regExp.exec( firstText ),
-				pattern: item,
-			};
-		}, {} );
+		const transformation = findTransform( patterns, ( item ) => {
+			return item.regExp.test( firstText );
+		} );
 
-		if ( ! result ) {
+		if ( ! transformation ) {
 			return;
 		}
+
+		const result = firstText.match( transformation.regExp );
 
 		const range = editor.selection.getRng();
 		const matchLength = result[ 0 ].length;
@@ -201,7 +196,7 @@ export default function( editor ) {
 			return;
 		}
 
-		const block = pattern.transform( {
+		const block = transformation.transform( {
 			content: [ remainingText, ...drop( content ) ],
 			match: result,
 		} );
@@ -223,7 +218,7 @@ export default function( editor ) {
 			return;
 		}
 
-		const pattern = find( enterPatterns, ( { regExp } ) => regExp.test( content[ 0 ] ) );
+		const pattern = findTransform( enterPatterns, ( { regExp } ) => regExp.test( content[ 0 ] ) );
 
 		if ( ! pattern ) {
 			return;

--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -250,6 +250,7 @@ transforms: {
 ```
 {% end %}
 
+To control the priority with which a transform is applied, define a `priority` numeric property on your transform object, where a lower value will take precedence over higher values. This behaves much like a [WordPress hook](https://codex.wordpress.org/Plugin_API#Hook_to_WordPress). Like hooks, the default priority is `10` when not otherwise set.
 
 #### useOnce (optional)
 

--- a/edit-post/hooks/validate-use-once/index.js
+++ b/edit-post/hooks/validate-use-once/index.js
@@ -6,7 +6,7 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createBlock, getBlockType } from '@wordpress/blocks';
+import { createBlock, getBlockType, findTransform, getBlockTransforms } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Warning } from '@wordpress/editor';
@@ -60,7 +60,7 @@ function withUseOnceValidation( BlockEdit ) {
 		}
 
 		const blockType = getBlockType( props.name );
-		const outboundType = getOutboundType( blockType );
+		const outboundType = getOutboundType( props.name );
 
 		return [
 			<div key="invalid-preview" style={ { minHeight: '100px' } }>
@@ -101,17 +101,18 @@ function withUseOnceValidation( BlockEdit ) {
 }
 
 /**
- * Given a base block type, returns the default block type to which to offer
+ * Given a base block name, returns the default block type to which to offer
  * transforms.
  *
- * @param {Object} blockType Base block type.
- * @return {?Object}         The chosen default block type.
+ * @param {string} blockName Base block name.
+ *
+ * @return {?Object} The chosen default block type.
  */
-function getOutboundType( blockType ) {
+function getOutboundType( blockName ) {
 	// Grab the first outbound transform
-	const { to = [] } = blockType.transforms || {};
-	const transform = find( to, ( { type, blocks } ) =>
-		type === 'block' && blocks.length === 1 // What about when .length > 1?
+	const transform = findTransform(
+		getBlockTransforms( 'to', blockName ),
+		( { type, blocks } ) => type === 'block' && blocks.length === 1 // What about when .length > 1?
 	);
 
 	if ( ! transform ) {

--- a/editor/components/block-drop-zone/index.js
+++ b/editor/components/block-drop-zone/index.js
@@ -2,13 +2,18 @@
  * External Dependencies
  */
 import { connect } from 'react-redux';
-import { reduce, get, find, castArray } from 'lodash';
+import { castArray } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { DropZone, withContext } from '@wordpress/components';
-import { getBlockTypes, rawHandler, cloneBlock } from '@wordpress/blocks';
+import {
+	rawHandler,
+	cloneBlock,
+	getBlockTransforms,
+	findTransform,
+} from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
 
 /**
@@ -28,15 +33,10 @@ function BlockDropZone( { index, isLocked, ...props } ) {
 	};
 
 	const onDropFiles = ( files, position ) => {
-		const transformation = reduce( getBlockTypes(), ( ret, blockType ) => {
-			if ( ret ) {
-				return ret;
-			}
-
-			return find( get( blockType, 'transforms.from', [] ), ( transform ) => (
-				transform.type === 'files' && transform.isMatch( files )
-			) );
-		}, false );
+		const transformation = findTransform(
+			getBlockTransforms( 'from' ),
+			( transform ) => transform.type === 'files' && transform.isMatch( files )
+		);
 
 		if ( transformation ) {
 			const insertIndex = getInsertIndex( position );

--- a/test/unit/setup-wp-aliases.js
+++ b/test/unit/setup-wp-aliases.js
@@ -1,7 +1,8 @@
 // Set up `wp.*` aliases.  Handled by Webpack outside of the test build.
 global.wp = {
 	shortcode: {
-		next: () => {},
+		next() {},
+		regexp: jest.fn().mockReturnValue( new RegExp() ),
 	},
 };
 


### PR DESCRIPTION
Fixes #5620

This pull request seeks to add a prioritization mechanism to block transforms, addressing two current issues with reliance on block registration order (paragraph and shortcode transforms as fallback). From a block implementer perspective, this simply adds a new property `priority` to the transform object, which behaves nearly identical to hooks prioritization (the similarity is not coincidental, as it uses hooks under the hood as the basis). At a code level, it introduces two new functions `getBlockTransforms` and `findTransform` which respectively return/normalize transforms and return a predicate-matching transform considering priority.

There may be room for further optimization here (e.g. sorting at registration time, caching transforms) but after a few failed attempts, I landed on this as a more direct/simple implementation.

__Testing instructions:__

Verify that there are no regressions in transform behavior. Notably, this impacts:

- Block transforms
- Paste transforms
- Shortcode transforms 
- Use-once validation
- File drop 