### PR TITLE
Updated/fixed contrast checker to respect recent changes on Notice component

### DIFF
--- a/blocks/contrast-checker/index.js
+++ b/blocks/contrast-checker/index.js
@@ -32,7 +32,9 @@ function ContrastChecker( { backgroundColor, textColor, isLargeText, fallbackBac
 		__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.' );
 	return (
 		<div className="blocks-contrast-checker">
-			<Notice status="warning" content={ msg } isDismissible={ false } />
+			<Notice status="warning" isDismissible={ false }>
+				{ msg }
+			</Notice>
 		</div>
 	);
 }

--- a/blocks/contrast-checker/test/__snapshots__/index.js.snap
+++ b/blocks/contrast-checker/test/__snapshots__/index.js.snap
@@ -1,37 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ContrastChecker should render component when the colors do not meet AA WCAG guidelines. 1`] = `
-<div
-  className="blocks-contrast-checker"
+<ContrastChecker
+  backgroundColor="#666"
+  fallbackBackgroundColor="#fff"
+  fallbackTextColor="#000"
+  isLargeText={true}
+  textColor="#666"
 >
-  <Notice
-    content="This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color."
-    isDismissible={false}
-    status="warning"
-  />
-</div>
+  <div
+    className="blocks-contrast-checker"
+  >
+    <Notice
+      isDismissible={false}
+      status="warning"
+    >
+      <div
+        className="notice notice-alt notice-warning"
+      >
+        <p>
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </p>
+      </div>
+    </Notice>
+  </div>
+</ContrastChecker>
 `;
 
 exports[`ContrastChecker should render different message matching snapshot when background color has less brightness than text color. 1`] = `
-<div
-  className="blocks-contrast-checker"
+<ContrastChecker
+  backgroundColor="#555"
+  fallbackBackgroundColor="#fff"
+  fallbackTextColor="#000"
+  isLargeText={false}
+  textColor="#666"
 >
-  <Notice
-    content="This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color."
-    isDismissible={false}
-    status="warning"
-  />
-</div>
+  <div
+    className="blocks-contrast-checker"
+  >
+    <Notice
+      isDismissible={false}
+      status="warning"
+    >
+      <div
+        className="notice notice-alt notice-warning"
+      >
+        <p>
+          This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.
+        </p>
+      </div>
+    </Notice>
+  </div>
+</ContrastChecker>
 `;
 
 exports[`ContrastChecker should render messages when the textColor is valid, but the fallback backgroundColor conflicts. 1`] = `
-<div
-  className="blocks-contrast-checker"
+<ContrastChecker
+  fallbackBackgroundColor="#000000"
+  textColor="#000000"
 >
-  <Notice
-    content="This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color."
-    isDismissible={false}
-    status="warning"
-  />
-</div>
+  <div
+    className="blocks-contrast-checker"
+  >
+    <Notice
+      isDismissible={false}
+      status="warning"
+    >
+      <div
+        className="notice notice-alt notice-warning"
+      >
+        <p>
+          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+        </p>
+      </div>
+    </Notice>
+  </div>
+</ContrastChecker>
 `;

--- a/blocks/contrast-checker/test/index.js
+++ b/blocks/contrast-checker/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ describe( 'ContrastChecker', () => {
 	const fallbackTextColor = '#000';
 	const sameShade = '#666';
 
-	const wrapper = shallow(
+	const wrapper = mount(
 		<ContrastChecker
 			backgroundColor={ backgroundColor }
 			textColor={ textColor }
@@ -26,7 +26,7 @@ describe( 'ContrastChecker', () => {
 	);
 
 	test( 'should render null when no colors are provided', () => {
-		expect( shallow( <ContrastChecker /> ).html() ).toBeNull();
+		expect( mount( <ContrastChecker /> ).html() ).toBeNull();
 	} );
 
 	test( 'should render null when the colors meet AA WCAG guidelines.', () => {
@@ -34,7 +34,7 @@ describe( 'ContrastChecker', () => {
 	} );
 
 	test( 'should render component when the colors do not meet AA WCAG guidelines.', () => {
-		const componentWrapper = shallow(
+		const componentWrapper = mount(
 			<ContrastChecker
 				backgroundColor={ sameShade }
 				textColor={ sameShade }
@@ -49,7 +49,7 @@ describe( 'ContrastChecker', () => {
 	test( 'should render different message matching snapshot when background color has less brightness than text color.', () => {
 		const darkerShade = '#555';
 
-		const componentWrapper = shallow(
+		const componentWrapper = mount(
 			<ContrastChecker
 				backgroundColor={ darkerShade }
 				textColor={ sameShade }
@@ -62,7 +62,7 @@ describe( 'ContrastChecker', () => {
 	} );
 
 	test( 'should render null when the colors meet AA WCAG guidelines, with only fallback colors.', () => {
-		const componentWrapper = shallow(
+		const componentWrapper = mount(
 			<ContrastChecker
 				isLargeText={ isLargeText }
 				fallbackBackgroundColor={ fallbackBackgroundColor }
@@ -73,7 +73,7 @@ describe( 'ContrastChecker', () => {
 	} );
 
 	test( 'should render messages when the textColor is valid, but the fallback backgroundColor conflicts.', () => {
-		const componentWrapper = shallow(
+		const componentWrapper = mount(
 			<ContrastChecker
 				textColor={ textColor }
 				fallbackBackgroundColor={ textColor } />


### PR DESCRIPTION
Notices component changed and now instead of receiving a content prop renders the children. Contrast checker is now updated to take into account this recent change of the notices component.

The test cases of ContrastChecker did not fail because they tested that the notices are shown when needed using the notice component, but did not test if the notices component, in fact, rendered the message. The use of shallow was changed to mount in the tests, as I think mount in this case, gives a bigger assurance that messages are in fact rendered. It may create false fails, e.g: class changes in notices. But when doing this changes we should probably test ContrastChecker so this fails just increase the probability of the manual inspection happening so they are good in my option.


## How Has This Been Tested?
Go to paragraph and/or button block, set the same color for background and test. Verify contrast checker messages are shown correctly.
