### PR TITLE
Properly detect NVM path on macOS using homebrew

### DIFF
--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -9,11 +9,11 @@ set -e
 
 # Load NVM
 if [ -n "$NVM_DIR" ]; then
-	# if using homebrew, use that to find path to nvm.sh
-	if [ -n "$(command -v brew)" ]; then
-		. "$(brew --prefix nvm)/nvm.sh" --no-use
-	else
+	if [ -f "$NVM_DIR/nvm.sh" ]; then
 		. "$NVM_DIR/nvm.sh" --no-use
+	elif [ -n "$(command -v brew)" ]; then
+		# use homebrew that to find path to nvm.sh
+		. "$(brew --prefix nvm)/nvm.sh" --no-use
 	fi
 fi
 

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -12,8 +12,8 @@ if [ -n "$NVM_DIR" ]; then
 	# The --no-use option ensures loading NVM doesn't switch the current version.
 	if [ -f "$NVM_DIR/nvm.sh" ]; then
 		. "$NVM_DIR/nvm.sh" --no-use
-	elif [ -n "$(command -v brew)" ]; then
-		# use homebrew that to find path to nvm.sh
+	elif [ -n "$(command -v brew)" ] && [ -f "$(brew --prefix nvm)/nvm.sh" ]; then
+		# use homebrew if that's how nvm was installed
 		. "$(brew --prefix nvm)/nvm.sh" --no-use
 	fi
 fi

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -9,8 +9,12 @@ set -e
 
 # Load NVM
 if [ -n "$NVM_DIR" ]; then
-	# The --no-use option ensures loading NVM doesn't switch the current version.
-	. "$NVM_DIR/nvm.sh" --no-use
+	# if using homebrew, use that to find path to nvm.sh
+	if [ -n "$(command -v brew)" ]; then
+		. "$(brew --prefix nvm)/nvm.sh" --no-use
+	else
+		. "$NVM_DIR/nvm.sh" --no-use
+	fi
 fi
 
 # Change to the expected directory

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -23,18 +23,23 @@ cd "$(dirname "$0")/.."
 # Check if nvm is installed
 if [ "$TRAVIS" != "true" ] && ! command_exists "nvm"; then
 	if ask "$(error_message "NVM isn't installed, would you like to download and install it automatically?")" Y; then
-		# The .bash_profile file needs to exist for NVM to install
-		if [ ! -e ~/.bash_profile ]; then
-			touch ~/.bash_profile
+
+		if [ -n "$(command -v brew)" ]; then
+			brew install nvm
+		else
+			# The .bash_profile file needs to exist for NVM to install
+			if [ ! -e ~/.bash_profile ]; then
+				touch ~/.bash_profile
+			fi
+
+			echo -en $(status_message "Installing NVM..." )
+			download "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/install.sh" | bash >/dev/null 2>&1
+			echo ' done!'
+
+			echo -e $(warning_message "NVM was updated, please run this command to reload it:" )
+			echo -e $(warning_message "$(action_format ". \$HOME/.nvm/nvm.sh")" )
+			echo -e $(warning_message "After that, re-run the setup script to continue." )
 		fi
-
-		echo -en $(status_message "Installing NVM..." )
-		download "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/install.sh" | bash >/dev/null 2>&1
-		echo ' done!'
-
-		echo -e $(warning_message "NVM was updated, please run this command to reload it:" )
-		echo -e $(warning_message "$(action_format ". \$HOME/.nvm/nvm.sh")" )
-		echo -e $(warning_message "After that, re-run the setup script to continue." )
 	else
 		echo -e $(error_message "")
 		echo -e $(error_message "Please install NVM manually, then re-run the setup script to continue.")

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -23,23 +23,18 @@ cd "$(dirname "$0")/.."
 # Check if nvm is installed
 if [ "$TRAVIS" != "true" ] && ! command_exists "nvm"; then
 	if ask "$(error_message "NVM isn't installed, would you like to download and install it automatically?")" Y; then
-
-		if [ -n "$(command -v brew)" ]; then
-			brew install nvm
-		else
-			# The .bash_profile file needs to exist for NVM to install
-			if [ ! -e ~/.bash_profile ]; then
-				touch ~/.bash_profile
-			fi
-
-			echo -en $(status_message "Installing NVM..." )
-			download "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/install.sh" | bash >/dev/null 2>&1
-			echo ' done!'
-
-			echo -e $(warning_message "NVM was updated, please run this command to reload it:" )
-			echo -e $(warning_message "$(action_format ". \$HOME/.nvm/nvm.sh")" )
-			echo -e $(warning_message "After that, re-run the setup script to continue." )
+		# The .bash_profile file needs to exist for NVM to install
+		if [ ! -e ~/.bash_profile ]; then
+			touch ~/.bash_profile
 		fi
+
+		echo -en $(status_message "Installing NVM..." )
+		download "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/install.sh" | bash >/dev/null 2>&1
+		echo ' done!'
+
+		echo -e $(warning_message "NVM was updated, please run this command to reload it:" )
+		echo -e $(warning_message "$(action_format ". \$HOME/.nvm/nvm.sh")" )
+		echo -e $(warning_message "After that, re-run the setup script to continue." )
 	else
 		echo -e $(error_message "")
 		echo -e $(error_message "Please install NVM manually, then re-run the setup script to continue.")

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -12,7 +12,7 @@ if [ -n "$NVM_DIR" ]; then
 	# The --no-use option ensures loading NVM doesn't switch the current version.
 	if [ -f "$NVM_DIR/nvm.sh" ]; then
 		. "$NVM_DIR/nvm.sh" --no-use
-	elif [ -n "$(command -v brew)" ] && [ -f "$(brew --prefix nvm)/nvm.sh" ]; then
+	elif command_exists "brew" && [ -f "$(brew --prefix nvm)/nvm.sh" ]; then
 		# use homebrew if that's how nvm was installed
 		. "$(brew --prefix nvm)/nvm.sh" --no-use
 	fi

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -9,6 +9,7 @@ set -e
 
 # Load NVM
 if [ -n "$NVM_DIR" ]; then
+	# The --no-use option ensures loading NVM doesn't switch the current version.
 	if [ -f "$NVM_DIR/nvm.sh" ]; then
 		. "$NVM_DIR/nvm.sh" --no-use
 	elif [ -n "$(command -v brew)" ]; then


### PR DESCRIPTION
## Description

When attempting to build the plugin on macOS, I encountered the following error:

```
(path to plugins)/gutenberg (master)$ ./bin/setup-local-env.sh
./bin/install-node-nvm.sh: line 13: /Users/me/.nvm/nvm.sh: No such file or directory
```

By detecting homebrew and using the `--prefix` command, we can find the true path to nvm.sh on macOS systems.

## How Has This Been Tested?
By running ./bin/setup-local-env.sh and seeing that it completes without error. Hopefully my `else` clause allows this to work properly on Linux machines, which I have NOT tested.

I also tried with `nvm` uninstalled, ensuring that `brew` was used to install `nvm` on systems with homebrew available.

## Types of changes
Check for `brew` command and use to find `nvm.sh`, and to install `nvm` if necessary.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
