### PR TITLE
Menu items toggle a11y improvements

### DIFF
--- a/components/menu-items/menu-items-toggle.js
+++ b/components/menu-items/menu-items-toggle.js
@@ -13,6 +13,7 @@ function MenuItemsToggle( { label, isSelected, onClick, shortcut } ) {
 				className="components-menu-items__button is-toggle is-selected"
 				icon="yes"
 				onClick={ onClick }
+				aria-pressed="true"
 			>
 				{ label }
 				<Shortcut shortcut={ shortcut } />
@@ -24,6 +25,7 @@ function MenuItemsToggle( { label, isSelected, onClick, shortcut } ) {
 		<Button
 			className="components-menu-items__button is-toggle"
 			onClick={ onClick }
+			aria-pressed="false"
 		>
 			{ label }
 			<Shortcut shortcut={ shortcut } />

--- a/edit-post/store/effects.js
+++ b/edit-post/store/effects.js
@@ -7,6 +7,8 @@ import { reduce, values, some } from 'lodash';
  * WordPress dependencies
  */
 import { select, subscribe } from '@wordpress/data';
+import { speak } from '@wordpress/a11y';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -83,6 +85,10 @@ const effects = {
 			data: formData,
 		} )
 			.then( () => store.dispatch( metaBoxUpdatesSuccess() ) );
+	},
+	SWITCH_MODE( action ) {
+		const message = action.mode === 'visual' ? __( 'Visual editor selected' ) : __( 'Code editor selected' );
+		speak( message, 'assertive' );
 	},
 };
 


### PR DESCRIPTION
This PR tries to improve the accessibility of the `MenuItemsToggle` buttons and tries to add a `speak` message for screen reader users to confirm when they switch editor mode. Thanks to the feedback from the accessibility testers, see #5699 and #5700.

1
to indicate the actual state of the `MenuItemsToggle`, adds an `aria-pressed` attribute on the buttons. This works pretty well with screen readers, see screenshots:

![screen shot 2018-03-20 at 15 35 00](https://user-images.githubusercontent.com/1682452/37667680-d93b33da-2c62-11e8-9335-07c5bff9143c.png)
![screen shot 2018-03-20 at 15 35 05](https://user-images.githubusercontent.com/1682452/37667681-d958a406-2c62-11e8-8e25-a68e61cb3f6a.png)
![screen shot 2018-03-20 at 15 35 31](https://user-images.githubusercontent.com/1682452/37667682-d9745304-2c62-11e8-8c29-cc75de31f0e1.png)

As mentioned in the related issue, for buttons the most appropriate ARIA attribute is `aria-pressed` https://www.w3.org/TR/wai-aria-1.1/#aria-pressed as `aria-selected` is not used for buttons https://www.w3.org/TR/wai-aria-1.1/#aria-selected

2
I've tried to add a `speak` message when switching editor mode. The switch happens:
- via shortcut `mod+Shift+Alt+M`
- when activating the toggle buttons

In order to implement the message just once, I'm doing it in the  "effects" where the `SWITCH_MODE` action is available. I've seen `speak` is already used in `editor/store/effects.js` and tried to follow a similar approach. I really don't know if this is a desired pattern or the best option, any feedback and suggestions are very welcome.

Fixes #5699 
Fixes #5700 