### PR TITLE
Fixed image href attribute matcher to not interfere with anchors inside the caption

### DIFF
--- a/blocks/library/image/index.js
+++ b/blocks/library/image/index.js
@@ -35,7 +35,7 @@ const blockAttributes = {
 	href: {
 		type: 'string',
 		source: 'attribute',
-		selector: 'a',
+		selector: 'figure > a',
 		attribute: 'href',
 	},
 	id: {


### PR DESCRIPTION
The href attribute was selecting any anchor attribute inside the image block. So anchors inside captions were being parsed as href attribute then the markup with that attribute was used for block validation,  so the block becomes invalid.
Now we select the first anchor inside the figure so anchors inside caption are not used as href attribute.

Fixes: https://github.com/WordPress/gutenberg/issues/5648
Props to @nikolov-tmw for extensively describing and reporting the issue.

## How Has This Been Tested?
Add an image block, add a caption to it and add a link in the caption. Save the post reload. Verify everything went ok, in master the post become invalid.

Past the following as plain text save and verift the post is valid.
```
<!-- wp:image -->
<figure class="wp-block-image"><img src="http://via.placeholder.com/350x150" alt="" />
    <figcaption>Wow <strong>caption</strong> <a href="http://www.example.com">example</a></figcaption>
</figure>
<!-- /wp:image -->
```
