### PR TITLE
Hide reusable block indicator from the inserter preview

### DIFF
--- a/editor/components/block-preview/style.scss
+++ b/editor/components/block-preview/style.scss
@@ -27,4 +27,8 @@
 	> div section {
 		height: auto;
 	}
+
+	> .reusable-block-indicator {
+		display: none;
+	}
 }


### PR DESCRIPTION
Hides the reusable block indicator which was added in https://github.com/WordPress/gutenberg/pull/5720 from appearing in the bottom right of the inserter preview window:

![bug](https://user-images.githubusercontent.com/1779930/37941333-b6a2e83a-313b-11e8-8cf0-3c4434ad5db9.png)