### PR TITLE
Writing Flow: Clear selected block on canvas focus only if is selected

### DIFF
--- a/editor/components/block-selection-clearer/index.js
+++ b/editor/components/block-selection-clearer/index.js
@@ -6,8 +6,8 @@ import { omit } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { withDispatch } from '@wordpress/data';
+import { Component, compose } from '@wordpress/element';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 class BlockSelectionClearer extends Component {
 	constructor() {
@@ -29,8 +29,9 @@ class BlockSelectionClearer extends Component {
 	 * @param {FocusEvent} event Focus event.
 	 */
 	clearSelectionIfFocusTarget( event ) {
-		if ( event.target === this.container ) {
-			this.props.clearSelectedBlock();
+		const { hasSelectedBlock, clearSelectedBlock } = this.props;
+		if ( event.target === this.container && hasSelectedBlock ) {
+			clearSelectedBlock();
 		}
 	}
 
@@ -42,13 +43,22 @@ class BlockSelectionClearer extends Component {
 				tabIndex={ -1 }
 				onFocus={ this.clearSelectionIfFocusTarget }
 				ref={ this.bindContainer }
-				{ ...omit( props, 'clearSelectedBlock' ) }
+				{ ...omit( props, [ 'clearSelectedBlock', 'hasSelectedBlock' ] ) }
 			/>
 		);
 	}
 }
 
-export default withDispatch( ( dispatch ) => {
-	const { clearSelectedBlock } = dispatch( 'core/editor' );
-	return { clearSelectedBlock };
-} )( BlockSelectionClearer );
+export default compose( [
+	withSelect( ( select ) => {
+		const { hasSelectedBlock } = select( 'core/editor' );
+
+		return {
+			hasSelectedBlock: hasSelectedBlock(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { clearSelectedBlock } = dispatch( 'core/editor' );
+		return { clearSelectedBlock };
+	} ),
+] )( BlockSelectionClearer );

--- a/editor/components/block-selection-clearer/index.js
+++ b/editor/components/block-selection-clearer/index.js
@@ -29,21 +29,29 @@ class BlockSelectionClearer extends Component {
 	 * @param {FocusEvent} event Focus event.
 	 */
 	clearSelectionIfFocusTarget( event ) {
-		const { hasSelectedBlock, clearSelectedBlock } = this.props;
-		if ( event.target === this.container && hasSelectedBlock ) {
+		const {
+			hasSelectedBlock,
+			hasMultiSelection,
+			clearSelectedBlock,
+		} = this.props;
+
+		const hasSelection = ( hasSelectedBlock || hasMultiSelection );
+		if ( event.target === this.container && hasSelection ) {
 			clearSelectedBlock();
 		}
 	}
 
 	render() {
-		const { ...props } = this.props;
-
 		return (
 			<div
 				tabIndex={ -1 }
 				onFocus={ this.clearSelectionIfFocusTarget }
 				ref={ this.bindContainer }
-				{ ...omit( props, [ 'clearSelectedBlock', 'hasSelectedBlock' ] ) }
+				{ ...omit( this.props, [
+					'clearSelectedBlock',
+					'hasSelectedBlock',
+					'hasMultiSelection',
+				] ) }
 			/>
 		);
 	}
@@ -51,10 +59,11 @@ class BlockSelectionClearer extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { hasSelectedBlock } = select( 'core/editor' );
+		const { hasSelectedBlock, hasMultiSelection } = select( 'core/editor' );
 
 		return {
 			hasSelectedBlock: hasSelectedBlock(),
+			hasMultiSelection: hasMultiSelection(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -508,6 +508,18 @@ export function getSelectedBlockCount( state ) {
 }
 
 /**
+ * Returns true if there is a single selected block, or false otherwise.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Whether a single block is selected.
+ */
+export function hasSelectedBlock( state ) {
+	const { start, end } = state.blockSelection;
+	return !! start && start === end;
+}
+
+/**
  * Returns the currently selected block, or null if there is no selected block.
  *
  * @param {Object} state Global application state.

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -40,6 +40,7 @@ const {
 	getBlock,
 	getBlocks,
 	getBlockCount,
+	hasSelectedBlock,
 	getSelectedBlock,
 	getBlockRootUID,
 	getEditedPostAttribute,
@@ -1327,6 +1328,41 @@ describe( 'selectors', () => {
 			};
 
 			expect( getBlockCount( state, '123' ) ).toBe( 2 );
+		} );
+	} );
+
+	describe( 'hasSelectedBlock', () => {
+		it( 'should return false if no selection', () => {
+			const state = {
+				blockSelection: {
+					start: null,
+					end: null,
+				},
+			};
+
+			expect( hasSelectedBlock( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if multi-selection', () => {
+			const state = {
+				blockSelection: {
+					start: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					end: '9db792c6-a25a-495d-adbd-97d56a4c4189',
+				},
+			};
+
+			expect( hasSelectedBlock( state ) ).toBe( false );
+		} );
+
+		it( 'should return true if singular selection', () => {
+			const state = {
+				blockSelection: {
+					start: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					end: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+				},
+			};
+
+			expect( hasSelectedBlock( state ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request seeks to remedy unnecessary dispatches which occur when focusing the editor canvas if no block selection exists. Currently, clicking the editor background canvas will dispatch `CLEAR_SELECTED_BLOCK` even if no block is selected. While this should have no impact on the reducer value, it results in unnecessary noise (Redux DevTools), middlewares execution, and comparing whether a dispatch has resulted in a change.

__Testing instructions:__

Repeat testing instructions from #5543