### PR TITLE
Framework: Fetch categories by common terms resolver

### DIFF
--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -13,9 +13,11 @@ import { getTaxonomyRESTBase } from './settings';
  * Requests terms from the REST API, yielding action objects on request
  * progress.
  *
+ * @param {Object} state State object.
+ *
  * @param {string} taxonomy Taxonomy for which terms should be requested.
  */
-export async function* getTerms( taxonomy ) {
+export async function* getTerms( state, taxonomy ) {
 	yield setRequested( 'terms', taxonomy );
 	const restBase = getTaxonomyRESTBase( taxonomy );
 	const terms = await apiRequest( { path: '/wp/v2/' + restBase } );
@@ -26,17 +28,19 @@ export async function* getTerms( taxonomy ) {
  * Requests categories from the REST API, yielding action objects on request
  * progress.
  *
+ * @param {Object} state State object.
+ *
  * @return {AsyncGenerator} Terms request generator.
  */
-export function getCategories() {
-	return getTerms( 'category' );
+export function getCategories( state ) {
+	return getTerms( state, 'category' );
 }
 
 /**
  * Requests a media element from the REST API.
  *
- * @param {Object} state State tree
- * @param {number} id    Media id
+ * @param {Object} state State tree.
+ * @param {number} id    Media id.
  */
 export async function* getMedia( state, id ) {
 	const media = await apiRequest( { path: `/wp/v2/media/${ id }` } );

--- a/core-data/resolvers.js
+++ b/core-data/resolvers.js
@@ -7,15 +7,29 @@ import apiRequest from '@wordpress/api-request';
  * Internal dependencies
  */
 import { setRequested, receiveTerms, receiveMedia } from './actions';
+import { getTaxonomyRESTBase } from './settings';
+
+/**
+ * Requests terms from the REST API, yielding action objects on request
+ * progress.
+ *
+ * @param {string} taxonomy Taxonomy for which terms should be requested.
+ */
+export async function* getTerms( taxonomy ) {
+	yield setRequested( 'terms', taxonomy );
+	const restBase = getTaxonomyRESTBase( taxonomy );
+	const terms = await apiRequest( { path: '/wp/v2/' + restBase } );
+	yield receiveTerms( taxonomy, terms );
+}
 
 /**
  * Requests categories from the REST API, yielding action objects on request
  * progress.
+ *
+ * @return {AsyncGenerator} Terms request generator.
  */
-export async function* getCategories() {
-	yield setRequested( 'terms', 'categories' );
-	const categories = await apiRequest( { path: '/wp/v2/categories' } );
-	yield receiveTerms( 'categories', categories );
+export function getCategories() {
+	return getTerms( 'category' );
 }
 
 /**

--- a/core-data/selectors.js
+++ b/core-data/selectors.js
@@ -18,7 +18,7 @@ export function getTerms( state, taxonomy ) {
  * @return {Array} Categories list.
  */
 export function getCategories( state ) {
-	return getTerms( state, 'categories' );
+	return getTerms( state, 'category' );
 }
 
 /**
@@ -43,7 +43,7 @@ export function isRequestingTerms( state, taxonomy ) {
  * @return {boolean} Whether a request is in progress for categories.
  */
 export function isRequestingCategories( state ) {
-	return isRequestingTerms( state, 'categories' );
+	return isRequestingTerms( state, 'category' );
 }
 
 /**

--- a/core-data/settings.js
+++ b/core-data/settings.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { settings } from '@wordpress/api-request';
+
+/**
+ * Given a post type slug, returns its REST API base route.
+ *
+ * @param {string} postType Post type slug.
+ *
+ * @return {string} Post type REST API base route.
+ */
+export function getPostTypeRESTBase( postType ) {
+	return settings.postTypeRestBaseMapping[ postType ];
+}
+
+/**
+ * Given a taxonomy slug, returns its REST API base route.
+ *
+ * @param {string} taxonomy Taxonomy slug.
+ *
+ * @return {string} Taxonomy REST API base route.
+ */
+export function getTaxonomyRESTBase( taxonomy ) {
+	return settings.taxonomyRestBaseMapping[ taxonomy ];
+}

--- a/core-data/test/__mocks__/@wordpress/api-request.js
+++ b/core-data/test/__mocks__/@wordpress/api-request.js
@@ -1,1 +1,10 @@
-module.exports = jest.fn();
+const apiRequest = jest.fn();
+
+apiRequest.settings = {
+	postTypeRestBaseMapping: {},
+	taxonomyRestBaseMapping: {
+		category: 'categories',
+	},
+};
+
+module.exports = apiRequest;

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -6,12 +6,12 @@ import apiRequest from '@wordpress/api-request';
 /**
  * Internal dependencies
  */
-import { getCategories, getMedia } from '../resolvers';
+import { getTerms, getMedia } from '../resolvers';
 import { setRequested, receiveTerms, receiveMedia } from '../actions';
 
 jest.mock( '@wordpress/api-request' );
 
-describe( 'getCategories', () => {
+describe( 'getTerms', () => {
 	const CATEGORIES = [ { id: 1 } ];
 
 	beforeAll( () => {
@@ -23,11 +23,11 @@ describe( 'getCategories', () => {
 	} );
 
 	it( 'yields with requested terms', async () => {
-		const fulfillment = getCategories();
+		const fulfillment = getTerms( 'category' );
 		const requested = ( await fulfillment.next() ).value;
 		expect( requested.type ).toBe( setRequested().type );
 		const received = ( await fulfillment.next() ).value;
-		expect( received ).toEqual( receiveTerms( 'categories', CATEGORIES ) );
+		expect( received ).toEqual( receiveTerms( 'category', CATEGORIES ) );
 	} );
 } );
 

--- a/core-data/test/resolvers.js
+++ b/core-data/test/resolvers.js
@@ -23,7 +23,7 @@ describe( 'getTerms', () => {
 	} );
 
 	it( 'yields with requested terms', async () => {
-		const fulfillment = getTerms( 'category' );
+		const fulfillment = getTerms( undefined, 'category' );
 		const requested = ( await fulfillment.next() ).value;
 		expect( requested.type ).toBe( setRequested().type );
 		const received = ( await fulfillment.next() ).value;

--- a/editor/components/provider/index.js
+++ b/editor/components/provider/index.js
@@ -3,7 +3,7 @@
  */
 import { bindActionCreators } from 'redux';
 import { Provider as ReduxProvider } from 'react-redux';
-import { flow, pick, noop } from 'lodash';
+import { flow, noop } from 'lodash';
 
 /**
  * WordPress Dependencies
@@ -127,13 +127,7 @@ class EditorProvider extends Component {
 			//  - context.getAPITaxonomyRestBaseMapping
 			[
 				APIProvider,
-				{
-					...wpApiSettings,
-					...pick( wp.api, [
-						'postTypeRestBaseMapping',
-						'taxonomyRestBaseMapping',
-					] ),
-				},
+				wpApiSettings,
 			],
 
 			// DropZone provider:

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -588,6 +588,7 @@ function gutenberg_set_wp_api_settings_mappings() {
 
 		foreach ( $objects as $object ) {
 			$rest_base = ! empty( $object->rest_base ) ? $object->rest_base : $object->name;
+
 			$mapping[ $object->name ] = $rest_base;
 		}
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -134,6 +134,17 @@ JS;
 add_action( 'wp_default_scripts', 'gutenberg_shim_api_request_emulate_http' );
 
 /**
+ * Shims assignment of API settings into apiRequest object.
+ *
+ * @param WP_Scripts $scripts WP_Scripts instance (passed by reference).
+ */
+function gutenberg_shim_api_request_settings( $scripts ) {
+	$api_settings_shim = 'wp.apiRequest.settings = window.wpApiSettings';
+	$scripts->add_inline_script( 'wp-api-request', $api_settings_shim, 'after' );
+}
+add_action( 'wp_default_scripts', 'gutenberg_shim_api_request_settings' );
+
+/**
  * Disables wpautop behavior in classic editor when post contains blocks, to
  * prevent removep from invalidating paragraph blocks.
  *


### PR DESCRIPTION
_This pull request is part of a series of pull request targeted at more complex use of selector resolvers introduced in #5219, namely toward paginated hierarchical terms picker._

This pull request seeks to refactor the category resolver implemented in #5219 to generalize its use toward terms fetching. There are no changes to the public interface for consuming categories, and it's expected that a `getCategories` selector will remain long-term as a boon to developer usability. The changes here enhance the existing `getTerms` selector on which categories extends to support resolution of other terms. This includes necessary changes to allow access to the REST base mappings within the core data module (via `wp.apiRequest.settings`).

__Implementation notes:__

It would be nice if we wouldn't need a standalone `getCategories` resolver, considering that the `getCategories` selector calls the `getTerms` selector, there should only need to be a resolver for `getTerms`. However, because selecting within a module's own selectors does not flow through the data module's abstraction, it does not trigger these resolvers automatically. While disappointing, this is a relatively minor consideration.

__Testing instructions:__

Verify there are no regressions in the display of categories block.

Verify there are no regressions in the behavior of `withAPIData`, whose provider has been slightly revised here. Example: Category picker.