### PR TITLE
Disable preview if post type does not supports it.

### DIFF
--- a/editor/components/post-preview-button/index.js
+++ b/editor/components/post-preview-button/index.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Component, compose } from '@wordpress/element';
+import { Button, ifCondition, withContext } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -123,14 +123,21 @@ export class PostPreviewButton extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		postId: state.currentPost.id,
-		link: getEditedPostPreviewLink( state ),
-		isDirty: isEditedPostDirty( state ),
-		isNew: isEditedPostNew( state ),
-		isSaveable: isEditedPostSaveable( state ),
-		modified: getEditedPostAttribute( state, 'modified' ),
-	} ),
-	{ autosave }
+export default compose(
+	withContext( 'editor' )(
+		( { disablePreview } ) => ( { disablePreview } )
+	),
+	ifCondition( ( { disablePreview } ) => ! disablePreview ),
+	connect(
+		( state ) => ( {
+			postId: state.currentPost.id,
+			link: getEditedPostPreviewLink( state ),
+			isDirty: isEditedPostDirty( state ),
+			isNew: isEditedPostNew( state ),
+			isSaveable: isEditedPostSaveable( state ),
+			modified: getEditedPostAttribute( state, 'modified' ),
+		} ),
+		{ autosave }
+	),
+
 )( PostPreviewButton );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -928,12 +928,15 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	 */
 	$allowed_block_types = apply_filters( 'allowed_block_types', true );
 
+	$post_type_object = get_post_type_object( $post_to_edit['type'] );
+
 	$editor_settings = array(
 		'alignWide'           => $align_wide || ! empty( $gutenberg_theme_support[0]['wide-images'] ), // Backcompat. Use `align-wide` outside of `gutenberg` array.
 		'availableTemplates'  => wp_get_theme()->get_page_templates( get_post( $post_to_edit['id'] ) ),
 		'blockTypes'          => $allowed_block_types,
 		'disableCustomColors' => get_theme_support( 'disable-custom-colors' ),
 		'disablePostFormats'  => ! current_theme_supports( 'post-formats' ),
+		'disablePreview'      => ! is_post_type_viewable( $post_type_object ),
 		'titlePlaceholder'    => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
 		'bodyPlaceholder'     => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
 	);
@@ -942,7 +945,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		$editor_settings['colors'] = $color_palette;
 	}
 
-	$post_type_object = get_post_type_object( $post_to_edit['type'] );
 	if ( ! empty( $post_type_object->template ) ) {
 		$editor_settings['template']     = $post_type_object->template;
 		$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) ? $post_type_object->template_lock : false;


### PR DESCRIPTION
In the classic editor, the preview button is only available if is_post_type_viewable returns true. We are updating the logic to follow the same behavior.

Fixes: https://github.com/WordPress/gutenberg/issues/5749

## How Has This Been Tested?
Register a post type with publicly_queryable set to false.
E.g:
```
function create_product_type() {
    register_post_type( 'acme_product',
        array(
			'label'  => 'Product',
            'labels' => array(
                'name' => __( 'Products' ),
                'singular_name' => __( 'Product' )
            ),
            'public' => true,
			'show_in_rest' => true,
			'publicly_queryable' => false,
        )
    );
}
add_action( 'init', 'create_product_type' );
```
Verify preview button is not available for posts of this Post Type.