### PR TITLE
Blocks: (Re-)enable selection of embed block by clicking

### DIFF
--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -71,7 +71,10 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 		edit: class extends Component {
 			constructor() {
 				super( ...arguments );
+
 				this.doServerSideRender = this.doServerSideRender.bind( this );
+				this.setIsSelected = this.setIsSelected.bind( this );
+
 				this.state = {
 					html: '',
 					type: '',
@@ -94,6 +97,10 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			componentWillUnmount() {
 				// can't abort the fetch promise, so let it know we will unmount
 				this.unmounting = true;
+			}
+
+			setIsSelected() {
+				this.props.setIsSelected( true );
 			}
 
 			getPhotoHtml( photo ) {
@@ -204,6 +211,7 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 							html={ html }
 							title={ iframeTitle }
 							type={ type }
+							onFocus={ this.setIsSelected }
 						/>
 					</div>
 				);

--- a/blocks/library/embed/index.js
+++ b/blocks/library/embed/index.js
@@ -73,7 +73,6 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 				super( ...arguments );
 
 				this.doServerSideRender = this.doServerSideRender.bind( this );
-				this.setIsSelected = this.setIsSelected.bind( this );
 
 				this.state = {
 					html: '',
@@ -97,10 +96,6 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 			componentWillUnmount() {
 				// can't abort the fetch promise, so let it know we will unmount
 				this.unmounting = true;
-			}
-
-			setIsSelected() {
-				this.props.setIsSelected( true );
 			}
 
 			getPhotoHtml( photo ) {
@@ -211,7 +206,6 @@ function getEmbedBlockSettings( { title, icon, category = 'embed', transforms, k
 							html={ html }
 							title={ iframeTitle }
 							type={ type }
-							onFocus={ this.setIsSelected }
 						/>
 					</div>
 				);

--- a/components/focusable-iframe/README.md
+++ b/components/focusable-iframe/README.md
@@ -1,11 +1,11 @@
 Focusable Iframe
 ================
 
-`<FocusableIframe />` is a component rendering an `iframe` element enhanced to support focus events. By default, it is not possible to detect when an iframe is focused or clicked within. This enhanced component uses a technique which checks whether the target of a window `blur` event is the iframe, inferring that this has resulted in the focus of the iframe.
+`<FocusableIframe />` is a component rendering an `iframe` element enhanced to support focus events. By default, it is not possible to detect when an iframe is focused or clicked within. This enhanced component uses a technique which checks whether the target of a window `blur` event is the iframe, inferring that this has resulted in the focus of the iframe. It dispatches an emulated [`FocusEvent`](https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent) on the iframe element with event bubbling, so a parent component binding its own `onFocus` event will account for focus transitioning within the iframe.
 
 ## Usage
 
-Use as you would a standard `iframe`, passing `onFocus` as the callback to be invoked when the iframe receives focus.
+Use as you would a standard `iframe`. You may pass `onFocus` directly as the callback to be invoked when the iframe receives focus, or on an ancestor component since the event will bubble.
 
 ```jsx
 import { FocusableIframe } from '@wordpress/components';
@@ -29,7 +29,7 @@ Any props aside from those listed below will be passed to the `FocusableIframe` 
 - Type: `Function`
 - Required: No
 
-Callback to invoke when iframe receives focus.
+Callback to invoke when iframe receives focus. Passes an emulated `FocusEvent` object as the first argument.
 
 ### `iframeRef`
 

--- a/components/focusable-iframe/README.md
+++ b/components/focusable-iframe/README.md
@@ -1,0 +1,39 @@
+Focusable Iframe
+================
+
+`<FocusableIframe />` is a component rendering an `iframe` element enhanced to support focus events. By default, it is not possible to detect when an iframe is focused or clicked within. This enhanced component uses a technique which checks whether the target of a window `blur` event is the iframe, inferring that this has resulted in the focus of the iframe.
+
+## Usage
+
+Use as you would a standard `iframe`, passing `onFocus` as the callback to be invoked when the iframe receives focus.
+
+```jsx
+import { FocusableIframe } from '@wordpress/components';
+
+function MyIframe() {
+	return (
+		<FocusableIframe
+			src="https://example.com"
+			onFocus={ /* ... */ }
+		/>
+	);
+}
+```
+
+## Props
+
+Any props aside from those listed below will be passed to the `FocusableIframe` will be passed through to the underlying `iframe` element.
+
+### `onFocus`
+
+- Type: `Function`
+- Required: No
+
+Callback to invoke when iframe receives focus.
+
+### `iframeRef`
+
+- Type: `wp.element.Ref`
+- Required: No
+
+If a reference to the underlying DOM element is needed, pass `iframeRef` as the result of a `wp.element.createRef` called from your component.

--- a/components/focusable-iframe/index.js
+++ b/components/focusable-iframe/index.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, createRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import withGlobalEvents from '../higher-order/with-global-events';
+
+class FocusableIframe extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.checkFocus = this.checkFocus.bind( this );
+
+		this.node = createRef();
+	}
+
+	/**
+	 * Checks whether the iframe is the activeElement, inferring that it has
+	 * then received focus, and calls the `onFocus` prop callback.
+	 */
+	checkFocus() {
+		const { onFocus } = this.props;
+		if ( onFocus && document.activeElement === this.node.current ) {
+			onFocus();
+		}
+	}
+
+	render() {
+		// Disable reason: The rendered iframe is a pass-through component,
+		// assigning props inherited from the rendering parent. It's the
+		// responsibility of the parent to assign a title.
+
+		/* eslint-disable jsx-a11y/iframe-has-title */
+		return (
+			<iframe
+				ref={ this.node }
+				{ ...omit( this.props, [ 'onFocus' ] ) }
+			/>
+		);
+		/* eslint-enable jsx-a11y/iframe-has-title */
+	}
+}
+
+export default withGlobalEvents( {
+	blur: 'checkFocus',
+} )( FocusableIframe );

--- a/components/focusable-iframe/index.js
+++ b/components/focusable-iframe/index.js
@@ -14,12 +14,12 @@ import { Component, createRef } from '@wordpress/element';
 import withGlobalEvents from '../higher-order/with-global-events';
 
 class FocusableIframe extends Component {
-	constructor() {
+	constructor( props ) {
 		super( ...arguments );
 
 		this.checkFocus = this.checkFocus.bind( this );
 
-		this.node = createRef();
+		this.node = props.iframeRef || createRef();
 	}
 
 	/**
@@ -42,7 +42,7 @@ class FocusableIframe extends Component {
 		return (
 			<iframe
 				ref={ this.node }
-				{ ...omit( this.props, [ 'onFocus' ] ) }
+				{ ...omit( this.props, [ 'iframeRef', 'onFocus' ] ) }
 			/>
 		);
 		/* eslint-enable jsx-a11y/iframe-has-title */

--- a/components/focusable-iframe/index.js
+++ b/components/focusable-iframe/index.js
@@ -13,6 +13,12 @@ import { Component, createRef } from '@wordpress/element';
  */
 import withGlobalEvents from '../higher-order/with-global-events';
 
+/**
+ * Browser dependencies
+ */
+
+const { FocusEvent } = window;
+
 class FocusableIframe extends Component {
 	constructor( props ) {
 		super( ...arguments );
@@ -27,9 +33,18 @@ class FocusableIframe extends Component {
 	 * then received focus, and calls the `onFocus` prop callback.
 	 */
 	checkFocus() {
+		const iframe = this.node.current;
+
+		if ( document.activeElement !== iframe ) {
+			return;
+		}
+
+		const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
+		iframe.dispatchEvent( focusEvent );
+
 		const { onFocus } = this.props;
-		if ( onFocus && document.activeElement === this.node.current ) {
-			onFocus();
+		if ( onFocus ) {
+			onFocus( focusEvent );
 		}
 	}
 

--- a/components/higher-order/with-global-events/README.md
+++ b/components/higher-order/with-global-events/README.md
@@ -1,0 +1,31 @@
+withGlobalEvents
+================
+
+`withGlobalEvents` is a higher-order component used to facilitate responding to global events, where one would otherwise use `window.addEventListener`.
+
+On behalf of the consuming developer, the higher-order component manages:
+
+- Unbinding when the component unmounts.
+- Binding at most a single event handler for the entire application.
+
+## Usage
+
+Pass an object where keys correspond to the DOM event type, the value the name of the method on the original component's instance which handles the event.
+
+```js
+import { withGlobalEvents } from '@wordpress/components';
+
+class ResizingComponent extends Component {
+	handleResize() {
+		// ...
+	}
+
+	render() {
+		// ...
+	}
+}
+
+export default withGlobalEvents( {
+	resize: 'handleResize',
+} )( ResizingComponent );
+```

--- a/components/higher-order/with-global-events/index.js
+++ b/components/higher-order/with-global-events/index.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Component,
+	createRef,
+	createHigherOrderComponent,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Listener from './listener';
+
+/**
+ * Listener instance responsible for managing document event handling.
+ *
+ * @type {Listener}
+ */
+const listener = new Listener();
+
+function withGlobalEvents( eventTypesToHandlers ) {
+	return createHigherOrderComponent( ( WrappedComponent ) => {
+		return class extends Component {
+			constructor() {
+				super( ...arguments );
+
+				this.handleEvent = this.handleEvent.bind( this );
+
+				this.ref = createRef();
+			}
+
+			componentDidMount() {
+				forEach( eventTypesToHandlers, ( handler, eventType ) => {
+					listener.add( eventType, this );
+				} );
+			}
+
+			componentWillUnmount() {
+				forEach( eventTypesToHandlers, ( handler, eventType ) => {
+					listener.remove( eventType, this );
+				} );
+			}
+
+			handleEvent( event ) {
+				const handler = eventTypesToHandlers[ event.type ];
+				if ( typeof this.ref.current[ handler ] === 'function' ) {
+					this.ref.current[ handler ]( event );
+				}
+			}
+
+			render() {
+				return <WrappedComponent ref={ this.ref } { ...this.props } />;
+			}
+		};
+	}, 'withGlobalEvents' );
+}
+
+export default withGlobalEvents;

--- a/components/higher-order/with-global-events/listener.js
+++ b/components/higher-order/with-global-events/listener.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { forEach, without } from 'lodash';
+
+/**
+ * Class responsible for orchestrating event handling on the global window,
+ * binding a single event to be shared across all handling instances, and
+ * removing the handler when no instances are listening for the event.
+ */
+class Listener {
+	constructor() {
+		this.listeners = {};
+
+		this.handleEvent = this.handleEvent.bind( this );
+	}
+
+	add( eventType, instance ) {
+		if ( ! this.listeners[ eventType ] ) {
+			// Adding first listener for this type, so bind event.
+			window.addEventListener( eventType, this.handleEvent );
+			this.listeners[ eventType ] = [];
+		}
+
+		this.listeners[ eventType ].push( instance );
+	}
+
+	remove( eventType, instance ) {
+		this.listeners[ eventType ] = without( this.listeners[ eventType ], instance );
+
+		if ( ! this.listeners[ eventType ].length ) {
+			// Removing last listener for this type, so unbind event.
+			window.removeEventListener( eventType, this.handleEvent );
+			delete this.listeners[ eventType ];
+		}
+	}
+
+	handleEvent( event ) {
+		forEach( this.listeners[ event.type ], ( instance ) => {
+			instance.handleEvent( event );
+		} );
+	}
+}
+
+export default Listener;

--- a/components/higher-order/with-global-events/test/index.js
+++ b/components/higher-order/with-global-events/test/index.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import withGlobalEvents from '../';
+import Listener from '../listener';
+
+jest.mock( '../listener', () => {
+	const ActualListener = require.requireActual( '../listener' ).default;
+
+	return class extends ActualListener {
+		constructor() {
+			super( ...arguments );
+
+			this.constructor._instance = this;
+
+			jest.spyOn( this, 'add' );
+			jest.spyOn( this, 'remove' );
+		}
+	};
+} );
+
+describe( 'withGlobalEvents', () => {
+	let wrapper;
+
+	class OriginalComponent extends Component {
+		handleResize( event ) {
+			this.props.onResize( event );
+		}
+
+		render() {
+			return <div>{ this.props.children }</div>;
+		}
+	}
+
+	beforeAll( () => {
+		jest.spyOn( OriginalComponent.prototype, 'handleResize' );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	afterEach( () => {
+		if ( wrapper ) {
+			wrapper.unmount();
+			wrapper = null;
+		}
+	} );
+
+	function mountEnhancedComponent( props ) {
+		const EnhancedComponent = withGlobalEvents( {
+			resize: 'handleResize',
+		} )( OriginalComponent );
+
+		wrapper = mount( <EnhancedComponent { ...props }>Hello</EnhancedComponent> );
+	}
+
+	it( 'renders with original component', () => {
+		mountEnhancedComponent();
+
+		expect( wrapper.childAt( 0 ).childAt( 0 ).type() ).toBe( 'div' );
+		expect( wrapper.childAt( 0 ).text() ).toBe( 'Hello' );
+	} );
+
+	it( 'binds events from passed object', () => {
+		mountEnhancedComponent();
+
+		expect( Listener._instance.add ).toHaveBeenCalledWith( 'resize', wrapper.instance() );
+	} );
+
+	it( 'handles events', () => {
+		const onResize = jest.fn();
+
+		mountEnhancedComponent( { onResize } );
+
+		const event = { type: 'resize' };
+
+		Listener._instance.handleEvent( event );
+
+		expect( OriginalComponent.prototype.handleResize ).toHaveBeenCalledWith( event );
+		expect( onResize ).toHaveBeenCalledWith( event );
+	} );
+} );

--- a/components/higher-order/with-global-events/test/listener.js
+++ b/components/higher-order/with-global-events/test/listener.js
@@ -1,0 +1,87 @@
+/**
+ * Internal dependencies
+ */
+import Listener from '../listener';
+
+describe( 'Listener', () => {
+	const createHandler = () => ( { handleEvent: jest.fn() } );
+
+	let listener, _addEventListener, _removeEventListener;
+	beforeAll( () => {
+		_addEventListener = global.window.addEventListener;
+		_removeEventListener = global.window.removeEventListener;
+		global.window.addEventListener = jest.fn();
+		global.window.removeEventListener = jest.fn();
+	} );
+
+	beforeEach( () => {
+		listener = new Listener();
+		jest.clearAllMocks();
+	} );
+
+	afterAll( () => {
+		global.window.addEventListener = _addEventListener;
+		global.window.removeEventListener = _removeEventListener;
+	} );
+
+	describe( '#add()', () => {
+		it( 'adds an event listener on first listener', () => {
+			listener.add( 'resize', createHandler() );
+
+			expect( window.addEventListener ).toHaveBeenCalledWith( 'resize', expect.any( Function ) );
+		} );
+
+		it( 'does not add event listener on subsequent listeners', () => {
+			listener.add( 'resize', createHandler() );
+			listener.add( 'resize', createHandler() );
+
+			expect( window.addEventListener ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( '#remove()', () => {
+		it( 'removes an event listener on last listener', () => {
+			const handler = createHandler();
+			listener.add( 'resize', handler );
+			listener.remove( 'resize', handler );
+
+			expect( window.removeEventListener ).toHaveBeenCalledWith( 'resize', expect.any( Function ) );
+		} );
+
+		it( 'does not remove event listener on remaining listeners', () => {
+			const firstHandler = createHandler();
+			const secondHandler = createHandler();
+			listener.add( 'resize', firstHandler );
+			listener.add( 'resize', secondHandler );
+			listener.remove( 'resize', firstHandler );
+
+			expect( window.removeEventListener ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( '#handleEvent()', () => {
+		it( 'calls concerned listeners', () => {
+			const handler = createHandler();
+			listener.add( 'resize', handler );
+
+			const event = { type: 'resize' };
+
+			listener.handleEvent( event );
+
+			expect( handler.handleEvent ).toHaveBeenCalledWith( event );
+		} );
+
+		it( 'calls all added handlers', () => {
+			const handler = createHandler();
+			listener.add( 'resize', handler );
+			listener.add( 'resize', handler );
+			listener.add( 'resize', handler );
+
+			const event = { type: 'resize' };
+
+			listener.handleEvent( event );
+
+			expect( handler.handleEvent ).toHaveBeenCalledTimes( 3 );
+		} );
+	} );
+} );

--- a/components/index.js
+++ b/components/index.js
@@ -16,6 +16,7 @@ export { default as DropZoneProvider } from './drop-zone/provider';
 export { default as Dropdown } from './dropdown';
 export { default as DropdownMenu } from './dropdown-menu';
 export { default as ExternalLink } from './external-link';
+export { default as FocusableIframe } from './focusable-iframe';
 export { default as FormFileUpload } from './form-file-upload';
 export { default as FormToggle } from './form-toggle';
 export { default as FormTokenField } from './form-token-field';

--- a/components/index.js
+++ b/components/index.js
@@ -60,6 +60,7 @@ export { default as withFallbackStyles } from './higher-order/with-fallback-styl
 export { default as withFilters } from './higher-order/with-filters';
 export { default as withFocusOutside } from './higher-order/with-focus-outside';
 export { default as withFocusReturn } from './higher-order/with-focus-return';
+export { default as withGlobalEvents } from './higher-order/with-global-events';
 export { default as withInstanceId } from './higher-order/with-instance-id';
 export { default as withSafeTimeout } from './higher-order/with-safe-timeout';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -180,13 +180,12 @@ class Sandbox extends Component {
 	}
 
 	render() {
-		const { title, onFocus } = this.props;
+		const { title } = this.props;
 
 		return (
 			<FocusableIframe
 				iframeRef={ this.iframe }
 				title={ title }
-				onFocus={ onFocus }
 				scrolling="no"
 				sandbox="allow-scripts allow-same-origin allow-presentation"
 				onLoad={ this.trySandbox }

--- a/components/sandbox/index.js
+++ b/components/sandbox/index.js
@@ -7,8 +7,9 @@ import { Component, renderToString, createRef } from '@wordpress/element';
  * Internal dependencies
  */
 import FocusableIframe from '../focusable-iframe';
+import withGlobalEvents from '../higher-order/with-global-events';
 
-export default class Sandbox extends Component {
+class Sandbox extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -24,16 +25,11 @@ export default class Sandbox extends Component {
 	}
 
 	componentDidMount() {
-		window.addEventListener( 'message', this.checkMessageForResize, false );
 		this.trySandbox();
 	}
 
 	componentDidUpdate() {
 		this.trySandbox();
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'message', this.checkMessageForResize );
 	}
 
 	isFrameAccessible() {
@@ -199,3 +195,9 @@ export default class Sandbox extends Component {
 		);
 	}
 }
+
+Sandbox = withGlobalEvents( {
+	message: 'checkMessageForResize',
+} )( Sandbox );
+
+export default Sandbox;

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -62,7 +62,6 @@ export class BlockListBlock extends Component {
 		this.setBlockListRef = this.setBlockListRef.bind( this );
 		this.bindBlockNode = this.bindBlockNode.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
-		this.setIsSelected = this.setIsSelected.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
 		this.hideHoverEffects = this.hideHoverEffects.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
@@ -206,27 +205,6 @@ export class BlockListBlock extends Component {
 				...this.props.meta,
 				...metaAttributes,
 			} );
-		}
-	}
-
-	/**
-	 * Sets a block as selected or unselected, if not already in the intended
-	 * condition.
-	 *
-	 * @param {boolean} nextIsSelected Whether block is to be selected.
-	 */
-	setIsSelected( nextIsSelected = true ) {
-		const { isSelected, onSelect, onDeselect } = this.props;
-
-		// No need to act if already in desired condition.
-		if ( isSelected === nextIsSelected ) {
-			return;
-		}
-
-		if ( nextIsSelected ) {
-			onSelect();
-		} else {
-			onDeselect();
 		}
 	}
 
@@ -575,7 +553,6 @@ export class BlockListBlock extends Component {
 							<BlockEdit
 								name={ blockName }
 								isSelected={ isSelected }
-								setIsSelected={ this.setIsSelected }
 								attributes={ block.attributes }
 								setAttributes={ this.setAttributes }
 								insertBlocksAfter={ isLocked ? undefined : this.insertBlocksAfter }
@@ -669,7 +646,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 	const {
 		updateBlockAttributes,
 		selectBlock,
-		clearSelectedBlock,
 		insertBlocks,
 		removeBlock,
 		mergeBlocks,
@@ -709,7 +685,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		toggleSelection( selectionEnabled ) {
 			toggleSelection( selectionEnabled );
 		},
-		onDeselect: clearSelectedBlock,
 	};
 } );
 

--- a/editor/components/block-list/block.js
+++ b/editor/components/block-list/block.js
@@ -62,6 +62,7 @@ export class BlockListBlock extends Component {
 		this.setBlockListRef = this.setBlockListRef.bind( this );
 		this.bindBlockNode = this.bindBlockNode.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
+		this.setIsSelected = this.setIsSelected.bind( this );
 		this.maybeHover = this.maybeHover.bind( this );
 		this.hideHoverEffects = this.hideHoverEffects.bind( this );
 		this.mergeBlocks = this.mergeBlocks.bind( this );
@@ -205,6 +206,27 @@ export class BlockListBlock extends Component {
 				...this.props.meta,
 				...metaAttributes,
 			} );
+		}
+	}
+
+	/**
+	 * Sets a block as selected or unselected, if not already in the intended
+	 * condition.
+	 *
+	 * @param {boolean} nextIsSelected Whether block is to be selected.
+	 */
+	setIsSelected( nextIsSelected = true ) {
+		const { isSelected, onSelect, onDeselect } = this.props;
+
+		// No need to act if already in desired condition.
+		if ( isSelected === nextIsSelected ) {
+			return;
+		}
+
+		if ( nextIsSelected ) {
+			onSelect();
+		} else {
+			onDeselect();
 		}
 	}
 
@@ -553,6 +575,7 @@ export class BlockListBlock extends Component {
 							<BlockEdit
 								name={ blockName }
 								isSelected={ isSelected }
+								setIsSelected={ this.setIsSelected }
 								attributes={ block.attributes }
 								setAttributes={ this.setAttributes }
 								insertBlocksAfter={ isLocked ? undefined : this.insertBlocksAfter }
@@ -646,6 +669,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 	const {
 		updateBlockAttributes,
 		selectBlock,
+		clearSelectedBlock,
 		insertBlocks,
 		removeBlock,
 		mergeBlocks,
@@ -653,6 +677,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		editPost,
 		toggleSelection,
 	} = dispatch( 'core/editor' );
+
 	return {
 		onChange( uid, attributes ) {
 			updateBlockAttributes( uid, attributes );
@@ -684,6 +709,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		toggleSelection( selectionEnabled ) {
 			toggleSelection( selectionEnabled );
 		},
+		onDeselect: clearSelectedBlock,
 	};
 } );
 

--- a/element/index.js
+++ b/element/index.js
@@ -1,7 +1,15 @@
 /**
  * External dependencies
  */
-import { createContext, createElement, Component, cloneElement, Children, Fragment } from 'react';
+import {
+	createElement,
+	createContext,
+	createRef,
+	Component,
+	cloneElement,
+	Children,
+	Fragment,
+} from 'react';
 import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
 import {
 	camelCase,
@@ -33,6 +41,15 @@ import serialize from './serialize';
  * @return {WPElement} Element.
  */
 export { createElement };
+
+/**
+ * Returns an object tracking a reference to a rendered element via its
+ * `current` property as either a DOMElement or Element, dependent upon the
+ * type of element rendered with the ref attribute.
+ *
+ * @return {Object} Ref object.
+ */
+export { createRef };
 
 /**
  * Renders a given element into the target DOM node.


### PR DESCRIPTION
Closes #5589
Related: #483

This pull request seeks to restore behaviors of embed click-to-select, originally implemented in #4011 and later regressing in #4872. In doing so, it adds a new function property passed to a block to allow a developer to programmatically select or deselect the block. This, in combination with a new `FocusableIframe` component, is leveraged to allow the embed block to be selected when its iframe receives focus.

- [View `FocusableIframe` Documentation](https://github.com/WordPress/gutenberg/blob/91b0b90ff80bcb65b031402853efff2e4a0621ff/components/focusable-iframe/README.md)
- [View `withGlobalEvents` Documentation](https://github.com/WordPress/gutenberg/blob/91b0b90ff80bcb65b031402853efff2e4a0621ff/components/higher-order/with-global-events/README.md)

__Testing instructions:__

Repeat testing instructions from #4011