### PR TITLE
Add visible text to the Gallery add item button

### DIFF
--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -252,7 +252,11 @@ class GalleryBlock extends Component {
 							onChange={ this.uploadFromFiles }
 							accept="image/*"
 							icon="insert"
-						/>
+						>
+							<span className="blocks-gallery-add-item-label">
+								{ __( 'Upload Image' ) }
+							</span>
+						</FormFileUpload>
 					</li>
 				}
 			</ul>,

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -253,7 +253,7 @@ class GalleryBlock extends Component {
 							accept="image/*"
 							icon="insert"
 						>
-							{ __( 'Upload an Image' ) }
+							{ __( 'Upload an image' ) }
 						</FormFileUpload>
 					</li>
 				}

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -253,9 +253,7 @@ class GalleryBlock extends Component {
 							accept="image/*"
 							icon="insert"
 						>
-							<span className="blocks-gallery-add-item-label">
-								{ __( 'Upload Image' ) }
-							</span>
+							{ __( 'Upload Image' ) }
 						</FormFileUpload>
 					</li>
 				}

--- a/blocks/library/gallery/block.js
+++ b/blocks/library/gallery/block.js
@@ -253,7 +253,7 @@ class GalleryBlock extends Component {
 							accept="image/*"
 							icon="insert"
 						>
-							{ __( 'Upload Image' ) }
+							{ __( 'Upload an Image' ) }
 						</FormFileUpload>
 					</li>
 				}

--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -44,7 +44,6 @@
 		border: none;
 		border-radius: 0;
 		min-height: 100px;
-		font-family: $default-font;
 
 		& .dashicon {
 			margin-top: 10px;

--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -52,6 +52,13 @@
 			border: 1px solid #999;
 		}
 	}
+
+	.blocks-gallery-add-item-label {
+		display: block;
+		line-height: normal;
+		margin-bottom: -1.22em; // line-height "normal" value
+		font-family: $default-font;
+	}
 }
 
 .blocks-gallery-item__inline-menu {

--- a/blocks/library/gallery/editor.scss
+++ b/blocks/library/gallery/editor.scss
@@ -37,27 +37,23 @@
 	}
 
 	.button.blocks-gallery-add-item-button {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 		box-shadow: none;
 		border: none;
 		border-radius: 0;
 		min-height: 100px;
+		font-family: $default-font;
 
 		& .dashicon {
 			margin-top: 10px;
 		}
 
-
 		&:hover,
 		&:focus {
 			border: 1px solid #999;
 		}
-	}
-
-	.blocks-gallery-add-item-label {
-		display: block;
-		line-height: normal;
-		margin-bottom: -1.22em; // line-height "normal" value
-		font-family: $default-font;
 	}
 }
 

--- a/edit-post/components/visual-editor/style.scss
+++ b/edit-post/components/visual-editor/style.scss
@@ -22,6 +22,10 @@
 	& ol {
 		list-style-type: decimal;
 	}
+
+	& .button {
+		font-family: $default-font;
+	}
 }
 
 .edit-post-visual-editor .editor-writing-flow__click-redirect {


### PR DESCRIPTION
This PR adds a visible `Upload Image` text to the Gallery add item button that was previously completely unlabeled. For more details please refer to the related issue #5823 

Screenshots:

![screen shot 2018-03-27 at 18 30 07](https://user-images.githubusercontent.com/1682452/37982410-c7916a94-31f0-11e8-9ac6-85dd0ba830f2.jpg)

![screen shot 2018-03-27 at 18 30 49](https://user-images.githubusercontent.com/1682452/37982411-c7aeeda8-31f0-11e8-8aad-f1cf1b499c6f.jpg)

Fixes #5823