### PR TITLE
Writing Flow: Improve emulated caret positioning

### DIFF
--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -240,11 +240,20 @@ class WritingFlow extends Component {
 			return;
 		}
 
-		// Emulate a rect at which caret should be placed using mouse event.
-		const rect = target.getBoundingClientRect();
-		const targetRect = new DOMRect( event.clientX, rect.top, 0, rect.height );
+		// To generate a caret rect (where its height determines buffer offset
+		// for caret target point), the element must first be focused.
+		target.focus();
+		const rect = computeCaretRect( target );
 
-		placeCaretAtVerticalEdge( target, false, targetRect );
+		// `computeCaretRect` may return undefined if it's unable to find a
+		// collapsed range.
+		if ( ! rect ) {
+			return;
+		}
+
+		// Emulate a rect at which caret should be placed using mouse event.
+		const targetRect = new DOMRect( event.clientX, 0, 0, rect.height );
+		placeCaretAtVerticalEdge( target, true, targetRect );
 	}
 
 	render() {

--- a/editor/components/writing-flow/index.js
+++ b/editor/components/writing-flow/index.js
@@ -40,14 +40,9 @@ import {
 } from '../../utils/dom';
 
 /**
- * Browser dependencies
- */
-
-const { DOMRect } = window;
-
-/**
  * Module Constants
  */
+
 const { UP, DOWN, LEFT, RIGHT } = keycodes;
 
 /**
@@ -228,32 +223,14 @@ class WritingFlow extends Component {
 	}
 
 	/**
-	 * Shifts focus to the last tabbable text field — if one exists — at the
-	 * given mouse event's X coordinate.
-	 *
-	 * @param {MouseEvent} event Mouse event to align caret X offset.
+	 * Sets focus to the end of the last tabbable text field, if one exists.
 	 */
-	focusLastTextField( event ) {
+	focusLastTextField() {
 		const focusableNodes = focus.focusable.find( this.container );
 		const target = findLast( focusableNodes, isTabbableTextField );
-		if ( ! target ) {
-			return;
+		if ( target ) {
+			placeCaretAtHorizontalEdge( target, true );
 		}
-
-		// To generate a caret rect (where its height determines buffer offset
-		// for caret target point), the element must first be focused.
-		target.focus();
-		const rect = computeCaretRect( target );
-
-		// `computeCaretRect` may return undefined if it's unable to find a
-		// collapsed range.
-		if ( ! rect ) {
-			return;
-		}
-
-		// Emulate a rect at which caret should be placed using mouse event.
-		const targetRect = new DOMRect( event.clientX, 0, 0, rect.height );
-		placeCaretAtVerticalEdge( target, true, targetRect );
 	}
 
 	render() {

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -271,6 +271,12 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 		return;
 	}
 
+	// Offset by a buffer half the height of the caret rect. This is needed
+	// because caretRangeFromPoint may default to the end of the selection if
+	// offset is too close to the edge. It's unclear how to precisely calculate
+	// this threshold; it may be the padded area of some combination of line
+	// height, caret height, and font size. The buffer offset is effectively
+	// equivalent to a point at half the height of a line of text.
 	const buffer = rect.height / 2;
 	const editableRect = container.getBoundingClientRect();
 	const x = rect.left + ( rect.width / 2 );


### PR DESCRIPTION
Related: #5541

This pull request seeks to improve the behavior introduced in #5541. For paragraphs longer than few lines, clicking below the editor will redirect to the wrong offset within the block, usually approximately half-way through the content of the block. This is due to a [buffer behavior](https://github.com/WordPress/gutenberg/blob/a1b11610f0b7177983d527064335914311684d88/utils/dom.js#L274-L277) of the `placeCaretAtVerticalEdge` implementation, needed to accommodate incorrect results which can occur by retrieving the range at an offset too close to the edge of the container. Previously we would pass the height of the entire container, when the `rect` expected is that of the caret (a single line of text). Thus, for paragraphs more than just a couple lines of text, the buffer was much larger than expected, and the caret placed at the wrong position.

__Testing instructions:__

Repeat testing instructions from #5541, _for both long and short paragraphs_.