### PR TITLE
Components: Create Slot/Fill Consumer component using faked React 16.3.0 context API

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -48,7 +48,12 @@ export { default as ToggleControl } from './toggle-control';
 export { default as Toolbar } from './toolbar';
 export { default as Tooltip } from './tooltip';
 export { default as TreeSelect } from './tree-select';
-export { Slot, Fill, Provider as SlotFillProvider } from './slot-fill';
+export {
+	Slot,
+	Fill,
+	Provider as SlotFillProvider,
+	Context as SlotFillContext,
+} from './slot-fill';
 
 // Higher-Order Components
 export { default as ifCondition } from './higher-order/if-condition';

--- a/components/slot-fill/context.js
+++ b/components/slot-fill/context.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { without } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Slot/Fill context.
+ *
+ * NOTE: In React 16.3.0, this will be assigned via new `createContext` API.
+ *
+ * @type {Object}
+ */
+const SlotFillContext = {};
+
+/**
+ * Currently mounted consumer instances.
+ *
+ * NOTE: In React 16.3.0, this will not be needed.
+ *
+ * @type {Array}
+ */
+let consumers = [];
+
+/**
+ * Current context.
+ *
+ * NOTE: In React 16.3.0, this will not be needed.
+ *
+ * @type {Object}
+ */
+let context;
+
+/**
+ * Triggers a forced render for all context consumers.
+ *
+ * NOTE: In React 16.3.0, this will not be needed.
+ */
+export function __interopForceUpdateConsumers() {
+	consumers.forEach( ( instance ) => instance.forceUpdate() );
+}
+
+/**
+ * Updates the current context and triggers a forced render on consumers.
+ *
+ * NOTE: In React 16.3.0, this will not be needed.
+ *
+ * @param {Object} nextContext Next context object.
+ */
+export function __interopSetContext( nextContext ) {
+	context = nextContext;
+	__interopForceUpdateConsumers();
+}
+
+SlotFillContext.Consumer = class extends Component {
+	componentDidMount() {
+		consumers.push( this );
+	}
+
+	componentWillUnmount() {
+		consumers = without( consumers, this );
+	}
+
+	render() {
+		return this.props.children( context );
+	}
+};
+
+export default SlotFillContext;

--- a/components/slot-fill/index.js
+++ b/components/slot-fill/index.js
@@ -4,9 +4,11 @@
 import Slot from './slot';
 import Fill from './fill';
 import Provider from './provider';
+import Context from './context';
 
 export { Slot };
 export { Fill };
 export { Provider };
+export { Context };
 
-export default { Slot, Fill, Provider };
+export default { Slot, Fill, Provider, Context };

--- a/components/slot-fill/provider.js
+++ b/components/slot-fill/provider.js
@@ -8,6 +8,11 @@ import { pick, sortBy, forEach, without, noop } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { __interopSetContext } from './context';
+
 class SlotFillProvider extends Component {
 	constructor() {
 		super( ...arguments );
@@ -21,6 +26,10 @@ class SlotFillProvider extends Component {
 
 		this.slots = {};
 		this.fills = {};
+	}
+
+	componentWillMount() {
+		__interopSetContext( this.getChildContext() );
 	}
 
 	getChildContext() {
@@ -41,6 +50,7 @@ class SlotFillProvider extends Component {
 		// Sometimes the fills are registered after the intial render of slot
 		// But before the registerSlot call, we need to rerender the slot
 		this.forceUpdateSlot( name );
+		__interopSetContext( this.getChildContext() );
 	}
 
 	registerFill( name, instance ) {
@@ -49,11 +59,13 @@ class SlotFillProvider extends Component {
 			instance,
 		];
 		this.forceUpdateSlot( name );
+		__interopSetContext( this.getChildContext() );
 	}
 
 	unregisterSlot( name ) {
 		delete this.slots[ name ];
 		this.forceUpdateFills( name );
+		__interopSetContext( this.getChildContext() );
 	}
 
 	unregisterFill( name, instance ) {
@@ -63,6 +75,7 @@ class SlotFillProvider extends Component {
 		);
 		this.resetFillOccurrence( name );
 		this.forceUpdateSlot( name );
+		__interopSetContext( this.getChildContext() );
 	}
 
 	getSlot( name ) {

--- a/edit-post/components/plugin-more-menu-group/index.js
+++ b/edit-post/components/plugin-more-menu-group/index.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/element';
-import { withContext, MenuGroup } from '@wordpress/components';
+import { SlotFillContext, MenuGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,19 +9,24 @@ import { __ } from '@wordpress/i18n';
  */
 import PluginMoreMenuItem, { SLOT_NAME } from '../plugin-more-menu-item';
 
-const PluginMoreMenuGroup = ( { getFills, fillProps } ) => {
-	// We don't want the plugins menu items group to be rendered if there are no fills.
-	if ( ! getFills( SLOT_NAME ).length ) {
-		return null;
-	}
+function PluginMoreMenuGroup( { fillProps } ) {
 	return (
-		<MenuGroup
-			label={ __( 'Plugins' ) } >
-			<PluginMoreMenuItem.Slot name={ SLOT_NAME } fillProps={ fillProps } />
-		</MenuGroup>
-	);
-};
+		<SlotFillContext.Consumer>
+			{ ( { getFills } ) => {
+				// We don't want the plugins menu items group to be rendered if there are no fills.
+				if ( ! getFills( SLOT_NAME ).length ) {
+					return null;
+				}
 
-export default compose( [
-	withContext( 'getFills' )(),
-] )( PluginMoreMenuGroup );
+				return (
+					<MenuGroup
+						label={ __( 'Plugins' ) } >
+						<PluginMoreMenuItem.Slot name={ SLOT_NAME } fillProps={ fillProps } />
+					</MenuGroup>
+				);
+			} }
+		</SlotFillContext.Consumer>
+	);
+}
+
+export default PluginMoreMenuGroup;


### PR DESCRIPTION
Fixes #5759

This pull request seeks to fix an issue where plugin menu item fills are not rendered on the initial menu rendering. This was caused by logic to avoid rendering the menu grouping if no plugin fills exist, but was not being updated in response to the addition of a new fill. This is a fundamental shortcoming of the existing React context API, but is resolved in the upcoming React 16.3.0 release with the introduction of a [new context API](https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md).

The changes here add a new `SlotFillContext.Consumer` component modeled on this new API, implemented via a series of hacks that can be dropped upon the release of React 16.3.0 (ETA last month 😄 ).

**Testing instructions:**

Repeat steps to reproduce from #5759, verifying that the expected behavior is present.