### PR TITLE
Add a shim to override wp.apiRequest, allowing HTTP/1.0 emulation

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -614,12 +614,6 @@ JS;
 			wp_json_encode( $schema_response->get_data() )
 		), 'before' );
 	}
-
-	/*
-	 * For API requests to happen over HTTP/1.0 methods,
-	 * as HTTP/1.1 methods are blocked in a variety of situations.
-	 */
-	wp_add_inline_script( 'wp-api', 'Backbone.emulateHTTP = true;', 'before' );
 }
 
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -117,7 +117,7 @@ function gutenberg_shim_api_request_emulate_http( $scripts ) {
 		if ( options.method ) {
 			if ( [ 'PATCH', 'PUT', 'DELETE' ].indexOf( options.method.toUpperCase() ) >= 0 ) {
 				if ( ! options.headers ) {
-					options.headers = [];
+					options.headers = {};
 				}
 				options.headers['X-HTTP-Method-Override'] = options.method;
 				options.method = 'POST';

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -117,7 +117,7 @@ function gutenberg_shim_api_request_emulate_http( $scripts ) {
 				if ( ! options.headers ) {
 					options.headers = [];
 				}
-				options.headers.push( 'X-HTTP-Method-Override: ' + options.method );
+				options.headers['X-HTTP-Method-Override'] = options.method;
 				options.method = 'POST';
 			}
 		}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -105,6 +105,8 @@ add_action( 'wp_default_scripts', 'gutenberg_shim_fix_api_request_plain_permalin
 /**
  * Shims support for emulating HTTP/1.0 requests in wp.apiRequest
  *
+ * @see https://core.trac.wordpress.org/ticket/43605
+ *
  * @param WP_Scripts $scripts WP_Scripts instance (passed by reference).
  */
 function gutenberg_shim_api_request_emulate_http( $scripts ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -115,7 +115,7 @@ function gutenberg_shim_api_request_emulate_http( $scripts ) {
 	var oldApiRequest = wp.apiRequest;
 	wp.apiRequest = function ( options ) {
 		if ( options.method ) {
-			if( [ 'GET', 'PUT', 'DELETE' ].indexOf( options.method.toUpperCase() ) >= 0 ) {
+			if ( [ 'GET', 'PUT', 'DELETE' ].indexOf( options.method.toUpperCase() ) >= 0 ) {
 				if ( ! options.headers ) {
 					options.headers = [];
 				}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -103,6 +103,35 @@ JS;
 add_action( 'wp_default_scripts', 'gutenberg_shim_fix_api_request_plain_permalinks' );
 
 /**
+ * Shims support for emulating HTTP/1.0 requests in wp.apiRequest
+ *
+ * @param WP_Scripts $scripts WP_Scripts instance (passed by reference).
+ */
+function gutenberg_shim_api_request_emulate_http( $scripts ) {
+	$api_request_fix = <<<JS
+( function( wp ) {
+	var oldApiRequest = wp.apiRequest;
+	wp.apiRequest = function ( options ) {
+		if ( options.method ) {
+			if( [ 'GET', 'PUT', 'DELETE' ].indexOf( options.method.toUpperCase() ) >= 0 ) {
+				if ( ! options.headers ) {
+					options.headers = [];
+				}
+				options.headers.push( 'X-HTTP-Method-Override: ' + options.method );
+				options.method = 'POST';
+			}
+		}
+
+		return oldApiRequest( options );
+	}
+} )( window.wp );
+JS;
+
+	$scripts->add_inline_script( 'wp-api-request', $api_request_fix, 'after' );
+}
+add_action( 'wp_default_scripts', 'gutenberg_shim_api_request_emulate_http' );
+
+/**
  * Disables wpautop behavior in classic editor when post contains blocks, to
  * prevent removep from invalidating paragraph blocks.
  *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -115,7 +115,7 @@ function gutenberg_shim_api_request_emulate_http( $scripts ) {
 	var oldApiRequest = wp.apiRequest;
 	wp.apiRequest = function ( options ) {
 		if ( options.method ) {
-			if ( [ 'GET', 'PUT', 'DELETE' ].indexOf( options.method.toUpperCase() ) >= 0 ) {
+			if ( [ 'PATCH', 'PUT', 'DELETE' ].indexOf( options.method.toUpperCase() ) >= 0 ) {
 				if ( ! options.headers ) {
 					options.headers = [];
 				}


### PR DESCRIPTION
## Description

#4396 switched API requests to using HTTP/1.0, using Backbone's `emulateHTTP` setting. #5253 changed to using `wp.apiRequests()` for API requests, which uses jQuery. Unfortunately, jQuery doesn't have a setting similar to `emulateHTTP`, so we need to manually do it, instead.

It seems that a lot of web application firewalls have stricter rules for `PUT` requests, so the merge of #5253 manifests itself as posts sporadically failing to save. For example: #5675, #5632, #5660.

I've also opened a [core ticket](https://core.trac.wordpress.org/ticket/43605) to address this behaviour.

## How Has This Been Tested?

Using your browser's dev tools, watch the network requests, and confirm that the save request for a post is sent as a `POST`, with the `X-HTTP-Method-Override: PUT` header. The post should save correctly.

If you have a WAF that currently blocks saving posts in Gutenberg 2.4, this PR should fix that behaviour.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
