### PR TITLE
Fix autosave while editing a post using the Text Mode editor

### DIFF
--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -31,6 +31,14 @@ class PostTextEditor extends Component {
 		};
 	}
 
+	componentWillReceiveProps( nextProps ) {
+		// If we receive a new value while we're editing (but before we've made
+		// changes), go ahead and clobber the local state
+		if ( this.props.value !== nextProps.value && this.state.value && ! this.state.isDirty ) {
+			this.setState( { value: nextProps.value } );
+		}
+	}
+
 	startEditing() {
 		// Copying the post content into local state ensures that edits won't be
 		// clobbered by changes to global editor state

--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import Textarea from 'react-autosize-textarea';
+import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
@@ -18,41 +18,45 @@ import { getEditedPostContent } from '../../store/selectors';
 import { editPost, resetBlocks, checkTemplateValidity } from '../../store/actions';
 
 class PostTextEditor extends Component {
-	constructor( props ) {
+	constructor() {
 		super( ...arguments );
 
-		this.onChange = this.onChange.bind( this );
-		this.onPersist = this.onPersist.bind( this );
+		this.handleFocus = this.handleFocus.bind( this );
+		this.handleChange = this.handleChange.bind( this );
+		this.handleBlur = this.handleBlur.bind( this );
 
 		this.state = {
-			initialValue: props.value,
+			value: null,
+			isDirty: false,
 		};
 	}
 
-	onChange( event ) {
-		this.props.onChange( event.target.value );
+	handleFocus() {
+		this.setState( { value: this.props.value } );
 	}
 
-	onPersist( event ) {
-		const { value } = event.target;
-		if ( value !== this.state.initialValue ) {
-			this.props.onPersist( value );
+	handleChange( event ) {
+		const value = event.target.value;
+		this.props.onChange( value );
+		this.setState( { value, isDirty: true } );
+	}
 
-			this.setState( {
-				initialValue: value,
-			} );
+	handleBlur() {
+		if ( this.state.isDirty ) {
+			this.props.onPersist( this.state.value );
 		}
+
+		this.setState( { value: null, isDirty: false } );
 	}
 
 	render() {
-		const { value } = this.props;
-
 		return (
 			<Textarea
 				autoComplete="off"
-				value={ value }
-				onChange={ this.onChange }
-				onBlur={ this.onPersist }
+				value={ this.state.value || this.props.value }
+				onFocus={ this.handleFocus }
+				onChange={ this.handleChange }
+				onBlur={ this.handleBlur }
 				className="editor-post-text-editor"
 			/>
 		);

--- a/editor/components/post-text-editor/index.js
+++ b/editor/components/post-text-editor/index.js
@@ -21,9 +21,9 @@ class PostTextEditor extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.handleFocus = this.handleFocus.bind( this );
-		this.handleChange = this.handleChange.bind( this );
-		this.handleBlur = this.handleBlur.bind( this );
+		this.startEditing = this.startEditing.bind( this );
+		this.edit = this.edit.bind( this );
+		this.stopEditing = this.stopEditing.bind( this );
 
 		this.state = {
 			value: null,
@@ -31,17 +31,19 @@ class PostTextEditor extends Component {
 		};
 	}
 
-	handleFocus() {
+	startEditing() {
+		// Copying the post content into local state ensures that edits won't be
+		// clobbered by changes to global editor state
 		this.setState( { value: this.props.value } );
 	}
 
-	handleChange( event ) {
+	edit( event ) {
 		const value = event.target.value;
 		this.props.onChange( value );
 		this.setState( { value, isDirty: true } );
 	}
 
-	handleBlur() {
+	stopEditing() {
 		if ( this.state.isDirty ) {
 			this.props.onPersist( this.state.value );
 		}
@@ -54,9 +56,9 @@ class PostTextEditor extends Component {
 			<Textarea
 				autoComplete="off"
 				value={ this.state.value || this.props.value }
-				onFocus={ this.handleFocus }
-				onChange={ this.handleChange }
-				onBlur={ this.handleBlur }
+				onFocus={ this.startEditing }
+				onChange={ this.edit }
+				onBlur={ this.stopEditing }
 				className="editor-post-text-editor"
 			/>
 		);


### PR DESCRIPTION
## Description
Fixes #2978. 

Text that was typed into the Text Mode editor would be wiped away if the post was autosaved. Here's what was happening:

1. A user switches to Text Mode and makes changes. The modified content is stored in `editor.present.edits.content`. Note that `editor.present.blocksByUid` is not modified until the text area is blurred.
2. After some time, the post is autosaved. When the successful save request finishes, `REQUEST_POST_UPDATE_SUCCESS` is dispatched.
3. `REQUEST_POST_UPDATE_SUCCESS` dispatches `RESET_POST`, which clears out the edits in `editor.present.edits`.
4. Now that `editor.present.edits.content` is undefined, `getEditedPostContent( state )` returns a serialisation of the blocks in `editor.present.blocksByUid`. But, since the editor was never blurred, this does not reflect the recent changes that were made! We therefore lose those changes.

I've fixed this by patching `PostTextEditor` so that it copies `value` into local state when focused. This means that the contents of the text field won't change if `value` changes because of a dispatch.

## How Has This Been Tested?
1. Write a new post in Gutenberg
2. Switch to Text Mode
3. Type in a bunch of stuff
4. Wait for autosave to kick in—your changes should remain there
6. Refresh the page—your changes should remain there
8. Switch back to Visual Mode—your changes should appear