### PR TITLE
Improved pre/post publish flow.

### DIFF
--- a/editor/components/post-publish-button/label.js
+++ b/editor/components/post-publish-button/label.js
@@ -37,6 +37,8 @@ export function PublishButtonLabel( {
 		return __( 'Publishing…' );
 	} else if ( isPublished && isSaving ) {
 		return __( 'Updating…' );
+	} else if ( isBeingScheduled && isSaving ) {
+		return __( 'Scheduling…' );
 	}
 
 	if ( isContributor ) {

--- a/editor/components/post-publish-button/test/label.js
+++ b/editor/components/post-publish-button/test/label.js
@@ -36,6 +36,11 @@ describe( 'PublishButtonLabel', () => {
 		expect( label ).toBe( 'Updating…' );
 	} );
 
+	it( 'should show scheduling if scheduled and saving in progress', () => {
+		const label = PublishButtonLabel( { user, isBeingScheduled: true, isSaving: true } );
+		expect( label ).toBe( 'Scheduling…' );
+	} );
+
 	it( 'should show publish if not published and saving in progress', () => {
 		const label = PublishButtonLabel( { user, isPublished: false, isSaving: true } );
 		expect( label ).toBe( 'Publish' );

--- a/editor/components/post-publish-panel/postpublish.js
+++ b/editor/components/post-publish-panel/postpublish.js
@@ -9,12 +9,13 @@ import { connect } from 'react-redux';
  */
 import { PanelBody, Button, ClipboardButton, withAPIData } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Component, compose } from '@wordpress/element';
+import { Component, compose, Fragment } from '@wordpress/element';
 
 /**
  * Internal Dependencies
  */
-import { getCurrentPost, getCurrentPostType } from '../../store/selectors';
+import PostScheduleLabel from '../post-schedule/label';
+import { getCurrentPost, getCurrentPostType, isCurrentPostScheduled } from '../../store/selectors';
 
 class PostPublishPanelPostpublish extends Component {
 	constructor() {
@@ -48,16 +49,23 @@ class PostPublishPanelPostpublish extends Component {
 	}
 
 	render() {
-		const { post, postType } = this.props;
+		const { isScheduled, post, postType } = this.props;
 		const viewPostLabel = get( postType, [ 'data', 'labels', 'view_item' ] );
+
+		const postPublishNonLinkHeader = isScheduled ?
+			<Fragment>{ __( 'is now scheduled. It will go live on' ) } <PostScheduleLabel />.</Fragment> :
+			__( 'is now live.' );
+		const postPublishBodyText = isScheduled ?
+			__( 'The post address will be:' ) :
+			__( 'What\'s next?' );
 
 		return (
 			<div className="post-publish-panel__postpublish">
 				<PanelBody className="post-publish-panel__postpublish-header">
-					<a href={ post.link }>{ post.title || __( '(no title)' ) }</a>{ __( ' is now live.' ) }
+					<a href={ post.link }>{ post.title || __( '(no title)' ) }</a> { postPublishNonLinkHeader }
 				</PanelBody>
 				<PanelBody>
-					<div><strong>{ __( 'What\'s next?' ) }</strong></div>
+					<div><strong>{ postPublishBodyText }</strong></div>
 					<input
 						className="post-publish-panel__postpublish-link-input"
 						readOnly
@@ -65,9 +73,11 @@ class PostPublishPanelPostpublish extends Component {
 						onFocus={ this.onSelectInput }
 					/>
 					<div className="post-publish-panel__postpublish-buttons">
-						<Button className="button" href={ post.link }>
-							{ viewPostLabel }
-						</Button>
+						{ ! isScheduled && (
+							<Button className="button" href={ post.link }>
+								{ viewPostLabel }
+							</Button>
+						) }
 
 						<ClipboardButton className="button" text={ post.link } onCopy={ this.onCopy }>
 							{ this.state.showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy Link' ) }
@@ -84,6 +94,7 @@ const applyConnect = connect(
 		return {
 			post: getCurrentPost( state ),
 			postTypeSlug: getCurrentPostType( state ),
+			isScheduled: isCurrentPostScheduled( state ),
 		};
 	}
 );

--- a/editor/components/post-publish-panel/toggle.js
+++ b/editor/components/post-publish-panel/toggle.js
@@ -19,8 +19,10 @@ import {
 	isSavingPost,
 	isEditedPostSaveable,
 	isEditedPostPublishable,
+	isCurrentPostPending,
 	isCurrentPostPublished,
 	isEditedPostBeingScheduled,
+	isCurrentPostScheduled,
 	getCurrentPostType,
 } from '../../store/selectors';
 
@@ -31,6 +33,8 @@ function PostPublishPanelToggle( {
 	isSaveable,
 	isPublished,
 	isBeingScheduled,
+	isPending,
+	isScheduled,
 	onToggle,
 	isOpen,
 	forceIsDirty,
@@ -42,7 +46,7 @@ function PostPublishPanelToggle( {
 
 	const userCanPublishPosts = get( user.data, [ 'post_type_capabilities', 'publish_posts' ], false );
 	const isContributor = user.data && ! userCanPublishPosts;
-	const showToggle = ! isContributor && ! isPublished && ! isBeingScheduled;
+	const showToggle = ! isPublished && ! ( isScheduled && isBeingScheduled ) && ! ( isPending && isContributor );
 
 	if ( ! showToggle ) {
 		return <PostPublishButton forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />;
@@ -57,7 +61,7 @@ function PostPublishPanelToggle( {
 			disabled={ ! isButtonEnabled }
 			isBusy={ isSaving && isPublished }
 		>
-			{ __( 'Publish...' ) }
+			{ isBeingScheduled ? __( 'Schedule...' ) : __( 'Publish...' ) }
 		</Button>
 	);
 }
@@ -67,7 +71,9 @@ const applyConnect = connect(
 		isSaving: isSavingPost( state ),
 		isSaveable: isEditedPostSaveable( state ),
 		isPublishable: isEditedPostPublishable( state ),
+		isPending: isCurrentPostPending( state ),
 		isPublished: isCurrentPostPublished( state ),
+		isScheduled: isCurrentPostScheduled( state ),
 		isBeingScheduled: isEditedPostBeingScheduled( state ),
 		postType: getCurrentPostType( state ),
 	} ),

--- a/editor/store/selectors.js
+++ b/editor/store/selectors.js
@@ -217,6 +217,17 @@ export function getEditedPostVisibility( state ) {
 }
 
 /**
+ * Returns true if post is pending review.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether current post is pending review.
+ */
+export function isCurrentPostPending( state ) {
+	return getCurrentPost( state ).status === 'pending';
+}
+
+/**
  * Return true if the current post has already been published.
  *
  * @param {Object} state Global application state.
@@ -228,6 +239,17 @@ export function isCurrentPostPublished( state ) {
 
 	return [ 'publish', 'private' ].indexOf( post.status ) !== -1 ||
 		( post.status === 'future' && moment( post.date ).isBefore( moment() ) );
+}
+
+/**
+ * Returns true if post is already scheduled.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether current post is scheduled to be posted.
+ */
+export function isCurrentPostScheduled( state ) {
+	return getCurrentPost( state ).status === 'future' && ! isCurrentPostPublished( state );
 }
 
 /**

--- a/editor/store/test/selectors.js
+++ b/editor/store/test/selectors.js
@@ -30,7 +30,9 @@ const {
 	getDocumentTitle,
 	getEditedPostExcerpt,
 	getEditedPostVisibility,
+	isCurrentPostPending,
 	isCurrentPostPublished,
+	isCurrentPostScheduled,
 	isEditedPostPublishable,
 	isEditedPostSaveable,
 	isEditedPostEmpty,
@@ -587,6 +589,36 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( 'isCurrentPostPending', () => {
+		it( 'should return true for posts in pending state', () => {
+			const state = {
+				currentPost: {
+					status: 'pending',
+				},
+			};
+
+			expect( isCurrentPostPending( state ) ).toBe( true );
+		} );
+
+		it( 'should return false for draft posts', () => {
+			const state = {
+				currentPost: {
+					status: 'draft',
+				},
+			};
+
+			expect( isCurrentPostPending( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if status is unknown', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( isCurrentPostPending( state ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'isCurrentPostPublished', () => {
 		it( 'should return true for public posts', () => {
 			const state = {
@@ -627,6 +659,58 @@ describe( 'selectors', () => {
 			};
 
 			expect( isCurrentPostPublished( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isCurrentPostScheduled', () => {
+		it( 'should return true for posts with status future', () => {
+			const state = {
+				currentPost: {
+					status: 'future',
+				},
+			};
+
+			expect( isCurrentPostScheduled( state ) ).toBe( true );
+		} );
+
+		it( 'should return true for future scheduled posts', () => {
+			const state = {
+				currentPost: {
+					status: 'future',
+					date: '2100-05-30T17:21:39',
+				},
+			};
+
+			expect( isCurrentPostScheduled( state ) ).toBe( true );
+		} );
+
+		it( 'should return false for old scheduled posts that were already published', () => {
+			const state = {
+				currentPost: {
+					status: 'future',
+					date: '2016-05-30T17:21:39',
+				},
+			};
+
+			expect( isCurrentPostScheduled( state ) ).toBe( false );
+		} );
+
+		it( 'should return false for auto draft posts', () => {
+			const state = {
+				currentPost: {
+					status: 'auto-draft',
+				},
+			};
+
+			expect( isCurrentPostScheduled( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if status is unknown', () => {
+			const state = {
+				currentPost: {},
+			};
+
+			expect( isCurrentPostScheduled( state ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/5343
Summary of button labels and flows as specified by @jasmussen.

Editors and admins:

Update — updates immediately, no pos-publish flow
Publish... — opens post-publish flow
Schedule... — opens post-publish flow
Contributors:

Publish... — opens post-publish flow where the confirm button says "Submit for Review".

## How Has This Been Tested?
**With an editor/admin:**
Open a new post, write something, verify that "Publish..." button appears, press it, see the pre-post publish panel, click "Publish" and see the post-post publish panel. (basic flow)
Open a new post, write something, schedule it to the future, verify that "Schedule..." button appears, press it, see the pre-post publish panel, click "Schedule" and see post publish panel for scheduled posts. Props to @jasmussen for designing it.
Open an already Schedule post, e.g: the one before. Change it, see "Schedule" appears, press schedule and see post was updated no pre-publish panel was shown.
Open an already Schedule post, e.g: can still the one before. Change the scheduled date, for now, see the Publish button changed from "Schedule" to "Publish...", press Publish... verify pre-post publish panel appear and the normal publish flow happens.
Open a post submitted for review by a contributor, verily we see "Publish..." as publish button and the normal publish flow can be followed.

**With a contributor:**
Create a new post write something, see the publish button appears as "Publish...", press it, see the pre-publish panel appear, with the publish button text as "Submit for review". Press submit for review and verify the publish sidebar closes.
Open a post already submitted for review (e.g: the one before), verify the "Publish" button appears as "Submit for review" and pressing it does not show the pre-publish panel (again).

