### PR TITLE
Fix centered multiline labels in the block settings menu 

### DIFF
--- a/editor/components/block-settings-menu/style.scss
+++ b/editor/components/block-settings-menu/style.scss
@@ -49,6 +49,7 @@
 	outline: none;
 	border-radius: 0;
 	color: $dark-gray-500;
+	text-align: left;
 	cursor: pointer;
 	@include menu-style__neutral;
 


### PR DESCRIPTION
## Description
Multiline labels in the block settings menu are centered instead of left aligned.

![screenshot from 2018-03-28 09-21-40](https://user-images.githubusercontent.com/6010232/38028668-ffe2a2fe-3269-11e8-9a15-0763e6dbb378.png)

So I just add `text-alignt: left` and multiline is turn into single line:

![screenshot from 2018-03-28 09-06-20](https://user-images.githubusercontent.com/6010232/38028244-bbed6e36-3268-11e8-9e60-e1fb45c1f6a8.png)

For tests purpose I repeated the last word:

![screenshot from 2018-03-28 09-06-54](https://user-images.githubusercontent.com/6010232/38028284-e7a35900-3268-11e8-924d-29196e84be38.png)

Closes #5788 

## How Has This Been Tested?
This has been tested with "npm test" and manually on Chrome and Firefox.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.
