### PR TITLE
Update react-autosize-textarea package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -242,34 +242,11 @@
 				"postcss": "5.2.18"
 			}
 		},
-		"@types/autosize": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/autosize/-/autosize-3.0.6.tgz",
-			"integrity": "sha512-gpfmXswGISLSWNOOdF2PDK96SfkaZdNtNixWJbYH10xn3Hqdt4VyS1GmoutuwOshWyCLuJw2jGhF0zkK7PUhrg==",
-			"requires": {
-				"@types/jquery": "3.3.0"
-			}
-		},
-		"@types/jquery": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.0.tgz",
-			"integrity": "sha512-szaKV2OQgwxYTGTY6qd9eeBfGGCaP7n2OGit4JdbOcfGgc9VWjfhMhnu5AVNhIAu8WWDIB36q9dfPVba1fGeIQ=="
-		},
 		"@types/node": {
 			"version": "9.4.6",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
 			"integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
 			"dev": true
-		},
-		"@types/prop-types": {
-			"version": "15.5.2",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.2.tgz",
-			"integrity": "sha512-pQRkAVoxiuUrLq8+CDwiQX4pTCep/PmmNgBbjIwnnsd/HoYjGpR81+FFPE030lvNXgR0haaAU6eoRtztWDE4Xw=="
-		},
-		"@types/react": {
-			"version": "15.6.7",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-15.6.7.tgz",
-			"integrity": "sha512-HMfRuwiTp7/MfjPOsVlvlduouJH3haDzjc0oXqZy3ZMn3OTl3i4gGgbxsqzA/u9gNyl/oKkwOrU2oVR6vG5SAw=="
 		},
 		"@wordpress/a11y": {
 			"version": "1.0.6",
@@ -793,9 +770,9 @@
 			}
 		},
 		"autosize": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.0.tgz",
-			"integrity": "sha1-egWZsbqE1zvXWJsNnaOHAVLGkjc="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.1.tgz",
+			"integrity": "sha512-Sapd3XwNqZin0VW0DFiAGfgr9s2d1Sudj2+hnE/jj6aJUKXvlaimkY+FFB2Xzm3nfD7tCaMSC2jo4sVB2EOqpw=="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -9538,14 +9515,11 @@
 			}
 		},
 		"react-autosize-textarea": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-2.0.0.tgz",
-			"integrity": "sha1-fDDSqktzic4WvkLtJj4utGwysiE=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.2.tgz",
+			"integrity": "sha1-K2hApp9xOHGavOpaQp7PcwF2jAc=",
 			"requires": {
-				"@types/autosize": "3.0.6",
-				"@types/prop-types": "15.5.2",
-				"@types/react": "15.6.7",
-				"autosize": "4.0.0",
+				"autosize": "4.0.1",
 				"line-height": "0.3.1",
 				"prop-types": "15.5.10"
 			}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"querystringify": "1.0.0",
 		"re-resizable": "4.0.3",
 		"react": "16.2.0",
-		"react-autosize-textarea": "2.0.0",
+		"react-autosize-textarea": "3.0.2",
 		"react-click-outside": "2.3.1",
 		"react-color": "2.13.4",
 		"react-datepicker": "0.61.0",


### PR DESCRIPTION
With the current version of the package, it's possible that the title shows up cropped on initial load of a page with a long title. Updating the package should fix it.

**Testing instructions**

 - Open the demo page
 - The title should show up properly
 - Save and reload
 - The title is still properly displayed