### PR TITLE
Fixed crash when postType does not supports title & Removed title UI 

### DIFF
--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -18,6 +18,7 @@ import { KeyboardShortcuts, withContext, withInstanceId, withFocusOutside } from
  */
 import './style.scss';
 import PostPermalink from '../post-permalink';
+import PostTypeSupportCheck from '../post-type-support-check';
 
 /**
  * Constants
@@ -92,29 +93,31 @@ class PostTitle extends Component {
 		const decodedPlaceholder = decodeEntities( placeholder );
 
 		return (
-			<div className={ className }>
-				{ isSelected && <PostPermalink /> }
-				<KeyboardShortcuts
-					shortcuts={ {
-						'mod+z': this.redirectHistory,
-						'mod+shift+z': this.redirectHistory,
-					} }
-				>
-					<label htmlFor={ `post-title-${ instanceId }` } className="screen-reader-text">
-						{ decodedPlaceholder || __( 'Add title' ) }
-					</label>
-					<Textarea
-						id={ `post-title-${ instanceId }` }
-						className="editor-post-title__input"
-						value={ title }
-						onChange={ this.onChange }
-						placeholder={ decodedPlaceholder || __( 'Add title' ) }
-						onFocus={ this.onSelect }
-						onKeyDown={ this.onKeyDown }
-						onKeyPress={ this.onUnselect }
-					/>
-				</KeyboardShortcuts>
-			</div>
+			<PostTypeSupportCheck supportKeys="title">
+				<div className={ className }>
+					{ isSelected && <PostPermalink /> }
+					<KeyboardShortcuts
+						shortcuts={ {
+							'mod+z': this.redirectHistory,
+							'mod+shift+z': this.redirectHistory,
+						} }
+					>
+						<label htmlFor={ `post-title-${ instanceId }` } className="screen-reader-text">
+							{ decodedPlaceholder || __( 'Add title' ) }
+						</label>
+						<Textarea
+							id={ `post-title-${ instanceId }` }
+							className="editor-post-title__input"
+							value={ title }
+							onChange={ this.onChange }
+							placeholder={ decodedPlaceholder || __( 'Add title' ) }
+							onFocus={ this.onSelect }
+							onKeyDown={ this.onKeyDown }
+							onKeyPress={ this.onUnselect }
+						/>
+					</KeyboardShortcuts>
+				</div>
+			</PostTypeSupportCheck>
 		);
 	}
 }

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -300,7 +300,7 @@ export function isEditedPostBeingScheduled( state ) {
 export function getDocumentTitle( state ) {
 	let title = getEditedPostAttribute( state, 'title' );
 
-	if ( ! title.trim() ) {
+	if ( ! title || ! title.trim() ) {
 		title = isCleanNewPost( state ) ? __( 'New post' ) : __( '(Untitled)' );
 	}
 	return title;


### PR DESCRIPTION
The selector getDocumentTitle did not check for null/undefined titles. That was the reason for the crash.
PostTypeSupportCheck was added to PostTitle component in order for it not to render when the title is not supported.

Fixes: https://github.com/WordPress/gutenberg/issues/5621.

## How Has This Been Tested?
Add a CPT that does not support title e.g:
```
function create_product_type() {
    register_post_type( 'acme_product',
        array(
	    'label'  => 'Product',
            'labels' => array(
                'name' => __( 'Products' ),
                'singular_name' => __( 'Product' )
            ),
            'public' => true,
            'show_in_rest' => true,
            'supports' => array( 'editor' ),
        )
    );
}
add_action( 'init', 'create_product_type' );
```
Create a new post, see that title field does not appear.
Save the post and open it. See no crash happens, in master editor would crash.

