### PR TITLE
Add an aria-label to the inserter items to make IE11 and JAWS happy.

### DIFF
--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -74,6 +74,7 @@ export default class InserterGroup extends Component {
 				onMouseLeave={ this.createToggleBlockHover( null ) }
 				onFocus={ this.createToggleBlockHover( item ) }
 				onBlur={ this.createToggleBlockHover( null ) }
+				aria-label={ item.title } // Fix for IE11 and JAWS 2018 see GitHub issue 5827.
 			>
 				<BlockIcon icon={ item.icon } />
 				{ item.title }

--- a/editor/components/inserter/group.js
+++ b/editor/components/inserter/group.js
@@ -74,7 +74,7 @@ export default class InserterGroup extends Component {
 				onMouseLeave={ this.createToggleBlockHover( null ) }
 				onFocus={ this.createToggleBlockHover( item ) }
 				onBlur={ this.createToggleBlockHover( null ) }
-				aria-label={ item.title } // Fix for IE11 and JAWS 2018 see GitHub issue 5827.
+				aria-label={ item.title } // Fix for IE11 and JAWS 2018.
 			>
 				<BlockIcon icon={ item.icon } />
 				{ item.title }


### PR DESCRIPTION
This PR fixes a specific bug in IE11 and JAWS 2018: they don't announce the Inserter menu items names. Adding an `aria-label` attribute with the same text used for the visible block name, fixes it.

> Note: I have no idea why this happens. I've inspected the accessibility tree and the accessible name is populated correctly so it should be properly exposed to browsers. My only guess is that the SVG icon as first children of the menu items plays a role, as it's technically "empty", and this specific combo might have troubles with an empty first children.

To test, there's really the need to test it on Windows with IE 11 and JAWS 2018... just navigate through the items in the inserter to reproduce the bug and then check the fix in this PR. I understand testing this is not so comfortable... Alternatively, since it's just an added HTML attribute that relates only to assistive technologies and doesn't have any other functional or visual effect, I'd suggest to rely on the testing made the pull request submitter.

Fixes #5827 
 