### PR TITLE
Components: Improve Disabled component (disabled attribute applicable, tabindex removal, pointer-events)

### DIFF
--- a/components/disabled/index.js
+++ b/components/disabled/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
+import { includes, debounce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +13,25 @@ import { focus } from '@wordpress/utils';
  * Internal dependencies
  */
 import './style.scss';
+
+/**
+ * Names of control nodes which qualify for disabled behavior.
+ *
+ * See WHATWG HTML Standard: 4.10.18.5: "Enabling and disabling form controls: the disabled attribute".
+ *
+ * @link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute
+ *
+ * @type {string[]}
+ */
+const DISABLED_ELIGIBLE_NODE_NAMES = [
+	'BUTTON',
+	'FIELDSET',
+	'INPUT',
+	'OPTGROUP',
+	'OPTION',
+	'SELECT',
+	'TEXTAREA',
+];
 
 class Disabled extends Component {
 	constructor() {
@@ -48,7 +67,7 @@ class Disabled extends Component {
 
 	disable() {
 		focus.focusable.find( this.node ).forEach( ( focusable ) => {
-			if ( ! focusable.hasAttribute( 'disabled' ) ) {
+			if ( includes( DISABLED_ELIGIBLE_NODE_NAMES, focusable.nodeName ) ) {
 				focusable.setAttribute( 'disabled', '' );
 			}
 

--- a/components/disabled/index.js
+++ b/components/disabled/index.js
@@ -71,6 +71,10 @@ class Disabled extends Component {
 				focusable.setAttribute( 'disabled', '' );
 			}
 
+			if ( focusable.hasAttribute( 'tabindex' ) ) {
+				focusable.removeAttribute( 'tabindex' );
+			}
+
 			if ( focusable.hasAttribute( 'contenteditable' ) ) {
 				focusable.setAttribute( 'contenteditable', 'false' );
 			}

--- a/components/disabled/style.scss
+++ b/components/disabled/style.scss
@@ -1,5 +1,6 @@
 .components-disabled {
 	position: relative;
+	pointer-events: none;
 
 	&:after {
 		content: '';

--- a/components/disabled/test/index.js
+++ b/components/disabled/test/index.js
@@ -56,8 +56,12 @@ describe( 'Disabled', () => {
 	it( 'will disable all fields', () => {
 		const wrapper = mount( <Disabled><Form /></Disabled> );
 
-		expect( wrapper.find( 'input' ).getDOMNode().hasAttribute( 'disabled' ) ).toBe( true );
-		expect( wrapper.find( '[contentEditable]' ).getDOMNode().getAttribute( 'contenteditable' ) ).toBe( 'false' );
+		const input = wrapper.find( 'input' ).getDOMNode();
+		const div = wrapper.find( '[contentEditable]' ).getDOMNode();
+
+		expect( input.hasAttribute( 'disabled' ) ).toBe( true );
+		expect( div.getAttribute( 'contenteditable' ) ).toBe( 'false' );
+		expect( div.hasAttribute( 'disabled' ) ).toBe( false );
 	} );
 
 	it( 'should cleanly un-disable via reconciliation', () => {

--- a/components/disabled/test/index.js
+++ b/components/disabled/test/index.js
@@ -51,7 +51,7 @@ describe( 'Disabled', () => {
 		window.MutationObserver = MutationObserver;
 	} );
 
-	const Form = () => <form><input /><div contentEditable /></form>;
+	const Form = () => <form><input /><div contentEditable tabIndex="0" /></form>;
 
 	it( 'will disable all fields', () => {
 		const wrapper = mount( <Disabled><Form /></Disabled> );
@@ -61,6 +61,7 @@ describe( 'Disabled', () => {
 
 		expect( input.hasAttribute( 'disabled' ) ).toBe( true );
 		expect( div.getAttribute( 'contenteditable' ) ).toBe( 'false' );
+		expect( div.hasAttribute( 'tabindex' ) ).toBe( false );
 		expect( div.hasAttribute( 'disabled' ) ).toBe( false );
 	} );
 
@@ -77,8 +78,12 @@ describe( 'Disabled', () => {
 		const wrapper = mount( <MaybeDisable /> );
 		wrapper.setProps( { isDisabled: false } );
 
-		expect( wrapper.find( 'input' ).getDOMNode().hasAttribute( 'disabled' ) ).toBe( false );
-		expect( wrapper.find( '[contentEditable]' ).getDOMNode().getAttribute( 'contenteditable' ) ).toBe( 'true' );
+		const input = wrapper.find( 'input' ).getDOMNode();
+		const div = wrapper.find( '[contentEditable]' ).getDOMNode();
+
+		expect( input.hasAttribute( 'disabled' ) ).toBe( false );
+		expect( div.getAttribute( 'contenteditable' ) ).toBe( 'true' );
+		expect( div.hasAttribute( 'tabindex' ) ).toBe( true );
 	} );
 
 	// Ideally, we'd have two more test cases here:


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/5658#issuecomment-375347499

This pull request seeks to improve the `Disabled` component to improve its durability in accurately disabling all interaction for content within. It resolves erroneous application of `disabled` attribute to non-eligible nodes [as defined by the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute), removes any `tabindex` attribute as these elements are intended to be omitted from the tabbable flow, and prevents pointer interactions (the specification is not entirely clear here except for mention of preventing click events, and while the issue is under discussion at https://github.com/whatwg/html/issues/2368 and https://github.com/w3c/pointerevents/issues/177, the behavior is consistent with the majority of browsers).

__Testing instructions:__

The behavior on master is unlikely to change.

This was observed in the course of reviewing #5658, where mouse events on disabled controls being fired conflicts with hover behavior of accessing block options of a shared block preview of a nested block. Testing may require cherry-picking commits into `try/improve-nested` until the pull request is merged.