### PR TITLE
Add ability to manually set image dimensions

### DIFF
--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -226,6 +226,9 @@ class ImageBlock extends Component {
 							/>
 						) }
 						<div className="blocks-image-dimensions">
+							<p className="blocks-image-dimensions__row">
+								{ __( 'Image Dimensions' ) }
+							</p>
 							<div className="blocks-image-dimensions__row">
 								<TextControl
 									type="number"

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -105,7 +105,11 @@ class ImageBlock extends Component {
 	}
 
 	onSelectImage( media ) {
-		this.props.setAttributes( pick( media, [ 'alt', 'id', 'caption', 'url' ] ) );
+		this.props.setAttributes( {
+			...pick( media, [ 'alt', 'id', 'caption', 'url' ] ),
+			width: undefined,
+			height: undefined,
+		} );
 	}
 
 	onSetHref( value ) {

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -59,6 +59,9 @@ class ImageBlock extends Component {
 		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSetHref = this.onSetHref.bind( this );
 		this.updateImageURL = this.updateImageURL.bind( this );
+		this.updateWidth = this.updateWidth.bind( this );
+		this.updateHeight = this.updateHeight.bind( this );
+		this.updateDimensions = this.updateDimensions.bind( this );
 
 		this.state = {
 			captionFocused: false,
@@ -138,6 +141,20 @@ class ImageBlock extends Component {
 
 	updateImageURL( url ) {
 		this.props.setAttributes( { url, width: undefined, height: undefined } );
+	}
+
+	updateWidth( width ) {
+		this.props.setAttributes( { width: parseInt( width, 10 ) } );
+	}
+
+	updateHeight( height ) {
+		this.props.setAttributes( { height: parseInt( height, 10 ) } );
+	}
+
+	updateDimensions( width = undefined, height = undefined ) {
+		return () => {
+			this.props.setAttributes( { width, height } );
+		};
 	}
 
 	getAvailableSizes() {
@@ -235,9 +252,7 @@ class ImageBlock extends Component {
 									label={ __( 'Width' ) }
 									value={ width !== undefined ? width : '' }
 									placeholder={ selectedSize.width }
-									onChange={ ( value ) => {
-										setAttributes( { width: parseInt( value, 10 ) } );
-									} }
+									onChange={ this.updateWidth }
 								/>
 								<TextControl
 									type="number"
@@ -245,9 +260,7 @@ class ImageBlock extends Component {
 									label={ __( 'Height' ) }
 									value={ height !== undefined ? height : '' }
 									placeholder={ selectedSize.height }
-									onChange={ ( value ) => {
-										setAttributes( { height: parseInt( value, 10 ) } );
-									} }
+									onChange={ this.updateHeight }
 								/>
 							</div>
 							<div className="blocks-image__dimensions__row">
@@ -264,9 +277,7 @@ class ImageBlock extends Component {
 												isSmall
 												isPrimary={ isCurrent }
 												aria-pressed={ isCurrent }
-												onClick={ () => {
-													setAttributes( { width: scaledWidth, height: scaledHeight } );
-												} }
+												onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
 											>
 												{ scale }%
 											</Button>
@@ -275,9 +286,7 @@ class ImageBlock extends Component {
 								</ButtonGroup>
 								<Button
 									isSmall
-									onClick={ () => {
-										setAttributes( { width: undefined, height: undefined } );
-									} }
+									onClick={ this.updateDimensions() }
 								>
 									{ __( 'Reset' ) }
 								</Button>

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -137,7 +137,7 @@ class ImageBlock extends Component {
 	}
 
 	updateImageURL( url ) {
-		this.props.setAttributes( { url } );
+		this.props.setAttributes( { url, width: undefined, height: undefined } );
 	}
 
 	getAvailableSizes() {

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -194,7 +194,7 @@ class ImageBlock extends Component {
 
 		const classes = classnames( className, {
 			'is-transient': 0 === url.indexOf( 'blob:' ),
-			'is-resized': !! width,
+			'is-resized': !! width || !! height,
 			'is-focused': isSelected,
 		} );
 
@@ -300,7 +300,11 @@ class ImageBlock extends Component {
 						const img = <img src={ url } alt={ alt } onClick={ this.onImageClick } />;
 
 						if ( ! isResizable || ! imageWidthWithinContainer ) {
-							return img;
+							return (
+								<div style={ { width, height } }>
+									{ img }
+								</div>
+							);
 						}
 
 						const currentWidth = width || imageWidthWithinContainer;

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -198,7 +198,6 @@ class ImageBlock extends Component {
 			'is-focused': isSelected,
 		} );
 
-		const figureStyle = width ? { width } : {};
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && ( ! viewPort.isExtraSmall() );
 
 		// Disable reason: Each block can be selected by clicking on it
@@ -287,7 +286,7 @@ class ImageBlock extends Component {
 					</PanelBody>
 				</InspectorControls>
 			),
-			<figure key="image" className={ classes } style={ figureStyle }>
+			<figure key="image" className={ classes }>
 				<ImageSize src={ url } dirtynessTrigger={ align }>
 					{ ( sizes ) => {
 						const {

--- a/blocks/library/image/block.js
+++ b/blocks/library/image/block.js
@@ -224,14 +224,14 @@ class ImageBlock extends Component {
 								onChange={ this.updateImageURL }
 							/>
 						) }
-						<div className="blocks-image-dimensions">
-							<p className="blocks-image-dimensions__row">
+						<div className="blocks-image__dimensions">
+							<p className="blocks-image__dimensions__row">
 								{ __( 'Image Dimensions' ) }
 							</p>
-							<div className="blocks-image-dimensions__row">
+							<div className="blocks-image__dimensions__row">
 								<TextControl
 									type="number"
-									className="blocks-image-dimensions__width"
+									className="blocks-image__dimensions__width"
 									label={ __( 'Width' ) }
 									value={ width !== undefined ? width : '' }
 									placeholder={ selectedSize.width }
@@ -241,7 +241,7 @@ class ImageBlock extends Component {
 								/>
 								<TextControl
 									type="number"
-									className="blocks-image-dimensions__height"
+									className="blocks-image__dimensions__height"
 									label={ __( 'Height' ) }
 									value={ height !== undefined ? height : '' }
 									placeholder={ selectedSize.height }
@@ -250,7 +250,7 @@ class ImageBlock extends Component {
 									} }
 								/>
 							</div>
-							<div className="blocks-image-dimensions__row">
+							<div className="blocks-image__dimensions__row">
 								<ButtonGroup aria-label={ __( 'Image Size' ) }>
 									{ [ 25, 50, 75, 100 ].map( ( scale ) => {
 										const scaledWidth = Math.round( selectedSize.width * ( scale / 100 ) );

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -7,6 +7,10 @@
 		width: 100%;
 	}
 
+	&.is-resized img {
+		height: 100%;
+	}
+
 	&.is-transient img {
 		@include loading_fade;
 	}

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -92,3 +92,23 @@
 		margin-right: auto;
 	}
 }
+
+.blocks-image-dimensions {
+	.blocks-image-dimensions__row {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.blocks-image-dimensions__width,
+	.blocks-image-dimensions__height {
+		margin-bottom: 0.5em;
+	}
+
+	.blocks-image-dimensions__width {
+		margin-right: 5px;
+	}
+
+	.blocks-image-dimensions__height {
+		margin-left: 5px;
+	}
+}

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -97,27 +97,29 @@
 	}
 }
 
-.blocks-image-dimensions {
+.edit-post-sidebar .blocks-image-dimensions {
+	margin-bottom: 1em;
+
 	.blocks-image-dimensions__row {
 		display: flex;
 		justify-content: space-between;
-	}
 
-	.blocks-image-dimensions__width,
-	.blocks-image-dimensions__height {
-		margin-bottom: 0.5em;
+		.blocks-image-dimensions__width,
+		.blocks-image-dimensions__height {
+			margin-bottom: 0.5em;
 
-		// Fix the text and placeholder text being misaligned in Safari
-		input {
-			line-height: 1.25;
+			// Fix the text and placeholder text being misaligned in Safari
+			input {
+				line-height: 1.25;
+			}
 		}
-	}
 
-	.blocks-image-dimensions__width {
-		margin-right: 5px;
-	}
+		.blocks-image-dimensions__width {
+			margin-right: 5px;
+		}
 
-	.blocks-image-dimensions__height {
-		margin-left: 5px;
+		.blocks-image-dimensions__height {
+			margin-left: 5px;
+		}
 	}
 }

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -97,15 +97,15 @@
 	}
 }
 
-.edit-post-sidebar .blocks-image-dimensions {
+.edit-post-sidebar .blocks-image__dimensions {
 	margin-bottom: 1em;
 
-	.blocks-image-dimensions__row {
+	.blocks-image__dimensions__row {
 		display: flex;
 		justify-content: space-between;
 
-		.blocks-image-dimensions__width,
-		.blocks-image-dimensions__height {
+		.blocks-image__dimensions__width,
+		.blocks-image__dimensions__height {
 			margin-bottom: 0.5em;
 
 			// Fix the text and placeholder text being misaligned in Safari
@@ -114,11 +114,11 @@
 			}
 		}
 
-		.blocks-image-dimensions__width {
+		.blocks-image__dimensions__width {
 			margin-right: 5px;
 		}
 
-		.blocks-image-dimensions__height {
+		.blocks-image__dimensions__height {
 			margin-left: 5px;
 		}
 	}

--- a/blocks/library/image/editor.scss
+++ b/blocks/library/image/editor.scss
@@ -106,6 +106,11 @@
 	.blocks-image-dimensions__width,
 	.blocks-image-dimensions__height {
 		margin-bottom: 0.5em;
+
+		// Fix the text and placeholder text being misaligned in Safari
+		input {
+			line-height: 1.25;
+		}
 	}
 
 	.blocks-image-dimensions__width {

--- a/blocks/library/paragraph/editor.scss
+++ b/blocks/library/paragraph/editor.scss
@@ -1,6 +1,7 @@
 .blocks-font-size__main {
 	display: flex;
 	justify-content: space-between;
+	margin-bottom: 1em;
 }
 
 .blocks-paragraph__custom-size-slider {

--- a/components/button-group/style.scss
+++ b/components/button-group/style.scss
@@ -1,6 +1,5 @@
 .components-button-group {
 	display: inline-block;
-	margin-bottom: 20px;
 
 	.components-button {
 		border-radius: 0;

--- a/components/button/index.js
+++ b/components/button/index.js
@@ -47,7 +47,7 @@ class Button extends Component {
 			...additionalProps
 		} = this.props;
 		const classes = classnames( 'components-button', className, {
-			button: ( isPrimary || isLarge ),
+			button: ( isPrimary || isLarge || isSmall ),
 			'button-primary': isPrimary,
 			'button-large': isLarge,
 			'button-small': isSmall,

--- a/components/button/test/index.js
+++ b/components/button/test/index.js
@@ -38,7 +38,7 @@ describe( 'Button', () => {
 
 		it( 'should render a button element with button-small class', () => {
 			const button = shallow( <Button isSmall /> );
-			expect( button.hasClass( 'button' ) ).toBe( false );
+			expect( button.hasClass( 'button' ) ).toBe( true );
 			expect( button.hasClass( 'button-large' ) ).toBe( false );
 			expect( button.hasClass( 'button-small' ) ).toBe( true );
 			expect( button.hasClass( 'button-primary' ) ).toBe( false );

--- a/components/text-control/README.md
+++ b/components/text-control/README.md
@@ -44,10 +44,18 @@ Type of the input element to render. Defaults to "text".
 
 ### value
 
-The current value of the input
+The current value of the input.
 
 - Type: `Number`
 - Required: Yes
+
+### className
+
+The class that will be added with "components-base-control" to the classes of the wrapper div.
+If no className is passed only components-base-control is used.
+
+- Type: `String`
+- Required: No
 
 ### onChange
 

--- a/components/text-control/index.js
+++ b/components/text-control/index.js
@@ -5,12 +5,12 @@ import BaseControl from '../base-control';
 import withInstanceId from '../higher-order/with-instance-id';
 import './style.scss';
 
-function TextControl( { label, value, help, instanceId, onChange, type = 'text', ...props } ) {
+function TextControl( { label, value, help, className, instanceId, onChange, type = 'text', ...props } ) {
 	const id = `inspector-text-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
-		<BaseControl label={ label } id={ id } help={ help }>
+		<BaseControl label={ label } id={ id } help={ help } className={ className }>
 			<input className="components-text-control__input"
 				type={ type }
 				id={ id }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11871,9 +11871,9 @@
 			"dev": true
 		},
 		"re-resizable": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.0.3.tgz",
-			"integrity": "sha512-6YpsC4JFT7zVG8/8gIXxdnrlHdz64/H7dpjHgXNCy5kwy2DIG1dVbdgASNUTwy4AaHgI8rvjJJzr2BxZAVu/3Q=="
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.4.8.tgz",
+			"integrity": "sha512-5Nm4FL5wz41/5SYz8yJIM1kCcftxNPXxv3Yfa5qhkrGasHPgYzmzbbu1pcYM9vuCHog79EVwKWuz7zxDH52Gfw=="
 		},
 		"react": {
 			"version": "16.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"mousetrap": "1.6.1",
 		"prop-types": "15.5.10",
 		"querystringify": "1.0.0",
-		"re-resizable": "4.0.3",
+		"re-resizable": "4.4.8",
 		"react": "16.3.0",
 		"react-autosize-textarea": "3.0.2",
 		"react-click-outside": "2.3.1",


### PR DESCRIPTION
## Description
Closes #4914.

Let users manually set the width and height of an image either using a text field or by a preset percentage amount.

## How Has This Been Tested?
1. Insert an image block
2. Open the block inspector
3. Resize the image using the preset % amounts (e.g. 25%)
4. Resize the image by manually entering a width and height
5. Resize the image by using the drag handles
6. Click _Reset_

In all cases, the width value, the height value, and the size of the image in the editor should reflect the entered size.

## Screenshots (jpeg or gifs if applicable):

![dimensions](https://user-images.githubusercontent.com/612155/37947253-c7d293cc-31d5-11e8-8c4c-96f9f829026d.png)