### PR TITLE
Move Post Types Data Fetching to the core-data module

### DIFF
--- a/core-data/actions.js
+++ b/core-data/actions.js
@@ -50,3 +50,17 @@ export function receiveMedia( media ) {
 		media: castArray( media ),
 	};
 }
+
+/**
+ * Returns an action object used in signalling that post types have been received.
+ *
+ * @param {Array|Object} postTypes Post Types received.
+ *
+ * @return {Object} Action object.
+ */
+export function receivePostTypes( postTypes ) {
+	return {
+		type: 'RECEIVE_POST_TYPES',
+		postTypes: castArray( postTypes ),
+	};
+}

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -62,7 +62,28 @@ export function media( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Reducer managing post types state. Keyed by slug.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {string} Updated state.
+ */
+export function postTypes( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_POST_TYPES':
+			return {
+				...state,
+				...keyBy( action.postTypes, 'slug' ),
+			};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	terms,
 	media,
+	postTypes,
 } );

--- a/core-data/reducer.js
+++ b/core-data/reducer.js
@@ -17,7 +17,7 @@ import { combineReducers } from '@wordpress/data';
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @return {string} Updated state.
+ * @return {Object} Updated state.
  */
 export function terms( state = {}, action ) {
 	switch ( action.type ) {
@@ -48,7 +48,7 @@ export function terms( state = {}, action ) {
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @return {string} Updated state.
+ * @return {Object} Updated state.
  */
 export function media( state = {}, action ) {
 	switch ( action.type ) {
@@ -68,7 +68,7 @@ export function media( state = {}, action ) {
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @return {string} Updated state.
+ * @return {Object} Updated state.
  */
 export function postTypes( state = {}, action ) {
 	switch ( action.type ) {

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -6,7 +6,12 @@ import apiRequest from '@wordpress/api-request';
 /**
  * Internal dependencies
  */
-import { setRequested, receiveTerms, receiveMedia } from './actions';
+import {
+	setRequested,
+	receiveTerms,
+	receiveMedia,
+	receivePostTypes,
+} from './actions';
 
 /**
  * Requests categories from the REST API, yielding action objects on request
@@ -27,4 +32,15 @@ export async function* getCategories() {
 export async function* getMedia( state, id ) {
 	const media = await apiRequest( { path: `/wp/v2/media/${ id }` } );
 	yield receiveMedia( media );
+}
+
+/**
+ * Requests a post type element from the REST API.
+ *
+ * @param {Object} state State tree
+ * @param {number} slug  Post Type slug
+ */
+export async function* getPostType( state, slug ) {
+	const postType = await apiRequest( { path: `/wp/v2/types/${ slug }?context=edit` } );
+	yield receivePostTypes( postType );
 }

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -57,3 +57,15 @@ export function isRequestingCategories( state ) {
 export function getMedia( state, id ) {
 	return state.media[ id ];
 }
+
+/**
+ * Returns the Post Type object by slug.
+ *
+ * @param {Object} state Data state.
+ * @param {number} slug  Post Type slug.
+ *
+ * @return {Object?}     Post Type object.
+ */
+export function getPostType( state, slug ) {
+	return state.postTypes[ slug ];
+}

--- a/core-data/test/reducer.js
+++ b/core-data/test/reducer.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { terms, media } from '../reducer';
+import { terms, media, postTypes } from '../reducer';
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -85,6 +85,27 @@ describe( 'media', () => {
 		expect( state ).toEqual( {
 			1: { id: 1, title: 'beach' },
 			2: { id: 2, title: 'sun' },
+		} );
+	} );
+} );
+
+describe( 'postTypes', () => {
+	it( 'returns an empty object by default', () => {
+		const state = postTypes( undefined, {} );
+
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns with received post types by slug', () => {
+		const originalState = deepFreeze( {} );
+		const state = postTypes( originalState, {
+			type: 'RECEIVE_POST_TYPES',
+			postTypes: [ { slug: 'b', title: 'beach' }, { slug: 's', title: 'sun' } ],
+		} );
+
+		expect( state ).toEqual( {
+			b: { slug: 'b', title: 'beach' },
+			s: { slug: 's', title: 'sun' },
 		} );
 	} );
 } );

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -6,8 +6,8 @@ import apiRequest from '@wordpress/api-request';
 /**
  * Internal dependencies
  */
-import { getCategories, getMedia } from '../resolvers';
-import { setRequested, receiveTerms, receiveMedia } from '../actions';
+import { getCategories, getMedia, getPostType } from '../resolvers';
+import { setRequested, receiveTerms, receiveMedia, receivePostTypes } from '../actions';
 
 jest.mock( '@wordpress/api-request' );
 
@@ -46,5 +46,23 @@ describe( 'getMedia', () => {
 		const fulfillment = getMedia( {}, 1 );
 		const received = ( await fulfillment.next() ).value;
 		expect( received ).toEqual( receiveMedia( MEDIA ) );
+	} );
+} );
+
+describe( 'getPostType', () => {
+	const POST_TYPE = { slug: 'post' };
+
+	beforeAll( () => {
+		apiRequest.mockImplementation( ( options ) => {
+			if ( options.path === '/wp/v2/types/post?context=edit' ) {
+				return Promise.resolve( POST_TYPE );
+			}
+		} );
+	} );
+
+	it( 'yields with requested post type', async () => {
+		const fulfillment = getPostType( {}, 'post' );
+		const received = ( await fulfillment.next() ).value;
+		expect( received ).toEqual( receivePostTypes( POST_TYPE ) );
 	} );
 } );

--- a/core-data/test/selectors.js
+++ b/core-data/test/selectors.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getTerms, isRequestingTerms, getMedia } from '../selectors';
+import { getTerms, isRequestingTerms, getMedia, getPostType } from '../selectors';
 
 describe( 'getTerms()', () => {
 	it( 'returns value of terms by taxonomy', () => {
@@ -72,5 +72,23 @@ describe( 'getMedia', () => {
 			},
 		} );
 		expect( getMedia( state, 1 ) ).toEqual( { id: 1 } );
+	} );
+} );
+
+describe( 'getPostType', () => {
+	it( 'should return undefined for unknown post type', () => {
+		const state = deepFreeze( {
+			postTypes: {},
+		} );
+		expect( getPostType( state, 'post' ) ).toBe( undefined );
+	} );
+
+	it( 'should return a post type by slug', () => {
+		const state = deepFreeze( {
+			postTypes: {
+				post: { slug: 'post' },
+			},
+		} );
+		expect( getPostType( state, 'post' ) ).toEqual( { slug: 'post' } );
 	} );
 } );

--- a/edit-post/components/sidebar/featured-image/index.js
+++ b/edit-post/components/sidebar/featured-image/index.js
@@ -1,23 +1,16 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, partial } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, withAPIData } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { PostFeaturedImage, PostFeaturedImageCheck } from '@wordpress/editor';
 import { compose } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { isEditorSidebarPanelOpened } from '../../../store/selectors';
-import { toggleGeneralSidebarEditorPanel } from '../../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Module Constants
@@ -30,7 +23,7 @@ function FeaturedImage( { isOpened, postType, onTogglePanel } ) {
 			<PanelBody
 				title={ get(
 					postType,
-					[ 'data', 'labels', 'featured_image' ],
+					[ 'labels', 'featured_image' ],
 					__( 'Featured Image' )
 				) }
 				opened={ isOpened }
@@ -42,34 +35,26 @@ function FeaturedImage( { isOpened, postType, onTogglePanel } ) {
 	);
 }
 
-const applyWithSelect = withSelect( ( select ) => ( {
-	postTypeSlug: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
-} ) );
+const applyWithSelect = withSelect( ( select ) => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getPostType } = select( 'core' );
+	const { isEditorSidebarPanelOpened } = select( 'core/edit-post' );
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
-		};
-	},
-	{
-		onTogglePanel() {
-			return toggleGeneralSidebarEditorPanel( PANEL_NAME );
-		},
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postTypeSlug } = props;
 	return {
-		postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
+		isOpened: isEditorSidebarPanelOpened( PANEL_NAME ),
+	};
+} );
+
+const applyWithDispatch = withDispatch( ( dispatch ) => {
+	const { toggleGeneralSidebarEditorPanel } = dispatch( 'core/edit-post' );
+
+	return {
+		onTogglePanel: partial( toggleGeneralSidebarEditorPanel, PANEL_NAME ),
 	};
 } );
 
 export default compose(
 	applyWithSelect,
-	applyConnect,
-	applyWithAPIData,
+	applyWithDispatch,
 )( FeaturedImage );

--- a/edit-post/components/sidebar/page-attributes/index.js
+++ b/edit-post/components/sidebar/page-attributes/index.js
@@ -1,23 +1,16 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, partial } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, PanelRow, withAPIData } from '@wordpress/components';
+import { PanelBody, PanelRow } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { PageAttributesCheck, PageAttributesOrder, PageAttributesParent, PageTemplate } from '@wordpress/editor';
-import { withSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { toggleGeneralSidebarEditorPanel } from '../../../store/actions';
-import { isEditorSidebarPanelOpened } from '../../../store/selectors';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Module Constants
@@ -25,13 +18,13 @@ import { isEditorSidebarPanelOpened } from '../../../store/selectors';
 const PANEL_NAME = 'page-attributes';
 
 export function PageAttributes( { isOpened, onTogglePanel, postType } ) {
-	if ( ! postType.data ) {
+	if ( ! postType ) {
 		return null;
 	}
 	return (
 		<PageAttributesCheck>
 			<PanelBody
-				title={ get( postType, 'data.labels.attributes', __( 'Page Attributes' ) ) }
+				title={ get( postType, 'labels.attributes', __( 'Page Attributes' ) ) }
 				opened={ isOpened }
 				onToggle={ onTogglePanel }
 			>
@@ -45,34 +38,25 @@ export function PageAttributes( { isOpened, onTogglePanel, postType } ) {
 	);
 }
 
-const applyWithSelect = withSelect( ( select ) => ( {
-	postTypeSlug: select( 'core/editor' ).getEditedPostAttribute( 'type' ),
-} ) );
-
-const applyConnect = connect(
-	( state ) => {
-		return {
-			isOpened: isEditorSidebarPanelOpened( state, PANEL_NAME ),
-		};
-	},
-	{
-		onTogglePanel() {
-			return toggleGeneralSidebarEditorPanel( PANEL_NAME );
-		},
-	},
-	undefined,
-	{ storeKey: 'edit-post' }
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postTypeSlug } = props;
+const applyWithSelect = withSelect( ( select ) => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { isEditorSidebarPanelOpened } = select( 'core/edit-post' );
+	const { getPostType } = select( 'core' );
 	return {
-		postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+		isOpened: isEditorSidebarPanelOpened( PANEL_NAME ),
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
+	};
+} );
+
+const applyWithDispatch = withDispatch( ( dispatch ) => {
+	const { toggleGeneralSidebarEditorPanel } = dispatch( 'core/edit-post' );
+
+	return {
+		onTogglePanel: partial( toggleGeneralSidebarEditorPanel, PANEL_NAME ),
 	};
 } );
 
 export default compose(
 	applyWithSelect,
-	applyConnect,
-	applyWithAPIData,
+	applyWithDispatch,
 )( PageAttributes );

--- a/editor/components/page-attributes/check.js
+++ b/editor/components/page-attributes/check.js
@@ -1,22 +1,17 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { withAPIData, withContext } from '@wordpress/components';
+import { withContext } from '@wordpress/components';
 import { compose } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { getCurrentPostType } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 export function PageAttributesCheck( { availableTemplates, postType, children } ) {
-	const supportsPageAttributes = get( postType, 'data.supports.page-attributes', false );
+	const supportsPageAttributes = get( postType, 'supports.page-attributes', false );
 
 	// Only render fields if post type supports page attributes or available templates exist.
 	if ( ! supportsPageAttributes && isEmpty( availableTemplates ) ) {
@@ -26,13 +21,13 @@ export function PageAttributesCheck( { availableTemplates, postType, children } 
 	return children;
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postTypeSlug: getCurrentPostType( state ),
-		};
-	}
-);
+const applyWithSelect = withSelect( ( select ) => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getPostType } = select( 'core' );
+	return {
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
+	};
+} );
 
 const applyWithContext = withContext( 'editor' )(
 	( settings ) => ( {
@@ -40,16 +35,7 @@ const applyWithContext = withContext( 'editor' )(
 	} )
 );
 
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postTypeSlug } = props;
-
-	return {
-		postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
-	};
-} );
-
 export default compose( [
-	applyConnect,
-	applyWithAPIData,
+	applyWithSelect,
 	applyWithContext,
 ] )( PageAttributesCheck );

--- a/editor/components/page-attributes/parent.js
+++ b/editor/components/page-attributes/parent.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { stringify } from 'querystringify';
 
@@ -9,19 +8,14 @@ import { stringify } from 'querystringify';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { TreeSelect, withInstanceId, withAPIData } from '@wordpress/components';
+import { TreeSelect, withAPIData } from '@wordpress/components';
 import { compose } from '@wordpress/element';
 import { buildTermsTree } from '@wordpress/utils';
-
-/**
- * Internal dependencies
- */
-import { getCurrentPostId, getEditedPostAttribute, getCurrentPostType } from '../../store/selectors';
-import { editPost } from '../../store/actions';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 export function PageAttributesParent( { parent, postType, items, onUpdateParent } ) {
-	const isHierarchical = get( postType, 'data.hierarchical', false );
-	const parentPageLabel = get( postType, 'data.labels.parent_item_colon' );
+	const isHierarchical = get( postType, 'hierarchical', false );
+	const parentPageLabel = get( postType, 'labels.parent_item_colon' );
 	const pageItems = get( items, 'data', [] );
 	if ( ! isHierarchical || ! parentPageLabel || ! pageItems.length ) {
 		return null;
@@ -43,31 +37,30 @@ export function PageAttributesParent( { parent, postType, items, onUpdateParent 
 	);
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postId: getCurrentPostId( state ),
-			parent: getEditedPostAttribute( state, 'parent' ),
-			postTypeSlug: getCurrentPostType( state ),
-		};
-	},
-	{
-		onUpdateParent( parent ) {
-			return editPost( { parent: parent || 0 } );
-		},
-	}
-);
-
-const applyWithAPIDataPostType = withAPIData( ( props ) => {
-	const { postTypeSlug } = props;
+const applyWithSelect = withSelect( ( select ) => {
+	const { getPostType } = select( 'core' );
+	const { getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
+	const postTypeSlug = getEditedPostAttribute( 'type' );
 	return {
-		postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+		postId: getCurrentPostId(),
+		parent: getEditedPostAttribute( 'parent' ),
+		postType: getPostType( postTypeSlug ),
+		postTypeSlug,
+	};
+} );
+
+const applyWithDispatch = withDispatch( ( dispatch ) => {
+	const { editPost } = dispatch( 'core/editor' );
+	return {
+		onUpdateParent( parent ) {
+			editPost( { parent: parent || 0 } );
+		},
 	};
 } );
 
 const applyWithAPIDataItems = withAPIData( ( props, { type } ) => {
 	const { postTypeSlug, postId } = props;
-	const isHierarchical = get( props, 'postType.data.hierarchical', false );
+	const isHierarchical = get( props, 'postType.hierarchical', false );
 	const queryString = stringify( {
 		context: 'edit',
 		per_page: 100,
@@ -81,8 +74,7 @@ const applyWithAPIDataItems = withAPIData( ( props, { type } ) => {
 } );
 
 export default compose( [
-	applyConnect,
-	applyWithAPIDataPostType,
+	applyWithSelect,
+	applyWithDispatch,
 	applyWithAPIDataItems,
-	withInstanceId,
 ] )( PageAttributesParent );

--- a/editor/components/page-attributes/test/check.js
+++ b/editor/components/page-attributes/test/check.js
@@ -10,10 +10,8 @@ import { PageAttributesCheck } from '../check';
 
 describe( 'PageAttributesCheck', () => {
 	const postType = {
-		data: {
-			supports: {
-				'page-attributes': true,
-			},
+		supports: {
+			'page-attributes': true,
 		},
 	};
 

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -1,32 +1,29 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Spinner, ResponsiveWrapper, withAPIData } from '@wordpress/components';
+import { Button, Spinner, ResponsiveWrapper } from '@wordpress/components';
 import { MediaUpload } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import PostFeaturedImageCheck from './check';
-import { getCurrentPostType, getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 
 //used when labels from post tyoe were not yet loaded or when they are not present.
 const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
 const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove featured image' );
 
 function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
-	const postLabel = get( postType, 'data.labels', {} );
+	const postLabel = get( postType, 'labels', {} );
 
 	return (
 		<PostFeaturedImageCheck>
@@ -80,39 +77,31 @@ function PostFeaturedImage( { featuredImageId, onUpdateImage, onRemoveImage, med
 	);
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			featuredImageId: getEditedPostAttribute( state, 'featured_media' ),
-			postTypeName: getCurrentPostType( state ),
-		};
-	},
-	{
-		onUpdateImage( image ) {
-			return editPost( { featured_media: image.id } );
-		},
-		onRemoveImage() {
-			return editPost( { featured_media: 0 } );
-		},
-	}
-);
-
-const applyWithAPIData = withAPIData( ( { postTypeName } ) => {
-	return {
-		postType: postTypeName ? `/wp/v2/types/${ postTypeName }?context=edit` : undefined,
-	};
-} );
-
-const applyWithSelect = withSelect( ( select, { featuredImageId } ) => {
-	const { getMedia } = select( 'core' );
+const applyWithSelect = withSelect( ( select ) => {
+	const { getMedia, getPostType } = select( 'core' );
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
 	return {
 		media: featuredImageId ? getMedia( featuredImageId ) : null,
+		postType: getPostType( select( 'core/editor' ).getEditedPostAttribute( 'type' ) ),
+		featuredImageId,
+	};
+} );
+
+const applyWithDispatch = withDispatch( ( dispatch ) => {
+	const { editPost } = dispatch( 'core/editor' );
+	return {
+		onUpdateImage( image ) {
+			editPost( { featured_media: image.id } );
+		},
+		onRemoveImage() {
+			editPost( { featured_media: 0 } );
+		},
 	};
 } );
 
 export default compose(
-	applyConnect,
-	applyWithAPIData,
 	applyWithSelect,
+	applyWithDispatch,
 )( PostFeaturedImage );

--- a/editor/components/post-featured-image/index.js
+++ b/editor/components/post-featured-image/index.js
@@ -84,7 +84,7 @@ const applyWithSelect = withSelect( ( select ) => {
 
 	return {
 		media: featuredImageId ? getMedia( featuredImageId ) : null,
-		postType: getPostType( select( 'core/editor' ).getEditedPostAttribute( 'type' ) ),
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		featuredImageId,
 	};
 } );

--- a/editor/components/post-publish-panel/postpublish.js
+++ b/editor/components/post-publish-panel/postpublish.js
@@ -2,20 +2,19 @@
  * External Dependencies
  */
 import { get } from 'lodash';
-import { connect } from 'react-redux';
 
 /**
  * WordPress Dependencies
  */
-import { PanelBody, Button, ClipboardButton, withAPIData } from '@wordpress/components';
+import { PanelBody, Button, ClipboardButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Component, compose, Fragment } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import PostScheduleLabel from '../post-schedule/label';
-import { getCurrentPost, getCurrentPostType, isCurrentPostScheduled } from '../../store/selectors';
 
 class PostPublishPanelPostpublish extends Component {
 	constructor() {
@@ -50,7 +49,7 @@ class PostPublishPanelPostpublish extends Component {
 
 	render() {
 		const { isScheduled, post, postType } = this.props;
-		const viewPostLabel = get( postType, [ 'data', 'labels', 'view_item' ] );
+		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
 
 		const postPublishNonLinkHeader = isScheduled ?
 			<Fragment>{ __( 'is now scheduled. It will go live on' ) } <PostScheduleLabel />.</Fragment> :
@@ -89,25 +88,13 @@ class PostPublishPanelPostpublish extends Component {
 	}
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			post: getCurrentPost( state ),
-			postTypeSlug: getCurrentPostType( state ),
-			isScheduled: isCurrentPostScheduled( state ),
-		};
-	}
-);
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postTypeSlug } = props;
+export default withSelect( ( select ) => {
+	const { getEditedPostAttribute, getCurrentPost, isCurrentPostScheduled } = select( 'core/editor' );
+	const { getPostType } = select( 'core' );
 
 	return {
-		postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+		post: getCurrentPost(),
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
+		isScheduled: isCurrentPostScheduled(),
 	};
-} );
-
-export default compose( [
-	applyConnect,
-	applyWithAPIData,
-] )( PostPublishPanelPostpublish );
+} )( PostPublishPanelPostpublish );

--- a/editor/components/post-type-support-check/index.js
+++ b/editor/components/post-type-support-check/index.js
@@ -1,23 +1,16 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { get, some, castArray } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { withAPIData } from '@wordpress/components';
-import { compose } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { getCurrentPostType } from '../../store/selectors';
+import { withSelect } from '@wordpress/data';
 
 function PostTypeSupportCheck( { postType, children, supportKeys } ) {
 	const isSupported = some(
-		castArray( supportKeys ), key => get( postType, [ 'data', 'supports', key ], false )
+		castArray( supportKeys ), key => get( postType, [ 'supports', key ], false )
 	);
 
 	if ( ! isSupported ) {
@@ -27,21 +20,10 @@ function PostTypeSupportCheck( { postType, children, supportKeys } ) {
 	return children;
 }
 
-const applyConnect = connect(
-	( state ) => {
-		return {
-			postTypeName: getCurrentPostType( state ),
-		};
-	}
-);
-
-const applyWithAPIData = withAPIData( ( { postTypeName } ) => {
+export default withSelect( ( select ) => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getPostType } = select( 'core' );
 	return {
-		postType: postTypeName ? `/wp/v2/types/${ postTypeName }?context=edit` : undefined,
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 	};
-} );
-
-export default compose(
-	applyConnect,
-	applyWithAPIData,
-)( PostTypeSupportCheck );
+} )( PostTypeSupportCheck );


### PR DESCRIPTION
Follow-up to #5219 

This PR refactors the usage of `withAPIData` to fetch the current post types to the data module.

 - It adds a sub-state tree to manager post types
 - It refactors all the components relying on this data to use `withSelect` and `withDispatch` instead of `connect` and `withAPIData`.

