### PR TITLE
Hide Embeds tab in the block insert menu if no embeds are registered

### DIFF
--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -210,7 +210,7 @@ export class InserterMenu extends Component {
 			( category ) => this.renderCategory( category, visibleItemsByCategory[ category.slug ] )
 		);
 	}
-	
+
 	getVisibleTabs() {
 		const tabs = [
 			{
@@ -234,12 +234,12 @@ export class InserterMenu extends Component {
 				className: 'editor-inserter__tab',
 			},
 		];
-		
+
 		// Remove embeds tab if there are no embeds to display.
 		if ( isEmpty( this.getItemsForTab( 'embeds' ) ) ) {
 			return tabs.filter( tab => 'embeds' !== tab.name );
 		}
-		
+
 		return tabs;
 	}
 

--- a/editor/components/inserter/menu.js
+++ b/editor/components/inserter/menu.js
@@ -210,6 +210,38 @@ export class InserterMenu extends Component {
 			( category ) => this.renderCategory( category, visibleItemsByCategory[ category.slug ] )
 		);
 	}
+	
+	getVisibleTabs() {
+		const tabs = [
+			{
+				name: 'frequent',
+				title: __( 'Frequent' ),
+				className: 'editor-inserter__tab',
+			},
+			{
+				name: 'blocks',
+				title: __( 'Blocks' ),
+				className: 'editor-inserter__tab',
+			},
+			{
+				name: 'embeds',
+				title: __( 'Embeds' ),
+				className: 'editor-inserter__tab',
+			},
+			{
+				name: 'shared',
+				title: __( 'Shared' ),
+				className: 'editor-inserter__tab',
+			},
+		];
+		
+		// Remove embeds tab if there are no embeds to display.
+		if ( isEmpty( this.getItemsForTab( 'embeds' ) ) ) {
+			return tabs.filter( tab => 'embeds' !== tab.name );
+		}
+		
+		return tabs;
+	}
 
 	switchTab( tab ) {
 		// store the scrollTop of the tab switched from
@@ -295,28 +327,7 @@ export class InserterMenu extends Component {
 				{ ! isSearching &&
 					<TabPanel className="editor-inserter__tabs" activeClass="is-active"
 						onSelect={ this.switchTab }
-						tabs={ [
-							{
-								name: 'frequent',
-								title: __( 'Frequent' ),
-								className: 'editor-inserter__tab',
-							},
-							{
-								name: 'blocks',
-								title: __( 'Blocks' ),
-								className: 'editor-inserter__tab',
-							},
-							{
-								name: 'embeds',
-								title: __( 'Embeds' ),
-								className: 'editor-inserter__tab',
-							},
-							{
-								name: 'shared',
-								title: __( 'Shared' ),
-								className: 'editor-inserter__tab',
-							},
-						] }
+						tabs={ this.getVisibleTabs() }
 					>
 						{ ( tabKey ) => (
 							<div ref={ ( ref ) => this.tabContainer = ref }>


### PR DESCRIPTION
Fixes #3992.

Removes the Embeds tab from the block insert menu if no embeds exist.

Add the following filter to replicate:

```
add_filter( 'allowed_block_types', function() {
    return [ 'core/paragraph', 'core/heading', 'core/image' ];
}, 10 );
```

Screenshot with filter applied:

<img width="454" alt="screen shot 2018-03-27 at 21 35 09" src="https://user-images.githubusercontent.com/704594/37993524-ce0530ca-3206-11e8-9e1b-69af9ccba397.png">