### PR TITLE
Try ARIA role application on the writing flow area.

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -279,7 +279,7 @@ class WritingFlow extends Component {
 		// bubbling events from children to determine focus transition intents.
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
-			<div className="editor-writing-flow">
+			<div className="editor-writing-flow"role="application">
 				<div
 					ref={ this.bindContainer }
 					onKeyDown={ this.onKeyDown }

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -279,7 +279,7 @@ class WritingFlow extends Component {
 		// bubbling events from children to determine focus transition intents.
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
-			<div className="editor-writing-flow"role="application">
+			<div className="editor-writing-flow" role="application">
 				<div
 					ref={ this.bindContainer }
 					onKeyDown={ this.onKeyDown }


### PR DESCRIPTION
Please don't merge :)

As discussed during [today's accessibility meeting on Slack](https://wordpress.slack.com/archives/C02RP4X03/p1522084754000572), this PR aims to try the ARIA `role="application"` on the post content area for a series of A/B testing with assistive technologies users.

The role is set on the Gutenberg "writing flow" area (which includes the post title) to make sure the writing flow keyboard events work as expected with screen readers.

The `role="application"` could solve a series of issues (see for example #5709 ) but also introduce new ones, so some actual testing is definitely necessary.