### PR TITLE
Fix onEnter patterns. Code and Separator blocks.

### DIFF
--- a/blocks/rich-text/patterns.js
+++ b/blocks/rich-text/patterns.js
@@ -52,7 +52,7 @@ export default function( editor ) {
 		}
 
 		if ( keyCode === ENTER ) {
-			enter();
+			enter( event );
 		// Wait for the browser to insert the character.
 		} else if ( keyCode === SPACE ) {
 			setTimeout( () => searchFirstText( spacePatterns ) );
@@ -204,7 +204,7 @@ export default function( editor ) {
 		onReplace( [ block ] );
 	}
 
-	function enter() {
+	function enter( event ) {
 		if ( ! onReplace ) {
 			return;
 		}
@@ -225,7 +225,11 @@ export default function( editor ) {
 		}
 
 		const block = pattern.transform( { content } );
+		onReplace( [ block ] );
 
-		editor.once( 'keyup', () => onReplace( [ block ] ) );
+		// We call preventDefault to prevent additional newlines.
+		event.preventDefault();
+		// stopImmediatePropagation is called to prevent TinyMCE's own processing of keydown which conflicts with the block replacement.
+		event.stopImmediatePropagation();
 	}
 }


### PR DESCRIPTION
The replace was happening on keyUp and sometimes that event did not fire. So now we do the replace right away if a pattern matches, and we cancel the event processing so no errors happen.
Sometimes the code regex did not match because of white spaces, related with the way browser handle an enter after '`' char so an optional whitespace char was added to the regex.

Because of browser behavior we now also accept \`\`\`\` followed by enter as a way to convert to the code block. Chrome automatically adds another \` if enter is pressed one time after \` so this allows the user to write \`\`\` and then press enter two times (first inserts the \`second one converts the block) to create the code block. This chrome behavior for entering is not specific to Gutenberg even in Github comment boxes it happens. Enter events did not fir when enter is inserting \`. In safari enter after \`creates a new line,  pressing two times after \`\`\`also creates a new line.

I think users using \`\`\` are aware of the strange browser use of enter and will probably press enter again as this is something, not Gutenberg specific so they are already probably aware of the behavior of enter after \`. Another alternative we have is handling '\`' keypress event so we can transform on third \` keypress without enter. The addition of this handles will make the code more complex that's why I preferred this approach.

Fixes: 
https://github.com/WordPress/gutenberg/issues/4290

## How Has This Been Tested?
Add a new paragraph write --- in it press enter and see it is transformed right away to separator block. In master, it wasn't but if after press key up to go up the transformation happened it was only transformed on the key up of the arrow not the key up of the enter.
In chrome add `` then press enter chrome automatically adds another ` now press enter and the transformation should happen. Safari creates a new line when pressing enter after `so if we insert ``` 
then press enter we get a new line if enter is pressed again the transform happens.

## Screenshots (jpeg or gifs if applicable):
Before:
![mar-23-2018 15-16-38](https://user-images.githubusercontent.com/11271197/37837572-756b618e-2ead-11e8-8e0d-93f651f90921.gif)
![mar-23-2018 15-15-39](https://user-images.githubusercontent.com/11271197/37837605-8a5d9800-2ead-11e8-8e58-bce8e1c32d03.gif)


After:
![mar-23-2018 15-00-47](https://user-images.githubusercontent.com/11271197/37837632-9c00bab0-2ead-11e8-83d1-d60adf1b1dbe.gif)
![mar-23-2018 15-10-32](https://user-images.githubusercontent.com/11271197/37837640-a1017a0e-2ead-11e8-87b7-9cadc05f822d.gif)



