### PR TITLE
[WIP] Move plugin registration data to store

### DIFF
--- a/plugins/api/index.js
+++ b/plugins/api/index.js
@@ -43,6 +43,7 @@ export function registerPlugin( name, settings ) {
 		console.error(
 			`Plugin "${ name }" is already registered.`
 		);
+		return null;
 	}
 	if ( ! isFunction( settings.render ) ) {
 		console.error(

--- a/plugins/api/index.js
+++ b/plugins/api/index.js
@@ -4,18 +4,12 @@
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
+import { select, dispatch } from '@wordpress/data';
 
 /**
  * External dependencies
  */
 import { isFunction } from 'lodash';
-
-/**
- * Plugin definitions keyed by plugin name.
- *
- * @type {Object.<string,WPPlugin>}
- */
-const plugins = {};
 
 /**
  * Registers a plugin to the editor.
@@ -45,7 +39,7 @@ export function registerPlugin( name, settings ) {
 		);
 		return null;
 	}
-	if ( plugins[ name ] ) {
+	if ( getPlugin( name ) ) {
 		console.error(
 			`Plugin "${ name }" is already registered.`
 		);
@@ -61,7 +55,9 @@ export function registerPlugin( name, settings ) {
 
 	settings = applyFilters( 'plugins.registerPlugin', settings, name );
 
-	return plugins[ settings.name ] = settings;
+	dispatch( 'core/plugins' ).registerPlugin( name, settings );
+
+	return settings;
 }
 
 /**
@@ -73,14 +69,14 @@ export function registerPlugin( name, settings ) {
  *                     successfully unregistered; otherwise `undefined`.
  */
 export function unregisterPlugin( name ) {
-	if ( ! plugins[ name ] ) {
+	if ( ! getPlugin( name ) ) {
 		console.error(
 			'Plugin "' + name + '" is not registered.'
 		);
 		return;
 	}
-	const oldPlugin = plugins[ name ];
-	delete plugins[ name ];
+	const oldPlugin = getPlugin( name );
+	dispatch( 'core/plugins' ).unregisterPlugin( name );
 	return oldPlugin;
 }
 
@@ -92,7 +88,7 @@ export function unregisterPlugin( name ) {
  * @return {?Object} Plugin setting.
  */
 export function getPlugin( name ) {
-	return plugins[ name ];
+	return select( 'core/plugins' ).getPlugin( name );
 }
 
 /**
@@ -101,5 +97,5 @@ export function getPlugin( name ) {
  * @return {Array} Plugin settings.
  */
 export function getPlugins() {
-	return Object.values( plugins );
+	return select( 'core/plugins' ).getPlugins();
 }

--- a/plugins/components/plugin-area/index.js
+++ b/plugins/components/plugin-area/index.js
@@ -4,20 +4,24 @@
 import { map } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import PluginContextProvider from '../plugin-context-provider';
-import { getPlugins } from '../../api';
 
 /**
  * A component that renders all plugin fills in a hidden div.
  *
  * @return {WPElement} Plugin area.
  */
-function PluginArea() {
+function PluginArea( { plugins } ) {
 	return (
 		<div style={ { display: 'none' } }>
-			{ map( getPlugins(), ( plugin ) => {
+			{ map( plugins, ( plugin ) => {
 				const { render: Plugin } = plugin;
 
 				return (
@@ -33,4 +37,10 @@ function PluginArea() {
 	);
 }
 
-export default PluginArea;
+/**
+ * Using withSelect instead of internal ./api/index.getPlugins() to force rerender
+ * when a new plugin is registered.
+ */
+export default withSelect( select => ( {
+	plugins: select( 'core/plugins' ).getPlugins(),
+} ) )( PluginArea );

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -1,2 +1,3 @@
+import './store';
 export * from './components';
 export * from './api';

--- a/plugins/store/actions.js
+++ b/plugins/store/actions.js
@@ -1,0 +1,14 @@
+export function registerPlugin( name, settings = {} ) {
+	return {
+		type: 'REGISTER_PLUGIN',
+		name,
+		settings,
+	};
+}
+
+export function unregisterPlugin( name ) {
+	return {
+		type: 'UNREGISTER_PLUGIN',
+		name,
+	};
+}

--- a/plugins/store/index.js
+++ b/plugins/store/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	registerStore,
+} from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+const store = registerStore( 'core/plugins', {
+	reducer,
+	actions,
+	selectors,
+} );
+
+export default store;

--- a/plugins/store/reducer.js
+++ b/plugins/store/reducer.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+export default function( state = {}, action ) {
+	switch ( action.type ) {
+		case 'REGISTER_PLUGIN':
+			return {
+				...state,
+				[ action.name ]: action.settings,
+			};
+		case 'UNREGISTER_PLUGIN':
+			return omit( state, action.name );
+	}
+	return state;
+}

--- a/plugins/store/selectors.js
+++ b/plugins/store/selectors.js
@@ -1,0 +1,7 @@
+export function getPlugins( state ) {
+	return state;
+}
+
+export function getPlugin( state, name ) {
+	return state[ name ];
+}

--- a/plugins/store/test/reducer.js
+++ b/plugins/store/test/reducer.js
@@ -1,0 +1,68 @@
+/**
+ * Internal dependencies.
+ */
+import reducer from '../reducer';
+
+describe( 'reducer', () => {
+	it( 'registers a plugin', () => {
+		const state = {};
+		const expectedState = {
+			'plugin-name': {
+				name: 'plugin-name',
+			},
+		};
+		const action = {
+			type: 'REGISTER_PLUGIN',
+			name: 'plugin-name',
+			settings: {
+				name: 'plugin-name',
+			},
+		};
+		expect( reducer( state, action ) ).toEqual( expectedState );
+	} );
+
+	it( 'registers an additional plugin', () => {
+		const state = {
+			'plugin-name': {
+				name: 'plugin-name',
+			},
+		};
+		const expectedState = {
+			'plugin-name': {
+				name: 'plugin-name',
+			},
+			'second-plugin': {
+				name: 'second-plugin',
+			},
+		};
+		const action = {
+			type: 'REGISTER_PLUGIN',
+			name: 'second-plugin',
+			settings: {
+				name: 'second-plugin',
+			},
+		};
+		expect( reducer( state, action ) ).toEqual( expectedState );
+	} );
+
+	it( 'unregisters a plugin', () => {
+		const state = {
+			'plugin-name': {
+				name: 'plugin-name',
+			},
+			'second-plugin': {
+				name: 'second-plugin',
+			},
+		};
+		const expectedState = {
+			'second-plugin': {
+				name: 'second-plugin',
+			},
+		};
+		const action = {
+			type: 'UNREGISTER_PLUGIN',
+			name: 'plugin-name',
+		};
+		expect( reducer( state, action ) ).toEqual( expectedState );
+	} );
+} );


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
In an attempt to fix https://github.com/WordPress/gutenberg/issues/5759, I've moved the plugin registration to a new store `core/plugins`.

I have yet to accomplish that the store update actually triggers a rerender of the `PluginSidebar` slot.

The question is whether this is desirable since this allows people to circumvent the plugin validation in `registerPlugin`.

Fixes #5759 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.
