### PR TITLE
Added "no title" text as tittle of the sidebar on mobile when title is empty.

### DIFF
--- a/edit-post/components/sidebar/header.js
+++ b/edit-post/components/sidebar/header.js
@@ -14,7 +14,7 @@ const SidebarHeader = ( { count, title, activeSidebarName, openSidebar, closeSid
 		<Fragment>
 			<div className="components-panel__header edit-post-sidebar__header">
 				<span className="edit-post-sidebar__title">
-					{ title }
+					{ title || __( '(no title)' ) }
 				</span>
 				<IconButton
 					onClick={ closeSidebar }


### PR DESCRIPTION
We have a space on the mobile sidebar for the post title, the problem is that if the post title is empty we don't show anything and just render a white space. This may look confusing and like a bug.
This PR just adds a condition to show "(no title)" when the title is empty so users know that title was supposed to appear there.

## How Has This Been Tested?
Resize the editor to mobile resolution (or use a mobile) open the sidebar and verify that if the title is empty (no title) appears instead on the sidebar.

## Screenshots (jpeg or gifs if applicable):
Before:
![img_5222](https://user-images.githubusercontent.com/11271197/37654846-61cc8136-2c3b-11e8-95ae-1e7b99e4c87f.PNG)
![img_f5217134da62-1](https://user-images.githubusercontent.com/11271197/37654864-75598af0-2c3b-11e8-9002-f0f4ecc72f43.jpeg)
After:
![img_5223](https://user-images.githubusercontent.com/11271197/37654876-7fd31a78-2c3b-11e8-9759-9e03a9bd4943.PNG)
![img_5220](https://user-images.githubusercontent.com/11271197/37654944-bc54d4c8-2c3b-11e8-85f7-49035631ad92.PNG)

