### PR TITLE
Make Popover initial focus work with screen readers.

### DIFF
--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { defer, isEqual, noop } from 'lodash';
+import { isEqual, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,19 +18,6 @@ import withFocusReturn from '../higher-order/with-focus-return';
 import PopoverDetectOutside from './detect-outside';
 import IconButton from '../icon-button';
 import { Slot, Fill } from '../slot-fill';
-
-/**
- * Value representing whether a key is currently pressed. Bound to the document
- * for use in determining whether the Popover component has mounted in response
- * to a keyboard event. Popover's focusOnMount behavior is specific to keyboard
- * interaction. Must be bound at the top-level and its unsetting deferred since
- * the component will have already mounted by the time keyup occurs.
- *
- * @type {boolean}
- */
-let isKeyDown = false;
-document.addEventListener( 'keydown', () => isKeyDown = true );
-document.addEventListener( 'keyup', defer.bind( null, () => isKeyDown = false ) );
 
 const FocusManaged = withFocusReturn( ( { children } ) => children );
 
@@ -107,7 +94,7 @@ class Popover extends Component {
 
 	focus() {
 		const { focusOnMount = true } = this.props;
-		if ( ! focusOnMount || ! isKeyDown ) {
+		if ( ! focusOnMount ) {
 			return;
 		}
 

--- a/components/popover/test/index.js
+++ b/components/popover/test/index.js
@@ -83,12 +83,6 @@ describe( 'Popover', () => {
 			expect( document.activeElement ).toBe( content );
 		} );
 
-		it( 'should not focus when opening in response to pointer event', () => {
-			wrapper = mount( <Popover /> );
-
-			expect( document.activeElement ).toBe( document.body );
-		} );
-
 		it( 'should allow focus-on-open behavior to be disabled', () => {
 			const activeElement = document.activeElement;
 


### PR DESCRIPTION
Te current implementation of the initial focus in the Popover component doesn't work when a screen reader is running. Screen readers intercept key presses, and they pass them back to the browsers only in specific circumstances. For example, when in "forms mode", or when in an ARIA widget with a specific ARIA role that expects specific keyboard events to happen.

In most of the other cases the browser is unaware a keyboard event has happened. In this specific case, this prevents the initial focus to be correctly set on the Popover component.

For more details and testing, please refer to the related issue, particularly to this comment: https://github.com/WordPress/gutenberg/issues/5559#issuecomment-375032497

Also, as noted in the related issue, many users are not exclusively "mouse users" or "keyboard users". Implementing the initial focus in a way that works only when there's the assumption a keyboard is being used wouldn't serve well users who make a mixed use of mouse and keyboard, or other devices.

Note: the patch removes a related test.

Fixes #5559