### PR TITLE
Fix reusable block cancelling

### DIFF
--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -30,6 +30,7 @@ class ReusableBlockEdit extends Component {
 		this.state = {
 			isEditing: !! ( reusableBlock && reusableBlock.isTemporary ),
 			title: null,
+			attributes: null,
 		};
 	}
 
@@ -40,11 +41,12 @@ class ReusableBlockEdit extends Component {
 	}
 
 	startEditing() {
-		const { reusableBlock } = this.props;
+		const { reusableBlock, block } = this.props;
 
 		this.setState( {
 			isEditing: true,
 			title: reusableBlock.title,
+			attributes: block.attributes,
 		} );
 	}
 
@@ -52,12 +54,17 @@ class ReusableBlockEdit extends Component {
 		this.setState( {
 			isEditing: false,
 			title: null,
+			attributes: null,
 		} );
 	}
 
 	setAttributes( attributes ) {
-		const { updateAttributes, block } = this.props;
-		updateAttributes( block.uid, attributes );
+		this.setState( ( prevState ) => {
+			if ( prevState.attributes !== null ) {
+				return { attributes: { ...prevState.attributes, ...attributes } };
+			}
+			return null;
+		} );
 	}
 
 	setTitle( title ) {
@@ -65,13 +72,14 @@ class ReusableBlockEdit extends Component {
 	}
 
 	save() {
-		const { reusableBlock, onUpdateTitle, onSave } = this.props;
+		const { reusableBlock, onUpdateTitle, updateAttributes, block, onSave } = this.props;
+		const { title, attributes } = this.state;
 
-		const { title } = this.state;
 		if ( title !== reusableBlock.title ) {
 			onUpdateTitle( title );
 		}
 
+		updateAttributes( block.uid, attributes );
 		onSave();
 
 		this.stopEditing();
@@ -79,7 +87,7 @@ class ReusableBlockEdit extends Component {
 
 	render() {
 		const { isSelected, reusableBlock, block, isFetching, isSaving } = this.props;
-		const { isEditing, title } = this.state;
+		const { isEditing, title, attributes } = this.state;
 
 		if ( ! reusableBlock && isFetching ) {
 			return <Placeholder><Spinner /></Placeholder>;
@@ -95,7 +103,7 @@ class ReusableBlockEdit extends Component {
 				isSelected={ isEditing && isSelected }
 				id={ block.uid }
 				name={ block.name }
-				attributes={ block.attributes }
+				attributes={ attributes !== null ? attributes : block.attributes }
 				setAttributes={ isEditing ? this.setAttributes : noop }
 			/>
 		);

--- a/blocks/library/block/index.js
+++ b/blocks/library/block/index.js
@@ -30,7 +30,7 @@ class ReusableBlockEdit extends Component {
 		this.state = {
 			isEditing: !! ( reusableBlock && reusableBlock.isTemporary ),
 			title: null,
-			attributes: null,
+			changedAttributes: null,
 		};
 	}
 
@@ -41,12 +41,12 @@ class ReusableBlockEdit extends Component {
 	}
 
 	startEditing() {
-		const { reusableBlock, block } = this.props;
+		const { reusableBlock } = this.props;
 
 		this.setState( {
 			isEditing: true,
 			title: reusableBlock.title,
-			attributes: block.attributes,
+			changedAttributes: {},
 		} );
 	}
 
@@ -54,16 +54,15 @@ class ReusableBlockEdit extends Component {
 		this.setState( {
 			isEditing: false,
 			title: null,
-			attributes: null,
+			changedAttributes: null,
 		} );
 	}
 
 	setAttributes( attributes ) {
 		this.setState( ( prevState ) => {
-			if ( prevState.attributes !== null ) {
-				return { attributes: { ...prevState.attributes, ...attributes } };
+			if ( prevState.changedAttributes !== null ) {
+				return { changedAttributes: { ...prevState.changedAttributes, ...attributes } };
 			}
-			return null;
 		} );
 	}
 
@@ -73,13 +72,13 @@ class ReusableBlockEdit extends Component {
 
 	save() {
 		const { reusableBlock, onUpdateTitle, updateAttributes, block, onSave } = this.props;
-		const { title, attributes } = this.state;
+		const { title, changedAttributes } = this.state;
 
 		if ( title !== reusableBlock.title ) {
 			onUpdateTitle( title );
 		}
 
-		updateAttributes( block.uid, attributes );
+		updateAttributes( block.uid, changedAttributes );
 		onSave();
 
 		this.stopEditing();
@@ -87,7 +86,7 @@ class ReusableBlockEdit extends Component {
 
 	render() {
 		const { isSelected, reusableBlock, block, isFetching, isSaving } = this.props;
-		const { isEditing, title, attributes } = this.state;
+		const { isEditing, title, changedAttributes } = this.state;
 
 		if ( ! reusableBlock && isFetching ) {
 			return <Placeholder><Spinner /></Placeholder>;
@@ -103,7 +102,7 @@ class ReusableBlockEdit extends Component {
 				isSelected={ isEditing && isSelected }
 				id={ block.uid }
 				name={ block.name }
-				attributes={ attributes !== null ? attributes : block.attributes }
+				attributes={ { ...block.attributes, ...changedAttributes } }
 				setAttributes={ isEditing ? this.setAttributes : noop }
 			/>
 		);


### PR DESCRIPTION
![dog](https://user-images.githubusercontent.com/612155/37696086-100b0fdc-2d28-11e8-9617-0fd6c45418af.gif)

Makes it so that pressing Cancel while editing a reusable block discards any unsaved changes that have been made to that block.

This fixes #5719, which is a regression introduced by https://github.com/WordPress/gutenberg/pull/5228.

### To test:

1. Insert a reusable block
2. Select it and click Edit
3. Make some changes to the block
4. Click Cancel
5. The block should appear how it did before you edited it