### PR TITLE
Use down and up arrow icons for the meta boxes panels.

### DIFF
--- a/components/panel/body.js
+++ b/components/panel/body.js
@@ -39,7 +39,7 @@ class PanelBody extends Component {
 	render() {
 		const { title, children, opened, className } = this.props;
 		const isOpened = opened === undefined ? this.state.opened : opened;
-		const icon = `arrow-${ isOpened ? 'down' : 'right' }`;
+		const icon = `arrow-${ isOpened ? 'up' : 'down' }`;
 		const classes = classnames( 'components-panel__body', className, { 'is-opened': isOpened } );
 
 		return (

--- a/components/panel/test/body.js
+++ b/components/panel/test/body.js
@@ -23,7 +23,7 @@ describe( 'PanelBody', () => {
 			expect( button.shallow().hasClass( 'components-panel__body-toggle' ) ).toBe( true );
 			expect( panelBody.state( 'opened' ) ).toBe( true );
 			expect( button.prop( 'onClick' ) ).toBe( panelBody.instance().toggle );
-			expect( icon.prop( 'icon' ) ).toBe( 'arrow-down' );
+			expect( icon.prop( 'icon' ) ).toBe( 'arrow-up' );
 			expect( button.childAt( 0 ).name() ).toBe( 'Dashicon' );
 			expect( button.childAt( 1 ).text() ).toBe( 'Some Text' );
 		} );
@@ -32,14 +32,14 @@ describe( 'PanelBody', () => {
 			const panelBody = shallow( <PanelBody title="Some Text" initialOpen={ false } /> );
 			expect( panelBody.state( 'opened' ) ).toBe( false );
 			const icon = panelBody.find( 'Dashicon' );
-			expect( icon.prop( 'icon' ) ).toBe( 'arrow-right' );
+			expect( icon.prop( 'icon' ) ).toBe( 'arrow-down' );
 		} );
 
 		it( 'should use the "opened" prop instead of state if provided', () => {
 			const panelBody = shallow( <PanelBody title="Some Text" opened={ true } initialOpen={ false } /> );
 			expect( panelBody.state( 'opened' ) ).toBe( false );
 			const icon = panelBody.find( 'Dashicon' );
-			expect( icon.prop( 'icon' ) ).toBe( 'arrow-down' );
+			expect( icon.prop( 'icon' ) ).toBe( 'arrow-up' );
 		} );
 
 		it( 'should render child elements within PanelBody element', () => {


### PR DESCRIPTION
This PR changes the arrow icons used for the sidebar meta boxes toggles from right/down to down/up for better clarity on the expected behavior and consistency with patterns already used in core. Screenshot:

<img width="346" alt="screen shot 2018-03-26 at 21 15 42" src="https://user-images.githubusercontent.com/1682452/37927911-8311a4de-313b-11e8-867a-4e03dffb47fb.png">

Updated the tests accordingly.

Fixes #5774 