### PR TITLE
Invert the speak messages

### DIFF
--- a/edit-post/components/visual-editor/block-inspector-button.js
+++ b/edit-post/components/visual-editor/block-inspector-button.js
@@ -21,9 +21,9 @@ export function BlockInspectorButton( {
 } ) {
 	const speakMessage = () => {
 		if ( areAdvancedSettingsOpened ) {
-			speak( __( 'Additional settings are now available in the Editor advanced settings sidebar' ) );
-		} else {
 			speak( __( 'Advanced settings closed' ) );
+		} else {
+			speak( __( 'Additional settings are now available in the Editor advanced settings sidebar' ) );
 		}
 	};
 


### PR DESCRIPTION
## Description
When opening/closing the inspector from teh block ellipsis menu, the speak messages should be inverted.

Closes #5713 

## How Has This Been Tested?
This has been tested with "npm test", "npm run test-e2e" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
