### PR TITLE
Improve block mover labels for speech recognition software

### DIFF
--- a/editor/components/block-mover/arrows.js
+++ b/editor/components/block-mover/arrows.js
@@ -1,6 +1,3 @@
-/**
- * Module constants
- */
 export const upArrow = (
 	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
 		<path d="M12.293 12.207L9 8.914l-3.293 3.293-1.414-1.414L9 6.086l4.707 4.707z" />

--- a/editor/components/block-mover/arrows.js
+++ b/editor/components/block-mover/arrows.js
@@ -1,0 +1,14 @@
+/**
+ * Module constants
+ */
+export const upArrow = (
+	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
+		<path d="M12.293 12.207L9 8.914l-3.293 3.293-1.414-1.414L9 6.086l4.707 4.707z" />
+	</svg>
+);
+
+export const downArrow = (
+	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
+		<path d="M12.293 6.086L9 9.379 5.707 6.086 4.293 7.5 9 12.207 13.707 7.5z" />
+	</svg>
+);

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -8,7 +8,7 @@ import { first } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, withContext } from '@wordpress/components';
+import { IconButton, withContext, withInstanceId } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { compose } from '@wordpress/element';
 
@@ -20,7 +20,7 @@ import { getBlockMoverDescription } from './mover-description';
 import { getBlockIndex, getBlock } from '../../store/selectors';
 import { upArrow, downArrow } from './arrows';
 
-export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked } ) {
+export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked, instanceId } ) {
 	if ( isLocked ) {
 		return null;
 	}
@@ -36,7 +36,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 				onClick={ isFirst ? null : onMoveUp }
 				icon={ upArrow }
 				label={ __( 'Move up' ) }
-				aria-describedby="editor-block-mover__up-description"
+				aria-describedby={ `editor-block-mover__up-description-${ instanceId }` }
 				aria-disabled={ isFirst }
 			/>
 			<IconButton
@@ -44,10 +44,10 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 				onClick={ isLast ? null : onMoveDown }
 				icon={ downArrow }
 				label={ __( 'Move down' ) }
-				aria-describedby="editor-block-mover__down-description"
+				aria-describedby={ `editor-block-mover__down-description-${ instanceId }` }
 				aria-disabled={ isLast }
 			/>
-			<span id="editor-block-mover__up-description" className="editor-block-mover__description">
+			<span id={ `editor-block-mover__up-description-${ instanceId }` } className="editor-block-mover__description">
 				{
 					getBlockMoverDescription(
 						uids.length,
@@ -59,7 +59,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 					)
 				}
 			</span>
-			<span id="editor-block-mover__down-description" className="editor-block-mover__description">
+			<span id={ `editor-block-mover__down-description-${ instanceId }` } className="editor-block-mover__description">
 				{
 					getBlockMoverDescription(
 						uids.length,
@@ -116,4 +116,5 @@ export default compose(
 			isLocked: templateLock === 'all',
 		};
 	} ),
+	withInstanceId,
 )( BlockMover );

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -18,21 +18,7 @@ import { compose } from '@wordpress/element';
 import './style.scss';
 import { getBlockMoverDescription } from './mover-description';
 import { getBlockIndex, getBlock } from '../../store/selectors';
-
-/**
- * Module constants
- */
-const upArrow = (
-	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
-		<path d="M12.293 12.207L9 8.914l-3.293 3.293-1.414-1.414L9 6.086l4.707 4.707z" />
-	</svg>
-);
-
-const downArrow = (
-	<svg tabIndex="-1" width="18" height="18" xmlns="http://www.w3.org/2000/svg" aria-hidden role="img" focusable="false">
-		<path d="M12.293 6.086L9 9.379 5.707 6.086 4.293 7.5 9 12.207 13.707 7.5z" />
-	</svg>
-);
+import { upArrow, downArrow } from './arrows';
 
 export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, blockType, firstIndex, isLocked } ) {
 	if ( isLocked ) {
@@ -49,8 +35,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 				className="editor-block-mover__control"
 				onClick={ isFirst ? null : onMoveUp }
 				icon={ upArrow }
-				tooltip={ __( 'Move Up' ) }
-				label={ __( 'Move Up' ) }
+				label={ __( 'Move up' ) }
 				aria-describedby="editor-block-mover__up-description"
 				aria-disabled={ isFirst }
 			/>
@@ -58,8 +43,7 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 				className="editor-block-mover__control"
 				onClick={ isLast ? null : onMoveDown }
 				icon={ downArrow }
-				tooltip={ __( 'Move Down' ) }
-				label={ __( 'Move Down' ) }
+				label={ __( 'Move down' ) }
 				aria-describedby="editor-block-mover__down-description"
 				aria-disabled={ isLast }
 			/>

--- a/editor/components/block-mover/index.js
+++ b/editor/components/block-mover/index.js
@@ -16,7 +16,7 @@ import { compose } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
-import { getBlockMoverLabel } from './mover-label';
+import { getBlockMoverDescription } from './mover-description';
 import { getBlockIndex, getBlock } from '../../store/selectors';
 
 /**
@@ -50,14 +50,8 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 				onClick={ isFirst ? null : onMoveUp }
 				icon={ upArrow }
 				tooltip={ __( 'Move Up' ) }
-				label={ getBlockMoverLabel(
-					uids.length,
-					blockType && blockType.title,
-					firstIndex,
-					isFirst,
-					isLast,
-					-1,
-				) }
+				label={ __( 'Move Up' ) }
+				aria-describedby="editor-block-mover__up-description"
 				aria-disabled={ isFirst }
 			/>
 			<IconButton
@@ -65,16 +59,34 @@ export function BlockMover( { onMoveUp, onMoveDown, isFirst, isLast, uids, block
 				onClick={ isLast ? null : onMoveDown }
 				icon={ downArrow }
 				tooltip={ __( 'Move Down' ) }
-				label={ getBlockMoverLabel(
-					uids.length,
-					blockType && blockType.title,
-					firstIndex,
-					isFirst,
-					isLast,
-					1,
-				) }
+				label={ __( 'Move Down' ) }
+				aria-describedby="editor-block-mover__down-description"
 				aria-disabled={ isLast }
 			/>
+			<span id="editor-block-mover__up-description" className="editor-block-mover__description">
+				{
+					getBlockMoverDescription(
+						uids.length,
+						blockType && blockType.title,
+						firstIndex,
+						isFirst,
+						isLast,
+						-1,
+					)
+				}
+			</span>
+			<span id="editor-block-mover__down-description" className="editor-block-mover__description">
+				{
+					getBlockMoverDescription(
+						uids.length,
+						blockType && blockType.title,
+						firstIndex,
+						isFirst,
+						isLast,
+						1,
+					)
+				}
+			</span>
 		</div>
 	);
 }

--- a/editor/components/block-mover/mover-description.js
+++ b/editor/components/block-mover/mover-description.js
@@ -17,11 +17,11 @@ import { __, sprintf } from '@wordpress/i18n';
  *
  * @return {string} Label for the block movement controls.
  */
-export function getBlockMoverLabel( selectedCount, type, firstIndex, isFirst, isLast, dir ) {
+export function getBlockMoverDescription( selectedCount, type, firstIndex, isFirst, isLast, dir ) {
 	const position = ( firstIndex + 1 );
 
 	if ( selectedCount > 1 ) {
-		return getMultiBlockMoverLabel( selectedCount, firstIndex, isFirst, isLast, dir );
+		return getMultiBlockMoverDescription( selectedCount, firstIndex, isFirst, isLast, dir );
 	}
 
 	if ( isFirst && isLast ) {
@@ -78,7 +78,7 @@ export function getBlockMoverLabel( selectedCount, type, firstIndex, isFirst, is
  *
  * @return {string} Label for the block movement controls.
  */
-export function getMultiBlockMoverLabel( selectedCount, firstIndex, isFirst, isLast, dir ) {
+export function getMultiBlockMoverDescription( selectedCount, firstIndex, isFirst, isLast, dir ) {
 	const position = ( firstIndex + 1 );
 
 	if ( dir < 0 && isFirst ) {

--- a/editor/components/block-mover/mover-description.js
+++ b/editor/components/block-mover/mover-description.js
@@ -26,13 +26,13 @@ export function getBlockMoverDescription( selectedCount, type, firstIndex, isFir
 
 	if ( isFirst && isLast ) {
 		// translators: %s: Type of block (i.e. Text, Image etc)
-		return sprintf( __( 'Block "%s" is the only block, and cannot be moved' ), type );
+		return sprintf( __( 'Block %s is the only block, and cannot be moved' ), type );
 	}
 
 	if ( dir > 0 && ! isLast ) {
 		// moving down
 		return sprintf(
-			__( 'Move "%(type)s" block from position %(position)d down to position %(newPosition)d' ),
+			__( 'Move %(type)s block from position %(position)d down to position %(newPosition)d' ),
 			{
 				type,
 				position,
@@ -44,13 +44,13 @@ export function getBlockMoverDescription( selectedCount, type, firstIndex, isFir
 	if ( dir > 0 && isLast ) {
 		// moving down, and is the last item
 		// translators: %s: Type of block (i.e. Text, Image etc)
-		return sprintf( __( 'Block "%s" is at the end of the content and can’t be moved down' ), type );
+		return sprintf( __( 'Block %s is at the end of the content and can’t be moved down' ), type );
 	}
 
 	if ( dir < 0 && ! isFirst ) {
 		// moving up
 		return sprintf(
-			__( 'Move "%(type)s" block from position %(position)d up to position %(newPosition)d' ),
+			__( 'Move %(type)s block from position %(position)d up to position %(newPosition)d' ),
 			{
 				type,
 				position,
@@ -62,7 +62,7 @@ export function getBlockMoverDescription( selectedCount, type, firstIndex, isFir
 	if ( dir < 0 && isFirst ) {
 		// moving up, and is the first item
 		// translators: %s: Type of block (i.e. Text, Image etc)
-		return sprintf( __( 'Block "%s" is at the beginning of the content and can’t be moved up' ), type );
+		return sprintf( __( 'Block %s is at the beginning of the content and can’t be moved up' ), type );
 	}
 }
 

--- a/editor/components/block-mover/style.scss
+++ b/editor/components/block-mover/style.scss
@@ -48,3 +48,7 @@
 		}
 	}
 }
+
+.editor-block-mover__description {
+	display: none;
+}

--- a/editor/components/block-mover/test/index.js
+++ b/editor/components/block-mover/test/index.js
@@ -27,20 +27,26 @@ describe( 'BlockMover', () => {
 
 			const moveUp = blockMover.childAt( 0 );
 			const moveDown = blockMover.childAt( 1 );
+			const moveUpDesc = blockMover.childAt( 2 );
+			const moveDownDesc = blockMover.childAt( 3 );
 			expect( moveUp.type().name ).toBe( 'IconButton' );
 			expect( moveDown.type().name ).toBe( 'IconButton' );
 			expect( moveUp.props() ).toMatchObject( {
 				className: 'editor-block-mover__control',
 				onClick: undefined,
-				label: 'Move 2 blocks from position 1 up by one place',
+				label: 'Move up',
 				'aria-disabled': undefined,
+				'aria-describedby': 'editor-block-mover__up-description',
 			} );
 			expect( moveDown.props() ).toMatchObject( {
 				className: 'editor-block-mover__control',
 				onClick: undefined,
-				label: 'Move 2 blocks from position 1 down by one place',
+				label: 'Move down',
 				'aria-disabled': undefined,
+				'aria-describedby': 'editor-block-mover__down-description',
 			} );
+			expect( moveUpDesc.text() ).toBe( 'Move 2 blocks from position 1 up by one place' );
+			expect( moveDownDesc.text() ).toBe( 'Move 2 blocks from position 1 down by one place' );
 		} );
 
 		it( 'should render the up arrow with a onMoveUp callback', () => {
@@ -67,7 +73,7 @@ describe( 'BlockMover', () => {
 			expect( moveDown.prop( 'onClick' ) ).toBe( onMoveDown );
 		} );
 
-		it( 'should render with a disabled up arrown when the block isFirst', () => {
+		it( 'should render with a disabled up arrow when the block isFirst', () => {
 			const onMoveUp = ( event ) => event;
 			const blockMover = shallow(
 				<BlockMover uids={ selectedUids }

--- a/editor/components/block-mover/test/index.js
+++ b/editor/components/block-mover/test/index.js
@@ -7,6 +7,7 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { BlockMover } from '../';
+import { upArrow, downArrow } from '../arrows';
 
 describe( 'BlockMover', () => {
 	describe( 'basic rendering', () => {
@@ -35,6 +36,7 @@ describe( 'BlockMover', () => {
 				className: 'editor-block-mover__control',
 				onClick: undefined,
 				label: 'Move up',
+				icon: upArrow,
 				'aria-disabled': undefined,
 				'aria-describedby': 'editor-block-mover__up-description',
 			} );
@@ -42,6 +44,7 @@ describe( 'BlockMover', () => {
 				className: 'editor-block-mover__control',
 				onClick: undefined,
 				label: 'Move down',
+				icon: downArrow,
 				'aria-disabled': undefined,
 				'aria-describedby': 'editor-block-mover__down-description',
 			} );

--- a/editor/components/block-mover/test/index.js
+++ b/editor/components/block-mover/test/index.js
@@ -23,7 +23,7 @@ describe( 'BlockMover', () => {
 		} );
 
 		it( 'should render two IconButton components with the following props', () => {
-			const blockMover = shallow( <BlockMover uids={ selectedUids } blockType={ blockType } firstIndex={ 0 } /> );
+			const blockMover = shallow( <BlockMover uids={ selectedUids } blockType={ blockType } firstIndex={ 0 } instanceId={ 1 } /> );
 			expect( blockMover.hasClass( 'editor-block-mover' ) ).toBe( true );
 
 			const moveUp = blockMover.childAt( 0 );
@@ -38,7 +38,7 @@ describe( 'BlockMover', () => {
 				label: 'Move up',
 				icon: upArrow,
 				'aria-disabled': undefined,
-				'aria-describedby': 'editor-block-mover__up-description',
+				'aria-describedby': 'editor-block-mover__up-description-1',
 			} );
 			expect( moveDown.props() ).toMatchObject( {
 				className: 'editor-block-mover__control',
@@ -46,7 +46,7 @@ describe( 'BlockMover', () => {
 				label: 'Move down',
 				icon: downArrow,
 				'aria-disabled': undefined,
-				'aria-describedby': 'editor-block-mover__down-description',
+				'aria-describedby': 'editor-block-mover__down-description-1',
 			} );
 			expect( moveUpDesc.text() ).toBe( 'Move 2 blocks from position 1 up by one place' );
 			expect( moveDownDesc.text() ).toBe( 'Move 2 blocks from position 1 down by one place' );

--- a/editor/components/block-mover/test/mover-description.js
+++ b/editor/components/block-mover/test/mover-description.js
@@ -1,17 +1,17 @@
 /**
  * Internal dependencies
  */
-import { getBlockMoverLabel, getMultiBlockMoverLabel } from '../mover-label';
+import { getBlockMoverDescription, getMultiBlockMoverDescription } from '../mover-description';
 
 describe( 'block mover', () => {
 	const dirUp = -1,
 		dirDown = 1;
 
-	describe( 'getBlockMoverLabel', () => {
+	describe( 'getBlockMoverDescription', () => {
 		const type = 'TestType';
 
 		it( 'Should generate a title for the first item moving up', () => {
-			expect( getBlockMoverLabel(
+			expect( getBlockMoverDescription(
 				1,
 				type,
 				0,
@@ -24,7 +24,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for the last item moving down', () => {
-			expect( getBlockMoverLabel(
+			expect( getBlockMoverDescription(
 				1,
 				type,
 				3,
@@ -35,7 +35,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for the second item moving up', () => {
-			expect( getBlockMoverLabel(
+			expect( getBlockMoverDescription(
 				1,
 				type,
 				1,
@@ -46,7 +46,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for the second item moving down', () => {
-			expect( getBlockMoverLabel(
+			expect( getBlockMoverDescription(
 				1,
 				type,
 				1,
@@ -57,7 +57,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for the only item in the list', () => {
-			expect( getBlockMoverLabel(
+			expect( getBlockMoverDescription(
 				1,
 				type,
 				0,
@@ -68,9 +68,9 @@ describe( 'block mover', () => {
 		} );
 	} );
 
-	describe( 'getMultiBlockMoverLabel', () => {
+	describe( 'getMultiBlockMoverDescription', () => {
 		it( 'Should generate a title moving multiple blocks up', () => {
-			expect( getMultiBlockMoverLabel(
+			expect( getMultiBlockMoverDescription(
 				4,
 				1,
 				false,
@@ -80,7 +80,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title moving multiple blocks down', () => {
-			expect( getMultiBlockMoverLabel(
+			expect( getMultiBlockMoverDescription(
 				4,
 				0,
 				true,
@@ -90,7 +90,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for a selection of blocks at the top', () => {
-			expect( getMultiBlockMoverLabel(
+			expect( getMultiBlockMoverDescription(
 				4,
 				1,
 				true,
@@ -100,7 +100,7 @@ describe( 'block mover', () => {
 		} );
 
 		it( 'Should generate a title for a selection of blocks at the bottom', () => {
-			expect( getMultiBlockMoverLabel(
+			expect( getMultiBlockMoverDescription(
 				4,
 				2,
 				false,

--- a/editor/components/block-mover/test/mover-description.js
+++ b/editor/components/block-mover/test/mover-description.js
@@ -19,7 +19,7 @@ describe( 'block mover', () => {
 				false,
 				dirUp,
 			) ).toBe(
-				`Block "${ type }" is at the beginning of the content and can’t be moved up`
+				`Block ${ type } is at the beginning of the content and can’t be moved up`
 			);
 		} );
 
@@ -31,7 +31,7 @@ describe( 'block mover', () => {
 				false,
 				true,
 				dirDown,
-			) ).toBe( `Block "${ type }" is at the end of the content and can’t be moved down` );
+			) ).toBe( `Block ${ type } is at the end of the content and can’t be moved down` );
 		} );
 
 		it( 'Should generate a title for the second item moving up', () => {
@@ -42,7 +42,7 @@ describe( 'block mover', () => {
 				false,
 				false,
 				dirUp,
-			) ).toBe( `Move "${ type }" block from position 2 up to position 1` );
+			) ).toBe( `Move ${ type } block from position 2 up to position 1` );
 		} );
 
 		it( 'Should generate a title for the second item moving down', () => {
@@ -53,7 +53,7 @@ describe( 'block mover', () => {
 				false,
 				false,
 				dirDown,
-			) ).toBe( `Move "${ type }" block from position 2 down to position 3` );
+			) ).toBe( `Move ${ type } block from position 2 down to position 3` );
 		} );
 
 		it( 'Should generate a title for the only item in the list', () => {
@@ -64,7 +64,7 @@ describe( 'block mover', () => {
 				true,
 				true,
 				dirDown,
-			) ).toBe( `Block "${ type }" is the only block, and cannot be moved` );
+			) ).toBe( `Block ${ type } is the only block, and cannot be moved` );
 		} );
 	} );
 


### PR DESCRIPTION
This PR tries to improve the block movers for use with speech recognition software.

Users will voice commands based on the visually displayed tooltip, however the accessible name of the block movers (their aria label attribute) doesn't match the displayed tooltip text. For more details please refer to the related issue #5750.

By matching the tooltip text with the aria-label, speech recognition software will execute the related command, e.g.: `Click Move up`.

The info about the position in the set of blocks is moved to a span element targeted with an aria-describedby attribute. Screen readers will announce in sequence:
- the aria label e.g. "Move up"
- the description e.g. "Move "Paragraph" block from position 2 up to position 1"

notes:
- I'm not using `withInstanceId`, please let me know if that's desired
- I've tried to fix the tests passing the same SVG used in the component, please notice I'm not sure the test was 100% correct even before

Fixes #5750 