### PR TITLE
Try library polish

### DIFF
--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -108,7 +108,6 @@ input[type="search"].editor-inserter__search {
 	&:not(:disabled) {
 		&:hover {
 			@include button-style__hover;
-			//outline: 1px solid $light-gray-500;
 		}
 
 		&:focus,

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -30,7 +30,7 @@ input[type="search"].editor-inserter__search {
 	display: block;
 	width: 100%;
 	margin: 0;
-	padding: 8px 16px;
+	padding: 11px 16px;
 	position: relative;
 	z-index: 1;
 	border: none;
@@ -83,16 +83,23 @@ input[type="search"].editor-inserter__search {
 .editor-inserter__block {
 	display: flex;
 	flex-direction: column;
-	width: 33%;
-	border-radius: $button-style__radius-roundrect;
+	width: calc( 33% - 6px );
+	margin: 3px;
 	font-size: $default-font-size;
 	color: $dark-gray-500;
-	padding: 12px;
+	padding: 4px 12px;
 	align-items: center;
+	justify-content: center;
 	cursor: pointer;
 	border: none;
-	line-height: 20px;
+	line-height: 1em;
 	background: transparent;
+	outline: 1px solid $light-gray-200;
+	min-height: 5em;
+
+	.dashicon {
+		margin-bottom: 3px;
+	}
 
 	&:disabled {
 		@include button-style__disabled;
@@ -101,6 +108,7 @@ input[type="search"].editor-inserter__search {
 	&:not(:disabled) {
 		&:hover {
 			@include button-style__hover;
+			//outline: 1px solid $light-gray-500;
 		}
 
 		&:focus,
@@ -137,7 +145,7 @@ input[type="search"].editor-inserter__search {
 	display: block;
 	text-align: center;
 	font-style: italic;
-	padding: 8px;
+	padding: 24px;
 }
 
 .editor-inserter__tabs {
@@ -170,7 +178,7 @@ input[type="search"].editor-inserter__search {
 		display: flex;
 		justify-content: space-between;
 		position: relative;
-		background: $light-gray-300;
+		background: $light-gray-100;
 		border-bottom: 1px solid $light-gray-500;
 		flex-shrink: 0;
 		margin-top: 1px;

--- a/editor/components/inserter/style.scss
+++ b/editor/components/inserter/style.scss
@@ -83,11 +83,11 @@ input[type="search"].editor-inserter__search {
 .editor-inserter__block {
 	display: flex;
 	flex-direction: column;
-	width: calc( 33% - 6px );
-	margin: 3px;
+	width: calc( 33% - 8px );
+	margin: 4px;
 	font-size: $default-font-size;
 	color: $dark-gray-500;
-	padding: 4px 12px;
+	padding: 8px 4px;
 	align-items: center;
 	justify-content: center;
 	cursor: pointer;
@@ -96,6 +96,8 @@ input[type="search"].editor-inserter__search {
 	background: transparent;
 	outline: 1px solid $light-gray-200;
 	min-height: 5em;
+	overflow: hidden;
+	word-break: break-word;
 
 	.dashicon {
 		margin-bottom: 3px;


### PR DESCRIPTION
This polishes the library aka "the inserter", per some design suggestions by @karmatosed:

- Tab bg is softer to make it feel more connected
- Blocks have a border even without being hovered, to create a connection with blocks that are inserted
- Blocks have better vertical heights so blocks like "Columns (Experimental)" that wrap two lines don't affect adjecent block heights
- Search bar has same height as tabbar
- No blocks found message is prettier

![library](https://user-images.githubusercontent.com/1204802/37762368-5ea59268-2dbc-11e8-9fcf-df3235599e09.gif)
