### PR TITLE
Fixed help text position on toggle control and range control.

### DIFF
--- a/components/base-control/index.js
+++ b/components/base-control/index.js
@@ -11,8 +11,10 @@ import './style.scss';
 function BaseControl( { id, label, help, className, children } ) {
 	return (
 		<div className={ classnames( 'components-base-control', className ) }>
-			{ label && <label className="components-base-control__label" htmlFor={ id }>{ label }</label> }
-			{ children }
+			<div className="components-base-control__field">
+				{ label && <label className="components-base-control__label" htmlFor={ id }>{ label }</label> }
+				{ children }
+			</div>
 			{ !! help && <p id={ id + '__help' } className="components-base-control__help">{ help }</p> }
 		</div>
 	);

--- a/components/range-control/style.scss
+++ b/components/range-control/style.scss
@@ -1,8 +1,11 @@
+
 .components-range-control {
-	display: flex;
-	justify-content: center;
-	flex-wrap: wrap;
-	align-items: center;
+	.components-base-control__field {
+		display: flex;
+		justify-content: center;
+		flex-wrap: wrap;
+		align-items: center;
+	}
 
 	.dashicon {
 		flex-shrink: 0;

--- a/components/toggle-control/style.scss
+++ b/components/toggle-control/style.scss
@@ -1,4 +1,4 @@
-.components-toggle-control {
+.components-toggle-control .components-base-control__field {
 	display: flex;
 	justify-content: space-between;
 }


### PR DESCRIPTION
Help text appeared on the line instead of below the control as in all the other controls.

Fixes: https://github.com/WordPress/gutenberg/issues/5498

## How Has This Been Tested?
Verify our controls still work as expected, e.g: user the inspector of the latest posts, button paragraph etc..

## Screenshots (jpeg or gifs if applicable):
These components were added in the same place so we can see them all.
Before:
Help text appears incorrectly in the toggle and range controls.
![image](https://user-images.githubusercontent.com/11271197/37723059-5a3f4990-2d25-11e8-8f5e-9896835836d8.png)
Help text appears correctly in the toggle and range controls and no other noticeable change exists:
![image](https://user-images.githubusercontent.com/11271197/37723125-8c418bce-2d25-11e8-90db-6559793f1b26.png)

