### PR TITLE
Skip setup if a role is not available, fixing a potentail PHP fatal

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -410,6 +410,11 @@ function gutenberg_register_post_types() {
 
 	foreach ( $caps_map as $role_name => $caps ) {
 		$role = get_role( $role_name );
+
+		if ( empty( $role ) ) {
+			continue;
+		}
+
 		foreach ( $caps as $cap ) {
 			if ( ! $role->has_cap( $cap ) ) {
 				$role->add_cap( $cap );


### PR DESCRIPTION
## Description
Exit early during role setup if a role is not available. 

Fixes https://github.com/WordPress/gutenberg/issues/5617

## How Has This Been Tested?
In your local install, remove the contributor user role: `wp role delete contributor`
load a page in wp-admin, before the change you will get a PHP fatal.

## Screenshots (jpeg or gifs if applicable):
![](https://cl.ly/0W1O1V432Z33/Image%202018-03-21%20at%203.58.26%20PM.png)


## Types of changes
Add a check to see if get_role returned an empty value, which is what it does if the role you pass it does not exist.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
