### PR TITLE
Issue/5612 - Alignfull class not working on columns

### DIFF
--- a/blocks/library/columns/index.js
+++ b/blocks/library/columns/index.js
@@ -16,8 +16,6 @@ import { RangeControl } from '@wordpress/components';
  */
 import './style.scss';
 import InspectorControls from '../../inspector-controls';
-import BlockControls from '../../block-controls';
-import BlockAlignmentToolbar from '../../block-alignment-toolbar';
 import InnerBlocks from '../../inner-blocks';
 
 /**
@@ -54,34 +52,20 @@ export const settings = {
 			type: 'number',
 			default: 2,
 		},
-		align: {
-			type: 'string',
-		},
+	},
+
+	supports: {
+		align: [ 'wide', 'full' ],
 	},
 
 	description: __( 'A multi-column layout of content.' ),
 
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-
-		return { 'data-align': align };
-	},
-
 	edit( { attributes, setAttributes, className, focus } ) {
-		const { align, columns } = attributes;
+		const { columns } = attributes;
 		const classes = classnames( className, `has-${ columns }-columns` );
 
 		return [
 			...focus ? [
-				<BlockControls key="controls">
-					<BlockAlignmentToolbar
-						controls={ [ 'wide', 'full' ] }
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-					/>
-				</BlockControls>,
 				<InspectorControls key="inspector">
 					<RangeControl
 						label={ __( 'Columns' ) }


### PR DESCRIPTION
## Description
The column block isn't outputting alignment classes to the front-end. I think we can fix that and update the block to the supports align extension in one fell swoop. 

Fix for #5612. 
Related to #5099. (cc @gziolo )

## How Has This Been Tested?
Tested locally by adding a column block to a new page, setting it to alignwide, saving and viewing the output markup on the front-end.

## Types of changes
Changes to the columns block index.js file by removing any alignment related code and adding: 

``
supports: {
		align: [ 'wide', 'full' ],
	},
``

Bug fix (non-breaking change which fixes an issue)

However, this will cause existing saved column blocks with to throw a validation error since it will now be expecting the class to be in the saved markup. I don't know a way around that?

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code has proper inline documentation.
