### PR TITLE
RichText: Keep caret visible when typing on mobile

### DIFF
--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -541,14 +541,21 @@ export class RichText extends Component {
 	}
 
 	scrollToCaret() {
+		if ( ! this.props.isViewportSmall ) {
+			return;
+		}
+
 		const { top: caretTop } = this.getEditorSelectionRect();
 
 		const container = getScrollContainer( this.editor.getBody() );
+		if ( ! container ) {
+			return;
+		}
 
 		// When scrolling, avoid positioning the caret at the very top of
 		// the viewport, providing some "air" and some textual context for
 		// the user, and avoiding toolbars.
-		const graceOffset = this.props.isViewportSmall ? 100 : 300;
+		const graceOffset = 100;
 
 		// Avoid pointless scrolling by establishing a threshold under
 		// which scrolling should be skipped;
@@ -876,8 +883,11 @@ RichText.defaultProps = {
 };
 
 export default compose( [
-	withSelect( ( select ) => ( {
-		isViewportSmall: select( 'core/viewport' ).isViewportMatch( '< small' ),
-	} ) ),
+	withSelect( ( select ) => {
+		const { isViewportMatch = identity } = select( 'core/viewport' ) || {};
+		return {
+			isViewportSmall: isViewportMatch( '< small' ),
+		};
+	} ),
 	withSafeTimeout,
 ] )( RichText );

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -537,15 +537,26 @@ export class RichText extends Component {
 
 	scrollToCaret() {
 		const caretRect = this.getEditorSelectionRect();
-		const caretHeight = caretRect.y;
-		if ( caretHeight !== this.caretHeight ) {
-			const toolbarOffset = 100;
-			window.scrollTo(
-				window.pageXOffset,
-				window.pageYOffset + caretHeight - toolbarOffset
-			);
+		const caretTop = caretRect.top;
+		if ( caretTop !== this.caretTop ) {
+			// When scrolling, avoid positioning the caret at the very top of
+			// the viewport, providing some "air" and some textual context for
+			// the user.
+			const graceOffset = 100;
+
+			// Avoid pointless scrolling by establishing a threshold under
+			// which scrolling should be skipped;
+			const epsilon = 10;
+			const delta = caretTop - graceOffset;
+
+			if ( Math.abs( delta ) > epsilon ) {
+				window.scrollTo(
+					window.pageXOffset,
+					window.pageYOffset + caretTop - graceOffset
+				);
+			}
 		}
-		this.caretHeight = caretHeight;
+		this.caretTop = caretTop;
 	}
 
 	/**

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -20,9 +20,10 @@ import 'element-closest';
 /**
  * WordPress dependencies
  */
-import { createElement, Component, renderToString, Fragment } from '@wordpress/element';
+import { createElement, Component, renderToString, Fragment, compose } from '@wordpress/element';
 import { keycodes, createBlobURL, isHorizontalEdge, getRectangleFromRange, getScrollContainer } from '@wordpress/utils';
 import { withSafeTimeout, Slot, Fill } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -547,7 +548,7 @@ export class RichText extends Component {
 		// When scrolling, avoid positioning the caret at the very top of
 		// the viewport, providing some "air" and some textual context for
 		// the user, and avoiding toolbars.
-		const graceOffset = document.documentElement.clientHeight / 3.0;
+		const graceOffset = this.props.isViewportSmall ? 100 : 300;
 
 		// Avoid pointless scrolling by establishing a threshold under
 		// which scrolling should be skipped;
@@ -874,4 +875,9 @@ RichText.defaultProps = {
 	formatters: [],
 };
 
-export default withSafeTimeout( RichText );
+export default compose( [
+	withSelect( ( select ) => ( {
+		isViewportSmall: select( 'core/viewport' ).isViewportMatch( '< small' ),
+	} ) ),
+	withSafeTimeout,
+] )( RichText );

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -140,7 +140,6 @@ export class RichText extends Component {
 		this.onPastePreProcess = this.onPastePreProcess.bind( this );
 		this.onPaste = this.onPaste.bind( this );
 		this.onCreateUndoLevel = this.onCreateUndoLevel.bind( this );
-		this.scrollToCaret = this.scrollToCaret.bind( this );
 
 		this.state = {
 			formats: {},
@@ -184,7 +183,6 @@ export class RichText extends Component {
 		} );
 
 		editor.on( 'init', this.onInit );
-		editor.on( 'focusin', this.scrollToCaret );
 		editor.on( 'NewBlock', this.onNewBlock );
 		editor.on( 'nodechange', this.onNodeChange );
 		editor.on( 'keydown', this.onKeyDown );
@@ -532,7 +530,13 @@ export class RichText extends Component {
 			this.onChange();
 		}
 
-		this.scrollToCaret();
+		// `scrollToCaret` is called on `nodechange`, whereas calling it on
+		// `keyup` *when* moving to a new RichText element results in incorrect
+		// scrolling. Though the following allows false positives, it results
+		// in much smoother scrolling.
+		if ( keyCode !== BACKSPACE && keyCode !== ENTER ) {
+			this.scrollToCaret();
+		}
 	}
 
 	scrollToCaret() {
@@ -662,6 +666,11 @@ export class RichText extends Component {
 
 		const focusPosition = this.getFocusPosition();
 		this.setState( { formats, focusPosition, selectedNodeId: this.state.selectedNodeId + 1 } );
+
+		// Originally called on `focusin`, that hook turned out to be
+		// premature. On `nodechange` we can work with the finalized TinyMCE
+		// instance and scroll to proper position.
+		this.scrollToCaret();
 	}
 
 	updateContent() {

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -140,6 +140,7 @@ export class RichText extends Component {
 		this.onPastePreProcess = this.onPastePreProcess.bind( this );
 		this.onPaste = this.onPaste.bind( this );
 		this.onCreateUndoLevel = this.onCreateUndoLevel.bind( this );
+		this.scrollToCaret = this.scrollToCaret.bind( this );
 
 		this.state = {
 			formats: {},
@@ -183,6 +184,7 @@ export class RichText extends Component {
 		} );
 
 		editor.on( 'init', this.onInit );
+		editor.on( 'focusin', this.scrollToCaret );
 		editor.on( 'NewBlock', this.onNewBlock );
 		editor.on( 'nodechange', this.onNodeChange );
 		editor.on( 'keydown', this.onKeyDown );
@@ -529,6 +531,21 @@ export class RichText extends Component {
 		if ( keyCode === BACKSPACE ) {
 			this.onChange();
 		}
+
+		this.scrollToCaret();
+	}
+
+	scrollToCaret() {
+		const caretRect = this.getEditorSelectionRect();
+		const caretHeight = caretRect.y;
+		if ( caretHeight !== this.caretHeight ) {
+			const toolbarOffset = 100;
+			window.scrollTo(
+				window.pageXOffset,
+				window.pageYOffset + caretHeight - toolbarOffset
+			);
+		}
+		this.caretHeight = caretHeight;
 	}
 
 	/**

--- a/blocks/rich-text/index.js
+++ b/blocks/rich-text/index.js
@@ -21,7 +21,7 @@ import 'element-closest';
  * WordPress dependencies
  */
 import { createElement, Component, renderToString, Fragment } from '@wordpress/element';
-import { keycodes, createBlobURL, isHorizontalEdge, getRectangleFromRange } from '@wordpress/utils';
+import { keycodes, createBlobURL, isHorizontalEdge, getRectangleFromRange, getScrollContainer } from '@wordpress/utils';
 import { withSafeTimeout, Slot, Fill } from '@wordpress/components';
 
 /**
@@ -540,27 +540,26 @@ export class RichText extends Component {
 	}
 
 	scrollToCaret() {
-		const caretRect = this.getEditorSelectionRect();
-		const caretTop = caretRect.top;
-		if ( caretTop !== this.caretTop ) {
-			// When scrolling, avoid positioning the caret at the very top of
-			// the viewport, providing some "air" and some textual context for
-			// the user.
-			const graceOffset = 100;
+		const { top: caretTop } = this.getEditorSelectionRect();
 
-			// Avoid pointless scrolling by establishing a threshold under
-			// which scrolling should be skipped;
-			const epsilon = 10;
-			const delta = caretTop - graceOffset;
+		const container = getScrollContainer( this.editor.getBody() );
 
-			if ( Math.abs( delta ) > epsilon ) {
-				window.scrollTo(
-					window.pageXOffset,
-					window.pageYOffset + caretTop - graceOffset
-				);
-			}
+		// When scrolling, avoid positioning the caret at the very top of
+		// the viewport, providing some "air" and some textual context for
+		// the user, and avoiding toolbars.
+		const graceOffset = document.documentElement.clientHeight / 3.0;
+
+		// Avoid pointless scrolling by establishing a threshold under
+		// which scrolling should be skipped;
+		const epsilon = 10;
+		const delta = caretTop - graceOffset;
+
+		if ( Math.abs( delta ) > epsilon ) {
+			container.scrollTo(
+				container.scrollLeft,
+				container.scrollTop + delta,
+			);
 		}
-		this.caretTop = caretTop;
 	}
 
 	/**

--- a/components/higher-order/with-filters/README.md
+++ b/components/higher-order/with-filters/README.md
@@ -24,4 +24,4 @@ function MyCustomElement() {
 export default withFilters( 'MyCustomElement' )( MyCustomElement );
 ```
 
-`withFilters` expects a string argument which provides a hook name. It returns a function which can then be used in composing your component. The hook name allows plugin developers to customize or completely override the component passed to this higher-order component using `wp.utils.addFilter` method.
+`withFilters` expects a string argument which provides a hook name. It returns a function which can then be used in composing your component. The hook name allows plugin developers to customize or completely override the component passed to this higher-order component using `wp.hooks.addFilter` method.

--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -75,6 +75,9 @@
 
 	// Pad the scroll box so content on the bottom can be scrolled up.
 	padding-bottom: 50vh;
+	@include break-small {
+		padding-bottom: 0;
+	}
 
 	// On mobile the main content area has to scroll otherwise you can invoke
 	// the overscroll bounce on the non-scrolling container, causing

--- a/edit-post/components/layout/style.scss
+++ b/edit-post/components/layout/style.scss
@@ -73,12 +73,14 @@
 	min-height: 100%;
 	flex-direction: column;
 
-	// on mobile the main content area has to scroll
-	// otherwise you can invoke the overscroll bounce on the non-scrolling container, causing (ノಠ益ಠ)ノ彡┻━┻
-	@include break-small {
-		overflow-y: auto;
-		-webkit-overflow-scrolling: touch;
-	}
+	// Pad the scroll box so content on the bottom can be scrolled up.
+	padding-bottom: 50vh;
+
+	// On mobile the main content area has to scroll otherwise you can invoke
+	// the overscroll bounce on the non-scrolling container, causing
+	// (ノಠ益ಠ)ノ彡┻━┻
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
 
 	.edit-post-visual-editor {
 		flex-basis: 100%;


### PR DESCRIPTION
## Description
A smaller iteration of #4775. Partly fixes #4731.

This PR is a spin-off of #4775 that focuses on keeping in sight the area into which a user is typing. The secondary goal is to leave a small footprint and reducing exceptions (e.g. per viewport width, per user agent).

A notable departure from #4775 is that this PR doesn't just cover Enter presses, but also line wraps — i.e., when enough text is typed that it is placed on a new line in the editor. This aggressive change warrants some extra testing, but, in my own testing, is a welcome addition.

## How Has This Been Tested?

- Make sure the experience of editing content on a desktop device is unchanged: (un)focusing blocks, typing in RichText elements (type enough characters so as to experience line wrap), pressing Enter in `multiline` blocks (e.g. Quote) and in non-multiline (e.g. Paragraph).
- Test the mobile experience, ideally also on non-iOS devices (of which I currently have none). Try the same things as for desktop.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
