### PR TITLE
Add centering style also to the theme style output

### DIFF
--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -1,6 +1,12 @@
-.wp-block-image figcaption {
-	margin-top: 0.5em;
-	color: $dark-gray-300;
-	text-align: center;
-	font-size: $default-font-size;
+.wp-block-image {
+	figcaption {
+		margin-top: 0.5em;
+		color: $dark-gray-300;
+		text-align: center;
+		font-size: $default-font-size;
+	}
+
+	&.aligncenter {
+		text-align: center;
+	}
 }

--- a/blocks/library/image/style.scss
+++ b/blocks/library/image/style.scss
@@ -7,6 +7,9 @@
 	}
 
 	&.aligncenter {
+		display: block;
+		margin-left: auto;
+		margin-right: auto;
 		text-align: center;
 	}
 }


### PR DESCRIPTION
Fixes comment in https://github.com/WordPress/gutenberg/pull/5209#issuecomment-374328167.

Previous implementation assumed the theme would handle centering, just like it's traditionally handled alignleft and alignright classes, but since the aligncenter is now applied to the `figure` element, any theme that uses code like `img.aligncenter` won't work. Hence this PR.
