### PR TITLE
Add Editable Permalinks

### DIFF
--- a/components/button/index.js
+++ b/components/button/index.js
@@ -17,7 +17,6 @@ class Button extends Component {
 	constructor( props ) {
 		super( props );
 		this.setRef = this.setRef.bind( this );
-		this.focus = this.focus.bind( this );
 	}
 
 	componentDidMount() {

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -17,6 +17,7 @@ class Button extends Component {
 	constructor( props ) {
 		super( props );
 		this.setRef = this.setRef.bind( this );
+		this.focus = this.focus.bind( this );
 	}
 
 	componentDidMount() {
@@ -27,6 +28,10 @@ class Button extends Component {
 
 	setRef( ref ) {
 		this.ref = ref;
+	}
+
+	focus() {
+		this.ref.focus();
 	}
 
 	render() {

--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -81,8 +81,8 @@ class ClipboardButton extends Component {
 		const classes = classnames( 'components-clipboard-button', className );
 
 		return (
-			<span ref={ this.bindContainer } className={ classes }>
-				<Button { ...buttonProps }>
+			<span ref={ this.bindContainer }>
+				<Button { ...buttonProps } className={ classes }>
 					{ children }
 				</Button>
 			</span>

--- a/components/clipboard-button/index.js
+++ b/components/clipboard-button/index.js
@@ -81,8 +81,8 @@ class ClipboardButton extends Component {
 		const classes = classnames( 'components-clipboard-button', className );
 
 		return (
-			<span ref={ this.bindContainer }>
-				<Button { ...buttonProps } className={ classes }>
+			<span ref={ this.bindContainer } className={ classes }>
+				<Button { ...buttonProps }>
 					{ children }
 				</Button>
 			</span>

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal Dependencies
+ */
+import './style.scss';
+import { getEditedPostAttribute } from '../../store/selectors';
+import { editPost } from '../../store/actions';
+
+class PostPermalinkEditor extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onSavePermalink = this.onSavePermalink.bind( this );
+	}
+
+	/**
+	 * Returns the permalink parts to populate the form.
+	 *
+	 * @return {Object} The prefix, suffix, and postName for the form.
+	 */
+	getPermalinkParts() {
+		const [ template, postName ] = this.props.samplePermalinkData;
+		const [ samplePermalinkPrefix, samplePermalinkSuffix ] = template.split( /%(?:postname|pagename)%/ );
+
+		return {
+			samplePermalinkPrefix,
+			samplePermalinkSuffix,
+			postName,
+		};
+	}
+
+	onSavePermalink() {
+		const postName = this.state.editedPostName.replace( /\s+/g, '-' );
+		const [ template, oldPostName ] = this.props.samplePermalinkData;
+
+		if ( ! postName || postName === oldPostName ) {
+			return;
+		}
+
+		this.props.editPost( {
+			slug: postName,
+			sample_permalink: [ template, postName ],
+		} );
+
+		this.setState( {
+			editedPostName: postName,
+		} );
+
+		this.props.onSave();
+	}
+
+	render() {
+		const {
+			samplePermalinkPrefix,
+			samplePermalinkSuffix,
+			postName,
+		} = this.getPermalinkParts();
+
+		return (
+			<div className="editor-post-permalink-editor">
+				<form
+					className="editor-post-permalink__edit-form"
+					onSubmit={ this.onSavePermalink }>
+					<span className="editor-post-permalink__prefix">
+						{ samplePermalinkPrefix }
+					</span>
+					<input
+						className="editor-post-permalink__edit"
+						aria-label={ __( 'Edit post permalink' ) }
+						defaultValue={ postName }
+						onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
+						required
+					/>
+					<span className="editor-post-permalink__suffix">
+						{ samplePermalinkSuffix }
+					</span>
+					<Button
+						className="editor-post-permalink__save button"
+						onClick={ this.onSavePermalink }
+					>
+						{ __( 'OK' ) }
+					</Button>
+				</form>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			samplePermalinkData: getEditedPostAttribute( state, 'sample_permalink' ),
+
+			permalinkStructure: window.wpApiSettings.schema.permalink_structure,
+		};
+	},
+	{
+		editPost,
+	}
+)( PostPermalinkEditor );
+

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -6,7 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { withDispatch } from '@wordpress/data';
+import { Component, compose } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
@@ -15,7 +16,6 @@ import { Button } from '@wordpress/components';
  */
 import './style.scss';
 import { getEditedPostAttribute } from '../../store/selectors';
-import { editPost } from '../../store/actions';
 
 class PostPermalinkEditor extends Component {
 	constructor() {
@@ -101,16 +101,15 @@ class PostPermalinkEditor extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
+export default compose( [
+	connect( ( state ) => {
 		return {
 			samplePermalinkData: getEditedPostAttribute( state, 'sample_permalink' ),
-
-			permalinkStructure: window.wpApiSettings.schema.permalink_structure,
 		};
-	},
-	{
-		editPost,
-	}
-)( PostPermalinkEditor );
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { editPost } = dispatch( 'core/editor' );
+		return { editPost };
+	} ),
+] )( PostPermalinkEditor );
 

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -84,6 +84,7 @@ class PostPermalinkEditor extends Component {
 					defaultValue={ postName }
 					onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
 					required
+					autoFocus
 				/>
 				<span className="editor-post-permalink-editor__suffix">
 					{ samplePermalinkSuffix }

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -71,6 +71,7 @@ class PostPermalinkEditor extends Component {
 			postName,
 		} = this.getPermalinkParts();
 
+		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<form
 				className="editor-post-permalink-editor"
@@ -97,6 +98,7 @@ class PostPermalinkEditor extends Component {
 				</Button>
 			</form>
 		);
+		/* eslint-enable jsx-a11y/no-autofocus */
 	}
 }
 

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -21,6 +21,10 @@ class PostPermalinkEditor extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.state = {
+			editedPostName: '',
+		};
+
 		this.onSavePermalink = this.onSavePermalink.bind( this );
 	}
 
@@ -44,6 +48,8 @@ class PostPermalinkEditor extends Component {
 		const postName = this.state.editedPostName.replace( /\s+/g, '-' );
 		const [ template, oldPostName ] = this.props.samplePermalinkData;
 
+		this.props.onSave();
+
 		if ( ! postName || postName === oldPostName ) {
 			return;
 		}
@@ -56,8 +62,6 @@ class PostPermalinkEditor extends Component {
 		this.setState( {
 			editedPostName: postName,
 		} );
-
-		this.props.onSave();
 	}
 
 	render() {

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -72,31 +72,29 @@ class PostPermalinkEditor extends Component {
 		} = this.getPermalinkParts();
 
 		return (
-			<div className="editor-post-permalink-editor">
-				<form
-					className="editor-post-permalink__edit-form"
-					onSubmit={ this.onSavePermalink }>
-					<span className="editor-post-permalink__prefix">
-						{ samplePermalinkPrefix }
-					</span>
-					<input
-						className="editor-post-permalink__edit"
-						aria-label={ __( 'Edit post permalink' ) }
-						defaultValue={ postName }
-						onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
-						required
-					/>
-					<span className="editor-post-permalink__suffix">
-						{ samplePermalinkSuffix }
-					</span>
-					<Button
-						className="editor-post-permalink__save button"
-						onClick={ this.onSavePermalink }
-					>
-						{ __( 'OK' ) }
-					</Button>
-				</form>
-			</div>
+			<form
+				className="editor-post-permalink-editor"
+				onSubmit={ this.onSavePermalink }>
+				<span className="editor-post-permalink-editor__prefix">
+					{ samplePermalinkPrefix }
+				</span>
+				<input
+					className="editor-post-permalink-editor__edit"
+					aria-label={ __( 'Edit post permalink' ) }
+					defaultValue={ postName }
+					onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
+					required
+				/>
+				<span className="editor-post-permalink-editor__suffix">
+					{ samplePermalinkSuffix }
+				</span>
+				<Button
+					className="editor-post-permalink-editor__save button"
+					onClick={ this.onSavePermalink }
+				>
+					{ __( 'OK' ) }
+				</Button>
+			</form>
 		);
 	}
 }

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -44,9 +44,11 @@ class PostPermalinkEditor extends Component {
 		};
 	}
 
-	onSavePermalink() {
+	onSavePermalink( event ) {
 		const postName = this.state.editedPostName.replace( /\s+/g, '-' );
 		const [ template, oldPostName ] = this.props.samplePermalinkData;
+
+		event.preventDefault();
 
 		this.props.onSave();
 

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -35,12 +35,13 @@ class PostPermalinkEditor extends Component {
 	 */
 	getPermalinkParts() {
 		const [ template, postName ] = this.props.samplePermalinkData;
+		const { editedPostName } = this.state;
 		const [ samplePermalinkPrefix, samplePermalinkSuffix ] = template.split( /%(?:postname|pagename)%/ );
 
 		return {
 			samplePermalinkPrefix,
 			samplePermalinkSuffix,
-			postName,
+			editedPostName: editedPostName || postName,
 		};
 	}
 
@@ -70,7 +71,7 @@ class PostPermalinkEditor extends Component {
 		const {
 			samplePermalinkPrefix,
 			samplePermalinkSuffix,
-			postName,
+			editedPostName,
 		} = this.getPermalinkParts();
 
 		/* eslint-disable jsx-a11y/no-autofocus */
@@ -85,7 +86,7 @@ class PostPermalinkEditor extends Component {
 				<input
 					className="editor-post-permalink-editor__edit"
 					aria-label={ __( 'Edit post permalink' ) }
-					defaultValue={ postName }
+					value={ editedPostName }
 					onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
 					required
 					autoFocus

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -89,7 +89,8 @@ class PostPermalinkEditor extends Component {
 					{ samplePermalinkSuffix }
 				</span>
 				<Button
-					className="editor-post-permalink-editor__save button"
+					className="editor-post-permalink-editor__save"
+					isLarge
 					onClick={ this.onSavePermalink }
 				>
 					{ __( 'OK' ) }

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -73,20 +73,24 @@ class PostPermalinkEditor extends Component {
 		return (
 			<form
 				className="editor-post-permalink-editor"
-				onSubmit={ this.onSavePermalink }>
-				<span className="editor-post-permalink-editor__prefix">
-					{ samplePermalinkPrefix }
-				</span>
-				<input
-					className="editor-post-permalink-editor__edit"
-					aria-label={ __( 'Edit post permalink' ) }
-					value={ editedPostName }
-					onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
-					required
-					autoFocus
-				/>
-				<span className="editor-post-permalink-editor__suffix">
-					{ samplePermalinkSuffix }
+				onSubmit={ this.onSavePermalink }
+			>
+				<span>
+					<span className="editor-post-permalink-editor__prefix">
+						{ samplePermalinkPrefix }
+					</span>
+					<input
+						className="editor-post-permalink-editor__edit"
+						aria-label={ __( 'Edit post permalink' ) }
+						value={ editedPostName }
+						onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
+						required
+						autoFocus
+					/>
+					<span className="editor-post-permalink-editor__suffix">
+						{ samplePermalinkSuffix }
+					</span>
+					&lrm;
 				</span>
 				<Button
 					className="editor-post-permalink-editor__save"

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -22,38 +22,19 @@ class PostPermalinkEditor extends Component {
 		this.onSavePermalink = this.onSavePermalink.bind( this );
 	}
 
-	/**
-	 * Returns the permalink parts to populate the form.
-	 *
-	 * @return {Object} The prefix, suffix, and postName for the form.
-	 */
-	getPermalinkParts() {
-		const [ template, postName ] = this.props.samplePermalinkData;
-		const { editedPostName } = this.state;
-		const [ samplePermalinkPrefix, samplePermalinkSuffix ] = template.split( /%(?:postname|pagename)%/ );
-
-		return {
-			samplePermalinkPrefix,
-			samplePermalinkSuffix,
-			editedPostName: editedPostName || postName,
-		};
-	}
-
 	onSavePermalink( event ) {
 		const postName = this.state.editedPostName.replace( /\s+/g, '-' );
-		const [ template, oldPostName ] = this.props.samplePermalinkData;
 
 		event.preventDefault();
 
 		this.props.onSave();
 
-		if ( ! postName || postName === oldPostName ) {
+		if ( ! postName || postName === this.props.postName ) {
 			return;
 		}
 
 		this.props.editPost( {
 			slug: postName,
-			sample_permalink: [ template, postName ],
 		} );
 
 		this.setState( {
@@ -63,10 +44,11 @@ class PostPermalinkEditor extends Component {
 
 	render() {
 		const {
-			samplePermalinkPrefix,
-			samplePermalinkSuffix,
-			editedPostName,
-		} = this.getPermalinkParts();
+			prefix,
+			suffix,
+			postName,
+		} = this.props.permalinkParts;
+		const editedPostName = this.state.editedPostName || postName;
 
 		/* eslint-disable jsx-a11y/no-autofocus */
 		// Autofocus is allowed here, as this mini-UI is only loaded when the user clicks to open it.
@@ -77,7 +59,7 @@ class PostPermalinkEditor extends Component {
 			>
 				<span>
 					<span className="editor-post-permalink-editor__prefix">
-						{ samplePermalinkPrefix }
+						{ prefix }
 					</span>
 					<input
 						className="editor-post-permalink-editor__edit"
@@ -88,7 +70,7 @@ class PostPermalinkEditor extends Component {
 						autoFocus
 					/>
 					<span className="editor-post-permalink-editor__suffix">
-						{ samplePermalinkSuffix }
+						{ suffix }
 					</span>
 					&lrm;
 				</span>
@@ -107,9 +89,9 @@ class PostPermalinkEditor extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getPermalinkParts } = select( 'core/editor' );
 		return {
-			samplePermalinkData: getEditedPostAttribute( 'sample_permalink' ),
+			permalinkParts: getPermalinkParts(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import { connect } from 'react-redux';
-
-/**
  * WordPress dependencies
  */
-import { withDispatch } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { Component, compose } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
@@ -15,7 +10,6 @@ import { Button } from '@wordpress/components';
  * Internal Dependencies
  */
 import './style.scss';
-import { getEditedPostAttribute } from '../../store/selectors';
 
 class PostPermalinkEditor extends Component {
 	constructor() {
@@ -107,9 +101,10 @@ class PostPermalinkEditor extends Component {
 }
 
 export default compose( [
-	connect( ( state ) => {
+	withSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
 		return {
-			samplePermalinkData: getEditedPostAttribute( state, 'sample_permalink' ),
+			samplePermalinkData: getEditedPostAttribute( 'sample_permalink' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -12,11 +12,11 @@ import { Button } from '@wordpress/components';
 import './style.scss';
 
 class PostPermalinkEditor extends Component {
-	constructor() {
+	constructor( { permalinkParts } ) {
 		super( ...arguments );
 
 		this.state = {
-			editedPostName: '',
+			editedPostName: permalinkParts.postName,
 		};
 
 		this.onSavePermalink = this.onSavePermalink.bind( this );
@@ -43,12 +43,8 @@ class PostPermalinkEditor extends Component {
 	}
 
 	render() {
-		const {
-			prefix,
-			suffix,
-			postName,
-		} = this.props.permalinkParts;
-		const editedPostName = this.state.editedPostName || postName;
+		const { prefix, suffix } = this.props.permalinkParts;
+		const { editedPostName } = this.state;
 
 		/* eslint-disable jsx-a11y/no-autofocus */
 		// Autofocus is allowed here, as this mini-UI is only loaded when the user clicks to open it.

--- a/editor/components/post-permalink/editor.js
+++ b/editor/components/post-permalink/editor.js
@@ -72,6 +72,7 @@ class PostPermalinkEditor extends Component {
 		} = this.getPermalinkParts();
 
 		/* eslint-disable jsx-a11y/no-autofocus */
+		// Autofocus is allowed here, as this mini-UI is only loaded when the user clicks to open it.
 		return (
 			<form
 				className="editor-post-permalink-editor"

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon, ClipboardButton, Button } from '@wordpress/components';
+import { Dashicon, ClipboardButton, Button, Tooltip } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -94,14 +94,15 @@ class PostPermalink extends Component {
 
 		return (
 			<div className="editor-post-permalink">
-				<ClipboardButton
-					className="editor-post-permalink__copy"
-					text={ samplePermalink }
-					title={ __( 'Copy the permalink to your clipboard.' ) }
-					onCopy={ () => this.setState( { iconClass: 'copied' } ) }
-				>
-					<Dashicon icon="admin-links" className={ iconClass } />
-				</ClipboardButton>
+				<Tooltip text={ __( 'Copy the permalink to your clipboard.' ) }>
+					<ClipboardButton
+						className="editor-post-permalink__copy"
+						text={ samplePermalink }
+						onCopy={ () => this.setState( { iconClass: 'copied' } ) }
+					>
+						<Dashicon icon="admin-links" className={ iconClass } />
+					</ClipboardButton>
+				</Tooltip>
 
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>
 

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -122,10 +122,10 @@ class PostPermalink extends Component {
 							{ samplePermalinkPrefix }
 						</span>
 						<input
-							type="text"
 							className="editor-post-permalink__edit"
+							aria-label={ __( 'Edit post permalink' ) }
 							defaultValue={ postName }
-							onChange={ ( e ) => this.setState( { editedPostName: e.target.value } ) }
+							onChange={ ( event ) => this.setState( { editedPostName: event.target.value } ) }
 							required
 						/>
 						<span className="editor-post-permalink__suffix">
@@ -135,7 +135,7 @@ class PostPermalink extends Component {
 							className="editor-post-permalink__save button"
 							onClick={ this.onSavePermalink }
 						>
-							{ __( 'Ok' ) }
+							{ __( 'OK' ) }
 						</Button>
 					</form>
 				}

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -28,6 +28,16 @@ class PostPermalink extends Component {
 		};
 	}
 
+	componentDidUpdate( prevProps, prevState ) {
+		// If we've just stopped editing the permalink, focus on the new permalink.
+		if ( prevState.editingPermalink && ! this.state.editingPermalink ) {
+			const permalinkButton = document.querySelector( '.editor-post-permalink__link' );
+			if ( permalinkButton ) {
+				permalinkButton.focus();
+			}
+		}
+	}
+
 	render() {
 		const { isNew, previewLink, isEditable, samplePermalink } = this.props;
 		const { iconClass, editingPermalink } = this.state;

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -23,6 +23,7 @@ class PostPermalink extends Component {
 		super( ...arguments );
 
 		this.state = {
+			iconClass: '',
 			samplePermalink: '',
 			samplePermalinkPrefix: '',
 			samplePermalinkSuffix: '',
@@ -79,6 +80,7 @@ class PostPermalink extends Component {
 	render() {
 		const { isNew, previewLink, permalinkStructure } = this.props;
 		const {
+			iconClass,
 			samplePermalink,
 			samplePermalinkPrefix,
 			samplePermalinkSuffix,
@@ -93,10 +95,12 @@ class PostPermalink extends Component {
 		return (
 			<div className="editor-post-permalink">
 				<ClipboardButton
+					className="editor-post-permalink__copy"
 					text={ samplePermalink }
 					title={ __( 'Copy the permalink to your clipboard.' ) }
+					onCopy={ () => this.setState( { iconClass: 'copied' } ) }
 				>
-					<Dashicon icon="admin-links" />
+					<Dashicon icon="admin-links" className={ iconClass } />
 				</ClipboardButton>
 
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Dashicon, Button } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal Dependencies
@@ -27,8 +28,37 @@ class PostPermalink extends Component {
 		this.onFinishCopy = this.onFinishCopy.bind( this );
 	}
 
+	componentWillMount() {
+		if ( this.props.samplePermalinkData ) {
+			this.setState( {
+				samplePermalink: this.generatePermalink( this.props.samplePermalinkData[0], this.props.samplePermalinkData[1] ),
+			} );
+		}
+	}
+
 	componentWillUnmount() {
 		clearTimeout( this.dismissCopyConfirmation );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		console.log( nextProps );
+		if ( this.props.samplePermalinkData !== nextProps.samplePermalinkData ) {
+			this.setState( {
+				samplePermalink: this.generatePermalink( nextProps.samplePermalinkData[0], nextProps.samplePermalinkData[1] ),
+			} );
+		}
+	}
+
+	/**
+	 * Replace the %postname% and %pagename% tags in a sample permalink URL with actual values.
+	 *
+	 * @param {string} template  Permalink structure to replace the tags in.
+	 * @param {string} post_name The post slug to use in replacements.
+	 *
+	 * @return {string} Prepared permalink.
+	 */
+	generatePermalink( template, post_name ) {
+		return template.replace( /%(postname|pagename)%/, post_name );
 	}
 
 	onCopy() {
@@ -45,17 +75,27 @@ class PostPermalink extends Component {
 
 	render() {
 		const { isNew, link, permalinkStructure } = this.props;
+		const { samplePermalink } = this.state;
+
 		if ( isNew || ! link ) {
 			return null;
+		}
+
+		var hrefLink = link;
+		var displayLink = decodeURI( link );
+		if ( samplePermalink ) {
+			hrefLink = addQueryArgs( hrefLink, { preview: true } );
+			displayLink = samplePermalink;
 		}
 
 		return (
 			<div className="editor-post-permalink">
 				<Dashicon icon="admin-links" />
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>
-				<Button className="editor-post-permalink__link" href={ link } target="_blank">
-					{ decodeURI( link ) }
+				<Button className="editor-post-permalink__link" href={ hrefLink } target="_blank">
+					{ samplePermalink }
 				</Button>
+
 				{ ! permalinkStructure &&
 					<Button
 						className="editor-post-permalink__change button"
@@ -75,6 +115,7 @@ export default connect(
 		return {
 			isNew: isEditedPostNew( state ),
 			link: getEditedPostAttribute( state, 'link' ),
+			samplePermalinkData: getEditedPostAttribute( state, 'sample_permalink' ),
 
 			permalinkStructure: window.wpApiSettings.schema.permalink_structure,
 		};

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -61,7 +61,7 @@ class PostPermalink extends Component {
 					</Button>
 				}
 
-				<Tooltip text={ __( 'Copy the permalink to your clipboard.' ) }>
+				<Tooltip text={ __( 'Copy the permalink to your clipboard' ) }>
 					<ClipboardButton
 						className="editor-post-permalink__copy"
 						text={ samplePermalink }

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -38,16 +38,6 @@ class PostPermalink extends Component {
 
 		return (
 			<div className="editor-post-permalink">
-				<Tooltip text={ __( 'Copy the permalink to your clipboard.' ) }>
-					<ClipboardButton
-						className="editor-post-permalink__copy"
-						text={ samplePermalink }
-						onCopy={ () => this.setState( { iconClass: 'is-copied' } ) }
-					>
-						<Dashicon icon="admin-links" className={ iconClass } />
-					</ClipboardButton>
-				</Tooltip>
-
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>
 
 				{ ! editingPermalink &&
@@ -70,6 +60,16 @@ class PostPermalink extends Component {
 						{ __( 'Edit' ) }
 					</Button>
 				}
+
+				<Tooltip text={ __( 'Copy the permalink to your clipboard.' ) }>
+					<ClipboardButton
+						className="editor-post-permalink__copy"
+						text={ samplePermalink }
+						onCopy={ () => this.setState( { iconClass: 'is-copied' } ) }
+					>
+						<Dashicon icon="admin-links" className={ iconClass } />
+					</ClipboardButton>
+				</Tooltip>
 
 				{ ! isEditable &&
 					<Button

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -22,10 +22,7 @@ class PostPermalink extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
-			showCopyConfirmation: false,
 		};
-		this.onCopy = this.onCopy.bind( this );
-		this.onFinishCopy = this.onFinishCopy.bind( this );
 	}
 
 	componentWillMount() {
@@ -34,10 +31,6 @@ class PostPermalink extends Component {
 				samplePermalink: this.generatePermalink( this.props.samplePermalinkData[0], this.props.samplePermalinkData[1] ),
 			} );
 		}
-	}
-
-	componentWillUnmount() {
-		clearTimeout( this.dismissCopyConfirmation );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -61,15 +54,7 @@ class PostPermalink extends Component {
 		return template.replace( /%(postname|pagename)%/, post_name );
 	}
 
-	onCopy() {
 		this.setState( {
-			showCopyConfirmation: true,
-		} );
-	}
-
-	onFinishCopy() {
-		this.setState( {
-			showCopyConfirmation: false,
 		} );
 	}
 

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon, Button } from '@wordpress/components';
+import { Dashicon, ClipboardButton, Button } from '@wordpress/components';
 
 /**
  * Internal Dependencies
@@ -92,7 +92,13 @@ class PostPermalink extends Component {
 
 		return (
 			<div className="editor-post-permalink">
-				<Dashicon icon="admin-links" />
+				<ClipboardButton
+					text={ samplePermalink }
+					title={ __( 'Copy the permalink to your clipboard.' ) }
+				>
+					<Dashicon icon="admin-links" />
+				</ClipboardButton>
+
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>
 
 				{ // Show the sample permalink when it isn't being editing.

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -38,6 +38,16 @@ class PostPermalink extends Component {
 
 		return (
 			<div className="editor-post-permalink">
+				<Tooltip text={ __( 'Copy the permalink to your clipboard' ) }>
+					<ClipboardButton
+						className="editor-post-permalink__copy"
+						text={ samplePermalink }
+						onCopy={ () => this.setState( { iconClass: 'is-copied' } ) }
+					>
+						<Dashicon icon="admin-links" className={ iconClass } />
+					</ClipboardButton>
+				</Tooltip>
+
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>
 
 				{ ! editingPermalink &&
@@ -60,16 +70,6 @@ class PostPermalink extends Component {
 						{ __( 'Edit' ) }
 					</Button>
 				}
-
-				<Tooltip text={ __( 'Copy the permalink to your clipboard' ) }>
-					<ClipboardButton
-						className="editor-post-permalink__copy"
-						text={ samplePermalink }
-						onCopy={ () => this.setState( { iconClass: 'is-copied' } ) }
-					>
-						<Dashicon icon="admin-links" className={ iconClass } />
-					</ClipboardButton>
-				</Tooltip>
 
 				{ ! isEditable &&
 					<Button

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -8,13 +8,14 @@ import { connect } from 'react-redux';
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon, ClipboardButton, Button } from '@wordpress/components';
+import { Dashicon, Button } from '@wordpress/components';
 
 /**
  * Internal Dependencies
  */
 import './style.scss';
 import { isEditedPostNew, getEditedPostAttribute } from '../../store/selectors';
+import { getWPAdminURL } from '../../utils/url';
 
 class PostPermalink extends Component {
 	constructor() {
@@ -43,7 +44,7 @@ class PostPermalink extends Component {
 	}
 
 	render() {
-		const { isNew, link } = this.props;
+		const { isNew, link, permalinkStructure } = this.props;
 		if ( isNew || ! link ) {
 			return null;
 		}
@@ -55,14 +56,15 @@ class PostPermalink extends Component {
 				<Button className="editor-post-permalink__link" href={ link } target="_blank">
 					{ decodeURI( link ) }
 				</Button>
-				<ClipboardButton
-					className="button"
-					text={ link }
-					onCopy={ this.onCopy }
-					onFinishCopy={ this.onFinishCopy }
-				>
-					{ this.state.showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy' ) }
-				</ClipboardButton>
+				{ ! permalinkStructure &&
+					<Button
+						className="editor-post-permalink__change button"
+						href={ getWPAdminURL( 'options-permalink.php' ) }
+						target="_blank"
+					>
+						{ __( 'Change Permalinks' ) }
+					</Button>
+				}
 			</div>
 		);
 	}
@@ -73,6 +75,8 @@ export default connect(
 		return {
 			isNew: isEditedPostNew( state ),
 			link: getEditedPostAttribute( state, 'link' ),
+
+			permalinkStructure: window.wpApiSettings.schema.permalink_structure,
 		};
 	}
 )( PostPermalink );

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -98,7 +98,7 @@ class PostPermalink extends Component {
 					<ClipboardButton
 						className="editor-post-permalink__copy"
 						text={ samplePermalink }
-						onCopy={ () => this.setState( { iconClass: 'copied' } ) }
+						onCopy={ () => this.setState( { iconClass: 'is-copied' } ) }
 					>
 						<Dashicon icon="admin-links" className={ iconClass } />
 					</ClipboardButton>

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -17,12 +17,17 @@ class PostPermalink extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.addVisibilityCheck = this.addVisibilityCheck.bind( this );
 		this.onVisibilityChange = this.onVisibilityChange.bind( this );
 
 		this.state = {
 			iconClass: '',
 			isEditingPermalink: false,
 		};
+	}
+
+	addVisibilityCheck() {
+		window.addEventListener( 'visibilitychange', this.onVisibilityChange );
 	}
 
 	onVisibilityChange() {
@@ -39,6 +44,10 @@ class PostPermalink extends Component {
 		if ( prevState.isEditingPermalink && ! this.state.isEditingPermalink ) {
 			this.permalinkButton.focus();
 		}
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'visibilitychange', this.addVisibilityCheck );
 	}
 
 	render() {
@@ -96,7 +105,7 @@ class PostPermalink extends Component {
 						className="editor-post-permalink__change"
 						isLarge
 						href={ getWPAdminURL( 'options-permalink.php' ) }
-						onClick={ window.addEventListener( 'visibilitychange', this.onVisibilityChange ) }
+						onClick={ this.addVisibilityCheck }
 						target="_blank"
 					>
 						{ __( 'Change Permalinks' ) }

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -25,7 +25,7 @@ class PostPermalink extends Component {
 		};
 	}
 
-	onVisibilityChange( event ) {
+	onVisibilityChange() {
 		const { isEditable, refreshPost } = this.props;
 		// If the user just returned after having clicked the "Change Permalinks" button,
 		// fetch a new copy of the post from the server, just in case they enabled permalinks.

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -31,10 +31,7 @@ class PostPermalink extends Component {
 	componentDidUpdate( prevProps, prevState ) {
 		// If we've just stopped editing the permalink, focus on the new permalink.
 		if ( prevState.editingPermalink && ! this.state.editingPermalink ) {
-			const permalinkButton = document.querySelector( '.editor-post-permalink__link' );
-			if ( permalinkButton ) {
-				permalinkButton.focus();
-			}
+			this.permalinkButton.focus();
 		}
 	}
 
@@ -61,7 +58,12 @@ class PostPermalink extends Component {
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>
 
 				{ ! editingPermalink &&
-					<Button className="editor-post-permalink__link" href={ previewLink } target="_blank">
+					<Button
+						className="editor-post-permalink__link"
+						href={ previewLink }
+						target="_blank"
+						ref={ ( permalinkButton ) => this.permalinkButton = permalinkButton }
+					>
 						{ decodeURI( samplePermalink ) }
 					</Button>
 				}

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -65,6 +65,7 @@ class PostPermalink extends Component {
 						ref={ ( permalinkButton ) => this.permalinkButton = permalinkButton }
 					>
 						{ decodeURI( samplePermalink ) }
+						&lrm;
 					</Button>
 				}
 

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -15,7 +15,7 @@ import { Dashicon, Button, ClipboardButton, Tooltip } from '@wordpress/component
  */
 import './style.scss';
 import PostPermalinkEditor from './editor.js';
-import { isEditedPostNew, isPermalinkEditable, getEditedPostPreviewLink, getSamplePermalink } from '../../store/selectors';
+import { isEditedPostNew, isPermalinkEditable, getEditedPostPreviewLink, getPermalink } from '../../store/selectors';
 import { getWPAdminURL } from '../../utils/url';
 
 class PostPermalink extends Component {
@@ -106,7 +106,7 @@ export default connect(
 			isNew: isEditedPostNew( state ),
 			previewLink: getEditedPostPreviewLink( state ),
 			isEditable: isPermalinkEditable( state ),
-			samplePermalink: getSamplePermalink( state ),
+			samplePermalink: getPermalink( state ),
 		};
 	}
 )( PostPermalink );

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -76,7 +76,8 @@ class PostPermalink extends Component {
 
 				{ isEditable && ! editingPermalink &&
 					<Button
-						className="editor-post-permalink__edit button"
+						className="editor-post-permalink__edit"
+						isLarge
 						onClick={ () => this.setState( { editingPermalink: true } ) }
 					>
 						{ __( 'Edit' ) }
@@ -85,7 +86,8 @@ class PostPermalink extends Component {
 
 				{ ! isEditable &&
 					<Button
-						className="editor-post-permalink__change button"
+						className="editor-post-permalink__change"
+						isLarge
 						href={ getWPAdminURL( 'options-permalink.php' ) }
 						target="_blank"
 					>

--- a/editor/components/post-permalink/index.js
+++ b/editor/components/post-permalink/index.js
@@ -24,20 +24,20 @@ class PostPermalink extends Component {
 
 		this.state = {
 			iconClass: '',
-			editingPermalink: false,
+			isEditingPermalink: false,
 		};
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
 		// If we've just stopped editing the permalink, focus on the new permalink.
-		if ( prevState.editingPermalink && ! this.state.editingPermalink ) {
+		if ( prevState.isEditingPermalink && ! this.state.isEditingPermalink ) {
 			this.permalinkButton.focus();
 		}
 	}
 
 	render() {
 		const { isNew, previewLink, isEditable, samplePermalink } = this.props;
-		const { iconClass, editingPermalink } = this.state;
+		const { iconClass, isEditingPermalink } = this.state;
 
 		if ( isNew || ! previewLink ) {
 			return null;
@@ -57,7 +57,7 @@ class PostPermalink extends Component {
 
 				<span className="editor-post-permalink__label">{ __( 'Permalink:' ) }</span>
 
-				{ ! editingPermalink &&
+				{ ! isEditingPermalink &&
 					<Button
 						className="editor-post-permalink__link"
 						href={ previewLink }
@@ -69,17 +69,17 @@ class PostPermalink extends Component {
 					</Button>
 				}
 
-				{ editingPermalink &&
+				{ isEditingPermalink &&
 					<PostPermalinkEditor
-						onSave={ () => this.setState( { editingPermalink: false } ) }
+						onSave={ () => this.setState( { isEditingPermalink: false } ) }
 					/>
 				}
 
-				{ isEditable && ! editingPermalink &&
+				{ isEditable && ! isEditingPermalink &&
 					<Button
 						className="editor-post-permalink__edit"
 						isLarge
-						onClick={ () => this.setState( { editingPermalink: true } ) }
+						onClick={ () => this.setState( { isEditingPermalink: true } ) }
 					>
 						{ __( 'Edit' ) }
 					</Button>

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -39,19 +39,42 @@
 	}
 }
 
-.editor-post-permalink__edit-form {
+.editor-post-permalink-editor {
 	width: 100%;
+	min-width: 20%;
+	display: inline-flex;
+	align-items: center;
+
+	// Higher specificity required to override core margin styles
+	.editor-post-permalink-editor__save {
+		margin-left: auto;
+	}
 }
 
-.editor-post-permalink__prefix,
-.editor-post-permalink__suffix {
+.editor-post-permalink-editor__prefix {
 	color: $dark-gray-300;
+	flex: initial;
+	min-width: 20%;
+	overflow: hidden;
+	position: relative;
+	white-space: nowrap;
+
+	&:after {
+		@include long-content-fade( $size: 20% );
+	}
 }
 
-.editor-post-permalink__edit {
+.editor-post-permalink-editor__edit {
+	flex: initial;
+	min-width: 20%;
 	margin: 0 5px;
 }
 
-.editor-post-permalink__save {
-	float: right;
+.editor-post-permalink-editor__suffix {
+	color: $dark-gray-300;
+	margin-right: 10px;
+}
+
+.editor-post-permalink-editor__save {
+	margin-left: auto;
 }

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -17,6 +17,10 @@
 	}
 }
 
+.editor-post-permalink__copy .copied {
+	opacity: 0.3;
+}
+
 .editor-post-permalink__label {
 	margin: 0 10px;
 }

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -34,3 +34,20 @@
 		@include long-content-fade( $size: 20% );
 	}
 }
+
+.editor-post-permalink__edit-form {
+	width: 100%;
+}
+
+.editor-post-permalink__prefix,
+.editor-post-permalink__suffix {
+	color: $dark-gray-300;
+}
+
+.editor-post-permalink__edit {
+	margin: 0 5px;
+}
+
+.editor-post-permalink__save {
+	float: right;
+}

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -17,7 +17,7 @@
 	}
 }
 
-.editor-post-permalink__copy .copied {
+.editor-post-permalink__copy .is-copied {
 	opacity: 0.3;
 }
 

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -17,10 +17,6 @@
 	}
 }
 
-.editor-post-permalink__copy {
-	order: -1;
-}
-
 .editor-post-permalink__copy .is-copied {
 	opacity: 0.3;
 }

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -17,6 +17,10 @@
 	}
 }
 
+.editor-post-permalink__copy {
+	order: -1;
+}
+
 .editor-post-permalink__copy .is-copied {
 	opacity: 0.3;
 }

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -58,10 +58,7 @@
 	overflow: hidden;
 	position: relative;
 	white-space: nowrap;
-
-	&:after {
-		@include long-content-fade( $size: 20% );
-	}
+	text-overflow: ellipsis;
 }
 
 .editor-post-permalink-editor__edit {

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -17,6 +17,10 @@
 	}
 }
 
+.editor-post-permalink__copy {
+	margin-top: 4px;
+}
+
 .editor-post-permalink__copy .is-copied {
 	opacity: 0.3;
 }

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -53,7 +53,6 @@
 
 .editor-post-permalink-editor__prefix {
 	color: $dark-gray-300;
-	flex: initial;
 	min-width: 20%;
 	overflow: hidden;
 	position: relative;
@@ -62,7 +61,6 @@
 }
 
 .editor-post-permalink-editor__edit {
-	flex: initial;
 	min-width: 20%;
 	margin: 0 5px;
 }

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -71,7 +71,3 @@
 	color: $dark-gray-300;
 	margin-right: 10px;
 }
-
-.editor-post-permalink-editor__save {
-	margin-left: auto;
-}

--- a/editor/components/post-permalink/style.scss
+++ b/editor/components/post-permalink/style.scss
@@ -35,7 +35,7 @@
 	white-space: nowrap;
 
 	&:after {
-		@include long-content-fade( $size: 20% );
+		@include long-content-fade( $size: 20%, $edge: 1px );
 	}
 }
 

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -95,7 +95,6 @@ class PostTitle extends Component {
 		return (
 			<PostTypeSupportCheck supportKeys="title">
 				<div className={ className }>
-					{ isSelected && <PostPermalink /> }
 					<KeyboardShortcuts
 						shortcuts={ {
 							'mod+z': this.redirectHistory,
@@ -116,6 +115,7 @@ class PostTitle extends Component {
 							onKeyPress={ this.onUnselect }
 						/>
 					</KeyboardShortcuts>
+					{ isSelected && <PostPermalink /> }
 				</div>
 			</PostTypeSupportCheck>
 		);

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -88,11 +88,10 @@ class PostTitle extends Component {
 	}
 
 	render() {
-		const { title, placeholder, instanceId, postType } = this.props;
+		const { title, placeholder, instanceId, isPostTypeViewable } = this.props;
 		const { isSelected } = this.state;
 		const className = classnames( 'editor-post-title', { 'is-selected': isSelected } );
 		const decodedPlaceholder = decodeEntities( placeholder );
-		const isPostTypeViewable = get( postType, 'is_viewable', false );
 
 		return (
 			<PostTypeSupportCheck supportKeys="title">
@@ -127,10 +126,11 @@ class PostTitle extends Component {
 const applyWithSelect = withSelect( ( select ) => {
 	const { getEditedPostAttribute } = select( 'core/editor' );
 	const { getPostType } = select( 'core' );
+	const postType = getPostType( getEditedPostAttribute( 'type' ) )
 
 	return {
 		title: getEditedPostAttribute( 'title' ),
-		postType: getPostType( getEditedPostAttribute( 'type' ) ),
+		isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 	};
 } );
 

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -126,7 +126,7 @@ class PostTitle extends Component {
 const applyWithSelect = withSelect( ( select ) => {
 	const { getEditedPostAttribute } = select( 'core/editor' );
 	const { getPostType } = select( 'core' );
-	const postType = getPostType( getEditedPostAttribute( 'type' ) )
+	const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 	return {
 		title: getEditedPostAttribute( 'title' ),

--- a/editor/components/post-title/index.js
+++ b/editor/components/post-title/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, compose } from '@wordpress/element';
 import { keycodes, decodeEntities } from '@wordpress/utils';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { KeyboardShortcuts, withContext, withInstanceId, withFocusOutside, withAPIData } from '@wordpress/components';
+import { KeyboardShortcuts, withContext, withInstanceId, withFocusOutside } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -92,7 +92,7 @@ class PostTitle extends Component {
 		const { isSelected } = this.state;
 		const className = classnames( 'editor-post-title', { 'is-selected': isSelected } );
 		const decodedPlaceholder = decodeEntities( placeholder );
-		const isPostTypeViewable = get( postType, 'data.is_viewable', false );
+		const isPostTypeViewable = get( postType, 'is_viewable', false );
 
 		return (
 			<PostTypeSupportCheck supportKeys="title">
@@ -125,19 +125,12 @@ class PostTitle extends Component {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getEditedPostAttribute, getCurrentPostType } = select( 'core/editor' );
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getPostType } = select( 'core' );
 
 	return {
 		title: getEditedPostAttribute( 'title' ),
-		postTypeSlug: getCurrentPostType(),
-	};
-} );
-
-const applyWithAPIData = withAPIData( ( props ) => {
-	const { postTypeSlug } = props;
-
-	return {
-		postType: `/wp/v2/types/${ postTypeSlug }?context=edit`,
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 	};
 } );
 
@@ -171,7 +164,6 @@ const applyEditorSettings = withContext( 'editor' )(
 
 export default compose(
 	applyWithSelect,
-	applyWithAPIData,
 	applyWithDispatch,
 	applyEditorSettings,
 	withInstanceId,

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -340,7 +340,7 @@ export function savePost() {
 export function refreshPost() {
 	return {
 		type: 'UPDATE_POST_FROM_SERVER',
-	}
+	};
 }
 
 export function trashPost( postId, postType ) {

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -339,7 +339,7 @@ export function savePost() {
 
 export function refreshPost() {
 	return {
-		type: 'UPDATE_POST_FROM_SERVER',
+		type: 'REFRESH_POST',
 	};
 }
 

--- a/editor/store/actions.js
+++ b/editor/store/actions.js
@@ -337,6 +337,12 @@ export function savePost() {
 	};
 }
 
+export function refreshPost() {
+	return {
+		type: 'UPDATE_POST_FROM_SERVER',
+	}
+}
+
 export function trashPost( postId, postType ) {
 	return {
 		type: 'TRASH_POST',

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -136,7 +136,7 @@ export default {
 		);
 	},
 	REQUEST_POST_UPDATE_SUCCESS( action, store ) {
-		const { previousPost, post, edits } = action;
+		const { previousPost, post } = action;
 		const { dispatch } = store;
 
 		const publishStatus = [ 'publish', 'private', 'future' ];
@@ -174,14 +174,6 @@ export default {
 				</p>,
 				{ id: SAVE_POST_NOTICE_ID, spokenMessage: noticeMessage }
 			) );
-		}
-
-		// The server can return a sanitised version of the slug,
-		// in which case we need to update our local copy.
-		if ( get( edits, [ 'slug' ] ) !== post.slug ) {
-			dispatch( {
-				type: 'POSTNAME_SANITIZED',
-			} );
 		}
 
 		if ( get( window.history.state, 'id' ) !== post.id ) {

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -247,7 +247,7 @@ export default {
 		const message = action.error.message && action.error.code !== 'unknown_error' ? action.error.message : __( 'Trashing failed' );
 		store.dispatch( createErrorNotice( message, { id: TRASH_POST_NOTICE_ID } ) );
 	},
-	UPDATE_POST_FROM_SERVER( action, store ) {
+	REFRESH_POST( action, store ) {
 		const { dispatch, getState } = store;
 
 		const state = getState();

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -178,7 +178,7 @@ export default {
 
 		// The server can return a sanitised version of the slug,
 		// in which case we need to update our local copy.
-		if ( get( edits, 'slug' ) !== post.slug ) {
+		if ( get( edits, [ 'slug' ] ) !== post.slug ) {
 			dispatch( {
 				type: 'POSTNAME_SANITIZED',
 			} );

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -250,7 +250,7 @@ export default {
 			context: 'edit',
 		};
 
-		wp.apiRequest( { path: `/wp/v2/${ basePath }/${ post.id }`, method: 'GET', data } ).then(
+		wp.apiRequest( { path: `/wp/v2/${ basePath }/${ post.id }`, data } ).then(
 			( newPost ) => {
 				dispatch( resetPost( newPost ) );
 			}

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -178,7 +178,7 @@ export default {
 
 		// The server can return a sanitised version of the slug,
 		// in which case we need to update our local copy.
-		if ( edits.slug !== post.slug ) {
+		if ( get( edits, 'slug' ) !== post.slug ) {
 			dispatch( {
 				type: 'POSTNAME_SANITIZED',
 			} );

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -247,6 +247,23 @@ export default {
 		const message = action.error.message && action.error.code !== 'unknown_error' ? action.error.message : __( 'Trashing failed' );
 		store.dispatch( createErrorNotice( message, { id: TRASH_POST_NOTICE_ID } ) );
 	},
+	UPDATE_POST_FROM_SERVER( action, store ) {
+		const { dispatch, getState } = store;
+
+		const state = getState();
+		const post = getCurrentPost( state );
+		const basePath = wp.api.getPostTypeRoute( getCurrentPostType( state ) );
+
+		const data = {
+			context: 'edit',
+		};
+
+		wp.apiRequest( { path: `/wp/v2/${ basePath }/${ post.id }`, method: 'GET', data } ).then(
+			( newPost ) => {
+				dispatch( resetPost( newPost ) );
+			}
+		);
+	},
 	MERGE_BLOCKS( action, store ) {
 		const { dispatch } = store;
 		const state = store.getState();

--- a/editor/store/effects.js
+++ b/editor/store/effects.js
@@ -117,6 +117,7 @@ export default {
 					type: 'REQUEST_POST_UPDATE_SUCCESS',
 					previousPost: post,
 					post: newPost,
+					edits: toSend,
 					optimist: { type: COMMIT, id: POST_UPDATE_TRANSACTION_ID },
 				} );
 			},
@@ -135,7 +136,7 @@ export default {
 		);
 	},
 	REQUEST_POST_UPDATE_SUCCESS( action, store ) {
-		const { previousPost, post } = action;
+		const { previousPost, post, edits } = action;
 		const { dispatch } = store;
 
 		const publishStatus = [ 'publish', 'private', 'future' ];
@@ -173,6 +174,14 @@ export default {
 				</p>,
 				{ id: SAVE_POST_NOTICE_ID, spokenMessage: noticeMessage }
 			) );
+		}
+
+		// The server can return a sanitised version of the slug,
+		// in which case we need to update our local copy.
+		if ( edits.slug !== post.slug ) {
+			dispatch( {
+				type: 'POSTNAME_SANITIZED',
+			} );
 		}
 
 		if ( get( window.history.state, 'id' ) !== post.id ) {

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -217,7 +217,7 @@ export const editor = flow( [
 	// Track undo history, starting at editor initialization.
 	withHistory( {
 		resetTypes: [ 'SETUP_EDITOR_STATE' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS', 'POSTNAME_SANITIZED' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS' ],
 		shouldOverwriteState,
 	} ),
 
@@ -225,7 +225,7 @@ export const editor = flow( [
 	// editor initialization firing post reset as an effect.
 	withChangeDetection( {
 		resetTypes: [ 'SETUP_EDITOR_STATE', 'RESET_POST' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS', 'POSTNAME_SANITIZED' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS' ],
 	} ),
 ] )( {
 	edits( state = {}, action ) {
@@ -254,9 +254,14 @@ export const editor = flow( [
 
 				return state;
 
+			case 'UPDATE_POST':
 			case 'RESET_POST':
+				const getCanonicalValue = action.type === 'UPDATE_POST' ?
+					( key ) => action.edits[ key ] :
+					( key ) => getPostRawValue( action.post[ key ] );
+
 				return reduce( state, ( result, value, key ) => {
-					if ( value !== getPostRawValue( action.post[ key ] ) ) {
+					if ( value !== getCanonicalValue( key ) ) {
 						return result;
 					}
 
@@ -267,11 +272,6 @@ export const editor = flow( [
 					delete result[ key ];
 					return result;
 				}, state );
-
-			case 'POSTNAME_SANITIZED':
-				if ( 'slug' in state ) {
-					return omit( state, 'slug' );
-				}
 		}
 
 		return state;

--- a/editor/store/reducer.js
+++ b/editor/store/reducer.js
@@ -217,7 +217,7 @@ export const editor = flow( [
 	// Track undo history, starting at editor initialization.
 	withHistory( {
 		resetTypes: [ 'SETUP_EDITOR_STATE' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS', 'POSTNAME_SANITIZED' ],
 		shouldOverwriteState,
 	} ),
 
@@ -225,7 +225,7 @@ export const editor = flow( [
 	// editor initialization firing post reset as an effect.
 	withChangeDetection( {
 		resetTypes: [ 'SETUP_EDITOR_STATE', 'RESET_POST' ],
-		ignoreTypes: [ 'RECEIVE_BLOCKS' ],
+		ignoreTypes: [ 'RECEIVE_BLOCKS', 'POSTNAME_SANITIZED' ],
 	} ),
 ] )( {
 	edits( state = {}, action ) {
@@ -267,6 +267,11 @@ export const editor = flow( [
 					delete result[ key ];
 					return result;
 				}, state );
+
+			case 'POSTNAME_SANITIZED':
+				if ( 'slug' in state ) {
+					return omit( state, 'slug' );
+				}
 		}
 
 		return state;

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1540,7 +1540,12 @@ export function isPermalinkEditable( state ) {
  */
 export function getPermalink( state ) {
 	const { prefix, postName, suffix } = getPermalinkParts( state );
-	return prefix + postName + suffix;
+
+	if ( isPermalinkEditable( state ) ) {
+		return prefix + postName + suffix;
+	} else {
+		return prefix;
+	}
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1557,7 +1557,7 @@ export function getPermalink( state ) {
  */
 export function getPermalinkParts( state ) {
 	const permalinkTemplate = getEditedPostAttribute( state, 'permalink_template' );
-	const postName = getEditedPostAttribute( state, 'slug' );
+	const postName = getEditedPostAttribute( state, 'slug' ) || getEditedPostAttribute( state, 'draft_slug' );
 
 	const [ prefix, suffix ] = permalinkTemplate.split( PERMALINK_POSTNAME_REGEX );
 

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -31,6 +31,7 @@ import { deprecated } from '@wordpress/utils';
  */
 const MAX_RECENT_BLOCKS = 9;
 export const POST_UPDATE_TRANSACTION_ID = 'post-update';
+const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -1525,20 +1526,41 @@ export function getProvisionalBlockUID( state ) {
  * @return {boolean} Whether or not the permalink is editable.
  */
 export function isPermalinkEditable( state ) {
-	const samplePermalinkData = getEditedPostAttribute( state, 'sample_permalink' );
+	const permalinkTemplate = getEditedPostAttribute( state, 'permalink_template' );
 
-	return /%(?:postname|pagename)%/.test( samplePermalinkData[ 0 ] );
+	return PERMALINK_POSTNAME_REGEX.test( permalinkTemplate );
 }
 
 /**
- * Returns the sample permalink for the post.
+ * Returns the permalink for the post.
  *
  * @param {Object} state Editor state.
  *
- * @return {string} The sample permalink.
+ * @return {string} The permalink.
  */
-export function getSamplePermalink( state ) {
-	const samplePermalinkData = getEditedPostAttribute( state, 'sample_permalink' );
+export function getPermalink( state ) {
+	const {prefix, postName, suffix } = getPermalinkParts( state );
+	return prefix + postName + suffix;
 
-	return samplePermalinkData[ 0 ].replace( /%(?:postname|pagename)%/, samplePermalinkData[ 1 ] );
+	return permalinkParts.values().join( '' );
+}
+
+/**
+ * Returns the permalink for a post, split into it's three parts: the prefix, the postName, and the suffix.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {Object} The prefix, postName, and suffix for the permalink.
+ */
+export function getPermalinkParts( state ) {
+	const permalinkTemplate = getEditedPostAttribute( state, 'permalink_template' );
+	const postName = getEditedPostAttribute( state, 'slug' );
+
+	const [ prefix, suffix ] = permalinkTemplate.split( PERMALINK_POSTNAME_REGEX );
+
+	return {
+		prefix,
+		postName,
+		suffix,
+	};
 }

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1543,9 +1543,9 @@ export function getPermalink( state ) {
 
 	if ( isPermalinkEditable( state ) ) {
 		return prefix + postName + suffix;
-	} else {
-		return prefix;
 	}
+
+	return prefix;
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1527,10 +1527,6 @@ export function getProvisionalBlockUID( state ) {
 export function isPermalinkEditable( state ) {
 	const samplePermalinkData = getEditedPostAttribute( state, 'sample_permalink' );
 
-	if ( ! samplePermalinkData || samplePermalinkData.length < 2 ) {
-		return false;
-	}
-
 	return /%(?:postname|pagename)%/.test( samplePermalinkData[ 0 ] );
 }
 
@@ -1543,10 +1539,6 @@ export function isPermalinkEditable( state ) {
  */
 export function getSamplePermalink( state ) {
 	const samplePermalinkData = getEditedPostAttribute( state, 'sample_permalink' );
-
-	if ( ! samplePermalinkData || samplePermalinkData.length < 2 ) {
-		return false;
-	}
 
 	return samplePermalinkData[ 0 ].replace( /%(?:postname|pagename)%/, samplePermalinkData[ 1 ] );
 }

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1516,3 +1516,29 @@ export function isPublishingPost( state ) {
 export function getProvisionalBlockUID( state ) {
 	return state.provisionalBlockUID;
 }
+
+/**
+ * Returns whether the permalink is editable or not.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Whether or not the permalink is editable.
+ */
+export function isPermalinkEditable( state ) {
+	const samplePermalinkData = getEditedPostAttribute( state, 'sample_permalink' );
+
+	return /%(?:postname|pagename)%/.test( samplePermalinkData[ 0 ] );
+}
+
+/**
+ * Returns the sample permalink for the post.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string} The sample permalink.
+ */
+export function getSamplePermalink( state ) {
+	const samplePermalinkData = getEditedPostAttribute( state, 'sample_permalink' );
+
+	return samplePermalinkData[ 0 ].replace( /%(?:postname|pagename)%/, samplePermalinkData[ 1 ] );
+}

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1539,10 +1539,8 @@ export function isPermalinkEditable( state ) {
  * @return {string} The permalink.
  */
 export function getPermalink( state ) {
-	const {prefix, postName, suffix } = getPermalinkParts( state );
+	const { prefix, postName, suffix } = getPermalinkParts( state );
 	return prefix + postName + suffix;
-
-	return permalinkParts.values().join( '' );
 }
 
 /**

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -1527,6 +1527,10 @@ export function getProvisionalBlockUID( state ) {
 export function isPermalinkEditable( state ) {
 	const samplePermalinkData = getEditedPostAttribute( state, 'sample_permalink' );
 
+	if ( ! samplePermalinkData || samplePermalinkData.length < 2 ) {
+		return false;
+	}
+
 	return /%(?:postname|pagename)%/.test( samplePermalinkData[ 0 ] );
 }
 
@@ -1539,6 +1543,10 @@ export function isPermalinkEditable( state ) {
  */
 export function getSamplePermalink( state ) {
 	const samplePermalinkData = getEditedPostAttribute( state, 'sample_permalink' );
+
+	if ( ! samplePermalinkData || samplePermalinkData.length < 2 ) {
+		return false;
+	}
 
 	return samplePermalinkData[ 0 ].replace( /%(?:postname|pagename)%/, samplePermalinkData[ 1 ] );
 }

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -84,6 +84,9 @@ const {
 	getTemplate,
 	getTemplateLock,
 	POST_UPDATE_TRANSACTION_ID,
+	isPermalinkEditable,
+	getPermalink,
+	getPermalinkParts,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -3091,6 +3094,95 @@ describe( 'selectors', () => {
 			};
 
 			expect( getTemplateLock( state ) ).toBe( 'all' );
+		} );
+	} );
+
+	describe( 'isPermalinkEditable', () => {
+		it( 'should be false if there is no permalink', () => {
+			const state = {
+				currentPost: { permalink_template: '' },
+			};
+
+			expect( isPermalinkEditable( state ) ).toBe( false );
+		} );
+
+		it( 'should be false if the permalink is not of an editable kind', () => {
+			const state = {
+				currentPost: { permalink_template: 'http://foo.test/bar/%baz%/' },
+			};
+
+			expect( isPermalinkEditable( state ) ).toBe( false );
+		} );
+
+		it( 'should be true if the permalink has %postname%', () => {
+			const state = {
+				currentPost: { permalink_template: 'http://foo.test/bar/%postname%/' },
+			};
+
+			expect( isPermalinkEditable( state ) ).toBe( true );
+		} );
+
+		it( 'should be true if the permalink has %pagename%', () => {
+			const state = {
+				currentPost: { permalink_template: 'http://foo.test/bar/%pagename%/' },
+			};
+
+			expect( isPermalinkEditable( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'getPermalink', () => {
+		it( 'should work if the permalink is not of an editable kind', () => {
+			const url = 'http://foo.test/?post=1';
+			const state = {
+				currentPost: { permalink_template: url },
+			};
+
+			expect( getPermalink( state ) ).toBe( url );
+		} );
+
+		it( 'should return the permalink if it is editable', () => {
+			const state = {
+				currentPost: {
+					permalink_template: 'http://foo.test/bar/%postname%/',
+					slug: 'baz',
+				},
+			};
+
+			expect( getPermalink( state ) ).toBe( 'http://foo.test/bar/baz/' );
+		} );
+	} );
+
+	describe( 'getPermalinkParts', () => {
+		it( 'should split the permalink correctly', () => {
+			const parts = {
+				prefix: 'http://foo.test/bar/',
+				postName: 'baz',
+				suffix: '/',
+			};
+			const state = {
+				currentPost: {
+					permalink_template: 'http://foo.test/bar/%postname%/',
+					slug: 'baz',
+				},
+			};
+
+			expect( getPermalinkParts( state ) ).toEqual( parts );
+		} );
+
+		it( 'should leave an uneditable permalink in the prefix', () => {
+			const parts = {
+				prefix: 'http://foo.test/?post=1',
+				postName: 'baz',
+			};
+			const state = {
+				currentPost: {
+					permalink_template: 'http://foo.test/?post=1',
+					slug: 'baz',
+				},
+			};
+
+			expect( getPermalinkParts( state ) ).toEqual( parts );
 		} );
 	} );
 } );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -437,3 +437,36 @@ function gutenberg_get_taxonomy_visibility_data( $object ) {
 }
 
 add_action( 'rest_api_init', 'gutenberg_add_taxonomy_visibility_field' );
+
+/**
+ * Add a sample permalink to draft posts in the post REST API response.
+ *
+ * @param WP_REST_Response $response WP REST API response of a post.
+ * @param WP_Post          $post The post being returned.
+ * @param WP_REST_Request  $request WP REST API request.
+ * @return WP_REST_Response Response containing the sample_permalink, where appropriate.
+ */
+function gutenberg_add_sample_permalink_to_draft_posts( $response, $post, $request ) {
+	if ( empty( $response->data['status'] ) || 'draft' !== $response->data['status'] ) {
+		return $response;
+	}
+	if ( 'edit' !== $request['context'] ) {
+		return $response;
+	}
+	if ( ! function_exists( 'get_sample_permalink' ) ) {
+		require_once ABSPATH . '/wp-admin/includes/post.php';
+	}
+	$response->data['sample_permalink'] = get_sample_permalink( $post );
+	return $response;
+}
+/**
+ * Whenever a post type is registered, ensure we're hooked into it's WP REST API response.
+ *
+ * @param string $post_type The newly registered post type.
+ * @return string That same post type.
+ */
+function gutenberg_register_sample_permalink_function( $post_type ) {
+	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_sample_permalink_to_draft_posts', 10, 3 );
+	return $post_type;
+}
+add_filter( 'registered_post_type', 'gutenberg_register_sample_permalink_function' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -439,12 +439,12 @@ function gutenberg_get_taxonomy_visibility_data( $object ) {
 add_action( 'rest_api_init', 'gutenberg_add_taxonomy_visibility_field' );
 
 /**
- * Add a sample permalink to draft posts in the post REST API response.
+ * Add a permalink template to posts in the post REST API response.
  *
  * @param WP_REST_Response $response WP REST API response of a post.
  * @param WP_Post          $post The post being returned.
  * @param WP_REST_Request  $request WP REST API request.
- * @return WP_REST_Response Response containing the sample_permalink.
+ * @return WP_REST_Response Response containing the permalink_template.
  */
 function gutenberg_add_sample_permalink_to_posts( $response, $post, $request ) {
 	if ( 'edit' !== $request['context'] ) {
@@ -455,7 +455,8 @@ function gutenberg_add_sample_permalink_to_posts( $response, $post, $request ) {
 		require_once ABSPATH . '/wp-admin/includes/post.php';
 	}
 
-	$response->data['sample_permalink'] = get_sample_permalink( $post->ID );
+	$sample_permalink = get_sample_permalink( $post->ID );
+	$response->data['permalink_template'] = $sample_permalink[0];
 	return $response;
 }
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -456,7 +456,9 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 	}
 
 	$sample_permalink = get_sample_permalink( $post->ID );
+
 	$response->data['permalink_template'] = $sample_permalink[0];
+
 	return $response;
 }
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -447,15 +447,14 @@ add_action( 'rest_api_init', 'gutenberg_add_taxonomy_visibility_field' );
  * @return WP_REST_Response Response containing the sample_permalink, where appropriate.
  */
 function gutenberg_add_sample_permalink_to_draft_posts( $response, $post, $request ) {
-	if ( empty( $response->data['status'] ) || 'draft' !== $response->data['status'] ) {
-		return $response;
-	}
 	if ( 'edit' !== $request['context'] ) {
 		return $response;
 	}
+
 	if ( ! function_exists( 'get_sample_permalink' ) ) {
 		require_once ABSPATH . '/wp-admin/includes/post.php';
 	}
+
 	$response->data['sample_permalink'] = get_sample_permalink( $post->ID );
 	return $response;
 }

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -456,7 +456,7 @@ function gutenberg_add_sample_permalink_to_draft_posts( $response, $post, $reque
 	if ( ! function_exists( 'get_sample_permalink' ) ) {
 		require_once ABSPATH . '/wp-admin/includes/post.php';
 	}
-	$response->data['sample_permalink'] = get_sample_permalink( $post );
+	$response->data['sample_permalink'] = get_sample_permalink( $post->ID );
 	return $response;
 }
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -459,6 +459,10 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 
 	$response->data['permalink_template'] = $sample_permalink[0];
 
+	if ( 'draft' === $post->post_status && ! $post->post_name ) {
+		$response->data['draft_slug'] = $sample_permalink[1];
+	}
+
 	return $response;
 }
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -451,6 +451,10 @@ function gutenberg_add_sample_permalink_to_draft_posts( $response, $post, $reque
 		return $response;
 	}
 
+	if ( ! get_post_type_object( $post->post_type )->public ) {
+		return $response;
+	}
+
 	if ( ! function_exists( 'get_sample_permalink' ) ) {
 		require_once ABSPATH . '/wp-admin/includes/post.php';
 	}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -446,7 +446,7 @@ add_action( 'rest_api_init', 'gutenberg_add_taxonomy_visibility_field' );
  * @param WP_REST_Request  $request WP REST API request.
  * @return WP_REST_Response Response containing the permalink_template.
  */
-function gutenberg_add_sample_permalink_to_posts( $response, $post, $request ) {
+function gutenberg_add_permalink_template_to_posts( $response, $post, $request ) {
 	if ( 'edit' !== $request['context'] ) {
 		return $response;
 	}
@@ -459,17 +459,18 @@ function gutenberg_add_sample_permalink_to_posts( $response, $post, $request ) {
 	$response->data['permalink_template'] = $sample_permalink[0];
 	return $response;
 }
+
 /**
  * Whenever a post type is registered, ensure we're hooked into it's WP REST API response.
  *
  * @param string $post_type The newly registered post type.
  * @return string That same post type.
  */
-function gutenberg_register_sample_permalink_function( $post_type ) {
-	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_sample_permalink_to_posts', 10, 3 );
+function gutenberg_register_permalink_template_function( $post_type ) {
+	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_permalink_template_to_posts', 10, 3 );
 	return $post_type;
 }
-add_filter( 'registered_post_type', 'gutenberg_register_sample_permalink_function' );
+add_filter( 'registered_post_type', 'gutenberg_register_permalink_template_function' );
 
 /**
  * Add an is_viewable flag to the  posttype REST API response.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -473,3 +473,17 @@ function gutenberg_register_sample_permalink_function( $post_type ) {
 	return $post_type;
 }
 add_filter( 'registered_post_type', 'gutenberg_register_sample_permalink_function' );
+
+/**
+ * Add an is_viewable flag to the  posttype REST API response.
+ *
+ * @param WP_REST_Response $response WP REST API response of a post.
+ * @param WP_Post_Type     $post_type The post_type being returned.
+ * @param WP_REST_Request  $request WP REST API request.
+ * @return WP_REST_Response Response containing is_viewable flag.
+ */
+function gutenberg_add_viewable_flag_to_post_types( $response, $post_type, $request ) {
+	$response->data['is_viewable'] = is_post_type_viewable( $post_type );
+	return $response;
+}
+add_filter( 'rest_prepare_post_type', 'gutenberg_add_viewable_flag_to_post_types', 10, 3 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -444,14 +444,10 @@ add_action( 'rest_api_init', 'gutenberg_add_taxonomy_visibility_field' );
  * @param WP_REST_Response $response WP REST API response of a post.
  * @param WP_Post          $post The post being returned.
  * @param WP_REST_Request  $request WP REST API request.
- * @return WP_REST_Response Response containing the sample_permalink, where appropriate.
+ * @return WP_REST_Response Response containing the sample_permalink.
  */
-function gutenberg_add_sample_permalink_to_draft_posts( $response, $post, $request ) {
+function gutenberg_add_sample_permalink_to_posts( $response, $post, $request ) {
 	if ( 'edit' !== $request['context'] ) {
-		return $response;
-	}
-
-	if ( ! get_post_type_object( $post->post_type )->public ) {
 		return $response;
 	}
 
@@ -469,7 +465,7 @@ function gutenberg_add_sample_permalink_to_draft_posts( $response, $post, $reque
  * @return string That same post type.
  */
 function gutenberg_register_sample_permalink_function( $post_type ) {
-	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_sample_permalink_to_draft_posts', 10, 3 );
+	add_filter( "rest_prepare_{$post_type}", 'gutenberg_add_sample_permalink_to_posts', 10, 3 );
 	return $post_type;
 }
 add_filter( 'registered_post_type', 'gutenberg_register_sample_permalink_function' );

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -124,13 +124,16 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertArraySubset(
-			array(
-				'id'      => self::$post_id,
-				'title'   => 'New cool block',
-				'content' => '<!-- wp:core/paragraph --><p>Wow!</p><!-- /wp:core/paragraph -->',
-			), $response->get_data()
-		);
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertArrayHasKey( 'title', $data );
+		$this->assertArrayHasKey( 'content', $data );
+
+		$this->assertEquals( self::$post_id, $data['id'] );
+		$this->assertEquals( 'New cool block', $data['title'] );
+		$this->assertEquals( '<!-- wp:core/paragraph --><p>Wow!</p><!-- /wp:core/paragraph -->', $data['content'] );
 	}
 
 	/**
@@ -150,13 +153,16 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertArraySubset(
-			array(
-				'id'      => self::$post_id,
-				'title'   => 'Updated cool block',
-				'content' => '<!-- wp:core/paragraph --><p>Nice!</p><!-- /wp:core/paragraph -->',
-			), $response->get_data()
-		);
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertArrayHasKey( 'title', $data );
+		$this->assertArrayHasKey( 'content', $data );
+
+		$this->assertEquals( self::$post_id, $data['id'] );
+		$this->assertEquals( 'Updated cool block', $data['title'] );
+		$this->assertEquals( '<!-- wp:core/paragraph --><p>Nice!</p><!-- /wp:core/paragraph -->', $data['content'] );
 	}
 
 	/**
@@ -170,16 +176,21 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertArraySubset(
-			array(
-				'deleted'  => true,
-				'previous' => array(
-					'id'      => self::$post_id,
-					'title'   => 'My cool block',
-					'content' => '<!-- wp:core/paragraph --><p>Hello!</p><!-- /wp:core/paragraph -->',
-				),
-			), $response->get_data()
-		);
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'deleted', $data );
+		$this->assertArrayHasKey( 'previous', $data );
+
+		$this->assertTrue( $data['deleted'] );
+
+		$this->assertArrayHasKey( 'id', $data['previous'] );
+		$this->assertArrayHasKey( 'title', $data['previous'] );
+		$this->assertArrayHasKey( 'content', $data['previous'] );
+
+		$this->assertEquals( self::$post_id, $data['previous']['id'] );
+		$this->assertEquals( 'My cool block', $data['previous']['title'] );
+		$this->assertEquals( '<!-- wp:core/paragraph --><p>Hello!</p><!-- /wp:core/paragraph -->', $data['previous']['content'] );
 	}
 
 	/**

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -124,7 +124,7 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals(
+		$this->assertArraySubset(
 			array(
 				'id'      => self::$post_id,
 				'title'   => 'New cool block',
@@ -150,7 +150,7 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals(
+		$this->assertArraySubset(
 			array(
 				'id'      => self::$post_id,
 				'title'   => 'Updated cool block',
@@ -170,7 +170,7 @@ class REST_Blocks_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals(
+		$this->assertArraySubset(
 			array(
 				'deleted'  => true,
 				'previous' => array(


### PR DESCRIPTION
## Description

#5414 has become way too unwieldy to work with, so this PR is a fresh attempt, based on @karmatosed's [design](https://github.com/WordPress/gutenberg/pull/3418#issuecomment-347016776).

## Screenshots (jpeg or gifs if applicable):

<img width="648" alt="Initial view of the permalink UI" src="https://user-images.githubusercontent.com/352291/37815016-34e7fc94-2ec1-11e8-961f-503ce3dd00e7.png">
<img width="646" alt="Editable view of the permalink UI" src="https://user-images.githubusercontent.com/352291/37815020-3a3456b6-2ec1-11e8-96ce-674e99f2b103.png">
<img width="645" alt="Edited permalink" src="https://user-images.githubusercontent.com/352291/37815025-40b0aa8a-2ec1-11e8-8801-a539001d00b0.png">
<img width="642" alt="Edited permalink after clicking Okay" src="https://user-images.githubusercontent.com/352291/37815028-440bd0a6-2ec1-11e8-8868-320a9e6eada0.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
