### PR TITLE
RangeControl input width 100px

### DIFF
--- a/components/range-control/style.scss
+++ b/components/range-control/style.scss
@@ -16,6 +16,7 @@
 	.components-range-control__slider {
 		margin-left: 0;
 		flex: 1;
+		width: 100px;
 	}
 }
 


### PR DESCRIPTION
`.components-range-control__slider` should atleast be `100px` wide.

## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
Just browsing through some block settings and testing `RangeControl`s

## Screenshots (jpeg or gifs if applicable):

Before fix:
![image](https://user-images.githubusercontent.com/11048263/37731396-f62a8c9c-2d67-11e8-9e27-bc9c61022c83.png)

After fix:
![image](https://user-images.githubusercontent.com/11048263/37732285-9d46e096-2d6a-11e8-9b05-4d11a5f3e04c.png)


## Types of changes
Simple CSS change to make sure range control doesn't collapse to `0px` width.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
