### PR TITLE
Accessibility: Try adding the keyboard navigation/edit mode

### DIFF
--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -94,20 +94,8 @@ class NavigableContainer extends Component {
 			return;
 		}
 
-		const preventDefaultKeyBehaviour = () => {
-			if ( ! stopNavigationEvents ) {
-				return;
-			}
-
-			// Prevents arrow key handlers bound to the document directly interfering
-			event.nativeEvent.stopImmediatePropagation();
-			event.preventDefault();
-			event.stopPropagation();
-		};
-
 		const { index, focusables } = context;
 		const nextIndex = cycle ? cycleValue( index, focusables.length, offset ) : index + offset;
-		preventDefaultKeyBehaviour();
 		if ( nextIndex >= 0 && nextIndex < focusables.length ) {
 			focusables[ nextIndex ].focus();
 			onNavigate( nextIndex, focusables[ nextIndex ] );

--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -47,27 +47,9 @@ class NavigableContainer extends Component {
 			.find( this.container )
 			.filter( ( node ) => deep || node.parentElement === this.container );
 
-		let previous = null;
-		let next = null;
-		let didReachContainer = false;
-		finder
-			.find( document.body )
-			.forEach( ( node ) => {
-				const isInsideContainer = this.container.contains( node );
-				if ( ! didReachContainer && ! isInsideContainer ) {
-					previous = node;
-				}
-				if ( isInsideContainer && ! didReachContainer ) {
-					didReachContainer = true;
-				}
-				if ( didReachContainer && ! isInsideContainer && ! next ) {
-					next = node;
-				}
-			} );
-
 		const index = this.getFocusableIndex( focusables, target );
 		if ( index > -1 && target ) {
-			return { index, target, focusables, next, previous };
+			return { index, target, focusables };
 		}
 		return null;
 	}
@@ -84,14 +66,10 @@ class NavigableContainer extends Component {
 			this.props.onKeyDown( event );
 		}
 
-		if ( this.props.disabled ) {
-			return;
-		}
-
 		const { getFocusableContext } = this;
-		const { cycle = true, eventToOffset, onNavigate = noop, stopNavigationEvents, restrictInsideContainer = true } = this.props;
+		const { cycle = true, eventToOffset, onNavigate = noop, stopNavigationEvents } = this.props;
 
-		const offset = eventToOffset( event, this.container );
+		const offset = eventToOffset( event );
 
 		// eventToOffset returns undefined if the event is not handled by the component
 		if ( offset !== undefined && stopNavigationEvents ) {
@@ -127,16 +105,12 @@ class NavigableContainer extends Component {
 			event.stopPropagation();
 		};
 
-		const { index, focusables, next, previous } = context;
+		const { index, focusables } = context;
 		const nextIndex = cycle ? cycleValue( index, focusables.length, offset ) : index + offset;
 		preventDefaultKeyBehaviour();
 		if ( nextIndex >= 0 && nextIndex < focusables.length ) {
 			focusables[ nextIndex ].focus();
 			onNavigate( nextIndex, focusables[ nextIndex ] );
-		} else if ( ! restrictInsideContainer ) {
-			const nextTarget = offset > 0 ? next || previous : previous || next;
-			nextTarget.focus();
-			onNavigate( -1 ); // this indicates that we're leaving the container
 		}
 	}
 
@@ -205,9 +179,9 @@ export class NavigableMenu extends Component {
 
 export class TabbableContainer extends Component {
 	render() {
-		const eventToOffset = ( evt, container ) => {
-			const { keyCode, shiftKey, target } = evt;
-			if ( TAB === keyCode && ( this.props.deep || target.parentElement === container ) ) {
+		const eventToOffset = ( evt ) => {
+			const { keyCode, shiftKey } = evt;
+			if ( TAB === keyCode ) {
 				return shiftKey ? -1 : 1;
 			}
 
@@ -231,7 +205,6 @@ export class TabbableContainer extends Component {
 			<NavigableContainer
 				stopNavigationEvents
 				onlyBrowserTabstops
-				restrictInsideContainer={ false }
 				eventToOffset={ eventToOffset }
 				{ ...this.props }
 			/>

--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -47,9 +47,27 @@ class NavigableContainer extends Component {
 			.find( this.container )
 			.filter( ( node ) => deep || node.parentElement === this.container );
 
+		let previous = null;
+		let next = null;
+		let didReachContainer = false;
+		finder
+			.find( document.body )
+			.forEach( ( node ) => {
+				const isInsideContainer = this.container.contains( node );
+				if ( ! didReachContainer && ! isInsideContainer ) {
+					previous = node;
+				}
+				if ( isInsideContainer && ! didReachContainer ) {
+					didReachContainer = true;
+				}
+				if ( didReachContainer && ! isInsideContainer && ! next ) {
+					next = node;
+				}
+			} );
+
 		const index = this.getFocusableIndex( focusables, target );
 		if ( index > -1 && target ) {
-			return { index, target, focusables };
+			return { index, target, focusables, next, previous };
 		}
 		return null;
 	}
@@ -71,7 +89,7 @@ class NavigableContainer extends Component {
 		}
 
 		const { getFocusableContext } = this;
-		const { cycle = true, eventToOffset, onNavigate = noop, stopNavigationEvents } = this.props;
+		const { cycle = true, eventToOffset, onNavigate = noop, stopNavigationEvents, restrictInsideContainer = true } = this.props;
 
 		const offset = eventToOffset( event, this.container );
 
@@ -98,11 +116,27 @@ class NavigableContainer extends Component {
 			return;
 		}
 
-		const { index, focusables } = context;
+		const preventDefaultKeyBehaviour = () => {
+			if ( ! stopNavigationEvents ) {
+				return;
+			}
+
+			// Prevents arrow key handlers bound to the document directly interfering
+			event.nativeEvent.stopImmediatePropagation();
+			event.preventDefault();
+			event.stopPropagation();
+		};
+
+		const { index, focusables, next, previous } = context;
 		const nextIndex = cycle ? cycleValue( index, focusables.length, offset ) : index + offset;
+		preventDefaultKeyBehaviour();
 		if ( nextIndex >= 0 && nextIndex < focusables.length ) {
 			focusables[ nextIndex ].focus();
 			onNavigate( nextIndex, focusables[ nextIndex ] );
+		} else if ( ! restrictInsideContainer ) {
+			const nextTarget = offset > 0 ? next || previous : previous || next;
+			nextTarget.focus();
+			onNavigate( -1 ); // this indicates that we're leaving the container
 		}
 	}
 
@@ -197,6 +231,7 @@ export class TabbableContainer extends Component {
 			<NavigableContainer
 				stopNavigationEvents
 				onlyBrowserTabstops
+				restrictInsideContainer={ false }
 				eventToOffset={ eventToOffset }
 				{ ...this.props }
 			/>

--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -66,10 +66,14 @@ class NavigableContainer extends Component {
 			this.props.onKeyDown( event );
 		}
 
+		if ( this.props.disabled ) {
+			return;
+		}
+
 		const { getFocusableContext } = this;
 		const { cycle = true, eventToOffset, onNavigate = noop, stopNavigationEvents } = this.props;
 
-		const offset = eventToOffset( event );
+		const offset = eventToOffset( event, this.container );
 
 		// eventToOffset returns undefined if the event is not handled by the component
 		if ( offset !== undefined && stopNavigationEvents ) {
@@ -118,7 +122,7 @@ class NavigableContainer extends Component {
 					'onlyBrowserTabstops',
 				] ) }
 				onKeyDown={ this.onKeyDown }
-				onFocus={ this.onFocus }>
+			>
 				{ children }
 			</div>
 		);
@@ -167,9 +171,9 @@ export class NavigableMenu extends Component {
 
 export class TabbableContainer extends Component {
 	render() {
-		const eventToOffset = ( evt ) => {
-			const { keyCode, shiftKey } = evt;
-			if ( TAB === keyCode ) {
+		const eventToOffset = ( evt, container ) => {
+			const { keyCode, shiftKey, target } = evt;
+			if ( TAB === keyCode && target.parentElement === container ) {
 				return shiftKey ? -1 : 1;
 			}
 

--- a/components/navigable-container/index.js
+++ b/components/navigable-container/index.js
@@ -173,7 +173,7 @@ export class TabbableContainer extends Component {
 	render() {
 		const eventToOffset = ( evt, container ) => {
 			const { keyCode, shiftKey, target } = evt;
-			if ( TAB === keyCode && target.parentElement === container ) {
+			if ( TAB === keyCode && ( this.props.deep || target.parentElement === container ) ) {
 				return shiftKey ? -1 : 1;
 			}
 

--- a/components/navigable-container/test/index.js
+++ b/components/navigable-container/test/index.js
@@ -38,7 +38,6 @@ function fireKeyDown( container, keyCode, shiftKey ) {
 		},
 		keyCode,
 		shiftKey,
-		target: document.activeElement,
 	} );
 
 	return interaction;

--- a/components/navigable-container/test/index.js
+++ b/components/navigable-container/test/index.js
@@ -38,6 +38,7 @@ function fireKeyDown( container, keyCode, shiftKey ) {
 		},
 		keyCode,
 		shiftKey,
+		target: document.activeElement,
 	} );
 
 	return interaction;

--- a/core-blocks/button/edit.js
+++ b/core-blocks/button/edit.js
@@ -88,6 +88,8 @@ class ButtonEdit extends Component {
 			clear,
 		} = attributes;
 
+		/* The disabling of autofocus, the input is being focused when you tab to the button block. */
+		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<Fragment>
 				<BlockControls>
@@ -148,12 +150,14 @@ class ButtonEdit extends Component {
 						<UrlInput
 							value={ url }
 							onChange={ ( value ) => setAttributes( { url: value } ) }
+							autoFocus={ false }
 						/>
 						<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 					</form>
 				) }
 			</Fragment>
 		);
+		/* eslint-enable jsx-a11y/no-autofocus */
 	}
 }
 

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -642,6 +642,7 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		isSelectionEnabled,
 		getSelectedBlocksInitialCaretPosition,
 		getEditorSettings,
+		getKeyboardMode,
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( uid );
 	const { templateLock, hasFixedToolbar } = getEditorSettings();
@@ -665,6 +666,7 @@ const applyWithSelect = withSelect( ( select, { uid, rootUID } ) => {
 		isEmptyDefaultBlock: block && isUnmodifiedDefaultBlock( block ),
 		isPreviousBlockADefaultEmptyBlock: previousBlock && isUnmodifiedDefaultBlock( previousBlock ),
 		isLocked: !! templateLock,
+		keyboardMode: getKeyboardMode(),
 		previousBlockUid,
 		block,
 		isSelected,
@@ -682,6 +684,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		replaceBlocks,
 		editPost,
 		toggleSelection,
+		setKeyboardMode,
 	} = dispatch( 'core/editor' );
 
 	return {
@@ -714,6 +717,9 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		},
 		toggleSelection( selectionEnabled ) {
 			toggleSelection( selectionEnabled );
+		},
+		onChangeKeyboardMode( mode ) {
+			setKeyboardMode( mode );
 		},
 	};
 } );

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/dom';
 import { keycodes } from '@wordpress/utils';
 import {
-	createBlock,
 	cloneBlock,
 	getBlockType,
 	getSaveElement,
@@ -52,7 +51,7 @@ import Inserter from '../inserter';
 import withHoverAreas from './with-hover-areas';
 import { createInnerBlockList } from '../../utils/block-list';
 
-const { BACKSPACE, DELETE, ENTER } = keycodes;
+const { BACKSPACE, DELETE, ENTER, ESCAPE } = keycodes;
 
 export class BlockListBlock extends Component {
 	constructor() {
@@ -68,7 +67,7 @@ export class BlockListBlock extends Component {
 		this.onFocus = this.onFocus.bind( this );
 		this.preventDrag = this.preventDrag.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
-		this.deleteOrInsertAfterWrapper = this.deleteOrInsertAfterWrapper.bind( this );
+		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onBlockError = this.onBlockError.bind( this );
 		this.onTouchStart = this.onTouchStart.bind( this );
 		this.onClick = this.onClick.bind( this );
@@ -145,10 +144,10 @@ export class BlockListBlock extends Component {
 	}
 
 	/**
-	 * When a block becomces selected, transition focus to an inner tabbable.
+	 * When a block becomes selected, transition focus to an inner tabbable.
 	 */
 	focusTabbable() {
-		const { initialPosition } = this.props;
+		const { initialPosition, keyboardMode } = this.props;
 
 		// Focus is captured by the wrapper node, so while focus transition
 		// should only consider tabbables within editable display, since it
@@ -158,12 +157,28 @@ export class BlockListBlock extends Component {
 			return;
 		}
 
+		// In navigation mode, we should select the parent node only
+		// This could be triggered when we remove a block from navigation mode (backspace)
+		if ( keyboardMode === 'navigation' ) {
+			this.wrapperNode.focus();
+			return;
+		}
+
+		this.focusFirstTextFieldOrContainer( -1 === initialPosition );
+	}
+
+	/**
+	 * Function focusing the first text field of the current block when called.
+	 * Fallback to the block container if no text field
+	 *
+	 * @param {boolean} isReverse select begining or end of the current block
+	 */
+	focusFirstTextFieldOrContainer( isReverse ) {
 		// Find all tabbables within node.
 		const textInputs = focus.tabbable.find( this.node ).filter( isTextField );
 
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.
-		const isReverse = -1 === initialPosition;
 		const target = ( isReverse ? last : first )( textInputs );
 
 		if ( ! target ) {
@@ -335,32 +350,37 @@ export class BlockListBlock extends Component {
 	}
 
 	/**
-	 * Interprets keydown event intent to remove or insert after block if key
+	 * Interprets keydown event intent to switch keyboard mode and remove or insert after block if key
 	 * event occurs on wrapper node. This can occur when the block has no text
 	 * fields of its own, particularly after initial insertion, to allow for
 	 * easy deletion and continuous writing flow to add additional content.
 	 *
 	 * @param {KeyboardEvent} event Keydown event.
 	 */
-	deleteOrInsertAfterWrapper( event ) {
+	onKeyDown( event ) {
 		const { keyCode, target } = event;
+		const { keyboardMode, onChangeKeyboardMode } = this.props;
 
-		if ( target !== this.wrapperNode || this.props.isLocked ) {
-			return;
-		}
+		const isWrapperFocused = target === this.wrapperNode;
 
+		// Keyboard navigation events
 		switch ( keyCode ) {
 			case ENTER:
-				// Insert default block after current block if enter and event
-				// not already handled by descendant.
-				this.props.onInsertBlocks( [
-					createBlock( 'core/paragraph' ),
-				], this.props.order + 1 );
-				event.preventDefault();
+				if ( isWrapperFocused && keyboardMode === 'navigation' ) {
+					event.preventDefault();
+					onChangeKeyboardMode( 'edit' );
+					this.focusFirstTextFieldOrContainer();
+				}
 				break;
-
+			case ESCAPE:
+				onChangeKeyboardMode( 'navigation' );
+				this.wrapperNode.focus();
+				break;
 			case BACKSPACE:
 			case DELETE:
+				if ( ! isWrapperFocused ) {
+					return;
+				}
 				// Remove block on backspace.
 				const { uid, onRemove, previousBlockUid, onSelect } = this.props;
 				onRemove( uid );
@@ -485,7 +505,7 @@ export class BlockListBlock extends Component {
 				onTouchStart={ this.onTouchStart }
 				onFocus={ this.onFocus }
 				onClick={ this.onClick }
-				onKeyDown={ this.deleteOrInsertAfterWrapper }
+				onKeyDown={ this.onKeyDown }
 				tabIndex="0"
 				childHandledEvents={ [
 					'onDragStart',

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -509,6 +509,8 @@ export class BlockListBlock extends Component {
 				onClick={ this.onClick }
 				onKeyDown={ this.onKeyDown }
 				tabIndex="0"
+				aria-label={ blockLabel }
+				role="group"
 				childHandledEvents={ [
 					'onDragStart',
 					'onMouseDown',
@@ -566,7 +568,6 @@ export class BlockListBlock extends Component {
 					onDragStart={ this.preventDrag }
 					onMouseDown={ this.onPointerDown }
 					className="editor-block-list__block-edit"
-					aria-label={ blockLabel }
 					data-block={ uid }
 				>
 

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -106,7 +106,7 @@ export class BlockListBlock extends Component {
 
 	componentDidMount() {
 		if ( this.props.isSelected ) {
-			this.focusTabbable();
+			this.focusTabbable( true );
 		}
 	}
 
@@ -145,8 +145,10 @@ export class BlockListBlock extends Component {
 
 	/**
 	 * When a block becomes selected, transition focus to an inner tabbable.
+	 *
+	 * @param {boolean} forceInnerFocus Whether or not to force focus to inner content
 	 */
-	focusTabbable() {
+	focusTabbable( forceInnerFocus = false ) {
 		const { initialPosition, keyboardMode } = this.props;
 
 		// Focus is captured by the wrapper node, so while focus transition
@@ -159,7 +161,7 @@ export class BlockListBlock extends Component {
 
 		// In navigation mode, we should select the parent node only
 		// This could be triggered when we remove a block from navigation mode (backspace)
-		if ( keyboardMode === 'navigation' ) {
+		if ( ! forceInnerFocus && keyboardMode === 'navigation' ) {
 			this.wrapperNode.focus();
 			return;
 		}

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -435,6 +435,7 @@ export class BlockListBlock extends Component {
 			isLargeViewport,
 			isEmptyDefaultBlock,
 			isPreviousBlockADefaultEmptyBlock,
+			keyboardMode,
 		} = this.props;
 		const isHovered = this.state.isHovered && ! isMultiSelecting;
 		const { name: blockName, isValid } = block;
@@ -446,15 +447,16 @@ export class BlockListBlock extends Component {
 
 		// If the block is selected and we're typing the block should not appear.
 		// Empty paragraph blocks should always show up as unselected.
+		const isKeyboardEditMode = keyboardMode === 'edit';
 		const isSelectedNotTyping = isSelected && ! isTypingWithinBlock;
 		const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 		const shouldAppearSelected = ! showEmptyBlockSideInserter && isSelectedNotTyping;
 		// We render block movers and block settings to keep them tabbale even if hidden
-		const shouldRenderMovers = ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isMultiSelected && ! isTypingWithinBlock;
-		const shouldRenderBlockSettings = ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isMultiSelected && ! isTypingWithinBlock;
+		const shouldRenderMovers = isKeyboardEditMode && ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isMultiSelected && ! isTypingWithinBlock;
+		const shouldRenderBlockSettings = isKeyboardEditMode && ( isSelected || hoverArea === 'right' ) && ! isMultiSelecting && ! isMultiSelected && ! isTypingWithinBlock;
 		const shouldShowBreadcrumb = isHovered;
-		const shouldShowContextualToolbar = shouldAppearSelected && isValid && ( ! hasFixedToolbar || ! isLargeViewport );
-		const shouldShowMobileToolbar = shouldAppearSelected;
+		const shouldShowContextualToolbar = isKeyboardEditMode && shouldAppearSelected && isValid && ( ! hasFixedToolbar || ! isLargeViewport );
+		const shouldShowMobileToolbar = isKeyboardEditMode && shouldAppearSelected;
 		const { error, dragging } = this.state;
 
 		// Insertion point can only be made visible when the side inserter is

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -151,18 +151,19 @@ export class BlockListBlock extends Component {
 	focusTabbable( forceInnerFocus = false ) {
 		const { initialPosition, keyboardMode } = this.props;
 
+		// In navigation mode, we should select the parent node only
+		// This could be triggered when we remove a block from navigation mode (backspace)
+		// or when we shift tab from the sidebar
+		if ( ! forceInnerFocus && keyboardMode === 'navigation' ) {
+			this.wrapperNode.focus();
+			return;
+		}
+
 		// Focus is captured by the wrapper node, so while focus transition
 		// should only consider tabbables within editable display, since it
 		// may be the wrapper itself or a side control which triggered the
 		// focus event, don't unnecessary transition to an inner tabbable.
 		if ( this.wrapperNode.contains( document.activeElement ) ) {
-			return;
-		}
-
-		// In navigation mode, we should select the parent node only
-		// This could be triggered when we remove a block from navigation mode (backspace)
-		if ( ! forceInnerFocus && keyboardMode === 'navigation' ) {
-			this.wrapperNode.focus();
 			return;
 		}
 

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -18,7 +18,6 @@ import 'element-closest';
  */
 import { Component, compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { TabbableContainer } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -37,8 +36,6 @@ class BlockListLayout extends Component {
 		this.onShiftSelection = this.onShiftSelection.bind( this );
 		this.setBlockRef = this.setBlockRef.bind( this );
 		this.setLastClientY = this.setLastClientY.bind( this );
-		this.onChangeKeyboardMode = this.onChangeKeyboardMode.bind( this );
-		this.unselectBlockIfLeaving = this.unselectBlockIfLeaving.bind( this );
 		this.onPointerMove = throttle( this.onPointerMove.bind( this ), 100 );
 		// Browser does not fire `*move` event when the pointer position changes
 		// relative to the document, so fire it with the last known position.
@@ -46,9 +43,6 @@ class BlockListLayout extends Component {
 
 		this.lastClientY = 0;
 		this.nodes = {};
-		this.state = {
-			keyboardMode: 'navigation',
-		};
 	}
 
 	componentDidMount() {
@@ -193,16 +187,6 @@ class BlockListLayout extends Component {
 		}
 	}
 
-	onChangeKeyboardMode( mode ) {
-		this.setState( { keyboardMode: mode } );
-	}
-
-	unselectBlockIfLeaving( index ) {
-		if ( index === -1 ) {
-			this.props.clearSelectedBlock();
-		}
-	}
-
 	render() {
 		const {
 			blockUIDs,
@@ -223,28 +207,21 @@ class BlockListLayout extends Component {
 
 		return (
 			<div className={ classes }>
-				<TabbableContainer
-					cycle={ false }
-					disabled={ this.state.keyboardMode !== 'navigation' }
-					onNavigate={ this.unselectBlockIfLeaving }
-				>
-					{ map( blockUIDs, ( uid, blockIndex ) => (
-						<BlockListBlock
-							key={ 'block-' + uid }
-							index={ blockIndex }
-							uid={ uid }
-							blockRef={ this.setBlockRef }
-							onSelectionStart={ this.onSelectionStart }
-							onShiftSelection={ this.onShiftSelection }
-							rootUID={ rootUID }
-							layout={ defaultLayout }
-							isFirst={ blockIndex === 0 }
-							isLast={ blockIndex === blockUIDs.length - 1 }
-							renderBlockMenu={ renderBlockMenu }
-							onChangeKeyboardMode={ this.onChangeKeyboardMode }
-						/>
-					) ) }
-				</TabbableContainer>
+				{ map( blockUIDs, ( uid, blockIndex ) => (
+					<BlockListBlock
+						key={ 'block-' + uid }
+						index={ blockIndex }
+						uid={ uid }
+						blockRef={ this.setBlockRef }
+						onSelectionStart={ this.onSelectionStart }
+						onShiftSelection={ this.onShiftSelection }
+						rootUID={ rootUID }
+						layout={ defaultLayout }
+						isFirst={ blockIndex === 0 }
+						isLast={ blockIndex === blockUIDs.length - 1 }
+						renderBlockMenu={ renderBlockMenu }
+					/>
+				) ) }
 				<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
 					<DefaultBlockAppender
 						rootUID={ rootUID }

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -38,6 +38,7 @@ class BlockListLayout extends Component {
 		this.setBlockRef = this.setBlockRef.bind( this );
 		this.setLastClientY = this.setLastClientY.bind( this );
 		this.onChangeKeyboardMode = this.onChangeKeyboardMode.bind( this );
+		this.unselectBlockIfLeaving = this.unselectBlockIfLeaving.bind( this );
 		this.onPointerMove = throttle( this.onPointerMove.bind( this ), 100 );
 		// Browser does not fire `*move` event when the pointer position changes
 		// relative to the document, so fire it with the last known position.
@@ -196,6 +197,12 @@ class BlockListLayout extends Component {
 		this.setState( { keyboardMode: mode } );
 	}
 
+	unselectBlockIfLeaving( index ) {
+		if ( index === -1 ) {
+			this.props.clearSelectedBlock();
+		}
+	}
+
 	render() {
 		const {
 			blockUIDs,
@@ -216,7 +223,11 @@ class BlockListLayout extends Component {
 
 		return (
 			<div className={ classes }>
-				<TabbableContainer disabled={ this.state.keyboardMode !== 'navigation' } restrictNavigationToChildren>
+				<TabbableContainer
+					cycle={ false }
+					disabled={ this.state.keyboardMode !== 'navigation' }
+					onNavigate={ this.unselectBlockIfLeaving }
+				>
 					{ map( blockUIDs, ( uid, blockIndex ) => (
 						<BlockListBlock
 							key={ 'block-' + uid }
@@ -270,6 +281,7 @@ export default compose( [
 			stopMultiSelect,
 			multiSelect,
 			selectBlock,
+			clearSelectedBlock,
 		} = dispatch( 'core/editor' );
 
 		return {
@@ -277,6 +289,7 @@ export default compose( [
 			onStopMultiSelect: stopMultiSelect,
 			onMultiSelect: multiSelect,
 			onSelect: selectBlock,
+			clearSelectedBlock,
 		};
 	} ),
 ] )( BlockListLayout );

--- a/editor/components/block-list/layout.js
+++ b/editor/components/block-list/layout.js
@@ -18,6 +18,7 @@ import 'element-closest';
  */
 import { Component, compose } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { TabbableContainer } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -36,6 +37,7 @@ class BlockListLayout extends Component {
 		this.onShiftSelection = this.onShiftSelection.bind( this );
 		this.setBlockRef = this.setBlockRef.bind( this );
 		this.setLastClientY = this.setLastClientY.bind( this );
+		this.onChangeKeyboardMode = this.onChangeKeyboardMode.bind( this );
 		this.onPointerMove = throttle( this.onPointerMove.bind( this ), 100 );
 		// Browser does not fire `*move` event when the pointer position changes
 		// relative to the document, so fire it with the last known position.
@@ -43,6 +45,9 @@ class BlockListLayout extends Component {
 
 		this.lastClientY = 0;
 		this.nodes = {};
+		this.state = {
+			keyboardMode: 'navigation',
+		};
 	}
 
 	componentDidMount() {
@@ -187,6 +192,10 @@ class BlockListLayout extends Component {
 		}
 	}
 
+	onChangeKeyboardMode( mode ) {
+		this.setState( { keyboardMode: mode } );
+	}
+
 	render() {
 		const {
 			blockUIDs,
@@ -207,21 +216,24 @@ class BlockListLayout extends Component {
 
 		return (
 			<div className={ classes }>
-				{ map( blockUIDs, ( uid, blockIndex ) => (
-					<BlockListBlock
-						key={ 'block-' + uid }
-						index={ blockIndex }
-						uid={ uid }
-						blockRef={ this.setBlockRef }
-						onSelectionStart={ this.onSelectionStart }
-						onShiftSelection={ this.onShiftSelection }
-						rootUID={ rootUID }
-						layout={ defaultLayout }
-						isFirst={ blockIndex === 0 }
-						isLast={ blockIndex === blockUIDs.length - 1 }
-						renderBlockMenu={ renderBlockMenu }
-					/>
-				) ) }
+				<TabbableContainer disabled={ this.state.keyboardMode !== 'navigation' } restrictNavigationToChildren>
+					{ map( blockUIDs, ( uid, blockIndex ) => (
+						<BlockListBlock
+							key={ 'block-' + uid }
+							index={ blockIndex }
+							uid={ uid }
+							blockRef={ this.setBlockRef }
+							onSelectionStart={ this.onSelectionStart }
+							onShiftSelection={ this.onShiftSelection }
+							rootUID={ rootUID }
+							layout={ defaultLayout }
+							isFirst={ blockIndex === 0 }
+							isLast={ blockIndex === blockUIDs.length - 1 }
+							renderBlockMenu={ renderBlockMenu }
+							onChangeKeyboardMode={ this.onChangeKeyboardMode }
+						/>
+					) ) }
+				</TabbableContainer>
 				<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
 					<DefaultBlockAppender
 						rootUID={ rootUID }

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -32,8 +32,7 @@ import {
 /**
  * Module Constants
  */
-
-const { UP, DOWN, LEFT, RIGHT, isKeyboardEvent } = keycodes;
+const { UP, DOWN, LEFT, RIGHT, TAB, isKeyboardEvent } = keycodes;
 
 /**
  * Given an element, returns true if the element is a tabbable text field, or
@@ -54,6 +53,7 @@ class WritingFlow extends Component {
 
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
+		this.bindAppender = this.bindAppender.bind( this );
 		this.clearVerticalRect = this.clearVerticalRect.bind( this );
 		this.focusLastTextField = this.focusLastTextField.bind( this );
 
@@ -69,6 +69,10 @@ class WritingFlow extends Component {
 
 	bindContainer( ref ) {
 		this.container = ref;
+	}
+
+	bindAppender( ref ) {
+		this.appender = ref;
 	}
 
 	clearVerticalRect() {
@@ -160,7 +164,10 @@ class WritingFlow extends Component {
 
 		if ( focusedBlockUid ) {
 			this.props.onSelectBlock( focusedBlockUid );
+			return true;
 		}
+
+		return false;
 	}
 
 	/**
@@ -180,9 +187,29 @@ class WritingFlow extends Component {
 	}
 
 	onKeyDown( event ) {
-		const { hasMultiSelection, onMultiSelect, blocks } = this.props;
-
+		const { hasMultiSelection, onMultiSelect, blocks, keyboardMode, nextBlockUid, previousBlockUid, selectedBlockUID } = this.props;
+		// selectedBlockUID, selectionStart, hasMultiSelection, keyboardMode, nextBlockUid, previousBlockUid
 		const { keyCode, target } = event;
+
+		// In navigation mode, tab and arrows navigate from block to blocks
+		if ( keyboardMode === 'navigation' ) {
+			const navigateUp = keyCode === TAB && event.shiftKey;
+			const navigateDown = keyCode === TAB && ! event.shiftKey;
+
+			if ( ( navigateDown && nextBlockUid ) || ( navigateUp && previousBlockUid ) ) {
+				event.preventDefault();
+				this.moveSelection( navigateUp );
+			}
+
+			// Special case when reaching the end of the blocks (navigate to the next tabbable outside of the writing flow)
+			if ( navigateDown && selectedBlockUID && ! nextBlockUid ) {
+				this.props.clearSelectedBlock();
+				this.appender.focus();
+			}
+			return;
+		}
+
+		// In edit mode, tab is kept natural and arrows navigate the cursor
 		const isUp = keyCode === UP;
 		const isDown = keyCode === DOWN;
 		const isLeft = keyCode === LEFT;
@@ -276,6 +303,7 @@ class WritingFlow extends Component {
 					{ children }
 				</div>
 				<div
+					ref={ this.bindAppender }
 					aria-hidden
 					tabIndex={ -1 }
 					onClick={ this.focusLastTextField }
@@ -299,6 +327,7 @@ export default compose( [
 			getLastMultiSelectedBlockUid,
 			hasMultiSelection,
 			getBlockOrder,
+			getKeyboardMode,
 		} = select( 'core/editor' );
 
 		const selectedBlockUID = getSelectedBlockUID();
@@ -310,17 +339,27 @@ export default compose( [
 			selectionStartUID,
 			selectionBeforeEndUID: getPreviousBlockUid( selectionEndUID || selectedBlockUID ),
 			selectionAfterEndUID: getNextBlockUid( selectionEndUID || selectedBlockUID ),
+			nextBlockUid: getNextBlockUid( selectionEndUID || selectedBlockUID ),
+			previousBlockUid: getPreviousBlockUid( selectionStartUID || selectedBlockUID ),
 			selectedFirstUid: getFirstMultiSelectedBlockUid(),
 			selectedLastUid: getLastMultiSelectedBlockUid(),
 			hasMultiSelection: hasMultiSelection(),
 			blocks: getBlockOrder(),
+			keyboardMode: getKeyboardMode(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { multiSelect, selectBlock } = dispatch( 'core/editor' );
+		const {
+			multiSelect,
+			selectBlock,
+			clearSelectedBlock,
+			setKeyboardMode,
+		} = dispatch( 'core/editor' );
 		return {
 			onMultiSelect: multiSelect,
 			onSelectBlock: selectBlock,
+			clearSelectedBlock,
+			setKeyboardMode,
 		};
 	} ),
 ] )( WritingFlow );

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -224,7 +224,10 @@ class WritingFlow extends Component {
 
 			if ( ( navigateDown && nextBlockUid ) || ( navigateUp && previousBlockUid ) ) {
 				event.preventDefault();
-				this.moveSelection( navigateUp );
+				const focusedBlockUid = navigateUp ? previousBlockUid : nextBlockUid;
+				if ( focusedBlockUid ) {
+					this.props.onSelectBlock( focusedBlockUid );
+				}
 			}
 
 			// Special case when reaching the end of the blocks (navigate to the next tabbable outside of the writing flow)

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -58,6 +58,9 @@ class WritingFlow extends Component {
 		this.focusLastTextField = this.focusLastTextField.bind( this );
 		this.swithToEditMode = this.swithToEditMode.bind( this );
 
+		this.lastClientY = null;
+		this.lastClientX = null;
+
 		/**
 		 * Here a rectangle is stored while moving the caret vertically so
 		 * vertical position of the start position can be restored.
@@ -76,10 +79,18 @@ class WritingFlow extends Component {
 		window.removeEventListener( 'mousemove', this.swithToEditMode );
 	}
 
-	swithToEditMode() {
-		if ( this.props.keyboardMode !== 'edit' ) {
+	swithToEditMode( { clientY, clientX } ) {
+		// Safari triggers mousemove even if we didn't really move the mouse
+		// On shift press for instance.
+		// To ensure we really moved the mouse, we compare the mouse position
+		if ( this.props.keyboardMode !== 'edit' &&
+			( this.lastClientX !== null && this.lastClientY !== null ) &&
+			( clientY !== this.lastClientY || clientX !== this.lastClientX )
+		) {
 			this.props.setKeyboardMode( 'edit' );
 		}
+		this.lastClientY = clientY;
+		this.lastClientX = clientX;
 	}
 
 	bindContainer( ref ) {

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -219,8 +219,8 @@ class WritingFlow extends Component {
 
 		// In navigation mode, tab and arrows navigate from block to blocks
 		if ( keyboardMode === 'navigation' ) {
-			const navigateUp = keyCode === TAB && event.shiftKey;
-			const navigateDown = keyCode === TAB && ! event.shiftKey;
+			const navigateUp = ( keyCode === TAB && event.shiftKey ) || keyCode === UP;
+			const navigateDown = ( keyCode === TAB && ! event.shiftKey ) || keyCode === DOWN;
 
 			if ( ( navigateDown && nextBlockUid ) || ( navigateUp && previousBlockUid ) ) {
 				event.preventDefault();
@@ -228,7 +228,7 @@ class WritingFlow extends Component {
 			}
 
 			// Special case when reaching the end of the blocks (navigate to the next tabbable outside of the writing flow)
-			if ( navigateDown && selectedBlockUID && ! nextBlockUid ) {
+			if ( navigateDown && selectedBlockUID && ! nextBlockUid && [ UP, DOWN ].indexOf( keyCode ) === -1 ) {
 				this.props.clearSelectedBlock();
 				this.appender.focus();
 			}

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -56,6 +56,7 @@ class WritingFlow extends Component {
 		this.bindAppender = this.bindAppender.bind( this );
 		this.clearVerticalRect = this.clearVerticalRect.bind( this );
 		this.focusLastTextField = this.focusLastTextField.bind( this );
+		this.swithToEditMode = this.swithToEditMode.bind( this );
 
 		/**
 		 * Here a rectangle is stored while moving the caret vertically so
@@ -65,6 +66,20 @@ class WritingFlow extends Component {
 		 * @type {?DOMRect}
 		 */
 		this.verticalRect = null;
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'mousemove', this.swithToEditMode );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'mousemove', this.swithToEditMode );
+	}
+
+	swithToEditMode() {
+		if ( this.props.keyboardMode !== 'edit' ) {
+			this.props.setKeyboardMode( 'edit' );
+		}
 	}
 
 	bindContainer( ref ) {

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -694,3 +694,17 @@ export function updateEditorSettings( settings ) {
 		settings,
 	};
 }
+
+/*
+ * Returns an action object used to set the keyboard mode
+ *
+ * @param {string} mode Keyboard mode
+ *
+ * @return {Object} Action object
+ */
+export function setKeyboardMode( mode ) {
+	return {
+		type: 'SET_KEYBOARD_MODE',
+		mode,
+	};
+}

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -748,6 +748,14 @@ export function blocksMode( state = {}, action ) {
 	return state;
 }
 
+export function keyboardMode( state = 'navigation', action ) {
+	if ( action.type === 'SET_KEYBOARD_MODE' ) {
+		return action.mode;
+	}
+
+	return state;
+}
+
 /**
  * Reducer returning the block insertion point visibility, a boolean value
  * reflecting whether the insertion point should be shown.
@@ -1071,4 +1079,5 @@ export default optimist( combineReducers( {
 	sharedBlocks,
 	template,
 	settings,
+	keyboardMode,
 } ) );

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1744,3 +1744,14 @@ export function getSupportedBlocks( state, uid, globallyEnabledBlockTypes ) {
 export function getEditorSettings( state ) {
 	return state.settings;
 }
+
+/*
+ * Returns the current keyboard mode.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string}      Keyboard Mode
+ */
+export function getKeyboardMode( state ) {
+	return state.keyboardMode;
+}

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -25,6 +25,9 @@ describe( 'adding blocks', () => {
 	}
 
 	it( 'Should insert content using the placeholder and the regular inserter', async () => {
+		// trigger the edit keyboard mode
+		await page.mouse.click( 200, 200 );
+
 		// Click below editor to focus last field (block appender)
 		await clickBelow( await page.$( '.editor-default-block-appender' ) );
 		expect( await page.$( '[data-type="core/paragraph"]' ) ).not.toBeNull();


### PR DESCRIPTION
refs #5694

Adding the navigation/edit mode can be very impacting for the edit flow, so it's best to try to do it by steps.

In this PR.

 - tabbing navigate to blocks directly
 - Enter enters "edit" mode 
 - Escape moves back to navigation mode

The drawback of the edit/navigation mode is that it's not possible to create an empty paragraph after the selected block by clicking "Enter", since "Enter" is the key used to move to edit mode. Is this acceptable?

Need help testing the different writing flow interactions to ensure there's no other regression.