### PR TITLE
Block API: Drop removed createReusableBlock function

### DIFF
--- a/blocks/api/index.js
+++ b/blocks/api/index.js
@@ -3,7 +3,6 @@ export {
 	cloneBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,
-	createReusableBlock,
 } from './factory';
 export { default as parse, getBlockAttributes } from './parser';
 export { default as rawHandler } from './raw-handling';


### PR DESCRIPTION
Related: #5228

This pull request seeks to drop the removed `createReusableBlock` function from the export of `blocks/api`. The function was removed in #5228, but the lingering reference was not noticed until #5267 where Webpack's detection of unknown imports was improved and a warning logged upon build.

__Testing instructions:__

There should be no use of this function, so no functional change. Verify instead that there are no other lingering references in the code.